### PR TITLE
Use npm magic "env" command instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "typings install",
     "start-server": "node dev_server.js",
     "start": "npm run build && npm-run-all --parallel dev start-server",
-    "dev": "node script/run",
+    "dev": "env NODE_ENV=development electron . --debug",
     "build": "tsc && webpack && cp -R static build",
     "clean": "rm -rf build",
     "lint": "tslint lib/**/*.ts lib/**/*.tsx"

--- a/script/run
+++ b/script/run
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-
-// This gets us the path to electron.exe within the node_modules directory.
-var electron = require('electron-prebuilt');
-var proc = require('child_process');
-
-proc.spawn(electron, [ ".", "--debug" ], { env: { "NODE_ENV" : "development" } });

--- a/script/run.cmd
+++ b/script/run.cmd
@@ -1,5 +1,0 @@
-@IF EXIST "%~dp0\node.exe" (
-  "%~dp0\node.exe"  "%~dp0\run" %*
-) ELSE (
-  node  "%~dp0\run" %*
-)


### PR DESCRIPTION
I added this in the PoC and it got ported over here. I was under the impression that there wasn't any xplat way of setting environment variables but I was wrong. npm run has special treatment for the "env" command and will replace it with "SET" on windows.

See https://docs.npmjs.com/cli/run-script

> The env script is a special built-in command that can be used to list environment variables that will be available to the script at runtime. If an "env" command is defined in your package it will take precedence over the built-in.

Also see https://github.com/npm/npm/blob/02a22b2ef28c353c4310380fe08b43888f24f1e3/lib/run-script.js#L142
