### PR TITLE
Fix subpixel antialiasing on Windows

### DIFF
--- a/src/main-process/app-window.ts
+++ b/src/main-process/app-window.ts
@@ -17,7 +17,7 @@ export default class AppWindow {
       // This fixes subpixel aliasing on Windows
       // See https://github.com/atom/atom/commit/683bef5b9d133cb194b476938c77cc07fd05b972
       backgroundColor: "#fff"
-  })
+    })
 
     this.stats = stats
   }


### PR DESCRIPTION
TL;DR: This makes text look crisp on Windows.

![image](https://cloud.githubusercontent.com/assets/634063/15582320/a8313552-2370-11e6-91a0-e269b8a2fb68.png)

After and then before (yes, confusing).

See https://github.com/atom/atom/commit/683bef5b9d133cb194b476938c77cc07fd05b972 for the details
