### PR TITLE
No text selection

### DIFF
--- a/styles/_globals.scss
+++ b/styles/_globals.scss
@@ -54,7 +54,7 @@ body {
 }
 
 :not(input):not(textarea) {
-  &::after, &::before {
+  &, &::after, &::before {
     -webkit-user-select: none;
     user-select: none;
     cursor: default;


### PR DESCRIPTION
Looks like this got missed in the sass conversion in https://github.com/desktop/desktop/pull/50.

Don’t allow text selection by default.
