### PR TITLE
Revert "Use __DEV__ instead of checking for the environment."

### DIFF
--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -1,1 +1,0 @@
-declare var __DEV__: boolean

--- a/src/main-process/main.ts
+++ b/src/main-process/main.ts
@@ -75,7 +75,7 @@ app.on('ready', () => {
   // TODO: Plumb the logged in .com user through here.
   // Truly we have been haacked.
   autoUpdater.setFeedURL(getFeedURL('haacked'))
-  if (__DEV__) {
+  if (process.env.NODE_ENV !== 'development') {
     try {
       autoUpdater.checkForUpdates()
     } catch (e) {


### PR DESCRIPTION
This reverts commit 199b07cf4281020cdba71ee26310f13712cacb09.

Because, of course, we don’t actually webpack the main process code (yet). So there’s no `__DEV__` at runtime no matter how nicely I declare it.
