### PR TITLE
Implement shouldComponentUpdate for Octicon

### DIFF
--- a/src/octicon.tsx
+++ b/src/octicon.tsx
@@ -49,6 +49,21 @@ export class Octicon extends React.Component<OcticonProps, void> {
     symbol: OcticonSymbol.markGithub
   }
 
+  public shouldComponentUpdate(nextProps: OcticonProps, nextState: void) {
+
+    if (nextProps.width !== this.props.width || nextProps.height !== this.props.height) {
+      return true
+    }
+
+    if (nextProps.symbol.w !== this.props.symbol.w ||
+       nextProps.symbol.h !== this.props.symbol.h ||
+       nextProps.symbol.d !== this.props.symbol.d) {
+       return true
+     }
+
+     return false
+  }
+
   public render() {
     const symbol = this.props.symbol
     const viewBox = `0 0 ${symbol.w} ${symbol.h}`


### PR DESCRIPTION
Might as well get into the habit of doing this.

I was looking at the `deep-compare` npm package thinking that it did... deep comparisons but it turns out it only does [very shallow comparisons](https://github.com/dangvanthanh/deep-compare/blob/86162c172507e20f710367b0a711d8c76f83e00a/index.js). Womp womp.
