### PR TITLE
Typo from jsdoc experimentation

### DIFF
--- a/src/octicon.tsx
+++ b/src/octicon.tsx
@@ -30,7 +30,7 @@ interface OcticonProps {
 }
 
 /**
- * # A React component for displaying octicon symbols in SVG format.
+ * A React component for displaying octicon symbols in SVG format.
  *
  * Note that the aspect ratios of the octicons will always be preserved
  * which is why the width and height properties specify the maximum and


### PR DESCRIPTION
No markdown for you, this was never supposed to go in.
