### PR TITLE
Make the repo list tooltip useful

### DIFF
--- a/src/ui/repos-list.tsx
+++ b/src/ui/repos-list.tsx
@@ -17,9 +17,14 @@ export default class ReposList extends React.Component<ReposListProps, void> {
   private renderRow(row: number): JSX.Element {
     const repo = this.props.repos[row]
     const symbol = this.iconForRepo(repo)
+    const repoPath = repo.path
+    const gitHubRepo = repo.gitHubRepository
+    const tooltip = gitHubRepo
+      ? gitHubRepo.fullName + '\n' + gitHubRepo.htmlURL + '\n' + repoPath
+      : repoPath
 
     return (
-      <div className='repository-list-item' key={row.toString()} title={repo.name}>
+      <div className='repository-list-item' key={row.toString()} title={tooltip}>
         <Octicon symbol={symbol} />
         <div className='name'>{repo.name}</div>
       </div>


### PR DESCRIPTION
For local repositories, we show the path. It's not really useful to show the name since you can see the name in the list.

<img src="https://cloud.githubusercontent.com/assets/19977/16852986/47e16f58-49bf-11e6-87ce-7df61bdcf968.png" width="320" />

For GitHub repositories we show the full name (owner/name) as well as the HTML URL and the path.

<img src="https://cloud.githubusercontent.com/assets/19977/16852987/47e3f228-49bf-11e6-82d1-a76ab0994b5b.png" width="320" />

Ignore the fact that the info shown in this tooltip is wrong. I had to fake it up because the GitHub info isn't being connected to the repo right now. But when that's fixed, that's what it'll look like.
