### PR TITLE
Don't let the avatar shrink

### DIFF
--- a/app/styles/ui/_commit-list.scss
+++ b/app/styles/ui/_commit-list.scss
@@ -15,6 +15,8 @@
     .avatar {
       width: 48px;
       height: 48px;
+      flex-shrink: 0;
+
       border-radius: 4px;
       align-self: center;
     }


### PR DESCRIPTION
Sometimes (?!) the avatar would get squished:

<img width="246" alt="screen shot 2016-07-28 at 4 54 59 pm" src="https://cloud.githubusercontent.com/assets/13760/17229109/21dc9118-54e4-11e6-8e4c-51df4298d69e.png">

This prevents that.
