### PR TITLE
Fix window controls on windows

### DIFF
--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -63,9 +63,11 @@
       padding: 0;
       margin: 0;
       overflow: hidden;
+
+      // Reset styles from global buttons
       border: none;
       box-shadow: none;
-      border-radius: 0px;
+      border-radius: 0;
 
       color: #000;
       background-color: transparent;


### PR DESCRIPTION
Some recent changes to the global `button` style caused the buttons used in window-controls to get rounded corners and a drop shadow.

![image](https://cloud.githubusercontent.com/assets/634063/17279552/08930300-5777-11e6-9d98-8346f561a9e1.png)

This resets those properties.
