### PR TITLE
Rename electron-prebuilt dependency to electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "css-loader": "^0.23.1",
     "electron-mocha": "2.1.0",
     "electron-packager": "^7.2.0",
-    "electron-prebuilt": "1.3.1",
+    "electron": "1.3.1",
     "electron-winstaller": "^2.3.0",
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
`electron` is the new npm name for `electron-prebuilt`.

Both will be published going forward but why not use that new shorter name 📏 

https://github.com/electron-userland/electron-prebuilt/issues/160

https://github.com/electron/electron.atom.io/pull/406
