### PR TITLE
Move the checkbox outside the label.

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -28,12 +28,12 @@ export class ChangedFile extends React.Component<IChangedFileProps, void> {
   public render() {
     return (
       <div className='changed-file'>
+        <input
+          type='checkbox'
+          checked={this.props.include}
+          onChange={event => this.handleChange(event)}/>
+
         <label className='path'>
-          <input
-            type='checkbox'
-            checked={this.props.include}
-            onChange={event => this.handleChange(event)}
-          />
           {this.props.path}
         </label>
 


### PR DESCRIPTION
Clicking on a row shouldn’t toggle its includedness. Only clicking the
checkbox should.

/cc @donokuda in case this was intentional.
