### PR TITLE
Break long words in the commit description section

### DIFF
--- a/app/styles/ui/_commit-summary.scss
+++ b/app/styles/ui/_commit-summary.scss
@@ -34,6 +34,7 @@
 
   &-description {
     font-family: var(--font-family-monospace);
+    word-wrap: break-word;
 
     &:empty {
       display: none;


### PR DESCRIPTION
Fixes the case when long words exceed the width of the panel

**Before**

<img width="484" alt="screen shot 2016-08-04 at 2 54 58 pm" src="https://cloud.githubusercontent.com/assets/1174461/17419707/8c58eae0-5a53-11e6-9e17-1e1fb26be4cf.png">

**After**

<img width="370" alt="screen shot 2016-08-04 at 2 52 17 pm" src="https://cloud.githubusercontent.com/assets/1174461/17419717/94310400-5a53-11e6-9e24-a46f55e323c8.png">
