### PR TITLE
[WIP] Style diffs

### DIFF
--- a/app/src/ui/file-diff.tsx
+++ b/app/src/ui/file-diff.tsx
@@ -8,7 +8,7 @@ import { FileChange } from '../models/status'
 
 import { LocalGitOperations, Diff, Commit } from '../lib/local-git-operations'
 
-const RowHeight = 19
+const RowHeight = 22
 
 interface IFileDiffProps {
   readonly repository: IRepository

--- a/app/styles/ui/_file-diff.scss
+++ b/app/styles/ui/_file-diff.scss
@@ -21,6 +21,12 @@
   tab-size: 4;
 
   .before,
+  .after,
+  .text {
+    padding: 3px 6px;
+  }
+
+  .before,
   .after {
     border-right: 1px solid;
     color: #CCC;
@@ -36,7 +42,6 @@
   }
 
   .text {
-    padding: 0 6px;
     flex-grow: 1;
   }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1174461/17499859/4d4a019c-5d85-11e6-9b4a-5886e29e9f22.png)

❓ Do we want code on one line (with horizontal scrolling) or break into multilines? This branch currently does neither. I find it easier to read if the code doesn't wrap but I'm curious to hear any other 💭 on this.

**GitHub Web**

![image](https://cloud.githubusercontent.com/assets/1174461/17500278/f619defc-5d88-11e6-93ac-355d992e53f9.png)

**GHD (Mac)**

![image](https://cloud.githubusercontent.com/assets/1174461/17500281/ff18c072-5d88-11e6-8bcd-4133603b2614.png)

---

**TODO**
- [ ] [Inconsistent widths for line numbers greater than 2 digits](https://cloud.githubusercontent.com/assets/1174461/17500223/7ce6fa4c-5d88-11e6-9473-c4f7761b58cb.png) 😢 
- [ ] Don't hardcode all the colors
