### PR TITLE
fix a couple of inter-related focus bugs

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -349,17 +349,17 @@ export default class AppStore {
 
       const includeAll = this.getIncludeAllState(mergedFiles)
 
-      let selectedFile: WorkingDirectoryFileChange | null = null
+      let selectedFile: WorkingDirectoryFileChange | undefined
 
       if (state.selectedFile) {
-        selectedFile = mergedFiles.filter(function(file, index, array) {
-              return file.path === state.selectedFile!.path
-        })[0]
+        selectedFile = mergedFiles.find(function(file) {
+          return file.id === state.selectedFile!.id
+        })
       }
 
       return {
         workingDirectory: new WorkingDirectoryStatus(mergedFiles, includeAll),
-        selectedFile: selectedFile,
+        selectedFile: selectedFile || null,
       }
     })
     this.emitUpdate()


### PR DESCRIPTION
This was driving me crazy while testing something in #179, so I had to fix it.

Two things that overlap:
- ~~when we rewrote `List` to use `react-virtualized`, we changed the scope of the `renderRow` function, so `this.props.*` is undefined  - this meant when the list is initially rendered, it wouldn't draw the correct row as selected.~~ NEVERMIND, thanks debugger for being an amazing troll
- when focusing on the app, we check the status of the working directory for selected repository and then deselect whatever file that was previously selected. We can do better than that, so I implemented a quick `filter` to find the previously selected file and set that.
