### PR TITLE
Disable textarea resize

### DIFF
--- a/app/styles/ui/_forms.scss
+++ b/app/styles/ui/_forms.scss
@@ -13,6 +13,8 @@ textarea {
   margin-bottom: var(--spacing);
   padding: calc(var(--spacing) / 2);
 
+  resize: none;
+
   &:focus {
     border-color: var(--box-border-accent-color);
   }


### PR DESCRIPTION
Otherwise you can lolz yourself like so:

<img width="768" alt="screen shot 2016-08-17 at 4 29 35 pm" src="https://cloud.githubusercontent.com/assets/13760/17752020/eef6ebd6-6497-11e6-9afe-454d0a43e7dc.png">
