### PR TITLE
bump ts-node for great justice (and faster test execution)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "style-loader": "^0.13.1",
     "to-camel-case": "^1.0.0",
     "ts-loader": "^0.8.2",
-    "ts-node": "^0.7.2",
+    "ts-node": "^1.3.0",
     "tslint": "^3.14.0",
     "typescript": "beta",
     "vrsource-tslint-rules": "^0.12.0",


### PR DESCRIPTION
Before this PR, I'd have a lovely feedback loop on Windows when running tests that looks like this:

``` powershell
> Measure-Command { npm run test:unit }


Days              : 0
Hours             : 0
Minutes           : 2
Seconds           : 5
Milliseconds      : 42
Ticks             : 1250427766
TotalDays         : 0.0014472543587963
TotalHours        : 0.0347341046111111
TotalMinutes      : 2.08404627666667
TotalSeconds      : 125.0427766
TotalMilliseconds : 125042.7766
```

Just fantastic. What I was seeing when I pointed `procmon` at the Electron process that `electron-mocha` launches is that it'd spend most of this time trying to resolve typescript definitions - and recursing directories unsuccessfully until it hits the drive root, checking for non-existent paths:

<img width="572" alt="screen shot 2016-08-23 at 5 41 56 pm" src="https://cloud.githubusercontent.com/assets/359239/17886799/d31fa820-6966-11e6-8f90-0fcf401a7445.png">

Anyway, I've traced this to our version of `ts-node` which is currently `0.7.3` - and the latest is `1.3.0` - [here's the diff on what's changed](https://github.com/TypeStrong/ts-node/compare/v0.7.3...v1.3.0), I couldn't spot anything obvious from the commit history that someone else had encountered this.

I've bumped the package in ec665ba and the times are now much better:

``` powershell
> Measure-Command { npm run test:unit }


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 25
Milliseconds      : 87
Ticks             : 250879965
TotalDays         : 0.000290370329861111
TotalHours        : 0.00696888791666667
TotalMinutes      : 0.418133275
TotalSeconds      : 25.0879965
TotalMilliseconds : 25087.9965
```

For reference, the actual unit test execution on `master` takes around 2 seconds (that's on Windows and macOS).

Let's see if this makes anything change on our CI servers (and on macOS)...
