### PR TITLE
'as' does not work as a C# person might hope

### DIFF
--- a/app/src/ui/file-diff.tsx
+++ b/app/src/ui/file-diff.tsx
@@ -241,10 +241,9 @@ export default class FileDiff extends React.Component<IFileDiffProps, IFileDiffS
     const file = this.props.file
     if (file) {
 
-      let invalidationProps = { path: file.path, selection: DiffSelectionType.None }
+      const invalidationProps = { path: file.path, selection: DiffSelectionType.None }
       if (file instanceof WorkingDirectoryFileChange) {
-        const selectionType = file.selection.getSelectionType()
-        invalidationProps = { path: file.path, selection: selectionType }
+        invalidationProps.selection = file.selection.getSelectionType()
       }
 
       let diffLineCount: number = 0


### PR DESCRIPTION
This fixes a bug where I was using `as` to implicitly cast to a subtype to check whether I was working with the base `FileChange` or the `WorkingDirectoryFileChange` which has the selection information I need. I expected it to return `null` but instead it's returning a partially-populated object. 

I'm now being a bit more defensive and checking the expected member exists.

For reference, the TS 1.8 spec for `as` is literally a TODO statement (see last bit of [this section](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#416-type-assertions)) and this PR adding support for it https://github.com/Microsoft/TypeScript/pull/3564 doesn't really make things clearer. 

Oh well.
