### PR TITLE
only display timings when command takes more than 50ms

### DIFF
--- a/app/src/lib/git-process.ts
+++ b/app/src/lib/git-process.ts
@@ -88,8 +88,15 @@ export class GitProcess {
       const gitLocation = GitProcess.resolveGitBinary()
       const startTime = performance.now()
       const logMessage = () => {
-        const time = ((performance.now() - startTime) / 1000).toFixed(3)
-        return `executing: git ${args.join(' ')} (took ${time}s)`
+        const rawTime = performance.now() - startTime
+
+        let timing = ''
+        if (rawTime > 50) {
+          const time = (rawTime / 1000).toFixed(3)
+          timing = ` (took ${time}s)`
+        }
+
+        return `executing: git ${args.join(' ')}${timing}`
       }
       const env = Object.assign({}, process.env, {
         GIT_EXEC_PATH: GitProcess.resolveGitExecPath(),


### PR DESCRIPTION
Digging into some, uh, _interesting_, timings and wanted to reduce the noise a bit.

Before:

<img width="882" src="https://cloud.githubusercontent.com/assets/359239/18235740/0c6c2cb6-7362-11e6-8259-29f083a32c58.png">

After:

<img width="1011" src="https://cloud.githubusercontent.com/assets/359239/18235746/1f820992-7362-11e6-834b-39625a5a7bea.png">

Chose 50ms arbitrarily, but this could easily be as low as 20ms-24ms as Chrome seems to use that as the threshold for jank:

<img width="476" src="https://cloud.githubusercontent.com/assets/359239/18235829/e95b0d68-7362-11e6-8086-e8639a4479fc.png">
