### PR TITLE
Cut initial compilation time in half using this One Weird Trick! Compilers HATE this!

### DIFF
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -18,7 +18,7 @@ module.exports = {
     loaders: [
       {
         test: /\.tsx?$/,
-        loaders: ['babel', 'ts'],
+        loaders: ['babel?cacheDirectory', 'ts'],
         include: path.join(__dirname, 'src')
       },
       {


### PR DESCRIPTION
Tell babel to use its cache.

This cuts initial compilation time in half for me.

Before:

```
webpack built 8ea813592373e2d5b5d8 in 12044ms
```

After:

```
webpack built 8ea813592373e2d5b5d8 in 6382ms
```

The incremental build time doesn’t improve much for me.
