### PR TITLE
Break long words in commit summary

### DIFF
--- a/app/styles/ui/_commit-summary.scss
+++ b/app/styles/ui/_commit-summary.scss
@@ -30,6 +30,7 @@
     font-size: 16px;
     font-weight: var(--font-weight-light);
     margin-bottom: var(--spacing-half);
+    word-wrap: break-word;
   }
 
   &-description {


### PR DESCRIPTION
Fixes #347

**Before**
<img width="390" alt="screen shot 2016-09-09 at 4 34 54 pm" src="https://cloud.githubusercontent.com/assets/1174461/18406091/5c6dd900-76ad-11e6-82b1-95f2b814804e.png">

**After**
<img width="193" alt="screen shot 2016-09-09 at 4 31 46 pm" src="https://cloud.githubusercontent.com/assets/1174461/18406092/5c6fbf4a-76ad-11e6-8baf-8bbdab0985ac.png">
