### PR TITLE
Enforce single-instance app on all platforms

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -22,33 +22,31 @@ app.on('will-finish-launching', () => {
   })
 })
 
-if (process.platform !== 'darwin') {
-  if (process.platform === 'win32' && process.argv.length > 1) {
-    if (handleSquirrelEvent(process.argv[1])) {
-      app.quit()
-    }
-  }
-
-  const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
-    // Someone tried to run a second instance, we should focus our window.
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) {
-        mainWindow.restore()
-      }
-      mainWindow.focus()
-    }
-
-    // look at the second argument received, it should have the OAuth
-    // callback contents and code for us to complete the signin flow
-    if (commandLine.length > 1) {
-      const action = parseURL(commandLine[1])
-      getMainWindow().sendURLAction(action)
-    }
-  })
-
-  if (shouldQuit) {
+if (process.platform === 'win32' && process.argv.length > 1) {
+  if (handleSquirrelEvent(process.argv[1])) {
     app.quit()
   }
+}
+
+const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
+  // Someone tried to run a second instance, we should focus our window.
+  if (mainWindow) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore()
+    }
+    mainWindow.focus()
+  }
+
+  // look at the second argument received, it should have the OAuth
+  // callback contents and code for us to complete the signin flow
+  if (commandLine.length > 1) {
+    const action = parseURL(commandLine[1])
+    getMainWindow().sendURLAction(action)
+  }
+})
+
+if (shouldQuit) {
+  app.quit()
 }
 
 app.on('ready', () => {


### PR DESCRIPTION
[As documented](https://git.io/viuIe) the default single instance behavior on osx doesn't cover app launches from the command line. We have no reason (that I can see) of being platform-specific with this.
