### PR TITLE
Explicitly set build-version

### DIFF
--- a/script/build
+++ b/script/build
@@ -34,6 +34,7 @@ if (process.platform === 'darwin' && process.env.TRAVIS_BRANCH) {
 const options = {
   platform: process.platform,
   arch: 'x64',
+  'build-version': appPackage.version,
   asar: false, // TODO: Probably wanna enable this down the road.
   out: path.join(projectRoot, 'dist'),
   icon: path.join(projectRoot, 'app', 'static', 'icon'),


### PR DESCRIPTION
This was removed in https://github.com/desktop/desktop/pull/307/files#r76084401 because we
thought `build-version` was inferred by `electron-packager`. But it turns out it only infers `app-version`: https://github.com/electron-userland/electron-packager/pull/449

FYI @kevinsawicki, I’m not sure if this is a bug in `electron-packager` or if we misunderstood what was inferred.
