### PR TITLE
Split changeHistorySelection in two

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1,9 +1,9 @@
 import { ipcRenderer } from 'electron'
 import { User, IUser } from '../../models/user'
 import { Repository, IRepository } from '../../models/repository'
-import { WorkingDirectoryFileChange } from '../../models/status'
+import { WorkingDirectoryFileChange, FileChange } from '../../models/status'
 import { guid } from '../guid'
-import { IHistorySelection, RepositorySection, Popup, IAppError } from '../app-state'
+import { RepositorySection, Popup, IAppError } from '../app-state'
 import { Action } from './actions'
 import { AppStore } from './app-store'
 import { CloningRepository } from './cloning-repositories-store'
@@ -174,9 +174,29 @@ export class Dispatcher {
     return this.appStore._loadChangedFilesForCurrentSelection(repository)
   }
 
-  /** Change the history selection. */
-  public changeHistorySelection(repository: Repository, selection: IHistorySelection): Promise<void> {
-    return this.appStore._changeHistorySelection(repository, selection)
+  /**
+   * Change the selected commit in the history view.
+   *
+   * @param repository The currently active repository instance
+   *
+   * @param sha The object id of one of the commits currently
+   *            the history list, represented as a SHA-1 hash
+   *            digest. This should match exactly that of Commit.Sha
+   */
+  public changeHistoryCommitSelection(repository: Repository, sha: string): Promise<void> {
+    return this.appStore._changeHistoryCommitSelection(repository, sha)
+  }
+
+  /**
+   * Change the selected changed file in the history view.
+   *
+   * @param repository The currently active repository instance
+   *
+   * @param file A FileChange instance among those available in
+   *            IHistoryState.changedFiles
+   */
+  public changeHistoryFileSelection(repository: Repository, file: FileChange | null): Promise<void> {
+    return this.appStore._changeHistoryFileSelection(repository, file)
   }
 
   /** Select the repository. */

--- a/app/src/ui/history/index.tsx
+++ b/app/src/ui/history/index.tsx
@@ -27,8 +27,7 @@ export class History extends React.Component<IHistoryProps, void> {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
 
   private onCommitChanged(commit: Commit) {
-    const newSelection = { sha: commit.sha, file: null }
-    this.props.dispatcher.changeHistorySelection(this.props.repository, newSelection)
+    this.props.dispatcher.changeHistoryCommitSelection(this.props.repository, commit.sha)
 
     this.loadChangedFilesScheduler.queue(() => {
       this.props.dispatcher.loadChangedFilesForCurrentSelection(this.props.repository)
@@ -36,8 +35,7 @@ export class History extends React.Component<IHistoryProps, void> {
   }
 
   private onFileSelected(file: FileChange) {
-    const newSelection = { sha: this.props.history.selection.sha, file }
-    this.props.dispatcher.changeHistorySelection(this.props.repository, newSelection)
+    this.props.dispatcher.changeHistoryFileSelection(this.props.repository, file)
   }
 
   private onScroll(start: number, end: number) {


### PR DESCRIPTION
Components shouldn't be in charge of clearing state so we'll split the history selection mutation method into two. 

This should make it easier to reason about state transitions in the dispatcher as well.
