### PR TITLE
some tweaks to packaging on Windows

### DIFF
--- a/script/package
+++ b/script/package
@@ -53,6 +53,7 @@ function packageWindows () {
     iconUrl: iconLocation,
     setupIcon: iconLocation,
     exe: `${productName}.exe`,
+    remoteReleases: 'https://central.github.com/api/deployments/desktop/desktop/latest/',
   }
 
   if (process.env.APPVEYOR) {


### PR DESCRIPTION
- [x] we only move the certificate when on AppVeyor - conditionally pass the arguments to `signtool`
- [x] use the published packages on central to create the new delta package

<img width="511" src="https://cloud.githubusercontent.com/assets/359239/18860206/97339e52-84be-11e6-9df1-61b4d4943852.png">
- [x] verify update detected and applied (tested by falling back to `0.0.1`, installing that and waiting for background update from central)

<img width="549" src="https://cloud.githubusercontent.com/assets/359239/18860921/ceae1280-84c4-11e6-9afa-1bbd03abdcbc.png">
