### PR TITLE
make integration test timeout consistent for local and CI

### DIFF
--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -8,11 +8,6 @@ chai.should()
 chai.use(chaiAsPromised)
 
 describe('App', function (this: any) {
-  if (process.env.CI) {
-    /* tslint:disable:no-invalid-this */
-    this.timeout(30000)
-  }
-
   let app: any
 
   beforeEach(function () {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "description": "The People's Glorious GitHub Client's build dependencies",
   "scripts": {
-    "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 mocha --require ts-node/register app/test/integration/*.ts",
+    "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 mocha -t 10000 --require ts-node/register app/test/integration/*.ts",
     "test:unit": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 electron-mocha --renderer --require ts-node/register app/test/*.ts app/test/*.tsx",
     "test": "npm run test:unit && npm run test:integration",
     "postinstall": "cd app && npm install && cd .. && git submodule update --recursive --init",


### PR DESCRIPTION
`mocha` supports a global test-case timeout, so let's use that everywhere and :fire: the CI-specific override.

Also, 30s is alot of time. Let's use 10s and see what happens.
