### PR TITLE
Plug gutter leak

### DIFF
--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -187,7 +187,6 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
       const relativeIndex = index - hunk.unifiedDiffStart
       const diffLine = hunk.lines[relativeIndex]
       if (diffLine) {
-        console.log('renderLine')
         const diffLineElement = element.children[0] as HTMLSpanElement
 
         const reactContainer = document.createElement('span')


### PR DESCRIPTION
See https://facebook.github.io/react/blog/2015/10/01/react-render-and-top-level-api.html

> Forgetting to call unmountComponentAtNode will cause your app to leak memory. There is no way for us to automatically detect when it is appropriate to do this work. Every system is different.

We're currently leaking one DiffLineGutter instance for each rendered diff line and needlessly filling up the callback table inside react's synthetic event model.
### Before

![image](https://cloud.githubusercontent.com/assets/634063/18959475/96129d8a-8666-11e6-9913-7fc328fa60c2.png)
### After (no DiffLineGutters retained)

![image](https://cloud.githubusercontent.com/assets/634063/18959481/9887a9a2-8666-11e6-8c3f-7450e8268894.png)
