### PR TITLE
Plug another diff gutter leak

### DIFF
--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -239,7 +239,13 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
 
         // If the line delete event fires we dispose of the disposable (disposing is
         // idempotent)
-        deleteHandler = () => gutterCleanup.dispose()
+        deleteHandler = () => {
+          const disp = this.lineCleanup.get(line)
+          if (disp) {
+            this.lineCleanup.delete(line)
+            disp.dispose()
+          }
+        }
         line.on('delete', deleteHandler)
 
         element.classList.add(this.getClassName(diffLine.type))


### PR DESCRIPTION
Turns out CodeMirror doesn't call the 'delete' callback for a line when it re-renders it and there's no event (that I've found) that lets us know it's being explicitly re-rendered.

This implements a dictionary keeping track of all lines rendered so that we can dispose of our react elements when we detect the lines being re-rendered.
