### PR TITLE
Upgrade to electron-packager@8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "css-loader": "^0.23.1",
     "electron": "1.3.4",
     "electron-mocha": "3.0.5",
-    "electron-packager": "7.7.0",
+    "electron-packager": "8.1.0",
     "electron-winstaller": "^2.3.0",
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/script/build
+++ b/script/build
@@ -34,7 +34,6 @@ if (process.platform === 'darwin' && process.env.TRAVIS_BRANCH) {
 const options = {
   platform: process.platform,
   arch: 'x64',
-  'build-version': appPackage.version,
   asar: false, // TODO: Probably wanna enable this down the road.
   out: path.join(projectRoot, 'dist'),
   icon: path.join(projectRoot, 'app', 'static', 'icon'),
@@ -65,7 +64,7 @@ const options = {
   'osx-sign': true,
 
   // Windows
-  'version-string': {
+  win32metadata: {
     'CompanyName': appPackage.companyName,
     'FileDescription': '',
     'OriginalFilename': '',


### PR DESCRIPTION
This version should properly default the `build-version` (and `app-version`) to the `package.json` `version` field so it shouldn't need to be explicitly configured.

https://github.com/electron-userland/electron-packager/blob/master/NEWS.md#810---2016-09-30

Refs #387
Refs https://github.com/electron-userland/electron-packager/pull/501
