### PR TITLE
Enable asar bundling in build

### DIFF
--- a/script/build
+++ b/script/build
@@ -35,7 +35,8 @@ const options = {
   platform: process.platform,
   arch: 'x64',
   asar: {
-    unpack: '*.node'
+    unpack: '*.node',
+    unpackDir: 'node_modules/git-kitchen-sink'
   },
   out: path.join(projectRoot, 'dist'),
   icon: path.join(projectRoot, 'app', 'static', 'icon'),


### PR DESCRIPTION
This pull request enables the `asar` option to `electron-packager`.

It currently sets two things as unpacked:
- `.node` files which are needed to load native modules like `keytar`
- `git-kitchen-sink` to ensure all Git related executable and files exist on disk as normal files
