### PR TITLE
Revert "Enable asar bundling in build"

### DIFF
--- a/script/build
+++ b/script/build
@@ -34,10 +34,7 @@ if (process.platform === 'darwin' && process.env.TRAVIS_BRANCH) {
 const options = {
   platform: process.platform,
   arch: 'x64',
-  asar: {
-    unpack: '*.node',
-    unpackDir: 'node_modules/git-kitchen-sink'
-  },
+  asar: false, // TODO: Probably wanna enable this down the road.
   out: path.join(projectRoot, 'dist'),
   icon: path.join(projectRoot, 'app', 'static', 'icon'),
   dir: outRoot,


### PR DESCRIPTION
Reverts desktop/desktop#465

Need to temporarily revert this as it breaks (some) git commands on Windows.

![image](https://cloud.githubusercontent.com/assets/634063/19092216/00fb827e-8a86-11e6-8a9f-0d385e5a97b2.png)

![image](https://cloud.githubusercontent.com/assets/634063/19092221/085b9bf8-8a86-11e6-8388-bbefa04d22c6.png)

cc @joshaber @kevinsawicki 
