### PR TITLE
Commit message on stdin

### DIFF
--- a/app/src/lib/local-git-operations.ts
+++ b/app/src/lib/local-git-operations.ts
@@ -259,8 +259,12 @@ export class LocalGitOperations {
       message = `${summary}\n\n${description}`
     }
 
-    // TODO: pipe standard input into this command
-    await git([ 'commit', '-m',  message ] , repository.path)
+    const writeCommitMessage = (process: ChildProcess.ChildProcess) => {
+      process.stdin.write(message)
+      process.stdin.end()
+    }
+
+    await git([ 'commit', '-F',  '-' ] , repository.path, { }, undefined, writeCommitMessage)
   }
 
   /**


### PR DESCRIPTION
I'm honestly not sure if we have to pass it on stdin, I was reading the [node.js argument escaping code](https://github.com/nodejs/node/blob/0ed8839a279ba2597ae9fc54517030b16116207d/deps/uv/src/win/process.c#L448) for Windows the other day and it seems pretty legit.

That said, passing unvalidated user input on the command line always does feel a bit... wrong.

Either way, I don't think it's gonna hurt us and I did some boy scouting while I was in there and rewrote the callback code to be async/await. 
