### PR TITLE
Fix toolbar in fullscreen on Win32

### DIFF
--- a/app/styles/ui/_toolbar.scss
+++ b/app/styles/ui/_toolbar.scss
@@ -15,7 +15,7 @@
     z-index: calc(var(--popup-z-index) - 1);
   }
 
-  @include darwin-fullscreen {
+  @include in-fullscreen {
     margin-top: var(--spacing-double);
   }
 }


### PR DESCRIPTION
This is #455 but applied to Windows as well which had the exact same problem
