### PR TITLE
Fix diff styles

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -153,6 +153,8 @@
    * Diff view
    */
 
+  --diff-font-color: #323232;
+
   --diff-border-color: #e5e5e5;
   --diff-line-number-color: #84929c;
   --diff-line-number-column-width: 50px;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -11,7 +11,7 @@
 .CodeMirror {
   background: var(--box-alt-background-color);
   height: 100%;
-  color: #323232;
+  color: var(--diff-font-color);
   font-size: var(--font-size-sm);
   font-family: var(--font-family-monospace);
 }
@@ -52,7 +52,7 @@
 }
 
 .diff-line-number {
-  border-right: 1px solid #EEE;
+  border-right: 1px solid var(--diff-border-color);
   display: inline-block;
   color: var(--diff-line-number-color);
   width: var(--diff-line-number-column-width);


### PR DESCRIPTION
- Use the monospace font family variable
- Adjust font size (the default size is pretty big after the correct font family was set)
- Minor visual adjustments

**Before**

![image](https://cloud.githubusercontent.com/assets/1174461/19162793/2f5506c6-8bae-11e6-8471-ed3162f6cfca.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1174461/19162766/0fe17de2-8bae-11e6-8bc9-0a7945226f18.png)
