### PR TITLE
[WIP] you don't read 100% of the commits you can't scroll

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -83,14 +83,16 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, void> {
           </ul>
         </div>
 
-        <EmojiText className='commit-summary-description' emoji={this.props.emoji}>{this.props.body}</EmojiText>
+        <div className='commit-summary-scrollable'>
+          <EmojiText className='commit-summary-description' emoji={this.props.emoji}>{this.props.body}</EmojiText>
 
-        <div className='files'>
-          <List rowRenderer={row => this.renderFile(row)}
-                rowCount={this.props.files.length}
-                rowHeight={40}
-                selectedRow={this.rowForFile(this.props.selectedFile)}
-                onSelectionChanged={row => this.onSelectionChanged(row)}/>
+          <div className='files'>
+            <List rowRenderer={row => this.renderFile(row)}
+                  rowCount={this.props.files.length}
+                  rowHeight={40}
+                  selectedRow={this.rowForFile(this.props.selectedFile)}
+                  onSelectionChanged={row => this.onSelectionChanged(row)}/>
+          </div>
         </div>
       </div>
     )

--- a/app/styles/ui/_commit-summary.scss
+++ b/app/styles/ui/_commit-summary.scss
@@ -3,11 +3,14 @@
 /** A React component holding the selected commit's detailed information */
 #commit-summary {
 
-  overflow: auto;
+  .commit-summary-scrollable {
+    overflow: auto;
+  }
 
   .files {
     display: flex;
     flex: 1;
+    min-height: 200px;
 
     .list-item {
       border-bottom: var(--light-border);


### PR DESCRIPTION
Fixes #519 
- [x] when commit description is long, let the user scroll
- [x] file list has a minimum height when rendered, so we scroll unnecessarily down as a result when we have a long commit description
- [ ] great, now we have nested scrollbars :skull:
