### PR TITLE
respect newlines in commit descriptions

### DIFF
--- a/app/styles/ui/_commit-summary.scss
+++ b/app/styles/ui/_commit-summary.scss
@@ -38,6 +38,7 @@
     font-size: var(--font-size-sm);
     padding: var(--spacing);
     word-wrap: break-word;
+    white-space: pre-line;
 
     &:empty {
       display: none;


### PR DESCRIPTION
Reference (Git CLI):

<img width="587" src="https://cloud.githubusercontent.com/assets/359239/19298442/5e3611d4-9099-11e6-8f1a-5ddc73ce63ab.png">

Before:

<img width="619" src="https://cloud.githubusercontent.com/assets/359239/19298452/73520690-9099-11e6-9ae7-aa5340e38d29.png">

After:

<img width="615" src="https://cloud.githubusercontent.com/assets/359239/19298459/807dbc4c-9099-11e6-9eee-cef4ef8f8a16.png">
