### PR TITLE
handle variable line endings when rendering diff text

### DIFF
--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -391,6 +391,10 @@ export class Diff extends React.Component<IDiffProps, void> {
     return null
   }
 
+  /**
+   * normalize the line endings in the diff so that the CodeMirror Editor
+   * will display the unified diff correctly
+   */
   private formatLineEnding(text: string): string {
     if (text.endsWith('\n')) {
       return text


### PR DESCRIPTION
Fixes #467 

**Before**

![](https://cloud.githubusercontent.com/assets/359239/19060119/0ef76d16-8a31-11e6-8c79-7fa7283e4512.png)

**After**

<img width="1393" alt="screen shot 2016-11-02 at 4 31 54 pm" src="https://cloud.githubusercontent.com/assets/359239/19951256/fabcca3a-a119-11e6-863d-97959633be6c.png">

Also fixes #578 

**Before**

![](https://cloud.githubusercontent.com/assets/359239/19949761/d938f2b6-a110-11e6-9478-ffc4a71f7923.png)

**After**

<img width="1382" alt="screen shot 2016-11-02 at 4 32 19 pm" src="https://cloud.githubusercontent.com/assets/359239/19951255/fabac05a-a119-11e6-8b22-94521d182a7d.png">
