### PR TITLE
History diffs should not be selectable

### DIFF
--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -266,9 +266,6 @@ export class Diff extends React.Component<IDiffProps, void> {
         }
 
         const mouseMoveHandler = (ev: MouseEvent) => {
-          if (this.props.readOnly) {
-            return
-          }
 
           // ignoring anything from diff context rows
           if (!this.isIncludableLine(diffLine)) {
@@ -295,11 +292,13 @@ export class Diff extends React.Component<IDiffProps, void> {
 
         const mouseUpHandler = (ev: UIEvent) => this.onMouseUp(index)
 
-        reactContainer.addEventListener('mouseenter', mouseEnterHandler)
-        reactContainer.addEventListener('mouseleave', mouseLeaveHandler)
-        reactContainer.addEventListener('mousemove', mouseMoveHandler)
-        reactContainer.addEventListener('mousedown', mouseDownHandler)
-        reactContainer.addEventListener('mouseup', mouseUpHandler)
+        if (!this.props.readOnly) {
+          reactContainer.addEventListener('mouseenter', mouseEnterHandler)
+          reactContainer.addEventListener('mouseleave', mouseLeaveHandler)
+          reactContainer.addEventListener('mousemove', mouseMoveHandler)
+          reactContainer.addEventListener('mousedown', mouseDownHandler)
+          reactContainer.addEventListener('mouseup', mouseUpHandler)
+        }
 
         this.cachedGutterElements.set(index, reactContainer)
 
@@ -328,11 +327,13 @@ export class Diff extends React.Component<IDiffProps, void> {
 
           this.cachedGutterElements.delete(index)
 
-          reactContainer.removeEventListener('mouseenter', mouseEnterHandler)
-          reactContainer.removeEventListener('mouseleave', mouseLeaveHandler)
-          reactContainer.removeEventListener('mousedown', mouseDownHandler)
-          reactContainer.removeEventListener('mousemove', mouseMoveHandler)
-          reactContainer.removeEventListener('mouseup', mouseUpHandler)
+          if (!this.props.readOnly) {
+            reactContainer.removeEventListener('mouseenter', mouseEnterHandler)
+            reactContainer.removeEventListener('mouseleave', mouseLeaveHandler)
+            reactContainer.removeEventListener('mousedown', mouseDownHandler)
+            reactContainer.removeEventListener('mousemove', mouseMoveHandler)
+            reactContainer.removeEventListener('mouseup', mouseUpHandler)
+          }
 
           ReactDOM.unmountComponentAtNode(reactContainer)
 


### PR DESCRIPTION
This fixes a bug that caused history diffs to behave sort-of like changes diffs. Hovering over line gutters would trigger style changes.

This is the minimal fix but I think there’s a lot we could still do here. I don’t think the removal of the subscriptions are necessary and I think that we should move event handler subscriptions into the DiffLineGutter like we do with all other handlers.