### PR TITLE
Fix toolbar height on Windows

### DIFF
--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -74,6 +74,5 @@
 body.platform-win32:not(.fullscreen) {
   #desktop-app-toolbar {
     margin-top: calc(var(--win32-title-bar-height) * -1);
-    padding-top: var(--win32-title-bar-height);
   }
 }


### PR DESCRIPTION
See https://github.com/desktop/desktop/pull/554#issuecomment-257920418

![image](https://cloud.githubusercontent.com/assets/634063/19937664/73c6572c-a122-11e6-9663-8f5820d2766d.png)

This fixes it by making the toolbar extend all the way to the top of the window. The unfortunate side-effect of it is that the only draggable area on Windows right now is non-occupied space on the toolbar.

I think this is fine for now but we should consider making the entire app area (minus buttons, list items and such) draggable on Windows. This would match the current behavior in GitHub for Windows.