### PR TITLE
Don't use Arial for buttons on Windows

### DIFF
--- a/app/styles/ui/_buttons.scss
+++ b/app/styles/ui/_buttons.scss
@@ -3,6 +3,11 @@ input[type='submit'] {
   background-color: var(--button-background);
   box-shadow: 0 1px 1px rgba(5, 5, 5, 0.04);
   color: var(--text-color);
+
+  // Chrome on Windows ignores the body element
+  // font-family and uses Arial so we redefine
+  // it here
+  font-family: var(--font-family-sans-serif);
   font-size: var(--font-size);
 
   padding: var(--spacing-half) var(--spacing);


### PR DESCRIPTION
Turns out Chrome on Windows ignores the body element and reverts button fonts to Arial.

#### ugly 
![image](https://cloud.githubusercontent.com/assets/634063/19969574/6d205c94-a1d9-11e6-8b1d-7fd7723c7ef7.png)

#### gorgeous

![image](https://cloud.githubusercontent.com/assets/634063/19969611/87a16d06-a1d9-11e6-806a-24517499b9ad.png)
