### PR TITLE
Bind event handler to current instance

### DIFF
--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -171,7 +171,7 @@ export class ToolbarDropdown extends React.Component<IToolbarDropdownProps, IToo
 
     return (
       <div id='foldout-container' style={this.getFoldoutContainerStyle()}>
-        <div className='overlay' onClick={this.handleOverlayClick}></div>
+        <div className='overlay' onClick={() => this.handleOverlayClick}></div>
         <div className='foldout' style={this.getFoldoutStyle()}>
           {this.props.dropdownContentRenderer()}
         </div>


### PR DESCRIPTION
Fixes #587

@desktop/core I fear this will be a fairly common mistake for us (me at least). Seems like an excellent candidate for static analysis tho I don’t know how easy that would be.