### PR TITLE
Only allow commit shortcut when files are selected

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -67,6 +67,7 @@ export class CommitMessage extends React.Component<ICommitMessageProps, ICommitM
   }
 
   private createCommit() {
+    if (!this.canCommit) { return }
     this.props.onCreateCommit(this.state.summary, this.state.description)
     this.setState({
       summary: '',


### PR DESCRIPTION
Noticed this when committing, I always use Ctrl/Cmd+Enter to commit and we didn’t check that there was any files selected. The button was disabled (fixed in #507) but the keyboard shortcut was using a different code path.