### PR TITLE
Update disturl from atom-shell to electron

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
-disturl = https://atom.io/download/atom-shell
+disturl = https://atom.io/download/electron
 target = 1.4.2
 arch = x64


### PR DESCRIPTION
This new URL shipped today 🐚 🔗 

The old URL will still be around for awhile, but hey, you gotta live in the now.