### PR TITLE
Undo style tweaks

### DIFF
--- a/app/styles/ui/changes/_undo-commit.scss
+++ b/app/styles/ui/changes/_undo-commit.scss
@@ -34,5 +34,7 @@
 
     // In order to not add to the margin already in commit-info.
     padding-left: 0;
+
+    button { height: 100%; }
   }
 }


### PR DESCRIPTION
This adds some consistent padding in the undo commit component and uses a consistent font-size for both the time row and the commit title row.

It also expands the button to take up all available height.

### Before
<img width="298" alt="screen shot 2016-11-08 at 18 22 45" src="https://cloud.githubusercontent.com/assets/634063/20109511/ac2fe188-a5e0-11e6-83a1-ec9280383bda.png">

### After

<img width="311" alt="screen shot 2016-11-08 at 18 22 17" src="https://cloud.githubusercontent.com/assets/634063/20109507/a78b7d22-a5e0-11e6-9091-aac629c0dfb2.png">
