### PR TITLE
Remove orange accent color

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -11,7 +11,6 @@
   // color is being used. Note that these variables should _never_ be
   // used outside of this scope.
   $blue: #4ca6eb;
-  $orange: #c9510c;
   $yellow: #d0b44c;
   $red: #d0b44c;
   $green: #6cc644;
@@ -119,7 +118,7 @@
   /**
    * Background color for selected boxes with active keyboard focus
    */
-  --box-selected-active-background-color: $orange;
+  --box-selected-active-background-color: $blue;
 
   /**
    * Text color for selected boxes with active keyboard focus
@@ -171,7 +170,7 @@
   --foldout-z-index: calc(var(--popup-z-index) - 2);
 
   /** The highlight color used for focus rings and focus box shadows */
-  --focus-color: $orange;
+  --focus-color: $blue;
 
   /**
    * Diff view


### PR DESCRIPTION
As per #549, we’ve ditched the orange accent color for a more familiar blue.

The careful observer might notice that this is not the same blue as in mine and @donokuda’s mocks. To you I say doan worry ‘bout eeit. @donokuda has got you covered in #602 and once that lands all will be right in the world once again.