### PR TITLE
Fix authentication in newly added repositories

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -164,11 +164,12 @@ export class Dispatcher {
   }
 
   /** Refresh the associated GitHub repository. */
-  public async refreshGitHubRepositoryInfo(repository: Repository): Promise<void> {
+  public async refreshGitHubRepositoryInfo(repository: Repository): Promise<Repository> {
     const refreshedRepository = await this.appStore._repositoryWithRefreshedGitHubRepository(repository)
-    if (refreshedRepository === repository) { return }
+    if (refreshedRepository === repository) { return refreshedRepository }
 
-    return this.dispatchToSharedProcess<void>({ name: 'update-github-repository', repository: refreshedRepository })
+    const repo = await this.dispatchToSharedProcess<IRepository>({ name: 'update-github-repository', repository: refreshedRepository })
+    return Repository.fromJSON(repo)
   }
 
   /** Load the history for the repository. */
@@ -302,7 +303,7 @@ export class Dispatcher {
   }
 
   /** Publish the repository to GitHub with the given properties. */
-  public async publishRepository(repository: Repository, name: string, description: string, private_: boolean, account: User, org: IAPIUser | null): Promise<void> {
+  public async publishRepository(repository: Repository, name: string, description: string, private_: boolean, account: User, org: IAPIUser | null): Promise<Repository> {
     await this.appStore._publishRepository(repository, name, description, private_, account, org)
     return this.refreshGitHubRepositoryInfo(repository)
   }

--- a/app/src/shared-process/index.ts
+++ b/app/src/shared-process/index.ts
@@ -117,6 +117,9 @@ register('request-oauth', () => {
 
 register('update-github-repository', async ({ repository }: IUpdateGitHubRepositoryAction) => {
   const inflatedRepository = Repository.fromJSON(repository as IRepository)
-  await repositoriesStore.updateGitHubRepository(inflatedRepository)
+  const updatedRepository = await repositoriesStore.updateGitHubRepository(inflatedRepository)
+
   broadcastUpdate()
+
+  return updatedRepository
 })


### PR DESCRIPTION
I _believe_ this fixes #441 

Because we weren't using the repository instance that was fully populated with its GitHub repository, we weren't able to determine the user to use for authentication. So authentication would always fail 💥 