### PR TITLE
no FETCH_HEAD, no problems

### DIFF
--- a/app/src/lib/dispatcher/git-store.ts
+++ b/app/src/lib/dispatcher/git-store.ts
@@ -406,11 +406,9 @@ export class GitStore {
         if (err) {
           // An error most likely means the repository's never been published.
           this._lastFetched = null
-        }
-
-        // If the file's empty then it _probably_ means the fetch failed and we
-        // shouldn't update the last fetched date.
-        if (stats.size > 0) {
+        } else if (stats.size > 0) {
+          // If the file's empty then it _probably_ means the fetch failed and we
+          // shouldn't update the last fetched date.
           this._lastFetched = stats.mtime
         }
 


### PR DESCRIPTION
As this currently works, we trip the happy path with an undefined `stats` if the file doesn't exist in the repository.

Let's just sprinkle some `else` in here...