### PR TITLE
tell VS Code to use the workspace version of TS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "./node_modules/typescript/lib"
+}


### PR DESCRIPTION
I switched over to use VS Code because I didn't have the patience to understand why `atom-typescript` is currently broken, and I found this file was created in the repo.

This comes up when VS Code isn't sure what version of TS you want to use:

<img width="1156" src="https://cloud.githubusercontent.com/assets/359239/20327699/1ab18dc0-ab43-11e6-8c12-1cd4f7469ff4.png">

I figure using the one in `package.json` is a good choice, so I click that and it tells me this:

<img width="828" src="https://cloud.githubusercontent.com/assets/359239/20327700/1ab29a80-ab43-11e6-9f0f-c610dc4517cc.png">

Seems a reasonable thing to commit, just in case.