### PR TITLE
lock these dependencies as a later version currently breaks under mocha

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "fs-extra": "^0.30.0",
-    "react-addons-perf": "^15.2.1",
-    "react-addons-test-utils": "^15.2.1",
+    "react-addons-perf": "15.3.2",
+    "react-addons-test-utils": "15.3.2",
     "style-loader": "^0.13.1",
     "temp": "^0.8.3",
     "webpack-hot-middleware": "^2.10.0"


### PR DESCRIPTION
`15.4.0` of these dependencies is bad and should feel bad.