### PR TITLE
Encode the asset name

### DIFF
--- a/script/publish
+++ b/script/publish
@@ -81,7 +81,7 @@ function upload (assetName, assetPath) {
   const s3 = new AWS.S3(s3Info)
 
   const bucket = process.env.S3_BUCKET
-  const key = `releases/${distInfo.getVersion()}-${sha}/${assetName}`
+  const key = `releases/${distInfo.getVersion()}-${sha}/${encodeURIComponent(assetName)}`
   const url = `https://s3.amazonaws.com/${bucket}/${key}`
 
   const uploadParams = {


### PR DESCRIPTION
The asset name has a space in it now, so we should encode it.