### PR TITLE
Global thermonuclear war

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "tslint \"./app/src/**/*.ts\" \"./app/src/**/*.tsx\" \"./app/test/**/*.ts\" \"./app/test/**/*.tsx\"",
     "publish": "node script/publish",
     "clean-slate": "npm run clean && rimraf node_modules app/node_modules && npm install",
-    "rebuild-hard:dev": "npm run clean-slate && npm rebuild:dev",
-    "rebuild-hard:prod": "npm run clean-slate && npm rebuild:prod"
+    "rebuild-hard:dev": "npm run clean-slate && npm run rebuild:dev",
+    "rebuild-hard:prod": "npm run clean-slate && npm run rebuild:prod"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Whenever we update electron, like we just did we need to blow away our node modules. Sometimes shit gets all messed up and we have to do it without knowing why (:cry:).

This adds two npm scripts that let you run all these very time-consuming commands once, `rebuild-hard:dev` and `rebuild-hard:prod`. These are aided by the `clean-slate` npm script.

So now you can run `npm run rebuild-hard:dev && npm start` and then go do other stuff until the app pops up