### PR TITLE
Let's just not bother with whitespace

### DIFF
--- a/script/publish
+++ b/script/publish
@@ -81,7 +81,7 @@ function upload (assetName, assetPath) {
   const s3 = new AWS.S3(s3Info)
 
   const bucket = process.env.S3_BUCKET
-  const key = `releases/${distInfo.getVersion()}-${sha}/${encodeURIComponent(assetName)}`
+  const key = `releases/${distInfo.getVersion()}-${sha}/${assetName.replace(/ /g, '')}`
   const url = `https://s3.amazonaws.com/${bucket}/${key}`
 
   const uploadParams = {


### PR DESCRIPTION
It turns out S3 will encode whitespace for us, but then the URL will be different from what we construct. So just avoid it.