### PR TITLE
Show the repositories list toolbar button even if there's no repository selected

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -418,7 +418,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       icon = this.iconForRepository(repository)
       title = repository.name
     } else {
-      icon = OcticonSymbol.threeBars
+      icon = OcticonSymbol.repo
       title = 'Select a repository'
     }
 


### PR DESCRIPTION
Otherwise we don't show anything and it looks broken.

![screen shot 2016-11-21 at 2 14 24 pm](https://cloud.githubusercontent.com/assets/13760/20496871/e05e12fe-aff4-11e6-9a26-f7c1e42099cf.png)
