### PR TITLE
Toolbar buttons should not be buttons

### DIFF
--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -75,17 +75,14 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, void> {
     const preContent = preContentRenderer && preContentRenderer()
 
     return (
-      <button
-        className={className}
-        onClick={this.onClick}
-        ref={this.onButtonRef}>
+      <div className={className}>
         {preContent}
-        <div className='toolbar-button-content-wrapper'>
+        <button onClick={this.onClick} ref={this.onButtonRef}>
           {icon}
           {this.renderText()}
           {this.props.children}
-        </div>
-      </button>
+        </button>
+      </div>
     )
   }
 

--- a/app/styles/ui/toolbar/_button.scss
+++ b/app/styles/ui/toolbar/_button.scss
@@ -1,27 +1,44 @@
 .toolbar-button {
-  -webkit-appearance: none;
 
-  // Reset styles from global buttons
-  border: none;
-  box-shadow: none;
-  background: transparent;
-  border-radius: 0;
-  text-align: left;
-  margin: 0;
-  padding: 0;
+  // General button behavior, mostly resets.
+  // For the button content styling see second button style. Note that we
+  // explicitly use > here to only target the direct descendant button since
+  // there might be buttons in foldouts which would otherwise be affected
+  // as well.
+  &>button {
+    // Reset styles from global buttons
+    -webkit-appearance: none;
+    border: none;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 0;
+    text-align: left;
+    margin: 0;
+    padding: 0;
 
-  // Reset
-  &:active { box-shadow: none; }
+    &:active { box-shadow: none; }
 
-  // NB This is important, without this the button
-  // element will add an extra 3px of invisible padding
-  // for some inexplicable reason. This forces the
-  // button to take up the entire available space.
-  &,&-content-wrapper {
+    // @TODO: Proper focus state
+    &:focus {
+      outline: none;
+      border-color: var(--toolbar-button-border-color);
+    }
+
+    &:not(:disabled):hover {
+      background-color: var(--toolbar-button-hover-background-color);
+      color: var(--toolbar-button-hover-color);
+      border-color: var(--toolbar-button-hover-border-color);
+
+      .description {
+        color: var(--toolbar-button-secondary-color);
+      }
+    }
+
     height: 100%;
+    width: 100%;
   }
 
-  &-content-wrapper {
+  &>button {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -64,20 +81,8 @@
     .title, .description { @include ellipsis }
   }
 
-  &:not(:disabled):hover {
-    .toolbar-button-content-wrapper {
-      background-color: var(--toolbar-button-hover-background-color);
-      color: var(--toolbar-button-hover-color);
-      border-color: var(--toolbar-button-hover-border-color);
-
-      .description {
-        color: var(--toolbar-button-secondary-color);
-      }
-    }
-  }
-
   &.dropdown.open {
-    .toolbar-button-content-wrapper {
+    &>button {
       color: var(--toolbar-button-active-color);
       background-color: var(--toolbar-button-active-background-color);
 
@@ -86,11 +91,5 @@
       // min-width of the foldout.
       border-color: var(--toolbar-button-active-border-color);
     }
-  }
-
-  // @TODO: Proper focus state
-  &:focus {
-    outline: none;
-    border-color: var(--toolbar-button-border-color);
   }
 }


### PR DESCRIPTION
This fixes the issue where the entire foldout becomes a clickable area because it was a descendant of the button element. It does so simply by making the toolbar button component itself a div which contains a button and any pre-content (foldout) becomes a sibling of that button rather than a descendant.