### PR TITLE
Small toolbar buttons

### DIFF
--- a/app/styles/ui/toolbar/_button.scss
+++ b/app/styles/ui/toolbar/_button.scss
@@ -57,6 +57,7 @@
     border-right: 1px solid var(--toolbar-button-border-color);
 
     .icon {
+      flex-shrink: 0;
       margin-right: var(--spacing);
     }
 
@@ -64,6 +65,7 @@
       width: 9px;
       height: 12px;
       margin-left: var(--spacing);
+      flex-shrink: 0;
     }
 
     .text {


### PR DESCRIPTION
Some fallout from #682 

This happened when a button shrunk beyond its intrinsic width

<img width="380" alt="screen shot 2016-11-23 at 23 22 21" src="https://cloud.githubusercontent.com/assets/634063/20580732/6301e1a0-b1d4-11e6-8e7a-800e94644c97.png">

If just fix that then we get tiny icons

<img width="259" alt="screen shot 2016-11-23 at 23 24 34" src="https://cloud.githubusercontent.com/assets/634063/20580736/66423dec-b1d4-11e6-8456-1b24f211de80.png">

This is how it should be (and is, now)

<img width="205" alt="screen shot 2016-11-23 at 23 25 02" src="https://cloud.githubusercontent.com/assets/634063/20580745/6c77f5da-b1d4-11e6-9f7f-aeb2e9c68106.png">