### PR TITLE
VSCode - ignore external folders 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,14 @@
         "**/node_modules": true,
         "**/dist": true,
         "**/out": true
+    },
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/.DS_Store": true,
+        "**/node_modules": true,
+        "**/dist": true,
+        "**/out": true
     }
 }


### PR DESCRIPTION
Another workspace tweak to exclude generated folders as well as `node_modules` when working. This affects the Explorer view as well as Search.