### PR TITLE
Allow variable height rows in lists

### DIFF
--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -85,8 +85,12 @@ interface IListProps {
    * The height of each individual row in the list. This height
    * is enforced for each row container and attempting to render a row
    * which does not fit inside that height is forbidden.
+   *
+   * Can either be a number (most efficient) in which case all rows
+   * are of equal height, or, a function that, given a row index returns
+   * the height of that particular row.
    */
-  readonly rowHeight: number
+  readonly rowHeight: number | ((info: { index: number }) => number)
 
   /**
    * The currently selected row index. Used to attach a special
@@ -416,13 +420,24 @@ export class List extends React.Component<IListProps, void> {
    *
    */
   private renderFakeScroll(height: number) {
+
+    let totalHeight: number = 0
+
+    if (typeof this.props.rowHeight === 'number') {
+      totalHeight = this.props.rowHeight * this.props.rowCount
+    } else {
+      for (let i = 0; i < this.props.rowCount; i++) {
+        totalHeight += this.props.rowHeight({ index: i })
+      }
+    }
+
     return (
       <div
         className='fake-scroll'
         ref={this.onFakeScrollRef}
         style={{ height }}
         onScroll={this.onFakeScroll}>
-        <div style={{ height: this.props.rowHeight * this.props.rowCount, pointerEvents: 'none' }}></div>
+        <div style={{ height: totalHeight, pointerEvents: 'none' }}></div>
       </div>
     )
   }


### PR DESCRIPTION
I need this for #689 but I'm breaking it out for separate review and for visibility.

This surfaces the already existing functionality of the React-Virtualized Grid component that allows consumers to provide a callback to give each row an individual height.

Note that this isn't the same thing as automatically sized rows. This is for scenarios when the row height can be computed (and computed fast) without any rendering side-effects. In my scenario I'm using it to determine if the menu item is a separator and if so return a more narrow row than for normal items.

Unfortunately, due to our need to create fake scrollbars in order for them to sit on top of content this means that we have to calculate the row height for each item in a list up-front which is why this is only really suitable for small lists such as menus.

Internally inside react-virtualized the rowHeight property is always considered a function so we're not missing out on any performance benefits there although that's certainly something that could change in a future release.

If https://github.com/w3c/csswg-drafts/issues/92 ever manages to make it into a standard we can ditch our fake scrollbar and restore some sanity again.