### PR TITLE
Close the foldout after selecting a repository

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -673,6 +673,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onSelectionChanged = (repository: Repository | CloningRepository) => {
     this.props.dispatcher.selectRepository(repository)
+    this.props.dispatcher.closeFoldout()
 
     if (repository instanceof Repository) {
       this.props.dispatcher.refreshGitHubRepositoryInfo(repository)


### PR DESCRIPTION
This works fine on the current release, but is broken on `master`. I'm not terribly sure how/why it worked before 😬 