### PR TITLE
Button reference fix

### DIFF
--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -24,7 +24,7 @@ interface IButtonProps {
    * handling of the `ref` type into some ungodly monstrosity. Hopefully someday
    * this will be unnecessary.
    */
-  readonly reference?: (instance: HTMLButtonElement) => void
+  readonly onButtonRef?: (instance: HTMLButtonElement) => void
 }
 
 /** A button component. */
@@ -38,7 +38,7 @@ export class Button extends React.Component<IButtonProps, void> {
         disabled={this.props.disabled}
         onClick={this.onClick}
         type={this.props.type}
-        ref={this.props.reference}>
+        ref={this.props.onButtonRef}>
         {this.props.children}
       </button>
     )

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -78,7 +78,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, void> {
     return (
       <div className={className}>
         {preContent}
-        <Button onClick={this.onClick} reference={this.onButtonRef}>
+        <Button onClick={this.onClick} onButtonRef={this.onButtonRef}>
           {icon}
           {this.renderText()}
           {this.props.children}


### PR DESCRIPTION
_Continuing from https://github.com/desktop/desktop/pull/699#discussion_r91049296_

@niik said:

```typescript
readonly reference?: React.Ref<HTMLButtonElement>
```

>Hmm, not wild about this since it allows consumers to pass a string which would update the (deprecated, I think) string ref on the component itself. Could we call this onButtonRef to indicate that it's a callback and convert it to an explicit function notation while we're at it?

👍 

>Secondly, I'm curious why you've opted for passing the elements through a callback like this instead of what we've previously done which is let parent components add a ref callback for the component and then access explicitly exposed elements and methods through the component itself.

I could go that way... I'm a little concerned about the slippery slope of having to wrap more and more of `HTMLButtonElement`s API. In the case of `List`, I think it makes more sense because there's no exact `HTMLElement` analogue. It'd be leaking an implementation detail to talk about the exact element. But in the case of `Button` (or at least how I've been thinking about it), we're not hiding the fact that it's a `<button>`, just making it app-specific.