### PR TITLE
fix linter rule to use a common type 

### DIFF
--- a/tslint-rules/reactNoUnboundDispatcherPropsRule.ts
+++ b/tslint-rules/reactNoUnboundDispatcherPropsRule.ts
@@ -36,16 +36,21 @@ export class Rule extends Lint.Rules.AbstractRule {
 class ReactNoUnboundDispatcherPropsWalker extends Lint.RuleWalker {
 
   protected visitJsxElement(node: ts.JsxElement): void {
-    this.visitJsxOpeningElement(node.openingElement) // a normal JSX element has-a OpeningElement
+    this.visitJsxOpeningLikeElement(node.openingElement)
     super.visitJsxElement(node)
   }
 
   protected visitJsxSelfClosingElement(node: ts.JsxSelfClosingElement): void {
-    this.visitJsxOpeningElement(node)  // a self closing JSX element is-a OpeningElement
+    this.visitJsxOpeningLikeElement(node)
     super.visitJsxSelfClosingElement(node)
   }
 
-  private visitJsxOpeningElement(node: ts.JsxOpeningElement): void {
+  /**
+   * Visit the node and apply the rule about ensuring the dispatcher is bound.
+   *
+   *  JsxOpeningLikeElement encompasses both self-closing and regular elements
+   */
+  private visitJsxOpeningLikeElement(node: ts.JsxOpeningLikeElement): void {
     // create violations if the listener is a reference to a class method that was not bound to 'this' in the constructor
     node.attributes.forEach(attributeLikeElement => {
 


### PR DESCRIPTION
Found this one with a `git clean -xdf` and `npm install` on macOS and Windows today. I've got typescript 2.0.10 installed, FWIW.

```
...
> @ compile:tslint /Users/shiftkey/src/desktop
> tsc -p tslint-rules

tslint-rules/reactNoUnboundDispatcherPropsRule.ts(44,33): error TS2345: Argument of type 'JsxSelfClosingElement' is not assignable to parameter of type 'JsxOpeningElement'.
  Types of property 'kind' are incompatible.
    Type 'SyntaxKind.JsxSelfClosingElement' is not assignable to type 'SyntaxKind.JsxOpeningElement'.
```

The fix seems to be to use this in the rule, which should satisfy both cases:

```
    type JsxOpeningLikeElement = JsxSelfClosingElement | JsxOpeningElement;
```

CI doesn't seem to be triggering this error, and with #703 lurking I don't think this is a big issue unless someone else encounters it.