### PR TITLE
Close the publish foldout

### DIFF
--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -119,7 +119,7 @@ export class PublishRepository extends React.Component<IPublishRepositoryProps, 
   private publishRepository = () => {
     const owningAccount = this.findOwningUserForSelectedUser()!
     this.props.dispatcher.publishRepository(this.props.repository, this.state.name, this.state.description, this.state.private, owningAccount, this.selectedOrg)
-    this.props.dispatcher.closePopup()
+    this.props.dispatcher.closeFoldout()
   }
 
   private onAccountChange = (event: React.FormEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
Creating this commit as a PR into a PR since I'm still learning how the code  base works.

@joshaber, since publish is a foldout, we should call `closeFoldout` not `closePopup`? This seems to cause the publish repository foldout to go away, but it's replaced shortly by the publish branch foldout. But the contents of the publish branch foldout looks just like the publish repository foldout, which doesn't make sense.