### PR TITLE
Center and add overlay for Popups

### DIFF
--- a/app/styles/ui/_popup.scss
+++ b/app/styles/ui/_popup.scss
@@ -6,9 +6,6 @@
   margin: var(--spacing-triple) var(--spacing);
   background-color: var(--box-alt-background-color);
   position: absolute;
-  border: var(--base-border);
-  border-radius: var(--border-radius);
-  box-shadow: 0 0 7px rgba(0,0,0,0.15);
   z-index: var(--popup-z-index);
 
   top: 50%;
@@ -52,4 +49,8 @@
 
 .popup-overlay {
   z-index: var(--popup-overlay-z-index);
+
+  background: black;
+  opacity: 0.4;
+  height: 100%;
 }


### PR DESCRIPTION
I submit this to the review of our esteemed designers @donokuda and @niik. I'm sure you both have Opinions® on how Popups should look, but in the mean time maybe this is better than what we currently have?

Before:

<img width="1000" alt="screen shot 2016-12-08 at 5 21 32 pm" src="https://cloud.githubusercontent.com/assets/13760/21030108/d0dbfef8-bd6a-11e6-82bd-f0c7ec8b41dc.png">

After:

<img width="1001" alt="screen shot 2016-12-08 at 5 16 35 pm" src="https://cloud.githubusercontent.com/assets/13760/21030035/6fb21f4a-bd6a-11e6-8a6b-3fd2db4005e5.png">
