### PR TITLE
unable to switch tabs in repository view

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -650,13 +650,13 @@ export class AppStore {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _changeRepositorySection(repository: Repository, section: RepositorySection): Promise<void> {
-    this.updateRepositoryState(repository, state => ({ ...state, section }))
+  public async _changeRepositorySection(repository: Repository, selectedSection: RepositorySection): Promise<void> {
+    this.updateRepositoryState(repository, state => ({ ...state, selectedSection }))
     this.emitUpdate()
 
-    if (section === RepositorySection.History) {
+    if (selectedSection === RepositorySection.History) {
       return this.refreshHistorySection(repository)
-    } else if (section === RepositorySection.Changes) {
+    } else if (selectedSection === RepositorySection.Changes) {
       return this.refreshChangesSection(repository, { includingStatus: true, clearPartialState: false })
     }
   }


### PR DESCRIPTION
While we were cleaning up code with the object spread syntax in `app-store` an innocuous change from `selectedSection` to `section` was introduced that didn't get caught (because it's still a valid `IRepositoryState` object, it just has a new field.

The effect of this is that we weren't able to switch tabs. I'm a bit concerned there's others, but given it's all in one file - and all through `updateRepositoryState` - at least its easy to review...