### PR TITLE
Don't start background fetching until the repository's been refreshed

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -480,7 +480,7 @@ export class AppStore {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public _selectRepository(repository: Repository | CloningRepository | null): Promise<void> {
+  public async _selectRepository(repository: Repository | CloningRepository | null): Promise<void> {
     this.selectedRepository = repository
     this.emitUpdate()
 
@@ -489,8 +489,6 @@ export class AppStore {
     if (!repository) { return Promise.resolve() }
 
     if (repository instanceof Repository) {
-      this.startBackgroundFetching(repository)
-
       localStorage.setItem(LastSelectedRepositoryIDKey, repository.id.toString())
 
       const gitHubRepository = repository.gitHubRepository
@@ -498,7 +496,9 @@ export class AppStore {
         this._updateIssues(gitHubRepository)
       }
 
-      return this._refreshRepository(repository)
+      await this._refreshRepository(repository)
+
+      this.startBackgroundFetching(repository)
     } else {
       return Promise.resolve()
     }


### PR DESCRIPTION
Otherwise we're racing loading the remote, and if we lose we won't perform the initial fetch.

@shiftkey reported this in #666 but we weren't sure how to reproduce it. It's more likely to happen on big repos.