### PR TITLE
Buttons without a type are just buttons

### DIFF
--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -37,7 +37,7 @@ export class Button extends React.Component<IButtonProps, void> {
         className={className}
         disabled={this.props.disabled}
         onClick={this.onClick}
-        type={this.props.type}
+        type={this.props.type || 'button'}
         ref={this.props.onButtonRef}>
         {this.props.children}
       </button>


### PR DESCRIPTION
Otherwise Chromium apparently assumes they're the submit button... but here's the twist: they're not.

Apparently:

>Always specify the type attribute for the <button> element. Different browsers may use different default types for the <button> element. (http://www.w3schools.com/tags/att_button_type.asp)

To reproduce:

1. Branch menu > Rename...
2. Type some things.
3. Hit enter.
4. It cancels instead of submits because reasons.