### PR TITLE
Close the popup after discarding changes

### DIFF
--- a/app/src/ui/discard-changes/index.tsx
+++ b/app/src/ui/discard-changes/index.tsx
@@ -33,5 +33,6 @@ export class DiscardChanges extends React.Component<IDiscardChangesProps, void> 
 
   private discard = () => {
     this.props.dispatcher.discardChanges(this.props.repository, this.props.files)
+    this.props.dispatcher.closePopup()
   }
 }


### PR DESCRIPTION
I think this worked previously because it'd also submit the form, which called Cancel, I think? See https://github.com/desktop/desktop/pull/744.