### PR TITLE
Fix fetch GitHub repository

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -128,14 +128,7 @@ export class API {
 
   /** Fetch a repo by its owner and name. */
   public async fetchRepository(owner: string, name: string): Promise<IAPIRepository> {
-    const response = await this.authenticatedRequest('GET', `repos/${owner}/${name}`)
-    const repository = deserialize<IAPIRepository>(response.body)
-
-    if (repository) {
-      return repository
-    }
-
-    throw new Error(`Unable to find repository: ${owner}/${name}`)
+    return this.client.repos(owner, name).fetch()
   }
 
   /** Fetch the logged in user. */


### PR DESCRIPTION
Go back to using octokat.js for this call.

This reverts 443d311. We can't convert just one call site since octokat.js gives us `camelCase` properties and the net modules gives us `snake_case` properties. That means our `IAPIRepository` is always wrong in one of the cases. We need to convert all call sites or none.