### PR TITLE
Use two spaces for tabs in Visual Studio code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
         "**/node_modules": true,
         "**/dist": true,
         "**/out": true
-    }
+    },
+    "editor.tabSize": 2
 }


### PR DESCRIPTION
This updates the workspace settings for vscode to use two spaces for tabs like we do everywhere else.