### PR TITLE
Don't care where the mouse is released in a selection

### DIFF
--- a/app/src/ui/diff/diff-line-gutter.tsx
+++ b/app/src/ui/diff/diff-line-gutter.tsx
@@ -54,11 +54,6 @@ interface IDiffGutterProps {
    * Callback to signal when the mouse is hovering over this element
    */
   readonly onMouseMove: (index: number) => void
-
-  /**
-   * Callback to signal when the mouse button is released on this element
-   */
-  readonly onMouseUp: (index: number) => void
 }
 
 /**
@@ -211,11 +206,6 @@ export class DiffLineGutter extends React.Component<IDiffGutterProps, void> {
     this.props.onMouseMove(this.props.index)
   }
 
-  private mouseUpHandler = (ev: MouseEvent) => {
-    ev.preventDefault()
-    this.props.onMouseUp(this.props.index)
-  }
-
   private mouseDownHandler = (ev: MouseEvent) => {
     ev.preventDefault()
     const isRangeSelection = isMouseCursorNearEdge(ev)
@@ -238,7 +228,6 @@ export class DiffLineGutter extends React.Component<IDiffGutterProps, void> {
       elem.addEventListener('mouseenter', this.mouseEnterHandler)
       elem.addEventListener('mouseleave', this.mouseLeaveHandler)
       elem.addEventListener('mousemove', this.mouseMoveHandler)
-      elem.addEventListener('mouseup', this.mouseUpHandler)
 
       // no point handling mousedown events on context lines
       if (this.props.line.isIncludeableLine()) {
@@ -254,7 +243,6 @@ export class DiffLineGutter extends React.Component<IDiffGutterProps, void> {
         this.elem_.removeEventListener('mouseleave', this.mouseLeaveHandler)
         this.elem_.removeEventListener('mousemove', this.mouseMoveHandler)
         this.elem_.removeEventListener('mousedown', this.mouseDownHandler)
-        this.elem_.removeEventListener('mouseup', this.mouseUpHandler)
       }
 
       this.elem_ = undefined


### PR DESCRIPTION
Fixes #661 by subscribing to the document level mouseup instead of the gutter when dragging in a selection.

Note that there's still a bunch of weird behaviors that this doesn't fix. Dragging while outside of the gutter doesn't update the selection as that's still updated through events on the gutter elements. We can fix this in a similar manner but I took a look at #782 and realized that I'd create merge hell by attempting it now so I'll open this and we can tackle the rest of the weirdness later.