### PR TITLE
Show selected file's full path 

### DIFF
--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 
 interface IChangedFileDetailsProps {
-  readonly filePath: string | null
+  readonly filePath: string
 }
 
 /** Displays information about a file */
 export class ChangedFileDetails extends React.Component<IChangedFileDetailsProps, void> {
   public render() {
-    const filePath = this.props.filePath ? this.props.filePath : undefined
+    const filePath = this.props.filePath
 
     return (
       <div id='changed-file-details'>

--- a/app/src/ui/changes/index.tsx
+++ b/app/src/ui/changes/index.tsx
@@ -33,7 +33,6 @@ export class Changes extends React.Component<IChangesProps, void> {
   public render() {
     const diff = this.props.changes.diff
     const file = this.props.changes.selectedFile
-    let filePath: string
 
     if (!diff || !file) {
       return (
@@ -43,7 +42,7 @@ export class Changes extends React.Component<IChangesProps, void> {
       )
     }
 
-    filePath = file.path
+    const filePath = file.path
 
     return (
       <div>


### PR DESCRIPTION
This PR fixes issue #693 

Adds the selected file's full path above the diff viewer. This PR is ready for review.

## Before

![nofilename](https://cloud.githubusercontent.com/assets/1715082/22045037/de0fcf74-dccc-11e6-8e5f-cd852663e15d.jpg)

## After

![fullfilename](https://cloud.githubusercontent.com/assets/1715082/22045008/b03f6780-dccc-11e6-9807-7bbef998a5ff.jpg)

@donokuda would you mind styling this?  