### PR TITLE
add styles for changes view to ensure it fills the available space

### DIFF
--- a/app/src/ui/changes/index.tsx
+++ b/app/src/ui/changes/index.tsx
@@ -45,7 +45,7 @@ export class Changes extends React.Component<IChangesProps, void> {
     const filePath = file.path
 
     return (
-      <div>
+      <div className='changed-file'>
         <ChangedFileDetails filePath={filePath} />
         <Diff repository={this.props.repository}
           file={file}

--- a/app/styles/ui/_changes.scss
+++ b/app/styles/ui/_changes.scss
@@ -2,3 +2,4 @@
 @import "changes/changes-list";
 @import "changes/sidebar";
 @import "changes/undo-commit";
+@import "changes/changes-view";

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -1,0 +1,4 @@
+.changed-file {
+  flex-grow: 1;
+  min-width: 0;
+}


### PR DESCRIPTION
Context: https://github.com/desktop/desktop/pull/816#issuecomment-273615982

Before:

![](https://cloud.githubusercontent.com/assets/359239/22085773/5c8491ba-dd8a-11e6-9f21-153f3b34945f.png)

After:

![](https://cloud.githubusercontent.com/assets/359239/22085747/44c8bec0-dd8a-11e6-94db-8cbe8b2c6b55.png)

Probably some additional work to do about the diff header to ensure it looks the same for changes and history view, but we can cross that bridge when I get to #605 or something...