### PR TITLE
create branch form disappears when typing

### DIFF
--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -60,8 +60,8 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
   }
 
   private receiveProps(nextProps: IBranchesProps) {
-    const expandCreateForm = nextProps.expandCreateForm || this.state.showCreateDialog
-    this.setState(this.createState(nextProps, this.state.filter, this.state.selectedRow, expandCreateForm))
+    const showCreateDialog = nextProps.expandCreateForm || this.state.showCreateDialog
+    this.setState(this.createState(nextProps, this.state.filter, this.state.selectedRow, showCreateDialog))
   }
 
   public componentWillReceiveProps(nextProps: IBranchesProps) {


### PR DESCRIPTION
Version: 0.0.19
OS: Windows

For some reason, React on Windows is firing `componentWillReceiveProps` for the branches list as soon as I try to type the branch name inside the create branch from - and this fallback value being false means the view is hidden.

I can't reproduce this behaviour on macOS (using `master` due to #835) to see `componentWillReceiveProps` fire again, but whatever - this is a better default.