### PR TITLE
you get a soft wrap, erryone gets a soft wrap

### DIFF
--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -501,7 +501,7 @@ export class Diff extends React.Component<IDiffProps, void> {
         readOnly: true,
         showCursorWhenSelecting: false,
         cursorBlinkRate: -1,
-        lineWrapping: localStorage.getItem('soft-wrap-is-best-wrap') ? true : false,
+        lineWrapping: true,
         // Make sure CodeMirror doesn't capture Tab and thus destroy tab navigation
         extraKeys: { Tab: false },
         scrollbarStyle: __DARWIN__ ? 'simple' : 'native',


### PR DESCRIPTION
Context: https://github.com/desktop/desktop/pull/844#issuecomment-275674166

We don't populate this in the app, so I'm just going to :fire: this lookup.

- [x] test hunk selection isn't affected