### PR TITLE
Prevent dispatcher update on each keypress

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -170,7 +170,6 @@ export class AppStore {
   }
 
   private emitUpdate() {
-    console.log('emitUpdate')
     if (this.emitQueued) { return }
 
     this.emitQueued = true


### PR DESCRIPTION
Our highlighting of access keys in menus when the Alt-key is pressed (from #689) was causing us to emit an app store update on each keypress. This was the underlying behavior which exposed the issue described in https://github.com/desktop/desktop/pull/838.

While this _shouldn't_ be causing issues in our code (any issues exposed by this are likely bugs as any type of asynchronous update would trigger them) it's far from ideal so we'll make sure to only emit an update when necessary.