### PR TITLE
Platform agnostic accelerator

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -187,7 +187,7 @@ export function buildDefaultMenu(sharedProcess: SharedProcess): Electron.Menu {
       {
         id: 'view-repository-on-github',
         label: __DARWIN__ ? 'View on GitHub' : '&View on GitHub',
-        accelerator: 'CmdOrCtrl+Option+G',
+        accelerator: 'CmdOrCtrl+Alt+G',
         click: emit('view-repository-on-github'),
       },
       { type: 'separator' },


### PR DESCRIPTION
Use `Alt` instead of `Option`

See http://electron.atom.io/docs/api/accelerator/#platform-notice

> Use `Alt` instead of `Option`. The `Option` key only exists on macOS, whereas the `Alt` key is available on all platforms.