### PR TITLE
Don't zero out HOME on macOS

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -200,7 +200,7 @@ function getAskPassScriptPath(): string {
 
 /** Get the environment for authenticating remote operations. */
 export function envForAuthentication(user: User | null): Object {
-  const env: any = {
+  const env = {
     'DESKTOP_PATH': process.execPath,
     'DESKTOP_ASKPASS_SCRIPT': getAskPassScriptPath(),
     'GIT_ASKPASS': getAskPassTrampolinePath(),


### PR DESCRIPTION
This would break AskPass because it would no longer be able to find the user's keychain.