### PR TITLE
Fix "Last fetched" reporting

### DIFF
--- a/app/src/lib/dispatcher/git-store.ts
+++ b/app/src/lib/dispatcher/git-store.ts
@@ -385,9 +385,9 @@ export class GitStore {
   public async fetch(user: User | null): Promise<void> {
     const remotes = await getRemotes(this.repository)
 
-    remotes.forEach(async remote => {
-      this.performFailableOperation(() => fetchRepo(this.repository, user, remote.name))
-    })
+    for (const remote of remotes) {
+      await this.performFailableOperation(() => fetchRepo(this.repository, user, remote.name))
+    }
   }
 
   /** Calculate the ahead/behind for the current branch. */


### PR DESCRIPTION
We needed to await each fetch so that by the time the function "returned", they were done. Otherwise we wouldn't update our last fetched time accurately.