### PR TITLE
pin this type declaration as more recent versions break CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/keytar": "^3.0.28",
     "@types/mocha": "^2.2.29",
     "@types/node": "^6.0.31",
-    "@types/react": "^15.0.4",
+    "@types/react": "15.0.4",
     "@types/react-addons-css-transition-group": "^15.0.1",
     "@types/react-addons-test-utils": "^0.14.17",
     "@types/react-dom": "^0.14.21",


### PR DESCRIPTION
This crept in overnight when the type declarations were bumped:

```
ERROR in C:\projects\desktop\app\test\unit\app-test.tsx
(46,7): error TS2345: Argument of type 'Element' is not assignable to parameter of type 'ReactElement<any>'.
  Type 'null' is not assignable to type 'ReactElement<any>'.
```

More errors are there when running `npm run build:dev`, so let's pin this while we understand what's changed...