### PR TITLE
Fix duplicate access key

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -191,7 +191,7 @@ export function buildDefaultMenu(sharedProcess: SharedProcess): Electron.Menu {
         click: emit('view-repository-on-github'),
       },
       {
-        label: __DARWIN__ ? 'Open in Shell' : '&Open in shell',
+        label: __DARWIN__ ? 'Open in Shell' : 'Op&en in shell',
         id: 'open-in-shell',
         click: emit('open-in-shell'),
       },


### PR DESCRIPTION
The O access key was already being used by the "Open working directory" menu item