### PR TITLE
bump these packages now that upstream PRs have been reverted

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
     "@types/keytar": "^3.0.28",
     "@types/mocha": "^2.2.29",
     "@types/node": "^6.0.31",
-    "@types/react": "15.0.4",
+    "@types/react": "^15.0.8",
     "@types/react-addons-css-transition-group": "^15.0.1",
     "@types/react-addons-test-utils": "^0.14.17",
-    "@types/react-dom": "^0.14.21",
+    "@types/react-dom": "^0.14.23",
     "@types/react-virtualized": "0.0.3",
     "@types/uuid": "^2.0.29",
     "@types/whatwg-fetch": "0.0.28"


### PR DESCRIPTION
See #880 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14476 for context.

`@types/react-dom` wasn't affected, but it has a new release so I'm pulling that in too. 