### PR TITLE
new file + index state => diff confused

### DIFF
--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -40,6 +40,7 @@ export function mapStatus(rawStatus: string): FileStatus {
   if (status === 'A') { return FileStatus.New }           // added
   if (status === 'D') { return FileStatus.Deleted }       // deleted
   if (status === 'R') { return FileStatus.Renamed }       // renamed
+  if (status === 'AM') { return FileStatus.New }          // added in index, modified in working directory
   if (status === 'RM') { return FileStatus.Renamed }      // renamed in index, modified in working directory
   if (status === 'RD') { return FileStatus.Conflicted }   // renamed in index, deleted in working directory
   if (status === 'DD') { return FileStatus.Conflicted }   // Unmerged, both deleted

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -211,5 +211,29 @@ describe('git/diff', () => {
       expect(first.lines[1].text).to.equal('-foo')
       expect(first.lines[2].text).to.equal('+bar')
     })
+
+    it('handles unborn repository with mixed state', async () => {
+
+      const repo = await setupEmptyRepository()
+
+      fs.writeFileSync(path.join(repo.path, 'foo'), 'WRITING THE FIRST LINE\n')
+
+      await GitProcess.exec([ 'add', 'foo' ], repo.path)
+
+      fs.writeFileSync(path.join(repo.path, 'foo'), 'WRITING OVER THE TOP\n')
+
+      const status = await getStatus(repo)
+      const files = status.workingDirectory.files
+
+      expect(files.length).to.equal(1)
+
+      const diff = await getTextDiff(repo, files[0])
+
+      expect(diff.hunks.length).to.equal(1)
+
+      const first = diff.hunks[0]
+      expect(first.lines.length).to.equal(2)
+      expect(first.lines[1].text).to.equal('+WRITING OVER THE TOP')
+    })
   })
 })


### PR DESCRIPTION
This fixes an edge case where the user:

 - creates the file
 - stages it
 - edits the file again
 - tries to view the diff

Because we know the file has been added first, we can use that state to ensure we render the diff correctly...