### PR TITLE
Fix URL protocol handler name (kinda)

### DIFF
--- a/script/build
+++ b/script/build
@@ -48,6 +48,7 @@ const options = {
     '/\\.git($|/)',
     '/node_modules/\\.bin($|/)'
   ],
+  'app-copyright': 'Copyright © 2017 GitHub, Inc.',
 
   // macOS
   'app-bundle-id': distInfo.getBundleID(),


### PR DESCRIPTION
Fixes #859, kinda. The real problem was that LaunchServices had gotten confused on my computer, and resetting it fixed it. But I took the opportunity to use a More Right value, and add a copyright.