### PR TITLE
show the desktop icon for local repositories

### DIFF
--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -55,7 +55,7 @@ function iconForRepository(repository: Repository | CloningRepository): OcticonS
     return OcticonSymbol.desktopDownload
   } else {
     const gitHubRepo = repository.gitHubRepository
-    if (!gitHubRepo) { return OcticonSymbol.repo }
+    if (!gitHubRepo) { return OcticonSymbol.deviceDesktop }
 
     if (gitHubRepo.private) { return OcticonSymbol.lock }
     if (gitHubRepo.fork) { return OcticonSymbol.repoForked }


### PR DESCRIPTION
Currently, "other" repositories looked like public GitHub repositories:

<img width="268" alt="screen shot 2017-02-17 at 8 57 48 am" src="https://cloud.githubusercontent.com/assets/359239/23043067/2eafb7de-f4ef-11e6-9e13-a2af610d0d32.png">

Let's bring back the ol' computer icon from Desktop Classic:

<img width="368" alt="screen shot 2017-02-17 at 8 56 44 am" src="https://cloud.githubusercontent.com/assets/359239/23043058/25f38472-f4ef-11e6-8904-d7254004e754.png">
