### PR TITLE
Make emitUpdate reentrant

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -165,8 +165,8 @@ export class AppStore {
     this.emitQueued = true
 
     window.requestAnimationFrame(() => {
-      this.emitter.emit('did-update', this.getState())
       this.emitQueued = false
+      this.emitter.emit('did-update', this.getState())
     })
   }
 


### PR DESCRIPTION
*Note, this is part of #961 but I'm breaking it out here to have it reviewed separately.*

Without resetting the emitQueued call prior to emitting it's possible for a reentrant call to emitUpdate to end up not notifying subscribers.

### The problem

1. The store updates
2. A component's `componentWillReceiveProps` or `componentDidMount` etc method is called
3. That component calls the dispatcher to do something which updates the app store
4. The AppStore sees that `emitQueued` is set and doesn't schedule a new animationFrame
5. The update isn't emitted until the next time someone causes the store to update

## Reentrant, not recursive

`requestAnimationFrame` will AFAICT [never run the callback synchronously](https://www.w3.org/TR/animation-timing/#dom-windowanimationtiming-requestanimationframe). It may decide to run it in the same animation frame as the previous one if there's time left over but there's no risk for this to recurse.