### PR TITLE
pin to TS 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ts-loader": "^1.3.3",
     "ts-node": "^1.7.3",
     "tslint": "^3.14.0",
-    "typescript": "^2.1.5",
+    "typescript": "2.1.5",
     "vrsource-tslint-rules": "^0.12.0",
     "webpack": "^1.12.15",
     "webpack-dev-middleware": "^1.6.1",


### PR DESCRIPTION
Turns out Typescript 2.2 has a [breaking change](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#changes-to-dom-apis-in-the-standard-library) around the `@types/whatwg-fetch` package:

> Standard library now has declarations for `Window.fetch`; dependencies to `@types\whatwg-fetch` will cause conflicting declaration errors and will need to be removed.

If you find yourself doing a fresh `npm install` you're probably gonna see this. 

```
> tsc -p tslint-rules

node_modules/@types/whatwg-fetch/index.d.ts(6,15): error TS2300: Duplicate identifier 'Request'.
node_modules/@types/whatwg-fetch/index.d.ts(21,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'headers' must be of type 'any', but here has type 'string[] | Headers | { [index: string]: string; } | undefined'.
node_modules/@types/whatwg-fetch/index.d.ts(23,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'mode' must be of type 'string | undefined', but here has type '"same-origin" | "no-cors" | "cors" | undefined'.
node_modules/@types/whatwg-fetch/index.d.ts(24,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'redirect' must be of type 'string | undefined', but here has type '"error" | "manual" | "follow" | undefined'.
node_modules/@types/whatwg-fetch/index.d.ts(25,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'credentials' must be of type 'string | undefined', but here has type '"same-origin" | "omit" | "include" | undefined'.
node_modules/@types/whatwg-fetch/index.d.ts(26,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'cache' must be of type 'string | undefined', but here has type '"default" | "reload" | "no-store" | "no-cache" | "force-cache" | "only-if-cached" | undefined'.
node_modules/@types/whatwg-fetch/index.d.ts(48,15): error TS2300: Duplicate identifier 'Headers'.
node_modules/@types/whatwg-fetch/index.d.ts(60,2): error TS2687: All declarations of 'bodyUsed' must have identical modifiers.
node_modules/@types/whatwg-fetch/index.d.ts(69,15): error TS2300: Duplicate identifier 'Response'.
node_modules/@types/whatwg-fetch/index.d.ts(85,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'status' must be of type 'number | undefined', but here has type 'number'.
node_modules/@types/whatwg-fetch/index.d.ts(85,2): error TS2687: All declarations of 'status' must have identical modifiers.
node_modules/@types/whatwg-fetch/index.d.ts(87,2): error TS2403: Subsequent variable declarations must have the same type.  Variable 'headers' must be of type 'any', but here has type 'string[] | Headers | undefined'.
node_modules/@types/whatwg-fetch/index.d.ts(91,14): error TS2300: Duplicate identifier 'BodyInit'.
node_modules/@types/whatwg-fetch/index.d.ts(92,14): error TS2300: Duplicate identifier 'RequestInfo'.
node_modules/@types/whatwg-fetch/index.d.ts(98,13): error TS2300: Duplicate identifier 'fetch'.
node_modules/typescript/lib/lib.es6.d.ts(12840,11): error TS2300: Duplicate identifier 'Headers'.
node_modules/typescript/lib/lib.es6.d.ts(12849,13): error TS2300: Duplicate identifier 'Headers'.
node_modules/typescript/lib/lib.es6.d.ts(15238,11): error TS2300: Duplicate identifier 'Request'.
node_modules/typescript/lib/lib.es6.d.ts(15255,13): error TS2300: Duplicate identifier 'Request'.
node_modules/typescript/lib/lib.es6.d.ts(15260,11): error TS2300: Duplicate identifier 'Response'.
node_modules/typescript/lib/lib.es6.d.ts(15271,13): error TS2300: Duplicate identifier 'Response'.
node_modules/typescript/lib/lib.es6.d.ts(20788,18): error TS2300: Duplicate identifier 'fetch'.
node_modules/typescript/lib/lib.es6.d.ts(20793,6): error TS2300: Duplicate identifier 'BodyInit'.
node_modules/typescript/lib/lib.es6.d.ts(20824,6): error TS2300: Duplicate identifier 'RequestInfo'.
```

So let's upgrade later.