### PR TITLE
re-add the add repository button when no repositories exist

### DIFF
--- a/app/src/ui/repositories-list/index.tsx
+++ b/app/src/ui/repositories-list/index.tsx
@@ -10,7 +10,7 @@ import { FilterList } from '../lib/filter-list'
 import { ExpandFoldoutButton } from '../lib/expand-foldout-button'
 import { assertNever } from '../../lib/fatal-error'
 
-/** 
+/**
  * TS can't parse generic specialization in JSX, so we have to alias it here
  * with the generic type. See https://github.com/Microsoft/TypeScript/issues/6395.
  */
@@ -98,11 +98,11 @@ export class RepositoriesList extends React.Component<IRepositoriesListProps, vo
 
   public render() {
     if (this.props.loading) {
-      return <Loading/>
+      return this.loading()
     }
 
     if (this.props.repositories.length < 1) {
-      return <NoRepositories/>
+      return this.noRepositories()
     }
 
     const groups = groupRepositories(this.props.repositories)
@@ -137,12 +137,28 @@ export class RepositoriesList extends React.Component<IRepositoriesListProps, vo
       </div>
     )
   }
-}
 
-function Loading() {
-  return <div className='sidebar-message'>Loading…</div>
-}
+  private noRepositories() {
+    return (
+      <div className='repository-list'>
+        <div className='filter-list'>
+          {this.renderExpandButton()}
+          <div className='sidebar-message'>No repositories</div>
+        </div>
 
-function NoRepositories() {
-  return <div className='sidebar-message'>No repositories</div>
+        {this.renderAddRepository()}
+      </div>)
+  }
+
+  private loading() {
+    return (
+      <div className='repository-list'>
+        <div className='filter-list'>
+          {this.renderExpandButton()}
+          <div className='sidebar-message'>Loading…</div>
+        </div>
+
+        {this.renderAddRepository()}
+      </div>)
+  }
 }

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -48,6 +48,14 @@
     }
   }
 
+  .sidebar-message {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
   .repository-group-label {
     opacity: 0.6;
     padding: 0 var(--spacing-half) 0 var(--spacing-double);


### PR DESCRIPTION
Fixes #983 

This got overlooked when we were adding in the new expand menu button. Didn't spend too much time on the UI here - just wanted it looking consistent when you didn't have any repositories (or things were loading).

Before:

<img width="479"  src="https://cloud.githubusercontent.com/assets/359239/23345246/1cd5c6fa-fcdf-11e6-97f6-f1e7712962cb.png">

After:

<img width="637" src="https://cloud.githubusercontent.com/assets/359239/23345253/27e70a7c-fcdf-11e6-9682-7ea911ed8feb.png">
