### PR TITLE
Dialog loading state

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -10,12 +10,12 @@ import { DialogHeader } from './header'
 const dismissGracePeriodMs = 250
 
 interface IDialogProps {
-  /** 
+  /**
    * An optional dialog title. Most, if not all dialogs should have
    * this. When present the Dialog renders a DialogHeader element
    * containing an icon (if the type prop warrants it), the title itself
    * and a close button (if the dialog is dismissable).
-   * 
+   *
    * By omitting this consumers may use their own custom DialogHeader
    * for when the default component doesn't cut it.
    */
@@ -27,11 +27,11 @@ interface IDialogProps {
    * the close button in the header (if a header was specified). Dismissal
    * will trigger the onDismissed event which callers must handle and pass
    * on to the dispatcher in order to close the dialog.
-   * 
+   *
    * A non-dismissable dialog can only be closed by means of the component
    * implementing a dialog. An example would be a critical error or warning
    * that requires explicit user action by for example clicking on a button.
-   * 
+   *
    * Defaults to true if omitted.
    */
   readonly dismissable?: boolean
@@ -50,7 +50,7 @@ interface IDialogProps {
   /**
    * An optional dialog type. A warning or error dialog type triggers custom
    * styling of the dialog, see _dialog.scss for more detail.
-   * 
+   *
    * Defaults to 'normal' if omitted
    */
   readonly type?: 'normal' | 'warning' | 'error'
@@ -58,7 +58,7 @@ interface IDialogProps {
   /**
    * An event triggered when the dialog form is submitted. All dialogs contain
    * a top-level form element which can be triggered through a submit button.
-   * 
+   *
    * Consumers should handle this rather than subscribing to the onClick event
    * on the button itself since there may be other ways of submitting a specific
    * form (such as Ctrl+Enter).
@@ -101,7 +101,7 @@ interface IDialogState {
    * backdrop of a dialog can be clicked to dismiss all it takes is one rogue
    * click and the dialog is gone. This is less than ideal if we're in the
    * middle of displaying an important error message.
-   * 
+   *
    * This state boolean is used to keep track of whether we're still in that
    * grace period or not.
    */
@@ -111,7 +111,7 @@ interface IDialogState {
 /**
  * A general purpose, versatile, dialog component which utilizes the new
  * <dialog> element. See https://demo.agektmr.com/dialog/
- * 
+ *
  * A dialog is opened as a modal that prevents keyboard or pointer access to
  * underlying elements. It's not possible to use the tab key to move focus
  * out of the dialog without first dismissing it.

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -23,7 +23,7 @@ interface IDialogHeaderProps {
   /**
    * An optional type of dialog header. If the type is error or warning
    * an applicable icon will be rendered top left in the dialog.
-   * 
+   *
    * Defaults to 'normal' if omitted.
    */
   readonly type?: 'normal' | 'warning' | 'error'
@@ -40,7 +40,7 @@ interface IDialogHeaderProps {
 
 /**
  * A high-level component for Dialog headers.
- * 
+ *
  * This component should typically not be used by consumers as the title prop
  * of the Dialog component should suffice. There are, however, cases where
  * custom content needs to be rendered in a dialog and in that scenario it


### PR DESCRIPTION
*Pulling this out of #961 to cut down on the review burden over there*

This adds an optional loading state for dialogs which introduces a spinning sync icon which replaces the dialog icon (temporarily).

We might tweak this later to put the loading state inside of the dialog submit button but this is good enough for now.
