### PR TITLE
Support passing a css class name to DialogContent

### DIFF
--- a/app/src/ui/dialog/content.tsx
+++ b/app/src/ui/dialog/content.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as classNames from 'classnames'
 
 interface IDialogContentProps {
-  className?: string
+  readonly className?: string
 }
 
 /**


### PR DESCRIPTION
This let's us set a classname on the `DialogContent` component. I need this over in #961 but I'm pulling it out to cut down on the review burden over there.