### PR TITLE
when filtering, check on enter for items before selecting first match 

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -217,7 +217,14 @@ export class FilterList<T extends IFilterListItem> extends React.Component<IFilt
 
       event.preventDefault()
     } else if (event.key === 'Enter') {
-      this.onRowClick(list.nextSelectableRow('down', 0))
+      // no repositories currently displayed, bail out
+      if (!this.state.rows.length) {
+        event.preventDefault()
+        return
+      }
+
+      const row = list.nextSelectableRow('down', 0)
+      this.onRowClick(row)
     }
   }
 }


### PR DESCRIPTION
Fixes #993 

There's a broken assumption in `List.nextSelectableRow` that we always have have a non-empty list of items (and the potential to recurse forever) but I'll address that in a separate PR.

EDIT: see #996 for underlying issue