### PR TITLE
bugfix - dump the returned JSON when a publish fails

### DIFF
--- a/script/publish
+++ b/script/publish
@@ -142,7 +142,7 @@ function updateDeploy (artifacts) {
       }
 
       if (response.statusCode !== 200) {
-        reject(new Error(`Received a non-200 response (${response.statusCode}): ${body}`))
+        reject(new Error(`Received a non-200 response (${response.statusCode}): ${JSON.stringify(body)}`))
         return
       }
 


### PR DESCRIPTION
<img width="745" alt="screen shot 2017-03-08 at 2 13 40 pm" src="https://cloud.githubusercontent.com/assets/359239/23688575/875a5adc-0409-11e7-82c1-6ad92837635b.png">

Objects are pretty great, but let's deserialize this and see what we've got inside.