### PR TITLE
bump some other build packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "css-loader": "^0.26.2",
     "electron": "1.6.2",
     "electron-mocha": "3.3.0",
-    "electron-packager": "8.1.0",
+    "electron-packager": "8.5.2",
     "electron-winstaller": "^2.3.0",
     "express": "^4.15.0",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
Most of the remaining outdated packages at the root fall into bigger/more annoying tasks:

 - migrate to webpack v2
 - tslint v4 changes the world
 - upgrade to node v7
