### PR TITLE
Bump electron to 1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai-datetime": "^1.4.1",
     "cross-env": "^3.2.3",
     "css-loader": "^0.26.2",
-    "electron": "^1.6.3",
+    "electron": "1.6.3",
     "electron-mocha": "3.3.0",
     "electron-packager": "8.5.2",
     "electron-winstaller": "^2.3.0",


### PR DESCRIPTION
@kevinsawicki needs us to upgrade to 1.6.3 so we can cut a new release for auditing