### PR TITLE
Fix kerning issue when highlighting access keys

### DIFF
--- a/app/src/ui/lib/access-text.tsx
+++ b/app/src/ui/lib/access-text.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import * as classNames from 'classnames'
 
 interface IAccessTextProps {
   /**
@@ -28,26 +29,14 @@ export class AccessText extends React.Component<IAccessTextProps, void> {
       this.props.highlight !== nextProps.highlight
   }
 
-  private renderWithoutAccessKeys(): JSX.Element {
-    const text = this.props.text
-      .replace(/&([^&])/, '$1')
-      .replace('&&', '')
-
-    return <span>{text}</span>
-  }
-
   public render() {
-
-    if (!this.props.highlight) {
-      return this.renderWithoutAccessKeys()
-    }
 
     // Match everything (if anything) before an ampersand followed by anything that's
     // not an ampersand and then capture the remainder.
     const m = this.props.text.match(/^(.*?)?(?:&([^&]))(.*)?$/)
 
     if (!m) {
-      return this.renderWithoutAccessKeys()
+      return <span>{this.props.text}</span>
     }
 
     const elements = new Array<JSX.Element>()
@@ -56,7 +45,12 @@ export class AccessText extends React.Component<IAccessTextProps, void> {
       elements.push(<span key={1}>{m[1].replace('&&', '&')}</span>)
     }
 
-    elements.push(<span key={2} className='access-key highlight'>{m[2]}</span>)
+    const className = classNames(
+      'access-key',
+      { highlight: this.props.highlight }
+    )
+
+    elements.push(<span key={2} className={className}>{m[2]}</span>)
 
     if (m[3]) {
       elements.push(<span key={3}>{m[3].replace('&&', '&')}</span>)


### PR DESCRIPTION
This fixes a subtle kerning issue when toggling between highlighting access keys that was bugging the hell out of me.

![access-text](https://cloud.githubusercontent.com/assets/634063/23963085/80b28888-09b0-11e7-9e4a-290d8712c7ae.gif)

It's perhaps most noticeable if you look at the **R** in Repository.

This fixes it by always having the `AccessText` component always render the same markup and only toggling a class name when access keys are to be highlighted.