### PR TITLE
react needs a key when returning array of elements

### DIFF
--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -45,7 +45,7 @@ export class RichText extends React.Component<IRichTextProps, void> {
         case TokenType.Link:
           return <LinkButton key={index} uri={token.url} children={token.text} />
         case TokenType.Text:
-          return <span>{token.text}</span>
+          return <span key={index}>{token.text}</span>
         default:
           return assertNever(token, 'Unknown token type: ${r.kind}')
       }


### PR DESCRIPTION
I overlooked this while reviewing #1034

<img width="663" src="https://cloud.githubusercontent.com/assets/359239/23974893/ab243724-0a2d-11e7-963a-b6d3d9821b39.png">
