### PR TITLE
ensure Windows shell opens in repository location

### DIFF
--- a/app/src/lib/open-shell.ts
+++ b/app/src/lib/open-shell.ts
@@ -10,14 +10,9 @@ export function openShell(fullPath: string, shell?: string) {
   }
 
   if (__WIN32__) {
-    const commandArgs = shell
-      // not sure what other sorts of arguments we expect here
-      // so for now let's just try and launch this other shell
-      ? [ shell ]
-      // '/K' to run the subseqent command and keep the prompt visible
-      // 'TITLE {value}' sets the Command Prompt title to {value}
-      : [ 'cmd', '/K', 'TITLE GitHub Desktop' ]
-    return spawn('START', commandArgs, { 'shell': true, cwd: fullPath })
+    // not sure what other sorts of arguments we expect here
+    // so for now let's just try and launch this other shell
+    return spawn('START', [ shell || 'cmd' ], { 'shell': true, cwd: fullPath })
   }
 
   return fatalError('Unsupported OS')


### PR DESCRIPTION
It looks like doing `Open in Shell` on Windows is defaulting to where the app is launched from, and not the repository location.

Before:

<img width="483" src="https://cloud.githubusercontent.com/assets/359239/23976501/0b4b437c-0a38-11e7-9f1d-c4273acc7f6d.png">

After:

<img width="542"  src="https://cloud.githubusercontent.com/assets/359239/23976471/d8285944-0a37-11e7-9e06-521b017bb438.png">

The message doesn't appear currently due to using `/K` to set the command prompt title. I'm fine with dropping that if we aren't attached to changing the title.

 - [x] test on Windows that a new shell is launched
 - [x] test on macOS that a new terminal is launched each time