### PR TITLE
set selected repository on launch

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -624,7 +624,7 @@ export class AppStore {
       newSelectedRepository = r
     }
 
-    if (newSelectedRepository !== null && this.repositories.length > 0) {
+    if (newSelectedRepository === null && this.repositories.length > 0) {
       const lastSelectedID = parseInt(localStorage.getItem(LastSelectedRepositoryIDKey) || '', 10)
       if (lastSelectedID && !isNaN(lastSelectedID)) {
         newSelectedRepository = this.repositories.find(r => r.id === lastSelectedID) || null


### PR DESCRIPTION
Seems to have been a regression introduced by #946.

Entering that loop only when a repository was previously found seems suboptimal, whereas it should be run when no repository is already selected.

 - [x] test launch when selected repository is found in previous session
 - [x] test launch when selected repository is missing in previous session