### PR TITLE
Work around faulty type signature in MenuItem#click

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -104,7 +104,8 @@ app.on('ready', () => {
     if (menuItem) {
       const window = BrowserWindow.fromWebContents(event.sender)
       const fakeEvent = { preventDefault: () => {}, sender: event.sender }
-      menuItem.click(menuItem, window, fakeEvent)
+      const m = menuItem as any
+      m.click(fakeEvent, window, event.sender)
     }
   })
 


### PR DESCRIPTION
So it turns out that the type signature for the click method on `MenuItem` was wrong in our type definitions. I've fixed it upstream in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15214 but this will work around the problem for now.

Fixes #1040.