### PR TITLE
Pin @types/react to avoid breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/keytar": "^3.0.30",
     "@types/mocha": "^2.2.29",
     "@types/node": "^6.0.31",
-    "@types/react": "15.0.17",
+    "@types/react": "15.0.16",
     "@types/react-addons-css-transition-group": "^15.0.1",
     "@types/react-addons-test-utils": "^0.14.17",
     "@types/react-dom": "^0.14.23",


### PR DESCRIPTION
Seems like the DefinitelyTyped package for React broke us by [stopping SVGElement from inheriting the attributes of HTMLElement](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14618).

Let's pin to the last known good version and wait and see where the discussion in that issue ends up.