### PR TITLE
sometimes you can get null mentionables

### DIFF
--- a/app/src/lib/dispatcher/github-user-store.ts
+++ b/app/src/lib/dispatcher/github-user-store.ts
@@ -61,6 +61,7 @@ export class GitHubUserStore {
 
     const response = await api.fetchMentionables(repository.owner.login, repository.name, etag)
     if (!response) { return }
+    if (!response.users) { return }
 
     if (response.etag) {
       this.mentionablesEtags.set(repositoryID, response.etag)


### PR DESCRIPTION
This seems to occur when refreshing a private GitHub repository when you're not signed in:

<img width="1393" src="https://cloud.githubusercontent.com/assets/359239/24174340/412badaa-0ee4-11e7-9e7c-619d233c291d.png">
