### PR TITLE
tidy up error message when issue fetch fails

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -559,8 +559,7 @@ export class AppStore {
     try {
       await this._issuesStore.fetchIssues(repository, user)
     } catch (e) {
-      console.log(`Error fetching issues for ${repository.name}:`)
-      console.error(e)
+      console.warn(`Unable to fetch issues for ${repository.fullName}: ${e}`)
     }
   }
 


### PR DESCRIPTION
This is silly noisy. We can hide the network error but the second/third errors could be better:

<img width="1393" src="https://cloud.githubusercontent.com/assets/359239/24174901/7420e600-0ee7-11e7-9129-a3f69b36b194.png">

Now:

<img width="1126"  src="https://cloud.githubusercontent.com/assets/359239/24175114/8e7498b6-0ee8-11e7-949e-4c2d1bdde7b1.png">
