### PR TITLE
restore the colour for the removed status octicon

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -23,7 +23,7 @@
   $white: #fff;
 
   --color-new: $green;
-  --color-removed: $red;
+  --color-deleted: $red;
   --color-modified: $yellow;
 
   --text-color: $darkGray;


### PR DESCRIPTION
Looks like the colour got renamed in https://github.com/desktop/desktop/commit/ef2fffbd32fd2371b1f427a61c589ff2cf9fbc1e but no linting picked up the missing reference on [this line](https://github.com/desktop/desktop/commit/ef2fffbd32fd2371b1f427a61c589ff2cf9fbc1e#diff-56bd8fb66c44d557d51ae54649ca2498R47).

Before:

<img width="380" src="https://cloud.githubusercontent.com/assets/359239/24176149/64e2ce54-0eee-11e7-8c26-113b8f59e7a9.png">

After:

<img width="391" src="https://cloud.githubusercontent.com/assets/359239/24176148/64e16168-0eee-11e7-835c-38c0eced6685.png">


