### PR TITLE
render the cancel button when prompting for 2FA

### DIFF
--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -68,6 +68,7 @@ export class SignIn extends React.Component<ISignInProps, void> {
         loading={state.loading}
         error={state.error}
         type={state.type}
+        additionalButtons={this.props.children}
         onOTPEntered={this.onOTPEntered}
       />
     )

--- a/app/src/ui/lib/two-factor-authentication.tsx
+++ b/app/src/ui/lib/two-factor-authentication.tsx
@@ -19,6 +19,9 @@ interface ITwoFactorAuthenticationProps {
    */
   readonly onOTPEntered: (otp: string) => void
 
+  /** An array of additional buttons to render after the "Sign In" button. */
+  readonly additionalButtons?: ReadonlyArray<JSX.Element>
+
   /**
    * An error which, if present, is presented to the
    * user in close proximity to the actions or input fields
@@ -75,6 +78,7 @@ export class TwoFactorAuthentication extends React.Component<ITwoFactorAuthentic
           {errors}
 
           <Button type='submit' disabled={signInDisabled}>Verify</Button>
+          {this.props.additionalButtons}
 
           {this.props.loading ? <Loading/> : null}
         </Form>


### PR DESCRIPTION
Fixes #867 for the welcome wizard flow (cancel puts you back on the "Welcome to GitHub Desktop" page):

<img width="825"  src="https://cloud.githubusercontent.com/assets/359239/24176960/84e03a7a-0ef3-11e7-9e9f-91999788708a.png">

The preferences flow is a bit more polished with the position of the buttons - @niik @donokuda want this to address that (and the submit button text being slightly different) while we're in here?

<img width="437"  src="https://cloud.githubusercontent.com/assets/359239/24176968/9a248aa8-0ef3-11e7-87d6-b8d32d88052c.png">
