### PR TITLE
Disable auxclick event

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -77,6 +77,11 @@ export class AppWindow {
       // This fixes subpixel aliasing on Windows
       // See https://github.com/atom/atom/commit/683bef5b9d133cb194b476938c77cc07fd05b972
       backgroundColor: '#fff',
+      webPreferences: {
+        // Disable auxclick event
+        // See https://developers.google.com/web/updates/2016/10/auxclick
+        disableBlinkFeatures: 'Auxclick',
+      },
     }
 
     if (__DARWIN__) {

--- a/app/src/shared-process/shared-process.ts
+++ b/app/src/shared-process/shared-process.ts
@@ -16,6 +16,11 @@ export class SharedProcess {
       height: 100,
       show: false,
       title: 'SharedProcess',
+      webPreferences: {
+        // Disable auxclick event
+        // See https://developers.google.com/web/updates/2016/10/auxclick
+        disableBlinkFeatures: 'Auxclick',
+      },
     })
 
     this.window.webContents.on('did-finish-load', () => {


### PR DESCRIPTION
Chrome 55 shipped the `auxclick` event which causes the `click` event to not fire on middle mouse clicks anymore.

This mean links middle clicked in desktop will open in new windows unless this option is disabled or an `auxclick` event handler is registered.

This pull request opts out of auxclick altogether so middle clicks don't open new windows.

https://developers.google.com/web/updates/2016/10/auxclick
https://www.chromestatus.com/feature/5663174342737920