### PR TITLE
Prevent all new-window webContents events

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -269,9 +269,10 @@ app.on('activate', () => {
 })
 
 app.on('web-contents-created', (event, contents) => {
-  contents.on('new-window', (event) => {
+  contents.on('new-window', (event, url) => {
     // Prevent links or window.open from opening new windows
     event.preventDefault()
+    sharedProcess!.console.log(`Prevented new window to: ${url}`)
   })
 })
 


### PR DESCRIPTION
This change adds a `new-window` listener for every `webContents` object created and prevents the event.

This will prevent Electron from opening new windows for link clicks or `window.open` calls since Desktop manages windows explicitly instead of relying on the browser-like behavior.

https://electron.atom.io/docs/api/web-contents/#event-new-window