### PR TITLE
Use real name if available

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -43,7 +43,9 @@ export class ConfigureGitUser extends React.Component<IConfigureGitUserProps, IC
 
     const user = this.props.users[0]
     if ((!name || !name.length) && user) {
-      name = user.login
+      name = user.name && user.name.length
+        ? user.name
+        : user.login
     }
 
     if ((!email || !email.length) && user) {


### PR DESCRIPTION
We were pre-filling the Git name based on the login (i.e. username) of the signed in user rather than the real name from the API.

We should use the real name