### PR TITLE
tidy up unnecessary packages in shrinkwrap file

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -2,28 +2,10 @@
   "name": "desktop",
   "version": "0.0.30",
   "dependencies": {
-    "7zip": {
-      "version": "0.0.6",
-      "from": "7zip@0.0.6",
-      "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
-      "dev": true
-    },
-    "accessibility-developer-tools": {
-      "version": "2.11.0",
-      "from": "accessibility-developer-tools@>=2.11.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.11.0.tgz",
-      "dev": true
-    },
     "ajv": {
       "version": "4.11.5",
       "from": "ajv@>=4.9.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz"
-    },
-    "ansi-html": {
-      "version": "0.0.6",
-      "from": "ansi-html@0.0.6",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.6.tgz",
-      "dev": true
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -95,12 +77,6 @@
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "optional": true
-    },
-    "big.js": {
-      "version": "3.1.3",
-      "from": "big.js@>=3.1.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-      "dev": true
     },
     "bl": {
       "version": "1.2.0",
@@ -207,12 +183,6 @@
       "from": "cross-spawn-async@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz"
     },
-    "cross-unzip": {
-      "version": "0.0.2",
-      "from": "cross-unzip@0.0.2",
-      "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.0.2.tgz",
-      "dev": true
-    },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
@@ -270,12 +240,6 @@
       "from": "delayed-stream@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
-    "devtron": {
-      "version": "1.4.0",
-      "from": "devtron@latest",
-      "resolved": "https://registry.npmjs.org/devtron/-/devtron-1.4.0.tgz",
-      "dev": true
-    },
     "dexie": {
       "version": "1.4.1",
       "from": "dexie@>=1.4.1 <2.0.0",
@@ -297,40 +261,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "optional": true
     },
-    "electron-debug": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/electron-debug/-/electron-debug-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-1.1.0.tgz",
-      "dev": true
-    },
-    "electron-devtools-installer": {
-      "version": "2.1.0",
-      "from": "electron-devtools-installer@latest",
-      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.1.0.tgz",
-      "dev": true
-    },
-    "electron-is-dev": {
-      "version": "0.1.2",
-      "from": "electron-is-dev@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-0.1.2.tgz",
-      "dev": true
-    },
-    "electron-localshortcut": {
-      "version": "0.6.1",
-      "from": "electron-localshortcut@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-0.6.1.tgz",
-      "dev": true
-    },
     "electron-window-state": {
       "version": "4.0.2",
       "from": "electron-window-state@4.0.2",
       "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-4.0.2.tgz"
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "from": "emojis-list@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -498,33 +432,15 @@
       "from": "hawk@>=3.1.3 <3.2.0",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
-    "highlight.js": {
-      "version": "9.9.0",
-      "from": "highlight.js@>=9.3.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.9.0.tgz",
-      "dev": true
-    },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
-    "html-entities": {
-      "version": "1.2.0",
-      "from": "html-entities@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
-      "dev": true
-    },
     "http-signature": {
       "version": "1.1.1",
       "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-    },
-    "humanize-plus": {
-      "version": "1.8.2",
-      "from": "humanize-plus@>=1.8.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.15",
@@ -628,12 +544,6 @@
       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
-    "json5": {
-      "version": "0.5.1",
-      "from": "json5@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "dev": true
-    },
     "jsonfile": {
       "version": "2.3.1",
       "from": "jsonfile@>=2.2.3 <3.0.0",
@@ -660,12 +570,6 @@
       "version": "3.0.2",
       "from": "keytar@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/keytar/-/keytar-3.0.2.tgz"
-    },
-    "loader-utils": {
-      "version": "1.0.3",
-      "from": "loader-utils@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.3.tgz",
-      "dev": true
     },
     "lodash": {
       "version": "4.17.4",
@@ -827,12 +731,6 @@
       "from": "qs@>=6.4.0 <6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
     },
-    "querystring": {
-      "version": "0.2.0",
-      "from": "querystring@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "dev": true
-    },
     "react": {
       "version": "15.4.2",
       "from": "react@>=15.4.2 <16.0.0",
@@ -843,22 +741,10 @@
       "from": "react-addons-css-transition-group@latest",
       "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.2.tgz"
     },
-    "react-addons-perf": {
-      "version": "15.4.2",
-      "from": "react-addons-perf@latest",
-      "resolved": "https://registry.npmjs.org/react-addons-perf/-/react-addons-perf-15.4.2.tgz",
-      "dev": true
-    },
     "react-addons-shallow-compare": {
       "version": "15.4.2",
       "from": "react-addons-shallow-compare@latest",
       "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.2.tgz"
-    },
-    "react-addons-test-utils": {
-      "version": "15.4.2",
-      "from": "react-addons-test-utils@latest",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
-      "dev": true
     },
     "react-dom": {
       "version": "15.4.2",
@@ -899,12 +785,6 @@
       "version": "1.0.5",
       "from": "seek-bzip@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz"
-    },
-    "semver": {
-      "version": "5.3.0",
-      "from": "semver@>=5.3.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "dev": true
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -969,12 +849,6 @@
       "version": "1.0.0",
       "from": "strip-eof@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
-    },
-    "style-loader": {
-      "version": "0.13.2",
-      "from": "style-loader@0.13.2",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
-      "dev": true
     },
     "sum-up": {
       "version": "1.0.3",
@@ -1068,12 +942,6 @@
       "version": "1.3.6",
       "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-    },
-    "webpack-hot-middleware": {
-      "version": "2.15.0",
-      "from": "webpack-hot-middleware@>=2.10.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.15.0.tgz",
-      "dev": true
     },
     "whatwg-fetch": {
       "version": "2.0.2",


### PR DESCRIPTION
While `npm install` and `npm uninstall` seem to also update the shrinkwrap file, it looks like a bunch of things are still lying around that we don't need.

Here's what I did, in case you want to try this on your setup:

```sh
npm install
npm prune
cd app
npm prune
npm shrinkwrap
```

I can also see some other packages that we probably don't need to ship, but that can be done later.