### PR TITLE
Fix text selection color again

### DIFF
--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react'
 import * as CodeMirror from 'codemirror'
 
+if (__DARWIN__) {
+  // This has to be required to support the `simple` scrollbar style.
+  require('codemirror/addon/scroll/simplescrollbars')
+}
+
+// Required for us to be able to customize the foreground color of selected text
+require('codemirror/addon/selection/mark-selection')
+
 interface ICodeMirrorHostProps {
   /**
    * An optional class name for the wrapper element around the

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -27,14 +27,6 @@ import { fatalError } from '../../lib/fatal-error'
 
 import { RangeSelectionSizePixels } from './edge-detection'
 
-if (__DARWIN__) {
-  // This has to be required to support the `simple` scrollbar style.
-  require('codemirror/addon/scroll/simplescrollbars')
-}
-
-// Required for us to be able to customize the foreground color of selected text
-require('codemirror/addon/selection/mark-selection')
-
 /** The props for the Diff component. */
 interface IDiffProps {
   readonly repository: Repository


### PR DESCRIPTION
The fix for text selection color that I implemented in #779 got accidentally removed in https://github.com/desktop/desktop/compare/50013ea198fc51b2ecb7fae68a816e22abaa89d6...09f64969ab4db1e1a0812064748d96510d65582a#diff-bc3468e262ccad6f24b313c094c98b5aL35

### Before

![image](https://cloud.githubusercontent.com/assets/634063/24521925/219e7b10-158e-11e7-96c9-8cc0c1cc1996.png)

### After

![image](https://cloud.githubusercontent.com/assets/634063/24521954/42e1113e-158e-11e7-909b-39bfe6845256.png)
