### PR TITLE
Bump Electron to 1.6.5

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 1.6.0
+target = 1.6.5
 arch = x64

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai-datetime": "^1.4.1",
     "cross-env": "^3.2.3",
     "css-loader": "^0.26.2",
-    "electron": "1.6.3",
+    "electron": "1.6.5",
     "electron-mocha": "3.3.0",
     "electron-packager": "8.6.0",
     "electron-winstaller": "2.5.2",


### PR DESCRIPTION
Bumping to see if this happens to fix #1122.

@desktop/core usual reminder that you'll have to delete `app/node_modules` when this lands so that native modules are rebuilt against the updated Electron.