### PR TITLE
Update to Electron 1.6.6

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 1.6.5
+target = 1.6.6
 arch = x64

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai-datetime": "^1.4.1",
     "cross-env": "^3.2.3",
     "css-loader": "^0.26.2",
-    "electron": "1.6.5",
+    "electron": "1.6.6",
     "electron-mocha": "3.3.0",
     "electron-packager": "8.6.0",
     "electron-winstaller": "2.5.2",


### PR DESCRIPTION
This includes the certificate trust API needed for https://github.com/desktop/desktop/issues/671.