### PR TITLE
Let's just use the same focus styles on both platforms

### DIFF
--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -133,12 +133,7 @@ button {
   outline: none;
 }
 
-// On windows the default outline is a sad-looking yellow thing which
-// diverges completely from our other focus styles so we'll tweak it
-// to feel more at home with the rest of the app.
-@include win32-context {
-  // http://stackoverflow.com/questions/7538771/what-is-webkit-focus-ring-color
-  :focus {
-    outline: auto 5px var(--focus-color);
-  }
+// http://stackoverflow.com/questions/7538771/what-is-webkit-focus-ring-color
+:focus {
+  outline: auto 5px var(--focus-color);
 }


### PR DESCRIPTION
I noticed today that list items on Windows had a fuzzy outline when focused.

![image](https://cloud.githubusercontent.com/assets/634063/24998330/14a1b13c-203a-11e7-8efb-dae8d8cd4778.png)

I traced this us using the win32-context to only apply the custom focus ring color on Windows which meant that the rule becae `body.platform-win32 :focus` which took precedence over our `.list-item:focus` rule which removed the outline.

We could make the list item focus rule more specific but after thinking about it I don't see any harm in us ensuring that the focus ring color is the same across platforms, it's pretty much identical (just slightly darker) to the default ring on macOS already and this will make it easier for us to spot when we break the focus styles regardless of platform.

### Before

![image](https://cloud.githubusercontent.com/assets/634063/24998428/5fa48f60-203a-11e7-897d-d51fc434f1e1.png)

### After

![image](https://cloud.githubusercontent.com/assets/634063/24998452/72efbc0c-203a-11e7-8fc8-5cc95bc30077.png)

### macOS focus ring before

<img width="276" alt="screen shot 2017-04-13 at 11 16 01" src="https://cloud.githubusercontent.com/assets/634063/24998512/a46d2abc-203a-11e7-8afb-5eea219b8992.png">


### macOS focus ring after

<img width="282" alt="screen shot 2017-04-13 at 11 16 49" src="https://cloud.githubusercontent.com/assets/634063/24998532/b6e35964-203a-11e7-9df7-643eff35facf.png">
