### PR TITLE
tidy up this workaround

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -8,40 +8,7 @@ import { URLActionType } from '../lib/parse-url'
 import { ILaunchStats } from '../lib/stats'
 import { menuFromElectronMenu } from '../models/app-menu'
 
-import * as Path from 'path'
-import * as Fs from 'fs'
-
 let windowStateKeeper: any | null = null
-
-// NOTE:
-// This is a workaround for an upstream issue with electron-window-state
-// where a null x/y will crash screen.getDisplayMatching() before our app
-// can launch correctly.
-//
-// This can be removed after we've updated our beta users to electron-window-state@4.0.1
-// which will serialize 0 correctly again. See the upstream PR:
-// https://github.com/mawie81/electron-window-state/pull/16/
-function sanitizeBeforeReadingSync() {
-  const userData = app.getPath('userData')
-  const file = 'window-state.json'
-  const filePath = Path.join(userData, file)
-
-  try {
-    const text = Fs.readFileSync(filePath, 'utf-8')
-    if (text.length) {
-      const json = JSON.parse(text)
-
-      if (json.x === null || json.x === null) {
-        json.x = json.x || 0
-        json.y = json.y || 0
-        const newContents = JSON.stringify(json)
-        Fs.writeFileSync(filePath, newContents)
-      }
-    }
-  } catch (e) {
-    // swallow this error, live a happy life
-  }
-}
 
 export class AppWindow {
   private window: Electron.BrowserWindow
@@ -58,8 +25,6 @@ export class AppWindow {
       // lazily.
       windowStateKeeper = require('electron-window-state')
     }
-
-    sanitizeBeforeReadingSync()
 
     const savedWindowState = windowStateKeeper({
       defaultWidth: 800,


### PR DESCRIPTION
For reference, this workaround was added in https://github.com/desktop/desktop/pull/843 and was first in `release-0.0.21` - we're at `release-0.0.33`, so we can probably clean this up now.