### PR TITLE
Menu can be null

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -228,8 +228,11 @@ export class AppWindow {
 
   /** Send the app menu to the renderer. */
   public sendAppMenu() {
-    const menu = menuFromElectronMenu(Menu.getApplicationMenu())
-    this.window.webContents.send('app-menu', { menu })
+    const appMenu = Menu.getApplicationMenu()
+    if (appMenu) {
+      const menu = menuFromElectronMenu(appMenu)
+      this.window.webContents.send('app-menu', { menu })
+    }
   }
 
   /** Report the exception to the renderer. */

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/chai-datetime": "0.0.30",
     "@types/classnames": "^0.0.32",
     "@types/codemirror": "0.0.38",
-    "@types/electron": "1.4.34",
+    "@types/electron": "^1.4.36",
     "@types/electron-window-state": "^2.0.28",
     "@types/event-kit": "^1.2.28",
     "@types/fs-extra": "0.0.37",


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15567 landed and updates the type definitions to correctly specify that there doesn't have to be a menu.

If there's not a menu we don't need to tell the renderer about it. Let's not worry about the theoretical case where the menu gets removed after having been added.