### PR TITLE
Fix the color of open menu bar buttons

### DIFF
--- a/app/styles/ui/window/_app-menu-bar.scss
+++ b/app/styles/ui/window/_app-menu-bar.scss
@@ -10,7 +10,7 @@
     }
   }
 
-  .toolbar-button:not(.open) > button {
+  .toolbar-dropdown:not(.open) > .toolbar-button > button {
     color: var(--toolbar-button-secondary-color);
 
     &:hover,&:focus {


### PR DESCRIPTION
This was inadvertently broken by me in #1208 when I created a container element around the toolbar-button in toolbar-dropdown

### Before

![image](https://cloud.githubusercontent.com/assets/634063/25203702/79a90d3a-255a-11e7-95bb-4188ccf352f6.png)


### After

![image](https://cloud.githubusercontent.com/assets/634063/25203697/726e8f72-255a-11e7-8f98-10cab521fd60.png)
