### PR TITLE
Fix git pull not using user name and email from config

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -1,4 +1,4 @@
-import { git, envForAuthentication } from './core'
+import { git, envForAuthentication, gitNetworkArguments } from './core'
 import { Repository } from '../../models/repository'
 import { Branch, BranchType } from '../../models/branch'
 import { Account } from '../../models/account'
@@ -29,9 +29,7 @@ export async function deleteBranch(repository: Repository, branch: Branch, accou
   // Let this propagate and leave it to the caller to handle
   if (remote) {
     const args = [
-      // Explicitly unset any defined credential helper, we rely on our
-      // own askpass for authentication.
-      '-c' , 'credential.helper=',
+      ...gitNetworkArguments,
       'push', remote, `:${branch.nameWithoutRemote}`,
     ]
 

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -1,4 +1,4 @@
-import { git, envForAuthentication } from './core'
+import { git, envForAuthentication, gitNetworkArguments } from './core'
 import { Account } from '../../models/account'
 import { ChildProcess } from 'child_process'
 
@@ -22,9 +22,7 @@ export async function clone(url: string, path: string, options: CloneOptions, pr
   }
 
   const args = [
-    // Explicitly unset any defined credential helper, we rely on our
-    // own askpass for authentication.
-      '-c' , 'credential.helper=',
+    ...gitNetworkArguments,
     'clone', '--recursive', '--progress',
   ]
 

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -207,6 +207,21 @@ function getAskPassScriptPath(): string {
   return Path.resolve(__dirname, 'ask-pass.js')
 }
 
+/**
+ * An array of command line arguments for network operation that unset
+ * or hard-code git configuration values that should not be read from
+ * local, global, or system level git configs.
+ *
+ * These arguments should be inserted before the subcommand, i.e in
+ * the case of `git pull` these arguments needs to go before the `pull`
+ * argument.
+ */
+export const gitNetworkArguments: ReadonlyArray<string> = [
+  // Explicitly unset any defined credential helper, we rely on our
+  // own askpass for authentication.
+  '-c' , 'credential.helper=',
+]
+
 /** Get the environment for authenticating remote operations. */
 export function envForAuthentication(account: Account | null): Object {
   const env = {

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -1,4 +1,4 @@
-import { git, envForAuthentication } from './core'
+import { git, envForAuthentication, gitNetworkArguments } from './core'
 import { Repository } from '../../models/repository'
 import { Account } from '../../models/account'
 
@@ -10,9 +10,7 @@ export async function fetch(repository: Repository, account: Account | null, rem
   }
 
   const args = [
-    // Explicitly unset any defined credential helper, we rely on our
-    // own askpass for authentication.
-    '-c' , 'credential.helper=',
+    ...gitNetworkArguments,
     'fetch', '--prune', remote,
   ]
 
@@ -27,9 +25,7 @@ export async function fetchRefspec(repository: Repository, account: Account | nu
   }
 
   const args = [
-    // Explicitly unset any defined credential helper, we rely on our
-    // own askpass for authentication.
-    '-c' , 'credential.helper=',
+    ...gitNetworkArguments,
     'fetch', remote, refspec,
   ]
 

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -1,4 +1,11 @@
-import { git, envForAuthentication, expectedAuthenticationErrors, GitError, IGitExecutionOptions } from './core'
+import {
+  git,
+  envForAuthentication,
+  expectedAuthenticationErrors,
+  GitError,
+  IGitExecutionOptions,
+  gitNetworkArguments,
+} from './core'
 import { Repository } from '../../models/repository'
 import { Account } from '../../models/account'
 
@@ -11,10 +18,8 @@ export async function pull(repository: Repository, account: Account | null, remo
   }
 
   const args = [
-    // Explicitly unset any defined credential helper, we rely on our
-    // own askpass for authentication.
-      '-c' , 'credential.helper=',
-      'pull' , '--verbose', remote, branch,
+    ...gitNetworkArguments,
+    'pull' , '--verbose', remote, branch,
   ]
 
   const result = await git(args, repository.path, 'pull', options)

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -1,13 +1,17 @@
-import { git, envForAuthentication, expectedAuthenticationErrors } from './core'
+import {
+  git,
+  envForAuthentication,
+  expectedAuthenticationErrors,
+  gitNetworkArguments,
+} from './core'
+
 import { Repository } from '../../models/repository'
 import { Account } from '../../models/account'
 
 /** Push from the remote to the branch, optionally setting the upstream. */
 export async function push(repository: Repository, account: Account | null, remote: string, branch: string, setUpstream: boolean): Promise<void> {
   const args = [
-    // Explicitly unset any defined credential helper, we rely on our
-    // own askpass for authentication.
-    '-c' , 'credential.helper=',
+    ...gitNetworkArguments,
     'push', remote, branch,
   ]
 


### PR DESCRIPTION
In #790 we started explicitly setting the `HOME` environment variable to an empty string for network operations to prevent Git from invoking any externally defined credential helper.

By unsetting the HOME environment variable we essentially make git only read configuration from the repository directory and the system, skipping the global (home config).

This does very little to prevent what it intends to prevent, to ensure that our network operations don't end up invoking a credential helper since if a credential helper is defined in the repository config that will still be used.

This also prevents users from setting using proxies or other configuration options that should apply globally for network operations. Most notably this prevents Git from reading `user.name` and `user.email` which is necessary for example for a pull operation where the pull ends up creating a merge commit.

Fixes #1261 