### PR TITLE
Listen for quit events on all platforms

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -60,20 +60,20 @@ export class AppWindow {
     this.window = new BrowserWindow(windowOptions)
     savedWindowState.manage(this.window)
 
+    let quitting = false
+    app.on('before-quit', () => {
+      quitting = true
+    })
+
+    ipcMain.on('will-quit', (event: Electron.IpcMainEvent) => {
+      quitting = true
+      event.returnValue = true
+    })
+
     // on macOS, when the user closes the window we really just hide it. This
     // lets us activate quickly and keep all our interesting logic in the
     // renderer.
     if (__DARWIN__) {
-      let quitting = false
-      app.on('before-quit', () => {
-        quitting = true
-      })
-
-      ipcMain.on('will-quit', (event: Electron.IpcMainEvent) => {
-        quitting = true
-        event.returnValue = true
-      })
-
       this.window.on('close', e => {
         if (!quitting) {
           e.preventDefault()


### PR DESCRIPTION
Fixes #1269

Otherwise we'd [send a synchronous message](https://github.com/desktop/desktop/blob/5fa1e6dabe7688f152de01fb0aca980f403b8347/app/src/ui/main-process-proxy.ts#L40) but never get a response, which would hang the renderer.

Alternatively, we could conditionalize _all_ this for Darwin. I slightly prefer this way so that we end up with less special-cased code.