### PR TITLE
Don't trust the Window state event

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -141,10 +141,11 @@ export class AppStore {
     this.signInStore = signInStore
     this.showWelcomeFlow = !hasShownWelcomeFlow()
 
-    this.windowState = getWindowState(remote.getCurrentWindow())
+    const window = remote.getCurrentWindow()
+    this.windowState = getWindowState(window)
 
     ipcRenderer.on('window-state-changed', (_, args) => {
-      this.windowState = args as WindowState
+      this.windowState = getWindowState(window)
       this.emitUpdate()
     })
 


### PR DESCRIPTION
Turns out that when we full-screen an app on macOS we get the following series of events about window state changes

```
hidden
full-screen
normal
```

This is due to a hack on our part in `app-windows.tsx` that should probably be looked at more closely but for now we'll explicitly retrieve the Window state when we get a notification about window state transitions.

Fixes #1247