### PR TITLE
Update the paddings for PathText in file list items

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -43,8 +43,8 @@ export class ChangedFile extends React.Component<IChangedFileProps, void> {
     const status = this.props.status
     const fileStatus = mapStatus(status)
 
-    const listItemPadding = 5 + 5
-    const checkboxWidth = 20 + 5
+    const listItemPadding = 10 * 2
+    const checkboxWidth = 20
     const statusWidth = 16
     const filePadding = 5
 

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -22,7 +22,9 @@ export class FileList extends React.Component<IFileListProps, void> {
     const status = file.status
     const fileStatus = mapStatus(status)
 
-    const listItemPadding = 5 + 5
+
+
+    const listItemPadding = 10 * 2
     const statusWidth = 16
     const filePathPadding = 5
     const availablePathWidth = this.props.availableWidth - listItemPadding - filePathPadding - statusWidth


### PR DESCRIPTION
These were updated in https://github.com/desktop/desktop/pull/1094/files#diff-1b60a35b9de691eef00bfcb35feb63ceR16 and https://github.com/desktop/desktop/commit/d350e1c5c319a5ded0de0888e2df2a34c0cdf651

Fixes #1270 