### PR TITLE
Document the ready-for-review label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ All changes are reviewed and the entire team is responsible for doing review.
 The usual flow:
 
 1. **Contributor** opens pull request.
-2. When it's ready for review, they comment on it saying so and add the `ready-for-review` label.
-3. Suddenly a wild **reviewer** appears!
-4. **Reviewer** assigns the PR to themselves.
-5. **Reviewer** leaves line comments with suggestions or questions.
-6. When the **reviewer** is done they comment on the PR with an emoji, meme, pokémon, or words.
-7. The **contributor** responds to feedback, makes changes, etc.
-8. When the **contributor** is ready for the **reviewer** to re-review, they comment on the PR with an emoji, meme, pokémon, or words.
-9. Goto 6 until both parties are happy with the PR.
-10. The **reviewer** hits the big green merge button and deletes the branch.
+1. When it's ready for review, they comment on it saying so and add the `ready-for-review` label.
+1. Suddenly a wild **reviewer** appears!
+1. **Reviewer** assigns the PR to themselves.
+1. **Reviewer** leaves line comments with suggestions or questions.
+1. When the **reviewer** is done they comment on the PR with an emoji, meme, pokémon, or words.
+1. The **contributor** responds to feedback, makes changes, etc.
+1. When the **contributor** is ready for the **reviewer** to re-review, they comment on the PR with an emoji, meme, pokémon, or words.
+1. Goto 6 until both parties are happy with the PR.
+1. The **reviewer** hits the big green merge button and deletes the branch.


### PR DESCRIPTION
We're using the `ready-for-review` label now so that we can better see the PRs that are ready.