### PR TITLE
Prevent whitespace branch names

### DIFF
--- a/app/src/ui/create-branch/index.tsx
+++ b/app/src/ui/create-branch/index.tsx
@@ -162,7 +162,7 @@ export class CreateBranch extends React.Component<ICreateBranchProps, ICreateBra
 
   private renderWarning() {
     if (/^\s+$/.test(this.state.proposedName)) {
-      return this.renderWarningMessage('  Branch name cannot be empty')
+      return this.renderWarningMessage('Branch name cannot be empty')
     } else if (this.state.proposedName !== this.state.sanitizedName) {
       return this.renderWarningMessage(`Will be created as ${this.state.sanitizedName}`)
     } else {


### PR DESCRIPTION
Fixes #1288 

I also added a warning for when the user attempts to name something along the lines of         .