### PR TITLE
Opening a create branch should persist the state it was opened with

### DIFF
--- a/app/src/ui/create-branch/index.tsx
+++ b/app/src/ui/create-branch/index.tsx
@@ -35,6 +35,7 @@ interface ICreateBranchState {
   readonly proposedName: string
   readonly sanitizedName: string
   readonly startPoint: StartPoint
+
   /**
    * Whether or not the dialog is currently creating a branch. This affects
    * the dialog loading state as well as the rendering of the branch selector.


### PR DESCRIPTION
Fixes #1304

@joshaber Curious to hear what you think about this solution. I felt like it was a nicer approach than ignoring prop updates in the CreateBranch dialog. Now we pass along all the state that should be required when we open the dialog.