### PR TITLE
bump the engines version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 6",
-    "npm": ">= 3"
+    "node": ">= 7",
+    "npm": ">= 4"
   },
   "dependencies": {
     "@niik/tslint-microsoft-contrib": "^2.0.14",


### PR DESCRIPTION
 A little bit of cleanup after bumping all the CI builds.

[Docs](https://docs.npmjs.com/files/package.json#engines):

> Unless the user has set the `engine-strict` config flag, this field is advisory only will produce warnings when your package is installed as a dependency.

Minor change, as this isn't published to `npm` and the `engine-strict` flag is no longer used since npm@3.
