### PR TITLE
types: what are they good for? saving things apparently

### DIFF
--- a/app/src/shared-process/database.ts
+++ b/app/src/shared-process/database.ts
@@ -10,7 +10,7 @@ export interface IDatabaseOwner {
 }
 
 export interface IDatabaseGitHubRepository {
-  id?: number
+  readonly id?: number | null
   readonly ownerID: number
   readonly name: string
   readonly private: boolean | null

--- a/app/src/shared-process/repositories-store.ts
+++ b/app/src/shared-process/repositories-store.ts
@@ -161,7 +161,7 @@ export class RepositoriesStore {
         }
       }
 
-      const info: IDatabaseGitHubRepository = {
+      let updatedInfo = {
         private: newGitHubRepo.private,
         fork: newGitHubRepo.fork,
         htmlURL: newGitHubRepo.htmlURL,
@@ -172,10 +172,10 @@ export class RepositoriesStore {
       }
 
       if (existingGitHubRepo) {
-        info.id = existingGitHubRepo.id
+        updatedInfo = { ...updatedInfo, id: existingGitHubRepo.id }
       }
 
-      gitHubRepositoryID = yield db.gitHubRepositories.put(info)
+      gitHubRepositoryID = yield db.gitHubRepositories.put(updatedInfo)
       yield db.repositories.update(localRepo.id, { gitHubRepositoryID })
     })
 


### PR DESCRIPTION
Fixes #1028 because we forget to persist the updated default branch name. Oops.
Also fixes #1314 by now correctly tracking when the default branch changes.

![](https://cloud.githubusercontent.com/assets/359239/25573423/9debb18e-2e88-11e7-97f2-6b44b396d871.png)

- [ ] tidy up the TYPES so that dexie is happy 

The commit 0d43c4e49507906b3b68743bf04051f2f8da807c is the important change here, as it drops the `any` usage and makes `id` properly optional (and also mutable).

With this change we would have caught the missing field:

>[at-loader] ./app/src/shared-process/repositories-store.ts:164:13 
    TS2322: Type '{ private: boolean | null; fork: boolean | null; htmlURL: string | null; name: string; ownerID: n...' is not assignable to type 'IDatabaseGitHubRepository'.
  Property 'defaultBranch' is missing in type '{ private: boolean | null; fork: boolean | null; htmlURL: string | null; name: string; ownerID: n...'.
