### PR TITLE
Make sure toolbar dropdowns have horizontal bounds

### DIFF
--- a/app/styles/ui/toolbar/_dropdown.scss
+++ b/app/styles/ui/toolbar/_dropdown.scss
@@ -1,4 +1,9 @@
 .toolbar-dropdown {
+
+  // Make sure the contents shrink beyond their intrinsic width
+  // See https://css-tricks.com/flexbox-truncated-text/
+  min-width: 0;
+
   &>.toolbar-button {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
I broke this by extracting the dropdown into its own container in #1208 

Fixes #1331.