### PR TITLE
bump the types

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "style-loader": "^0.16.1",
     "to-camel-case": "^1.0.0",
     "ts-loader": "^2.0.3",
-    "ts-node": "^1.7.3",
+    "ts-node": "^3.0.2",
     "tslint": "^3.14.0",
     "typescript": "2.3.2",
     "vrsource-tslint-rules": "^0.12.0",


### PR DESCRIPTION
Typescript [had a hotfix update](https://github.com/Microsoft/TypeScript/releases/tag/v2.3.2) a few days ago, but `ts-node` - which we use in our tests - is rather far behind.

Given `ts-node` is helpful for https://github.com/desktop/desktop/issues/48 it's probably worth checking we're all up to date here (`tslint` is the other one, but that's more critical and still complains about trailing commas that aren't necessary _sigh_). 