### PR TITLE
Fix padding for longer commit descriptions

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -75,11 +75,12 @@
 
   &-description-scroll-view {
     overflow: hidden;
-    max-height: 50px;
+    // The extra pixel makes the space align up with the commit list.
+    max-height: 61px;
 
     &:before {
       content: "";
-      background: linear-gradient(180deg, rgba(255,255,255,0) 40px, rgba(255,255,255,0.8));
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0) 40px, rgba(255, 255, 255, 0.5) 40px, white 60px);
       position: absolute;
       height: 100%;
       width: 100%;


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/1345

Since the original intention of removing the bottom padding was to hint that there's more information, I took a stab at bringing back the padding while keeping the affordance of more information. The expand/collapse commit description interaction still isn't perfect and is something I'd like to revisit post-beta.

**Before**

One line
<img width="725" alt="screen shot 2017-05-03 at 9 21 51 am" src="https://cloud.githubusercontent.com/assets/1174461/25670663/47674d40-2fe2-11e7-9582-e45efd385151.png">

Multiple lines
<img width="730" alt="screen shot 2017-05-03 at 9 21 42 am" src="https://cloud.githubusercontent.com/assets/1174461/25670662/47649dc0-2fe2-11e7-88af-21c8f8a77629.png">

**After**

I tried out showing part of the extra text and softening the cropping by using a slight fade. Open to suggestions on how to improve this.:

One line
<img width="724" alt="screen shot 2017-05-03 at 9 18 01 am" src="https://cloud.githubusercontent.com/assets/1174461/25670681/55c914ae-2fe2-11e7-85af-a62f3da1b394.png">

Multiple lines
<img width="727" alt="screen shot 2017-05-03 at 9 17 46 am" src="https://cloud.githubusercontent.com/assets/1174461/25670682/55d1a556-2fe2-11e7-8887-6e250521730b.png">




