### PR TITLE
Remove left margin from ahead-behind counter

### DIFF
--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -48,7 +48,6 @@
 .ahead-behind {
   display: flex;
 
-  margin-left: var(--spacing);
   background: var(--ahead-behind-background-color);
 
   // Perfectly round semi circle ends with real tight


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/1352

Prevents text from truncating a little too soon.

Since we already have some horizontal margin for the text to the left, this left margin isn't needed.

<img width="242" alt="screen shot 2017-05-03 at 1 03 01 pm" src="https://cloud.githubusercontent.com/assets/1174461/25679273/ab5d5cbc-3001-11e7-8334-d5ec11f43421.png">

