### PR TITLE
Fix Undo commit after switching repositories

### DIFF
--- a/app/src/lib/dispatcher/git-store.ts
+++ b/app/src/lib/dispatcher/git-store.ts
@@ -550,6 +550,8 @@ export class GitStore {
       this._tip = { kind: TipState.Unknown }
     }
 
+    this.emitUpdate()
+
     return status
   }
 


### PR DESCRIPTION
Fixes #1373

We update `tip` as part of the `loadStatus` call, so we also need to emit an update so that the updated tip gets copied into the branches state.