### PR TITLE
refresh installer icon for public launch

### DIFF
--- a/script/package
+++ b/script/package
@@ -46,7 +46,7 @@ function packageWindows () {
 
   // TODO: change this when the repository is public
   // 'https://raw.githubusercontent.com/desktop/desktop/master/app/static/logos/icon-logo.ico'
-  const iconUrl = 'https://www.dropbox.com/s/6n9wuyqhy9xhow4/icon.ico?dl=1'
+  const iconUrl = 'https://www.dropbox.com/s/l69699nsdv2hl64/icon-logo.ico?dl=1'
 
   const options = {
     appDirectory: distPath,


### PR DESCRIPTION
Squirrel likes a remote URL for the setup icon, so this needs to go in (with a new installer created) before the public reveal so that we get the shiny new icon displayed everywhere on Windows.

I'll queue up a PR after this for post-launch to swap in a public URL so we can finally get rid of this hack.