### PR TITLE
Fix blank second instance window

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -47,7 +47,7 @@ if (__WIN32__ && process.argv.length > 1) {
   }
 }
 
-const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
+const isDuplicateInstance = app.makeSingleInstance((commandLine, workingDirectory) => {
   // Someone tried to run a second instance, we should focus our window.
   if (mainWindow) {
     if (mainWindow.isMinimized()) {
@@ -64,7 +64,7 @@ const shouldQuit = app.makeSingleInstance((commandLine, workingDirectory) => {
   }
 })
 
-if (shouldQuit) {
+if (isDuplicateInstance) {
   app.quit()
 }
 
@@ -89,6 +89,8 @@ app.on('will-finish-launching', () => {
 })
 
 app.on('ready', () => {
+  if (isDuplicateInstance) { return }
+
   const now = Date.now()
   readyTime = now - launchTime
 


### PR DESCRIPTION
Fixes #1382 

It turns out we were hitting https://github.com/electron/electron/issues/8862. The second instance would get the `ready` event and end up throwing an exception. The blank window we'd see briefly was the uncaught exception window.