### PR TITLE
Workaround for resize observer not firing for scale transitions

### DIFF
--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -260,7 +260,7 @@ export class List extends React.Component<IListProps, IListState> {
     // bounding rectangle on Windows which we know will give us sane pixels.
     const { width, height } = __DARWIN__
       ? contentRect
-      : target.getBoundingClientRect()
+      : { width: target.offsetWidth, height: target.offsetHeight }
 
     if (this.state.width !== width || this.state.height !== height) {
       this.setState({ width, height })


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements

> If you need to know the total amount of space an element occupies, including the width of the visible content, scrollbars (if any), padding, and border, you want to use the offsetWidth and offsetHeight properties. Most of the time these are the same as width and height of getBoundingClientRect(), when there aren't any transforms applied to the element. In case of transforms, the **offsetWidth and offsetHeight returns the element's layout width and height**, while **getBoundingClientRect() returns the rendering width and height**. As an example, if the element has width: 100px; and transform: scale(0.5); the getBoundingClientRect() will return 50 as the width, while offsetWidth will return 100.

So that's the problem, the resize observer triggers when the layout dimensions changes, not the render dimensions so we get one call from the ResizeObserver when the dialog is transitioning in (and is at 75% scale) and then no updates as it's transitioning.

From: https://wicg.github.io/ResizeObserver/#intro

> - observation will fire when watched Element is inserted/removed from DOM.
> - observation will fire when watched Element display gets set to none.
> - observations do not fire for non-replaced inline Elements.
> - observations will not be triggered by CSS transforms.
> - observation will fire when observation starts if Element has display, and Element’s size is not 0,0.

By switching to `offsetWidth`/`offsetHeight` we loose subpixel resolution (which we don't need) but we gain a [pretty decent performance boost](https://jsperf.com/getboundingclientrect-vs-offsetwidth).

Fixes #1210 