### PR TITLE
Download the icon from our CDN

### DIFF
--- a/script/package
+++ b/script/package
@@ -46,7 +46,7 @@ function packageWindows () {
 
   // TODO: change this when the repository is public
   // 'https://raw.githubusercontent.com/desktop/desktop/master/app/static/logos/icon-logo.ico'
-  const iconUrl = 'https://www.dropbox.com/s/l69699nsdv2hl64/icon-logo.ico?dl=1'
+  const iconUrl = 'https://desktop.githubusercontent.com/icon-logo.ico'
 
   const options = {
     appDirectory: distPath,


### PR DESCRIPTION
I believe right now it sits on @shiftkey's dropbox and I definitely don't want this to hit any rate-limits. We're not going to be able to switch to the one in our repo (and tbh I'm not convinced we should) until after launch so it's better if we update now.