### PR TITLE
Uniqueier app id

### DIFF
--- a/script/package
+++ b/script/package
@@ -49,8 +49,7 @@ function packageWindows () {
   const iconUrl = 'https://www.dropbox.com/s/l69699nsdv2hl64/icon-logo.ico?dl=1'
 
   const options = {
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx#how
-    name: 'GitHub.Desktop',
+    name: 'GitHubDesktop',
     appDirectory: distPath,
     outputDirectory: outputDir,
     authors: distInfo.getCompanyName(),


### PR DESCRIPTION
When we're not specifying a name Squirrel (or rather electron-winstaller) will use the name from our package.json which is `desktop`. That means that Squirrel ends up installing into `AppData\Local\desktop`

![image](https://cloud.githubusercontent.com/assets/634063/25971606/27ea9032-369d-11e7-93ba-c14b23b89f4e.png)

That's not ideal as it could easily clash with something else.

⚠️ This change means that anyone who's got the app installed on Windows will have to uninstall and reinstall which is why it's way better we do that now than after the ship on Tuesday. ⚠️