### PR TITLE
Fix trailing carriage returns

### DIFF
--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -527,10 +527,28 @@ export class Diff extends React.Component<IDiffProps, void> {
         specialChars: /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200f\u2028\u2029\ufeff]/,
       }
 
+      // If the text looks like it could have been formatted using Windows
+      // line endings (\r\n) we  need to massage it a bit before we hand it
+      // off to CodeMirror. That's because CodeMirror has two ways of splitting
+      // lines, one is the built in which splits on \n, \r\n and \r. The last
+      // one is important because that will match carriage return characters
+      // inside a diff line. The other way is when consumers supply the 
+      // lineSeparator option. That option only takes a string meaning we can
+      // either make it split on '\r\n', '\n' or '\r' but not what we would like
+      // to do, namely '\r?\n'. We want to keep CR characters inside of a diff
+      // line so that we can mark them using the specialChars attribute so
+      // we convert all \r\n to \n and remove any trailing \r character.
+      const text = diff.text.indexOf('\r') !== -1
+        ? diff.text
+          // Capture the \r if followed by (positive lookahead) a \n or
+          // the end of the string. Note that this does not capture the \n.
+          .replace(/\r(?=\n|$)/g, '')
+        : diff.text
+
       return (
         <CodeMirrorHost
           className='diff-code-mirror'
-          value={diff.text}
+          value={text}
           options={options}
           isSelectionEnabled={this.isSelectionEnabled}
           onChanges={this.onChanges}


### PR DESCRIPTION
In #1234 I made CodeMirror show carriage returns as special characters which worked excellent in the tiny example that I pulled out where we had one giant diff line interspersed with carriage returns.

![image](https://cloud.githubusercontent.com/assets/634063/25992737/ceccc27a-3707-11e7-82cf-6724a7f6413a.png)

Unfortunately, it did not work as great for files saved with windows line endings.

![image](https://cloud.githubusercontent.com/assets/634063/25992679/a5c4efd8-3707-11e7-80f7-c9bc30605d26.png)

With this change we strip out carriage return characters *if they are followed by a newline or sit at the end of the diff*. The result being

![image](https://cloud.githubusercontent.com/assets/634063/25992722/c0ad395e-3707-11e7-9df3-1c5a5cc13a61.png)

While still preserving the behavior we want for long lines with interspersed carriage return characters.

Note that this is a presentation concern only which is why this resides inside of the Diff component and not in the diff parsing logic. We need to preserve these special characters in the raw diff so that we can accurately construct a patch file when committing partial files.