### PR TITLE
GPU layers need an opaque background to apply subpixel aliasing

### DIFF
--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -6,6 +6,10 @@
   // constrain to the size of their flexbox
   // parent.
   min-width: 0;
+
+  .ReactVirtualized__Grid {
+    background: var(--background-color);
+  }
 }
 
 @include win32-context {


### PR DESCRIPTION
This enables ClearType (or subpixel antialiasing) in **non-overflowed** virtualized lists

![cleartype](https://cloud.githubusercontent.com/assets/634063/26003464/09d1415e-3733-11e7-9100-db6e2976817a.gif)

https://bugs.chromium.org/p/chromium/issues/detail?id=227101