### PR TITLE
handle unborn branch scenarios better

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -968,6 +968,8 @@ export class AppStore {
     if (state.branchesState.tip.kind === TipState.Valid) {
       const currentBranch = state.branchesState.tip.branch
       await gitStore.loadLocalCommits(currentBranch)
+    } else if (state.branchesState.tip.kind === TipState.Unborn) {
+      await gitStore.loadLocalCommits(null)
     }
   }
 

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1481,6 +1481,17 @@ export class AppStore {
 
     await gitStore.undoCommit(commit)
 
+    const state = this.getRepositoryState(repository)
+    const selectedCommit = state.historyState.selection.sha
+
+    if (selectedCommit === commit.sha) {
+      // clear the selection of this commit in the history view
+      this.updateHistoryState(repository, state => {
+        const selection = { sha: null, file: null }
+        return { selection }
+      })
+    }
+
     return this._refreshRepository(repository)
   }
 

--- a/app/src/lib/dispatcher/git-store.ts
+++ b/app/src/lib/dispatcher/git-store.ts
@@ -322,7 +322,15 @@ export class GitStore {
   /** The most recently checked out branches. */
   public get recentBranches(): ReadonlyArray<Branch> { return this._recentBranches }
 
-  /** Load the local commits. */
+  /**
+   * Load local commits into memory for the current repository.
+   *
+   * @param branch The branch to query for unpublished commits.
+   *
+   * If the tip of the repository does not have commits (i.e. is unborn), this
+   * should be invoked with `null`, which clears any existing commits from the
+   * store.
+   */
   public async loadLocalCommits(branch: Branch | null): Promise<void> {
 
     if (branch === null) {

--- a/app/src/lib/dispatcher/git-store.ts
+++ b/app/src/lib/dispatcher/git-store.ts
@@ -323,7 +323,13 @@ export class GitStore {
   public get recentBranches(): ReadonlyArray<Branch> { return this._recentBranches }
 
   /** Load the local commits. */
-  public async loadLocalCommits(branch: Branch): Promise<void> {
+  public async loadLocalCommits(branch: Branch | null): Promise<void> {
+
+    if (branch === null) {
+      this._localCommitSHAs = [ ]
+      return
+    }
+
     let localCommits: ReadonlyArray<Commit> | undefined
     if (branch.upstream) {
       const revRange = `${branch.upstream}..${branch.name}`

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -917,6 +917,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     const remoteName = state.remote ? state.remote.name : null
     const progress = state.pushPullFetchProgress
 
+    const tip =  selection.state.branchesState.tip
+    const branchExists = tip.kind === TipState.Valid
+
     return <PushPullButton
       dispatcher={this.props.dispatcher}
       repository={selection.repository}
@@ -924,6 +927,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       remoteName={remoteName}
       lastFetched={state.lastFetched}
       networkActionInProgress={state.isPushPullFetchInProgress}
+      branchExists={branchExists}
       progress={progress}
     />
   }

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -27,7 +27,10 @@ interface IPushPullButtonProps {
   readonly progress: Progress | null
 
   readonly dispatcher: Dispatcher
+
   readonly repository: Repository
+
+  readonly branchExists: boolean
 }
 
 /**
@@ -49,7 +52,9 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, void> 
       ? progress.value
       : undefined
 
-    const disabled = this.props.networkActionInProgress || !!this.props.progress
+    const disabled = this.props.branchExists
+     ? this.props.networkActionInProgress || !!this.props.progress
+     : true
 
     return (
       <ToolbarButton

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -24,13 +24,17 @@ interface IPushPullButtonProps {
   /** The date of the last fetch. */
   readonly lastFetched: Date | null
 
+  /** Progress information associated with the current operation */
   readonly progress: Progress | null
 
+  /** True if the current repository has a valid local branch. False if unborn. */
+  readonly branchExists: boolean
+
+  /** The global dispatcher, to invoke repository operations. */
   readonly dispatcher: Dispatcher
 
+  /** The current repository */
   readonly repository: Repository
-
-  readonly branchExists: boolean
 }
 
 /**

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -124,6 +124,18 @@ describe('GitStore', () => {
       expect(context).to.not.be.null
       expect(context!.summary).to.equal(commitMessage)
     })
+
+    it('clears the undo commit dialog', async () => {
+      const gitStore = new GitStore(repo!, shell)
+
+      const commit = await getCommit(repo!, 'master')
+      expect(commit).to.not.equal(null)
+      expect(commit!.parentSHAs.length).to.equal(0)
+
+      await gitStore.undoCommit(commit!)
+
+      expect(gitStore.localCommitSHAs).to.be.empty
+    })
   })
 
   it('hides commented out lines from MERGE_MSG', async () => {


### PR DESCRIPTION
Fixes #1450 

- [x] update undo dialog when branch is unborn
- [x] clear selected commit if we just undid it
- [x] publish should be disabled for unborn branch