### PR TITLE
use an array to send menu updates to the main process

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -195,5 +195,9 @@ export function updateMenuState(state: IAppState, currentAppMenu: AppMenu | null
     return
   }
 
-  ipcUpdateMenuState(menuState)
+  // because we can't send Map over the wire, we need to convert
+  // the remaining entries into an array that can be serialized
+  const array = new Array<{id: MenuIDs, state: IMenuItemState}>()
+  menuState.forEach((value, key) => array.push({ id: key, state: value }))
+  ipcUpdateMenuState(array)
 }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -130,12 +130,12 @@ app.on('ready', () => {
     }
   })
 
-  ipcMain.on('update-menu-state', (event: Electron.IpcMainEvent, items: { [id: string]: IMenuItemState }) => {
+  ipcMain.on('update-menu-state', (event: Electron.IpcMainEvent, items: Array<{ id: string, state: IMenuItemState }>) => {
     let sendMenuChangedEvent = false
 
-    for (const id of Object.keys(items)) {
+    for (const item of items) {
+      const { id, state } = item
       const menuItem = findMenuItemByID(menu, id)
-      const state = items[id]
 
       if (menuItem) {
         // Only send the updated app menu when the state actually changes

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -4,7 +4,7 @@ import { MenuIDs } from '../main-process/menu'
 import { IMenuItemState } from '../lib/menu-update'
 
 /** Set the menu item's enabledness. */
-export function updateMenuState(state: Map<MenuIDs, IMenuItemState>) {
+export function updateMenuState(state: Array<{id: MenuIDs, state: IMenuItemState}>) {
   ipcRenderer.send('update-menu-state', state)
 }
 


### PR DESCRIPTION
This is related to #1447 but I wanted to open this first to see if this is worth including with the beta release.

Due to `Map` not being serializable over IPC, no menu updates are successfully received by the main process. This means all menu items are enabled by default, which is visible in the latest `0.5.0` release.