### PR TITLE
keep beta users out of normal support channels

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -253,13 +253,6 @@ export function buildDefaultMenu(sharedProcess: SharedProcess): Electron.Menu {
     })
   }
 
-  const contactSupportItem: Electron.MenuItemOptions = {
-    label: __DARWIN__ ? 'Contact GitHub Support…' : 'Contact GitHub &support…',
-    click () {
-      shell.openExternal('https://github.com/support')
-    },
-  }
-
   const submitIssueItem: Electron.MenuItemOptions = {
     label: __DARWIN__ ? 'Report Issue...' : 'Report issue...',
     click() {
@@ -276,7 +269,6 @@ export function buildDefaultMenu(sharedProcess: SharedProcess): Electron.Menu {
   }
 
   const helpItems = [
-    contactSupportItem,
     submitIssueItem,
     showLogsItem,
   ]


### PR DESCRIPTION
This link sends the user over to our existing support channel. For now, I'd rather they go to "Report an Issue" so they end up in this repo.

We can come back to this after things settle down and we have an idea of the support load.