### PR TITLE
Update samples URL

### DIFF
--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -12,7 +12,7 @@ interface IAdvancedPreferencesState {
   readonly reportingOptOut: boolean
 }
 
-const SamplesURL = 'https://desktop.github.com/samples/'
+const SamplesURL = 'https://desktop.github.com/samples/tng'
 
 export class Advanced extends React.Component<IAdvancedPreferencesProps, IAdvancedPreferencesState> {
   public constructor(props: IAdvancedPreferencesProps) {

--- a/app/src/ui/welcome/usage-opt-out.tsx
+++ b/app/src/ui/welcome/usage-opt-out.tsx
@@ -7,7 +7,7 @@ import { Form } from '../lib/form'
 import { Button } from '../lib/button'
 import { Row } from '../lib/row'
 
-const SamplesURL = 'https://desktop.github.com/samples/'
+const SamplesURL = 'https://desktop.github.com/samples/tng'
 
 interface IUsageOptOutProps {
   readonly dispatcher: Dispatcher


### PR DESCRIPTION
We're adding a new page for the data submissions samples on desktop.github.com. We can't use the old one since we're not going to be able to update the classic apps.

See https://github.com/github/desktop.github.com/issues/59