### PR TITLE
launch browser only once per login flow

### DIFF
--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -17,6 +17,9 @@ interface ILinkButtonProps {
 
   /** The tab index of the anchor element. */
   readonly tabIndex?: number
+
+  /** Disable the link from being clicked */
+  readonly disabled?: boolean
 }
 
 /** A link component. */
@@ -31,6 +34,7 @@ export class LinkButton extends React.Component<ILinkButtonProps, void> {
         href={href}
         onClick={this.onClick}
         tabIndex={this.props.tabIndex}
+        disabled={this.props.disabled}
       >
         {this.props.children}
       </a>
@@ -39,6 +43,10 @@ export class LinkButton extends React.Component<ILinkButtonProps, void> {
 
   private onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
+
+    if (this.props.disabled) {
+      return
+    }
 
     const uri = this.props.uri
     if (uri) {

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -180,6 +180,8 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       )
     }
 
+    const disableSubmit = state.loading
+
     return (
       <DialogContent>
         <Row>
@@ -203,7 +205,10 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         <div className='horizontal-rule'><span className='horizontal-rule-content'>or</span></div>
 
         <Row className='sign-in-with-browser'>
-          <LinkButton className='link-with-icon' onClick={this.onSignInWithBrowser}>
+          <LinkButton
+            className='link-with-icon'
+            onClick={this.onSignInWithBrowser}
+            disabled={disableSubmit}>
             Sign in using your browser
             <Octicon symbol={OcticonSymbol.linkExternal} />
           </LinkButton>

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -62,6 +62,12 @@
     text-decoration: underline;
   }
 
+  &[disabled] {
+    opacity: 0.6;
+    cursor: default;
+    text-decoration: none;
+  }
+
   &.link-with-icon .octicon {
     margin-left: var(--spacing-half);
   }


### PR DESCRIPTION
Fixes #1427 by closing a way that the user can launch many browser tabs to sign in, preventing GitHub Dot Com The Website from getting mad at the user.