### PR TITLE
persist the local path after initialized

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -16,7 +16,7 @@ import { Select } from '../lib/select'
 import { getGitIgnoreNames, writeGitIgnore } from './gitignores'
 import { ILicense, getLicenses, writeLicense } from './licenses'
 import { writeGitAttributes } from './git-attributes'
-import { getDefaultDir } from '../lib/default-dir'
+import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
 
@@ -200,6 +200,8 @@ export class CreateRepository extends React.Component<ICreateRepositoryProps, IC
     }
 
     this.setState({ ...this.state, creating: false })
+
+    setDefaultDir(this.state.path)
 
     this.props.dispatcher.selectRepository(repository)
     this.props.onDismissed()


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/1486

We update your preferred local path when you clone a repository, but we don't do this when you create a new repository. This seems good for consistency between the two flows.