### PR TITLE
Fix branch selector

### DIFF
--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -27,11 +27,11 @@ fieldset.vertical-segmented-control {
 
     li {
       padding: var(--spacing);
+      margin: 0;
       border-left: var(--base-border);
       border-right: var(--base-border);
       border-top: var(--base-border);
       border-bottom: none;
-      margin: 0;
 
       &:last-child {
         border-bottom: var(--base-border);


### PR DESCRIPTION
Fixes #1479 by increasing the specificity of the vertical segmented control selector.

This is a hack but it's also (IMO) the approach that's least likely to cause unforeseen issues this close to beta. Going forward I'd like to remove some of the nesting from our dialog styles to reduce the specificity in those styles but I'm not comfortable doing that this close to beta.

scss is pretty wonderful but it does lend itself to unnecessary levels of nesting.

![image](https://cloud.githubusercontent.com/assets/634063/26092594/1285acb8-3a12-11e7-9bdf-9e0a093b8253.png)
