### PR TITLE
fs.mkdir will throw if the path already exists

### DIFF
--- a/app/src/lib/logging/logger.ts
+++ b/app/src/lib/logging/logger.ts
@@ -64,20 +64,15 @@ function create(filename: string) {
 
 export function createLogger(directory: string): Promise<ILogger> {
   return new Promise<ILogger>((resolve, reject) => {
-    Fs.exists(directory, (exists) => {
-
-      if (exists) {
-        resolve(create(getLogFilePath(directory)))
-        return
+    Fs.mkdir(directory, (error) => {
+      if (error) {
+        if (error.code !== 'EEXIST') {
+          reject(error)
+          return
+        }
       }
 
-      Fs.mkdir(directory, (error) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(create(getLogFilePath(directory)))
-        }
-      })
+      resolve(create(getLogFilePath(directory)))
     })
   })
 }

--- a/app/src/lib/logging/logger.ts
+++ b/app/src/lib/logging/logger.ts
@@ -64,12 +64,20 @@ function create(filename: string) {
 
 export function createLogger(directory: string): Promise<ILogger> {
   return new Promise<ILogger>((resolve, reject) => {
-    Fs.mkdir(directory, (error) => {
-      if (error) {
-        reject(error)
-      } else {
+    Fs.exists(directory, (exists) => {
+
+      if (exists) {
         resolve(create(getLogFilePath(directory)))
+        return
       }
+
+      Fs.mkdir(directory, (error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(create(getLogFilePath(directory)))
+        }
+      })
     })
   })
 }


### PR DESCRIPTION
@niik found this error just now:

> `Uncaught (in promise) Error: EEXIST: file already exists, mkdir 'C:\Users\{name}\AppData\Roaming\GitHub Desktop-dev\logs'`

Looks like I misread the `mkdir` [docs](http://man7.org/linux/man-pages/man2/mkdir.2.html), and we should check the folder exists to avoid unnecessary handling of `EEXIST`.