### PR TITLE
Better compatibility with password managers

### DIFF
--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -79,7 +79,8 @@ export class AuthenticationForm extends React.Component<IAuthenticationFormProps
           label='Username or email address'
           disabled={disabled}
           autoFocus={true}
-          onChange={this.onUsernameChange}/>
+          onChange={this.onUsernameChange}
+          tabIndex={1}/>
 
         <TextBox
           label='Password'
@@ -87,7 +88,8 @@ export class AuthenticationForm extends React.Component<IAuthenticationFormProps
           disabled={disabled}
           onChange={this.onPasswordChange}
           labelLinkText='Forgot password?'
-          labelLinkUri={this.props.forgotPasswordUrl}/>
+          labelLinkUri={this.props.forgotPasswordUrl}
+          tabIndex={2}/>
 
         {this.renderError()}
 


### PR DESCRIPTION
*(And also some humans)*

Password managers like KeePass have an auto insert that by default automate LOGIN[TAB]PASSWORD[ENTER] but the current login workflow has the "Forgot password?" link selected when tab is pressed from the login field. After this change while still visually in the same place the "Forgot password?" link is after the password field in the tab order.

![2017-05-16 22_31_37-github desktop-dev](https://cloud.githubusercontent.com/assets/131878/26126892/a62598aa-3a87-11e7-9369-e18ceea43ae6.png)
