### PR TITLE
Only handle the first uncaught exception

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -47,7 +47,7 @@ if (!process.env.TEST_ENV) {
   require('../../styles/desktop.scss')
 }
 
-process.on('uncaughtException', (error: Error) => {
+process.once('uncaughtException', (error: Error) => {
   reportError(error)
   logError('Uncaught exception on renderer process', error)
   postUnhandledError(error)


### PR DESCRIPTION
Once we get any uncaught exception, all bets are off. Worst case we end up causing exception feedback by continually re-rendering as a result of exceptions.