### PR TITLE
Fix crash for users without orgs

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -261,7 +261,9 @@ export class API {
   /** Fetch all the orgs to which the user belongs. */
   public async fetchOrgs(): Promise<ReadonlyArray<IAPIUser>> {
     const result = await this.client.user.orgs.fetch()
-    return result.items || []
+    return result && Array.isArray(result.items)
+      ? result.items
+      : []
   }
 
   /** Create a new GitHub repository with the given properties. */

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -261,7 +261,7 @@ export class API {
   /** Fetch all the orgs to which the user belongs. */
   public async fetchOrgs(): Promise<ReadonlyArray<IAPIUser>> {
     const result = await this.client.user.orgs.fetch()
-    return result.items
+    return result.items || []
   }
 
   /** Create a new GitHub repository with the given properties. */


### PR DESCRIPTION
This certainly isn't great, but it'll solve the immediate issue of crashes due to us returning `undefined` out of a method that's supposed to always return an array.

It should stop the immediate problems with crashes in the publish dialog for users that aren't members of any orgs.

This problems runs deeper though, more PRs incoming