### PR TITLE
Stats fixups

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -143,8 +143,8 @@ export class StatsStore {
 
   /** Determines if an account is a dotCom and/or enterprise user */
   private determineUserType(accounts: ReadonlyArray<Account>) {
-    const dotComAccount = accounts.find(a => a.endpoint === getDotComAPIEndpoint()) !== undefined
-    const enterpriseAccount = accounts.find(a => a.endpoint !== getDotComAPIEndpoint()) !== undefined
+    const dotComAccount = !!accounts.find(a => a.endpoint === getDotComAPIEndpoint())
+    const enterpriseAccount = !!accounts.find(a => a.endpoint !== getDotComAPIEndpoint())
 
     return {
       dotComAccount,

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -190,6 +190,8 @@ export class StatsStore {
     return {
       ...DefaultDailyMeasures,
       ...measures,
+      // We could spread the database ID in, but we really don't want it.
+      id: undefined,
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -100,6 +100,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         // loading the app. So defer it until we have some breathing space.
         requestIdleCallback(() => {
           props.appStore.loadEmoji()
+
+          this.props.dispatcher.reportStats()
+
+          setInterval(() => this.props.dispatcher.reportStats(), SendStatsInterval)
         })
       }, { timeout: ReadyDelay })
     })
@@ -135,15 +139,12 @@ export class App extends React.Component<IAppProps, IAppState> {
     setInterval(() => this.checkForUpdates(), UpdateCheckInterval)
     this.checkForUpdates()
 
-    ipcRenderer.on('launch-timing-stats', async (event: Electron.IpcRendererEvent, { stats }: { stats: ILaunchStats }) => {
+    ipcRenderer.on('launch-timing-stats', (event: Electron.IpcRendererEvent, { stats }: { stats: ILaunchStats }) => {
       console.info(`App ready time: ${stats.mainReadyTime}ms`)
       console.info(`Load time: ${stats.loadTime}ms`)
       console.info(`Renderer ready time: ${stats.rendererReadyTime}ms`)
 
-      await this.props.dispatcher.recordLaunchStats(stats)
-      this.props.dispatcher.reportStats()
-
-      setInterval(() => this.props.dispatcher.reportStats(), SendStatsInterval)
+      this.props.dispatcher.recordLaunchStats(stats)
     })
 
     ipcRenderer.on('certificate-error', (event: Electron.IpcRendererEvent, { certificate, error, url }: { certificate: Electron.Certificate, error: string, url: string }) => {


### PR DESCRIPTION
Maybe fixes #1516. All the JSON I saw coming out of the app included `enterpriseAccount`. I'll check further up our stats reporting to see if we're missing it somewhere else.

We also had a problem @niik noticed where we wouldn't schedule stats reporting after the window's been reloaded. That's probably pretty uncommon, but we should still fix it up.