### PR TITLE
Some icon cleanup

### DIFF
--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -24,6 +24,8 @@
 
     .icon {
       margin-right: var(--spacing-half);
+      width: 16px; // Force a consistent width
+      flex-shrink: 0;
     }
 
     .name {

--- a/app/styles/ui/_octicons.scss
+++ b/app/styles/ui/_octicons.scss
@@ -2,6 +2,8 @@ svg.octicon {
   /* https://css-tricks.com/cascading-svg-fill-color/ */
   fill: currentColor;
 
-  width: 16px;
+  /* Only height is specified here since not every Octicon is a 16px wide.
+  Forcing a width of 16px would result in some blurry icons showing up.
+  Instead, let's imply width: auto; instead. */
   height: 16px;
 }

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -40,6 +40,9 @@
 
       // Always let the octicon dictate the amount of space it needs
       flex-shrink: 0;
+      
+      // Force the octicon width
+      width: 16px;
     }
 
     .name {

--- a/app/styles/ui/toolbar/_button.scss
+++ b/app/styles/ui/toolbar/_button.scss
@@ -99,7 +99,7 @@
 
     .dropdownArrow {
       width: 9px;
-      height: 12px;
+      height: 13px;
       flex-shrink: 0;
       position: relative;
     }


### PR DESCRIPTION
Howdy! This PR addresses some minor pixel alignment and layout issues with the Octicons.

1. Fixes blurriness in the diff icon in the compare toolbar. I've done this by removing the 16px width assumption from `.octicon`.

**Before**
![screen shot 2017-05-17 at 4 43 09 pm](https://cloud.githubusercontent.com/assets/1369864/26179604/4a0168e4-3b2a-11e7-9945-9799b298d239.png)

**After**
![screen shot 2017-05-17 at 4 42 35 pm](https://cloud.githubusercontent.com/assets/1369864/26179611/5345fa96-3b2a-11e7-9e1b-9f7216060609.png)

2. Applies a consistent width and behavior to list items icons

**Before**
![screen shot 2017-05-17 at 5 49 49 pm](https://cloud.githubusercontent.com/assets/1369864/26179639/80584cbe-3b2a-11e7-8040-3dccebf9bc1e.png)

**After**
![screen shot 2017-05-17 at 5 59 39 pm](https://cloud.githubusercontent.com/assets/1369864/26179671/a1189b98-3b2a-11e7-8084-c8411c7d28b3.png)

Cool, cool. 😎
