### PR TITLE
remove the HOME unset from the trampoline

### DIFF
--- a/app/static/darwin/ask-pass-trampoline.sh
+++ b/app/static/darwin/ask-pass-trampoline.sh
@@ -1,6 +1,3 @@
 #!/bin/sh
 
-# We set HOME to an empty string in lib/git/core.ts to avoid picking up the
-# user's git config, but our AskPass script needs it in order to find the user's
-# keychain.
-env -u HOME ELECTRON_RUN_AS_NODE=1 "$DESKTOP_PATH" "$DESKTOP_ASKPASS_SCRIPT" "$@"
+ELECTRON_RUN_AS_NODE=1 "$DESKTOP_PATH" "$DESKTOP_ASKPASS_SCRIPT" "$@"


### PR DESCRIPTION
This workaround is no longer needed, and it might be the root cause of #1514 because some users have a different version of `env` installed that doesn't support `-u` anyway.