### PR TITLE
Respond to action on double-click in titlebar on macOS

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -57,6 +57,8 @@ interface IAppProps {
   readonly startTime: number
 }
 
+type AppleActionOnDoubleClickPref = 'Maximize' | 'Minimize' | 'None'
+
 export const dialogTransitionEnterTimeout = 250
 export const dialogTransitionLeaveTimeout = 100
 
@@ -585,8 +587,8 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onTitlebarDoubleClick() {
     if (__DARWIN__) {
-      const actionOnDoubleClick = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
-      const mainWindow = remote.getCurrentWindow()
+      const actionOnDoubleClick: AppleActionOnDoubleClickPref = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
+      const mainWindow: Electron.BrowserWindow = remote.getCurrentWindow()
 
       if (mainWindow) {
         switch (actionOnDoubleClick) {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -590,18 +590,16 @@ export class App extends React.Component<IAppProps, IAppState> {
       const actionOnDoubleClick: AppleActionOnDoubleClickPref = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
       const mainWindow: Electron.BrowserWindow = remote.getCurrentWindow()
 
-      if (mainWindow) {
-        switch (actionOnDoubleClick) {
-          case 'Maximize':
-          default:
-            mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
-            break
-          case 'Minimize':
-            mainWindow.minimize()
-            break
-          case 'None':
-            break
-        }
+      switch (actionOnDoubleClick) {
+        case 'Maximize':
+          mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
+          break
+        case 'Minimize':
+          mainWindow.minimize()
+          break
+        case 'None':
+        default:
+          break
       }
     }
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ipcRenderer, shell } from 'electron'
+import { ipcRenderer, remote, shell } from 'electron'
 
 import { RepositoriesList } from './repositories-list'
 import { RepositoryView } from './repository'
@@ -583,6 +583,27 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setAppMenuState(menu => menu.withReset())
   }
 
+  private onTitlebarDoubleClick() {
+    if (__DARWIN__) {
+      const actionOnDoubleClick = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string');
+      const mainWindow = remote.getCurrentWindow();
+
+      if (mainWindow) {
+        switch (actionOnDoubleClick) {
+          case 'Maximize':
+          default:
+            mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize();
+            break;
+          case 'Minimize':
+            mainWindow.minimize();
+            break;
+          case 'None':
+            break;
+        }
+      }
+    }
+  }
+
   private renderTitlebar() {
 
     const inFullScreen = this.state.windowState === 'full-screen'
@@ -626,7 +647,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       : null
 
     return (
-      <div className={titleBarClass} id='desktop-app-title-bar'>
+      <div className={titleBarClass} id='desktop-app-title-bar' onDoubleClick={this.onTitlebarDoubleClick}>
         {topResizeHandle}
         {leftResizeHandle}
         {appIcon}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -585,22 +585,20 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setAppMenuState(menu => menu.withReset())
   }
 
-  private onTitlebarDoubleClick() {
-    if (__DARWIN__) {
-      const actionOnDoubleClick: AppleActionOnDoubleClickPref = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
-      const mainWindow: Electron.BrowserWindow = remote.getCurrentWindow()
+  private onTitlebarDoubleClickDarwin() {
+    const actionOnDoubleClick: AppleActionOnDoubleClickPref = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
+    const mainWindow = remote.getCurrentWindow()
 
-      switch (actionOnDoubleClick) {
-        case 'Maximize':
-          mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
-          break
-        case 'Minimize':
-          mainWindow.minimize()
-          break
-        case 'None':
-        default:
-          break
-      }
+    switch (actionOnDoubleClick) {
+      case 'Maximize':
+        mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
+        break
+      case 'Minimize':
+        mainWindow.minimize()
+        break
+      case 'None':
+      default:
+        break
     }
   }
 
@@ -646,7 +644,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       ? <Octicon className='app-icon' symbol={OcticonSymbol.markGithub} />
       : null
 
-    const onTitlebarDoubleClick = __DARWIN__ ? this.onTitlebarDoubleClick : undefined
+    const onTitlebarDoubleClick = __DARWIN__ ? this.onTitlebarDoubleClickDarwin : undefined
 
     return (
       <div className={titleBarClass} id='desktop-app-title-bar' onDoubleClick={onTitlebarDoubleClick}>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -596,9 +596,6 @@ export class App extends React.Component<IAppProps, IAppState> {
       case 'Minimize':
         mainWindow.minimize()
         break
-      case 'None':
-      default:
-        break
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -585,20 +585,20 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onTitlebarDoubleClick() {
     if (__DARWIN__) {
-      const actionOnDoubleClick = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string');
-      const mainWindow = remote.getCurrentWindow();
+      const actionOnDoubleClick = remote.systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
+      const mainWindow = remote.getCurrentWindow()
 
       if (mainWindow) {
         switch (actionOnDoubleClick) {
           case 'Maximize':
           default:
-            mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize();
-            break;
+            mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
+            break
           case 'Minimize':
-            mainWindow.minimize();
-            break;
+            mainWindow.minimize()
+            break
           case 'None':
-            break;
+            break
         }
       }
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -648,8 +648,10 @@ export class App extends React.Component<IAppProps, IAppState> {
       ? <Octicon className='app-icon' symbol={OcticonSymbol.markGithub} />
       : null
 
+    const onTitlebarDoubleClick = __DARWIN__ ? this.onTitlebarDoubleClick : undefined
+
     return (
-      <div className={titleBarClass} id='desktop-app-title-bar' onDoubleClick={this.onTitlebarDoubleClick}>
+      <div className={titleBarClass} id='desktop-app-title-bar' onDoubleClick={onTitlebarDoubleClick}>
         {topResizeHandle}
         {leftResizeHandle}
         {appIcon}


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/1590

This lets the titlebar respond to double-clicks based on the user's system preference for this behavior on macOS. 🎉 