### PR TITLE
Send IPC messages from menu over webContents channel rather than broadcast

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -307,10 +307,18 @@ export function buildDefaultMenu(sharedProcess: SharedProcess): Electron.Menu {
   return Menu.buildFromTemplate(template)
 }
 
+type ClickHandler = (menuItem: Electron.MenuItem, browserWindow: Electron.BrowserWindow, event: Electron.Event) => void
+
 /**
  * Utility function returning a Click event handler which, when invoked, emits
  * the provided menu event over IPC.
  */
-function emit(name: MenuEvent): () => void {
-  return () => ipcMain.emit('menu-event', { name })
+function emit(name: MenuEvent): ClickHandler {
+  return (menuItem, window) => {
+    if (window) {
+      window.webContents.send('menu-event', { name })
+    } else {
+      ipcMain.emit('menu-event', { name })
+    }
+  }
 }

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -1,5 +1,5 @@
 import * as Path from 'path'
-import { shell, Menu, ipcMain, app } from 'electron'
+import { shell, Menu, app } from 'electron'
 import { SharedProcess } from '../../shared-process/shared-process'
 import { ensureItemIds } from './ensure-item-ids'
 import { MenuEvent } from './menu-event'
@@ -315,10 +315,6 @@ type ClickHandler = (menuItem: Electron.MenuItem, browserWindow: Electron.Browse
  */
 function emit(name: MenuEvent): ClickHandler {
   return (menuItem, window) => {
-    if (window) {
-      window.webContents.send('menu-event', { name })
-    } else {
-      ipcMain.emit('menu-event', { name })
-    }
+    window.webContents.send('menu-event', { name })
   }
 }


### PR DESCRIPTION
For some unknown reason dispatching over ipcMain causes the ui window to restore its position if snapped.

Fixes #1603