### PR TITLE
Disable URL becomming links in undo

### DIFF
--- a/app/src/ui/changes/undo-commit.tsx
+++ b/app/src/ui/changes/undo-commit.tsx
@@ -33,7 +33,8 @@ export class UndoCommit extends React.Component<IUndoCommitProps, void> {
           <RichText
             emoji={this.props.emoji}
             className='summary'
-            text={this.props.commit.summary} />
+            text={this.props.commit.summary}
+            renderUrlsAsLinks={false} />
         </div>
         <div className='actions' title={title}>
           <Button size='small' disabled={disabled} onClick={this.props.onUndo}>Undo</Button>


### PR DESCRIPTION
Follow a comment by @niik on #1605 (That was applying the same to the commit list items)

![2017-05-18 11_14_33-github desktop-dev](https://cloud.githubusercontent.com/assets/131878/26195383/ea28f332-3bbb-11e7-9938-90d1a7ec22a4.png)
