### PR TITLE
Legal cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
     - $HOME/.electron
 
 install:
-  - npm install -g npm
+  - npm install -g npm@4.6.1
   - npm prune
   - cd app && npm prune && cd ..
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
-  - npm ls
-  - cd app && npm ls && cd ..
 
 script:
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
+  - npm ls
+  - cd app && npm ls && cd ..
 
 script:
   - npm run lint

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -238,7 +238,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
             <LinkButton onClick={this.props.onShowTermsAndConditions}>Terms and Conditions</LinkButton>
           </p>
           <p>
-            <LinkButton onClick={this.props.onShowAcknowledgements}>Acknowledgements</LinkButton>
+            <LinkButton onClick={this.props.onShowAcknowledgements}>License and Open Source Notices</LinkButton>
           </p>
           {this.renderUpdateDetails()}
           {this.renderUpdateButton()}

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -25,6 +25,7 @@ interface ILicense {
 type Licenses = { [key: string]: ILicense }
 
 interface IAcknowledgementsState {
+  readonly licenseText: string | null
   readonly licenses: Licenses | null
 }
 
@@ -33,10 +34,21 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
   public constructor(props: IAcknowledgementsProps) {
     super(props)
 
-    this.state = { licenses: null }
+    this.state = { licenses: null, licenseText: null }
   }
 
   public componentDidMount() {
+    const licensePath = Path.join(getAppPath(), 'static', 'LICENSE')
+    Fs.readFile(licensePath, 'utf8', (err, data) => {
+      if (err) {
+        console.error('Error loading license text')
+        console.error(err)
+        return
+      }
+
+      this.setState({ licenseText: data })
+    })
+
     const path = Path.join(getAppPath(), 'static', 'licenses.json')
     Fs.readFile(path, 'utf8', (err, data) => {
       if (err) {
@@ -93,7 +105,7 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
 
   public render() {
     const licenses = this.state.licenses
-    const licenseText = 'text goes here'
+    const licenseText = this.state.licenseText
     return (
       <Dialog
         id='acknowledgements'

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -97,7 +97,7 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
     return (
       <Dialog
         id='acknowledgements'
-        title='Acknowledgements'
+        title='License and Open Source Notices'
         onSubmit={this.props.onDismissed}
         onDismissed={this.props.onDismissed}>
         <DialogContent>

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -125,8 +125,7 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
           </p>
 
           <p>
-            GitHub Desktop stands on the shoulders of giants! GitHub Desktop
-            distributes these libraries as part of it's application.
+            GitHub Desktop also distributes these libraries.
           </p>
 
           {licenses ? this.renderLicenses(licenses) : <Loading/>}

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -8,9 +8,8 @@ import { LinkButton } from '../lib/link-button'
 import { ButtonGroup } from '../lib/button-group'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 
+const WebsiteURL = 'https://desktop.github.com'
 const RepositoryURL = 'https://github.com/desktop/desktop'
-const ElectronURL = 'https://electron.atom.io'
-const TypeScriptURL = 'http://www.typescriptlang.org'
 
 interface IAcknowledgementsProps {
   /** The function to call when the dialog should be dismissed. */
@@ -94,6 +93,7 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
 
   public render() {
     const licenses = this.state.licenses
+    const licenseText = 'text goes here'
     return (
       <Dialog
         id='acknowledgements'
@@ -101,7 +101,21 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
         onSubmit={this.props.onDismissed}
         onDismissed={this.props.onDismissed}>
         <DialogContent>
-          <p>GitHub Desktop stands on the shoulders of giants! We're <LinkButton uri={RepositoryURL}>open source</LinkButton>, built on <LinkButton uri={ElectronURL}>Electron</LinkButton> and written in <LinkButton uri={TypeScriptURL}>TypeScript</LinkButton>. Check out <LinkButton uri={RepositoryURL}>our repository</LinkButton> for more details.</p>
+
+          <p>
+            <LinkButton uri={WebsiteURL}>GitHub Desktop</LinkButton> is an open
+            source project published under the MIT License. You can view the
+            source code and contribute to this project on <LinkButton uri={RepositoryURL}>GitHub</LinkButton>.
+          </p>
+
+          <p className='license-text'>
+            {licenseText}
+          </p>
+
+          <p>
+            GitHub Desktop stands on the shoulders of giants! GitHub Desktop
+            distributes these libraries as part of it's application.
+          </p>
 
           {licenses ? this.renderLicenses(licenses) : <Loading/>}
         </DialogContent>

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -125,7 +125,7 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
           </p>
 
           <p>
-            GitHub Desktop also distributes these libraries.
+            GitHub Desktop also distributes these libraries:
           </p>
 
           {licenses ? this.renderLicenses(licenses) : <Loading/>}

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -30,7 +30,6 @@ interface ILicense {
 type Licenses = { [key: string]: ILicense }
 
 interface IAcknowledgementsState {
-  readonly licenseText: string | null
   readonly licenses: Licenses | null
 }
 
@@ -39,21 +38,10 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
   public constructor(props: IAcknowledgementsProps) {
     super(props)
 
-    this.state = { licenses: null, licenseText: null }
+    this.state = { licenses: null }
   }
 
   public componentDidMount() {
-    const licensePath = Path.join(getAppPath(), 'static', 'LICENSE')
-    Fs.readFile(licensePath, 'utf8', (err, data) => {
-      if (err) {
-        console.error('Error loading license text')
-        console.error(err)
-        return
-      }
-
-      this.setState({ licenseText: data })
-    })
-
     const path = Path.join(getAppPath(), 'static', 'licenses.json')
     Fs.readFile(path, 'utf8', (err, data) => {
       if (err) {

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -14,6 +14,11 @@ const RepositoryURL = 'https://github.com/desktop/desktop'
 interface IAcknowledgementsProps {
   /** The function to call when the dialog should be dismissed. */
   readonly onDismissed: () => void
+
+  /**
+   * The currently installed (and running) version of the app.
+   */
+  readonly applicationVersion: string
 }
 
 interface ILicense {
@@ -105,7 +110,14 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
 
   public render() {
     const licenses = this.state.licenses
-    const licenseText = this.state.licenseText
+
+    let desktopLicense: JSX.Element | null = null
+    if (licenses) {
+      const key = `desktop@${this.props.applicationVersion}`
+      const entry = licenses[key]
+      desktopLicense = <p className='license-text'>{entry.sourceText}</p>
+    }
+
     return (
       <Dialog
         id='acknowledgements'
@@ -120,9 +132,7 @@ export class Acknowledgements extends React.Component<IAcknowledgementsProps, IA
             source code and contribute to this project on <LinkButton uri={RepositoryURL}>GitHub</LinkButton>.
           </p>
 
-          <p className='license-text'>
-            {licenseText}
-          </p>
+          {desktopLicense}
 
           <p>
             GitHub Desktop also distributes these libraries:

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -796,6 +796,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <Acknowledgements
             key='acknowledgements'
             onDismissed={this.onPopupDismissed}
+            applicationVersion={getVersion()}
           />
         )
       case PopupType.RemoveRepository:

--- a/app/styles/ui/_acknowledgements.scss
+++ b/app/styles/ui/_acknowledgements.scss
@@ -1,5 +1,5 @@
 #acknowledgements {
-  width: 580px;
+  width: 600px;
 
   .dialog-content {
     height: 300px;

--- a/app/styles/ui/_acknowledgements.scss
+++ b/app/styles/ui/_acknowledgements.scss
@@ -9,6 +9,10 @@
       font-family: var(--font-family-monospace);
       white-space: pre-wrap;
       margin-bottom: var(--spacing-double);
+
+      // make the text selectable
+      cursor: text;
+      user-select: text;
     }
   }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,6 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
-  - npm ls
-  - cd app && npm ls && cd ..
 
 build_script:
   - npm run lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
+  - npm ls
+  - cd app && npm ls && cd ..
 
 build_script:
   - npm run lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ version: "{build}"
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - npm install -g npm
+  - npm install -g npm@4.6.1
   - git submodule update --init --recursive
   - npm prune
   - cd app && npm prune && cd ..

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "got": "^6.3.0",
     "html-webpack-plugin": "^2.28.0",
     "klaw-sync": "^1.1.2",
-    "legal-eagle": "^0.15.0",
+    "legal-eagle": "0.15.0",
     "mocha": "^3.0.2",
     "node-native-loader": "^1.1.1",
     "node-sass": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "got": "^6.3.0",
     "html-webpack-plugin": "^2.28.0",
     "klaw-sync": "^1.1.2",
+    "legal-eagle": "^0.15.0",
     "mocha": "^3.0.2",
     "node-native-loader": "^1.1.1",
     "node-sass": "^4.5.2",
@@ -100,7 +101,6 @@
     "@types/react-virtualized": "^9.7.0",
     "@types/ua-parser-js": "^0.7.30",
     "@types/uuid": "^2.0.29",
-    "@types/winston": "^2.2.0",
-    "legal-eagle": "^0.15.0"
+    "@types/winston": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
     "@types/ua-parser-js": "^0.7.30",
     "@types/uuid": "^2.0.29",
     "@types/winston": "^2.2.0",
-    "legal-eagle": "^0.14.0"
+    "legal-eagle": "^0.15.0"
   }
 }

--- a/script/build
+++ b/script/build
@@ -205,6 +205,11 @@ function copyDependencies () {
 }
 
 function updateLicenseDump (callback) {
+
+  const licenseSource = path.join(projectRoot, 'LICENSE')
+  const licenseDest = path.join(outRoot, 'static', 'LICENSE')
+  fs.copySync(licenseSource, licenseDest)
+
   const appRoot = path.join(projectRoot, 'app')
   const outPath = path.join(outRoot, 'static', 'licenses.json')
   const licenseOverrides = require('./license-overrides')

--- a/script/build
+++ b/script/build
@@ -189,10 +189,10 @@ function copyDependencies () {
 
   if (!isProductionBuild) {
     console.log('  Installing 7zip (dependency for electron-devtools-installer)')
-    
+
     const sevenZipSource = path.resolve(projectRoot, 'app/node_modules/7zip')
     const sevenZipDestination = path.resolve(outRoot, 'node_modules/7zip')
-    
+
     fs.mkdirpSync(sevenZipDestination)
     fs.copySync(sevenZipSource, sevenZipDestination)
   }

--- a/script/build
+++ b/script/build
@@ -205,7 +205,6 @@ function copyDependencies () {
 }
 
 function updateLicenseDump (callback) {
-
   const appRoot = path.join(projectRoot, 'app')
   const outPath = path.join(outRoot, 'static', 'licenses.json')
   const licenseOverrides = require('./license-overrides')
@@ -234,7 +233,8 @@ function updateLicenseDump (callback) {
         }
 
         // legal-eagle still chooses to ignore the LICENSE at the root
-        // this here overrides that before we dump the file to disk
+        // this injects the current license and pins the source URL before we
+        // dump the JSON file to disk
         const licenseSource = path.join(projectRoot, 'LICENSE')
         const licenseText = fs.readFileSync(licenseSource, { encoding: 'utf-8' })
         const appVersion = distInfo.getVersion()

--- a/script/build
+++ b/script/build
@@ -206,10 +206,6 @@ function copyDependencies () {
 
 function updateLicenseDump (callback) {
 
-  const licenseSource = path.join(projectRoot, 'LICENSE')
-  const licenseDest = path.join(outRoot, 'static', 'LICENSE')
-  fs.copySync(licenseSource, licenseDest)
-
   const appRoot = path.join(projectRoot, 'app')
   const outPath = path.join(outRoot, 'static', 'licenses.json')
   const licenseOverrides = require('./license-overrides')
@@ -235,6 +231,19 @@ function updateLicenseDump (callback) {
         if (err) {
           callback(err)
           return
+        }
+
+        // legal-eagle still chooses to ignore the LICENSE at the root
+        // this here overrides that before we dump the file to disk
+        const licenseSource = path.join(projectRoot, 'LICENSE')
+        const licenseText = fs.readFileSync(licenseSource, { encoding: 'utf-8' })
+        const appVersion = distInfo.getVersion()
+
+        summary[`desktop@${appVersion}`] = {
+          repository: 'https://github.com/desktop/desktop',
+          license: 'MIT',
+          source: `https://github.com/desktop/desktop/blob/release-${appVersion}/LICENSE`,
+          sourceText: licenseText
         }
 
         fs.writeFileSync(outPath, JSON.stringify(summary), 'utf8')


### PR DESCRIPTION
Fixes #1576 

 - [x] use a more accurate label for the dialog and link
 - [x] display Desktop license from `legal-eagle` output
 - [x] make license text selectable wherever we render it
 - [x] update `legal-eagle` to get new package licenses
 - ~~[ ] collapse license text to make this list less crazy to scroll through~~ :boot:
