### PR TITLE
Prefer window IPC but fall back to broadcast

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -1,5 +1,5 @@
 import * as Path from 'path'
-import { shell, Menu, app } from 'electron'
+import { shell, Menu, ipcMain, app } from 'electron'
 import { SharedProcess } from '../../shared-process/shared-process'
 import { ensureItemIds } from './ensure-item-ids'
 import { MenuEvent } from './menu-event'
@@ -315,6 +315,10 @@ type ClickHandler = (menuItem: Electron.MenuItem, browserWindow: Electron.Browse
  */
 function emit(name: MenuEvent): ClickHandler {
   return (menuItem, window) => {
-    window.webContents.send('menu-event', { name })
+    if (window) {
+      window.webContents.send('menu-event', { name })
+    } else {
+      ipcMain.emit('menu-event', { name })
+    }
   }
 }


### PR DESCRIPTION
This partially reverts #1606, I failed to account for the fact that on macOS we don't necessarily have an 
 originating window. @shiftkey spotted this in chat

> TL;DR: in dev mode you can launch the app without it being focused. if you then go and launch a dialog > from the menu bar (like About) it'll :boom: (edited)
> this is on macOS
> ```
> TypeError: Cannot read property 'webContents' of null
>    at eval (eval at <anonymous> (/Users/shiftkey/src/desktop/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app/Contents/Resources/app/main.js:875:1), <anonymous>:225:15)
>    at MenuItem.click (/Users/shiftkey/src/desktop/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app/Contents/Resources/electron.asar/browser/api/menu-item.js:52:9)
>    at Function.executeCommand (/Users/shiftkey/src/desktop/desktop/dist/GitHub Desktop-dev-darwin-> x64/GitHub Desktop-dev.app/Contents/Resources/electron.asar/browser/api/menu.js:121:15)```
> ```