### PR TITLE
Fix the Untrusted Certificate dialog

### DIFF
--- a/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
+++ b/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
@@ -45,7 +45,7 @@ export class UntrustedCertificate extends React.Component<IUntrustedCertificateP
       <Dialog
         title={__DARWIN__ ? 'Untrusted Server' : 'Untrusted server'}
         onDismissed={this.props.onDismissed}
-        onSubmit={this.onContinue}
+        onSubmit={this.props.onDismissed}
         type={type}
       >
         <DialogContent>

--- a/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
+++ b/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
@@ -31,7 +31,7 @@ export class UntrustedCertificate extends React.Component<IUntrustedCertificateP
     const type = __DARWIN__ ? 'warning' : 'error'
     const buttonGroup = __DARWIN__
       ? (
-        <ButtonGroup>
+        <ButtonGroup destructive>
           <Button type='submit'>Cancel</Button>
           <Button>View Certificate</Button>
         </ButtonGroup>

--- a/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
+++ b/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
@@ -33,7 +33,7 @@ export class UntrustedCertificate extends React.Component<IUntrustedCertificateP
       ? (
         <ButtonGroup destructive>
           <Button type='submit'>Cancel</Button>
-          <Button>View Certificate</Button>
+          <Button onClick={this.onContinue}>View Certificate</Button>
         </ButtonGroup>
       )
       : (


### PR DESCRIPTION
1. Mark the buttons as destructive so they're in the right order on macOS.
2. The Cancel button is our submit button. So it should dismiss the dialog, while the other button should continue.

![screen shot 2017-05-18 at 11 44 04 am](https://cloud.githubusercontent.com/assets/13760/26211082/9482e218-3bbf-11e7-8778-e886be8e675a.png)
