### PR TITLE
Fix searching in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
         "**/node_modules": true,
         "**/dist": true,
         "**/out": true,
-        "tslint-rules/**.js": true
+        "tslint-rules/**/*.js": true
     },
     "editor.tabSize": 2
 }


### PR DESCRIPTION
Using the search function (Ctrl + Shift + F on Windows) gives an error message about parsing glob.