### PR TITLE
Handle "Clone in Desktop" from cold start

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -598,6 +598,11 @@ export class AppStore {
     // The selected repository could have changed while we were refreshing.
     if (this.selectedRepository !== repository) { return null }
 
+    // "Clone in Desktop" from a cold start can trigger this twice, and
+    // for edge cases where _selectRepository is re-entract, calling this here
+    // ensures we clean up the existing background fetcher correctly (if set)
+    this.stopBackgroundFetching()
+
     this.startBackgroundFetching(repository, !previouslySelectedRepository)
     this.refreshMentionables(repository)
 

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -639,16 +639,6 @@ export class AppStore {
   }
 
   private startBackgroundFetching(repository: Repository, withInitialSkew: boolean) {
-
-    if (this.currentBackgroundFetcher) {
-      const backgroundFetcherRepo = this.currentBackgroundFetcher.repository
-      if (repository === backgroundFetcherRepo) {
-        // we're already fetching for this repository, don't worry about it
-        return
-      }
-    }
-
-
     if (this.currentBackgroundFetcher) {
       fatalError(`We should only have on background fetcher active at once, but we're trying to start background fetching on ${repository.name} while another background fetcher is still active!`)
       return

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -634,6 +634,16 @@ export class AppStore {
   }
 
   private startBackgroundFetching(repository: Repository, withInitialSkew: boolean) {
+
+    if (this.currentBackgroundFetcher) {
+      const backgroundFetcherRepo = this.currentBackgroundFetcher.repository
+      if (repository === backgroundFetcherRepo) {
+        // we're already fetching for this repository, don't worry about it
+        return
+      }
+    }
+
+
     if (this.currentBackgroundFetcher) {
       fatalError(`We should only have on background fetcher active at once, but we're trying to start background fetching on ${repository.name} while another background fetcher is still active!`)
       return

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -598,11 +598,6 @@ export class AppStore {
     // The selected repository could have changed while we were refreshing.
     if (this.selectedRepository !== repository) { return null }
 
-    // "Clone in Desktop" from a cold start can trigger this twice, and
-    // for edge cases where _selectRepository is re-entract, calling this here
-    // ensures we clean up the existing background fetcher correctly (if set)
-    this.stopBackgroundFetching()
-
     this.startBackgroundFetching(repository, !previouslySelectedRepository)
     this.refreshMentionables(repository)
 

--- a/app/src/lib/dispatcher/background-fetcher.ts
+++ b/app/src/lib/dispatcher/background-fetcher.ts
@@ -24,7 +24,7 @@ const SkewUpperBound = 30 * 1000
 
 /** The class which handles doing background fetches of the repository. */
 export class BackgroundFetcher {
-  public readonly repository: Repository
+  private readonly repository: Repository
   private readonly account: Account
   private readonly fetch: (repository: Repository) => Promise<void>
 

--- a/app/src/lib/dispatcher/background-fetcher.ts
+++ b/app/src/lib/dispatcher/background-fetcher.ts
@@ -24,7 +24,7 @@ const SkewUpperBound = 30 * 1000
 
 /** The class which handles doing background fetches of the repository. */
 export class BackgroundFetcher {
-  private readonly repository: Repository
+  public readonly repository: Repository
   private readonly account: Account
   private readonly fetch: (repository: Repository) => Promise<void>
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -45,6 +45,11 @@ process.on('uncaughtException', (error: Error) => {
 if (__WIN32__ && process.argv.length > 1) {
   if (handleSquirrelEvent(process.argv[1])) {
     app.quit()
+  } else {
+    const url = parseURL(process.argv[1])
+    if (url.name === 'open-repository') {
+      launchURLAction = url
+    }
   }
 }
 


### PR DESCRIPTION
This fixes #1582 by addressing two related bugs:

 - [x] we need to handle the URL being provided by the protocol handler for first launch
   - [x] handle this on Windows
   - ~~[ ] confirm this fix is not needed for macOS~~
 - ~~[ ] race condition when selecting repository again on startup triggers [this guard clause](https://github.com/desktop/desktop/blob/master/app/src/lib/dispatcher/app-store.ts#L638)~~
 - [x] if repository is already selected, the checkout doesn't fire on cold start sometimes 🤷‍♂️ 