### PR TITLE
Remove useless check for confirm remove repository modal

### DIFF
--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -31,7 +31,7 @@ export class ConfirmRemoveRepository extends React.Component<IConfirmRemoveRepos
         id='confirm-remove-repository'
         key='remove-repository-confirmation'
         type='warning'
-        title={ __DARWIN__ ? 'Remove Repository' : 'Remove repository' }
+        title='Remove repository'
         onDismissed={this.cancel}
         onSubmit={this.onConfirmed}
       >


### PR DESCRIPTION
Hi,

Maybe I don't see the use of this check but it seems useless, unless `Repository` is better on Mac than `repository`