### PR TITLE
Prevent update notification banner from compressing

### DIFF
--- a/app/styles/ui/_update-notification.scss
+++ b/app/styles/ui/_update-notification.scss
@@ -10,7 +10,7 @@
 
   height: 0px;
   transition: height 0.25s;
-
+  flex: none;
 
   &.active {
     height: 30px;

--- a/app/styles/ui/_update-notification.scss
+++ b/app/styles/ui/_update-notification.scss
@@ -10,6 +10,8 @@
 
   height: 0px;
   transition: height 0.25s;
+  // Prevents the notification banner from decreasing its height
+  // when a large diff is rendered.
   flex: none;
 
   &.active {


### PR DESCRIPTION
Fixes #1632

When viewing a diff that's large enough to have to scroll, the update notification banner would decrease its height based on what flexbox determines. This PR prevents that from happening since we are hardcoding the height itself. 

![screen shot 2017-05-19 at 2 01 25 pm](https://cloud.githubusercontent.com/assets/1174461/26266792/d85cd516-3c9b-11e7-8c4d-77c7538ea572.png)