### PR TITLE
bump to get latest Git LFS

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.0.39",
+  "version": "0.5.5",
   "dependencies": {
     "7zip": {
       "version": "0.0.6",
@@ -240,9 +240,9 @@
       "resolved": "https://registry.npmjs.org/dom-matches/-/dom-matches-2.0.0.tgz"
     },
     "dugite": {
-      "version": "1.27.0",
-      "from": "dugite@>=1.25.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.27.0.tgz"
+      "version": "1.28.0",
+      "from": "dugite@1.28.0",
+      "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.28.0.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "codemirror": "^5.24.2",
     "deep-equal": "^1.0.1",
     "dexie": "^1.4.1",
-    "dugite": "^1.25.0",
+    "dugite": "^1.28.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "front-matter": "^2.1.2",


### PR DESCRIPTION
This updates us to the latest Git LFS (which is packaged but not currently used) which addresses a security issue. See the Git LFS release notes for more information: https://github.com/git-lfs/git-lfs/releases/tag/v2.1.1