### PR TITLE
Set title with full commit message

### DIFF
--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -60,7 +60,7 @@ export class RichText extends React.Component<IRichTextProps, void> {
 
     return (
       <div className={this.props.className} title={str}>
-        {elements}
+        { elements }
       </div>
     )
   }

--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -44,7 +44,7 @@ export class RichText extends React.Component<IRichTextProps, void> {
     const elements = tokenizer.tokenize(str).map((token, index) => {
       switch (token.kind) {
         case TokenType.Emoji:
-          return <img key={index} alt={token.text} title={token.text} className='emoji' src={token.path}/>
+          return <img key={index} alt={token.text} className='emoji' src={token.path}/>
         case TokenType.Link:
           if (this.props.renderUrlsAsLinks !== false) {
             return <LinkButton key={index} uri={token.url} children={token.text} />
@@ -52,15 +52,15 @@ export class RichText extends React.Component<IRichTextProps, void> {
             return <span key={index}>{token.text}</span>
           }
         case TokenType.Text:
-          return <span key={index} title={token.text}>{token.text}</span>
+          return <span key={index}>{token.text}</span>
         default:
           return assertNever(token, 'Unknown token type: ${r.kind}')
       }
     })
 
     return (
-      <div className={this.props.className}>
-        { elements }
+      <div className={this.props.className} title={str}>
+        {elements}
       </div>
     )
   }


### PR DESCRIPTION
Instead of providing a title for each individual part of the commit summary, we now set the title for the parent container with full commit text instead.

Resolves: #1483
Related:   #1648

CC @niik