### PR TITLE
Add Reveal in Explorer option to changed file's context menu

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -840,6 +840,16 @@ export class Dispatcher {
     return this.appStore._setConfirmRepoRemoval(value)
   }
 
+  /**
+   * Reveals a file from a repository in the native file manager.
+   * @param repository The currently active repository instance
+   * @param path The path of the file relative to the root of the repository
+   */
+  public revealInFileManager(repository: Repository, path: string): boolean {
+    const normalized = Path.join(repository.path, path)
+    return shell.showItemInFolder(normalized)
+  }
+
   private async handleCloneInDesktopOptions(repository: Repository, args: IOpenRepositoryArgs): Promise<void> {
     const { filepath, pr, branch } = args
 

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -16,6 +16,11 @@ interface IChangedFileProps {
   readonly include: boolean | null
   readonly onIncludeChanged: (path: string, include: boolean) => void
   readonly onDiscardChanges: (path: string) => void
+  /**
+   * Called to reveal a file in the native file manager.
+   * @param path The path of the file relative to the root of the repository
+   */
+  readonly onRevealInFileManager: (path: string) => void
   readonly availableWidth: number
   readonly onIgnore: (pattern: string) => void
 }
@@ -100,6 +105,14 @@ export class ChangedFile extends React.Component<IChangedFileProps, void> {
       })
     }
 
+    items.push(
+      { type: 'separator' },
+      {
+        label: __DARWIN__ ? 'Reveal in Finder' : 'Show in Explorer',
+        action: () => this.props.onRevealInFileManager(this.props.path),
+        enabled: this.props.status !== AppFileStatus.Deleted,
+      },
+    )
     showContextualMenu(items)
   }
 }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -26,6 +26,11 @@ interface IChangesListProps {
   readonly onCreateCommit: (message: ICommitMessage) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly onDiscardAllChanges: (files: ReadonlyArray<WorkingDirectoryFileChange>) => void
+  /**
+   * Called to reveal a file in the native file manager.
+   * @param path The path of the file relative to the root of the repository
+   */
+  readonly onRevealInFileManager: (path: string) => void
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly gitHubUser: IGitHubUser | null
@@ -72,6 +77,7 @@ export class ChangesList extends React.Component<IChangesListProps, void> {
         key={file.id}
         onIncludeChanged={this.props.onIncludeChanged}
         onDiscardChanges={this.onDiscardChanges}
+        onRevealInFileManager={this.props.onRevealInFileManager}
         availableWidth={this.props.availableWidth}
         onIgnore={this.props.onIgnore}
       />

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -114,6 +114,14 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, void> 
   }
 
   /**
+   * Reveals a file from a repository in the native file manager.
+   * @param path The path of the file relative to the root of the repository
+   */
+  private onRevealInFileManager = (path: string) => {
+    this.props.dispatcher.revealInFileManager(this.props.repository, path)
+  }
+
+  /**
    * Toggles the selection of a given working directory file.
    * If the file is partially selected it the selection is cleared
    * in order to match the behavior of clicking on an indeterminate
@@ -203,6 +211,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, void> 
           onSelectAll={this.onSelectAll}
           onDiscardChanges={this.onDiscardChanges}
           onDiscardAllChanges={this.onDiscardAllChanges}
+          onRevealInFileManager={this.onRevealInFileManager}
           onRowClick={this.onChangedItemClick}
           commitAuthor={this.props.commitAuthor}
           branch={this.props.branch}


### PR DESCRIPTION
Fixes #1566.

I tested this on Windows 10; I don't have a Mac, but I think this would still work there since it just uses electron's shell api.

![ghdesktop_openinfinder](https://cloud.githubusercontent.com/assets/704768/26281217/e2d3b63a-3dbe-11e7-9e47-130e7fa4b8a0.PNG)

Questions:

- should I refactor the path normalization code into a helper function? I just copied and pasted it from the repo clone code from the same file.