### PR TITLE
Allow the usage of TARGET_PLATFORM env var for cross platform building

### DIFF
--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -7,6 +7,9 @@ declare const __OAUTH_CLIENT_ID__: string | undefined
 /** The OAuth secret the app should use. */
 declare const __OAUTH_SECRET__: string | undefined
 
+/** The platform that we are running under. */
+declare const __PLATFORM__: 'darwin' | 'win32'
+
 /** Is the app being built to run on Darwin? */
 declare const __DARWIN__: boolean
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -125,7 +125,7 @@ export class StatsStore {
     return {
       version: getVersion(),
       osVersion: getOS(),
-      platform: process.platform,
+      platform: __PLATFORM__,
       ...launchStats,
       ...dailyMeasures,
       ...userType,

--- a/app/src/main-process/error-page.ts
+++ b/app/src/main-process/error-page.ts
@@ -32,7 +32,7 @@ export function showFallbackPage(error: Error) {
 
   const content = `<p class='stack'>
     <strong>Version:</strong> ${app.getVersion()}<br />
-    <strong>Platform:</strong> ${process.platform}<br />
+    <strong>Platform:</strong> ${__PLATFORM__}<br />
     <strong>Error:</strong> <span id='error-content'></span>
   </p>
   <script>

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -86,7 +86,7 @@ dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(createMissingRepositoryHandler(appStore))
 dispatcher.registerErrorHandler(unhandledExceptionHandler)
 
-document.body.classList.add(`platform-${process.platform}`)
+document.body.classList.add(`platform-${__PLATFORM__}`)
 
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 

--- a/app/src/ui/lib/exception-reporting.ts
+++ b/app/src/ui/lib/exception-reporting.ts
@@ -20,7 +20,7 @@ export async function reportError(error: Error) {
 
   data.append('version', getVersion())
   data.append('osVersion', getOS())
-  data.append('platform', process.platform)
+  data.append('platform', __PLATFORM__)
   data.append('guid', getGUID())
 
   const options = {

--- a/app/test/globals.ts
+++ b/app/test/globals.ts
@@ -8,6 +8,7 @@ import 'chai-datetime'
 // These constants are defined by Webpack at build time, but since tests aren't
 // built with Webpack we need to make sure these exist at runtime.
 const g: any = global
-g['__WIN32__'] = process.platform === 'win32'
-g['__DARWIN__'] = process.platform === 'darwin'
+g['__PLATFORM__'] = process.env.TARGET_PLATFORM || process.platform
+g['__WIN32__'] = g['__PLATFORM__'] === 'win32'
+g['__DARWIN__'] = g['__PLATFORM__'] === 'darwin'
 g['__RELEASE_ENV__'] = 'development'

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -8,6 +8,7 @@ import * as chai from 'chai'
 const chaiAsPromised = require('chai-as-promised')
 const { Application } = require('spectron')
 const path = require('path')
+const targetPlatform = process.env.TARGET_PLATFORM || process.platform
 
 chai.should()
 chai.use(chaiAsPromised)
@@ -17,7 +18,7 @@ describe('App', function (this: any) {
 
   beforeEach(function () {
     let appPath = path.join(__dirname, '..', '..', '..', 'node_modules', '.bin', 'electron')
-    if (process.platform === 'win32') {
+    if (targetPlatform === 'win32') {
       appPath += '.cmd'
     }
     app = new Application({

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -10,15 +10,16 @@ const devClientId = '3a723b10ac5575cc5bb9'
 const devClientSecret = '22c34d87789a365981ed921352a7b9a8c3f69d54'
 
 const environment = process.env.NODE_ENV || 'development'
+const targetPlatform = process.env.TARGET_PLATFORM || process.platform
 
 const replacements = {
   __OAUTH_CLIENT_ID__: JSON.stringify(process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId),
   __OAUTH_SECRET__: JSON.stringify(process.env.DESKTOP_OAUTH_CLIENT_SECRET || devClientSecret),
-  __DARWIN__: process.platform === 'darwin',
-  __WIN32__: process.platform === 'win32',
+  __PLATFORM__: JSON.stringify(targetPlatform),
+  __DARWIN__: targetPlatform === 'darwin',
+  __WIN32__: targetPlatform === 'win32',
   __DEV__: environment === 'development',
   __RELEASE_ENV__: JSON.stringify(environment),
-  'process.platform': JSON.stringify(process.platform),
   'process.env.NODE_ENV': JSON.stringify(environment),
   'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),
 }

--- a/app/webpack.production.js
+++ b/app/webpack.production.js
@@ -8,9 +8,9 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const BabelPlugin = require('babel-webpack-plugin')
 
 let branchName = ''
-if (process.platform === 'darwin') {
+if (common.replacements.__DARWIN__) {
   branchName = process.env.TRAVIS_BRANCH
-} else if (process.platform === 'win32') {
+} else if (common.replacements.__WIN32__) {
   branchName = process.env.APPVEYOR_REPO_BRANCH
 }
 

--- a/script/build
+++ b/script/build
@@ -12,6 +12,7 @@ const projectRoot = path.join(__dirname, '..')
 const outRoot = path.join(projectRoot, 'out')
 const distInfo = require('./dist-info')
 
+const targetPlatform = distInfo.getTargetPlatform()
 const isProductionBuild = process.env.NODE_ENV === 'production'
 
 console.log(`Building for ${process.env.NODE_ENV}…`)
@@ -29,7 +30,7 @@ console.log('Copying static resources…')
 copyStaticResources()
 
 const isFork = process.env.TRAVIS_SECURE_ENV_VARS !== 'true'
-if (process.platform === 'darwin' && process.env.TRAVIS && !isFork) {
+if (targetPlatform === 'darwin' && process.env.TRAVIS && !isFork) {
   console.log('Setting up keychain…')
   cp.execSync(path.join(__dirname, 'setup-macos-keychain'))
 }
@@ -61,7 +62,7 @@ updateLicenseDump(err => {
 function packageApp (callback) {
   const options = {
     name: distInfo.getProductName(),
-    platform: process.platform,
+    platform: targetPlatform,
     arch: 'x64',
     asar: false, // TODO: Probably wanna enable this down the road.
     out: path.join(projectRoot, 'dist'),
@@ -132,8 +133,7 @@ function copyEmoji () {
 }
 
 function copyStaticResources () {
-  const dirName = process.platform
-  const platformSpecific = path.join(projectRoot, 'app', 'static', dirName)
+  const platformSpecific = path.join(projectRoot, 'app', 'static', targetPlatform)
   const common = path.join(projectRoot, 'app', 'static', 'common')
   const destination = path.join(outRoot, 'static')
   fs.removeSync(destination)

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -6,8 +6,18 @@ const os = require('os')
 const projectRoot = path.join(__dirname, '..')
 const appPackage = require(path.join(projectRoot, 'app', 'package.json'))
 
+function getTargetPlatform () {
+  const targetPlatform = process.env.TARGET_PLATFORM || process.platform
+  if(targetPlatform !== 'darwin' && targetPlatform !== 'win32') {
+    console.error(`Exiting - I'm not set up to work on ${targetPlatform} yet! :(`)
+    process.exit(1)
+  }
+
+  return targetPlatform
+}
+
 function getDistPath () {
-  return path.join(projectRoot, 'dist', `${getProductName()}-${process.platform}-x64`)
+  return path.join(projectRoot, 'dist', `${getProductName()}-${getTargetPlatform()}-x64`)
 }
 
 function getProductName () {
@@ -63,14 +73,11 @@ function getBundleID () {
 }
 
 function getUserDataPath () {
-  if (process.platform === 'win32') {
+  if (getTargetPlatform() === 'win32') {
     return path.join(process.env.APPDATA, getProductName())
-  } else if (process.platform === 'darwin') {
+  } else if (getTargetPlatform() === 'darwin') {
     const home = os.homedir()
     return path.join(home, 'Library', 'Application Support', getProductName())
-  } else {
-    console.error(`I dunno how to review for ${process.platform} :(`)
-    process.exit(1)
   }
 }
 
@@ -93,5 +100,6 @@ module.exports = {
   getWindowsFullNugetPackagePath,
   getBundleID,
   getUserDataPath,
-  getWindowsIdentifierName
+  getWindowsIdentifierName,
+  getTargetPlatform
 }

--- a/script/package
+++ b/script/package
@@ -9,14 +9,12 @@ const distInfo = require('./dist-info')
 
 const distPath = distInfo.getDistPath()
 const productName = distInfo.getProductName()
+const targetPlatform = distInfo.getTargetPlatform()
 
-if (process.platform === 'darwin') {
+if (targetPlatform === 'darwin') {
   packageOSX()
-} else if (process.platform === 'win32') {
+} else if (targetPlatform === 'win32') {
   packageWindows()
-} else {
-  console.error(`I dunno how to package for ${process.platform} :(`)
-  process.exit(1)
 }
 
 function packageOSX () {

--- a/script/publish
+++ b/script/publish
@@ -4,10 +4,13 @@
 
 const TEST_PUBLISH = false
 
+const distInfo = require('./dist-info')
+const targetPlatform = distInfo.getTargetPlatform()
+
 let branchName = ''
-if (process.platform === 'darwin') {
+if (targetPlatform === 'darwin') {
   branchName = process.env.TRAVIS_BRANCH
-} else if (process.platform === 'win32') {
+} else if (targetPlatform === 'win32') {
   branchName = process.env.APPVEYOR_REPO_BRANCH
 }
 
@@ -19,32 +22,22 @@ if (!/^__release.*/.test(branchName) && !TEST_PUBLISH) {
 const fs = require('fs')
 const cp = require('child_process')
 const AWS = require('aws-sdk')
-const distInfo = require('./dist-info')
 const crypto = require('crypto')
 const request = require('request')
 
 console.log('Packaging…')
 cp.execSync('npm run package')
 
-let sha = ''
-if (process.platform === 'darwin') {
-  sha = process.env.TRAVIS_COMMIT
-} else if (process.platform === 'win32') {
-  sha = process.env.APPVEYOR_REPO_COMMIT
-}
-
-sha = sha.substr(0, 8)
-
 console.log('Uploading…')
 
+let sha = ''
 let uploadPromise = null
-if (process.platform === 'darwin') {
+if (targetPlatform === 'darwin') {
+  sha = process.env.TRAVIS_COMMIT.substr(0, 8)
   uploadPromise = uploadOSXAssets()
-} else if (process.platform === 'win32') {
+} else if (targetPlatform === 'win32') {
+  sha = process.env.APPVEYOR_REPO_COMMIT.substr(0, 8)
   uploadPromise = uploadWindowsAssets()
-} else {
-  console.error(`I dunno how to publish a release for ${process.platform} :(`)
-  process.exit(1)
 }
 
 uploadPromise
@@ -119,7 +112,7 @@ function createSignature (body) {
 
 function updateDeploy (artifacts) {
   const body = {
-    context: process.platform,
+    context: targetPlatform,
     branch_name: branchName,
     artifacts
   }

--- a/script/run.js
+++ b/script/run.js
@@ -7,15 +7,13 @@ const distInfo = require('./dist-info')
 
 const distPath = distInfo.getDistPath()
 const productName = distInfo.getProductName()
+const targetPlatform = distInfo.getTargetPlatform()
 
 let binaryPath = ''
-if (process.platform === 'darwin') {
+if (targetPlatform === 'darwin') {
   binaryPath = path.join(distPath, `${productName}.app`, 'Contents', 'MacOS', `${productName}`)
-} else if (process.platform === 'win32') {
+} else if (targetPlatform === 'win32') {
   binaryPath = path.join(distPath, `${productName}.exe`)
-} else {
-  console.error(`I dunno how to run on ${process.arch} :(`)
-  process.exit(1)
 }
 
 module.exports = function (spawnOptions) {

--- a/script/test-review
+++ b/script/test-review
@@ -4,6 +4,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const distInfo = require('./dist-info')
 const { getUserDataPath } = require('./dist-info')
 
 function reviewLogs() {
@@ -23,13 +24,11 @@ function reviewLogs() {
   })
 }
 
-if (process.platform === 'darwin') {
+if (distInfo.getTargetPlatform() === 'darwin') {
   if (process.env.TRAVIS_TEST_RESULT === '1') {
     reviewLogs()
   }
-}
-
-if (process.platform === 'win32') {
+} else if (distInfo.getTargetPlatform() === 'win32') {
   if (process.env.APPVEYOR_TEST_RESULT !== '0') {
     reviewLogs()
   }


### PR DESCRIPTION
This is currently in progress just to show progress and get some feedback, and to see if it's something that you guys want.

For example, this lets me build for windows and OSX from linux (notably WSL/BashOnWindows) by using `TARGET_PLATFORM=win32 npm run build:prod`.

Let me know if you want me to open an issue for this to better discuss this, or if there's a better way of doing this.

Current issues:

- Convert the Windows powershell scripts to javascript - #1673
- Easier cross platform building - https://github.com/desktop/dugite/issues/95
- keytar.node :( Currently I just copy the compiled version from a release.

Additional linux notes:

- If your default python is not python2.7 then set the
executable in npm: `npm config set python python2.7`
- You need to install both pkg-config and libsecret-1:
`sudo apt-get install -y pkg-config libsecret-1-dev`
- Wine [must be installed](https://github.com/electron-userland/electron-packager#building-windows-apps-from-non-windows-platforms) if targeting windows to set the metadata,
if it's not installed then building won't be successful.
You can use [electron-packager-dummy-wine](https://github.com/rahatarmanahmed/electron-packager-dummy-wine) to skip setting metadata.