### PR TITLE
Polish commit summary description area

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -77,6 +77,7 @@
     overflow: hidden;
     // The extra pixel makes the space align up with the commit list.
     max-height: 61px;
+    flex: 1;
 
     &:before {
       content: "";

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -80,7 +80,7 @@
 
     &:before {
       content: "";
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0) 40px, rgba(255, 255, 255, 0.5) 40px, white 60px);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0px, rgba(255, 255, 255, 0) 40px, rgba(255, 255, 255, 0.5) 40px, white 60px);
       position: absolute;
       height: 100%;
       width: 100%;


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/1695

Couple of small UI fixes for the commit summary area:

On Windows, the gradient for "collapsed description" was starting at `0px` instead of `40px`. Adding an extra color stop at `0px` fixes the appearance of grayed text.

**Fixed (1 line)**

![commit-descrip-one](https://cloud.githubusercontent.com/assets/1174461/26322000/034af250-3ede-11e7-947f-0df785be855e.PNG)

**2 lines**

![commit-descrip-two](https://cloud.githubusercontent.com/assets/1174461/26322039/2c830edc-3ede-11e7-8d9d-8909043f6394.PNG)

**3 lines (collapsed)**

![commit-descrip-three](https://cloud.githubusercontent.com/assets/1174461/26322059/3df2c3ce-3ede-11e7-940c-b22da8e8e5ec.PNG)

Also fixed an issue where the commit description container didn't take up the entire width:

**Before**

![long-description](https://cloud.githubusercontent.com/assets/1174461/26321970/df328a04-3edd-11e7-8f54-dd85c56bc732.PNG)

**After**

![long-description-fixt](https://cloud.githubusercontent.com/assets/1174461/26321987/f6ddd55a-3edd-11e7-98c3-d497360064b5.PNG)
