### PR TITLE
A fresh coat of mostly the same paint

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "dependencies": {
     "7zip": {
       "version": "0.0.6",
@@ -117,7 +117,7 @@
     },
     "byline": {
       "version": "4.2.2",
-      "from": "byline@>=4.2.2 <5.0.0",
+      "from": "byline@4.2.2",
       "resolved": "https://registry.npmjs.org/byline/-/byline-4.2.2.tgz"
     },
     "caseless": {
@@ -137,7 +137,7 @@
     },
     "classnames": {
       "version": "2.2.5",
-      "from": "classnames@>=2.2.5 <3.0.0",
+      "from": "classnames@>=2.2.3 <3.0.0",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
     },
     "co": {
@@ -147,7 +147,7 @@
     },
     "codemirror": {
       "version": "5.25.2",
-      "from": "codemirror@latest",
+      "from": "codemirror@>=5.24.2 <6.0.0",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.25.2.tgz"
     },
     "colors": {
@@ -215,7 +215,7 @@
     },
     "devtron": {
       "version": "1.4.0",
-      "from": "devtron@>=1.4.0 <2.0.0",
+      "from": "devtron@latest",
       "resolved": "https://registry.npmjs.org/devtron/-/devtron-1.4.0.tgz",
       "dev": true
     },
@@ -252,7 +252,7 @@
     },
     "electron-debug": {
       "version": "1.1.0",
-      "from": "electron-debug@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/electron-debug/-/electron-debug-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-1.1.0.tgz",
       "dev": true
     },
@@ -337,12 +337,12 @@
     },
     "front-matter": {
       "version": "2.1.2",
-      "from": "front-matter@>=2.1.2 <3.0.0",
+      "from": "front-matter@2.1.2",
       "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-2.1.2.tgz"
     },
     "fs-extra": {
       "version": "2.1.2",
-      "from": "fs-extra@>=2.0.0 <3.0.0",
+      "from": "fs-extra@2.1.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz"
     },
     "fs.realpath": {
@@ -432,7 +432,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "is-stream": {
@@ -646,6 +646,11 @@
       "from": "performance-now@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
     },
+    "primer-support": {
+      "version": "4.0.0",
+      "from": "primer-support@latest",
+      "resolved": "https://registry.npmjs.org/primer-support/-/primer-support-4.0.0.tgz"
+    },
     "progress": {
       "version": "2.0.0",
       "from": "progress@>=2.0.0 <3.0.0",
@@ -658,7 +663,7 @@
     },
     "prop-types": {
       "version": "15.5.8",
-      "from": "prop-types@>=15.5.7 <16.0.0",
+      "from": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.8.tgz",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.8.tgz"
     },
     "pseudomap": {
@@ -689,7 +694,7 @@
     },
     "react-addons-perf": {
       "version": "15.4.2",
-      "from": "react-addons-perf@>=15.4.2 <16.0.0",
+      "from": "react-addons-perf@latest",
       "resolved": "https://registry.npmjs.org/react-addons-perf/-/react-addons-perf-15.4.2.tgz",
       "dev": true
     },
@@ -795,7 +800,7 @@
     },
     "style-loader": {
       "version": "0.13.2",
-      "from": "style-loader@>=0.13.2 <0.14.0",
+      "from": "style-loader@0.13.2",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
       "dev": true
     },
@@ -820,7 +825,7 @@
     },
     "textarea-caret": {
       "version": "3.0.2",
-      "from": "textarea-caret@>=3.0.2 <4.0.0",
+      "from": "textarea-caret@3.0.2",
       "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.0.2.tgz"
     },
     "tough-cookie": {
@@ -841,22 +846,22 @@
     },
     "ua-parser-js": {
       "version": "0.7.12",
-      "from": "ua-parser-js@>=0.7.12 <0.8.0",
+      "from": "ua-parser-js@latest",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "untildify": {
       "version": "3.0.2",
-      "from": "untildify@>=3.0.2 <4.0.0",
+      "from": "untildify@latest",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz"
     },
     "username": {
       "version": "2.3.0",
-      "from": "username@>=2.3.0 <3.0.0",
+      "from": "username@2.3.0",
       "resolved": "https://registry.npmjs.org/username/-/username-2.3.0.tgz"
     },
     "uuid": {
       "version": "3.0.1",
-      "from": "uuid@>=3.0.1 <4.0.0",
+      "from": "uuid@latest",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
     },
     "verror": {
@@ -887,12 +892,12 @@
     },
     "wicg-focus-ring": {
       "version": "1.0.1",
-      "from": "wicg-focus-ring@>=1.0.1 <2.0.0",
+      "from": "wicg-focus-ring@latest",
       "resolved": "https://registry.npmjs.org/wicg-focus-ring/-/wicg-focus-ring-1.0.1.tgz"
     },
     "winston": {
       "version": "2.3.1",
-      "from": "winston@>=2.3.1 <3.0.0",
+      "from": "winston@2.3.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz"
     },
     "winston-daily-rotate-file": {

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,7 @@
     "keytar": "^4.0.2",
     "moment": "^2.17.1",
     "octokat": "^0.8.0",
+    "primer-support": "^4.0.0",
     "react": "^15.5.4",
     "react-addons-shallow-compare": "^15.5.2",
     "react-dom": "^15.5.4",

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -14,7 +14,7 @@ $gray-500:        #6a737d !default;
 $gray-600:        #586069 !default;
 $gray-700:        #444d56 !default;
 $gray-800:        #2f363d !default;
-$gray-900:        #24292e !default; // body font color
+$gray-900:        #24292e !default;
 
 :root {
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -269,7 +269,7 @@
   --dialog-error-color: $red;
 
   /** Inline paths and code */
-  --path-segment-background: #E3F1FD;
+  --path-segment-background: $blue-000;
   --path-segment-padding: var(--spacing-third);
 
   // http://easings.net/#easeOutBack

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -32,12 +32,6 @@ $gray-900:        #24292e !default;
   $lightRed: #f04747;
   $green: #28a745;
   $orange: #f66a0a;
-  $black: #24292e;
-  $darkerGray: #6a737d;
-  $darkGray: #959da5;
-  $gray: #E1E4E8;
-  $lightGray: #F6F8FA;
-  $lighterGray: #fafbfc;
   $white: #fff;
 
   --color-new: $green;
@@ -46,8 +40,8 @@ $gray-900:        #24292e !default;
   --color-renamed: $blue;
   --color-conflicted: $orange;
 
-  --text-color: $black;
-  --text-secondary-color: $darkerGray;
+  --text-color: $gray-900;
+  --text-secondary-color: $gray-500;
   --background-color: $white;
 
   --button-height: 25px;
@@ -60,10 +54,10 @@ $gray-900:        #24292e !default;
 
   --link-button-color: $blue;
 
-  --secondary-button-background: $lighterGray;
+  --secondary-button-background: $gray-000;
   --secondary-button-hover-background: $white;
   --secondary-button-text-color: var(--text-color);
-  --secondary-button-focus-shadow-color: rgba($gray, 0.75);
+  --secondary-button-focus-shadow-color: rgba($gray-200, 0.75);
   --secondary-button-focus-border-color: #D1D5DA;
 
   // Typography
@@ -116,18 +110,17 @@ $gray-900:        #24292e !default;
   // or an item in a tab control header. It's up to each implementation
   // to decide what states to support (active selection, selection, etc).
 
-  --box-alt-background-color: $lightGray;
+  --box-alt-background-color: $gray-100;
 
   /**
    * Border color for boxes.
    */
-  --box-border-color: $gray;
+  --box-border-color: $gray-200;
   --box-border-accent-color: $blue;
 
   /**
    * Background color for selected boxes without keyboard focus
    */
-  --box-selected-background-color: $lightGray;
 
   /**
    * Text color for when a user hovers over a boxe with a
@@ -135,7 +128,7 @@ $gray-900:        #24292e !default;
    * implement a hover state since this will conflict with
    * selection and active selection
    */
-  --box-hover-text-color: $black;
+  --box-hover-text-color: $gray-900;
 
   /**
    * Background color for when a user hovers over a boxe with a
@@ -143,17 +136,16 @@ $gray-900:        #24292e !default;
    * implement a hover state since this will conflict with
    * selection and active selection
    */
-  --box-hover-background-color: $lightGray;
 
   /**
    * Text color for selected boxes without keyboard focus
    */
-  --box-selected-text-color: $black;
+  --box-selected-text-color: $gray-900;
 
   /**
    * Border color for selected boxes without keyboard focus
    */
-  --box-selected-border-color: $darkGray;
+  --box-selected-border-color: $gray-400;
 
   /**
    * Background color for selected boxes with active keyboard focus
@@ -168,11 +160,11 @@ $gray-900:        #24292e !default;
   /**
    * Border color for selected boxes with active keyboard focus
    */
-  --box-selected-active-border-color: $darkGray;
+  --box-selected-active-border-color: $gray-400;
 
   /** The height of the title bar area on Win32 platforms */
   --win32-title-bar-height: 28px;
-  --win32-title-bar-background-color: $black;
+  --win32-title-bar-background-color: $gray-900;
 
   /** The height of the title bar area on darwin platforms */
   --darwin-title-bar-height: 22px;
@@ -192,20 +184,20 @@ $gray-900:        #24292e !default;
 
   --toolbar-height: 50px;
 
-  --toolbar-background-color: $black;
+  --toolbar-background-color: $gray-900;
   --toolbar-text-color: $white;
-  --toolbar-text-secondary-color: $darkGray;
+  --toolbar-text-secondary-color: $gray-400;
 
   --toolbar-button-color: var(--toolbar-text-color);
   --toolbar-button-background-color: transparent;
-  --toolbar-button-border-color: darken($black, 20%);
+  --toolbar-button-border-color: darken($gray-900, 20%);
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
   --toolbar-button-hover-color: $white;
-  --toolbar-button-hover-background-color: lighten($black, 5%);
+  --toolbar-button-hover-background-color: lighten($gray-900, 5%);
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: lighten($black, 5%);
+  --toolbar-button-focus-background-color: lighten($gray-900, 5%);
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);
@@ -261,11 +253,11 @@ $gray-900:        #24292e !default;
 
   --diff-add-background-color: #EAFFEA;
   --diff-add-border-color: #b3e3b2;
-  --diff-add-text-color: $gray;
+  --diff-add-text-color: $gray-200;
 
   --diff-delete-background-color: #FFECEC;
   --diff-delete-border-color: #eaaead;
-  --diff-delete-text-color: $gray;
+  --diff-delete-text-color: $gray-200;
 
   --diff-hunk-background-color: #f8f8ff;
   --diff-hunk-border-color: #e4e4fe;
@@ -282,7 +274,7 @@ $gray-900:        #24292e !default;
   /**
    * Ahead/behind view
    */
-  --ahead-behind-background-color: $darkerGray;
+  --ahead-behind-background-color: $gray-500;
 
   // Colors for form errors
   --error-color: $red;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -102,6 +102,7 @@
   /**
    * Background color for selected boxes without keyboard focus
    */
+  --box-selected-background-color: $gray-100;
 
   /**
    * Text color for when a user hovers over a boxe with a

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -3,18 +3,7 @@
 // This files contains CSS variables accessible to all selectors
 
 // Primer colors, see https://github.com/primer/primer-support/blob/master/lib/variables/color-system.scss
-//
-// -------- Grays --------
-$gray-000:        #fafbfc !default;
-$gray-100:        #f6f8fa !default;
-$gray-200:        #e1e4e8 !default;
-$gray-300:        #d1d5da !default;
-$gray-400:        #959da5 !default;
-$gray-500:        #6a737d !default;
-$gray-600:        #586069 !default;
-$gray-700:        #444d56 !default;
-$gray-800:        #2f363d !default;
-$gray-900:        #24292e !default;
+@import '~primer-support/lib/variables/color-system.scss';
 
 :root {
 
@@ -24,14 +13,8 @@ $gray-900:        #24292e !default;
   // in variables. It also makes it easier to read and understand what
   // color is being used. Note that these variables should _never_ be
   // used outside of this scope.
-  $darkBlue: #005CC5;
-  $blue: #0366d6;
-  $yellow: #ffd33d;
   $lightYellow: #f6a623;
-  $red: #d73a49;
   $lightRed: #f04747;
-  $green: #28a745;
-  $orange: #f66a0a;
   $white: #fff;
 
   --color-new: $green;
@@ -50,7 +33,7 @@ $gray-900:        #24292e !default;
   --button-border-radius: 2px;
   --button-hover-background: lighten($blue, 5%);
   --button-text-color: $white;
-  --button-focus-border-color: $darkBlue;
+  --button-focus-border-color: $blue-600;
 
   --link-button-color: $blue;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -240,7 +240,7 @@
   --diff-hunk-background-color: $blue-000;
   --diff-hunk-border-color: $blue-200;
   --diff-hunk-gutter-color: $blue-200;
-  --diff-hunk-text-color: $blue-800;
+  --diff-hunk-text-color: $gray;
 
   --diff-hover-background-color: $blue-300;
   --diff-hover-border-color: $blue-400;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -265,8 +265,9 @@
   --form-error-border-color: #d3b2b2;
 
   /** Dialog */
-  --dialog-warning-color: $lightYellow;
-  --dialog-error-color: $lightRed;
+  --dialog-warning-color: $yellow-600;
+  --dialog-warning-text-color: $yellow-800;
+  --dialog-error-color: $red;
 
   /** Inline paths and code */
   --path-segment-background: #E3F1FD;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -190,7 +190,7 @@ $gray-900:        #24292e !default;
 
   --toolbar-button-color: var(--toolbar-text-color);
   --toolbar-button-background-color: transparent;
-  --toolbar-button-border-color: darken($gray-900, 20%);
+  --toolbar-button-border-color: black;
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
   --toolbar-button-hover-color: $white;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -7,14 +7,6 @@
 
 :root {
 
-  // Colors
-  //
-  // These are declared here to let us avoid duplicating color constants
-  // in variables. It also makes it easier to read and understand what
-  // color is being used. Note that these variables should _never_ be
-  // used outside of this scope.
-  $white: #fff;
-
   --color-new: $green;
   --color-deleted: $red;
   --color-modified: $yellow;
@@ -223,30 +215,36 @@
    * Diff view
    */
 
-  --diff-font-color: #323232;
+  --diff-text-color: $gray-900;
+  --diff-border-color: $gray-200;
+  --diff-gutter-color: $gray-200;
 
-  --diff-border-color: #e5e5e5;
-  --diff-line-number-color: #84929c;
+  --diff-line-number-color: $gray-700;
   --diff-line-number-column-width: 50px;
 
-  --diff-selected-background-color: #5A93E0;
-  --diff-selected-border-color: #4f86d5;
+  --diff-selected-background-color: $blue-400;
+  --diff-selected-border-color: $blue-600;
+  --diff-selected-gutter-color: $blue-600;
   --diff-selected-text-color: var(--background-color);
 
-  --diff-add-background-color: #EAFFEA;
-  --diff-add-border-color: #b3e3b2;
-  --diff-add-text-color: $gray-200;
+  --diff-add-background-color: $green-000;
+  --diff-add-border-color: $green-200;
+  --diff-add-gutter-color: $green-200;
+  --diff-add-text-color: var(--diff-text-color);
 
-  --diff-delete-background-color: #FFECEC;
-  --diff-delete-border-color: #eaaead;
-  --diff-delete-text-color: $gray-200;
+  --diff-delete-background-color: $red-000;
+  --diff-delete-border-color: $red-100;
+  --diff-delete-gutter-color: $red-200;
+  --diff-delete-text-color: var(--diff-text-color);
 
-  --diff-hunk-background-color: #f8f8ff;
-  --diff-hunk-border-color: #e4e4fe;
-  --diff-hunk-text-color: var(--diff-line-number-color);
+  --diff-hunk-background-color: $blue-000;
+  --diff-hunk-border-color: $blue-200;
+  --diff-hunk-gutter-color: $blue-200;
+  --diff-hunk-text-color: $blue-800;
 
-  --diff-hover-background-color: #96b8ec;
-  --diff-hover-border-color: #89a9dc;
+  --diff-hover-background-color: $blue-300;
+  --diff-hover-border-color: $blue-400;
+  --diff-hover-gutter-color: $blue-400;
   --diff-hover-text-color: var(--background-color);
 
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -39,7 +39,7 @@
   --secondary-button-hover-background: $white;
   --secondary-button-text-color: var(--text-color);
   --secondary-button-focus-shadow-color: rgba($gray-200, 0.75);
-  --secondary-button-focus-border-color: #D1D5DA;
+  --secondary-button-focus-border-color: $gray-300;
 
   // Typography
   //
@@ -184,10 +184,10 @@
   --toolbar-button-active-background-color: var(--background-color);
   --toolbar-button-active-border-color: var(--background-color);
 
-  --toolbar-button-progress-color: #2F363D;
-  --toolbar-button-focus-progress-color: #444D56;
-  --toolbar-button-hover-progress-color: #444D56;
-  --toolbar-dropdown-open-progress-color: #E1E4E8;
+  --toolbar-button-progress-color: $gray-800;
+  --toolbar-button-focus-progress-color: $gray-700;
+  --toolbar-button-hover-progress-color: $gray-700;
+  --toolbar-dropdown-open-progress-color: $gray-200;
 
   --tab-bar-height: 29px;
   --tab-bar-active-color: $blue;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -2,6 +2,20 @@
 //
 // This files contains CSS variables accessible to all selectors
 
+// Primer colors, see https://github.com/primer/primer-support/blob/master/lib/variables/color-system.scss
+//
+// -------- Grays --------
+$gray-000:        #fafbfc !default;
+$gray-100:        #f6f8fa !default;
+$gray-200:        #e1e4e8 !default;
+$gray-300:        #d1d5da !default;
+$gray-400:        #959da5 !default;
+$gray-500:        #6a737d !default;
+$gray-600:        #586069 !default;
+$gray-700:        #444d56 !default;
+$gray-800:        #2f363d !default;
+$gray-900:        #24292e !default; // body font color
+
 :root {
 
   // Colors

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -13,8 +13,6 @@
   // in variables. It also makes it easier to read and understand what
   // color is being used. Note that these variables should _never_ be
   // used outside of this scope.
-  $lightYellow: #f6a623;
-  $lightRed: #f04747;
   $white: #fff;
 
   --color-new: $green;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -261,8 +261,9 @@
 
   // Colors for form errors
   --error-color: $red;
-  --form-error-background: #fddede;
-  --form-error-border-color: #d3b2b2;
+  --form-error-background: $red-100;
+  --form-error-border-color: $red-200;
+  --form-error-text-color: $red-800;
 
   /** Dialog */
   --dialog-warning-color: $yellow-600;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -194,10 +194,10 @@ $gray-900:        #24292e !default;
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
   --toolbar-button-hover-color: $white;
-  --toolbar-button-hover-background-color: lighten($gray-900, 5%);
+  --toolbar-button-hover-background-color: $gray-800;
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: lighten($gray-900, 5%);
+  --toolbar-button-focus-background-color: $gray-800;
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -233,7 +233,8 @@ dialog {
   // Custom branding of a warning dialog. Used for dangerous actions
   &.warning {
     .dialog-header {
-      color: var(--dialog-warning-color);
+      .icon { color: var(--dialog-warning-color); }
+      h1 { color: var(--dialog-warning-text-color); }
     }
 
     border-top: 3px solid var(--dialog-warning-color);

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -263,6 +263,7 @@ dialog {
 
     background: var(--form-error-background);
     border-bottom: 1px solid var(--form-error-border-color);
+    color: var(--form-error-text-color);
 
     > .octicon {
       flex-grow: 0;

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -263,7 +263,6 @@ dialog {
 
     background: var(--form-error-background);
     border-bottom: 1px solid var(--form-error-border-color);
-    color: var(--error-color);
 
     > .octicon {
       flex-grow: 0;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -8,7 +8,7 @@
 
 .CodeMirror {
   height: 100%;
-  color: var(--diff-font-color);
+  color: var(--diff-text-color);
   font-size: var(--font-size-sm);
   font-family: var(--font-family-monospace);
 
@@ -87,28 +87,43 @@
 
 .diff-add {
   background: var(--diff-add-background-color);
+  color: var(--diff-add-text-color);
   padding: 0;
 
   .diff-line-number {
     border-color: var(--diff-add-border-color);
+
+    &:last-child {
+      border-color: var(--diff-add-gutter-color);
+    }
   }
 }
 
 .diff-delete {
   background: var(--diff-delete-background-color);
+  color: var(--diff-delete-text-color);
   padding: 0;
 
   .diff-line-number {
     border-color: var(--diff-delete-border-color);
+
+    &:last-child {
+      border-color: var(--diff-delete-gutter-color);
+    }
   }
 }
 
 .diff-context {
   background: var(--background-color);
+  color: var(--diff-context-text-color);
   padding: 0;
 
   .diff-line-number {
     border-color: var(--diff-border-color);
+
+    &:last-child {
+      border-color: var(--diff-gutter-color);
+    }
   }
 }
 
@@ -117,12 +132,29 @@
   color: var(--diff-hunk-text-color);
 }
 
+.cm-diff-delete {
+  color: var(--diff-delete-text-color);
+}
+
+.cm-diff-add {
+  color: var(--diff-add-text-color);
+}
+
+.cm-diff-context {
+  color: var(--diff-context-text-color);
+}
+
 .diff-hunk {
   background: var(--diff-hunk-background-color);
+  color: var(--diff-hunk-text-color);
   padding: 0;
 
   .diff-line-number {
     border-color: var(--diff-hunk-border-color);
+
+    &:last-child {
+      border-color: var(--diff-hunk-gutter-color);
+    }
   }
 }
 
@@ -132,6 +164,10 @@
     background: var(--diff-selected-background-color);
     border-color: var(--diff-selected-border-color);
     color: var(--diff-selected-text-color);
+
+    &:last-child {
+      border-color: var(--diff-selected-gutter-color);
+    }
   }
 }
 
@@ -140,7 +176,11 @@
   .diff-line-number {
     background: var(--diff-hover-background-color);
     border-color: var(--diff-hover-border-color);
-    color: var(--background-color);
+    color: var(--diff-hover-text-color);
+
+    &:last-child {
+      border-color: var(--diff-hover-gutter-color);      
+    }
   }
 }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -36,6 +36,7 @@
       // Add a little bit of space to the left of code diff
       // `padding-left` here means mouse move events are not raised
       padding-left: var(--spacing-half);
+      align-self: center;      
     }
 
     svg.no-newline {


### PR DESCRIPTION
This finished the work that @donokuda started to bring us onto the primer color scheme. With this we're importing the color variables (and only the color variables) from primer and using that instead of our own hard coded (and poorly named) variables. This will hopefully make it much easier for us to reason about contrast and complementary colors going forward.

For the most part this isn't really noticeable in the app as most of the colors we were using were identical, or very close to, their primer counterparts.

The error and warning dialogs were the only places where we didn't quite abide by the primer color scheme so I've had to tweak those a bit.

### Before

![image](https://cloud.githubusercontent.com/assets/634063/26355157/e68d131a-3fc7-11e7-85df-7b2dcc9fda69.png)

The title text is not legible and it gets even worse when aligning to primer so I've opted for a custom, darker yellow for the text now. I plan to revisit these dialog header designs as soon as I get some spare time anyway so we shouldn't spend too much time on it.

### After

![image](https://cloud.githubusercontent.com/assets/634063/26355139/d4c0039a-3fc7-11e7-88d0-59b6494dfbe6.png)

![image](https://cloud.githubusercontent.com/assets/634063/26356055/1b47facc-3fcb-11e7-81ad-a8477bde650c.png)

### Diffs

Our colors already aligned pretty well with primer but I took the opportunity to tweak our gutters and to split the color of the line number divider and the main gutter color so that we could get more nicely aligned (contrast wise) vertical lines in the gutter.

#### Before

![image](https://cloud.githubusercontent.com/assets/634063/26356242/b80d7d82-3fcb-11e7-9645-9cffd024edc3.png)

#### After

![image](https://cloud.githubusercontent.com/assets/634063/26356248/bf22aaf2-3fcb-11e7-873a-c7978e410656.png)


This checks of one of the long standing items on mine and @donokuda's design agenda

> - [x] @donokuda or @niik to pull primer color variables into our stylesheets