### PR TITLE
Tab bars are buttons, but not submit buttons

### DIFF
--- a/app/src/ui/tab-bar.tsx
+++ b/app/src/ui/tab-bar.tsx
@@ -118,6 +118,7 @@ class TabBarItem extends React.Component<ITabBarItemProps, void> {
         aria-selected={selected}
         tabIndex={selected ? 0 : -1}
         onKeyDown={this.onKeyDown}
+        type='button'
       >
         {this.props.children}
       </button>


### PR DESCRIPTION
If we don't provide a type, Chrome decides they're submit buttons. But that's just a lie.

Fixes #1724 