### PR TITLE
Don't do rebase on pull

### DIFF
--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -11,13 +11,13 @@ import { Account } from '../../models/account'
 import { PullProgressParser, executionOptionsWithProgress } from '../progress'
 import { IPullProgress } from '../app-state'
 
-/** 
+/**
  * Pull from the specified remote.
- * 
+ *
  * @param repository - The repository in which the pull should take place
- * 
+ *
  * @param remote     - The name of the remote that should be pulled from
- * 
+ *
  * @param progressCallback - An optional function which will be invoked
  *                           with information about the current progress
  *                           of the pull operation. When provided this enables
@@ -39,7 +39,7 @@ export async function pull(repository: Repository, account: Account | null, remo
       // In addition to progress output from the remote end and from
       // git itself, the stderr output from pull contains information
       // about ref updates. We don't need to bring those into the progress
-      // stream so we'll just punt on anything we don't know about for now. 
+      // stream so we'll just punt on anything we don't know about for now.
       if (progress.kind === 'context') {
         if (!progress.text.startsWith('remote: Counting objects')) {
           return

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -60,8 +60,8 @@ export async function pull(repository: Repository, account: Account | null, remo
   }
 
   const args = progressCallback
-    ? [ ...gitNetworkArguments, 'pull', '--progress', remote ]
-    : [ ...gitNetworkArguments, 'pull', remote ]
+    ? [ ...gitNetworkArguments, 'pull', '--no-rebase', '--progress', remote ]
+    : [ ...gitNetworkArguments, 'pull', '--no-rebase', remote ]
 
   const result = await git(args, repository.path, 'pull', opts)
 


### PR DESCRIPTION
In #1627 @jlperla had (unknowingly) the [`pull.rebase` git config variable](https://git-scm.com/docs/git-config#git-config-pullrebase) set to true and that caused the app to behave in unexpected ways when pulling down changes.

While it would be nice if we could respect this config var we have a bit of work ahead of us before we can do so (see #1652, #788, #1478 etc). So for now we'll explicitly turn off rebase for pulls. 

Fixes #1627 