### PR TITLE
log an error with the context if creating a repository failed

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -293,10 +293,12 @@ export class API {
         const message: string = e.message
         const error = await deserialize<IError>(message)
         if (error) {
+          logError(`createRepository return an API error: ${JSON.stringify(error)}`, e)
           throw new Error(error.message)
         }
       }
 
+      logError(`createRepository return an unknown error`, e)
       throw e
     }
   }


### PR DESCRIPTION
As part of investigating #1750, this dumps the API error information (if it's valid JSON) or the raw error body when creating a repository fails - this should help us see what field it thinks is invalid as part of returning the 422 error, and maybe figure out why it's an intermittent thing.