### PR TITLE
Add link to copy SHA to clipboard

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -180,7 +180,15 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
     )
   }
 
-  private renderExternalLink(url: string | null) {
+  private renderExternalLink() {
+    let url: string | null = null
+    if (!this.props.isLocal) {
+      const gitHubRepository = this.props.repository.gitHubRepository
+      if (gitHubRepository) {
+        url = `${gitHubRepository.htmlURL}/commit/${this.props.sha}`
+      }
+    }
+
     if (!url) {
       return null
     }
@@ -203,15 +211,6 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
     const filesDescription = `${fileCount} changed ${filesPlural}`
     const longSHA = this.props.sha
     const shortSHA = this.props.sha.slice(0, 7)
-
-    let url: string | null = null
-    if (!this.props.isLocal) {
-      const gitHubRepository = this.props.repository.gitHubRepository
-      if (gitHubRepository) {
-        url = `${gitHubRepository.htmlURL}/commit/${this.props.sha}`
-      }
-    }
-
     const author = this.props.author
     const authorTitle = `${author.name} <${author.email}>`
     let avatarUser = undefined
@@ -262,7 +261,7 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
               {filesDescription}
             </li>
 
-            {this.renderExternalLink(url)}
+            {this.renderExternalLink()}
           </ul>
         </div>
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as classNames from 'classnames'
+import {clipboard}  from 'electron'
 
 import { FileChange } from '../../models/status'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -179,10 +180,28 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
     )
   }
 
+  private renderExternalLink(url: string | null) {
+    if (!url) {
+      return null
+    }
+
+    return (
+      <li className='commit-summary-meta-item'
+        title="View this commit on github.com">
+        <span aria-hidden='true'>
+          <Octicon symbol={OcticonSymbol.linkExternal} />
+        </span>
+
+        <LinkButton uri={url}>View on GitHub</LinkButton>
+      </li>
+    )
+  }
+
   public render() {
     const fileCount = this.props.files.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
     const filesDescription = `${fileCount} changed ${filesPlural}`
+    const longSHA = this.props.sha
     const shortSHA = this.props.sha.slice(0, 7)
 
     let url: string | null = null
@@ -226,12 +245,12 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
             </li>
 
             <li className='commit-summary-meta-item'
-              title={shortSHA} aria-label='SHA'>
+              title="Copy SHA to clipboard" aria-label='SHA'>
               <span aria-hidden='true'>
                 <Octicon symbol={OcticonSymbol.gitCommit} />
               </span>
 
-              {url ? <LinkButton uri={url}>{shortSHA}</LinkButton> : shortSHA}
+              <LinkButton onClick={() => clipboard.writeText(longSHA)}>{shortSHA}</LinkButton>
             </li>
 
             <li className='commit-summary-meta-item'
@@ -242,6 +261,8 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
 
               {filesDescription}
             </li>
+
+            {this.renderExternalLink(url)}
           </ul>
         </div>
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as classNames from 'classnames'
-import {clipboard}  from 'electron'
+import { clipboard }  from 'electron'
 
 import { FileChange } from '../../models/status'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -63,6 +63,10 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
         }
       })
     }
+  }
+
+  private onCopyShaToClipboard = () => {
+    clipboard.writeText(this.props.sha)
   }
 
   private onResized = () => {
@@ -195,9 +199,9 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
 
     return (
       <li className='commit-summary-meta-item'
-        title="View this commit on github.com">
+        title='View this commit on github.com'>
         <span aria-hidden='true'>
-          <Octicon symbol={OcticonSymbol.octoface} />
+          <Octicon symbol={OcticonSymbol.markGithub} />
         </span>
 
         <LinkButton uri={url}>View on GitHub</LinkButton>
@@ -209,7 +213,6 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
     const fileCount = this.props.files.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
     const filesDescription = `${fileCount} changed ${filesPlural}`
-    const longSHA = this.props.sha
     const shortSHA = this.props.sha.slice(0, 7)
     const author = this.props.author
     const authorTitle = `${author.name} <${author.email}>`
@@ -244,12 +247,12 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
             </li>
 
             <li className='commit-summary-meta-item'
-              title="Copy SHA to clipboard" aria-label='SHA'>
+              title='Copy SHA to clipboard' aria-label='SHA'>
               <span aria-hidden='true'>
                 <Octicon symbol={OcticonSymbol.gitCommit} />
               </span>
 
-              <LinkButton onClick={() => clipboard.writeText(longSHA)}>{shortSHA}</LinkButton>
+              <LinkButton onClick={this.onCopyShaToClipboard}>{shortSHA}</LinkButton>
             </li>
 
             <li className='commit-summary-meta-item'

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -197,7 +197,7 @@ export class CommitSummary extends React.Component<ICommitSummaryProps, ICommitS
       <li className='commit-summary-meta-item'
         title="View this commit on github.com">
         <span aria-hidden='true'>
-          <Octicon symbol={OcticonSymbol.linkExternal} />
+          <Octicon symbol={OcticonSymbol.octoface} />
         </span>
 
         <LinkButton uri={url}>View on GitHub</LinkButton>

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -114,10 +114,6 @@
   }
 
   &-meta-item {
-    a {
-      -webkit-user-select: text;
-      user-select: text;
-    }
     @include ellipsis;
     margin-right: var(--spacing);
     font-size: var(--font-size-sm);


### PR DESCRIPTION
This is to get feedback on the feature. It updates the commit sha link so when clicked it copies it to the clipboard. The existing link is moved to a new **View on GitHub** link similar to the native client and only shows if the commit isn't local.

The style rule added in #1291 was removed since you no longer need to select the link in order to copy it.

![image](https://cloud.githubusercontent.com/assets/831974/26468259/bbcd5ed0-4163-11e7-9fb4-e0af4e162aff.png)

cc #1501 