### PR TITLE
Cacheable (and working) issues

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -352,9 +352,7 @@ export class API {
     const issues = new Array<IAPIIssue>()
 
     do {
-      debugger
       response = await this.authenticatedRequest('GET', url)
-      debugger
       const items = await deserialize<ReadonlyArray<IAPIIssue>>(response)
       if (items) {
         issues.push(...items)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -359,6 +359,13 @@ export class API {
     return issues.filter((i: any) => !i.pullRequest)
   }
 
+  /**
+   * Authenticated requests to a paginating resource such as issues.
+   *
+   * Follows the GitHub API hypermedia links to get the subsequent
+   * pages when available, buffers all items and returns them in
+   * one array when done.
+   */
   private async fetchAll<T>(url: string): Promise<ReadonlyArray<T>> {
     const buf = new Array<T>()
     let nextUrl: string | null = url

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -201,7 +201,7 @@ function getNextPageUrl(response: Response): string | null {
  *
  * If the url already has a query the new parameters will be appended.
  */
-function urlWithQueryString(url: string, params: { [key: string]: any }): string {
+function urlWithQueryString(url: string, params: { [key: string]: string }): string {
   const qs = Object.keys(params)
     .map(key => `${key}=${encodeURIComponent(params[key])}`)
     .join('&')

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -181,8 +181,7 @@ function getNextPageUrl(response: Response): string | null {
     const match = part.match(/<([^>]+)>; rel="([^"]+)"/)
 
     if (match && match[2] === 'next') {
-      const url = URL.parse(match[1])
-      return url.path || null
+      return match[1]
     }
   }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -119,6 +119,7 @@ export interface IAPIIssue {
   readonly number: number
   readonly title: string
   readonly state: 'open' | 'closed'
+  readonly updated_at: string
 }
 
 /** The metadata about a GitHub server. */

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -371,7 +371,7 @@ export class API {
     let nextUrl: string | null = url
 
     do {
-      const response = await this.authenticatedRequest('GET', url)
+      const response = await this.authenticatedRequest('GET', nextUrl)
       const items = await deserialize<ReadonlyArray<T>>(response)
       if (items) {
         buf.push(...items)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -348,12 +348,11 @@ export class API {
    */
   public async fetchIssues(owner: string, name: string, state: 'open' | 'closed' | 'all', since: Date | null): Promise<ReadonlyArray<IAPIIssue>> {
 
-    let url: string | null = `repos/${owner}/${name}/issues`
+    const params = since && !isNaN(since.getTime())
+      ? { since: toGitHubIsoDateString(since) }
+      : { }
 
-    if (since && !isNaN(since.getTime())) {
-      url = urlWithQueryString(url, { since: toGitHubIsoDateString(since) })
-    }
-
+    const url = urlWithQueryString(`repos/${owner}/${name}/issues`, params)
     const issues = await this.fetchAll<IAPIIssue>(url)
 
     // PRs are issues! But we only want Really Seriously Issues.

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -206,6 +206,10 @@ function urlWithQueryString(url: string, params: { [key: string]: any }): string
     .map(key => `${key}=${encodeURIComponent(params[key])}`)
     .join('&')
 
+  if (!qs.length) {
+    return url
+  }
+
   if (url.indexOf('?') === -1) {
     return `${url}?${qs}`
   } else {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -170,6 +170,13 @@ interface IAPIMentionablesResponse {
   readonly users: ReadonlyArray<IAPIMentionableUser>
 }
 
+/**
+ * Parses the Link header from GitHub and returns the 'next' url
+ * if one is present. While the GitHub API returns absolute links
+ * this method makes no guarantee that the url will be absolute.
+ *
+ * If no link rel next header is found this method returns null.
+ */
 function getNextPageUrl(response: Response): string | null {
   const linkHeader = response.headers.get('Link')
 
@@ -189,6 +196,11 @@ function getNextPageUrl(response: Response): string | null {
   return null
 }
 
+/**
+ * Appends the parameters provided to the url as query string parameters.
+ *
+ * If the url already has a query the new parameters will be appended.
+ */
 function urlWithQueryString(url: string, params: { [key: string]: any }): string {
   const qs = Object.keys(params)
     .map(key => `${key}=${encodeURIComponent(params[key])}`)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -240,26 +240,6 @@ export class API {
     })
   }
 
-  /**
-   * Loads all repositories accessible to the current user.
-   *
-   * Loads public and private repositories across all organizations
-   * as well as the user account.
-   *
-   * @returns A promise yielding an array of {APIRepository} instances or error
-   */
-  public async fetchRepos(): Promise<ReadonlyArray<IAPIRepository>> {
-    const results: IAPIRepository[] = []
-    let nextPage = this.client.user.repos
-    while (nextPage) {
-      const request = await nextPage.fetch()
-      results.push(...request.items)
-      nextPage = request.nextPage
-    }
-
-    return results
-  }
-
   /** Fetch a repo by its owner and name. */
   public async fetchRepository(owner: string, name: string): Promise<IAPIRepository | null> {
     try {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -214,6 +214,16 @@ function urlWithQueryString(url: string, params: { [key: string]: any }): string
 }
 
 /**
+ * Returns an ISO 8601 time string with second resolution instead of
+ * the standard javascript toISOString which returns millisecond
+ * resolution. The GitHub API doesn't return dates with milliseconds
+ * so we won't send any back either.
+ */
+function toGitHubIsoDateString(date: Date) {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+/**
  * An object for making authenticated requests to the GitHub API
  */
 export class API {
@@ -358,7 +368,7 @@ export class API {
     let url: string | null = `repos/${owner}/${name}/issues`
 
     if (since && !isNaN(since.getTime())) {
-      url = urlWithQueryString(url, { since: since.toISOString().replace(/\.\d{3}Z$/, 'Z') })
+      url = urlWithQueryString(url, { since: toGitHubIsoDateString(since) })
     }
 
     const issues = new Array<IAPIIssue>()

--- a/app/src/lib/dispatcher/issues-database.ts
+++ b/app/src/lib/dispatcher/issues-database.ts
@@ -1,13 +1,14 @@
 import Dexie from 'dexie'
 
 // NB: This _must_ be incremented whenever the DB key scheme changes.
-const DatabaseVersion = 1
+const DatabaseVersion = 2
 
 export interface IIssue {
   readonly id?: number
   readonly gitHubRepositoryID: number
   readonly number: number
   readonly title: string
+  readonly updated_at?: string
 }
 
 export class IssuesDatabase extends Dexie {
@@ -16,8 +17,12 @@ export class IssuesDatabase extends Dexie {
   public constructor(name: string) {
     super(name)
 
-    this.version(DatabaseVersion).stores({
+    this.version(1).stores({
       issues: '++id, &[gitHubRepositoryID+number], gitHubRepositoryID, number',
     })
+
+    this.version(DatabaseVersion).stores({
+      issues: '++id, &[gitHubRepositoryID+number], gitHubRepositoryID, number, [gitHubRepositoryID+updated_at]',
+    }).upgrade(t => t.table('issues').clear())
   }
 }

--- a/app/src/lib/dispatcher/issues-database.ts
+++ b/app/src/lib/dispatcher/issues-database.ts
@@ -31,6 +31,18 @@ export class IssuesDatabase extends Dexie {
         .filter(key => /^IssuesStore\/\d+\/lastFetch$/.test(key))
         .forEach(key => localStorage.removeItem(key))
 
+      // Unfortunately we have to clear the issues in order to maintain
+      // data consistency in the database. The issues table is only supposed
+      // to store 'open' issues and if we kept the existing issues (which)
+      // don't have an updated_at field around the initial query for
+      // max(updated_at) would return null, causing us to fetch all _open_
+      // issues which in turn means we wouldn't be able to detect if we
+      // have any issues in the database that have been closed since the
+      // last time we fetched. Not only that, these closed issues wouldn't
+      // be updated to include the updated_at field unless they were actually
+      // modified at a later date.
+      //
+      // TL;DR; This is the safest approach
       return t.table('issues').clear()
     })
   }

--- a/app/src/lib/dispatcher/issues-database.ts
+++ b/app/src/lib/dispatcher/issues-database.ts
@@ -23,6 +23,15 @@ export class IssuesDatabase extends Dexie {
 
     this.version(DatabaseVersion).stores({
       issues: '++id, &[gitHubRepositoryID+number], gitHubRepositoryID, number, [gitHubRepositoryID+updated_at]',
-    }).upgrade(t => t.table('issues').clear())
+    }).upgrade(t => {
+
+      // Clear deprecated localStorage keys, we compute the since parameter
+      // using the database now.
+      Object.keys(localStorage)
+        .filter(key => /IssuesStore\/\d+\/lastFetch/.test(key))
+        .forEach(key => localStorage.removeItem(key))
+
+      return t.table('issues').clear()
+    })
   }
 }

--- a/app/src/lib/dispatcher/issues-database.ts
+++ b/app/src/lib/dispatcher/issues-database.ts
@@ -28,7 +28,7 @@ export class IssuesDatabase extends Dexie {
       // Clear deprecated localStorage keys, we compute the since parameter
       // using the database now.
       Object.keys(localStorage)
-        .filter(key => /IssuesStore\/\d+\/lastFetch/.test(key))
+        .filter(key => /^IssuesStore\/\d+\/lastFetch$/.test(key))
         .forEach(key => localStorage.removeItem(key))
 
       return t.table('issues').clear()

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -16,7 +16,7 @@ export class IssuesStore {
     this.db = db
   }
 
-  private async getLatestUpdatedAt(repository: GitHubRepository): Promise<string | null> {
+  private async getLatestUpdatedAt(repository: GitHubRepository): Promise<Date | null> {
     const gitHubRepositoryID = repository.dbID
     if (!gitHubRepositoryID) {
       return fatalError(`Cannot get issues for a repository that hasn't been inserted into the database!`)
@@ -29,8 +29,8 @@ export class IssuesStore {
       .between([ gitHubRepositoryID ], [ gitHubRepositoryID + 1 ], true, false)
       .last()
 
-    return latestUpdatedIssue
-      ? latestUpdatedIssue.updated_at || null
+    return latestUpdatedIssue && latestUpdatedIssue.updated_at
+      ? new Date(latestUpdatedIssue.updated_at)
       : null
   }
 
@@ -44,8 +44,7 @@ export class IssuesStore {
 
     let issues: ReadonlyArray<IAPIIssue>
     if (lastUpdatedAt) {
-      const since = new Date(lastUpdatedAt)
-      issues = await api.fetchIssues(repository.owner.login, repository.name, 'all', since)
+      issues = await api.fetchIssues(repository.owner.login, repository.name, 'all', lastUpdatedAt)
     } else {
       issues = await api.fetchIssues(repository.owner.login, repository.name, 'open', null)
     }

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -26,7 +26,7 @@ export class IssuesStore {
 
     const latestUpdatedIssue = await db.issues
       .where('[gitHubRepositoryID+updated_at]')
-      .equals([ gitHubRepositoryID ])
+      .between([ gitHubRepositoryID ], [ gitHubRepositoryID + 1 ], true, false)
       .last()
 
     debugger

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -24,7 +24,7 @@ export class IssuesStore {
   private async getLatestUpdatedAt(repository: GitHubRepository): Promise<Date | null> {
     const gitHubRepositoryID = repository.dbID
     if (!gitHubRepositoryID) {
-      return fatalError(`Cannot get issues for a repository that hasn't been inserted into the database!`)
+      return fatalError('Cannot get issues for a repository that hasn\'t been inserted into the database!')
     }
 
     const db = this.db
@@ -120,7 +120,7 @@ export class IssuesStore {
   public async getIssuesMatching(repository: GitHubRepository, text: string): Promise<ReadonlyArray<IIssue>> {
     const gitHubRepositoryID = repository.dbID
     if (!gitHubRepositoryID) {
-      fatalError(`Cannot get issues for a repository that hasn't been inserted into the database!`)
+      fatalError('Cannot get issues for a repository that hasn\'t been inserted into the database!')
       return []
     }
 

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -16,6 +16,11 @@ export class IssuesStore {
     this.db = db
   }
 
+  /**
+   * Get the highest value of the 'updated_at' field for issues in a given
+   * repository. This value is used to request delta updates from the API
+   * using the 'since' parameter.
+   */
   private async getLatestUpdatedAt(repository: GitHubRepository): Promise<Date | null> {
     const gitHubRepositoryID = repository.dbID
     if (!gitHubRepositoryID) {

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -53,7 +53,7 @@ export class IssuesStore {
     const api = new API(account)
     const lastUpdatedAt = await this.getLatestUpdatedAt(repository)
 
-    // If we don't have a lastUpdatedAt that mean we haven't fetch any issues
+    // If we don't have a lastUpdatedAt that mean we haven't fetched any issues
     // for the repository yet which in turn means we only have to fetch the
     // currently open issues. If we have fetched before we get all issues
     // that have been modified since the last time we fetched so that we

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -29,8 +29,6 @@ export class IssuesStore {
       .between([ gitHubRepositoryID ], [ gitHubRepositoryID + 1 ], true, false)
       .last()
 
-    debugger
-
     return latestUpdatedIssue
       ? latestUpdatedIssue.updated_at || null
       : null
@@ -47,7 +45,6 @@ export class IssuesStore {
     let issues: ReadonlyArray<IAPIIssue>
     if (lastUpdatedAt) {
       const since = new Date(lastUpdatedAt)
-      debugger
       issues = await api.fetchIssues(repository.owner.login, repository.name, 'all', since)
     } else {
       issues = await api.fetchIssues(repository.owner.login, repository.name, 'open', null)

--- a/app/src/lib/dispatcher/issues-store.ts
+++ b/app/src/lib/dispatcher/issues-store.ts
@@ -34,8 +34,14 @@ export class IssuesStore {
       .between([ gitHubRepositoryID ], [ gitHubRepositoryID + 1 ], true, false)
       .last()
 
-    return latestUpdatedIssue && latestUpdatedIssue.updated_at
-      ? new Date(latestUpdatedIssue.updated_at)
+    if (!latestUpdatedIssue || !latestUpdatedIssue.updated_at) {
+      return null
+    }
+
+    const lastUpdatedAt = new Date(latestUpdatedIssue.updated_at)
+
+    return !isNaN(lastUpdatedAt.getTime())
+      ? lastUpdatedAt
       : null
   }
 

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -30,12 +30,13 @@ export async function deserialize<T>(response: Response | string): Promise<T | n
  * @param endpoint      - The API endpoint.
  * @param authorization - The value to pass in the `Authorization` header.
  * @param method        - The HTTP method.
- * @param path          - The path without a leading /.
+ * @param path          - The path, including any query string parameters.
  * @param body          - The body to send.
  * @param customHeaders - Any optional additional headers to send.
  */
 export function request(endpoint: string, authorization: string | null, method: HTTPMethod, path: string, body?: Object, customHeaders?: Object): Promise<Response> {
-  const url = `${endpoint}/${path}`
+  const url = new URL(path, endpoint)
+
   const headers: any = Object.assign({}, {
     'Accept': 'application/vnd.github.v3+json, application/json',
     'Content-Type': 'application/json',
@@ -52,7 +53,7 @@ export function request(endpoint: string, authorization: string | null, method: 
     body: JSON.stringify(body),
   }
 
-  return fetch(url, options)
+  return fetch(url.href, options)
 }
 
 /** Get the user agent to use for all requests. */


### PR DESCRIPTION
This is a story in two parts

### Broken paging

I noticed that we weren't populating issues properly for new repositories. This was due to our paging being broken due to us disabling the hypermedia plugin in https://github.com/desktop/desktop/pull/1281 causing us to only fetch the first page of issues. I tried switching us over to using the `fetchAll` plugin but found that to be broken as well (I've submitted a [fix upstream](https://github.com/philschatz/octokat.js/pull/175) for that issue). Ultimately I settled on fetching the issues without octokat intervention for now. I've also removed the only other function that relied on paging (fetchRepos) since that was unused.

### Caching

While looking through our API stats I saw that we weren't ever hitting the priced `304 Not modified` path for the issues endpoint. This was caused by our algorithm for partial updates of our local issue database.

Our in-prod algorithm looks a little like this

1. Do we know when we last fetched issues for this repository?
   - Yes
     1. Fetch all issues that have been updated at or after the last time we fetched issues
     1. Insert or update any modified issues in our local database
     1. Set the last time we fetched issues to `Date.now()`
   - No
     1. Fetch all **open** issues in the repository
     1. Insert all retrieved issues in our local database

There's two problems with this. First, the lastFetched will be updated on each request meaning that we can't leverage caching at all. Second, it's subject to a race condition since we're conflating user time with server time. We could be missing out on issues due to the user's clock running ahead of the server.

The new algorithm looks like this

1. Do we have any locally stored issues for this repository in our database
   - Yes
     1. Query the maximum value of the `updated_at` timestamp field for all our issues that belong to this repository
     1. Fetch all issues that have been updated at or after `MAX(updated_at)`
     1. Insert or update any modified issues in our local database
   - No
     1. Fetch all **open** issues in the repository
     1. Insert all retrieved issues in our local database

This eliminates both our problems, we no longer rely on machine-time and we get a consistent value to use when fetching which means that we can leverage caching using ETags but also that we can respect the `max-age` value that GitHub sends us (60 seconds) to avoid asking for issues repeatedly.

One noteworthy thing about this algorithm is that since the GitHub API returns issues that have been updated *at or after* the timestamp we give it we will always receive a minimum of one issue in our requests. This shouldn't be an issue for us since the small cost of updating an unmodified entry should be negligible. We can implement logic to avoid it should we see any problems with it but for now the decrease in data transfer and API usage quota far outweigh that.