### PR TITLE
getting some tests in for AppStore

### DIFF
--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -40,14 +40,12 @@ describe('AppStore', () => {
     const statsDb = new TestStatsDatabase()
     await statsDb.reset()
 
-    const statsStore = new StatsStore(statsDb)
-
     return new AppStore(
       new GitHubUserStore(db),
       new CloningRepositoriesStore(),
       new EmojiStore(),
       new IssuesStore(issuesDb),
-      statsStore,
+      new StatsStore(statsDb),
       new SignInStore(),
     )
   }

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -48,7 +48,7 @@ describe('AppStore', () => {
       new EmojiStore(),
       new IssuesStore(issuesDb),
       statsStore,
-      new SignInStore()
+      new SignInStore(),
     )
   }
 

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -65,9 +65,6 @@ describe('AppStore', () => {
   })
 
   describe('undo first commit', () => {
-    let repo: Repository | null = null
-    let firstCommit: Commit | null = null
-
     function getAppState(appStore: AppStore): IRepositoryState {
       const selectedState = appStore.getState().selectedState
       if (!selectedState) {
@@ -82,6 +79,9 @@ describe('AppStore', () => {
       }
     }
 
+    let repo: Repository | null = null
+    let firstCommit: Commit | null = null
+
     beforeEach(async () => {
       repo = await setupEmptyRepository()
 
@@ -93,7 +93,7 @@ describe('AppStore', () => {
       await GitProcess.exec([ 'add', file ], repo.path)
       await GitProcess.exec([ 'commit', '-m', 'added file' ], repo.path)
 
-      firstCommit = await getCommit(repo!, 'master')
+      firstCommit = await getCommit(repo, 'master')
       expect(firstCommit).to.not.equal(null)
       expect(firstCommit!.parentSHAs.length).to.equal(0)
     })

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -1,0 +1,119 @@
+/* tslint:disable:no-sync-functions */
+
+import * as chai from 'chai'
+const expect = chai.expect
+
+import * as Path from 'path'
+import * as Fs from 'fs'
+import { GitProcess } from 'dugite'
+
+import {
+  AppStore,
+  GitHubUserStore,
+  CloningRepositoriesStore,
+  EmojiStore,
+  IssuesStore,
+  SignInStore,
+} from '../../src/lib/dispatcher'
+import { TestGitHubUserDatabase } from '../test-github-user-database'
+import { TestStatsDatabase } from '../test-stats-database'
+import { TestIssuesDatabase } from '../test-issues-database'
+import { StatsStore } from '../../src/lib/stats'
+
+import { RepositorySection, SelectionType, IRepositoryState } from '../../src/lib/app-state'
+import { Repository } from '../../src/models/repository'
+import { Commit } from '../../src/models/commit'
+import { getCommit } from '../../src/lib/git'
+
+import { setupEmptyRepository } from '../fixture-helper'
+
+describe('AppStore', () => {
+
+  async function createAppStore(): Promise<AppStore> {
+
+    const db = new TestGitHubUserDatabase()
+    await db.reset()
+
+    const issuesDb = new TestIssuesDatabase()
+    await issuesDb.reset()
+
+    const statsDb = new TestStatsDatabase()
+    await statsDb.reset()
+
+    const statsStore = new StatsStore(statsDb)
+
+    return new AppStore(
+      new GitHubUserStore(db),
+      new CloningRepositoriesStore(),
+      new EmojiStore(),
+      new IssuesStore(issuesDb),
+      statsStore,
+      new SignInStore()
+    )
+  }
+
+  it('can select a repository', async () => {
+    const appStore = await createAppStore()
+
+    const repo = await setupEmptyRepository()
+
+    await appStore._selectRepository(repo)
+
+    const state = appStore.getState()
+    expect(state.selectedState).is.not.null
+    expect(state.selectedState!.repository.path).to.equal(repo.path)
+  })
+
+  describe('undo first commit', () => {
+    let repo: Repository | null = null
+    let firstCommit: Commit | null = null
+
+    function getAppState(appStore: AppStore): IRepositoryState {
+      const selectedState = appStore.getState().selectedState
+      if (!selectedState) {
+        throw new chai.AssertionError('No selected state for AppStore')
+      }
+
+      switch (selectedState.type) {
+        case SelectionType.Repository:
+          return selectedState.state
+        default:
+          throw new chai.AssertionError(`Got selected state of type ${selectedState.type} which is not supported.`)
+      }
+    }
+
+    beforeEach(async () => {
+      repo = await setupEmptyRepository()
+
+      const file = 'README.md'
+      const filePath = Path.join(repo.path, file)
+
+      Fs.writeFileSync(filePath, 'SOME WORDS GO HERE\n')
+
+      await GitProcess.exec([ 'add', file ], repo.path)
+      await GitProcess.exec([ 'commit', '-m', 'added file' ], repo.path)
+
+      firstCommit = await getCommit(repo!, 'master')
+      expect(firstCommit).to.not.equal(null)
+      expect(firstCommit!.parentSHAs.length).to.equal(0)
+    })
+
+    it('clears the undo commit dialog', async () => {
+      const repository = repo!
+
+      const appStore = await createAppStore()
+
+      // select the repository and show the changes view
+      await appStore._selectRepository(repository)
+      await appStore._changeRepositorySection(repository, RepositorySection.Changes)
+
+      let state = getAppState(appStore)
+      expect(state.localCommitSHAs.length).to.equal(1)
+
+      await appStore._undoCommit(repository, firstCommit!)
+
+      state = getAppState(appStore)
+      expect(state.localCommitSHAs).to.be.empty
+    })
+  })
+})


### PR DESCRIPTION
This is some work I had lying around from when I was testing #1461 - I wanted to see what testing `AppStore` would feel like, and it didn't turn out bad.

By testing higher-level components we cover more of the codebase, and we should be able to find things that don't feel as natural as they should be.  But getting more coverage around complex parts of the codebase - `AppStore` currently sits at 1800 lines - will be good for the sanity as things evolve over time.