### PR TITLE
Fix error messages for non-repositories

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1,6 +1,5 @@
 import { Emitter, Disposable } from 'event-kit'
 import { ipcRenderer, remote } from 'electron'
-import * as Path from 'path'
 import {
   IRepositoryState,
   IHistoryState,
@@ -51,7 +50,6 @@ import { fatalError } from '../fatal-error'
 import { updateMenuState } from '../menu-update'
 
 import {
-  getGitDir,
   getAuthorIdentity,
   pull as pullRepo,
   push as pushRepo,
@@ -1178,17 +1176,6 @@ export class AppStore {
     this.emitUpdate()
 
     return Promise.resolve()
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _validatedRepositoryPath(path: string): Promise<string | null> {
-    try {
-      const gitDir = await getGitDir(path)
-      return gitDir ? Path.dirname(gitDir) : null
-    } catch (e) {
-      this.emitError(e)
-      return null
-    }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -25,6 +25,7 @@ import { isGitOnPath } from '../open-shell'
 import { uuid } from '../uuid'
 import { URLActionType, IOpenRepositoryArgs } from '../parse-url'
 import { requestAuthenticatedUser, resolveOAuthRequest, rejectOAuthRequest } from '../../lib/oauth'
+import { validatedRepositoryPath } from './validated-repository-path'
 
 /**
  * Extend Error so that we can create new Errors with a callstack different from
@@ -139,7 +140,7 @@ export class Dispatcher {
   public async addRepositories(paths: ReadonlyArray<string>): Promise<ReadonlyArray<Repository>> {
     const validatedPaths = new Array<string>()
     for (const path of paths) {
-      const validatedPath = await this.appStore._validatedRepositoryPath(path)
+      const validatedPath = await validatedRepositoryPath(path)
       if (validatedPath) {
         validatedPaths.push(validatedPath)
       } else {

--- a/app/src/lib/dispatcher/validated-repository-path.ts
+++ b/app/src/lib/dispatcher/validated-repository-path.ts
@@ -1,0 +1,16 @@
+import * as Path from 'path'
+
+import { getGitDir } from '../git'
+
+/**
+ * Get the path to the parent of the .git directory or null if the path isn't a
+ * valid repository.
+ */
+export async function validatedRepositoryPath(path: string): Promise<string | null> {
+  try {
+    const gitDir = await getGitDir(path)
+    return gitDir ? Path.dirname(gitDir) : null
+  } catch (e) {
+    return null
+  }
+}

--- a/app/test/unit/validated-repository-path-test.ts
+++ b/app/test/unit/validated-repository-path-test.ts
@@ -1,0 +1,23 @@
+/* tslint:disable:no-sync-functions */
+
+import * as chai from 'chai'
+const expect = chai.expect
+
+const temp = require('temp').track()
+
+import { setupFixtureRepository } from '../fixture-helper'
+import { validatedRepositoryPath } from '../../src/lib/dispatcher/validated-repository-path'
+
+describe('validatedRepositoryPath', () => {
+  it('returns the path to the repository', async () => {
+    const testRepoPath = setupFixtureRepository('test-repo')
+    const result = await validatedRepositoryPath(testRepoPath)
+    expect(result).to.equal(testRepoPath)
+  })
+
+  it('returns null if the path is not a repository', async () => {
+    const testRepoPath = temp.openSync('repo-test').path
+    const result = await validatedRepositoryPath(testRepoPath)
+    expect(result).to.equal(null)
+  })
+})


### PR DESCRIPTION
Fixes #1747 

Validating a potential repository path can be a standalone function. Then we can leave error reporting up to the caller.

![screen shot 2017-05-31 at 4 56 43 pm](https://cloud.githubusercontent.com/assets/13760/26653832/7a61c832-4622-11e7-9f8d-3d4e1cefb86e.png)
