### PR TITLE
Preserve our git env var

### DIFF
--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -139,10 +139,6 @@ async function getEnvironmentFromShell(updateEnvironment: (env: IndexLookup) => 
  * @param env The new environment variables from the user's shell.
  */
 function mergeEnvironmentVariables(env: IndexLookup) {
-  for (const key in process.env) {
-    delete process.env[key]
-  }
-
   for (const key in env) {
     process.env[key] = env[key]
   }

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -8,6 +8,11 @@ type IndexLookup = {
 }
 
 /**
+ * The names of any env vars that we shouldn't copy from the shell environment.
+ */
+const BlacklistedNames = new Set([ 'LOCAL_GIT_DIRECTORY' ])
+
+/**
  * Inspect whether the current process needs to be patched to get important
  * environment variables for Desktop to work and integrate with other tools
  * the user may invoke as part of their workflow.
@@ -140,6 +145,8 @@ async function getEnvironmentFromShell(updateEnvironment: (env: IndexLookup) => 
  */
 function mergeEnvironmentVariables(env: IndexLookup) {
   for (const key in env) {
+    if (BlacklistedNames.has(key)) { continue }
+
     process.env[key] = env[key]
   }
 }


### PR DESCRIPTION
We [set a custom `LOCAL_GIT_DIRECTORY`](https://github.com/desktop/desktop/blob/0b2411081848fe7e9ab0fcd4920ccbf22929e24d/app/src/ui/index.tsx#L40) env var, but then our shell environment copying logic would delete it, so that the app could never find git. Git's pretty important tho.

We shouldn't delete env vars we already have, and we should also prevent users' env vars from smashing ours.