### PR TITLE
Pass values to functions, source-mapping edition

### DIFF
--- a/app/src/lib/enable-source-maps.ts
+++ b/app/src/lib/enable-source-maps.ts
@@ -8,7 +8,7 @@ const sourceMapSupport = require('source-map-support')
  * This array tells the source map logic which files that we can expect to
  * be able to resolve a source map for and they should reflect the chunks
  * entry names from our webpack config.
- * 
+ *
  * Note that we explicitly don't enable source maps for the crash process
  * since it's possible that the error which caused us to spawn the crash
  * process was related to source maps.

--- a/app/src/lib/logging/format-error.ts
+++ b/app/src/lib/logging/format-error.ts
@@ -1,8 +1,12 @@
+import { withSourceMappedStack } from '../source-map-support'
+
 /**
  * Formats an error for log file output. Use this instead of
  * multiple calls to log.error.
  */
 export function formatError(error: Error, title?: string) {
+  error = withSourceMappedStack(error)
+
   if (error.stack) {
     return title
       ? `${title}\n${error.stack}`

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -99,7 +99,10 @@ export function enableSourceMaps() {
   AnyError.prepareStackTrace = prepareStackTrace
 }
 
-/** Make a new copy of the error with a source-mapped stack trace. */
+/**
+ * Make a copy of the error with a source-mapped stack trace. If it couldn't
+ * perform the source mapping, it'll use the original error stack.
+ */
 export function withSourceMappedStack(error: Error): Error {
   return {
     name: error.name,

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -67,7 +67,7 @@ const stackFrameMap = new WeakMap<Error, ReadonlyArray<any>>()
 
 /**
  * The `prepareStackTrace` that comes from the `source-map-support` module.
- * We'll use this when the user explicitly calls `sourceMappedStackTrace`.
+ * We'll use this when the user explicitly wants the stack source mapped.
  */
 let prepareStackTraceWithSourceMap: (error: Error, frames: ReadonlyArray<any>) => string
 
@@ -95,6 +95,8 @@ export function enableSourceMaps() {
   })
 
   const AnyError = Error as any
+  // We want to keep `source-map-support`s `prepareStackTrace` around to use
+  // later, but our cheaper `prepareStackTrace` should be the default.
   prepareStackTraceWithSourceMap = AnyError.prepareStackTrace
   AnyError.prepareStackTrace = prepareStackTrace
 }

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -20,6 +20,8 @@ export function enableSourceMaps() {
     environment: 'node',
     handleUncaughtExceptions: false,
     retrieveSourceMap: function(source: string) {
+      console.log('HERERERERERE', source)
+      debugger
       // This is a happy path in case we know for certain that we won't be
       // able to resolve a source map for the given location.
       if (!knownFilesWithSourceMap.some(file => source.endsWith(file))) {

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -100,7 +100,7 @@ export function enableSourceMaps() {
 }
 
 /** Make a new copy of the error with a source-mapped stack trace. */
-export function errorWithSourceMappedStack(error: Error): Error {
+export function withSourceMappedStack(error: Error): Error {
   return {
     name: error.name,
     message: error.message,

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -15,58 +15,59 @@ const sourceMapSupport = require('source-map-support')
  */
 const knownFilesWithSourceMap = [ 'renderer.js', 'main.js', 'shared.js' ]
 
+function retrieveSourceMap(source: string) {
+  // This is a happy path in case we know for certain that we won't be
+  // able to resolve a source map for the given location.
+  if (!knownFilesWithSourceMap.some(file => source.endsWith(file))) {
+    return null
+  }
+
+  // We get a file uri when we're inside a renderer, convert to a path
+  if (source.startsWith('file://')) {
+    source = fileUriToPath(source)
+  }
+
+  // We store our source maps right next to the bundle
+  const path = `${source}.map`
+
+  if (__DEV__ && path.startsWith('http://')) {
+    try {
+      const xhr = new XMLHttpRequest()
+      xhr.open('GET', path, false)
+      xhr.send(null)
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        return { url: Path.basename(path), map: xhr.responseText }
+      }
+    } catch (error) {
+      return
+    }
+    return
+  }
+
+  // We don't have an option here, see
+  //  https://github.com/v8/v8/wiki/Stack-Trace-API#customizing-stack-traces
+  // This happens on-demand when someone accesses the stack
+  // property on an error object and has to be synchronous :/
+  // tslint:disable-next-line:no-sync-functions
+  if (!Fs.existsSync(path)) {
+    return
+  }
+
+  try {
+    // tslint:disable-next-line:no-sync-functions
+    const map = Fs.readFileSync(path, 'utf8')
+    return { url: Path.basename(path), map }
+  } catch (error) {
+    return
+  }
+}
+/** Enable source map support in the current process. */
 export function enableSourceMaps() {
   sourceMapSupport.install({
     environment: 'node',
     handleUncaughtExceptions: false,
-    retrieveSourceMap: function(source: string) {
-      console.log('HERERERERERE', source)
-      debugger
-      // This is a happy path in case we know for certain that we won't be
-      // able to resolve a source map for the given location.
-      if (!knownFilesWithSourceMap.some(file => source.endsWith(file))) {
-        return null
-      }
-
-      // We get a file uri when we're inside a renderer, convert to a path
-      if (source.startsWith('file://')) {
-        source = fileUriToPath(source)
-      }
-
-      // We store our source maps right next to the bundle
-      const path = `${source}.map`
-
-      if (__DEV__ && path.startsWith('http://')) {
-        try {
-          const xhr = new XMLHttpRequest()
-          xhr.open('GET', path, false)
-          xhr.send(null)
-          if (xhr.readyState === 4 && xhr.status === 200) {
-            return { url: Path.basename(path), map: xhr.responseText }
-          }
-        } catch (error) {
-          return
-        }
-        return
-      }
-
-      // We don't have an option here, see
-      //  https://github.com/v8/v8/wiki/Stack-Trace-API#customizing-stack-traces
-      // This happens on-demand when someone accesses the stack
-      // property on an error object and has to be synchronous :/
-      // tslint:disable-next-line:no-sync-functions
-      if (!Fs.existsSync(path)) {
-        return
-      }
-
-      try {
-        // tslint:disable-next-line:no-sync-functions
-        const map = Fs.readFileSync(path, 'utf8')
-        return { url: Path.basename(path), map }
-      } catch (error) {
-        return
-      }
-    },
+    retrieveSourceMap,
   })
 
+}
 }

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -78,9 +78,6 @@ let prepareStackTraceWithSourceMap: (error: Error, frames: ReadonlyArray<any>) =
 function prepareStackTrace(error: Error, frames: ReadonlyArray<any>) {
   stackFrameMap.set(error, frames)
 
-  console.log(sourceMappedStackTrace(error))
-  debugger
-
   // Ideally we'd use the default `Error.prepareStackTrace` here but it's
   // undefined so V8 must doing something fancy. Instead we'll do a decent
   // impression.
@@ -102,8 +99,17 @@ export function enableSourceMaps() {
   AnyError.prepareStackTrace = prepareStackTrace
 }
 
+/** Make a new copy of the error with a source-mapped stack trace. */
+export function errorWithSourceMappedStack(error: Error): Error {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: sourceMappedStackTrace(error),
+  }
+}
+
 /** Get the source mapped stack trace for the error. */
-export function sourceMappedStackTrace(error: Error): string | undefined {
+function sourceMappedStackTrace(error: Error): string | undefined {
   const frames = stackFrameMap.get(error)
   if (!frames) {
     return error.stack

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -1,7 +1,7 @@
 import * as Path from 'path'
 import * as Fs from 'fs'
 
-const fileUriToPath = require('file-uri-to-path') as (uri: string) => string
+const fileUriToPath: (uri: string) => string = require('file-uri-to-path')
 const sourceMapSupport = require('source-map-support')
 
 /**

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -16,7 +16,7 @@ import { LogLevel } from '../lib/logging/log-level'
 import { log as writeLog } from './log'
 import { formatError } from '../lib/logging/format-error'
 import { reportError } from './exception-reporting'
-import { enableSourceMaps } from '../lib/enable-source-maps'
+import { enableSourceMaps } from '../lib/source-map-support'
 import { now } from './now'
 
 enableSourceMaps()

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -16,7 +16,7 @@ import { LogLevel } from '../lib/logging/log-level'
 import { log as writeLog } from './log'
 import { formatError } from '../lib/logging/format-error'
 import { reportError } from './exception-reporting'
-import { enableSourceMaps } from '../lib/source-map-support'
+import { enableSourceMaps, withSourceMappedStack } from '../lib/source-map-support'
 import { now } from './now'
 
 enableSourceMaps()
@@ -35,6 +35,7 @@ type OnDidLoadFn = (window: AppWindow) => void
 let onDidLoadFns: Array<OnDidLoadFn> | null = []
 
 function uncaughtException(error: Error) {
+  error = withSourceMappedStack(error)
 
   log.error(formatError(error))
 

--- a/app/src/shared-process/index.ts
+++ b/app/src/shared-process/index.ts
@@ -18,11 +18,13 @@ import {
 } from '../lib/dispatcher'
 import { API } from '../lib/api'
 import { sendErrorReport, reportUncaughtException } from '../ui/main-process-proxy'
-import { enableSourceMaps } from '../lib/source-map-support'
+import { enableSourceMaps, withSourceMappedStack } from '../lib/source-map-support'
 
 enableSourceMaps()
 
 process.on('uncaughtException', (error: Error) => {
+  error = withSourceMappedStack(error)
+
   console.error('Uncaught exception', error)
 
   sendErrorReport(error)

--- a/app/src/shared-process/index.ts
+++ b/app/src/shared-process/index.ts
@@ -18,7 +18,7 @@ import {
 } from '../lib/dispatcher'
 import { API } from '../lib/api'
 import { sendErrorReport, reportUncaughtException } from '../ui/main-process-proxy'
-import { enableSourceMaps } from '../lib/enable-source-maps'
+import { enableSourceMaps } from '../lib/source-map-support'
 
 enableSourceMaps()
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -23,7 +23,7 @@ import { installDevGlobals } from './install-globals'
 import { reportUncaughtException, sendErrorReport } from './main-process-proxy'
 import { getOS } from '../lib/get-os'
 import { getGUID } from '../lib/stats'
-import { enableSourceMaps } from '../lib/source-map-support'
+import { enableSourceMaps, withSourceMappedStack } from '../lib/source-map-support'
 
 if (__DEV__) {
   installDevGlobals()
@@ -58,6 +58,8 @@ if (!process.env.TEST_ENV) {
 }
 
 process.once('uncaughtException', (error: Error) => {
+  error = withSourceMappedStack(error)
+
   console.error('Uncaught exception', error)
 
   if (__DEV__ || process.env.TEST_ENV) {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -23,7 +23,7 @@ import { installDevGlobals } from './install-globals'
 import { reportUncaughtException, sendErrorReport } from './main-process-proxy'
 import { getOS } from '../lib/get-os'
 import { getGUID } from '../lib/stats'
-import { enableSourceMaps } from '../lib/enable-source-maps'
+import { enableSourceMaps } from '../lib/source-map-support'
 
 if (__DEV__) {
   installDevGlobals()


### PR DESCRIPTION
This one goes out to our performance charts that made me notice our renderer load time had gotten worse in 0.5.9 🎉 

![screen shot 2017-06-05 at 4 07 30 pm](https://cloud.githubusercontent.com/assets/13760/26800976/35ec0646-4a09-11e7-89ca-d22b6f62c717.png)

Our source map support requires that we synchronously load our source maps from disk when an error's `stack` property was accessed. That was kind of a bummer because our source maps are big and synchronous IO is bad.

But we figured that wouldn't be a big deal since (1) they'll be cached so it'll only be a bummer the first time, (2) the `stack` property should only be accessed when we have an uncaught exception, in which case life is bad already.

But it turns out [Electron accesses the `stack` property](https://github.com/electron/electron/blob/dfab1043d98067b43b45d8dcbe9d0b84d4820555/lib/common/api/callbacks-registry.js#L23) when you register a callback function for a method called through `remote`. Unfortunately, [we do that](https://github.com/desktop/desktop/blob/7857879f955e4e5bcbf502c813c9ec08c3ce8a26/app/src/lib/dispatcher/app-store.ts#L168) as part of startup.

We could fix the specific Electron case, but it made @niik and I wonder if it was just a matter of time until another library bit us. So we talked it over and decided to go a different route. Instead of automagically source mapping every `Error`s `stack` on demand, we'll now have to specifically source map `Error`s.