### PR TITLE
test needs user information

### DIFF
--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -73,6 +73,8 @@ describe('git/rev-parse', () => {
 
       await git([ 'init', 'repo1' ], fixturePath, '')
       await git([ 'init', 'repo2' ], fixturePath, '')
+      await git([ 'config' , 'user.name', 'Cai Hsu' ], secondRepoPath, '')
+      await git([ 'config' , 'user.email', 'cai.hsu@not-a-real-site.com' ], secondRepoPath, '')
 
       await git([ 'commit', '--allow-empty', '-m', 'Initial commit' ], secondRepoPath, '')
       await git([ 'submodule', 'add', '../repo2' ], firstRepoPath, '')


### PR DESCRIPTION
#1897 found out that we need to provide `user.email` and `user.name` to create commits when running tests, and then #1881 was merged which added a new test that didn't catch this change on Appveyor, e.g https://ci.appveyor.com/project/github-windows/desktop/build/4648

This fixes the new test to get the build back to green, but I plan to move this to `test-setup` and make it more robust so you don't need to codify this in any actual tests in the future.