### PR TITLE
Prepare for a Typed Octokat

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -76,10 +76,9 @@ export interface IAPICommit {
 export interface IAPIUser {
   readonly id: number
   readonly url: string
-  readonly type: 'user' | 'org'
   readonly login: string
   readonly avatar_url: string
-  readonly name: string
+  readonly name?: string
 }
 
 /** The users we get from the mentionables endpoint. */
@@ -554,7 +553,7 @@ export async function fetchUser(endpoint: string, token: string): Promise<Accoun
     emails = [ ]
   }
 
-  return new Account(user.login, endpoint, token, emails, user.avatarUrl, user.id, user.name)
+  return new Account(user.login, endpoint, token, emails, user.avatar_url, user.id, user.name)
 }
 
 /** Get metadata from the server. */

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -56,7 +56,7 @@ export interface IAPIRepository {
   readonly clone_url: string
   readonly html_url: string
   readonly name: string
-  readonly owner: IAPIUser
+  readonly owner: IAPIUserNoName
   readonly private: boolean
   readonly fork: boolean
   readonly default_branch: string
@@ -67,18 +67,24 @@ export interface IAPIRepository {
  */
 export interface IAPICommit {
   readonly sha: string
-  readonly author: IAPIUser | null
+  readonly author: IAPIUserNoName | null
 }
 
 /**
  * Information about a user as returned by the GitHub API.
  */
-export interface IAPIUser {
+export interface IAPIUserNoName {
   readonly id: number
   readonly url: string
   readonly login: string
   readonly avatar_url: string
-  readonly name?: string
+}
+
+export interface IAPIUserWithName extends IAPIUserNoName {
+  readonly name: string
+}
+
+export interface IAPIOrganizationSlug extends IAPIUserNoName {
 }
 
 /** The users we get from the mentionables endpoint. */
@@ -252,7 +258,7 @@ export class API {
   }
 
   /** Fetch the logged in account. */
-  public fetchAccount(): Promise<IAPIUser> {
+  public fetchAccount(): Promise<IAPIUserWithName> {
     return this.client.user.fetch()
   }
 
@@ -291,7 +297,7 @@ export class API {
   }
 
   /** Search for a user with the given public email. */
-  public async searchForUserWithEmail(email: string): Promise<IAPIUser | null> {
+  public async searchForUserWithEmail(email: string): Promise<IAPIUserNoName | null> {
     try {
       const result = await this.client.search.users.fetch({ q: `${email} in:email type:user` })
       // The results are sorted by score, best to worst. So the first result is
@@ -305,7 +311,7 @@ export class API {
   }
 
   /** Fetch all the orgs to which the user belongs. */
-  public async fetchOrgs(): Promise<ReadonlyArray<IAPIUser>> {
+  public async fetchOrgs(): Promise<ReadonlyArray<IAPIOrganizationSlug>> {
     const result = await this.client.user.orgs.fetch()
     return result && Array.isArray(result.items)
       ? result.items
@@ -313,7 +319,7 @@ export class API {
   }
 
   /** Create a new GitHub repository with the given properties. */
-  public async createRepository(org: IAPIUser | null, name: string, description: string, private_: boolean): Promise<IAPIRepository> {
+  public async createRepository(org: IAPIOrganizationSlug | null, name: string, description: string, private_: boolean): Promise<IAPIRepository> {
     try {
       if (org) {
         return await this.client.orgs(org.login).repos.create({ name, description, private: private_ })

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -22,7 +22,7 @@ import { GitHubRepository } from '../../models/github-repository'
 import { FileChange, WorkingDirectoryStatus, WorkingDirectoryFileChange } from '../../models/status'
 import { DiffSelection, DiffSelectionType, DiffType } from '../../models/diff'
 import { matchGitHubRepository } from '../../lib/repository-matching'
-import { API, getAccountForEndpoint, IAPIUser } from '../../lib/api'
+import { API, getAccountForEndpoint, IAPIOrganizationSlug } from '../../lib/api'
 import { caseInsensitiveCompare } from '../compare'
 import { Branch, BranchType } from '../../models/branch'
 import { TipState } from '../../models/tip'
@@ -1462,7 +1462,7 @@ export class AppStore {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _publishRepository(repository: Repository, name: string, description: string, private_: boolean, account: Account, org: IAPIUser | null): Promise<void> {
+  public async _publishRepository(repository: Repository, name: string, description: string, private_: boolean, account: Account, org: IAPIOrganizationSlug | null): Promise<void> {
     const api = new API(account)
     const apiRepository = await api.createRepository(org, name, description, private_)
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -13,7 +13,7 @@ import { AppStore } from './app-store'
 import { CloningRepository } from './cloning-repositories-store'
 import { Branch } from '../../models/branch'
 import { Commit } from '../../models/commit'
-import { IAPIUser } from '../../lib/api'
+import { IAPIOrganizationSlug } from '../../lib/api'
 import { GitHubRepository } from '../../models/github-repository'
 import { ICommitMessage } from './git-store'
 import { executeMenuItem } from '../../ui/main-process-proxy'
@@ -371,7 +371,7 @@ export class Dispatcher {
   }
 
   /** Publish the repository to GitHub with the given properties. */
-  public async publishRepository(repository: Repository, name: string, description: string, private_: boolean, account: Account, org: IAPIUser | null): Promise<Repository> {
+  public async publishRepository(repository: Repository, name: string, description: string, private_: boolean, account: Account, org: IAPIOrganizationSlug | null): Promise<Repository> {
     await this.appStore._publishRepository(repository, name, description, private_, account, org)
     return this.refreshGitHubRepositoryInfo(repository)
   }

--- a/app/src/lib/dispatcher/github-user-database.ts
+++ b/app/src/lib/dispatcher/github-user-database.ts
@@ -9,7 +9,7 @@ export interface IGitHubUser {
   readonly email: string
   readonly login: string
   readonly avatarURL: string
-  readonly name: string
+  readonly name?: string
 }
 
 export interface IMentionableAssociation {

--- a/app/src/lib/dispatcher/github-user-database.ts
+++ b/app/src/lib/dispatcher/github-user-database.ts
@@ -9,7 +9,6 @@ export interface IGitHubUser {
   readonly email: string
   readonly login: string
   readonly avatarURL: string
-  readonly name?: string
 }
 
 export interface IMentionableAssociation {

--- a/app/src/lib/dispatcher/github-user-store.ts
+++ b/app/src/lib/dispatcher/github-user-store.ts
@@ -154,7 +154,6 @@ export class GitHubUserStore {
           login: apiCommit.author.login,
           avatarURL: apiCommit.author.avatar_url,
           endpoint: account.endpoint,
-          name: apiCommit.author.name,
         }
       }
     }
@@ -166,7 +165,6 @@ export class GitHubUserStore {
         login: matchingUser.login,
         avatarURL: matchingUser.avatar_url,
         endpoint: account.endpoint,
-        name: matchingUser.name,
       }
     }
 
@@ -309,12 +307,7 @@ export class GitHubUserStore {
         return MaxScore
       }
 
-      // `name` shouldn't even be `undefined` going forward, but older versions
-      // of the user cache didn't persist `name`. The `GitHubUserStore` will fix
-      // that, but autocompletions could be requested before that happens. So we
-      // need to check here even though the type says its superfluous.
-      const name = u.name
-      if (name && name.toLowerCase().includes(text.toLowerCase())) {
+      if (u.login.toLowerCase().includes(text.toLowerCase())) {
         return MaxScore - 0.1
       }
 

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -43,14 +43,14 @@ export class Account implements IAccount {
     return new Account('', getDotComAPIEndpoint(), '', [ ], '', -1, '')
   }
 
-  public constructor(login: string, endpoint: string, token: string, emails: ReadonlyArray<IEmail>, avatarURL: string, id: number, name: string) {
+  public constructor(login: string, endpoint: string, token: string, emails: ReadonlyArray<IEmail>, avatarURL: string, id: number, name?: string) {
     this.login = login
     this.endpoint = endpoint
     this.token = token
     this.emails = emails
     this.avatarURL = avatarURL
     this.id = id
-    this.name = name
+    this.name = name || login
   }
 
   public withToken(token: string): Account {

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -43,14 +43,14 @@ export class Account implements IAccount {
     return new Account('', getDotComAPIEndpoint(), '', [ ], '', -1, '')
   }
 
-  public constructor(login: string, endpoint: string, token: string, emails: ReadonlyArray<IEmail>, avatarURL: string, id: number, name?: string) {
+  public constructor(login: string, endpoint: string, token: string, emails: ReadonlyArray<IEmail>, avatarURL: string, id: number, name: string) {
     this.login = login
     this.endpoint = endpoint
     this.token = token
     this.emails = emails
     this.avatarURL = avatarURL
     this.id = id
-    this.name = name || login
+    this.name = name
   }
 
   public withToken(token: string): Account {

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -31,7 +31,7 @@ export class UserAutocompletionProvider implements IAutocompletionProvider<IUser
 
   public async getAutocompletionItems(text: string): Promise<ReadonlyArray<IUserHit>> {
     const users = await this.gitHubUserStore.getMentionableUsersMatching(this.repository, text)
-    return users.map(u => ({ username: u.login, name: u.name }))
+    return users.map(u => ({ username: u.login, name: u.name || u.login }))
   }
 
   public renderItem(item: IUserHit): JSX.Element {

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -8,9 +8,6 @@ import { GitHubRepository } from '../../models/github-repository'
 export interface IUserHit {
   /** The username. */
   readonly username: string
-
-  /** The user's name. */
-  readonly name: string
 }
 
 /** The autocompletion provider for user mentions in a GitHub repository. */
@@ -31,14 +28,13 @@ export class UserAutocompletionProvider implements IAutocompletionProvider<IUser
 
   public async getAutocompletionItems(text: string): Promise<ReadonlyArray<IUserHit>> {
     const users = await this.gitHubUserStore.getMentionableUsersMatching(this.repository, text)
-    return users.map(u => ({ username: u.login, name: u.name || u.login }))
+    return users.map(u => ({ username: u.login }))
   }
 
   public renderItem(item: IUserHit): JSX.Element {
     return (
       <div className='user' key={item.username}>
         <span className='username'>{item.username}</span>
-        <span className='name'>{item.name}</span>
       </div>
     )
   }

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Account } from '../../models/account'
-import { API, IAPIUser } from '../../lib/api'
+import { API, IAPIOrganizationSlug } from '../../lib/api'
 import { TextBox } from '../lib/text-box'
 import { Select } from '../lib/select'
 import { DialogContent } from '../dialog'
@@ -32,11 +32,11 @@ export interface IPublishRepositorySettings {
    * The org to which this repository belongs. If null, the repository should be
    * published as a personal repository.
    */
-  readonly org: IAPIUser | null
+  readonly org: IAPIOrganizationSlug | null
 }
 
 interface IPublishRepositoryState {
-  readonly orgs: ReadonlyArray<IAPIUser>
+  readonly orgs: ReadonlyArray<IAPIOrganizationSlug>
 }
 
 /** The Publish Repository component. */


### PR DESCRIPTION
Many responses from GitHub's API yield JSON that describes a User but are missing the `name:` field (see below for a partial list).

This Pull Request changes the API `interface` to match that expectation.

This work is part of https://github.com/philschatz/octokat.js/pull/176 (**add TypeScript Definitions**) and refs #1522 and #1281

To verify that these are the only changes needed, I plugged the `octokat/index.d.ts` file into Desktop and ran the CI tests. Here is a branch of that work: https://github.com/philschatz/desktop/compare/master...philschatz:octokat-typescript-example 

---

# GitHub API Routes and User Objects

The following routes yield a User with a `name:` field in the Response JSON:

```
GET /users/:username yields a 'UserWithName'
GET /user yields a 'UserWithName'
```

The following routes (39) yield a User that **does not** contain the `name:` field in the Response JSON:

- [GET /repos/:owner/:repo](https://api.github.com/repos/philschatz/octokat.js) (click to see the API Response)
- [GET /repos/:owner/:repo/issues/events](https://api.github.com/repos/philschatz/octokat.js/issues/events)
- [GET /repos/:owner/:repo/issues](https://api.github.com/repos/philschatz/octokat.js/issues)
- [GET /repos/:owner/:repo/pulls/:pull_request_number](https://api.github.com/repos/philschatz/octokat.js/pull/176)
- [GET /repos/:owner/:repo](https://api.github.com/repos/philschatz/octokat.js)

<details>
<summary><strong>[Click me] to see all the routes...</strong></summary>

```
GET /repos/:owner/:repo/issues/events
GET /users/:username/starred
GET /user/starred
GET /repos/:owner/:repo/subscribers
GET /issues
GET /repos/:owner/:repo/issues
GET /repos/:owner/:repo/issues/:issue_number
GET /repos/:owner/:repo/assignees
GET /repos/:owner/:repo/issues/:issue_number/comments
GET /repos/:owner/:repo/issues/comments
GET /repos/:owner/:repo/issues/comments/:issue_comment_id
GET /repos/:owner/:repo/issues/:issue_number/events
GET /repos/:owner/:repo/issues/events
GET /repos/:owner/:repo/pulls/:pull_request_number
GET /repos/:owner/:repo/pulls/:pull_request_number/commits
GET /repos/:owner/:repo/pulls/:pull_request_number/reviews
GET /repos/:owner/:repo/pulls/:pull_request_number/reviews/:review_id
GET /repos/:owner/:repo/pulls/:pull_request_number/reviews/:review_id/comments
GET /repos/:owner/:repo/pulls/:pull_request_number/comments
GET /repos/:owner/:repo/pulls/comments
GET /user/repos
GET /users/:username/repos
GET /repositories/:repository_id
GET /repos/:owner/:repo
GET /repos/:owner/:repo/collaborators
GET /repos/:owner/:repo/collaborators/:username/permission
GET /repos/:owner/:repo/comments
GET /repos/:owner/:repo/commits/:commit_sha/comments
GET /repos/:owner/:repo/comments/:repo_comment_id
GET /repos/:owner/:repo/commits
GET /repos/:owner/:repo/commits/:commit_sha
GET /repos/:owner/:repo/deployments
GET /repos/:owner/:repo/pages/builds
GET /repos/:owner/:repo/pages/builds/latest
GET /users
GET /users/:username/followers
GET /user/followers
GET /users/:username/following
GET /user/following
```

</details>
