### PR TITLE
Send the build sha to central

### DIFF
--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -13,6 +13,10 @@ declare const __DARWIN__: boolean
 /** Is the app being built to run on Win32? */
 declare const __WIN32__: boolean
 
+/**
+ * The commit id of the repository HEAD at build time.
+ * Represented as a 40 character SHA-1 hexadecimal digest string.
+ */
 declare const __SHA__: string
 
 /** The environment for which the release was created. */

--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -13,6 +13,8 @@ declare const __DARWIN__: boolean
 /** Is the app being built to run on Win32? */
 declare const __WIN32__: boolean
 
+declare const __SHA__: string
+
 /** The environment for which the release was created. */
 declare const __RELEASE_ENV__: 'production' | 'beta' | 'test' | 'development'
 

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -19,6 +19,7 @@ export async function reportError(error: Error, extra?: { [key: string]: string 
   }
 
   data.set('platform', process.platform)
+  data.set('sha', __SHA__)
   data.set('version', app.getVersion())
 
   if (extra) {

--- a/app/test/globals.ts
+++ b/app/test/globals.ts
@@ -12,6 +12,7 @@ g['__WIN32__'] = process.platform === 'win32'
 g['__DARWIN__'] = process.platform === 'darwin'
 g['__DEV__'] = 'false'
 g['__RELEASE_ENV__'] = 'test'
+g['__SHA__'] = 'test'
 
 g['log'] = <IDesktopLogger>{
   error: () => { },

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const path = require('path')
+const Fs = require('fs')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const webpack = require('webpack')
@@ -11,6 +12,30 @@ const devClientSecret = '22c34d87789a365981ed921352a7b9a8c3f69d54'
 
 const environment = process.env.NODE_ENV || 'development'
 
+/**
+ * Attempt to dereference the given ref without requiring a Git environment
+ * to be present. Note that this method will not be able to dereference packed
+ * refs but should suffice for simple refs like 'HEAD'.
+ *
+ * Will throw an error for unborn HEAD.
+ *
+ * @param {string} gitDir The path to the Git repository's .git directory
+ * @param {string} ref    A qualified git ref such as 'HEAD' or 'refs/heads/master'
+ */
+function revParse(gitDir, ref) {
+
+  const refPath = path.join(gitDir, ref)
+  const refContents = Fs.readFileSync(refPath)
+  const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m
+  const refMatch = refRe.exec(refContents)
+
+  if (!refMatch) {
+    throw new Error(`Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`)
+  }
+
+  return refMatch[1] || revParse(gitDir, refMatch[2])
+}
+
 const replacements = {
   __OAUTH_CLIENT_ID__: JSON.stringify(process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId),
   __OAUTH_SECRET__: JSON.stringify(process.env.DESKTOP_OAUTH_CLIENT_SECRET || devClientSecret),
@@ -18,6 +43,7 @@ const replacements = {
   __WIN32__: process.platform === 'win32',
   __DEV__: environment === 'development',
   __RELEASE_ENV__: JSON.stringify(environment),
+  __SHA__: JSON.stringify(revParse(path.resolve(__dirname, '../.git'), 'HEAD')),
   'process.platform': JSON.stringify(process.platform),
   'process.env.NODE_ENV': JSON.stringify(environment),
   'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),


### PR DESCRIPTION
By passing along the SHA of the current build in our error reports we can light up some features tying stack traces to actual source code.

Initially I thought we'd be able to do this server-side by matching up the version but we don't have a version->sha lookup readily available there.