### PR TITLE
Apply source maps for uncaught errors in main process

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -35,8 +35,6 @@ type OnDidLoadFn = (window: AppWindow) => void
 let onDidLoadFns: Array<OnDidLoadFn> | null = []
 
 function uncaughtException(error: Error) {
-  error = withSourceMappedStack(error)
-
   log.error(formatError(error))
 
   if (hasReportedUncaughtException) {
@@ -93,6 +91,8 @@ function uncaughtException(error: Error) {
 }
 
 process.on('uncaughtException', (error: Error) => {
+  error = withSourceMappedStack(error)
+
   reportError(error)
   uncaughtException(error)
 })


### PR DESCRIPTION
I tried provoking an uncaught error in the main process and saw that the stack wasn't source mapped. I believe this is due to us not applying source maps before calling `reportError`.

This changes also stops errors submitted from renderers passing through `withSourceMappedStack` since they're not true error instance and they should have had their maps applied already.