### PR TITLE
Fix Unicode diffs

### DIFF
--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -23,27 +23,17 @@ export function spawnAndComplete(args: string[], path: string, name: string, suc
     const startTime = (performance && performance.now) ? performance.now() : null
 
     const process = GitProcess.spawn(args, path)
-    process.stdout.setEncoding('binary')
-    process.stderr.setEncoding('binary')
 
     const stdout = new Array<Buffer>()
     let output: Buffer | undefined
-    process.stdout.on('data', (chunk) => {
-      if (chunk instanceof Buffer) {
-        stdout.push(chunk)
-      } else {
-        stdout.push(Buffer.from(chunk))
-      }
+    process.stdout.on('data', chunk => {
+      stdout.push(chunk as Buffer)
     })
 
     const stderr = new Array<Buffer>()
     let error: Buffer | undefined
-    process.stderr.on('data', (chunk) => {
-      if (chunk instanceof Buffer) {
-        stderr.push(chunk)
-      } else {
-        stderr.push(Buffer.from(chunk))
-      }
+    process.stderr.on('data', chunk => {
+      stderr.push(chunk as Buffer)
     })
 
     function reportTimings() {

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -267,4 +267,21 @@ describe('git/diff', () => {
       expect(diff.lineEndingsChange!.to).to.equal('CRLF')
     })
   })
+
+  describe('getWorkingDirectoryDiff/unicode', () => {
+    it('displays unicode characters', async () => {
+      const repo = await setupEmptyRepository()
+      const filePath = path.join(repo.path, 'foo')
+
+      const testString = 'here are some cool characters: • é  漢字'
+      fs.writeFileSync(filePath, testString)
+
+      const status = await getStatus(repo)
+      const files = status.workingDirectory.files
+      expect(files.length).to.equal(1)
+
+      const diff = await getTextDiff(repo, files[0])
+      expect(diff.text).to.equal(`@@ -0,0 +1 @@\n+${testString}`)
+    })
+  })
 })


### PR DESCRIPTION
Fixes #1954 

It turns out the `binary` encoding is [just an alias](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) for `latin1`, which we certainly don't want.

We want to leave the chunks as `Buffer`s and convert them to UTF8 later.

<img width="410" alt="screen shot 2017-06-09 at 2 26 50 pm" src="https://user-images.githubusercontent.com/13760/26990053-59b175c6-4d23-11e7-9c78-b020c01f73b7.png">
