### PR TITLE
Bail if we don't have any autocompletion items

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -276,7 +276,7 @@ export abstract class AutocompletingTextInput<ElementType extends HTMLInputEleme
 
     const currentAutoCompletionState = this.state.autocompletionState
 
-    if (!currentAutoCompletionState) {
+    if (!currentAutoCompletionState || !currentAutoCompletionState.items.length) {
       return
     }
 


### PR DESCRIPTION
Fixes #1961 

To reproduce the original crash:

1. Start typing in the commit summary field.
1. Hit `#` to trigger issue autocompletion.
1. Keep typing numbers until there are no autocompletions shown anymore.
1. Hit the up or down arrow.
1. 💥 