### PR TITLE
pin @types/electron to block breaking change in update

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@types/chai-datetime": "0.0.30",
     "@types/classnames": "^0.0.32",
     "@types/codemirror": "0.0.38",
-    "@types/electron": "^1.4.36",
+    "@types/electron": "1.4.38",
     "@types/electron-window-state": "^2.0.28",
     "@types/event-kit": "^1.2.28",
     "@types/fs-extra": "2.1.0",


### PR DESCRIPTION
Fixes #1975 

An update to `@types/electron` - 1.6.10 - from yesterday is being pulled in, will affect `npm install` due to our linting step:

```
$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
$  git clean -xdf node_modules 
Removing node_modules/
$ npm i
npm WARN deprecated @types/electron@1.6.10: This is a stub types definition for electron (https://github.com/electron/electron). electron provides its own type definitions, so you don't need @types/electron installed!

...

> @ compile:tslint /Users/shiftkey/src/desktop/desktop
> tsc -p tslint-rules

node_modules/@types/electron-window-state/index.d.ts(6,1): error TS2688: Cannot find type definition file for 'electron'.
node_modules/@types/electron-window-state/index.d.ts(52,15): error TS2503: Cannot find namespace 'Electron'.
node_modules/@types/electron-window-state/index.d.ts(57,18): error TS2503: Cannot find namespace 'Electron'.

npm ERR! Darwin 16.6.0

...
```

As we're moving towards eliminating our need for `@types/electron` completely, this pins us to the last 1.4.x version until we can get #1430 merged.