### PR TITLE
Filter the license list

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -28,6 +28,7 @@ const NoLicenseValue: ILicense = {
   name: 'None',
   featured: false,
   body: '',
+  hidden: false,
 }
 
 interface ICreateRepositoryProps {
@@ -250,7 +251,8 @@ export class CreateRepository extends React.Component<ICreateRepositoryProps, IC
 
   private renderLicenses() {
     const licenses = this.state.licenses || []
-    const options = [ NoLicenseValue, ...licenses ]
+    const featuredLicenses = [ NoLicenseValue, ...(licenses.filter(l => l.featured)) ]
+    const nonFeaturedLicenses = licenses.filter(l => !l.featured)
 
     return (
       <Row>
@@ -259,7 +261,9 @@ export class CreateRepository extends React.Component<ICreateRepositoryProps, IC
           value={this.state.license}
           onChange={this.onLicenseChange}
         >
-          {options.map(l => <option key={l.name} value={l.name}>{l.name}</option>)}
+          {featuredLicenses.map(l => <option key={l.name} value={l.name}>{l.name}</option>)}
+          <option disabled>────────────────────</option>
+          {nonFeaturedLicenses.map(l => <option key={l.name} value={l.name}>{l.name}</option>)}
         </Select>
       </Row>
     )

--- a/app/src/ui/add-repository/licenses.ts
+++ b/app/src/ui/add-repository/licenses.ts
@@ -71,7 +71,7 @@ export function getLicenses(): Promise<ReadonlyArray<ILicense>> {
             const license: ILicense = {
               name: result.attributes.nickname || result.attributes.title,
               featured: result.attributes.featured || false,
-              hidden: typeof result.attributes.hidden === 'undefined' || result.attributes.hidden,
+              hidden: result.attributes.hidden === undefined || result.attributes.hidden,
               body: result.body.trim(),
             }
 

--- a/app/src/ui/add-repository/licenses.ts
+++ b/app/src/ui/add-repository/licenses.ts
@@ -12,6 +12,7 @@ interface IChooseALicense {
   readonly title: string
   readonly nickname?: string
   readonly featured?: boolean
+  readonly hidden?: boolean
 }
 
 export interface ILicense {
@@ -23,6 +24,9 @@ export interface ILicense {
 
   /** The actual text of the license. */
   readonly body: string
+
+  /** Whether to hide the license from the standard list */
+  readonly hidden: boolean
 }
 
 interface ILicenseFields {
@@ -67,10 +71,13 @@ export function getLicenses(): Promise<ReadonlyArray<ILicense>> {
             const license: ILicense = {
               name: result.attributes.nickname || result.attributes.title,
               featured: result.attributes.featured || false,
+              hidden: typeof result.attributes.hidden == 'undefined' || result.attributes.hidden,
               body: result.body.trim(),
             }
 
-            licenses.push(license)
+            if (!license.hidden) {
+              licenses.push(license)
+            }
           }
 
           cachedLicenses = licenses.sort((a, b) => {

--- a/app/src/ui/add-repository/licenses.ts
+++ b/app/src/ui/add-repository/licenses.ts
@@ -71,7 +71,7 @@ export function getLicenses(): Promise<ReadonlyArray<ILicense>> {
             const license: ILicense = {
               name: result.attributes.nickname || result.attributes.title,
               featured: result.attributes.featured || false,
-              hidden: typeof result.attributes.hidden == 'undefined' || result.attributes.hidden,
+              hidden: typeof result.attributes.hidden === 'undefined' || result.attributes.hidden,
               body: result.body.trim(),
             }
 


### PR DESCRIPTION
* Filters the license list to only show featured and not hidden licenses
* Adds a separator in the dropdown between the two classes of licenses

Fixes #1987