### PR TITLE
FilterLists everywhere!

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import { CommitMessage } from './commit-message'
 import { ChangedFile } from './changed-file'
-import { List, ClickSource } from '../list'
+import { ClickSource, SelectionSource } from '../list'
+import { FilterList, IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 
 import { WorkingDirectoryStatus, WorkingDirectoryFileChange } from '../../models/status'
 import { DiffSelectionType } from '../../models/diff'
@@ -15,6 +16,13 @@ import { Repository } from '../../models/repository'
 import { showContextualMenu, IMenuItem } from '../main-process-proxy'
 
 const RowHeight = 29
+
+/**
+ * TS can't parse generic specialization in JSX, so we have to alias it here
+ * with the generic type. See https://github.com/Microsoft/TypeScript/issues/6395.
+ */
+const ChangesFilterList: new() => FilterList<IFileListItem> = FilterList as any
+
 
 interface IChangesListProps {
   readonly repository: Repository
@@ -61,14 +69,28 @@ interface IChangesListProps {
   readonly onIgnore: (pattern: string) => void
 }
 
+interface IFileListItem extends IFilterListItem {
+  readonly text: string
+  readonly id: string
+  readonly file: WorkingDirectoryFileChange
+}
+
 export class ChangesList extends React.Component<IChangesListProps, void> {
+  private onItemClick: (item: IFileListItem, source: ClickSource) => void
+  private onSelectionChanged: (selectedItem: IFileListItem | null, source: SelectionSource) => void
+
+  public constructor (props: IChangesListProps) {
+    super(props)
+    this.onItemClick = this.listEventHandler('onRowClick')
+    this.onSelectionChanged = this.listEventHandler('onFileSelectionChanged')
+  }
+
   private onIncludeAllChanged = (event: React.FormEvent<HTMLInputElement>) => {
     const include = event.currentTarget.checked
     this.props.onSelectAll(include)
   }
 
-  private renderRow = (row: number): JSX.Element => {
-    const file = this.props.workingDirectory.files[row]
+  private renderRow = ({ file }: IFileListItem): JSX.Element => {
     const selection = file.selection.getSelectionType()
 
     const includeAll = selection === DiffSelectionType.All
@@ -129,9 +151,30 @@ export class ChangesList extends React.Component<IChangesListProps, void> {
     showContextualMenu(items)
   }
 
+  private listEventHandler = (key: 'onRowClick' | 'onFileSelectionChanged') => (item: IFileListItem, arg?: any): void => {
+    const handler = this.props[key] as (item: number, source: any) => void
+    if (handler) {
+      handler(this.listGroups[0].items.findIndex(file => file.file === item.file), arg)
+    }
+  }
+
+  private get listGroups(): ReadonlyArray<IFilterListGroup<IFileListItem>> {
+    return [
+      {
+        identifier: 'files',
+        hasHeader: false,
+        items: this.props.workingDirectory.files.map(file => ({
+          id: file.id,
+          text: [ file.oldPath, file.path ].filter(x => x).join(' '),
+          file,
+        })),
+      },
+    ]
+  }
+
   public render() {
     const fileList = this.props.workingDirectory.files
-    const selectedRow = fileList.findIndex(file => file.id === this.props.selectedFileID)
+    const selectedItem = this.listGroups[0].items.find(item => item.file.id === this.props.selectedFileID) || null
     const fileCount = fileList.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
     const filesDescription = `${fileCount} changed ${filesPlural}`
@@ -147,14 +190,17 @@ export class ChangesList extends React.Component<IChangesListProps, void> {
           />
         </div>
 
-        <List id='changes-list'
-              rowCount={this.props.workingDirectory.files.length}
-              rowHeight={RowHeight}
-              rowRenderer={this.renderRow}
-              selectedRow={selectedRow}
-              onSelectionChanged={this.props.onFileSelectionChanged}
-              invalidationProps={this.props.workingDirectory}
-              onRowClick={this.props.onRowClick}/>
+        <ChangesFilterList
+          autoFocus={false}
+          groups={this.listGroups}
+          rowHeight={RowHeight}
+          className='changes-list'
+          selectedItem={selectedItem}
+          renderItem={this.renderRow}
+          onSelectionChanged={this.onSelectionChanged}
+          invalidationProps={this.props.workingDirectory}
+          onItemClick={this.onItemClick}
+        />
 
         <CommitMessage
           onCreateCommit={this.props.onCreateCommit}

--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -165,7 +165,7 @@ interface IListProps {
   /** Whether or not selection should follow pointer device */
   readonly selectOnHover?: boolean
 
-  /** 
+  /**
    * Whether or not to explicitly move focus to a row if it was selected
    * by hovering (has no effect if selectOnHover is not set). Defaults to
    * true if not defined.

--- a/app/styles/ui/changes/_changes-list.scss
+++ b/app/styles/ui/changes/_changes-list.scss
@@ -1,7 +1,17 @@
 @import "../../mixins";
 
-#changes-list {
+.changes-list {
   min-height: 0;
+
+  // otherwise, the list gets 0 height and won’t render.
+  .filter-list-container {
+    flex-direction: column;
+  }
+
+  .filter-field-row {
+    background: var(--box-alt-background-color);
+    border-bottom: 1px solid var(--box-border-color);
+  }
 }
 
 /** A React component holding the currently selected repository's changes */
@@ -12,7 +22,6 @@
 
   .header {
     background: var(--box-alt-background-color);
-    border-bottom: 1px solid var(--box-border-color);
     padding: 0 var(--spacing);
     height: 29px;
 
@@ -38,7 +47,7 @@
       input[type=checkbox] {
         flex-grow: 0;
         flex-shrink: 0;
-      }  
+      }
     }
   }
 }

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -7,6 +7,10 @@
   flex-direction: column;
   flex: 1;
 
+  .filter-field-row {
+    border-bottom: var(--base-border);
+  }
+
   .commit {
     display: flex;
     flex-direction: row;

--- a/app/styles/ui/history/_file-list.scss
+++ b/app/styles/ui/history/_file-list.scss
@@ -4,5 +4,9 @@
     flex: 1;
 
     border-right: var(--base-border);
+
+    .filter-field-row {
+      border-bottom: var(--base-border);
+    }
   }
 }


### PR DESCRIPTION
Fixes #2030.

A small issue is that when filtering the commit history, the app won’t load more commits when you scroll to the bottom of the list. This could be fixed by adding some sort of `onWillReachBottom` handler to `List`, and threading it up through `FilterList` to `ChangesList`.