### PR TITLE
Disable Merge Button With 0 Commits

### DIFF
--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -139,7 +139,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>
-            <Button type='submit' disabled={disabled}>
+            <Button type='submit' disabled={disabled || this.state.commitCount === 0}>
               Merge into <strong>{currentBranch ? currentBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -93,7 +93,6 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
   }
 
   private renderMergeInfo() {
-
     const commitCount = this.state.commitCount
     const countPlural = commitCount === 1 ? 'commit' : 'commits'
     const countText = commitCount === undefined
@@ -111,13 +110,26 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     )
   }
 
+  private renderUpToDateInfo() {
+    const currentBranch = this.props.currentBranch
+    const selectedBranch = this.state.selectedBranch
+
+    return (
+      <p className='merge-info'>
+        <strong>{currentBranch ? currentBranch.name : ''}</strong>
+        {' is up-to-date with '}
+        <strong>{selectedBranch ? selectedBranch.name : 'HEAD'}</strong>
+      </p>
+    )
+  }
+
   public render() {
     const selectedBranch = this.state.selectedBranch
     const currentBranch = this.props.currentBranch
 
     const disabled = (selectedBranch === null || currentBranch === null) || currentBranch.name === selectedBranch.name
 
-    const mergeInfo = disabled ? null : this.renderMergeInfo()
+    const mergeInfo = disabled ? null : (this.state.commitCount === 0 ? this.renderUpToDateInfo() : this.renderMergeInfo())
 
     return (
       <Dialog

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -92,11 +92,12 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     }
   }
 
-  private renderMergeInfo(invalidBranch: boolean) {
+  private renderMergeInfo() {
     const commitCount = this.state.commitCount
     const selectedBranch = this.state.selectedBranch
+    const currentBranch = this.props.currentBranch
 
-    if (invalidBranch) {
+    if ((selectedBranch === null || currentBranch === null) || currentBranch.name === selectedBranch.name) {
       return null
     }
 
@@ -122,8 +123,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     const selectedBranch = this.state.selectedBranch
     const currentBranch = this.props.currentBranch
 
-    const invalidBranch = (selectedBranch === null || currentBranch === null) || currentBranch.name === selectedBranch.name
-    const disabled = invalidBranch || this.state.commitCount === 0
+    const disabled = (selectedBranch === null || currentBranch === null) || currentBranch.name === selectedBranch.name || this.state.commitCount === 0
 
     return (
       <Dialog
@@ -149,7 +149,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
               Merge into <strong>{currentBranch ? currentBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>
-          {this.renderMergeInfo(invalidBranch)}
+          {this.renderMergeInfo()}
         </DialogFooter>
       </Dialog>
     )

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -92,14 +92,22 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     }
   }
 
-  private renderMergeInfo() {
+  private renderMergeInfo(invalidBranch: boolean) {
     const commitCount = this.state.commitCount
-    const countPlural = commitCount === 1 ? 'commit' : 'commits'
-    const countText = commitCount === undefined
-      ? 'commits'
-      : <strong>{commitCount} {countPlural}</strong>
-
     const selectedBranch = this.state.selectedBranch
+
+    if (invalidBranch) {
+      return null
+    }
+
+    if (commitCount === 0) {
+      return (
+        <p className='merge-info'>Nothing to merge</p>
+      )
+    }
+
+    const countPlural = commitCount === 1 ? 'commit' : 'commits'
+    const countText = commitCount === undefined ? 'commits' : <strong>{commitCount} {countPlural}</strong>
 
     return (
       <p className='merge-info'>
@@ -110,26 +118,12 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     )
   }
 
-  private renderUpToDateInfo() {
-    const currentBranch = this.props.currentBranch
-    const selectedBranch = this.state.selectedBranch
-
-    return (
-      <p className='merge-info'>
-        <strong>{currentBranch ? currentBranch.name : ''}</strong>
-        {' is up-to-date with '}
-        <strong>{selectedBranch ? selectedBranch.name : 'HEAD'}</strong>
-      </p>
-    )
-  }
-
   public render() {
     const selectedBranch = this.state.selectedBranch
     const currentBranch = this.props.currentBranch
 
-    const disabled = (selectedBranch === null || currentBranch === null) || currentBranch.name === selectedBranch.name
-
-    const mergeInfo = disabled ? null : (this.state.commitCount === 0 ? this.renderUpToDateInfo() : this.renderMergeInfo())
+    const invalidBranch = (selectedBranch === null || currentBranch === null) || currentBranch.name === selectedBranch.name
+    const disabled = invalidBranch || this.state.commitCount === 0
 
     return (
       <Dialog
@@ -151,11 +145,11 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>
-            <Button type='submit' disabled={disabled || this.state.commitCount === 0}>
+            <Button type='submit' disabled={disabled}>
               Merge into <strong>{currentBranch ? currentBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>
-          {mergeInfo}
+          {this.renderMergeInfo(invalidBranch)}
         </DialogFooter>
       </Dialog>
     )

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -83,10 +83,10 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     }
   }
 
-  private onSelectionChanged = (selectedBranch: Branch | null) => {
+  private onSelectionChanged = async (selectedBranch: Branch | null) => {
     if (selectedBranch) {
       this.setState({ selectedBranch })
-      this.updateCommitCount(selectedBranch)
+      await this.updateCommitCount(selectedBranch)
     } else {
       this.setState({ selectedBranch, commitCount: 0 })
     }
@@ -155,18 +155,17 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     )
   }
 
-  private async updateCommitCount(branch: Branch) {
-    this.setState({ commitCount: undefined })
-
+ private async updateCommitCount(branch: Branch) {
     const range = `...${branch.name}`
     const aheadBehind = await getAheadBehind(this.props.repository, range)
     const commitCount = aheadBehind ? aheadBehind.behind : 0
 
-    // The branch changed while we were waiting on the result of
-    // `getAheadBehind`.
-    if (this.state.selectedBranch !== branch) { return }
-
-    this.setState({ commitCount })
+    if (this.state.selectedBranch !== branch) {
+      // The branch changed while we were waiting on the result of `getAheadBehind`.
+      this.setState({ commitCount: undefined })
+    } else {
+      this.setState({ commitCount })
+    }
   }
 
   private merge = () => {


### PR DESCRIPTION
Did disable logic where I did so that zero commits message still shows. That way it is clear why button is disabled. Fixes #1359. See example below.
<img width="500" alt="disable with 0 commits" src="https://user-images.githubusercontent.com/7467062/27264277-d73817c4-5440-11e7-9b0b-4c5711408440.png">