### PR TITLE
Log bundle sizes

### DIFF
--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -100,5 +100,6 @@ module.exports = {
   getWindowsFullNugetPackagePath,
   getBundleID,
   getUserDataPath,
-  getWindowsIdentifierName
+  getWindowsIdentifierName,
+  getBundleSizes
 }

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const os = require('os')
+const fs = require('fs')
 
 const projectRoot = path.join(__dirname, '..')
 const appPackage = require(path.join(projectRoot, 'app', 'package.json'))
@@ -76,6 +77,12 @@ function getUserDataPath () {
 
 function getWindowsIdentifierName () {
   return 'GitHubDesktop'
+}
+
+function getBundleSizes () {
+  const rendererStats = fs.statSync(path.join(projectRoot, 'out', 'renderer.js'))
+  const mainStats = fs.statSync(path.join(projectRoot, 'out', 'main.js'))
+  return { rendererSize: rendererStats.size, mainSize: mainStats.size }
 }
 
 module.exports = {

--- a/script/publish
+++ b/script/publish
@@ -118,10 +118,16 @@ function createSignature (body) {
 }
 
 function updateDeploy (artifacts) {
+  const { rendererSize, mainSize } = distInfo.getBundleSizes()
   const body = {
     context: process.platform,
     branch_name: branchName,
-    artifacts
+    artifacts,
+    stats: {
+      platform: process.platform,
+      rendererBundleSize: rendererSize,
+      mainBundleSize: mainSize,
+    }
   }
   const signature = createSignature(body)
   const options = {


### PR DESCRIPTION
Report the bundle sizes when we build releases so that we can track them over time.