### PR TITLE
Reenable Menu Items For Removed Repo

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -155,8 +155,15 @@ function getMenuState(state: IAppState): Map<MenuIDs, IMenuItemState> {
     menuStateBuilder.setEnabled('pull', hasPublishedBranch && !networkActionInProgress)
     menuStateBuilder.setEnabled('create-branch', !tipStateIsUnknown)
   } else {
-    for (const id of repositoryScopedIDs) {
-      menuStateBuilder.disable(id)
+    if (selectedState && selectedState.type === SelectionType.MissingRepository) {
+      menuStateBuilder.enable('view-repository-on-github')
+      menuStateBuilder.enable('remove-repository')
+    } else {
+      for (const id of repositoryScopedIDs) {
+        menuStateBuilder.disable(id)
+      }
+
+      menuStateBuilder.disable('view-repository-on-github')
     }
 
     menuStateBuilder.disable('rename-branch')
@@ -165,7 +172,6 @@ function getMenuState(state: IAppState): Map<MenuIDs, IMenuItemState> {
     menuStateBuilder.disable('merge-branch')
     menuStateBuilder.disable('compare-branch')
 
-    menuStateBuilder.disable('view-repository-on-github')
     menuStateBuilder.disable('push')
     menuStateBuilder.disable('pull')
   }

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -155,15 +155,17 @@ function getMenuState(state: IAppState): Map<MenuIDs, IMenuItemState> {
     menuStateBuilder.setEnabled('pull', hasPublishedBranch && !networkActionInProgress)
     menuStateBuilder.setEnabled('create-branch', !tipStateIsUnknown)
   } else {
-    if (selectedState && selectedState.type === SelectionType.MissingRepository) {
-      menuStateBuilder.enable('view-repository-on-github')
-      menuStateBuilder.enable('remove-repository')
-    } else {
-      for (const id of repositoryScopedIDs) {
-        menuStateBuilder.disable(id)
-      }
+    for (const id of repositoryScopedIDs) {
+      menuStateBuilder.disable(id)
+    }
 
-      menuStateBuilder.disable('view-repository-on-github')
+    menuStateBuilder.disable('view-repository-on-github')
+
+    if (selectedState && selectedState.type === SelectionType.MissingRepository) {
+      if (selectedState.repository.gitHubRepository) {
+        menuStateBuilder.enable('view-repository-on-github')
+      }
+      menuStateBuilder.enable('remove-repository')
     }
 
     menuStateBuilder.disable('rename-branch')

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -464,12 +464,11 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private removeRepository = (repository: Repository | CloningRepository | null) => {
-
     if (!repository) {
       return
     }
 
-    if (repository instanceof CloningRepository) {
+    if (repository instanceof CloningRepository || repository.missing) {
       this.props.dispatcher.removeRepositories([ repository ])
       return
     }


### PR DESCRIPTION
- Fixes #1776
- Allow to View Repo or Remove when Missing via menu
- Check for missing before warning about deleting