### PR TITLE
a promise is not a contract, but it's very nice

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -185,8 +185,11 @@ export class API {
   public async fetchRepository(owner: string, name: string): Promise<IAPIRepository | null> {
     try {
       const response = await this.request('GET', `repos/${owner}/${name}`)
-      const result = await parsedResponse<IAPIRepository>(response)
-      return result
+      if (response.status === 404) {
+        log.warn(`fetchRepository: '${owner}/${name}' returned a 404`)
+        return null
+      }
+      return await parsedResponse<IAPIRepository>(response)
     } catch (e) {
       log.warn(`fetchRepository: not found '${owner}/${name}'`, e)
       return null

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -22,6 +22,11 @@ const Scopes = [
   'user',
 ]
 
+enum HttpStatusCodes {
+  NotModified = 304,
+  NotFound = 404,
+}
+
 /** The note URL used for authorizations the app creates. */
 const NoteURL = 'https://desktop.github.com/'
 
@@ -185,7 +190,7 @@ export class API {
   public async fetchRepository(owner: string, name: string): Promise<IAPIRepository | null> {
     try {
       const response = await this.request('GET', `repos/${owner}/${name}`)
-      if (response.status === 404) {
+      if (response.status === HttpStatusCodes.NotFound) {
         log.warn(`fetchRepository: '${owner}/${name}' returned a 404`)
         return null
       }
@@ -372,7 +377,7 @@ export class API {
 
     try {
       const response = await this.request('GET', `repos/${owner}/${name}/mentionables/users`, undefined, headers)
-      if (response.status === 304) { return null }
+      if (response.status === HttpStatusCodes.NotModified) { return null }
 
       const users = await parsedResponse<ReadonlyArray<IAPIMentionableUser>>(response)
       const responseEtag = response.headers.get('etag')

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -191,7 +191,7 @@ export class API {
       }
       return await parsedResponse<IAPIRepository>(response)
     } catch (e) {
-      log.warn(`fetchRepository: not found '${owner}/${name}'`, e)
+      log.warn(`fetchRepository: an error occurred for '${owner}/${name}'`, e)
       return null
     }
   }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -238,10 +238,15 @@ export class API {
   /** Fetch a commit from the repository. */
   public async fetchCommit(owner: string, name: string, sha: string): Promise<IAPICommit | null> {
     try {
-      const response = await this.request('GET', `repos/${owner}/${name}/commits/${sha}`)
+      const path = `repos/${owner}/${name}/commits/${sha}`
+      const response = await this.request('GET', path)
+      if (response.status === HttpStatusCode.NotFound) {
+        log.warn(`fetchCommit: '${path}' returned a 404`)
+        return null
+      }
       return parsedResponse<IAPICommit>(response)
     } catch (e) {
-      log.warn(`fetchCommit: not found '${owner}/${name}@${sha}'`, e)
+      log.warn(`fetchCommit: returned an error '${owner}/${name}@${sha}'`, e)
       return null
     }
   }
@@ -329,6 +334,11 @@ export class API {
 
     do {
       const response = await this.request('GET', nextPath)
+      if (response.status === HttpStatusCode.NotFound) {
+        log.warn(`fetchAll: '${path}' returned a 404`)
+        return []
+      }
+
       const items = await parsedResponse<ReadonlyArray<T>>(response)
       if (items) {
         buf.push(...items)
@@ -376,9 +386,13 @@ export class API {
     }
 
     try {
-      const response = await this.request('GET', `repos/${owner}/${name}/mentionables/users`, undefined, headers)
+      const path = `repos/${owner}/${name}/mentionables/users`
+      const response = await this.request('GET', path, undefined, headers)
       if (response.status === HttpStatusCode.NotModified) { return null }
-
+      if (response.status === HttpStatusCode.NotFound) {
+        log.warn(`fetchAll: '${path}' returned a 404`)
+        return null
+      }
       const users = await parsedResponse<ReadonlyArray<IAPIMentionableUser>>(response)
       const responseEtag = response.headers.get('etag')
       return { users, etag: responseEtag || '' }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -22,7 +22,7 @@ const Scopes = [
   'user',
 ]
 
-enum HttpStatusCodes {
+enum HttpStatusCode {
   NotModified = 304,
   NotFound = 404,
 }
@@ -190,7 +190,7 @@ export class API {
   public async fetchRepository(owner: string, name: string): Promise<IAPIRepository | null> {
     try {
       const response = await this.request('GET', `repos/${owner}/${name}`)
-      if (response.status === HttpStatusCodes.NotFound) {
+      if (response.status === HttpStatusCode.NotFound) {
         log.warn(`fetchRepository: '${owner}/${name}' returned a 404`)
         return null
       }
@@ -377,7 +377,7 @@ export class API {
 
     try {
       const response = await this.request('GET', `repos/${owner}/${name}/mentionables/users`, undefined, headers)
-      if (response.status === HttpStatusCodes.NotModified) { return null }
+      if (response.status === HttpStatusCode.NotModified) { return null }
 
       const users = await parsedResponse<ReadonlyArray<IAPIMentionableUser>>(response)
       const responseEtag = response.headers.get('etag')

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -185,7 +185,8 @@ export class API {
   public async fetchRepository(owner: string, name: string): Promise<IAPIRepository | null> {
     try {
       const response = await this.request('GET', `repos/${owner}/${name}`)
-      return parsedResponse<IAPIRepository>(response)
+      const result = await parsedResponse<IAPIRepository>(response)
+      return result
     } catch (e) {
       log.warn(`fetchRepository: not found '${owner}/${name}'`, e)
       return null


### PR DESCRIPTION
As part of the refactoring in #2080 a subtle bug was introduced around how promises raise errors.

If you're working with `async`/`await`, you need to `await` the promise and return the result, rather than returning the promise directly. This is important if you have a try-catch block, as returning the promise means that it escapes this local error handling.

There might be other things to do here (we're tracking #2061 for example) but this should close out #1624 again.