### PR TITLE
only push after publish if the tip is a valid branch

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1470,7 +1470,12 @@ export class AppStore {
     const gitStore = this.getGitStore(repository)
     await gitStore.performFailableOperation(() => addRemote(repository, 'origin', apiRepository.clone_url))
     await gitStore.loadCurrentRemote()
-    return this._push(repository, account)
+
+    // skip pushing if the current branch is a detached HEAD or the repository
+    // is unborn
+    if (gitStore.tip.kind === TipState.Valid) {
+      await this._push(repository, account)
+    }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */


### PR DESCRIPTION
Fixes #2086 by looking at the tip state when publishing