### PR TITLE
Fixing some spelling and language in markdown documents

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ https://github.com/desktop/desktop/blob/master/CODE_OF_CONDUCT.md
 
 -->
 
-Please summarise the issue in the title, and then use the template below to
+Please summarize the issue in the title, and then use the template below to
 fill out the details so we can reproduce the issue on our end.
 
 ### Description
@@ -44,9 +44,9 @@ about that repository will make it is easier to recreate the issue.
 If you think screenshots or a GIF recording will help demonstrate the issue
 better, feel free to add them here.
 
-**Expected behaviour:** [What you expected to happen]
+**Expected behavior:** [What you expected to happen]
 
-**Actual behaviour:** [What actually happened]
+**Actual behavior:** [What actually happened]
 
 **Reproduces how often:** [What percentage of the time does it reproduce?]
 
@@ -70,5 +70,5 @@ reproduce the issue.
 
 If you are dealing with a performance issue or regression, attaching a
 [Timeline profile](https://github.com/desktop/desktop/blob/master/docs/contributing/timeline-profile.md)
-of the task will help the developers understand the runtime behaviour of the
+of the task will help the developers understand the runtime behavior of the
 application on your machine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Please report unacceptable behavior to [opensource+desktop@github.com](mailto:op
 Currently GitHub Desktop is in a public beta, and the team is focused on
 triaging reported issues and working towards a 1.0 milestone - where the
 application can be used in place of the classic Mac and Windows applications.
-You can follow this progress progress under the [Milestones](https://github.com/desktop/desktop/milestones)
+You can follow this progress under the [Milestones](https://github.com/desktop/desktop/milestones)
 tab.
 
 We're still thinking about where we want to take GitHub Desktop after we reach
@@ -78,7 +78,7 @@ The information we are interested in includes:
  - details about your environment - which build, which operating system
  - details about reproducing the issue - what steps to take, what happens, how
    often it happens
- - other relevant information - log files, screenshots, etc
+ - other relevant information - log files, screenshots, etc.
 
 ### Suggesting Enhancements
 
@@ -114,7 +114,7 @@ and provide the following information:
   much detail as possible. This additional context helps the maintainers to
   understand the enhancement from your perspective
 * **Explain why this enhancement would be useful** to GitHub Desktop users.
-* **Include screenshots and animated GIFs** if relevent to help you demonstrate
+* **Include screenshots and animated GIFs** if relevant to help you demonstrate
   the steps or point out the part of GitHub Desktop which the suggestion is
   related to. You can use [this tool](http://www.cockos.com/licecap/) to record
   GIFs on macOS and Windows.

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -25,7 +25,7 @@ You will need to install these tools on your machine:
  - *Run `npm config set msvs_version 2015` to tell node the right toolchain to use for compiling native modules.*
 
 ## Verification
- 
+
 With these things installed, open a shell and validate you have these commands
 available and that the versions look similar:
 
@@ -41,7 +41,7 @@ Python 2.7.13
 ```
 
 There are also [additional resources](tooling.md) to
-configure your favourite editor to work nicely with the GitHub Desktop
+configure your favorite editor to work nicely with the GitHub Desktop
 repository.
 
 ## Building Desktop

--- a/docs/contributing/styleguide.md
+++ b/docs/contributing/styleguide.md
@@ -72,5 +72,5 @@ synchronous functions across the codebase.
 
 ### Scripts
 
-For scripts we should favour synchronous APIs as the asynchronous benefits are
+For scripts we should favor synchronous APIs as the asynchronous benefits are
 not so important there, and  it makes the code easier to read.

--- a/docs/process/issue-triage.md
+++ b/docs/process/issue-triage.md
@@ -15,8 +15,8 @@ We will use the `more-information-needed` and `reproduction-required` labels to
 indicate when issues are incomplete.
 
 Once enough detail has been captured about the issue, and it can be reproduced
-by one of the maintainers, these should be prioritised by the team. Severe bugs
-or bugs affecting many users would be prioritised above minor or low impact
+by one of the maintainers, these should be prioritized by the team. Severe bugs
+or bugs affecting many users would be prioritized above minor or low impact
 bugs.
 
 ## Enhancements


### PR DESCRIPTION
I was ~plagiarizing~ forking some of your documentation.
I noticed a few errors and some British English spellings.
I hope you don't mind.