### PR TITLE
Prevent Dialog dismissal when clicking title bar

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -214,6 +214,14 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     if (e.target !== this.dialogElement) {
       return
     }
+    
+    const titleBarHeight = __DARWIN__ ? 22 : 28
+    
+    const isTitleBar = e.clientY <= titleBarHeight
+
+    if(isTitleBar) {
+      return
+    }
 
     // Figure out if the user clicked on the backdrop or in the dialog itself.
     const rect = e.currentTarget.getBoundingClientRect()

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -220,9 +220,9 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
       return
     }
 
-    const isTitleBar = e.clientY <= titleBarHeight
+    const isInTitleBar = e.clientY <= titleBarHeight
 
-    if (isTitleBar) {
+    if (isInTitleBar) {
       return
     }
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -214,12 +214,12 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     if (e.target !== this.dialogElement) {
       return
     }
-    
+
     const titleBarHeight = __DARWIN__ ? 22 : 28
-    
+
     const isTitleBar = e.clientY <= titleBarHeight
 
-    if(isTitleBar) {
+    if (isTitleBar) {
       return
     }
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -10,6 +10,11 @@ import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
  */
 const dismissGracePeriodMs = 250
 
+/**
+ * Title bar height in pixels. Values taken from 'app/styles/_variables.scss'.
+ */
+const titleBarHeight = __DARWIN__ ? 22 : 28
+
 interface IDialogProps {
   /**
    * An optional dialog title. Most, if not all dialogs should have
@@ -214,8 +219,6 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     if (e.target !== this.dialogElement) {
       return
     }
-
-    const titleBarHeight = __DARWIN__ ? 22 : 28
 
     const isTitleBar = e.clientY <= titleBarHeight
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -137,11 +137,17 @@
    */
   --box-selected-active-border-color: $gray-400;
 
-  /** The height of the title bar area on Win32 platforms */
+  /**
+   * The height of the title bar area on Win32 platforms
+   * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
+  */
   --win32-title-bar-height: 28px;
   --win32-title-bar-background-color: $gray-900;
 
-  /** The height of the title bar area on darwin platforms */
+  /**
+   * The height of the title bar area on darwin platforms
+   * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
+  */
   --darwin-title-bar-height: 22px;
 
   --spacing: 10px;


### PR DESCRIPTION
Performs a check to determine if click was within the title bar and if so prevents Dialog dismissal.

I don't like how titleBarHeight is a hard coded number. Is there a way to pull this from the css variables?

Closes #2056