### PR TITLE
swap out direct event handlers for simpler handler

### DIFF
--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -13,12 +13,12 @@ interface IGitProps {
 
 export class Git extends React.Component<IGitProps, void> {
 
-  private onNameChanged = (e: React.FormEvent<HTMLInputElement>) => {
-    this.props.onNameChanged(e.currentTarget.value)
+  private onNameChanged = (text: string) => {
+    this.props.onNameChanged(text)
   }
 
-  private onEmailChanged = (e: React.FormEvent<HTMLInputElement>) => {
-    this.props.onEmailChanged(e.currentTarget.value)
+  private onEmailChanged = (text: string) => {
+    this.props.onEmailChanged(text)
   }
 
   public render() {
@@ -28,7 +28,7 @@ export class Git extends React.Component<IGitProps, void> {
           <TextBox
             label='Name'
             value={this.props.name}
-            onChange={this.onNameChanged}
+            onValueChanged={this.onNameChanged}
             autoFocus
           />
         </Row>
@@ -36,7 +36,7 @@ export class Git extends React.Component<IGitProps, void> {
           <TextBox
             label='Email'
             value={this.props.email}
-            onChange={this.onEmailChanged}
+            onValueChanged={this.onEmailChanged}
           />
         </Row>
       </DialogContent>

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -12,15 +12,6 @@ interface IGitProps {
 }
 
 export class Git extends React.Component<IGitProps, void> {
-
-  private onNameChanged = (text: string) => {
-    this.props.onNameChanged(text)
-  }
-
-  private onEmailChanged = (text: string) => {
-    this.props.onEmailChanged(text)
-  }
-
   public render() {
     return (
       <DialogContent>
@@ -28,7 +19,7 @@ export class Git extends React.Component<IGitProps, void> {
           <TextBox
             label='Name'
             value={this.props.name}
-            onValueChanged={this.onNameChanged}
+            onValueChanged={this.props.onNameChanged}
             autoFocus
           />
         </Row>
@@ -36,7 +27,7 @@ export class Git extends React.Component<IGitProps, void> {
           <TextBox
             label='Email'
             value={this.props.email}
-            onValueChanged={this.onEmailChanged}
+            onValueChanged={this.props.onEmailChanged}
           />
         </Row>
       </DialogContent>

--- a/app/src/ui/repository-settings/remote.tsx
+++ b/app/src/ui/repository-settings/remote.tsx
@@ -18,13 +18,12 @@ export class Remote extends React.Component<IRemoteProps, void> {
     return (
       <DialogContent>
         <div>Primary remote repository ({remote.name})</div>
-        <TextBox placeholder='Remote URL' value={remote.url} onChange={this.onChange}/>
+        <TextBox placeholder='Remote URL' value={remote.url} onValueChanged={this.onChange}/>
       </DialogContent>
     )
   }
 
-  private onChange = (event: React.FormEvent<HTMLInputElement>) => {
-    const url = event.currentTarget.value
-    this.props.onRemoteUrlChanged(url)
+  private onChange = (text: string) => {
+    this.props.onRemoteUrlChanged(text)
   }
 }

--- a/app/src/ui/repository-settings/remote.tsx
+++ b/app/src/ui/repository-settings/remote.tsx
@@ -18,12 +18,8 @@ export class Remote extends React.Component<IRemoteProps, void> {
     return (
       <DialogContent>
         <div>Primary remote repository ({remote.name})</div>
-        <TextBox placeholder='Remote URL' value={remote.url} onValueChanged={this.onChange}/>
+        <TextBox placeholder='Remote URL' value={remote.url} onValueChanged={this.props.onRemoteUrlChanged}/>
       </DialogContent>
     )
-  }
-
-  private onChange = (text: string) => {
-    this.props.onRemoteUrlChanged(text)
   }
 }


### PR DESCRIPTION
`TextBox` has a `onValueChanged` prop that you can use to handle when the text has changed, rather than `onChanged` which gives you the raw form event.