### PR TITLE
Fix links in releasing-updates.md

### DIFF
--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -8,9 +8,9 @@ update this process.
 
 ## The Process
 
-1. Ensure the release notes for `RELEASE_VERSION` in [`changelog.json`](../changelog.json) are up-to-date.
-1. Bump `version` in [`app/package.json`](../app/package.json) to `RELEASE_VERSION`.
-1. Create a new, empty entry in [`changelog.json`](../changelog.json) for `RELEASE_VERSION + 1`.
+1. Ensure the release notes for `RELEASE_VERSION` in [`changelog.json`](../../changelog.json) are up-to-date.
+1. Bump `version` in [`app/package.json`](../../app/package.json) to `RELEASE_VERSION`.
+1. Create a new, empty entry in [`changelog.json`](../../changelog.json) for `RELEASE_VERSION + 1`.
 1. Commit & push the changes.
 1. Run `.release! desktop/YOUR_BRANCH to {production|test}`.
   * We're using `.release` with a bang so that we don't have to wait for any current CI on the branch to finish. This might feel a little wrong, but it's OK since making the release itself will also run CI.


### PR DESCRIPTION
They were linking to `docs/` instead of the root of the repository

---

On another note, have you considered putting the `docs/` directory on GitHub Pages? It might make it easier to read through.