### PR TITLE
tidy up current labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ change over time as we learn and refine how we work with the community.
 [How Can I Contribute?](#how-can-i-contribute)
   * [Reporting Bugs](#reporting-bugs)
   * [Suggesting Enhancements](#suggesting-enhancements)
-  * [Up for Grabs](#up-for-grabs)
+  * [Accepting PRs](#accepting-prs)
 
 [Additional Notes](#additional-notes)
   * [Issue and Pull Request Labels](#issue-and-pull-request-labels)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ pull requests.
 
 | Label name | :mag_right: | Description |
 | --- | --- | --- |
-| `Accepting PRs` | [search](https://github.com/desktop/desktop/labels/accepting-prs)  | Issues marked as ideal for external contributors. |
+| `accepting-prs` | [search](https://github.com/desktop/desktop/labels/accepting-prs)  | Issues marked as ideal for external contributors. |
 | `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions. |
 | `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require some design input from the maintainers as part of completing the work. |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,20 +120,20 @@ and provide the following information:
   GIFs on macOS and Windows.
 * **List some other applications where this enhancement exists, if applicable.**
 
-### Up For Grabs
+### Accepting PRs
 
-As the team is working towards the 1.0 release, we'll identify enhancements or
-bugs that can be categorised as tasks that:
+As part of building GitHub Desktop, we'll identify tasks that are good for
+external contributors to pick up. These tasks:
 
  - have low impact, or have a known workaround
- - should be fixed
+ - should be addressed
  - have a narrow scope and/or easy reproduction steps
  - can be worked on independent of other tasks
 
-These issues will be labelled as [`up-for-grabs`](https://github.com/desktop/desktop/labels/up-for-grabs)
+These issues will be labelled as [`accepting-prs`](https://github.com/desktop/desktop/labels/accepting-prs)
 in the repository. If you are interested in contributing to the project, please
-comment on the issue to let the maintainers (and community) know you are
-interested in picking this up.
+comment on the issue to let the core team (and the community) know you are
+interested in the issue.
 
 ## Additional Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ pull requests.
 | --- | --- | --- |
 | `accepting-prs` | [search](https://github.com/desktop/desktop/labels/accepting-prs)  | Issues marked as ideal for external contributors. |
 | `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions. |
-| `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require some design input from the maintainers as part of completing the work. |
+| `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require design input from the core team before the work can be started. |
 
 #### Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,6 @@ pull requests.
 | --- | --- | --- |
 | `enhancement` | [search](https://github.com/desktop/desktop/labels/enhancement) | Feature requests. |
 | `bug` | [search](https://github.com/desktop/desktop/labels/bug)  | Confirmed bugs or reports that are very likely to be bugs. |
-| `question` | [search](https://github.com/desktop/desktop/labels/question)  | Questions more than bug reports or feature requests (e.g. how do I do X). |
 | `more-information-needed` | [search](https://github.com/desktop/desktop/labels/more-information-needed) | More information needs to be collected about these problems or feature requests (e.g. steps to reproduce). |
 | `needs-reproduction` | [search](https://github.com/desktop/desktop/labels/needs-reproduction)  | Likely bugs, but haven't been reliably reproduced. |
 | `macOS` | [search](https://github.com/desktop/desktop/labels/macOS)  | Issues specific to macOS users. |
@@ -158,10 +157,9 @@ pull requests.
 
 | Label name | :mag_right: | Description |
 | --- | --- | --- |
-| `up-for-grabs` | [search](https://github.com/desktop/desktop/labels/up-for-grabs)  | Issues marked as ideal for external contributors. |
-| `polish` | [search](https://github.com/desktop/desktop/labels/polish) | Issues not critical to the application but would provide a better experience if resolved. |
+| `Accepting PRs` | [search](https://github.com/desktop/desktop/labels/accepting-prs)  | Issues marked as ideal for external contributors. |
 | `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions. |
-| `design` | [search](https://github.com/desktop/desktop/labels/design)  | Issues that require some design input from the maintainers as part of completing the work. |
+| `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require some design input from the maintainers as part of completing the work. |
 
 #### Workflow
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The [CONTRIBUTING.md](./CONTRIBUTING.md) document will help you get setup and
 familiar with the source. The [documentation](docs/) folder also contains more
 resources relevant to the project.
 
-If you're looking for something to work on, check out the [up-for-grabs](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) label.
+If you're looking for something to work on, check out the [accepting-prs](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Aaccepting-prs) label.
 
 ## More Resources
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -102,7 +102,7 @@ require('devtron').install()
 
 You're almost there! Here's a couple of things we recommend you read next:
 
- - [Up for Grabs](../../CONTRIBUTING.md#up-for-grabs) - we've marked some tasks in
+ - [Accepting PRs](../../CONTRIBUTING.md#accepting-prs) - we've marked some tasks in
    the backlog that are ideal for external contributors
  - [Code Reviews](../process/reviews.md) - some notes on how the team does
    code reviews


### PR DESCRIPTION
As we discussed yesterday, we need to clarify out usages of labels and then review how they are currently assigned:

 - [x] get approval on the documentation changes
 - [x] **up-for-grabs** -> **accepting-prs** 
    - [x] update label
    - [x] rewrite documentation section about this
    - [x] review assigned issues to ensure they are detailed enough
- [x] **question** -> 🗑 
- [x] **polish** -> 🗑 
    - [x] review assigned issues and label as `enhancement` or `bug`
    - [x] remove label
- [x] **design** -> **needs-design-input**
    - [x] review assigned issues and drop for issues that don't need design input
    - [x] update label
    