### PR TITLE
Don't set Prettier's line width

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,23 +1,22 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib",
-    "search.exclude": {
-        "**/node_modules": true,
-        "**/dist": true,
-        "**/out": true
-    },
-    "files.exclude": {
-        "**/.git": true,
-        "**/.svn": true,
-        "**/.hg": true,
-        "**/.DS_Store": true,
-        "**/node_modules": true,
-        "**/dist": true,
-        "**/out": true,
-        "tslint-rules/**/*.js": true
-    },
-    "editor.tabSize": 2,
-    "prettier.semi": false,
-    "prettier.singleQuote": true,
-    "prettier.trailingComma": "es5",
-    "prettier.printWidth": 100
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/out": true,
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/.DS_Store": true,
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/out": true,
+    "tslint-rules/**/*.js": true,
+  },
+  "editor.tabSize": 2,
+  "prettier.semi": false,
+  "prettier.singleQuote": true,
+  "prettier.trailingComma": "es5",
 }


### PR DESCRIPTION
The diff isn't terribly helpful because of the auto formatting (lol) but this removes the `"prettier.printWidth": 100` setting.

The reason being that, since we format to [80 characters](https://github.com/desktop/desktop/blob/6867b32806f2c9815a97909d9c5d4d8f762bb4f1/package.json#L32), if we use 100 characters in the editor then our local diffs are super noisy and it's hard to do line commits. That said, if you really prefer 100 characters, you can still set it in your user settings and it'll trickle down.

So it's the best of both worlds.