### PR TITLE
Prettify on windows too

### DIFF
--- a/app/test/unit/app-test.tsx
+++ b/app/test/unit/app-test.tsx
@@ -43,7 +43,7 @@ describe('App', () => {
       new EmojiStore(),
       new IssuesStore(issuesDb),
       statsStore,
-      new SignInStore(),
+      new SignInStore()
     )
 
     dispatcher = new InMemoryDispatcher(appStore)
@@ -51,7 +51,7 @@ describe('App', () => {
 
   it('renders', async () => {
     const app = TestUtils.renderIntoDocument(
-      <App dispatcher={dispatcher!} appStore={appStore!} startTime={0}/>,
+      <App dispatcher={dispatcher!} appStore={appStore!} startTime={0} />
     ) as React.Component<any, any>
     // Give any promises a tick to resolve.
     await wait(0)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "precommit": "lint-staged",
     "prepush": "lint-staged",
     "prettier:base": "prettier --parser typescript --single-quote --trailing-comma es5 --tab-width 2 --no-semi --print-width 80 --write",
-    "prettify": "npm run prettier:base 'app/src/**/*.ts' && npm run prettier:base 'app/src/**/*.tsx' && npm run prettier:base 'app/test/**/*.ts'"
+    "prettify": "npm run prettier:base \"app/src/**/*.ts\" && npm run prettier:base \"app/src/**/*.tsx\" && npm run prettier:base \"app/test/**/*.ts\""
   },
   "lint-staged": {
     "app/{src, test}/**/*.{ts, tsx}": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "rebuild-hard:prod": "npm run clean-slate && npm run build:prod",
     "precommit": "lint-staged",
     "prepush": "lint-staged",
-    "prettier:base": "prettier --parser typescript --single-quote --trailing-comma es5 --tab-width 2 --no-semi --print-width 80 --write",
+    "prettier:base": "prettier --parser typescript --single-quote --trailing-comma es5 --no-semi --write",
     "prettify": "npm run prettier:base \"app/{src, test}/**/*.{ts, tsx}\""
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "rebuild-hard:dev": "npm run clean-slate && npm run build:dev",
     "rebuild-hard:prod": "npm run clean-slate && npm run build:prod",
     "precommit": "lint-staged",
-    "prepush": "lint-staged",
     "prettier:base": "prettier --single-quote --trailing-comma es5 --no-semi --write",
     "prettify": "npm run prettier:base \"app/{src,test}/**/*.{ts,tsx}\""
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "prepush": "lint-staged",
     "prettier:base": "prettier --parser typescript --single-quote --trailing-comma es5 --no-semi --write",
     "prettify": "npm run prettier:base \"app/{src, test}/**/*.{ts, tsx}\""
+    "prettify": "npm run prettier:base \"app/{src,test}/**/*.{ts,tsx}\""
   },
   "lint-staged": {
-    "app/{src, test}/**/*.{ts, tsx}": [
+    "app/{src,test}/**/*.{ts,tsx}": [
       "npm run prettier:base",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "precommit": "lint-staged",
     "prepush": "lint-staged",
     "prettier:base": "prettier --parser typescript --single-quote --trailing-comma es5 --tab-width 2 --no-semi --print-width 80 --write",
-    "prettify": "npm run prettier:base \"app/src/**/*.ts\" && npm run prettier:base \"app/src/**/*.tsx\" && npm run prettier:base \"app/test/**/*.ts\""
+    "prettify": "npm run prettier:base \"app/{src, test}/**/*.{ts, tsx}\""
   },
   "lint-staged": {
     "app/{src, test}/**/*.{ts, tsx}": [

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "rebuild-hard:prod": "npm run clean-slate && npm run build:prod",
     "precommit": "lint-staged",
     "prepush": "lint-staged",
-    "prettier:base": "prettier --parser typescript --single-quote --trailing-comma es5 --no-semi --write",
-    "prettify": "npm run prettier:base \"app/{src, test}/**/*.{ts, tsx}\""
+    "prettier:base": "prettier --single-quote --trailing-comma es5 --no-semi --write",
     "prettify": "npm run prettier:base \"app/{src,test}/**/*.{ts,tsx}\""
   },
   "lint-staged": {

--- a/script/is-it-pretty.js
+++ b/script/is-it-pretty.js
@@ -3,7 +3,7 @@
 const prettier = require('prettier');
 const glob = require('glob');
 const fs = require('fs');
-const globPattern = 'app/{src, test}/**/*.{ts, tsx}'
+const globPattern = 'app/{src,test}/**/*.{ts,tsx}'
 const prettierOptions = {
   "parser": "typescript",
   "singleQuote": true,


### PR DESCRIPTION
Prettify didn't run on Windows due to the use of single quotes in the arguments to `prettier:base`. As I was fixing that I also switched to a single glob instead of invoking prettier three times which reduced the runtime of `npm run prettify` from 14s to 9s on my machine. I also added prettification of tsx files inside the test directory.

Furthermore I removed command line arguments to prettify that sets already default values such that it's more clear which settings we're overriding.

Lastly, I removed the `prepush` hook as that doesn't make a tonne of sense (though I might certainly be missing something). If we want to do some sort of pre-commit verification we should run the checks on what's in the index, not on what's in the working directory and as we've already run prettier on each commit leading up to the push it seems redundant and it should suffice to let CI deal with any edge-cases.