### PR TITLE
Fix #1901

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -78,7 +78,7 @@ export class AppWindow {
       this.window.on('close', e => {
         if (!quitting) {
           e.preventDefault()
-          this.window.hide()
+          Menu.sendActionToFirstResponder('hide:')
         }
       })
     }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -403,7 +403,6 @@ function createWindow() {
 
   window.onClose(() => {
     mainWindow = null
-
     if (!__DARWIN__ && !preventQuit) {
       app.quit()
     }


### PR DESCRIPTION
When the red close button is pressed (macOS), instead of hiding the window, we hide the app (as if `Cmd-h` was pressed).