### PR TITLE
Don't try to validate the children

### DIFF
--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -40,14 +40,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
   }
 
   private renderEndpointEntryStep(state: IEndpointEntryState) {
-    const children = this.props.children as ReadonlyArray<JSX.Element> | null
-    if (!children || !children.length) {
-      console.error(
-        'unexpected child elements provided to EnterpriseServerEntry - someone should look into this!'
-      )
-      return null
-    }
-
+    const children = this.props.children as ReadonlyArray<JSX.Element>
     return (
       <EnterpriseServerEntry
         loading={state.loading}
@@ -59,14 +52,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
   }
 
   private renderAuthenticationStep(state: IAuthenticationState) {
-    const children = this.props.children as ReadonlyArray<JSX.Element> | null
-    if (!children || !children.length) {
-      console.error(
-        'unexpected child elements provided to AuthenticationForm - someone should look into this!'
-      )
-      return null
-    }
-
+    const children = this.props.children as ReadonlyArray<JSX.Element>
     return (
       <AuthenticationForm
         loading={state.loading}


### PR DESCRIPTION
Fixes #2218.

This was introduced in https://github.com/desktop/desktop/pull/2124 because React's type declarations for `children` is wacky and we're trying to hide it from our internal types. We should just cast and let React deal with its wacky types.