### PR TITLE
Error and warning dialog refinements

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import * as classNames from 'classnames'
 import { DialogHeader } from './header'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { assertNever } from '../../lib/fatal-error'
 
 /**
  * The time (in milliseconds) from when the dialog is mounted
@@ -297,9 +299,27 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
         titleId={this.state.titleId}
         dismissable={this.isDismissable()}
         onDismissed={this.onDismiss}
-        type={this.props.type}
         loading={this.props.loading}
       />
+    )
+  }
+
+  private renderIcon() {
+    if (this.props.loading === true) {
+      return <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
+    }
+
+    if (this.props.type === undefined || this.props.type === 'normal') {
+      return null
+    } else if (this.props.type === 'error') {
+      return <Octicon className="icon" symbol={OcticonSymbol.stop} />
+    } else if (this.props.type === 'warning') {
+      return <Octicon className="icon" symbol={OcticonSymbol.alert} />
+    }
+
+    return assertNever(
+      this.props.type,
+      `Unknown dialog header type ${this.props.type}`
     )
   }
 
@@ -321,6 +341,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
         aria-labelledby={this.state.titleId}
       >
         {this.renderHeader()}
+        {this.renderIcon()}
 
         <form onSubmit={this.onSubmit} autoFocus={true}>
           <fieldset disabled={this.props.disabled}>

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 import * as classNames from 'classnames'
 import { DialogHeader } from './header'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
-import { Octicon, OcticonSymbol } from '../octicons'
-import { assertNever } from '../../lib/fatal-error'
 
 /**
  * The time (in milliseconds) from when the dialog is mounted
@@ -304,25 +302,6 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     )
   }
 
-  private renderIcon() {
-    if (this.props.loading === true) {
-      return <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
-    }
-
-    if (this.props.type === undefined || this.props.type === 'normal') {
-      return null
-    } else if (this.props.type === 'error') {
-      return <Octicon className="icon" symbol={OcticonSymbol.stop} />
-    } else if (this.props.type === 'warning') {
-      return <Octicon className="icon" symbol={OcticonSymbol.alert} />
-    }
-
-    return assertNever(
-      this.props.type,
-      `Unknown dialog header type ${this.props.type}`
-    )
-  }
-
   public render() {
     const className = classNames(
       {
@@ -341,7 +320,6 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
         aria-labelledby={this.state.titleId}
       >
         {this.renderHeader()}
-        {this.renderIcon()}
 
         <form onSubmit={this.onSubmit} autoFocus={true}>
           <fieldset disabled={this.props.disabled}>

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Octicon, OcticonSymbol } from '../octicons'
-import { assertNever } from '../../lib/fatal-error'
 
 interface IDialogHeaderProps {
   /**
@@ -26,14 +25,6 @@ interface IDialogHeaderProps {
    * ways described in the dismissable prop.
    */
   readonly onDismissed?: () => void
-
-  /**
-   * An optional type of dialog header. If the type is error or warning
-   * an applicable icon will be rendered top left in the dialog.
-   *
-   * Defaults to 'normal' if omitted.
-   */
-  readonly type?: 'normal' | 'warning' | 'error'
 
   /**
    * Whether or not the dialog contents are currently involved in processing
@@ -77,29 +68,9 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     )
   }
 
-  private renderIcon() {
-    if (this.props.loading === true) {
-      return <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
-    }
-
-    if (this.props.type === undefined || this.props.type === 'normal') {
-      return null
-    } else if (this.props.type === 'error') {
-      return <Octicon className="icon" symbol={OcticonSymbol.stop} />
-    } else if (this.props.type === 'warning') {
-      return <Octicon className="icon" symbol={OcticonSymbol.alert} />
-    }
-
-    return assertNever(
-      this.props.type,
-      `Unknown dialog header type ${this.props.type}`
-    )
-  }
-
   public render() {
     return (
       <header className="dialog-header">
-        {this.renderIcon()}
         <h1 id={this.props.titleId}>
           {this.props.title}
         </h1>

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -68,12 +68,21 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     )
   }
 
+  private renderIcon() {
+    if (this.props.loading === true) {
+      return <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
+    }
+
+    return null
+  }
+
   public render() {
     return (
       <header className="dialog-header">
         <h1 id={this.props.titleId}>
           {this.props.title}
         </h1>
+        {this.renderIcon()}
         {this.renderCloseButton()}
       </header>
     )

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -68,21 +68,17 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     )
   }
 
-  private renderIcon() {
-    if (this.props.loading === true) {
-      return <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
-    }
-
-    return null
-  }
-
   public render() {
+    const spinner = this.props.loading
+      ? <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
+      : null
+
     return (
       <header className="dialog-header">
         <h1 id={this.props.titleId}>
           {this.props.title}
         </h1>
-        {this.renderIcon()}
+        {spinner}
         {this.renderCloseButton()}
       </header>
     )

--- a/app/src/ui/install-git/install.tsx
+++ b/app/src/ui/install-git/install.tsx
@@ -44,7 +44,7 @@ export class InstallGit extends React.Component<IInstallGitProps, {}> {
       <Dialog
         id="install-git"
         type="warning"
-        title={__DARWIN__ ? 'Open in Terminal' : 'Open command prompt'}
+        title={__DARWIN__ ? 'Unable to Locate Git' : 'Unable to locate Git'}
         onSubmit={this.props.onDismissed}
         onDismissed={this.props.onDismissed}
       >

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -15,6 +15,7 @@ dialog {
   // Related: https://css-tricks.com/probably-dont-base64-svg/
   --dialog-icon-alert: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 12,1.5 c -0.5,0 -1.5,0 -2,1 L 5,11 0.33203125,19.234375 C -0.5,21 0.5,23 2.4902344,23 L 12,23 21.509766,23 C 23.5,23 24.5,21 23.667969,19.234375 L 19,11 14,2.5 c -0.5,-1 -1.5,-1 -2,-1 z m -1,5.5 2,0 0,8 -2,0 z m 0,10 2,0 0,2 -2,0 z" /></svg>');
   --dialog-icon-stop: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 16,2 -9,0 -6,6 0,9 6,6 9,0 6,-6 0,-9 z m 4.5,14.25 -5.25,5.25 -7.5,0 -5.25,-5.25 0,-7.5 5.25,-5.25 7.5,0 5.25,5.25 z M 10,6 l 3,0 0,8 -3,0 z m 0,10 3,0 0,3 -3,0 z" /></svg>');
+  --dialog-icon-size: 24px;
 
   border: var(--base-border);
   box-shadow: var(--base-box-shadow);
@@ -161,8 +162,19 @@ dialog {
       // A zero padding would mean the icon and the text lines up so we
       // add another double spacing plus the width of the icon to ensure
       // we have a decently horizontally centered placement of the icon.
-      padding-left: calc(var(--spacing-double) + 24px);
+      padding-left: calc(var(--spacing-double) + var(--dialog-icon-size));
 
+      // Ensure that the dialog contents always have room for the icon,
+      // account for two double spacers at top and bottom plus the 5px
+      // icon offset (margin-top) and the size of the icon itself.
+      min-height: calc(var(--spacing-double) * 2 + var(--spacing-half) + var(--dialog-icon-size));
+
+      // We're creating an opaque 24 by 24px div with the background color
+      // that we want the icon to appear in and then apply the icon path
+      // as a mask, that way we can control the color dynamically based on
+      // our variables instead of hardcoding it in the SVG.
+      //
+      // https://codepen.io/noahblon/post/coloring-svgs-in-css-background-images
       &::before {
         content: '';
         display: block;
@@ -177,7 +189,6 @@ dialog {
 
   &.warning {
     .dialog-content::before {
-      // https://codepen.io/noahblon/post/coloring-svgs-in-css-background-images
       background-color: var(--dialog-warning-color);
       -webkit-mask: var(--dialog-icon-alert);
     }
@@ -185,7 +196,6 @@ dialog {
 
   &.error {
     .dialog-content::before {
-      // https://codepen.io/noahblon/post/coloring-svgs-in-css-background-images
       background-color: var(--dialog-error-color);
       -webkit-mask: var(--dialog-icon-stop);
     }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -92,53 +92,39 @@ dialog {
   .dialog-header {
     height: 50px;
     border-bottom: var(--base-border);
-    position: relative;
 
-    // There's at most three elements in the header,
-    //   1. The icon (optional, only for errors, warnings, etc)
-    //   2. The title, a h1 element which is always present if the
-    //      header element is visible
-    //   3. The close button (optional, hidden when dialog isn't dismissable).
-    //
-    // In order to correctly center the title in all scenarios we lay out the
-    // children in a flexbox but we position the icon and close button
-    // absolutely to the left and right side leaving the h1 all available
-    // width. We then add a 40px margin on each side of the h1 ensuring that
-    // even in the scenario where only one of the two optional elements is
-    // visible the h1 stays centered horizontally.
     display: flex;
     flex-direction: row;
-    justify-content: center;
     align-items: center;
+    padding: var(--spacing-double);
 
     svg.icon {
-      position: absolute;
-      left: var(--spacing);
+      flex-shrink: 0;
+      margin-right: var(--spacing);
     }
 
     h1 {
       font-weight: var(--font-weight-semibold);
       font-size: var(--font-size-md);
-
-      // See comment above. 40px is enough space to clear both the icon
-      // and the close button with their respective margins.
-      margin: 0 40px;
-      text-align: center;
+      margin: 0;
       padding: 0;
-      flex-grow: 1;
+      margin-right: var(--spacing);
 
       @include ellipsis;
     }
 
     .close {
-      position: absolute;
-      right: var(--spacing);
-      top: var(--spacing);
+      flex-shrink: 0;
 
       border: 0;
       height: 16px;
       width: 16px;
-      margin: 0;
+
+      // Set the left margin to auto so that flexbox positions the button
+      // on the right hand side of the dialog and add a -10px right hand
+      // side margin to put the button where it should be (we use a double
+      // margin for the header itself).
+      margin: 0 calc(var(--spacing) * -1) 0 auto;
       padding: 0;
       background: transparent;
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -8,6 +8,14 @@
 // allow easy layout using generalized components and elements such as <Row>
 // and <p>.
 dialog {
+
+  // These are custom version of the alert and stop octicons that have been
+  // scaled and adjusted to render crisply at 24px.
+  //
+  // Related: https://css-tricks.com/probably-dont-base64-svg/
+  --dialog-icon-alert: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 12,0.5 c -0.5,0 -1.5,0 -2,1 L 5,10 0.33203125,18.234375 C -0.5,20 0.5,22 2.4902344,22 L 12,22 21.509766,22 C 23.5,22 24.5,20 23.667969,18.234375 L 19,10 14,1.5 c -0.5,-1 -1.5,-1 -2,-1 z m -1,5.5 2,0 0,8 -2,0 z m 0,10 2,0 0,2 -2,0 z" /></svg>');
+  --dialog-icon-stop: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 16,2 -9,0 -6,6 0,9 6,6 9,0 6,-6 0,-9 z m 4.5,14.25 -5.25,5.25 -7.5,0 -5.25,-5.25 0,-7.5 5.25,-5.25 7.5,0 5.25,5.25 z M 10,6 l 3,0 0,8 -3,0 z m 0,10 3,0 0,3 -3,0 z" /></svg>');
+
   border: var(--base-border);
   box-shadow: var(--base-box-shadow);
   padding: 0;
@@ -143,6 +151,43 @@ dialog {
       &:focus {
         outline: 0;
       }
+    }
+  }
+
+  &.warning, &.error {
+    .dialog-content {
+      position: relative;
+      margin-left: var(--spacing-double);
+      // A zero padding would mean the icon and the text lines up so we
+      // add another double spacing plus the width of the icon to ensure
+      // we have a decently horizontally centered placement of the icon.
+      padding-left: calc(var(--spacing-double) + 24px);
+
+      &::before {
+        content: '';
+        display: block;
+        position: absolute;
+        left: 0;
+        height: 24px;
+        width: 24px;
+        -webkit-mask-repeat: no-repeat;
+      }
+    }
+  }
+
+  &.warning {
+    .dialog-content::before {
+      // https://codepen.io/noahblon/post/coloring-svgs-in-css-background-images
+      background-color: var(--dialog-warning-color);
+      -webkit-mask: var(--dialog-icon-alert);
+    }
+  }
+
+  &.error {
+    .dialog-content::before {
+      // https://codepen.io/noahblon/post/coloring-svgs-in-css-background-images
+      background-color: var(--dialog-error-color);
+      -webkit-mask: var(--dialog-icon-stop);
     }
   }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -231,25 +231,6 @@ dialog {
     }
   }
 
-  // Custom branding of a warning dialog. Used for dangerous actions
-  &.warning {
-    .dialog-header {
-      .icon { color: var(--dialog-warning-color); }
-      h1 { color: var(--dialog-warning-text-color); }
-    }
-
-    border-top: 3px solid var(--dialog-warning-color);
-  }
-
-  // Custom branding of an error dialog. Used for displaying errors
-  &.error {
-    .dialog-header {
-      color: var(--dialog-error-color);
-    }
-
-    border-top: 3px solid var(--dialog-error-color);
-  }
-
   // Inline error component rendered at the top of the dialog just below
   // the header (if the dialog has one).
   .dialog-error {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -13,7 +13,7 @@ dialog {
   // scaled and adjusted to render crisply at 24px.
   //
   // Related: https://css-tricks.com/probably-dont-base64-svg/
-  --dialog-icon-alert: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 12,0.5 c -0.5,0 -1.5,0 -2,1 L 5,10 0.33203125,18.234375 C -0.5,20 0.5,22 2.4902344,22 L 12,22 21.509766,22 C 23.5,22 24.5,20 23.667969,18.234375 L 19,10 14,1.5 c -0.5,-1 -1.5,-1 -2,-1 z m -1,5.5 2,0 0,8 -2,0 z m 0,10 2,0 0,2 -2,0 z" /></svg>');
+  --dialog-icon-alert: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 12,1.5 c -0.5,0 -1.5,0 -2,1 L 5,11 0.33203125,19.234375 C -0.5,21 0.5,23 2.4902344,23 L 12,23 21.509766,23 C 23.5,23 24.5,21 23.667969,19.234375 L 19,11 14,2.5 c -0.5,-1 -1.5,-1 -2,-1 z m -1,5.5 2,0 0,8 -2,0 z m 0,10 2,0 0,2 -2,0 z" /></svg>');
   --dialog-icon-stop: url('data:image/svg+xml;utf8,<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m 16,2 -9,0 -6,6 0,9 6,6 9,0 6,-6 0,-9 z m 4.5,14.25 -5.25,5.25 -7.5,0 -5.25,-5.25 0,-7.5 5.25,-5.25 7.5,0 5.25,5.25 z M 10,6 l 3,0 0,8 -3,0 z m 0,10 3,0 0,3 -3,0 z" /></svg>');
 
   border: var(--base-border);


### PR DESCRIPTION
This implements the dialog refinements outlined in https://github.com/desktop/desktop/pull/2185#issuecomment-314513347. Note that this only affects warning and error type dialogs.


Dialog changes

 - Moved the icon from the header down to the content
 - Made custom 24px versions of the stop and alert octicons
 - Removed colored top border
 - Left align dialog title
 - Moved progress indicator to the right hand side of the title
 - Removed custom text color of title in error and warning dialogs
 
# Before

![image](https://user-images.githubusercontent.com/634063/28373606-11ca3596-6ca3-11e7-9d06-7f4950eab1f1.png)

![image](https://user-images.githubusercontent.com/634063/28373672-25c11bd2-6ca3-11e7-9bb5-cd40c2dd9a88.png)

# After

![image](https://user-images.githubusercontent.com/634063/28373396-81d8ba0c-6ca2-11e7-85a3-d785c538d25d.png)

![image](https://user-images.githubusercontent.com/634063/28373444-a93ab4b0-6ca2-11e7-9b7e-b3eee8057f00.png)

![image](https://user-images.githubusercontent.com/634063/28373513-d202cc70-6ca2-11e7-81da-d476185f5db9.png)