### PR TITLE
Wrap the parsed error in an API error

### DIFF
--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -133,7 +133,7 @@ export async function parsedResponse<T>(response: Response): Promise<T> {
       throw new APIError(response, null)
     }
 
-    throw apiError
+    throw new APIError(response, apiError)
   }
 }
 


### PR DESCRIPTION
Fixes #2279

This is why it'd be nice to have typed `throws` declarations :disappointed: