### PR TITLE
Preserve repository API information if possible

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1357,11 +1357,14 @@ export class AppStore {
   public async _repositoryWithRefreshedGitHubRepository(
     repository: Repository
   ): Promise<Repository> {
+    const oldGitHubRepository = repository.gitHubRepository
+
     const updatedRepository = await this.updateGitHubRepositoryAssociation(
       repository
     )
-    const gitHubRepository = updatedRepository.gitHubRepository
-    if (!gitHubRepository) {
+
+    const updatedGitHubRepository = updatedRepository.gitHubRepository
+    if (!updatedGitHubRepository) {
       return updatedRepository
     }
 
@@ -1372,12 +1375,12 @@ export class AppStore {
       // instance won't have any API information while the previous one might.
       // We'll only swap it out if the endpoint has changed in which case the
       // old API information will be invalid anyway.
-      if (!repository.gitHubRepository) {
+      if (!oldGitHubRepository) {
         return updatedRepository
       }
 
       // The endpoints have changed, all bets are off
-      if (gitHubRepository.endpoint !== repository.gitHubRepository.endpoint) {
+      if (updatedGitHubRepository.endpoint !== oldGitHubRepository.endpoint) {
         return updatedRepository
       }
 
@@ -1386,8 +1389,8 @@ export class AppStore {
 
     const api = API.fromAccount(account)
     const apiRepo = await api.fetchRepository(
-      gitHubRepository.owner.login,
-      gitHubRepository.name
+      updatedGitHubRepository.owner.login,
+      updatedGitHubRepository.name
     )
 
     if (!apiRepo) {
@@ -1403,11 +1406,11 @@ export class AppStore {
       // return exact repository given if no association could be found or
       // a copy of the given repository with only the gitHubRepository property
       // changed.
-      return repository.gitHubRepository ? repository : updatedRepository
+      return oldGitHubRepository ? repository : updatedRepository
     }
 
     return updatedRepository.withGitHubRepository(
-      gitHubRepository.withAPI(apiRepo)
+      updatedGitHubRepository.withAPI(apiRepo)
     )
   }
 

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1364,6 +1364,7 @@ export class AppStore {
     )
 
     const updatedGitHubRepository = updatedRepository.gitHubRepository
+
     if (!updatedGitHubRepository) {
       return updatedRepository
     }

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1367,7 +1367,15 @@ export class AppStore {
 
     const account = this.getAccountForRepository(updatedRepository)
     if (!account) {
-      return updatedRepository
+      if (!repository.gitHubRepository) {
+        return updatedRepository
+      }
+
+      if (gitHubRepository.endpoint !== repository.gitHubRepository.endpoint) {
+        return updatedRepository
+      }
+
+      return repository
     }
 
     const api = API.fromAccount(account)
@@ -1375,8 +1383,9 @@ export class AppStore {
       gitHubRepository.owner.login,
       gitHubRepository.name
     )
+
     if (!apiRepo) {
-      return updatedRepository
+      return repository.gitHubRepository ? repository : updatedRepository
     }
 
     return updatedRepository.withGitHubRepository(


### PR DESCRIPTION
This fixes a bug where we would loose Repository API information if the API call for repository details failed for some reason (for example connectivity issues).

We now try our best to preserve whatever information we have for as long as possible.

### Steps to reproduce bug

1. Select a GitHub repository and ensure that the 'Create Pull Request` menu item is enabled
1. Force a connectivity issue either by disconnecting from your network or loophole `api.github.com` in your hosts file
1. Select another repository (can be local or whatever)
1. Switch back to the original repository (which forces an refresh from the API)

Expected results: the `Create Pull Request` menu item should still be enabled
Actual results: It is not