### PR TITLE
Remove obsolete parts of AppError

### DIFF
--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -85,25 +85,6 @@ export function createMissingRepositoryHandler(
   }
 }
 
-/** Trap and handle uncaught errors to ensure the app exits cleanly */
-export async function unhandledExceptionHandler(
-  error: Error,
-  dispatcher: Dispatcher
-) {
-  const e = asErrorWithMetadata(error)
-  if (!e) {
-    return error
-  }
-
-  const metadata = e.metadata
-  if (metadata.uncaught) {
-    await dispatcher.presentError(error)
-    return null
-  }
-
-  return error
-}
-
 /** Handle errors that happen as a result of a background task. */
 export async function backgroundTaskHandler(
   error: Error,

--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -1,9 +1,6 @@
 export interface IErrorMetadata {
   /** Was the action which caused this error part of a background task? */
   readonly backgroundTask?: boolean
-
-  /** Was the error raised by the `uncaughtException` event on `process` */
-  readonly uncaught?: boolean
 }
 
 /** An error which contains additional metadata. */

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -23,7 +23,6 @@ import {
   defaultErrorHandler,
   createMissingRepositoryHandler,
   backgroundTaskHandler,
-  unhandledExceptionHandler,
 } from '../lib/dispatcher'
 import { shellNeedsPatching, updateEnvironmentForProcess } from '../lib/shell'
 import { installDevGlobals } from './install-globals'
@@ -109,7 +108,6 @@ const dispatcher = new Dispatcher(appStore)
 dispatcher.registerErrorHandler(defaultErrorHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(createMissingRepositoryHandler(appStore))
-dispatcher.registerErrorHandler(unhandledExceptionHandler)
 
 document.body.classList.add(`platform-${process.platform}`)
 


### PR DESCRIPTION
This removes all logic for dealing with uncaught errors in the `AppError` component.

#1562 moved all handling of uncaught errors from the renderers to the main process and on to a dedicated crash renderer which takes over and shuts down all other renderers. Prior to that the `AppError`  component was responsible for dealing with uncaught errors and when I did #1562 I forgot to remove those obsoleted bits.