### PR TITLE
Fix devtron installation

### DIFF
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -57,8 +57,13 @@ const replacements = {
 
 const outputDir = 'out'
 
+const externals = ['7zip']
+if (environment === 'development') {
+  externals.push('devtron')
+}
+
 const commonConfig = {
-  externals: ['7zip'],
+  externals: externals,
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, '..', outputDir),


### PR DESCRIPTION
Devtron requires that the contents of the module be copied, since it
uses the manifest.json (for the Chrome plugin) and the static files in
the devtools extension.

This copies the module only when built under a development environment.