### PR TITLE
different modes to show image diffs

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -26,6 +26,13 @@ export enum SelectionType {
   MissingRepository,
 }
 
+export enum ImageDiffType {
+  TwoUp,
+  Swipe,
+  OnionSkin,
+  Difference,
+}
+
 export type PossibleSelections =
   | {
       type: SelectionType.Repository
@@ -132,6 +139,9 @@ export interface IAppState {
 
   /** Whether we should show a confirmation dialog */
   readonly confirmRepoRemoval: boolean
+
+  /** What type of visual diff mode we should use to compare images */
+  readonly imageDiffType: ImageDiffType
 }
 
 export enum PopupType {

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -15,6 +15,7 @@ import {
   SelectionType,
   ICheckoutProgress,
   Progress,
+  ImageDiffType,
 } from '../app-state'
 import { Account } from '../../models/account'
 import { Repository } from '../../models/repository'
@@ -88,6 +89,9 @@ const commitSummaryWidthConfigKey: string = 'commit-summary-width'
 const confirmRepoRemovalDefault: boolean = true
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 
+const imageDiffTypeDefault: ImageDiffType = ImageDiffType.TwoUp
+const imageDiffTypeKey: string = 'imageDiffType'
+
 export class AppStore {
   private emitter = new Emitter()
 
@@ -152,6 +156,7 @@ export class AppStore {
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false
   private confirmRepoRemoval: boolean = confirmRepoRemovalDefault
+  private imageDiffType: ImageDiffType = imageDiffTypeDefault
 
   private readonly statsStore: StatsStore
 
@@ -452,6 +457,7 @@ export class AppStore {
       highlightAccessKeys: this.highlightAccessKeys,
       isUpdateAvailableBannerVisible: this.isUpdateAvailableBannerVisible,
       confirmRepoRemoval: this.confirmRepoRemoval,
+      imageDiffType: this.imageDiffType,
     }
   }
 
@@ -857,6 +863,13 @@ export class AppStore {
       confirmRepoRemovalValue === null
         ? confirmRepoRemovalDefault
         : confirmRepoRemovalValue === '1'
+
+    const imageDiffTypeValue = localStorage.getItem(imageDiffTypeKey)
+
+    this.imageDiffType =
+      imageDiffTypeValue === null
+        ? imageDiffTypeDefault
+        : parseInt(imageDiffTypeValue)
 
     if (initialLoad) {
       // For the intitial load, synchronously emit the update so that the window
@@ -2103,6 +2116,14 @@ export class AppStore {
   public _setConfirmRepoRemoval(confirmRepoRemoval: boolean): Promise<void> {
     this.confirmRepoRemoval = confirmRepoRemoval
     localStorage.setItem(confirmRepoRemovalKey, confirmRepoRemoval ? '1' : '0')
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _changeImageDiffType(type: ImageDiffType): Promise<void> {
+    this.imageDiffType = type
+    localStorage.setItem(imageDiffTypeKey, JSON.stringify(this.imageDiffType))
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -13,6 +13,7 @@ import {
   PopupType,
   Foldout,
   FoldoutType,
+  ImageDiffType,
 } from '../app-state'
 import { Action } from './actions'
 import { AppStore } from './app-store'
@@ -1131,5 +1132,9 @@ export class Dispatcher {
 
       this.postError(e)
     }
+  }
+
+  public changeImageDiffType(type: ImageDiffType): Promise<void> {
+    return this.appStore._changeImageDiffType(type)
   }
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1354,6 +1354,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           commitSummaryWidth={this.state.commitSummaryWidth}
           issuesStore={this.props.appStore.issuesStore}
           gitHubUserStore={this.props.appStore.gitHubUserStore}
+          imageDiffType={this.state.imageDiffType}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/changes/index.tsx
+++ b/app/src/ui/changes/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Diff } from '../diff'
 import { ChangedFileDetails } from './changed-file-details'
+import { ImageDiffType } from '../../lib/app-state'
 import { DiffSelection, IDiff } from '../../models/diff'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
@@ -15,6 +16,7 @@ interface IChangesProps {
   readonly file: WorkingDirectoryFileChange
   readonly diff: IDiff
   readonly dispatcher: Dispatcher
+  readonly imageDiffType: ImageDiffType
 }
 
 export class Changes extends React.Component<IChangesProps, {}> {
@@ -42,6 +44,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
         <div className="diff-wrapper">
           <Diff
             repository={this.props.repository}
+            imageDiffType={this.props.imageDiffType}
             file={file}
             readOnly={false}
             onIncludeChanged={this.onDiffLineIncludeChanged}

--- a/app/src/ui/diff/deleted-image-diff.tsx
+++ b/app/src/ui/diff/deleted-image-diff.tsx
@@ -15,8 +15,10 @@ export class DeletedImageDiff extends React.Component<
   public render() {
     return (
       <div className="panel image" id="diff">
-        <div className="image-header">this image will be removed</div>
-        {renderImage(this.props.previous)}
+        <div className="image-diff__before">
+          <div className="image-diff__header">Deleted</div>
+          {renderImage(this.props.previous)}
+        </div>
       </div>
     )
   }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -11,6 +11,7 @@ import { Editor } from 'codemirror'
 import { CodeMirrorHost } from './code-mirror-host'
 import { Repository } from '../../models/repository'
 
+import { ImageDiffType } from '../../lib/app-state'
 import {
   FileChange,
   WorkingDirectoryFileChange,
@@ -72,6 +73,9 @@ interface IDiffProps {
 
   /** propagate errors up to the main application */
   readonly dispatcher: Dispatcher
+
+  /**  */
+  readonly imageDiffType: number
 }
 
 /** A component which renders a diff for a file. */
@@ -554,10 +558,16 @@ export class Diff extends React.Component<IDiffProps, {}> {
     this.restoreScrollPosition(cm)
   }
 
+  private onChangeImageDiffType = (type: ImageDiffType) => {
+    this.props.dispatcher.changeImageDiffType(type)
+  }
+
   private renderImage(imageDiff: IImageDiff) {
     if (imageDiff.current && imageDiff.previous) {
       return (
         <ModifiedImageDiff
+          onChangeDiffType={this.onChangeImageDiffType}
+          diffType={this.props.imageDiffType}
           current={imageDiff.current}
           previous={imageDiff.previous}
         />

--- a/app/src/ui/diff/modified-image-diff.tsx
+++ b/app/src/ui/diff/modified-image-diff.tsx
@@ -1,25 +1,342 @@
 import * as React from 'react'
 
+import { ImageDiffType } from '../../lib/app-state'
 import { Image } from '../../models/diff'
 import { renderImage } from './render-image'
+import { TabBar, TabBarType } from '../tab-bar'
 
 interface IModifiedImageDiffProps {
   readonly previous: Image
   readonly current: Image
+  readonly diffType: ImageDiffType
+  readonly onChangeDiffType: (type: number) => void
+}
+
+const SIZE_CONTROLS = 60
+const PADDING = 20
+
+const getDimensions = (
+  naturalHeight: number | null,
+  naturalWidth: number | null,
+  _containerWidth: number,
+  _containerHeight: number
+) => {
+  // keep some padding
+  const containerWidth = _containerWidth - PADDING
+  const containerHeight = _containerHeight - PADDING - SIZE_CONTROLS
+
+  // check wether we will need to scale the images or not
+  const heightRatio =
+    containerHeight < (naturalHeight || 0)
+      ? (naturalHeight || 0) / containerHeight
+      : 1
+  const widthRatio =
+    containerWidth < (naturalWidth || 0)
+      ? (naturalWidth || 0) / containerWidth
+      : 1
+
+  // Use max to prevent scaling up the image
+  let ratio = Math.max(1, widthRatio)
+  if (widthRatio < heightRatio) {
+    // fit to height
+    ratio = Math.max(1, heightRatio)
+  }
+
+  return {
+    width: (naturalWidth || 0) / ratio,
+    height: (naturalHeight || 0) / ratio,
+  }
 }
 
 /** A component which renders the changes to an image in the repository */
 export class ModifiedImageDiff extends React.Component<
   IModifiedImageDiffProps,
-  {}
+  {
+    value: number
+    naturalWidthBefore: number | null
+    naturalHeightBefore: number | null
+    naturalWidthAfter: number | null
+    naturalHeightAfter: number | null
+  }
 > {
+  private _container: HTMLDivElement | null
+
+  public constructor(props: IModifiedImageDiffProps) {
+    super(props)
+    this.state = {
+      value: 1,
+      naturalWidthBefore: null,
+      naturalHeightBefore: null,
+      naturalWidthAfter: null,
+      naturalHeightAfter: null,
+    }
+  }
+
+  private handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({
+      value: parseFloat(e.currentTarget.value),
+    })
+  }
+
+  private handleImgLoadBefore = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalHeight, naturalWidth } = e.target as HTMLImageElement
+    this.setState({
+      naturalHeightBefore: naturalHeight,
+      naturalWidthBefore: naturalWidth,
+    })
+  }
+
+  private handleImgLoadAfter = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalHeight, naturalWidth } = e.target as HTMLImageElement
+    this.setState({
+      naturalHeightAfter: naturalHeight,
+      naturalWidthAfter: naturalWidth,
+    })
+  }
+
+  private getScaledDimensions() {
+    const {
+      naturalWidthBefore,
+      naturalHeightBefore,
+      naturalWidthAfter,
+      naturalHeightAfter,
+    } = this.state
+
+    const widthContainer =
+      (this._container && this._container.getBoundingClientRect().width) || 0
+    const heightContainer =
+      (this._container && this._container.getBoundingClientRect().height) || 0
+
+    let height = 0
+    let width = 0
+
+    if (naturalHeightBefore && naturalHeightAfter) {
+      const before = getDimensions(
+        naturalHeightBefore,
+        naturalWidthBefore,
+        widthContainer,
+        heightContainer
+      )
+      const after = getDimensions(
+        naturalHeightAfter,
+        naturalWidthAfter,
+        widthContainer,
+        heightContainer
+      )
+
+      height = Math.max(before.height, after.height)
+      width = Math.max(before.width, after.height)
+    }
+
+    return {
+      height,
+      width,
+      heightContainer,
+      widthContainer,
+    }
+  }
+
+  private onContainerRef = (c: HTMLDivElement | null) => {
+    this._container = c
+  }
+
   public render() {
+    const { height, width, widthContainer } = this.getScaledDimensions()
     return (
-      <div className="panel image" id="diff">
-        <div className="image-header">this image</div>
-        {renderImage(this.props.previous)}
-        <div className="image-header">will be replaced with</div>
-        {renderImage(this.props.current)}
+      <div className="panel image" id="diff" ref={this.onContainerRef}>
+        {this.props.diffType === ImageDiffType.TwoUp &&
+          this.render2Up(height, width, widthContainer)}
+        {this.props.diffType === ImageDiffType.Swipe &&
+          this.renderSwipe(height, width, widthContainer)}
+        {this.props.diffType === ImageDiffType.OnionSkin &&
+          this.renderFade(height, width, widthContainer)}
+        {this.props.diffType === ImageDiffType.Difference &&
+          this.renderDifference(height, width, widthContainer)}
+        <TabBar
+          selectedIndex={this.props.diffType}
+          onTabClicked={this.props.onChangeDiffType}
+          type={TabBarType.Switch}
+        >
+          <span>2-up</span>
+          <span>Swipe</span>
+          <span>Onion Skin</span>
+          <span>Difference</span>
+        </TabBar>
+      </div>
+    )
+  }
+
+  private render2Up(height: number, width: number, widthContainer: number) {
+    const style = {
+      maxHeight: height + SIZE_CONTROLS,
+      maxWidth: Math.min((widthContainer - 20) / 2, width),
+    }
+    return (
+      <div className="image-diff_inner--two-up">
+        <div className="image-diff__before">
+          <div className="image-diff__header">Deleted</div>
+          {renderImage(this.props.previous, {
+            onLoad: this.handleImgLoadBefore,
+            style,
+          })}
+          <div className="image-diff__footer">
+            <span className="strong">W:</span> {this.state.naturalWidthBefore}px
+            | <span className="strong">H:</span>{' '}
+            {this.state.naturalHeightBefore}px
+          </div>
+        </div>
+        <div className="image-diff__after">
+          <div className="image-diff__header">Added</div>
+          {renderImage(this.props.current, {
+            onLoad: this.handleImgLoadAfter,
+            style,
+          })}
+          <div className="image-diff__footer">
+            <span className="strong">W:</span> {this.state.naturalWidthAfter}px
+            | <span className="strong">H:</span> {this.state.naturalHeightAfter}px
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  private renderDifference(
+    height: number,
+    width: number,
+    widthContainer: number
+  ) {
+    return (
+      <div
+        className="image-diff_inner--difference"
+        style={{
+          height,
+          width,
+          left: (widthContainer - PADDING - width) / 2 + PADDING / 2,
+        }}
+      >
+        <div className="image-diff__before">
+          {renderImage(this.props.previous, {
+            onLoad: this.handleImgLoadBefore,
+            style: {
+              maxHeight: height,
+              maxWidth: width,
+            },
+          })}
+        </div>
+        <div className="image-diff__after">
+          {renderImage(this.props.current, {
+            onLoad: this.handleImgLoadAfter,
+            style: {
+              maxHeight: height,
+              maxWidth: width,
+              mixBlendMode: 'difference',
+            },
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  private renderFade(height: number, width: number, widthContainer: number) {
+    const style = {
+      height,
+      width,
+    }
+    return (
+      <div
+        className="image-diff_inner--fade"
+        style={{
+          ...style,
+          marginBottom: 30,
+          left: (widthContainer - PADDING - width) / 2 + PADDING / 2,
+        }}
+      >
+        <div className="image-diff__before" style={style}>
+          {renderImage(this.props.previous, {
+            onLoad: this.handleImgLoadBefore,
+            style: {
+              maxHeight: height,
+              maxWidth: width,
+            },
+          })}
+        </div>
+        <div
+          className="image-diff__after"
+          style={{
+            ...style,
+            opacity: this.state.value,
+          }}
+        >
+          {renderImage(this.props.current, {
+            onLoad: this.handleImgLoadAfter,
+            style: {
+              maxHeight: height,
+              maxWidth: width,
+            },
+          })}
+        </div>
+        <input
+          style={{ margin: `${height + 10}px 0 0 ${(width - 129) / 2}px` }}
+          type="range"
+          max={1}
+          min={0}
+          value={this.state.value}
+          step={0.001}
+          onChange={this.handleValueChange}
+        />
+      </div>
+    )
+  }
+
+  private renderSwipe(height: number, width: number, widthContainer: number) {
+    const style = {
+      height,
+      width,
+    }
+    return (
+      <div
+        className="image-diff_inner--swipe"
+        style={{
+          ...style,
+          marginBottom: 30,
+          left: (widthContainer - PADDING - width) / 2 + PADDING / 2,
+        }}
+      >
+        <div className="image-diff__after" style={style}>
+          {renderImage(this.props.current, {
+            onLoad: this.handleImgLoadAfter,
+            style: {
+              maxHeight: height,
+              maxWidth: width,
+            },
+          })}
+        </div>
+        <div
+          className="image-diff--swiper"
+          style={{
+            width: width * (1 - this.state.value),
+            height: height + 10,
+          }}
+        >
+          <div className="image-diff__before" style={style}>
+            {renderImage(this.props.previous, {
+              onLoad: this.handleImgLoadBefore,
+              style: {
+                maxHeight: height,
+                maxWidth: width,
+              },
+            })}
+          </div>
+        </div>
+        <input
+          style={{ margin: `${height + 10}px 0 0 -7px`, width: width + 14 }}
+          type="range"
+          max={1}
+          min={0}
+          value={this.state.value}
+          step={0.001}
+          onChange={this.handleValueChange}
+        />
       </div>
     )
   }

--- a/app/src/ui/diff/new-image-diff.tsx
+++ b/app/src/ui/diff/new-image-diff.tsx
@@ -12,8 +12,10 @@ export class NewImageDiff extends React.Component<INewImageDiffProps, {}> {
   public render() {
     return (
       <div className="panel image" id="diff">
-        <div className="image-header">this new image will be committed</div>
-        {renderImage(this.props.current)}
+        <div className="image-diff__after">
+          <div className="image-diff__header">Added</div>
+          {renderImage(this.props.current)}
+        </div>
       </div>
     )
   }

--- a/app/src/ui/diff/render-image.tsx
+++ b/app/src/ui/diff/render-image.tsx
@@ -2,12 +2,18 @@ import * as React from 'react'
 
 import { Image } from '../../models/diff'
 
-export function renderImage(image: Image | undefined) {
+export function renderImage(
+  image: Image | undefined,
+  props?: {
+    style?: {}
+    onLoad?: (e: React.SyntheticEvent<HTMLImageElement>) => void
+  }
+) {
   if (!image) {
     return null
   }
 
   const imageSource = `data:${image.mediaType};base64,${image.contents}`
 
-  return <img src={imageSource} />
+  return <img src={imageSource} {...props} />
 }

--- a/app/src/ui/history/index.tsx
+++ b/app/src/ui/history/index.tsx
@@ -6,7 +6,10 @@ import { Repository } from '../../models/repository'
 import { FileChange } from '../../models/status'
 import { Commit } from '../../models/commit'
 import { Dispatcher } from '../../lib/dispatcher'
-import { IHistoryState as IAppHistoryState } from '../../lib/app-state'
+import {
+  IHistoryState as IAppHistoryState,
+  ImageDiffType,
+} from '../../lib/app-state'
 import { ThrottledScheduler } from '../lib/throttled-scheduler'
 import { IGitHubUser } from '../../lib/dispatcher'
 import { Resizable } from '../resizable'
@@ -24,6 +27,7 @@ interface IHistoryProps {
   readonly localCommitSHAs: ReadonlyArray<string>
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
+  readonly imageDiffType: ImageDiffType
 }
 
 interface IHistoryState {
@@ -81,6 +85,7 @@ export class History extends React.Component<IHistoryProps, IHistoryState> {
     return (
       <Diff
         repository={this.props.repository}
+        imageDiffType={this.props.imageDiffType}
         file={file}
         diff={diff}
         readOnly={true}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -10,6 +10,7 @@ import { TabBar } from './tab-bar'
 import {
   IRepositoryState as IRepositoryModelState,
   RepositorySection,
+  ImageDiffType,
 } from '../lib/app-state'
 import { Dispatcher, IssuesStore, GitHubUserStore } from '../lib/dispatcher'
 import { assertNever } from '../lib/fatal-error'
@@ -24,6 +25,7 @@ interface IRepositoryProps {
   readonly commitSummaryWidth: number
   readonly issuesStore: IssuesStore
   readonly gitHubUserStore: GitHubUserStore
+  readonly imageDiffType: ImageDiffType
 }
 
 const enum Tab {
@@ -160,6 +162,7 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
             dispatcher={this.props.dispatcher}
             file={selectedFile}
             diff={diff}
+            imageDiffType={this.props.imageDiffType}
           />
         )
       }
@@ -174,6 +177,7 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
           localCommitSHAs={this.props.state.localCommitSHAs}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}
+          imageDiffType={this.props.imageDiffType}
         />
       )
     } else {

--- a/app/src/ui/tab-bar.tsx
+++ b/app/src/ui/tab-bar.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react'
 import * as classNames from 'classnames'
 
+export enum TabBarType {
+  Tabs,
+  Switch,
+}
+
 interface ITabBarProps {
   /** The currently selected tab. */
   readonly selectedIndex: number
 
   /** A function which is called when a tab is clicked on. */
   readonly onTabClicked: (index: number) => void
+
+  /** The type of TabBar controlling its style */
+  readonly type?: TabBarType
 }
 
 /**
@@ -19,7 +27,13 @@ export class TabBar extends React.Component<ITabBarProps, {}> {
 
   public render() {
     return (
-      <div className="tab-bar" role="tablist">
+      <div
+        className={
+          'tab-bar ' +
+          (this.props.type === TabBarType.Switch ? 'switch' : 'tabs')
+        }
+        role="tablist"
+      >
         {this.renderItems()}
       </div>
     )

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -2,3 +2,4 @@
 @import "mixins/ellipsis";
 @import "mixins/octicon-status";
 @import "mixins/textboxish";
+@import "mixins/checkboard-background";

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -2,7 +2,7 @@
 //
 // This files contains CSS variables accessible to all selectors
 
-// Primer colors, see https://github.com/primer/primer-support/blob/master/lib/variables/color-system.scss
+// Primer colors, see https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/color-system.scss
 @import '~primer-support/lib/variables/color-system.scss';
 
 :root {

--- a/app/styles/mixins/_checkboard-background.scss
+++ b/app/styles/mixins/_checkboard-background.scss
@@ -1,0 +1,7 @@
+/**
+ * Draw a checkboard in the background
+ * (useful to see the transparent part of an image)
+ */
+@mixin checkboard-background {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUAQMAAAC3R49OAAAABlBMVEX5+fn///8pDrwNAAAAFElEQVQI12NgsP/AQAz+f4CBGAwAJIIdTTn0+w0AAAAASUVORK5CYII=);
+}

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -36,7 +36,7 @@
       // Add a little bit of space to the left of code diff
       // `padding-left` here means mouse move events are not raised
       padding-left: var(--spacing-half);
-      align-self: center;      
+      align-self: center;
     }
 
     svg.no-newline {
@@ -180,7 +180,7 @@
     color: var(--diff-hover-text-color);
 
     &:last-child {
-      border-color: var(--diff-hover-gutter-color);      
+      border-color: var(--diff-hover-gutter-color);
     }
   }
 }
@@ -228,7 +228,7 @@
   min-width: 0;
   min-height: 0;
   object-fit: contain;
-  padding: 0 var(--spacing);
+  padding: 0;
 }
 // ***************************************************************************************************************************
 #diff a {
@@ -239,4 +239,129 @@
 
 #diff a:link {
   color: (orange);
+}
+
+.panel.image {
+  padding-top: 10px;
+
+  .tab-bar {
+    width: 350px;
+    margin: 10px auto 0;
+  }
+
+  .image-diff__before {
+    color: var(--color-deleted);
+  }
+  .image-diff__after {
+    color: var(--color-new);
+  }
+
+  .image-diff__before,
+  .image-diff__after {
+    text-align: center;
+
+    img {
+      @include checkboard-background;
+      border: 1px solid currentColor;
+    }
+  }
+
+  .image-diff__header {
+    font-weight: var(--font-weight-semibold);
+    padding-bottom: 10px;
+  }
+
+  .image-diff__footer {
+    color: var(--text-secondary-color);
+    .strong {
+      font-weight: var(--font-weight-semibold);
+    }
+  }
+}
+
+.image-diff_inner {
+
+  &--two-up {
+    display: flex;
+    justify-content: center;
+
+    .image-diff__before {
+      margin-right: 7.5px;
+    }
+    .image-diff__after {
+      margin-left: 7.5px;
+    }
+  }
+
+  &--difference {
+    position: relative;
+
+    .image-diff__before,
+    .image-diff__after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      img : {
+        border: 0;
+        background: transparent;
+      }
+    }
+  }
+
+  &--fade {
+    @include checkboard-background;
+    margin: 0;
+    position: relative;
+
+    .image-diff__before,
+    .image-diff__after {
+      position: absolute;
+      margin: 0;
+
+      img {
+        border: 0;
+        background: transparent;
+      }
+    }
+
+    .image-diff__before {
+      border: 1px solid var(--color-deleted);
+    }
+    .image-diff__after {
+      border: 1px solid var(--color-new);
+    }
+  }
+
+  &--swipe {
+    margin: 0;
+    position: relative;
+
+    .image-diff__before,
+    .image-diff__after {
+      @include checkboard-background;
+      position: absolute;
+      margin: 0;
+
+      img {
+        border: 0;
+        background: transparent;
+      }
+    }
+
+    .image-diff__before {
+      border: 1px solid var(--color-deleted);
+      right: 0;
+    }
+    .image-diff__after {
+      border: 1px solid var(--color-new);
+    }
+
+    .image-diff--swiper {
+      border-left: 1px solid var(--text-secondary-color);
+      margin: 0;
+      overflow: hidden;
+      position: absolute;
+      right: 0;
+    }
+  }
 }

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -5,7 +5,7 @@
 
   background: var(--tab-bar-background-color);
 
-  &-item {
+  &.tabs &-item {
     // Reset styles from global buttons
     border: none;
     box-shadow: none;
@@ -50,6 +50,43 @@
       color: var(--tab-bar-active-color);
       margin-left: 4px;
       margin-top: 1px;
+    }
+  }
+
+  &.switch  &-item {
+    // Reset styles from global buttons
+    cursor: pointer;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    color: var(--text-color);
+    background: var(--background-color);
+    font-family: var(--font-family-sans-serif);
+    font-size: var(--font-size);
+
+    // Give each item equal space
+    flex: 1;
+
+    // Center item contest horizontally and vertically
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border-right: 1px solid var(--box-border-color);
+
+    // This makes it so that we never render a double-width item border.
+    // It has the unintended consequence of making it impossible to have a tab
+    // bar with just one item but we can live with that.
+    &:last-child {
+      border-right: none;
+    }
+
+    // We intentionally swap foreground and background here to create
+    // a more intense selected state. The tab bar is kind of a special snowflake
+    // in so far that it doesn't have an active selection state, just a selected
+    // one.
+    &.selected {
+      font-weight: var(--font-weight-semibold);
     }
   }
 }


### PR DESCRIPTION
I know that @niik is assigned to #2137 but I already implemented this for Kactus, wanted to contribute back :)

Screenshots:

![screen shot 2017-07-19 at 20 02 25](https://user-images.githubusercontent.com/3254314/28398803-b8eb1b28-6cbd-11e7-83c1-49fcc29ed227.png)
![screen shot 2017-07-19 at 20 02 40](https://user-images.githubusercontent.com/3254314/28398807-befe2168-6cbd-11e7-8d4e-e6edc19e76d6.png)
![screen shot 2017-07-19 at 20 02 50](https://user-images.githubusercontent.com/3254314/28398810-c3b4c568-6cbd-11e7-9844-b2356238a0d3.png)
![screen shot 2017-07-19 at 20 02 56](https://user-images.githubusercontent.com/3254314/28398814-c71d8550-6cbd-11e7-8b76-b1c45204d1ca.png)


