### PR TITLE
Add a shebang line to the github executable

### DIFF
--- a/app/static/darwin/github.sh
+++ b/app/static/darwin/github.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # The least terrible way to resolve a symlink to its real path.
 function realpath() {
   /usr/bin/python -c "import os,sys; print os.path.realpath(sys.argv[1])" "$0";


### PR DESCRIPTION
Fish shell currently doesn't recognize it as a shell script, and says the following:

```
The file '/usr/local/bin/github' is marked as an executable but could not be run by the operating system.
```