### PR TITLE
some additional helpers for linux builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   },
   "description": "GitHub Desktop build dependencies",
   "scripts": {
-    "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 mocha -t 10000 --compilers ts:ts-node/register,tsx:ts-node/register app/test/integration/*.ts",
-    "test:unit": "cross-env GIT_AUTHOR_NAME=\"Joe Bloggs\" GIT_AUTHOR_EMAIL=\"joe.bloggs@somewhere.com\" GIT_COMMITTER_NAME=\"Joe Bloggs\" GIT_COMMITTER_EMAIL=\"joe.bloggs@somewhere.com\" TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 electron-mocha -t 10000 --renderer --compilers ts:ts-node/register,tsx:ts-node/register --require ./app/test/globals.ts app/test/unit/*.ts app/test/unit/git/*.ts app/test/unit/progress/*.ts app/test/unit/main-process/* app/test/unit/*.tsx",
+    "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe mocha -t 10000 --compilers ts:ts-node/register,tsx:ts-node/register app/test/integration/*.ts",
+    "test:unit": "cross-env GIT_AUTHOR_NAME=\"Joe Bloggs\" GIT_AUTHOR_EMAIL=\"joe.bloggs@somewhere.com\" GIT_COMMITTER_NAME=\"Joe Bloggs\" GIT_COMMITTER_EMAIL=\"joe.bloggs@somewhere.com\" TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe electron-mocha -t 10000 --renderer --compilers ts:ts-node/register,tsx:ts-node/register --require ./app/test/globals.ts app/test/unit/*.ts app/test/unit/git/*.ts app/test/unit/progress/*.ts app/test/unit/main-process/* app/test/unit/*.tsx",
     "test": "npm run test:unit && npm run test:integration",
     "test:setup": "node script/test-setup",
     "test:review": "node script/test-review",
@@ -90,6 +90,7 @@
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.18.0",
     "webpack-merge": "^4.1.0",
+    "xvfb-maybe": "^0.2.1",
     "xml2js": "^0.4.16"
   },
   "devDependencies": {

--- a/script/build
+++ b/script/build
@@ -142,7 +142,9 @@ function copyStaticResources() {
   const common = path.join(projectRoot, 'app', 'static', 'common')
   const destination = path.join(outRoot, 'static')
   fs.removeSync(destination)
-  fs.copySync(platformSpecific, destination)
+  if (fs.existsSync(platformSpecific)) {
+    fs.copySync(platformSpecific, destination)
+  }
   fs.copySync(common, destination, { clobber: false })
 }
 

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -102,11 +102,14 @@ function getUserDataPath() {
     const home = os.homedir()
     return path.join(home, 'Library', 'Application Support', getProductName())
   } else if (process.platform === 'linux') {
+    if (process.env.XDG_CONFIG_HOME) {
+      return path.join(process.env.XDG_CONFIG_HOME, getProductName())
+    }
     const home = os.homedir()
-    return path.join(home, '.' + getProductName())
+    return path.join(home, '.config', getProductName())
   } else {
     console.error(
-      `I dunno how to review for ${process.platform} ${process.arch} :(`
+      `I dunno how to resolve the user data path for ${process.platform} ${process.arch} :(`
     )
     process.exit(1)
   }


### PR DESCRIPTION
Some tweaks to the scripts after #2271 was merged:

 - `xvfb-maybe` is a helper [package](https://github.com/paulcbetts/xvfb-maybe) for headless electron testing "if the platform is Linux and DISPLAY isn't set." - 🎩 @paulcbetts. This will probably need the Linux distro to install `xvfb` as [the docs](https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md#travis-ci) suggest to get the tests working properly, but it's a no-op for other platforms
 - I changed the way the user data path is resolved for Linux due to [this documentation](https://github.com/electron/electron/blob/master/docs/api/app.md#appgetpathname) which states (for Linux):
   - `appData` resolves to `$XDG_CONFIG_HOME` (if set) or `~/.config` 
   - `userData` resolves to `{appData}/{appName}`
 - `app/static/common` doesn't currently contain anything for Linux builds, so copying the directory will fail

cc @gengjiawen @ptomato