### PR TITLE
always be invoking functions

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -209,7 +209,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   private onDialogClick = (e: React.MouseEvent<HTMLElement>) => {
-    if (this.isDismissable === false) {
+    if (this.isDismissable() === false) {
       return
     }
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -209,7 +209,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   private onDialogClick = (e: React.MouseEvent<HTMLElement>) => {
-    if (!this.isDismissable()) {
+    if (this.isDismissable === false) {
       return
     }
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -209,7 +209,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   private onDialogClick = (e: React.MouseEvent<HTMLElement>) => {
-    if (!this.isDismissable) {
+    if (!this.isDismissable()) {
       return
     }
 


### PR DESCRIPTION
Fixes #2211 unless I hear more information about the behaviour from the reporter.

`this.isDismissable` is actually a function, so we should invoke it here and check rather than relying on truthiness.

The current behaviour seems to be "this function is never `null`, so continue on with trying to dismiss the dialog", instead of checking the underlying `dismissable` prop.
