### PR TITLE
store the caret position whenever the text input changes

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -110,7 +110,7 @@ export class AddExistingRepository extends React.Component<
               value={this.state.path}
               label={__DARWIN__ ? 'Local Path' : 'Local path'}
               placeholder="repository path"
-              onChange={this.onPathChanged}
+              onValueChanged={this.onPathChanged}
               autoFocus={true}
             />
             <Button onClick={this.showFilePicker}>Choose…</Button>
@@ -130,8 +130,7 @@ export class AddExistingRepository extends React.Component<
     )
   }
 
-  private onPathChanged = async (event: React.FormEvent<HTMLInputElement>) => {
-    const path = event.currentTarget.value
+  private onPathChanged = async (path: string) => {
     const isRepository = await isGitRepository(path)
 
     this.setState({ path, isRepository })

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -47,7 +47,7 @@ interface ITextBoxProps {
   readonly type?: 'text' | 'search' | 'password'
 
   /** A callback to receive the underlying `input` instance. */
-  readonly onInputRef?: (instance: HTMLInputElement) => void
+  readonly onInputRef?: (instance: HTMLInputElement | null) => void
 
   /**
    * An optional text for a link label element. A link label is, for the purposes
@@ -92,7 +92,7 @@ interface ITextBoxState {
 
 /** An input element with app-standard styles. */
 export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
-  private instance?: HTMLInputElement
+  private instance: HTMLInputElement | null = null
 
   private caretPosition = -1
   private cachedString = ''
@@ -121,7 +121,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
    *  - example workaround: https://gist.github.com/shiftkey/a713712182288b0870952fd5a1bfcebe
    */
   private updateCaretPosition = () => {
-    if (this.instance === undefined || this.props.value === undefined) {
+    if (this.instance === null || this.props.value === undefined) {
       return
     }
 
@@ -155,7 +155,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     }
   }
 
-  private onRef = (instance: HTMLInputElement) => {
+  private onRef = (instance: HTMLInputElement | null) => {
     this.instance = instance
 
     if (this.props.onInputRef) {

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -106,7 +106,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
   /*
    * Store the selection end and previous string between updates so that the
-   * caret posiiton can be reapplied to the input element.
+   * caret position can be reapplied to the input element.
    */
   private storeCaretPosition = (target: HTMLInputElement) => {
     this.caretPosition = target.selectionEnd
@@ -115,7 +115,10 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
   /*
    * Update the caret position of the input element if it can be reapplied.
-   * Reference: https://gist.github.com/shiftkey/a713712182288b0870952fd5a1bfcebe
+   *
+   * References:
+   *  - upstream issue: https://github.com/facebook/react/issues/955
+   *  - example workaround: https://gist.github.com/shiftkey/a713712182288b0870952fd5a1bfcebe
    */
   private updateCaretPosition = () => {
     if (this.instance === undefined || this.props.value === undefined) {

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -104,11 +104,19 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     this.setState({ inputId })
   }
 
+  /*
+   * Store the selection end and previous string between updates so that the
+   * caret posiiton can be reapplied to the input element.
+   */
   private storeCaretPosition = (target: HTMLInputElement) => {
     this.caretPosition = target.selectionEnd
     this.cachedString = target.value
   }
 
+  /*
+   * Update the caret position of the input element if it can be reapplied.
+   * Reference: https://gist.github.com/shiftkey/a713712182288b0870952fd5a1bfcebe
+   */
   private updateCaretPosition = () => {
     if (this.instance === undefined || this.props.value === undefined) {
       return


### PR DESCRIPTION
Fixes #2222 

This is a workaround for the `input` element forgetting it's caret position after a prop update and moving the caret to the end.

Spelunking a bunch of old React issues suggests this shouldn't happen, but I see this recent comment suggest that it's still something that needs to be worked around: https://github.com/facebook/react/issues/955#issuecomment-316118969

 - [x] document the workarounds