### PR TITLE
bump keytar to 4.0.4

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -531,9 +531,9 @@
       }
     },
     "keytar": {
-      "version": "4.0.2",
-      "from": "keytar@4.0.2",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.0.2.tgz"
+      "version": "4.0.4",
+      "from": "keytar@4.0.4",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.0.4.tgz"
     },
     "loader-utils": {
       "version": "1.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "file-uri-to-path": "0.0.2",
     "front-matter": "^2.1.2",
     "fs-extra": "^2.1.2",
-    "keytar": "^4.0.2",
+    "keytar": "^4.0.4",
     "moment": "^2.17.1",
     "primer-support": "^4.0.0",
     "react": "^15.6.1",


### PR DESCRIPTION
Fixes #189

https://github.com/atom/node-keytar/pull/66 has been merged and made available. Let's use it.