### PR TITLE
handle the firstrun event from squirrel

### DIFF
--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -18,6 +18,9 @@ const exeName = Path.basename(process.execPath)
  */
 export function handleSquirrelEvent(eventName: string): Promise<void> | null {
   switch (eventName) {
+    case '--squirrel-firstrun':
+      return Promise.resolve()
+
     case '--squirrel-install':
       return handleInstalled()
 


### PR DESCRIPTION
A little something found while proving #2350 is working:

<img width="583"  src="https://user-images.githubusercontent.com/359239/28714570-5a379e5e-736a-11e7-8f06-be3329f93f7d.png">

This is the event that Squirrel raises after a fresh installation, and I don't think we want to do anything here aside from handling it.

From [the docs](https://github.com/electron/windows-installer#handling-squirrel-events) (after the long code snippet):

> Notice that the first time the installer launches your app, your app will see a `--squirrel-firstrun` flag. This allows you to do things like showing up a splash screen or presenting a settings UI. 