### PR TITLE
Only enable Reload for dev builds

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -160,7 +160,7 @@ export function buildDefaultMenu(): Electron.Menu {
             focusedWindow.reload()
           }
         },
-        visible: __RELEASE_CHANNEL__ !== 'production',
+        visible: __RELEASE_CHANNEL__ === 'development',
       },
       {
         id: 'show-devtools',


### PR DESCRIPTION
Otherwise we get conflicting shortcuts for reload and open PR in beta and test builds.

s/o @tierninho 