### PR TITLE
Adds short-cut to open terminal/console

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -210,6 +210,7 @@ export function buildDefaultMenu(): Electron.Menu {
       {
         label: __DARWIN__ ? 'Open in Terminal' : 'Op&en command prompt',
         id: 'open-in-shell',
+        accelerator: 'Ctrl+`',
         click: emit('open-in-shell'),
       },
       {


### PR DESCRIPTION
This PR fixes issue #2138.

Now you can open a terminal or console using ```Control/Ctrl + ` ```