### PR TITLE
open Preferences/Options to a given tab

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -17,6 +17,7 @@ import { IMenu } from '../models/app-menu'
 import { IRemote } from '../models/remote'
 import { WindowState } from './window-state'
 import { RetryAction } from './retry-actions'
+import { PreferencesTab } from '../models/preferences'
 
 export { ICommitMessage }
 export { IAheadBehind }
@@ -167,7 +168,7 @@ export type Popup =
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
     }
-  | { type: PopupType.Preferences }
+  | { type: PopupType.Preferences; initialFocusTab?: PreferencesTab }
   | { type: PopupType.MergeBranch; repository: Repository }
   | { type: PopupType.RepositorySettings; repository: Repository }
   | { type: PopupType.AddRepository; path?: string }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -168,7 +168,7 @@ export type Popup =
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
     }
-  | { type: PopupType.Preferences; initialFocusTab?: PreferencesTab }
+  | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | { type: PopupType.MergeBranch; repository: Repository }
   | { type: PopupType.RepositorySettings; repository: Repository }
   | { type: PopupType.AddRepository; path?: string }

--- a/app/src/models/preferences.ts
+++ b/app/src/models/preferences.ts
@@ -1,0 +1,5 @@
+export enum PreferencesTab {
+  Accounts = 0,
+  Git,
+  Advanced,
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -844,7 +844,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <Preferences
             key="preferences"
-            initialFocusTab={popup.initialFocusTab}
+            initialSelectedTab={popup.initialSelectedTab}
             dispatcher={this.props.dispatcher}
             dotComAccount={this.getDotComAccount()}
             confirmRepoRemoval={this.state.confirmRepoRemoval}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -844,6 +844,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <Preferences
             key="preferences"
+            initialFocusTab={popup.initialFocusTab}
             dispatcher={this.props.dispatcher}
             dotComAccount={this.getDotComAccount()}
             confirmRepoRemoval={this.state.confirmRepoRemoval}

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -23,7 +23,7 @@ interface IPreferencesProps {
   readonly onDismissed: () => void
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepoRemoval: boolean
-  readonly initialFocusTab?: PreferencesTab
+  readonly initialSelectedTab?: PreferencesTab
 }
 
 interface IPreferencesState {
@@ -43,7 +43,7 @@ export class Preferences extends React.Component<
     super(props)
 
     this.state = {
-      selectedIndex: this.props.initialFocusTab || PreferencesTab.Accounts,
+      selectedIndex: this.props.initialSelectedTab || PreferencesTab.Accounts,
       committerName: '',
       committerEmail: '',
       isOptedOut: false,

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Account } from '../../models/account'
+import { PreferencesTab } from '../../models/preferences'
 import { Dispatcher } from '../../lib/dispatcher'
 import { TabBar } from '../tab-bar'
 import { Accounts } from './accounts'
@@ -22,12 +23,7 @@ interface IPreferencesProps {
   readonly onDismissed: () => void
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepoRemoval: boolean
-}
-
-enum PreferencesTab {
-  Accounts = 0,
-  Git,
-  Advanced,
+  readonly initialFocusTab?: PreferencesTab
 }
 
 interface IPreferencesState {
@@ -47,7 +43,7 @@ export class Preferences extends React.Component<
     super(props)
 
     this.state = {
-      selectedIndex: PreferencesTab.Accounts,
+      selectedIndex: this.props.initialFocusTab || PreferencesTab.Accounts,
       committerName: '',
       committerEmail: '',
       isOptedOut: false,


### PR DESCRIPTION
Splitting this off from #2407 where I have this use case:

 - user tries to open the app in an external editor
 - it's been uninstalled or the executable is missing or it errors, so :boom:
 - display details about the error to the user, and suggest opening Preferences/Options to change to another editor
 - app invokes `showPopup` to change dialogs

With this change, I can put the user on the Advanced tab (where the setting lives) rather than leave them disoriented and not sure where to go. The default behaviour (focus on Accounts) will remain if this argument hasn't been provided.