### PR TITLE
set the publish branch message based on GitHub API info

### DIFF
--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -162,7 +162,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
       return 'Publish this repository to GitHub'
     }
     if (!this.props.aheadBehind) {
-      const isGitHub = this.props.repository.gitHubRepository !== null
+      const isGitHub = !!this.props.repository.gitHubRepository
       return isGitHub
         ? 'Publish this branch to GitHub'
         : 'Publish this branch to the remote'

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -162,7 +162,10 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
       return 'Publish this repository to GitHub'
     }
     if (!this.props.aheadBehind) {
-      return 'Publish this branch to GitHub'
+      const isGitHub = this.props.repository.gitHubRepository !== null
+      return isGitHub
+        ? 'Publish this branch to GitHub'
+        : 'Publish this branch to the remote'
     }
 
     const lastFetched = this.props.lastFetched


### PR DESCRIPTION
Fixes #1498

For a GitHub repository:

<img width="794" src="https://user-images.githubusercontent.com/359239/29155504-00d9a2f0-7de0-11e7-9336-7004e4f9ad07.png">

For a remote we don't recognize:

<img width="789" src="https://user-images.githubusercontent.com/359239/29155519-13470c98-7de0-11e7-92d0-3c94646ae88d.png">
