### PR TITLE
introduce commit context menu

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -2436,7 +2436,9 @@ export class AppStore {
   ): Promise<void> {
     const gitStore = this.getGitStore(repository)
 
-    gitStore.revertCommit(repository, commit)
+    await gitStore.revertCommit(repository, commit)
+
+    return gitStore.loadHistory()
   }
 
   public async promptForGenericGitAuthentication(

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -405,8 +405,8 @@ export class Dispatcher {
   }
 
   /** Revert the commit with the given SHA */
-  public revertCommit(repositoy: Repository, commit: Commit): Promise<void> {
-    return this.appStore._revertCommit(repositoy, commit)
+  public revertCommit(repository: Repository, commit: Commit): Promise<void> {
+    return this.appStore._revertCommit(repository, commit)
   }
 
   /**

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -4,6 +4,7 @@ import { IAvatarUser } from '../../models/avatar'
 import { RichText } from '../lib/rich-text'
 import { Avatar } from '../lib/avatar'
 import { RelativeTime } from '../relative-time'
+import { showContextualMenu, IMenuItem } from '../main-process-proxy'
 
 interface ICommitProps {
   readonly commit: Commit
@@ -18,7 +19,7 @@ export class CommitListItem extends React.Component<ICommitProps, {}> {
     const author = commit.author
 
     return (
-      <div className="commit">
+      <div className="commit" onContextMenu={this.onContextMenu}>
         <Avatar user={this.props.user || undefined} />
         <div className="info">
           <RichText
@@ -40,5 +41,17 @@ export class CommitListItem extends React.Component<ICommitProps, {}> {
       this.props.commit.sha !== nextProps.commit.sha ||
       this.props.user !== nextProps.user
     )
+  }
+
+  private onContextMenu = (event: React.MouseEvent<any>) => {
+    event.preventDefault()
+
+    const items: IMenuItem[] = [
+      {
+        label: __DARWIN__ ? 'Do Something…' : 'Do something…',
+      },
+    ]
+
+    showContextualMenu(items)
   }
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Commit } from '../../models/commit'
-import { Repository } from '../../models/repository'
+import { GitHubRepository } from '../../models/github-repository'
 import { IAvatarUser } from '../../models/avatar'
 import { RichText } from '../lib/rich-text'
 import { Avatar } from '../lib/avatar'
@@ -10,7 +10,7 @@ import { clipboard } from 'electron'
 import { showContextualMenu, IMenuItem } from '../main-process-proxy'
 
 interface ICommitProps {
-  readonly repository: Repository | null
+  readonly gitHubRepository: GitHubRepository | null
   readonly commit: Commit
   readonly user: IAvatarUser | null
   readonly emoji: Map<string, string>
@@ -64,9 +64,7 @@ export class CommitListItem extends React.Component<ICommitProps, {}> {
     event.preventDefault()
 
     let label: string = ''
-    const gitHubRepository = this.props.repository
-      ? this.props.repository.gitHubRepository
-      : null
+    const gitHubRepository = this.props.gitHubRepository
 
     if (gitHubRepository) {
       const isDotCom = gitHubRepository.endpoint === getDotComAPIEndpoint()

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -43,7 +43,6 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       }
     }
 
-    // TODO: where are we getting this from?
     const isLocal = this.props.localCommitSHAs.indexOf(commit.sha) > -1
 
     return (

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -48,7 +48,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     return (
       <CommitListItem
         key={commit.sha}
-        repository={this.props.repository}
+        gitHubRepository={this.props.repository.gitHubRepository}
         isLocal={isLocal}
         commit={commit}
         user={avatarUser}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Repository } from '../../models/repository'
 import { Commit } from '../../models/commit'
 import { CommitListItem } from './commit-list-item'
 import { List } from '../list'
@@ -9,11 +10,15 @@ const RowHeight = 48
 interface ICommitListProps {
   readonly onCommitChanged: (commit: Commit) => void
   readonly onScroll: (start: number, end: number) => void
+  readonly onRevertCommit: (commit: Commit) => void
+  readonly onViewCommitOnGitHub: (sha: string) => void
+  readonly repository: Repository
   readonly history: ReadonlyArray<string>
   readonly commits: Map<string, Commit>
   readonly selectedSHA: string | null
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly emoji: Map<string, string>
+  readonly localCommitSHAs: ReadonlyArray<string>
 }
 
 /** A component which displays the list of commits. */
@@ -38,12 +43,19 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       }
     }
 
+    // TODO: where are we getting this from?
+    const isLocal = this.props.localCommitSHAs.indexOf(commit.sha) > -1
+
     return (
       <CommitListItem
         key={commit.sha}
+        repository={this.props.repository}
+        isLocal={isLocal}
         commit={commit}
         user={avatarUser}
         emoji={this.props.emoji}
+        onRevertCommit={this.props.onRevertCommit}
+        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
   }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -1,30 +1,22 @@
 import * as React from 'react'
-import { clipboard } from 'electron'
 import * as classNames from 'classnames'
 
 import { FileChange } from '../../models/status'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { RichText } from '../lib/rich-text'
-import { LinkButton } from '../lib/link-button'
 import { IGitHubUser } from '../../lib/dispatcher'
 import { Repository } from '../../models/repository'
 import { Avatar } from '../lib/avatar'
-import { showContextualMenu, IMenuItem } from '../main-process-proxy'
-import { Dispatcher } from '../../lib/dispatcher'
-import { getDotComAPIEndpoint } from '../../lib/api'
 import { Commit } from '../../models/commit'
 
 interface ICommitSummaryProps {
-  readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly commit: Commit
   readonly files: ReadonlyArray<FileChange>
   readonly emoji: Map<string, string>
-  readonly isLocal: boolean
   readonly gitHubUser: IGitHubUser | null
   readonly isExpanded: boolean
   readonly onExpandChanged: (isExpanded: boolean) => void
-  readonly onViewCommitOnGitHub: (SHA: string) => void
 }
 
 interface ICommitSummaryState {
@@ -195,50 +187,6 @@ export class CommitSummary extends React.Component<
     )
   }
 
-  private onShowCommitOptions = () => {
-    let label: string = ''
-    const gitHubRepository = this.props.repository.gitHubRepository
-
-    if (gitHubRepository) {
-      const isDotCom = gitHubRepository.endpoint === getDotComAPIEndpoint()
-      label = isDotCom ? 'View on GitHub' : 'View on GitHub Enterprise'
-    }
-
-    const items: IMenuItem[] = [
-      {
-        label: __DARWIN__ ? 'Revert This Commit' : 'Revert this commit',
-        action: this.onRevertCommit,
-      },
-      { type: 'separator' },
-      {
-        label: 'Copy SHA',
-        action: this.onCopySHA,
-      },
-      {
-        label: label,
-        action: this.onViewOnGitHub,
-        enabled: !this.props.isLocal && !!gitHubRepository,
-      },
-    ]
-
-    showContextualMenu(items)
-  }
-
-  private onRevertCommit = async () => {
-    await this.props.dispatcher.revertCommit(
-      this.props.repository,
-      this.props.commit
-    )
-  }
-
-  private onCopySHA = () => {
-    clipboard.writeText(this.props.commit.sha)
-  }
-
-  private onViewOnGitHub = () => {
-    this.props.onViewCommitOnGitHub(this.props.commit.sha)
-  }
-
   public render() {
     const fileCount = this.props.files.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
@@ -299,16 +247,6 @@ export class CommitSummary extends React.Component<
               </span>
 
               {filesDescription}
-            </li>
-
-            <li className="commit-summary-meta-item">
-              <LinkButton
-                className="more-dropdown"
-                onClick={this.onShowCommitOptions}
-              >
-                Actions
-                <Octicon symbol={OcticonSymbol.triangleDown} />
-              </LinkButton>
             </li>
           </ul>
         </div>

--- a/app/src/ui/history/index.tsx
+++ b/app/src/ui/history/index.tsx
@@ -21,10 +21,8 @@ interface IHistoryProps {
   readonly history: IAppHistoryState
   readonly emoji: Map<string, string>
   readonly commits: Map<string, Commit>
-  readonly localCommitSHAs: ReadonlyArray<string>
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
-  readonly onViewCommitOnGitHub: (SHA: string) => void
 }
 
 interface IHistoryState {
@@ -91,22 +89,18 @@ export class History extends React.Component<IHistoryProps, IHistoryState> {
   }
 
   private renderCommitSummary(commit: Commit) {
-    const isLocal = this.props.localCommitSHAs.indexOf(commit.sha) > -1
     const gitHubUser =
       this.props.gitHubUsers.get(commit.author.email.toLowerCase()) || null
 
     return (
       <CommitSummary
-        dispatcher={this.props.dispatcher}
         commit={commit}
         files={this.props.history.changedFiles}
         emoji={this.props.emoji}
         repository={this.props.repository}
-        isLocal={isLocal}
         gitHubUser={gitHubUser}
         onExpandChanged={this.onExpandChanged}
         isExpanded={this.state.isExpanded}
-        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
   }

--- a/app/src/ui/history/sidebar.tsx
+++ b/app/src/ui/history/sidebar.tsx
@@ -16,6 +16,9 @@ interface IHistorySidebarProps {
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly emoji: Map<string, string>
   readonly commits: Map<string, Commit>
+  readonly localCommitSHAs: ReadonlyArray<string>
+  readonly onRevertCommit: (commit: Commit) => void
+  readonly onViewCommitOnGitHub: (sha: string) => void
 }
 
 /** The History component. Contains the commit list, commit summary, and diff. */
@@ -49,6 +52,7 @@ export class HistorySidebar extends React.Component<IHistorySidebarProps, {}> {
   public render() {
     return (
       <CommitList
+        repository={this.props.repository}
         commits={this.props.commits}
         history={this.props.history.history}
         selectedSHA={this.props.history.selection.sha}
@@ -56,6 +60,9 @@ export class HistorySidebar extends React.Component<IHistorySidebarProps, {}> {
         onScroll={this.onScroll}
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}
+        localCommitSHAs={this.props.localCommitSHAs}
+        onRevertCommit={this.props.onRevertCommit}
+        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
   }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -134,21 +134,21 @@ export class ConfigureGitUser extends React.Component<
             commit={dummyCommit1}
             emoji={emoji}
             user={null}
-            repository={null}
+            gitHubRepository={null}
             isLocal={false}
           />
           <CommitListItem
             commit={dummyCommit2}
             emoji={emoji}
             user={this.getAvatarUser()}
-            repository={null}
+            gitHubRepository={null}
             isLocal={false}
           />
           <CommitListItem
             commit={dummyCommit3}
             emoji={emoji}
             user={null}
-            repository={null}
+            gitHubRepository={null}
             isLocal={false}
           />
         </div>

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -130,13 +130,27 @@ export class ConfigureGitUser extends React.Component<
         </Form>
 
         <div id="commit-list" className="commit-list-example">
-          <CommitListItem commit={dummyCommit1} emoji={emoji} user={null} />
+          <CommitListItem
+            commit={dummyCommit1}
+            emoji={emoji}
+            user={null}
+            repository={null}
+            isLocal={false}
+          />
           <CommitListItem
             commit={dummyCommit2}
             emoji={emoji}
             user={this.getAvatarUser()}
+            repository={null}
+            isLocal={false}
           />
-          <CommitListItem commit={dummyCommit3} emoji={emoji} user={null} />
+          <CommitListItem
+            commit={dummyCommit3}
+            emoji={emoji}
+            user={null}
+            repository={null}
+            isLocal={false}
+          />
         </div>
       </div>
     )

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Repository as Repo } from '../models/repository'
+import { Commit } from '../models/commit'
 import { TipState } from '../models/tip'
 import { UiView } from './ui-view'
 import { Changes, ChangesSidebar } from './changes'
@@ -100,6 +101,9 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
         gitHubUsers={this.props.state.gitHubUsers}
         emoji={this.props.emoji}
         commits={this.props.state.commits}
+        localCommitSHAs={this.props.state.localCommitSHAs}
+        onRevertCommit={this.onRevertCommit}
+        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
   }
@@ -172,10 +176,8 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
           history={this.props.state.historyState}
           emoji={this.props.emoji}
           commits={this.props.state.commits}
-          localCommitSHAs={this.props.state.localCommitSHAs}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}
-          onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         />
       )
     } else {
@@ -194,6 +196,10 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
 
   private openRepository = () => {
     this.props.dispatcher.revealInFileManager(this.props.repository, '')
+  }
+
+  private onRevertCommit = (commit: Commit) => {
+    this.props.dispatcher.revertCommit(this.props.repository, commit)
   }
 
   private onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
Fixes #2382 

<img width="370"  src="https://user-images.githubusercontent.com/359239/29158834-d67c3b84-7def-11e7-99f6-c9e6fb864b0e.png">

- [x] history doesn't refresh when reverting
- [x] see if more things can be lifted up and out of `CommitListItem`