### PR TITLE
Increase the max sidebar width

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -15,6 +15,9 @@ import { Dispatcher, IssuesStore, GitHubUserStore } from '../lib/dispatcher'
 import { assertNever } from '../lib/fatal-error'
 import { Octicon, OcticonSymbol } from './octicons'
 
+/** The widest the sidebar can be with the minimum window size. */
+const MaxSidebarWidth = 495
+
 interface IRepositoryProps {
   readonly repository: Repo
   readonly state: IRepositoryModelState
@@ -131,6 +134,7 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
         width={this.props.sidebarWidth}
         onReset={this.handleSidebarWidthReset}
         onResize={this.handleSidebarResize}
+        maximumWidth={MaxSidebarWidth}
       >
         {this.renderTabs()}
         {this.renderSidebarContents()}


### PR DESCRIPTION
Fixes #1588 

This is the easy way out by increasing the minimum width to the max it can be when the window is at its smallest and still have room for the toolbar buttons.

Ideally we'd calculate this dynamically based on the window width, but that might be more complexity than it's worth right now. For now this is an easy win.

<img width="993" alt="screen shot 2017-08-10 at 10 22 52 am" src="https://user-images.githubusercontent.com/13760/29175110-2b7841d0-7db6-11e7-86b0-7b3d7343f8ea.png">