### PR TITLE
Darker unfocused selection color

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -2,7 +2,7 @@
 //
 // This files contains CSS variables accessible to all selectors
 
-// Primer colors, see https://github.com/primer/primer-support/blob/master/lib/variables/color-system.scss
+// Primer colors, see https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/color-system.scss
 @import '~primer-support/lib/variables/color-system.scss';
 
 :root {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -95,7 +95,7 @@
   /**
    * Background color for selected boxes without keyboard focus
    */
-  --box-selected-background-color: $gray-100;
+  --box-selected-background-color: #ebeef1;
 
   /**
    * Text color for when a user hovers over a boxe with a


### PR DESCRIPTION
Fixes #1669 

I pulled the exact value from @niik's [comment](https://github.com/desktop/desktop/issues/1669#issuecomment-314668885).

Before:

<img width="507" alt="screen shot 2017-08-10 at 3 41 25 pm" src="https://user-images.githubusercontent.com/13760/29188819-69e564b2-7de2-11e7-8f47-0f2c0f25159d.png">

After:

<img width="506" alt="screen shot 2017-08-10 at 3 39 58 pm" src="https://user-images.githubusercontent.com/13760/29188793-52509e0c-7de2-11e7-9042-abb224b1ceed.png">
