### PR TITLE
Swap around some callouts for no repositories

### DIFF
--- a/app/src/ui/blank-slate/blank-slate.tsx
+++ b/app/src/ui/blank-slate/blank-slate.tsx
@@ -39,20 +39,20 @@ export class BlankSlateView extends React.Component<IBlankSlateProps, {}> {
           </div>
 
           <div className="callout">
-            <Octicon symbol={OcticonSymbol.repoClone} />
-            <div>Clone an existing project from GitHub to your computer</div>
-            <Button onClick={this.props.onClone}>
-              {__DARWIN__ ? 'Clone a Repository' : 'Clone a repository'}
-            </Button>
-          </div>
-
-          <div className="callout">
             <Octicon symbol={OcticonSymbol.deviceDesktop} />
             <div>
               Add an existing project on your computer and publish it to GitHub
             </div>
             <Button onClick={this.props.onAdd}>
               {__DARWIN__ ? 'Add a Local Repository' : 'Add a local repository'}
+            </Button>
+          </div>
+
+          <div className="callout">
+            <Octicon symbol={OcticonSymbol.repoClone} />
+            <div>Clone an existing project from GitHub to your computer</div>
+            <Button onClick={this.props.onClone}>
+              {__DARWIN__ ? 'Clone a Repository' : 'Clone a repository'}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/2264 by having the content in the same order as the menu items.

![image](https://user-images.githubusercontent.com/1174461/29192684-24a147c8-7dd7-11e7-8116-b165bc7ac0ca.png)
