### PR TITLE
Tweak styles for no editors found message

### DIFF
--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -101,7 +101,7 @@ export class Advanced extends React.Component<
       // TODO: see whether it makes sense to have a fallback UI
       // which we display when the select list is empty
       return (
-        <div className="select-component">
+        <div className="select-component no-options-found">
           <label>
             {label}
           </label>

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -37,3 +37,7 @@
     }
   }
 }
+
+#external-editor-error {
+  width: 450px;
+}

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -26,4 +26,14 @@
       }
     }
   }
+
+  .no-options-found {
+    label {
+      margin-bottom: 0;
+    }
+
+    span {
+      color: var(--text-secondary-color);
+    }
+  }
 }


### PR DESCRIPTION
(Targets branch `open-in-external-editor`)

Super tiny style tweaks in the preferences for when we can't find any external editors:

I deemphasized the text plus tightened up the spacing between the label and the text underneath so that they feel more as a grouped item.

**Before**

<img width="515" alt="screen shot 2017-08-10 at 5 18 44 pm" src="https://user-images.githubusercontent.com/1174461/29197656-ffedf9e2-7df1-11e7-85f1-99e8fcbffe12.png">

**After**

<img width="524" alt="screen shot 2017-08-10 at 4 17 04 pm" src="https://user-images.githubusercontent.com/1174461/29197655-ffecb5aa-7df1-11e7-9c4b-d2f48b8e4afa.png">