### PR TITLE
use %WINDIR% environment variable instead of hard-coding

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -13,7 +13,8 @@ import { assertNever } from '../fatal-error'
 // the keys found by `reg.exe`, and rather than trying to fix and potentially
 // regress other parts I've extracted just the bit that I need to use.
 
-const regPath = Path.join(process.env.windir, 'System32', 'reg.exe')
+const windir = process.env.windir || 'C:\\Windows'
+const regPath = Path.join(windir, 'System32', 'reg.exe')
 
 const ITEM_PATTERN = /^(.*)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
 

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -13,7 +13,7 @@ import { assertNever } from '../fatal-error'
 // the keys found by `reg.exe`, and rather than trying to fix and potentially
 // regress other parts I've extracted just the bit that I need to use.
 
-const regPath = 'C:\\Windows\\System32\\reg.exe'
+const regPath = Path.join(process.env.windir, 'System32', 'reg.exe')
 
 const ITEM_PATTERN = /^(.*)\s(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)\s+([^\s].*)$/
 


### PR DESCRIPTION
The location of the Windows installation is not guaranteed to be `C:\Windows`, and this was mentioned in https://github.com/desktop/desktop/pull/2407#discussion_r133107896.

From [Wikipedia](https://en.wikipedia.org/wiki/Environment_variable#Windows):

> `%windir%`
> This variable points to the Windows directory (on Windows NT-based operating systems it is identical to the `%SystemRoot% `variable, above). If the system is on drive C:, then the default values are `"C:\WINDOWS"` on Windows 95, Windows 98, Windows Me, Windows XP, Windows Server 2003, Windows Vista, Windows Server 2008 and Windows 7 and `"C:\WINNT"` for Windows NT 4, and Windows 2000. Windows NT 4 Terminal Server Edition by default installs to "C:\WTSRV".

cc @shimpossible 