### PR TITLE
restrict "Open in" context menu for files which are Danger Zone™

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -129,8 +129,8 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       },
       {
         label: __DARWIN__
-          ? 'Open with External Editor'
-          : 'Open with external editor',
+          ? 'Open with Default Program'
+          : 'Open with default program',
         action: () => this.props.onOpenItem(this.props.path),
         enabled: this.props.status !== AppFileStatus.Deleted,
       }

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -9,7 +9,7 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 const GitIgnoreFileName = '.gitignore'
 
-const RestrictedFileExtensions = ['.cmd', '.exe', '.bat']
+const RestrictedFileExtensions = ['.cmd', '.exe', '.bat', '.sh']
 
 interface IChangedFileProps {
   readonly path: string

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -9,6 +9,8 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 const GitIgnoreFileName = '.gitignore'
 
+const RestrictedFileExtensions = ['.cmd', '.exe', '.bat']
+
 interface IChangedFileProps {
   readonly path: string
   readonly status: AppFileStatus
@@ -120,6 +122,10 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       })
     }
 
+    const isSafeExtension = __WIN32__
+      ? RestrictedFileExtensions.indexOf(extension.toLowerCase()) === -1
+      : true
+
     items.push(
       { type: 'separator' },
       {
@@ -132,7 +138,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
           ? 'Open with Default Program'
           : 'Open with default program',
         action: () => this.props.onOpenItem(this.props.path),
-        enabled: this.props.status !== AppFileStatus.Deleted,
+        enabled: isSafeExtension && this.props.status !== AppFileStatus.Deleted,
       }
     )
 


### PR DESCRIPTION
Fixes #2464 in two ways:

 - updates the changed file context menu to mention "Default Program" to distinguish it from "Open in External Editor"
 - disables the menu item for known extensions that execute whe the `Open` verb is used by Electron as per [here](https://github.com/electron/electron/blob/eb63bea87c299b3c440d6a36ccced3cc9653e1c4/atom/common/platform_util_win.cc#L308-L315)