### PR TITLE
add TextMate as external editor

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -17,6 +17,8 @@ function getBundleIdentifier(editor: ExternalEditor): string {
       return 'com.microsoft.VSCode'
     case ExternalEditor.SublimeText:
       return 'com.sublimetext.3'
+    case ExternalEditor.TextMate:
+      return 'com.macromates.TextMate'
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -80,10 +82,11 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<FoundEditor> = []
 
-  const [atom, code, sublime] = await Promise.all([
+  const [atom, code, sublime, textmate] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.SublimeText),
+    findApplication(ExternalEditor.TextMate),
   ])
 
   if (atom.installed && atom.pathExists) {
@@ -96,6 +99,10 @@ export async function getAvailableEditors(): Promise<
 
   if (sublime.installed && sublime.pathExists) {
     results.push({ editor: sublime.editor, path: sublime.path })
+  }
+
+  if (textmate.installed && textmate.pathExists) {
+    results.push({ editor: textmate.editor, path: textmate.path })
   }
 
   return results
@@ -119,6 +126,11 @@ export async function getFirstEditorOrDefault(): Promise<FoundEditor | null> {
   const sublime = await findApplication(ExternalEditor.SublimeText)
   if (sublime.installed && sublime.pathExists) {
     return { editor: sublime.editor, path: sublime.path }
+  }
+
+  const textmate = await findApplication(ExternalEditor.TextMate)
+  if (textmate.installed && textmate.pathExists) {
+    return { editor: textmate.editor, path: textmate.path }
   }
 
   return null

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -42,6 +42,8 @@ function getExecutableShim(
       )
     case ExternalEditor.SublimeText:
       return Path.join(installPath, 'Contents', 'SharedSupport', 'bin', 'subl')
+    case ExternalEditor.TextMate:
+      return Path.join(installPath, 'Contents', 'Resources', 'mate')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }

--- a/app/src/models/editors.ts
+++ b/app/src/models/editors.ts
@@ -2,6 +2,7 @@ export enum ExternalEditor {
   Atom = 'Atom',
   VisualStudioCode = 'Visual Studio Code',
   SublimeText = 'Sublime Text',
+  TextMate = 'TextMate',
 }
 
 export function parse(label: string | null): ExternalEditor {
@@ -15,6 +16,10 @@ export function parse(label: string | null): ExternalEditor {
 
   if (label === ExternalEditor.SublimeText) {
     return ExternalEditor.SublimeText
+  }
+
+  if (label === ExternalEditor.TextMate) {
+    return ExternalEditor.TextMate
   }
 
   return ExternalEditor.Atom

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -12,8 +12,9 @@ Currently Desktop supports these external editors:
  - [Atom](https://atom.io/)
  - [Visual Studio Code](https://code.visualstudio.com/)
  - [Sublime Text](https://www.sublimetext.com/)
+ - [TextMate](https://macromates.com/)
 
-These editors have been chosen because they are cross-platform and provide a
+These editors have been chosen because they are cross-platform and/or provide a
 command line interface that other applications can interact with.
 
 ## Resolving External Editors


### PR DESCRIPTION
Since all editors in this list support TextMate bundles I think TextMate itself deserves a spot in this list.

**Edit** I only just read the markdown document, describing the decision of editors was based on cross-platform support. So maybe a better solution would be to have a dynamic way of adding editors from the UI.