### PR TITLE
Keep `includeAll` up to date with the included files

### DIFF
--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -1092,8 +1092,12 @@ export class AppStore {
       selectableLines
     )
     const selectedFile = currentlySelectedFile.withSelection(newSelection)
-    const workingDirectory = changesState.workingDirectory.byReplacingFile(
-      selectedFile
+    const updatedFiles = changesState.workingDirectory.files.map(
+      f => (f.id === selectedFile.id ? selectedFile : f)
+    )
+    const workingDirectory = new WorkingDirectoryStatus(
+      updatedFiles,
+      this.getIncludeAllState(updatedFiles)
     )
 
     this.updateChangesState(repository, state => ({ diff, workingDirectory }))

--- a/app/src/lib/dispatcher/app-store.ts
+++ b/app/src/lib/dispatcher/app-store.ts
@@ -337,9 +337,8 @@ export class AppStore {
         diff: null,
       },
       changesState: {
-        workingDirectory: new WorkingDirectoryStatus(
-          new Array<WorkingDirectoryFileChange>(),
-          true
+        workingDirectory: WorkingDirectoryStatus.fromFiles(
+          new Array<WorkingDirectoryFileChange>()
         ),
         selectedFileID: null,
         diff: null,
@@ -964,11 +963,7 @@ export class AppStore {
         })
         .sort((x, y) => caseInsensitiveCompare(x.path, y.path))
 
-      const includeAll = this.getIncludeAllState(mergedFiles)
-      const workingDirectory = new WorkingDirectoryStatus(
-        mergedFiles,
-        includeAll
-      )
+      const workingDirectory = WorkingDirectoryStatus.fromFiles(mergedFiles)
 
       let selectedFileID = state.selectedFileID
       const matchedFile = mergedFiles.find(x => x.id === selectedFileID)
@@ -1095,10 +1090,7 @@ export class AppStore {
     const updatedFiles = changesState.workingDirectory.files.map(
       f => (f.id === selectedFile.id ? selectedFile : f)
     )
-    const workingDirectory = new WorkingDirectoryStatus(
-      updatedFiles,
-      this.getIncludeAllState(updatedFiles)
-    )
+    const workingDirectory = WorkingDirectoryStatus.fromFiles(updatedFiles)
 
     this.updateChangesState(repository, state => ({ diff, workingDirectory }))
     this.emitUpdate()
@@ -1144,26 +1136,6 @@ export class AppStore {
     return result || false
   }
 
-  private getIncludeAllState(
-    files: ReadonlyArray<WorkingDirectoryFileChange>
-  ): boolean | null {
-    const allSelected = files.every(
-      f => f.selection.getSelectionType() === DiffSelectionType.All
-    )
-    const noneSelected = files.every(
-      f => f.selection.getSelectionType() === DiffSelectionType.None
-    )
-
-    let includeAll: boolean | null = null
-    if (allSelected) {
-      includeAll = true
-    } else if (noneSelected) {
-      includeAll = false
-    }
-
-    return includeAll
-  }
-
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _changeFileIncluded(
     repository: Repository,
@@ -1201,8 +1173,7 @@ export class AppStore {
         f => (f.id === file.id ? f.withSelection(selection) : f)
       )
 
-      const includeAll = this.getIncludeAllState(newFiles)
-      const workingDirectory = new WorkingDirectoryStatus(newFiles, includeAll)
+      const workingDirectory = WorkingDirectoryStatus.fromFiles(newFiles)
       const diff = state.selectedFileID ? state.diff : null
       return { workingDirectory, diff }
     })

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -134,7 +134,7 @@ export async function getStatus(
     }
   }
 
-  const workingDirectory = new WorkingDirectoryStatus(files, true)
+  const workingDirectory = WorkingDirectoryStatus.fromFiles(files)
 
   return {
     currentBranch,

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -224,20 +224,6 @@ export class WorkingDirectoryStatus {
     return new WorkingDirectoryStatus(newFiles, includeAll)
   }
 
-  /** Update by replacing the file with the same ID with a new file. */
-  public byReplacingFile(
-    file: WorkingDirectoryFileChange
-  ): WorkingDirectoryStatus {
-    const newFiles = this.files.map(f => {
-      if (f.id === file.id) {
-        return file
-      } else {
-        return f
-      }
-    })
-    return new WorkingDirectoryStatus(newFiles, this.includeAll)
-  }
-
   /** Find the file with the given ID. */
   public findFileWithID(id: string): WorkingDirectoryFileChange | null {
     return this.files.find(f => f.id === id) || null

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -1,4 +1,4 @@
-import { DiffSelection } from './diff'
+import { DiffSelection, DiffSelectionType } from './diff'
 import { OcticonSymbol } from '../ui/octicons'
 import { assertNever } from '../lib/fatal-error'
 
@@ -208,7 +208,14 @@ export class WorkingDirectoryStatus {
    */
   public readonly includeAll: boolean | null = true
 
-  public constructor(
+  /** Create a new status with the given files. */
+  public static fromFiles(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ): WorkingDirectoryStatus {
+    return new WorkingDirectoryStatus(files, getIncludeAllState(files))
+  }
+
+  private constructor(
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     includeAll: boolean | null
   ) {
@@ -228,4 +235,28 @@ export class WorkingDirectoryStatus {
   public findFileWithID(id: string): WorkingDirectoryFileChange | null {
     return this.files.find(f => f.id === id) || null
   }
+}
+
+function getIncludeAllState(
+  files: ReadonlyArray<WorkingDirectoryFileChange>
+): boolean | null {
+  if (!files.length) {
+    return true
+  }
+
+  const allSelected = files.every(
+    f => f.selection.getSelectionType() === DiffSelectionType.All
+  )
+  const noneSelected = files.every(
+    f => f.selection.getSelectionType() === DiffSelectionType.None
+  )
+
+  let includeAll: boolean | null = null
+  if (allSelected) {
+    includeAll = true
+  } else if (noneSelected) {
+    includeAll = false
+  }
+
+  return includeAll
 }


### PR DESCRIPTION
Fixes #2490

The root of the problem was that we were updating the list of files but not updating the `includeAll` flag. We can do this as part of creating `WorkingDirectoryStatus` to guarantee they don't fall out of sync... I'm not sure why it was a parameter previously.