### PR TITLE
Fix copying text within a line

### DIFF
--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -42,7 +42,7 @@ interface ICodeMirrorHostProps {
    * Called when content has been copied. The default behavior may be prevented
    * by calling `preventDefault` on the event.
    */
-  readonly onCopy?: (selection: string, event: Event) => void
+  readonly onCopy?: (editor: CodeMirror.Editor, event: Event) => void
 }
 
 /**
@@ -76,9 +76,7 @@ export class CodeMirrorHost extends React.Component<ICodeMirrorHostProps, {}> {
 
   private onCopy = (instance: CodeMirror.Editor, event: Event) => {
     if (this.props.onCopy) {
-      const doc = instance.getDoc()
-      const selection = doc.getSelection()
-      this.props.onCopy(selection, event)
+      this.props.onCopy(instance, event)
     }
   }
 

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -650,7 +650,7 @@ export class Diff extends React.Component<IDiffProps, {}> {
     )
   }
 
-  private onCopy = (selection: string, event: Event) => {
+  private onCopy = (editor: CodeMirror.Editor, event: Event) => {
     event.preventDefault()
 
     // Remove all the diff markers.


### PR DESCRIPTION
Fixes #2492

I don't know why this didn't occur to me when I was writing this originally 🙈

We should only trim diff line markers when the selection includes the 0th character.