### PR TITLE
introduce feature flagging abstraction

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -1,0 +1,16 @@
+/**
+ * Enables the application to opt-in for preview features based on runtime
+ * checks. This is backed by the GITHUB_DESKTOP_PREVIEW_FEATURES environment
+ * variable, which is checked for non-development environments.
+ */
+export function enablePreviewFeatures(): boolean {
+  if (__DEV__) {
+    return true
+  }
+
+  if (process.env.GITHUB_DESKTOP_PREVIEW_FEATURES) {
+    return true
+  }
+
+  return false
+}

--- a/app/src/ui/clone-repository/clone-generic-repository.tsx
+++ b/app/src/ui/clone-repository/clone-generic-repository.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react'
 import { TextBox } from '../lib/text-box'
 import { Button } from '../lib/button'
-import { getDefaultDir } from '../lib/default-dir'
 import { Row } from '../lib/row'
-import { IRepositoryIdentifier } from '../../lib/remote-parsing'
 import { DialogContent } from '../dialog'
 import { Monospaced } from '../lib/monospaced'
 
 interface ICloneGenericRepositoryProps {
-  /** The initial URL or `owner/name` shortcut to use. */
-  readonly initialURL: string | null
+  readonly url: string
+
+  readonly path: string
 
   readonly onPathChanged: (path: string) => void
 
@@ -18,47 +17,13 @@ interface ICloneGenericRepositoryProps {
   readonly onChooseDirectory: () => Promise<string | undefined>
 }
 
-interface ICloneGenericRepositoryState {
-  /** The user-entered URL or `owner/name` shortcut. */
-  readonly url: string
-
-  /** The local path to clone to. */
-  readonly path: string
-
-  /**
-   * The repository identifier that was last parsed from the user-entered URL.
-   */
-  readonly lastParsedIdentifier: IRepositoryIdentifier | null
-}
-
 /** The component for cloning a repository. */
 export class CloneGenericRepository extends React.Component<
   ICloneGenericRepositoryProps,
-  ICloneGenericRepositoryState
+  {}
 > {
   public constructor(props: ICloneGenericRepositoryProps) {
     super(props)
-
-    this.state = {
-      url: '',
-      path: getDefaultDir(),
-      lastParsedIdentifier: null,
-    }
-  }
-
-  public componentDidMount() {
-    if (this.props.initialURL) {
-      this.props.onUrlChanged(this.props.initialURL)
-    }
-  }
-
-  public componentWillReceiveProps(nextProps: ICloneGenericRepositoryProps) {
-    if (
-      nextProps.initialURL &&
-      nextProps.initialURL !== this.props.initialURL
-    ) {
-      this.props.onUrlChanged(nextProps.initialURL)
-    }
   }
 
   public render() {
@@ -72,7 +37,7 @@ export class CloneGenericRepository extends React.Component<
         <Row>
           <TextBox
             placeholder="URL or username/repository"
-            value={this.state.url}
+            value={this.props.url}
             onValueChanged={this.onUrlChanged}
             autoFocus={true}
           />
@@ -80,7 +45,7 @@ export class CloneGenericRepository extends React.Component<
 
         <Row>
           <TextBox
-            value={this.state.path}
+            value={this.props.path}
             label={__DARWIN__ ? 'Local Path' : 'Local path'}
             placeholder="repository path"
             onValueChanged={this.props.onPathChanged}
@@ -95,12 +60,11 @@ export class CloneGenericRepository extends React.Component<
     const path = await this.props.onChooseDirectory()
 
     if (path) {
-      this.setState({ path })
+      this.props.onPathChanged(path)
     }
   }
 
   private onUrlChanged = (url: string) => {
-    this.setState({ url })
     this.props.onUrlChanged(url)
   }
 }

--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 
 import { Account } from '../../models/account'
-import { getDefaultDir } from '../lib/default-dir'
 import { DialogContent } from '../dialog'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -18,6 +17,7 @@ import {
 interface ICloneGithubRepositoryProps {
   readonly api: API
   readonly account: Account
+  readonly path: string
   readonly onPathChanged: (path: string) => void
   readonly onDismissed: () => void
   readonly onChooseDirectory: () => Promise<string | undefined>
@@ -26,7 +26,6 @@ interface ICloneGithubRepositoryProps {
 
 interface ICloneGithubRepositoryState {
   readonly loading: boolean
-  readonly path: string
   readonly repositoryName: string
   readonly repositories: ReadonlyArray<
     IFilterListGroup<IClonableRepositoryListItem>
@@ -48,7 +47,6 @@ export class CloneGithubRepository extends React.Component<
 
     this.state = {
       loading: false,
-      path: getDefaultDir(),
       repositoryName: '',
       repositories: [],
       selectedItem: null,
@@ -81,7 +79,7 @@ export class CloneGithubRepository extends React.Component<
 
         <Row>
           <TextBox
-            value={this.state.path}
+            value={this.props.path}
             label={__DARWIN__ ? 'Local Path' : 'Local path'}
             placeholder="repository path"
             onValueChanged={this.onPathChanged}
@@ -133,12 +131,11 @@ export class CloneGithubRepository extends React.Component<
     const path = await this.props.onChooseDirectory()
 
     if (path) {
-      this.setState({ path })
+      this.props.onPathChanged(path)
     }
   }
 
   private onPathChanged = (path: string) => {
-    this.setState({ path })
     this.props.onPathChanged(path)
   }
 

--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -6,6 +6,7 @@ import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Button } from '../lib/button'
 import { Loading } from '../lib/loading'
+import { Octicon } from '../octicons'
 import { FilterList } from '../lib/filter-list'
 import { API } from '../../lib/api'
 import { IFilterListGroup } from '../lib/filter-list'
@@ -145,17 +146,20 @@ export class CloneGithubRepository extends React.Component<
 
   private renderGroupHeader = (header: string) => {
     return (
-      <strong>
+      <div className="clone-repository-list-content clone-repository-list-group-header">
         {header}
-      </strong>
+      </div>
     )
   }
 
   private renderItem = (item: IClonableRepositoryListItem) => {
     return (
-      <p>
-        {item.text}
-      </p>
+      <div className="clone-repository-list-item">
+        <Octicon className="icon" symbol={item.icon} />
+        <div className="name" title={name}>
+          {item.text}
+        </div>
+      </div>
     )
   }
 }

--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -92,7 +92,11 @@ export class CloneGithubRepository extends React.Component<
 
   private renderRepositoryList() {
     if (this.state.loading) {
-      return <Loading />
+      return (
+        <div className="clone-github-repo">
+          <Loading />
+        </div>
+      )
     }
 
     return (

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -34,8 +34,7 @@ interface ICloneRepositoryProps {
   /** The initial URL or `owner/name` shortcut to use. */
   readonly initialURL: string | null
 
-  /** The initial tab to open on load
-   */
+  /** The initial tab to open on load */
   readonly initialSelectedTab?: CloneRepositoryTab
 }
 
@@ -72,7 +71,7 @@ export class CloneRepository extends React.Component<
     super(props)
 
     this.state = {
-      url: '',
+      url: this.props.initialURL || '',
       path: getDefaultDir(),
       loading: false,
       error: null,
@@ -156,7 +155,8 @@ export class CloneRepository extends React.Component<
           : null}
 
         <CloneGenericRepository
-          initialURL={this.props.initialURL}
+          url={this.state.url}
+          path={this.state.path}
           onPathChanged={this.updatePath}
           onUrlChanged={this.updateUrl}
           onChooseDirectory={this.onChooseDirectory}
@@ -184,7 +184,8 @@ export class CloneRepository extends React.Component<
     if (index === CloneRepositoryTab.Generic) {
       return (
         <CloneGenericRepository
-          initialURL={this.props.initialURL}
+          path={this.state.path}
+          url={this.state.url}
           onPathChanged={this.updatePath}
           onUrlChanged={this.updateUrl}
           onChooseDirectory={this.onChooseDirectory}
@@ -271,6 +272,8 @@ export class CloneRepository extends React.Component<
       error.name = DestinationExistsErrorName
 
       this.setState({ error })
+    } else {
+      this.setState({ error: null })
     }
 
     this.updatePath(newPath)

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -201,7 +201,7 @@ export class CloneRepository extends React.Component<
           api={api}
           account={account}
           onPathChanged={this.updatePath}
-          onGitHubRepositorySelected={this.onGitHubRepositorySelected}
+          onGitHubRepositorySelected={this.updateUrl}
           onChooseDirectory={this.onChooseDirectory}
           onDismissed={this.props.onDismissed}
         />
@@ -236,20 +236,14 @@ export class CloneRepository extends React.Component<
       error.name = DestinationExistsErrorName
 
       this.setState({ error })
+    } else {
+      this.setState({ error: null })
     }
 
     return directory
   }
 
-  private updateUrl = async (input: string) => {
-    this.updateState(input)
-  }
-
-  private onGitHubRepositorySelected = async (url: string) => {
-    this.updateState(url)
-  }
-
-  private updateState = async (url: string) => {
+  private updateUrl = async (url: string) => {
     const parsed = parseRepositoryIdentifier(url)
     const lastParsedIdentifier = this.state.lastParsedIdentifier
 

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -19,6 +19,8 @@ import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloneGenericRepository } from './clone-generic-repository'
 import { CloneGithubRepository } from './clone-github-repository'
 
+import { enablePreviewFeatures } from '../../lib/feature-flag'
+
 /** The name for the error when the destination already exists. */
 const DestinationExistsErrorName = 'DestinationExistsError'
 
@@ -80,6 +82,14 @@ export class CloneRepository extends React.Component<
   }
 
   public render() {
+    if (enablePreviewFeatures()) {
+      return this.renderPreviewInterface()
+    } else {
+      return this.renderClassicInterface()
+    }
+  }
+
+  private renderPreviewInterface() {
     const error = this.state.error
     const disabled =
       this.state.url.length === 0 ||
@@ -110,6 +120,47 @@ export class CloneRepository extends React.Component<
           : null}
 
         {this.renderActiveTab()}
+
+        <DialogFooter>
+          <ButtonGroup>
+            <Button disabled={disabled} type="submit">
+              Clone
+            </Button>
+            <Button onClick={this.props.onDismissed}>Cancel</Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderClassicInterface() {
+    const error = this.state.error
+    const disabled =
+      this.state.url.length === 0 ||
+      this.state.path.length === 0 ||
+      this.state.loading ||
+      (!!error && error.name === DestinationExistsErrorName)
+
+    return (
+      <Dialog
+        className="clone-repository"
+        title="Clone a repository"
+        onSubmit={this.clone}
+        onDismissed={this.props.onDismissed}
+        loading={this.state.loading}
+      >
+        {error
+          ? <DialogError>
+              {error.message}
+            </DialogError>
+          : null}
+
+        <CloneGenericRepository
+          initialURL={this.props.initialURL}
+          onPathChanged={this.updatePath}
+          onUrlChanged={this.updateUrl}
+          onChooseDirectory={this.onChooseDirectory}
+        />
 
         <DialogFooter>
           <ButtonGroup>

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -197,6 +197,7 @@ export class CloneRepository extends React.Component<
 
       return (
         <CloneGithubRepository
+          path={this.state.path}
           api={api}
           account={account}
           onPathChanged={this.updatePath}
@@ -241,7 +242,14 @@ export class CloneRepository extends React.Component<
   }
 
   private updateUrl = async (input: string) => {
-    const url = input
+    this.updateState(input)
+  }
+
+  private onGitHubRepositorySelected = async (url: string) => {
+    this.updateState(url)
+  }
+
+  private updateState = async (url: string) => {
     const parsed = parseRepositoryIdentifier(url)
     const lastParsedIdentifier = this.state.lastParsedIdentifier
 
@@ -261,22 +269,19 @@ export class CloneRepository extends React.Component<
 
     const pathExist = await this.doesPathExist(newPath)
 
+    let error = null
+
+    if (pathExist) {
+      error = new Error('The destination already exists.')
+      error.name = DestinationExistsErrorName
+    }
+
     this.setState({
       url,
       path: newPath,
       lastParsedIdentifier: parsed,
+      error,
     })
-
-    if (pathExist) {
-      const error: Error = new Error('The destination already exists.')
-      error.name = DestinationExistsErrorName
-
-      this.setState({ error })
-    } else {
-      this.setState({ error: null })
-    }
-
-    this.updatePath(newPath)
   }
 
   private doesPathExist(path: string) {
@@ -303,10 +308,6 @@ export class CloneRepository extends React.Component<
         return resolve(false)
       })
     })
-  }
-
-  private onGitHubRepositorySelected = async (url: string) => {
-    this.setState({ url })
   }
 
   /**

--- a/app/src/ui/clone-repository/group-repositories.ts
+++ b/app/src/ui/clone-repository/group-repositories.ts
@@ -1,6 +1,7 @@
 import { IAPIRepository } from '../../lib/api'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
 import { caseInsensitiveCompare } from '../../lib/compare'
+import { OcticonSymbol } from '../octicons'
 
 export interface IClonableRepositoryListItem extends IFilterListItem {
   readonly id: string
@@ -8,7 +9,19 @@ export interface IClonableRepositoryListItem extends IFilterListItem {
   readonly isPrivate: boolean
   readonly org: string
   readonly name: string
+  readonly icon: OcticonSymbol
   readonly url: string
+}
+
+function getIcon(gitHubRepo: IAPIRepository): OcticonSymbol {
+  if (gitHubRepo.private) {
+    return OcticonSymbol.lock
+  }
+  if (gitHubRepo.fork) {
+    return OcticonSymbol.repoForked
+  }
+
+  return OcticonSymbol.repo
 }
 
 function convert(
@@ -17,12 +30,15 @@ function convert(
   const repos: ReadonlyArray<
     IClonableRepositoryListItem
   > = repositories.map(repo => {
+    const icon = getIcon(repo)
+
     return {
       id: repo.html_url,
       text: `${repo.owner.login}/${repo.name}`,
       url: repo.clone_url,
       org: repo.owner.login,
       name: repo.name,
+      icon,
       isPrivate: repo.private,
     }
   })

--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -9,4 +9,24 @@
 .clone-github-repo {
   height: 150px;
   width: 450px;
+
+  .clone-repository-list {
+    &-item {
+      padding: 0 var(--spacing);
+    }
+
+    &-item {
+      display: flex;
+      flex-direction: row;
+      min-width: 0;
+      flex-grow: 1;
+      align-items: center;
+
+      .icon {
+        margin-right: var(--spacing-half);
+        width: 16px; // Force a consistent width
+        flex-shrink: 0;
+      }
+    }
+  }
 }

--- a/docs/contributing/preview-features.md
+++ b/docs/contributing/preview-features.md
@@ -1,0 +1,14 @@
+# Preview Features
+
+If you're running GitHub Desktop you can enable **"preview features"**, which
+we consider something we want to eventually ship to everyone, but needs some
+sort of refinement before we can do that, and in the meantime we would like
+feedback from users on these features.
+
+To opt-in for testing preview features, set the
+`GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value and launch
+the Desktop app.
+
+## Preview Features
+
+Coming Soon™

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -1,0 +1,46 @@
+# Feature Flagging
+
+To ensure Desktop along without being blocked on design feedback, we need a way to be able to ship features that are stable but not necessarily ready for general usage. This document outlines what we should flag and how it works.
+
+## What Should Be Feature Flagged?
+
+Features that the team agrees are ready to work on can be considered **"preview features"**.
+
+For these features:
+
+ - the scope of the feature is relatively well-known
+ - a consensus exists that the team is happy to proceed, but
+ - some details need to be thought through
+
+We're currently focused on user interface changes - new views, significant changes to existing views, and so on. We can revisit this when we identify other cases where this sort of feature flagging needs to occur.
+
+## Why not just ship it?
+
+A few reasons:
+
+ - some solutions just need time to appear, and this lets us get working code out quicker.
+ - we want to get feedback easily - users can opt-in to these preview features.
+ - we want to be conservative with evolving the UI - most users aren't fans of frequent, unnecessary churn.
+ - if we don't like something we can pull it before people get too attached to it.
+
+## How to Feature Flag?
+
+At runtime your code should check [`enablePreviewFeatures()`](https://github.com/desktop/desktop/blob/2286edb0e1cf376ab81a1ffe02115abdde88527f/app/src/lib/feature-flag.ts#L6) and either display the new feature or the existing one.
+
+A simple example is the new clone experience in [#2436](https://github.com/desktop/desktop/pull/2436):
+
+```ts
+public render() {
+  if (enablePreviewFeatures()) {
+    return this.renderPreviewInterface()
+  } else {
+    return this.renderClassicInterface()
+  }
+}
+```
+
+This separation and naming scheme makes it easier to clean up the new or old feature once things are stabilized.
+
+## How to test
+
+To opt-in for testing preview features, set the `GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value and launch the Desktop app.

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -1,31 +1,38 @@
 # Feature Flagging
 
-To ensure Desktop along without being blocked on design feedback, we need a way to be able to ship features that are stable but not necessarily ready for general usage. This document outlines what we should flag and how it works.
+To ensure Desktop along without being blocked on design feedback, we need a way
+to be able to ship features that are stable but not necessarily ready for
+general usage. This document outlines what we should flag and how to flag
+these features.
 
 ## What Should Be Feature Flagged?
 
-Features that the team agrees are ready to work on can be considered **"preview features"**.
+A **preview feature** can be considered as:
 
-For these features:
-
- - the scope of the feature is relatively well-known
+ - something that has a well-defined scope
  - a consensus exists that the team is happy to proceed, but
- - some details need to be thought through
+ - some details need to be thought through or clarified
 
-We're currently focused on user interface changes - new views, significant changes to existing views, and so on. We can revisit this when we identify other cases where this sort of feature flagging needs to occur.
+We're currently focused on user interface changes - new views, significant
+changes to existing views, and so on. We can revisit this list when we
+identify other cases where this sort of feature flagging needs to occur.
 
 ## Why not just ship it?
 
 A few reasons:
 
- - some solutions just need time to appear, and this lets us get working code out quicker.
+ - some solutions just need time to appear, and this lets us get working code
+   out quicker.
  - we want to get feedback easily - users can opt-in to these preview features.
- - we want to be conservative with evolving the UI - most users aren't fans of frequent, unnecessary churn.
- - if we don't like something we can pull it before people get too attached to it.
+ - we want to be conservative with evolving the UI - most users aren't fans of
+   frequent, unnecessary churn.
+ - if we don't like something we can pull it before people get too attached to
+   it.
 
 ## How to Feature Flag?
 
-At runtime your code should check [`enablePreviewFeatures()`](https://github.com/desktop/desktop/blob/2286edb0e1cf376ab81a1ffe02115abdde88527f/app/src/lib/feature-flag.ts#L6) and either display the new feature or the existing one.
+At runtime your code should check [`enablePreviewFeatures()`](https://github.com/desktop/desktop/blob/2286edb0e1cf376ab81a1ffe02115abdde88527f/app/src/lib/feature-flag.ts#L6)
+and either display the new feature or the existing one.
 
 A simple example is the new clone experience in [#2436](https://github.com/desktop/desktop/pull/2436):
 
@@ -39,8 +46,11 @@ public render() {
 }
 ```
 
-This separation and naming scheme makes it easier to clean up the new or old feature once things are stabilized.
+This separation and naming scheme makes it easier to clean up the new or old
+feature once things are stabilized.
 
 ## How to test
 
-To opt-in for testing preview features, set the `GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value and launch the Desktop app.
+To opt-in for testing preview features, set the
+`GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value and launch
+the Desktop app.


### PR DESCRIPTION
There's been various sorts of discussions within the team about being able to roll out features without being blocked on design feedback. This PR is an experiment to let us switch between the current clone experience and the new one that's being implemented in #2436 at runtime.

This is a visual change and reusing the same functionality, but is an interesting case because it touches React components. I don't expect us to get to perfect solution in the scope of this PR, mostly because we're figuring out what we need. But it should be a good first start.

 - [x] it works
 - [x] bugfix: updating the generic repository input doesn't update in the repository path
 - [x] write some documentation about this feature
 - [x] it's not slow