### PR TITLE
Prevents list from wrapping to end of list

### DIFF
--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -349,7 +349,7 @@ export class List extends React.Component<IListProps, IListState> {
   ) {
     const newRow = this.nextSelectableRow(direction, this.props.selectedRow)
 
-    if (this.props.onSelectionChanged) {
+    if (this.props.onSelectionChanged && newRow !== this.props.selectedRow) {
       this.props.onSelectionChanged(newRow, { kind: 'keyboard', event })
     }
 

--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -322,7 +322,7 @@ export class List extends React.Component<IListProps, IListState> {
     if (direction === 'up') {
       newRow = row - 1
       if (newRow < 0) {
-        newRow = this.props.rowCount - 1
+        newRow = 0
       }
     } else {
       newRow = row + 1

--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -319,16 +319,15 @@ export class List extends React.Component<IListProps, IListState> {
    */
   public nextSelectableRow(direction: 'up' | 'down', row: number): number {
     let newRow = row
+
     if (direction === 'up') {
       newRow = row - 1
-      if (newRow < 0) {
-        newRow = 0
-      }
     } else {
       newRow = row + 1
-      if (newRow > this.props.rowCount - 1) {
-        newRow = 0
-      }
+    }
+
+    if (newRow < 0 || newRow >= this.props.rowCount) {
+      newRow = this.props.selectedRow
     }
 
     if (this.canSelectRow(newRow)) {


### PR DESCRIPTION
Partially fixes issue #2479. Since the history list can pull more items on scroll, we never really know what the end is, so I ignored the down key wrapping.