### PR TITLE
PR for local branch not checked out after clone

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -866,9 +866,12 @@ export class Dispatcher {
   ): Promise<void> {
     const { filepath, pr, branch } = action
 
-    // we need to refetch for a forked PR and check that out
     if (pr && branch) {
+      // we need to refetch for a forked PR and check that out
       await this.fetchRefspec(repository, `pull/${pr}/head:${branch}`)
+    }
+
+    if (branch) {
       await this.checkoutBranch(repository, branch)
     }
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -784,6 +784,12 @@ export class Dispatcher {
         const repository = await this.openRepository(url, branchToClone)
         if (repository) {
           this.handleCloneInDesktopOptions(repository, action)
+        } else {
+          log.warn(
+            `Open Repository from URL failed, did not find repository: ${url} - payload: ${JSON.stringify(
+              action
+            )}`
+          )
         }
         break
 


### PR DESCRIPTION
PRs from a local branch have this sort of format:

`x-github-client://openRepo/https://github.com/desktop/desktop?branch=bring-support-back`

PRs from a fork have a format like this:

`x-github-client://openRepo/https://github.com/desktop/desktop?branch=pr%2F2372&pr=2372`

What I see when cloning a PR from a local branch (like #2501) is that the clone is initiated, but once completed it doesn't checkout the branch. That seems to be because it was expecting a `pr` value as well - which is only set for PRs from forks.

This fixes that by making the `checkoutBranch` separate to the `fetchRefspec` step.