### PR TITLE
spawn considers start to be an executable, and stuff breaks

### DIFF
--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -16,5 +16,8 @@ const env = { ...process.env }
 // `ELECTRON_RUN_AS_NODE`. This seems to only happen on Windows.
 delete env['ELECTRON_RUN_AS_NODE']
 
-const command = __DARWIN__ ? 'open' : 'start'
-ChildProcess.spawn(command, [url], { env })
+if (__DARWIN__) {
+  ChildProcess.spawn('open', [url], { env })
+} else if (__WIN32__) {
+  ChildProcess.spawn('cmd', ['/c', 'start', url], { env })
+}


### PR DESCRIPTION
Fixes #2563 

For reference, in other places where we use `start` to launch our pre-configured shells we set `{ shell: true }`. I didn't do that here because [the docs for `spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) advise against using this for unsanitised user input:

> Note: If the `shell` option is enabled, **do not pass unsanitised user input to this function**. Any input containing shell metacharacters may be used to trigger arbitrary command execution.

So let's keep it vanilla and boring.