### PR TITLE
simplify file cleanup work in unit tests

### DIFF
--- a/app/test/fixture-helper.ts
+++ b/app/test/fixture-helper.ts
@@ -5,14 +5,18 @@ import * as FSE from 'fs-extra'
 
 const klawSync = require('klaw-sync')
 
-const temp = require('temp').track()
-
 import { Repository } from '../src/models/repository'
 import { GitProcess } from 'dugite'
 
 type KlawEntry = {
   path: string
 }
+
+import * as temp from 'temp'
+const _temp = temp.track()
+
+export const mkdirSync = _temp.mkdirSync
+export const openSync = _temp.openSync
 
 /**
  * Set up the named fixture repository to be used in a test.
@@ -21,7 +25,7 @@ type KlawEntry = {
  */
 export function setupFixtureRepository(repositoryName: string): string {
   const testRepoFixturePath = Path.join(__dirname, 'fixtures', repositoryName)
-  const testRepoPath = temp.mkdirSync('desktop-git-test-')
+  const testRepoPath = _temp.mkdirSync('desktop-git-test-')
   FSE.copySync(testRepoFixturePath, testRepoPath)
 
   FSE.renameSync(
@@ -51,9 +55,11 @@ export function setupFixtureRepository(repositoryName: string): string {
 
 /**
  * Initializes a new, empty, git repository at in a temporary location.
+ *
+ * @returns the new local repository
  */
 export async function setupEmptyRepository(): Promise<Repository> {
-  const repoPath = temp.mkdirSync('desktop-empty-repo-')
+  const repoPath = _temp.mkdirSync('desktop-empty-repo-')
   await GitProcess.exec(['init'], repoPath)
 
   return new Repository(repoPath, -1, null, false)
@@ -61,6 +67,8 @@ export async function setupEmptyRepository(): Promise<Repository> {
 
 /**
  * Setup a repository and create a merge conflict
+ *
+ * @returns the new local repository
  *
  * The current branch will be 'other-branch' and the merged branch will be
  * 'master' in your test harness.

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -32,7 +32,6 @@ import {
 } from '../../../src/models/diff'
 
 import * as fs from 'fs-extra'
-const temp = require('temp').track()
 
 async function getTextDiff(
   repo: Repository,
@@ -49,10 +48,6 @@ describe('git/commit', () => {
   beforeEach(async () => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('createCommit normal', () => {

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -6,18 +6,12 @@ import { Repository } from '../../../src/models/repository'
 import { getConfigValue } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../fixture-helper'
 
-const temp = require('temp').track()
-
 describe('git/config', () => {
   let repository: Repository | null = null
 
   beforeEach(() => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('config', () => {

--- a/app/test/unit/git/core-test.ts
+++ b/app/test/unit/git/core-test.ts
@@ -7,18 +7,12 @@ import { Repository } from '../../../src/models/repository'
 import { git } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../fixture-helper'
 
-const temp = require('temp').track()
-
 describe('git/core', () => {
   let repository: Repository | null = null
 
   beforeEach(() => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('error handling', () => {

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -8,18 +8,12 @@ import { setupFixtureRepository } from '../../fixture-helper'
 import { AppFileStatus } from '../../../src/models/status'
 import { GitProcess } from 'dugite'
 
-const temp = require('temp').track()
-
 describe('git/log', () => {
   let repository: Repository | null = null
 
   beforeEach(() => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('getCommits', () => {

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -14,8 +14,6 @@ import { Branch, BranchType } from '../../../src/models/branch'
 import { Commit } from '../../../src/models/commit'
 import { CommitIdentity } from '../../../src/models/commit-identity'
 
-const temp = require('temp').track()
-
 async function createAndCheckout(
   repository: Repository,
   name: string
@@ -30,10 +28,6 @@ describe('git/reflog', () => {
   beforeEach(() => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('getRecentBranches', () => {

--- a/app/test/unit/git/remote-test.ts
+++ b/app/test/unit/git/remote-test.ts
@@ -14,13 +14,7 @@ import {
   setupEmptyRepository,
 } from '../../fixture-helper'
 
-const temp = require('temp').track()
-
 describe('git/remote', () => {
-  after(() => {
-    temp.cleanupSync()
-  })
-
   describe('getRemotes', () => {
     it('should return both remotes', async () => {
       const testRepoPath = setupFixtureRepository('repo-with-multiple-remotes')

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -11,9 +11,7 @@ import {
   getTopLevelWorkingDirectory,
 } from '../../../src/lib/git/rev-parse'
 import { git } from '../../../src/lib/git/core'
-import { setupFixtureRepository } from '../../fixture-helper'
-
-const temp = require('temp').track()
+import { setupFixtureRepository, mkdirSync } from '../../fixture-helper'
 
 describe('git/rev-parse', () => {
   let repository: Repository | null = null
@@ -21,10 +19,6 @@ describe('git/rev-parse', () => {
   beforeEach(() => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('isGitRepository', () => {
@@ -66,9 +60,7 @@ describe('git/rev-parse', () => {
     })
 
     it('should return correct path for submodules', async () => {
-      const fixturePath = temp.mkdirSync(
-        'get-top-level-working-directory-test-'
-      )
+      const fixturePath = mkdirSync('get-top-level-working-directory-test-')
 
       const firstRepoPath = path.join(fixturePath, 'repo1')
       const secondRepoPath = path.join(fixturePath, 'repo2')

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -13,7 +13,6 @@ import { AppFileStatus } from '../../../src/models/status'
 import { GitProcess } from 'dugite'
 
 import * as fs from 'fs-extra'
-const temp = require('temp').track()
 
 describe('git/status', () => {
   let repository: Repository | null = null
@@ -21,10 +20,6 @@ describe('git/status', () => {
   beforeEach(() => {
     const testRepoPath = setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  after(() => {
-    temp.cleanupSync()
   })
 
   describe('getStatus', () => {

--- a/app/test/unit/validated-repository-path-test.ts
+++ b/app/test/unit/validated-repository-path-test.ts
@@ -3,9 +3,7 @@
 import * as chai from 'chai'
 const expect = chai.expect
 
-const temp = require('temp').track()
-
-import { setupFixtureRepository } from '../fixture-helper'
+import { setupFixtureRepository, openSync } from '../fixture-helper'
 import { validatedRepositoryPath } from '../../src/lib/dispatcher/validated-repository-path'
 
 describe('validatedRepositoryPath', () => {
@@ -16,7 +14,7 @@ describe('validatedRepositoryPath', () => {
   })
 
   it('returns null if the path is not a repository', async () => {
-    const testRepoPath = temp.openSync('repo-test').path
+    const testRepoPath = openSync('repo-test').path
     const result = await validatedRepositoryPath(testRepoPath)
     expect(result).to.equal(null)
   })

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@types/react-dom": "15.5.1",
     "@types/react-transition-group": "1.1.1",
     "@types/react-virtualized": "9.7.2",
+    "@types/temp": "^0.8.29",
     "@types/ua-parser-js": "^0.7.30",
     "@types/uuid": "^3.4.0",
     "@types/winston": "^2.2.0",


### PR DESCRIPTION
As part of #2567 I stumbled upon some misuse of the file tracking that comes with the `temp` module.

Creating new instances of `temp.track()` seems unnecessary (see [docs](https://www.npmjs.com/package/temp#want-cleanup-make-sure-you-ask-for-it)) when the module is already configured to cleanup files when the process exits, so this PR removes up any additional usage and routes everything through `fixture-helper.ts`.

This has also been tested on top of #2567, which I'll revisit after this merges.