### PR TITLE
update prettier, track package versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
-  - npm ls
+  - npm ls --prod
   - npm ls --dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
+  - npm ls
+  - npm ls --dev
 
 script:
   - npm run check-prettiness

--- a/app/src/crash/crash-app.tsx
+++ b/app/src/crash/crash-app.tsx
@@ -122,9 +122,7 @@ export class CrashApp extends React.Component<ICrashAppProps, ICrashAppState> {
     return (
       <header>
         <Octicon symbol={OcticonSymbol.stop} className="error-icon" />
-        <h1>
-          {message}
-        </h1>
+        <h1>{message}</h1>
       </header>
     )
   }
@@ -158,19 +156,11 @@ export class CrashApp extends React.Component<ICrashAppProps, ICrashAppState> {
       return
     }
 
-    return (
-      <pre className="error">
-        {prepareErrorMessage(error)}
-      </pre>
-    )
+    return <pre className="error">{prepareErrorMessage(error)}</pre>
   }
 
   private renderFooter() {
-    return (
-      <div className="footer">
-        {this.renderQuitButton()}
-      </div>
-    )
+    return <div className="footer">{this.renderQuitButton()}</div>
   }
 
   private renderQuitButton() {

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -250,9 +250,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
           <Row className="logo">
             <Octicon symbol={OcticonSymbol.markGithub} />
           </Row>
-          <h2>
-            {name}
-          </h2>
+          <h2>{name}</h2>
           <p className="no-padding">
             <LinkButton
               title="Click to copy"

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -65,7 +65,9 @@ export class Acknowledgements extends React.Component<
 
   private renderLicenses(licenses: Licenses) {
     const elements = []
-    for (const [index, key] of Object.keys(licenses).sort().entries()) {
+    for (const [index, key] of Object.keys(licenses)
+      .sort()
+      .entries()) {
       // The first entry is Desktop itself. We don't need to thank us.
       if (index === 0) {
         continue
@@ -77,11 +79,7 @@ export class Acknowledgements extends React.Component<
 
       if (repository) {
         const uri = normalizedGitHubURL(repository)
-        nameElement = (
-          <LinkButton uri={uri}>
-            {key}
-          </LinkButton>
-        )
+        nameElement = <LinkButton uri={uri}>{key}</LinkButton>
       } else {
         nameElement = key
       }
@@ -96,11 +94,7 @@ export class Acknowledgements extends React.Component<
         licenseText = 'Unknown license'
       }
 
-      const nameHeader = (
-        <h2 key={`${key}-header`}>
-          {nameElement}
-        </h2>
-      )
+      const nameHeader = <h2 key={`${key}-header`}>{nameElement}</h2>
       const licenseParagraph = (
         <p key={`${key}-text`} className="license-text">
           {licenseText}
@@ -120,11 +114,7 @@ export class Acknowledgements extends React.Component<
     if (licenses) {
       const key = `desktop@${this.props.applicationVersion}`
       const entry = licenses[key]
-      desktopLicense = (
-        <p className="license-text">
-          {entry.sourceText}
-        </p>
-      )
+      desktopLicense = <p className="license-text">{entry.sourceText}</p>
     }
 
     return (

--- a/app/src/ui/add-repository/clone-repository.tsx
+++ b/app/src/ui/add-repository/clone-repository.tsx
@@ -99,11 +99,7 @@ export class CloneRepository extends React.Component<
         onDismissed={this.props.onDismissed}
         loading={this.state.loading}
       >
-        {error
-          ? <DialogError>
-              {error.message}
-            </DialogError>
-          : null}
+        {error ? <DialogError>{error.message}</DialogError> : null}
 
         <DialogContent>
           <p>

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -306,11 +306,11 @@ export class CreateRepository extends React.Component<
           value={this.state.gitIgnore}
           onChange={this.onGitIgnoreChange}
         >
-          {options.map(n =>
+          {options.map(n => (
             <option key={n} value={n}>
               {n}
             </option>
-          )}
+          ))}
         </Select>
       </Row>
     )
@@ -331,17 +331,17 @@ export class CreateRepository extends React.Component<
           value={this.state.license}
           onChange={this.onLicenseChange}
         >
-          {featuredLicenses.map(l =>
+          {featuredLicenses.map(l => (
             <option key={l.name} value={l.name}>
               {l.name}
             </option>
-          )}
+          ))}
           <option disabled={true}>────────────────────</option>
-          {nonFeaturedLicenses.map(l =>
+          {nonFeaturedLicenses.map(l => (
             <option key={l.name} value={l.name}>
               {l.name}
             </option>
-          )}
+          ))}
         </Select>
       </Row>
     )
@@ -439,9 +439,11 @@ export class CreateRepository extends React.Component<
             <Checkbox
               label="Initialize this repository with a README"
               value={
-                this.state.createWithReadme
-                  ? CheckboxValue.On
-                  : CheckboxValue.Off
+                this.state.createWithReadme ? (
+                  CheckboxValue.On
+                ) : (
+                  CheckboxValue.Off
+                )
               }
               onChange={this.onCreateWithReadmeChange}
             />

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -128,11 +128,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
 
     const className = monospace ? 'monospace' : undefined
 
-    return (
-      <p className={className}>
-        {error.message}
-      </p>
-    )
+    return <p className={className}>{error.message}</p>
   }
 
   private renderDialog() {
@@ -152,12 +148,8 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
         onDismissed={this.onDismissed}
         disabled={this.state.disabled}
       >
-        <DialogContent>
-          {this.renderErrorMessage(error)}
-        </DialogContent>
-        <DialogFooter>
-          {this.renderFooter(error)}
-        </DialogFooter>
+        <DialogContent>{this.renderErrorMessage(error)}</DialogContent>
+        <DialogFooter>{this.renderFooter(error)}</DialogFooter>
       </Dialog>
     )
   }

--- a/app/src/ui/app-menu/menu-list-item.tsx
+++ b/app/src/ui/app-menu/menu-list-item.tsx
@@ -104,21 +104,21 @@ export class MenuListItem extends React.Component<IMenuListItemProps, {}> {
     }
 
     const arrow =
-      item.type === 'submenuItem' && this.props.renderSubMenuArrow !== false
-        ? <Octicon
-            className="submenu-arrow"
-            symbol={OcticonSymbol.triangleRight}
-          />
-        : null
+      item.type === 'submenuItem' && this.props.renderSubMenuArrow !== false ? (
+        <Octicon
+          className="submenu-arrow"
+          symbol={OcticonSymbol.triangleRight}
+        />
+      ) : null
 
     const accelerator =
       item.type !== 'submenuItem' &&
       item.accelerator &&
-      this.props.renderAcceleratorText !== false
-        ? <div className="accelerator">
-            {friendlyAcceleratorText(item.accelerator)}
-          </div>
-        : null
+      this.props.renderAcceleratorText !== false ? (
+        <div className="accelerator">
+          {friendlyAcceleratorText(item.accelerator)}
+        </div>
+      ) : null
 
     const className = classNames(
       'menu-item',

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1513,9 +1513,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     return (
       <div id="desktop-app-chrome" className={className}>
         {this.renderTitlebar()}
-        {this.state.showWelcomeFlow
-          ? this.renderWelcomeFlow()
-          : this.renderApp()}
+        {this.state.showWelcomeFlow ? (
+          this.renderWelcomeFlow()
+        ) : (
+          this.renderApp()
+        )}
         {this.renderZoomInfo()}
         {this.renderFullScreenInfo()}
       </div>

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -95,19 +95,13 @@ export class EmojiAutocompletionProvider
     const emoji = hit.emoji
 
     if (!hit.matchLength) {
-      return (
-        <div className="title">
-          {emoji}
-        </div>
-      )
+      return <div className="title">{emoji}</div>
     }
 
     return (
       <div className="title">
         {emoji.substr(0, hit.matchStart)}
-        <mark>
-          {emoji.substr(hit.matchStart, hit.matchLength)}
-        </mark>
+        <mark>{emoji.substr(hit.matchStart, hit.matchLength)}</mark>
         {emoji.substr(hit.matchStart + hit.matchLength)}
       </div>
     )

--- a/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
@@ -61,12 +61,8 @@ export class IssuesAutocompletionProvider
   public renderItem(item: IIssueHit): JSX.Element {
     return (
       <div className="issue" key={item.number}>
-        <span className="number">
-          #{item.number}
-        </span>
-        <span className="title">
-          {item.title}
-        </span>
+        <span className="number">#{item.number}</span>
+        <span className="title">{item.title}</span>
       </div>
     )
   }

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -46,12 +46,8 @@ export class UserAutocompletionProvider
   public renderItem(item: IUserHit): JSX.Element {
     return (
       <div className="user" key={item.username}>
-        <span className="username">
-          {item.username}
-        </span>
-        <span className="name">
-          {item.name}
-        </span>
+        <span className="username">{item.username}</span>
+        <span className="name">{item.name}</span>
       </div>
     )
   }

--- a/app/src/ui/branches/push-branch-commits.tsx
+++ b/app/src/ui/branches/push-branch-commits.tsx
@@ -89,9 +89,7 @@ export class PushBranchCommits extends React.Component<
       >
         {this.renderDialogContent()}
 
-        <DialogFooter>
-          {this.renderButtonGroup()}
-        </DialogFooter>
+        <DialogFooter>{this.renderButtonGroup()}</DialogFooter>
       </Dialog>
     )
   }

--- a/app/src/ui/cli-installed/cli-installed.tsx
+++ b/app/src/ui/cli-installed/cli-installed.tsx
@@ -15,9 +15,11 @@ export class CLIInstalled extends React.Component<ICLIInstalledProps, {}> {
     return (
       <Dialog
         title={
-          __DARWIN__
-            ? 'Command Line Tool Installed'
-            : 'Command line tool installed'
+          __DARWIN__ ? (
+            'Command Line Tool Installed'
+          ) : (
+            'Command line tool installed'
+          )
         }
         onDismissed={this.props.onDismissed}
         onSubmit={this.props.onDismissed}

--- a/app/src/ui/cloning-repository.tsx
+++ b/app/src/ui/cloning-repository.tsx
@@ -24,14 +24,10 @@ export class CloningRepositoryView extends React.Component<
       <UiView id="cloning-repository-view">
         <div className="title-container">
           <Octicon symbol={OcticonSymbol.desktopDownload} />
-          <div className="title">
-            Cloning {this.props.repository.name}
-          </div>
+          <div className="title">Cloning {this.props.repository.name}</div>
         </div>
         <progress value={progressValue} />
-        <div className="details">
-          {this.props.progress.description}
-        </div>
+        <div className="details">{this.props.progress.description}</div>
       </UiView>
     )
   }

--- a/app/src/ui/create-branch/index.tsx
+++ b/app/src/ui/create-branch/index.tsx
@@ -235,11 +235,7 @@ export class CreateBranch extends React.Component<
         loading={this.state.isCreatingBranch}
         disabled={this.state.isCreatingBranch}
       >
-        {error
-          ? <DialogError>
-              {error.message}
-            </DialogError>
-          : null}
+        {error ? <DialogError>{error.message}</DialogError> : null}
 
         <DialogContent>
           <Row>

--- a/app/src/ui/delete-branch/index.tsx
+++ b/app/src/ui/delete-branch/index.tsx
@@ -72,9 +72,11 @@ export class DeleteBranch extends React.Component<
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={
-              this.state.includeRemoteBranch
-                ? CheckboxValue.On
-                : CheckboxValue.Off
+              this.state.includeRemoteBranch ? (
+                CheckboxValue.On
+              ) : (
+                CheckboxValue.Off
+              )
             }
             onChange={this.onIncludeRemoteChanged}
           />

--- a/app/src/ui/dialog/error.tsx
+++ b/app/src/ui/dialog/error.tsx
@@ -19,9 +19,7 @@ export class DialogError extends React.Component<IDialogErrorProps, {}> {
     return (
       <div className="dialog-error">
         <Octicon symbol={OcticonSymbol.stop} />
-        <div>
-          {this.props.children}
-        </div>
+        <div>{this.props.children}</div>
       </div>
     )
   }

--- a/app/src/ui/dialog/footer.tsx
+++ b/app/src/ui/dialog/footer.tsx
@@ -9,10 +9,6 @@ import * as React from 'react'
  */
 export class DialogFooter extends React.Component<{}, {}> {
   public render() {
-    return (
-      <div className="dialog-footer">
-        {this.props.children}
-      </div>
-    )
+    return <div className="dialog-footer">{this.props.children}</div>
   }
 }

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -69,15 +69,13 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
   }
 
   public render() {
-    const spinner = this.props.loading
-      ? <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
-      : null
+    const spinner = this.props.loading ? (
+      <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
+    ) : null
 
     return (
       <header className="dialog-header">
-        <h1 id={this.props.titleId}>
-          {this.props.title}
-        </h1>
+        <h1 id={this.props.titleId}>{this.props.title}</h1>
         {spinner}
         {this.renderCloseButton()}
       </header>

--- a/app/src/ui/discard-changes/index.tsx
+++ b/app/src/ui/discard-changes/index.tsx
@@ -84,13 +84,13 @@ export class DiscardChanges extends React.Component<
         <div>
           <p>Are you sure you want to discard all changes to:</p>
           <ul>
-            {this.props.files.map(p =>
+            {this.props.files.map(p => (
               <li key={p.id}>
                 <Monospaced>
                   <PathText path={p.path} />
                 </Monospaced>
               </li>
-            )}
+            ))}
           </ul>
         </div>
       )

--- a/app/src/ui/editor/editor-error.tsx
+++ b/app/src/ui/editor/editor-error.tsx
@@ -85,13 +85,9 @@ export class EditorError extends React.Component<IEditorErrorProps, {}> {
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>
-          <p>
-            {this.props.message}
-          </p>
+          <p>{this.props.message}</p>
         </DialogContent>
-        <DialogFooter>
-          {buttonGroup}
-        </DialogFooter>
+        <DialogFooter>{buttonGroup}</DialogFooter>
       </Dialog>
     )
   }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -229,9 +229,7 @@ export class CommitSummary extends React.Component<
               <span aria-hidden="true">
                 <Octicon symbol={OcticonSymbol.gitCommit} />
               </span>
-              <span>
-                {shortSHA}
-              </span>
+              <span>{shortSHA}</span>
             </li>
 
             <li className="commit-summary-meta-item" title={filesDescription}>

--- a/app/src/ui/lib/access-text.tsx
+++ b/app/src/ui/lib/access-text.tsx
@@ -41,11 +41,7 @@ export class AccessText extends React.Component<IAccessTextProps, {}> {
     const m = this.props.text.match(/^(.*?)?(?:&([^&]))(.*)?$/)
 
     if (!m) {
-      return (
-        <span>
-          {this.props.text}
-        </span>
-      )
+      return <span>{this.props.text}</span>
     }
 
     const elements = new Array<JSX.Element>()
@@ -82,10 +78,6 @@ export class AccessText extends React.Component<IAccessTextProps, {}> {
 
     const plainText = `${preText}${accessKeyText}${postText}`
 
-    return (
-      <span aria-label={plainText}>
-        {elements}
-      </span>
-    )
+    return <span aria-label={plainText}>{elements}</span>
   }
 }

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -108,22 +108,22 @@ export class AuthenticationForm extends React.Component<
     )
     return (
       <div className="actions">
-        {this.props.supportsBasicAuth
-          ? <Button type="submit" disabled={signInDisabled}>
-              {this.props.loading ? <Loading /> : null} Sign in
-            </Button>
-          : null}
+        {this.props.supportsBasicAuth ? (
+          <Button type="submit" disabled={signInDisabled}>
+            {this.props.loading ? <Loading /> : null} Sign in
+          </Button>
+        ) : null}
 
         {this.props.additionalButtons}
 
-        {this.props.supportsBasicAuth
-          ? <LinkButton
-              className="forgot-password-link"
-              uri={this.props.forgotPasswordUrl}
-            >
-              Forgot password
-            </LinkButton>
-          : null}
+        {this.props.supportsBasicAuth ? (
+          <LinkButton
+            className="forgot-password-link"
+            uri={this.props.forgotPasswordUrl}
+          >
+            Forgot password
+          </LinkButton>
+        ) : null}
       </div>
     )
   }
@@ -149,12 +149,12 @@ export class AuthenticationForm extends React.Component<
     return (
       <div>
         {basicAuth ? <hr className="short-rule" /> : null}
-        {basicAuth
-          ? null
-          : <p>
-              Your GitHub Enterprise instance requires you to sign in with your
-              browser.
-            </p>}
+        {basicAuth ? null : (
+          <p>
+            Your GitHub Enterprise instance requires you to sign in with your
+            browser.
+          </p>
+        )}
 
         <div className="sign-in-footer">
           {basicAuth ? browserSignInLink : browserSignInButton}
@@ -170,11 +170,7 @@ export class AuthenticationForm extends React.Component<
       return null
     }
 
-    return (
-      <Errors>
-        {error.message}
-      </Errors>
-    )
+    return <Errors>{error.message}</Errors>
   }
 
   private onUsernameChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/app/src/ui/lib/button-group.tsx
+++ b/app/src/ui/lib/button-group.tsx
@@ -55,10 +55,6 @@ export class ButtonGroup extends React.Component<IButtonGroupProps, {}> {
       }
     }
 
-    return (
-      <div className="button-group">
-        {buttons}
-      </div>
-    )
+    return <div className="button-group">{buttons}</div>
   }
 }

--- a/app/src/ui/lib/checkbox.tsx
+++ b/app/src/ui/lib/checkbox.tsx
@@ -81,11 +81,7 @@ export class Checkbox extends React.Component<ICheckboxProps, ICheckboxState> {
     const label = this.props.label
     const inputId = this.state.inputId
 
-    return !!label
-      ? <label htmlFor={inputId}>
-          {label}
-        </label>
-      : null
+    return !!label ? <label htmlFor={inputId}>{label}</label> : null
   }
 
   public render() {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -122,9 +122,7 @@ export class ConfigureGitUser extends React.Component<
           />
 
           <Row>
-            <Button type="submit">
-              {this.props.saveLabel || 'Save'}
-            </Button>
+            <Button type="submit">{this.props.saveLabel || 'Save'}</Button>
             {this.props.children}
           </Row>
         </Form>

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -61,11 +61,7 @@ export class EnterpriseServerEntry extends React.Component<
           placeholder="https://github.example.com"
         />
 
-        {this.props.error
-          ? <Errors>
-              {this.props.error.message}
-            </Errors>
-          : null}
+        {this.props.error ? <Errors>{this.props.error.message}</Errors> : null}
 
         <div className="actions">
           <Button type="submit" disabled={disableSubmission}>

--- a/app/src/ui/lib/errors.tsx
+++ b/app/src/ui/lib/errors.tsx
@@ -14,10 +14,6 @@ interface IErrorsProps {
 export class Errors extends React.Component<IErrorsProps, {}> {
   public render() {
     const className = classNames('errors-component', this.props.className)
-    return (
-      <div className={className}>
-        {this.props.children}
-      </div>
-    )
+    return <div className={className}>{this.props.children}</div>
   }
 }

--- a/app/src/ui/lib/monospaced.tsx
+++ b/app/src/ui/lib/monospaced.tsx
@@ -3,10 +3,6 @@ import * as React from 'react'
 /** A component for monospaced text. */
 export class Monospaced extends React.Component<{}, {}> {
   public render() {
-    return (
-      <span className="monospaced">
-        {this.props.children}
-      </span>
-    )
+    return <span className="monospaced">{this.props.children}</span>
   }
 }

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -274,11 +274,9 @@ export class PathText extends React.PureComponent<
 
   public render() {
     const directoryElement =
-      this.state.directoryText && this.state.directoryText.length
-        ? <span className="dirname">
-            {this.state.directoryText}
-          </span>
-        : null
+      this.state.directoryText && this.state.directoryText.length ? (
+        <span className="dirname">{this.state.directoryText}</span>
+      ) : null
 
     const truncated = this.state.length < this.state.normalizedPath.length
     const title = truncated ? this.state.normalizedPath : undefined
@@ -291,9 +289,7 @@ export class PathText extends React.PureComponent<
       >
         <span ref={this.onPathInnerElementRef}>
           {directoryElement}
-          <span className="filename">
-            {this.state.fileText}
-          </span>
+          <span className="filename">{this.state.fileText}</span>
         </span>
       </div>
     )

--- a/app/src/ui/lib/ref.tsx
+++ b/app/src/ui/lib/ref.tsx
@@ -11,10 +11,6 @@ import * as React from 'react'
  */
 export class Ref extends React.Component<{}, {}> {
   public render() {
-    return (
-      <em className="ref-component">
-        {this.props.children}
-      </em>
-    )
+    return <em className="ref-component">{this.props.children}</em>
   }
 }

--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -60,18 +60,10 @@ export class RichText extends React.Component<IRichTextProps, {}> {
               <LinkButton key={index} uri={token.url} children={token.text} />
             )
           } else {
-            return (
-              <span key={index}>
-                {token.text}
-              </span>
-            )
+            return <span key={index}>{token.text}</span>
           }
         case TokenType.Text:
-          return (
-            <span key={index}>
-              {token.text}
-            </span>
-          )
+          return <span key={index}>{token.text}</span>
         default:
           return assertNever(token, 'Unknown token type: ${r.kind}')
       }

--- a/app/src/ui/lib/row.tsx
+++ b/app/src/ui/lib/row.tsx
@@ -14,10 +14,6 @@ interface IRowProps {
 export class Row extends React.Component<IRowProps, {}> {
   public render() {
     const className = classNames('row-component', this.props.className)
-    return (
-      <div className={className}>
-        {this.props.children}
-      </div>
-    )
+    return <div className={className}>{this.props.children}</div>
   }
 }

--- a/app/src/ui/lib/select.tsx
+++ b/app/src/ui/lib/select.tsx
@@ -47,11 +47,7 @@ export class Select extends React.Component<ISelectProps, ISelectState> {
     const label = this.props.label
     const inputId = this.state.inputId
 
-    return !!label
-      ? <label htmlFor={inputId}>
-          {label}
-        </label>
-      : null
+    return !!label ? <label htmlFor={inputId}>{label}</label> : null
   }
 
   public render() {

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -186,9 +186,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
     return (
       <div className="label-container">
-        <label htmlFor={this.state.inputId}>
-          {this.props.label}
-        </label>
+        <label htmlFor={this.state.inputId}>{this.props.label}</label>
         {this.renderLabelLink()}
       </div>
     )

--- a/app/src/ui/lib/two-factor-authentication.tsx
+++ b/app/src/ui/lib/two-factor-authentication.tsx
@@ -66,17 +66,13 @@ export class TwoFactorAuthentication extends React.Component<
     // ensure user has entered non-whitespace characters
     const codeProvided = /\S+/.test(this.state.otp)
     const signInDisabled = !codeProvided || this.props.loading
-    const errors = this.props.error
-      ? <Errors>
-          {this.props.error.message}
-        </Errors>
-      : null
+    const errors = this.props.error ? (
+      <Errors>{this.props.error.message}</Errors>
+    ) : null
 
     return (
       <div>
-        <p className="welcome-text">
-          {getWelcomeMessage(this.props.type)}
-        </p>
+        <p className="welcome-text">{getWelcomeMessage(this.props.type)}</p>
 
         <Form onSubmit={this.signIn}>
           <TextBox

--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -43,11 +43,11 @@ export class SegmentedItem extends React.Component<ISegmentedItemProps, {}> {
   }
 
   public render() {
-    const description = this.props.description
-      ? <p>
-          {this.props.description}
-        </p>
-      : undefined
+    const description = this.props.description ? (
+      <p>{this.props.description}</p>
+    ) : (
+      undefined
+    )
 
     const isSelected = this.props.isSelected
     const className = isSelected ? 'selected' : undefined
@@ -60,9 +60,7 @@ export class SegmentedItem extends React.Component<ISegmentedItemProps, {}> {
         id={this.props.id}
         aria-checked={isSelected ? 'true' : 'false'}
       >
-        <div className="title">
-          {this.props.title}
-        </div>
+        <div className="title">{this.props.title}</div>
         {description}
       </li>
     )

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -167,11 +167,11 @@ export class VerticalSegmentedControl extends React.Component<
     }
 
     const selectedIndex = this.props.selectedIndex
-    const label = this.props.label
-      ? <legend onClick={this.onLegendClick}>
-          {this.props.label}
-        </legend>
-      : undefined
+    const label = this.props.label ? (
+      <legend onClick={this.onLegendClick}>{this.props.label}</legend>
+    ) : (
+      undefined
+    )
 
     const activeDescendant = this.getListItemId(selectedIndex)
 

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -115,11 +115,13 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
 
     const countPlural = commitCount === 1 ? 'commit' : 'commits'
     const countText =
-      commitCount === undefined
-        ? 'commits'
-        : <strong>
-            {commitCount} {countPlural}
-          </strong>
+      commitCount === undefined ? (
+        'commits'
+      ) : (
+        <strong>
+          {commitCount} {countPlural}
+        </strong>
+      )
 
     return (
       <p className="merge-info">

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -42,18 +42,14 @@ export class MissingRepository extends React.Component<
     return (
       <UiView id="missing-repository-view">
         <div className="title-container">
-          <div className="title">
-            Can't find "{this.props.repository.name}"
-          </div>
+          <div className="title">Can't find "{this.props.repository.name}"</div>
           <div className="details">
             It was last seen at{' '}
             <span className="path">{this.props.repository.path}</span>
           </div>
         </div>
 
-        <Row>
-          {buttons}
-        </Row>
+        <Row>{buttons}</Row>
       </UiView>
     )
   }

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -59,11 +59,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
       return null
     }
 
-    return (
-      <title>
-        {title}
-      </title>
-    )
+    return <title>{title}</title>
   }
 
   public render() {
@@ -78,9 +74,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
         version="1.1"
         viewBox={viewBox}
       >
-        <path d={symbol.d}>
-          {this.renderTitle()}
-        </path>
+        <path d={symbol.d}>{this.renderTitle()}</path>
       </svg>
     )
   }

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -28,14 +28,18 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
     return (
       <DialogContent className="accounts-tab">
         <h2>GitHub.com</h2>
-        {this.props.dotComAccount
-          ? this.renderAccount(this.props.dotComAccount)
-          : this.renderSignIn(SignInType.DotCom)}
+        {this.props.dotComAccount ? (
+          this.renderAccount(this.props.dotComAccount)
+        ) : (
+          this.renderSignIn(SignInType.DotCom)
+        )}
 
         <h2>Enterprise</h2>
-        {this.props.enterpriseAccount
-          ? this.renderAccount(this.props.enterpriseAccount)
-          : this.renderSignIn(SignInType.Enterprise)}
+        {this.props.enterpriseAccount ? (
+          this.renderAccount(this.props.enterpriseAccount)
+        ) : (
+          this.renderSignIn(SignInType.Enterprise)
+        )}
       </DialogContent>
     )
   }
@@ -54,12 +58,8 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
       <Row className="account-info">
         <Avatar user={avatarUser} />
         <div className="user-info">
-          <div className="name">
-            {account.name}
-          </div>
-          <div className="login">
-            @{account.login}
-          </div>
+          <div className="name">{account.name}</div>
+          <div className="login">@{account.login}</div>
         </div>
         <Button onClick={this.logout(account)}>
           {__DARWIN__ ? 'Sign Out' : 'Sign out'}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -139,9 +139,7 @@ export class Advanced extends React.Component<
       // which we display when the select list is empty
       return (
         <div className="select-component no-options-found">
-          <label>
-            {label}
-          </label>
+          <label>{label}</label>
           <span>
             No editors found.{' '}
             <LinkButton uri="https://atom.io/">Install Atom?</LinkButton>
@@ -156,11 +154,11 @@ export class Advanced extends React.Component<
         value={this.state.selectedExternalEditor}
         onChange={this.onSelectedEditorChanged}
       >
-        {options.map(n =>
+        {options.map(n => (
           <option key={n} value={n}>
             {n}
           </option>
-        )}
+        ))}
       </Select>
     )
   }
@@ -174,11 +172,11 @@ export class Advanced extends React.Component<
         value={this.state.selectedShell}
         onChange={this.onSelectedShellChanged}
       >
-        {options.map(n =>
+        {options.map(n => (
           <option key={n} value={n}>
             {n}
           </option>
-        )}
+        ))}
       </Select>
     )
   }
@@ -186,12 +184,8 @@ export class Advanced extends React.Component<
   public render() {
     return (
       <DialogContent>
-        <Row>
-          {this.renderExternalEditor()}
-        </Row>
-        <Row>
-          {this.renderSelectedShell()}
-        </Row>
+        <Row>{this.renderExternalEditor()}</Row>
+        <Row>{this.renderSelectedShell()}</Row>
         <Row>
           <Checkbox
             label={this.reportDesktopUsageLabel()}
@@ -205,9 +199,11 @@ export class Advanced extends React.Component<
           <Checkbox
             label="Show confirmation dialog before removing repositories"
             value={
-              this.state.confirmRepoRemoval
-                ? CheckboxValue.On
-                : CheckboxValue.Off
+              this.state.confirmRepoRemoval ? (
+                CheckboxValue.On
+              ) : (
+                CheckboxValue.Off
+              )
             }
             onChange={this.onConfirmRepoRemovalChanged}
           />

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -91,11 +91,9 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
           <span>Enterprise</span>
         </TabBar>
 
-        {this.state.error
-          ? <DialogError>
-              {this.state.error.message}
-            </DialogError>
-          : null}
+        {this.state.error ? (
+          <DialogError>{this.state.error.message}</DialogError>
+        ) : null}
 
         {this.renderContent()}
         {this.renderFooter()}
@@ -115,11 +113,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
         />
       )
     } else {
-      return (
-        <DialogContent>
-          {this.renderSignInTab(tab)}
-        </DialogContent>
-      )
+      return <DialogContent>{this.renderSignInTab(tab)}</DialogContent>
     }
   }
 

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -121,9 +121,7 @@ export class RelativeTime extends React.Component<
 
   public render() {
     return (
-      <span title={this.state.absoluteText}>
-        {this.state.relativeText}
-      </span>
+      <span title={this.state.absoluteText}>{this.state.relativeText}</span>
     )
   }
 }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -57,14 +57,8 @@ export class RepositoryListItem extends React.Component<
         <Octicon symbol={iconForRepository(repository)} />
 
         <div className="name">
-          {prefix
-            ? <span className="prefix">
-                {prefix}
-              </span>
-            : null}
-          <span>
-            {repository.name}
-          </span>
+          {prefix ? <span className="prefix">{prefix}</span> : null}
+          <span>{repository.name}</span>
         </div>
       </div>
     )

--- a/app/src/ui/repository-settings/remote.tsx
+++ b/app/src/ui/repository-settings/remote.tsx
@@ -17,9 +17,7 @@ export class Remote extends React.Component<IRemoteProps, {}> {
     const remote = this.props.remote
     return (
       <DialogContent>
-        <div>
-          Primary remote repository ({remote.name})
-        </div>
+        <div>Primary remote repository ({remote.name})</div>
         <TextBox
           placeholder="Remote URL"
           value={remote.url}

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -74,11 +74,7 @@ export class RepositorySettings extends React.Component<
 
     return errors.map((err, ix) => {
       const key = `err-${ix}`
-      return (
-        <DialogError key={key}>
-          {err}
-        </DialogError>
-      )
+      return <DialogError key={key}>{err}</DialogError>
     })
   }
 
@@ -98,9 +94,7 @@ export class RepositorySettings extends React.Component<
           selectedIndex={this.state.selectedTab}
         >
           <span>Remote</span>
-          <span>
-            {__DARWIN__ ? 'Ignored Files' : 'Ignored files'}
-          </span>
+          <span>{__DARWIN__ ? 'Ignored Files' : 'Ignored files'}</span>
         </TabBar>
 
         {this.renderActiveTab()}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -51,12 +51,12 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
       <TabBar selectedIndex={selectedTab} onTabClicked={this.onTabClicked}>
         <span className="with-indicator">
           <span>Changes</span>
-          {hasChanges
-            ? <Octicon
-                className="indicator"
-                symbol={OcticonSymbol.primitiveDot}
-              />
-            : null}
+          {hasChanges ? (
+            <Octicon
+              className="indicator"
+              symbol={OcticonSymbol.primitiveDot}
+            />
+          ) : null}
         </span>
         <span>History</span>
       </TabBar>

--- a/app/src/ui/shell/shell-error.tsx
+++ b/app/src/ui/shell/shell-error.tsx
@@ -43,9 +43,7 @@ export class ShellError extends React.Component<IShellErrorProps, {}> {
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>
-          <p>
-            {this.props.message}
-          </p>
+          <p>{this.props.message}</p>
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -231,9 +231,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
   ) {
     return (
       <DialogContent>
-        <p>
-          {getWelcomeMessage(state.type)}
-        </p>
+        <p>{getWelcomeMessage(state.type)}</p>
         <Row>
           <TextBox
             label="Authentication code"
@@ -279,11 +277,9 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
 
     const disabled = state.loading
 
-    const errors = state.error
-      ? <DialogError>
-          {state.error.message}
-        </DialogError>
-      : null
+    const errors = state.error ? (
+      <DialogError>{state.error.message}</DialogError>
+    ) : null
 
     return (
       <Dialog

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -136,12 +136,12 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
   }
 
   public render() {
-    const icon = this.props.icon
-      ? <Octicon
-          symbol={this.props.icon}
-          className={classNames('icon', this.props.iconClassName)}
-        />
-      : null
+    const icon = this.props.icon ? (
+      <Octicon
+        symbol={this.props.icon}
+        className={classNames('icon', this.props.iconClassName)}
+      />
+    ) : null
 
     const className = classNames(
       'toolbar-button',
@@ -155,12 +155,14 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
         : undefined
 
     const progress =
-      progressValue !== undefined
-        ? <div
-            className="progress"
-            style={{ transform: `scaleX(${progressValue})` }}
-          />
-        : undefined
+      progressValue !== undefined ? (
+        <div
+          className="progress"
+          style={{ transform: `scaleX(${progressValue})` }}
+        />
+      ) : (
+        undefined
+      )
 
     return (
       <div
@@ -195,18 +197,14 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
     }
 
     const title =
-      this.props.title !== undefined
-        ? <div className="title">
-            {this.props.title}
-          </div>
-        : null
+      this.props.title !== undefined ? (
+        <div className="title">{this.props.title}</div>
+      ) : null
 
     const description =
-      this.props.description !== undefined
-        ? <div className="description">
-            {this.props.description}
-          </div>
-        : null
+      this.props.description !== undefined ? (
+        <div className="description">{this.props.description}</div>
+      ) : null
 
     const style = this.props.style || ToolbarButtonStyle.Standard
     switch (style) {
@@ -221,9 +219,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
       case ToolbarButtonStyle.Subtitle:
         return (
           <div className="text">
-            <div className="title">
-              {this.props.title}
-            </div>
+            <div className="title">{this.props.title}</div>
             {description}
           </div>
         )

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -103,11 +103,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
       )
     }
 
-    return (
-      <div className="ahead-behind">
-        {content}
-      </div>
-    )
+    return <div className="ahead-behind">{content}</div>
   }
 
   private getTitle(): string {

--- a/app/src/ui/ui-view.tsx
+++ b/app/src/ui/ui-view.tsx
@@ -21,10 +21,6 @@ export class UiView extends React.Component<IUiViewProps, {}> {
     const className = classNames(this.props.className, 'ui-view')
     const props = { ...this.props, className }
 
-    return (
-      <div {...props}>
-        {this.props.children}
-      </div>
-    )
+    return <div {...props}>{this.props.children}</div>
   }
 }

--- a/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
+++ b/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
@@ -32,14 +32,16 @@ export class UntrustedCertificate extends React.Component<
   public render() {
     const host = URL.parse(this.props.url).hostname
     const type = __DARWIN__ ? 'warning' : 'error'
-    const buttonGroup = __DARWIN__
-      ? <ButtonGroup destructive={true}>
-          <Button type="submit">Cancel</Button>
-          <Button onClick={this.onContinue}>View Certificate</Button>
-        </ButtonGroup>
-      : <ButtonGroup>
-          <Button type="submit">Close</Button>
-        </ButtonGroup>
+    const buttonGroup = __DARWIN__ ? (
+      <ButtonGroup destructive={true}>
+        <Button type="submit">Cancel</Button>
+        <Button onClick={this.onContinue}>View Certificate</Button>
+      </ButtonGroup>
+    ) : (
+      <ButtonGroup>
+        <Button type="submit">Close</Button>
+      </ButtonGroup>
+    )
     return (
       <Dialog
         title={__DARWIN__ ? 'Untrusted Server' : 'Untrusted server'}
@@ -68,9 +70,7 @@ export class UntrustedCertificate extends React.Component<
             administrator.
           </p>
         </DialogContent>
-        <DialogFooter>
-          {buttonGroup}
-        </DialogFooter>
+        <DialogFooter>{buttonGroup}</DialogFooter>
       </Dialog>
     )
   }

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -95,9 +95,9 @@ export class TitleBar extends React.Component<ITitleBarProps, ITitleBarState> {
     const titleBarClass =
       this.props.titleBarStyle === 'light' ? 'light-title-bar' : ''
 
-    const appIcon = this.props.showAppIcon
-      ? <Octicon className="app-icon" symbol={OcticonSymbol.markGithub} />
-      : null
+    const appIcon = this.props.showAppIcon ? (
+      <Octicon className="app-icon" symbol={OcticonSymbol.markGithub} />
+    ) : null
 
     const onTitlebarDoubleClick = __DARWIN__
       ? this.onTitlebarDoubleClickDarwin

--- a/app/src/ui/window/zoom-info.tsx
+++ b/app/src/ui/window/zoom-info.tsx
@@ -92,9 +92,7 @@ export class ZoomInfo extends React.Component<IZoomInfoProps, IZoomInfoState> {
 
     return (
       <div>
-        <span>
-          {zoomPercent}
-        </span>
+        <span>{zoomPercent}</span>
       </div>
     )
   }

--- a/app/test/unit/progress/git-test.ts
+++ b/app/test/unit/progress/git-test.ts
@@ -73,61 +73,53 @@ describe('progress parser', () => {
   it('parses progress with no total', () => {
     const result = parse('remote: Counting objects: 167587')
 
-    expect(result).to.deep.equal(
-      <IGitProgressInfo>{
-        title: 'remote: Counting objects',
-        text: 'remote: Counting objects: 167587',
-        value: 167587,
-        done: false,
-        percent: undefined,
-        total: undefined,
-      }
-    )
+    expect(result).to.deep.equal(<IGitProgressInfo>{
+      title: 'remote: Counting objects',
+      text: 'remote: Counting objects: 167587',
+      value: 167587,
+      done: false,
+      percent: undefined,
+      total: undefined,
+    })
   })
 
   it('parses final progress with no total', () => {
     const result = parse('remote: Counting objects: 167587, done.')
 
-    expect(result).to.deep.equal(
-      <IGitProgressInfo>{
-        title: 'remote: Counting objects',
-        text: 'remote: Counting objects: 167587, done.',
-        value: 167587,
-        done: true,
-        percent: undefined,
-        total: undefined,
-      }
-    )
+    expect(result).to.deep.equal(<IGitProgressInfo>{
+      title: 'remote: Counting objects',
+      text: 'remote: Counting objects: 167587, done.',
+      value: 167587,
+      done: true,
+      percent: undefined,
+      total: undefined,
+    })
   })
 
   it('parses progress with total', () => {
     const result = parse('remote: Compressing objects:  72% (16/22)')
 
-    expect(result).to.deep.equal(
-      <IGitProgressInfo>{
-        title: 'remote: Compressing objects',
-        text: 'remote: Compressing objects:  72% (16/22)',
-        value: 16,
-        done: false,
-        percent: 72,
-        total: 22,
-      }
-    )
+    expect(result).to.deep.equal(<IGitProgressInfo>{
+      title: 'remote: Compressing objects',
+      text: 'remote: Compressing objects:  72% (16/22)',
+      value: 16,
+      done: false,
+      percent: 72,
+      total: 22,
+    })
   })
 
   it('parses final with total', () => {
     const result = parse('remote: Compressing objects: 100% (22/22), done.')
 
-    expect(result).to.deep.equal(
-      <IGitProgressInfo>{
-        title: 'remote: Compressing objects',
-        text: 'remote: Compressing objects: 100% (22/22), done.',
-        value: 22,
-        done: true,
-        percent: 100,
-        total: 22,
-      }
-    )
+    expect(result).to.deep.equal(<IGitProgressInfo>{
+      title: 'remote: Compressing objects',
+      text: 'remote: Compressing objects: 100% (22/22), done.',
+      value: 22,
+      done: true,
+      percent: 100,
+      total: 22,
+    })
   })
 
   it('parses with total and throughput', () => {
@@ -135,17 +127,14 @@ describe('progress parser', () => {
       'Receiving objects:  99% (166741/167587), 267.24 MiB | 2.40 MiB/s'
     )
 
-    expect(result).to.deep.equal(
-      <IGitProgressInfo>{
-        title: 'Receiving objects',
-        text:
-          'Receiving objects:  99% (166741/167587), 267.24 MiB | 2.40 MiB/s',
-        value: 166741,
-        done: false,
-        percent: 99,
-        total: 167587,
-      }
-    )
+    expect(result).to.deep.equal(<IGitProgressInfo>{
+      title: 'Receiving objects',
+      text: 'Receiving objects:  99% (166741/167587), 267.24 MiB | 2.40 MiB/s',
+      value: 166741,
+      done: false,
+      percent: 99,
+      total: 167587,
+    })
   })
 
   it('parses final with total and throughput', () => {
@@ -153,17 +142,15 @@ describe('progress parser', () => {
       'Receiving objects: 100% (167587/167587), 279.67 MiB | 2.43 MiB/s, done.'
     )
 
-    expect(result).to.deep.equal(
-      <IGitProgressInfo>{
-        title: 'Receiving objects',
-        text:
-          'Receiving objects: 100% (167587/167587), 279.67 MiB | 2.43 MiB/s, done.',
-        value: 167587,
-        done: true,
-        percent: 100,
-        total: 167587,
-      }
-    )
+    expect(result).to.deep.equal(<IGitProgressInfo>{
+      title: 'Receiving objects',
+      text:
+        'Receiving objects: 100% (167587/167587), 279.67 MiB | 2.43 MiB/s, done.',
+      value: 167587,
+      done: true,
+      percent: 100,
+      total: 167587,
+    })
   })
 
   it("does not parse things that aren't progress", () => {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
+  - npm ls
+  - npm ls --dev
 
 build_script:
   - npm run check-prettiness

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@types/ua-parser-js": "^0.7.30",
     "@types/uuid": "^3.4.0",
     "@types/winston": "^2.2.0",
-    "prettier": "1.5.3",
+    "prettier": "^1.6.1",
     "tslint-config-prettier": "^1.1.0",
     "tslint-react": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@types/ua-parser-js": "^0.7.30",
     "@types/uuid": "^3.4.0",
     "@types/winston": "^2.2.0",
-    "prettier": "^1.5.0",
+    "prettier": "1.5.3",
     "tslint-config-prettier": "^1.1.0",
     "tslint-react": "^3.0.0"
   }


### PR DESCRIPTION
If you do a  `git clean node_modules -f && npm install` right now on `master` you'll get prettier 1.6.x, which has some new rules and doesn't like our current code. Let's update and tidy them up while we're in here.

We're also caching packages on CI to speed things up (which is why it doesn't have this issue as it's happy on `1.5.0`). I've added some tracing to help compare what's used for a CI build versus what you have locally.