### PR TITLE
a sad tale of unicode account names, shells and code pages

### DIFF
--- a/app/src/lib/registry.ts
+++ b/app/src/lib/registry.ts
@@ -114,8 +114,7 @@ export async function readRegistryKeySafe(
   }
 
   const activeCodePage = await getActiveCodePage()
-  if (activeCodePage) {
-  } else {
+  if (!activeCodePage) {
     log.debug('Unable to resolve active code page')
     return []
   }

--- a/app/src/lib/registry.ts
+++ b/app/src/lib/registry.ts
@@ -59,12 +59,12 @@ function getPathToBatchFile(): string {
 
 const batchFilePath = getPathToBatchFile()
 
-function readRegistryInner(
+function readRegistry(
   key: string,
-  codePage: number
+  currentCodePage: number
 ): Promise<ReadonlyArray<IRegistryEntry>> {
   return new Promise<ReadonlyArray<IRegistryEntry>>((resolve, reject) => {
-    const proc = spawn(batchFilePath, [key, codePage.toString()], {
+    const proc = spawn(batchFilePath, [key, currentCodePage.toString()], {
       cwd: undefined,
     })
 
@@ -113,12 +113,12 @@ export async function readRegistryKeySafe(
     return []
   }
 
-  const codePage = await getActiveCodePage()
-  if (codePage) {
+  const currentCodePage = await getActiveCodePage()
+  if (currentCodePage) {
   } else {
     log.debug('Unable to resolve active code page')
     return []
   }
 
-  return await readRegistryInner(key, codePage)
+  return await readRegistry(key, currentCodePage)
 }

--- a/app/src/lib/registry.ts
+++ b/app/src/lib/registry.ts
@@ -1,4 +1,6 @@
 import * as Path from 'path'
+import { pathExists } from './file-system'
+
 import { spawn } from 'child_process'
 import { getActiveCodePage } from './shell'
 
@@ -95,16 +97,23 @@ function readRegistryInner(
  *
  * @param key The registry key to lookup
  */
-export function readRegistryKeySafe(
+export async function readRegistryKeySafe(
   key: string
 ): Promise<ReadonlyArray<IRegistryEntry>> {
-  return getActiveCodePage().then(
-    codePage => {
-      return codePage ? readRegistryInner(key, codePage) : []
-    },
-    err => {
-      log.debug('Unable to resolve active code page', err)
-      return []
-    }
-  )
+  const exists = await pathExists(batchFilePath)
+  if (!exists) {
+    log.error(
+      `Unable to find batch script at expected location: '${batchFilePath}'`
+    )
+    return []
+  }
+
+  const codePage = await getActiveCodePage()
+  if (codePage) {
+  } else {
+    log.debug('Unable to resolve active code page')
+    return []
+  }
+
+  return await readRegistryInner(key, codePage)
 }

--- a/app/src/lib/registry.ts
+++ b/app/src/lib/registry.ts
@@ -61,10 +61,10 @@ const batchFilePath = getPathToBatchFile()
 
 function readRegistry(
   key: string,
-  currentCodePage: number
+  activeCodePage: number
 ): Promise<ReadonlyArray<IRegistryEntry>> {
   return new Promise<ReadonlyArray<IRegistryEntry>>((resolve, reject) => {
-    const proc = spawn(batchFilePath, [key, currentCodePage.toString()], {
+    const proc = spawn(batchFilePath, [key, activeCodePage.toString()], {
       cwd: undefined,
     })
 
@@ -113,12 +113,12 @@ export async function readRegistryKeySafe(
     return []
   }
 
-  const currentCodePage = await getActiveCodePage()
-  if (currentCodePage) {
+  const activeCodePage = await getActiveCodePage()
+  if (activeCodePage) {
   } else {
     log.debug('Unable to resolve active code page')
     return []
   }
 
-  return await readRegistry(key, currentCodePage)
+  return await readRegistry(key, activeCodePage)
 }

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -176,7 +176,7 @@ const chcpOutputRegex = /^Active code page: (\d{1,}).*/
  * Code Page 65001 represents UTF-8 character set.
  */
 export function getActiveCodePage(): Promise<number | null> {
-  if (process.platform !== 'win32') {
+  if (!__WIN32__) {
     return Promise.resolve(null)
   }
 

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -165,3 +165,39 @@ function mergeEnvironmentVariables(env: IndexLookup) {
 export function updateEnvironmentForProcess(): Promise<void> {
   return getEnvironmentFromShell(mergeEnvironmentVariables)
 }
+
+const chcpOutputRegex = /^Active code page: (\d{1,}).*/
+
+/**
+ * Resolve the active code page from the Windows console. It doesn't support
+ * Unicode natively, which is why we have to ask it.
+ *
+ * Code Page 437 is the character set associated with the original IBM PC, and
+ * Code Page 65001 represents UTF-8 character set.
+ */
+export function getActiveCodePage(): Promise<number | null> {
+  if (process.platform !== 'win32') {
+    return Promise.resolve(null)
+  }
+
+  return new Promise<number>((resolve, reject) => {
+    const child = ChildProcess.spawn('chcp')
+
+    const buffers: Array<Buffer> = []
+
+    child.stdout.on('data', (data: Buffer) => {
+      buffers.push(data)
+    })
+
+    child.on('close', (code: number, signal) => {
+      const output = Buffer.concat(buffers).toString('utf8')
+      const result = chcpOutputRegex.exec(output)
+      if (result) {
+        const value = result[1]
+        resolve(parseInt(value, 10))
+      } else {
+        reject(`regex did not match output: '${output}'`)
+      }
+    })
+  })
+}

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -194,7 +194,12 @@ export function getActiveCodePage(): Promise<number | null> {
       const result = chcpOutputRegex.exec(output)
       if (result) {
         const value = result[1]
-        resolve(parseInt(value, 10))
+        const parsedInt = parseInt(value, 10)
+        if (isNaN(parsedInt)) {
+          resolve(null)
+        } else {
+          resolve(parsedInt)
+        }
       } else {
         log.debug(`regex did not match output: '${output}'`)
         resolve(null)

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -180,7 +180,7 @@ export function getActiveCodePage(): Promise<number | null> {
     return Promise.resolve(null)
   }
 
-  return new Promise<number>((resolve, reject) => {
+  return new Promise<number | null>((resolve, reject) => {
     const child = ChildProcess.spawn('chcp')
 
     const buffers: Array<Buffer> = []
@@ -196,7 +196,8 @@ export function getActiveCodePage(): Promise<number | null> {
         const value = result[1]
         resolve(parseInt(value, 10))
       } else {
-        reject(`regex did not match output: '${output}'`)
+        log.debug(`regex did not match output: '${output}'`)
+        resolve(null)
       }
     })
   })

--- a/app/static/win32/registry.bat
+++ b/app/static/win32/registry.bat
@@ -1,0 +1,7 @@
+@echo off
+
+chcp 65001
+
+CALL %WINDIR%\System32\reg.exe QUERY %1
+
+chcp %2

--- a/app/static/win32/registry.bat
+++ b/app/static/win32/registry.bat
@@ -1,7 +1,15 @@
 @echo off
 
-chcp 65001
+set ACTUAL_ARGS_COUNT=0
+set EXPECTED_ARGS_COUNT=2
 
-CALL %WINDIR%\System32\reg.exe QUERY %1
+for %%i in (%*) do set /A ACTUAL_ARGS_COUNT+=1
 
-chcp %2
+if %ACTUAL_ARGS_COUNT% EQU %EXPECTED_ARGS_COUNT% (
+  chcp 65001
+
+  CALL %WINDIR%\System32\reg.exe QUERY %1
+
+  chcp %2
+)
+

--- a/app/test/unit/registry-test.ts
+++ b/app/test/unit/registry-test.ts
@@ -1,0 +1,24 @@
+import * as chai from 'chai'
+const expect = chai.expect
+
+import { readRegistryKeySafe } from '../../src/lib/registry'
+
+if (process.platform === 'win32') {
+  describe('registry', () => {
+    describe('readRegistryKeySafe', () => {
+      it('returns an empty array for an invalid key', async () => {
+        const entries = await readRegistryKeySafe(
+          'HKEY_LOCAL_MACHINE\\asgkahkgshakgashjgksahgkas'
+        )
+        expect(entries.length).to.equal(0)
+      })
+
+      it('returns an array for a known entry', async () => {
+        const entries = await readRegistryKeySafe(
+          'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
+        )
+        expect(entries.length).to.be.greaterThan(0)
+      })
+    })
+  })
+}

--- a/app/test/unit/registry-test.ts
+++ b/app/test/unit/registry-test.ts
@@ -5,36 +5,34 @@ import { getActiveCodePage } from '../../src/lib/shell'
 import { readRegistryKeySafe } from '../../src/lib/registry'
 
 if (process.platform === 'win32') {
-  describe('registry', () => {
-    describe('readRegistryKeySafe', () => {
-      it('returns an empty array for an invalid key', async () => {
-        const entries = await readRegistryKeySafe(
-          'HKEY_LOCAL_MACHINE\\asgkahkgshakgashjgksahgkas'
-        )
-        expect(entries.length).to.equal(0)
-      })
+  describe('registry/readRegistryKeySafe', () => {
+    it('returns an empty array for an invalid key', async () => {
+      const entries = await readRegistryKeySafe(
+        'HKEY_LOCAL_MACHINE\\asgkahkgshakgashjgksahgkas'
+      )
+      expect(entries.length).to.equal(0)
+    })
 
-      it('returns an array for a known entry', async () => {
-        const entries = await readRegistryKeySafe(
-          'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
-        )
-        expect(entries.length).to.be.greaterThan(0)
-      })
+    it('returns an array for a known entry', async () => {
+      const entries = await readRegistryKeySafe(
+        'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
+      )
+      expect(entries.length).to.be.greaterThan(0)
+    })
 
-      it('cleans up changes to the active code page', async () => {
-        const utf8CodePage = 65001
+    it('cleans up changes to the active code page', async () => {
+      const utf8CodePage = 65001
 
-        const beforeCodePage = await getActiveCodePage()
-        expect(beforeCodePage).to.not.equal(utf8CodePage)
+      const beforeCodePage = await getActiveCodePage()
+      expect(beforeCodePage).to.not.equal(utf8CodePage)
 
-        await readRegistryKeySafe(
-          'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
-        )
-        const afterCodePage = await getActiveCodePage()
+      await readRegistryKeySafe(
+        'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
+      )
+      const afterCodePage = await getActiveCodePage()
 
-        expect(afterCodePage).to.not.equal(utf8CodePage)
-        expect(afterCodePage).to.equal(beforeCodePage)
-      })
+      expect(afterCodePage).to.not.equal(utf8CodePage)
+      expect(afterCodePage).to.equal(beforeCodePage)
     })
   })
 }

--- a/app/test/unit/registry-test.ts
+++ b/app/test/unit/registry-test.ts
@@ -1,6 +1,7 @@
 import * as chai from 'chai'
 const expect = chai.expect
 
+import { getActiveCodePage } from '../../src/lib/shell'
 import { readRegistryKeySafe } from '../../src/lib/registry'
 
 if (process.platform === 'win32') {
@@ -18,6 +19,21 @@ if (process.platform === 'win32') {
           'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
         )
         expect(entries.length).to.be.greaterThan(0)
+      })
+
+      it('cleans up changes to the active code page', async () => {
+        const utf8CodePage = 65001
+
+        const beforeCodePage = await getActiveCodePage()
+        expect(beforeCodePage).to.not.equal(utf8CodePage)
+
+        await readRegistryKeySafe(
+          'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate'
+        )
+        const afterCodePage = await getActiveCodePage()
+
+        expect(afterCodePage).to.not.equal(utf8CodePage)
+        expect(afterCodePage).to.equal(beforeCodePage)
       })
     })
   })

--- a/app/test/unit/shell-test.ts
+++ b/app/test/unit/shell-test.ts
@@ -1,0 +1,25 @@
+import * as chai from 'chai'
+const expect = chai.expect
+
+import { getActiveCodePage } from '../../src/lib/shell'
+
+describe('shell', () => {
+  describe('getActiveCodePage', () => {
+    it('can resolve the current code page on Windows', async () => {
+      if (process.platform !== 'win32') {
+        return
+      }
+
+      const codePage = await getActiveCodePage()
+      expect(codePage).to.be.greaterThan(0)
+    })
+
+    it('returns null for non-Windows platforms', async () => {
+      if (process.platform === 'win32') {
+        return
+      }
+      const codePage = await getActiveCodePage()
+      expect(codePage).to.be.null
+    })
+  })
+})

--- a/app/test/unit/shell-test.ts
+++ b/app/test/unit/shell-test.ts
@@ -3,20 +3,18 @@ const expect = chai.expect
 
 import { getActiveCodePage } from '../../src/lib/shell'
 
-describe('shell', () => {
-  describe('getActiveCodePage', () => {
-    if (process.platform === 'win32') {
-      it('can resolve the current code page on Windows', async () => {
-        const codePage = await getActiveCodePage()
-        expect(codePage).to.be.greaterThan(0)
-      })
-    }
+describe('shell/getActiveCodePage', () => {
+  if (process.platform === 'win32') {
+    it('can resolve the current code page on Windows', async () => {
+      const codePage = await getActiveCodePage()
+      expect(codePage).to.be.greaterThan(0)
+    })
+  }
 
-    if (process.platform !== 'win32') {
-      it('returns null for non-Windows platforms', async () => {
-        const codePage = await getActiveCodePage()
-        expect(codePage).to.be.null
-      })
-    }
-  })
+  if (process.platform !== 'win32') {
+    it('returns null for non-Windows platforms', async () => {
+      const codePage = await getActiveCodePage()
+      expect(codePage).to.be.null
+    })
+  }
 })

--- a/app/test/unit/shell-test.ts
+++ b/app/test/unit/shell-test.ts
@@ -5,21 +5,18 @@ import { getActiveCodePage } from '../../src/lib/shell'
 
 describe('shell', () => {
   describe('getActiveCodePage', () => {
-    it('can resolve the current code page on Windows', async () => {
-      if (process.platform !== 'win32') {
-        return
-      }
+    if (process.platform === 'win32') {
+      it('can resolve the current code page on Windows', async () => {
+        const codePage = await getActiveCodePage()
+        expect(codePage).to.be.greaterThan(0)
+      })
+    }
 
-      const codePage = await getActiveCodePage()
-      expect(codePage).to.be.greaterThan(0)
-    })
-
-    it('returns null for non-Windows platforms', async () => {
-      if (process.platform === 'win32') {
-        return
-      }
-      const codePage = await getActiveCodePage()
-      expect(codePage).to.be.null
-    })
+    if (process.platform !== 'win32') {
+      it('returns null for non-Windows platforms', async () => {
+        const codePage = await getActiveCodePage()
+        expect(codePage).to.be.null
+      })
+    }
   })
 })

--- a/app/test/unit/shell-test.ts
+++ b/app/test/unit/shell-test.ts
@@ -9,9 +9,7 @@ describe('shell/getActiveCodePage', () => {
       const codePage = await getActiveCodePage()
       expect(codePage).to.be.greaterThan(0)
     })
-  }
-
-  if (process.platform !== 'win32') {
+  } else {
     it('returns null for non-Windows platforms', async () => {
       const codePage = await getActiveCodePage()
       expect(codePage).to.be.null


### PR DESCRIPTION
Notice anything wrong with this picture?

<img width="595" src="https://user-images.githubusercontent.com/359239/30095867-8a289c26-9318-11e7-957a-7ea092e07119.png">

I'll give you a hint:

<img width="585" src="https://user-images.githubusercontent.com/359239/30095955-06d885ec-9319-11e7-98b7-5f209e4a035f.png">

I'm not quite familiar with how Git Bash is differentiating between these two, but it's unimportant to the problem at hand, which is #2585. It took a while to get to the bottom of why the Atom installation wasn't being detected for @DRSAgile, but it's related to having non-ASCII characters in their account name.

Here's my test account running [this example script](https://gist.github.com/shiftkey/aa650e7238b41fb8c720f34fc2e74358) to read the registry:

```
C:\Users\hösentägen\Desktop\testing>node index.js
got: [
  {
    "name": "DisplayIcon",
    "type": "REG_SZ",
    "value": ""C:\\Users\\h�sent�gen\\AppData\\Local\\atom\\app.ico"
  },
  {
    "name": "DisplayName",
    "type": "REG_SZ",
    "value": "Atom"
  },
  {
    "name": "DisplayVersion",
    "type": "REG_SZ",
    "value": "1.19.5"
  },
  {
    "name": "InstallDate",
    "type": "REG_SZ",
    "value": "20170906"
  },
  {
    "name": "InstallLocation",
    "type": "REG_SZ",
    "value": ""C:\\Users\\h�sent�gen\\AppData\\Local\\atom"
  },
  {
    "name": "Publisher",
    "type": "REG_SZ",
    "value": "GitHub Inc."
  },
  {
    "name": "QuietUninstallString",
    "type": "REG_SZ",
    "value": "\""C:\\Users\\h�sent�gen\\AppData\\Local\\atom\\Update.exe\" --uninstall -s"
  },
  {
    "name": "UninstallString",
    "type": "REG_SZ",
    "value": "\""C:\\Users\\h�sent�gen\\AppData\\Local\\atom\\Update.exe\" --uninstall"
  },
  {
    "name": "EstimatedSize",
    "type": "REG_DWORD",
    "value": "0x2bc0e"
  },
  {
    "name": "NoModify",
    "type": "REG_DWORD",
    "value": "0x1"
  },
  {
    "name": "NoRepair",
    "type": "REG_DWORD",
    "value": "0x1"
  },
  {
    "name": "Language",
    "type": "REG_DWORD",
    "value": "0x409"
  }
]
```

It's those � characters that are the root cause of the issue.

If you're particularly sharp you might have noticed that directory path in the prompt is rendered correctly. Your eyes aren't deceiving you.

**But it's 2017! Doesn't Windows support Unicode?**

Yes, Windows supports Unicode character sets and code pages. But specific parts of the Windows operating system, for compatibility reasons, don't have this enabled by default - like the Windows Console. It turns out we already encountered this problem in a different context when we were retrieving the `PATH` environment variable for the current user using a PowerShell script (shout out to the Atom team for finding this earlier):

```ts
  const args = [
    '-noprofile',
    '-ExecutionPolicy',
    'RemoteSigned',
    '-command',
    // Set encoding and execute the command, capture the output, and return it
    // via .NET's console in order to have consistent UTF-8 encoding.
    // See http://stackoverflow.com/questions/22349139/utf-8-output-from-powershell
    // to address https://github.com/atom/atom/issues/5063
    `
      [Console]::OutputEncoding=[System.Text.Encoding]::UTF8
      $output=[environment]::GetEnvironmentVariable('Path', 'User')
      [Console]::WriteLine($output)
    `,
  ]

  const stdout = await spawn(powershellPath, args)
  ...
```

**Why do we need to do these shenanigans?**

Compatibility, mostly. If you're running the Command Prompt in Windows 10 chances are you have the same code page set as the IBM PC supported. That's right, [Code Page 437](https://en.wikipedia.org/wiki/Code_page_437), baby!

<img width="578" src="https://user-images.githubusercontent.com/359239/30096219-999e4096-931a-11e7-850c-0100ec3f67b8.png">

Before going any further, I should give some back story. **Code pages** are conceptually similar to character sets, but because of History™ there's lots of platform-specific code pages still floating around. The [documented list of these](https://msdn.microsoft.com/en-us/library/windows/desktop/dd317756(v=vs.85).aspx) is pretty entertaining read, if only to understand how messy this is.

Most code pages are a superset of ASCII, so any time you see that � or garbled text you're likely dealing with that problem. This ignores discussions around fonts, but I'm not going to deal with that here.

Anyway, Windows has an **active code page** set which affects how characters are rendered in a terminal. This also affects the behaviour of Win32 APIs - for example, `ShellExecuteA` is the ANSI API for `ShellExecute` and it's behaviour is affected by the active code page. `ShellExecuteW` is the Unicode version and is unaffected by the active code page.

Oh, and the **active code page** is set globally, so you need to be really, really careful 😱

Did you know that everything is terrible?

**What can we do here?**

The excellent people over at [`node-winreg`](https://github.com/fresc81/node-winreg) pointed out that you probably need to care about the active code page [for any UTF-8 data it reads](https://github.com/fresc81/node-winreg#processing-utf-8-data), and suggested this workaround:

> An even better approach would be to extract and store the value returned by a call to `chcp` prior setting the console to UTF-8 and resetting the codepage after your script is done.

That's the approach I've gone with here, and I'll dig more into this now that I know where I'm heading.

**But doesn't Node support Unicode? Why not just use that?**

By the time Node gets the chance to read these bytes into the stream, they're already invalid. We need to tell the shell which code page to use before spawning `reg.exe` so we get the right characters back.

 - [x] add `getActiveCodePage` method to retrieve the current code page
 - [x] add some registry tests as a safety harness
 - [x] move the registry lookup code into an external script that manages the code page