### PR TITLE
Fix missing "View on GitHub" menu item

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -66,11 +66,11 @@ export class CommitListItem extends React.Component<ICommitProps, {}> {
     let viewOnGitHubLabel = 'View on GitHub'
     const gitHubRepository = this.props.gitHubRepository
 
-    if (gitHubRepository) {
-      const isDotCom = gitHubRepository.endpoint === getDotComAPIEndpoint()
-      viewOnGitHubLabel = isDotCom
-        ? 'View on GitHub'
-        : 'View on GitHub Enterprise'
+    if (
+      gitHubRepository &&
+      gitHubRepository.endpoint !== getDotComAPIEndpoint()
+    ) {
+      viewOnGitHubLabel = 'View on GitHub Enterprise'
     }
 
     const items: IMenuItem[] = [

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -63,12 +63,14 @@ export class CommitListItem extends React.Component<ICommitProps, {}> {
   private onContextMenu = (event: React.MouseEvent<any>) => {
     event.preventDefault()
 
-    let label: string = ''
+    let viewOnGitHubLabel = 'View on GitHub'
     const gitHubRepository = this.props.gitHubRepository
 
     if (gitHubRepository) {
       const isDotCom = gitHubRepository.endpoint === getDotComAPIEndpoint()
-      label = isDotCom ? 'View on GitHub' : 'View on GitHub Enterprise'
+      viewOnGitHubLabel = isDotCom
+        ? 'View on GitHub'
+        : 'View on GitHub Enterprise'
     }
 
     const items: IMenuItem[] = [
@@ -86,7 +88,7 @@ export class CommitListItem extends React.Component<ICommitProps, {}> {
         action: this.onCopySHA,
       },
       {
-        label: label,
+        label: viewOnGitHubLabel,
         action: this.onViewOnGitHub,
         enabled: !this.props.isLocal && !!gitHubRepository,
       },


### PR DESCRIPTION
Fixes #2615 

It looks like the logic was already there to disable it, we were just giving it an empty label too.

<img width="205" alt="screen shot 2017-09-06 at 2 59 07 pm" src="https://user-images.githubusercontent.com/13760/30129517-1b8d498c-9314-11e7-83ea-d3eeb6564bc0.png">