### PR TITLE
ensure the repository list is always accessible

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -141,7 +141,6 @@ function getMenuState(state: IAppState): Map<MenuIDs, IMenuItemState> {
     'create-branch',
     'show-changes',
     'show-history',
-    'show-repository-list',
     'show-branches-list',
     'open-external-editor',
   ]


### PR DESCRIPTION
Fixes #2648 

Previously we would disable the "Show Repository List" menu shortcut when the repository is missing. These two things aren't related - we should always let the user change repositories.
