### PR TITLE
use shift for shortcut chord instead of alt

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -165,7 +165,7 @@ export function buildDefaultMenu(
       {
         label: '&Reload',
         id: 'reload-window',
-        accelerator: 'CmdOrCtrl+Shift+R',
+        accelerator: 'CmdOrCtrl+Alt+R',
         click(item: any, focusedWindow: Electron.BrowserWindow) {
           if (focusedWindow) {
             focusedWindow.reload()

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -165,6 +165,11 @@ export function buildDefaultMenu(
       {
         label: '&Reload',
         id: 'reload-window',
+        // Ctrl+Alt is interpreted as AltGr on international keyboards and this
+        // can clash with other shortcuts. We should always use Ctrl+Shift for
+        // chorded shortcuts, but this menu item is not a user-facing feature
+        // so we are going to keep this one around and save Ctrl+Shift+R for
+        // a different shortcut in the future...
         accelerator: 'CmdOrCtrl+Alt+R',
         click(item: any, focusedWindow: Electron.BrowserWindow) {
           if (focusedWindow) {

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -165,7 +165,7 @@ export function buildDefaultMenu(
       {
         label: '&Reload',
         id: 'reload-window',
-        accelerator: 'CmdOrCtrl+Alt+R',
+        accelerator: 'CmdOrCtrl+Shift+R',
         click(item: any, focusedWindow: Electron.BrowserWindow) {
           if (focusedWindow) {
             focusedWindow.reload()

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -215,7 +215,7 @@ export function buildDefaultMenu(
       {
         id: 'view-repository-on-github',
         label: __DARWIN__ ? 'View on GitHub' : '&View on GitHub',
-        accelerator: 'CmdOrCtrl+Alt+G',
+        accelerator: 'CmdOrCtrl+Shift+G',
         click: emit('view-repository-on-github'),
       },
       {


### PR DESCRIPTION
Fixes #2607 (again)

Six of our existing shortcuts use `CmdOrCtrl+Shift` for the chorded shortcut, and two use `CmdOrCtrl+Alt`. And as mentioned in this comment https://github.com/desktop/desktop/issues/2607#issuecomment-328385687 some keyboards layouts will handle `Ctrl+Alt` differently on Windows.

As we can't rely on handling `AltGr` separately to `Alt`, let's just avoid it completely. This is What Windows Does™.

@joshaber any objections to this on the macOS side?