### PR TITLE
autocomplete ignores mouse down events

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -179,12 +179,27 @@ export abstract class AutocompletingTextInput<
           scrollToRow={selectedRow}
           selectOnHover={true}
           focusOnHover={false}
+          onRowMouseDown={this.onRowMouseDown}
           onRowClick={this.insertCompletionOnClick}
           onSelectionChanged={this.onSelectionChanged}
           invalidationProps={searchText}
         />
       </div>
     )
+  }
+
+  private onRowMouseDown = (row: number, event: React.MouseEvent<any>) => {
+    const currentAutoCompletionState = this.state.autocompletionState
+
+    if (!currentAutoCompletionState) {
+      return
+    }
+
+    const item = currentAutoCompletionState.items[row]
+
+    if (item) {
+      this.insertCompletion(item)
+    }
   }
 
   private onSelectionChanged = (row: number, source: SelectionSource) => {

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -62,9 +62,8 @@ interface IBranchListProps {
 
   /**
    * This function will be called when the selection changes as a result of a
-   * user keyboard or mouse action (i.e. not when props change). Note that this
-   * differs from `onRowSelected`. For example, it won't be called if an already
-   * selected row is clicked on.
+   * user keyboard or mouse action (i.e. not when props change). This function
+   * will not be invoked when an already selected row is clicked on.
    *
    * @param selectedItem - The Branch that was just selected
    * @param source       - The kind of user action that provoked the change,

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -68,9 +68,8 @@ interface IFilterListProps<T extends IFilterListItem> {
 
   /**
    * This function will be called when the selection changes as a result of a
-   * user keyboard or mouse action (i.e. not when props change). Note that this
-   * differs from `onRowSelected`. For example, it won't be called if an already
-   * selected row is clicked on.
+   * user keyboard or mouse action (i.e. not when props change). This function
+   * will not be invoked when an already selected row is clicked on.
    *
    * @param selectedItem - The item that was just selected
    * @param source       - The kind of user action that provoked the change,

--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -135,6 +135,13 @@ interface IListProps {
   readonly onRowKeyDown?: (row: number, event: React.KeyboardEvent<any>) => void
 
   /**
+   * A handler called whenever a mouse down event is received on the
+   * row container element. Unlike onSelectionChanged, this event is raised
+   * for every mouse down, whether the row is selected or not.
+   */
+  readonly onRowMouseDown?: (row: number, event: React.MouseEvent<any>) => void
+
+  /**
    * An optional handler called to determine whether a given row is
    * selectable or not. Reasons for why a row might not be selectable
    * includes it being a group header or the item being disabled.
@@ -655,6 +662,10 @@ export class List extends React.Component<IListProps, IListState> {
 
   private handleMouseDown = (row: number, event: React.MouseEvent<any>) => {
     if (this.canSelectRow(row)) {
+      if (this.props.onRowMouseDown) {
+        this.props.onRowMouseDown(row, event)
+      }
+
       if (row !== this.props.selectedRow && this.props.onSelectionChanged) {
         this.props.onSelectionChanged(row, { kind: 'mouseclick', event })
       }

--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -112,9 +112,8 @@ interface IListProps {
 
   /**
    * This function will be called when the selection changes as a result of a
-   * user keyboard or mouse action (i.e. not when props change). Note that this
-   * differs from `onRowSelected`. For example, it won't be called if an already
-   * selected row is clicked on.
+   * user keyboard or mouse action (i.e. not when props change). This function
+   * will not be invoked when an already selected row is clicked on.
    *
    * @param row    - The index of the row that was just selected
    * @param source - The kind of user action that provoked the change, either

--- a/app/src/ui/list.tsx
+++ b/app/src/ui/list.tsx
@@ -136,8 +136,8 @@ interface IListProps {
 
   /**
    * A handler called whenever a mouse down event is received on the
-   * row container element. Unlike onSelectionChanged, this event is raised
-   * for every mouse down, whether the row is selected or not.
+   * row container element. Unlike onSelectionChanged, this is raised
+   * for every mouse down event, whether the row is selected or not.
    */
   readonly onRowMouseDown?: (row: number, event: React.MouseEvent<any>) => void
 


### PR DESCRIPTION
Fixes #2674

The core of this problem is that the autocomplete list ensures an item is always selected (the first item on initial render, then whichever item is under the mouse cursor (this is `this.props.selectOnHover`), and `onSelectionChanged` won't be raised when it considers the list item already selected.

I landed on this fix because I didn't want to change the internal behaviour of `List` this close to 1.0 and re-test everywhere, and stripping back the `selectOnHover` behaviour felt off.