### PR TITLE
Don't launch as a shell when launching the shell app

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -79,5 +79,5 @@ export async function getAvailableShells(): Promise<
 export async function launch(shell: Shell, path: string): Promise<void> {
   const bundleID = getBundleID(shell)
   const commandArgs = ['-b', bundleID, path]
-  await spawn('open', commandArgs, { shell: true })
+  await spawn('open', commandArgs)
 }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -19,5 +19,5 @@ export async function getAvailableShells(): Promise<
 
 export async function launch(shell: Shell, path: string): Promise<void> {
   const commandArgs = ['--working-directory', path]
-  await spawn('gnome-terminal', commandArgs, { shell: true })
+  await spawn('gnome-terminal', commandArgs)
 }


### PR DESCRIPTION
Fixes #2682 

The path was being passed as an argument, which meant we would need to escape whitespace. This isn't a problem on Windows where we were already doing that.

Instead, just don't launch as a shell.