### PR TITLE
don't rely on PATH for knowing where to find chcp

### DIFF
--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -2,6 +2,7 @@
 
 import * as ChildProcess from 'child_process'
 import * as os from 'os'
+import * as Path from 'path'
 
 type IndexLookup = {
   [propName: string]: string
@@ -181,7 +182,9 @@ export function getActiveCodePage(): Promise<number | null> {
   }
 
   return new Promise<number | null>((resolve, reject) => {
-    const child = ChildProcess.spawn('chcp')
+    const path = Path.join(process.env.windir, 'System32', 'chcp')
+
+    const child = ChildProcess.spawn(path)
 
     const buffers: Array<Buffer> = []
     let errorThrown = false

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -182,7 +182,8 @@ export function getActiveCodePage(): Promise<number | null> {
   }
 
   return new Promise<number | null>((resolve, reject) => {
-    const path = Path.join(process.env.windir, 'System32', 'chcp')
+    const windir = process.env.windir || 'C:\\Windows'
+    const path = Path.join(windir, 'System32', 'chcp')
 
     const child = ChildProcess.spawn(path)
 

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -183,7 +183,7 @@ export function getActiveCodePage(): Promise<number | null> {
 
   return new Promise<number | null>((resolve, reject) => {
     const windir = process.env.windir || 'C:\\Windows'
-    const path = Path.join(windir, 'System32', 'chcp')
+    const path = Path.join(windir, 'System32', 'chcp.com')
 
     const child = ChildProcess.spawn(path)
 


### PR DESCRIPTION
Fixes #2678:

 - [x] use the known path for `chcp`, don't rely on `PATH` being helpful
 - [x] catch errors and log in the unlikely scenario this has been removed
