### PR TITLE
Fix "Clone with Desktop" path

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -228,7 +228,7 @@ export class CloneRepository extends React.Component<
   }
 
   private updatePath = (path: string) => {
-    this.setState({ path: path })
+    this.setState({ path })
   }
 
   private onChooseDirectory = async () => {

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -80,6 +80,13 @@ export class CloneRepository extends React.Component<
     }
   }
 
+  public componentDidMount() {
+    const initialURL = this.props.initialURL
+    if (initialURL) {
+      this.updateUrl(initialURL)
+    }
+  }
+
   public render() {
     const error = this.state.error
     return (


### PR DESCRIPTION
We weren't sending the initial URL through the proper machinery, so the path wouldn't be appended with the name of the repository.