### PR TITLE
Fix issue template links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ reports :mag_right:.
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report)
 as you might find out that you don't need to create one. When you are creating
 a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
-Fill out [the required template](../../.github/ISSUE_TEMPLATE.md), the information
+Fill out [the required template](./.github/ISSUE_TEMPLATE.md), the information
 it asks for helps us resolve issues faster.
 
 #### Before Submitting A Bug Report
@@ -71,7 +71,7 @@ comment to the existing issue if there is extra information you can contribute.
 Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
 Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues)
-and fill out the provided [issue template](../../.github/ISSUE_TEMPLATE.md).
+and fill out the provided [issue template](./.github/ISSUE_TEMPLATE.md).
 
 The information we are interested in includes:
 
@@ -91,7 +91,7 @@ community understand your suggestion :pencil: and find related suggestions
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion)
 as you might find out that you don't need to create one. When you are creating
 an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
-Fill in [the template](../../.github/ISSUE_TEMPLATE.md), including the steps
+Fill in [the template](./.github/ISSUE_TEMPLATE.md), including the steps
 that you imagine you would take if the feature you're requesting existed.
 
 #### Before Submitting An Enhancement Suggestion


### PR DESCRIPTION
I was scanning through the old `CONTRIBUTING.md` while working on an Atom issue and noticed the `ISSUE_TEMPLATE.md` links were broken - currently linking to:

https://github.com/desktop/desktop/.github/ISSUE_TEMPLATE.md

This fixes the relative links to link them to:

https://github.com/desktop/desktop/blob/master/.github/ISSUE_TEMPLATE.md

![link-works](https://68.media.tumblr.com/5fb689ddf6025ee283ca62a2789424dc/tumblr_nezxqwcTTg1s8ouhxo1_500.gif)