### PR TITLE
bump spectron to ensure it remains in sync with electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "request": "^2.72.0",
     "rimraf": "^2.5.2",
     "sass-loader": "^6.0.6",
-    "spectron": "^3.6.0",
+    "spectron": "^3.7.2",
     "style-loader": "^0.18.2",
     "to-camel-case": "^1.0.0",
     "ts-loader": "^2.0.3",


### PR DESCRIPTION
Found this message while spelunking build logs:

```
> @ test:integration C:\projects\desktop
> cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe mocha -t 10000 --compilers ts:ts-node/register,tsx:ts-node/register app/test/integration/*.ts



  App

Warning: Installed minor versions are mismatched: 6 vs 7
spectron: 3.6.1
electron: 1.7.5

    √ opens a window on launch (189ms)

  1 passing (4s)
```

Taking us up to `3.7.x` should do the trick.