### PR TITLE
Stick to patches for tslint-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "@types/winston": "^2.2.0",
     "prettier": "^1.6.1",
     "tslint-config-prettier": "^1.1.0",
-    "tslint-react": "^3.0.0"
+    "tslint-react": "~3.0.0"
   }
 }


### PR DESCRIPTION
Otherwise we'll get a version that requires we update `tslint`, which we don't wanna do given https://github.com/desktop/desktop/pull/2405.

```
npm ERR! peer dep missing: tslint@^5.1.0, required by tslint-react@3.2.0
Command exited with code 1
npm run test:review
```