### PR TITLE
Don't install hooks when checking if a repo uses LFS

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -255,9 +255,9 @@
       "resolved": "https://registry.npmjs.org/dom-matches/-/dom-matches-2.0.0.tgz"
     },
     "dugite": {
-      "version": "1.42.0",
-      "from": "dugite@1.42.0",
-      "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.42.0.tgz"
+      "version": "1.43.0",
+      "from": "dugite@latest",
+      "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.43.0.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "codemirror": "^5.29.0",
     "deep-equal": "^1.0.1",
     "dexie": "^1.4.1",
-    "dugite": "^1.42.0",
+    "dugite": "^1.43.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -26,6 +26,11 @@ export async function installLFSHooks(
 
 /** Is the repository configured to track any paths with LFS? */
 export async function isUsingLFS(repository: Repository): Promise<boolean> {
-  const result = await git(['lfs', 'track'], repository.path, 'isUsingLFS')
+  const env = {
+    GIT_LFS_TRACK_NO_INSTALL_HOOKS: '1',
+  }
+  const result = await git(['lfs', 'track'], repository.path, 'isUsingLFS', {
+    env,
+  })
   return result.stdout.length > 0
 }


### PR DESCRIPTION
Fixes #2732 

This is dependent on Git LFS 2.3.0.