### PR TITLE
log a launch message after everything is ready

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -75,6 +75,7 @@ import { RetryAction } from '../lib/retry-actions'
 import { ShellError } from './shell'
 import { InitializeLFS, AttributeMismatch } from './lfs'
 import { CloneRepositoryTab } from '../models/clone-repository-tab'
+import { getOS } from '../lib/get-os'
 
 /** The interval at which we should check for updates. */
 const UpdateCheckInterval = 1000 * 60 * 60 * 4
@@ -215,6 +216,8 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     setInterval(() => this.checkForUpdates(true), UpdateCheckInterval)
     this.checkForUpdates(true)
+
+    log.info(`launching: ${getVersion()} (${getOS()})`)
   }
 
   private onMenuEvent(name: MenuEvent): any {


### PR DESCRIPTION
Fixes #2765 

We can't do this in the main process because `ua-parser-js` needs to parse the user-agent from Chromium to get the right macOS version info.

<img width="661" src="https://user-images.githubusercontent.com/359239/30628034-3a0b5882-9e17-11e7-894a-be25b5542bc2.png">

Anything else we should be gathering at launch time?