### PR TITLE
Fix target URL for "Show User Guides" menu item

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -20,13 +20,13 @@ export function buildDefaultMenu(
   const template = new Array<Electron.MenuItemConstructorOptions>()
   const separator: Electron.MenuItemConstructorOptions = { type: 'separator' }
 
-  if ( __DARWIN__ ) {
-    template.push( {
+  if (__DARWIN__) {
+    template.push({
       label: 'GitHub Desktop',
       submenu: [
         {
           label: 'About GitHub Desktop',
-          click: emit( 'show-about' ),
+          click: emit('show-about'),
           id: 'about',
         },
         separator,
@@ -34,13 +34,13 @@ export function buildDefaultMenu(
           label: 'Preferences…',
           id: 'preferences',
           accelerator: 'CmdOrCtrl+,',
-          click: emit( 'show-preferences' ),
+          click: emit('show-preferences'),
         },
         separator,
         {
           label: 'Install Command Line Tool…',
           id: 'install-cli',
-          click: emit( 'install-cli' ),
+          click: emit('install-cli'),
         },
         separator,
         {
@@ -54,7 +54,7 @@ export function buildDefaultMenu(
         separator,
         { role: 'quit' },
       ],
-    } )
+    })
   }
 
   const fileMenu: Electron.MenuItemConstructorOptions = {
@@ -63,7 +63,7 @@ export function buildDefaultMenu(
       {
         label: __DARWIN__ ? 'New Repository…' : 'New &repository…',
         id: 'new-repository',
-        click: emit( 'create-repository' ),
+        click: emit('create-repository'),
         accelerator: 'CmdOrCtrl+N',
       },
       separator,
@@ -71,18 +71,18 @@ export function buildDefaultMenu(
         label: __DARWIN__ ? 'Add Local Repository…' : 'Add &local repository…',
         id: 'add-local-repository',
         accelerator: 'CmdOrCtrl+O',
-        click: emit( 'add-local-repository' ),
+        click: emit('add-local-repository'),
       },
       {
         label: __DARWIN__ ? 'Clone Repository…' : 'Clo&ne repository…',
         id: 'clone-repository',
         accelerator: 'CmdOrCtrl+Shift+O',
-        click: emit( 'clone-repository' ),
+        click: emit('clone-repository'),
       },
     ],
   }
 
-  if ( !__DARWIN__ ) {
+  if (!__DARWIN__) {
     const fileItems = fileMenu.submenu as Electron.MenuItemConstructorOptions[]
 
     fileItems.push(
@@ -91,16 +91,16 @@ export function buildDefaultMenu(
         label: '&Options…',
         id: 'preferences',
         accelerator: 'CmdOrCtrl+,',
-        click: emit( 'show-preferences' ),
+        click: emit('show-preferences'),
       },
       separator,
       { role: 'quit' }
     )
   }
 
-  template.push( fileMenu )
+  template.push(fileMenu)
 
-  template.push( {
+  template.push({
     label: __DARWIN__ ? 'Edit' : '&Edit',
     submenu: [
       { role: 'undo', label: __DARWIN__ ? 'Undo' : '&Undo' },
@@ -111,34 +111,34 @@ export function buildDefaultMenu(
       { role: 'paste', label: __DARWIN__ ? 'Paste' : '&Paste' },
       { role: 'selectall', label: __DARWIN__ ? 'Select All' : 'Select &all' },
     ],
-  } )
+  })
 
-  template.push( {
+  template.push({
     label: __DARWIN__ ? 'View' : '&View',
     submenu: [
       {
         label: __DARWIN__ ? 'Show Changes' : '&Changes',
         id: 'show-changes',
         accelerator: 'CmdOrCtrl+1',
-        click: emit( 'select-changes' ),
+        click: emit('select-changes'),
       },
       {
         label: __DARWIN__ ? 'Show History' : '&History',
         id: 'show-history',
         accelerator: 'CmdOrCtrl+2',
-        click: emit( 'select-history' ),
+        click: emit('select-history'),
       },
       {
         label: __DARWIN__ ? 'Show Repository List' : 'Repository &list',
         id: 'show-repository-list',
         accelerator: 'CmdOrCtrl+T',
-        click: emit( 'choose-repository' ),
+        click: emit('choose-repository'),
       },
       {
         label: __DARWIN__ ? 'Show Branches List' : '&Branches list',
         id: 'show-branches-list',
         accelerator: 'CmdOrCtrl+B',
-        click: emit( 'show-branches' ),
+        click: emit('show-branches'),
       },
       separator,
       {
@@ -149,17 +149,17 @@ export function buildDefaultMenu(
       {
         label: __DARWIN__ ? 'Reset Zoom' : 'Reset zoom',
         accelerator: 'CmdOrCtrl+0',
-        click: zoom( ZoomDirection.Reset ),
+        click: zoom(ZoomDirection.Reset),
       },
       {
         label: __DARWIN__ ? 'Zoom In' : 'Zoom in',
         accelerator: 'CmdOrCtrl+=',
-        click: zoom( ZoomDirection.In ),
+        click: zoom(ZoomDirection.In),
       },
       {
         label: __DARWIN__ ? 'Zoom Out' : 'Zoom out',
         accelerator: 'CmdOrCtrl+-',
-        click: zoom( ZoomDirection.Out ),
+        click: zoom(ZoomDirection.Out),
       },
       separator,
       {
@@ -171,8 +171,8 @@ export function buildDefaultMenu(
         // so we are going to keep this one around and save Ctrl+Shift+R for
         // a different shortcut in the future...
         accelerator: 'CmdOrCtrl+Alt+R',
-        click( item: any, focusedWindow: Electron.BrowserWindow ) {
-          if ( focusedWindow ) {
+        click(item: any, focusedWindow: Electron.BrowserWindow) {
+          if (focusedWindow) {
             focusedWindow.reload()
           }
         },
@@ -183,19 +183,19 @@ export function buildDefaultMenu(
         label: __DARWIN__
           ? 'Toggle Developer Tools'
           : '&Toggle developer tools',
-        accelerator: ( () => {
+        accelerator: (() => {
           return __DARWIN__ ? 'Alt+Command+I' : 'Ctrl+Shift+I'
-        } )(),
-        click( item: any, focusedWindow: Electron.BrowserWindow ) {
-          if ( focusedWindow ) {
+        })(),
+        click(item: any, focusedWindow: Electron.BrowserWindow) {
+          if (focusedWindow) {
             focusedWindow.webContents.toggleDevTools()
           }
         },
       },
     ],
-  } )
+  })
 
-  template.push( {
+  template.push({
     label: __DARWIN__ ? 'Repository' : '&Repository',
     id: 'repository',
     submenu: [
@@ -203,54 +203,54 @@ export function buildDefaultMenu(
         id: 'push',
         label: __DARWIN__ ? 'Push' : 'P&ush',
         accelerator: 'CmdOrCtrl+P',
-        click: emit( 'push' ),
+        click: emit('push'),
       },
       {
         id: 'pull',
         label: __DARWIN__ ? 'Pull' : 'Pu&ll',
         accelerator: 'CmdOrCtrl+Shift+P',
-        click: emit( 'pull' ),
+        click: emit('pull'),
       },
       {
         label: __DARWIN__ ? 'Remove' : '&Remove',
         id: 'remove-repository',
-        click: emit( 'remove-repository' ),
+        click: emit('remove-repository'),
       },
       separator,
       {
         id: 'view-repository-on-github',
         label: __DARWIN__ ? 'View on GitHub' : '&View on GitHub',
         accelerator: 'CmdOrCtrl+Shift+G',
-        click: emit( 'view-repository-on-github' ),
+        click: emit('view-repository-on-github'),
       },
       {
         label: shellLabel,
         id: 'open-in-shell',
         accelerator: 'Ctrl+`',
-        click: emit( 'open-in-shell' ),
+        click: emit('open-in-shell'),
       },
       {
         label: __DARWIN__ ? 'Show in Finder' : 'Show in E&xplorer',
         id: 'open-working-directory',
         accelerator: 'CmdOrCtrl+Shift+F',
-        click: emit( 'open-working-directory' ),
+        click: emit('open-working-directory'),
       },
       {
         label: editorLabel,
         id: 'open-external-editor',
         accelerator: 'CmdOrCtrl+Shift+A',
-        click: emit( 'open-external-editor' ),
+        click: emit('open-external-editor'),
       },
       separator,
       {
         label: __DARWIN__ ? 'Repository Settings…' : 'Repository &settings…',
         id: 'show-repository-settings',
-        click: emit( 'show-repository-settings' ),
+        click: emit('show-repository-settings'),
       },
     ],
-  } )
+  })
 
-  template.push( {
+  template.push({
     label: __DARWIN__ ? 'Branch' : '&Branch',
     id: 'branch',
     submenu: [
@@ -258,17 +258,17 @@ export function buildDefaultMenu(
         label: __DARWIN__ ? 'New Branch…' : 'New &branch…',
         id: 'create-branch',
         accelerator: 'CmdOrCtrl+Shift+N',
-        click: emit( 'create-branch' ),
+        click: emit('create-branch'),
       },
       {
         label: __DARWIN__ ? 'Rename…' : '&Rename…',
         id: 'rename-branch',
-        click: emit( 'rename-branch' ),
+        click: emit('rename-branch'),
       },
       {
         label: __DARWIN__ ? 'Delete…' : '&Delete…',
         id: 'delete-branch',
-        click: emit( 'delete-branch' ),
+        click: emit('delete-branch'),
       },
       separator,
       {
@@ -276,33 +276,33 @@ export function buildDefaultMenu(
           ? 'Update From Default Branch'
           : '&Update from default branch',
         id: 'update-branch',
-        click: emit( 'update-branch' ),
+        click: emit('update-branch'),
       },
       {
         label: __DARWIN__
           ? 'Merge Into Current Branch…'
           : '&Merge into current branch…',
         id: 'merge-branch',
-        click: emit( 'merge-branch' ),
+        click: emit('merge-branch'),
       },
       separator,
       {
         label: __DARWIN__ ? 'Compare on GitHub' : '&Compare on GitHub',
         id: 'compare-branch',
         accelerator: 'CmdOrCtrl+Shift+C',
-        click: emit( 'compare-branch' ),
+        click: emit('compare-branch'),
       },
       {
         label: __DARWIN__ ? 'Create Pull Request' : 'Create &pull request',
         id: 'create-pull-request',
         accelerator: 'CmdOrCtrl+R',
-        click: emit( 'create-pull-request' ),
+        click: emit('create-pull-request'),
       },
     ],
-  } )
+  })
 
-  if ( __DARWIN__ ) {
-    template.push( {
+  if (__DARWIN__) {
+    template.push({
       role: 'window',
       submenu: [
         { role: 'minimize' },
@@ -311,13 +311,13 @@ export function buildDefaultMenu(
         separator,
         { role: 'front' },
       ],
-    } )
+    })
   }
 
   const submitIssueItem: Electron.MenuItemConstructorOptions = {
     label: __DARWIN__ ? 'Report Issue…' : 'Report issue…',
     click() {
-      shell.openExternal( 'https://github.com/desktop/desktop/issues/new' )
+      shell.openExternal('https://github.com/desktop/desktop/issues/new')
     },
   }
 
@@ -325,7 +325,7 @@ export function buildDefaultMenu(
     label: __DARWIN__ ? 'Contact GitHub Support…' : '&Contact GitHub support…',
     click() {
       shell.openExternal(
-        `https://github.com/contact?from_desktop_app=1&app_version=${ app.getVersion() }`
+        `https://github.com/contact?from_desktop_app=1&app_version=${app.getVersion()}`
       )
     },
   }
@@ -333,7 +333,7 @@ export function buildDefaultMenu(
   const showUserGuides: Electron.MenuItemConstructorOptions = {
     label: 'Show User Guides',
     click() {
-      shell.openExternal( 'https://help.github.com/desktop/guides/' )
+      shell.openExternal('https://help.github.com/desktop/guides/')
     },
   }
 
@@ -341,13 +341,13 @@ export function buildDefaultMenu(
     label: __DARWIN__ ? 'Show Logs in Finder' : 'S&how logs in Explorer',
     click() {
       const logPath = getLogPath()
-      mkdirIfNeeded( logPath )
-        .then( () => {
-          shell.showItemInFolder( logPath )
-        } )
-        .catch( err => {
-          log( 'error', err.message )
-        } )
+      mkdirIfNeeded(logPath)
+        .then(() => {
+          shell.showItemInFolder(logPath)
+        })
+        .catch(err => {
+          log('error', err.message)
+        })
     },
   }
 
@@ -358,45 +358,45 @@ export function buildDefaultMenu(
     showLogsItem,
   ]
 
-  if ( __DEV__ ) {
+  if (__DEV__) {
     helpItems.push(
       separator,
       {
         label: 'Crash main process…',
         click() {
-          throw new Error( 'Boomtown!' )
+          throw new Error('Boomtown!')
         },
       },
       {
         label: 'Crash renderer process…',
-        click: emit( 'boomtown' ),
+        click: emit('boomtown'),
       }
     )
   }
 
-  if ( __DARWIN__ ) {
-    template.push( {
+  if (__DARWIN__) {
+    template.push({
       role: 'help',
       submenu: helpItems,
-    } )
+    })
   } else {
-    template.push( {
+    template.push({
       label: '&Help',
       submenu: [
         ...helpItems,
         separator,
         {
           label: '&About GitHub Desktop',
-          click: emit( 'show-about' ),
+          click: emit('show-about'),
           id: 'about',
         },
       ],
-    } )
+    })
   }
 
-  ensureItemIds( template )
+  ensureItemIds(template)
 
-  return Menu.buildFromTemplate( template )
+  return Menu.buildFromTemplate(template)
 }
 
 type ClickHandler = (
@@ -409,12 +409,12 @@ type ClickHandler = (
  * Utility function returning a Click event handler which, when invoked, emits
  * the provided menu event over IPC.
  */
-function emit( name: MenuEvent ): ClickHandler {
-  return ( menuItem, window ) => {
-    if ( window ) {
-      window.webContents.send( 'menu-event', { name } )
+function emit(name: MenuEvent): ClickHandler {
+  return (menuItem, window) => {
+    if (window) {
+      window.webContents.send('menu-event', { name })
     } else {
-      ipcMain.emit( 'menu-event', { name } )
+      ipcMain.emit('menu-event', { name })
     }
   }
 }
@@ -426,38 +426,38 @@ enum ZoomDirection {
 }
 
 /** The zoom steps that we support, these factors must sorted */
-const ZoomInFactors = [ 1, 1.1, 1.25, 1.5, 1.75, 2 ]
+const ZoomInFactors = [1, 1.1, 1.25, 1.5, 1.75, 2]
 const ZoomOutFactors = ZoomInFactors.slice().reverse()
 
 /**
  * Returns the element in the array that's closest to the value parameter. Note
  * that this function will throw if passed an empty array.
  */
-function findClosestValue( arr: Array<number>, value: number ) {
-  return arr.reduce( ( previous, current ) => {
-    return Math.abs( current - value ) < Math.abs( previous - value )
+function findClosestValue(arr: Array<number>, value: number) {
+  return arr.reduce((previous, current) => {
+    return Math.abs(current - value) < Math.abs(previous - value)
       ? current
       : previous
-  } )
+  })
 }
 
 /**
  * Figure out the next zoom level for the given direction and alert the renderer
  * about a change in zoom factor if necessary.
  */
-function zoom( direction: ZoomDirection ): ClickHandler {
-  return ( menuItem, window ) => {
-    if ( !window ) {
+function zoom(direction: ZoomDirection): ClickHandler {
+  return (menuItem, window) => {
+    if (!window) {
       return
     }
 
     const { webContents } = window
 
-    if ( direction === ZoomDirection.Reset ) {
-      webContents.setZoomFactor( 1 )
-      webContents.send( 'zoom-factor-changed', 1 )
+    if (direction === ZoomDirection.Reset) {
+      webContents.setZoomFactor(1)
+      webContents.send('zoom-factor-changed', 1)
     } else {
-      webContents.getZoomFactor( rawZoom => {
+      webContents.getZoomFactor(rawZoom => {
         const zoomFactors =
           direction === ZoomDirection.In ? ZoomInFactors : ZoomOutFactors
 
@@ -465,7 +465,7 @@ function zoom( direction: ZoomDirection ): ClickHandler {
         // precision numbers from chromium that don't always round nicely so
         // we'll have to do a little trick to figure out which of our supported
         // zoom factors the value is referring to.
-        const currentZoom = findClosestValue( zoomFactors, rawZoom )
+        const currentZoom = findClosestValue(zoomFactors, rawZoom)
 
         const nextZoomLevel = zoomFactors.find(
           f =>
@@ -478,9 +478,9 @@ function zoom( direction: ZoomDirection ): ClickHandler {
         const newZoom =
           nextZoomLevel === undefined ? currentZoom : nextZoomLevel
 
-        webContents.setZoomFactor( newZoom )
-        webContents.send( 'zoom-factor-changed', newZoom )
-      } )
+        webContents.setZoomFactor(newZoom)
+        webContents.send('zoom-factor-changed', newZoom)
+      })
     }
   }
 }

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -20,13 +20,13 @@ export function buildDefaultMenu(
   const template = new Array<Electron.MenuItemConstructorOptions>()
   const separator: Electron.MenuItemConstructorOptions = { type: 'separator' }
 
-  if (__DARWIN__) {
-    template.push({
+  if ( __DARWIN__ ) {
+    template.push( {
       label: 'GitHub Desktop',
       submenu: [
         {
           label: 'About GitHub Desktop',
-          click: emit('show-about'),
+          click: emit( 'show-about' ),
           id: 'about',
         },
         separator,
@@ -34,13 +34,13 @@ export function buildDefaultMenu(
           label: 'Preferences…',
           id: 'preferences',
           accelerator: 'CmdOrCtrl+,',
-          click: emit('show-preferences'),
+          click: emit( 'show-preferences' ),
         },
         separator,
         {
           label: 'Install Command Line Tool…',
           id: 'install-cli',
-          click: emit('install-cli'),
+          click: emit( 'install-cli' ),
         },
         separator,
         {
@@ -54,7 +54,7 @@ export function buildDefaultMenu(
         separator,
         { role: 'quit' },
       ],
-    })
+    } )
   }
 
   const fileMenu: Electron.MenuItemConstructorOptions = {
@@ -63,7 +63,7 @@ export function buildDefaultMenu(
       {
         label: __DARWIN__ ? 'New Repository…' : 'New &repository…',
         id: 'new-repository',
-        click: emit('create-repository'),
+        click: emit( 'create-repository' ),
         accelerator: 'CmdOrCtrl+N',
       },
       separator,
@@ -71,18 +71,18 @@ export function buildDefaultMenu(
         label: __DARWIN__ ? 'Add Local Repository…' : 'Add &local repository…',
         id: 'add-local-repository',
         accelerator: 'CmdOrCtrl+O',
-        click: emit('add-local-repository'),
+        click: emit( 'add-local-repository' ),
       },
       {
         label: __DARWIN__ ? 'Clone Repository…' : 'Clo&ne repository…',
         id: 'clone-repository',
         accelerator: 'CmdOrCtrl+Shift+O',
-        click: emit('clone-repository'),
+        click: emit( 'clone-repository' ),
       },
     ],
   }
 
-  if (!__DARWIN__) {
+  if ( !__DARWIN__ ) {
     const fileItems = fileMenu.submenu as Electron.MenuItemConstructorOptions[]
 
     fileItems.push(
@@ -91,16 +91,16 @@ export function buildDefaultMenu(
         label: '&Options…',
         id: 'preferences',
         accelerator: 'CmdOrCtrl+,',
-        click: emit('show-preferences'),
+        click: emit( 'show-preferences' ),
       },
       separator,
       { role: 'quit' }
     )
   }
 
-  template.push(fileMenu)
+  template.push( fileMenu )
 
-  template.push({
+  template.push( {
     label: __DARWIN__ ? 'Edit' : '&Edit',
     submenu: [
       { role: 'undo', label: __DARWIN__ ? 'Undo' : '&Undo' },
@@ -111,34 +111,34 @@ export function buildDefaultMenu(
       { role: 'paste', label: __DARWIN__ ? 'Paste' : '&Paste' },
       { role: 'selectall', label: __DARWIN__ ? 'Select All' : 'Select &all' },
     ],
-  })
+  } )
 
-  template.push({
+  template.push( {
     label: __DARWIN__ ? 'View' : '&View',
     submenu: [
       {
         label: __DARWIN__ ? 'Show Changes' : '&Changes',
         id: 'show-changes',
         accelerator: 'CmdOrCtrl+1',
-        click: emit('select-changes'),
+        click: emit( 'select-changes' ),
       },
       {
         label: __DARWIN__ ? 'Show History' : '&History',
         id: 'show-history',
         accelerator: 'CmdOrCtrl+2',
-        click: emit('select-history'),
+        click: emit( 'select-history' ),
       },
       {
         label: __DARWIN__ ? 'Show Repository List' : 'Repository &list',
         id: 'show-repository-list',
         accelerator: 'CmdOrCtrl+T',
-        click: emit('choose-repository'),
+        click: emit( 'choose-repository' ),
       },
       {
         label: __DARWIN__ ? 'Show Branches List' : '&Branches list',
         id: 'show-branches-list',
         accelerator: 'CmdOrCtrl+B',
-        click: emit('show-branches'),
+        click: emit( 'show-branches' ),
       },
       separator,
       {
@@ -149,17 +149,17 @@ export function buildDefaultMenu(
       {
         label: __DARWIN__ ? 'Reset Zoom' : 'Reset zoom',
         accelerator: 'CmdOrCtrl+0',
-        click: zoom(ZoomDirection.Reset),
+        click: zoom( ZoomDirection.Reset ),
       },
       {
         label: __DARWIN__ ? 'Zoom In' : 'Zoom in',
         accelerator: 'CmdOrCtrl+=',
-        click: zoom(ZoomDirection.In),
+        click: zoom( ZoomDirection.In ),
       },
       {
         label: __DARWIN__ ? 'Zoom Out' : 'Zoom out',
         accelerator: 'CmdOrCtrl+-',
-        click: zoom(ZoomDirection.Out),
+        click: zoom( ZoomDirection.Out ),
       },
       separator,
       {
@@ -171,8 +171,8 @@ export function buildDefaultMenu(
         // so we are going to keep this one around and save Ctrl+Shift+R for
         // a different shortcut in the future...
         accelerator: 'CmdOrCtrl+Alt+R',
-        click(item: any, focusedWindow: Electron.BrowserWindow) {
-          if (focusedWindow) {
+        click( item: any, focusedWindow: Electron.BrowserWindow ) {
+          if ( focusedWindow ) {
             focusedWindow.reload()
           }
         },
@@ -183,19 +183,19 @@ export function buildDefaultMenu(
         label: __DARWIN__
           ? 'Toggle Developer Tools'
           : '&Toggle developer tools',
-        accelerator: (() => {
+        accelerator: ( () => {
           return __DARWIN__ ? 'Alt+Command+I' : 'Ctrl+Shift+I'
-        })(),
-        click(item: any, focusedWindow: Electron.BrowserWindow) {
-          if (focusedWindow) {
+        } )(),
+        click( item: any, focusedWindow: Electron.BrowserWindow ) {
+          if ( focusedWindow ) {
             focusedWindow.webContents.toggleDevTools()
           }
         },
       },
     ],
-  })
+  } )
 
-  template.push({
+  template.push( {
     label: __DARWIN__ ? 'Repository' : '&Repository',
     id: 'repository',
     submenu: [
@@ -203,54 +203,54 @@ export function buildDefaultMenu(
         id: 'push',
         label: __DARWIN__ ? 'Push' : 'P&ush',
         accelerator: 'CmdOrCtrl+P',
-        click: emit('push'),
+        click: emit( 'push' ),
       },
       {
         id: 'pull',
         label: __DARWIN__ ? 'Pull' : 'Pu&ll',
         accelerator: 'CmdOrCtrl+Shift+P',
-        click: emit('pull'),
+        click: emit( 'pull' ),
       },
       {
         label: __DARWIN__ ? 'Remove' : '&Remove',
         id: 'remove-repository',
-        click: emit('remove-repository'),
+        click: emit( 'remove-repository' ),
       },
       separator,
       {
         id: 'view-repository-on-github',
         label: __DARWIN__ ? 'View on GitHub' : '&View on GitHub',
         accelerator: 'CmdOrCtrl+Shift+G',
-        click: emit('view-repository-on-github'),
+        click: emit( 'view-repository-on-github' ),
       },
       {
         label: shellLabel,
         id: 'open-in-shell',
         accelerator: 'Ctrl+`',
-        click: emit('open-in-shell'),
+        click: emit( 'open-in-shell' ),
       },
       {
         label: __DARWIN__ ? 'Show in Finder' : 'Show in E&xplorer',
         id: 'open-working-directory',
         accelerator: 'CmdOrCtrl+Shift+F',
-        click: emit('open-working-directory'),
+        click: emit( 'open-working-directory' ),
       },
       {
         label: editorLabel,
         id: 'open-external-editor',
         accelerator: 'CmdOrCtrl+Shift+A',
-        click: emit('open-external-editor'),
+        click: emit( 'open-external-editor' ),
       },
       separator,
       {
         label: __DARWIN__ ? 'Repository Settings…' : 'Repository &settings…',
         id: 'show-repository-settings',
-        click: emit('show-repository-settings'),
+        click: emit( 'show-repository-settings' ),
       },
     ],
-  })
+  } )
 
-  template.push({
+  template.push( {
     label: __DARWIN__ ? 'Branch' : '&Branch',
     id: 'branch',
     submenu: [
@@ -258,17 +258,17 @@ export function buildDefaultMenu(
         label: __DARWIN__ ? 'New Branch…' : 'New &branch…',
         id: 'create-branch',
         accelerator: 'CmdOrCtrl+Shift+N',
-        click: emit('create-branch'),
+        click: emit( 'create-branch' ),
       },
       {
         label: __DARWIN__ ? 'Rename…' : '&Rename…',
         id: 'rename-branch',
-        click: emit('rename-branch'),
+        click: emit( 'rename-branch' ),
       },
       {
         label: __DARWIN__ ? 'Delete…' : '&Delete…',
         id: 'delete-branch',
-        click: emit('delete-branch'),
+        click: emit( 'delete-branch' ),
       },
       separator,
       {
@@ -276,33 +276,33 @@ export function buildDefaultMenu(
           ? 'Update From Default Branch'
           : '&Update from default branch',
         id: 'update-branch',
-        click: emit('update-branch'),
+        click: emit( 'update-branch' ),
       },
       {
         label: __DARWIN__
           ? 'Merge Into Current Branch…'
           : '&Merge into current branch…',
         id: 'merge-branch',
-        click: emit('merge-branch'),
+        click: emit( 'merge-branch' ),
       },
       separator,
       {
         label: __DARWIN__ ? 'Compare on GitHub' : '&Compare on GitHub',
         id: 'compare-branch',
         accelerator: 'CmdOrCtrl+Shift+C',
-        click: emit('compare-branch'),
+        click: emit( 'compare-branch' ),
       },
       {
         label: __DARWIN__ ? 'Create Pull Request' : 'Create &pull request',
         id: 'create-pull-request',
         accelerator: 'CmdOrCtrl+R',
-        click: emit('create-pull-request'),
+        click: emit( 'create-pull-request' ),
       },
     ],
-  })
+  } )
 
-  if (__DARWIN__) {
-    template.push({
+  if ( __DARWIN__ ) {
+    template.push( {
       role: 'window',
       submenu: [
         { role: 'minimize' },
@@ -311,13 +311,13 @@ export function buildDefaultMenu(
         separator,
         { role: 'front' },
       ],
-    })
+    } )
   }
 
   const submitIssueItem: Electron.MenuItemConstructorOptions = {
     label: __DARWIN__ ? 'Report Issue…' : 'Report issue…',
     click() {
-      shell.openExternal('https://github.com/desktop/desktop/issues/new')
+      shell.openExternal( 'https://github.com/desktop/desktop/issues/new' )
     },
   }
 
@@ -325,7 +325,7 @@ export function buildDefaultMenu(
     label: __DARWIN__ ? 'Contact GitHub Support…' : '&Contact GitHub support…',
     click() {
       shell.openExternal(
-        `https://github.com/contact?from_desktop_app=1&app_version=${app.getVersion()}`
+        `https://github.com/contact?from_desktop_app=1&app_version=${ app.getVersion() }`
       )
     },
   }
@@ -333,7 +333,7 @@ export function buildDefaultMenu(
   const showUserGuides: Electron.MenuItemConstructorOptions = {
     label: 'Show User Guides',
     click() {
-      shell.openExternal('https://help.github.com/desktop-beta/guides/')
+      shell.openExternal( 'https://help.github.com/desktop/guides/' )
     },
   }
 
@@ -341,13 +341,13 @@ export function buildDefaultMenu(
     label: __DARWIN__ ? 'Show Logs in Finder' : 'S&how logs in Explorer',
     click() {
       const logPath = getLogPath()
-      mkdirIfNeeded(logPath)
-        .then(() => {
-          shell.showItemInFolder(logPath)
-        })
-        .catch(err => {
-          log('error', err.message)
-        })
+      mkdirIfNeeded( logPath )
+        .then( () => {
+          shell.showItemInFolder( logPath )
+        } )
+        .catch( err => {
+          log( 'error', err.message )
+        } )
     },
   }
 
@@ -358,45 +358,45 @@ export function buildDefaultMenu(
     showLogsItem,
   ]
 
-  if (__DEV__) {
+  if ( __DEV__ ) {
     helpItems.push(
       separator,
       {
         label: 'Crash main process…',
         click() {
-          throw new Error('Boomtown!')
+          throw new Error( 'Boomtown!' )
         },
       },
       {
         label: 'Crash renderer process…',
-        click: emit('boomtown'),
+        click: emit( 'boomtown' ),
       }
     )
   }
 
-  if (__DARWIN__) {
-    template.push({
+  if ( __DARWIN__ ) {
+    template.push( {
       role: 'help',
       submenu: helpItems,
-    })
+    } )
   } else {
-    template.push({
+    template.push( {
       label: '&Help',
       submenu: [
         ...helpItems,
         separator,
         {
           label: '&About GitHub Desktop',
-          click: emit('show-about'),
+          click: emit( 'show-about' ),
           id: 'about',
         },
       ],
-    })
+    } )
   }
 
-  ensureItemIds(template)
+  ensureItemIds( template )
 
-  return Menu.buildFromTemplate(template)
+  return Menu.buildFromTemplate( template )
 }
 
 type ClickHandler = (
@@ -409,12 +409,12 @@ type ClickHandler = (
  * Utility function returning a Click event handler which, when invoked, emits
  * the provided menu event over IPC.
  */
-function emit(name: MenuEvent): ClickHandler {
-  return (menuItem, window) => {
-    if (window) {
-      window.webContents.send('menu-event', { name })
+function emit( name: MenuEvent ): ClickHandler {
+  return ( menuItem, window ) => {
+    if ( window ) {
+      window.webContents.send( 'menu-event', { name } )
     } else {
-      ipcMain.emit('menu-event', { name })
+      ipcMain.emit( 'menu-event', { name } )
     }
   }
 }
@@ -426,38 +426,38 @@ enum ZoomDirection {
 }
 
 /** The zoom steps that we support, these factors must sorted */
-const ZoomInFactors = [1, 1.1, 1.25, 1.5, 1.75, 2]
+const ZoomInFactors = [ 1, 1.1, 1.25, 1.5, 1.75, 2 ]
 const ZoomOutFactors = ZoomInFactors.slice().reverse()
 
 /**
  * Returns the element in the array that's closest to the value parameter. Note
  * that this function will throw if passed an empty array.
  */
-function findClosestValue(arr: Array<number>, value: number) {
-  return arr.reduce((previous, current) => {
-    return Math.abs(current - value) < Math.abs(previous - value)
+function findClosestValue( arr: Array<number>, value: number ) {
+  return arr.reduce( ( previous, current ) => {
+    return Math.abs( current - value ) < Math.abs( previous - value )
       ? current
       : previous
-  })
+  } )
 }
 
 /**
  * Figure out the next zoom level for the given direction and alert the renderer
  * about a change in zoom factor if necessary.
  */
-function zoom(direction: ZoomDirection): ClickHandler {
-  return (menuItem, window) => {
-    if (!window) {
+function zoom( direction: ZoomDirection ): ClickHandler {
+  return ( menuItem, window ) => {
+    if ( !window ) {
       return
     }
 
     const { webContents } = window
 
-    if (direction === ZoomDirection.Reset) {
-      webContents.setZoomFactor(1)
-      webContents.send('zoom-factor-changed', 1)
+    if ( direction === ZoomDirection.Reset ) {
+      webContents.setZoomFactor( 1 )
+      webContents.send( 'zoom-factor-changed', 1 )
     } else {
-      webContents.getZoomFactor(rawZoom => {
+      webContents.getZoomFactor( rawZoom => {
         const zoomFactors =
           direction === ZoomDirection.In ? ZoomInFactors : ZoomOutFactors
 
@@ -465,7 +465,7 @@ function zoom(direction: ZoomDirection): ClickHandler {
         // precision numbers from chromium that don't always round nicely so
         // we'll have to do a little trick to figure out which of our supported
         // zoom factors the value is referring to.
-        const currentZoom = findClosestValue(zoomFactors, rawZoom)
+        const currentZoom = findClosestValue( zoomFactors, rawZoom )
 
         const nextZoomLevel = zoomFactors.find(
           f =>
@@ -478,9 +478,9 @@ function zoom(direction: ZoomDirection): ClickHandler {
         const newZoom =
           nextZoomLevel === undefined ? currentZoom : nextZoomLevel
 
-        webContents.setZoomFactor(newZoom)
-        webContents.send('zoom-factor-changed', newZoom)
-      })
+        webContents.setZoomFactor( newZoom )
+        webContents.send( 'zoom-factor-changed', newZoom )
+      } )
     }
   }
 }


### PR DESCRIPTION
fixes #2792, sets target url to https://help.github.com/desktop/guides/