### PR TITLE
don't crash the app on non-macOS and non-Windows platforms

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -100,26 +100,3 @@ export async function getAvailableEditors(): Promise<
 
   return results
 }
-
-/**
- * Find the first editor that exists on the user's machine, or return null if
- * no matches are found.
- */
-export async function getFirstEditorOrDefault(): Promise<FoundEditor | null> {
-  const atom = await findApplication(ExternalEditor.Atom)
-  if (atom.installed && atom.pathExists) {
-    return { editor: atom.editor, path: atom.path }
-  }
-
-  const code = await findApplication(ExternalEditor.VisualStudioCode)
-  if (code.installed && code.pathExists) {
-    return { editor: code.editor, path: code.path }
-  }
-
-  const sublime = await findApplication(ExternalEditor.SublimeText)
-  if (sublime.installed && sublime.pathExists) {
-    return { editor: sublime.editor, path: sublime.path }
-  }
-
-  return null
-}

--- a/app/src/lib/editors/lookup.ts
+++ b/app/src/lib/editors/lookup.ts
@@ -31,9 +31,11 @@ export async function getAvailableEditors(): Promise<
     return editorCache
   }
 
-  return Promise.reject(
+  log.warn(
     `Platform not currently supported for resolving editors: ${process.platform}`
   )
+
+  return []
 }
 
 /**
@@ -49,9 +51,10 @@ export function getFirstEditorOrDefault(): Promise<FoundEditor | null> {
     return getFirstEditorOrDefaultWindows()
   }
 
-  return Promise.reject(
+  log.warn(
     `Platform not currently supported for resolving editors: ${process.platform}`
   )
+  return Promise.resolve(null)
 }
 
 /**

--- a/app/src/lib/editors/lookup.ts
+++ b/app/src/lib/editors/lookup.ts
@@ -1,12 +1,6 @@
 import { FoundEditor, ExternalEditorError } from './shared'
-import {
-  getAvailableEditors as getAvailableEditorsDarwin,
-  getFirstEditorOrDefault as getFirstEditorOrDefaultDarwin,
-} from './darwin'
-import {
-  getAvailableEditors as getAvailableEditorsWindows,
-  getFirstEditorOrDefault as getFirstEditorOrDefaultWindows,
-} from './win32'
+import { getAvailableEditors as getAvailableEditorsDarwin } from './darwin'
+import { getAvailableEditors as getAvailableEditorsWindows } from './win32'
 
 let editorCache: ReadonlyArray<FoundEditor> | null = null
 
@@ -36,25 +30,6 @@ export async function getAvailableEditors(): Promise<
   )
 
   return []
-}
-
-/**
- * Find the first editor that exists on the user's machine, or return null if
- * no matches are found.
- */
-export function getFirstEditorOrDefault(): Promise<FoundEditor | null> {
-  if (__DARWIN__) {
-    return getFirstEditorOrDefaultDarwin()
-  }
-
-  if (__WIN32__) {
-    return getFirstEditorOrDefaultWindows()
-  }
-
-  log.warn(
-    `Platform not currently supported for resolving editors: ${process.platform}`
-  )
-  return Promise.resolve(null)
 }
 
 /**

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -216,26 +216,3 @@ export async function getAvailableEditors(): Promise<
 
   return results
 }
-
-/**
- * Find the first editor that exists on the user's machine, or return null if
- * no matches are found.
- */
-export async function getFirstEditorOrDefault(): Promise<FoundEditor | null> {
-  const atom = await findApplication(ExternalEditor.Atom)
-  if (atom.installed && atom.pathExists) {
-    return { editor: atom.editor, path: atom.path }
-  }
-
-  const code = await findApplication(ExternalEditor.VisualStudioCode)
-  if (code.installed && code.pathExists) {
-    return { editor: code.editor, path: code.path }
-  }
-
-  const sublime = await findApplication(ExternalEditor.SublimeText)
-  if (sublime.installed && sublime.pathExists) {
-    return { editor: sublime.editor, path: sublime.path }
-  }
-
-  return null
-}


### PR DESCRIPTION
This was introduced in #2407 as fallback behaviour where we hadn't implemented a way to resolve available editors on an given platform.

Unfortunately in #2611 these checks were now performed in `AppStore.loadInitialState()`, so the error wasn't handled which meant it would fail before it had a chance to show some UI about the error.

For now I've swapped this out to a warning and empty list, which has the same result but with 100% less crashing.

There's also some unused code in here that I've :fire:d.