### PR TITLE
enable linux build and test using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,24 @@ notifications:
     on_success: never
     on_failure: change
 
-os:
-  - osx
+dist: trusty
+
+matrix:
+  include:
+    - os: linux
+      env: CC=clang CXX=clang++ npm_config_clang=1
+      compiler: clang
+
+addons:
+  apt:
+    packages:
+      # by default the container VMs have Git 1.9.1, ermagherd...
+      - git-all
+      # this is required to compile keytar
+      - libsecret-1-dev
+      # this package is essential for testing Electron in a headless fashion
+      # https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
+      - xvfb
 
 branches:
   only:
@@ -35,9 +51,6 @@ script:
   - npm run build:prod
   - npm run test:setup
   - npm test
-
-after_success:
-  - npm run publish
 
 after_failure:
   - npm run test:review


### PR DESCRIPTION
After uncovering that I'd broken the app completely for Linux users in #2807, I'd like to get us back and running tests on Travis against the Linux version so we catch these earlier.

I've disabled publishing for now to ensure we don't accidentally publish things, but once we start exploring the packaging stuff again in #2300 and ensure our update server can consume new releases we can start talking about what official support looks like.