### PR TITLE
disable hook creation when cloning

### DIFF
--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -45,6 +45,10 @@ export async function clone(
     'clone',
     '--recursive',
     '--progress',
+    // git-lfs will create the hooks it requires by default
+    // and we don't know if the repository is LFS enabled
+    // at this stage so let's not do this
+    '--skip-repo',
   ]
 
   let opts: IGitExecutionOptions = { env }


### PR DESCRIPTION
Fixes #2809 

 - [x] no hooks initialized on repository when cloning
 - [x] prompt appears for LFS-enabled repository after clone
 - [x] repository state valid after enabling LFS (all good, same behaviour occurs on 1.0.0)