### PR TITLE
validate the source matches the release tag

### DIFF
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -13,42 +13,6 @@ const devClientSecret = '22c34d87789a365981ed921352a7b9a8c3f69d54'
 
 const channel = distInfo.getReleaseChannel()
 
-/**
- * Attempt to dereference the given ref without requiring a Git environment
- * to be present. Note that this method will not be able to dereference packed
- * refs but should suffice for simple refs like 'HEAD'.
- *
- * Will throw an error for unborn HEAD.
- *
- * @param {string} gitDir The path to the Git repository's .git directory
- * @param {string} ref    A qualified git ref such as 'HEAD' or 'refs/heads/master'
- */
-function revParse(gitDir, ref) {
-  const refPath = path.join(gitDir, ref)
-  const refContents = Fs.readFileSync(refPath)
-  const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m
-  const refMatch = refRe.exec(refContents)
-
-  if (!refMatch) {
-    throw new Error(
-      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`
-    )
-  }
-
-  return refMatch[1] || revParse(gitDir, refMatch[2])
-}
-
-function getSHA() {
-  // CircleCI does some funny stuff where HEAD points to an packed ref, but
-  // luckily it gives us the SHA we want in the environment.
-  const circleSHA = process.env.CIRCLE_SHA1
-  if (circleSHA) {
-    return circleSHA
-  }
-
-  return revParse(path.resolve(__dirname, '../.git'), 'HEAD')
-}
-
 const replacements = {
   __OAUTH_CLIENT_ID__: JSON.stringify(
     process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId
@@ -62,7 +26,7 @@ const replacements = {
   __DEV__: channel === 'development',
   __RELEASE_CHANNEL__: JSON.stringify(channel),
   __UPDATES_URL__: JSON.stringify(distInfo.getUpdatesURL()),
-  __SHA__: JSON.stringify(getSHA()),
+  __SHA__: JSON.stringify(distInfo.getSHA()),
   'process.platform': JSON.stringify(process.platform),
   'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
   'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -159,6 +159,42 @@ function shouldMakeDelta() {
   return channelsWithDeltas.indexOf(getReleaseChannel()) > -1
 }
 
+/**
+ * Attempt to dereference the given ref without requiring a Git environment
+ * to be present. Note that this method will not be able to dereference packed
+ * refs but should suffice for simple refs like 'HEAD'.
+ *
+ * Will throw an error for unborn HEAD.
+ *
+ * @param {string} gitDir The path to the Git repository's .git directory
+ * @param {string} ref    A qualified git ref such as 'HEAD' or 'refs/heads/master'
+ */
+function revParse(gitDir, ref) {
+  const refPath = path.join(gitDir, ref)
+  const refContents = fs.readFileSync(refPath)
+  const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m
+  const refMatch = refRe.exec(refContents)
+
+  if (!refMatch) {
+    throw new Error(
+      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`
+    )
+  }
+
+  return refMatch[1] || revParse(gitDir, refMatch[2])
+}
+
+function getSHA() {
+  // CircleCI does some funny stuff where HEAD points to an packed ref, but
+  // luckily it gives us the SHA we want in the environment.
+  const circleSHA = process.env.CIRCLE_SHA1
+  if (circleSHA) {
+    return circleSHA
+  }
+
+  return revParse(path.resolve(__dirname, '../.git'), 'HEAD')
+}
+
 module.exports = {
   getDistPath,
   getProductName,
@@ -177,10 +213,12 @@ module.exports = {
   getWindowsIdentifierName,
   getBundleSizes,
   getReleaseChannel,
+  getReleaseSHA,
   getUpdatesURL,
   getWindowsDeltaNugetPackageName,
   getWindowsDeltaNugetPackagePath,
   shouldMakeDelta,
   getReleaseBranchName,
   getExecutableName,
+  getSHA,
 }

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -148,6 +148,16 @@ function getReleaseChannel() {
   return pieces[1]
 }
 
+function getReleaseSHA() {
+  // Branch name format: __release-CHANNEL-DEPLOY_ID
+  const pieces = getReleaseBranchName().split('-')
+  if (pieces.length < 3 || pieces[0] !== '__release') {
+    return null
+  }
+
+  return pieces[2]
+}
+
 function getUpdatesURL() {
   return `https://central.github.com/api/deployments/desktop/desktop/latest?version=${getVersion()}&env=${getReleaseChannel()}`
 }

--- a/script/publish
+++ b/script/publish
@@ -11,6 +11,16 @@ if (PUBLISH_CHANNELS.indexOf(distInfo.getReleaseChannel()) < 0) {
   process.exit(0)
 }
 
+const releaseSHA = distInfo.getReleaseSHA()
+const currentTipSHA = distInfo.getSHA()
+
+if (!releaseSHA || !currentTipSHA.startsWith(releaseSHA)) {
+  console.log(
+    `Current tip ${currentTipSHA} does not match release SHA ${releaseSHA}. Skipping publish.`
+  )
+  process.exit(0)
+}
+
 const fs = require('fs')
 const cp = require('child_process')
 const AWS = require('aws-sdk')

--- a/script/publish
+++ b/script/publish
@@ -18,7 +18,10 @@ if (!releaseSHA) {
 }
 
 const currentTipSHA = distInfo.getSHA()
-if (!currentTipSHA || !currentTipSHA.startsWith(releaseSHA)) {
+if (
+  !currentTipSHA ||
+  !currentTipSHA.toUpperCase().startsWith(releaseSHA.toUpperCase())
+) {
   console.log(
     `Current tip '${currentTipSHA}' does not match release SHA '${releaseSHA}'. Skipping publish.`
   )

--- a/script/publish
+++ b/script/publish
@@ -12,11 +12,15 @@ if (PUBLISH_CHANNELS.indexOf(distInfo.getReleaseChannel()) < 0) {
 }
 
 const releaseSHA = distInfo.getReleaseSHA()
-const currentTipSHA = distInfo.getSHA()
+if (!releaseSHA) {
+  console.log(`No release SHA found for build. Skipping publish.`)
+  process.exit(0)
+}
 
-if (!releaseSHA || !currentTipSHA.startsWith(releaseSHA)) {
+const currentTipSHA = distInfo.getSHA()
+if (!currentTipSHA || !currentTipSHA.startsWith(releaseSHA)) {
   console.log(
-    `Current tip ${currentTipSHA} does not match release SHA ${releaseSHA}. Skipping publish.`
+    `Current tip '${currentTipSHA}' does not match release SHA '${releaseSHA}'. Skipping publish.`
   )
   process.exit(0)
 }


### PR DESCRIPTION
This ensures when `npm run publish` runs that the tagged release branch matches the current tip.

Without a tagged release, `publish` exits early:

```sh
$ git rev-parse HEAD
aceb06773eea63670e617f5d76aadd9d4526d8c8

$ npm run publish

> @ publish /Users/shiftkey/src/desktop/desktop
> node script/publish

Not a publishable build. Skipping publish.
```

If the release has been tagged (this is what CircleCI sets), we now compare the current tip with the shortened SHA in the branch. We shouldn't continue if those are different.

```sh
$ CIRCLE_BRANCH=__release-test-AAAAAAA npm run publish

> @ publish /Users/shiftkey/src/desktop/desktop
> node script/publish

Current tip 'aceb06773eea63670e617f5d76aadd9d4526d8c8' does not match release SHA 'AAAAAAA'. Skipping publish.
```

When the current tip matches (we don't embed the full SHA, so checking the starting characters should be enough), the publish will continue after packaging:

```
$ CIRCLE_BRANCH=__release-test-aceb0677 npm run publish

> @ publish /Users/shiftkey/src/desktop/desktop
> node script/publish

Packaging…
Bailing out before doing the publish!
```
