### PR TITLE
Add pull requests and commit status endpoints

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -107,12 +107,12 @@ export interface IAPIIssue {
   readonly updated_at: string
 }
 
-/** The status of a ref. */
-export type APIRefStatus = 'failure' | 'pending' | 'success'
+/** The combined state of a ref. */
+export type APIRefState = 'failure' | 'pending' | 'success'
 
 /** The API response to a ref status request. */
 interface IAPIRefStatus {
-  readonly status: APIRefStatus
+  readonly state: APIRefState
 }
 
 interface IAPIPullRequestRef {
@@ -401,12 +401,12 @@ export class API {
     owner: string,
     name: string,
     ref: string
-  ): Promise<APIRefStatus> {
+  ): Promise<APIRefState> {
     const path = `repos/${owner}/${name}/commits/${ref}/status`
     try {
       const response = await this.request('GET', path)
       const status = await parsedResponse<IAPIRefStatus>(response)
-      return status.status
+      return status.state
     } catch (e) {
       log.warn(
         `fetchRefStatus: failed for repository ${owner}/${name} on ref ${ref}`,

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -409,7 +409,7 @@ export class API {
       return status.state
     } catch (e) {
       log.warn(
-        `fetchRefStatus: failed for repository ${owner}/${name} on ref ${ref}`,
+        `fetchCombinedRefStatus: failed for repository ${owner}/${name} on ref ${ref}`,
         e
       )
       throw e

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -107,6 +107,14 @@ export interface IAPIIssue {
   readonly updated_at: string
 }
 
+/** Information about a pull request as returned by the GitHub API. */
+export interface IAPIPullRequest {
+  readonly number: number
+  readonly title: string
+  readonly created_at: string
+  readonly user: IAPIUser
+}
+
 /** The metadata about a GitHub server. */
 export interface IServerMetadata {
   /**
@@ -352,6 +360,22 @@ export class API {
       return issues.filter((i: any) => !i.pullRequest)
     } catch (e) {
       log.warn(`fetchIssues: failed for repository ${owner}/${name}`, e)
+      throw e
+    }
+  }
+
+  /** Fetch the pull requests in the given repository. */
+  public async fetchPullRequests(
+    owner: string,
+    name: string,
+    state: 'open' | 'closed' | 'all'
+  ): Promise<ReadonlyArray<IAPIPullRequest>> {
+    const url = urlWithQueryString(`repos/${owner}/${name}/pulls`, { state })
+    try {
+      const prs = await this.fetchAll<IAPIPullRequest>(url)
+      return prs
+    } catch (e) {
+      log.warn(`fetchPullRequests: failed for repository ${owner}/${name}`, e)
       throw e
     }
   }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -107,6 +107,14 @@ export interface IAPIIssue {
   readonly updated_at: string
 }
 
+/** The status of a ref. */
+export type APIRefStatus = 'failure' | 'pending' | 'success'
+
+/** The API response to a ref status request. */
+interface IAPIRefStatus {
+  readonly status: APIRefStatus
+}
+
 /** Information about a pull request as returned by the GitHub API. */
 export interface IAPIPullRequest {
   readonly number: number
@@ -376,6 +384,26 @@ export class API {
       return prs
     } catch (e) {
       log.warn(`fetchPullRequests: failed for repository ${owner}/${name}`, e)
+      throw e
+    }
+  }
+
+  /** Get the combined status for the given ref. */
+  public async fetchCombinedRefStatus(
+    owner: string,
+    name: string,
+    ref: string
+  ): Promise<APIRefStatus> {
+    const path = `repos/${owner}/${name}/commits/${ref}/status`
+    try {
+      const response = await this.request('GET', path)
+      const status = await parsedResponse<IAPIRefStatus>(response)
+      return status.status
+    } catch (e) {
+      log.warn(
+        `fetchRefStatus: failed for repository ${owner}/${name} on ref ${ref}`,
+        e
+      )
       throw e
     }
   }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -115,12 +115,19 @@ interface IAPIRefStatus {
   readonly status: APIRefStatus
 }
 
+interface IAPIPullRequestRef {
+  readonly ref: string
+  readonly repo: IAPIRepository
+}
+
 /** Information about a pull request as returned by the GitHub API. */
 export interface IAPIPullRequest {
   readonly number: number
   readonly title: string
   readonly created_at: string
   readonly user: IAPIUser
+  readonly head: IAPIPullRequestRef
+  readonly base: IAPIPullRequestRef
 }
 
 /** The metadata about a GitHub server. */

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -117,6 +117,7 @@ interface IAPIRefStatus {
 
 interface IAPIPullRequestRef {
   readonly ref: string
+  readonly sha: string
   readonly repo: IAPIRepository
 }
 


### PR DESCRIPTION
Fixes #2799

Unfortunately the `pulls` endpoint doesn't support a `since` parameter, so we're stuck fetching all the PRs all the time :hurtrealbad: 

The `issues` endpoint contains pull requests, but it only provides the API URL for them, so we'd be stuck doing _N_ requests to actually get the pull request info.

I think this'll have to do for now, until we can join the glorious GraphQL future.