### PR TITLE
show contents of directory if asked, not parent folder

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -1,6 +1,8 @@
 import '../lib/logging/main/install'
 
 import { app, Menu, MenuItem, ipcMain, BrowserWindow, shell } from 'electron'
+import * as Fs from 'fs'
+import * as Url from 'url'
 
 import { AppWindow } from './app-window'
 import { buildDefaultMenu, MenuEvent, findMenuItemByID } from './menu'
@@ -305,7 +307,23 @@ app.on('ready', () => {
   ipcMain.on(
     'show-item-in-folder',
     (event: Electron.IpcMessageEvent, { path }: { path: string }) => {
-      shell.showItemInFolder(path)
+      Fs.stat(path, (err, stats) => {
+        if (err) {
+          log.error(`Unable to find file at '${path}'`, err)
+          return
+        }
+
+        if (stats.isDirectory) {
+          const fileURL = Url.format({
+            pathname: path,
+            protocol: 'file:',
+            slashes: true,
+          })
+          shell.openExternal(fileURL)
+        } else {
+          shell.showItemInFolder(path)
+        }
+      })
     }
   )
 })


### PR DESCRIPTION
Fixes #2798 

I'd rather make these IPC events specific to the Desktop app, so that these events:

```ts
  ipcMain.on(
    'open-external',
    (event: Electron.IpcMessageEvent, { path }: { path: string }) => {
        // code
    }
  )

  ipcMain.on(
    'show-item-in-folder',
    (event: Electron.IpcMessageEvent, { path }: { path: string }) => {
      // code      
    }
  )
```

Looks more like this in the main process:

```ts
  ipcMain.on(
    'open-url',
    (event: Electron.IpcMessageEvent, { path }: { path: string }) => {
        // code
    }
  )

  ipcMain.on(
    'open-file',
    (event: Electron.IpcMessageEvent, { path }: { path: string }) => {
      // code      
    }
  )

  ipcMain.on(
    'open-folder',
    (event: Electron.IpcMessageEvent, { path }: { path: string }) => {
      // code      
    }
  )
```

And we move and complexity into the renderer, where we know more about the context for making the call. But I'll spin that off to a new `tech-debt` task if we're :thumbsup: on going down that path.
