### PR TITLE
display warning about existing folder before cloning

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -234,8 +234,12 @@ export class CloneRepository extends React.Component<
     this.props.dispatcher.showEnterpriseSignInDialog()
   }
 
-  private updatePath = async (path: string) => {
+  private updatePath = (path: string) => {
     this.setState({ path })
+  }
+
+  private updateAndValidatePath = async (path: string) => {
+    this.updatePath(path)
 
     const doesDirectoryExist = await this.doesPathExist(path)
 
@@ -263,18 +267,7 @@ export class CloneRepository extends React.Component<
       ? Path.join(directories[0], lastParsedIdentifier.name)
       : directories[0]
 
-    this.updatePath(directory)
-
-    const doesDirectoryExist = await this.doesPathExist(directory)
-
-    if (doesDirectoryExist) {
-      const error: Error = new Error('The destination already exists.')
-      error.name = DestinationExistsErrorName
-
-      this.setState({ error })
-    } else {
-      this.setState({ error: null })
-    }
+    this.updateAndValidatePath(directory)
 
     return directory
   }
@@ -297,23 +290,12 @@ export class CloneRepository extends React.Component<
       newPath = this.state.path
     }
 
-    this.updatePath(newPath)
-
-    const pathExist = await this.doesPathExist(newPath)
-
-    let error = null
-
-    if (pathExist) {
-      error = new Error('The destination already exists.')
-      error.name = DestinationExistsErrorName
-    }
-
     this.setState({
       url,
-      path: newPath,
       lastParsedIdentifier: parsed,
-      error,
     })
+
+    this.updateAndValidatePath(newPath)
   }
 
   private async doesPathExist(path: string) {

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -234,8 +234,19 @@ export class CloneRepository extends React.Component<
     this.props.dispatcher.showEnterpriseSignInDialog()
   }
 
-  private updatePath = (path: string) => {
+  private updatePath = async (path: string) => {
     this.setState({ path })
+
+    const doesDirectoryExist = await this.doesPathExist(path)
+
+    if (doesDirectoryExist) {
+      const error: Error = new Error('The destination already exists.')
+      error.name = DestinationExistsErrorName
+
+      this.setState({ error })
+    } else {
+      this.setState({ error: null })
+    }
   }
 
   private onChooseDirectory = async () => {
@@ -285,6 +296,8 @@ export class CloneRepository extends React.Component<
     } else {
       newPath = this.state.path
     }
+
+    this.updatePath(newPath)
 
     const pathExist = await this.doesPathExist(newPath)
 


### PR DESCRIPTION
Fixes #2777
Fixes #2830 

The root cause of both of these problems is tucked away in `doesPathExist`:

```ts
  private async doesPathExist(path: string) {
    const exists = await pathExists(path)
    // If the path changed while we were checking, we don't care anymore.
    if (this.state.path !== path) {
      return
    }

    return exists
  }
```

You need to set `this.state.path` before invoking this, otherwise the result is thrown away, and whenever we were modifying the clone URL or alias we weren't - so it never did this check.

This consolidates the checks to make it harder for future contributors to not make the same mistake.

