### PR TITLE
Update to Electron 1.7.8

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 1.7.5
+target = 1.7.8
 arch = x64

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "clean-webpack-plugin": "^0.1.16",
     "cross-env": "^5.0.5",
     "css-loader": "^0.28.5",
-    "electron": "1.7.5",
+    "electron": "1.7.8",
     "electron-mocha": "^4.0.0",
     "electron-packager": "^8.7.2",
     "electron-winstaller": "2.5.2",


### PR DESCRIPTION
1.7.8 includes a fix for a Chromium RCE vulnerability. I don't think we're vulnerable since we don't load any remote content, but better safe than sorry.