### PR TITLE
Convert the generate-octicons script to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:dev": "npm run compile:dev && cross-env NODE_ENV=development ts-node script/build.ts",
     "build:prod": "npm run compile:prod && cross-env NODE_ENV=production ts-node script/build.ts",
     "package": "node script/package",
+    "generate-octicons": "ts-node script/generate-octicons.ts",
     "clean:tslint": "rimraf tslint-rules/*.js",
     "compile:tslint": "tsc -p tslint-rules",
     "lint": "npm run compile:tslint && tslint \"./app/{src,test}/**/*.{ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate-octicons": "ts-node script/generate-octicons.ts",
     "clean:tslint": "rimraf tslint-rules/*.js",
     "compile:tslint": "tsc -p tslint-rules",
-    "lint": "npm run compile:tslint && tslint \"./app/{src,test}/**/*.{ts,tsx}\"",
+    "lint": "npm run compile:tslint && tslint \"./app/{src,test}/**/*.{ts,tsx}\" \"./scripts/*.ts\"",
     "check-prettiness": "node script/is-it-pretty",
     "publish": "node script/publish",
     "clean-slate": "rimraf out node_modules app/node_modules && npm install",

--- a/package.json
+++ b/package.json
@@ -104,11 +104,12 @@
     "@types/react-transition-group": "1.1.1",
     "@types/react-virtualized": "9.7.2",
     "@types/temp": "^0.8.29",
+    "@types/to-camel-case": "^1.0.0",
     "@types/ua-parser-js": "^0.7.30",
     "@types/uuid": "^3.4.0",
     "@types/winston": "^2.2.0",
-    "prettier": "~1.7.0",
     "@types/xml2js": "^0.4.0",
+    "prettier": "~1.7.0",
     "tslint-config-prettier": "^1.1.0",
     "tslint-react": "~3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/uuid": "^3.4.0",
     "@types/winston": "^2.2.0",
     "prettier": "~1.7.0",
+    "@types/xml2js": "^0.4.0",
     "tslint-config-prettier": "^1.1.0",
     "tslint-react": "~3.0.0"
   }

--- a/script/generate-octicons.ts
+++ b/script/generate-octicons.ts
@@ -5,10 +5,7 @@
  * downloads the latest version of the `sprite.octicons.svg` file.
  */
 
-'use strict'
-
 import fs = require('fs')
-import process = require('process')
 import xml2js = require('xml2js')
 import path = require('path')
 import toCamelCase = require('to-camel-case')
@@ -22,17 +19,18 @@ const filePath = path.resolve(
   'sprite.octicons.svg'
 )
 
+/* tslint:disable:no-sync-functions */
 const file = fs.readFileSync(filePath, 'utf-8')
 
-interface XML2JSResult {
-  svg: { symbol: ReadonlyArray<XML2JSNode> }
+interface IXML2JSResult {
+  svg: { symbol: ReadonlyArray<IXML2JSNode> }
 }
-interface XML2JSNode {
+interface IXML2JSNode {
   $: { [key: string]: string }
-  path: ReadonlyArray<XML2JSNode>
+  path: ReadonlyArray<IXML2JSNode>
 }
 
-xml2js.parseString(file, function(err, result: XML2JSResult) {
+xml2js.parseString(file, function(err, result: IXML2JSResult) {
   const viewBoxRe = /0 0 (\d+) (\d+)/
   const out = fs.createWriteStream(
     path.resolve(__dirname, '../app/src/ui/octicons/octicons.generated.ts'),

--- a/script/generate-octicons.ts
+++ b/script/generate-octicons.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /* generate-octicons
  *
  * Utility script for generating a strongly typed representation of all
@@ -9,11 +7,11 @@
 
 'use strict'
 
-const fs = require('fs')
-const process = require('process')
-const xml2js = require('xml2js')
-const path = require('path')
-const toCamelCase = require('to-camel-case')
+import fs = require('fs')
+import process = require('process')
+import xml2js = require('xml2js')
+import path = require('path')
+import toCamelCase = require('to-camel-case')
 
 const filePath = path.resolve(
   __dirname,
@@ -26,7 +24,16 @@ const filePath = path.resolve(
 
 const file = fs.readFileSync(filePath)
 
-xml2js.parseString(file, function(err, result) {
+interface XML2JSResult {
+  svg: { symbol: ReadonlyArray<XML2JSNode> }
+}
+interface XML2JSNode {
+  $: { [key: string]: string }
+  path: ReadonlyArray<XML2JSNode>
+
+}
+
+xml2js.parseString(file, function(err, result: XML2JSResult) {
   const viewBoxRe = /0 0 (\d+) (\d+)/
   const out = fs.createWriteStream(
     path.resolve(__dirname, '../app/src/ui/octicons/octicons.generated.ts')

--- a/script/generate-octicons.ts
+++ b/script/generate-octicons.ts
@@ -30,7 +30,6 @@ interface XML2JSResult {
 interface XML2JSNode {
   $: { [key: string]: string }
   path: ReadonlyArray<XML2JSNode>
-
 }
 
 xml2js.parseString(file, function(err, result: XML2JSResult) {
@@ -38,7 +37,7 @@ xml2js.parseString(file, function(err, result: XML2JSResult) {
   const out = fs.createWriteStream(
     path.resolve(__dirname, '../app/src/ui/octicons/octicons.generated.ts'),
     {
-      encoding: 'utf-8'
+      encoding: 'utf-8',
     }
   )
 

--- a/script/generate-octicons.ts
+++ b/script/generate-octicons.ts
@@ -22,7 +22,7 @@ const filePath = path.resolve(
   'sprite.octicons.svg'
 )
 
-const file = fs.readFileSync(filePath)
+const file = fs.readFileSync(filePath, 'utf-8')
 
 interface XML2JSResult {
   svg: { symbol: ReadonlyArray<XML2JSNode> }
@@ -36,7 +36,10 @@ interface XML2JSNode {
 xml2js.parseString(file, function(err, result: XML2JSResult) {
   const viewBoxRe = /0 0 (\d+) (\d+)/
   const out = fs.createWriteStream(
-    path.resolve(__dirname, '../app/src/ui/octicons/octicons.generated.ts')
+    path.resolve(__dirname, '../app/src/ui/octicons/octicons.generated.ts'),
+    {
+      encoding: 'utf-8'
+    }
   )
 
   out.write('/*\n')

--- a/script/generate-octicons.ts
+++ b/script/generate-octicons.ts
@@ -64,8 +64,9 @@ xml2js.parseString(file, function(err, result: XML2JSResult) {
     const viewBoxMatch = viewBoxRe.exec(viewBox)
 
     if (!viewBoxMatch) {
-      console.error(`Unexpected viewBox format for ${id}`)
-      process.exit(1)
+      console.error(`*** ERROR! Unexpected viewBox format for ${id}`)
+      process.exitCode = 1
+      return
     }
 
     const [, w, h] = viewBoxMatch


### PR DESCRIPTION
Also, update the `fs` calls in the script to use UTF-8 when reading and writing.