### PR TITLE
Catch logging exceptions

### DIFF
--- a/app/src/lib/logging/get-log-path.ts
+++ b/app/src/lib/logging/get-log-path.ts
@@ -1,13 +1,13 @@
 import * as Path from 'path'
 import { app } from 'electron'
 
-let logFilePath: string | null = null
+let logDirectoryPath: string | null = null
 
-export function getLogPath() {
-  if (!logFilePath) {
+export function getLogDirectoryPath() {
+  if (!logDirectoryPath) {
     const userData = app.getPath('userData')
-    logFilePath = Path.join(userData, 'logs')
+    logDirectoryPath = Path.join(userData, 'logs')
   }
 
-  return logFilePath
+  return logDirectoryPath
 }

--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -1,7 +1,7 @@
 import * as Path from 'path'
 import * as winston from 'winston'
 
-import { getLogPath } from '../lib/logging/get-log-path'
+import { getLogDirectoryPath } from '../lib/logging/get-log-path'
 import { LogLevel } from '../lib/logging/log-level'
 import { mkdirIfNeeded } from '../lib/file-system'
 
@@ -71,11 +71,11 @@ function getLogger(): Promise<winston.LogMethod> {
   }
 
   loggerPromise = new Promise<winston.LogMethod>((resolve, reject) => {
-    const logPath = getLogPath()
+    const logDirectory = getLogDirectoryPath()
 
-    mkdirIfNeeded(logPath)
+    mkdirIfNeeded(logDirectory)
       .then(() => {
-        resolve(initializeWinston(getLogFilePath(logPath)))
+        resolve(initializeWinston(getLogFilePath(logDirectory)))
       })
       .catch(error => {
         reject(error)

--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -75,7 +75,12 @@ function getLogger(): Promise<winston.LogMethod> {
 
     mkdirIfNeeded(logDirectory)
       .then(() => {
-        resolve(initializeWinston(getLogFilePath(logDirectory)))
+        try {
+          const logger = initializeWinston(getLogFilePath(logDirectory))
+          resolve(logger)
+        } catch (err) {
+          reject(err)
+        }
       })
       .catch(error => {
         reject(error)

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -1,7 +1,7 @@
 import { Menu, ipcMain, shell, app } from 'electron'
 import { ensureItemIds } from './ensure-item-ids'
 import { MenuEvent } from './menu-event'
-import { getLogPath } from '../../lib/logging/get-log-path'
+import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { mkdirIfNeeded } from '../../lib/file-system'
 
 import { log } from '../log'
@@ -340,7 +340,7 @@ export function buildDefaultMenu(
   const showLogsItem: Electron.MenuItemConstructorOptions = {
     label: __DARWIN__ ? 'Show Logs in Finder' : 'S&how logs in Explorer',
     click() {
-      const logPath = getLogPath()
+      const logPath = getLogDirectoryPath()
       mkdirIfNeeded(logPath)
         .then(() => {
           shell.showItemInFolder(logPath)


### PR DESCRIPTION
We get a surprising amount of exceptions from situations where we can't open the log (mostly out of space error, sometimes other nonsense). See https://haystack.githubapp.com/desktop/rollups/d41d8cd98f00b204e9800998ecf8427e.

Failing to open the log file shouldn't be fatal.