### PR TITLE
git reset needs to be explicit because HEAD might also be a file

### DIFF
--- a/app/src/lib/git/reset.ts
+++ b/app/src/lib/git/reset.ts
@@ -84,7 +84,7 @@ export async function resetPaths(
     // as macOS and Linux don't have this same shell limitation. See
     // https://github.com/desktop/desktop/issues/2833#issuecomment-331352952
     // for more context.
-    const args = [...baseArgs, '--stdin', '-z']
+    const args = [...baseArgs, '--stdin', '-z', '--']
     await git(args, repository.path, 'resetPaths', {
       stdin: paths.join('\0'),
     })


### PR DESCRIPTION
This was reported in https://github.com/desktop/desktop/issues/2721#issuecomment-333433436 but I don't think is the entire resolution to the issue.

```
install.ts:35 Executing resetPaths: git reset HEAD --stdin -z
install.ts:23 `git reset HEAD --stdin -z` exited with an unexpected code: 128.
fatal: ambiguous argument 'HEAD': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

error @ install.ts:23
t.git @ core.ts:172
_tickCallback @ internal/process/next_tick.js:109
```
