### PR TITLE
"Clone in Desktop" flow now recognizes gists

### DIFF
--- a/app/src/lib/find-account.ts
+++ b/app/src/lib/find-account.ts
@@ -93,7 +93,7 @@ export async function findAccountForRemoteURL(
   }
 
   const repositoryIdentifier = parseRepositoryIdentifier(urlOrRepositoryAlias)
-  if (repositoryIdentifier) {
+  if (repositoryIdentifier && repositoryIdentifier.kind === 'repository') {
     const { owner, name } = repositoryIdentifier
     const account = await findRepositoryAccount(allAccounts, owner, name)
     if (account) {

--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -22,11 +22,13 @@ export function parseRemote(url: string): IGitRemoteURL | null {
   // https://github.com/octocat/Hello-World.git/
   // git@github.com:octocat/Hello-World.git
   // git:github.com/octocat/Hello-World.git
+  // https://gist.github.com/8675309
   const regexes = [
     new RegExp('^https?://(?:.+@)?(.+)/(.+)/(.+?)(?:/|.git/?)?$'),
     new RegExp('^git@(.+):(.+)/(.+?)(?:/|.git)?$'),
     new RegExp('^git:(.+)/(.+)/(.+?)(?:/|.git)?$'),
     new RegExp('^ssh://git@(.+)/(.+)/(.+?)(?:/|.git)?$'),
+    new RegExp('^https?://(?:.+@)?(.+)/([0-9]+)'),
   ]
 
   for (const regex of regexes) {
@@ -35,11 +37,21 @@ export function parseRemote(url: string): IGitRemoteURL | null {
       continue
     }
 
-    const hostname = result[1]
-    const owner = result[2]
-    const name = result[3]
-    if (hostname) {
-      return { hostname, owner, name }
+    if (result.length === 4) {
+      const hostname = result[1]
+      const owner = result[2]
+      const name = result[3]
+      if (hostname) {
+        return { hostname, owner, name }
+      }
+    }
+
+    if (result.length === 3) {
+      const hostname = result[1]
+      const name = result[2]
+      if (hostname) {
+        return { hostname, owner: null, name }
+      }
     }
   }
 

--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -59,14 +59,20 @@ export function parseRemote(url: string): IGitRemoteURL | null {
 }
 
 export interface IRepositoryIdentifier {
+  readonly kind: 'repository'
   readonly owner: string
+  readonly name: string
+}
+
+export interface IGistIdentifier {
+  readonly kind: 'gist'
   readonly name: string
 }
 
 /** Try to parse an owner and name from a URL or owner/name shortcut. */
 export function parseRepositoryIdentifier(
   url: string
-): IRepositoryIdentifier | null {
+): IRepositoryIdentifier | IGistIdentifier | null {
   const parsed = parseRemote(url)
   // If we can parse it as a remote URL, we'll assume they gave us a proper
   // URL. If not, we'll try treating it as a GitHub repository owner/name
@@ -75,7 +81,11 @@ export function parseRepositoryIdentifier(
     const owner = parsed.owner
     const name = parsed.name
     if (owner && name) {
-      return { owner, name }
+      return { kind: 'repository', owner, name }
+    }
+
+    if (name) {
+      return { kind: 'gist', name }
     }
   }
 
@@ -83,7 +93,7 @@ export function parseRepositoryIdentifier(
   if (pieces.length === 2 && pieces[0].length > 0 && pieces[1].length > 0) {
     const owner = pieces[0]
     const name = pieces[1]
-    return { owner, name }
+    return { kind: 'repository', owner, name }
   }
 
   return null

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -8,6 +8,7 @@ import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import { Account } from '../../models/account'
 import {
   IRepositoryIdentifier,
+  IGistIdentifier,
   parseRepositoryIdentifier,
 } from '../../lib/remote-parsing'
 import { findAccountForRemoteURL } from '../../lib/find-account'
@@ -60,7 +61,7 @@ interface ICloneRepositoryState {
   /**
    * The repository identifier that was last parsed from the user-entered URL.
    */
-  readonly lastParsedIdentifier: IRepositoryIdentifier | null
+  readonly lastParsedIdentifier: IRepositoryIdentifier | IGistIdentifier | null
 }
 
 /** The component for cloning a repository. */
@@ -325,7 +326,7 @@ export class CloneRepository extends React.Component<
     }
 
     const account = await findAccountForRemoteURL(url, accounts)
-    if (identifier && account) {
+    if (identifier && identifier.kind === 'repository' && account) {
       const api = API.fromAccount(account)
       const repo = await api.fetchRepository(identifier.owner, identifier.name)
       if (repo) {

--- a/app/test/unit/remote-parsing-test.ts
+++ b/app/test/unit/remote-parsing-test.ts
@@ -98,4 +98,11 @@ describe('URL remote parsing', () => {
     expect(remote!.owner).to.equal('hubot')
     expect(remote!.name).to.equal('repo')
   })
+
+  it('parses Gist URLs', () => {
+    const remote = parseRemote('https://gist.github.com/8128922')
+    expect(remote).not.to.equal(null)
+    expect(remote!.hostname).to.equal('gist.github.com')
+    expect(remote!.name).to.equal('8128922')
+  })
 })


### PR DESCRIPTION
Fixes #2886 

Currently, we don't recognise gist URLs, and the first screen you see in the app after you try and clone a Gist from the browser looks intimidating:

<img width="473" src="https://user-images.githubusercontent.com/359239/31072768-0e4a7c30-a7b5-11e7-9e82-db2af7c7ea2b.png">

This is because we don't handle the gist format, `https://gist.github.com/{number}`, correctly.

With this change, the first view now looks like this:

<img width="490" src="https://user-images.githubusercontent.com/359239/31072880-8146e1e2-a7b5-11e7-99a0-aa451ea048d3.png">

~~Still pondering how I feel about this fix, and ensure the shape of things makes sense. Any additional thoughts are more than welcome.~~