### PR TITLE
Add a message about the “minimize” tooltip to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,17 @@ https://github.com/desktop/desktop/blob/master/CODE_OF_CONDUCT.md
 
 <!--
 
+Are you encountering an issue where the “Minimize” tooltip stays visible
+when you click the minimize button in the window? If so, that is an issue
+with Electron, the framework the app uses. Please subscribe to the issue
+at this link for updates on the issue:
+
+https://github.com/electron/electron/issues/9943
+
+-->
+
+<!--
+
 Please summarize the issue in the title, and then use the template below to
 fill out the details so we can reproduce the issue on our end.
 


### PR DESCRIPTION
There are currently nine references from this repo on https://github.com/electron/electron/issues/9943. This should save people a lot of effort because they won’t have to fill out the issue template, then have it closed as a duplicate by a team member, and can instead click the 👍 button on the issue.