### PR TITLE
level up our tracing of git operations that rely on the network

### DIFF
--- a/app/src/lib/git/authentication.ts
+++ b/app/src/lib/git/authentication.ts
@@ -13,15 +13,30 @@ export interface IGitAccount {
   readonly endpoint: string
 }
 
+interface ITracingOptions {
+  logFile: string
+}
+
 /** Get the environment for authenticating remote operations. */
-export function envForAuthentication(auth: IGitAccount | null): Object {
-  const env = {
+export function envForAuthentication(
+  auth: IGitAccount | null,
+  options: ITracingOptions | null = null
+): Object {
+  let env: Object = {
     DESKTOP_PATH: process.execPath,
     DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
     GIT_ASKPASS: getAskPassTrampolinePath(),
     // supported since Git 2.3, this is used to ensure we never interactively prompt
     // for credentials - even as a fallback
     GIT_TERMINAL_PROMPT: '0',
+  }
+
+  if (options) {
+    env = {
+      ...env,
+      GIT_TRACE: options.logFile,
+      GIT_TRACE_CURL: options.logFile,
+    }
   }
 
   if (!auth) {

--- a/app/src/lib/git/authentication.ts
+++ b/app/src/lib/git/authentication.ts
@@ -13,30 +13,15 @@ export interface IGitAccount {
   readonly endpoint: string
 }
 
-interface ITracingOptions {
-  logFile: string
-}
-
 /** Get the environment for authenticating remote operations. */
-export function envForAuthentication(
-  auth: IGitAccount | null,
-  options: ITracingOptions | null = null
-): Object {
-  let env: Object = {
+export function envForAuthentication(auth: IGitAccount | null): Object {
+  const env = {
     DESKTOP_PATH: process.execPath,
     DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
     GIT_ASKPASS: getAskPassTrampolinePath(),
     // supported since Git 2.3, this is used to ensure we never interactively prompt
     // for credentials - even as a fallback
     GIT_TERMINAL_PROMPT: '0',
-  }
-
-  if (options) {
-    env = {
-      ...env,
-      GIT_TRACE: options.logFile,
-      GIT_TRACE_CURL: options.logFile,
-    }
   }
 
   if (!auth) {

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -3,13 +3,12 @@ import { ICloneProgress } from '../app-state'
 import { CloneProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication, IGitAccount } from './authentication'
 
-import * as Fs from 'fs-extra'
-import * as Path from 'path'
-import * as Os from 'os'
-import { uuid } from '../uuid'
-
-import { pathExists } from '../file-system'
-import { getUserDataPath } from '../../ui/lib/app-proxy'
+import {
+  getLogFilePath,
+  moveTracingToLogDirectory,
+  moveLFSTraceFilesToLogDirectory,
+  cleanupTracing,
+} from './tracing'
 
 /** Additional arguments to provide when cloning a repository */
 export type CloneOptions = {
@@ -17,54 +16,6 @@ export type CloneOptions = {
   readonly account: IGitAccount | null
   /** The branch to checkout after the clone has completed. */
   readonly branch?: string
-}
-
-function getLogFilePath(action: string): string {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth() + 1
-  const day = now.getDate()
-  const fileName = `${year}-${month}-${day}-desktop.${action}.${uuid()}.log`
-  // TODO: probably a better pattern for generating this file path
-  return Path.join(Os.tmpdir(), fileName)
-}
-
-async function moveTracingToLogDirectory(logFile: string): Promise<void> {
-  const exists = await pathExists(logFile)
-  if (exists) {
-    return new Promise<void>((resolve, reject) => {
-      const userData = getUserDataPath()
-      const logsDir = Path.join(userData, 'logs')
-      Fs.move(logFile, logsDir, err => {
-        if (err) {
-          log.debug('Unable to move tracing file to logs directory', err)
-        }
-        resolve()
-      })
-    })
-  }
-}
-
-async function moveLFSTraceFilesToLogDirectory(
-  directory: string
-): Promise<void> {
-  // TODO: scan directory for LFS log files
-  // TODO: copy any files to log directory
-  await Promise.resolve()
-}
-
-async function cleanupTracing(logFile: string): Promise<void> {
-  const exists = await pathExists(logFile)
-  if (exists) {
-    return new Promise<void>((resolve, reject) => {
-      Fs.unlink(logFile, err => {
-        if (err) {
-          log.debug('Unable to move tracing file to log directory', err)
-        }
-      })
-      resolve()
-    })
-  }
 }
 
 /**

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -9,7 +9,7 @@ import * as Os from 'os'
 import { uuid } from '../uuid'
 
 import { pathExists } from '../file-system'
-import { getLogDirectoryPath } from '../logging/get-log-path'
+import { getUserDataPath } from '../../ui/lib/app-proxy'
 
 /** Additional arguments to provide when cloning a repository */
 export type CloneOptions = {
@@ -33,10 +33,11 @@ async function moveTracingToLogDirectory(logFile: string): Promise<void> {
   const exists = await pathExists(logFile)
   if (exists) {
     return new Promise<void>((resolve, reject) => {
-      const destination = getLogDirectoryPath()
-      Fs.move(logFile, destination, err => {
+      const userData = getUserDataPath()
+      const logsDir = Path.join(userData, 'logs')
+      Fs.move(logFile, logsDir, err => {
         if (err) {
-          log.debug('Unable to move tracing file to log directory', err)
+          log.debug('Unable to move tracing file to logs directory', err)
         }
         resolve()
       })

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -3,7 +3,7 @@ import { ICloneProgress } from '../app-state'
 import { CloneProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication, IGitAccount } from './authentication'
 
-import { getLogFilePath, withTracingCleanup } from './tracing'
+import { getLogFilePath, addTracing, withTracingCleanup } from './tracing'
 
 /** Additional arguments to provide when cloning a repository */
 export type CloneOptions = {
@@ -40,7 +40,7 @@ export async function clone(
   progressCallback?: (progress: ICloneProgress) => void
 ): Promise<void> {
   const logFile = getLogFilePath('clone')
-  const env = envForAuthentication(options.account, { logFile })
+  const env = addTracing(envForAuthentication(options.account), logFile)
 
   const args = [
     ...gitNetworkArguments,

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -4,7 +4,7 @@ import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
 import { IFetchProgress } from '../app-state'
 import { IGitAccount, envForAuthentication } from './authentication'
 
-import { getLogFilePath, withTracingCleanup } from './tracing'
+import { getLogFilePath, addTracing, withTracingCleanup } from './tracing'
 
 /**
  * Fetch from the given remote.
@@ -31,7 +31,7 @@ export async function fetch(
 
   let opts: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
-    env: envForAuthentication(account, { logFile }),
+    env: addTracing(envForAuthentication(account), logFile),
   }
 
   if (progressCallback) {
@@ -86,7 +86,7 @@ export async function fetchRefspec(
 
   const options = {
     successExitCodes: new Set([0, 128]),
-    env: envForAuthentication(account, { logFile }),
+    env: addTracing(envForAuthentication(account), logFile),
   }
 
   const args = [...gitNetworkArguments, 'fetch', remote, refspec]

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -4,6 +4,8 @@ import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
 import { IFetchProgress } from '../app-state'
 import { IGitAccount, envForAuthentication } from './authentication'
 
+import { getLogFilePath, withTracingCleanup } from './tracing'
+
 /**
  * Fetch from the given remote.
  *
@@ -25,9 +27,11 @@ export async function fetch(
   remote: string,
   progressCallback?: (progress: IFetchProgress) => void
 ): Promise<void> {
+  const logFile = getLogFilePath('fetch')
+
   let opts: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
-    env: envForAuthentication(account),
+    env: envForAuthentication(account, { logFile }),
   }
 
   if (progressCallback) {
@@ -64,7 +68,11 @@ export async function fetch(
     ? [...gitNetworkArguments, 'fetch', '--progress', '--prune', remote]
     : [...gitNetworkArguments, 'fetch', '--prune', remote]
 
-  await git(args, repository.path, 'fetch', opts)
+  await withTracingCleanup(
+    () => git(args, repository.path, 'fetch', opts),
+    logFile,
+    repository.path
+  )
 }
 
 /** Fetch a given refspec from the given remote. */
@@ -74,12 +82,18 @@ export async function fetchRefspec(
   remote: string,
   refspec: string
 ): Promise<void> {
+  const logFile = getLogFilePath('fetch')
+
   const options = {
     successExitCodes: new Set([0, 128]),
-    env: envForAuthentication(account),
+    env: envForAuthentication(account, { logFile }),
   }
 
   const args = [...gitNetworkArguments, 'fetch', remote, refspec]
 
-  await git(args, repository.path, 'fetchRefspec', options)
+  await withTracingCleanup(
+    () => git(args, repository.path, 'fetchRefspec', options),
+    logFile,
+    repository.path
+  )
 }

--- a/app/src/lib/git/tracing.ts
+++ b/app/src/lib/git/tracing.ts
@@ -5,7 +5,6 @@ import { uuid } from '../uuid'
 
 import { pathExists } from '../file-system'
 import { getUserDataPath } from '../../ui/lib/app-proxy'
-import { IGitResult } from './core'
 
 function padNumber(n: number): string {
   return n.toString().padStart(2, '0')
@@ -128,7 +127,7 @@ async function cleanupTracing(logFile: string): Promise<void> {
  * @param repositoryPath The folder associated with the repository, for additional investigating.
  */
 export async function withTracingCleanup(
-  action: () => Promise<IGitResult>,
+  action: () => Promise<any>,
   logFile: string,
   repositoryPath: string
 ): Promise<void> {

--- a/app/src/lib/git/tracing.ts
+++ b/app/src/lib/git/tracing.ts
@@ -25,6 +25,12 @@ export function getLogFilePath(action: string): string {
   return Path.join(Os.tmpdir(), fileName)
 }
 
+/**
+ * Append trace environment variables to an existing set of environment variables
+ *
+ * @param env The environment variables object to extend
+ * @param logFile The log file to use for tracing
+ */
 export function addTracing(env: Object, logFile: string): Object {
   return {
     ...env,

--- a/app/src/lib/git/tracing.ts
+++ b/app/src/lib/git/tracing.ts
@@ -25,6 +25,14 @@ export function getLogFilePath(action: string): string {
   return Path.join(Os.tmpdir(), fileName)
 }
 
+export function addTracing(env: Object, logFile: string): Object {
+  return {
+    ...env,
+    GIT_TRACE: logFile,
+    GIT_TRACE_CURL: logFile,
+  }
+}
+
 function getLogsDir(): string {
   const userData = getUserDataPath()
   return Path.join(userData, 'logs')

--- a/app/src/lib/git/tracing.ts
+++ b/app/src/lib/git/tracing.ts
@@ -34,7 +34,6 @@ export function addTracing(env: Object, logFile: string): Object {
   return {
     ...env,
     GIT_TRACE: logFile,
-    GIT_TRACE_CURL: logFile,
   }
 }
 

--- a/app/src/lib/git/tracing.ts
+++ b/app/src/lib/git/tracing.ts
@@ -1,0 +1,65 @@
+import * as Fs from 'fs-extra'
+import * as Path from 'path'
+import * as Os from 'os'
+import { uuid } from '../uuid'
+
+import { pathExists } from '../file-system'
+import { getUserDataPath } from '../../ui/lib/app-proxy'
+
+function padNumber(n: number): string {
+  return n.toString().padStart(2, '0')
+}
+
+/**
+ *
+ * @param action the Git action to use in the file name
+ */
+export function getLogFilePath(action: string): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = padNumber(now.getMonth() + 1)
+  const day = padNumber(now.getDate())
+  const fileName = `${year}-${month}-${day}-desktop.${action}.${uuid()}.log`
+  return Path.join(Os.tmpdir(), fileName)
+}
+
+export async function moveTracingToLogDirectory(
+  logFile: string
+): Promise<void> {
+  const exists = await pathExists(logFile)
+  if (exists) {
+    return new Promise<void>((resolve, reject) => {
+      const fileName = Path.basename(logFile)
+      const userData = getUserDataPath()
+      const logsDir = Path.join(userData, 'logs', fileName)
+      Fs.move(logFile, logsDir, err => {
+        if (err) {
+          log.debug('Unable to move tracing file to logs directory', err)
+        }
+        resolve()
+      })
+    })
+  }
+}
+
+export async function moveLFSTraceFilesToLogDirectory(
+  directory: string
+): Promise<void> {
+  // TODO: scan directory for LFS log files
+  // TODO: copy any files to log directory
+  await Promise.resolve()
+}
+
+export async function cleanupTracing(logFile: string): Promise<void> {
+  const exists = await pathExists(logFile)
+  if (exists) {
+    return new Promise<void>((resolve, reject) => {
+      Fs.unlink(logFile, err => {
+        if (err) {
+          log.debug('Unable to move tracing file to log directory', err)
+        }
+      })
+      resolve()
+    })
+  }
+}

--- a/app/src/lib/git/tracing.ts
+++ b/app/src/lib/git/tracing.ts
@@ -12,6 +12,7 @@ function padNumber(n: number): string {
 }
 
 /**
+ * Get the path to a unique log file in the temporary directory for the machine.
  *
  * @param action the Git action to use in the file name
  */
@@ -63,6 +64,16 @@ async function cleanupTracing(logFile: string): Promise<void> {
   }
 }
 
+/**
+ * Execute a Git operation with error handling to move log files into the app's
+ * log directory, to make bug reports easier to understand.
+ *
+ * Will not move files over if the operation doesn't raise an error.
+ *
+ * @param action The Git action to perform
+ * @param logFile A log file that might be generated as part of the
+ * @param repositoryPath The folder associated with the repository, for additional investigating.
+ */
 export async function withTracingCleanup(
   action: () => Promise<IGitResult>,
   logFile: string,


### PR DESCRIPTION
We have a few outstanding issues that are challenging to diagnose due to lack of information. Some examples: 

 - #2908 - some vague authentication error
 - #2812 - LFS is doing something unexpected 
 - #2900 - a vague error around connectivity

So what extra information can we get to help us understand and address issues like these? This is where my thinking is at:

 - `GIT_TRACE` are both environment variables that can be set to a path, which Git will use to output the messages rather than outputting to screen.

[From the docs](https://github.com/git/git/blob/master/Documentation/git.txt):

```
`GIT_TRACE`::
	Enables general trace messages, e.g. alias expansion, built-in
	command execution and external command execution.
+
If this variable is set to "1", "2" or "true" (comparison
is case insensitive), trace messages will be printed to
stderr.
+
If the variable is set to an integer value greater than 2
and lower than 10 (strictly) then Git will interpret this
value as an open file descriptor and will try to write the
trace messages into this file descriptor.
+
Alternatively, if the variable is set to an absolute path
(starting with a '/' character), Git will interpret this
as a file path and will try to write the trace messages
into it.
+
Unsetting the variable, or setting it to empty, "0" or
"false" (case insensitive) disables trace messages.
```
 - If a Git operation fails (each operation has it's own conditions for failure) then we should move those generated log files into the application's logs directory - for easier reference when reporting an issue. We'll use the same file format `YYYY-MM-DD` prefixing for easier sorting, but the file name should make it clear it's about a specific task.
 - The failing Git operation should be handled by our current error handling, so no rewriting of that work here - just rethrow the error
 - If the Git operation completes, just cleanup the file afterwards
 - Git LFS has it's own way of capturing these tracing files - we should also scan for any log files under `.git/lfs/objects/logs/` and copy those over if the Git operation fails


**Notes:**
    - `GIT_TRACE_CURL` is out because it generates way too much noise (>100MB files on a non-trivial clone yaaaaay)
    - `GIT_CURL_VERBOSE` doesn't care about `GIT_TRACE` and always writes things to `stdout` (or maybe it's `stderr`, I forget)

TODO: 

 - [x] wrap `clone`
 - [x] wrap `fetch`
 - [x] wrap `push`
 - [x] wrap `pull`
 - [ ] ensure log files provide helpful information for network failure mid-clone
 - [ ] ensure log files provide helpful information for credential failure
 - [ ] do a bunch of testing on macOS and Windows
 - [ ] update some documentation?
 - [ ] confirm rethrown error has same useful stack trace
 - [ ] as this isn't part of `winston`, we probably need to handle our own cleanup of files over time

