### PR TITLE
types for byline library

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "1.0.2",
+  "version": "1.0.4-beta0",
   "dependencies": {
     "7zip": {
       "version": "0.0.6",
@@ -121,9 +121,9 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
     },
     "byline": {
-      "version": "4.2.2",
-      "from": "byline@>=4.2.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-4.2.2.tgz"
+      "version": "5.0.0",
+      "from": "byline@5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz"
     },
     "caseless": {
       "version": "0.12.0",

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "app-path": "^2.2.0",
-    "byline": "^4.2.2",
+    "byline": "^5.0.0",
     "classnames": "^2.2.5",
     "codemirror": "^5.29.0",
     "deep-equal": "^1.0.1",

--- a/app/src/lib/progress/from-process.ts
+++ b/app/src/lib/progress/from-process.ts
@@ -1,14 +1,14 @@
 import { ChildProcess } from 'child_process'
+import * as byline from 'byline'
+
 import { GitProgressParser, IGitProgress, IGitOutput } from './git'
 import { IGitExecutionOptions } from '../git/core'
 import { merge } from '../merge'
 
-const byline = require('byline')
-
 /**
  * Merges an instance of IGitExecutionOptions with a process callback provided
  * by progressProcessCallback.
- * 
+ *
  * If the given options object already has a processCallback specified it will
  * be overwritten.
  */

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "xvfb-maybe": "^0.2.1"
   },
   "devDependencies": {
+    "@types/byline": "^4.2.31",
     "@types/chai": "^4.0.3",
     "@types/chai-datetime": "0.0.30",
     "@types/classnames": "^2.2.2",


### PR DESCRIPTION
Looking at some of our clone work, I realise we were still explicitly requiring `byline` for parsing progress. This adds the type declaration and bumps it to `5.0.0`, which I retested with cloning (text displayed) and switching branches (progress meter fills).