### PR TITLE
Revert "Make file path in lists selectable"

### DIFF
--- a/app/styles/ui/_file-list.scss
+++ b/app/styles/ui/_file-list.scss
@@ -43,12 +43,6 @@
       margin-right: var(--spacing-half);
     }
 
-    .path-text-component {
-      span {
-        user-select: text;
-      }
-    }
-
     .rename-arrow {
       flex: 1;
       flex-shrink: 0;


### PR DESCRIPTION
Reverts desktop/desktop#2848

As pointed out in #2944. This css-only approach doesn't work with our PathText components since we're not relying on css to do the truncation for us. Let's revert this and think through the options