### PR TITLE
no need to set progress twice when cloning

### DIFF
--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -44,7 +44,6 @@ export async function clone(
     'lfs',
     'clone',
     '--recursive',
-    '--progress',
     // git-lfs will create the hooks it requires by default
     // and we don't know if the repository is LFS enabled
     // at this stage so let's not do this


### PR DESCRIPTION
We already set this further down if a progress callback is provided, so having it here is unnecessary and silly:

```ts
   if (progressCallback) {
     args.push('--progress')

     // other code
  }
```