### PR TITLE
handle duplicate config values when saving user.name and user.email

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -20,7 +20,7 @@ export async function setGlobalConfigValue(
   value: string
 ): Promise<void> {
   await git(
-    ['config', '--global', name, value],
+    ['config', '--global', '--replace-all', name, value],
     __dirname,
     'setGlobalConfigValue'
   )

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -3,7 +3,13 @@
 import { expect } from 'chai'
 
 import { Repository } from '../../../src/models/repository'
-import { getConfigValue, getGlobalConfigPath } from '../../../src/lib/git'
+import {
+  getConfigValue,
+  getGlobalConfigPath,
+  getGlobalConfigValue,
+  setGlobalConfigValue,
+} from '../../../src/lib/git'
+import { GitProcess } from 'dugite'
 import { setupFixtureRepository } from '../../fixture-helper'
 
 describe('git/config', () => {
@@ -34,6 +40,34 @@ describe('git/config', () => {
       const path = await getGlobalConfigPath()
       expect(path).not.to.equal(null)
       expect(path!.length).to.be.greaterThan(0)
+    })
+  })
+
+  describe('setGlobalConfigValue', () => {
+    const key = 'foo.bar'
+
+    beforeEach(async () => {
+      await GitProcess.exec(
+        ['config', '--add', '--global', key, 'first'],
+        __dirname
+      )
+      await GitProcess.exec(
+        ['config', '--add', '--global', key, 'second'],
+        __dirname
+      )
+    })
+
+    it('will replace all entries for a global value', async () => {
+      await setGlobalConfigValue(key, 'the correct value')
+      const value = await getGlobalConfigValue(key)
+      expect(value).to.equal('the correct value')
+    })
+
+    afterEach(async () => {
+      await GitProcess.exec(
+        ['config', '--unset-all', '--global', key],
+        __dirname
+      )
     })
   })
 })


### PR DESCRIPTION
Fixes #2945 by ensuring we replace all values when updating the global config.