### PR TITLE
Fix 'create without pushing' button not working

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1023,8 +1023,26 @@ export class Dispatcher {
     return this.appStore._changeBranchesTab(tab)
   }
 
-  /** Open the Create Pull Request page on GitHub. */
-  public openCreatePullRequest(repository: Repository): Promise<void> {
-    return this.appStore._openCreatePullRequest(repository)
+  /**
+   * Open the Create Pull Request page on GitHub after verifying ahead/behind.
+   *
+   * Note that this method will present the user with a dialog in case the
+   * current branch in the repository is ahead or behind the remote.
+   * The dialog lets the user choose whether get in sync with the remote
+   * or open the PR anyway. This is distinct from the
+   * openCreatePullRequestInBrowser method which immediately opens the
+   * create pull request page without showing a dialog.
+   */
+  public createPullRequest(repository: Repository): Promise<void> {
+    return this.appStore._createPullRequest(repository)
+  }
+
+  /**
+   * Immediately open the Create Pull Request page on GitHub.
+   *
+   * See the createPullRequest method for more details.
+   */
+  public openCreatePullRequestInBrowser(repository: Repository): Promise<void> {
+    return this.appStore._openCreatePullRequestInBrowser(repository)
   }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2673,7 +2673,7 @@ export class AppStore {
     return Promise.resolve()
   }
 
-  public async _openCreatePullRequest(repository: Repository): Promise<void> {
+  public async _createPullRequest(repository: Repository): Promise<void> {
     const gitHubRepository = repository.gitHubRepository
     if (!gitHubRepository) {
       return
@@ -2703,8 +2703,26 @@ export class AppStore {
         unPushedCommits: aheadBehind.ahead,
       })
     } else {
-      const baseURL = `${gitHubRepository.htmlURL}/pull/new/${branch.nameWithoutRemote}`
-      await this._openInBrowser(baseURL)
+      await this._openCreatePullRequestInBrowser(repository)
     }
+  }
+
+  public async _openCreatePullRequestInBrowser(repository: Repository): Promise<void> {
+    const gitHubRepository = repository.gitHubRepository
+    if (!gitHubRepository) {
+      return
+    }
+
+    const state = this.getRepositoryState(repository)
+    const tip = state.branchesState.tip
+
+    if (tip.kind !== TipState.Valid) {
+      return
+    }
+
+    const branch = tip.branch
+
+    const baseURL = `${gitHubRepository.htmlURL}/pull/new/${branch.nameWithoutRemote}`
+    await this._openInBrowser(baseURL)
   }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2707,7 +2707,9 @@ export class AppStore {
     }
   }
 
-  public async _openCreatePullRequestInBrowser(repository: Repository): Promise<void> {
+  public async _openCreatePullRequestInBrowser(
+    repository: Repository
+  ): Promise<void> {
     const gitHubRepository = repository.gitHubRepository
     if (!gitHubRepository) {
       return

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1081,7 +1081,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             branch={popup.branch}
             unPushedCommits={popup.unPushedCommits}
-            onConfirm={this.openPullRequestOnGitHub}
+            onConfirm={this.openCreatePullRequestInBrowser}
             onDismissed={this.onPopupDismissed}
           />
         )
@@ -1405,11 +1405,11 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    return this.openPullRequestOnGitHub(state.repository)
+    return this.props.dispatcher.createPullRequest(state.repository)
   }
 
-  private openPullRequestOnGitHub = (repository: Repository) => {
-    this.props.dispatcher.openCreatePullRequest(repository)
+  private openCreatePullRequestInBrowser = (repository: Repository) => {
+    this.props.dispatcher.openCreatePullRequestInBrowser(repository)
   }
 
   private onBranchDropdownStateChanged = (newState: DropdownState) => {

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -85,9 +85,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
     let countElement = null
     if (this.props.pullRequests) {
       countElement = (
-        <span className="count">
-          {this.props.pullRequests.length}
-        </span>
+        <span className="count">{this.props.pullRequests.length}</span>
       )
     }
 

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -85,7 +85,9 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
     let countElement = null
     if (this.props.pullRequests) {
       countElement = (
-        <span className="count">{this.props.pullRequests.length}</span>
+        <span className="count">
+          {this.props.pullRequests.length}
+        </span>
       )
     }
 
@@ -180,7 +182,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
 
   private onCreatePullRequest = () => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
-    this.props.dispatcher.openCreatePullRequest(this.props.repository)
+    this.props.dispatcher.createPullRequest(this.props.repository)
   }
 
   private onTabClicked = (tab: BranchesTab) => {

--- a/app/src/ui/branches/push-branch-commits.tsx
+++ b/app/src/ui/branches/push-branch-commits.tsx
@@ -25,10 +25,10 @@ interface IPushBranchCommitsState {
   /**
    * A value indicating whether we're currently working on publishing
    * or pushing the branch to the remote. This value is used to tell
-   * the dialog to apply the loading state which adds a spinner and
-   * disables form controls for the duration of the operation.
+   * the dialog to apply the loading and disabled state which adds a
+   * spinner and disables form controls for the duration of the operation.
    */
-  readonly loading: boolean
+  readonly isPushingOrPublishing: boolean
 }
 
 /**
@@ -74,7 +74,7 @@ export class PushBranchCommits extends React.Component<
   public constructor(props: IPushBranchCommitsProps) {
     super(props)
 
-    this.state = { loading: false }
+    this.state = { isPushingOrPublishing: false }
   }
 
   public render() {
@@ -85,8 +85,8 @@ export class PushBranchCommits extends React.Component<
         title={this.renderDialogTitle()}
         onDismissed={this.cancel}
         onSubmit={this.cancel}
-        loading={this.state.loading}
-        disabled={this.state.loading}
+        loading={this.state.isPushingOrPublishing}
+        disabled={this.state.isPushingOrPublishing}
       >
         {this.renderDialogContent()}
 
@@ -177,12 +177,12 @@ export class PushBranchCommits extends React.Component<
 
     const { repository, branch } = this.props
 
-    this.setState({ loading: true })
+    this.setState({ isPushingOrPublishing: true })
 
     try {
       await this.props.dispatcher.push(repository)
     } finally {
-      this.setState({ loading: false })
+      this.setState({ isPushingOrPublishing: false })
     }
 
     this.props.onConfirm(repository, branch)

--- a/app/src/ui/branches/push-branch-commits.tsx
+++ b/app/src/ui/branches/push-branch-commits.tsx
@@ -89,7 +89,9 @@ export class PushBranchCommits extends React.Component<
       >
         {this.renderDialogContent()}
 
-        <DialogFooter>{this.renderButtonGroup()}</DialogFooter>
+        <DialogFooter>
+          {this.renderButtonGroup()}
+        </DialogFooter>
       </Dialog>
     )
   }
@@ -167,7 +169,11 @@ export class PushBranchCommits extends React.Component<
     this.props.onDismissed()
   }
 
-  private onPushOrPublishButtonClick = async () => {
+  private onPushOrPublishButtonClick = async (
+    e: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    e.preventDefault()
+
     const { repository, branch } = this.props
 
     this.setState({ loading: true })

--- a/app/src/ui/branches/push-branch-commits.tsx
+++ b/app/src/ui/branches/push-branch-commits.tsx
@@ -161,11 +161,7 @@ export class PushBranchCommits extends React.Component<
     this.props.onDismissed()
   }
 
-  private onCreateWithoutPushButtonClick = (
-    e: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    e.preventDefault()
-
+  private onCreateWithoutPushButtonClick = () => {
     this.props.onConfirm(this.props.repository, this.props.branch)
     this.props.onDismissed()
   }

--- a/app/src/ui/branches/push-branch-commits.tsx
+++ b/app/src/ui/branches/push-branch-commits.tsx
@@ -86,6 +86,7 @@ export class PushBranchCommits extends React.Component<
         onDismissed={this.cancel}
         onSubmit={this.cancel}
         loading={this.state.loading}
+        disabled={this.state.loading}
       >
         {this.renderDialogContent()}
 

--- a/app/src/ui/branches/push-branch-commits.tsx
+++ b/app/src/ui/branches/push-branch-commits.tsx
@@ -90,9 +90,7 @@ export class PushBranchCommits extends React.Component<
       >
         {this.renderDialogContent()}
 
-        <DialogFooter>
-          {this.renderButtonGroup()}
-        </DialogFooter>
+        <DialogFooter>{this.renderButtonGroup()}</DialogFooter>
       </Dialog>
     )
   }


### PR DESCRIPTION
This fixes #2917 which was accidentally broken in https://github.com/desktop/desktop/pull/2823/commits/852ba4dd265eddbdcf3d488b87fb00cfe4a9154c by combining two methods that shouldn't have been combined. This change mirrors what we had prior to in that we now have two methods, one that cares about whether the branch is ahead/behind and one that only opens the create PR page in a browser.

This also fixes another problem which was broken in #2595 when we changed the type of the push/publish button from normal to 'submit'. Submit buttons automatically dismiss the dialog so we need to cancel that even before we start doing things with state.

Finally I change the behavior of the 'loading' state such that it not only shows the loading spinner in the dialog but also disables form controls. This was documented to be the case already but that was wrong.

Fixes #2917