### PR TITLE
just open the log directory

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -2,7 +2,6 @@ import '../lib/logging/main/install'
 
 import { app, Menu, MenuItem, ipcMain, BrowserWindow, shell } from 'electron'
 import * as Fs from 'fs'
-import * as Url from 'url'
 
 import { AppWindow } from './app-window'
 import { buildDefaultMenu, MenuEvent, findMenuItemByID } from './menu'
@@ -14,6 +13,7 @@ import { fatalError } from '../lib/fatal-error'
 import { IMenuItemState } from '../lib/menu-update'
 import { LogLevel } from '../lib/logging/log-level'
 import { log as writeLog } from './log'
+import { openPathSafe } from './shell'
 import { reportError } from './exception-reporting'
 import {
   enableSourceMaps,
@@ -314,12 +314,7 @@ app.on('ready', () => {
         }
 
         if (stats.isDirectory()) {
-          const fileURL = Url.format({
-            pathname: path,
-            protocol: 'file:',
-            slashes: true,
-          })
-          shell.openExternal(fileURL)
+          openPathSafe(path)
         } else {
           shell.showItemInFolder(path)
         }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -13,7 +13,7 @@ import { fatalError } from '../lib/fatal-error'
 import { IMenuItemState } from '../lib/menu-update'
 import { LogLevel } from '../lib/logging/log-level'
 import { log as writeLog } from './log'
-import { openPathSafe } from './shell'
+import { openDirectorySafe } from './shell'
 import { reportError } from './exception-reporting'
 import {
   enableSourceMaps,
@@ -314,7 +314,7 @@ app.on('ready', () => {
         }
 
         if (stats.isDirectory()) {
-          openPathSafe(path)
+          openDirectorySafe(path)
         } else {
           shell.showItemInFolder(path)
         }

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -5,7 +5,7 @@ import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { mkdirIfNeeded } from '../../lib/file-system'
 
 import { log } from '../log'
-import { openPathSafe } from '../shell'
+import { openDirectorySafe } from '../shell'
 
 const defaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
@@ -344,7 +344,7 @@ export function buildDefaultMenu(
       const logPath = getLogDirectoryPath()
       mkdirIfNeeded(logPath)
         .then(() => {
-          openPathSafe(logPath)
+          openDirectorySafe(logPath)
         })
         .catch(err => {
           log('error', err.message)

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -5,7 +5,7 @@ import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { mkdirIfNeeded } from '../../lib/file-system'
 
 import { log } from '../log'
-import * as Url from 'url'
+import { openPathSafe } from '../shell'
 
 const defaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
@@ -344,13 +344,7 @@ export function buildDefaultMenu(
       const logPath = getLogDirectoryPath()
       mkdirIfNeeded(logPath)
         .then(() => {
-          const directoryURL = Url.format({
-            pathname: logPath,
-            protocol: 'file:',
-            slashes: true,
-          })
-
-          shell.openExternal(directoryURL)
+          openPathSafe(logPath)
         })
         .catch(err => {
           log('error', err.message)

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -5,6 +5,7 @@ import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { mkdirIfNeeded } from '../../lib/file-system'
 
 import { log } from '../log'
+import * as Url from 'url'
 
 const defaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
@@ -343,7 +344,13 @@ export function buildDefaultMenu(
       const logPath = getLogDirectoryPath()
       mkdirIfNeeded(logPath)
         .then(() => {
-          shell.showItemInFolder(logPath)
+          const directoryURL = Url.format({
+            pathname: logPath,
+            protocol: 'file:',
+            slashes: true,
+          })
+
+          shell.openExternal(directoryURL)
         })
         .catch(err => {
           log('error', err.message)

--- a/app/src/main-process/shell.ts
+++ b/app/src/main-process/shell.ts
@@ -1,0 +1,25 @@
+import * as Url from 'url'
+import { shell } from 'electron'
+
+/**
+ * Wraps the inbuilt shell.openItem path to address a focus issue that affects macOS.
+ *
+ * When opening a folder in Finder, the window will appear behind the application
+ * window, which may confuse users. As a workaround, we will fallback to using
+ * shell.openExternal for macOS until it can be fixed upstream.
+ *
+ * @param path directory to open
+ */
+export function openPathSafe(path: string) {
+  if (__DARWIN__) {
+    const directoryURL = Url.format({
+      pathname: path,
+      protocol: 'file:',
+      slashes: true,
+    })
+
+    shell.openExternal(directoryURL)
+  } else {
+    shell.openItem(path)
+  }
+}

--- a/app/src/main-process/shell.ts
+++ b/app/src/main-process/shell.ts
@@ -10,7 +10,7 @@ import { shell } from 'electron'
  *
  * @param path directory to open
  */
-export function openPathSafe(path: string) {
+export function openDirectorySafe(path: string) {
   if (__DARWIN__) {
     const directoryURL = Url.format({
       pathname: path,


### PR DESCRIPTION
`showItemInFolder` is designed for revealing a file in the file manager, by opening the parent directory and focusing on it. This isn't great for our case with opening the logs directory - we should open that directory instead of making this flow confusing.

As `openExternal` expects a URL, this also uses the `Url.format` helper function to generate a safe representation of the folder.