### PR TITLE
diff-index needs to be mindful of a HEAD file on disk

### DIFF
--- a/app/src/lib/git/diff-index.ts
+++ b/app/src/lib/git/diff-index.ts
@@ -82,7 +82,7 @@ export async function getIndexChanges(
   const args = ['diff-index', '--cached', '--name-status', '--no-renames', '-z']
 
   let result = await git(
-    [...args, 'HEAD'],
+    [...args, 'HEAD', '--'],
     repository.path,
     'getIndexChanges',
     {


### PR DESCRIPTION
Fixes #2721

This was the same root cause as #2938 but was a more subtle change, as we'd handle this error and incorrectly consider the repository was unborn - which would then consider all the files as new, so it wouldn't restore the files like we expected.

I'll follow up with some tests on a repository with a `HEAD` file on disk - this is a good corner case and we use `HEAD` in a lot of places when we're invoking Git.

cc @sdwebguy