### PR TITLE
Increase diff contrast and improve gutter behavior

### DIFF
--- a/app/src/ui/diff/diff-line-gutter.tsx
+++ b/app/src/ui/diff/diff-line-gutter.tsx
@@ -256,19 +256,17 @@ export class DiffLineGutter extends React.Component<
       return
     }
 
-    if (elem) {
+    // no point handling mouse events on context lines
+    if (elem && this.props.line.isIncludeableLine()) {
       elem.addEventListener('mouseenter', this.mouseEnterHandler)
       elem.addEventListener('mouseleave', this.mouseLeaveHandler)
       elem.addEventListener('mousemove', this.mouseMoveHandler)
-
-      // no point handling mousedown events on context lines
-      if (this.props.line.isIncludeableLine()) {
-        elem.addEventListener('mousedown', this.mouseDownHandler)
-      }
+      elem.addEventListener('mousedown', this.mouseDownHandler)
     } else {
       // this callback fires a second time when the DOM element
-      // is unmounted, so we can use this as a chance to cleanup
-
+      // is unmounted, so we can use this as a chance to cleanup.
+      // We unsubscribe without checking for isIncludeableLine since
+      // that might have changed underneath us
       if (this.elem_) {
         this.elem_.removeEventListener('mouseenter', this.mouseEnterHandler)
         this.elem_.removeEventListener('mouseleave', this.mouseLeaveHandler)

--- a/app/src/ui/diff/diff-line-gutter.tsx
+++ b/app/src/ui/diff/diff-line-gutter.tsx
@@ -150,7 +150,9 @@ export class DiffLineGutter extends React.Component<IDiffGutterProps, {}> {
     const lineClass = this.getLineClassName()
     const selectedClass = this.isIncluded() ? selectedLineClass : null
 
-    return classNames('diff-line-gutter', lineClass, selectedClass)
+    return classNames('diff-line-gutter', lineClass, selectedClass, {
+      'read-only': this.props.readOnly,
+    })
   }
 
   private updateHoverState(isRangeSelection: boolean, isActive: boolean) {

--- a/app/src/ui/diff/diff-mode.ts
+++ b/app/src/ui/diff/diff-mode.ts
@@ -13,6 +13,7 @@ const TokenNames: { [key: string]: string | null } = {
   '+': 'diff-add',
   '-': 'diff-delete',
   '@': 'diff-hunk',
+  ' ': 'diff-context',
 }
 
 /** Get the mode for diffs. */

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -200,9 +200,8 @@ export class Diff extends React.Component<IDiffProps, {}> {
       // onscreen
       const viewport = this.codeMirror.getScrollInfo()
       const top = viewport.top
-      const cm = this.codeMirror as any
 
-      const row = cm.lineAtHeight(top, 'local')
+      const row = this.codeMirror.lineAtHeight(top, 'local')
       const element = this.cachedGutterElements.get(row)
 
       if (!element) {

--- a/app/src/ui/diff/selection/range-selection-strategy.ts
+++ b/app/src/ui/diff/selection/range-selection-strategy.ts
@@ -27,7 +27,7 @@ export class RangeSelection implements ISelectionStrategy {
   }
 
   public paint(elements: Map<number, DiffLineGutter>) {
-    range(this._start, this._end).forEach(row => {
+    range(this._start, this._end + 1).forEach(row => {
       const element = elements.get(row)
 
       if (!element) {

--- a/app/src/ui/diff/selection/range-selection-strategy.ts
+++ b/app/src/ui/diff/selection/range-selection-strategy.ts
@@ -39,9 +39,7 @@ export class RangeSelection implements ISelectionStrategy {
         return
       }
 
-      const selected = this._desiredSelection
-
-      element.setSelected(selected)
+      element.setSelected(this._desiredSelection)
     })
   }
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -232,15 +232,17 @@
   --diff-selected-gutter-color: $blue-600;
   --diff-selected-text-color: var(--background-color);
 
-  --diff-add-border-color: $green-200;
-  --diff-add-gutter-color: $green-200;
   --diff-add-background-color: darken($green-000, 2%);
+  --diff-add-border-color: $green-300;
+  --diff-add-gutter-color: $green-300;
+  --diff-add-gutter-background-color: darken($green-100, 3%);
   --diff-add-inner-background-color: #acf2bd;
   --diff-add-text-color: var(--diff-text-color);
 
   --diff-delete-background-color: $red-000;
-  --diff-delete-border-color: $red-100;
+  --diff-delete-border-color: $red-200;
   --diff-delete-gutter-color: $red-200;
+  --diff-delete-gutter-background-color: $red-100;
   --diff-delete-inner-background-color: #fdb8c0;
   --diff-delete-text-color: var(--diff-text-color);
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -249,6 +249,7 @@
   --diff-hunk-background-color: $blue-000;
   --diff-hunk-border-color: $blue-200;
   --diff-hunk-gutter-color: $blue-200;
+  --diff-hunk-gutter-background-color: $blue-100;
   --diff-hunk-text-color: $gray;
 
   --diff-hover-background-color: $blue-300;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -220,6 +220,8 @@
    * Diff view
    */
 
+  --diff-line-padding-y: 2px;
+
   --diff-text-color: $gray-900;
   --diff-border-color: $gray-200;
   --diff-gutter-color: $gray-200;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -248,7 +248,7 @@
 
   --diff-hunk-background-color: $blue-000;
   --diff-hunk-border-color: $blue-200;
-  --diff-hunk-gutter-color: $blue-200;
+  --diff-hunk-gutter-color: darken($blue-200, 5%);
   --diff-hunk-gutter-background-color: $blue-100;
   --diff-hunk-text-color: $gray;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -257,6 +257,16 @@
   --diff-hover-gutter-color: $blue-400;
   --diff-hover-text-color: var(--background-color);
 
+  --diff-add-hover-background-color: $green-300;
+  --diff-add-hover-border-color: $green-400;
+  --diff-add-hover-gutter-color: $green-400;
+  --diff-add-hover-text-color: var(--text-color);
+
+  --diff-delete-hover-background-color: $red-200;
+  --diff-delete-hover-border-color: $red-300;
+  --diff-delete-hover-gutter-color: $red-300;
+  --diff-delete-hover-text-color: var(--text-color);
+
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`
   // specified in `changes/index.tsx`.
   --undo-animation-duration: 500ms;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -232,9 +232,9 @@
   --diff-selected-gutter-color: $blue-600;
   --diff-selected-text-color: var(--background-color);
 
-  --diff-add-background-color: $green-000;
   --diff-add-border-color: $green-200;
   --diff-add-gutter-color: $green-200;
+  --diff-add-background-color: darken($green-000, 2%);
   --diff-add-inner-background-color: #acf2bd;
   --diff-add-text-color: var(--diff-text-color);
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -85,6 +85,10 @@
   .after {
     border-right: 4px solid var(--diff-border-color);
   }
+
+  &.read-only .after {
+    border-right-width: 1px;
+  }
 }
 
 .diff-line-number {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -78,6 +78,10 @@
     background: var(--diff-delete-gutter-background-color);
   }
 
+  &.diff-hunk {
+    background: var(--diff-hunk-gutter-background-color);
+  }
+
   .before {
     border-right: 1px solid var(--diff-border-color);
   }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -70,6 +70,14 @@
   display: flex;
   height: 100%;
 
+  &.diff-add {
+    background: var(--diff-add-gutter-background-color);
+  }
+
+  &.diff-delete {
+    background: var(--diff-delete-gutter-background-color);
+  }
+
   .before {
     border-right: 1px solid var(--diff-border-color);
   }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -206,6 +206,32 @@
       border-color: var(--diff-hover-gutter-color);
     }
   }
+
+  &:not(.diff-line-selected) {
+    &.diff-add {
+      .diff-line-number {
+        background: var(--diff-add-hover-background-color);
+        border-color: var(--diff-add-hover-border-color);
+        color: var(--diff-add-hover-text-color);
+
+        &:last-child {
+          border-color: var(--diff-add-hover-gutter-color);
+        }
+      }
+    }
+
+    &.diff-delete {
+      .diff-line-number {
+        background: var(--diff-delete-hover-background-color);
+        border-color: var(--diff-delete-hover-border-color);
+        color: var(--diff-delete-hover-text-color);
+
+        &:last-child {
+          border-color: var(--diff-delete-hover-gutter-color);
+        }
+      }
+    }
+  }
 }
 
 // Windows has custom scroll bars, see _scroll.scss

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -36,7 +36,9 @@
       // Add a little bit of space to the left of code diff
       // `padding-left` here means mouse move events are not raised
       padding-left: var(--spacing-half);
-      align-self: center;
+      padding-top: var(--diff-line-padding-y);
+      padding-bottom: var(--diff-line-padding-y);
+      display: inline-block;
     }
 
     svg.no-newline {
@@ -66,7 +68,6 @@
 // The container element which holds the before and after
 // diff-line-number spans.
 .diff-line-gutter {
-  line-height: normal;
   display: flex;
   height: 100%;
 
@@ -99,7 +100,7 @@
   display: inline-block;
   color: var(--diff-line-number-color);
   width: var(--diff-line-number-column-width);
-  padding: var(--spacing-third) var(--spacing-half);
+  padding: var(--diff-line-padding-y) var(--spacing-half);
   text-align: right;
 }
 


### PR DESCRIPTION
### Increase contrast of red/green backgrounds

We're now using the same colors as GitHub.com

![screen shot 2017-10-10 at 18 25 16](https://user-images.githubusercontent.com/634063/31398198-6b998b72-ade8-11e7-8964-1d12dce81775.png)

(Before on the left, after on the right)

### Darker backgrounds in gutter

We now use an even darker shade in the gutter to highlight the gutter area

![screen shot 2017-10-10 at 18 26 35](https://user-images.githubusercontent.com/634063/31398238-926b65cc-ade8-11e7-9d50-5c211654cd9d.png)

### Thin border for gutter in read-only mode

Editable
![screen shot 2017-10-10 at 18 27 50](https://user-images.githubusercontent.com/634063/31398295-bfc5caa8-ade8-11e7-8388-0b4d14c9ac60.png)

Read-only
![screen shot 2017-10-10 at 18 27 32](https://user-images.githubusercontent.com/634063/31398275-b18b81c6-ade8-11e7-9187-0369d59a6f31.png)

### One more state for hover depending on selected/unselected

![colors](https://user-images.githubusercontent.com/634063/31398370-04c2c426-ade9-11e7-875f-63252af544f1.gif)

This is showing before and after, illustrating the problem of clicking with no visual feedback

### Fix for hunk highlight when hovering on context line

![moargutter](https://user-images.githubusercontent.com/634063/31398400-19e8eb78-ade9-11e7-8d92-685a271869f1.gif)

# Fix flickering when hovering close to the gutter

![flicker](https://user-images.githubusercontent.com/634063/31398430-34e1bfe0-ade9-11e7-8ac1-a489a43d0f1a.gif)

Additionally this moves our `DiffLineGutter` component from directly manipulating the DOM and instead manipulating state and re-rendering.

cc @donokuda for a look but I welcome a code review here as well.

Fixes #2586 
Fixes #2181
