### PR TITLE
adding some tracing when interacting with backing stores

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -966,7 +966,7 @@ export class Dispatcher {
     username: string,
     password: string
   ): Promise<void> {
-    log.info(`storing generic credentials for '${hostname}' and ${username}`)
+    log.info(`storing generic credentials for '${hostname}' and '${username}'`)
     setGenericUsername(hostname, username)
     await setGenericPassword(hostname, username, password)
   }

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -966,6 +966,7 @@ export class Dispatcher {
     username: string,
     password: string
   ): Promise<void> {
+    log.info(`storing generic credentials for '${hostname}' and ${username}`)
     GenericGitAuth.setGenericUsername(hostname, username)
     await GenericGitAuth.setGenericPassword(hostname, username, password)
   }

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -41,7 +41,7 @@ import {
   rejectOAuthRequest,
 } from '../../lib/oauth'
 import { installCLI } from '../../ui/lib/install-cli'
-import * as GenericGitAuth from '../generic-git-auth'
+import { setGenericUsername, setGenericPassword } from '../generic-git-auth'
 import { RetryAction, RetryActionType } from '../retry-actions'
 import { Shell } from '../shells'
 import { CloneRepositoryTab } from '../../models/clone-repository-tab'
@@ -967,8 +967,8 @@ export class Dispatcher {
     password: string
   ): Promise<void> {
     log.info(`storing generic credentials for '${hostname}' and ${username}`)
-    GenericGitAuth.setGenericUsername(hostname, username)
-    await GenericGitAuth.setGenericPassword(hostname, username, password)
+    setGenericUsername(hostname, username)
+    await setGenericPassword(hostname, username, password)
   }
 
   /** Perform the given retry action. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2609,7 +2609,7 @@ export class AppStore {
       const hasValidToken =
         account.token.length > 0 ? 'has token' : 'empty token'
       log.info(
-        `[withAuthenticatingUser] account found for remote: ${remote} - ${account.login} (${hasValidToken})`
+        `[withAuthenticatingUser] account found for repository: ${repository.name} - ${account.login} (${hasValidToken})`
       )
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2453,10 +2453,12 @@ export class AppStore {
   }
 
   public _removeAccount(account: Account): Promise<void> {
+    log.info(`removing account ${account.login} (${account.name}) from store`)
     return this.accountsStore.removeAccount(account)
   }
 
   public _addAccount(account: Account): Promise<void> {
+    log.info(`adding account ${account.login} (${account.name}) to store`)
     return this.accountsStore.addAccount(account)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1997,8 +1997,11 @@ export class AppStore {
     const hostname = getGenericHostname(remote)
     const username = getGenericUsername(hostname)
     if (username != null) {
+      log.info(`found generic credentials for '${hostname}' and '${username}'`)
       return { login: username, endpoint: hostname }
     }
+
+    log.info(`no generic credentials found for ${remote}`)
 
     return null
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -866,6 +866,11 @@ export class AppStore {
       this.repositoriesStore.getAll(),
     ])
 
+    log.info(`loading ${repositories.length} repositories from store`)
+    accounts.forEach(a => {
+      log.info(`found account: ${a.login} (${a.name})`)
+    })
+
     this.accounts = accounts
     this.repositories = repositories
 
@@ -2470,6 +2475,8 @@ export class AppStore {
     for (const path of paths) {
       const validatedPath = await validatedRepositoryPath(path)
       if (validatedPath) {
+        log.info(`adding repository at ${validatedPath} to store`)
+
         const addedRepo = await this.repositoriesStore.addRepository(
           validatedPath
         )

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2605,6 +2605,14 @@ export class AppStore {
       }
     }
 
+    if (account instanceof Account) {
+      const hasValidToken =
+        account.token.length > 0 ? 'has token' : 'empty token'
+      log.info(
+        `[withAuthenticatingUser] account found for remote: ${remote} - ${account.login} (${hasValidToken})`
+      )
+    }
+
     return fn(updatedRepository, account)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1990,6 +1990,11 @@ export class AppStore {
         gitHubRepository.endpoint
       )
       if (account) {
+        const hasValidToken =
+          account.token.length > 0 ? 'has token' : 'empty token'
+        log.info(
+          `account found for remote: ${remote} - ${account.login} (${hasValidToken})`
+        )
         return account
       }
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1993,7 +1993,7 @@ export class AppStore {
         const hasValidToken =
           account.token.length > 0 ? 'has token' : 'empty token'
         log.info(
-          `account found for remote: ${remote} - ${account.login} (${hasValidToken})`
+          `[getAccountForRemoteURL] account found for remote: ${remote} - ${account.login} (${hasValidToken})`
         )
         return account
       }
@@ -2002,11 +2002,15 @@ export class AppStore {
     const hostname = getGenericHostname(remote)
     const username = getGenericUsername(hostname)
     if (username != null) {
-      log.info(`found generic credentials for '${hostname}' and '${username}'`)
+      log.info(
+        `[getAccountForRemoteURL] found generic credentials for '${hostname}' and '${username}'`
+      )
       return { login: username, endpoint: hostname }
     }
 
-    log.info(`no generic credentials found for ${remote}`)
+    log.info(
+      `[getAccountForRemoteURL] no generic credentials found for '${remote}'`
+    )
 
     return null
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2455,7 +2455,7 @@ export class AppStore {
     return this.accountsStore.removeAccount(account)
   }
 
-  public _addAccount(account: Account): Promise<void> {
+  public async _addAccount(account: Account): Promise<void> {
     log.info(`adding account ${account.login} (${account.name}) to store`)
     await this.accountsStore.addAccount(account)
     const selectedState = this.getState().selectedState

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ install:
   - npm prune
   - cd app && npm prune && cd ..
   - npm install
-  - npm ls
-  - npm ls --dev
+  - npm ls --prod || true
+  - npm ls --dev || true
 
 build_script:
   - npm run check-prettiness


### PR DESCRIPTION
Related issues:

 - "Repos disappear and do not show after cloning" https://github.com/desktop/desktop/issues/2997#issuecomment-335507341

> I only had two repos added. Both went missing today morning when i opened github desktop. Yesterday they were still there.

 - "Can't push to repositories from organisation" https://github.com/desktop/desktop/issues/2908#issuecomment-335629545

> After logout and log back in it appears to have resolved the issue 👍

We have a fair bit of tracing around our Git operations, but not much around some other areas.

This gives us a bit more insight into the launch process and interacting with stored credentials, so we have a better idea about the current state of the user's app without needing further info from them:

```
2017-10-10T23:43:30.699Z - info: [ui] loading 3 repositories from store
2017-10-10T23:43:30.700Z - info: [ui] found account: shiftkey (Brendan Forster)
...
2017-10-11T00:27:16.012Z - info: [ui] [withAuthenticatingUser] account found for repository: git-lfs-test - shiftkey (has token)
2017-10-11T00:27:17.359Z - info: [ui] Executing fetch: git -c credential.helper= fetch --progress --prune origin (took 1.338s)
```

 - [x] repository store - track when restoring and updating list
 - [x] account store - track restoring, updating list and associating account with Git operations
 - [x] generic credentials - track storing  and associating account with Git operations