### PR TITLE
pull request head might be null

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -120,7 +120,7 @@ export interface IAPIRefStatus {
 interface IAPIPullRequestRef {
   readonly ref: string
   readonly sha: string
-  readonly repo: IAPIRepository
+  readonly repo: IAPIRepository | null
 }
 
 /** Information about a pull request as returned by the GitHub API. */

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -196,11 +196,15 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
     }
 
     const head = pullRequest.head
-    const isRefInThisRepo = head.repo.clone_url === gitHubRepository.cloneURL
-    if (isRefInThisRepo) {
-      this.checkoutBranch(head.ref)
-    } else {
-      // TODO: It's in a fork so we'll need to do ... something.
+    const repo = head.repo
+
+    if (repo) {
+      const isRefInThisRepo = repo.clone_url === gitHubRepository.cloneURL
+      if (isRefInThisRepo) {
+        this.checkoutBranch(head.ref)
+      } else {
+        // TODO: It's in a fork so we'll need to do ... something.
+      }
     }
   }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -300,6 +300,7 @@ function findCurrentPullRequest(
   for (const pr of pullRequests) {
     if (
       pr.head.ref === upstream &&
+      pr.head.repo &&
       // TODO: This doesn't work for when I've checked out a PR from a fork.
       pr.head.repo.clone_url === gitHubRepository.cloneURL
     ) {


### PR DESCRIPTION
If someone opens a pull request and then deletes their fork, the API response for the pull request returns a null `head.repo`.

 - Example PR: https://github.com/Microsoft/vscode/pull/32222
 - API response:

```json
  "head": {
    "label": "dericcain:master",
    "ref": "master",
    "sha": "209afc6c7a203951ab50e94c1acecd6bc1c1aa25",
    "user": {
      "login": "dericcain",
      "id": 9561913,
      "avatar_url": "https://avatars0.githubusercontent.com/u/9561913?v=4",
      "gravatar_id": "",
      "url": "https://api.github.com/users/dericcain",
      "html_url": "https://github.com/dericcain",
      "followers_url": "https://api.github.com/users/dericcain/followers",
      "following_url": "https://api.github.com/users/dericcain/following{/other_user}",
      "gists_url": "https://api.github.com/users/dericcain/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/dericcain/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/dericcain/subscriptions",
      "organizations_url": "https://api.github.com/users/dericcain/orgs",
      "repos_url": "https://api.github.com/users/dericcain/repos",
      "events_url": "https://api.github.com/users/dericcain/events{/privacy}",
      "received_events_url": "https://api.github.com/users/dericcain/received_events",
      "type": "User",
      "site_admin": false
    },
    "repo": null
  },
```

You should see this by cloning down https://github.com/Microsoft/vscode, adding it to the app and waiting a minute or so for it to fetch pull requests in the background.

```
error: [main] TypeError: Cannot read property 'clone_url' of null
    at findCurrentPullRequest (/Users/shiftkey/src/desktop/webpack:/app/src/ui/toolbar/branch-dropdown.tsx:304:19)
    at BranchDropdown.get currentPullRequest [as currentPullRequest] (/Users/shiftkey/src/desktop/webpack:/app/src/ui/toolbar/branch-dropdown.tsx:184:36)
    at BranchDropdown.render (/Users/shiftkey/src/desktop/webpack:/app/src/ui/toolbar/branch-dropdown.tsx:213:13)
    at /Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:793:1
    at measureLifeCyclePerf (/Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:73:1)
    at ReactCompositeComponentWrapper._renderValidatedComponentWithoutOwnerOrContext (/Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:792:1)
    at ReactCompositeComponentWrapper._renderValidatedComponent (/Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:819:1)
    at ReactCompositeComponentWrapper._updateRenderedComponent (/Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:743:1)
    at ReactCompositeComponentWrapper._performComponentUpdate (/Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:721:1)
    at ReactCompositeComponentWrapper.updateComponent (/Users/shiftkey/src/desktop/webpack:/app/node_modules/react-dom/lib/ReactCompositeComponent.js:642:1)
```

This error will crash the app, so it'd be nice to fix in case this accidentally goes out in the next update.