### PR TITLE
Don't compile the world

### DIFF
--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+/// <reference types="electron" />
+
 /** Is the app running in dev mode? */
 declare const __DEV__: boolean
 
@@ -38,7 +41,12 @@ declare const __UPDATES_URL__: string
  * The currently executing process kind, this is specific to desktop
  * and identifies the processes that we have.
  */
-declare const __PROCESS_KIND__: 'main' | 'ui' | 'crash' | 'askpass'
+declare const __PROCESS_KIND__:
+  | 'main'
+  | 'ui'
+  | 'crash'
+  | 'askpass'
+  | 'highlighter'
 
 /**
  * The DOMHighResTimeStamp type is a double and is used to store a time value.
@@ -180,7 +188,7 @@ declare const log: IDesktopLogger
 
 declare namespace NodeJS {
   // tslint:disable-next-line:interface-name
-  interface Process extends EventEmitter {
+  interface Process extends NodeJS.EventEmitter {
     once(event: 'uncaughtException', listener: (error: Error) => void): this
     on(event: 'uncaughtException', listener: (error: Error) => void): this
     removeListener(event: 'exit', listener: Function): this

--- a/script/build.ts
+++ b/script/build.ts
@@ -1,4 +1,5 @@
 /* tslint:disable:no-sync-functions */
+/// <reference path="./globals.d.ts" />
 
 import * as path from 'path'
 import * as cp from 'child_process'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "strict": true,
     "outDir": "./out"
   },
+  "files": [
+    "app/src/lib/globals.d.ts"
+  ],
   "exclude": [
     "node_modules",
     "app/node_modules",


### PR DESCRIPTION
While doing some prep work for hack-week next week I noticed that a file which was not included in any of our current processes was causing compile-time errors in all of them. That was surprising as I thought that we only compiled directly (or indirectly) referenced files.

Turns out we do only compiled referenced files but our tsconfig.json was set up in such a way that it would compile all .ts/tsx files found in any subdirectories except for those explicitly excluded in tsconfig.json.

Changing this to only implicitly requiring our globals.d.ts file shaved close to 30% or 28 seconds of my build time. I don't know if there's caveats around doing it this way but it felt like a solid boost that's at least worth investigating.

cc @desktop/core for feels and any thoughts on how this might break us horribly.