### PR TITLE
pass the full shell information into the launch process

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -76,8 +76,11 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
-export async function launch(shell: Shell, path: string): Promise<void> {
-  const bundleID = getBundleID(shell)
+export async function launch(
+  foundShell: IFoundShell<Shell>,
+  path: string
+): Promise<void> {
+  const bundleID = getBundleID(foundShell.shell)
   const commandArgs = ['-b', bundleID, path]
   await spawn('open', commandArgs)
 }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -17,7 +17,10 @@ export async function getAvailableShells(): Promise<
   return [{ shell: Shell.Gnome, path: '/usr/bin/gnome-terminal' }]
 }
 
-export async function launch(shell: Shell, path: string): Promise<void> {
+export async function launch(
+  shell: IFoundShell<Shell>,
+  path: string
+): Promise<void> {
   const commandArgs = ['--working-directory', path]
   await spawn('gnome-terminal', commandArgs)
 }

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -84,11 +84,11 @@ export async function launchShell(shell: FoundShell, path: string) {
   }
 
   if (__DARWIN__) {
-    return Darwin.launch(shell.shell as Darwin.Shell, path)
+    return Darwin.launch(shell as IFoundShell<Darwin.Shell>, path)
   } else if (__WIN32__) {
-    return Win32.launch(shell.shell as Win32.Shell, path)
+    return Win32.launch(shell as IFoundShell<Win32.Shell>, path)
   } else if (__LINUX__) {
-    return Linux.launch(shell.shell as Linux.Shell, path)
+    return Linux.launch(shell as IFoundShell<Linux.Shell>, path)
   }
 
   return Promise.reject(

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -68,7 +68,12 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
-export async function launch(shell: Shell, path: string): Promise<void> {
+export async function launch(
+  foundShell: IFoundShell<Shell>,
+  path: string
+): Promise<void> {
+  const shell = foundShell.shell
+
   if (shell === Shell.PowerShell) {
     const psCommand = `"Set-Location -LiteralPath '${path}'"`
     await spawn('START', ['powershell', '-NoExit', '-Command', psCommand], {
@@ -76,7 +81,7 @@ export async function launch(shell: Shell, path: string): Promise<void> {
       cwd: path,
     })
   } else if (shell === Shell.GitBash) {
-    await spawn('"%ProgramFiles%\\Git\\git-bash.exe"', [`--cd="${path}"`], {
+    await spawn(foundShell.path, [`--cd="${path}"`], {
       shell: true,
       cwd: path,
     })


### PR DESCRIPTION
Writing up some words on the shell integration, and realised that Git Bash was hard-coded to launch under `%PROGRAMFILES%`, always.

```ts
} else if (shell === Shell.GitBash) {
  await spawn('"%ProgramFiles%\\Git\\git-bash.exe"', [`--cd="${path}"`], {
    shell: true,
    cwd: path,
  })
```

You can install Git for Windows anywhere, so that's going to break anytime you choose a different directory.

We actually know where this is, because we look for it in the registry:

```ts
const gitBash = await readRegistryKeySafe(
  'HKEY_LOCAL_MACHINE\\SOFTWARE\\GitForWindows'
)
if (gitBash.length > 0) {
  const installPathEntry = gitBash.find(e => e.name === 'InstallPath')
  if (installPathEntry) {
    shells.push({
      shell: Shell.GitBash,
      path: Path.join(installPathEntry.value, 'git-bash.exe'),
    })
  }
}
```

So I've tidied up the `launch` methods on all platforms to take in the full `IFoundShell<T>` abstraction, so they can determine how to handle this.
