### PR TITLE
handle accounts with URL-hostile characters

### DIFF
--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -1,6 +1,7 @@
 import * as Fs from 'fs-extra'
 import * as Os from 'os'
 import * as Path from 'path'
+import * as Url from 'url'
 import { Disposable } from 'event-kit'
 import { Tailer } from './tailer'
 
@@ -109,5 +110,19 @@ export function pathExists(path: string): Promise<boolean> {
         resolve(true)
       }
     })
+  })
+}
+
+/**
+ * Resolve and encode the path information into a URL.
+ *
+ * @param pathSegments array of path segments to resolve
+ */
+export function encodePath(...pathSegments: string[]): string {
+  const path = Path.resolve(...pathSegments)
+  return Url.format({
+    pathname: path,
+    protocol: 'file:',
+    slashes: true,
   })
 }

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, ipcMain, Menu, app, dialog } from 'electron'
 import { Emitter, Disposable } from 'event-kit'
+import { encodePath } from '../lib/file-system'
 import { registerWindowStateChangedEvents } from '../lib/window-state'
 import { MenuEvent } from './menu'
 import { URLActionType } from '../lib/parse-app-url'
@@ -132,8 +133,7 @@ export class AppWindow {
     this.window.on('blur', () => this.window.webContents.send('blur'))
 
     registerWindowStateChangedEvents(this.window)
-
-    this.window.loadURL(`file://${__dirname}/index.html`)
+    this.window.loadURL(encodePath(__dirname, 'index.html'))
   }
 
   /**

--- a/app/test/unit/file-system-tests.ts
+++ b/app/test/unit/file-system-tests.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai'
+
+import { encodePath } from '../../src/lib/file-system'
+
+describe('file-system', () => {
+  describe('encodePath', () => {
+    it('should encode hash symbol', () => {
+      const dirName =
+        'C:/Users/The Kong #2\\AppData\\Local\\GitHubDesktop\\app-1.0.4\\resources\\app'
+      const uri = encodePath(dirName, 'index.html')
+      expect(uri.startsWith('file://'))
+      expect(uri.indexOf('%20') > 0)
+      expect(uri.indexOf('%23') > 0)
+    })
+  })
+})

--- a/app/test/unit/file-system-tests.ts
+++ b/app/test/unit/file-system-tests.ts
@@ -4,13 +4,22 @@ import { encodePath } from '../../src/lib/file-system'
 
 describe('file-system', () => {
   describe('encodePath', () => {
+    it('handles and already encoded path', () => {
+      const dirName =
+        'C:/Users/shift%20key%20\\AppData\\Local\\GitHubDesktop\\app-1.0.4\\resources\\app'
+      const uri = encodePath(dirName, 'index.html')
+      expect(uri.startsWith('file://'))
+      expect(uri.indexOf('%20')).is.greaterThan(0)
+      expect(uri.indexOf('%2520')).is.equal(-1)
+    })
+
     it('should encode hash symbol', () => {
       const dirName =
         'C:/Users/The Kong #2\\AppData\\Local\\GitHubDesktop\\app-1.0.4\\resources\\app'
       const uri = encodePath(dirName, 'index.html')
       expect(uri.startsWith('file://'))
-      expect(uri.indexOf('%20') > 0)
-      expect(uri.indexOf('%23') > 0)
+
+      expect(uri.indexOf('%23')).is.greaterThan(0)
     })
   })
 })


### PR DESCRIPTION
Investigating a fix for #3107 as well as any subsequent issues that might appear.

 - [ ] can launch app when account name has `#` in it
 - [ ] ???