### PR TITLE
Change libxscrnsaver package name to libXScrnSaver

### DIFF
--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -35,7 +35,7 @@ $ curl --silent --location https://rpm.nodesource.com/setup_8.x | sudo bash -
 After that, install the dependencies to build and test the app:
 
 ```shellsession
-$ sudo dnf install -y nodejs gcc-c++ make libsecret-devel libxscrnsaver
+$ sudo dnf install -y nodejs gcc-c++ make libsecret-devel libXScrnSaver
 ```
 
 If you want to package Desktop for distribution, you will need these additional dependencies:


### PR DESCRIPTION
The package `libxscrnsaver` seems to be called `libXScrnSaver` in Fedora 26.
![screenshot from 2017-10-20 23-14-21](https://user-images.githubusercontent.com/4258550/31842026-702ff7be-b5ec-11e7-89a1-dd8eecf69f35.png)
