### PR TITLE
Fix sign in hanging

### DIFF
--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -93,8 +93,8 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
     // Only advance when the state first changes...
     if (this.props.signInState.kind === nextProps.signInState.kind) {
       log.info(
-        `[Welcome] kind ${this.props.signInState.kind} is the same ${nextProps
-          .signInState.kind}. ignoring...`
+        `[Welcome] kind ${this.props.signInState
+          .kind} is the same as ${nextProps.signInState.kind}. ignoring...`
       )
       return
     }


### PR DESCRIPTION
Fixes #2769

I haven't been able to reproduce the bug, but I think I understand what's happening.

We would only advance to the next step of the Welcome flow when the `Welcome` component was rendered twice with the same sign in step. That was a logic error introduced in https://github.com/desktop/desktop/commit/ed2a5b917977c159249832c1af5d31bbdb272ddd.

This bug didn't manifest most of the time because most of the time we'd get lucky. Our account store's state update and login store's state update would happen across two separate animation frames. The `Welcome` component would be rendered twice with the same sign in step, and life would go on. But on slower or busier computers, those two state updates could be coalesced into the same animation frame. The `Welcome` component would only get rendered once and so it'd get stuck.