### PR TITLE
leave PRs alone, request-info bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -7,3 +7,7 @@ requestInfoReplyComment: >
   more time fixing bugs, implementing enhancements, and reviewing and merging pull requests.
 
 requestInfoLabelToAdd: more-information-needed
+
+requestInfoOn:
+  pullRequest: false
+  issue: true


### PR DESCRIPTION
This should prevent future issues like https://github.com/desktop/desktop/pull/3133 where the request-info bot looks at PRs.