### PR TITLE
Update README.md: brew cask install github

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are several community-supported package managers that can be used to insta
  - Windows users can install using [Chocolatey](https://chocolatey.org/) package manager:
       `c:\> choco install github-desktop`
  - macOS users can install using [Homebrew](https://brew.sh/) package manager:
-      `$ brew cask install github-desktop`
+      `$ brew cask install github`
 
 You can install this alongside your existing GitHub Desktop for Mac or GitHub
 Desktop for Windows application.


### PR DESCRIPTION
Cask token for GitHub Desktop has been renamed from `github-desktop` to `github`

https://github.com/caskroom/homebrew-cask/pull/39883

https://github.com/caskroom/homebrew-cask/pull/39708