### PR TITLE
fix focus with dialog issue on Linux

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -202,10 +202,10 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   private onWindowFocus = () => {
-    // On Windows, a click which focuses the window will also get passed down
-    // into the DOM. But we don't want to dismiss the dialog based on that
-    // click. See https://github.com/desktop/desktop/issues/2486.
-    if (__WIN32__) {
+    // On Windows and Linux, a click which focuses the window will also get
+    // passed down into the DOM. But we don't want to dismiss the dialog based
+    // on that click. See https://github.com/desktop/desktop/issues/2486.
+    if (__WIN32__ || __LINUX__) {
       this.clearClickDismissalTimer()
 
       this.disableClickDismissal = true


### PR DESCRIPTION
I found this while testing a couple of PRs on Fedora. See #2488 for the original PR.

Repro steps:

 - run the dev build
 - open **Files** and ensure it's _above_ Desktop
 - drag-and-drop a Git repository from the **Files** app to Desktop, the "Add Existing Repository" dialog appears
 - click to focus on Desktop

Expected behaviour: can see "Add Existing Repository" dialog
Actual behaviour: dialog disappears