### PR TITLE
bump to Git 2.14.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "codemirror": "^5.29.0",
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
-    "dugite": "1.46.0",
+    "dugite": "1.47.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -270,9 +270,9 @@ dom-matches@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dom-matches/-/dom-matches-2.0.0.tgz#d2728b416a87533980eb089b848d253cf23a758c"
 
-dugite@1.46.0:
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.46.0.tgz#86e2585ee2784c228298068f3ea0bb5de08e7a98"
+dugite@1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.47.0.tgz#b1029b1d0a1c2bbebe385e049777cd5f33978f56"
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
Hot off the presses:

 - [Git release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.14.3.txt)
 - [Git for Windows release notes](https://github.com/git-for-windows/git/releases/tag/v2.14.3.windows.1)
