### PR TITLE
handle watch error when tailing LFS output

### DIFF
--- a/app/src/lib/tailer.ts
+++ b/app/src/lib/tailer.ts
@@ -41,8 +41,13 @@ export class Tailer {
       )
     }
 
-    const watcher = Fs.watch(this.path, this.onWatchEvent)
-    this.state = { watcher, position: 0 }
+    try {
+      const watcher = Fs.watch(this.path, this.onWatchEvent)
+      this.state = { watcher, position: 0 }
+    } catch (e) {
+      log.debug(`unable to watch path: ${this.path}`, e)
+      this.state = null
+    }
   }
 
   private onWatchEvent = (event: string) => {


### PR DESCRIPTION
Fixes #3046

 - [x] catch error when `watch` occurs on a `TEMP` path the user doesn't have permissions to read/write
 - [x] ensure push/pull/fetch are unaffected when this file isn't setup correctly