### PR TITLE
Report errors from secure storage

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -969,7 +969,17 @@ export class Dispatcher {
   ): Promise<void> {
     log.info(`storing generic credentials for '${hostname}' and '${username}'`)
     setGenericUsername(hostname, username)
-    await setGenericPassword(hostname, username, password)
+
+    try {
+      await setGenericPassword(hostname, username, password)
+    } catch (e) {
+      log.error(
+        `Error saving generic git credentials: ${username}@${hostname}`,
+        e
+      )
+
+      this.postError(e)
+    }
   }
 
   /** Perform the given retry action. */

--- a/app/src/lib/generic-git-auth.ts
+++ b/app/src/lib/generic-git-auth.ts
@@ -28,15 +28,6 @@ export function getGenericUsername(hostname: string): string | null {
   return localStorage.getItem(key)
 }
 
-/** Get the password for the host. */
-export function getGenericPassword(
-  hostname: string,
-  username: string
-): Promise<string | null> {
-  const key = getKeyForEndpoint(hostname)
-  return TokenStore.getItem(key, username)
-}
-
 /** Set the username for the host. */
 export function setGenericUsername(hostname: string, username: string) {
   const key = getKeyForUsername(hostname)

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -57,9 +57,18 @@ export class AccountsStore {
     this.emitter.emit('did-update', {})
   }
 
+  private emitError(error: Error) {
+    this.emitter.emit('did-error', error)
+  }
+
   /** Register a function to be called when the store updates. */
   public onDidUpdate(fn: () => void): Disposable {
     return this.emitter.on('did-update', fn)
+  }
+
+  /** Register a function to be called when an error occurs. */
+  public onDidError(fn: (error: Error) => void): Disposable {
+    return this.emitter.on('did-error', fn)
   }
 
   /**
@@ -148,6 +157,8 @@ export class AccountsStore {
         accountsWithTokens.push(accountWithoutToken.withToken(token || ''))
       } catch (e) {
         log.error(`Error getting token for '${key}'. Skipping.`, e)
+
+        this.emitError(e)
       }
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -288,6 +288,7 @@ export class AppStore {
       this.accounts = accounts
       this.emitUpdate()
     })
+    accountsStore.onDidError(error => this.emitError(error))
 
     repositoriesStore.onDidUpdate(async () => {
       const repositories = await this.repositoriesStore.getAll()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2471,34 +2471,18 @@ export class AppStore {
     return this.repositoriesStore.updateRepositoryPath(repository, path)
   }
 
-  public async _removeAccount(account: Account): Promise<void> {
+  public _removeAccount(account: Account): Promise<void> {
     log.info(
       `[AppStore] removing account ${account.login} (${account.name}) from store`
     )
-
-    try {
-      await this.accountsStore.removeAccount(account)
-    } catch (e) {
-      log.error(`Error removing account '${account.login}'`, e)
-
-      this.emitError(e)
-    }
+    return this.accountsStore.removeAccount(account)
   }
 
   public async _addAccount(account: Account): Promise<void> {
     log.info(
       `[AppStore] adding account ${account.login} (${account.name}) to store`
     )
-
-    try {
-      await this.accountsStore.addAccount(account)
-    } catch (e) {
-      log.error(`Error adding account '${account.login}'`, e)
-
-      this.emitError(e)
-      return
-    }
-
+    await this.accountsStore.addAccount(account)
     const selectedState = this.getState().selectedState
 
     if (selectedState && selectedState.type === SelectionType.Repository) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2470,18 +2470,34 @@ export class AppStore {
     return this.repositoriesStore.updateRepositoryPath(repository, path)
   }
 
-  public _removeAccount(account: Account): Promise<void> {
+  public async _removeAccount(account: Account): Promise<void> {
     log.info(
       `[AppStore] removing account ${account.login} (${account.name}) from store`
     )
-    return this.accountsStore.removeAccount(account)
+
+    try {
+      await this.accountsStore.removeAccount(account)
+    } catch (e) {
+      log.error(`Error removing account '${account.login}'`, e)
+
+      this.emitError(e)
+    }
   }
 
   public async _addAccount(account: Account): Promise<void> {
     log.info(
       `[AppStore] adding account ${account.login} (${account.name}) to store`
     )
-    await this.accountsStore.addAccount(account)
+
+    try {
+      await this.accountsStore.addAccount(account)
+    } catch (e) {
+      log.error(`Error adding account '${account.login}'`, e)
+
+      this.emitError(e)
+      return
+    }
+
     const selectedState = this.getState().selectedState
 
     if (selectedState && selectedState.type === SelectionType.Repository) {


### PR DESCRIPTION
I noticed this while debugging a support issue.

We weren't reporting any errors from interacting with secure storage. The likelihood of errors from there is low, which is how we've gotten away with it for this long. But there's still a chance and we should report them.