### PR TITLE
Ignore should ask about removing tracked files (if found)

### DIFF
--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -111,3 +111,20 @@ export function pathExists(path: string): Promise<boolean> {
     })
   })
 }
+
+/**
+ * Helper function to promisify fs.unlink for deleting a file from disk.
+ *
+ * @param path Path to delete from disk.
+ */
+export function removeFile(path: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    Fs.unlink(path, error => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -14,7 +14,7 @@ import { ErrorWithMetadata, IErrorMetadata } from '../error-with-metadata'
 import { structuralEquals } from '../../lib/equality'
 import { compare } from '../../lib/compare'
 import { queueWorkHigh } from '../../lib/queue-work'
-import { removeFile } from '../../lib/file-system'
+import { removeFile, pathExists } from '../../lib/file-system'
 
 import {
   reset,
@@ -814,9 +814,12 @@ export class GitStore {
         // if we have pending changes against this file, discard it
         // using the workflow defined by the user
         await this.discardChanges([match])
-      } else {
-        // the file is tracked but has no pending changes, just remove it
-        const path = Path.join(repository.path, pattern)
+      }
+
+      // the file is tracked but has no pending changes, just remove it
+      const path = Path.join(repository.path, pattern)
+      const exists = await pathExists(path)
+      if (exists) {
         await removeFile(path)
       }
     }

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -74,11 +74,9 @@ describe('GitStore', () => {
     status = await getStatus(repo)
     files = status.workingDirectory.files
 
-    expect(files.length).to.equal(2)
+    expect(files.length).to.equal(1)
     expect(files[0].path).to.equal('README.md')
     expect(files[0].status).to.equal(AppFileStatus.Modified)
-    expect(files[1].path).to.equal('LICENSE.md')
-    expect(files[1].status).to.equal(AppFileStatus.New)
   })
 
   it('discarding a tracked file will remove it from disk', async () => {

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -101,10 +101,10 @@ describe('GitStore', () => {
     const files = status.workingDirectory.files
 
     expect(files.length).to.equal(2)
-    expect(files[0].path).equals('.gitignore')
-    expect(files[0].status).equals(AppFileStatus.New)
-    expect(files[1].path).equals(relativeFilePath)
-    expect(files[1].status).equals(AppFileStatus.Deleted)
+    expect(files[0].path).equals(relativeFilePath)
+    expect(files[0].status).equals(AppFileStatus.Deleted)
+    expect(files[1].path).equals('.gitignore')
+    expect(files[1].status).equals(AppFileStatus.New)
   })
 
   it('can discard a renamed file', async () => {


### PR DESCRIPTION
A proposed solution for #2537 as way to reduce confusion when a file is ignored but already tracked by Git:

 - [ ] ignore specific path
   - [ ] check if file is tracked by Git
   - [ ] warn user that these files should be removed
   - [ ] if approved, remove file from working directory to mark it as ready for deletion
- [ ] ignore wildcard path
   - [ ] find all files matching expression
   - [ ] check if files is tracked by Git
   - [ ] warn user that these files should be removed
   - [ ] discard files if changed in working directory
   - [ ] remove all files
- [ ] update impacted tests
- [ ] ???