### PR TITLE
checkout needs credentials for LFS repositories

### DIFF
--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -6,6 +6,12 @@ import {
 } from '../progress'
 import { ICheckoutProgress } from '../app-state'
 
+import {
+  IGitAccount,
+  envForAuthentication,
+  AuthenticationErrors,
+} from './authentication'
+
 export type ProgressCallback = (progress: ICheckoutProgress) => void
 
 /**
@@ -24,10 +30,14 @@ export type ProgressCallback = (progress: ICheckoutProgress) => void
  */
 export async function checkoutBranch(
   repository: Repository,
+  account: IGitAccount | null,
   name: string,
   progressCallback?: ProgressCallback
 ): Promise<void> {
-  let opts: IGitExecutionOptions = {}
+  let opts: IGitExecutionOptions = {
+    env: envForAuthentication(account),
+    expectedErrors: AuthenticationErrors,
+  }
 
   if (progressCallback) {
     const title = `Checking out branch ${name}`

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -1,4 +1,4 @@
-import { git, IGitExecutionOptions } from './core'
+import { git, IGitExecutionOptions, gitNetworkArguments } from './core'
 import { Repository } from '../../models/repository'
 import {
   CheckoutProgressParser,
@@ -62,8 +62,8 @@ export async function checkoutBranch(
   }
 
   const args = progressCallback
-    ? ['checkout', '--progress', name, '--']
-    : ['checkout', name, '--']
+    ? [...gitNetworkArguments, 'checkout', '--progress', name, '--']
+    : [...gitNetworkArguments, 'checkout', name, '--']
 
   await git(args, repository.path, 'checkoutBranch', opts)
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1468,13 +1468,13 @@ export class AppStore {
     const gitStore = this.getGitStore(repository)
     const kind = 'checkout'
 
-    await this.withAuthenticatingUser(repository, (repository, account) => {
-      return gitStore.performFailableOperation(() =>
+    await this.withAuthenticatingUser(repository, (repository, account) =>
+      gitStore.performFailableOperation(() =>
         checkoutBranch(repository, account, name, progress => {
           this.updateCheckoutProgress(repository, progress)
         })
       )
-    })
+    )
 
     try {
       this.updateCheckoutProgress(repository, {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1468,10 +1468,12 @@ export class AppStore {
     const gitStore = this.getGitStore(repository)
     const kind = 'checkout'
 
-    await gitStore.performFailableOperation(() => {
-      return checkoutBranch(repository, name, progress => {
-        this.updateCheckoutProgress(repository, progress)
-      })
+    await this.withAuthenticatingUser(repository, (repository, account) => {
+      return gitStore.performFailableOperation(() =>
+        checkoutBranch(repository, account, name, progress => {
+          this.updateCheckoutProgress(repository, progress)
+        })
+      )
     })
 
     try {
@@ -1629,7 +1631,7 @@ export class AppStore {
       const gitStore = this.getGitStore(repository)
 
       await gitStore.performFailableOperation(() =>
-        checkoutBranch(repository, defaultBranch.name)
+        checkoutBranch(repository, account, defaultBranch.name)
       )
       await gitStore.performFailableOperation(() =>
         deleteBranch(repository, branch, account, includeRemote)

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -16,7 +16,7 @@ describe('git/checkout', () => {
 
     let errorRaised = false
     try {
-      await checkoutBranch(repository, '..')
+      await checkoutBranch(repository, null, '..')
     } catch (error) {
       errorRaised = true
       expect(error.message).to.equal('fatal: invalid reference: ..\n')
@@ -29,7 +29,7 @@ describe('git/checkout', () => {
     const path = await setupFixtureRepository('repo-with-many-refs')
     const repository = new Repository(path, -1, null, false)
 
-    await checkoutBranch(repository, 'commit-with-long-description')
+    await checkoutBranch(repository, null, 'commit-with-long-description')
 
     const store = new GitStore(repository, shell)
     await store.loadStatus()

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -19,7 +19,7 @@ async function createAndCheckout(
   name: string
 ): Promise<void> {
   await createBranch(repository, name)
-  await checkoutBranch(repository, name)
+  await checkoutBranch(repository, null, name)
 }
 
 describe('git/reflog', () => {


### PR DESCRIPTION
This should fix #3155 

 - [x] confirm with test that private LFS-enabled repository will clone down these resources
 - [x] confirm regular checkouts aren't affected
 - ~~[ ] investigate why progress isn't displayed in the UI (animation occurs, that's all)~~ :boot: spinning out to a new issue, see https://github.com/desktop/desktop/pull/2355#issuecomment-330556198 for what's happening

cc @joshaber for any other thoughts on addressing this