### PR TITLE
Fix Branches list not displaying

### DIFF
--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -103,7 +103,11 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
   }
 
   private renderSelectedTab() {
-    const tab = this.props.selectedTab
+    let tab = this.props.selectedTab
+    if (!enablePreviewFeatures()) {
+      tab = BranchesTab.Branches
+    }
+
     switch (tab) {
       case BranchesTab.Branches:
         return (

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -104,7 +104,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
 
   private renderSelectedTab() {
     let tab = this.props.selectedTab
-    if (!enablePreviewFeatures()) {
+    if (!enablePreviewFeatures() || !this.props.repository.gitHubRepository) {
       tab = BranchesTab.Branches
     }
 

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -162,31 +162,10 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
   }
 
   public render() {
-    if (this.props.repository.gitHubRepository) {
-      return (
-        <div className="branches-container">
-          {this.renderTabBar()}
-          {this.renderSelectedTab()}
-        </div>
-      )
-    }
-
     return (
-      <div className="branches-list-container">
-        <BranchList
-          defaultBranch={this.props.defaultBranch}
-          currentBranch={this.props.currentBranch}
-          allBranches={this.props.allBranches}
-          recentBranches={this.props.recentBranches}
-          onItemClick={this.onItemClick}
-          filterText={this.state.filterText}
-          onFilterKeyDown={this.onFilterKeyDown}
-          onFilterTextChanged={this.onFilterTextChanged}
-          selectedBranch={this.state.selectedBranch}
-          onSelectionChanged={this.onSelectionChanged}
-          canCreateNewBranch={true}
-          onCreateNewBranch={this.onCreateBranchWithName}
-        />
+      <div className="branches-container">
+        {this.renderTabBar()}
+        {this.renderSelectedTab()}
       </div>
     )
   }


### PR DESCRIPTION
Fixes #3169

We had a branch (lol) to display only the Branches list if we weren't in a GitHub repository. But that didn't include the container `div`, so the list wasn't sized properly. And as it turns out, that condition was unnecessary as we were already conditionalizing for non-GitHub repositories further down in the rendering chain.