### PR TITLE
address path issue with invoking Git Bash

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -99,7 +99,7 @@ export async function launch(
     )
     addErrorTracing(`PowerShell`, cp)
   } else if (shell === Shell.GitBash) {
-    const cp = spawn(foundShell.path, [`--cd="${path}"`], {
+    const cp = spawn(`"${foundShell.path}"`, [`--cd="${path}"`], {
       shell: true,
       cwd: path,
     })

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, ChildProcess } from 'child_process'
 import * as Path from 'path'
 import { assertNever } from '../fatal-error'
 import { readRegistryKeySafe } from '../registry'
@@ -68,6 +68,19 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
+function wrap(context: string, cp: ChildProcess) {
+  cp.stderr.on('data', chunk => {
+    const text = chunk instanceof Buffer ? chunk.toString() : chunk
+    log.debug(`[${context}] stderr: '${text}'`)
+  })
+
+  cp.on('exit', code => {
+    if (code !== 0) {
+      log.debug(`[${context}] exit code: ${code}`)
+    }
+  })
+}
+
 export async function launch(
   foundShell: IFoundShell<Shell>,
   path: string
@@ -86,16 +99,7 @@ export async function launch(
       cwd: path,
     })
 
-    cp.stderr.on('data', chunk => {
-      const text = chunk instanceof Buffer ? chunk.toString() : chunk
-      log.debug(`[Git Bash] stderr: '${text}'`)
-    })
-
-    cp.on('exit', code => {
-      if (code !== 0) {
-        log.debug(`[Git Bash] exit code: ${code}`)
-      }
-    })
+    wrap(`Git Bash`, cp)
   } else if (shell === Shell.Cmd) {
     await spawn('START', ['cmd'], { shell: true, cwd: path })
   } else {

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -81,9 +81,20 @@ export async function launch(
       cwd: path,
     })
   } else if (shell === Shell.GitBash) {
-    await spawn(foundShell.path, [`--cd="${path}"`], {
+    const cp = spawn(foundShell.path, [`--cd="${path}"`], {
       shell: true,
       cwd: path,
+    })
+
+    cp.stderr.on('data', chunk => {
+      const text = chunk instanceof Buffer ? chunk.toString() : chunk
+      log.debug(`[Git Bash] stderr: '${text}'`)
+    })
+
+    cp.on('exit', code => {
+      if (code !== 0) {
+        log.debug(`[Git Bash] exit code: ${code}`)
+      }
     })
   } else if (shell === Shell.Cmd) {
     await spawn('START', ['cmd'], { shell: true, cwd: path })


### PR DESCRIPTION
Fixes #3186 

This was a subtle regression introduced in #3087 when I reused the found shell path, because the install location can be changed by the user.

First off, I added tracing to dump any `stderr` and non-zero exit code info to the console - this highlights the underlying issue, and will help with any future issues we encounter around here:

<img width="928" src="https://user-images.githubusercontent.com/359239/32149707-bd230c24-bd5c-11e7-930e-cb52515b11db.png">

Second, fix the actual bug by wrapping the path in quote marks. This was how it originally behaved, but #3087 dropped this by mistake

 - [x] test CMD and PowerShell are fine with this change
