### PR TITLE
Only reset scale of title bar on macOS

### DIFF
--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -32,6 +32,12 @@ interface ITitleBarState {
 }
 
 function getState(props: ITitleBarProps): ITitleBarState {
+  // See windowZoomFactor in ITitleBarProps, this is only
+  // applicable on macOS.
+  if (!__DARWIN__) {
+    return { style: undefined }
+  }
+
   return {
     style: props.windowZoomFactor
       ? { zoom: 1 / props.windowZoomFactor }


### PR DESCRIPTION
We already had an escape hatch for non-macOS in `componentWillReceiveProps` but we were still calling `getState` from the constructor and ignoring the platform.

Fixes #3193