### PR TITLE
bump yarn to 1.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ cache:
     - .eslintcache
 
 install:
-  - npm install -g yarn@1.2.1
+  - npm install -g yarn@1.3.2
   - yarn install --force
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ version: "{build}"
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - npm install -g yarn@1.2.1
+  - npm install -g yarn@1.3.2
   - git submodule update --init --recursive
   - yarn install --force
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
 
   pre:
     - brew install node || brew upgrade node
-    - npm install -g yarn@1.2.1
+    - npm install -g yarn@1.3.2
 
   override:
     - yarn install --force

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -81,7 +81,7 @@ With these things installed, open a shell and install `yarn` (you might need
 to `sudo` here depending on how Node was installed):
 
 ```shellsession
-$ npm install -g yarn@1.2.0
+$ npm install -g yarn@1.3.2
 ```
 
 This is important because yarn uses lock files to pin dependencies. If you find


### PR DESCRIPTION
A [bunch of fixes](https://github.com/yarnpkg/yarn/releases/tag/v1.3.0) to keep up with.

The `1.3.1` and `1.3.2` builds are due to publishing issues.