### PR TITLE
port build script to use yarn for keeping bundled node_modules in sync

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -233,8 +233,8 @@ function copyDependencies() {
     Object.keys(newDependencies).length ||
     Object.keys(newDevDependencies).length
   ) {
-    console.log('  Installing npm dependencies…')
-    cp.execSync('npm install', { cwd: outRoot, env: process.env })
+    console.log('  Installing dependencies via yarn…')
+    cp.execSync('yarn install', { cwd: outRoot, env: process.env })
   }
 
   if (!isPublishableBuild) {


### PR DESCRIPTION
A little thing that we do as part of building the app is to embed any `node_modules` that we can't webpack into the app. Some devDependencies, some more crucial, and that's fine.

```shellsession
~/src/desktop/ ls out/node_modules
7zip                          highlight.js
accessibility-developer-tools humanize-plus
devtron
```

This behaviour _might_ change between when we upgrade incidentally to `npm@5`, so let's instead tie this to `yarn` which we have more control over.