### PR TITLE
Link directly to syntax highlight pull request

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.0.8-beta0": [
-      "[New] Syntax highlighted diffs - #1312",
+      "[New] Syntax highlighted diffs - #3101",
       "[New] Add upstream to forked repositories - #2364",
       "[Fixed] Only reset scale of title bar on macOS - #3193",
       "[Fixed] Filter symbolic refs in the branch list - #3196",
@@ -11,7 +11,7 @@
       "[Fixed] Assorted changelog typos - #3174 #3184 #3207. Thanks @strafe, @alanaasmaa and @jt2k!"
     ],
     "1.0.7": [
-      "[New] Syntax highlighted diffs - #1312",
+      "[New] Syntax highlighted diffs - #3101",
       "[New] Add upstream to forked repositories - #2364",
       "[Fixed] Only reset scale of title bar on macOS - #3193",
       "[Fixed] Filter symbolic refs in the branch list - #3196",


### PR DESCRIPTION
Is it currently linking to an issue about "Remove git timing logging?", which does not really make sense