### PR TITLE
Fancy load tweaks

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -354,14 +354,17 @@ export abstract class AutocompletingTextInput<
         direction,
         selectedRow
       )
-      const newSelectedItem = currentAutoCompletionState.items[nextRow]
 
-      const newAutoCompletionState = {
-        ...currentAutoCompletionState,
-        selectedItem: newSelectedItem,
+      if (nextRow !== null) {
+        const newSelectedItem = currentAutoCompletionState.items[nextRow]
+
+        const newAutoCompletionState = {
+          ...currentAutoCompletionState,
+          selectedItem: newSelectedItem,
+        }
+
+        this.setState({ autocompletionState: newAutoCompletionState })
       }
-
-      this.setState({ autocompletionState: newAutoCompletionState })
     } else if (event.key === 'Enter' || event.key === 'Tab') {
       const item = currentAutoCompletionState.selectedItem
       if (item) {

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import * as moment from 'moment'
+import * as classNames from 'classnames'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { CIStatus } from './ci-status'
 import { PullRequestStatus } from '../../models/pull-request'
 
-interface IPullRequestListItemProps {
+export interface IPullRequestListItemProps {
   /** The title. */
   readonly title: string
 
@@ -19,19 +20,40 @@ interface IPullRequestListItemProps {
 
   /** The CI status. */
   readonly status: PullRequestStatus | null
+
+  /**
+   * Whether or not this list item is a skeleton item
+   * put in place while the pull request information is
+   * being loaded. This adds a special 'loading' class
+   * to the container and prevents any text from rendering
+   * inside the list item.
+   */
+  readonly loading?: boolean
 }
 
 /** Pull requests as rendered in the Pull Requests list. */
 export class PullRequestListItem extends React.Component<
-  IPullRequestListItemProps,
-  {}
+  IPullRequestListItemProps
 > {
-  public render() {
+  private getSubtitle() {
+    if (this.props.loading === true) {
+      return undefined
+    }
+
     const timeAgo = moment(this.props.created).fromNow()
-    const { title, author } = this.props
-    const subtitle = `#${this.props.number} opened ${timeAgo} by ${author}`
+    return `#${this.props.number} opened ${timeAgo} by ${this.props.author}`
+  }
+
+  public render() {
+    const title = this.props.loading === true ? undefined : this.props.title
+    const subtitle = this.getSubtitle()
+
+    const className = classNames('pull-request-item', {
+      loading: this.props.loading === true,
+    })
+
     return (
-      <div className="pull-request-item">
+      <div className={className}>
         <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
         <div className="info">
           <div className="title" title={title}>

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -21,7 +21,7 @@ const PullRequestFilterList: new () => FilterList<
   IPullRequestListItem
 > = FilterList as any
 
-const RowHeight = 47
+export const RowHeight = 47
 
 interface IPullRequestListProps {
   /** The pull requests to display. */

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -4,8 +4,7 @@ import {
   PullRequestListItem,
   IPullRequestListItemProps,
 } from './pull-request-list-item'
-
-const RowHeight = 45
+import { RowHeight } from './pull-request-list'
 
 const FacadeCount = 6
 

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -55,7 +55,7 @@ export class PullRequestsLoading extends React.Component<{}, {}> {
         selectedItem={null}
         renderItem={this.renderItem}
         invalidationProps={groups}
-        filterDisabled={true}
+        disabled={true}
       />
     )
   }

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { FilterList, IFilterListItem } from '../lib/filter-list'
-import { Octicon, OcticonSymbol } from '../octicons'
+import {
+  PullRequestListItem,
+  IPullRequestListItemProps,
+} from './pull-request-list-item'
 
 const RowHeight = 45
 
@@ -13,6 +16,19 @@ const FacadeCount = 6
 const PullRequestsLoadingList: new () => FilterList<
   IFilterListItem
 > = FilterList as any
+
+const prLoadingItemProps: IPullRequestListItemProps = {
+  loading: true,
+  author: '',
+  created: new Date(0),
+  number: 0,
+  title: '',
+  status: {
+    sha: '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+    totalCount: 1,
+    state: 'pending',
+  },
+}
 
 /** The placeholder for when pull requests are still loading. */
 export class PullRequestsLoading extends React.Component<{}, {}> {
@@ -46,17 +62,6 @@ export class PullRequestsLoading extends React.Component<{}, {}> {
   }
 
   private renderItem = (item: IFilterListItem) => {
-    return (
-      <div className="pull-request-loading-item">
-        <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
-
-        <div className="info">
-          <div className="title" />
-          <div className="subtitle" />
-        </div>
-
-        <Octicon className="status" symbol={OcticonSymbol.primitiveDot} />
-      </div>
-    )
+    return <PullRequestListItem {...prLoadingItemProps} />
   }
 }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -96,8 +96,11 @@ interface IFilterListProps<T extends IFilterListItem> {
   /** Called when the filter text is changed by the user */
   readonly onFilterTextChanged?: (text: string) => void
 
-  /** Is the filter field disabled? */
-  readonly filterDisabled?: boolean
+  /**
+   * Whether or not the filter list should allow selection
+   * and filtering. Defaults to false.
+   */
+  readonly disabled?: boolean
 
   /** Any props which should cause a re-render if they change. */
   readonly invalidationProps: any
@@ -157,7 +160,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
             onKeyDown={this.onKeyDown}
             onInputRef={this.onInputRef}
             value={this.props.filterText}
-            disabled={this.props.filterDisabled}
+            disabled={this.props.disabled}
           />
 
           {this.props.renderPostFilter ? this.props.renderPostFilter() : null}
@@ -275,6 +278,10 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   private canSelectRow = (index: number) => {
+    if (this.props.disabled) {
+      return false
+    }
+
     const row = this.state.rows[index]
     return row.kind === 'item'
   }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -329,20 +329,23 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     if (event.key === 'ArrowDown') {
       if (this.state.rows.length > 0) {
-        this.setState(
-          { selectedRow: list.nextSelectableRow('down', -1) },
-          () => {
+        const selectedRow = list.nextSelectableRow('down', -1)
+        if (selectedRow) {
+          this.setState({ selectedRow }, () => {
             list.focus()
-          }
-        )
+          })
+        }
       }
 
       event.preventDefault()
     } else if (event.key === 'ArrowUp') {
       if (this.state.rows.length > 0) {
-        this.setState({ selectedRow: list.nextSelectableRow('up', 0) }, () => {
-          list.focus()
-        })
+        const selectedRow = list.nextSelectableRow('up', 0)
+        if (selectedRow) {
+          this.setState({ selectedRow }, () => {
+            list.focus()
+          })
+        }
       }
 
       event.preventDefault()
@@ -354,7 +357,10 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
       }
 
       const row = list.nextSelectableRow('down', -1)
-      this.onRowClick(row)
+
+      if (row) {
+        this.onRowClick(row)
+      }
     }
   }
 }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -325,26 +325,24 @@ export class List extends React.Component<IListProps, IListState> {
   /**
    * Determine the next selectable row, given the direction and row. This will
    * take `canSelectRow` into account.
+   *
+   * Returns null if no row can be selected.
    */
-  public nextSelectableRow(direction: 'up' | 'down', row: number): number {
-    let newRow = row
-    if (direction === 'up') {
-      newRow = row - 1
-      if (newRow < 0) {
-        newRow = this.props.rowCount - 1
-      }
-    } else {
-      newRow = row + 1
-      if (newRow > this.props.rowCount - 1) {
-        newRow = 0
+  public nextSelectableRow(
+    direction: 'up' | 'down',
+    row: number
+  ): number | null {
+    for (let i = 1; i < this.props.rowCount; i++) {
+      const delta = direction === 'up' ? i * -1 : i
+      // Modulo accounting for negative values, see https://stackoverflow.com/a/4467559
+      const nextRow = (row + delta + this.props.rowCount) % this.props.rowCount
+
+      if (this.canSelectRow(nextRow)) {
+        return nextRow
       }
     }
 
-    if (this.canSelectRow(newRow)) {
-      return newRow
-    } else {
-      return this.nextSelectableRow(direction, newRow)
-    }
+    return null
   }
 
   /** Convenience method for invoking canSelectRow callback when it exists */
@@ -358,11 +356,13 @@ export class List extends React.Component<IListProps, IListState> {
   ) {
     const newRow = this.nextSelectableRow(direction, this.props.selectedRow)
 
-    if (this.props.onSelectionChanged) {
-      this.props.onSelectionChanged(newRow, { kind: 'keyboard', event })
-    }
+    if (newRow !== null) {
+      if (this.props.onSelectionChanged) {
+        this.props.onSelectionChanged(newRow, { kind: 'keyboard', event })
+      }
 
-    this.scrollRowToVisible(newRow)
+      this.scrollRowToVisible(newRow)
+    }
   }
 
   private scrollRowToVisible(row: number) {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -86,6 +86,11 @@
   --box-alt-background-color: $gray-100;
 
   /**
+   * Background color for skeleton or "loading" boxes
+   */
+  --box-skeleton-background-color: $gray-200;
+
+  /**
    * Border color for boxes.
    */
   --box-border-color: $gray-200;

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -127,50 +127,40 @@
         color: var(--text-secondary-color);
       }
     }
-  }
 
-  .pull-request-loading-item {
-    padding: 0 var(--spacing);
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    min-width: 0;
-    flex-grow: 1;
-
-    --background-color: $gray-200;
-
-    .icon {
-      margin-right: var(--spacing-half);
-      width: 16px; // Force a consistent width
-      flex-shrink: 0;
-      color: var(--background-color);
-    }
-
-    .info {
-      display: flex;
-      flex-direction: column;
-      flex: 1;
-
-      .title {
-        height: 12px;
-        flex: 1;
-        background-color: var(--background-color);
-        margin-right: var(--spacing-half);
-        margin-bottom: var(--spacing-half);
+    &.loading {
+      --background-color: $gray-200;
+      .icon {
+        color: var(--background-color);
       }
 
-      .subtitle {
-        height: 12px;
-        flex: 1;
-        background-color: var(--background-color);
-        margin-right: var(--spacing-half);
+      .info {
+        .title,
+        .subtitle {
+          background-color: var(--background-color);
+          margin-bottom: var(--spacing-half);
+          height: 12px;
+        }
       }
-    }
 
-    .status {
-      width: 16px;
-      flex-shrink: 0;
-      color: var(--background-color);
+      .ci-status {
+        color: var(--background-color);
+      }
+
+      &::after {
+        background: -webkit-linear-gradient(
+          left,
+          rgba(255, 255, 255, 0) 0%,
+          rgba(255, 255, 255, 0.5) 50%,
+          rgba(255, 255, 255, 0) 100%
+        );
+        content: '';
+        display: block;
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        animation: loading-pulse 1.5s ease-in-out infinite;
+      }
     }
   }
 }
@@ -182,21 +172,6 @@
   to {
     transform: translate(200%, 0);
   }
-}
-
-.pull-request-loading-item::after {
-  background: -webkit-linear-gradient(
-    left,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.5) 50%,
-    rgba(255, 255, 255, 0) 100%
-  );
-  content: '';
-  display: block;
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  animation: loading-pulse 1.5s ease-in-out infinite;
 }
 
 .branches-list {

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -138,8 +138,17 @@
         .title,
         .subtitle {
           background-color: var(--background-color);
-          margin-bottom: var(--spacing-half);
-          height: 12px;
+          // The title with text in it is 18px (1em = 12px and with 1.5 x
+          // line height we'll get 18) but we don't want to fill the entire
+          // box because then we'll end up with one big slab of gray rather
+          // than two fake gray text lines. So we'll split the difference
+          // between 1em and 1.5em between the top and bottom margin so that
+          // it looks nicely positioned with the text that'll fade in later.
+          height: 1em;
+          margin-top: 0.2em;
+          margin-bottom: 0.3em;
+
+          border-radius: 1px;
         }
       }
 

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -129,15 +129,14 @@
     }
 
     &.loading {
-      --background-color: $gray-200;
       .icon {
-        color: var(--background-color);
+        color: var(--box-skeleton-background-color);
       }
 
       .info {
         .title,
         .subtitle {
-          background-color: var(--background-color);
+          background-color: var(--box-skeleton-background-color);
           // The title with text in it is 18px (1em = 12px and with 1.5 x
           // line height we'll get 18) but we don't want to fill the entire
           // box because then we'll end up with one big slab of gray rather
@@ -153,7 +152,7 @@
       }
 
       .ci-status {
-        color: var(--background-color);
+        color: var(--box-skeleton-background-color);
       }
 
       &::after {

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -124,6 +124,10 @@
       }
     }
 
+    .ci-status {
+      margin-right: var(--spacing-half);
+    }
+
     &.loading {
       --background-color: $gray-200;
       .icon {

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -93,6 +93,7 @@
     flex-grow: 1;
 
     .icon {
+      margin-left: var(--spacing-half);
       margin-right: var(--spacing);
       flex-shrink: 0;
 

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -93,7 +93,7 @@
     flex-grow: 1;
 
     .icon {
-      margin-right: var(--spacing-half);
+      margin-right: var(--spacing);
       flex-shrink: 0;
 
       // Align the icon baseline with the title text
@@ -106,7 +106,7 @@
       flex-direction: column;
       min-width: 0;
       flex-grow: 1;
-      margin-right: var(--spacing-half);
+      margin-right: var(--spacing);
 
       .title {
         @include ellipsis;

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -112,16 +112,12 @@
       .title {
         @include ellipsis;
         min-width: 0;
-        margin-right: var(--spacing-half);
-
         font-weight: var(--font-weight-semibold);
       }
 
       .subtitle {
         @include ellipsis;
         min-width: 0;
-        margin-right: var(--spacing-half);
-
         font-weight: var(--font-weight-light);
         font-size: var(--font-size-sm);
         color: var(--text-secondary-color);

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -94,7 +94,6 @@
 
     .icon {
       margin-right: var(--spacing-half);
-      width: 16px; // Force a consistent width
       flex-shrink: 0;
 
       // Align the icon baseline with the title text


### PR DESCRIPTION
🌵 Targeting #3228 🌵 

![loading-animation](https://user-images.githubusercontent.com/634063/32552274-ad801df0-c493-11e7-85fc-eef91fff292e.gif)

- Line up PR icons so that they're in the same spot when loading or showing real data
- Reuse PR list item and use a modifier css class so that we don't fall out of sync as easily
- Tweak spacing in PR list to match mocks
- Don't allow selection changes in loading list (also fixes #996)

@joshaber Giving this back to u to review 😛 