### PR TITLE
Avoid text selection when dragging Resizables

### DIFF
--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -47,6 +47,8 @@ export class Resizable extends React.Component<IResizableProps, {}> {
 
     document.addEventListener('mousemove', this.handleDragMove)
     document.addEventListener('mouseup', this.handleDragStop)
+
+    e.preventDefault()
   }
 
   /**
@@ -64,6 +66,8 @@ export class Resizable extends React.Component<IResizableProps, {}> {
     if (this.props.onResize) {
       this.props.onResize(newWidthClamped)
     }
+
+    e.preventDefault()
   }
 
   /**
@@ -73,6 +77,8 @@ export class Resizable extends React.Component<IResizableProps, {}> {
   private handleDragStop = (e: MouseEvent) => {
     document.removeEventListener('mousemove', this.handleDragMove)
     document.removeEventListener('mouseup', this.handleDragStop)
+
+    e.preventDefault()
   }
 
   /**


### PR DESCRIPTION
![text-selection-drag](https://user-images.githubusercontent.com/634063/32552575-af077ffa-c494-11e7-8718-6bd9d610a049.gif)

This prevents text selection while dragging resizables by preventing the default action on the event.