### PR TITLE
Dynamic branch button width

### DIFF
--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -35,7 +35,10 @@
   }
 
   .toolbar-dropdown {
-    &.branch-button { width: 230px; }
+    &.branch-button {
+      max-width: 460px;
+      min-width: 230px;
+    }
   }
 
   .toolbar-button {


### PR DESCRIPTION
Makes branch button width dynamic, thus helping to see long branch names easier.

Width of the button was fixed to 230px previously.

Removing `width` will set width to `100%` (via `.toolbar-dropdown > .toolbar-button`), but `max/min-width` properties will cap it to 230px—460px depending on the width of button contents (mainly current branch name) and width of the application window.

## Problem
When working with long branch names, they tend to contain not so useful information at the beginning (e.g. `update/header-ui-branch-button-width`).

It's obviously preferable to work with short branch names, but sometimes that's not feasible with repositories with hundreds of active branches (in big monolithic repositories).

With 230px button width even [Git flow's example branch names](https://guides.github.com/introduction/flow/index.html) wouldn't fit if you prefix them with `update/`.

Now, I can see the branch name when hovering the button (picture below), but hovering and waiting for information like this feels like a clumsy last resort.

![image](https://user-images.githubusercontent.com/87168/32553993-1067a0a2-c4a1-11e7-8df1-36130050b1ee.png)

When keeping the window wider than 1300px+ on big 🖥  — I see all that empty space in the header yet I'm unable to see my current branch name properly? That's silly! 🤔 

## Solution
Let the button width change dynamically with content and window size. :tada:

### Why 460px?
2 x default button width. Could've been anything really. Capping it to _something_ feels right.

### Affects to dropdown?
Doesn't seem to be affecting anyhow.

Dropdown with 230px fixed width:
![image](https://user-images.githubusercontent.com/87168/32554149-95f9995a-c4a1-11e7-9aeb-4ed54d88981d.png)

Dropdown with dynamic width:
![image](https://user-images.githubusercontent.com/87168/32554170-9e5f84ba-c4a1-11e7-98f0-5778b4410251.png)

(Might be hard to see from screenshots, but dropdown width stays the same between before/after the change).


## Screenshots after the change

1. Long branch name + wide window + push-pull-button visible:

![image](https://user-images.githubusercontent.com/87168/32553460-afed3ecc-c49f-11e7-912e-9dbefd527b30.png)

2. Long branch name + narrow window + push-pull-button visible:

![image](https://user-images.githubusercontent.com/87168/32553479-c19b27f6-c49f-11e7-8b79-09f79484fd38.png)

3. Short branch name + narrow window + push-pull-button visible:

![image](https://user-images.githubusercontent.com/87168/32553513-d4bbdcd6-c49f-11e7-844a-e7e6da73704d.png)

4. Short branch name + wide window + push-pull-button visible:

![image](https://user-images.githubusercontent.com/87168/32553548-e36f19e6-c49f-11e7-9904-8b2df88cc558.png)

5. Long branch name + narrow window + push-pull-button hidden:

![image](https://user-images.githubusercontent.com/87168/32553556-e86ffc4e-c49f-11e7-8406-339a3ee0a58d.png)

--- 
Hope this helps and lemme know what you think! Thanks for the great tool! ❤️  🍻 
