### PR TITLE
Fix parsing statuses which include a newline

### DIFF
--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -75,7 +75,7 @@ export function parsePorcelainStatus(
 }
 
 // 1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>
-const changedEntryRe = /^1 ([MADRCU?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) (.*?)$/
+const changedEntryRe = /^1 ([MADRCU?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([\s\S]*?)$/
 
 function parseChangedEntry(field: string): IStatusEntry {
   const match = changedEntryRe.exec(field)
@@ -92,7 +92,7 @@ function parseChangedEntry(field: string): IStatusEntry {
 }
 
 // 2 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <X><score> <path><sep><origPath>
-const renamedOrCopiedEntryRe = /^2 ([MADRCU?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([RC]\d+) (.*?)$/
+const renamedOrCopiedEntryRe = /^2 ([MADRCU?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([RC]\d+) ([\s\S]*?)$/
 
 function parsedRenamedOrCopiedEntry(
   field: string,
@@ -121,7 +121,7 @@ function parsedRenamedOrCopiedEntry(
 }
 
 // u <xy> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
-const unmergedEntryRe = /^u ([DAU]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([a-f0-9]+) (.*?)$/
+const unmergedEntryRe = /^u ([DAU]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([a-f0-9]+) ([\s\S]*?)$/
 
 function parseUnmergedEntry(field: string): IStatusEntry {
   const match = unmergedEntryRe.exec(field)

--- a/app/test/unit/status-parser-test.ts
+++ b/app/test/unit/status-parser-test.ts
@@ -88,4 +88,17 @@ describe('parsePorcelainStatus', () => {
     expect(entries[i++].value).to.equal('branch.upstream origin/master')
     expect(entries[i++].value).to.equal('branch.ab +1 -0')
   })
+
+  it('parses a path which includes a newline', () => {
+    const x = `1 D. N... 100644 000000 000000 dc9fb24e86f7445720b39dcb39a7fc0e410d9583 0000000000000000000000000000000000000000 ProjectSID/Images.xcassets/iPhone 67/Status Center/Report X68 Y461
+      /.DS_Store`
+    const entries = parsePorcelainStatus(x) as ReadonlyArray<IStatusEntry>
+
+    expect(entries.length).to.equal(1)
+
+    expect(entries[0].statusCode).to.equal('D.')
+    expect(entries[0].path).to
+      .equal(`ProjectSID/Images.xcassets/iPhone 67/Status Center/Report X68 Y461
+      /.DS_Store`)
+  })
 })

--- a/app/test/unit/status-parser-test.ts
+++ b/app/test/unit/status-parser-test.ts
@@ -96,7 +96,6 @@ describe('parsePorcelainStatus', () => {
 
     expect(entries.length).to.equal(1)
 
-    expect(entries[0].statusCode).to.equal('D.')
     expect(entries[0].path).to
       .equal(`ProjectSID/Images.xcassets/iPhone 67/Status Center/Report X68 Y461
       /.DS_Store`)

--- a/app/test/unit/status-parser-test.ts
+++ b/app/test/unit/status-parser-test.ts
@@ -100,5 +100,6 @@ describe('parsePorcelainStatus', () => {
     expect(entries[0].path).to
       .equal(`ProjectSID/Images.xcassets/iPhone 67/Status Center/Report X68 Y461
       /.DS_Store`)
+    expect(entries[0].statusCode).to.equal('D.')
   })
 })


### PR DESCRIPTION
From a support request.

Putting a newline in a path seems like a guaranteed Bad Time, but here we are. I suspect this is the fault of tools.