### PR TITLE
Flesh out the first responder role

### DIFF
--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -21,4 +21,4 @@ Once those things are done, you should feel free to spend your time scratching y
 
 That said, tasks which need design work generally *aren't* well-suited to this. It would pull our fantastic designers away from milestone work and it would be hard to get done in a week's time.
 
-If you're at a loss for ideas or wonder if something is an appropriate first responder task, ask the rest of the team!
+If you're at a loss for ideas or wonder if something is an appropriate first responder task, ask the rest of the team! Or poke through the [`tech-debt`](https://github.com/desktop/desktop/labels/tech-debt) label for some inspiration.

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -14,6 +14,7 @@ Each rotation is a week long. While first responder your primary duties are:
   * Ensure issues are labeled accurately.
   * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
   * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
+1. Check community pull requests and label ones that are `ready-for-review`.
 1. Review community pull requests.
 
 Once those things are done, you should feel free to spend your time scratching your own itches on the project. Really wanna refactor that one monstrous component? Go for it! Wanna fix that one bug that drives you nuts? Do it! Wanna upgrade all of our dependencies? You're an awesome masochist!

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -13,7 +13,7 @@ Each rotation is a week long. While first responder your primary duties are:
   * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
   * Ensure issues are labeled accurately.
   * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
-  * See https://github.com/desktop/issue-triage/blob/master/issue-triage.md for more information on our issue triage process.
+  * See (issue-triage.md)[issue-triage.md] for more information on our issue triage process.
 1. Review community pull requests.
 
 Once those things are done, you should feel free to spend your time scratching your own itches on the project. Really wanna refactor that one monstrous component? Go for it! Wanna fix that one bug that drives you nuts? Do it! Wanna upgrade all of our dependencies? You're an awesome masochist!

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -10,10 +10,10 @@ We have a first responder rotation. The goals of the rotation are:
 Each rotation is a week long. While first responder your primary duties are:
 
 1. Triage issues.
-  * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
-  * Ensure issues are labeled accurately.
-  * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
-  * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
+    * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
+    * Ensure issues are labeled accurately.
+    * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
+    * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
 1. Check community pull requests and label ones that are `ready-for-review`.
 1. Review community pull requests.
 

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -5,16 +5,19 @@ We have a first responder rotation. The goals of the rotation are:
 1. Ensure community issues and PRs are answered in a timely manner.
 1. Ensure support load is shared across the whole team.
 1. Free up the rest of the team to focus on milestone work.
-1. Allocate time to less prioritized work.
+1. Give everyone a regular break from the milestone work.
 
-Each rotation is a week long. While first responder your duties are:
+Each rotation is a week long. While first responder your primary duties are:
 
 1. Triage issues.
-  * Troubleshoot or follow up on troubleshooting started by the previous first responder.
+  * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
+  * Ensure issues are labeled accurately.
   * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
   * See https://github.com/desktop/issue-triage/blob/master/issue-triage.md for more information on our issue triage process.
 1. Review community pull requests.
-1. Address technical debt, pet bugs, etc.
-1. Anything that supports the goals outlined above.
 
-It's kind of a [big block of cheese](https://www.youtube.com/watch?v=Vm9HZq53rqU) situation.
+Once those things are done, you should feel free to spend your time scratching your own itches on the project. Really wanna refactor that one monstrous component? Go for it! Wanna fix that one bug that drives you nuts? Do it! Wanna upgrade all of our dependencies? You're an awesome masochist!
+
+That said, tasks which need design work generally *aren't* well-suited to this. It would pull our fantastic designers away from milestone work and it would be hard to get done in a week's time.
+
+If you're at a loss for ideas or wonder if something is an appropriate first responder task, ask the rest of the team!

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -12,7 +12,7 @@ Each rotation is a week long. While first responder your primary duties are:
 1. Triage issues.
     * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
     * Ensure issues are labeled accurately.
-    * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
+    * Review the [`more-information-needed`](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [`needs-reproduction`](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
     * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
 1. Check community pull requests and label ones that are `ready-for-review`.
 1. Review community pull requests.

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -5,7 +5,7 @@ We have a first responder rotation. The goals of the rotation are:
 1. Ensure community issues and PRs are answered in a timely manner.
 1. Ensure support load is shared across the whole team.
 1. Free up the rest of the team to focus on milestone work.
-1. Give everyone a regular break from the milestone work.
+1. Give everyone a regular break from milestone work.
 
 Each rotation is a week long. While first responder your primary duties are:
 

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -13,7 +13,7 @@ Each rotation is a week long. While first responder your primary duties are:
   * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
   * Ensure issues are labeled accurately.
   * Review the [more-information-needed](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and [needs-reproduction](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Aneeds-reproduction) issues and close any that have gone 2 weeks with no new activity.
-  * See (issue-triage.md)[issue-triage.md] for more information on our issue triage process.
+  * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
 1. Review community pull requests.
 
 Once those things are done, you should feel free to spend your time scratching your own itches on the project. Really wanna refactor that one monstrous component? Go for it! Wanna fix that one bug that drives you nuts? Do it! Wanna upgrade all of our dependencies? You're an awesome masochist!

--- a/docs/process/issue-triage.md
+++ b/docs/process/issue-triage.md
@@ -94,6 +94,8 @@ issues from time to time that isn't and won't be covered here.
 1. Label the issue as an `enhancement` if the issue mentions new behaviour
    or functionality that the app should have.
 
+# Labels
+
 ## More Information Needed
 
 Periodically we should be doing a sweep of issues that are open and labeled
@@ -107,8 +109,6 @@ If a problem is consistently not reproducible, we **need** more information
 from the person reporting the problem. If it isn't a simple misunderstanding
 about the steps to reproduce the problem, then we should label it
 `more-information-needed` as well and follow that process.
-
-Incoming issues should be grouped into one of these buckets:
 
 ## Bugs
 

--- a/docs/process/issue-triage.md
+++ b/docs/process/issue-triage.md
@@ -1,5 +1,113 @@
 # Issue Triage
 
+> Triage (/ˈtriːɑːʒ/ or /triːˈɑːʒ/) is the process of determining the priority
+> of patients' treatments based on the severity of their condition. This
+> rations patient treatment efficiently when resources are insufficient for all
+> to be treated immediately.
+>
+> *From Wikipedia*
+
+The above describes medical triage but it is clear that it also applies to our
+situation. Triage is a process of sifting through all the things that we could
+work on to select the few things that we will work on. In order to maximize the
+impact we have for the people that use GitHub Desktop, things that will get top
+priority are items that are well-described, clearly presented and have obvious
+benefit.
+
+Additionally, we want to encourage helpful feedback and meaningful
+participation. In order to do this, we will have to be clear about what we need
+from people so that we can deliver what they need. This also means that we will
+have to be very clear and decisive when we are not getting the information or
+cooperation we need so that we can move on. Just like in an emergency room, if
+it is a choice between spending several hours to have a 10% chance of saving
+one person or spending several hours definitely saving multiple people, the
+choice is clear.
+
+## Goals
+
+* Communicate clearly and effectively
+    * What the maintainers will work on
+    * What pull requests will be reviewed for acceptance
+    * What pull requests *will not* be reviewed for acceptance
+* Outline exactly what is expected for an issue to meet the "triage bar" so
+  that issues that don't meet the bar can be closed
+* Reduce the amount of time and back-and-forth needed to take an issue from
+  being first-opened to `triaged` or closed
+* Accept input from the community that helps us deliver meaningful results back
+  to the Atom community
+
+## The Issues List Is Our Backlog
+
+The GitHub Desktop issues list is what the maintainers team uses to guide our
+work. In order for our work to be focused and efficient, our issues list must
+be clean and well-organized. Accepting input from the community is a
+significant benefit *when it does not distract us from making things better*.
+
+* Untriaged issues are tasks that are being evaluated to determine if they meet
+  the triage bar
+* Open triaged issues are tasks that the maintainers have agreed to work on
+* Closed issues are things that either didn't meet the triage bar or are tasks
+  that the maintainers will not be taking on
+
+## The Triage Bar
+
+In order to be considered triaged an issue **must** contain or be edited to
+contain in the body of the issue:
+
+* The build number associated with the given issue
+* The operating system and OS version number that the problem was reproduced on
+* Specific steps to reproduce the problem or desired behavior
+* If the steps to reproduce the problem do not reproduce it 100% of the time,
+  an estimate of how often it reproduces with the given steps and configuration
+* **One** and only one issue
+* Any other information that is required to reproduce the problem (sample Git
+  repository, specific OS configuration, etc)
+
+### The Body of the Issue
+
+You'll notice above that the body of the issue gets special mention. The body
+of the issue is the description of the task to be done. A maintainer should
+only have to read the body of the issue to understand what needs to happen.
+They should not have to read the pages of comments to understand what they need
+to do in order to address the issue at hand.
+
+## Process
+
+Keep in mind that this is not the 100% complete maintainer's guide to issues.
+This is only a triage process. Once everything has been checked, the issue
+reproduced and appropriate labels have been applied, the triage process is done
+with the issue. There may be additional maintenance that needs to be done on
+issues from time to time that isn't and won't be covered here.
+
+1. Person files a new issue
+1. Maintainer checks to ensure they adequately filled out the template. If not,
+   close with the [request to fill out the template](canned-messages/needs-template.md).
+1. Label the issue as a `bug` if the issue is a regression or behaviour that
+   needs to be fixed.
+1. If the issue has already been fixed, add a comment linking to the original
+   issue and close the issue.
+1. If anything is unclear but the template is adequately filled out, post what
+   questions you have and label with `more-information-needed`
+1. Maintainer attempts to reproduce the problem
+    1. If the problem is not reproducible, label with `needs-reproduction` and
+       ask the author of the issue for [clarification on the repro steps](canned-messages/repro-steps.md)
+1. Label the issue as an `enhancement` if the issue mentions new behaviour
+   or functionality that the app should have.
+
+## More Information Needed
+
+Periodically we should be doing a sweep of issues that are open and labeled
+`more-information-needed`. If the original poster has not responded within
+two weeks after the last question by an official maintainer, close the issue
+with [the no response message](canned-messages/no-response.md).
+
+## Needs Reproduction
+
+If a problem is consistently not reproducible, we **need** more information
+from the person reporting the problem. If it isn't a simple misunderstanding
+about the steps to reproduce the problem, then we should label it
+`more-information-needed` as well and follow that process.
+
 Incoming issues should be grouped into one of these buckets:
 
 ## Bugs
@@ -42,7 +150,7 @@ e.g. GitHub Desktop should support worktrees as a first class feature.
 The Desktop team has a [roadmap](roadmap.md) defined for the next few releases,
 so that you can see what our future plans look like. Some enhancements suggested
 by the community will be for things that are interesting but are also well
-beyond the current plans of the team. 
+beyond the current plans of the team.
 
 We will apply the `future-proposal` label to these issues, so that they can be
 searched for when it comes time to plan for the future. However, to keep


### PR DESCRIPTION
This has a few objectives:

1. Make the goals clearer.
1. Make the troubleshooting responsibilities clearer.
1. Flesh out what the rest of the time can be used for.
1. Make the issue triage doc public.

@desktop/core Could everyone give it a 👀 please? 🙏 Does this help solve the problems discussed in the retrospective?