### PR TITLE
bugfix to prevent 'Open without Git' dialog from looping

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -573,9 +573,12 @@ export class Dispatcher {
   }
 
   /** Opens a Git-enabled terminal setting the working directory to the repository path */
-  public async openShell(path: string): Promise<void> {
+  public async openShell(
+    path: string,
+    ignoreWarning: boolean = false
+  ): Promise<void> {
     const gitFound = await isGitOnPath()
-    if (gitFound) {
+    if (gitFound || ignoreWarning) {
       this.appStore._openShell(path)
     } else {
       this.appStore._showPopup({ type: PopupType.InstallGit, path })

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1022,7 +1022,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <InstallGit
             key="install-git"
             onDismissed={this.onPopupDismissed}
-            onOpenShell={this.onOpenShell}
+            onOpenShell={this.onOpenShellIgnoreWarning}
             path={popup.path}
           />
         )
@@ -1180,8 +1180,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
   }
 
-  private onOpenShell = (path: string) => {
-    this.props.dispatcher.openShell(path)
+  private onOpenShellIgnoreWarning = (path: string) => {
+    this.props.dispatcher.openShell(path, true)
     this.onPopupDismissed()
   }
 


### PR DESCRIPTION
We don't have a way to continue on if the user wants to launch a shell without Git being present - it just continues to show the dialog. This adds an appropriate escape hatch.

See https://github.com/desktop/desktop/issues/3289#issuecomment-343341530 for the original context.