### PR TITLE
Parse more change types

### DIFF
--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -75,7 +75,7 @@ export function parsePorcelainStatus(
 }
 
 // 1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>
-const changedEntryRe = /^1 ([MADRCU?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([\s\S]*?)$/
+const changedEntryRe = /^1 ([MADRCUTX?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([\s\S]*?)$/
 
 function parseChangedEntry(field: string): IStatusEntry {
   const match = changedEntryRe.exec(field)
@@ -92,7 +92,7 @@ function parseChangedEntry(field: string): IStatusEntry {
 }
 
 // 2 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <X><score> <path><sep><origPath>
-const renamedOrCopiedEntryRe = /^2 ([MADRCU?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([RC]\d+) ([\s\S]*?)$/
+const renamedOrCopiedEntryRe = /^2 ([MADRCUTX?!.]{2}) (N\.\.\.|S[C.][M.][U.]) (\d+) (\d+) (\d+) ([a-f0-9]+) ([a-f0-9]+) ([RC]\d+) ([\s\S]*?)$/
 
 function parsedRenamedOrCopiedEntry(
   field: string,

--- a/app/test/unit/status-parser-test.ts
+++ b/app/test/unit/status-parser-test.ts
@@ -101,4 +101,15 @@ describe('parsePorcelainStatus', () => {
       /.DS_Store`)
     expect(entries[0].statusCode).to.equal('D.')
   })
+
+  it('parses a typechange', () => {
+    const x =
+      '1 .T N... 120000 120000 100755 6165716e8b408ad09b51d1a37aa1ef50e7f84376 6165716e8b408ad09b51d1a37aa1ef50e7f84376 pdf_linux-x64/lib/libQt5Core.so.5'
+    const entries = parsePorcelainStatus(x) as ReadonlyArray<IStatusEntry>
+
+    expect(entries.length).to.equal(1)
+
+    expect(entries[0].path).to.equal('pdf_linux-x64/lib/libQt5Core.so.5')
+    expect(entries[0].statusCode).to.equal('.T')
+  })
 })


### PR DESCRIPTION
Fixes #3334

It turns out there are two additional change types that aren't documented in git's man pages 😱: https://github.com/git/git/blob/89ea799ffcc5c8a0547d3c9075eb979256ee95b8/diff.h#L371-L372

For now I think it's ok that we parse them and treat them as any other changed file. In the future we might want to give them a more specialized treatment (/cc https://github.com/desktop/desktop/issues/557).