### PR TITLE
Don’t use native tooltips for the window buttons on Windows

### DIFF
--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -84,7 +84,7 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
     return (
       <button
         aria-label={name}
-        title={title}
+        data-title={title}
         tabIndex={-1}
         className={className}
         onClick={onClick}

--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -66,7 +66,6 @@
       height: 100%;
       padding: 0;
       margin: 0;
-      overflow: hidden;
 
       // Reset styles from global buttons
       border: none;
@@ -76,6 +75,40 @@
       color: #a0a0a0;
       background-color: transparent;
       transition: background-color 0.25s ease;
+
+      &::before {
+        content: attr(data-title);
+
+        background-color: var(--box-alt-background-color);
+        color: black;
+
+        border-radius: 2px;
+        padding: 8px;
+
+        margin-top: 4px;
+      }
+
+      &::after {
+        content: '';
+
+        border: 4px solid transparent;
+        border-bottom-color: var(--box-alt-background-color);
+        margin-top: -4px
+      }
+
+      &::before, &::after {
+        opacity: 0;
+        visibility: hidden;
+
+        pointer-events: none;
+
+        position: absolute;
+        top: 100%;
+        right: 50%;
+        transform: translateX(50%);
+
+        transition: opacity 0.25s ease;
+      }
 
       &:focus { outline: none; }
 
@@ -93,13 +126,25 @@
           // Immediate feedback when clicking
           transition: none;
         }
+
+        &::before, &::after {
+          opacity: 1;
+          visibility: visible;
+        }
       }
 
       // Close button is a special case, it needs to be red
       // on hover and slightly lighter red on active.
       &.close:hover {
-        background-color: #e81123;
+        --close-red: #e81223;
+        background-color: var(--close-red);
         color: #fff;
+
+        &::before {
+          background-color: var(--close-red);
+          color: white;
+        }
+        &::after { border-bottom-color: #e81123; }
 
         &:active {
           background-color: #bf0f1d;


### PR DESCRIPTION
Fixes the issues involving the “Minimize” tooltip:

<img width="178" alt="screen shot 2017-11-15 at 15 47 14" src="https://user-images.githubusercontent.com/25517624/32859416-714f9660-ca1c-11e7-8094-603c4c30410b.png">

<sup>Sorry for the macOS window box — I don’t have a Windows machine to test on</sup>

<details><summary>Hack to switch OSes</summary>

```diff
diff --git a/app/src/ui/index.tsx b/app/src/ui/index.tsx
index aa510beef..8d00e142d 100644
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -144,7 +144,7 @@ dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)
 
-document.body.classList.add(`platform-${process.platform}`)
+document.body.classList.add(`platform-win32`) // ${process.platform}`)
 
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
diff --git a/app/webpack.common.js b/app/webpack.common.js
index 729101a5c..69a4f64be 100644
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -20,8 +20,8 @@ const replacements = {
   __OAUTH_SECRET__: JSON.stringify(
     process.env.DESKTOP_OAUTH_CLIENT_SECRET || devClientSecret
   ),
-  __DARWIN__: process.platform === 'darwin',
-  __WIN32__: process.platform === 'win32',
+  __DARWIN__: process.platform === 'win32', // darwin
+  __WIN32__: process.platform === 'darwin', // win32
   __LINUX__: process.platform === 'linux',
   __DEV__: channel === 'development',
   __RELEASE_CHANNEL__: JSON.stringify(channel),
```

</details>