### PR TITLE
Introduce PR integration on the beta channel

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -22,6 +22,11 @@ export function enablePreviewFeatures(): boolean {
 }
 
 /** Should the app enable beta features? */
-export function enableBetaFeatures(): boolean {
+function enableBetaFeatures(): boolean {
   return enablePreviewFeatures() || __RELEASE_CHANNEL__ === 'beta'
+}
+
+/** Should PR integration be enabled? */
+export function enablePRIntegration(): boolean {
+  return enableBetaFeatures()
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -20,3 +20,8 @@ export function enablePreviewFeatures(): boolean {
 
   return false
 }
+
+/** Should the app enable beta features? */
+export function enableBetaFeatures(): boolean {
+  return enablePreviewFeatures() || __RELEASE_CHANNEL__ === 'beta'
+}

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -5,7 +5,7 @@ const Disable = false
  * checks. This is backed by the GITHUB_DESKTOP_PREVIEW_FEATURES environment
  * variable, which is checked for non-development environments.
  */
-export function enablePreviewFeatures(): boolean {
+function enablePreviewFeatures(): boolean {
   if (Disable) {
     return false
   }
@@ -29,4 +29,9 @@ function enableBetaFeatures(): boolean {
 /** Should PR integration be enabled? */
 export function enablePRIntegration(): boolean {
   return enableBetaFeatures()
+}
+
+/** Should merge tool integration be enabled? */
+export function enableMergeTool(): boolean {
+  return enablePreviewFeatures()
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -5,7 +5,7 @@ const Disable = false
  * checks. This is backed by the GITHUB_DESKTOP_PREVIEW_FEATURES environment
  * variable, which is checked for non-development environments.
  */
-function enablePreviewFeatures(): boolean {
+function enableDevelopmentFeatures(): boolean {
   if (Disable) {
     return false
   }
@@ -23,7 +23,7 @@ function enablePreviewFeatures(): boolean {
 
 /** Should the app enable beta features? */
 function enableBetaFeatures(): boolean {
-  return enablePreviewFeatures() || __RELEASE_CHANNEL__ === 'beta'
+  return enableDevelopmentFeatures() || __RELEASE_CHANNEL__ === 'beta'
 }
 
 /** Should PR integration be enabled? */
@@ -33,5 +33,5 @@ export function enablePRIntegration(): boolean {
 
 /** Should merge tool integration be enabled? */
 export function enableMergeTool(): boolean {
-  return enablePreviewFeatures()
+  return enableDevelopmentFeatures()
 }

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -7,7 +7,7 @@ import { BranchList } from './branch-list'
 import { TabBar } from '../tab-bar'
 import { BranchesTab } from '../../models/branches-tab'
 import { assertNever } from '../../lib/fatal-error'
-import { enablePreviewFeatures } from '../../lib/feature-flag'
+import { enableBetaFeatures } from '../../lib/feature-flag'
 import { PullRequestList } from './pull-request-list'
 import { PullRequestsLoading } from './pull-requests-loading'
 import { NoPullRequests } from './no-pull-requests'
@@ -76,7 +76,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
       return null
     }
 
-    if (!enablePreviewFeatures()) {
+    if (!enableBetaFeatures()) {
       return null
     }
 
@@ -104,7 +104,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
 
   private renderSelectedTab() {
     let tab = this.props.selectedTab
-    if (!enablePreviewFeatures() || !this.props.repository.gitHubRepository) {
+    if (!enableBetaFeatures() || !this.props.repository.gitHubRepository) {
       tab = BranchesTab.Branches
     }
 

--- a/app/src/ui/branches/index.tsx
+++ b/app/src/ui/branches/index.tsx
@@ -7,7 +7,7 @@ import { BranchList } from './branch-list'
 import { TabBar } from '../tab-bar'
 import { BranchesTab } from '../../models/branches-tab'
 import { assertNever } from '../../lib/fatal-error'
-import { enableBetaFeatures } from '../../lib/feature-flag'
+import { enablePRIntegration } from '../../lib/feature-flag'
 import { PullRequestList } from './pull-request-list'
 import { PullRequestsLoading } from './pull-requests-loading'
 import { NoPullRequests } from './no-pull-requests'
@@ -79,7 +79,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
       return null
     }
 
-    if (!enableBetaFeatures()) {
+    if (!enablePRIntegration()) {
       return null
     }
 
@@ -107,7 +107,7 @@ export class Branches extends React.Component<IBranchesProps, IBranchesState> {
 
   private renderSelectedTab() {
     let tab = this.props.selectedTab
-    if (!enableBetaFeatures() || !this.props.repository.gitHubRepository) {
+    if (!enablePRIntegration() || !this.props.repository.gitHubRepository) {
       tab = BranchesTab.Branches
     }
 

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -4,7 +4,7 @@ import { AppFileStatus, mapStatus, iconForStatus } from '../../models/status'
 import { IDiff, DiffType } from '../../models/diff'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Button } from '../lib/button'
-import { enablePreviewFeatures } from '../../lib/feature-flag'
+import { enableMergeTool } from '../../lib/feature-flag'
 
 interface IChangedFileDetailsProps {
   readonly path: string
@@ -45,7 +45,7 @@ export class ChangedFileDetails extends React.Component<
   private renderDecorator() {
     const status = this.props.status
     const diff = this.props.diff
-    if (status === AppFileStatus.Conflicted && enablePreviewFeatures()) {
+    if (status === AppFileStatus.Conflicted && enableMergeTool()) {
       return (
         <Button className="open-merge-tool" onClick={this.onOpenMergeTool}>
           {__DARWIN__ ? 'Open Merge Tool' : 'Open merge tool'}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -8,7 +8,7 @@ import { Select } from '../lib/select'
 import { ExternalEditor, parse as parseEditor } from '../../lib/editors'
 import { Shell, parse as parseShell } from '../../lib/shells'
 import { TextBox } from '../lib/text-box'
-import { enablePreviewFeatures } from '../../lib/feature-flag'
+import { enableMergeTool } from '../../lib/feature-flag'
 import { IMergeTool } from '../../lib/git/config'
 
 interface IAdvancedPreferencesProps {
@@ -192,7 +192,7 @@ export class Advanced extends React.Component<
   }
 
   private renderMergeTool() {
-    if (!enablePreviewFeatures()) {
+    if (!enableMergeTool()) {
       return null
     }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -8,7 +8,7 @@ import { IRepositoryState } from '../../lib/app-state'
 import { Branches } from '../branches'
 import { assertNever } from '../../lib/fatal-error'
 import { BranchesTab } from '../../models/branches-tab'
-import { enableBetaFeatures } from '../../lib/feature-flag'
+import { enablePRIntegration } from '../../lib/feature-flag'
 import { PullRequest } from '../../models/pull-request'
 import { PullRequestBadge } from '../branches/pull-request-badge'
 import { PathText } from '../lib/path-text'
@@ -161,7 +161,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       return null
     }
 
-    if (!enableBetaFeatures()) {
+    if (!enablePRIntegration()) {
       return null
     }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -8,7 +8,7 @@ import { IRepositoryState } from '../../lib/app-state'
 import { Branches } from '../branches'
 import { assertNever } from '../../lib/fatal-error'
 import { BranchesTab } from '../../models/branches-tab'
-import { enablePreviewFeatures } from '../../lib/feature-flag'
+import { enableBetaFeatures } from '../../lib/feature-flag'
 import { PullRequest } from '../../models/pull-request'
 import { PullRequestBadge } from '../branches/pull-request-badge'
 
@@ -159,7 +159,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       return null
     }
 
-    if (!enablePreviewFeatures()) {
+    if (!enableBetaFeatures()) {
       return null
     }
 

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -17,6 +17,15 @@ We're currently focused on user interface changes - new views, significant
 changes to existing views, and so on. We can revisit this list when we
 identify other cases where this sort of feature flagging needs to occur.
 
+A **beta feature** should be:
+
+- a feature that is slated for an upcoming release, and
+- is usably complete, but
+- needs more testing, or
+- needs to be used to see how it feels
+
+Beta features are a superset of preview features.
+
 ## Why not just ship it?
 
 A few reasons:
@@ -31,8 +40,8 @@ A few reasons:
 
 ## How to Feature Flag?
 
-At runtime your code should check [`enablePreviewFeatures()`](https://github.com/desktop/desktop/blob/2286edb0e1cf376ab81a1ffe02115abdde88527f/app/src/lib/feature-flag.ts#L6)
-and either display the new feature or the existing one.
+At runtime your code should check either [`enablePreviewFeatures()`](https://github.com/desktop/desktop/blob/2286edb0e1cf376ab81a1ffe02115abdde88527f/app/src/lib/feature-flag.ts#L6)
+or [`enableBetaFeatures()`](https://github.com/desktop/desktop/blob/f68f2270aa50934c6523b5b06bac5413dab91451/app/src/lib/feature-flag.ts#L25) and either display the new feature or the existing one.
 
 A simple example is the new clone experience in [#2436](https://github.com/desktop/desktop/pull/2436):
 

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -40,20 +40,9 @@ A few reasons:
 
 ## How to Feature Flag?
 
-At runtime your code should check either [`enablePreviewFeatures()`](https://github.com/desktop/desktop/blob/2286edb0e1cf376ab81a1ffe02115abdde88527f/app/src/lib/feature-flag.ts#L6)
-or [`enableBetaFeatures()`](https://github.com/desktop/desktop/blob/f68f2270aa50934c6523b5b06bac5413dab91451/app/src/lib/feature-flag.ts#L25) and either display the new feature or the existing one.
+First add a new function to [feature-flag.ts](https://github.com/desktop/desktop/blob/3ee29eb1bd083a53f69fdbec2e2b10ec93404e44/app/src/lib/feature-flag.ts#L30). The function should usually check `enableDevelopmentFeatures()` or `enableBetaFeatures()`. Then, at runtime, your code should check either your feature flag function and either display the new feature or the existing one.
 
-A simple example is the new clone experience in [#2436](https://github.com/desktop/desktop/pull/2436):
-
-```ts
-public render() {
-  if (enablePreviewFeatures()) {
-    return this.renderPreviewInterface()
-  } else {
-    return this.renderClassicInterface()
-  }
-}
-```
+See pull request integration in [#3339](https://github.com/desktop/desktop/pull/3339) for an example.
 
 This separation and naming scheme makes it easier to clean up the new or old
 feature once things are stabilized.


### PR DESCRIPTION
`enablePreviewFeatures` is great because it's allowed us to develop and merge PR integration in small pieces. But the feature is at the point now where I'd like to live with it and let others live with it, in order to shake out the bugs and find usability problems.

So to that end, I've introduced `enableBetaFeatures` which, as you might guess, enables features for the beta channel.

This is a decent sized change in that it introduces a new variant of feature-flagging and also beta ships PR integration. So this can wait until next week when more people are around.