### PR TITLE
Fixes #3206 Unborn-repo-description-in-toolbar

### DIFF
--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -178,7 +178,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
     }
 
     if (tipState === TipState.Unborn) {
-      return 'Cannot publish unborn repository'
+      return 'Cannot publish unborn HEAD'
     }
 
     if (!this.props.aheadBehind) {


### PR DESCRIPTION
This PR fixes the issue referenced in #3206 
The description is now concise enough to fit inside the Push-Pull Toolbar