### PR TITLE
Syntax Highlighting.md: Add Swift to the supported languages

### DIFF
--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -16,6 +16,7 @@ Initially we support syntax highlighting for the following languages.
  - Yaml
  - XML
  - Objective-C
+ - Swift
  - Scala
  - Java
  - C


### PR DESCRIPTION
@niik With my previous PR #3305 related to swift support I forgot to add Swift to the supported languages from the highlighter inside the .md file. This PR fixes that!