### PR TITLE
Highlight .m as Objective-C

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -47,7 +47,6 @@ extensionMIMEMap.set('.csproj', 'text/xml')
 extensionMIMEMap.set('.svg', 'text/xml')
 
 import 'codemirror/mode/clike/clike'
-extensionMIMEMap.set('.objc', 'text/x-objectivec')
 extensionMIMEMap.set('.m', 'text/x-objectivec')
 extensionMIMEMap.set('.scala', 'text/x-scala')
 extensionMIMEMap.set('.sc', 'text/x-scala')

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -48,6 +48,7 @@ extensionMIMEMap.set('.svg', 'text/xml')
 
 import 'codemirror/mode/clike/clike'
 extensionMIMEMap.set('.objc', 'text/x-objectivec')
+extensionMIMEMap.set('.m', 'text/x-objectivec')
 extensionMIMEMap.set('.scala', 'text/x-scala')
 extensionMIMEMap.set('.sc', 'text/x-scala')
 extensionMIMEMap.set('.cs', 'text/x-csharp')


### PR DESCRIPTION
the common extension in iOS and Mac development for Objective-C files is `.m`