### PR TITLE
Syntax Highlighter: Add support for CoffeeScript

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -14,10 +14,12 @@ import { ITokens, IHighlightRequest } from '../lib/highlighter/types'
 const extensionMIMEMap = new Map<string, string>()
 
 import 'codemirror/mode/javascript/javascript'
-
 extensionMIMEMap.set('.ts', 'text/typescript')
 extensionMIMEMap.set('.js', 'text/javascript')
 extensionMIMEMap.set('.json', 'application/json')
+
+import 'codemirror/mode/coffeescript/coffeescript'
+extensionMIMEMap.set('.coffee', 'text/x-coffeescript')
 
 import 'codemirror/mode/jsx/jsx'
 extensionMIMEMap.set('.tsx', 'text/typescript-jsx')

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -11,6 +11,7 @@ Initially we support syntax highlighting for the following languages.
  - JavaScript
  - JSON
  - TypeScript
+ - Coffeescript
  - HTML
  - Markdown
  - Yaml


### PR DESCRIPTION
With this PR the syntax highlighter is going to support the CoffeeScript programming language.

### TO-DO
- [x] Add CoffeeScript to the list of the supported languages
- [x] Create a [PR](https://github.com/desktop/highlighter-tests/pull/3) in the desktop/highlighter-tests repo