### PR TITLE
Use path truncation strategy for branch names

### DIFF
--- a/app/src/ui/branches/branch.tsx
+++ b/app/src/ui/branches/branch.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as moment from 'moment'
 
 import { Octicon, OcticonSymbol } from '../octicons'
+import { PathText } from '../lib/path-text'
 
 interface IBranchProps {
   readonly name: string
@@ -26,9 +27,7 @@ export class BranchListItem extends React.Component<IBranchProps, {}> {
     return (
       <div className="branches-list-item">
         <Octicon className="icon" symbol={icon} />
-        <div className="name" title={name}>
-          {name}
-        </div>
+        <PathText path={name} className="name" />
         <div className="description" title={infoTitle}>
           {date}
         </div>

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
+import * as classNames from 'classnames'
+
 import { clamp } from '../../lib/clamp'
 
 interface IPathTextProps {
@@ -15,6 +17,12 @@ interface IPathTextProps {
    * though never updated after the initial measurement.
    */
   readonly availableWidth?: number
+
+  /**
+   * An optional className to be applied to the rendered
+   * top level element of the component.
+   */
+  readonly className?: string
 }
 
 interface IPathDisplayState {
@@ -280,13 +288,10 @@ export class PathText extends React.PureComponent<
 
     const truncated = this.state.length < this.state.normalizedPath.length
     const title = truncated ? this.state.normalizedPath : undefined
+    const className = classNames('path-text-component', this.props.className)
 
     return (
-      <div
-        className="path-text-component"
-        ref={this.onPathElementRef}
-        title={title}
-      >
+      <div className={className} ref={this.onPathElementRef} title={title}>
         <span ref={this.onPathInnerElementRef}>
           {directoryElement}
           <span className="filename">{this.state.fileText}</span>

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -11,6 +11,7 @@ import { BranchesTab } from '../../models/branches-tab'
 import { enablePreviewFeatures } from '../../lib/feature-flag'
 import { PullRequest } from '../../models/pull-request'
 import { PullRequestBadge } from '../branches/pull-request-badge'
+import { PathText } from '../lib/path-text'
 
 interface IBranchDropdownProps {
   readonly dispatcher: Dispatcher
@@ -86,7 +87,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
 
     let icon = OcticonSymbol.gitBranch
     let iconClassName: string | undefined = undefined
-    let title: string
+    let title: string | JSX.Element
     let description = __DARWIN__ ? 'Current Branch' : 'Current branch'
     let canOpen = true
     let tooltip: string
@@ -108,8 +109,8 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       icon = OcticonSymbol.gitCommit
       description = 'Detached HEAD'
     } else if (tip.kind === TipState.Valid) {
-      title = tip.branch.name
-      tooltip = `Current branch is ${title}`
+      title = <PathText path={tip.branch.name} />
+      tooltip = `Current branch is ${tip.branch.name}`
     } else {
       return assertNever(tip, `Unknown tip state: ${tipKind}`)
     }
@@ -118,7 +119,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     let progressValue: number | undefined = undefined
 
     if (checkoutProgress) {
-      title = checkoutProgress.targetBranch
+      title = <PathText path={checkoutProgress.targetBranch} />
       description = __DARWIN__ ? 'Switching to Branch' : 'Switching to branch'
 
       if (checkoutProgress.value > 0) {

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -16,7 +16,7 @@ export enum ToolbarButtonStyle {
 
 export interface IToolbarButtonProps {
   /** The primary button text, describing its function */
-  readonly title?: string
+  readonly title?: string | JSX.Element
 
   /** An optional description of the function of the button */
   readonly description?: JSX.Element | string

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -9,7 +9,7 @@ export type DropdownState = 'open' | 'closed'
 
 export interface IToolbarDropdownProps {
   /** The primary button text, describing its function */
-  readonly title?: string
+  readonly title?: string | JSX.Element
 
   /** An optional description of the function of the button */
   readonly description?: string | JSX.Element

--- a/app/styles/ui/_path-text.scss
+++ b/app/styles/ui/_path-text.scss
@@ -2,6 +2,9 @@
 
 .path-text-component {
   @include ellipsis;
+  max-width: 100%;
 
-  .dirname { color: var(--text-secondary-color); }
+  .dirname {
+    color: var(--text-secondary-color);
+  }
 }

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -35,7 +35,16 @@
   }
 
   .toolbar-dropdown {
-    &.branch-button { width: 230px; }
+    &.branch-button {
+      width: 230px;
+
+      // Reset the styles applied from the PathText component when used.
+      // Note that the .text qualifier is important or else we'll apply
+      // this to path text components within the foldout as well.
+      .text .dirname {
+        color: inherit;
+      }
+    }
   }
 
   .toolbar-button {


### PR DESCRIPTION
See https://github.com/desktop/desktop/pull/3269#issuecomment-344648587

This applies our `PathText` component for "clever" truncation of path-like strings to the branch button and the branch list. Hovering over truncated branch names will show a tooltip with the full branch name.

### Before and after
![screen shot 2017-11-17 at 16 35 26](https://user-images.githubusercontent.com/634063/32958010-84566606-cbbd-11e7-81ad-8d53f2fe0fcc.png)

### Truncation in lists
![screen shot 2017-11-17 at 16 35 37](https://user-images.githubusercontent.com/634063/32958011-84793b68-cbbd-11e7-918a-b2a93fbc220f.png)
