### PR TITLE
Add vue highlighting support

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -32,6 +32,9 @@ extensionMIMEMap.set('.css', 'text/css')
 extensionMIMEMap.set('.scss', 'text/x-scss')
 extensionMIMEMap.set('.less', 'text/x-less')
 
+import 'codemirror/mode/vue/vue'
+extensionMIMEMap.set('.vue', 'text/x-vue')
+
 import 'codemirror/mode/markdown/markdown'
 extensionMIMEMap.set('.markdown', 'text/x-markdown')
 extensionMIMEMap.set('.md', 'text/x-markdown')


### PR DESCRIPTION
## What

Add support for vue highlighting.

## How

- Added `.vue` property to `extensionMIMEMap` with MIME-type [`text/x-vue`](https://github.com/codemirror/CodeMirror/blob/master/mode/vue/vue.js#L76).
- Submitted [PR](https://github.com/desktop/highlighter-tests/pull/4) to `highlighter-test` repository