### PR TITLE
tidy up VSCode lookup

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -163,7 +163,7 @@ function extractApplicationInformation(
         displayName = item.value
       } else if (item.name === 'Publisher') {
         publisher = item.value
-      } else if (item.name === 'Inno Setup: App Path') {
+      } else if (item.name === 'InstallLocation') {
         installLocation = item.value
       }
     }
@@ -181,7 +181,7 @@ function extractApplicationInformation(
         displayName = item.value
       } else if (item.name === 'Publisher') {
         publisher = item.value
-      } else if (item.name === 'Inno Setup: App Path') {
+      } else if (item.name === 'InstallLocation') {
         installLocation = item.value
       }
     }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -174,9 +174,8 @@ function extractApplicationInformation(
   if (editor === ExternalEditor.SublimeText) {
     for (const item of keys) {
       // NOTE:
-      // Sublime Text bakes the build number into the DisplayName value, so for
-      // forward-compatibility whenever they decide to drop a new build let's
-      // use this entry which doesn't contain the version number
+      // Sublime Text appends the build number to the DisplayName value, so for
+      // forward-compatibility let's do a simple check for the identifier
       if (
         item.name === 'DisplayName' &&
         item.value &&

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -16,7 +16,6 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Atom) {
     return ExternalEditor.Atom
   }
-
   if (label === ExternalEditor.VisualStudioCode) {
     return ExternalEditor.VisualStudioCode
   }
@@ -111,9 +110,8 @@ function isExpectedInstallation(
       return displayName === 'Atom' && publisher === 'GitHub Inc.'
     case ExternalEditor.VisualStudioCode:
       return (
-        (displayName === 'Visual Studio Code' ||
-          displayName === 'Microsoft Visual Studio Code' ||
-          displayName === 'Visual Studio Code - Insiders') &&
+        (displayName === 'Microsoft Visual Studio Code' ||
+          displayName === 'Microsoft Visual Studio Code Insiders') &&
         publisher === 'Microsoft Corporation'
       )
     case ExternalEditor.SublimeText:
@@ -159,11 +157,26 @@ function extractApplicationInformation(
     return { displayName, publisher, installLocation }
   }
 
-  if (
-    editor === ExternalEditor.VisualStudioCode ||
-    editor === ExternalEditor.SublimeText
-  ) {
+  if (editor === ExternalEditor.VisualStudioCode) {
     for (const item of keys) {
+      if (item.name === 'DisplayName') {
+        displayName = item.value
+      } else if (item.name === 'Publisher') {
+        publisher = item.value
+      } else if (item.name === 'Inno Setup: App Path') {
+        installLocation = item.value
+      }
+    }
+
+    return { displayName, publisher, installLocation }
+  }
+
+  if (editor === ExternalEditor.SublimeText) {
+    for (const item of keys) {
+      // NOTE:
+      // Sublime Text bakes the build number into the DisplayName value, so for
+      // forward-compatibility whenever they decide to drop a new build let's
+      // use this entry which doesn't contain the version number
       if (item.name === 'Inno Setup: Icon Group') {
         displayName = item.value
       } else if (item.name === 'Publisher') {

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -177,8 +177,12 @@ function extractApplicationInformation(
       // Sublime Text bakes the build number into the DisplayName value, so for
       // forward-compatibility whenever they decide to drop a new build let's
       // use this entry which doesn't contain the version number
-      if (item.name === 'Inno Setup: Icon Group') {
-        displayName = item.value
+      if (
+        item.name === 'DisplayName' &&
+        item.value &&
+        item.value.startsWith('Sublime Text')
+      ) {
+        displayName = 'Sublime Text'
       } else if (item.name === 'Publisher') {
         publisher = item.value
       } else if (item.name === 'InstallLocation') {


### PR DESCRIPTION
Fixes #3304 and adds some extra context.

The original use of `Inno Setup: Icon Group` was because Sublime Text bakes the build number into it's `DisplayName` value. That's going to break whenever they release a new update.

<img width="1071" src="https://user-images.githubusercontent.com/359239/32996819-1a65354e-cddc-11e7-81d5-aa6b8bb5ee86.png">

VSCode however doesn't do this, so I broke this out to it's own code path and switched back to `DisplayName` because that's what everyone expects.

<img width="1088" src="https://user-images.githubusercontent.com/359239/32996795-cd3c2b1a-cddb-11e7-9822-25741b197d7b.png">

And the Insiders build is done in the same way:

<img width="1334" src="https://user-images.githubusercontent.com/359239/32996801-e8e14648-cddb-11e7-8e43-28eef211988e.png">

