### PR TITLE
decompose dist-info.js into more granular modules

### DIFF
--- a/app/app-info.d.ts
+++ b/app/app-info.d.ts
@@ -1,0 +1,2 @@
+export function getReplacements(): any
+export function getCLICommands(): string[]

--- a/app/app-info.d.ts
+++ b/app/app-info.d.ts
@@ -1,2 +1,2 @@
-export function getReplacements(): any
+export function getReplacements(): {}
 export function getCLICommands(): string[]

--- a/app/app-info.js
+++ b/app/app-info.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const gitInfo = require('./git-info')
+const distInfo = require('../script/dist-info')
+
+const projectRoot = path.join(__dirname, '..')
+
+const devClientId = '3a723b10ac5575cc5bb9'
+const devClientSecret = '22c34d87789a365981ed921352a7b9a8c3f69d54'
+
+const channel = distInfo.getReleaseChannel()
+
+function getCLICommands() {
+  return (
+    // eslint-disable-next-line no-sync
+    fs
+      .readdirSync(path.resolve(projectRoot, 'app', 'src', 'cli', 'commands'))
+      .filter(name => name.endsWith('.ts'))
+      .map(name => name.replace(/\.ts$/, ''))
+  )
+}
+
+function s(text) {
+  return JSON.stringify(text)
+}
+
+function getReplacements() {
+  return {
+    __OAUTH_CLIENT_ID__: s(process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId),
+    __OAUTH_SECRET__: s(
+      process.env.DESKTOP_OAUTH_CLIENT_SECRET || devClientSecret
+    ),
+    __DARWIN__: process.platform === 'darwin',
+    __WIN32__: process.platform === 'win32',
+    __LINUX__: process.platform === 'linux',
+    __DEV__: channel === 'development',
+    __RELEASE_CHANNEL__: s(channel),
+    __UPDATES_URL__: s(distInfo.getUpdatesURL()),
+    __SHA__: s(gitInfo.getSHA()),
+    __CLI_COMMANDS__: s(getCLICommands()),
+    'process.platform': s(process.platform),
+    'process.env.NODE_ENV': s(process.env.NODE_ENV || 'development'),
+    'process.env.TEST_ENV': s(process.env.TEST_ENV),
+  }
+}
+
+module.exports = { getReplacements, getCLICommands }

--- a/app/git-info.d.ts
+++ b/app/git-info.d.ts
@@ -1,0 +1,1 @@
+export function getSHA(): string

--- a/app/git-info.js
+++ b/app/git-info.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * Attempt to dereference the given ref without requiring a Git environment
+ * to be present. Note that this method will not be able to dereference packed
+ * refs but should suffice for simple refs like 'HEAD'.
+ *
+ * Will throw an error for unborn HEAD.
+ *
+ * @param {string} gitDir The path to the Git repository's .git directory
+ * @param {string} ref    A qualified git ref such as 'HEAD' or 'refs/heads/master'
+ */
+function revParse(gitDir, ref) {
+  const refPath = path.join(gitDir, ref)
+  // eslint-disable-next-line no-sync
+  const refContents = fs.readFileSync(refPath)
+  const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m
+  const refMatch = refRe.exec(refContents)
+
+  if (!refMatch) {
+    throw new Error(
+      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`
+    )
+  }
+
+  return refMatch[1] || revParse(gitDir, refMatch[2])
+}
+
+function getSHA() {
+  // CircleCI does some funny stuff where HEAD points to an packed ref, but
+  // luckily it gives us the SHA we want in the environment.
+  const circleSHA = process.env.CIRCLE_SHA1
+  if (circleSHA) {
+    return circleSHA
+  }
+
+  return revParse(path.resolve(__dirname, '../.git'), 'HEAD')
+}
+
+module.exports = {
+  getSHA,
+}

--- a/app/package-info.d.ts
+++ b/app/package-info.d.ts
@@ -1,0 +1,4 @@
+export function getProductName(): string
+export function getCompanyName(): string
+export function getVersion(): string
+export function getBundleID(): string

--- a/app/package-info.js
+++ b/app/package-info.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const path = require('path')
+
+const projectRoot = __dirname
+// eslint-disable-next-line import/no-dynamic-require
+const appPackage = require(path.join(projectRoot, 'package.json'))
+
+function getProductName() {
+  const productName = appPackage.productName
+  return process.env.NODE_ENV === 'development'
+    ? `${productName}-dev`
+    : productName
+}
+
+function getCompanyName() {
+  return appPackage.companyName
+}
+
+function getVersion() {
+  return appPackage.version
+}
+
+function getBundleID() {
+  return appPackage.bundleID
+}
+
+module.exports = {
+  getProductName,
+  getCompanyName,
+  getVersion,
+  getBundleID,
+}

--- a/app/src/cli/dev-commands-global.js
+++ b/app/src/cli/dev-commands-global.js
@@ -1,6 +1,3 @@
-const Fs = require('fs')
-const path = require('path')
+const appInfo = require('../../../app/app-info')
 
-const distInfo = require('../../../script/dist-info')
-
-global.__CLI_COMMANDS__ = distInfo.getCLICommands()
+global.__CLI_COMMANDS__ = appInfo.getCLICommands()

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -6,6 +6,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CleanWebpackPlugin = require('clean-webpack-plugin')
 const webpack = require('webpack')
 const merge = require('webpack-merge')
+const appInfo = require('./app-info')
+const packageInfo = require('./package-info')
 const distInfo = require('../script/dist-info')
 
 const devClientId = '3a723b10ac5575cc5bb9'
@@ -13,25 +15,7 @@ const devClientSecret = '22c34d87789a365981ed921352a7b9a8c3f69d54'
 
 const channel = distInfo.getReleaseChannel()
 
-const replacements = {
-  __OAUTH_CLIENT_ID__: JSON.stringify(
-    process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId
-  ),
-  __OAUTH_SECRET__: JSON.stringify(
-    process.env.DESKTOP_OAUTH_CLIENT_SECRET || devClientSecret
-  ),
-  __DARWIN__: process.platform === 'darwin',
-  __WIN32__: process.platform === 'win32',
-  __LINUX__: process.platform === 'linux',
-  __DEV__: channel === 'development',
-  __RELEASE_CHANNEL__: JSON.stringify(channel),
-  __UPDATES_URL__: JSON.stringify(distInfo.getUpdatesURL()),
-  __SHA__: JSON.stringify(distInfo.getSHA()),
-  __CLI_COMMANDS__: JSON.stringify(distInfo.getCLICommands()),
-  'process.platform': JSON.stringify(process.platform),
-  'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
-  'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),
-}
+const replacements = appInfo.getReplacements()
 
 const outputDir = 'out'
 

--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -10,19 +10,15 @@ const appInfo = require('./app-info')
 const packageInfo = require('./package-info')
 const distInfo = require('../script/dist-info')
 
-const devClientId = '3a723b10ac5575cc5bb9'
-const devClientSecret = '22c34d87789a365981ed921352a7b9a8c3f69d54'
-
 const channel = distInfo.getReleaseChannel()
-
-const replacements = appInfo.getReplacements()
-
-const outputDir = 'out'
 
 const externals = ['7zip']
 if (channel === 'development') {
   externals.push('devtron')
 }
+
+const outputDir = 'out'
+const replacements = appInfo.getReplacements()
 
 const commonConfig = {
   externals: externals,

--- a/docs/technical/placeholders.md
+++ b/docs/technical/placeholders.md
@@ -1,0 +1,120 @@
+## Placeholders and Replacements in Source Code
+
+As GitHub Desktop uses Webpack to transpile, minify and merge our code
+into unified scripts for each configuration we define, we use some tricks
+to manage complexity and enable some optimizations.
+
+For example, you might come across this code in [`app-window.ts`](https://github.com/desktop/desktop/blob/master/app/src/main-process/app-window.ts):
+
+```ts
+if (__DARWIN__) {
+  windowOptions.titleBarStyle = 'hidden'
+} else if (__WIN32__) {
+  windowOptions.frame = false
+}
+```
+
+You may be inclined to refactor this to be:
+
+```ts
+if (process.platform === 'darwin') {
+  windowOptions.titleBarStyle = 'hidden'
+} else if (process.platform === 'win32') {
+  windowOptions.frame = false
+}
+```
+
+And while both of these are semantically the same, how we bundle Desktop means
+we get significant benefits from doing it the first way.
+
+### Replacements
+
+The replacements defined for Desktop are found in [`app/app-info.js`](https://github.com/desktop/desktop/blob/master/app/app-info.js)
+as a hash of key-value pairs.
+
+```ts
+function getReplacements() {
+  return {
+    __OAUTH_CLIENT_ID__: s(process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId),
+    __OAUTH_SECRET__: s(
+      process.env.DESKTOP_OAUTH_CLIENT_SECRET || devClientSecret
+    ),
+    __DARWIN__: process.platform === 'darwin',
+    __WIN32__: process.platform === 'win32',
+    __LINUX__: process.platform === 'linux',
+    __DEV__: channel === 'development',
+    __RELEASE_CHANNEL__: s(channel),
+    __UPDATES_URL__: s(distInfo.getUpdatesURL()),
+    __SHA__: s(gitInfo.getSHA()),
+    __CLI_COMMANDS__: s(getCLICommands()),
+    'process.platform': s(process.platform),
+    'process.env.NODE_ENV': s(process.env.NODE_ENV || 'development'),
+    'process.env.TEST_ENV': s(process.env.TEST_ENV),
+  }
+}
+```
+
+This means we can embed values at build time based on the current platform.
+Note the values we are embeddeding for `__DARWIN__` and `__WIN32__`:
+
+```ts
+__DARWIN__: process.platform === 'darwin',
+__WIN32__: process.platform === 'win32',
+```
+
+Because we evaluate these values at build time, the original code snippet will
+now look like this on macOS:
+
+```js
+if (true) {
+  windowOptions.titleBarStyle = 'hidden'
+} else if (false) {
+  windowOptions.frame = false
+}
+```
+
+And look like this on Windows:
+
+```js
+if (false) {
+  windowOptions.titleBarStyle = 'hidden'
+} else if (true) {
+  windowOptions.frame = false
+}
+```
+
+As part of Webpack's minification and bundling, the dead code paths are
+eliminated, leaving this code for macOS:
+
+```js
+windowOptions.titleBarStyle = 'hidden'
+```
+
+And this code for Windows:
+
+```js
+windowOptions.frame = false
+```
+
+This means less code is emitted as part of the packaged app, and less
+JavaScript is interpreted and executed at runtime.
+
+### Placeholders
+
+As we are working in TypeScript, we need to define these placeholders as
+globals under [`app/src/lib/globals.ts`](https://github.com/desktop/desktop/blob/master/app/src/lib/globals.d.ts)
+to provide the appropriate type information to the source code.
+
+For example, the values for `__DARWIN__` and `__WIN32__` are declared as
+booleans.
+
+```ts
+/** Is the app being built to run on Darwin? */
+declare const __DARWIN__: boolean
+
+/** Is the app being built to run on Win32? */
+declare const __WIN32__: boolean
+```
+
+As a convention, globals which should be replaced by Webpack should be prefixed
+and suffixed with two underscores, e.g. `__DEV__`.

--- a/script/build.ts
+++ b/script/build.ts
@@ -10,14 +10,13 @@ import * as packager from 'electron-packager'
 const legalEagle: LegalEagle = require('legal-eagle')
 
 import {
-  getReleaseChannel,
-  getDistRoot,
-  getExecutableName,
   getBundleID,
   getCompanyName,
   getProductName,
   getVersion,
-} from './dist-info'
+} from '../app/package-info'
+
+import { getReleaseChannel, getDistRoot, getExecutableName } from './dist-info'
 
 const projectRoot = path.join(__dirname, '..')
 const outRoot = path.join(projectRoot, 'out')

--- a/script/dist-info.d.ts
+++ b/script/dist-info.d.ts
@@ -1,8 +1,5 @@
 export function getDistRoot(): string
 export function getDistPath(): string
-export function getProductName(): string
-export function getCompanyName(): string
-export function getVersion(): string
 export function getOSXZipName(): string
 export function getOSXZipPath(): string
 export function getWindowsInstallerName(): string
@@ -11,8 +8,6 @@ export function getWindowsStandaloneName(): string
 export function getWindowsStandalonePath(): string
 export function getWindowsFullNugetPackageName(): string
 export function getWindowsFullNugetPackagePath(): string
-export function getBundleID(): string
-export function getUserDataPath(): string
 export function getWindowsIdentifierName(): string
 export function getBundleSizes(): { rendererSize: number; mainSize: number }
 export function getReleaseChannel(): string | null
@@ -23,4 +18,3 @@ export function getWindowsDeltaNugetPackagePath(): string
 export function shouldMakeDelta(): boolean
 export function getReleaseBranchName(): string
 export function getExecutableName(): string
-export function getSHA(): string

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const path = require('path')
-const os = require('os')
 const fs = require('fs')
 
+const packageInfo = require('../app/package-info')
+const productName = packageInfo.getProductName()
+const version = packageInfo.getVersion()
+
 const projectRoot = path.join(__dirname, '..')
-// eslint-disable-next-line import/no-dynamic-require
-const appPackage = require(path.join(projectRoot, 'app', 'package.json'))
 
 function getDistRoot() {
   return path.join(projectRoot, 'dist')
@@ -24,26 +25,10 @@ function getExecutableName() {
 
   return process.platform === 'win32'
     ? `${getWindowsIdentifierName()}${suffix}`
-    : getProductName()
-}
-
-function getProductName() {
-  const productName = appPackage.productName
-  return process.env.NODE_ENV === 'development'
-    ? `${productName}-dev`
     : productName
 }
 
-function getCompanyName() {
-  return appPackage.companyName
-}
-
-function getVersion() {
-  return appPackage.version
-}
-
 function getOSXZipName() {
-  const productName = getProductName()
   return `${productName}.zip`
 }
 
@@ -70,7 +55,7 @@ function getWindowsStandalonePath() {
 }
 
 function getWindowsFullNugetPackageName() {
-  return `${getWindowsIdentifierName()}-${getVersion()}-full.nupkg`
+  return `${getWindowsIdentifierName()}-${version}-full.nupkg`
 }
 
 function getWindowsFullNugetPackagePath() {
@@ -83,7 +68,7 @@ function getWindowsFullNugetPackagePath() {
 }
 
 function getWindowsDeltaNugetPackageName() {
-  return `${getWindowsIdentifierName()}-${getVersion()}-delta.nupkg`
+  return `${getWindowsIdentifierName()}-${version}-delta.nupkg`
 }
 
 function getWindowsDeltaNugetPackagePath() {
@@ -93,29 +78,6 @@ function getWindowsDeltaNugetPackagePath() {
     'installer',
     getWindowsDeltaNugetPackageName()
   )
-}
-
-function getBundleID() {
-  return appPackage.bundleID
-}
-
-function getUserDataPath() {
-  if (process.platform === 'win32') {
-    return path.join(process.env.APPDATA, getExecutableName())
-  } else if (process.platform === 'darwin') {
-    const home = os.homedir()
-    return path.join(home, 'Library', 'Application Support', getProductName())
-  } else if (process.platform === 'linux') {
-    if (process.env.XDG_CONFIG_HOME) {
-      return path.join(process.env.XDG_CONFIG_HOME, getProductName())
-    }
-    const home = os.homedir()
-    return path.join(home, '.config', getProductName())
-  } else {
-    throw new Error(
-      `I dunno how to resolve the user data path for ${process.platform} ${process.arch} :(`
-    )
-  }
 }
 
 function getWindowsIdentifierName() {
@@ -162,7 +124,7 @@ function getReleaseSHA() {
 }
 
 function getUpdatesURL() {
-  return `https://central.github.com/api/deployments/desktop/desktop/latest?version=${getVersion()}&env=${getReleaseChannel()}`
+  return `https://central.github.com/api/deployments/desktop/desktop/latest?version=${version}&env=${getReleaseChannel()}`
 }
 
 function shouldMakeDelta() {
@@ -172,55 +134,9 @@ function shouldMakeDelta() {
   return channelsWithDeltas.indexOf(getReleaseChannel()) > -1
 }
 
-function getCLICommands() {
-  return fs
-    .readdirSync(path.resolve(projectRoot, 'app', 'src', 'cli', 'commands'))
-    .filter(name => name.endsWith('.ts'))
-    .map(name => name.replace(/\.ts$/, ''))
-}
-
-/**
- * Attempt to dereference the given ref without requiring a Git environment
- * to be present. Note that this method will not be able to dereference packed
- * refs but should suffice for simple refs like 'HEAD'.
- *
- * Will throw an error for unborn HEAD.
- *
- * @param {string} gitDir The path to the Git repository's .git directory
- * @param {string} ref    A qualified git ref such as 'HEAD' or 'refs/heads/master'
- */
-function revParse(gitDir, ref) {
-  const refPath = path.join(gitDir, ref)
-  const refContents = fs.readFileSync(refPath)
-  const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m
-  const refMatch = refRe.exec(refContents)
-
-  if (!refMatch) {
-    throw new Error(
-      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`
-    )
-  }
-
-  return refMatch[1] || revParse(gitDir, refMatch[2])
-}
-
-function getSHA() {
-  // CircleCI does some funny stuff where HEAD points to an packed ref, but
-  // luckily it gives us the SHA we want in the environment.
-  const circleSHA = process.env.CIRCLE_SHA1
-  if (circleSHA) {
-    return circleSHA
-  }
-
-  return revParse(path.resolve(__dirname, '../.git'), 'HEAD')
-}
-
 module.exports = {
   getDistRoot,
   getDistPath,
-  getProductName,
-  getCompanyName,
-  getVersion,
   getOSXZipName,
   getOSXZipPath,
   getWindowsInstallerName,
@@ -229,8 +145,6 @@ module.exports = {
   getWindowsStandalonePath,
   getWindowsFullNugetPackageName,
   getWindowsFullNugetPackagePath,
-  getBundleID,
-  getUserDataPath,
   getWindowsIdentifierName,
   getBundleSizes,
   getReleaseChannel,
@@ -241,6 +155,4 @@ module.exports = {
   shouldMakeDelta,
   getReleaseBranchName,
   getExecutableName,
-  getCLICommands,
-  getSHA,
 }

--- a/script/eslint.ts
+++ b/script/eslint.ts
@@ -28,7 +28,7 @@ const ESLINT_ARGS = [
   '--rulesdir=./eslint-rules',
   './{script,eslint-rules}/**/*.{j,t}s?(x)',
   './tslint-rules/**/*.ts',
-  './app/webpack*.js',
+  './app/*.js',
   './app/{src,typings,test}/**/*.{j,t}s?(x)',
   ...process.argv.slice(2),
 ]

--- a/script/package.ts
+++ b/script/package.ts
@@ -4,13 +4,12 @@ import * as fs from 'fs-extra'
 import * as cp from 'child_process'
 import * as path from 'path'
 import * as electronInstaller from 'electron-winstaller'
+import { getProductName, getCompanyName } from '../app/package-info'
 import {
   getDistRoot,
   getDistPath,
-  getProductName,
   getOSXZipPath,
   getWindowsIdentifierName,
-  getCompanyName,
   getWindowsStandaloneName,
   getWindowsInstallerName,
   shouldMakeDelta,

--- a/script/publish
+++ b/script/publish
@@ -5,6 +5,7 @@
 const TEST_PUBLISH = false
 const PUBLISH_CHANNELS = ['production', 'test', 'beta']
 const distInfo = require('./dist-info')
+const gitInfo = require('../app/git-info')
 
 if (PUBLISH_CHANNELS.indexOf(distInfo.getReleaseChannel()) < 0) {
   console.log('Not a publishable build. Skipping publish.')
@@ -17,7 +18,7 @@ if (!releaseSHA) {
   process.exit(0)
 }
 
-const currentTipSHA = distInfo.getSHA()
+const currentTipSHA = gitInfo.getSHA()
 if (
   !currentTipSHA ||
   !currentTipSHA.toUpperCase().startsWith(releaseSHA.toUpperCase())

--- a/script/review-logs.ts
+++ b/script/review-logs.ts
@@ -2,7 +2,28 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
-import { getUserDataPath } from './dist-info'
+import * as os from 'os'
+import { getProductName } from '../app/package-info'
+import { getExecutableName } from './dist-info'
+
+function getUserDataPath() {
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA, getExecutableName())
+  } else if (process.platform === 'darwin') {
+    const home = os.homedir()
+    return path.join(home, 'Library', 'Application Support', getProductName())
+  } else if (process.platform === 'linux') {
+    if (process.env.XDG_CONFIG_HOME) {
+      return path.join(process.env.XDG_CONFIG_HOME, getProductName())
+    }
+    const home = os.homedir()
+    return path.join(home, '.config', getProductName())
+  } else {
+    throw new Error(
+      `I dunno how to resolve the user data path for ${process.platform} ${process.arch} :(`
+    )
+  }
+}
 
 export function getLogFiles(): ReadonlyArray<string> {
   const directory = path.join(getUserDataPath(), 'logs')

--- a/script/test-setup.ts
+++ b/script/test-setup.ts
@@ -3,7 +3,8 @@
 import * as fs from 'fs'
 import * as cp from 'child_process'
 import { getLogFiles } from './review-logs'
-import { getProductName, getDistPath } from './dist-info'
+import { getProductName } from '../app/package-info'
+import { getDistPath } from './dist-info'
 
 const isFork = process.env.CIRCLE_PR_USERNAME
 


### PR DESCRIPTION
Supersedes #3288

This decomposes `dist-info.js` into a number of specialized modules:

 - `app/app-info.js` - functions required when building the app
 - `app/git-info.js` - functions for interacting with the underlying Git repository
 - `app/package-info.js` - a wrapper for reading fields from `app/package.json`

This isn't all the work required to tease things out, but at least helps us to identify the coupling better.

I also added some docs around how placeholders work in the app - [rendered link](https://github.com/desktop/desktop/blob/0246b86820e8417f4c13d1e196e467128d572f3f/docs/technical/placeholders.md).