### PR TITLE
SQL Highlighter Support

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -67,6 +67,9 @@ extensionMIMEMap.set('.swift', 'text/x-swift')
 import 'codemirror/mode/shell/shell'
 extensionMIMEMap.set('.sh', 'text/x-sh')
 
+import 'codemirror/mode/sql/sql'
+extensionMIMEMap.set('.sql', 'text/x-sql')
+
 import 'codemirror/mode/go/go'
 extensionMIMEMap.set('.go', 'text/x-go')
 


### PR DESCRIPTION
Add Support for SQL Highlighting. Goes hand in hand with https://github.com/desktop/highlighter-tests/pull/5. 

<img width="961" alt="add-sql-support" src="https://user-images.githubusercontent.com/7467062/33056706-bb0f7836-ce4c-11e7-90ce-8fc1f01babe8.png">