### PR TITLE
yarn docs recommend installing yarn differently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
 addons:
   apt:
     packages:
-      # by default the container VMs have Git 1.9.1, ermagherd...
-      - git-all
       # this is required to compile keytar
       - libsecret-1-dev
       # this package is essential for testing Electron in a headless fashion

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ notifications:
 
 dist: trusty
 
+sudo: false
+
 matrix:
   include:
     - os: linux
@@ -40,14 +42,18 @@ node_js:
   - "8.9.0"
 
 cache:
+  yarn: true
   timeout: 600
   directories:
     - node_modules
     - $HOME/.electron
     - .eslintcache
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 install:
-  - npm install -g yarn@1.3.2
   - yarn install --force
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ cache:
   - .eslintcache
   - node_modules
   - '%USERPROFILE%\.electron'
+  - '%LOCALAPPDATA%\Yarn'
 
 branches:
   only:
@@ -23,7 +24,6 @@ version: "{build}"
 install:
   - cmd: regedit /s script\default-to-tls12-on-appveyor.reg
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - npm install -g yarn@1.3.2
   - git submodule update --init --recursive
   - yarn install --force
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,11 +14,12 @@ dependencies:
     - ".eslintcache"
     - "node_modules"
     - "~/.electron"
+    - "~/Library/Caches/Yarn/v1"
 
   pre:
     - brew update
     - brew upgrade node@8
-    - npm install -g yarn@1.3.2
+    - brew install yarn
 
   override:
     - yarn install --force


### PR DESCRIPTION
Noticed this while poking around builds:

<img width="1133" src="https://user-images.githubusercontent.com/359239/33056773-9d5d5184-cedb-11e7-9267-df32432dba17.png">

<img width="990" src="https://user-images.githubusercontent.com/359239/33056888-1bf2fd3c-cedc-11e7-85cb-0ec928564bff.png">

<img width="908" src="https://user-images.githubusercontent.com/359239/33057488-55758e82-cedf-11e7-8d65-6e5e7dc55ee8.png">

Let's see what happens when we do exactly [what the docs suggest](https://yarnpkg.com/lang/en/docs/install-ci/).

 - [x] [CircleCI](https://circleci.com/docs/1.0/yarn/) Mac agent doesn't have it preinstalled, use `homebrew` instead
 - [x] [Appveyor](https://yarnpkg.com/lang/en/docs/install-ci/#appveyor-tab) has it preinstalled, enable caching
 - [x] [Travis](https://yarnpkg.com/lang/en/docs/install-ci/#travis-tab) has it preinstalled too, enable caching
 - [x] summarize changes to `yarn install`