### PR TITLE
Don't overwrite existing .gitattributes

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -28,6 +28,7 @@ import { Dialog, DialogContent, DialogFooter, DialogError } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
 import { PopupType } from '../../lib/app-state'
+import { pathExists } from '../../lib/file-system'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -272,7 +273,11 @@ export class CreateRepository extends React.Component<
     }
 
     try {
-      await writeGitAttributes(fullPath)
+      const gitAttributes = Path.join(fullPath, '.gitattributes')
+      const gitAttributesExists = await pathExists(gitAttributes)
+      if (!gitAttributesExists) {
+        await writeGitAttributes(fullPath)
+      }
     } catch (e) {
       log.error(
         `createRepository: unable to write .gitattributes at ${fullPath}`,

--- a/app/src/ui/add-repository/git-attributes.ts
+++ b/app/src/ui/add-repository/git-attributes.ts
@@ -8,7 +8,7 @@ export function writeGitAttributes(path: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const fullPath = Path.join(path, '.gitattributes')
     const contents =
-      '# Auto detect text files and perform LF normalization\n* text=auto'
+      '# Auto detect text files and perform LF normalization\n* text=auto\n'
 
     FS.writeFile(fullPath, contents, err => {
       if (err) {


### PR DESCRIPTION
This change is simply what @shiftkey posted in #3363 and seems to work nicely for new repositories that do or do not contains a `.gitattributes` file.

Resolves #3363.