### PR TITLE
Fixed category for desktop file

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   },
   "build": {
     "linux": {
-      "category": "public.app-category.developer-tools",
+      "category": "Development",
       "icon": "app/static/logos"
     }
   }


### PR DESCRIPTION
Category values have to be from registered values: https://standards.freedesktop.org/menu-spec/latest/apa.html

The previous value is for Mac OS X, not free desktop standard.

This prevents appimage to be correctly built because it checks that desktop file is correct.