### PR TITLE
support VSCode Insiders build alongside Stable

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -97,10 +97,15 @@ async function findApplication(editor: ExternalEditor): Promise<string | null> {
  */
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-  > {
+> {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+  ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.VisualStudioCodeInsiders),
@@ -116,7 +121,10 @@ export async function getAvailableEditors(): Promise<
   }
 
   if (codeInsidersPath) {
-    results.push({ editor: ExternalEditor.VisualStudioCodeInsiders, path: codeInsidersPath })
+    results.push({
+      editor: ExternalEditor.VisualStudioCodeInsiders,
+      path: codeInsidersPath,
+    })
   }
 
   if (sublimePath) {

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -6,6 +6,7 @@ import { assertNever } from '../fatal-error'
 export enum ExternalEditor {
   Atom = 'Atom',
   VisualStudioCode = 'Visual Studio Code',
+  VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
   SublimeText = 'Sublime Text',
 }
 
@@ -13,9 +14,11 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Atom) {
     return ExternalEditor.Atom
   }
-
   if (label === ExternalEditor.VisualStudioCode) {
     return ExternalEditor.VisualStudioCode
+  }
+  if (label === ExternalEditor.VisualStudioCodeInsiders) {
+    return ExternalEditor.VisualStudioCodeInsiders
   }
   if (label === ExternalEditor.SublimeText) {
     return ExternalEditor.SublimeText
@@ -34,7 +37,9 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
     case ExternalEditor.Atom:
       return ['com.github.atom']
     case ExternalEditor.VisualStudioCode:
-      return ['com.microsoft.VSCode', 'com.microsoft.VSCodeInsiders']
+      return ['com.microsoft.VSCode']
+    case ExternalEditor.VisualStudioCodeInsiders:
+      return ['com.microsoft.VSCodeInsiders']
     case ExternalEditor.SublimeText:
       return ['com.sublimetext.3']
     default:
@@ -50,6 +55,7 @@ function getExecutableShim(
     case ExternalEditor.Atom:
       return Path.join(installPath, 'Contents', 'Resources', 'app', 'atom.sh')
     case ExternalEditor.VisualStudioCode:
+    case ExternalEditor.VisualStudioCodeInsiders:
       return Path.join(
         installPath,
         'Contents',
@@ -91,12 +97,13 @@ async function findApplication(editor: ExternalEditor): Promise<string | null> {
  */
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-> {
+  > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, sublimePath] = await Promise.all([
+  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
+    findApplication(ExternalEditor.VisualStudioCodeInsiders),
     findApplication(ExternalEditor.SublimeText),
   ])
 
@@ -106,6 +113,10 @@ export async function getAvailableEditors(): Promise<
 
   if (codePath) {
     results.push({ editor: ExternalEditor.VisualStudioCode, path: codePath })
+  }
+
+  if (codeInsidersPath) {
+    results.push({ editor: ExternalEditor.VisualStudioCodeInsiders, path: codeInsidersPath })
   }
 
   if (sublimePath) {

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -100,17 +100,14 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    sublimePath,
-  ] = await Promise.all([
-    findApplication(ExternalEditor.Atom),
-    findApplication(ExternalEditor.VisualStudioCode),
-    findApplication(ExternalEditor.VisualStudioCodeInsiders),
-    findApplication(ExternalEditor.SublimeText),
-  ])
+  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all(
+    [
+      findApplication(ExternalEditor.Atom),
+      findApplication(ExternalEditor.VisualStudioCode),
+      findApplication(ExternalEditor.VisualStudioCodeInsiders),
+      findApplication(ExternalEditor.SublimeText),
+    ]
+  )
 
   if (atomPath) {
     results.push({ editor: ExternalEditor.Atom, path: atomPath })

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -100,7 +100,12 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+  ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -100,12 +100,7 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    sublimePath,
-  ] = await Promise.all([
+  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -108,15 +108,19 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath, bbeditPath] = await Promise.all(
-    [
-      findApplication(ExternalEditor.Atom),
-      findApplication(ExternalEditor.VisualStudioCode),
-      findApplication(ExternalEditor.VisualStudioCodeInsiders),
-      findApplication(ExternalEditor.SublimeText),
-      findApplication(ExternalEditor.BBEdit),      
-    ]
-  )
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+    bbeditPath,
+  ] = await Promise.all([
+    findApplication(ExternalEditor.Atom),
+    findApplication(ExternalEditor.VisualStudioCode),
+    findApplication(ExternalEditor.VisualStudioCodeInsiders),
+    findApplication(ExternalEditor.SublimeText),
+    findApplication(ExternalEditor.BBEdit),
+  ])
 
   if (atomPath) {
     results.push({ editor: ExternalEditor.Atom, path: atomPath })

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -5,6 +5,7 @@ import { assertNever } from '../fatal-error'
 export enum ExternalEditor {
   Atom = 'Atom',
   VisualStudioCode = 'Visual Studio Code',
+  VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
   SublimeText = 'Sublime Text',
 }
 
@@ -14,6 +15,10 @@ export function parse(label: string): ExternalEditor | null {
   }
 
   if (label === ExternalEditor.VisualStudioCode) {
+    return ExternalEditor.VisualStudioCode
+  }
+
+  if (label === ExternalEditor.VisualStudioCodeInsiders) {
     return ExternalEditor.VisualStudioCode
   }
 
@@ -33,10 +38,8 @@ function getEditorPath(editor: ExternalEditor): Promise<string | null> {
     case ExternalEditor.Atom:
       return getPathIfAvailable('/usr/bin/atom')
     case ExternalEditor.VisualStudioCode:
-      const codePath = getPathIfAvailable('/usr/bin/code')
-      if (codePath) {
-        return codePath
-      }
+      return getPathIfAvailable('/usr/bin/code')
+    case ExternalEditor.VisualStudioCodeInsiders:
       return getPathIfAvailable('/usr/bin/code-insiders')
     case ExternalEditor.SublimeText:
       return getPathIfAvailable('/usr/bin/subl')
@@ -47,12 +50,13 @@ function getEditorPath(editor: ExternalEditor): Promise<string | null> {
 
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-> {
+  > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, sublimePath] = await Promise.all([
+  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
     getEditorPath(ExternalEditor.Atom),
     getEditorPath(ExternalEditor.VisualStudioCode),
+    getEditorPath(ExternalEditor.VisualStudioCodeInsiders),
     getEditorPath(ExternalEditor.SublimeText),
   ])
 
@@ -62,6 +66,10 @@ export async function getAvailableEditors(): Promise<
 
   if (codePath) {
     results.push({ editor: ExternalEditor.VisualStudioCode, path: codePath })
+  }
+
+  if (codeInsidersPath) {
+    results.push({ editor: ExternalEditor.VisualStudioCode, path: codeInsidersPath })
   }
 
   if (sublimePath) {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -50,10 +50,15 @@ function getEditorPath(editor: ExternalEditor): Promise<string | null> {
 
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-  > {
+> {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+  ] = await Promise.all([
     getEditorPath(ExternalEditor.Atom),
     getEditorPath(ExternalEditor.VisualStudioCode),
     getEditorPath(ExternalEditor.VisualStudioCodeInsiders),
@@ -69,7 +74,10 @@ export async function getAvailableEditors(): Promise<
   }
 
   if (codeInsidersPath) {
-    results.push({ editor: ExternalEditor.VisualStudioCode, path: codeInsidersPath })
+    results.push({
+      editor: ExternalEditor.VisualStudioCode,
+      path: codeInsidersPath,
+    })
   }
 
   if (sublimePath) {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -53,7 +53,12 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+  ] = await Promise.all([
     getEditorPath(ExternalEditor.Atom),
     getEditorPath(ExternalEditor.VisualStudioCode),
     getEditorPath(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -53,17 +53,14 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    sublimePath,
-  ] = await Promise.all([
-    getEditorPath(ExternalEditor.Atom),
-    getEditorPath(ExternalEditor.VisualStudioCode),
-    getEditorPath(ExternalEditor.VisualStudioCodeInsiders),
-    getEditorPath(ExternalEditor.SublimeText),
-  ])
+  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all(
+    [
+      getEditorPath(ExternalEditor.Atom),
+      getEditorPath(ExternalEditor.VisualStudioCode),
+      getEditorPath(ExternalEditor.VisualStudioCodeInsiders),
+      getEditorPath(ExternalEditor.SublimeText),
+    ]
+  )
 
   if (atomPath) {
     results.push({ editor: ExternalEditor.Atom, path: atomPath })

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -53,12 +53,7 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    sublimePath,
-  ] = await Promise.all([
+  const [atomPath, codePath, codeInsidersPath, sublimePath] = await Promise.all([
     getEditorPath(ExternalEditor.Atom),
     getEditorPath(ExternalEditor.VisualStudioCode),
     getEditorPath(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -273,7 +273,13 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath, cfBuilderPath] = await Promise.all([
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+    cfBuilderPath,
+  ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -120,12 +120,12 @@ function isExpectedInstallation(
       return displayName === 'Atom' && publisher === 'GitHub Inc.'
     case ExternalEditor.VisualStudioCode:
       return (
-        (displayName === 'Microsoft Visual Studio Code') &&
+        displayName === 'Microsoft Visual Studio Code' &&
         publisher === 'Microsoft Corporation'
       )
     case ExternalEditor.VisualStudioCodeInsiders:
       return (
-        (displayName === 'Microsoft Visual Studio Code Insiders') &&
+        displayName === 'Microsoft Visual Studio Code Insiders' &&
         publisher === 'Microsoft Corporation'
       )
     case ExternalEditor.SublimeText:
@@ -171,7 +171,10 @@ function extractApplicationInformation(
     return { displayName, publisher, installLocation }
   }
 
-  if (editor === ExternalEditor.VisualStudioCode || editor === ExternalEditor.VisualStudioCodeInsiders) {
+  if (
+    editor === ExternalEditor.VisualStudioCode ||
+    editor === ExternalEditor.VisualStudioCodeInsiders
+  ) {
     for (const item of keys) {
       if (item.name === 'DisplayName') {
         displayName = item.value
@@ -267,10 +270,16 @@ async function findApplication(editor: ExternalEditor): Promise<string | null> {
  */
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-  > {
+> {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, codeInsidersPath, sublimePath, cfBuilderPath] = await Promise.all([
+  const [
+    atomPath,
+    codePath,
+    codeInsidersPath,
+    sublimePath,
+    cfBuilderPath,
+  ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -273,13 +273,7 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    sublimePath,
-    cfBuilderPath,
-  ] = await Promise.all([
+  const [atomPath, codePath, codeInsidersPath, sublimePath, cfBuilderPath] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.VisualStudioCodeInsiders),

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -92,8 +92,9 @@ function getExecutableShim(
     case ExternalEditor.Atom:
       return Path.join(installLocation, 'bin', 'atom.cmd')
     case ExternalEditor.VisualStudioCode:
-    case ExternalEditor.VisualStudioCodeInsiders:
       return Path.join(installLocation, 'bin', 'code.cmd')
+    case ExternalEditor.VisualStudioCodeInsiders:
+      return Path.join(installLocation, 'bin', 'code-insiders.cmd')
     case ExternalEditor.SublimeText:
       return Path.join(installLocation, 'subl.exe')
     case ExternalEditor.CFBuilder:


### PR DESCRIPTION
- All Platforms

Addresses #3011 @shiftkey's comment 

> @MSathieu maybe? I don't think we can have multiple enum values mapped to a single string (so we can separate the logic for ExternalEditor.VisualStudioCodeInsiders but make it appear in the UI as 'Visual Studio Code') so maybe we'll need to call it 'Visual Studio Code (Insiders)'.

Its pretty typical for those with VS Code Insiders installed to also have VS Code (vanilla) installed side by side. This allows each to be selected.