### PR TITLE
Remove eslint_d

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-typescript": "^0.8.1",
-    "eslint_d": "^5.2.0",
     "express": "^4.15.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "fs-extra": "^2.1.2",

--- a/script/eslint.ts
+++ b/script/eslint.ts
@@ -1,29 +1,10 @@
 #!/usr/bin/env ts-node
 
+import * as Path from 'path'
 import chalk from 'chalk'
+import { execFile } from 'child_process'
 
-/**
- * A partial `eslint_d` client interface.
- * It currently only includes the methods actually used by this file.
- */
-interface IClient {
-  // there’s other stuff; I’m not including it
-  // because it’s not needed here.
-  // If you want to add to it, here’s the source:
-  // https://github.com/mantoni/eslint_d.js/blob/v5.1.0/lib/client.js
-  /**
-   * Lint a project using the ESLint server instance,
-   * or start a new instance if one is not available.
-   * @param args The arguments to pass to ESLint.
-   *             Interpreted as if passed after `eslint` on the command line.
-   * @param text The text to lint, if no files are passed as arguments.
-   */
-  lint(args: string[], text?: string): void
-}
-
-const client: IClient = require('eslint_d/lib/client')
-
-const ESLINT_ARGS = [
+const args = [
   '--cache',
   '--rulesdir=./eslint-rules',
   './{script,eslint-rules}/**/*.{j,t}s?(x)',
@@ -33,14 +14,14 @@ const ESLINT_ARGS = [
   ...process.argv.slice(2),
 ]
 
-client.lint(ESLINT_ARGS)
+const root = Path.join(__dirname, '..')
+const eslintPath = Path.join(root, 'node_modules', '.bin', 'eslint')
+const child = execFile(eslintPath, args, { cwd: root }, (err, stdout) => {
+  console.log(stdout)
+})
 
-type ProcessOnExit = (cb: (code: number) => void) => void
-/** HACK: allow process.on('exit') to be called with a `number` */
-const onExit = process.on.bind(process, 'exit') as ProcessOnExit
-
-onExit(code => {
-  if (code && ESLINT_ARGS.indexOf('--fix') === -1) {
+child.on('exit', code => {
+  if (code && args.indexOf('--fix') === -1) {
     console.error(
       chalk`{bold.green → To fix some of these errors, run {underline yarn eslint:fix}}`
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,7 +195,7 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.1.1, acorn@^5.2.1:
+acorn@^5.0.0, acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
@@ -214,7 +214,7 @@ ajv@^4.7.0, ajv@^4.9.1, ajv@^4.9.2:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.0, ajv@^5.2.3:
+ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
   dependencies:
@@ -2583,48 +2583,6 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.0.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.10.0.tgz#f25d0d7955c81968c2309aa5c9a229e045176bb7"
-  dependencies:
-    ajv "^5.2.0"
-    babel-code-frame "^6.22.0"
-    chalk "^2.1.0"
-    concat-stream "^1.6.0"
-    cross-spawn "^5.1.0"
-    debug "^3.0.1"
-    doctrine "^2.0.0"
-    eslint-scope "^3.7.1"
-    espree "^3.5.1"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
-    functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
-    globals "^9.17.0"
-    ignore "^3.3.3"
-    imurmurhash "^0.1.4"
-    inquirer "^3.0.6"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.9.1"
-    json-stable-stringify "^1.0.1"
-    levn "^0.3.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.2"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
-    progress "^2.0.0"
-    require-uncached "^1.0.3"
-    semver "^5.3.0"
-    strip-ansi "^4.0.0"
-    strip-json-comments "~2.0.1"
-    table "^4.0.1"
-    text-table "~0.2.0"
-
 eslint@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.12.0.tgz#a7ce78eba8cc8f2443acfbbc870cc31a65135884"
@@ -2666,23 +2624,6 @@ eslint@^4.12.0:
     strip-json-comments "~2.0.1"
     table "^4.0.1"
     text-table "~0.2.0"
-
-eslint_d@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/eslint_d/-/eslint_d-5.2.0.tgz#36b2817c4173f61c6dcf12567701321c81003635"
-  dependencies:
-    chalk "^1.1.1"
-    eslint "^4.0.0"
-    optionator "^0.8.1"
-    resolve "^1.1.7"
-    supports-color "^3.1.2"
-
-espree@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
-  dependencies:
-    acorn "^5.1.1"
-    acorn-jsx "^3.0.0"
 
 espree@^3.5.2:
   version "3.5.2"
@@ -3271,7 +3212,7 @@ globals@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.0.1.tgz#12a87bb010e5154396acc535e1e43fc753b0e5e8"
 
-globals@^9.17.0, globals@^9.18.0:
+globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -4894,7 +4835,7 @@ optimist@~0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -5899,7 +5840,7 @@ resolve-url@^0.2.1, resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.3.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:


### PR DESCRIPTION
`eslint_d` does some caching. In theory that's ok except that whenever Prettier's formatting changes, it means you have to manually stop the running daemon and restart it or it will keep reformatting the code wrongly.

That can be super confusing for everyone involved and more trouble than it's worth.