### PR TITLE
Update octicon colors in pull request dropdown

### DIFF
--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -59,7 +59,7 @@
 
   .selected:focus {
     .ci-status {
-      fill: var(--background-color);
+      color: inherit;
     }
   }
 

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -23,7 +23,7 @@
   .count {
     display: flex;
 
-    background: $gray-300;
+    background: $gray-200;
     color: var(--text-color);
 
     margin-left: var(--spacing-half);

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -57,6 +57,12 @@
     padding-bottom: var(--spacing-half);
   }
 
+  .selected:focus {
+    .ci-status {
+      fill: var(--background-color);
+    }
+  }
+
   .pull-request-item {
     padding: 0 var(--spacing);
     display: flex;

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -57,7 +57,7 @@
     padding-bottom: var(--spacing-half);
   }
 
-  .selected:focus {
+  .list-item.selected:focus {
     .ci-status {
       color: inherit;
     }

--- a/app/styles/ui/_ci-status.scss
+++ b/app/styles/ui/_ci-status.scss
@@ -4,7 +4,7 @@
 }
 
 .ci-status-pending {
-  color: $yellow-500;
+  color: $yellow-700;
 }
 
 .ci-status-failure {

--- a/app/styles/ui/_ci-status.scss
+++ b/app/styles/ui/_ci-status.scss
@@ -4,7 +4,7 @@
 }
 
 .ci-status-pending {
-  color: $orange-700;
+  color: $yellow-500;
 }
 
 .ci-status-failure {

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -1,5 +1,5 @@
 .toolbar-dropdown.open .pr-badge {
-  background: $gray-300;
+  background: $gray-200;
 }
 
 .toolbar-dropdown:not(.open) .pr-badge {

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -35,7 +35,7 @@
 }
 
 .toolbar-dropdown.open .ci-status-pending {
-  color: $orange-800;
+  color: $yellow-500;
 }
 
 .toolbar-dropdown.open .ci-status-failure {

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -35,7 +35,7 @@
 }
 
 .toolbar-dropdown.open .ci-status-pending {
-  color: $yellow-500;
+  color: $yellow-700;
 }
 
 .toolbar-dropdown.open .ci-status-failure {

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -43,5 +43,5 @@
 }
 
 .toolbar-dropdown.open .ci-status-success {
-  color: $green-700;
+  color: $green-500;
 }


### PR DESCRIPTION
This pull request updates the octicons in the pull request dropdown.
Here's what it looked like before (notice that the octicon's isn't legible if the list item is in focus.)

![image](https://user-images.githubusercontent.com/1174461/33347994-8d308e8e-d449-11e7-92d4-2f091e2c7233.png)

I went ahead and updated them so that they're more aligned with the colors on the web. Specifically, the greens are a little brighter and we're using yellow instead of orange for the pending dot. I also lightened the gray background for the pull request counter:

<img width="983" alt="screen shot 2017-11-28 at 2 31 26 pm" src="https://user-images.githubusercontent.com/1174461/33348083-cc016f84-d449-11e7-896f-3a4fb91a5dbc.png">
<img width="627" alt="screen shot 2017-11-28 at 2 30 17 pm" src="https://user-images.githubusercontent.com/1174461/33348085-cc15c04c-d449-11e7-8ca6-bb991cdd2727.png">
<img src="https://user-images.githubusercontent.com/1174461/33348111-e3666e40-d449-11e7-9a3a-37fbd74a8111.gif" />

😎 