### PR TITLE
Repository: Allow for Retry When Not Found

### DIFF
--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -34,6 +34,12 @@ export class MissingRepository extends React.Component<
     }
 
     buttons.push(
+      <Button key="retry" onClick={this.retry}>
+        Retry
+      </Button>
+    )
+
+    buttons.push(
       <Button key="remove" onClick={this.remove}>
         Remove
       </Button>
@@ -57,6 +63,10 @@ export class MissingRepository extends React.Component<
   private canCloneAgain() {
     const gitHubRepository = this.props.repository.gitHubRepository
     return gitHubRepository && gitHubRepository.cloneURL
+  }
+
+  private retry = () => {
+    this.props.dispatcher.updateRepositoryMissing(this.props.repository, false)
   }
 
   private remove = () => {


### PR DESCRIPTION
- Addresses #3301 

Testing:
- Clone Repo
- Moving cloned repo to different folder, see that it is "unfindable"

Postitive Test Case:
- Moved repo back to original location hit `retry`, see that its resolved

Negative Test Case:
- Hit `retry`, see that its not resolved