### PR TITLE
Add Hyper to Shell choices on Windows

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -61,10 +61,10 @@ export async function getAvailableShells(): Promise<
     'HKEY_CURRENT_USER\\Software\\Classes\\Directory\\Background\\shell\\Hyper\\command'
   )
   if (hyper.length > 0) {
-    const commandPieces = hyper[0].value.match(
-      /(["'])(.*?)\1/
-    )
-    const path = commandPieces ? commandPieces[2] : process.env.LocalAppData.concat('\\hyper\\Hyper.exe')
+    const commandPieces = hyper[0].value.match(/(["'])(.*?)\1/)
+    const path = commandPieces
+      ? commandPieces[2]
+      : process.env.LocalAppData.concat('\\hyper\\Hyper.exe')
     shells.push({
       shell: Shell.Hyper,
       path: path,

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -7,6 +7,7 @@ import { IFoundShell } from './found-shell'
 export enum Shell {
   Cmd = 'Command Prompt',
   PowerShell = 'PowerShell',
+  Hyper = 'Hyper',
   GitBash = 'Git Bash',
 }
 
@@ -19,6 +20,10 @@ export function parse(label: string): Shell {
 
   if (label === Shell.PowerShell) {
     return Shell.PowerShell
+  }
+
+  if (label === Shell.Hyper) {
+    return Shell.Hyper
   }
 
   if (label === Shell.GitBash) {
@@ -49,6 +54,20 @@ export async function getAvailableShells(): Promise<
     shells.push({
       shell: Shell.PowerShell,
       path,
+    })
+  }
+
+  const hyper = await readRegistryKeySafe(
+    'HKEY_CURRENT_USER\\Software\\Classes\\Directory\\Background\\shell\\Hyper\\command'
+  )
+  if (hyper.length > 0) {
+    const commandPieces = hyper[0].value.match(
+      /(["'])(.*?)\1/
+    )
+    const path = commandPieces ? commandPieces[2] : process.env.LocalAppData.concat('\\hyper\\Hyper.exe')
+    shells.push({
+      shell: Shell.Hyper,
+      path: path,
     })
   }
 
@@ -98,6 +117,12 @@ export async function launch(
       }
     )
     addErrorTracing(`PowerShell`, cp)
+  } else if (shell === Shell.Hyper) {
+    const cp = spawn(`"${foundShell.path}"`, [`"${path}"`], {
+      shell: true,
+      cwd: path,
+    })
+    addErrorTracing(`Hyper`, cp)
   } else if (shell === Shell.GitBash) {
     const cp = spawn(`"${foundShell.path}"`, [`--cd="${path}"`], {
       shell: true,

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -61,10 +61,14 @@ export async function getAvailableShells(): Promise<
     'HKEY_CURRENT_USER\\Software\\Classes\\Directory\\Background\\shell\\Hyper\\command'
   )
   if (hyper.length > 0) {
+    // Registry key is structured as "{installationPath}\app-x.x.x\Hyper.exe" "%V"
+
+    // Get the pieces in between quotes
+    // commandPieces = ['"{installationPath}\app-x.x.x\Hyper.exe"', '"', '{installationPath}\app-x.x.x\Hyper.exe', ...]
     const commandPieces = hyper[0].value.match(/(["'])(.*?)\1/)
     const path = commandPieces
-      ? commandPieces[2]
-      : process.env.LocalAppData.concat('\\hyper\\Hyper.exe')
+      ? commandPieces[2] // Get path from the pieces when not null
+      : process.env.LocalAppData.concat('\\hyper\\Hyper.exe') // Else fall back to the launcher in install root
     shells.push({
       shell: Shell.Hyper,
       path: path,


### PR DESCRIPTION
[Hyper](https://hyper.is) was added for macOS when implementing #888 but not for Windows.

This uses the `HKEY_CURRENT_USER\Software\Classes\Directory\\Background\shell\Hyper\command` registry key to get the version-specific path to `Hyper.exe` e.g. `C:\Users\Jordan\AppData\Local\hyper\app-1.4.8\Hyper.exe` which can be given an argument of the directory to start the shell in.

If the key is empty then this falls back to the generic executable `%LOCALAPPDATA%\hyper\Hyper.exe` which currently does not accept a parameter to specify the directory.

See https://github.com/zeit/hyper/issues/1920#issuecomment-307623677