### PR TITLE
Adds BBEdit to the list of avilable macOS editors

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -122,7 +122,7 @@ export async function getAvailableEditors(): Promise<
   }
 
   if (bbeditPath) {
-    results.push({ editor: ExternalEditor.BBEdit, path: bbedit.bbeditPath })
+    results.push({ editor: ExternalEditor.BBEdit, path: bbeditPath })
   }
 
   return results

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -7,6 +7,7 @@ export enum ExternalEditor {
   Atom = 'Atom',
   VisualStudioCode = 'Visual Studio Code',
   SublimeText = 'Sublime Text',
+  BBEdit = 'BBEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -19,6 +20,9 @@ export function parse(label: string): ExternalEditor | null {
   }
   if (label === ExternalEditor.SublimeText) {
     return ExternalEditor.SublimeText
+  }
+  if (label === ExternalEditor.BBEdit) {
+    return ExternalEditor.BBEdit
   }
 
   return null
@@ -37,6 +41,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.microsoft.VSCode', 'com.microsoft.VSCodeInsiders']
     case ExternalEditor.SublimeText:
       return ['com.sublimetext.3']
+    case ExternalEditor.BBEdit:
+      return ['com.barebones.bbedit']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -60,6 +66,8 @@ function getExecutableShim(
       )
     case ExternalEditor.SublimeText:
       return Path.join(installPath, 'Contents', 'SharedSupport', 'bin', 'subl')
+    case ExternalEditor.BBEdit:
+      return Path.join(installPath, 'Contents', 'Helpers', 'bbedit_tool')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -94,10 +102,11 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [atomPath, codePath, sublimePath] = await Promise.all([
+  const [atomPath, codePath, sublimePath, bbeditPath] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
     findApplication(ExternalEditor.SublimeText),
+    findApplication(ExternalEditor.BBEdit),
   ])
 
   if (atomPath) {
@@ -110,6 +119,10 @@ export async function getAvailableEditors(): Promise<
 
   if (sublimePath) {
     results.push({ editor: ExternalEditor.SublimeText, path: sublimePath })
+  }
+
+  if (bbeditPath) {
+    results.push({ editor: ExternalEditor.BBEdit, path: bbedit.bbeditPath })
   }
 
   return results

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -204,6 +204,7 @@ These editors are currently supported:
  - [Atom](https://atom.io/)
  - [Visual Studio Code](https://code.visualstudio.com/)
  - [Sublime Text](https://www.sublimetext.com/)
+ - [BBEdit](http://www.barebones.com/products/bbedit/)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
This is pull request number two, since the first one ([pull/2941](https://github.com/desktop/desktop/pull/2941)) got borked. I'm sorry for the confusion caused.