### PR TITLE
Add Clojure syntax highlighting

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -93,6 +93,9 @@ extensionMIMEMap.set('.py', 'text/x-python')
 import 'codemirror/mode/ruby/ruby'
 extensionMIMEMap.set('.rb', 'text/x-ruby')
 
+import 'codemirror/mode/clojure/clojure'
+extensionMIMEMap.set('.clj', 'text/x-clojure')
+
 function guessMimeType(contents: string) {
   if (contents.startsWith('<?xml')) {
     return 'text/xml'

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby
+JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
Add Clojure syntax highlighting to desktop (companion test file here: https://github.com/desktop/highlighter-tests/pull/10)

![image](https://user-images.githubusercontent.com/2616083/33685969-27f66eea-da88-11e7-93b5-d0b7e1e8442d.png)