### PR TITLE
throw an error if a current pull request exists

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -419,11 +419,20 @@ export class App extends React.Component<IAppProps, IAppState> {
     const tip = state.state.branchesState.tip
 
     if (tip.kind === TipState.Valid) {
-      this.props.dispatcher.showPopup({
-        type: PopupType.DeleteBranch,
-        repository: state.repository,
-        branch: tip.branch,
-      })
+      const currentPullRequest = state.state.branchesState.currentPullRequest
+      if (currentPullRequest) {
+        this.props.dispatcher.postError(
+          new Error(
+            `You can't delete this branch because it has an open pull request.`
+          )
+        )
+      } else {
+        this.props.dispatcher.showPopup({
+          type: PopupType.DeleteBranch,
+          repository: state.repository,
+          branch: tip.branch,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #3453 

I'd rather not get into designing a whole new dialog for this. Also, I'd rather not disable the menu item as it lacks the context of the website to tell people _why_ it's blocked from the UI:

 - [x] throw up a simple dialog when the current branch has an open PR
