### PR TITLE
Fix pull request list keyboard navigation

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -337,7 +337,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     if (event.key === 'ArrowDown') {
       if (this.state.rows.length > 0) {
         const selectedRow = list.nextSelectableRow('down', -1)
-        if (selectedRow) {
+        if (selectedRow != null) {
           this.setState({ selectedRow }, () => {
             list.focus()
           })
@@ -348,7 +348,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     } else if (event.key === 'ArrowUp') {
       if (this.state.rows.length > 0) {
         const selectedRow = list.nextSelectableRow('up', 0)
-        if (selectedRow) {
+        if (selectedRow != null) {
           this.setState({ selectedRow }, () => {
             list.focus()
           })

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -367,7 +367,7 @@ export class List extends React.Component<IListProps, IListState> {
   ) {
     const newRow = this.nextSelectableRow(direction, this.props.selectedRow)
 
-    if (newRow !== null) {
+    if (newRow != null) {
       if (this.props.onSelectionChanged) {
         this.props.onSelectionChanged(newRow, { kind: 'keyboard', event })
       }


### PR DESCRIPTION
Fixes #3499

We were checking falsiness which includes 0, but 0's totally a valid row. We hadn't run into this bug yet because in all of our other lists, the 0th row is always a non-selectable header of some type so it was skipped already.