### PR TITLE
put history view into the correct state after a successful pull 

### DIFF
--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -8,3 +8,16 @@ export async function merge(
 ): Promise<void> {
   await git(['merge', branch], repository.path, 'merge')
 }
+
+export async function getMergeBase(
+  repository: Repository,
+  firstRef: string,
+  secondRef: string
+): Promise<string> {
+  const process = await git(
+    ['merge-base', firstRef, secondRef],
+    repository.path,
+    'merge-base'
+  )
+  return process.stdout.trim()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1978,7 +1978,7 @@ export class AppStore {
           mergeBase = await getMergeBase(
             repository,
             tip.branch.name,
-            tip.branch.upstream!
+            tip.branch.upstream
           )
         }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2021,6 +2021,8 @@ export class AppStore {
             value: refreshStartProgress,
           })
 
+          gitStore.invalidateHistory()
+
           await this._refreshRepository(repository)
 
           this.updatePushPullFetchProgress(repository, {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -138,6 +138,10 @@ export class GitStore {
     return this.emitter.on('did-error', fn)
   }
 
+  /**
+   * Reconcile the local history view with the repository state
+   * after a pull has completed, to include merged remote commits.
+   */
   public async reconcileHistory(mergeBase: string): Promise<void> {
     if (this._history.length === 0) {
       return

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -156,7 +156,7 @@ export class GitStore {
     const commits = await this.performFailableOperation(() =>
       getCommits(this.repository, `HEAD..${mergeBase}`, CommitBatchSize)
     )
-    if (!commits) {
+    if (commits == null) {
       return
     }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -164,6 +164,12 @@ export class GitStore {
     const index = existingHistory.findIndex(c => c === mergeBase)
 
     if (index > -1) {
+      log.debug(
+        `reconciling history - adding ${
+          commits.length
+        } commits before merge base ${mergeBase.substr(0, 8)}`
+      )
+
       // rebuild the local history state by combining the commits _before_ the
       // merge base with the current commits on the tip of this current branch
       const remainingHistory = existingHistory.slice(index)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -138,6 +138,10 @@ export class GitStore {
     return this.emitter.on('did-error', fn)
   }
 
+  public invalidateHistory() {
+    this._history = new Array()
+  }
+
   /** Load history from HEAD. */
   public async loadHistory() {
     if (this.requestsInFight.has(LoadingHistoryRequestKey)) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -157,14 +157,12 @@ export class GitStore {
     const index = existingHistory.findIndex(c => c === mergeBase)
 
     if (index > -1) {
+      // rebuild the local history state by combining the commits _before_ the
+      // merge base with the current commits on the tip of this current branch
       const remainingHistory = existingHistory.slice(index)
-      // TODO: confirm we don't have duplicates of the merge base
-      // TODO: confirm this list includes the merge base
       this._history = [...commits.map(c => c.sha), ...remainingHistory]
     }
 
-    // TODO: commits may contain existing local commits
-    //       are there any gotchas in here to worry about?
     this.storeCommits(commits)
     this.emitNewCommitsLoaded(commits)
     this.emitUpdate()

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -146,14 +146,14 @@ export class GitStore {
       return
     }
 
-    let commits = await this.performFailableOperation(() =>
+    const commits = await this.performFailableOperation(() =>
       getCommits(this.repository, `HEAD..${mergeBase}`, CommitBatchSize)
     )
     if (!commits) {
       return
     }
 
-    let existingHistory = this._history
+    const existingHistory = this._history
     const index = existingHistory.findIndex(c => c === mergeBase)
 
     if (index > -1) {


### PR DESCRIPTION
Fixes #2737 

The problem manifests itself in a couple of ways:

 - you have some existing history to look at
 - you perform a pull which merges in some remote commits

Because of how `loadHistory` merges new commits with the current history, you can find yourself in a situation where remote commits (which occurred _before_ the tip of the current history) are not loaded into this array of commits.

https://github.com/desktop/desktop/blob/f12ff8c4775904bbb44ef6fdb78b26e734c14455/app/src/lib/stores/git-store.ts#L156-L171

The quick fix for this is to nuke the history and let it reload, but results in a flicker when you are viewing the list. This is also probably bad for scenarios where you've scrolled down the history.

The better fix for this is to reconcile the two histories manually. Given the remote ref and local branch should share a common ancestor, we should be able to invalidate a subset of the commits currently loaded: 

```shellsession
$ git merge-base master origin/master
b7641d1de6ca0b05b0279266df9120f6a945bf52
```

This also means that an existing selected commit is remembered, even after moving the history around.