### PR TITLE
address recent CircleCI issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,15 @@ dependencies:
 
   pre:
     - brew update
-    - brew upgrade node@8
-    - brew install yarn
+    # uninstall Node 6 which is shipped by default on Circle
+    - brew uninstall node
+    # install latest Node LTS (8.9.3 as of writing)
+    - brew install node@8 --force
+    # everything is terrible, but we must march on
+    - brew link --overwrite node@8 --force
+    # this isn't the recommended way but some dependencies don't
+    # yet have native bindings for Node 9.2.1
+    - npm install -g yarn
 
   override:
     - yarn install --force


### PR DESCRIPTION
The last three PR builds on Circle all fail installing node:

```shellsession
$ brew upgrade node@8
Error: node@8 not installed

brew upgrade node@8 returned exit code 1

Action failed: brew upgrade node@8
```

This also uncovers a different issue, where `yarn` (which now references Node 9.2.1 rather than the one previously chosen) and fails to build the native bindings right:

```
yarn install v1.3.2
...
[5/5] 📃  Rebuilding all packages...
error /Users/distiller/Desktop/node_modules/rabin-bindings: Command failed.
Exit code: 127
Command: prebuild-install || node-gyp rebuild
Arguments: 
Directory: /Users/distiller/Desktop/node_modules/rabin-bindings
Output:
prebuild-install info begin Prebuild-install version 2.3.0
prebuild-install info looking for local prebuild @ prebuilds/rabin-bindings-v1.7.3-node-v59-darwin-x64.tar.gz
prebuild-install info npm cache directory missing, creating it... 
prebuild-install info looking for cached prebuild @ /Users/distiller/.npm/_prebuilds/https-github.com-develar-rabin-bindings-releases-download-v1.7.3-rabin-bindings-v1.7.3-node-v59-darwin-x64.tar.gz
prebuild-install http request GET https://github.com/develar/rabin-bindings/releases/download/v1.7.3/rabin-bindings-v1.7.3-node-v59-darwin-x64.tar.gz
prebuild-install http 404 https://github.com/develar/rabin-bindings/releases/download/v1.7.3/rabin-bindings-v1.7.3-node-v59-darwin-x64.tar.gz
prebuild-install WARN install No prebuilt binaries found (target=9.2.1 runtime=node arch=x64 platform=darwin)
/bin/sh: node-gyp: command not found
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

I've got Christmas things to do this weekend, but shout if you spot anything interesting what might have changed in CircleCI's configuration or Homebrew that might explain these issues suddenly appearing...