### PR TITLE
[WIP] more flexible electron-builder setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ script:
   - yarn build:prod
   - yarn test:setup
   - yarn test
+  - yarn run package
 
 after_failure:
   - yarn test:review

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
     "electron": "1.7.9",
-    "electron-builder": "19.45.5",
+    "electron-builder": "19.48.3",
     "electron-installer-appimage": "^1.0.1",
     "electron-mocha": "^5.0.0",
     "electron-packager": "^8.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,14 @@
     "7zip-bin-mac" "^1.0.1"
     "7zip-bin-win" "^2.1.1"
 
+"7zip-bin@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-2.3.4.tgz#0861a3c99793dd794f4dd6175ec4ddfa6af8bc9d"
+  optionalDependencies:
+    "7zip-bin-linux" "^1.1.0"
+    "7zip-bin-mac" "^1.0.1"
+    "7zip-bin-win" "^2.1.1"
+
 "@types/byline@^4.2.31":
   version "4.2.31"
   resolved "https://registry.yarnpkg.com/@types/byline/-/byline-4.2.31.tgz#0e61fcb9c03e047d21c4496554c7116297ab60cd"
@@ -203,7 +211,7 @@ ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
-ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
+ajv-keywords@^2.0.0, ajv-keywords@^2.1.0, ajv-keywords@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
@@ -226,6 +234,15 @@ ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3:
 ajv@^5.3.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -303,16 +320,16 @@ app-package-builder@1.3.3:
     js-yaml "^3.10.0"
     rabin-bindings "~1.7.3"
 
-app-package-builder@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/app-package-builder/-/app-package-builder-1.5.0.tgz#3263598b07ac577b3df2205171a449f2dd5f30ca"
+app-package-builder@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/app-package-builder/-/app-package-builder-1.5.3.tgz#a24776370dae3b7c35e7aedfbc77b93137d2ab4c"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^3.2.1"
-    builder-util-runtime "^3.1.0"
+    builder-util "^3.4.3"
+    builder-util-runtime "^3.3.0"
     fs-extra-p "^4.4.4"
-    int64-buffer "^0.1.9"
-    rabin-bindings "~1.7.3"
+    int64-buffer "^0.1.10"
+    rabin-bindings "~1.7.4"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -1144,13 +1161,13 @@ builder-util-runtime@2.5.0, builder-util-runtime@^2.5.0:
     fs-extra-p "^4.4.4"
     sax "^1.2.4"
 
-builder-util-runtime@3.2.0, builder-util-runtime@^3.1.0, builder-util-runtime@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-3.2.0.tgz#b946032b61c940533fa5e8f05afc550b8e56c94c"
+builder-util-runtime@3.3.1, builder-util-runtime@^3.3.0, builder-util-runtime@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-3.3.1.tgz#d905cd5b7be7e60124a532ddd0e988e12c1bd5c3"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
-    fs-extra-p "^4.4.4"
+    fs-extra-p "^4.4.5"
     sax "^1.2.4"
 
 builder-util@3.2.0, builder-util@^3.2.0:
@@ -1174,46 +1191,25 @@ builder-util@3.2.0, builder-util@^3.2.0:
     temp-file "^2.0.3"
     tunnel-agent "^0.6.0"
 
-builder-util@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.2.2.tgz#9660f74f168f6d4e175ca3c25c8e0d0ed7ff965c"
+builder-util@3.4.4, builder-util@^3.4.2, builder-util@^3.4.3:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.4.4.tgz#cab30f37c1ee4fb23d33b20ac71e76e3c8451d28"
   dependencies:
-    "7zip-bin" "^2.2.7"
+    "7zip-bin" "^2.3.4"
     bluebird-lst "^1.0.5"
-    builder-util-runtime "^3.2.0"
+    builder-util-runtime "^3.3.1"
     chalk "^2.3.0"
     debug "^3.1.0"
-    fs-extra-p "^4.4.4"
-    ini "^1.3.4"
-    is-ci "^1.0.10"
-    js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
-    node-emoji "^1.8.1"
-    semver "^5.4.1"
-    source-map-support "^0.5.0"
-    stat-mode "^0.2.2"
-    temp-file "^2.0.3"
-    tunnel-agent "^0.6.0"
-
-builder-util@^3.2.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-3.4.1.tgz#b9f079ff4c279699ca52f42930bab1c19ff62517"
-  dependencies:
-    "7zip-bin" "^2.2.7"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^3.2.0"
-    chalk "^2.3.0"
-    debug "^3.1.0"
-    fs-extra-p "^4.4.4"
+    fs-extra-p "^4.4.5"
     ini "^1.3.5"
     is-ci "^1.0.10"
     js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
+    lazy-val "^1.0.3"
     node-emoji "^1.8.1"
     semver "^5.4.1"
     source-map-support "^0.5.0"
     stat-mode "^0.2.2"
-    temp-file "^2.1.1"
+    temp-file "^3.0.0"
     tunnel-agent "^0.6.0"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
@@ -2030,12 +2026,12 @@ dmg-builder@2.1.5:
     js-yaml "^3.10.0"
     parse-color "^1.0.0"
 
-dmg-builder@2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-2.1.6.tgz#a37f0c8360794a7051a30a571582968cb1e3ce30"
+dmg-builder@2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-2.1.8.tgz#80455063144a4e7446d55acae6e01bafc4137f7d"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^3.2.1"
+    builder-util "^3.4.2"
     debug "^3.1.0"
     fs-extra-p "^4.4.4"
     iconv-lite "^0.4.19"
@@ -2135,38 +2131,52 @@ ejs@^2.5.7, ejs@~2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-builder@19.45.5:
-  version "19.45.5"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-19.45.5.tgz#67a949d71cd2e947efd333fc9a933bd36c552cc6"
+electron-builder-lib@19.48.3:
+  version "19.48.3"
+  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-19.48.3.tgz#2d04948f1f0a98dc0edc4578b591122bde7440f6"
   dependencies:
-    "7zip-bin" "^2.2.7"
-    app-package-builder "1.5.0"
+    "7zip-bin" "^2.3.4"
+    app-package-builder "1.5.3"
     asar-integrity "0.2.3"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"
-    builder-util "3.2.2"
-    builder-util-runtime "3.2.0"
-    chalk "^2.3.0"
+    builder-util "3.4.4"
+    builder-util-runtime "3.3.1"
     chromium-pickle-js "^0.2.0"
     debug "^3.1.0"
-    dmg-builder "2.1.6"
+    dmg-builder "2.1.8"
     ejs "^2.5.7"
-    electron-download-tf "4.3.4"
     electron-osx-sign "0.4.7"
-    electron-publish "19.45.0"
-    fs-extra-p "^4.4.4"
+    electron-publish "19.46.5"
+    fs-extra-p "^4.4.5"
     hosted-git-info "^2.5.0"
     is-ci "^1.0.10"
     isbinaryfile "^3.0.2"
     js-yaml "^3.10.0"
-    lazy-val "^1.0.2"
+    lazy-val "^1.0.3"
     minimatch "^3.0.4"
     normalize-package-data "^2.4.0"
     plist "^2.1.0"
-    read-config-file "1.2.0"
+    read-config-file "1.2.1"
     sanitize-filename "^1.6.1"
     semver "^5.4.1"
-    temp-file "^2.0.3"
+    temp-file "^3.0.0"
+
+electron-builder@19.48.3:
+  version "19.48.3"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-19.48.3.tgz#5bfa39c73aa8c17a1ef1775af70b0a8b20b8011f"
+  dependencies:
+    bluebird-lst "^1.0.5"
+    builder-util "3.4.4"
+    builder-util-runtime "3.3.1"
+    chalk "^2.3.0"
+    electron-builder-lib "19.48.3"
+    electron-download-tf "4.3.4"
+    fs-extra-p "^4.4.5"
+    is-ci "^1.0.10"
+    lazy-val "^1.0.3"
+    read-config-file "1.2.1"
+    sanitize-filename "^1.6.1"
     update-notifier "^2.3.0"
     yargs "^10.0.3"
 
@@ -2343,13 +2353,13 @@ electron-publish@19.43.0:
     fs-extra-p "^4.4.4"
     mime "^2.0.3"
 
-electron-publish@19.45.0:
-  version "19.45.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-19.45.0.tgz#7cdcf4f54dd821bffaf4dcc59b21223cfbd8ac4c"
+electron-publish@19.46.5:
+  version "19.46.5"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-19.46.5.tgz#eb545af247edc78297a9ace6ebb2bad7c0fcc2a4"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^3.2.1"
-    builder-util-runtime "^3.1.0"
+    builder-util "^3.4.2"
+    builder-util-runtime "^3.3.0"
     chalk "^2.3.0"
     fs-extra-p "^4.4.4"
     mime "^2.0.3"
@@ -2998,6 +3008,13 @@ fs-extra-p@^4.4.0, fs-extra-p@^4.4.4:
     bluebird-lst "^1.0.4"
     fs-extra "^4.0.2"
 
+fs-extra-p@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.4.5.tgz#90875f2615b53d0085b562e15d579281b9d454c2"
+  dependencies:
+    bluebird-lst "^1.0.5"
+    fs-extra "^4.0.3"
+
 fs-extra@0.26.7, fs-extra@^0.26.7:
   version "0.26.7"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
@@ -3036,6 +3053,14 @@ fs-extra@^3.0.0:
 fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3595,6 +3620,10 @@ inquirer@~3.0.6:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
+int64-buffer@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
+
 int64-buffer@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.9.tgz#9e039da043b24f78b196b283e04653ef5e990f61"
@@ -4076,6 +4105,10 @@ lazy-val@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.2.tgz#d9b07fb1fce54cbc99b3c611de431b83249369b6"
 
+lazy-val@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.3.tgz#bb97b200ef00801d94c317e29dc6ed39e31c5edc"
+
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -4492,6 +4525,10 @@ mute-stream@0.0.7:
 nan@^2.3.0, nan@^2.3.2, nan@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nan@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 nanomatch@^1.2.5:
   version "1.2.5"
@@ -5497,6 +5534,14 @@ rabin-bindings@~1.7.3:
     nan "^2.7.0"
     prebuild-install "^2.3.0"
 
+rabin-bindings@~1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/rabin-bindings/-/rabin-bindings-1.7.4.tgz#174581d3b9a3c1b09ece75dc21f1b4ae0dd79974"
+  dependencies:
+    bindings "^1.3.0"
+    nan "^2.8.0"
+    prebuild-install "^2.3.0"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -5543,6 +5588,20 @@ read-config-file@1.2.0:
     ajv "^5.2.3"
     ajv-keywords "^2.1.0"
     bluebird-lst "^1.0.4"
+    dotenv "^4.0.0"
+    dotenv-expand "^4.0.1"
+    fs-extra-p "^4.4.4"
+    js-yaml "^3.10.0"
+    json5 "^0.5.1"
+    lazy-val "^1.0.2"
+
+read-config-file@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-1.2.1.tgz#f889ea5c13372319433f5df09d7a9742c72d0b25"
+  dependencies:
+    ajv "^5.5.1"
+    ajv-keywords "^2.1.1"
+    bluebird-lst "^1.0.5"
     dotenv "^4.0.0"
     dotenv-expand "^4.0.1"
     fs-extra-p "^4.4.4"
@@ -6503,9 +6562,9 @@ temp-file@^2.0.3:
     fs-extra-p "^4.4.0"
     lazy-val "^1.0.2"
 
-temp-file@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-2.1.1.tgz#7c2db304595007461b16a06e3625639cbf69a91d"
+temp-file@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-3.0.0.tgz#1e9eca9c411a41564f5746bc2774c39080021db0"
   dependencies:
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"


### PR DESCRIPTION
The `electron-installer-*` packages are nice helpers, but it'd be really nice if we could just use `electron-builder` directly, with our prebuilt output. Let's see what this feels like.

 - [ ] confirm we can still generate packages
 - [ ] experiment with [CLI interface](https://www.electron.build/cli) to generate AppImage instead
 - [ ] ???