### PR TITLE
Fixes #3013 Cannot create a branch beginning with a period

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -231,7 +231,7 @@ export class CreateBranch extends React.Component<
 
   public render() {
     const disabled =
-      !this.state.proposedName.length ||
+      this.state.proposedName.length <= 0 ||
       !!this.state.currentError ||
       /^\s*$/.test(this.state.sanitizedName)
     const error = this.state.currentError

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -230,11 +230,10 @@ export class CreateBranch extends React.Component<
   }
 
   public render() {
-    const proposedName = this.state.proposedName
     const disabled =
-      !proposedName.length ||
+      !this.state.proposedName.length ||
       !!this.state.currentError ||
-      /^\s*$/.test(this.state.proposedName)
+      /^\s*$/.test(this.state.sanitizedName)
     const error = this.state.currentError
 
     return (

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -16,7 +16,7 @@ export function renderBranchNameWarning(
   proposedName: string,
   sanitizedName: string
 ) {
-  if (/^\s+$/.test(proposedName)) {
+  if (proposedName !== '' && /^\s*$/.test(sanitizedName)) {
     return renderWarningMessage('Branch name cannot be empty')
   } else if (proposedName !== sanitizedName) {
     return renderWarningMessage(`Will be created as ${sanitizedName}`)

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -8,7 +8,7 @@ export function renderBranchNameWarning(
   proposedName: string,
   sanitizedName: string
 ) {
-  if (proposedName !== '' && /^\s*$/.test(sanitizedName)) {
+  if (proposedName.length > 0 && /^\s*$/.test(sanitizedName)) {
     return (
       <Row className="warning-helper-text">
         <Octicon symbol={OcticonSymbol.alert} />

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -2,24 +2,30 @@ import * as React from 'react'
 
 import { Row } from './row'
 import { Octicon, OcticonSymbol } from '../octicons'
-
-function renderWarningMessage(message: string) {
-  return (
-    <Row className="warning-helper-text">
-      <Octicon symbol={OcticonSymbol.alert} />
-      {message}
-    </Row>
-  )
-}
+import { Ref } from './ref'
 
 export function renderBranchNameWarning(
   proposedName: string,
   sanitizedName: string
 ) {
   if (proposedName !== '' && /^\s*$/.test(sanitizedName)) {
-    return renderWarningMessage('Branch name cannot be empty')
+    return (
+      <Row className="warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+        <p>
+          <Ref>{proposedName}</Ref> is not a valid branch name.
+        </p>
+      </Row>
+    )
   } else if (proposedName !== sanitizedName) {
-    return renderWarningMessage(`Will be created as ${sanitizedName}`)
+    return (
+      <Row className="warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+        <p>
+          Will be created as <Ref>{sanitizedName}</Ref>.
+        </p>
+      </Row>
+    )
   } else {
     return null
   }


### PR DESCRIPTION
Fixes #3013 by calculating the disabled state based on the sanitized name (the name that will actually be used to create the branch)

I would appreciate some feedback on how to inform the user about why the name is invalid.

Before this PR entering `--` would give:
![image](https://user-images.githubusercontent.com/2552068/33807371-d6f98308-ddcd-11e7-89a3-49d342ed34fd.png)
With this PR:
![image](https://user-images.githubusercontent.com/2552068/33807374-e0f8c92c-ddcd-11e7-9c62-f49ad0fba3f6.png)

In general before the PR, entered names that resolve to empty will result in the `Will be created as ` warning (empty name argument) which is confusing as that name cannot be created.
With this PR, they result in the `Branch name cannot be empty` warning.

Neither is that helpful to the user for understanding the problem. Any thoughts?