### PR TITLE
Fixes #3551 updateLabel

### DIFF
--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -79,7 +79,7 @@ export class RepositoriesList extends React.Component<
 
   private getGroupLabel(identifier: RepositoryGroupIdentifier) {
     if (identifier === 'github') {
-      return 'GitHub'
+      return 'GitHub.com'
     } else if (identifier === 'enterprise') {
       return 'Enterprise'
     } else if (identifier === 'other') {


### PR DESCRIPTION
For consistency, update the label in the repo list to "GitHub.com"