### PR TITLE
Misc Windows app menu fixes

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -273,6 +273,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       menuStateBuilder.enable('remove-repository')
     }
 
+    menuStateBuilder.disable('create-branch')
     menuStateBuilder.disable('rename-branch')
     menuStateBuilder.disable('delete-branch')
     menuStateBuilder.disable('update-branch')

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -258,7 +258,7 @@ export class AppMenuBarButton extends React.Component<
   private dropDownContentRenderer = () => {
     const menuState = this.props.menuState
 
-    if (!this.isMenuOpen) {
+    if (!this.isMenuOpen || !this.props.menuItem.enabled) {
       return null
     }
 

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -185,7 +185,6 @@ export class AppMenuBarButton extends React.Component<
   public render() {
     const item = this.props.menuItem
     const dropDownState = this.isMenuOpen ? 'open' : 'closed'
-    const disabled = !item.enabled
 
     return (
       <ToolbarDropdown
@@ -197,7 +196,6 @@ export class AppMenuBarButton extends React.Component<
         showDisclosureArrow={false}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}
-        disabled={disabled}
         tabIndex={-1}
         role="menuitem"
       >

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -258,7 +258,7 @@ export class AppMenuBarButton extends React.Component<
   private dropDownContentRenderer = () => {
     const menuState = this.props.menuState
 
-    if (!this.isMenuOpen || !this.props.menuItem.enabled) {
+    if (!this.isMenuOpen) {
       return null
     }
 

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -64,6 +64,21 @@ export type CloseSource = IKeyboardCloseSource | IItemExecutedCloseSource
 
 const expandCollapseTimeout = 300
 
+function menuPaneClassNameFromId(id: string) {
+  const className = id
+    // Get rid of the leading @. for auto-generated ids
+    .replace(/^@\./, '')
+    // No accelerator key modifier necessary
+    .replace('&', '')
+    // Get rid of stuff that's not safe for css class names
+    .replace(/[^a-z0-9_]+/gi, '-')
+    // Get rid of redundant underscores
+    .replace(/_+/, '_')
+    .toLowerCase()
+
+  return className.length ? `menu-pane-${className}` : undefined
+}
+
 export class AppMenu extends React.Component<IAppMenuProps, {}> {
   /**
    * The index of the menu pane that should receive focus after the
@@ -267,11 +282,13 @@ export class AppMenu extends React.Component<IAppMenuProps, {}> {
     // versa.
     // If the menu doesn't have an id it's the root menu
     const key = menu.id || '@'
+    const className = menu.id ? menuPaneClassNameFromId(menu.id) : undefined
 
     return (
       <MenuPane
         key={key}
         ref={this.onMenuPaneRef}
+        className={className}
         autoHeight={this.props.autoHeight}
         depth={depth}
         items={menu.items}

--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -64,6 +64,11 @@ export type CloseSource = IKeyboardCloseSource | IItemExecutedCloseSource
 
 const expandCollapseTimeout = 300
 
+/**
+ * Converts a menu pane id into something that's reasonable to use as
+ * a classname by replacing forbidden characters and cleaning it
+ * up in general.
+ */
 function menuPaneClassNameFromId(id: string) {
   const className = id
     // Get rid of the leading @. for auto-generated ids

--- a/app/src/ui/app-menu/menu-pane.tsx
+++ b/app/src/ui/app-menu/menu-pane.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import * as classNames from 'classnames'
 
 import { List, ClickSource, SelectionSource } from '../lib/list'
 import {
@@ -9,6 +10,11 @@ import {
 import { MenuListItem } from './menu-list-item'
 
 interface IMenuPaneProps {
+  /**
+   * An optional classname which will be appended to the 'menu-pane' class
+   */
+  readonly className?: string
+
   /**
    * The current Menu pane depth, starts at zero and increments by one for each
    * open submenu.
@@ -256,9 +262,11 @@ export class MenuPane extends React.Component<IMenuPaneProps, IMenuPaneState> {
         ? { height: getListHeight(this.props.items) + 5, maxHeight: '100%' }
         : {}
 
+    const className = classNames('menu-pane', this.props.className)
+
     return (
       <div
-        className="menu-pane"
+        className={className}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}
         style={style}

--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -17,6 +17,14 @@
     width: 275px;
   }
 
+  &.menu-pane-edit {
+    width: 175px;
+  }
+
+  &.menu-pane-help {
+    width: 200px;
+  }
+
   // Open panes (except the first one) should have a border on their
   // right hand side to create a divider between them and their parent
   // menu.

--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -25,6 +25,10 @@
     width: 200px;
   }
 
+  &.menu-pane-file {
+    width: 200px;
+  }
+
   // Open panes (except the first one) should have a border on their
   // right hand side to create a divider between them and their parent
   // menu.

--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -22,7 +22,7 @@
   }
 
   &.menu-pane-help {
-    width: 200px;
+    width: 220px;
   }
 
   &.menu-pane-file {

--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -9,13 +9,12 @@
   height: 100%;
   width: 240px;
 
-  // Need just a wee bit more vertical space for
-  // the branch menu on Windows due to long accelerator
-  // texts for the merge and update menu items, see #3547
-  @include win32 {
-    &.menu-pane-branch {
-      width: 275px;
-    }
+  // Custom widths for some menus since we don't have
+  // auto-sizeable foldouts at the moment (or rather we
+  // do but our List implementation prevents them from
+  // working). See #3547 for an example.
+  &.menu-pane-branch {
+    width: 275px;
   }
 
   // Open panes (except the first one) should have a border on their

--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -9,6 +9,15 @@
   height: 100%;
   width: 240px;
 
+  // Need just a wee bit more vertical space for
+  // the branch menu on Windows due to long accelerator
+  // texts for the merge and update menu items, see #3547
+  @include win32 {
+    &.menu-pane-branch {
+      width: 275px;
+    }
+  }
+
   // Open panes (except the first one) should have a border on their
   // right hand side to create a divider between them and their parent
   // menu.


### PR DESCRIPTION
Makes the widths of menu panes on Windows customizable so we can tweak them to accommodate wide (or narrow) menu items.
![screen shot 2017-12-11 at 16 15 29](https://user-images.githubusercontent.com/634063/33838575-3433938e-de90-11e7-9d7d-909c91325309.png)

Fixes bug where disabled top level menu items would be opened when hovering even though they looked disabled. The proper fix of making the top level menu items disabled wasn't worth it so I've adjusted them to work like the macOS menu items for now, i.e. they will still open but every item underneath will be disabled.

![screen shot 2017-12-11 at 16 14 47](https://user-images.githubusercontent.com/634063/33838574-341204c6-de90-11e7-83d6-72e3a38cd14d.png)

Finally I fixed a case where the `New Branch` menu item was enabled when no repository was selected.

![screen shot 2017-12-11 at 16 27 44](https://user-images.githubusercontent.com/634063/33838584-3e08253c-de90-11e7-9764-052a5fc9c960.png)

Fixes #3547  
Fixes #3391 
Fixes #1521