### PR TITLE
no longer need to use `git lfs clone`

### DIFF
--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -39,11 +39,7 @@ export async function clone(
 ): Promise<void> {
   const env = envForAuthentication(options.account)
 
-  const args = [
-    ...gitNetworkArguments,
-    'clone',
-    '--recursive'
-  ]
+  const args = [...gitNetworkArguments, 'clone', '--recursive']
 
   let opts: IGitExecutionOptions = { env }
 

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -41,13 +41,8 @@ export async function clone(
 
   const args = [
     ...gitNetworkArguments,
-    'lfs',
     'clone',
-    '--recursive',
-    // git-lfs will create the hooks it requires by default
-    // and we don't know if the repository is LFS enabled
-    // at this stage so let's not do this
-    '--skip-repo',
+    '--recursive'
   ]
 
   let opts: IGitExecutionOptions = { env }


### PR DESCRIPTION
Fixes #3574 

Confirmed that Git LFS will pull down objects as part of the clone operation:

<img width="696" src="https://user-images.githubusercontent.com/359239/33861695-545d8360-df33-11e7-9b93-18f7466031ad.png">

The proper progress is being tracked in #3171. I also saw the "Initialize Git LFS" prompt once the clone was completed.