### PR TITLE
bump to latest stable prettier to address IDE change

### DIFF
--- a/app/git-info.js
+++ b/app/git-info.js
@@ -22,9 +22,7 @@ function revParse(gitDir, ref) {
 
   if (!refMatch) {
     throw new Error(
-      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${
-        refContents
-      }`
+      `Could not de-reference HEAD to SHA, invalid ref in ${refPath}: ${refContents}`
     )
   }
 

--- a/app/src/cli/main.ts
+++ b/app/src/cli/main.ts
@@ -93,9 +93,7 @@ function runCommand(name: string) {
         throw new CommandError(
           `Value passed to flag ${dasherizeOption(
             flag
-          )} was of type ${typeof value}, but was expected to be of type ${
-            expectedType
-          }`
+          )} was of type ${typeof value}, but was expected to be of type ${expectedType}`
         )
       }
     }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -417,9 +417,7 @@ export class API {
       return status
     } catch (e) {
       log.warn(
-        `fetchCombinedRefStatus: failed for repository ${owner}/${
-          name
-        } on ref ${ref}`,
+        `fetchCombinedRefStatus: failed for repository ${owner}/${name} on ref ${ref}`,
         e
       )
       throw e
@@ -722,9 +720,7 @@ async function getNote(): Promise<string> {
     localUsername = await username()
   } catch (e) {
     log.error(
-      `getNote: unable to resolve machine username, using '${
-        localUsername
-      }' as a fallback`,
+      `getNote: unable to resolve machine username, using '${localUsername}' as a fallback`,
       e
     )
   }
@@ -804,9 +800,7 @@ export function getOAuthAuthorizationURL(
 ): string {
   const urlBase = getHTMLURL(endpoint)
   const scope = encodeURIComponent(Scopes.join(' '))
-  return `${urlBase}/login/oauth/authorize?client_id=${ClientID}&scope=${
-    scope
-  }&state=${state}`
+  return `${urlBase}/login/oauth/authorize?client_id=${ClientID}&scope=${scope}&state=${state}`
 }
 
 export async function requestOAuthToken(

--- a/app/src/lib/diff-parser.ts
+++ b/app/src/lib/diff-parser.ts
@@ -196,9 +196,7 @@ export class DiffParser {
     if (!str) {
       if (!defaultValue) {
         throw new Error(
-          `Group ${
-            group
-          } missing from regexp match and no defaultValue was provided`
+          `Group ${group} missing from regexp match and no defaultValue was provided`
         )
       }
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -336,9 +336,7 @@ export class Dispatcher {
 
     if (currentError) {
       fatalError(
-        `Unhandled error ${
-          currentError
-        }. This shouldn't happen! All errors should be handled, even if it's just by the default handler.`
+        `Unhandled error ${currentError}. This shouldn't happen! All errors should be handled, even if it's just by the default handler.`
       )
     }
   }
@@ -805,9 +803,9 @@ export class Dispatcher {
           this.handleCloneInDesktopOptions(repository, action)
         } else {
           log.warn(
-            `Open Repository from URL failed, did not find repository: ${
-              url
-            } - payload: ${JSON.stringify(action)}`
+            `Open Repository from URL failed, did not find repository: ${url} - payload: ${JSON.stringify(
+              action
+            )}`
           )
         }
         break

--- a/app/src/lib/editors/lookup.ts
+++ b/app/src/lib/editors/lookup.ts
@@ -63,9 +63,7 @@ export async function findEditorOrDefault(
     const match = editors.find(p => p.editor === name) || null
     if (!match) {
       const menuItemName = __DARWIN__ ? 'Preferences' : 'Options'
-      const message = `The editor '${name}' could not be found. Please open ${
-        menuItemName
-      } and choose an available editor.`
+      const message = `The editor '${name}' could not be found. Please open ${menuItemName} and choose an available editor.`
 
       throw new ExternalEditorError(message, { openPreferences: true })
     }

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -86,9 +86,7 @@ export function spawnAndComplete(
           } else {
             reject(
               new Error(
-                `Git returned an unexpected exit code '${
-                  code
-                }' which should be handled by the caller.'`
+                `Git returned an unexpected exit code '${code}' which should be handled by the caller.'`
               )
             )
           }

--- a/app/src/lib/open-file.ts
+++ b/app/src/lib/open-file.ts
@@ -10,9 +10,7 @@ export async function openFile(
   if (!result) {
     const error = {
       name: 'no-external-program',
-      message: `Unable to open file ${
-        fullPath
-      } in an external program. Please check you have a program associated with this file extension`,
+      message: `Unable to open file ${fullPath} in an external program. Please check you have a program associated with this file extension`,
     }
     await dispatcher.postError(error)
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -908,9 +908,7 @@ export class AppStore {
       const timeInSeconds = Math.floor(timeSinceFetch / 1000)
 
       log.debug(
-        `skipping background fetch as repository was fetched ${
-          timeInSeconds
-        }s ago`
+        `skipping background fetch as repository was fetched ${timeInSeconds}s ago`
       )
       return false
     }
@@ -2130,9 +2128,9 @@ export class AppStore {
         const hasValidToken =
           account.token.length > 0 ? 'has token' : 'empty token'
         log.info(
-          `[AppStore.getAccountForRemoteURL] account found for remote: ${
-            remote
-          } - ${account.login} (${hasValidToken})`
+          `[AppStore.getAccountForRemoteURL] account found for remote: ${remote} - ${
+            account.login
+          } (${hasValidToken})`
         )
         return account
       }
@@ -2142,17 +2140,13 @@ export class AppStore {
     const username = getGenericUsername(hostname)
     if (username != null) {
       log.info(
-        `[AppStore.getAccountForRemoteURL] found generic credentials for '${
-          hostname
-        }' and '${username}'`
+        `[AppStore.getAccountForRemoteURL] found generic credentials for '${hostname}' and '${username}'`
       )
       return { login: username, endpoint: hostname }
     }
 
     log.info(
-      `[AppStore.getAccountForRemoteURL] no generic credentials found for '${
-        remote
-      }'`
+      `[AppStore.getAccountForRemoteURL] no generic credentials found for '${remote}'`
     )
 
     return null
@@ -3070,9 +3064,9 @@ export class AppStore {
 
     const branch = tip.branch
     const urlEncodedBranchName = QueryString.escape(branch.nameWithoutRemote)
-    const baseURL = `${gitHubRepository.htmlURL}/pull/new/${
-      urlEncodedBranchName
-    }`
+    const baseURL = `${
+      gitHubRepository.htmlURL
+    }/pull/new/${urlEncodedBranchName}`
 
     await this._openInBrowser(baseURL)
   }

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -348,9 +348,7 @@ export class GitHubUserStore {
       const userID = user.id
       if (!userID) {
         fatalError(
-          `Cannot prune removed mentionables with a user that hasn't been cached yet: ${
-            user
-          }`
+          `Cannot prune removed mentionables with a user that hasn't been cached yet: ${user}`
         )
         return
       }

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -24,9 +24,7 @@ import { AuthenticationMode } from '../../lib/2fa'
 import { minimumSupportedEnterpriseVersion } from '../../lib/enterprise'
 
 function getUnverifiedUserErrorMessage(login: string): string {
-  return `Unable to authenticate. The account ${
-    login
-  } is lacking a verified email address. Please sign in to GitHub.com, confirm your email address in the Emails section under Personal settings, and try again.`
+  return `Unable to authenticate. The account ${login} is lacking a verified email address. Please sign in to GitHub.com, confirm your email address in the Emails section under Personal settings, and try again.`
 }
 
 const EnterpriseTooOldMessage = `The GitHub Enterprise version does not support GitHub Desktop. Talk to your server's administrator about upgrading to the latest version of GitHub Enterprise.`
@@ -236,9 +234,7 @@ export class SignInStore {
       }
     } else {
       throw new Error(
-        `Unable to authenticate with the GitHub Enterprise instance. Verify that the URL is correct, that your GitHub Enterprise instance is running version ${
-          minimumSupportedEnterpriseVersion
-        } or later, that you have an internet connection and try again.`
+        `Unable to authenticate with the GitHub Enterprise instance. Verify that the URL is correct, that your GitHub Enterprise instance is running version ${minimumSupportedEnterpriseVersion} or later, that you have an internet connection and try again.`
       )
     }
   }
@@ -535,9 +531,7 @@ export class SignInStore {
     ) {
       const stepText = currentState ? currentState.kind : 'null'
       fatalError(
-        `Sign in step '${
-          stepText
-        }' not compatible with two factor authentication`
+        `Sign in step '${stepText}' not compatible with two factor authentication`
       )
       return
     }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -201,9 +201,7 @@ export class CreateRepository extends React.Component<
     } catch (e) {
       this.setState({ creating: false })
       log.error(
-        `createRepository: unable to initialize a Git repository at ${
-          fullPath
-        }`,
+        `createRepository: unable to initialize a Git repository at ${fullPath}`,
         e
       )
       return this.props.dispatcher.postError(e)
@@ -244,9 +242,7 @@ export class CreateRepository extends React.Component<
         await writeGitDescription(fullPath, description)
       } catch (e) {
         log.error(
-          `createRepository: unable to write .git/description file at ${
-            fullPath
-          }`,
+          `createRepository: unable to write .git/description file at ${fullPath}`,
           e
         )
         this.props.dispatcher.postError(e)

--- a/app/src/ui/add-repository/gitignores.ts
+++ b/app/src/ui/add-repository/gitignores.ts
@@ -50,9 +50,7 @@ async function getGitIgnoreText(name: string): Promise<string> {
     if (!path) {
       reject(
         new Error(
-          `Unknown gitignore: ${
-            name
-          }. Only names returned from getGitIgnoreNames() can be used.`
+          `Unknown gitignore: ${name}. Only names returned from getGitIgnoreNames() can be used.`
         )
       )
       return

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -391,9 +391,7 @@ export abstract class AutocompletingTextInput<
       const regex = new RegExp(provider.getRegExp())
       if (!regex.global) {
         fatalError(
-          `The regex (${regex}) returned from ${
-            provider
-          } isn't global, but it should be!`
+          `The regex (${regex}) returned from ${provider} isn't global, but it should be!`
         )
         continue
       }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -505,9 +505,7 @@ export class Diff extends React.Component<IDiffProps, {}> {
 
       if (this.gutterWidth === 0) {
         console.error(
-          `element at row ${
-            row
-          } does not have a width, should probably look into that`
+          `element at row ${row} does not have a width, should probably look into that`
         )
       }
     }

--- a/app/src/ui/lib/install-cli.ts
+++ b/app/src/ui/lib/install-cli.ts
@@ -44,9 +44,7 @@ function symlinkCLI(asAdmin: boolean) {
   let exitCode = runas('/bin/rm', ['-f', InstalledCLIPath], { admin: asAdmin })
   if (exitCode !== 0) {
     throw new Error(
-      `Failed to remove file at ${
-        InstalledCLIPath
-      }. Authorization of GitHub Desktop Helper is required.`
+      `Failed to remove file at ${InstalledCLIPath}. Authorization of GitHub Desktop Helper is required.`
     )
   }
 

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -339,11 +339,7 @@ describe('git/diff', () => {
 
       fs.writeFileSync(
         filePath,
-        `WRITING MANY LINES ${lineEnding} USING THIS LINE ENDING ${
-          lineEnding
-        } TO SHOW THAT GIT${lineEnding} WILL INSERT IT WITHOUT CHANGING THING ${
-          lineEnding
-        } HA HA BUSINESS`
+        `WRITING MANY LINES ${lineEnding} USING THIS LINE ENDING ${lineEnding} TO SHOW THAT GIT${lineEnding} WILL INSERT IT WITHOUT CHANGING THING ${lineEnding} HA HA BUSINESS`
       )
 
       await GitProcess.exec(['add', 'foo'], repo.path)
@@ -357,11 +353,7 @@ describe('git/diff', () => {
 
       fs.writeFileSync(
         filePath,
-        `WRITING MANY LINES ${lineEnding} USING THIS LINE ENDING ${
-          lineEnding
-        } TO SHOW THAT GIT${lineEnding} WILL INSERT IT WITHOUT CHANGING THING ${
-          lineEnding
-        } HA HA BUSINESS`
+        `WRITING MANY LINES ${lineEnding} USING THIS LINE ENDING ${lineEnding} TO SHOW THAT GIT${lineEnding} WILL INSERT IT WITHOUT CHANGING THING ${lineEnding} HA HA BUSINESS`
       )
 
       const status = await getStatus(repo)

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "~3.2.0",
     "typescript": "2.6.2",
-    "typescript-eslint-parser": "^9.0.0",
+    "typescript-eslint-parser": "^10.0.0",
     "webpack": "^3.5.5",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node-sass": "^4.5.2",
     "octicons": "^7.0.1",
     "parallel-webpack": "^2.1.0",
-    "prettier": "1.8.2",
+    "prettier": "1.9.2",
     "request": "^2.72.0",
     "rimraf": "^2.5.2",
     "sass-loader": "^6.0.6",

--- a/script/build.ts
+++ b/script/build.ts
@@ -316,9 +316,7 @@ function updateLicenseDump(callback: (err: Error | null) => void) {
           }\n`
         }
 
-        const message = `The following dependencies have unknown or non-permissive licenses. Check it out and update ${
-          overridesPath
-        } if appropriate:\n${licensesMessage}`
+        const message = `The following dependencies have unknown or non-permissive licenses. Check it out and update ${overridesPath} if appropriate:\n${licensesMessage}`
         callback(new Error(message))
       } else {
         legalEagle(
@@ -341,9 +339,7 @@ function updateLicenseDump(callback: (err: Error | null) => void) {
             summary[`desktop@${appVersion}`] = {
               repository: 'https://github.com/desktop/desktop',
               license: 'MIT',
-              source: `https://github.com/desktop/desktop/blob/release-${
-                appVersion
-              }/LICENSE`,
+              source: `https://github.com/desktop/desktop/blob/release-${appVersion}/LICENSE`,
               sourceText: licenseText,
             }
 

--- a/script/dist-info.js
+++ b/script/dist-info.js
@@ -124,9 +124,7 @@ function getReleaseSHA() {
 }
 
 function getUpdatesURL() {
-  return `https://central.github.com/api/deployments/desktop/desktop/latest?version=${
-    version
-  }&env=${getReleaseChannel()}`
+  return `https://central.github.com/api/deployments/desktop/desktop/latest?version=${version}&env=${getReleaseChannel()}`
 }
 
 function shouldMakeDelta() {

--- a/script/generate-octicons.ts
+++ b/script/generate-octicons.ts
@@ -96,9 +96,7 @@ generateIconData().then(result => {
   result.forEach(function(symbol) {
     const { jsFriendlyName, pathData, width, height } = symbol
     out.write(
-      `  public static get ${jsFriendlyName}() { return new OcticonSymbol(${
-        width
-      }, ${height}, '${pathData}') }\n`
+      `  public static get ${jsFriendlyName}() { return new OcticonSymbol(${width}, ${height}, '${pathData}') }\n`
     )
   })
 

--- a/script/package.ts
+++ b/script/package.ts
@@ -76,9 +76,7 @@ function packageWindows() {
 
   if (!fs.existsSync(splashScreenPath)) {
     console.error(
-      `expected setup splash screen gif not found at location: ${
-        splashScreenPath
-      }`
+      `expected setup splash screen gif not found at location: ${splashScreenPath}`
     )
     process.exit(1)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5367,9 +5367,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+prettier@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
 
 pretty-bytes@^1.0.2:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6756,9 +6756,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-9.0.0.tgz#6a9e9c4bafbebc7e6df53c631bc7036597227d18"
+typescript-eslint-parser@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-10.0.0.tgz#82b550253659c311c2e4a4d18311b94dd08a36d7"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.4.1"


### PR DESCRIPTION
In VSCode we have it set up so that prettier will auto-format the file when you save. Well, kinda:

<img width="994" src="https://user-images.githubusercontent.com/359239/33868413-f4e5eaf2-df56-11e7-8d2f-b90b2568c49d.png">

I've traced this to their markdown support and it's a bit of a mess:

 - **1.8.2**: `proseWrap` accepts a boolean
 - **1.9.0**: `proseWrap` no longer accepts boolean, use `"always"`  `"never"` or `"preserve"`

Looks like the prettier extension expects you're on 1.9.x, even though we don't specify this in under the `.vscode/settings.json` file.

I see @j-f1 is looking at more of the linting stuff over in #3569, but for now I just want my "formatting on save" functionality back so I've bumped prettier - and I'll do the needful on the formatting.