### PR TITLE
Keeps the currently selected PR selected even when a manual fetch is done

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -82,7 +82,7 @@ export class BranchesContainer extends React.Component<
     this.setState({ filterText })
   }
 
-  private onSelectionChanged = (selectedBranch: Branch | null) => {
+  private onBranchSelectionChanged = (selectedBranch: Branch | null) => {
     this.setState({ selectedBranch })
   }
 
@@ -136,7 +136,7 @@ export class BranchesContainer extends React.Component<
             onFilterKeyDown={this.onFilterKeyDown}
             onFilterTextChanged={this.onFilterTextChanged}
             selectedBranch={this.state.selectedBranch}
-            onSelectionChanged={this.onSelectionChanged}
+            onSelectionChanged={this.onBranchSelectionChanged}
             canCreateNewBranch={true}
             onCreateNewBranch={this.onCreateBranchWithName}
           />

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -252,7 +252,7 @@ export class BranchesContainer extends React.Component<
       // TODO: It's in a fork so we'll need to do ... something.
     }
 
-    this.setState({ selectedPullRequest: pullRequest})
+    this.onPullRequestSelectionChanged(pullRequest)
   }
 
   private onDismiss = () => {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -168,7 +168,9 @@ export class BranchesContainer extends React.Component<
           key="pr-list"
           pullRequests={pullRequests}
           currentPullRequest={this.props.currentPullRequest}
-          onPullRequestClicked={this.onPullRequestClicked}
+          onSelectionChanged={this.onPullRequestSelectionChanged}
+          selectedPullRequest={this.state.selectedPullRequest}
+          onItemClick={this.onPullRequestClicked}
           onDismiss={this.onDismiss}
         />
       )

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -37,6 +37,7 @@ interface IBranchesProps {
 interface IBranchesState {
   readonly selectedBranch: Branch | null
   readonly filterText: string
+  readonly selectedPullRequest: PullRequest | null
 }
 
 /** The unified Branches and Pull Requests component. */
@@ -50,6 +51,7 @@ export class BranchesContainer extends React.Component<
     this.state = {
       selectedBranch: props.currentBranch,
       filterText: '',
+      selectedPullRequest: props.currentPullRequest
     }
   }
 
@@ -241,6 +243,8 @@ export class BranchesContainer extends React.Component<
     } else {
       // TODO: It's in a fork so we'll need to do ... something.
     }
+
+    this.setState({ selectedPullRequest: pullRequest})
   }
 
   private onDismiss = () => {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -36,8 +36,8 @@ interface IBranchesProps {
 
 interface IBranchesState {
   readonly selectedBranch: Branch | null
-  readonly filterText: string
   readonly selectedPullRequest: PullRequest | null
+  readonly filterText: string
 }
 
 /** The unified Branches and Pull Requests component. */
@@ -50,8 +50,8 @@ export class BranchesContainer extends React.Component<
 
     this.state = {
       selectedBranch: props.currentBranch,
+      selectedPullRequest: props.currentPullRequest,
       filterText: '',
-      selectedPullRequest: props.currentPullRequest
     }
   }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -86,6 +86,12 @@ export class BranchesContainer extends React.Component<
     this.setState({ selectedBranch })
   }
 
+  private onPullRequestSelectionChanged = (
+    selectedPullRequest: PullRequest | null
+  ) => {
+    this.setState({ selectedPullRequest })
+  }
+
   private renderTabBar() {
     if (!this.props.repository.gitHubRepository) {
       return null

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -62,10 +62,16 @@ export class PullRequestList extends React.Component<
     super(props)
 
     const group = createListItems(props.pullRequests)
-    const pullRequest = props.currentPullRequest
-    const selectedItem = pullRequest
-      ? findItemForPullRequest(group, pullRequest)
-      : null
+    const selectedPullRequest = props.selectedPullRequest
+
+    let selectedItem: IPullRequestListItem | null =
+      props.currentPullRequest != null
+        ? findItemForPullRequest(group, props.currentPullRequest)
+        : null
+
+    if (selectedPullRequest != null) {
+      selectedItem = findItemForPullRequest(group, selectedPullRequest)
+    }
 
     this.state = {
       groupedItems: [group],

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -185,5 +185,5 @@ function findItemForPullRequest(
   group: IFilterListGroup<IPullRequestListItem>,
   pullRequest: PullRequest
 ): IPullRequestListItem | null {
-  return group.items.find(i => i.pullRequest.id === pullRequest.id) || null
+  return group.items.find(i => i.pullRequest.number === pullRequest.number) || null
 }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -34,10 +34,17 @@ interface IPullRequestListProps {
   readonly currentPullRequest: PullRequest | null
 
   /** Called when the user clicks on a pull request. */
-  readonly onPullRequestClicked: (pullRequest: PullRequest) => void
+  readonly onItemClick: (pullRequest: PullRequest) => void
 
   /** Called when the user wants to dismiss the foldout. */
   readonly onDismiss: () => void
+
+  readonly selectedPullRequest: PullRequest | null
+
+  readonly onSelectionChanged?: (
+    pullRequest: PullRequest | null,
+    source: SelectionSource
+  ) => void
 }
 
 interface IPullRequestListState {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -93,11 +93,14 @@ export class PullRequestList extends React.Component<
 
     if (currentlySelectedItem == null) {
       selectedItem =
-        this.props.currentPullRequest != null ?
-          findItemForPullRequest(group, this.props.currentPullRequest) :
-          null
+        this.props.currentPullRequest != null
+          ? findItemForPullRequest(group, this.props.currentPullRequest)
+          : null
     } else {
-      selectedItem = findItemForPullRequest(group, currentlySelectedItem.pullRequest)
+      selectedItem = findItemForPullRequest(
+        group,
+        currentlySelectedItem.pullRequest
+      )
     }
 
     this.setState({ groupedItems: [group], selectedItem })
@@ -185,5 +188,7 @@ function findItemForPullRequest(
   group: IFilterListGroup<IPullRequestListItem>,
   pullRequest: PullRequest
 ): IPullRequestListItem | null {
-  return group.items.find(i => i.pullRequest.number === pullRequest.number) || null
+  return (
+    group.items.find(i => i.pullRequest.number === pullRequest.number) || null
+  )
 }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -137,9 +137,10 @@ export class PullRequestList extends React.Component<
     this.setState({ filterText })
   }
 
-  private onItemClick = (selectedItem: IPullRequestListItem) => {
-    const pr = selectedItem.pullRequest
-    this.props.onPullRequestClicked(pr)
+  private onItemClick = (item: IPullRequestListItem) => {
+    if (this.props.onItemClick) {
+      this.props.onItemClick(item.pullRequest)
+    }
   }
 
   private onSelectionChanged = (selectedItem: IPullRequestListItem | null) => {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -87,9 +87,17 @@ export class PullRequestList extends React.Component<
 
     const group = createListItems(nextProps.pullRequests)
     const currentlySelectedItem = this.state.selectedItem
-    const selectedItem = currentlySelectedItem
-      ? findItemForPullRequest(group, currentlySelectedItem.pullRequest)
-      : null
+
+    let selectedItem: IPullRequestListItem | null = null
+
+    if (currentlySelectedItem == null) {
+      selectedItem =
+        this.props.currentPullRequest != null ?
+          findItemForPullRequest(group, this.props.currentPullRequest) :
+          null
+    } else {
+      selectedItem = findItemForPullRequest(group, currentlySelectedItem.pullRequest)
+    }
 
     this.setState({ groupedItems: [group], selectedItem })
   }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -3,6 +3,7 @@ import {
   FilterList,
   IFilterListGroup,
   IFilterListItem,
+  SelectionSource,
 } from '../lib/filter-list'
 import { PullRequestListItem } from './pull-request-list-item'
 import { PullRequest } from '../../models/pull-request'
@@ -143,8 +144,16 @@ export class PullRequestList extends React.Component<
     }
   }
 
-  private onSelectionChanged = (selectedItem: IPullRequestListItem | null) => {
-    this.setState({ selectedItem })
+  private onSelectionChanged = (
+    selectedItem: IPullRequestListItem | null,
+    source: SelectionSource
+  ) => {
+    if (this.props.onSelectionChanged) {
+      this.props.onSelectionChanged(
+        selectedItem != null ? selectedItem.pullRequest : null,
+        source
+      )
+    }
   }
 
   private onFilterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Fixes #3524.

This issue was a bit challenging to get to the bottom of. The short version of this story is that we should **not** base conditional expression on the `id` property of any objects coming from IndexedDB since those IDs **will** change.  