### PR TITLE
Prevent saving of disallowed character strings for user's name and email 

### DIFF
--- a/app/src/ui/preferences/identifier-rules.ts
+++ b/app/src/ui/preferences/identifier-rules.ts
@@ -1,0 +1,33 @@
+import { fatalError } from '../../lib/fatal-error'
+
+export function disallowedCharacters(values: string): string | null {
+  for (const value of values) {
+    if (disallowedCharacter(value) === false) {
+      return null
+    }
+  }
+  return values
+}
+
+function disallowedCharacter(value: string): boolean {
+  if (value.length !== 1) {
+    return fatalError('`value` must be a single character')
+  }
+
+  const disallowedCharacters = [
+    '.',
+    ',',
+    ':',
+    ';',
+    '<',
+    '>',
+    '"',
+    '\\',
+    "'",
+    ' ',
+  ]
+  const hasDisallowedCharacter = disallowedCharacters.indexOf(value) >= 0
+  const hasDisallowedAsciiCharacter = value.charCodeAt(0) <= 32
+
+  return hasDisallowedCharacter || hasDisallowedAsciiCharacter
+}

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -166,13 +166,9 @@ export class Preferences extends React.Component<
     const disallowedEmailCharacters = disallowedCharacters(email)
 
     if (disallowedNameCharacters !== null) {
-      return `Git name field cannot be a disallowed character "${
-        disallowedNameCharacters
-      }"`
+      return `Git name field cannot be a disallowed character "${disallowedNameCharacters}"`
     } else if (disallowedEmailCharacters !== null) {
-      return `Git email field cannot be a disallowed character "${
-        disallowedEmailCharacters
-      }"`
+      return `Git email field cannot be a disallowed character "${disallowedEmailCharacters}"`
     } else {
       return null
     }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -165,11 +165,11 @@ export class Preferences extends React.Component<
     const disallowedNameCharacters = disallowedCharacters(name)
     const disallowedEmailCharacters = disallowedCharacters(email)
 
-    if (disallowedNameCharacters) {
+    if (disallowedNameCharacters !== null) {
       return `Git name field cannot be a disallowed character "${
         disallowedNameCharacters
       }"`
-    } else if (disallowedEmailCharacters) {
+    } else if (disallowedEmailCharacters !== null) {
       return `Git email field cannot be a disallowed character "${
         disallowedEmailCharacters
       }"`
@@ -179,7 +179,7 @@ export class Preferences extends React.Component<
   }
 
   private renderDisallowedCharactersError(message: string | null) {
-    if (message) {
+    if (message !== null) {
       return <DialogError>{message}</DialogError>
     } else {
       return null

--- a/app/test/unit/identifier-rules-test.ts
+++ b/app/test/unit/identifier-rules-test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai'
+import { disallowedCharacters } from '../../src/ui/preferences/identifier-rules'
+
+describe('Identifier rules', () => {
+  it('returns any value that is a disallowed character', () => {
+    expect(disallowedCharacters('.')).to.equal('.')
+    expect(disallowedCharacters(',')).to.equal(',')
+    expect(disallowedCharacters(':')).to.equal(':')
+    expect(disallowedCharacters(';')).to.equal(';')
+    expect(disallowedCharacters('<')).to.equal('<')
+    expect(disallowedCharacters('>')).to.equal('>')
+    expect(disallowedCharacters('"')).to.equal('"')
+    expect(disallowedCharacters('\\')).to.equal('\\')
+    expect(disallowedCharacters("'")).to.equal("'")
+    expect(disallowedCharacters(' ')).to.equal(' ')
+  })
+
+  it('returns values that are for ascii character codes 0-32 inclusive', () => {
+    for (let i = 0; i <= 32; i++) {
+      const char = String.fromCharCode(i)
+      expect(disallowedCharacters(char)).to.equal(char)
+    }
+  })
+
+  it('returns the value if it is a series of disallowed characters', () => {
+    const disallowed = '.;:<>'
+    expect(disallowedCharacters(disallowed)).to.equal(disallowed)
+  })
+
+  it('returns null if the value consists of allowed characters', () => {
+    const allowed = 'this is great'
+    expect(disallowedCharacters(allowed)).to.equal(null)
+  })
+
+  it('return null if the value contains allowed characters with disallowed characters', () => {
+    const allowed = `;hi. there;${String.fromCharCode(31)}`
+    expect(disallowedCharacters(allowed)).to.equal(null)
+  })
+
+  it('returns null if the value contains ASCII characters whose code point is greater than 32', () => {
+    const allowed = String.fromCharCode(33)
+    expect(disallowedCharacters(allowed)).to.equal(null)
+  })
+})


### PR DESCRIPTION
Fixes #3204
 - Checks against [git's rules](https://github.com/git/git/blob/e629a7d28a405e48fae6b064a781a10e885159fc/ident.c#L191-L203) for name/email (replicated in our codebase as we don't expect them to change)
 - Surfaces dialog error message in preference window (includes disallowed character string)
 - Disabled save button when name or email has disallowed characters
 - Provides identifier rules function that checks if the string exclusively contains disallowed characters (test file explains many of the rules)

Valid name/email:
![screen shot 2017-12-12 at 3 32 45 pm](https://user-images.githubusercontent.com/1834387/33914159-be2ba9de-df51-11e7-9fe3-a25a6a42273d.png)

Invalid name (with valid email):
![screen shot 2017-12-12 at 3 31 25 pm](https://user-images.githubusercontent.com/1834387/33914167-cc2adfdc-df51-11e7-85b3-36d6ed3bd6ce.png)

Invalid email (with valid name):
![screen shot 2017-12-12 at 3 32 19 pm](https://user-images.githubusercontent.com/1834387/33914174-d2c842d0-df51-11e7-9ec1-d699468809ab.png)

Invalid name + email will show an error message for the name only; when the name is resolved, it will surface the dialog error message for an invalid email.