### PR TITLE
update electron-devtools-installer

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "devtron": "^1.4.0",
     "electron-debug": "^1.1.0",
-    "electron-devtools-installer": "^2.1.0",
+    "electron-devtools-installer": "^2.2.1",
     "react-addons-perf": "15.4.2",
     "react-addons-test-utils": "^15.6.2",
     "style-loader": "^0.13.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -292,9 +292,9 @@ electron-debug@^1.1.0:
     electron-is-dev "^0.3.0"
     electron-localshortcut "^3.0.0"
 
-electron-devtools-installer@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz#9813e6811afcd69ddca3cae5416db72ea7ecfb6a"
+electron-devtools-installer@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.1.tgz#0beb73ccbf65cbc4d09e706cebda638f839b8c55"
   dependencies:
     "7zip" "0.0.6"
     cross-unzip "0.0.2"


### PR DESCRIPTION
Fixes https://github.com/shiftkey/desktop/issues/5

Without this fix, you'll probably see this when running the app in development mode:

```shellsession
$ yarn start
yarn run v1.3.2
$ cross-env NODE_ENV=development node script/start
Server running at http://localhost:3000
2017-12-14 21:43:59.058 GitHub Desktop-dev[91940:4184602] *** WARNING: Textured window <AtomNSWindow: 0x7fdc3af3b740> is getting an implicitly transparent titlebar. This will break when linking against newer SDKs. Use NSWindow's -titlebarAppearsTransparent=YES instead.

[at-loader] Using typescript@2.6.2 from typescript and "tsconfig.json" from /Users/shiftkey/src/desktop/tsconfig.json.

Failed to read content scripts { Error: EACCES: permission denied, open '/Users/shiftkey/Library/Application Support/GitHub Desktop-dev/extensions/fmkadmapgofadopljbjfkapdkoienihi/build/inject.js'
    at Object.fs.openSync (fs.js:584:18)
    at Object.module.(anonymous function) [as openSync] (ELECTRON_ASAR.js:173:20)
    at Object.fs.readFileSync (fs.js:491:33)
    at Object.fs.readFileSync (ELECTRON_ASAR.js:505:29)
    at readArrayOfFiles (/Users/shiftkey/src/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app/Contents/Resources/electron.asar/browser/chrome-extension.js:235:23)
    at Array.map (native)
    at contentScriptToEntry (/Users/shiftkey/src/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app/Contents/Resources/electron.asar/browser/chrome-extension.js:242:21)
    at Array.map (native)
    at injectContentScripts (/Users/shiftkey/src/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app/Contents/Resources/electron.asar/browser/chrome-extension.js:250:48)
    at loadExtension (/Users/shiftkey/src/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app/Contents/Resources/electron.asar/browser/chrome-extension.js:279:3)
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/Users/shiftkey/Library/Application Support/GitHub Desktop-dev/extensions/fmkadmapgofadopljbjfkapdkoienihi/build/inject.js' }
...
```

@picandocodigo spotted this, and it was something I'd seen for a while without digging into.

Turns out bumping this package is the fix (for both macOS and Linux): https://github.com/MarshallOfSound/electron-devtools-installer/pull/64