### PR TITLE
address keyboard support inside PR list

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -249,6 +249,11 @@ export class BranchesContainer extends React.Component<
     if (isRefInThisRepo) {
       this.checkoutBranch(head.ref)
     } else {
+      log.debug(
+        `onPullRequestClicked, but we can't checkout the branch: '${
+          head.ref
+        }' belongs to fork '${pullRequest.author}'`
+      )
       // TODO: It's in a fork so we'll need to do ... something.
     }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -173,7 +173,6 @@ export class BranchesContainer extends React.Component<
         <PullRequestList
           key="pr-list"
           pullRequests={pullRequests}
-          currentPullRequest={this.props.currentPullRequest}
           onSelectionChanged={this.onPullRequestSelectionChanged}
           selectedPullRequest={this.state.selectedPullRequest}
           onItemClick={this.onPullRequestClicked}

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -28,12 +28,6 @@ interface IPullRequestListProps {
   /** The pull requests to display. */
   readonly pullRequests: ReadonlyArray<PullRequest>
 
-  /**
-   * The pull request associated with the current branch. This is used to
-   * pre-select the currently checked out PR in the list of pull requests.
-   */
-  readonly currentPullRequest: PullRequest | null
-
   /** Called when the user clicks on a pull request. */
   readonly onItemClick: (pullRequest: PullRequest) => void
 

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -87,12 +87,14 @@ export class PullRequestList extends React.Component<
 
     let selectedItem: IPullRequestListItem | null = null
 
-    if (currentlySelectedItem == null) {
-      selectedItem =
-        this.props.currentPullRequest != null
-          ? findItemForPullRequest(group, this.props.currentPullRequest)
-          : null
-    } else {
+    if (nextProps.selectedPullRequest != null) {
+      selectedItem = findItemForPullRequest(
+        group,
+        nextProps.selectedPullRequest
+      )
+    }
+
+    if (selectedItem == null && currentlySelectedItem != null) {
       selectedItem = findItemForPullRequest(
         group,
         currentlySelectedItem.pullRequest

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -82,10 +82,6 @@ export class PullRequestList extends React.Component<
   }
 
   public componentWillReceiveProps(nextProps: IPullRequestListProps) {
-    if (nextProps.pullRequests === this.props.pullRequests) {
-      return
-    }
-
     const group = createListItems(nextProps.pullRequests)
     const currentlySelectedItem = this.state.selectedItem
 

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -48,6 +48,27 @@ interface IPullRequestListState {
   readonly selectedItem: IPullRequestListItem | null
 }
 
+function resolveSelectedItem(
+  group: IFilterListGroup<IPullRequestListItem>,
+  props: IPullRequestListProps,
+  currentlySelectedItem: IPullRequestListItem | null
+): IPullRequestListItem | null {
+  let selectedItem: IPullRequestListItem | null = null
+
+  if (props.selectedPullRequest != null) {
+    selectedItem = findItemForPullRequest(group, props.selectedPullRequest)
+  }
+
+  if (selectedItem == null && currentlySelectedItem != null) {
+    selectedItem = findItemForPullRequest(
+      group,
+      currentlySelectedItem.pullRequest
+    )
+  }
+
+  return selectedItem
+}
+
 /** The list of open pull requests. */
 export class PullRequestList extends React.Component<
   IPullRequestListProps,
@@ -57,7 +78,7 @@ export class PullRequestList extends React.Component<
     super(props)
 
     const group = createListItems(props.pullRequests)
-    const selectedItem = this.resolveSelectedItem(group, props, null)
+    const selectedItem = resolveSelectedItem(group, props, null)
 
     this.state = {
       groupedItems: [group],
@@ -68,33 +89,12 @@ export class PullRequestList extends React.Component<
 
   public componentWillReceiveProps(nextProps: IPullRequestListProps) {
     const group = createListItems(nextProps.pullRequests)
-    const selectedItem = this.resolveSelectedItem(
+    const selectedItem = resolveSelectedItem(
       group,
       nextProps,
       this.state.selectedItem
     )
     this.setState({ groupedItems: [group], selectedItem })
-  }
-
-  private resolveSelectedItem(
-    group: IFilterListGroup<IPullRequestListItem>,
-    props: IPullRequestListProps,
-    currentlySelectedItem: IPullRequestListItem | null
-  ): IPullRequestListItem | null {
-    let selectedItem: IPullRequestListItem | null = null
-
-    if (props.selectedPullRequest != null) {
-      selectedItem = findItemForPullRequest(group, props.selectedPullRequest)
-    }
-
-    if (selectedItem == null && currentlySelectedItem != null) {
-      selectedItem = findItemForPullRequest(
-        group,
-        currentlySelectedItem.pullRequest
-      )
-    }
-
-    return selectedItem
   }
 
   public render() {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -63,16 +63,7 @@ export class PullRequestList extends React.Component<
     super(props)
 
     const group = createListItems(props.pullRequests)
-    const selectedPullRequest = props.selectedPullRequest
-
-    let selectedItem: IPullRequestListItem | null =
-      props.currentPullRequest != null
-        ? findItemForPullRequest(group, props.currentPullRequest)
-        : null
-
-    if (selectedPullRequest != null) {
-      selectedItem = findItemForPullRequest(group, selectedPullRequest)
-    }
+    const selectedItem = this.resolveSelectedItem(group, props, null)
 
     this.state = {
       groupedItems: [group],
@@ -83,15 +74,23 @@ export class PullRequestList extends React.Component<
 
   public componentWillReceiveProps(nextProps: IPullRequestListProps) {
     const group = createListItems(nextProps.pullRequests)
-    const currentlySelectedItem = this.state.selectedItem
+    const selectedItem = this.resolveSelectedItem(
+      group,
+      nextProps,
+      this.state.selectedItem
+    )
+    this.setState({ groupedItems: [group], selectedItem })
+  }
 
+  private resolveSelectedItem(
+    group: IFilterListGroup<IPullRequestListItem>,
+    props: IPullRequestListProps,
+    currentlySelectedItem: IPullRequestListItem | null
+  ): IPullRequestListItem | null {
     let selectedItem: IPullRequestListItem | null = null
 
-    if (nextProps.selectedPullRequest != null) {
-      selectedItem = findItemForPullRequest(
-        group,
-        nextProps.selectedPullRequest
-      )
+    if (props.selectedPullRequest != null) {
+      selectedItem = findItemForPullRequest(group, props.selectedPullRequest)
     }
 
     if (selectedItem == null && currentlySelectedItem != null) {
@@ -101,7 +100,7 @@ export class PullRequestList extends React.Component<
       )
     }
 
-    this.setState({ groupedItems: [group], selectedItem })
+    return selectedItem
   }
 
   public render() {


### PR DESCRIPTION
Fixes #3607

 - [x] `ArrowDown` from filter textbox chooses first PR (not current PR as per original issue)
 - [x] `ArrowUp` and `ArrowDown` in PR list will update the current PR
 - [x] `Enter` when selecting a PR should checkout and switch branch (unless #3602)
 - [x] Mouse click on PR should checkout and switch branch (unless #3602)

The fact that there is both `this.props.selectedPullRequest` and `this.props.currentPullRequest` has confused me a bit, so I'm trying to be as careful as possible here.