### PR TITLE
Fix for account being unusable after starting the app without connectivity

### DIFF
--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -2,8 +2,7 @@ import { Emitter, Disposable } from 'event-kit'
 import { IDataStore, ISecureStore } from './stores'
 import { getKeyForAccount } from '../auth'
 import { Account } from '../../models/account'
-import { API, EmailVisibility } from '../api'
-import { getAvatarWithEnterpriseFallback } from '../gravatar'
+import { fetchUser, EmailVisibility } from '../api'
 import { fatalError } from '../fatal-error'
 
 /** The data-only interface for storage. */
@@ -218,24 +217,5 @@ async function updatedAccount(account: Account): Promise<Account> {
     )
   }
 
-  const api = API.fromAccount(account)
-  const user = await api.fetchAccount()
-  const emails = await api.fetchEmails()
-
-  const defaultEmail = emails[0].email || ''
-  const avatarURL = getAvatarWithEnterpriseFallback(
-    user.avatar_url,
-    defaultEmail,
-    account.endpoint
-  )
-
-  return new Account(
-    account.login,
-    account.endpoint,
-    account.token,
-    emails,
-    avatarURL,
-    user.id,
-    user.name
-  )
+  return fetchUser(account.endpoint, account.token)
 }

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -118,6 +118,7 @@ export class AccountsStore {
       this.accounts.map(acc => this.tryUpdateAccount(acc))
     )
 
+    this.save()
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -105,14 +105,13 @@ export class AccountsStore {
       return
     }
 
-    this.accounts = [ ...this.accounts, updated ]
+    this.accounts = [...this.accounts, updated]
 
     this.save()
   }
 
   /** Refresh all accounts by fetching their latest info from the API. */
   public async refresh(): Promise<void> {
-
     this.accounts = await Promise.all(
       this.accounts.map(acc => this.tryUpdateAccount(acc))
     )

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -116,8 +116,7 @@ export class AccountsStore {
     const updatedAccounts = new Array<Account>()
     for (const account of this.accounts) {
       try {
-        const updated = await updatedAccount(account)
-        updatedAccounts.push(updated)
+        updatedAccounts.push(await updatedAccount(account))
       } catch (e) {
         log.warn(`Error refreshing account '${account.login}'`, e)
       }

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -105,7 +105,7 @@ export class AccountsStore {
       return
     }
 
-    this.accounts = this.accounts.concat(updated)
+    this.accounts = [ ...this.accounts, updated ]
 
     this.save()
   }

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -113,23 +113,20 @@ export class AccountsStore {
 
   /** Refresh all accounts by fetching their latest info from the API. */
   public async refresh(): Promise<void> {
-    const updatedAccounts = new Array<Account>()
-    for (const account of this.accounts) {
-      try {
-        updatedAccounts.push(await updatedAccount(account))
-      } catch (e) {
+
+    this.accounts = await Promise.all(this.accounts
+      .map(account => updatedAccount(account).catch(e => {
         log.warn(`Error refreshing account '${account.login}'`, e)
+
         // If the fetch failed for whatever reason we'll retain
         // the old Account instance. Usually this fails due to
         // connectivity issues but in the future we should
         // investigate whether we're able to detect here that the
         // token is definitely not valid anymore and let the
         // user know that they've been signed out.
-        updatedAccounts.push(account)
-      }
-    }
+        return account
+      })))
 
-    this.accounts = updatedAccounts
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -114,20 +114,31 @@ export class AccountsStore {
   /** Refresh all accounts by fetching their latest info from the API. */
   public async refresh(): Promise<void> {
 
-    this.accounts = await Promise.all(this.accounts
-      .map(account => updatedAccount(account).catch(e => {
-        log.warn(`Error refreshing account '${account.login}'`, e)
-
-        // If the fetch failed for whatever reason we'll retain
-        // the old Account instance. Usually this fails due to
-        // connectivity issues but in the future we should
-        // investigate whether we're able to detect here that the
-        // token is definitely not valid anymore and let the
-        // user know that they've been signed out.
-        return account
-      })))
+    this.accounts = await Promise.all(
+      this.accounts.map(acc => this.tryUpdateAccount(acc))
+    )
 
     this.emitUpdate()
+  }
+
+  /**
+   * Attempts to update the Account with new information from
+   * the API.
+   *
+   * If the update fails for whatever reason this function
+   * will return the old Account instance. Usually updates fails
+   * due to connectivity issues but in the future we should
+   * investigate whether we're able to detect here that the
+   * token is definitely not valid anymore and let the
+   * user know that they've been signed out.
+   */
+  private async tryUpdateAccount(account: Account): Promise<Account> {
+    try {
+      return await updatedAccount(account)
+    } catch (e) {
+      log.warn(`Error refreshing account '${account.login}'`, e)
+      return account
+    }
   }
 
   /**

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -119,6 +119,13 @@ export class AccountsStore {
         updatedAccounts.push(await updatedAccount(account))
       } catch (e) {
         log.warn(`Error refreshing account '${account.login}'`, e)
+        // If the fetch failed for whatever reason we'll retain
+        // the old Account instance. Usually this fails due to
+        // connectivity issues but in the future we should
+        // investigate whether we're able to detect here that the
+        // token is definitely not valid anymore and let the
+        // user know that they've been signed out.
+        updatedAccounts.push(account)
       }
     }
 


### PR DESCRIPTION
Fixes #3641 

There's some boy scout checkins in here cleaning up and de-duplicating some code but the meat of the fix is https://github.com/desktop/desktop/commit/b0a954e59f5a91cda79fbec8ab14ae486cde0e46.

Whenever we did a refresh we discarded any accounts that we failed to refresh while suppressing the error. I believe this is the cause of other errors we've seen (or I've seen at least) where the account just disappears from the preferences dialog after running the app for a while.

With this PR we're retaining all accounts whether or not we can refresh them. At some point in the future we might consider spotting when an account is actually not usable anymore (i.e. revoked token) and alert the user but this should get us past the immediate issue.