### PR TITLE
some upgrade prep for react-transition-group

### DIFF
--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -131,13 +131,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
     return <p className={className}>{error.message}</p>
   }
 
-  private renderDialog() {
-    const error = this.state.error
-
-    if (!error) {
-      return null
-    }
-
+  private renderDialog(error: Error): JSX.Element {
     return (
       <Dialog
         id="app-error"
@@ -174,6 +168,11 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
   }
 
   public render() {
+    const error = this.state.error
+    if (error == null) {
+      return null
+    }
+
     return (
       <CSSTransitionGroup
         transitionName="modal"
@@ -181,7 +180,7 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
         transitionEnterTimeout={dialogTransitionEnterTimeout}
         transitionLeaveTimeout={dialogTransitionLeaveTimeout}
       >
-        {this.renderDialog()}
+        {this.renderDialog(error)}
       </CSSTransitionGroup>
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1244,6 +1244,11 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private renderPopup() {
+    const content = this.currentPopupContent()
+    if (content == null) {
+      return null
+    }
+
     return (
       <CSSTransitionGroup
         transitionName="modal"
@@ -1251,7 +1256,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         transitionEnterTimeout={dialogTransitionEnterTimeout}
         transitionLeaveTimeout={dialogTransitionLeaveTimeout}
       >
-        {this.currentPopupContent()}
+        {content}
       </CSSTransitionGroup>
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -889,8 +889,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     const popup = this.state.currentPopup
-
-    if (!popup) {
+    if (popup == null) {
       return null
     }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -166,7 +166,7 @@ export class BranchesContainer extends React.Component<
     return assertNever(tab, `Unknown Branches tab: ${tab}`)
   }
 
-  private renderPullRequests() {
+  private renderPullRequests(): JSX.Element {
     const pullRequests = this.props.pullRequests
     if (pullRequests.length) {
       return (

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -227,15 +227,6 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       return null
     }
 
-    const child = (
-      <UndoCommit
-        isPushPullFetchInProgress={this.props.isPushPullFetchInProgress}
-        commit={commit}
-        onUndo={this.onUndo}
-        emoji={this.props.emoji}
-      />
-    )
-
     return (
       <CSSTransitionGroup
         transitionName="undo"
@@ -244,7 +235,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         transitionEnterTimeout={UndoCommitAnimationTimeout}
         transitionLeaveTimeout={UndoCommitAnimationTimeout}
       >
-        {child}
+        <UndoCommit
+          isPushPullFetchInProgress={this.props.isPushPullFetchInProgress}
+          commit={commit}
+          onUndo={this.onUndo}
+          emoji={this.props.emoji}
+        />
       </CSSTransitionGroup>
     )
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -221,19 +221,20 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
   }
 
-  private renderMostRecentLocalCommit() {
+  private renderMostRecentLocalCommit(): JSX.Element | null {
     const commit = this.props.mostRecentLocalCommit
-    let child: JSX.Element | null = null
-    if (commit) {
-      child = (
-        <UndoCommit
-          isPushPullFetchInProgress={this.props.isPushPullFetchInProgress}
-          commit={commit}
-          onUndo={this.onUndo}
-          emoji={this.props.emoji}
-        />
-      )
+    if (commit == null) {
+      return null
     }
+
+    const child = (
+      <UndoCommit
+        isPushPullFetchInProgress={this.props.isPushPullFetchInProgress}
+        commit={commit}
+        onUndo={this.onUndo}
+        emoji={this.props.emoji}
+      />
+    )
 
     return (
       <CSSTransitionGroup

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -85,11 +85,7 @@ export class FullScreenInfo extends React.Component<
     this.setState({ renderTransitionGroup: false })
   }
 
-  private renderFullScreenNotification() {
-    if (!this.state.renderInfo) {
-      return null
-    }
-
+  private renderFullScreenNotification(): JSX.Element {
     const kbdShortcut = __DARWIN__ ? '⌃⌘F' : 'F11'
 
     return (
@@ -101,6 +97,10 @@ export class FullScreenInfo extends React.Component<
 
   public render() {
     if (!this.state.renderTransitionGroup) {
+      return null
+    }
+
+    if (!this.state.renderInfo) {
       return null
     }
 

--- a/app/src/ui/window/zoom-info.tsx
+++ b/app/src/ui/window/zoom-info.tsx
@@ -83,11 +83,7 @@ export class ZoomInfo extends React.Component<IZoomInfoProps, IZoomInfoState> {
     this.setState({ renderTransitionGroup: false })
   }
 
-  private renderZoomInfo() {
-    if (!this.state.renderInfo) {
-      return null
-    }
-
+  private renderZoomInfo(): JSX.Element {
     const zoomPercent = `${(this.state.windowZoomFactor * 100).toFixed(0)} %`
 
     return (
@@ -99,6 +95,10 @@ export class ZoomInfo extends React.Component<IZoomInfoProps, IZoomInfoState> {
 
   public render() {
     if (!this.state.renderTransitionGroup) {
+      return null
+    }
+
+    if (!this.state.renderInfo) {
       return null
     }
 


### PR DESCRIPTION
The next major version of `react-transition-group` has a bunch of breaking changes, one of which is that it doesn't support `null` children:

https://github.com/reactjs/react-transition-group/blob/master/src/Transition.js#L342

[This API throws an error at runtime when it receives a `null`.](https://reactjs.org/docs/react-api.html#reactchildrenonly)

This PR tightens up our usage of `react-transition-group` so we're always passing a valid node to `CSSTransitionGroup`...