### PR TITLE
Add min-height to btn's (Blank Slate)

### DIFF
--- a/app/styles/ui/_blank-slate.scss
+++ b/app/styles/ui/_blank-slate.scss
@@ -47,6 +47,7 @@
 
     button {
       flex-grow: 0;
+      min-height: 40px;
     }
   }
 


### PR DESCRIPTION
It might not be major bug-fix but it fixes something :)

**Before**:
<img width="671" alt="screen shot 2017-12-25 at 8 00 33 pm" src="https://user-images.githubusercontent.com/2890683/34340692-d0ff150c-e9ae-11e7-927d-3e3181e94df3.png">

**After**
![image](https://user-images.githubusercontent.com/2890683/34340695-d956939c-e9ae-11e7-9cf3-7968d84d8ea3.png)
