### PR TITLE
allow links in unexpanded summary to be clickable

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -85,6 +85,7 @@
       position: absolute;
       height: 100%;
       width: 100%;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
the `:before` pseudo-element prevented any link in the summary to be clickable.
Only when the summary was expanded links would be clickable. However the expand button doesn't show when the content fits the container.
By disabling pointer events on the pseudo-element links are now always clickable.