### PR TITLE
sometimes it doesn't make sense to create a branch

### DIFF
--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -224,7 +224,12 @@ export class BranchList extends React.Component<
   }
 
   private renderNoItems = () => {
-    return <NoBranches onCreateNewBranch={this.onCreateNewBranch} />
+    return (
+      <NoBranches
+        onCreateNewBranch={this.onCreateNewBranch}
+        canCreateNewBranch={this.props.canCreateNewBranch}
+      />
+    )
   }
 
   private renderNewButton = () => {

--- a/app/src/ui/branches/no-branches.tsx
+++ b/app/src/ui/branches/no-branches.tsx
@@ -8,33 +8,46 @@ const BlankSlateImage = encodePathAsUrl(
 )
 
 interface INoBranchesProps {
+  /** The callback to invoke when the user wishes to create a new branch */
   readonly onCreateNewBranch: () => void
+  /** True to display the UI elements for creating a new branch, false to hide them */
+  readonly canCreateNewBranch: boolean
 }
 
 export class NoBranches extends React.Component<INoBranchesProps> {
   public render() {
+    if (this.props.canCreateNewBranch) {
+      return (
+        <div className="no-branches">
+          <img src={BlankSlateImage} className="blankslate-image" />
+
+          <div className="title">Sorry, I can't find that branch</div>
+
+          <div className="subtitle">
+            Do you want to create a new branch instead?
+          </div>
+
+          <Button
+            className="create-branch-button"
+            onClick={this.props.onCreateNewBranch}
+            type="submit"
+          >
+            {__DARWIN__ ? 'Create New Branch' : 'Create new branch'}
+          </Button>
+
+          <div className="protip">
+            ProTip! Press {this.renderShortcut()} to quickly create a new branch
+            from anywhere within the app
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className="no-branches">
         <img src={BlankSlateImage} className="blankslate-image" />
 
         <div className="title">Sorry, I can't find that branch</div>
-
-        <div className="subtitle">
-          Do you want to create a new branch instead?
-        </div>
-
-        <Button
-          className="create-branch-button"
-          onClick={this.props.onCreateNewBranch}
-          type="submit"
-        >
-          {__DARWIN__ ? 'Create New Branch' : 'Create new branch'}
-        </Button>
-
-        <div className="protip">
-          ProTip! Press {this.renderShortcut()} to quickly create a new branch
-          from anywhere within the app
-        </div>
       </div>
     )
   }


### PR DESCRIPTION
Fixes #3733 

This is what you now see when a branch can't be found in the merge dialog:

<img width="480" src="https://user-images.githubusercontent.com/359239/34632022-96d326a4-f249-11e7-8836-d11d763ed665.png">

I wanted to use [React fragments](https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html) in here to avoid refactoring the layout and CSS, but that doesn't seem to be supported in pre-16. This is what it would look like:

```tsx
  public render() {
    return (
      <div className="no-branches">
        <img src={BlankSlateImage} className="blankslate-image" />

        <div className="title">Sorry, I can't find that branch</div>

        {this.renderCreateBranch()}
      </div>
    )
  }

  private renderCreateBranch(): JSX.Element | null {
    if (this.props.canCreateNewBranch) {
      return (
        <>
          <div className="subtitle">
            Do you want to create a new branch instead?
          </div>

          <Button
            className="create-branch-button"
            onClick={this.props.onCreateNewBranch}
            type="submit"
          >
            {__DARWIN__ ? 'Create New Branch' : 'Create new branch'}
          </Button>

          <div className="protip">
            ProTip! Press {this.renderShortcut()} to quickly create a new branch
            from anywhere within the app
          </div>
        </>
      )
    } else {
      return null
    }
  }
```


