### PR TITLE
find the ref in the packed-refs file as part of building

### DIFF
--- a/app/git-info.js
+++ b/app/git-info.js
@@ -7,6 +7,9 @@ function packedRefsParse(gitDir, ref) {
   const packedRefsPath = path.join(gitDir, 'packed-refs')
 
   try {
+    // by performing a `stat` before reading the file contents,
+    // we can confirm the file exists on disk or try something else
+
     // eslint-disable-next-line no-sync
     fs.statSync(packedRefsPath)
   } catch (err) {
@@ -41,6 +44,9 @@ function revParse(gitDir, ref) {
   const refPath = path.join(gitDir, ref)
 
   try {
+    // by performing a `stat` before reading the file contents,
+    // we can confirm the file exists on disk or try something else
+
     // eslint-disable-next-line no-sync
     fs.statSync(refPath)
   } catch (err) {

--- a/app/git-info.js
+++ b/app/git-info.js
@@ -44,6 +44,11 @@ function revParse(gitDir, ref) {
     // eslint-disable-next-line no-sync
     fs.statSync(refPath)
   } catch (err) {
+    const packedRefMatch = packedRefsParse(gitDir, ref)
+    if (packedRefMatch) {
+      return packedRefMatch
+    }
+
     throw new Error(
       `Could not de-reference HEAD to SHA, ref does not exist on disk: ${refPath}`
     )

--- a/app/git-info.js
+++ b/app/git-info.js
@@ -3,6 +3,30 @@
 const fs = require('fs')
 const path = require('path')
 
+function packedRefsParse(gitDir, ref) {
+  const refPath = path.join(gitDir, 'packed-refs')
+
+  try {
+    // eslint-disable-next-line no-sync
+    fs.statSync(refPath)
+  } catch (err) {
+    // fail quietly if no packed-refs file exists
+    return null
+  }
+
+  // eslint-disable-next-line no-sync
+  const packedRefsContents = fs.readFileSync(refPath)
+
+  // we need to build up the regex on the fly using the ref
+  const refRe = new RegExp('([a-f0-9]{40}) ' + ref)
+  const packedRefMatch = refRe.exec(packedRefsContents)
+
+  if (!packedRefMatch) {
+    throw new Error(`Could not find ref entry in .git/packed-refs file: ${ref}`)
+  }
+  return packedRefMatch[1]
+}
+
 /**
  * Attempt to dereference the given ref without requiring a Git environment
  * to be present. Note that this method will not be able to dereference packed

--- a/app/git-info.js
+++ b/app/git-info.js
@@ -3,13 +3,20 @@
 const fs = require('fs')
 const path = require('path')
 
-function packedRefsParse(gitDir, ref) {
+/**
+ * Attempt to find a ref in the .git/packed-refs file, which is often
+ * created by Git as part of cleaning up loose refs in the repository.
+ *
+ * Will return null if the packed-refs file is missing.
+ * Will throw an error if the entry is not found in the packed-refs file
+ *
+ * @param {string} gitDir The path to the Git repository's .git directory
+ * @param {string} ref    A qualified git ref such as 'refs/heads/master'
+ */
+function readPackedRefsFile(gitDir, ref) {
   const packedRefsPath = path.join(gitDir, 'packed-refs')
 
   try {
-    // by performing a `stat` before reading the file contents,
-    // we can confirm the file exists on disk or try something else
-
     // eslint-disable-next-line no-sync
     fs.statSync(packedRefsPath)
   } catch (err) {
@@ -44,13 +51,10 @@ function revParse(gitDir, ref) {
   const refPath = path.join(gitDir, ref)
 
   try {
-    // by performing a `stat` before reading the file contents,
-    // we can confirm the file exists on disk or try something else
-
     // eslint-disable-next-line no-sync
     fs.statSync(refPath)
   } catch (err) {
-    const packedRefMatch = packedRefsParse(gitDir, ref)
+    const packedRefMatch = readPackedRefsFile(gitDir, ref)
     if (packedRefMatch) {
       return packedRefMatch
     }

--- a/app/git-info.js
+++ b/app/git-info.js
@@ -15,6 +15,15 @@ const path = require('path')
  */
 function revParse(gitDir, ref) {
   const refPath = path.join(gitDir, ref)
+
+  try {
+    // eslint-disable-next-line no-sync
+    fs.statSync(refPath)
+  } catch (err) {
+    throw new Error(
+      `Could not de-reference HEAD to SHA, ref does not exist on disk: ${refPath}`
+    )
+  }
   // eslint-disable-next-line no-sync
   const refContents = fs.readFileSync(refPath)
   const refRe = /^([a-f0-9]{40})|(?:ref: (refs\/.*))$/m

--- a/app/git-info.js
+++ b/app/git-info.js
@@ -4,18 +4,18 @@ const fs = require('fs')
 const path = require('path')
 
 function packedRefsParse(gitDir, ref) {
-  const refPath = path.join(gitDir, 'packed-refs')
+  const packedRefsPath = path.join(gitDir, 'packed-refs')
 
   try {
     // eslint-disable-next-line no-sync
-    fs.statSync(refPath)
+    fs.statSync(packedRefsPath)
   } catch (err) {
-    // fail quietly if no packed-refs file exists
+    // fail quietly if packed-refs not found
     return null
   }
 
   // eslint-disable-next-line no-sync
-  const packedRefsContents = fs.readFileSync(refPath)
+  const packedRefsContents = fs.readFileSync(packedRefsPath)
 
   // we need to build up the regex on the fly using the ref
   const refRe = new RegExp('([a-f0-9]{40}) ' + ref)


### PR DESCRIPTION
I just did a `git gc` after tidying up some remotes in my repository and encountered this error when I wanted to get back to work:

```shellsession
$ yarn build:dev
yarn run v1.3.2
$ yarn compile:dev && cross-env NODE_ENV=development ts-node script/build.ts
$ cross-env NODE_ENV=development parallel-webpack --config app/webpack.development.js
[WEBPACK] Could not load configuration file /Users/shiftkey/src/desktop/app/webpack.development.js
Error: ENOENT: no such file or directory, open '/Users/shiftkey/src/desktop/.git/refs/heads/master'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

`HEAD` is currently pointing to a valid ref:

```shellsession
$ more .git/HEAD
ref: refs/heads/master
```

And sure enough, the file doesn't exist on disk:

```shellsession
$ ls .git/refs/heads/
agis                    feature
```

You might think that this repository is corrupted beyond repair, but it's not. Git has just decided to cleanup all the loose refs on disk into `.git/packed-refs`, which is a file that looks like this:

```
# pack-refs with: peeled fully-peeled sorted 
9a313e2dd1ee5cc8f5d40ab420b0f3fee1db5aa0 refs/heads/add-permissions-hash-for-repository
65bf62873a35fe7629cfbcd593104ff67879ede5 refs/heads/beta-link-to-release-notes-works
e0460e31a279cf1109cd2a05b4c5233e5275803c refs/heads/bump-to-react-16
4902cd4dd3662aea8825fa08fbced4debe8968e0 refs/heads/changelog-new-format
c392d65adc86462cfac1082038d2b28479b7df70 refs/heads/circle-electron-cache-issue
89b93f5e51f31fecbb129e1285b07ab71367f634 refs/heads/committer-is-also-important
39fcadcfd2cb097cfa97e44dfa9a390a7c7192e4 refs/heads/config-shows-untracked-files
3bf358b93a9b569c7419268b861cd241bb0ec5e7 refs/heads/confirm-delete-pull-request
5af633467af1ef4bdc665ed20dcd9f628ce77d09 refs/heads/dont-remove-submodules
a95f5e71a72a6867a588363517c1055128d599b7 refs/heads/encodings-as-a-first-class-thing
ddffb0f53ec4089c4648f2c5565e12915c652e1b refs/heads/explorer-and-file-manager
c9c984800a79823213ff2a63d955c86ecdf13184 refs/heads/feature/svg-visual-diffs
f39d0d013461c885c77d9ef3fceab4fe5655f934 refs/heads/flip-the-order-of-branches
097e955c3c9874ba28654c9209c1f1fbb2b520be refs/heads/ignore-should-remove-tracked-files
9af16919d89200731191a4cd4da813e728b8b5e6 refs/heads/in-app-release-notes
d1c32b6ba2a73370fad45ab61c06b6c7176ca4f4 refs/heads/its-more-prettier
4c10d321435d4565c1ee9cc9b1858a345f386e7f refs/heads/master
19823864d2caa1f3ae6d3bb97c036ec40db5118f refs/heads/menu-labels
...
```

And you can see our `refs/heads/master` entry in there. This is how Git is able to resolve where we are in the repository without the existing loose ref.

This PR makes our `revParse` function looked for `.git/packed-refs` as a fallback, to see if it can find this ref. This should also resolve our issue with CircleCI using packed-refs, but I'm happy to leave that workaround in there for now while we ensure this code is resilient.

```ts
  // CircleCI does some funny stuff where HEAD points to an packed ref, but
  // luckily it gives us the SHA we want in the environment.
  const circleSHA = process.env.CIRCLE_SHA1
  if (circleSHA) {
    return circleSHA
  }
```
  