### PR TITLE
defer user/email validation in Preferences

### DIFF
--- a/app/src/ui/preferences/identifier-rules.ts
+++ b/app/src/ui/preferences/identifier-rules.ts
@@ -1,6 +1,10 @@
 import { fatalError } from '../../lib/fatal-error'
 
 export function disallowedCharacters(values: string): string | null {
+  if (values.length === 0) {
+    return null
+  }
+
   for (const value of values) {
     if (disallowedCharacter(value) === false) {
       return null

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -39,6 +39,7 @@ interface IPreferencesState {
   readonly selectedIndex: PreferencesTab
   readonly committerName: string
   readonly committerEmail: string
+  readonly disallowedCharactersMessage: string | null
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
@@ -61,6 +62,7 @@ export class Preferences extends React.Component<
       selectedIndex: this.props.initialSelectedTab || PreferencesTab.Accounts,
       committerName: '',
       committerEmail: '',
+      disallowedCharactersMessage: null,
       availableEditors: [],
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
@@ -118,12 +120,6 @@ export class Preferences extends React.Component<
   }
 
   public render() {
-    const disallowedCharactersError = this.disallowedCharacterErrorMessage(
-      this.state.committerName,
-      this.state.committerEmail
-    )
-    const hasDisallowedCharacter = disallowedCharactersError !== null
-
     return (
       <Dialog
         id="preferences"
@@ -131,7 +127,7 @@ export class Preferences extends React.Component<
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSave}
       >
-        {this.renderDisallowedCharactersError(disallowedCharactersError)}
+        {this.renderDisallowedCharactersError()}
         <TabBar
           onTabClicked={this.onTabClicked}
           selectedIndex={this.state.selectedIndex}
@@ -142,7 +138,7 @@ export class Preferences extends React.Component<
         </TabBar>
 
         {this.renderActiveTab()}
-        {this.renderFooter(hasDisallowedCharacter)}
+        {this.renderFooter()}
       </Dialog>
     )
   }
@@ -163,18 +159,20 @@ export class Preferences extends React.Component<
 
   private disallowedCharacterErrorMessage(name: string, email: string) {
     const disallowedNameCharacters = disallowedCharacters(name)
-    const disallowedEmailCharacters = disallowedCharacters(email)
-
     if (disallowedNameCharacters !== null) {
       return `Git name field cannot be a disallowed character "${disallowedNameCharacters}"`
-    } else if (disallowedEmailCharacters !== null) {
-      return `Git email field cannot be a disallowed character "${disallowedEmailCharacters}"`
-    } else {
-      return null
     }
+
+    const disallowedEmailCharacters = disallowedCharacters(email)
+    if (disallowedEmailCharacters !== null) {
+      return `Git email field cannot be a disallowed character "${disallowedEmailCharacters}"`
+    }
+
+    return null
   }
 
-  private renderDisallowedCharactersError(message: string | null) {
+  private renderDisallowedCharactersError() {
+    const message = this.state.disallowedCharactersMessage
     if (message !== null) {
       return <DialogError>{message}</DialogError>
     } else {
@@ -246,11 +244,21 @@ export class Preferences extends React.Component<
   }
 
   private onCommitterNameChanged = (committerName: string) => {
-    this.setState({ committerName })
+    const disallowedCharactersMessage = this.disallowedCharacterErrorMessage(
+      committerName,
+      this.state.committerEmail
+    )
+
+    this.setState({ committerName, disallowedCharactersMessage })
   }
 
   private onCommitterEmailChanged = (committerEmail: string) => {
-    this.setState({ committerEmail })
+    const disallowedCharactersMessage = this.disallowedCharacterErrorMessage(
+      this.state.committerName,
+      committerEmail
+    )
+
+    this.setState({ committerEmail, disallowedCharactersMessage })
   }
 
   private onSelectedEditorChanged = (editor: ExternalEditor) => {
@@ -261,7 +269,9 @@ export class Preferences extends React.Component<
     this.setState({ selectedShell: shell })
   }
 
-  private renderFooter(hasDisabledError: boolean) {
+  private renderFooter() {
+    const hasDisabledError = this.state.disallowedCharactersMessage !== null
+
     const index = this.state.selectedIndex
     switch (index) {
       case PreferencesTab.Accounts:

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -159,12 +159,12 @@ export class Preferences extends React.Component<
 
   private disallowedCharacterErrorMessage(name: string, email: string) {
     const disallowedNameCharacters = disallowedCharacters(name)
-    if (disallowedNameCharacters !== null) {
+    if (disallowedNameCharacters != null) {
       return `Git name field cannot be a disallowed character "${disallowedNameCharacters}"`
     }
 
     const disallowedEmailCharacters = disallowedCharacters(email)
-    if (disallowedEmailCharacters !== null) {
+    if (disallowedEmailCharacters != null) {
       return `Git email field cannot be a disallowed character "${disallowedEmailCharacters}"`
     }
 
@@ -173,7 +173,7 @@ export class Preferences extends React.Component<
 
   private renderDisallowedCharactersError() {
     const message = this.state.disallowedCharactersMessage
-    if (message !== null) {
+    if (message != null) {
       return <DialogError>{message}</DialogError>
     } else {
       return null
@@ -270,7 +270,7 @@ export class Preferences extends React.Component<
   }
 
   private renderFooter() {
-    const hasDisabledError = this.state.disallowedCharactersMessage !== null
+    const hasDisabledError = this.state.disallowedCharactersMessage != null
 
     const index = this.state.selectedIndex
     switch (index) {

--- a/app/test/unit/identifier-rules-test.ts
+++ b/app/test/unit/identifier-rules-test.ts
@@ -15,6 +15,10 @@ describe('Identifier rules', () => {
     expect(disallowedCharacters(' ')).to.equal(' ')
   })
 
+  it('returns null when it receives an empty string', () => {
+    expect(disallowedCharacters('')).to.be.null
+  })
+
   it('returns values that are for ascii character codes 0-32 inclusive', () => {
     for (let i = 0; i <= 32; i++) {
       const char = String.fromCharCode(i)


### PR DESCRIPTION
Fixes #3722 by only firing the validation when the app detects the user/email fields have been changed.

Also catches a corner case where `disallowedCharacters` doesn't handle an empty string.