### PR TITLE
[experiment] tracing our GIT_ASKPASS work on Windows

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.0.12",
+  "version": "1.0.12-test1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.0.12-test1",
+  "version": "1.0.12-test2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/ask-pass/ask-pass.ts
+++ b/app/src/ask-pass/ask-pass.ts
@@ -1,12 +1,15 @@
 import { getKeyForEndpoint } from '../lib/auth'
 import { TokenStore } from '../lib/stores/token-store'
 
+import { appendToAskPassLog } from './logger'
+
 /** Parse the GIT_ASKPASS prompt and determine the appropriate response. */
 export async function responseForPrompt(
   prompt: string
 ): Promise<string | null> {
   const username: string | null = process.env.DESKTOP_USERNAME
   if (!username || !username.length) {
+    appendToAskPassLog(`username '${username}' is not valid`)
     return null
   }
 
@@ -15,12 +18,19 @@ export async function responseForPrompt(
   } else if (prompt.startsWith('Password')) {
     const endpoint: string | null = process.env.DESKTOP_ENDPOINT
     if (!endpoint || !endpoint.length) {
+      appendToAskPassLog(`endpoint '${endpoint}' is not valid`)
       return null
     }
 
     const key = getKeyForEndpoint(endpoint)
-    return await TokenStore.getItem(key, username)
+    appendToAskPassLog(`using key '${key}' to find token`)
+    const token = await TokenStore.getItem(key, username)
+    if (!token || !token.length) {
+      appendToAskPassLog(`token '${token}' is not what we expected`)
+    }
+    return token
   }
 
+  appendToAskPassLog(`prompt '${prompt}' was unhandled`)
   return null
 }

--- a/app/src/ask-pass/logger.ts
+++ b/app/src/ask-pass/logger.ts
@@ -16,5 +16,6 @@ export function appendToAskPassLog(message: string) {
   }
 
   const file = Path.join(getLogDirectoryPath(), askPassLogFile)
+  // eslint-disable-next-line no-sync
   Fs.appendFileSync(file, `${message}\n`)
 }

--- a/app/src/ask-pass/logger.ts
+++ b/app/src/ask-pass/logger.ts
@@ -1,0 +1,20 @@
+import * as Path from 'path'
+import * as Fs from 'fs'
+
+function getLogDirectoryPath() {
+  const appData = process.env.APPDATA
+  const folderName = __DEV__ ? 'GitHub Desktop-dev' : 'GitHub Desktop'
+  const directory = Path.join(appData, folderName, 'logs')
+  return directory
+}
+
+const askPassLogFile = 'ask-pass.log'
+
+export function appendToAskPassLog(message: string) {
+  if (!__WIN32__) {
+    return
+  }
+
+  const file = Path.join(getLogDirectoryPath(), askPassLogFile)
+  Fs.appendFileSync(file, `${message}\n`)
+}

--- a/app/src/ask-pass/main.ts
+++ b/app/src/ask-pass/main.ts
@@ -3,11 +3,24 @@
  */
 
 import { responseForPrompt } from './ask-pass'
+import { appendToAskPassLog } from './logger'
 
 const prompt = process.argv[2]
-responseForPrompt(prompt).then(response => {
-  if (response) {
-    process.stdout.write(response)
-    process.stdout.end()
-  }
-})
+
+appendToAskPassLog(`received arguments: ${JSON.stringify(process.argv)}`)
+appendToAskPassLog(`environment variables: ${JSON.stringify(process.env)}`)
+appendToAskPassLog(`received prompt: '${prompt}'`)
+
+responseForPrompt(prompt)
+  .then(response => {
+    if (response) {
+      appendToAskPassLog(`emitting response: ${response.length} characters`)
+      process.stdout.write(response)
+      process.stdout.end()
+    } else {
+      appendToAskPassLog(`skipping response as responseForPrompt returned null`)
+    }
+  })
+  .then(() => {
+    appendToAskPassLog(`exiting...`)
+  })

--- a/app/src/ask-pass/main.ts
+++ b/app/src/ask-pass/main.ts
@@ -8,7 +8,12 @@ import { appendToAskPassLog } from './logger'
 const prompt = process.argv[2]
 
 appendToAskPassLog(`received arguments: ${JSON.stringify(process.argv)}`)
-appendToAskPassLog(`environment variables: ${JSON.stringify(process.env)}`)
+appendToAskPassLog(
+  `process.env.DESKTOP_USERNAME: '${process.env.DESKTOP_USERNAME}'`
+)
+appendToAskPassLog(
+  `process.env.DESKTOP_ENDPOINT: '${process.env.DESKTOP_ENDPOINT}'`
+)
 appendToAskPassLog(`received prompt: '${prompt}'`)
 
 responseForPrompt(prompt)

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.0.12-test2": [
+      "[Improved] Now with even fewer environment variables logged"
+    ],
     "1.0.12-test1": [
       "[Improved] Adding tracing to GIT_ASKPASS implementation to understand the behaviour"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.0.12-test1": [
+      "[Improved] Adding tracing to GIT_ASKPASS implementation to understand the behaviour"
+    ],
     "1.0.12": [
       "[New] Syntax highlighting for Rust files - #3666. Thanks @subnomo!",
       "[New] Syntax highlighting for Clojure cljc, cljs, and edn files - #3610. Thanks @mtkp!",


### PR DESCRIPTION
🌵 🌵 🌵 🌵  **THIS IS NOT INTENDED TO BE MERGED, LIKE EVER** 🌵 🌵 🌵 🌵 

We've had a few issues with our `GIT_ASKPASS` implementation over time - #2623 #2747 #2812 are examples - and I thought I was close in #3752 to understanding this, but it's still an opaque box (for good reason).

This PR is an experiment to get better tracing when Desktop needs to serve credentials, so we can catch these erroneous cases as they occur.

Here's an example of this working on my machine:

```
received arguments: ["C:\\Users\\shiftkey\\AppData\\Local\\GitHubDesktop\\app-1.0.12-test2\\GitHubDesktop.exe","C:\\Users\\shiftkey\\AppData\\Local\\GitHubDesktop\\app-1.0.12-test2\\resources\\app\\ask-pass.js","Password for 'https://shiftkey@github.com': "]
process.env.DESKTOP_USERNAME: 'shiftkey'
process.env.DESKTOP_ENDPOINT: 'https://api.github.com'
received prompt: 'Password for 'https://shiftkey@github.com': '
using key 'GitHub - https://api.github.com' to find token
emitting response: 40 characters
exiting...
```

For the moment, I'm planning to cut a test release so that we can understand what's happening with Git LFS using our `GIT_ASKPASS` implementation, but if this helps us to understand other issues maybe we can enable this more formally using our existing logging infrastructure so that it handles rotating log files.