### PR TITLE
hide .eslintcache from the VS code sidebar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
     "**/dist": true,
     "**/out": true,
     "tslint-rules/**/*.js": true,
-    ".awcache": true
+    ".awcache": true,
+    ".eslintcache": true
   },
   "editor.tabSize": 2,
   "prettier.semi": false,


### PR DESCRIPTION
<img width="318" src="https://user-images.githubusercontent.com/359239/34841763-be0d179e-f6df-11e7-9c2d-978bf000fc72.png">

The grayed out text indicates this file is ignored by Git - and we don't need to look at it or edit it so let's hide it away...