### PR TITLE
add link to commit SHA in History/CommitSummary

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -15,6 +15,7 @@ interface ICommitSummaryProps {
   readonly files: ReadonlyArray<FileChange>
   readonly emoji: Map<string, string>
   readonly gitHubUser: IGitHubUser | null
+  readonly onViewCommitOnGitHub: (sha: string) => void
 
   /**
    * Whether or not the commit body container should
@@ -187,6 +188,10 @@ export class CommitSummary extends React.Component<
     this.props.onExpandChanged(false)
   }
 
+  private onViewCommitOnGitHubClicked = () => {
+    this.props.onViewCommitOnGitHub(this.props.commit.sha)
+  }
+
   private updateOverflow() {
     const scrollView = this.descriptionScrollViewRef
     if (scrollView) {
@@ -301,11 +306,15 @@ export class CommitSummary extends React.Component<
               {author.name}
             </li>
 
-            <li className="commit-summary-meta-item" aria-label="SHA">
+            <li
+              className="commit-summary-meta-item"
+              onClick={this.onViewCommitOnGitHubClicked}
+              aria-label="SHA"
+            >
               <span aria-hidden="true">
                 <Octicon symbol={OcticonSymbol.gitCommit} />
               </span>
-              <span className="sha">{shortSHA}</span>
+              <span className="sha link-button-component">{shortSHA}</span>
             </li>
 
             <li className="commit-summary-meta-item" title={filesDescription}>

--- a/app/src/ui/history/history.tsx
+++ b/app/src/ui/history/history.tsx
@@ -24,6 +24,7 @@ interface IHistoryProps {
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly imageDiffType: ImageDiffType
+  readonly onViewCommitOnGitHub: (sha: string) => void
 }
 
 interface IHistoryState {
@@ -103,6 +104,7 @@ export class History extends React.Component<IHistoryProps, IHistoryState> {
         gitHubUser={gitHubUser}
         onExpandChanged={this.onExpandChanged}
         isExpanded={this.state.isExpanded}
+        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -191,6 +191,7 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}
           imageDiffType={this.props.imageDiffType}
+          onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         />
       )
     } else {


### PR DESCRIPTION
"View commit on GitHub" feature was available only from commit list context menu. Since SHA is exposed in CommitSummary I think that for usability sake it will be nice to add link to it.