### PR TITLE
Add Elixir syntax highlighting

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "chalk": "^2.3.0",
     "classnames": "^2.2.5",
     "codemirror": "^5.31.0",
-    "codemirror-mode-elixir": "^1.1.1",
+    "codemirror-mode-elixir": "1.1.1",
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "dugite": "1.53.0",

--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "chalk": "^2.3.0",
     "classnames": "^2.2.5",
     "codemirror": "^5.31.0",
+    "codemirror-mode-elixir": "^1.1.1",
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "dugite": "1.53.0",

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -108,6 +108,10 @@ extensionMIMEMap.set('.edn', 'text/x-clojure')
 import 'codemirror/mode/rust/rust'
 extensionMIMEMap.set('.rs', 'text/x-rustsrc')
 
+import 'codemirror-mode-elixir'
+extensionMIMEMap.set('.ex', 'text/x-elixir')
+extensionMIMEMap.set('.exs', 'text/x-elixir')
+
 function guessMimeType(contents: string) {
   if (contents.startsWith('<?xml')) {
     return 'text/xml'

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -155,7 +155,7 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
-codemirror-mode-elixir@^1.1.1:
+codemirror-mode-elixir@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/codemirror-mode-elixir/-/codemirror-mode-elixir-1.1.1.tgz#cc5b79bf5f93b6da426e32364a673a681391416c"
   dependencies:

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -155,6 +155,16 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
+codemirror-mode-elixir@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/codemirror-mode-elixir/-/codemirror-mode-elixir-1.1.1.tgz#cc5b79bf5f93b6da426e32364a673a681391416c"
+  dependencies:
+    codemirror "^5.20.2"
+
+codemirror@^5.20.2:
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.33.0.tgz#462ad9a6fe8d38b541a9536a3997e1ef93b40c6a"
+
 codemirror@^5.31.0:
   version "5.31.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.31.0.tgz#ecf3d057eb74174147066bfc7c5f37b4c4e07df2"

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust
+JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
CodeMirror no longer accepting new modes into the main distribution. I had to add codemirror-mode-elixir package for elixir syntax highlighting
Example files can be found on this PR: https://github.com/desktop/highlighter-tests/pull/16

Example:
![Elixir Example](https://user-images.githubusercontent.com/6165892/34854676-3a4eab0a-f722-11e7-8539-757f00b414a5.png)
