### PR TITLE
Include the target branch name in checkout progress

### DIFF
--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -43,7 +43,7 @@ export async function checkoutBranch(
   if (progressCallback) {
     const title = `Checking out branch ${branch.name}`
     const kind = 'checkout'
-    const targetBranch = name
+    const targetBranch = branch.name
 
     opts = await executionOptionsWithProgress(
       { ...opts, trackLFSProgress: true },

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1635,7 +1635,7 @@ export class AppStore {
         kind,
         title: __DARWIN__ ? 'Refreshing Repository' : 'Refreshing repository',
         value: 1,
-        targetBranch: name,
+        targetBranch: foundBranch.name,
       })
 
       await this._refreshRepository(repository)


### PR DESCRIPTION
In https://github.com/desktop/desktop/pull/3624 and more specifically [this commit](https://github.com/desktop/desktop/commit/36d09c4eef8889de0e270ad3c75f1fb0d3e85cf3#diff-add0573c153f21fa8f761218c9a1fbd8) the name of the function parameter to `checkout` was changed from `name` to `branch` (and switched types). We were relying on `name` for the checkout progress `targetBranch` argument which is used to display the branch name that's being checked out in the branch toolbar button.

https://github.com/desktop/desktop/blob/f275521d0d0e30d7c062deb82ae38a5140e6efd9/app/src/lib/git/checkout.ts#L46-L56

Normally this oversight would have caused a compilation error but it turns out that `name` is a globally defined const of type `never`

![screen shot 2018-01-12 at 16 28 07](https://user-images.githubusercontent.com/634063/34882060-9f81f49e-f7b5-11e7-86d6-58cb8dbdfbf3.png)

😞 

