### PR TITLE
add a hint about the directory where the app is launching from

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -227,6 +227,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.checkForUpdates(true)
 
     log.info(`launching: ${getVersion()} (${getOS()})`)
+    log.info(`execPath: '${process.execPath}'`)
   }
 
   private onMenuEvent(name: MenuEvent): any {


### PR DESCRIPTION
This came to me while investigating #3752.

It took a while for it to click that the user's account name was important to reproducing this issue, and having this information up front in the log will probably help speed up the troubleshooting of issues down the track.