### PR TITLE
Clear repository filter text when switching tabs

### DIFF
--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -37,7 +37,7 @@ interface ICloneGithubRepositoryProps {
   /** Called when a repository is selected. */
   readonly onGitHubRepositorySelected: (url: string) => void
 
-  /** Should we clear the filterText on render? */
+  /** Should the component clear the filter text on render? */
   readonly shouldClearFilter: boolean
 }
 

--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -36,6 +36,9 @@ interface ICloneGithubRepositoryProps {
 
   /** Called when a repository is selected. */
   readonly onGitHubRepositorySelected: (url: string) => void
+
+  /** Should we clear the filterText on render? */
+  readonly shouldClearFilter: boolean
 }
 
 interface ICloneGithubRepositoryState {
@@ -114,6 +117,12 @@ export class CloneGithubRepository extends React.Component<
   }
 
   public componentWillReceiveProps(nextProps: ICloneGithubRepositoryProps) {
+    if (nextProps.shouldClearFilter) {
+      this.setState({
+        filterText: '',
+      })
+    }
+
     if (nextProps.account.id !== this.props.account.id) {
       this.loadRepositories(nextProps.account)
     }

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -62,7 +62,7 @@ interface ICloneRepositoryState {
    */
   readonly lastParsedIdentifier: IRepositoryIdentifier | null
 
-  /** Should we clear the filterText on render? */
+  /** Should the component clear the filter text on render? */
   readonly shouldClearFilter: boolean
 }
 

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -61,6 +61,9 @@ interface ICloneRepositoryState {
    * The repository identifier that was last parsed from the user-entered URL.
    */
   readonly lastParsedIdentifier: IRepositoryIdentifier | null
+
+  /** Should we clear the filterText on render? */
+  readonly shouldClearFilter: boolean
 }
 
 /** The component for cloning a repository. */
@@ -77,7 +80,14 @@ export class CloneRepository extends React.Component<
       loading: false,
       error: null,
       lastParsedIdentifier: null,
+      shouldClearFilter: false,
     }
+  }
+
+  public componentWillReceiveProps(nextProps: ICloneRepositoryProps) {
+    this.setState({
+      shouldClearFilter: this.props.selectedTab !== nextProps.selectedTab,
+    })
   }
 
   public componentDidMount() {
@@ -176,6 +186,7 @@ export class CloneRepository extends React.Component<
               onGitHubRepositorySelected={this.updateUrl}
               onChooseDirectory={this.onChooseDirectory}
               onDismissed={this.props.onDismissed}
+              shouldClearFilter={this.state.shouldClearFilter}
             />
           )
         }


### PR DESCRIPTION
... in the Clone Repository modal.

Addressing issue #3739

----

The issue was labeled with `help-wanted` so I decided to give it a go, hope you guys don't mind me interfering. 

This is a first approach using @tierninho 's suggestion in https://github.com/desktop/desktop/issues/3739#issuecomment-356107533, so it doesn't take into account my own inquiry in https://github.com/desktop/desktop/issues/3739#issuecomment-357322240.
Would have no problem in changing the implementation if a different behavior is desired by the team.

Let me know what you guys think. 

**Current behavior**:

![clear-filter-before](https://user-images.githubusercontent.com/7514993/34894748-efbb801c-f7b8-11e7-853e-428f5f38e2a8.gif)

**Pull request behavior**:

![clear-filter](https://user-images.githubusercontent.com/7514993/34894350-72a10ea4-f7b7-11e7-82f4-58eeaad2d8a1.gif)
