### PR TITLE
Allows double dashes in branch name

### DIFF
--- a/app/src/lib/sanitize-branch.ts
+++ b/app/src/lib/sanitize-branch.ts
@@ -8,7 +8,6 @@ const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]|@{|\.\.+|^\.|\.$|\.
 export function sanitizedBranchName(name: string): string {
   return name
     .replace(invalidCharacterRegex, '-')
-    .replace(/--+/g, '-')
     .replace(/^-/g, '')
 }
 

--- a/app/src/lib/sanitize-branch.ts
+++ b/app/src/lib/sanitize-branch.ts
@@ -6,9 +6,7 @@ const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]|@{|\.\.+|^\.|\.$|\.
 
 /** Sanitize a proposed branch name by replacing illegal characters. */
 export function sanitizedBranchName(name: string): string {
-  return name
-    .replace(invalidCharacterRegex, '-')
-    .replace(/^-/g, '')
+  return name.replace(invalidCharacterRegex, '-').replace(/^-/g, '')
 }
 
 /** Validate a branch does not contain any invalid characters */

--- a/app/src/lib/sanitize-branch.ts
+++ b/app/src/lib/sanitize-branch.ts
@@ -2,7 +2,7 @@
 // ASCII Control chars and space, DEL, ~ ^ : ? * [ \
 // | " < and > is technically a valid refname but not on Windows
 // the magic sequence @{, consecutive dots, leading and trailing dot, ref ending in .lock
-const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]|@{|\.\.+|^\.|\.$|\.lock$|\/$/g
+const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]+|@{|\.\.+|^\.|\.$|\.lock$|\/$/g
 
 /** Sanitize a proposed branch name by replacing illegal characters. */
 export function sanitizedBranchName(name: string): string {

--- a/app/test/unit/sanitize-test-name-test.ts
+++ b/app/test/unit/sanitize-test-name-test.ts
@@ -44,4 +44,10 @@ describe('sanitizedBranchName', () => {
     const result = sanitizedBranchName(branchName)
     expect(result).to.equal('branch-name')
   })
+
+  it('allows double dashes after first character', () => {
+    const branchName = 'branch--name'
+    const result = sanitizedBranchName(branchName)
+    expect(result).to.equal(branchName)
+  })
 })

--- a/app/test/unit/sanitize-test-name-test.ts
+++ b/app/test/unit/sanitize-test-name-test.ts
@@ -39,12 +39,6 @@ describe('sanitizedBranchName', () => {
     expect(result).to.equal('first.dot.is.not.ok')
   })
 
-  it('collapses double dashes', () => {
-    const branchName = 'branch  ? -|name'
-    const result = sanitizedBranchName(branchName)
-    expect(result).to.equal('branch-name')
-  })
-
   it('allows double dashes after first character', () => {
     const branchName = 'branch--name'
     const result = sanitizedBranchName(branchName)


### PR DESCRIPTION
Fixes #3599 

## Before
![test-branch-before](https://user-images.githubusercontent.com/29465981/34922055-4658cc3e-f950-11e7-9065-a233f213b340.PNG)

## After
![test-branch-after](https://user-images.githubusercontent.com/29465981/34922059-4bffacde-f950-11e7-8ad7-8fc035477167.PNG)
