### PR TITLE
Allow window to accept single click on focus

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -52,6 +52,7 @@ export class AppWindow {
         // Enable, among other things, the ResizeObserver
         experimentalFeatures: true,
       },
+      acceptFirstMouse: true,
     }
 
     if (__DARWIN__) {


### PR DESCRIPTION
This PR addresses feedback from @kevinsawicki: the window required one click to set focus and another to actually perform any useful actions.

- [x] Test on macOS
- [x] Test on Windows
- [x] Make sure dialogs don't respond to focus event
  - [x] macOS
  - [x] Windows

## Before 
![2018-01-22 17_50_21](https://user-images.githubusercontent.com/1715082/35250550-bcfebfae-ff9c-11e7-8a04-d54af6e3a900.gif)

## After
![2018-01-22 17_54_45](https://user-images.githubusercontent.com/1715082/35250704-7dfbfd8e-ff9d-11e7-893e-55aab310816c.gif)
