### PR TITLE
bump embedded Git to 2.16.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "codemirror": "^5.31.0",
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
-    "dugite": "1.53.0",
+    "dugite": "1.56.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -268,9 +268,9 @@ dom-matches@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dom-matches/-/dom-matches-2.0.0.tgz#d2728b416a87533980eb089b848d253cf23a758c"
 
-dugite@1.53.0:
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.53.0.tgz#2c402ca92ac34ffeb3a2b6f8b1a6774c2309a41c"
+dugite@1.56.0:
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.56.0.tgz#a19b5aee2bf0e05679316aeb2288e8a60fe2d58c"
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
Fixes #3617
Fixes #3828

This also enables us to revisit #3618