### PR TITLE
Work around PR status db object missing statuses property

### DIFF
--- a/app/src/lib/databases/pull-request-database.ts
+++ b/app/src/lib/databases/pull-request-database.ts
@@ -60,8 +60,12 @@ export interface IPullRequestStatus {
   /** The SHA for which this status applies. */
   readonly sha: string
 
-  /** The list of statuses for this specific ref */
-  readonly statuses: ReadonlyArray<IAPIRefStatusItem>
+  /**
+   * The list of statuses for this specific ref or undefined
+   * if the database object was created prior to status support
+   * being added in #3588
+   */
+  readonly statuses: ReadonlyArray<IAPIRefStatusItem> | undefined
 }
 
 export class PullRequestDatabase extends Dexie {

--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -234,7 +234,7 @@ export class PullRequestStore {
       return null
     }
 
-    const combinedRefStatuses = result.statuses.map(x => {
+    const combinedRefStatuses = (result.statuses || []).map(x => {
       return {
         id: x.id,
         state: x.state,


### PR DESCRIPTION
As I spun up desktop@master on my Windows machine today I got this error

```
Uncaught (in promise) TypeError: Cannot read property 'map' of undefined
    at PullRequestStore.getPRStatusById (pull-request-store.ts:237)
    at <anonymous>
```

It seems the `statuses` property was added in #3588 and typed as `ReadonlyArray<IAPIRefStatusItem>` but since no corresponding database upgrade function was added to ensure that the property exists on prior database objects we can't rely on it being there.

I could add an upgrade function but seeing as we're pretty close to a release I would rather just mark the property accurately and make sure we don't have any other places which rely on it always being present.

We can revisit and clean this up in a later version.