### PR TITLE
Don't normalize line endings in fixture repositories on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/app/test/fixtures/** -text


### PR DESCRIPTION
I encountered this today when the listSubmodules tests failed on my Windows machine. Debugging into it I found that the for-each-ref command was printing warnings in the `submodule-basic-setup` repository.

```warning: ignoring ref with broken name refs/remotes/origin/feature-branch?```

Further debugging lead me to https://github.com/desktop/desktop/blob/a05ebffab716a2295ca54b74d9ab222249772b42/app/test/fixtures/submodule-basic-setup/_git/modules/foo/submodule/packed-refs and the realization that the packed-refs file had been checked out with CRLF line endings on my Windows machine.

This should ensure that we don't ever normalize line endings in the fixture directory