### PR TITLE
Fix expanded avatar stack overflow

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -293,7 +293,10 @@ export class CommitSummary extends React.Component<
           />
 
           <ul className="commit-summary-meta">
-            <li className="commit-summary-meta-item" aria-label="Author">
+            <li
+              className="commit-summary-meta-item without-truncation"
+              aria-label="Author"
+            >
               <AvatarStack users={this.state.avatarUsers} />
               <CommitAttribution
                 gitHubRepository={this.props.repository.gitHubRepository}

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -114,11 +114,15 @@
     padding: 0 var(--spacing) var(--spacing);
   }
 
+  &-meta-item:not(.without-truncation) {
+    @include ellipsis;
+  }
+
   &-meta-item {
     display: flex;
     flex-direction: row;
+    min-width: 0;
 
-    @include ellipsis;
     margin-right: var(--spacing);
     font-size: var(--font-size-sm);
 


### PR DESCRIPTION
This fixes an issue that was discovered by @tierninho during the internal testing of #3879 where the avatar stack in the commit summary was cut off when you had an insane amount of users.

### Before

![lotsa-authors-before](https://user-images.githubusercontent.com/634063/35570221-e1503f9e-05ce-11e8-899e-8027d0866712.gif)

### After

![lotsa-authors](https://user-images.githubusercontent.com/634063/35570232-e609f8ae-05ce-11e8-80a6-4b1acd4caf49.gif)
