### PR TITLE
ensure renames are detected when viewing commit diffs

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -101,6 +101,10 @@ export async function getCommitDiff(
     file.path,
   ]
 
+  if (file.oldPath) {
+    args.push(file.oldPath)
+  }
+
   const { output } = await spawnAndComplete(
     args,
     repository.path,

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -101,7 +101,7 @@ export async function getCommitDiff(
     file.path,
   ]
 
-  if (file.oldPath) {
+  if (file.oldPath != null) {
     args.push(file.oldPath)
   }
 

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -1,4 +1,4 @@
-@import "../../mixins";
+@import '../../mixins';
 
 /** A React component holding the currently selected repository's history */
 #history {
@@ -30,5 +30,17 @@
     // necessary for "no files in commit" view to
     // look right alongside blank diff
     border-right: var(--base-border);
+  }
+
+  .panel {
+    display: flex;
+    flex: 1;
+
+    &.empty,
+    &.renamed,
+    &.binary {
+      justify-content: center;
+      align-items: center;
+    }
   }
 }


### PR DESCRIPTION
Fixes #3673 

A minor fix that will tell Git to follow renames. Following the steps in https://github.com/desktop/desktop/issues/3673#issuecomment-354013294 shows that this is the diff that's displayed:

```
$ git log HEAD -m -1 -M --first-parent --patch-with-raw -z --no-color -- test-2.txt
commit 0d3188df43876a2aa50ec4a92233f8f4f29538b8 (HEAD -> master)
Author: Brendan Forster <github@brendanforster.com>
Date:   Wed Jan 31 13:54:55 2018 +1100

    rename

:000000 100644 0000000 d8d2090 A^@test-2.txt^@^@diff --git a/test-2.txt b/test-2                                              .txt
new file mode 100644
index 0000000..d8d2090
--- /dev/null
+++ b/test-2.txt
@@ -0,0 +1 @@
+'foo bar baz'
```

The problem is that we need to pass in _both_ file paths to get it to detect the rename properly:

```
$ git log HEAD -m -1 -M --first-parent --patch-with-raw -z --no-color -- test-2.txt test-1.txt
commit 0d3188df43876a2aa50ec4a92233f8f4f29538b8 (HEAD -> master)
Author: Brendan Forster <github@brendanforster.com>
Date:   Wed Jan 31 13:54:55 2018 +1100

    rename

:100644 100644 d8d2090 d8d2090 R100^@test-1.txt^@test-2.txt^@^@diff --git a/test                                              -1.txt b/test-2.txt
similarity index 100%
rename from test-1.txt
rename to test-2.txt
```

 - [x] fix the bug
 - [x] align the message to the center of the view

<img width="981" alt="screen shot 2018-01-31 at 2 20 30 pm" src="https://user-images.githubusercontent.com/359239/35603546-ed5bc876-0691-11e8-8002-95c7c8391b8e.png">
