### PR TITLE
drop unnecessary comments before issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,25 +1,5 @@
 <!--
 
-Have you read GitHub Desktop's Code of Conduct? By filing an Issue, you are
-expected to comply with it, including treating everyone with respect:
-
-https://github.com/desktop/desktop/blob/master/CODE_OF_CONDUCT.md
-
--->
-
-<!--
-
-Are you encountering an issue where the “Minimize” tooltip stays visible
-when you click the minimize button in the window? If so, that is an issue
-with Electron, the framework the app uses. Please subscribe to the issue
-at this link for updates on the issue:
-
-https://github.com/electron/electron/issues/9943
-
--->
-
-<!--
-
 Please summarize the issue in the title, and then use the template below to
 fill out the details so we can reproduce the issue on our end.
 


### PR DESCRIPTION
This came up when I was pairing with @nerdneha today.

What's the first thing you see when you create a new issue? The mention of our code of conduct:

<img width="779" src="https://user-images.githubusercontent.com/359239/35658290-b0fb4104-0754-11e8-8f8e-a337e5f98e22.png">

That's cool, but there's already a link to it in the header above.

If you remove that, you see our mention of a known issue:

<img width="790" src="https://user-images.githubusercontent.com/359239/35658310-cf11c05a-0754-11e8-9d98-5b6345e50816.png">

While this is helpful to tell users about, it's very specific and takes up a lot of space.

**I believe both of these things are distracting from the actual purpose of the template - to guide users to fill out the template - and without that instruction they're just filling in the header.**

If we see an uptick in the minimize tooltip after this, I'd recommend including something like this in the header and linking out to a known issues doc to keep this minimized:

```
<!--

Please summarize the issue in the title, and then use the template below to
fill out the details so we can reproduce the issue on our end.

Please also check out our list of known issues that are currently tracked:

https://github.com/desktop/desktop/blob/master/docs/contributing/known_issues.md

-->
```
