### PR TITLE
Adjust exact match definition

### DIFF
--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -629,9 +629,9 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
       needle
     )
 
-    const exactMatch =
-      hits.length === 1 &&
-      hits[0].username.toLowerCase() === needle.toLowerCase()
+    const exactMatch = hits.some(hit => {
+      return hit.username.toLowerCase() === needle.toLowerCase()
+    })
 
     const existingUsernames = new Set(this.authors.map(x => x.username))
 

--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -629,9 +629,9 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
       needle
     )
 
-    const exactMatch = hits.some(hit => {
-      return hit.username.toLowerCase() === needle.toLowerCase()
-    })
+    const exactMatch = hits.some(
+      hit => hit.username.toLowerCase() === needle.toLowerCase()
+    )
 
     const existingUsernames = new Set(this.authors.map(x => x.username))
 


### PR DESCRIPTION
Fixes #3887 

Sets exactMatch to true as long as one of the hits exactly matches the needle. 

Before we were setting to true only if there was 1 hit but ran into the counterexample below:

Before:
<img width="261" alt="screen shot 2018-01-30 at 10 48 26 am" src="https://user-images.githubusercontent.com/634063/35585149-6bd149d8-05f7-11e8-91e9-8c6845e6ffc2.png">

After:
<img width="261" alt="screen shot 2018-01-31 at 9 52 38 pm" src="https://user-images.githubusercontent.com/1834387/35663382-d52e48f6-06d1-11e8-81e7-344ffe1bff89.png">
