### PR TITLE
Switch to a saner default gravatar size

### DIFF
--- a/app/src/lib/gravatar.ts
+++ b/app/src/lib/gravatar.ts
@@ -8,7 +8,7 @@ import { getDotComAPIEndpoint } from './api'
  * @param email The email address associated with a user
  * @param size The size (in pixels) of the avatar to render
  */
-export function generateGravatarUrl(email: string, size: number = 200): string {
+export function generateGravatarUrl(email: string, size: number = 60): string {
   const input = email.trim().toLowerCase()
   const hash = crypto
     .createHash('md5')

--- a/app/src/models/avatar.ts
+++ b/app/src/models/avatar.ts
@@ -28,7 +28,7 @@ function getFallbackAvatarUrlForAuthor(
   ) {
     return `https://avatars.githubusercontent.com/u/e?email=${encodeURIComponent(
       author.email
-    )}&s=40`
+    )}&s=60`
   }
 
   return generateGravatarUrl(author.email)


### PR DESCRIPTION
This was supposed to be part of the co-authors PR but this commit got left accidentally on my Windows machine.

The biggest avatar we display in the app right now is 28x28 so 60 should be a good default for retina monitors