### PR TITLE
 Add small space between commit summary and description

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -5,7 +5,7 @@ import { CommitListItem } from './commit-list-item'
 import { List } from '../lib/list'
 import { IGitHubUser } from '../../lib/databases'
 
-const RowHeight = 48
+const RowHeight = 50
 
 interface ICommitListProps {
   readonly onCommitChanged: (commit: Commit) => void

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -20,13 +20,14 @@
     .info {
       display: flex;
       flex-direction: column;
-      margin-top: -5px;
+      margin-top: -3px;
       overflow: hidden;
       width: 100%;
 
       .description {
         display: flex;
         flex-direction: row;
+        margin-top: 3px;
       }
 
       .summary {

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -20,7 +20,7 @@
     .info {
       display: flex;
       flex-direction: column;
-      margin-top: -3px;
+      margin-top: -4px;
       overflow: hidden;
       width: 100%;
 


### PR DESCRIPTION
I noticed that the commit list has been redesigned. I think it can be better a bit.

This commit brings down commit description by 3px while keeping commit summary in place.

Preview:

![screenshot 28](https://user-images.githubusercontent.com/20214420/35760078-5601303a-08b0-11e8-9e1f-6ff2b08693ce.png)

Close up difference:

![screenshot 27](https://user-images.githubusercontent.com/20214420/35760021-ff5445e2-08af-11e8-9d3b-cf1a862ad643.png)
