### PR TITLE
move remote detection into dialog component when deleting branch

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -216,7 +216,6 @@ export type Popup =
       type: PopupType.DeleteBranch
       repository: Repository
       branch: Branch
-      existsOnRemote: boolean
     }
   | {
       type: PopupType.ConfirmDiscardChanges

--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -1,6 +1,7 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
 import { IRemote } from '../../models/remote'
+import { Branch } from '../../models/branch'
 
 /** Get the remote names. */
 export async function getRemotes(
@@ -68,4 +69,22 @@ export async function setRemoteURL(
   url: string
 ): Promise<void> {
   await git(['remote', 'set-url', name, url], repository.path, 'setRemoteURL')
+}
+
+export async function checkBranchExistsOnRemote(
+  repository: Repository,
+  branch: Branch
+): Promise<boolean> {
+  if (branch.upstream == null) {
+    return false
+  }
+
+  const result = await git(
+    ['show-ref', '--verify', `refs/remotes/${branch.upstream}`],
+    repository.path,
+    'checkBranchExistsOnRemote',
+    { successExitCodes: new Set([0, 128]) }
+  )
+
+  return result.exitCode === 0
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -428,13 +428,10 @@ export class App extends React.Component<IAppProps, IAppState> {
           pullRequest: currentPullRequest,
         })
       } else {
-        const existsOnRemote = state.state.aheadBehind !== null
-
         this.props.dispatcher.showPopup({
           type: PopupType.DeleteBranch,
           repository: state.repository,
           branch: tip.branch,
-          existsOnRemote: existsOnRemote,
         })
       }
     }
@@ -919,7 +916,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             branch={popup.branch}
-            existsOnRemote={popup.existsOnRemote}
             onDismissed={this.onPopupDismissed}
           />
         )

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -54,9 +54,6 @@ export class DeleteBranch extends React.Component<
       this.checkingRemote = true
 
       checkBranchExistsOnRemote(this.props.repository, this.props.branch)
-        .then(existsOnRemote => {
-          this.setState({ existsOnRemote }, this.checkCompleted)
-        })
         .catch(err => {
           log.warn(
             `[DeleteBranch] unable to resolve upstream branch: '${
@@ -64,7 +61,11 @@ export class DeleteBranch extends React.Component<
             }'`,
             err
           )
-          this.setState({ existsOnRemote: false }, this.checkCompleted)
+
+          return false
+        })
+        .then(existsOnRemote => {
+          this.setState({ existsOnRemote }, this.checkCompleted)
         })
     }
   }

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -37,6 +37,10 @@ export class DeleteBranch extends React.Component<
     }
   }
 
+  private checkCompleted = () => {
+    this.checkingRemote = false
+  }
+
   public componentWillReceiveProps(nextProps: IDeleteBranchProps) {
     if (this.checkingRemote) {
       // a check is being performed, don't start another
@@ -51,9 +55,7 @@ export class DeleteBranch extends React.Component<
 
       checkBranchExistsOnRemote(this.props.repository, this.props.branch)
         .then(existsOnRemote => {
-          this.setState({ existsOnRemote }, () => {
-            this.checkingRemote = false
-          })
+          this.setState({ existsOnRemote }, this.checkCompleted)
         })
         .catch(err => {
           log.warn(
@@ -62,9 +64,7 @@ export class DeleteBranch extends React.Component<
             }'`,
             err
           )
-          this.setState({ existsOnRemote: false }, () => {
-            this.checkingRemote = false
-          })
+          this.setState({ existsOnRemote: false }, this.checkCompleted)
         })
     }
   }

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -55,6 +55,9 @@ export class DeleteBranch extends React.Component<
 
       checkBranchExistsOnRemote(this.props.repository, this.props.branch)
         .catch(err => {
+          // if we encounter an unhandled error from Git, log an error
+          // and provide 'false' as the fallback value for the callback
+
           log.error(
             `[DeleteBranch] unable to resolve upstream branch: '${
               this.props.branch.upstream

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -97,7 +97,7 @@ export class DeleteBranch extends React.Component<
   }
 
   private renderDeleteOnRemote() {
-    if (this.props.branch.remote && this.state.existsOnRemote == true) {
+    if (this.props.branch.remote && this.state.existsOnRemote === true) {
       return (
         <div>
           <p>

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -8,16 +8,17 @@ import { ButtonGroup } from '../lib/button-group'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
+import { checkBranchExistsOnRemote } from '../../lib/git'
 
 interface IDeleteBranchProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly branch: Branch
-  readonly existsOnRemote: boolean
   readonly onDismissed: () => void
 }
 
 interface IDeleteBranchState {
+  readonly existsOnRemote: boolean | null
   readonly includeRemoteBranch: boolean
 }
 
@@ -29,6 +30,7 @@ export class DeleteBranch extends React.Component<
     super(props)
 
     this.state = {
+      existsOnRemote: null,
       includeRemoteBranch: false,
     }
   }
@@ -61,7 +63,7 @@ export class DeleteBranch extends React.Component<
   }
 
   private renderDeleteOnRemote() {
-    if (this.props.branch.remote && this.props.existsOnRemote) {
+    if (this.props.branch.remote && this.state.existsOnRemote == true) {
       return (
         <div>
           <p>

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -55,7 +55,7 @@ export class DeleteBranch extends React.Component<
 
       checkBranchExistsOnRemote(this.props.repository, this.props.branch)
         .catch(err => {
-          log.info(
+          log.error(
             `[DeleteBranch] unable to resolve upstream branch: '${
               this.props.branch.upstream
             }'`,
@@ -98,7 +98,7 @@ export class DeleteBranch extends React.Component<
   }
 
   private renderDeleteOnRemote() {
-    if (this.props.branch.remote && this.state.existsOnRemote === true) {
+    if (this.props.branch.remote && this.state.existsOnRemote) {
       return (
         <div>
           <p>

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -55,7 +55,7 @@ export class DeleteBranch extends React.Component<
 
       checkBranchExistsOnRemote(this.props.repository, this.props.branch)
         .catch(err => {
-          log.warn(
+          log.info(
             `[DeleteBranch] unable to resolve upstream branch: '${
               this.props.branch.upstream
             }'`,

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -35,6 +35,25 @@ export class DeleteBranch extends React.Component<
     }
   }
 
+  public componentWillReceiveProps(nextProps: IDeleteBranchProps) {
+    // TODO: re-run this if this.props.branch has changed
+    if (this.state.existsOnRemote == null) {
+      checkBranchExistsOnRemote(this.props.repository, this.props.branch)
+        .then(existsOnRemote => {
+          this.setState({ existsOnRemote })
+        })
+        .catch(err => {
+          log.warn(
+            `[DeleteBranch] unable to resolve remote branch: ${
+              this.props.branch.name
+            }`,
+            err
+          )
+          this.setState({ existsOnRemote: false })
+        })
+    }
+  }
+
   public render() {
     return (
       <Dialog


### PR DESCRIPTION
Supersedes #3600 

This takes the original work from @JordanMussi but moves the check closer to the decision time for the user. This avoids the overhead of computing whether the remote exists for every ref, but lets us be more accurate than what we previously had (by querying the remote).