### PR TITLE
propagate fetch progress when initializing remote for fork

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3228,8 +3228,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const gitStore = this.getGitStore(repository)
 
       await this.withAuthenticatingUser(repository, async (repo, account) => {
-        await gitStore.fetchRemote(account, remoteName, false)
+        await gitStore.fetchRemote(account, remoteName, false, progress => {
+          this.updatePushPullFetchProgress(repository, {
+            ...progress,
+            value: progress.value,
+          })
+        })
       })
+
+      this.updatePushPullFetchProgress(repository, null)
 
       const localBranchName = `pr/${pullRequest.number}`
       const doesBranchExist =


### PR DESCRIPTION
The first time you open a PR from a fork, Desktop will `git remote add` and then `git fetch` this new remote. This can take a couple of seconds before Desktop will then checkout the PR ref, and we don't display any visual feedback of what's happening.

But now we do!

**Before**

![](https://user-images.githubusercontent.com/359239/35895087-0f143066-0c0a-11e8-95ef-ae4cf49e7b18.gif)

Note the period of no feedback, and then the checkout of the PR branch.

**After**

![](https://user-images.githubusercontent.com/359239/35895348-30833408-0c0b-11e8-9fb0-ea8dd997ddec.gif)

Note that we now see `Fetching {remote}` (it only takes a couple of seconds to fetch all the refs, so we don't get real progress beyond "Hang on...") and then the checkout occurs.