### PR TITLE
better error handling around ENOENT

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, ChildProcess } from 'child_process'
 import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
 
@@ -76,11 +76,11 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
-export async function launch(
+export function launch(
   foundShell: IFoundShell<Shell>,
   path: string
-): Promise<void> {
+): ChildProcess {
   const bundleID = getBundleID(foundShell.shell)
   const commandArgs = ['-b', bundleID, path]
-  await spawn('open', commandArgs)
+  return spawn('open', commandArgs)
 }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -99,23 +99,22 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
-export function launch(shell: IFoundShell<Shell>, path: string): ChildProcess {
-  if (shell.shell === Shell.Urxvt) {
-    const commandArgs = ['-cd', path]
-    return spawn(shell.path, commandArgs)
+export function launch(
+  foundShell: IFoundShell<Shell>,
+  path: string
+): ChildProcess {
+  const shell = foundShell.shell
+  switch (shell) {
+    case Shell.Urxvt:
+      return spawn(foundShell.path, ['-cd', path])
+    case Shell.Konsole:
+      return spawn(foundShell.path, ['--workdir', path])
+    case Shell.Xterm:
+      return spawn(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
+    case Shell.Tilix:
+    case Shell.Gnome:
+      return spawn(foundShell.path, ['--working-directory', path])
+    default:
+      return assertNever(shell, `Unknown shell: ${shell}`)
   }
-
-  if (shell.shell === Shell.Konsole) {
-    const commandArgs = ['--workdir', path]
-    return spawn(shell.path, commandArgs)
-  }
-
-  if (shell.shell === Shell.Xterm) {
-    const commandArgs = ['-e', '/bin/bash']
-    const commandOptions = { cwd: path }
-    return spawn(shell.path, commandArgs, commandOptions)
-  }
-
-  const commandArgs = ['--working-directory', path]
-  return spawn(shell.path, commandArgs)
 }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, ChildProcess } from 'child_process'
 import { pathExists } from '../file-system'
 import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
@@ -99,26 +99,23 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
-export async function launch(
-  shell: IFoundShell<Shell>,
-  path: string
-): Promise<void> {
+export function launch(shell: IFoundShell<Shell>, path: string): ChildProcess {
   if (shell.shell === Shell.Urxvt) {
     const commandArgs = ['-cd', path]
-    await spawn(shell.path, commandArgs)
+    return spawn(shell.path, commandArgs)
   }
 
   if (shell.shell === Shell.Konsole) {
     const commandArgs = ['--workdir', path]
-    await spawn(shell.path, commandArgs)
+    return spawn(shell.path, commandArgs)
   }
 
   if (shell.shell === Shell.Xterm) {
     const commandArgs = ['-e', '/bin/bash']
     const commandOptions = { cwd: path }
-    await spawn(shell.path, commandArgs, commandOptions)
+    return spawn(shell.path, commandArgs, commandOptions)
   }
 
   const commandArgs = ['--working-directory', path]
-  await spawn(shell.path, commandArgs)
+  return spawn(shell.path, commandArgs)
 }

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -1,3 +1,5 @@
+import { ChildProcess } from 'child_process'
+
 import * as Darwin from './darwin'
 import * as Win32 from './win32'
 import * as Linux from './linux'
@@ -71,7 +73,11 @@ export async function findShellOrDefault(shell: Shell): Promise<FoundShell> {
 }
 
 /** Launch the given shell at the path. */
-export async function launchShell(shell: FoundShell, path: string) {
+export async function launchShell(
+  shell: FoundShell,
+  path: string,
+  onError: (error: Error) => void
+): Promise<void> {
   // We have to manually cast the wider `Shell` type into the platform-specific
   // type. This is less than ideal, but maybe the best we can do without
   // platform-specific build targets.
@@ -88,7 +94,9 @@ export async function launchShell(shell: FoundShell, path: string) {
   if (__DARWIN__) {
     return Darwin.launch(shell as IFoundShell<Darwin.Shell>, path)
   } else if (__WIN32__) {
-    return Win32.launch(shell as IFoundShell<Win32.Shell>, path)
+    const cp = Win32.launch(shell as IFoundShell<Win32.Shell>, path)
+    addErrorTracing(shell.shell, cp, onError)
+    return Promise.resolve()
   } else if (__LINUX__) {
     return Linux.launch(shell as IFoundShell<Linux.Shell>, path)
   }
@@ -96,4 +104,26 @@ export async function launchShell(shell: FoundShell, path: string) {
   return Promise.reject(
     `Platform not currently supported for launching shells: ${process.platform}`
   )
+}
+
+function addErrorTracing(
+  shell: Shell,
+  cp: ChildProcess,
+  onError: (error: Error) => void
+) {
+  cp.stderr.on('data', chunk => {
+    const text = chunk instanceof Buffer ? chunk.toString() : chunk
+    log.debug(`[${shell}] stderr: '${text}'`)
+  })
+
+  cp.on('error', err => {
+    log.debug(`[${shell}] an error was encountered`, err)
+    onError(err)
+  })
+
+  cp.on('exit', code => {
+    if (code !== 0) {
+      log.debug(`[${shell}] exit code: ${code}`)
+    }
+  })
 }

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -91,19 +91,26 @@ export async function launchShell(
     )
   }
 
+  let cp: ChildProcess | null = null
+
   if (__DARWIN__) {
-    return Darwin.launch(shell as IFoundShell<Darwin.Shell>, path)
+    cp = Darwin.launch(shell as IFoundShell<Darwin.Shell>, path)
   } else if (__WIN32__) {
-    const cp = Win32.launch(shell as IFoundShell<Win32.Shell>, path)
-    addErrorTracing(shell.shell, cp, onError)
-    return Promise.resolve()
+    cp = Win32.launch(shell as IFoundShell<Win32.Shell>, path)
   } else if (__LINUX__) {
-    return Linux.launch(shell as IFoundShell<Linux.Shell>, path)
+    cp = Linux.launch(shell as IFoundShell<Linux.Shell>, path)
   }
 
-  return Promise.reject(
-    `Platform not currently supported for launching shells: ${process.platform}`
-  )
+  if (cp != null) {
+    addErrorTracing(shell.shell, cp, onError)
+    return Promise.resolve()
+  } else {
+    return Promise.reject(
+      `Platform not currently supported for launching shells: ${
+        process.platform
+      }`
+    )
+  }
 }
 
 function addErrorTracing(

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -127,12 +127,16 @@ export function launch(
       cwd: path,
     })
   } else if (shell === Shell.Hyper) {
-    return spawn(`"${foundShell.path}"`, [`"${path}"`], {
+    const executable = `"${foundShell.path}"`
+    log.info(`launching ${shell} at path: ${executable}`)
+    return spawn(executable, [`"${path}"`], {
       shell: true,
       cwd: path,
     })
   } else if (shell === Shell.GitBash) {
-    return spawn(`"${foundShell.path}"`, [`--cd="${path}"`], {
+    const executable = `"${foundShell.path}"`
+    log.info(`launching ${shell} at path: ${executable}`)
+    return spawn(executable, [`--cd="${path}"`], {
       shell: true,
       cwd: path,
     })

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -120,29 +120,30 @@ export function launch(
 ): ChildProcess {
   const shell = foundShell.shell
 
-  if (shell === Shell.PowerShell) {
-    const psCommand = `"Set-Location -LiteralPath '${path}'"`
-    return spawn('START', ['powershell', '-NoExit', '-Command', psCommand], {
-      shell: true,
-      cwd: path,
-    })
-  } else if (shell === Shell.Hyper) {
-    const executable = `"${foundShell.path}"`
-    log.info(`launching ${shell} at path: ${executable}`)
-    return spawn(executable, [`"${path}"`], {
-      shell: true,
-      cwd: path,
-    })
-  } else if (shell === Shell.GitBash) {
-    const executable = `"${foundShell.path}"`
-    log.info(`launching ${shell} at path: ${executable}`)
-    return spawn(executable, [`--cd="${path}"`], {
-      shell: true,
-      cwd: path,
-    })
-  } else if (shell === Shell.Cmd) {
-    return spawn('START', ['cmd'], { shell: true, cwd: path })
-  } else {
-    return assertNever(shell, `Unknown shell: ${shell}`)
+  switch (shell) {
+    case Shell.PowerShell:
+      const psCommand = `"Set-Location -LiteralPath '${path}'"`
+      return spawn('START', ['powershell', '-NoExit', '-Command', psCommand], {
+        shell: true,
+        cwd: path,
+      })
+    case Shell.Hyper:
+      const hyperPath = `"${foundShell.path}"`
+      log.info(`launching ${shell} at path: ${hyperPath}`)
+      return spawn(hyperPath, [`"${path}"`], {
+        shell: true,
+        cwd: path,
+      })
+    case Shell.GitBash:
+      const gitBashPath = `"${foundShell.path}"`
+      log.info(`launching ${shell} at path: ${gitBashPath}`)
+      return spawn(gitBashPath, [`--cd="${path}"`], {
+        shell: true,
+        cwd: path,
+      })
+    case Shell.Cmd:
+      return spawn('START', ['cmd'], { shell: true, cwd: path })
+    default:
+      return assertNever(shell, `Unknown shell: ${shell}`)
   }
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -114,52 +114,31 @@ export async function getAvailableShells(): Promise<
   return shells
 }
 
-function addErrorTracing(context: string, cp: ChildProcess) {
-  cp.stderr.on('data', chunk => {
-    const text = chunk instanceof Buffer ? chunk.toString() : chunk
-    log.debug(`[${context}] stderr: '${text}'`)
-  })
-
-  cp.on('exit', code => {
-    if (code !== 0) {
-      log.debug(`[${context}] exit code: ${code}`)
-    }
-  })
-}
-
-export async function launch(
+export function launch(
   foundShell: IFoundShell<Shell>,
   path: string
-): Promise<void> {
+): ChildProcess {
   const shell = foundShell.shell
 
   if (shell === Shell.PowerShell) {
     const psCommand = `"Set-Location -LiteralPath '${path}'"`
-    const cp = spawn(
-      'START',
-      ['powershell', '-NoExit', '-Command', psCommand],
-      {
-        shell: true,
-        cwd: path,
-      }
-    )
-    addErrorTracing(`PowerShell`, cp)
+    return spawn('START', ['powershell', '-NoExit', '-Command', psCommand], {
+      shell: true,
+      cwd: path,
+    })
   } else if (shell === Shell.Hyper) {
-    const cp = spawn(`"${foundShell.path}"`, [`"${path}"`], {
+    return spawn(`"${foundShell.path}"`, [`"${path}"`], {
       shell: true,
       cwd: path,
     })
-    addErrorTracing(`Hyper`, cp)
   } else if (shell === Shell.GitBash) {
-    const cp = spawn(`"${foundShell.path}"`, [`--cd="${path}"`], {
+    return spawn(`"${foundShell.path}"`, [`--cd="${path}"`], {
       shell: true,
       cwd: path,
     })
-    addErrorTracing(`Git Bash`, cp)
   } else if (shell === Shell.Cmd) {
-    const cp = spawn('START', ['cmd'], { shell: true, cwd: path })
-    addErrorTracing(`CMD`, cp)
+    return spawn('START', ['cmd'], { shell: true, cwd: path })
   } else {
-    assertNever(shell, `Unknown shell: ${shell}`)
+    return assertNever(shell, `Unknown shell: ${shell}`)
   }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2488,7 +2488,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     try {
       const match = await findShellOrDefault(this.selectedShell)
-      await launchShell(match, path)
+      await launchShell(match, path, error => this._pushError(error))
     } catch (error) {
       this.emitError(error)
     }


### PR DESCRIPTION
This lays the groundwork for resolving #3825 and #3882 by:

 - adding tracing when invoking shells for all OSes, not just Windows
 - handling the `error` event on a spawned child process (if we don't, this crashes the renderer)
 - display the error to the user rather than hiding it away

See for yourself (on Windows):

 - apply this patch to this branch

```diff
diff --git a/app/src/lib/shells/win32.ts b/app/src/lib/shells/win32.ts
index bd814808f..5ab2cb068 100644
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -141,7 +141,9 @@ export function launch(
       cwd: path,
     })
   } else if (shell === Shell.Cmd) {
-    return spawn('START', ['cmd'], { shell: true, cwd: path })
+    const executable = `"C:\\Windows\\System32\\cmd.exe"`
+    log.info(`launching ${shell} at path: ${executable}`)
+    return spawn(executable, undefined, { shell: true, cwd: path })
   } else {
     return assertNever(shell, `Unknown shell: ${shell}`)
   }
```

 - run the app up
 - use **Repository** | **Open in Command Prompt** to trigger this error

<img width="433" src="https://user-images.githubusercontent.com/359239/35904424-2bf8480c-0c37-11e8-8d7e-feb5eb1864b9.png">

Why this doesn't work as expected is what I'm currently wrestling with, but it'd be nice to get this into the next update so we have better diagnostics.
 