### PR TITLE
Show UI when no PRs exists

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -66,16 +66,22 @@ export class BranchesContainer extends React.Component<
     }
   }
 
-  private onPullRequestFilterKeyDown = () =>
-    this.closeFoldoutOnEsc(() => this.state.pullRequestFilterText.length === 0)
-  private onBranchFilterKeyDown = () =>
-    this.closeFoldoutOnEsc(() => this.state.branchFilterText.length === 0)
-
-  private closeFoldoutOnEsc = (shouldCloseFoldout: () => boolean) => (
+  private closePullRequrstFoldoutOnEsc = (
     event: React.KeyboardEvent<HTMLElement>
   ) => {
     if (event.key === 'Escape') {
-      if (shouldCloseFoldout()) {
+      if (this.state.pullRequestFilterText.length === 0) {
+        this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+        event.preventDefault()
+      }
+    }
+  }
+
+  private closeBranchFoldoutOnEsc = (
+    event: React.KeyboardEvent<HTMLElement>
+  ) => {
+    if (event.key === 'Escape') {
+      if (this.state.branchFilterText.length === 0) {
         this.props.dispatcher.closeFoldout(FoldoutType.Branch)
         event.preventDefault()
       }
@@ -147,7 +153,7 @@ export class BranchesContainer extends React.Component<
             recentBranches={this.props.recentBranches}
             onItemClick={this.onItemClick}
             filterText={this.state.branchFilterText}
-            onFilterKeyDown={this.onBranchFilterKeyDown()}
+            onFilterKeyDown={this.closeBranchFoldoutOnEsc}
             onFilterTextChanged={this.onBranchFilterTextChanged}
             selectedBranch={this.state.selectedBranch}
             onSelectionChanged={this.onBranchSelectionChanged}
@@ -201,9 +207,7 @@ export class BranchesContainer extends React.Component<
         onCreatePullRequest={this.onCreatePullRequest}
         filterText={this.state.pullRequestFilterText}
         onFilterTextChanged={this.onPullRequestFilterTextChanged}
-        onFilterKeyDown={this.closeFoldoutOnEsc(
-          () => this.state.pullRequestFilterText.length === 0
-        )}
+        onFilterKeyDown={this.closePullRequrstFoldoutOnEsc}
         onItemClick={this.onPullRequestClicked}
         onDismiss={this.onDismiss}
       />

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -10,7 +10,6 @@ import { assertNever } from '../../lib/fatal-error'
 import { enablePRIntegration } from '../../lib/feature-flag'
 import { PullRequestList } from './pull-request-list'
 import { PullRequestsLoading } from './pull-requests-loading'
-import { NoPullRequests } from './no-pull-requests'
 import { PullRequest } from '../../models/pull-request'
 import { CSSTransitionGroup } from 'react-transition-group'
 
@@ -174,40 +173,35 @@ export class BranchesContainer extends React.Component<
 
   private renderPullRequests() {
     const pullRequests = this.props.pullRequests
-    if (pullRequests.length) {
+    const repo = this.props.repository
+    const name = repo.gitHubRepository
+      ? repo.gitHubRepository.fullName
+      : repo.name
+    const isOnDefaultBranch =
+      this.props.defaultBranch &&
+      this.props.currentBranch &&
+      this.props.defaultBranch.name === this.props.currentBranch.name
+
+    if (this.props.isLoadingPullRequests) {
+      return <PullRequestsLoading key="prs-loading" />
+    } else {
       return (
         <PullRequestList
           key="pr-list"
           pullRequests={pullRequests}
+          selectedPullRequest={this.state.selectedPullRequest}
+          repositoryName={name}
+          isOnDefaultBranch={!!isOnDefaultBranch}
           onSelectionChanged={this.onPullRequestSelectionChanged}
+          onCreateBranch={this.onCreateBranch}
+          onCreatePullRequest={this.onCreatePullRequest}
           filterText={this.state.pullRequestFilterText}
+          onFilterTextChanged={this.onPullRequestFilterTextChanged}
           onFilterKeyDown={this.closeFoldoutOnEsc(
             () => this.state.pullRequestFilterText.length === 0
           )}
-          onFilterTextChanged={this.onPullRequestFilterTextChanged}
-          selectedPullRequest={this.state.selectedPullRequest}
           onItemClick={this.onPullRequestClicked}
           onDismiss={this.onDismiss}
-        />
-      )
-    } else if (this.props.isLoadingPullRequests) {
-      return <PullRequestsLoading key="prs-loading" />
-    } else {
-      const repo = this.props.repository
-      const name = repo.gitHubRepository
-        ? repo.gitHubRepository.fullName
-        : repo.name
-      const isOnDefaultBranch =
-        this.props.defaultBranch &&
-        this.props.currentBranch &&
-        this.props.defaultBranch.name === this.props.currentBranch.name
-      return (
-        <NoPullRequests
-          key="no-prs"
-          repositoryName={name}
-          isOnDefaultBranch={!!isOnDefaultBranch}
-          onCreateBranch={this.onCreateBranch}
-          onCreatePullRequest={this.onCreatePullRequest}
         />
       )
     }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -172,6 +172,10 @@ export class BranchesContainer extends React.Component<
   }
 
   private renderPullRequests() {
+    if (this.props.isLoadingPullRequests) {
+      return <PullRequestsLoading key="prs-loading" />
+    }
+
     const pullRequests = this.props.pullRequests
     const repo = this.props.repository
     const name = repo.gitHubRepository
@@ -182,29 +186,25 @@ export class BranchesContainer extends React.Component<
       this.props.currentBranch &&
       this.props.defaultBranch.name === this.props.currentBranch.name
 
-    if (this.props.isLoadingPullRequests) {
-      return <PullRequestsLoading key="prs-loading" />
-    } else {
-      return (
-        <PullRequestList
-          key="pr-list"
-          pullRequests={pullRequests}
-          selectedPullRequest={this.state.selectedPullRequest}
-          repositoryName={name}
-          isOnDefaultBranch={!!isOnDefaultBranch}
-          onSelectionChanged={this.onPullRequestSelectionChanged}
-          onCreateBranch={this.onCreateBranch}
-          onCreatePullRequest={this.onCreatePullRequest}
-          filterText={this.state.pullRequestFilterText}
-          onFilterTextChanged={this.onPullRequestFilterTextChanged}
-          onFilterKeyDown={this.closeFoldoutOnEsc(
-            () => this.state.pullRequestFilterText.length === 0
-          )}
-          onItemClick={this.onPullRequestClicked}
-          onDismiss={this.onDismiss}
-        />
-      )
-    }
+    return (
+      <PullRequestList
+        key="pr-list"
+        pullRequests={pullRequests}
+        selectedPullRequest={this.state.selectedPullRequest}
+        repositoryName={name}
+        isOnDefaultBranch={!!isOnDefaultBranch}
+        onSelectionChanged={this.onPullRequestSelectionChanged}
+        onCreateBranch={this.onCreateBranch}
+        onCreatePullRequest={this.onCreatePullRequest}
+        filterText={this.state.pullRequestFilterText}
+        onFilterTextChanged={this.onPullRequestFilterTextChanged}
+        onFilterKeyDown={this.closeFoldoutOnEsc(
+          () => this.state.pullRequestFilterText.length === 0
+        )}
+        onItemClick={this.onPullRequestClicked}
+        onDismiss={this.onDismiss}
+      />
+    )
   }
 
   public render() {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -15,6 +15,8 @@ interface INoPullRequestsProps {
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
 
+  readonly isSearch: boolean
+
   /* Called when the user wants to create a new branch. */
   readonly onCreateBranch: () => void
 

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -15,6 +15,7 @@ interface INoPullRequestsProps {
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
 
+  /** Is this component being used due to a search? */
   readonly isSearch: boolean
 
   /* Called when the user wants to create a new branch. */

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -30,16 +30,25 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
     return (
       <div className="no-pull-requests">
         <img src={BlankSlateImage} className="blankslate-image" />
-
-        <div className="title">You're all set!</div>
-
-        <div className="no-prs">
-          No open pull requests in <Ref>{this.props.repositoryName}</Ref>
-        </div>
-
+        {this.renderTitle()}
         {this.renderCallToAction()}
       </div>
     )
+  }
+
+  private renderTitle() {
+    if (this.props.isSearch) {
+      return <div className="title">Sorry, I can't find that pull request!</div>
+    } else {
+      return (
+        <div>
+          <div className="title">You're all set!</div>
+          <div className="no-prs">
+            No open pull requests in <Ref>{this.props.repositoryName}</Ref>
+          </div>
+        </div>
+      )
+    }
   }
 
   private renderCallToAction() {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -15,7 +15,7 @@ interface INoPullRequestsProps {
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
 
-  /** Is this component being used due to a search? */
+  /** Is this component being rendered due to a search? */
   readonly isSearch: boolean
 
   /* Called when the user wants to create a new branch. */

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -7,6 +7,7 @@ import {
 } from '../lib/filter-list'
 import { PullRequestListItem } from './pull-request-list-item'
 import { PullRequest, PullRequestStatus } from '../../models/pull-request'
+import { NoPullRequests } from './no-pull-requests'
 
 interface IPullRequestListItem extends IFilterListItem {
   readonly id: string
@@ -125,6 +126,19 @@ export class PullRequestList extends React.Component<
         onItemClick={this.onItemClick}
         onSelectionChanged={this.onSelectionChanged}
         onFilterKeyDown={this.props.onFilterKeyDown}
+        renderNoItems={this.renderNoItems}
+      />
+    )
+  }
+
+  private renderNoItems = () => {
+    return (
+      <NoPullRequests
+        isSearch={this.props.filterText.length > 0}
+        repositoryName={this.props.repositoryName}
+        isOnDefaultBranch={this.props.isOnDefaultBranch}
+        onCreateBranch={this.props.onCreateBranch}
+        onCreatePullRequest={this.props.onCreatePullRequest}
       />
     )
   }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -27,6 +27,12 @@ export const RowHeight = 47
 interface IPullRequestListProps {
   /** The pull requests to display. */
   readonly pullRequests: ReadonlyArray<PullRequest>
+  readonly selectedPullRequest: PullRequest | null
+  readonly repositoryName: string
+  readonly isOnDefaultBranch: boolean
+
+  /** The current filter text to render */
+  readonly filterText: string
 
   /** Called when the user clicks on a pull request. */
   readonly onItemClick: (pullRequest: PullRequest) => void
@@ -34,8 +40,10 @@ interface IPullRequestListProps {
   /** Called when the user wants to dismiss the foldout. */
   readonly onDismiss: () => void
 
-  readonly selectedPullRequest: PullRequest | null
-
+  /** Callback to fire when the filter text is changed */
+  readonly onFilterTextChanged: (filterText: string) => void
+  readonly onCreateBranch: () => void
+  readonly onCreatePullRequest: () => void
   readonly onSelectionChanged?: (
     pullRequest: PullRequest | null,
     source: SelectionSource
@@ -48,12 +56,6 @@ interface IPullRequestListProps {
   readonly onFilterKeyDown?: (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => void
-
-  /** The current filter text to render */
-  readonly filterText: string
-
-  /** Callback to fire when the filter text is changed */
-  readonly onFilterTextChanged: (filterText: string) => void
 }
 
 interface IPullRequestListState {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -28,8 +28,14 @@ export const RowHeight = 47
 interface IPullRequestListProps {
   /** The pull requests to display. */
   readonly pullRequests: ReadonlyArray<PullRequest>
+
+  /** The currently selected pull request */
   readonly selectedPullRequest: PullRequest | null
+
+  /** The name of the repository. */
   readonly repositoryName: string
+
+  /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
 
   /** The current filter text to render */

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -49,8 +49,14 @@ interface IPullRequestListProps {
 
   /** Callback to fire when the filter text is changed */
   readonly onFilterTextChanged: (filterText: string) => void
+
+  /** Called when the user opts to create a branch */
   readonly onCreateBranch: () => void
+
+  /** Called when the user opts to create a pull request */
   readonly onCreatePullRequest: () => void
+
+  /** Callbacked fired when user selects a new pull request */
   readonly onSelectionChanged?: (
     pullRequest: PullRequest | null,
     source: SelectionSource


### PR DESCRIPTION
**This PR depends on PR #3972 first**

When no matches exist when filtering in the PR list, it has no contents. This fixes that.

## Before
![before](https://user-images.githubusercontent.com/1715082/35991470-e75f29a4-0ccc-11e8-971e-ca276454fdc5.gif)

## After
![after](https://user-images.githubusercontent.com/1715082/35991476-eb2b5d78-0ccc-11e8-9ced-7600a6f3b197.gif)

_I based this PR on `show-no-prs` so the diff would be easier to read_