### PR TITLE
Support legacy usernames as co-authors

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -80,12 +80,6 @@ export interface IAPIUser {
   readonly type: 'User' | 'Organization'
 }
 
-/**
- * An expression that validates a GitHub.com or GitHub Enterprise
- * username
- */
-export const validLoginExpression = /^[a-z0-9]+(-[a-z0-9]+)*$/i
-
 /** The users we get from the mentionables endpoint. */
 export interface IAPIMentionableUser {
   readonly avatar_url: string

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -567,7 +567,10 @@ export class API {
    */
   public async fetchUser(login: string): Promise<IAPIUser | null> {
     try {
-      const response = await this.request('GET', `users/${login}`)
+      const response = await this.request(
+        'GET',
+        `users/${encodeURIComponent(login)}`
+      )
 
       if (response.status === 404) {
         return null

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -5,7 +5,6 @@ import { GitHubUserStore } from '../../lib/stores'
 import { GitHubRepository } from '../../models/github-repository'
 import { Account } from '../../models/account'
 import { IGitHubUser } from '../../lib/databases/index'
-import { validLoginExpression } from '../../lib/api'
 
 /** An autocompletion hit for a user. */
 export interface IUserHit {
@@ -102,14 +101,6 @@ export class UserAutocompletionProvider
    */
   public async exactMatch(login: string): Promise<IUserHit | null> {
     if (this.account === null) {
-      return null
-    }
-
-    // While nothing bad can happen if we attempt to fetch a user
-    // with an invalid handle (since the request is sanitized/encoded)
-    // there's no need for us to go to the API if we already know that
-    // the username is invalid.
-    if (!validLoginExpression.test(login)) {
       return null
     }
 

--- a/app/src/ui/autocompletion/user-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/user-autocompletion-provider.tsx
@@ -105,11 +105,10 @@ export class UserAutocompletionProvider
       return null
     }
 
-    // Since we might be looking up stuff in the API it's
-    // important we sanitize this input or someone could lead with
-    // ../ and then start GETing random resources in the API.
-    // Not that they should be able to do any harm with just GET
-    // but still, it ain't cool
+    // While nothing bad can happen if we attempt to fetch a user
+    // with an invalid handle (since the request is sanitized/encoded)
+    // there's no need for us to go to the API if we already know that
+    // the username is invalid.
     if (!validLoginExpression.test(login)) {
       return null
     }

--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -4,7 +4,7 @@ import * as URL from 'url'
 import * as classNames from 'classnames'
 import { UserAutocompletionProvider, IUserHit } from '../autocompletion'
 import { Editor, Doc, Position } from 'codemirror'
-import { validLoginExpression, getDotComAPIEndpoint } from '../../lib/api'
+import { getDotComAPIEndpoint } from '../../lib/api'
 import { compare } from '../../lib/compare'
 import { arrayEquals } from '../../lib/equality'
 import { OcticonSymbol } from '../octicons'
@@ -646,7 +646,7 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
         hint: this.applyCompletion,
       }))
 
-    if (!exactMatch && needle.length > 0 && validLoginExpression.test(needle)) {
+    if (!exactMatch && needle.length > 0) {
       list.push({
         text: `@${needle}`,
         username: needle,


### PR DESCRIPTION
Skip the client-side tests and make sure we're properly escaping the user-input to the API.

Fixes #3897