### PR TITLE
Always calls passed in props to FilterList component

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -321,16 +321,12 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   private onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const list = this.list
-    if (!list) {
-      return
-    }
-
     if (this.props.onFilterKeyDown) {
       this.props.onFilterKeyDown(event)
     }
 
-    if (event.defaultPrevented) {
+    const list = this.list
+    if (list == null || event.defaultPrevented) {
       return
     }
 


### PR DESCRIPTION
🌵 🌵 🌵  **Depends on #3972, ensure that gets merged first** 🌵 🌵 🌵 

This fixes an issue where if you pass an empty list to a FilterList component, it would return on KeyDown without calling the OnKeyDown prop first. This moves that conditions **after** calling the prop event handler.