### PR TITLE
latest yarn merges two lockfile entries

### DIFF
--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -161,11 +161,7 @@ codemirror-mode-elixir@1.1.1:
   dependencies:
     codemirror "^5.20.2"
 
-codemirror@^5.20.2:
-  version "5.33.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.33.0.tgz#462ad9a6fe8d38b541a9536a3997e1ef93b40c6a"
-
-codemirror@^5.31.0:
+codemirror@^5.20.2, codemirror@^5.31.0:
   version "5.33.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.33.0.tgz#462ad9a6fe8d38b541a9536a3997e1ef93b40c6a"
 


### PR DESCRIPTION
If you have yarn `v1.3.2` installed and run `yarn` on master (from the repository root) you'll probably see the lockfile is modified (tested on both macOS and Windows).

I think this crept in as part of #3774, and it seems to be tidying up the lockfile contents and not a behaviour change.