### PR TITLE
Fix branch blankslate image

### DIFF
--- a/app/styles/ui/_blank-slate.scss
+++ b/app/styles/ui/_blank-slate.scss
@@ -82,16 +82,32 @@
   .callout:not(:last-child) {
     border-right: var(--base-border);
   }
+
+  // Custom image sizing explicitly for the dedicated
+  // blank slate view (a.k.a the no-repositories view).
+  .blankslate-image {
+    width: 80%;
+    flex-grow: 0.6;
+    // Background image url is set in react since we need to
+    // calculate it at runtime.
+    background-repeat: no-repeat;
+    background-position: center bottom;
+    background-size: contain;
+  }
 }
 
-.blankslate-image {
-  width: 80%;
-  flex-grow: 0.6;
-  // Background image url is set in react since we need to
-  // calculate it at runtime.
-  background-repeat: no-repeat;
-  background-position: center bottom;
-  background-size: contain;
+// For all views other than the dedicated blank slate
+// view. Yes, this is confusing.
+.ui-view:not(#blank-slate) .blankslate-image {
+  width: 50%;
+  min-width: 400px;
+  max-width: 800px;
+}
+
+// In the foldout we want the image to fill the
+// full width of the container (minus padding).
+.foldout .blankslate-image {
+  width: 100%;
 }
 
 // When there's not enough space to show the blankslate

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -252,11 +252,6 @@
   text-align: center;
   padding: var(--spacing);
 
-  .blankslate-image {
-    width: 257px;
-    min-width: 0;
-  }
-
   .title {
     font-weight: var(--font-weight-semibold);
   }

--- a/app/styles/ui/_no-branches.scss
+++ b/app/styles/ui/_no-branches.scss
@@ -6,11 +6,6 @@
 
   padding: var(--spacing);
 
-  .blankslate-image {
-    width: 257px;
-    min-width: 0;
-  }
-
   .title {
     font-weight: var(--font-weight-semibold);
     text-align: center;

--- a/app/styles/ui/_panel.scss
+++ b/app/styles/ui/_panel.scss
@@ -2,9 +2,4 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-
-.panel-container {
-  display: flex;
-  flex-direction: row;
-  flex: 1;
 }

--- a/app/styles/ui/_panel.scss
+++ b/app/styles/ui/_panel.scss
@@ -1,13 +1,7 @@
 .panel {
-  border-right: 1px solid var(--box-border-color);
   display: flex;
   flex-direction: column;
   flex: 1;
-
-  &:last-child {
-    border-right: none;
-  }
-}
 
 .panel-container {
   display: flex;


### PR DESCRIPTION
I accidentally messed this up in #3777 as I didn't realize that we were using the `blankslate-image` class in foldouts.

### Before

![screen shot 2018-02-14 at 14 30 05](https://user-images.githubusercontent.com/634063/36207038-ce8ab6a6-1194-11e8-8838-e3506ddfa5e8.png)

### After
![screen shot 2018-02-14 at 14 30 14](https://user-images.githubusercontent.com/634063/36207039-ceac5018-1194-11e8-82c8-b6ca283bc34a.png)

### Bonus

The `panel` class added an extra border in the history view blank slate.

![screen shot 2018-02-14 at 14 31 30](https://user-images.githubusercontent.com/634063/36207040-cece94e8-1194-11e8-9ec2-c0b19a059ba0.png)
