### PR TITLE
Adds Co-authored commit tracking

### DIFF
--- a/app/src/lib/git/interpret-trailers.ts
+++ b/app/src/lib/git/interpret-trailers.ts
@@ -17,7 +17,7 @@ export interface ITrailer {
  * Co-Authored-By. Does not validate the token value.
  */
 export function isCoAuthoredByTrailer(trailer: ITrailer) {
-  return trailer.token.toLowerCase() === 'Co-Authored-By'
+  return trailer.token.toLowerCase() === 'co-authored-by'
 }
 
 /**

--- a/app/src/lib/git/interpret-trailers.ts
+++ b/app/src/lib/git/interpret-trailers.ts
@@ -13,6 +13,14 @@ export interface ITrailer {
 }
 
 /**
+ * Gets a value indicating whether the trailer token is
+ * Co-Authored-By. Does not validate the token value.
+ */
+export function isCoAuthoredByTrailer(trailer: ITrailer) {
+  return trailer.token.toLowerCase() === 'Co-Authored-By'
+}
+
+/**
  * Parse a string containing only unfolded trailers produced by
  * git-interpret-trailers --only-input --only-trailers --unfold or
  * a derivative such as git log --format="%(trailers:only,unfold)"

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -37,8 +37,11 @@ export interface IDailyMeasures {
 
   /** The number of partial commits. */
   readonly partialCommits: number
+
+  /** The number of commits created with one or more co-authors. */
+  readonly coAuthoredCommits: number
 }
-// co-authors
+
 export class StatsDatabase extends Dexie {
   public launches: Dexie.Table<ILaunchStats, number>
   public dailyMeasures: Dexie.Table<IDailyMeasures, number>

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -38,7 +38,7 @@ export interface IDailyMeasures {
   /** The number of partial commits. */
   readonly partialCommits: number
 }
-
+// co-authors
 export class StatsDatabase extends Dexie {
   public launches: Dexie.Table<ILaunchStats, number>
   public dailyMeasures: Dexie.Table<IDailyMeasures, number>

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -28,6 +28,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   commits: 0,
   partialCommits: 0,
   openShellCount: 0,
+  coAuthoredCommits: 0,
 }
 
 interface ICalculatedStats {
@@ -276,6 +277,13 @@ export class StatsStore {
   public recordPartialCommit(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       partialCommits: m.partialCommits + 1,
+    }))
+  }
+
+  /** Record that a commit was created with one or more co-authors. */
+  public recordCoAuthoredCommit(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      coAuthoredCommits: m.coAuthoredCommits + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -75,6 +75,7 @@ import {
   getMergeBase,
   getRemotes,
   ITrailer,
+  isCoAuthoredByTrailer,
 } from '../git'
 
 import { launchExternalEditor } from '../editors'
@@ -1399,7 +1400,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordPartialCommit()
       }
 
-      if (trailers && trailers.length && trailers.some(x => x.token.toLowerCase() === 'co-authored-by')) {
+      if (trailers && trailers.some(isCoAuthoredByTrailer)) {
         this.statsStore.recordCoAuthoredCommit()
       }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1400,7 +1400,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordPartialCommit()
       }
 
-      if (trailers && trailers.some(isCoAuthoredByTrailer)) {
+      if (trailers != null && trailers.some(isCoAuthoredByTrailer)) {
         this.statsStore.recordCoAuthoredCommit()
       }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1399,6 +1399,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordPartialCommit()
       }
 
+      if (trailers && trailers.length && trailers.some(x => x.token.toLowerCase() === 'co-authored-by')) {
+        this.statsStore.recordCoAuthoredCommit()
+      }
+
       await this._refreshRepository(repository)
       await this.refreshChangesSection(repository, {
         includingStatus: true,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -48,6 +48,7 @@ import {
   mergeTrailers,
   getTrailerSeparatorCharacters,
   parseSingleUnfoldedTrailer,
+  isCoAuthoredByTrailer,
 } from '../git'
 import { IGitAccount } from '../git/authentication'
 import { RetryAction, RetryActionType } from '../retry-actions'
@@ -543,9 +544,7 @@ export class GitStore extends BaseStore {
     // Next we extract any co-authored-by trailers we
     // can find. We use interpret-trailers for this
     const foundTrailers = await parseTrailers(repository, message)
-    const coAuthorTrailers = foundTrailers.filter(
-      t => t.token.toLowerCase() === 'co-authored-by'
-    )
+    const coAuthorTrailers = foundTrailers.filter(isCoAuthoredByTrailer)
 
     // This is the happy path, nothing more for us to do
     if (coAuthorTrailers.length === 0) {

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -4,6 +4,10 @@ import { GitAuthor } from './git-author'
 import { GitHubRepository } from './github-repository'
 import { getDotComAPIEndpoint } from '../lib/api'
 
+/**
+ * Extract any Co-Authored-By trailers from an array of arbitrary
+ * trailers.
+ */
 function extractCoAuthors(trailers: ReadonlyArray<ITrailer>) {
   const coAuthors = []
 

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -1,5 +1,5 @@
 import { CommitIdentity } from './commit-identity'
-import { ITrailer } from '../lib/git/interpret-trailers'
+import { ITrailer, isCoAuthoredByTrailer } from '../lib/git/interpret-trailers'
 import { GitAuthor } from './git-author'
 import { GitHubRepository } from './github-repository'
 import { getDotComAPIEndpoint } from '../lib/api'
@@ -12,7 +12,7 @@ function extractCoAuthors(trailers: ReadonlyArray<ITrailer>) {
   const coAuthors = []
 
   for (const trailer of trailers) {
-    if (trailer.token.toLowerCase() === 'co-authored-by') {
+    if (isCoAuthoredByTrailer(trailer)) {
       const author = GitAuthor.parse(trailer.value)
       if (author) {
         coAuthors.push(author)


### PR DESCRIPTION
Fixes issue #3964

#### Plumbing
- [x] Add `co-authored-commit` field to `IDailyMeasures` in `stats` database
- [x] Add the method, `recordCoAuthoredCommit`, to `statsStore`
- [x] Add a new field `co-authored-commit` to `DefaultDailyMeasure` in `statsStore`
#### Back-end (Central)
- [x] Add measure to `desktop_usage_event.rb`
- [x] Update `usage_test.rb`
- [x] Update `fake_desktop_data` in `helper.rb`
#### Database
- [x] Open an issue on _github/analytics_ to get new field pulled into view, update airflow, and update reports
#### Other
- [x] Update the [usage-data page](https://desktop.github.com/usage-data/) on desktop.github.com

*This depends on PRs in central, desktop.github.com, analytics being merged.*