### PR TITLE
Remove preview features doc and update feature flagging.

### DIFF
--- a/docs/contributing/preview-features.md
+++ b/docs/contributing/preview-features.md
@@ -11,4 +11,6 @@ the Desktop app.
 
 ## Preview Features
 
-Coming Soon™
+* Enhanced branch selector that allows you to view pull requests
+
+* The [status](https://help.github.com/articles/about-statuses/) for each pull request is not surfaced in the UI

--- a/docs/contributing/preview-features.md
+++ b/docs/contributing/preview-features.md
@@ -1,3 +1,0 @@
-# Preview Features
-
-We are hard at work building the latest features, we will have something to show soon...

--- a/docs/contributing/preview-features.md
+++ b/docs/contributing/preview-features.md
@@ -1,16 +1,3 @@
 # Preview Features
 
-If you're running GitHub Desktop you can enable **"preview features"**, which
-we consider something we want to eventually ship to everyone, but needs some
-sort of refinement before we can do that, and in the meantime we would like
-feedback from users on these features.
-
-To opt-in for testing preview features, set the
-`GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value and launch
-the Desktop app.
-
-## Preview Features
-
-* Enhanced branch selector that allows you to view pull requests
-
-* The [status](https://help.github.com/articles/about-statuses/) for each pull request is not surfaced in the UI
+We are hard at work building the latest features, we will have something to show soon...

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -49,9 +49,16 @@ feature once things are stabilized.
 
 ## How to test
 
-Set the `GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value to opt-in for preview featurs.
+**Opting-in for preview features**
+1. Set the `GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value
+1. Restart GitHub Desktop
 
 Don't have that environment variable? 
 No worries, simply create it. (here's a [handy guide](https://www.schrodinger.com/kb/1842) for doing that on most major OSs).
 
-Note, if you would like to opt-out of preview feautures, you will need to remove this variable from your environment.
+**Opting-out for preview features**
+1. Remove the `GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable
+1. Restart GitHub Desktop
+
+
+

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -50,5 +50,9 @@ feature once things are stabilized.
 ## How to test
 
 To opt-in for testing preview features, set the
-`GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value and launch
-the Desktop app.
+`GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value.
+
+
+Don't have that environment variable? No worries, simply create it. (here's a [handy guide](https://www.schrodinger.com/kb/1842) on creating environment variables on most major OSs).
+
+Note, if you want to opt-out of preview feautures, you will need to remove this variable from your environment.

--- a/docs/technical/feature-flagging.md
+++ b/docs/technical/feature-flagging.md
@@ -49,10 +49,9 @@ feature once things are stabilized.
 
 ## How to test
 
-To opt-in for testing preview features, set the
-`GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value.
+Set the `GITHUB_DESKTOP_PREVIEW_FEATURES` environment variable to any value to opt-in for preview featurs.
 
+Don't have that environment variable? 
+No worries, simply create it. (here's a [handy guide](https://www.schrodinger.com/kb/1842) for doing that on most major OSs).
 
-Don't have that environment variable? No worries, simply create it. (here's a [handy guide](https://www.schrodinger.com/kb/1842) on creating environment variables on most major OSs).
-
-Note, if you want to opt-out of preview feautures, you will need to remove this variable from your environment.
+Note, if you would like to opt-out of preview feautures, you will need to remove this variable from your environment.


### PR DESCRIPTION
Reading through the docs, noticed that we don't call out the features under preview. 

@desktop/core feels on screenshots or gifs to illustrate each feature?