### PR TITLE
release the kraken

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -26,6 +26,11 @@ function enableBetaFeatures(): boolean {
   return enableDevelopmentFeatures() || __RELEASE_CHANNEL__ === 'beta'
 }
 
+/** Should the new Compare view be enabled? */
+export function enableCompareBranch(): boolean {
+  return enableBetaFeatures()
+}
+
 /** Should PR integration be enabled? */
 export function enablePRIntegration(): boolean {
   return true

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -28,7 +28,7 @@ function enableBetaFeatures(): boolean {
 
 /** Should PR integration be enabled? */
 export function enablePRIntegration(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 /** Should merge tool integration be enabled? */


### PR DESCRIPTION
This makes the PR integration available for the next stable update :tada:

I also added a placeholder flag for the 1.2 work so I wouldn't have to eliminate the `enableBetaFeatures` function.