### PR TITLE
report EPIPE and EOF errors betterer

### DIFF
--- a/app/src/lib/git/show.ts
+++ b/app/src/lib/git/show.ts
@@ -2,7 +2,7 @@ import { ChildProcess } from 'child_process'
 
 import { git } from './core'
 import { spawnAndComplete } from './spawn'
-import { protectProcessOutput } from '../process'
+import { reportProcessOutputError } from '../process'
 
 import { Repository } from '../../models/repository'
 
@@ -30,7 +30,7 @@ export async function getBlobContents(
   const successExitCodes = new Set([0, 1])
   const setBinaryEncoding: (process: ChildProcess) => void = cb => {
     cb.stdout.setEncoding('binary')
-    protectProcessOutput(cb, 'getBlobContents')
+    reportProcessOutputError(cb, 'getBlobContents')
   }
 
   const args = ['show', `${commitish}:${path}`]

--- a/app/src/lib/git/show.ts
+++ b/app/src/lib/git/show.ts
@@ -2,6 +2,7 @@ import { ChildProcess } from 'child_process'
 
 import { git } from './core'
 import { spawnAndComplete } from './spawn'
+import { protectProcessOutput } from '../process'
 
 import { Repository } from '../../models/repository'
 
@@ -27,8 +28,10 @@ export async function getBlobContents(
   path: string
 ): Promise<Buffer> {
   const successExitCodes = new Set([0, 1])
-  const setBinaryEncoding: (process: ChildProcess) => void = cb =>
+  const setBinaryEncoding: (process: ChildProcess) => void = cb => {
     cb.stdout.setEncoding('binary')
+    protectProcessOutput(cb, 'getBlobContents')
+  }
 
   const args = ['show', `${commitish}:${path}`]
   const opts = {

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -1,6 +1,6 @@
 import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
-import { protectProcessOutput } from '../process'
+import { reportProcessOutputError } from '../process'
 
 type ProcessOutput = {
   output: Buffer
@@ -53,7 +53,7 @@ export function spawnAndComplete(
           }
         })
 
-        protectProcessOutput(process, 'spawnAndComplete')
+        reportProcessOutputError(process, 'spawnAndComplete')
 
         const stderrChunks = new Array<Buffer>()
         process.stderr.on('data', (chunk: Buffer) => {

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -1,5 +1,6 @@
 import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
+import { protectProcessOutput } from '../process'
 
 type ProcessOutput = {
   output: Buffer
@@ -51,6 +52,8 @@ export function spawnAndComplete(
             killSignalSent = true
           }
         })
+
+        protectProcessOutput(process, 'spawnAndComplete')
 
         const stderrChunks = new Array<Buffer>()
         process.stderr.on('data', (chunk: Buffer) => {

--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -193,6 +193,10 @@ declare namespace NodeJS {
   }
 }
 
+interface ErrorWithCode extends Error {
+  code: string | number | undefined
+}
+
 declare namespace Electron {
   interface MenuItem {
     readonly accelerator?: Electron.Accelerator

--- a/app/src/lib/process.ts
+++ b/app/src/lib/process.ts
@@ -1,6 +1,6 @@
 import { ChildProcess } from 'child_process'
 
-export function protectProcessOutput(
+export function reportProcessOutputError(
   childProcess: ChildProcess,
   context: string
 ) {

--- a/app/src/lib/process.ts
+++ b/app/src/lib/process.ts
@@ -1,0 +1,24 @@
+import { ChildProcess } from 'child_process'
+
+export function protectProcessOutput(
+  childProcess: ChildProcess,
+  context: string
+) {
+  childProcess.stdout.on('error', err => {
+    const errWithCode = err as ErrorWithCode
+    let code = errWithCode.code
+
+    if (typeof code === 'string') {
+      if (code === 'EPIPE') {
+        log.error(`[${context}] stdout was terminated with an EPIPE`, err)
+        return
+      }
+      if (code === 'EOF') {
+        log.error(`[${context}] stdout was terminated with an EOF`, err)
+        return
+      }
+    }
+
+    log.error(`[${context}] stdout reported an error`, err)
+  })
+}

--- a/app/src/lib/process.ts
+++ b/app/src/lib/process.ts
@@ -6,7 +6,7 @@ export function protectProcessOutput(
 ) {
   childProcess.stdout.on('error', err => {
     const errWithCode = err as ErrorWithCode
-    let code = errWithCode.code
+    const code = errWithCode.code
 
     if (typeof code === 'string') {
       if (code === 'EPIPE') {

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -3,6 +3,8 @@
 import * as ChildProcess from 'child_process'
 import * as os from 'os'
 
+import { protectProcessOutput } from './process'
+
 type IndexLookup = {
   [propName: string]: string
 }
@@ -74,6 +76,8 @@ async function getRawShellEnv(): Promise<string | null> {
     child.stdout.on('data', (data: Buffer) => {
       buffers.push(data)
     })
+
+    protectProcessOutput(child, 'getRawShellEnv')
 
     child.on('close', (code: number, signal) => {
       done = true

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -3,7 +3,7 @@
 import * as ChildProcess from 'child_process'
 import * as os from 'os'
 
-import { protectProcessOutput } from './process'
+import { reportProcessOutputError } from './process'
 
 type IndexLookup = {
   [propName: string]: string
@@ -77,7 +77,7 @@ async function getRawShellEnv(): Promise<string | null> {
       buffers.push(data)
     })
 
-    protectProcessOutput(child, 'getRawShellEnv')
+    reportProcessOutputError(child, 'getRawShellEnv')
 
     child.on('close', (code: number, signal) => {
       done = true

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -3,7 +3,7 @@ import * as Path from 'path'
 import * as Os from 'os'
 
 import { pathExists, mkdirIfNeeded, writeFile } from '../lib/file-system'
-import { protectProcessOutput } from '../lib/process'
+import { reportProcessOutputError } from '../lib/process'
 
 const appFolder = Path.resolve(process.execPath, '..')
 const rootAppDir = Path.resolve(appFolder, '..')
@@ -221,7 +221,7 @@ function spawn(
         stdout += data
       })
 
-      protectProcessOutput(child, context)
+      reportProcessOutputError(child, context)
 
       child.on('close', code => {
         if (code === 0) {

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -1,7 +1,9 @@
 import * as ChildProcess from 'child_process'
 import * as Path from 'path'
 import * as Os from 'os'
+
 import { pathExists, mkdirIfNeeded, writeFile } from '../lib/file-system'
+import { protectProcessOutput } from '../lib/process'
 
 const appFolder = Path.resolve(process.execPath, '..')
 const rootAppDir = Path.resolve(appFolder, '..')
@@ -109,7 +111,7 @@ async function writeShellScriptCLITrampoline(binPath: string): Promise<void> {
 async function spawnSquirrelUpdate(
   commands: ReadonlyArray<string>
 ): Promise<void> {
-  await spawn(updateDotExe, commands)
+  await spawn(updateDotExe, commands, 'update.exe')
 }
 
 type ShortcutLocations = ReadonlyArray<'StartMenu' | 'Desktop'>
@@ -186,7 +188,7 @@ async function getPathSegments(): Promise<ReadonlyArray<string>> {
     `,
   ]
 
-  const stdout = await spawn(powershellPath, args)
+  const stdout = await spawn(powershellPath, args, 'powershell')
   const pathOutput = stdout.replace(/^\s+|\s+$/g, '')
   return pathOutput.split(/;+/).filter(segment => segment.length)
 }
@@ -202,11 +204,15 @@ async function setPathSegments(paths: ReadonlyArray<string>): Promise<void> {
     setxPath = 'setx.exe'
   }
 
-  await spawn(setxPath, ['Path', paths.join(';')])
+  await spawn(setxPath, ['Path', paths.join(';')], 'setx')
 }
 
 /** Spawn a command with arguments and capture its output. */
-function spawn(command: string, args: ReadonlyArray<string>): Promise<string> {
+function spawn(
+  command: string,
+  args: ReadonlyArray<string>,
+  context: string
+): Promise<string> {
   try {
     const child = ChildProcess.spawn(command, args as string[])
     return new Promise<string>((resolve, reject) => {
@@ -214,6 +220,8 @@ function spawn(command: string, args: ReadonlyArray<string>): Promise<string> {
       child.stdout.on('data', data => {
         stdout += data
       })
+
+      protectProcessOutput(child, context)
 
       child.on('close', code => {
         if (code === 0) {


### PR DESCRIPTION
There's a couple of common-but-obscure errors sitting in Haystack that I'd like to understand more about. 

This one only occurs on macOS:

```
error: write EPIPE
exports._errnoException (util.js:1050:11)
WriteWrap.afterWrite (net.js:813:14)
```

This one only occurs on Windows:

```
error: write EOF
exports._errnoException (util.js:1050:11)
WriteWrap.afterWrite (net.js:813:14)
```

Digging into more details about these errors, I stumble upon this project: https://github.com/mhart/epipebomb

> By default, node throws `EPIPE` errors if `process.stdout` is being written to and a user runs it through a pipe that gets closed while the process is still outputting (eg, the simple case of piping a node app through `head`).
> 
> This seemed a little overzealous to me, so I wrote this to suppress such errors.

I'm not quite sure how this might apply to Desktop, but the details of this suppression was very interesting: they do this by attaching to the `error` event on `process.stdout`.

This is interesting, for a couple of reasons:

 - #3954 was a situation where I did the exact same thing to listen for `error` events from the spawned process (to stop the renderer from crashing)
 - the stack trace for both errors are the same, which makes me think I can handle both errors by handling the `error` event on `process.stdout`

~~There's also `GitProcess` in `dugite` that might be responsible for these errors, and I'll address that separately to this, but~~ this PR should help us identify the source of these errors better than what's currently delivered to Haystack.