### PR TITLE
Add "Branch" to "New" branch button

### DIFF
--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -239,7 +239,7 @@ export class BranchList extends React.Component<
     if (this.props.canCreateNewBranch) {
       return (
         <Button className="new-branch-button" onClick={this.onCreateNewBranch}>
-          New Branch
+          {__DARWIN__ ? 'New Branch' : 'New branch'}
         </Button>
       )
     } else {

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -239,7 +239,7 @@ export class BranchList extends React.Component<
     if (this.props.canCreateNewBranch) {
       return (
         <Button className="new-branch-button" onClick={this.onCreateNewBranch}>
-          New
+          New Branch
         </Button>
       )
     } else {

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -239,7 +239,6 @@
   button.new-branch-button {
     align-self: center;
     margin-right: var(--spacing);
-    width: 60px;
   }
 }
 


### PR DESCRIPTION
This small pull request clarifies that the "new" button refers to a branch in the branch dropdown:

**Before**
<img width="960" alt="screen shot 2018-02-16 at 2 46 39 pm" src="https://user-images.githubusercontent.com/1174461/36336020-58e1370a-1328-11e8-81ea-0835fbb46999.png">

**After**
<img width="960" alt="screen shot 2018-02-16 at 2 47 30 pm" src="https://user-images.githubusercontent.com/1174461/36336025-5fb74254-1328-11e8-8d5a-01137924210b.png">

I'm personally in favor of clarifying an action as much as possible, but am open to be persuaded otherwise 😄 
