### PR TITLE
handle error when where is not on PATH

### DIFF
--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -11,9 +11,14 @@ export function isGitOnPath(): Promise<boolean> {
 
   // adapted from http://stackoverflow.com/a/34953561/1363815
   return new Promise<boolean>((resolve, reject) => {
-    const process = spawn('where', ['git'])
-
     if (__WIN32__) {
+      const process = spawn('where', ['git'])
+
+      process.on('error', error => {
+        log.warn('Unable to spawn where.exe', error)
+        resolve(false)
+      })
+
       // `where` will return 0 when the executable
       // is found under PATH, or 1 if it cannot be found
       process.on('close', function(code) {

--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -12,7 +12,7 @@ export function isGitOnPath(): Promise<boolean> {
   // adapted from http://stackoverflow.com/a/34953561/1363815
   return new Promise<boolean>((resolve, reject) => {
     if (__WIN32__) {
-      const process = spawn('where', ['git'])
+      const process = spawn('C:\\Windows\\System32\\where.exe', ['git'])
 
       process.on('error', error => {
         log.warn('Unable to spawn where.exe', error)


### PR DESCRIPTION
Fixes #3882 
Fixes #3825

 - [x] using the full path to `where` when spawning, in case it doesn't exist on `PATH`
 - [x] handling the `error` event in case this doesn't exist on disk, and logging a message
 - [x] confirm `START` without `cmd.exe` and `powershell.exe` on PATH is also resolved
