### PR TITLE
Give up and assume diff is too large

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -200,13 +200,14 @@ export async function getWorkingDirectoryDiff(
     ]
   }
 
-  const { output, error } = await spawnAndComplete(
+  const { output, error, didReadAllBytes } = await spawnAndComplete(
     args,
     repository.path,
     'getWorkingDirectoryDiff',
-    successExitCodes
+    successExitCodes,
+    MaxBytesToRead
   )
-  if (isBufferTooLarge(output)) {
+  if (!didReadAllBytes || isBufferTooLarge(output)) {
     // we know we can't transform this process output into a diff, so let's
     // just return a placeholder for now that we can display to the user
     // to say we're at the limits of the runtime

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -113,12 +113,14 @@ export async function getCommitDiff(
     args.push(file.oldPath)
   }
 
-  const { output } = await spawnAndComplete(
+  const { output, didReadAllBytes } = await spawnAndComplete(
     args,
     repository.path,
-    'getCommitDiff'
+    'getCommitDiff',
+    undefined,
+    MaxBytesToRead
   )
-  if (isBufferTooLarge(output)) {
+  if (!didReadAllBytes || isBufferTooLarge(output)) {
     return { kind: DiffType.TooLarge, length: output.length }
   }
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -39,6 +39,14 @@ const MaxDiffBufferSize = 268435441
 const MaxReasonableDiffSize = 3000000
 
 /**
+ * Where `MaxReasonableDiffSize` is a soft limit, and `MaxDiffBufferSize`
+ * is an absolute limit, this is the MAX number of bytes to read from the
+ * buffer before _assuming_ the current buffer being read is `MaxDiffBufferSize`.
+ * This is done so that the UI isn't waiting for the entire buffer to be read.
+ */
+const MaxBytesToRead = MaxDiffBufferSize / 8 //~32MB
+
+/**
  * The longest line length we should try to display. If a diff has a line longer
  * than this, we probably shouldn't attempt it.
  */

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -3,6 +3,7 @@ import * as GitPerf from '../../ui/lib/git-perf'
 
 type ProcessOutput = {
   output: Buffer
+  didReadAllBytes: boolean
   error: Buffer
 }
 

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -35,6 +35,7 @@ export function spawnAndComplete(
         const process = GitProcess.spawn(args, path)
         let totalStdoutLength = 0
         let killSignalSent = false
+        let didReadAllBytes = true
 
         const stdoutChunks = new Array<Buffer>()
         process.stdout.on('data', (chunk: Buffer) => {
@@ -50,6 +51,7 @@ export function spawnAndComplete(
           ) {
             process.kill()
             killSignalSent = true
+            didReadAllBytes = false
           }
         })
 
@@ -81,6 +83,7 @@ export function spawnAndComplete(
           if (exitCodes.has(code) || signal) {
             resolve({
               output: stdout,
+              didReadAllBytes,
               error: stderr,
             })
             return


### PR DESCRIPTION
*Please make sure this is merged before PR #4050, so that I can fix merge conflicts in that branch*

I noticed this issue while working on PR #3980, which is now closed to make code review easier. Shoutout to @shiftkey for letting me know that `spawn` can be given the maximum number of bytes to read.

Notice how long it takes the UI to catch up and let me know the diff can't be displayed. This changes means that we give up sooner and assume a diff is too large so the UX can be a bit better.

### Before
![before](https://user-images.githubusercontent.com/1715082/36407459-6c77c48e-15c4-11e8-91e9-70cf36abe196.gif)

### After
![after](https://user-images.githubusercontent.com/1715082/36407463-71b1bbc6-15c4-11e8-8fbd-b0a3ea84892a.gif)
