### PR TITLE
Fetch default remote if it differs from the current

### DIFF
--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -30,8 +30,10 @@ export async function addRemote(
   repository: Repository,
   name: string,
   url: string
-): Promise<void> {
+): Promise<IRemote> {
   await git(['remote', 'add', name, url], repository.path, 'addRemote')
+
+  return { url, name }
 }
 
 /** Removes an existing remote, or silently errors if it doesn't exist */

--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -1,6 +1,7 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
 import { IRemote } from '../../models/remote'
+import { findDefaultRemote } from '../stores/helpers/find-default-remote'
 
 /** Get the remote names. */
 export async function getRemotes(
@@ -21,18 +22,7 @@ export async function getRemotes(
 export async function getDefaultRemote(
   repository: Repository
 ): Promise<IRemote | null> {
-  const remotes = await getRemotes(repository)
-  if (remotes.length === 0) {
-    return null
-  }
-
-  const remote = remotes.find(x => x.name === 'origin')
-
-  if (remote) {
-    return remote
-  }
-
-  return remotes[0]
+  return findDefaultRemote(await getRemotes(repository))
 }
 
 /** Add a new remote with the given URL. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2360,9 +2360,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * Note that this method will not perform the fetch of the specified remote
    * if _any_ fetches or pulls are currently in-progress.
    */
-  private _fetchRemote(repository: Repository, remote: IRemote, fetchType: FetchType): Promise<void> {
+  private _fetchRemote(
+    repository: Repository,
+    remote: IRemote,
+    fetchType: FetchType
+  ): Promise<void> {
     return this.withAuthenticatingUser(repository, (repository, account) => {
-      return this.performFetch(repository, account, fetchType, [ remote ])
+      return this.performFetch(repository, account, fetchType, [remote])
     })
   }
 
@@ -2397,7 +2401,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
         if (remotes === undefined) {
           await gitStore.fetch(account, isBackgroundTask, progressCallback)
         } else {
-          await gitStore.fetchRemotes(account, remotes, isBackgroundTask, progressCallback)
+          await gitStore.fetchRemotes(
+            account,
+            remotes,
+            isBackgroundTask,
+            progressCallback
+          )
         }
 
         const refreshTitle = __DARWIN__
@@ -3270,7 +3279,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // TODO: I think we could skip this fetch if we know that we have the branch locally
       // already. That way we'd match the behavior of checking out a branch.
       if (defaultRemote) {
-        await this._fetchRemote(repository, defaultRemote, FetchType.UserInitiatedTask)
+        await this._fetchRemote(
+          repository,
+          defaultRemote,
+          FetchType.UserInitiatedTask
+        )
       }
       await this._checkoutBranch(repository, head.ref)
     } else if (head.gitHubRepository != null) {
@@ -3282,7 +3295,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         head.gitHubRepository.owner.login
       )
       const remotes = await getRemotes(repository)
-      const remote = remotes.find(r => r.name === remoteName)|| await addRemote(repository, remoteName, cloneURL)
+      const remote =
+        remotes.find(r => r.name === remoteName) ||
+        (await addRemote(repository, remoteName, cloneURL))
 
       if (remote.url !== cloneURL) {
         const error = new Error(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1500,12 +1500,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     await Promise.all([
-      gitStore.loadCurrentRemote(),
+      gitStore.loadRemotes(),
       gitStore.updateLastFetched(),
       this.refreshAuthor(repository),
       gitStore.loadContextualCommitMessage(),
       refreshSectionPromise,
-      gitStore.loadUpstreamRemote(),
     ])
 
     this._updateCurrentPullRequest(repository)
@@ -2216,7 +2215,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await gitStore.performFailableOperation(() =>
       addRemote(repository, 'origin', apiRepository.clone_url)
     )
-    await gitStore.loadCurrentRemote()
+    await gitStore.loadRemotes()
 
     // skip pushing if the current branch is a detached HEAD or the repository
     // is unborn

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3267,6 +3267,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (isRefInThisRepo) {
       // We need to fetch FIRST because someone may have created a PR since the last fetch
       const defaultRemote = await getDefaultRemote(repository)
+      // TODO: I think we could skip this fetch if we know that we have the branch locally
+      // already. That way we'd match the behavior of checking out a branch.
       if (defaultRemote) {
         await this._fetchRemote(repository, defaultRemote, FetchType.UserInitiatedTask)
       }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -108,6 +108,8 @@ export class GitStore extends BaseStore {
 
   private _aheadBehind: IAheadBehind | null = null
 
+  private _defaultRemote: IRemote | null = null
+
   private _remote: IRemote | null = null
 
   private _upstream: IRemote | null = null
@@ -879,7 +881,7 @@ export class GitStore extends BaseStore {
 
   public async loadRemotes(): Promise<void> {
     const remotes = await getRemotes(this.repository)
-    const defaultRemote = findDefaultRemote(remotes)
+    this._defaultRemote = findDefaultRemote(remotes)
 
     const currentRemoteName =
       this.tip.kind === TipState.Valid && this.tip.branch.remote !== null
@@ -891,8 +893,8 @@ export class GitStore extends BaseStore {
     // been removed we'll default to the default branch.
     this._remote =
       currentRemoteName !== null
-        ? remotes.find(r => r.name === currentRemoteName) || defaultRemote
-        : defaultRemote
+        ? remotes.find(r => r.name === currentRemoteName) || this._defaultRemote
+        : this._defaultRemote
 
     const parent =
       this.repository.gitHubRepository &&
@@ -953,6 +955,11 @@ export class GitStore extends BaseStore {
    */
   public get aheadBehind(): IAheadBehind | null {
     return this._aheadBehind
+  }
+
+  /** Get the remote we're working with. */
+  public get defaultRemote(): IRemote | null {
+    return this._defaultRemote
   }
 
   /** Get the remote we're working with. */

--- a/app/src/lib/stores/helpers/find-default-remote.ts
+++ b/app/src/lib/stores/helpers/find-default-remote.ts
@@ -1,0 +1,14 @@
+import { IRemote } from '../../../models/remote'
+
+/**
+ * Attempt to find the remote which we consider to be the "default"
+ * remote, i.e. in most cases the 'origin' remote.
+ *
+ * If no remotes are given this method will return null, if no "default"
+ * branch could be found the first remote is considered the default.
+ *
+ * @param remotes A list of remotes for a given repository
+ */
+export function findDefaultRemote(remotes: ReadonlyArray<IRemote>) {
+  return remotes.find(x => x.name === 'origin') || remotes[0] || null
+}


### PR DESCRIPTION
The global fetch method only fetches the 'current' (i.e. the remote derived from the tracking branch of the current branch). This changes it so that it fetches the distinct set of the default, current, and upstream remotes.

This also changes the behavior of `_checkoutPullRequest` so that it always fetches the remote we're switching to first. As noted in the comments I think we can relax this a little going forward.

There's one potential race condition in here that I don't plan on fixing now. The previous `_checkoutPullRequest` implementation did a fetch without wrapping it in the `withPushPull` operation that guarantees we only run one network operation at a time. So there's a potential risk here that we could silently skip the fetch if a background fetch happens to be running at the same time. That risk seems like an improvement over potentially running two fetches concurrently and risking two git processes fighting over resources.

As an additional improvement this cuts down on the number of times we need to shell out to git to get all configured remotes by consolidating them all into one method.

Fixes #4056 