### PR TITLE
Use values instead of events

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -253,7 +253,7 @@ export class CreateBranch extends React.Component<
               label="Name"
               value={this.state.proposedName}
               autoFocus={true}
-              onChange={this.onBranchNameChange}
+              onValueChanged={this.onBranchNameChange}
             />
           </Row>
 
@@ -277,9 +277,8 @@ export class CreateBranch extends React.Component<
     )
   }
 
-  private onBranchNameChange = (event: React.FormEvent<HTMLInputElement>) => {
-    const str = event.currentTarget.value
-    this.updateBranchName(str)
+  private onBranchNameChange = (name: string) => {
+    this.updateBranchName(name)
   }
 
   private updateBranchName(name: string) {

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -83,14 +83,14 @@ export class AuthenticationForm extends React.Component<
           label="Username or email address"
           disabled={disabled}
           autoFocus={true}
-          onChange={this.onUsernameChange}
+          onValueChanged={this.onUsernameChange}
         />
 
         <TextBox
           label="Password"
           type="password"
           disabled={disabled}
-          onChange={this.onPasswordChange}
+          onValueChanged={this.onPasswordChange}
         />
 
         {this.renderError()}
@@ -173,12 +173,12 @@ export class AuthenticationForm extends React.Component<
     return <Errors>{error.message}</Errors>
   }
 
-  private onUsernameChange = (event: React.FormEvent<HTMLInputElement>) => {
-    this.setState({ username: event.currentTarget.value })
+  private onUsernameChange = (username: string) => {
+    this.setState({ username })
   }
 
-  private onPasswordChange = (event: React.FormEvent<HTMLInputElement>) => {
-    this.setState({ password: event.currentTarget.value })
+  private onPasswordChange = (password: string) => {
+    this.setState({ password })
   }
 
   private signInWithBrowser = (event?: React.MouseEvent<HTMLButtonElement>) => {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -100,14 +100,14 @@ export class ConfigureGitUser extends React.Component<
             label="Name"
             placeholder="Your Name"
             value={this.state.name}
-            onChange={this.onNameChange}
+            onValueChanged={this.onNameChange}
           />
 
           <TextBox
             label="Email"
             placeholder="your-email@example.com"
             value={this.state.email}
-            onChange={this.onEmailChange}
+            onValueChanged={this.onEmailChange}
           />
 
           <Row>
@@ -131,16 +131,15 @@ export class ConfigureGitUser extends React.Component<
     )
   }
 
-  private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
+  private onNameChange = (name: string) => {
     this.setState({
-      name: event.currentTarget.value,
+      name,
       email: this.state.email,
       avatarURL: this.state.avatarURL,
     })
   }
 
-  private onEmailChange = (event: React.FormEvent<HTMLInputElement>) => {
-    const email = event.currentTarget.value
+  private onEmailChange = (email: string) => {
     const avatarURL = this.avatarURLForEmail(email)
 
     this.setState({

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -134,8 +134,6 @@ export class ConfigureGitUser extends React.Component<
   private onNameChange = (name: string) => {
     this.setState({
       name,
-      email: this.state.email,
-      avatarURL: this.state.avatarURL,
     })
   }
 

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -163,7 +163,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
             autoFocus={true}
             placeholder="Filter"
             className="filter-list-filter-field"
-            onChange={this.onFilterChanged}
+            onValueChanged={this.onFilterChanged}
             onKeyDown={this.onKeyDown}
             onInputRef={this.onInputRef}
             value={this.props.filterText}
@@ -244,8 +244,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     }
   }
 
-  private onFilterChanged = (event: React.FormEvent<HTMLInputElement>) => {
-    const text = event.currentTarget.value
+  private onFilterChanged = (text: string) => {
     if (this.props.onFilterTextChanged) {
       this.props.onFilterTextChanged(text)
     }

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -115,10 +115,9 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
   private onChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value
-    const defaultPrevented = event.defaultPrevented
 
     this.setState({ value }, () => {
-      if (this.props.onValueChanged && !defaultPrevented) {
+      if (this.props.onValueChanged) {
         this.props.onValueChanged(value)
       }
     })

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -25,9 +25,6 @@ interface ITextBoxProps {
   /** Whether the input field is disabled. */
   readonly disabled?: boolean
 
-  /** Called when the user changes the value in the input field. */
-  readonly onChange?: (event: React.FormEvent<HTMLInputElement>) => void
-
   /**
    * Called when the user changes the value in the input field.
    *
@@ -118,11 +115,6 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
   private onChange = (event: React.FormEvent<HTMLInputElement>) => {
     const value = event.currentTarget.value
-
-    if (this.props.onChange) {
-      this.props.onChange(event)
-    }
-
     const defaultPrevented = event.defaultPrevented
 
     this.setState({ value }, () => {

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -78,12 +78,12 @@ export class PublishRepository extends React.Component<
     this.props.onSettingsChanged(newSettings)
   }
 
-  private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
-    this.updateSettings({ name: event.currentTarget.value })
+  private onNameChange = (name: string) => {
+    this.updateSettings({ name })
   }
 
-  private onDescriptionChange = (event: React.FormEvent<HTMLInputElement>) => {
-    this.updateSettings({ description: event.currentTarget.value })
+  private onDescriptionChange = (description: string) => {
+    this.updateSettings({ description })
   }
 
   private onPrivateChange = (event: React.FormEvent<HTMLInputElement>) => {
@@ -146,7 +146,7 @@ export class PublishRepository extends React.Component<
             label="Name"
             value={this.props.settings.name}
             autoFocus={true}
-            onChange={this.onNameChange}
+            onValueChanged={this.onNameChange}
           />
         </Row>
 
@@ -154,7 +154,7 @@ export class PublishRepository extends React.Component<
           <TextBox
             label="Description"
             value={this.props.settings.description}
-            onChange={this.onDescriptionChange}
+            onValueChanged={this.onDescriptionChange}
           />
         </Row>
 

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -47,7 +47,7 @@ export class RenameBranch extends React.Component<
               label="Name"
               autoFocus={true}
               value={this.state.newName}
-              onChange={this.onNameChange}
+              onValueChanged={this.onNameChange}
               onKeyDown={this.onKeyDown}
             />
           </Row>
@@ -75,8 +75,8 @@ export class RenameBranch extends React.Component<
     }
   }
 
-  private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
-    this.setState({ newName: event.currentTarget.value })
+  private onNameChange = (name: string) => {
+    this.setState({ newName: name })
   }
 
   private cancel = () => {


### PR DESCRIPTION
This PR removes `onChange` from props and updates all usages of that prop to use the `onValueChange` callback instead. 

This was done to limit implementation details from leaking out of the component. See this [comment](https://github.com/desktop/desktop/pull/3972#issuecomment-367764382) for more context.

cc/ @niik 