### PR TITLE
Don't let changes sidebar get too small

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -22,6 +22,9 @@ import { Account } from '../models/account'
 /** The widest the sidebar can be with the minimum window size. */
 const MaxSidebarWidth = 495
 
+/** The narrowist the sidebar can be with the minumum window size. */
+const MinSideBarWidth = 250
+
 interface IRepositoryProps {
   readonly repository: Repo
   readonly state: IRepositoryModelState
@@ -149,6 +152,7 @@ export class RepositoryView extends React.Component<IRepositoryProps, {}> {
         onReset={this.handleSidebarWidthReset}
         onResize={this.handleSidebarResize}
         maximumWidth={MaxSidebarWidth}
+        minimumWidth={MinSideBarWidth}
       >
         {this.renderTabs()}
         {this.renderSidebarContents()}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -23,7 +23,7 @@ import { Account } from '../models/account'
 const MaxSidebarWidth = 495
 
 /** The narrowist the sidebar can be with the minumum window size. */
-const MinSideBarWidth = 250
+const MinSideBarWidth = 225
 
 interface IRepositoryProps {
   readonly repository: Repo


### PR DESCRIPTION
Adds a minimum width (up from the default of `150px`) for `RepositoryView`.

### Before
![before](https://user-images.githubusercontent.com/1715082/36563240-1f6aa112-17df-11e8-930d-3e7a6681192e.gif)

### After
![after](https://user-images.githubusercontent.com/1715082/36563250-25e3a034-17df-11e8-9eb5-beb6b867daf4.gif)

I'd love to know what @desktop/design thoughts are. I felt the default of `150px` was a bit too cramped. Is setting a min width of `225px` too much?


