### PR TITLE
use SYSTEMROOT environment variable when spawning tools under System32

### DIFF
--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import * as Path from 'path'
 
 export function isGitOnPath(): Promise<boolean> {
   // Modern versions of macOS ship with a Git shim that guides you through
@@ -12,16 +13,19 @@ export function isGitOnPath(): Promise<boolean> {
   // adapted from http://stackoverflow.com/a/34953561/1363815
   return new Promise<boolean>((resolve, reject) => {
     if (__WIN32__) {
-      const process = spawn('C:\\Windows\\System32\\where.exe', ['git'])
+      const windowsRoot = process.env.SystemRoot || 'C:\\Windows'
+      const wherePath = Path.join(windowsRoot, 'System32', 'where.exe')
 
-      process.on('error', error => {
+      const cp = spawn(wherePath, ['git'])
+
+      cp.on('error', error => {
         log.warn('Unable to spawn where.exe', error)
         resolve(false)
       })
 
       // `where` will return 0 when the executable
       // is found under PATH, or 1 if it cannot be found
-      process.on('close', function(code) {
+      cp.on('close', function(code) {
         resolve(code === 0)
       })
       return


### PR DESCRIPTION
See https://github.com/desktop/desktop/pull/4044#issuecomment-367841128 and the reply for the context. `%SYSTEMROOT%` should always exist when we launch Desktop, but just in case we'll have a fallback value.

cc @iAmWillShepherd 