### PR TITLE
ensure compare is comparing the right sort of string

### DIFF
--- a/app/src/lib/compare.ts
+++ b/app/src/lib/compare.ts
@@ -71,7 +71,7 @@ export function compareDescending<T>(x: T, y: T): number {
  * used in a sort operation the comparands will be sorted in ascending order.
  */
 export function caseInsensitiveCompare(x: string, y: string): number {
-  return compare(x.toLowerCase(), y.toLocaleLowerCase())
+  return compare(x.toLowerCase(), y.toLowerCase())
 }
 
 /**
@@ -80,5 +80,5 @@ export function caseInsensitiveCompare(x: string, y: string): number {
  * used in a sort operation the comparands will be sorted in descending order.
  */
 export function caseInsensitiveCompareDescending(x: string, y: string): number {
-  return compareDescending(x.toLowerCase(), y.toLocaleLowerCase())
+  return compareDescending(x.toLowerCase(), y.toLowerCase())
 }


### PR DESCRIPTION
Found while tidying up #4090 and traced it back to dd63bc0fc5a5f735539da2875bb0077e1024b192 which seems to suggest this was a copy-paste gone wrong, and both should be `toLowerCase()`.