### PR TITLE
Remove curly rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -52,7 +52,6 @@ rules:
   ###########
   # BUILTIN #
   ###########
-  curly: error
   no-new-wrappers: error
   no-redeclare:
     - error


### PR DESCRIPTION
Omitting the rule 'curly' from eslint can mean that the visual complexity and clutter can be reduced for very simple if statements, etc.

Instead of this

```typescript
    if (this.stopped) {
      return
    }

    const shouldFetch = this.shouldPerformFetch(this.repository)
    if (shouldFetch) {
      try {
        await this.fetch(this.repository)
      } catch (e) {
        log.error('Error performing periodic fetch', e)
      }
    }

    if (this.stopped) {
      return
    }

    const interval = await this.getFetchInterval(repository)
    if (this.stopped) {
      return
    }

    this.timeoutHandle = window.setTimeout(
      () => this.performAndScheduleFetch(repository),
      interval
    )
```

Can look something like this:

```typescript
    if (this.stopped) return

    const shouldFetch = this.shouldPerformFetch(this.repository)
    if (shouldFetch) {
      try {
        await this.fetch(this.repository)
      } catch (e) {
        log.error('Error performing periodic fetch', e)
      }
    }

    if (this.stopped) return

    const interval = await this.getFetchInterval(repository)
    if (this.stopped) return

    this.timeoutHandle = window.setTimeout(
      () => this.performAndScheduleFetch(repository),
      interval
    )
```