### PR TITLE
when there are no open pull requests we should still clear the cache

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -388,16 +388,7 @@ export class PullRequestStore extends TypedBaseStore<GitHubRepository> {
       })
     }
 
-    if (prsToInsert.length <= 0) {
-      return
-    }
-
     return this.pullRequestDatabase.transaction('rw', table, async () => {
-      // since all PRs come from the same repository
-      // using the base repoId of the fist element
-      // is sufficient here
-      const repoDbId = prsToInsert[0].base.repoId!
-
       // we need to delete the stales PRs from the db
       // so we remove all for a repo to avoid having to
       // do diffing
@@ -406,7 +397,9 @@ export class PullRequestStore extends TypedBaseStore<GitHubRepository> {
         .equals(repoDbId)
         .delete()
 
-      await table.bulkAdd(prsToInsert)
+      if (prsToInsert.length > 0) {
+        await table.bulkAdd(prsToInsert)
+      }
     })
   }
 


### PR DESCRIPTION
Fixes #4122 

This issue seems to be related to the scenario where you merge out the last PR in a repository, and the API now returns no open pull requests. In theory, we should be clearing the table in IndexedDB when this occurs, but instead we exit early because we don't have any pull request to add.

Instead, we should always clear the underlying table, and conditionally insert the new pull requests.