### PR TITLE
Race Around The Fetch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3317,7 +3317,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       const gitStore = this.getGitStore(repository)
 
-      this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
+      await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
 
       const localBranchName = `pr/${pullRequest.number}`
       const doesBranchExist =

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3315,9 +3315,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.emitError(error)
       }
 
-      const gitStore = this.getGitStore(repository)
-
       await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
+
+      const gitStore = this.getGitStore(repository)
 
       const localBranchName = `pr/${pullRequest.number}`
       const doesBranchExist =


### PR DESCRIPTION
Spotted this error while checking out a fork PR:

```
debug: [ui] Executing addRemote: git remote add github-desktop-ergaziz https://github.com/ergaziz/desktop.git
info: [ui] [AppStore.withAuthenticatingUser] account found for repository: desktop - shiftkey (has token)
debug: [ui] Executing createBranch: git branch pr/4120 github-desktop-ergaziz/master
error: [ui] `git branch pr/4120 github-desktop-ergaziz/master` exited with an unexpected code: 128.
fatal: Not a valid object name: 'github-desktop-ergaziz/master'.

error: [ui] createBranch failed
GitError: fatal: Not a valid object name: 'github-desktop-ergaziz/master'.

    at Object.git (/Users/shiftkey/src/desktop/webpack:/app/src/lib/git/core.ts:166:9)
    at <anonymous>
debug: [ui] Executing fetch: git -c credential.helper= fetch --progress --prune github-desktop-ergaziz
info: [ui] Executing fetch: git -c credential.helper= fetch --progress --prune github-desktop-ergaziz (took 2.201s)
```

Notice the order of events:

 - add remote
 - create branch
 - fetch

This is because we don't `await` on the `fetch` before checkout. With this change, things are now in-order:

```
debug: [ui] Executing getRemotes: git remote -v
debug: [ui] Executing addRemote: git remote add github-desktop-ergaziz https://github.com/ergaziz/desktop.git
info: [ui] [AppStore.withAuthenticatingUser] account found for repository: desktop - shiftkey (has token)
debug: [ui] Executing fetch: git -c credential.helper= fetch --progress --prune github-desktop-ergaziz
info: [ui] Executing fetch: git -c credential.helper= fetch --progress --prune github-desktop-ergaziz (took 1.130s)
debug: [ui] Executing getStatus: git status --untracked-files=all --branch --porcelain=2 -z
debug: [ui] Executing getBranches: git for-each-ref --format=%(refname)%00%(refname:short)%00%(upstream:short)%00%(objectname)%00%(author)%00%(committer)%00%(parent)%00%(symref)%00%(subject)%00%(body)%00%(trailers:unfold,only)%00%1F refs/heads refs/remotes
debug: [ui] Executing getRecentBranches: git log -g --no-abbrev-commit --pretty=oneline HEAD -n 2500 --
debug: [ui] Executing getConfigValueInPath: git config -z trailer.separators
debug: [ui] Executing getCommits: git log HEAD --date=raw --max-count=100 --pretty=%H%x1F%s%x1F%b%x1F%an <%ae> %ad%x1F%cn <%ce> %cd%x1F%P%x1F%(trailers:unfold,only) -z --no-color --not --remotes --
debug: [ui] Executing getRemotes: git remote -v
debug: [ui] Executing getAuthorIdentity: git var GIT_AUTHOR_IDENT
debug: [ui] Executing createBranch: git branch pr/4120 github-desktop-ergaziz/master
debug: [ui] Executing getBranches: git for-each-ref --format=%(refname)%00%(refname:short)%00%(upstream:short)%00%(objectname)%00%(author)%00%(committer)%00%(parent)%00%(symref)%00%(subject)%00%(body)%00%(trailers:unfold,only)%00%1F refs/heads/pr/4120
```