### PR TITLE
hide github-desktop-* from branches list

### DIFF
--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -102,6 +102,14 @@ export async function getBranches(
       continue
     }
 
+    if (ref.startsWith('refs/remotes/github-desktop-')) {
+      // hide refs from our known remotes as these are considered plumbing
+      // and can add noise to everywhere in the user interface where we
+      // display branches as forks will likely contain duplicates of the same
+      // ref names
+      continue
+    }
+
     branches.push(
       new Branch(name, upstream.length > 0 ? upstream : null, tip, type)
     )

--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -3,10 +3,13 @@ import { Repository } from '../../models/repository'
 import { Commit } from '../../models/commit'
 import { Branch, BranchType } from '../../models/branch'
 import { CommitIdentity } from '../../models/commit-identity'
+import { ForkedRemotePrefix } from '../../models/remote'
 import {
   getTrailerSeparatorCharacters,
   parseRawUnfoldedTrailers,
 } from './interpret-trailers'
+
+const ForksReferencesPrefix = `refs/remotes/${ForkedRemotePrefix}`
 
 /** Get all the branches. */
 export async function getBranches(
@@ -102,7 +105,7 @@ export async function getBranches(
       continue
     }
 
-    if (ref.startsWith('refs/remotes/github-desktop-')) {
+    if (ref.startsWith(ForksReferencesPrefix)) {
       // hide refs from our known remotes as these are considered plumbing
       // and can add noise to everywhere in the user interface where we
       // display branches as forks will likely contain duplicates of the same

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -93,7 +93,6 @@ import {
   EmojiStore,
   GitHubUserStore,
   CloningRepositoriesStore,
-  ForkedRemotePrefix,
 } from '../stores'
 import { validatedRepositoryPath } from './helpers/validated-repository-path'
 import { IGitAccount } from '../git/authentication'
@@ -119,7 +118,7 @@ import { Owner } from '../../models/owner'
 import { PullRequest } from '../../models/pull-request'
 import { PullRequestUpdater } from './helpers/pull-request-updater'
 import * as QueryString from 'querystring'
-import { IRemote } from '../../models/remote'
+import { IRemote, ForkedRemotePrefix } from '../../models/remote'
 import { IAuthor } from '../../models/author'
 
 /**

--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -16,14 +16,7 @@ import {
 import { TypedBaseStore } from './base-store'
 import { Repository } from '../../models/repository'
 import { getRemotes, removeRemote } from '../git'
-import { IRemote } from '../../models/remote'
-
-/**
- * This is the magic remote name prefix
- * for when we add a remote on behalf of
- * the user.
- */
-export const ForkedRemotePrefix = 'github-desktop-'
+import { IRemote, ForkedRemotePrefix } from '../../models/remote'
 
 const Decrement = (n: number) => n - 1
 const Increment = (n: number) => n + 1

--- a/app/src/models/remote.ts
+++ b/app/src/models/remote.ts
@@ -1,3 +1,10 @@
+/**
+ * This is the magic remote name prefix
+ * for when we add a remote on behalf of
+ * the user.
+ */
+export const ForkedRemotePrefix = 'github-desktop-'
+
 /** A remote as defined in Git. */
 export interface IRemote {
   readonly name: string


### PR DESCRIPTION
Fixes #4127 to make the branch list easier to browse

Before: branches and branches for days

<img width="300" src="https://user-images.githubusercontent.com/359239/36877634-44dc99ec-1e0f-11e8-8b88-7fe52ab460bd.png">

After: all `github-desktop-*` refs are no longer listed, other remotes still listed

<img width="324" src="https://user-images.githubusercontent.com/359239/36877732-c0c741e2-1e0f-11e8-8992-5bb797f18f7a.png">





- [x] confirm branch operations like checkout fork PRs aren't affected by this
