### PR TITLE
Close issues faster

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,14 +1,14 @@
 # Configuration for no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response
-daysUntilClose: 14
+daysUntilClose: 7
 # Label requiring a response
 # TODO: also close `needs-reproduction` issues (blocked by https://github.com/probot/no-response/issues/11)
 responseRequiredLabel: more-information-needed
-# Comment to post when closing an issue due to lack of response. 
+# Comment to post when closing an issue due to lack of response.
 closeComment: >
   Thank you for your issue!
-  
+
   We haven’t gotten a response to our questions above.
   With only the information that is currently in the issue,
   we don’t have enough information to take action.

--- a/docs/process/issue-triage.md
+++ b/docs/process/issue-triage.md
@@ -100,7 +100,7 @@ issues from time to time that isn't and won't be covered here.
 
 Periodically we should be doing a sweep of issues that are open and labeled
 `more-information-needed`. If the original poster has not responded within
-two weeks after the last question by an official maintainer, close the issue
+7 days after the last question by an official maintainer, close the issue
 with a message saying that you're closing the issue due to inactivity but are
 happy to re-open if they can provide more details.
 


### PR DESCRIPTION
Figured this is as good a place as any to ask the question is 14 days too long?

Close out issues labelled `more information needed` faster.