### PR TITLE
Delete gitignore file when no entries provided

### DIFF
--- a/app/src/lib/stores/repository-settings-store.ts
+++ b/app/src/lib/stores/repository-settings-store.ts
@@ -49,17 +49,29 @@ export class RepositorySettingsStore extends BaseStore {
   public async saveGitIgnore(text: string): Promise<void> {
     const repository = this._repository
     const ignorePath = Path.join(repository.path, '.gitignore')
-    const fileContents = await formatGitIgnoreContents(text, repository)
 
-    return new Promise<void>((resolve, reject) => {
-      FS.writeFile(ignorePath, fileContents, err => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
+    if (text === '') {
+      return new Promise<void>((resolve, reject) => {
+        FS.unlink(ignorePath, err => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
       })
-    })
+    } else {
+      const fileContents = await formatGitIgnoreContents(text, repository)
+      return new Promise<void>((resolve, reject) => {
+        FS.writeFile(ignorePath, fileContents, err => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+      })
+    }
   }
 
   /** Ignore the given path or pattern. */

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -190,7 +190,7 @@ export class RepositorySettings extends React.Component<
       try {
         await this.props.dispatcher.saveGitIgnore(
           this.props.repository,
-          this.state.ignoreText || ''
+          this.state.ignoreText
         )
       } catch (e) {
         log.error(

--- a/app/test/unit/repository-settings-store-test.ts
+++ b/app/test/unit/repository-settings-store-test.ts
@@ -25,6 +25,22 @@ describe('RepositorySettingsStore', () => {
     expect(exists).is.true
   })
 
+  it('deletes gitignore file when no entries provided', async () => {
+    const repo = await setupEmptyRepository()
+    const path = repo.path
+
+    const ignoreFile = `${path}/.gitignore`
+    FS.writeFileSync(ignoreFile, 'node_modules\n')
+
+    const sut = new RepositorySettingsStore(repo)
+
+    // update gitignore file to be empty
+    await sut.saveGitIgnore('')
+
+    const exists = await pathExists(ignoreFile)
+    expect(exists).is.false
+  })
+
   it('can ignore a file in a repository', async () => {
     const repo = await setupEmptyRepository()
     const sut = new RepositorySettingsStore(repo)


### PR DESCRIPTION
Fixes #1896 

I tested the following manually:

1. Use the Repository Settings dialog to create a `.gitignore` file
1. Use the Repository Settings dialog to delete the `.gitignore` file by deleting the contents
1. Create the file with one line without committing it via the command line, then delete it via the Repository Settings dialog by emptying it

The only scenario that I could find that wasn't covered was to create the `.gitignore` file as empty via `touch .gitignore`, then open the Repository Settings dialog and attempt to delete it. Because the file contents don't change, it doesn't delete the file. Do we want to cover this case?