### PR TITLE
Bump toolbar contrast

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2715,15 +2715,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.signInStore.setTwoFactorOTP(otp)
   }
 
-  public _setAppFocusState(isFocused: boolean): Promise<void> {
-    const changed = this.appIsFocused !== isFocused
-    this.appIsFocused = isFocused
-
-    if (changed) {
+  public async _setAppFocusState(isFocused: boolean): Promise<void> {
+    if (this.appIsFocused !== isFocused) {
+      this.appIsFocused = isFocused
       this.emitUpdate()
     }
-
-    return Promise.resolve()
   }
 
   /**

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -149,14 +149,15 @@ document.body.classList.add(`platform-${process.platform}`)
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
 ipcRenderer.on('focus', () => {
-  dispatcher.setAppFocusState(true)
-
   const state = appStore.getState().selectedState
-  if (!state || state.type !== SelectionType.Repository) {
-    return
+
+  // Refresh the currently selected repository on focus (if
+  // we have a selected repository).
+  if (state && state.type === SelectionType.Repository) {
+    dispatcher.refreshRepository(state.repository)
   }
 
-  dispatcher.refreshRepository(state.repository)
+  dispatcher.setAppFocusState(true)
 })
 
 ipcRenderer.on('blur', () => {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -150,7 +150,7 @@ dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
 ipcRenderer.on('focus', () => {
   dispatcher.setAppFocusState(true)
-  
+
   const state = appStore.getState().selectedState
   if (!state || state.type !== SelectionType.Repository) {
     return

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -149,12 +149,13 @@ document.body.classList.add(`platform-${process.platform}`)
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
 ipcRenderer.on('focus', () => {
+  dispatcher.setAppFocusState(true)
+  
   const state = appStore.getState().selectedState
   if (!state || state.type !== SelectionType.Repository) {
     return
   }
 
-  dispatcher.setAppFocusState(true)
   dispatcher.refreshRepository(state.repository)
 })
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -149,12 +149,12 @@ document.body.classList.add(`platform-${process.platform}`)
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
 ipcRenderer.on('focus', () => {
-  const state = appStore.getState().selectedState
+  const { selectedState } = appStore.getState()
 
   // Refresh the currently selected repository on focus (if
   // we have a selected repository).
-  if (state && state.type === SelectionType.Repository) {
-    dispatcher.refreshRepository(state.repository)
+  if (selectedState && selectedState.type === SelectionType.Repository) {
+    dispatcher.refreshRepository(selectedState.repository)
   }
 
   dispatcher.setAppFocusState(true)

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -174,7 +174,7 @@
 
   --toolbar-background-color: $gray-900;
   --toolbar-text-color: $white;
-  --toolbar-text-secondary-color: $gray-400;
+  --toolbar-text-secondary-color: $gray-300;
 
   --toolbar-button-color: var(--toolbar-text-color);
   --toolbar-button-background-color: transparent;

--- a/app/styles/ui/window/_app-menu-bar.scss
+++ b/app/styles/ui/window/_app-menu-bar.scss
@@ -11,7 +11,7 @@
   }
 
   .toolbar-dropdown:not(.open) > .toolbar-button > button {
-    color: var(--toolbar-button-secondary-color);
+    color: var(--toolbar-text-color);
 
     &:hover,
     &:focus {

--- a/app/styles/ui/window/_title-bar.scss
+++ b/app/styles/ui/window/_title-bar.scss
@@ -75,6 +75,10 @@
       background-color: transparent;
       transition: background-color 0.25s ease;
 
+      // Explicitly setting the line height to the height
+      // of the SVG illustrations helps with vertical alignment.
+      line-height: 10px;
+
       &:focus {
         outline: none;
       }


### PR DESCRIPTION
Fixes #4219.

Bumps the text secondary color for the toolbar one notch from gray-400 to gray-300. Changes the menu item text from the secondary to the primary color (white) to match the visual weight of the primary toolbar button text.

### Before and after

![win-merged](https://user-images.githubusercontent.com/634063/37286065-2c36bfae-2601-11e8-9e64-c7b713515e42.png)

@donokuda Please try this out. Initially I felt like going to 300 would make the description and title elements in the toolbar button too similar but after having run it for a little while I can't say that I do any longer. If you feel like the change is too strong we should mix our own gray-350.