### PR TITLE
Add `Discard All Changes...` to right click context menu on changed file list

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -19,7 +19,7 @@ interface IChangedFileProps {
   readonly include: boolean | null
   readonly onIncludeChanged: (path: string, include: boolean) => void
   readonly onDiscardChanges: (path: string) => void
-
+  readonly onDiscardAllChanges: () => void
   /**
    * Called to reveal a file in the native file manager.
    * @param path The path of the file relative to the root of the repository
@@ -104,6 +104,10 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
       {
         label: __DARWIN__ ? 'Discard Changes…' : 'Discard changes…',
         action: () => this.props.onDiscardChanges(this.props.path),
+      },
+      {
+        label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
+        action: () => this.props.onDiscardAllChanges(),
       },
       { type: 'separator' },
       {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -112,6 +112,7 @@ export class ChangesList extends React.Component<IChangesListProps, {}> {
         key={file.id}
         onIncludeChanged={this.props.onIncludeChanged}
         onDiscardChanges={this.onDiscardChanges}
+        onDiscardAllChanges={this.onDiscardAllChanges}
         onRevealInFileManager={this.props.onRevealInFileManager}
         onOpenItem={this.props.onOpenItem}
         availableWidth={this.props.availableWidth}


### PR DESCRIPTION
**Fixes #4197** 

- [x] Test if issue exists manually in GitHub Desktop
- [x] Find implementations that need to be changed
- [x] Pass onDiscardAllChanges from changed-file-list to changed-file using React.props
- [x] Add new function to context menu
- [x] Test if issue is fixed manually in GitHub Desktop
- [x] Automated Testing?

**Right click context menu on changed file list before the commit:**
<img width="249" alt="context menu before change" src="https://user-images.githubusercontent.com/10974298/37307310-cd439cf8-263a-11e8-9b76-a21aec140848.png">

**Right click context menu on changed file list after the commit:**
<img width="249" alt="context menu after change" src="https://user-images.githubusercontent.com/10974298/37307309-cd224210-263a-11e8-93d6-3017f0de158a.png">


Discard All Changes was only shown by clicking the Changed Files Header.
Behavior is changed to show Discard All Changes in the right click menu item.