### PR TITLE
Branches button is disabled while on an unborn branch

### DIFF
--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -104,7 +104,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     } else if (tip.kind === TipState.Unborn) {
       title = tip.ref
       tooltip = `Current branch is ${tip.ref}`
-      canOpen = false
+      canOpen = branchesState.allBranches.length > 0
     } else if (tip.kind === TipState.Detached) {
       title = `On ${tip.currentSha.substr(0, 7)}`
       tooltip = 'Currently on a detached HEAD'


### PR DESCRIPTION
Fixes: #2121

As discussed in #2121 this issue isn't "exactly" fixed, but I thought it would be a good idea to kick off this PR since this is a UX issue and I'm so into them. ❤️  

@shiftkey You think we should leave it as it is with the solution you proposed or make any other changes for example in the error message that's appeared after this change etc? Would be more than happy to make any other changes so we're in a really good position to merge this in!