### PR TITLE
Add visual indicator that a folder can be dropped on Desktop

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3277,9 +3277,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (isRefInThisRepo) {
       // We need to fetch FIRST because someone may have created a PR since the last fetch
       const defaultRemote = await getDefaultRemote(repository)
-      // TODO: I think we could skip this fetch if we know that we have the branch locally
-      // already. That way we'd match the behavior of checking out a branch.
-      if (defaultRemote) {
+      const gitStore = this.getGitStore(repository)
+      const localBranchName = `pr/${pullRequest.number}`
+      const doesBranchExist =
+        gitStore.allBranches.find(branch => branch.name === localBranchName) !=
+        null
+
+      if (defaultRemote && (!doesBranchExist)) {
         await this._fetchRemote(
           repository,
           defaultRemote,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3277,13 +3277,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (isRefInThisRepo) {
       // We need to fetch FIRST because someone may have created a PR since the last fetch
       const defaultRemote = await getDefaultRemote(repository)
-      const gitStore = this.getGitStore(repository)
-      const localBranchName = `pr/${pullRequest.number}`
-      const doesBranchExist =
-        gitStore.allBranches.find(branch => branch.name === localBranchName) !=
-        null
-
-      if (defaultRemote && (!doesBranchExist)) {
+      // TODO: I think we could skip this fetch if we know that we have the branch locally
+      // already. That way we'd match the behavior of checking out a branch.
+      if (defaultRemote) {
         await this._fetchRemote(
           repository,
           defaultRemote,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -535,7 +535,19 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   public componentDidMount() {
-    document.ondragover = document.ondrop = e => e.preventDefault()
+    document.ondragover = e => {
+      if (this.state.currentPopup != null) {
+        e.dataTransfer.dropEffect = 'none'
+      } else {
+        e.dataTransfer.dropEffect = 'copy'
+      }
+
+      e.preventDefault()
+    }
+
+    document.ondrop = e => {
+      e.preventDefault()
+    }
 
     document.body.ondrop = e => {
       if (this.state.currentPopup != null) {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -536,7 +536,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   public componentDidMount() {
     document.ondragover = e => {
-      if (this.state.currentPopup != null) {
+      if (this.isShowingModal != null) {
         e.dataTransfer.dropEffect = 'none'
       } else {
         e.dataTransfer.dropEffect = 'copy'
@@ -550,7 +550,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     document.body.ondrop = e => {
-      if (this.state.currentPopup != null) {
+      if (this.isShowingModal != null) {
         return
       }
       const files = e.dataTransfer.files

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -122,7 +122,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    * modal dialog such as the preferences, or an error dialog.
    */
   private get isShowingModal() {
-    return this.state.currentPopup || this.state.errors.length
+    return this.state.currentPopup !== null || this.state.errors.length > 0
   }
 
   public constructor(props: IAppProps) {
@@ -536,7 +536,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   public componentDidMount() {
     document.ondragover = e => {
-      if (this.isShowingModal != null) {
+      if (this.isShowingModal) {
         e.dataTransfer.dropEffect = 'none'
       } else {
         e.dataTransfer.dropEffect = 'copy'
@@ -550,7 +550,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     document.body.ondrop = e => {
-      if (this.isShowingModal != null) {
+      if (this.isShowingModal) {
         return
       }
       const files = e.dataTransfer.files


### PR DESCRIPTION
Fixes: #4004 

Since this is another UX related kind of issue I thought I will chime in and start working on it.

@shiftkey Here's the results of the tests cases that you posted in #4004:

> There's two scenarios to test here with this change:
> whether the cursor changes when you drag a folder onto Desktop (to indicate it can be added)

This seems to be the case. Now when you drag a folder into Github Desktop a plus icon appears near the folder (macOS)

> whether the cursor also changes when a modal is displayed (to indicate that it is being ignored)

The folder remains as it is neither the cursor change it's appearance.

Note: I tested the app only in a macOS enviroment so it would be a good idea to test this with a windows machine as well.