### PR TITLE
simplify constructors across the codebase

### DIFF
--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -6,43 +6,27 @@ import { getDotComAPIEndpoint, IAPIEmail } from '../lib/api'
  * This contains a token that will be used for operations that require authentication.
  */
 export class Account {
-  /** The access token used to perform operations on behalf of this account */
-  public readonly token: string
-  /** The login name for this account  */
-  public readonly login: string
-  /** The server for this account - GitHub or a GitHub Enterprise instance */
-  public readonly endpoint: string
-  /** The current list of email addresses associated with the account */
-  public readonly emails: ReadonlyArray<IAPIEmail>
-  /** The profile URL to render for this account */
-  public readonly avatarURL: string
-  /** The database id for this account */
-  public readonly id: number
-  /** The friendly name associated with this account */
-  public readonly name: string
-
   /** Create an account which can be used to perform unauthenticated API actions */
   public static anonymous(): Account {
     return new Account('', getDotComAPIEndpoint(), '', [], '', -1, '')
   }
 
   public constructor(
-    login: string,
-    endpoint: string,
-    token: string,
-    emails: ReadonlyArray<IAPIEmail>,
-    avatarURL: string,
-    id: number,
-    name: string
-  ) {
-    this.login = login
-    this.endpoint = endpoint
-    this.token = token
-    this.emails = emails
-    this.avatarURL = avatarURL
-    this.id = id
-    this.name = name
-  }
+    /** The login name for this account  */
+    public readonly login: string,
+    /** The server for this account - GitHub or a GitHub Enterprise instance */
+    public readonly endpoint: string,
+    /** The access token used to perform operations on behalf of this account */
+    public readonly token: string,
+    /** The current list of email addresses associated with the account */
+    public readonly emails: ReadonlyArray<IAPIEmail>,
+    /** The profile URL to render for this account */
+    public readonly avatarURL: string,
+    /** The database id for this account */
+    public readonly id: number,
+    /** The friendly name associated with this account */
+    public readonly name: string
+  ) {}
 
   public withToken(token: string): Account {
     return new Account(


### PR DESCRIPTION
@iAmWillShepherd and I noticed this in a slide deck at TSConf, and I wanted to open this up as a discussion for some `tech-debt` cleanup opportunities.

Basically, TS has a neat feature called "parameter properties" which lets you simplify your constructors by passing in the access modifier:

> Parameter properties are declared by prefixing a constructor parameter with an accessibility modifier or `readonly`, or both. **Using `private` for a parameter property declares and initialises a private member; likewise, the same is done for `public`, `protected`, and `readonly`.**

This eliminates a potential source of errors where you forget to assign a constructor parameter to the corresponding member. `tsc` does identify these and report them as compiler errors already, so the benefits to this are more aesthetic-based:

<img width="623" alt="screen shot 2018-03-15 at 8 33 04 am" src="https://user-images.githubusercontent.com/359239/37432289-1f2feb4c-2795-11e8-97ff-33ac635ed9f5.png">

I chose the `Account` class to illustrate the aesthetic changes in the attached diff, and that we can move existing JSDoc comments into the constructor to retain Intellisense when browsing the members:

<img width="532" src="https://user-images.githubusercontent.com/359239/37432013-343597ae-2794-11e8-8d67-30e5c0b62b3a.png">

If we're :thumbsup: on this direction I propose we capture a task to tidy up our `app/src/models/` folder and see how that feels.
