### PR TITLE
Fix zoom's order of options and key bindings

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -152,11 +152,6 @@ export function buildDefaultMenu(
       },
       separator,
       {
-        label: __DARWIN__ ? 'Reset Zoom' : 'Reset zoom',
-        accelerator: 'CmdOrCtrl+0',
-        click: zoom(ZoomDirection.Reset),
-      },
-      {
         label: __DARWIN__ ? 'Zoom In' : 'Zoom in',
         accelerator: 'CmdOrCtrl+=',
         click: zoom(ZoomDirection.In),
@@ -165,6 +160,11 @@ export function buildDefaultMenu(
         label: __DARWIN__ ? 'Zoom Out' : 'Zoom out',
         accelerator: 'CmdOrCtrl+-',
         click: zoom(ZoomDirection.Out),
+      },
+      {
+        label: __DARWIN__ ? 'Reset Zoom' : 'Reset zoom',
+        accelerator: 'CmdOrCtrl+0',
+        click: zoom(ZoomDirection.Reset),
       },
       separator,
       {


### PR DESCRIPTION
Fixes: #3913 

## Before

![screen shot 2018-03-15 at 00 32 49](https://user-images.githubusercontent.com/10944108/37434820-a20c0bc8-27e9-11e8-98ea-9fe45d26827d.png)

## After 

![screen shot 2018-03-15 at 00 36 32](https://user-images.githubusercontent.com/10944108/37434829-a9be833c-27e9-11e8-8353-eb04977f5e0c.png)

Here's my question @iAmWillShepherd: How I can change the key binding of the Zoom in from `CMD=` to `CMD+`? I tried to change  the `CmdOrCtrl+=` to `CmdOrCtrl++` and I got as a result:

Any ideas how I can fix that?

![screen shot 2018-03-15 at 00 28 15](https://user-images.githubusercontent.com/10944108/37434992-2af92a88-27ea-11e8-926e-81a88ac523fc.png)
