### PR TITLE
Moved 'Forgot password' below input area on sign-in prompt

### DIFF
--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -121,7 +121,7 @@ export class AuthenticationForm extends React.Component<
             className="forgot-password-link"
             uri={this.props.forgotPasswordUrl}
           >
-            Forgot password
+            Forgot password?
           </LinkButton>
         ) : null}
       </div>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -210,7 +210,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             className="forgot-password-link-sign-in"
             uri={state.forgotPasswordUrl}
           >
-            Forgot password
+            Forgot password?
           </LinkButton>
         </Row>
 

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -203,9 +203,15 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             value={this.state.password}
             type="password"
             onValueChanged={this.onPasswordChanged}
-            labelLinkText="Forgot password?"
-            labelLinkUri={state.forgotPasswordUrl}
           />
+        </Row>
+        <Row>
+          <LinkButton
+            className="forgot-password-link-sign-in"
+            uri={state.forgotPasswordUrl}
+          >
+            Forgot password
+          </LinkButton>
         </Row>
 
         <div className="horizontal-rule">

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -371,6 +371,10 @@ dialog {
       font-size: var(--font-size-sm);
       justify-content: flex-end;
     }
+
+    .forgot-password-link-sign-in {
+      margin-left: auto;
+    }
   }
 
   &#add-existing-repository {


### PR DESCRIPTION
Fixes #4109

Before:
<img src="https://user-images.githubusercontent.com/13363433/37588103-e72e40a8-2b69-11e8-89da-6631e794b887.png" width="395" />

After:
<img src="https://user-images.githubusercontent.com/13363433/37588119-f5f6897e-2b69-11e8-88f8-3e9e67334b43.png" width="395" />



cc @nerdneha (I can't mention @desktop/design 😛)