### PR TITLE
relax regex rule to catch more merged PRs when generating changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "cli": "ts-node --require ./app/test/globals.ts --require ./app/src/cli/dev-commands-global.js app/src/cli/main.ts",
     "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe mocha -t 30000 --require ts-node/register app/test/integration/*.ts",
-    "test:unit": "cross-env GIT_AUTHOR_NAME=\"Joe Bloggs\" GIT_AUTHOR_EMAIL=\"joe.bloggs@somewhere.com\" GIT_COMMITTER_NAME=\"Joe Bloggs\" GIT_COMMITTER_EMAIL=\"joe.bloggs@somewhere.com\" TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe electron-mocha -t 10000 --renderer --require ts-node/register --require ./app/test/globals.ts app/test/unit/*.{ts,tsx} app/test/unit/**/*.{ts,tsx}",
-    "test": "yarn test:unit && yarn test:integration",
+    "test:unit": "cross-env GIT_AUTHOR_NAME=\"Joe Bloggs\" GIT_AUTHOR_EMAIL=\"joe.bloggs@somewhere.com\" GIT_COMMITTER_NAME=\"Joe Bloggs\" GIT_COMMITTER_EMAIL=\"joe.bloggs@somewhere.com\" TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe electron-mocha -t 10000 --renderer --require ts-node/register --require ./app/test/globals.ts app/test/unit/*.{ts,tsx} app/test/unit/**/*.{ts,tsx} script/changelog/test/*.ts",
+    "test:script": "mocha -t 10000 --require ts-node/register script/changelog/test/*.ts",
+    "test": "yarn test:unit && yarn test:script && yarn test:integration",
     "test:setup": "ts-node script/test-setup.ts",
     "test:review": "ts-node script/test-review.ts",
     "postinstall": "cd app && yarn install --force && cd .. && git submodule update --recursive --init && yarn compile:tslint",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "cli": "ts-node --require ./app/test/globals.ts --require ./app/src/cli/dev-commands-global.js app/src/cli/main.ts",
     "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe mocha -t 30000 --require ts-node/register app/test/integration/*.ts",
-    "test:unit": "cross-env GIT_AUTHOR_NAME=\"Joe Bloggs\" GIT_AUTHOR_EMAIL=\"joe.bloggs@somewhere.com\" GIT_COMMITTER_NAME=\"Joe Bloggs\" GIT_COMMITTER_EMAIL=\"joe.bloggs@somewhere.com\" TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe electron-mocha -t 10000 --renderer --require ts-node/register --require ./app/test/globals.ts app/test/unit/*.{ts,tsx} app/test/unit/**/*.{ts,tsx} script/changelog/test/*.ts",
+    "test:unit": "cross-env GIT_AUTHOR_NAME=\"Joe Bloggs\" GIT_AUTHOR_EMAIL=\"joe.bloggs@somewhere.com\" GIT_COMMITTER_NAME=\"Joe Bloggs\" GIT_COMMITTER_EMAIL=\"joe.bloggs@somewhere.com\" TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe electron-mocha -t 10000 --renderer --require ts-node/register --require ./app/test/globals.ts app/test/unit/*.{ts,tsx} app/test/unit/**/*.{ts,tsx}",
     "test:script": "mocha -t 10000 --require ts-node/register script/changelog/test/*.ts",
     "test": "yarn test:unit && yarn test:script && yarn test:integration",
     "test:setup": "ts-node script/test-setup.ts",

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -40,7 +40,7 @@ function getChangelogEntry(commit: IParsedCommit, pr: IAPIPR): string {
   let type = PlaceholderChangeType
   const description = capitalized(pr.title)
 
-  const re = /Fixes #(\d+)/gi
+  const re = /Fixes:? #(\d+)/gi
   let match: RegExpExecArray | null = null
   do {
     match = re.exec(pr.body)

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -42,7 +42,10 @@ export function findIssueRef(body: string): string {
   let match: RegExpExecArray | null = null
   do {
     match = re.exec(body)
-    if (match && match.length > 1) {
+    if (match && match.length === 4) {
+      // a match should always have four elements - the matching text
+      // as well as the three groups within the match. We're only
+      // interested in the last match - the issue reference number
       issueRef += ` #${match[3]}`
     }
   } while (match)

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -35,19 +35,27 @@ function capitalized(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
-function getChangelogEntry(commit: IParsedCommit, pr: IAPIPR): string {
+export function findIssueRef(body: string): string {
   let issueRef = ''
-  let type = PlaceholderChangeType
-  const description = capitalized(pr.title)
 
   const re = /Fixes:? #(\d+)/gi
   let match: RegExpExecArray | null = null
   do {
-    match = re.exec(pr.body)
+    match = re.exec(body)
     if (match && match.length > 1) {
-      issueRef += ` #${match[1]}`
+      const length = match.length
+      issueRef += ` #${match[length - 1]}`
     }
   } while (match)
+
+  return issueRef
+}
+
+function getChangelogEntry(commit: IParsedCommit, pr: IAPIPR): string {
+  let type = PlaceholderChangeType
+  const description = capitalized(pr.title)
+
+  let issueRef = findIssueRef(pr.body)
 
   if (issueRef.length) {
     type = 'Fixed'

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -43,8 +43,7 @@ export function findIssueRef(body: string): string {
   do {
     match = re.exec(body)
     if (match && match.length > 1) {
-      const length = match.length
-      issueRef += ` #${match[length - 1]}`
+      issueRef += ` #${match[3]}`
     }
   } while (match)
 

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -38,7 +38,7 @@ function capitalized(str: string): string {
 export function findIssueRef(body: string): string {
   let issueRef = ''
 
-  const re = /Fixes:? #(\d+)/gi
+  const re = /(close[s]?|fix(e[sd])?|resolve[sd]):?\s*#(\d+)/gi
   let match: RegExpExecArray | null = null
   do {
     match = re.exec(body)

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -45,7 +45,7 @@ export function findIssueRef(body: string): string {
     if (match && match.length === 4) {
       // a match should always have four elements - the matching text
       // as well as the three groups within the match. We're only
-      // interested in the last match - the issue reference number
+      // interested in the last group - the issue reference number
       issueRef += ` #${match[3]}`
     }
   } while (match)

--- a/script/changelog/test/parser-test.ts
+++ b/script/changelog/test/parser-test.ts
@@ -4,7 +4,7 @@ import { findIssueRef } from '../parser'
 
 describe('changelog/parser', () => {
   describe('findIssueRef', () => {
-    it('detected closed message at start of PR body', () => {
+    it('detected fixes message at start of PR body', () => {
       const body = `
 Fixes #2314
 
@@ -15,7 +15,7 @@ quam vel augue.`
       expect(findIssueRef(body)).to.equal(' #2314')
     })
 
-    it('detects multiple issues when linked', () => {
+    it('detects multiple fixed issues in PR body', () => {
       const body = `
 Fixes #2314
 Fixes #1234
@@ -25,6 +25,35 @@ tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. D
 ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
 quam vel augue.`
       expect(findIssueRef(body)).to.equal(' #2314 #1234')
+    })
+
+    it('handles colon after fixed message', () => {
+      const body = `
+Pellentesque pellentesque finibus fermentum. Aenean eget semper libero.
+
+Fixes: #2314
+
+Nam malesuada augue vel velit vehicula suscipit. Nunc posuere, velit at sodales
+malesuada, quam tellus rutrum orci, et tincidunt sem nunc non velit. Cras
+placerat, massa vel tristique iaculis, urna nisl tristique nibh, eget luctus
+nisl quam in metus.`
+      expect(findIssueRef(body)).to.equal(' #2314')
+    })
+
+    it('handles closes syntax', () => {
+      const body = `
+Closes: #2314
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.`
+      expect(findIssueRef(body)).to.equal(' #2314')
+    })
+
+    it('handles resolves syntax', () => {
+      const body = `This resolves #2314 and is totally wild`
+      expect(findIssueRef(body)).to.equal(' #2314')
     })
   })
 })

--- a/script/changelog/test/parser-test.ts
+++ b/script/changelog/test/parser-test.ts
@@ -15,17 +15,16 @@ quam vel augue.`
       expect(findIssueRef(body)).to.equal(' #2314')
     })
 
-    it('handles colon after message', () => {
+    it('detects multiple issues when linked', () => {
       const body = `
-Pellentesque pellentesque finibus fermentum. Aenean eget semper libero.
+Fixes #2314
+Fixes #1234
 
-Fixes: #2314
-
-Nam malesuada augue vel velit vehicula suscipit. Nunc posuere, velit at sodales
-malesuada, quam tellus rutrum orci, et tincidunt sem nunc non velit. Cras
-placerat, massa vel tristique iaculis, urna nisl tristique nibh, eget luctus
-nisl quam in metus.`
-      expect(findIssueRef(body)).to.equal(' #2314')
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.`
+      expect(findIssueRef(body)).to.equal(' #2314 #1234')
     })
   })
 })

--- a/script/changelog/test/parser-test.ts
+++ b/script/changelog/test/parser-test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai'
+
+import { findIssueRef } from '../parser'
+
+describe('changelog/parser', () => {
+  describe('findIssueRef', () => {
+    it('detected closed message at start of PR body', () => {
+      const body = `
+Fixes #2314
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.`
+      expect(findIssueRef(body)).to.equal(' #2314')
+    })
+
+    it('handles colon after message', () => {
+      const body = `
+Pellentesque pellentesque finibus fermentum. Aenean eget semper libero.
+
+Fixes: #2314
+
+Nam malesuada augue vel velit vehicula suscipit. Nunc posuere, velit at sodales
+malesuada, quam tellus rutrum orci, et tincidunt sem nunc non velit. Cras
+placerat, massa vel tristique iaculis, urna nisl tristique nibh, eget luctus
+nisl quam in metus.`
+      expect(findIssueRef(body)).to.equal(' #2314')
+    })
+  })
+})


### PR DESCRIPTION
This came up as part of #4234, and it looks like some PRs can link to issues using `Fixes: #id` (with the colon). This is valid syntax for auto-closing issues when the PR is merged:

<img width="389" src="https://user-images.githubusercontent.com/359239/37628569-126c056a-2c2e-11e8-9828-6b901bd68ad0.png">

Our parser doesn't handle this, so it was overlooked in the release notes generator:

```
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

$ GITHUB_ACCESS_TOKEN=[token] yarn draft-release beta | grep \#4004

$ git checkout relax-regex-for-fixed-issue
Switched to branch 'relax-regex-for-fixed-issue'

$ GITHUB_ACCESS_TOKEN=[token] yarn draft-release beta | grep \#4004
    "[Fixed] Add visual indicator that a folder can be dropped on Desktop - #4004. Thanks @agisilaos!",
```

 - [x] extract this into something more testable
 - [x] throw a bunch of the documented keywords at it

