### PR TITLE
add a sanity check when generating the changelog and an empty log is returned

### DIFF
--- a/script/changelog/git.ts
+++ b/script/changelog/git.ts
@@ -13,9 +13,9 @@ export async function getLogLines(
     '--',
   ])
 
-  const entries = log.split('\0')
+  if (log.length === 0) {
+    return []
+  }
 
-  // this ensures empty entries are ignored - git log might just
-  // return a `\0` to indicate that there are no new merged PRs
-  return entries.filter(e => e.trim().length > 0)
+  return log.split('\0')
 }

--- a/script/changelog/git.ts
+++ b/script/changelog/git.ts
@@ -13,5 +13,9 @@ export async function getLogLines(
     '--',
   ])
 
-  return log.split('\0')
+  const entries = log.split('\0')
+
+  // this ensures empty entries are ignored - git log might just
+  // return a `\0` to indicate that there are no new merged PRs
+  return entries.filter(e => e.trim().length > 0)
 }


### PR DESCRIPTION
When there's nothing new to release, the changelog command freaks out:

```shellsession
$ GITHUB_ACCESS_TOKEN=[token] yarn changelog release-1.1.1-beta3
yarn run v1.5.1
$ ts-node script/changelog/index.ts release-1.1.1-beta3
Unable to parse line, using the full message. Error: Unable to parse ''
    at parseCommitTitle (/Users/shiftkey/src/desktop/script/changelog/parser.ts:20:11)
    at Object.convertToChangelogFormat (/Users/shiftkey/src/desktop/script/changelog/parser.ts:72:22)
    at Object.run (/Users/shiftkey/src/desktop/script/changelog/run.ts:51:34)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:118:7)
[
  "[???] "
]
✨  Done in 0.48s.
```

This is because the `git log` command may return an empty string when it has no entries, which is returned as an array with one value:

<img width="138" src="https://user-images.githubusercontent.com/359239/37747297-a9e18fe6-2dd2-11e8-959e-8e1ac2c0aebf.png">

This skips the problematic split command completely.