### PR TITLE
refresh issues when user manually fetches

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -487,8 +487,8 @@ export class Dispatcher {
   }
 
   /** Update the repository's issues from GitHub. */
-  public updateIssues(repository: GitHubRepository): Promise<void> {
-    return this.appStore._updateIssues(repository)
+  public refreshIssues(repository: GitHubRepository): Promise<void> {
+    return this.appStore._refreshIssues(repository)
   }
 
   /** End the Welcome flow. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -823,7 +823,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitHubRepository = repository.gitHubRepository
 
     if (gitHubRepository != null) {
-      this._updateIssues(gitHubRepository)
+      this._refreshIssues(gitHubRepository)
       this.loadPullRequests(repository, async () => {
         const promiseForPRs = this.pullRequestStore.fetchPullRequestsFromCache(
           gitHubRepository
@@ -871,14 +871,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._repositoryWithRefreshedGitHubRepository(repository)
   }
 
-  public async _updateIssues(repository: GitHubRepository) {
+  public async _refreshIssues(repository: GitHubRepository) {
     const user = getAccountForEndpoint(this.accounts, repository.endpoint)
     if (!user) {
       return
     }
 
     try {
-      await this._issuesStore.fetchIssues(repository, user)
+      await this._issuesStore.refreshIssues(repository, user)
     } catch (e) {
       log.warn(`Unable to fetch issues for ${repository.fullName}`, e)
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2439,6 +2439,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
         if (fetchType === FetchType.UserInitiatedTask) {
           this._refreshPullRequests(repository)
+          if (repository.gitHubRepository != null) {
+            this._refreshIssues(repository.gitHubRepository)
+          }
         }
       }
     })

--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -48,10 +48,10 @@ export class IssuesStore {
   }
 
   /**
-   * Fetch the issues for the repository. This will delete any issues that have
+   * Refresh the issues for the current repository. This will delete any issues that have
    * been closed and update or add any issues that have changed or been added.
    */
-  public async fetchIssues(repository: GitHubRepository, account: Account) {
+  public async refreshIssues(repository: GitHubRepository, account: Account) {
     const api = API.fromAccount(account)
     const lastUpdatedAt = await this.getLatestUpdatedAt(repository)
 

--- a/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
@@ -52,7 +52,7 @@ export class IssuesAutocompletionProvider
     text: string
   ): Promise<ReadonlyArray<IIssueHit>> {
     this.updateIssuesScheduler.queue(() => {
-      this.dispatcher.updateIssues(this.repository)
+      this.dispatcher.refreshIssues(this.repository)
     })
 
     return this.issuesStore.getIssuesMatching(this.repository, text)


### PR DESCRIPTION
Fixes #4076

I didn't like how we use `update` and `fetch` in this API, so I took the chance to clean this up so it looked similar to the PR APIs inside `app-store` and other components - these behave similarly in terms of handling the refreshing under the hood, might as well ensure they're named consistently.