### PR TITLE
add note about infrastructure label

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -170,4 +170,5 @@ pull requests.
 
 | Label name | :mag_right: | Description |
 | --- | --- | --- |
+| `infrastructure` | [search](https://github.com/desktop/desktop/labels/infrastructure) | Pull requests not related to the core application - documentation, dependencies, tooling, etc. |
 | `ready-for-review` | [search](https://github.com/desktop/desktop/labels/ready-for-review)  | Pull Requests that are ready to be reviewed by the maintainers. |


### PR DESCRIPTION
You might have seen the `infrastructure` label appear next to some pull requests yesterday:

<img width="999" src="https://user-images.githubusercontent.com/359239/37807722-09b100f0-2e9b-11e8-8fbd-4b83442eb8f0.png">

I wanted to experiment with this to help reviewers differentiate between contributions to application features, and contributions not directly related to the application.

Examples of infrastructure contributions:

 - new documentation, or improvements to existing documentation
 - updating dependencies - we should keep up with new versions, but getting these in will ebb and flow based on other priorities
 - improvements to infrastructure scripts - the maintenance of the tooling inside the Desktop repository is also an ongoing effort

Marking infrastructure PRs will also help our changelog generation with releases - these changes are not typically user-facing, so we can skip over them rather than manually removing them.

The number of open pull requests can be overwhelming at times, and while we're actively trying to pay this down this extra bit of context should help guide reviewers with how best to spend their time. For example, they might want to take a break from reviewing application fixes to helping improve the overall project by reviewing something infrastructure-related.
