### PR TITLE
add back a dropped dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,7 +1503,7 @@ commander@2.11.0, commander@2.11.x, commander@^2.9.0, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
-commander@^2.14.1:
+commander@^2.12.1, commander@^2.14.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 


### PR DESCRIPTION
Looks like one of my merged depedency PRs didn't catch this lockfile update.

You'll notice this if you run `yarn` against `master` such as 58af53bf0ca8fb7d053bb68d6a2bef6413cfe4fd.

It doesn't affect the running app, just a bit of nuisance if you're working against the latest changes.