### PR TITLE
add support for publishing to a team within an organization

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -80,6 +80,12 @@ export interface IAPIUser {
   readonly type: 'User' | 'Organization'
 }
 
+export interface IAPITeam {
+  readonly id: number
+  /** The identifier for the team */
+  readonly name: string
+}
+
 /** The users we get from the mentionables endpoint. */
 export interface IAPIMentionableUser {
   readonly avatar_url: string
@@ -355,19 +361,34 @@ export class API {
     }
   }
 
+  public async fetchTeams(org: IAPIUser): Promise<ReadonlyArray<IAPITeam>> {
+    const url = `orgs/${org.login}/teams`
+    try {
+      return this.fetchAll<IAPITeam>(url)
+    } catch (e) {
+      log.warn(`fetchTeams: failed with endpoint ${this.endpoint}${url}`, e)
+      return []
+    }
+  }
+
   /** Create a new GitHub repository with the given properties. */
   public async createRepository(
     org: IAPIUser | null,
+    team: IAPITeam | null,
     name: string,
     description: string,
     private_: boolean
   ): Promise<IAPIRepository> {
     try {
       const apiPath = org ? `orgs/${org.login}/repos` : 'user/repos'
+
+      const team_id = team != null ? team.id : undefined
+
       const response = await this.request('POST', apiPath, {
         name,
         description,
         private: private_,
+        team_id,
       })
 
       return await parsedResponse<IAPIRepository>(response)

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -23,7 +23,7 @@ import { CloningRepository } from '../../models/cloning-repository'
 import { Branch } from '../../models/branch'
 import { Commit } from '../../models/commit'
 import { ExternalEditor } from '../../lib/editors'
-import { IAPIUser } from '../../lib/api'
+import { IAPIUser, IAPITeam } from '../../lib/api'
 import { GitHubRepository } from '../../models/github-repository'
 import { ICommitMessage } from '../stores/git-store'
 import { executeMenuItem } from '../../ui/main-process-proxy'
@@ -323,7 +323,8 @@ export class Dispatcher {
     description: string,
     private_: boolean,
     account: Account,
-    org: IAPIUser | null
+    org: IAPIUser | null,
+    team: IAPITeam | null
   ): Promise<Repository> {
     return this.appStore._publishRepository(
       repository,
@@ -331,7 +332,8 @@ export class Dispatcher {
       description,
       private_,
       account,
-      org
+      org,
+      team
     )
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -32,7 +32,7 @@ import {
   IMatchedGitHubRepository,
   repositoryMatchesRemote,
 } from '../../lib/repository-matching'
-import { API, getAccountForEndpoint, IAPIUser } from '../../lib/api'
+import { API, getAccountForEndpoint, IAPIUser, IAPITeam } from '../../lib/api'
 import { caseInsensitiveCompare } from '../compare'
 import { Branch, BranchType } from '../../models/branch'
 import { TipState } from '../../models/tip'
@@ -2207,11 +2207,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     description: string,
     private_: boolean,
     account: Account,
-    org: IAPIUser | null
+    org: IAPIUser | null,
+    team: IAPITeam | null
   ): Promise<Repository> {
     const api = API.fromAccount(account)
     const apiRepository = await api.createRepository(
       org,
+      team,
       name,
       description,
       private_

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -70,6 +70,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       description: '',
       private: true,
       org: null,
+      team: null,
     }
 
     this.state = {
@@ -229,7 +230,8 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
         settings.description,
         settings.private,
         account,
-        settings.org
+        settings.org,
+        settings.team
       )
 
       this.props.onDismissed()


### PR DESCRIPTION
Fixes #826 

We haven't seen many requests for this, but it seemed simple enough to add that I took a shot at it now.

- [ ] test `None` behaves as expected when publishing
- [ ] test selecting a team works as expected
- [ ] filter teams that can only publish a repository (`push` or `admin` based on `permission` listed [here](https://developer.github.com/v3/teams/#add-or-update-team-repository))
- [ ] add a tooltip to explain that selecting a team is optional, and this team will own the repository