### PR TITLE
validate the changelog to catch errors before it's time to release

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ plugins:
   - babel
   - react
   - prettier
+  - json
 
 extends:
   - prettier

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - yarn install --force
 
 script:
-  - yarn lint && yarn build:prod && yarn validate-changelog && yarn test:setup && yarn test
+  - yarn validate-changelog && yarn lint && yarn build:prod && yarn test:setup && yarn test
 
 after_failure:
   - yarn test:review

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - yarn install --force
 
 script:
-  - yarn validate-changelog && yarn lint && yarn build:prod && yarn test:setup && yarn test
+  - yarn lint && yarn validate-changelog && yarn build:prod && yarn test:setup && yarn test
 
 after_failure:
   - yarn test:review

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - yarn install --force
 
 script:
-  - yarn lint && yarn build:prod && yarn test:setup && yarn test
+  - yarn lint && yarn build:prod && yarn validate-changelog && yarn test:setup && yarn test
 
 after_failure:
   - yarn test:review

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,9 @@ install:
   - yarn install --force
 
 build_script:
+  - yarn validate-changelog
   - yarn lint
   - yarn build:prod
-  - yarn validate-changelog
 
 test_script:
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ install:
   - yarn install --force
 
 build_script:
-  - yarn validate-changelog
   - yarn lint
+  - yarn validate-changelog
   - yarn build:prod
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ install:
 build_script:
   - yarn lint
   - yarn build:prod
+  - yarn validate-changelog
 
 test_script:
   - node --version

--- a/changelog.json
+++ b/changelog.json
@@ -1,8 +1,5 @@
 {
   "releases": {
-    "some-new-release": [
-
-    ],
     "1.1.2-beta1": [
 
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -671,7 +671,6 @@
       "[Fixed] Windows: Don't removing the running app out from under itself when there are updates pending - #2373",
       "[Fixed] Windows: Respect `core.autocrlf` and `core.safeclrf` when modifying the .gitignore - #1535",
       "[Fixed] Windows: Fix opening the app from the command line - #2396",
-      "[Fixed] 'Create Without Pushing' button throwing an exception while opening a pull request - #2368"
     ],
     "0.7.3-beta5": [],
     "0.7.3-beta4": [],

--- a/changelog.json
+++ b/changelog.json
@@ -670,7 +670,7 @@
       "[Fixed] 'Create Without Pushing' button throwing an exception while opening a pull request - #2368",
       "[Fixed] Windows: Don't removing the running app out from under itself when there are updates pending - #2373",
       "[Fixed] Windows: Respect `core.autocrlf` and `core.safeclrf` when modifying the .gitignore - #1535",
-      "[Fixed] Windows: Fix opening the app from the command line - #2396",
+      "[Fixed] Windows: Fix opening the app from the command line - #2396"
     ],
     "0.7.3-beta5": [],
     "0.7.3-beta4": [],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "some-new-release": [
+
+    ],
     "1.1.2-beta1": [
 
     ],

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ compile:
   override:
     - yarn lint
     - yarn build:prod
+    - yarn validate-changelog
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -32,9 +32,10 @@ dependencies:
 
 compile:
   override:
+    - yarn validate-changelog
     - yarn lint
     - yarn build:prod
-    - yarn validate-changelog
+
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,6 @@ compile:
     - yarn validate-changelog
     - yarn build:prod
 
-
 test:
   override:
     - yarn test:setup

--- a/circle.yml
+++ b/circle.yml
@@ -32,8 +32,8 @@ dependencies:
 
 compile:
   override:
-    - yarn validate-changelog
     - yarn lint
+    - yarn validate-changelog
     - yarn build:prod
 
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "rebuild-hard:dev": "yarn clean-slate && yarn build:dev",
     "rebuild-hard:prod": "yarn clean-slate && yarn build:prod",
     "changelog": "ts-node script/changelog/index.ts",
-    "draft-release": "ts-node script/draft-release/index.ts"
+    "draft-release": "ts-node script/draft-release/index.ts",
+    "validate-changelog": "ts-node script/validate-changelog.ts"
   },
   "author": {
     "name": "GitHub, Inc.",
@@ -50,6 +51,7 @@
     "yarn": ">= 1.2.0"
   },
   "dependencies": {
+    "ajv": "^6.4.0",
     "awesome-typescript-loader": "^3.4.0",
     "aws-sdk": "^2.23.0",
     "babel-core": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-typescript": "^0.10.0",

--- a/script/eslint.ts
+++ b/script/eslint.ts
@@ -30,6 +30,6 @@ console.log(eslint.getFormatter()(report.results))
 if (report.errorCount > 0) {
   process.exitCode = 1
   console.error(
-    chalk`{bold.green → To fix some of these errors, run {underline yarn eslint:fix}}`
+    chalk`{bold.green → To fix some of these errors, run {underline yarn eslint --fix}}`
   )
 }

--- a/script/eslint.ts
+++ b/script/eslint.ts
@@ -18,6 +18,7 @@ const report = eslint.executeOnFiles([
   './tslint-rules/**/*.ts',
   './app/*.js',
   './app/{src,typings,test}/**/*.{j,t}s?(x)',
+  './changelog.json',
 ])
 
 if (shouldFix) {

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -5,10 +5,23 @@ import * as Fs from 'fs'
 
 import * as Ajv from 'ajv'
 
+function handleError(error: any) {
+  console.error(error)
+  process.exit(-1)
+}
+
 const repositoryRoot = Path.dirname(__dirname)
 const changelogPath = Path.join(repositoryRoot, 'changelog.json')
 
 const changelog = Fs.readFileSync(changelogPath)
+
+try {
+  JSON.parse(changelog.toString())
+} catch {
+  handleError(
+    'The contents of changelog.json are not valid JSON. Please check the file contents and address this.'
+  )
+}
 
 const schema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
@@ -36,8 +49,7 @@ const valid = validate(changelog)
 
 console.log(`got: ${JSON.stringify(valid)}`)
 if (!valid) {
-  console.log(validate.errors)
-  process.exitCode = -1
-} else {
-  console.log('The changelog is totally fine')
+  handleError(validate.errors)
 }
+
+console.log('The changelog is totally fine')

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env ts-node
+
+import * as Path from 'path'
+import * as Fs from 'fs'
+
+import * as Ajv from 'ajv'
+
+const repositoryRoot = Path.dirname(__dirname)
+const changelogPath = Path.join(repositoryRoot, 'changelog.json')
+
+const changelog = Fs.readFileSync(changelogPath)
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    releases: {
+      type: 'object',
+      patternProperties: {
+        '^([0-9]+.[0-9]+.[0-9]+)(-beta[0-9]+|-test[0-9]+)?$': {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+}
+
+const ajv = new Ajv({ allErrors: true })
+const validate = ajv.compile(schema)
+
+const valid = validate(changelog)
+
+console.log(`got: ${JSON.stringify(valid)}`)
+if (!valid) {
+  console.log(validate.errors)
+  process.exitCode = -1
+} else {
+  console.log('The changelog is totally fine')
+}

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -35,6 +35,7 @@ const schema = {
           items: {
             type: 'string',
           },
+          uniqueItems: true,
         },
       },
       additionalProperties: false,

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -44,7 +44,7 @@ try {
   changelogObj = JSON.parse(changelog)
 } catch {
   handleError(
-    'The contents of changelog.json are not valid JSON. Please check the file contents and address this.'
+    'Unable to parse the contents of changelog.json into a JSON object. Please review the file contents.'
   )
 }
 

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -5,7 +5,7 @@ import * as Fs from 'fs'
 
 import * as Ajv from 'ajv'
 
-function handleError(error: any) {
+function handleError(error: string) {
   console.error(error)
   process.exit(-1)
 }

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -28,7 +28,7 @@ function formatErrors(errors: Ajv.ErrorObject[]): string {
       // dataPath starts with a leading "."," which is a bit confusing
       const element = dataPath.substr(1)
 
-      return `Error: ${element} - ${message}${additionalPropertyText}`
+      return ` - ${element} - ${message}${additionalPropertyText}`
     })
     .join('\n')
 }
@@ -74,7 +74,7 @@ const validate = ajv.compile(schema)
 const valid = validate(changelogObj)
 
 if (!valid && validate.errors != null) {
-  handleError(formatErrors(validate.errors))
+  handleError(`Errors: \n${formatErrors(validate.errors)}`)
 }
 
 console.log('The changelog is totally fine')

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -13,10 +13,12 @@ function handleError(error: any) {
 const repositoryRoot = Path.dirname(__dirname)
 const changelogPath = Path.join(repositoryRoot, 'changelog.json')
 
-const changelog = Fs.readFileSync(changelogPath)
+const changelog = Fs.readFileSync(changelogPath, 'utf8')
+
+let changelogObj = null
 
 try {
-  JSON.parse(changelog.toString())
+  changelogObj = JSON.parse(changelog)
 } catch {
   handleError(
     'The contents of changelog.json are not valid JSON. Please check the file contents and address this.'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,6 +1404,13 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+cli@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cli/-/cli-1.0.1.tgz#22817534f24bfa4950c34d532d48ecbc621b8c14"
+  dependencies:
+    exit "0.1.2"
+    glob "^7.1.1"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1556,7 +1563,7 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
-console-browserify@^1.1.0:
+console-browserify@1.1.x, console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
   dependencies:
@@ -2039,13 +2046,19 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
+  dependencies:
+    domelementtype "1"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5, domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
   dependencies:
@@ -2331,6 +2344,10 @@ enhanced-resolve@^3.3.0, enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
+entities@1.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
+
 entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
@@ -2451,6 +2468,12 @@ eslint-config-prettier@^2.9.0:
 eslint-plugin-babel@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
+
+eslint-plugin-json@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-json/-/eslint-plugin-json-1.2.0.tgz#9ba73bb0be99d50093e889f5b968463d2a30efae"
+  dependencies:
+    jshint "^2.8.0"
 
 eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
@@ -2601,6 +2624,10 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+exit@0.1.2, exit@0.1.x:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -3365,6 +3392,16 @@ html-webpack-plugin@^2.30.1:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
+htmlparser2@3.8.x:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
+  dependencies:
+    domelementtype "1"
+    domhandler "2.3"
+    domutils "1.5"
+    entities "1.0"
+    readable-stream "1.1"
+
 htmlparser2@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
@@ -3873,6 +3910,19 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+jshint@^2.8.0:
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.5.tgz#1e7252915ce681b40827ee14248c46d34e9aa62c"
+  dependencies:
+    cli "~1.0.0"
+    console-browserify "1.1.x"
+    exit "0.1.x"
+    htmlparser2 "3.8.x"
+    lodash "3.7.x"
+    minimatch "~3.0.2"
+    shelljs "0.3.x"
+    strip-json-comments "1.0.x"
+
 json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
@@ -4151,6 +4201,10 @@ lodash.unescape@4.0.1:
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+
+lodash@3.7.x:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.4"
@@ -5538,6 +5592,15 @@ readable-stream@1.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@1.1:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^1.1.8, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -6028,6 +6091,10 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shelljs@0.3.x:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -6328,6 +6395,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-json-comments@1.0.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,6 +262,15 @@ ajv@^6.1.1:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ajv@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.4.0.tgz#d3aff78e9277549771daf0164cff48482b754fc6"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+    uri-js "^3.0.2"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -5379,6 +5388,10 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
 q@^1.1.2, q@~1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -6804,6 +6817,12 @@ update-notifier@^2.3.0:
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+
+uri-js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-3.0.2.tgz#f90b858507f81dea4dcfbb3c4c3dbfa2b557faaa"
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Turns out I broke the changelog in b0966a27bd8815f0ae0f004d078557e38fe3db10 which affected publishing a release today. Oops, sorry @nerdneha!

This PR is an attempt to catch this issue and some others that would affect releases before they get merged.

 - [x] commit a malformed changelog JSON -> :boom: goes CI, helpful error message

<img width="617" src="https://user-images.githubusercontent.com/359239/37941485-19c645dc-31ba-11e8-8f9d-2c951a147ecc.png">

 - [x] catch a duplicate changelog entry -> :boom: goes CI, helpful error message

<img width="714"  src="https://user-images.githubusercontent.com/359239/37941020-95fabe06-31b7-11e8-99f3-472c6b7d827d.png">

 - [x] add a release that doesn't match our expected format -> :boom: goes CI, helpful error message

<img width="693" src="https://user-images.githubusercontent.com/359239/37941705-44bba8da-31bb-11e8-9fb7-877a01996dcf.png">

 - [x] fix these issues - ✅ goes CI

<img width="388" src="https://user-images.githubusercontent.com/359239/37941951-835b004e-31bc-11e8-91fc-00dd9b219bd1.png">
