### PR TITLE
do license parsing at build time to avoid bundling a hefty YAML parser

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,6 @@
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",
     "file-url": "^2.0.2",
-    "front-matter": "^2.1.2",
     "fs-extra": "^2.1.2",
     "fuzzaldrin-plus": "^0.6.0",
     "keytar": "^4.0.4",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -43,12 +43,6 @@ app-path@^2.2.0:
   dependencies:
     execa "^0.4.0"
 
-argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
-  dependencies:
-    sprintf-js "~1.0.2"
-
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -338,10 +332,6 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
-
 event-kit@^2.0.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/event-kit/-/event-kit-2.4.0.tgz#718aaf22df76670024ad66922483e1bba0544f33"
@@ -408,12 +398,6 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-front-matter@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-2.2.0.tgz#35205f67522430b1213ef26149ecb068579fe38a"
-  dependencies:
-    js-yaml "^3.4.6"
 
 fs-extra@^2.1.2:
   version "2.1.2"
@@ -546,13 +530,6 @@ isstream@0.1.x, isstream@~0.1.2:
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-js-yaml@^3.4.6:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -902,10 +879,6 @@ source-map-support@^0.4.15:
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
   version "1.13.1"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-typescript": "^0.10.0",
     "express": "^4.15.0",
     "extract-text-webpack-plugin": "^3.0.0",
+    "front-matter": "^2.3.0",
     "fs-extra": "^2.1.2",
     "html-webpack-plugin": "^2.30.1",
     "json-pretty": "^0.0.1",

--- a/script/build.ts
+++ b/script/build.ts
@@ -61,7 +61,7 @@ console.log('Copying static resources…')
 copyStaticResources()
 
 console.log('Parsing license metadata…')
-parseLicenseMetadata(outRoot)
+generateLicenseMetadata(outRoot)
 
 const isFork = process.env.CIRCLE_PR_USERNAME
 if (process.platform === 'darwin' && process.env.CIRCLECI && !isFork) {
@@ -380,7 +380,7 @@ function updateLicenseDump(callback: (err: Error | null) => void) {
   )
 }
 
-function parseLicenseMetadata(outRoot: string) {
+function generateLicenseMetadata(outRoot: string) {
   const chooseALicense = path.join(outRoot, 'static', 'choosealicense.com')
   const licensesDir = path.join(chooseALicense, '_licenses')
 
@@ -404,13 +404,29 @@ function parseLicenseMetadata(outRoot: string) {
     }
   }
 
-  const destination = path.join(outRoot, 'static', 'available-licenses.json')
+  const licensePayload = path.join(outRoot, 'static', 'available-licenses.json')
   const text = JSON.stringify(licenses)
-  fs.writeFileSync(destination, text, 'utf8')
+  fs.writeFileSync(licensePayload, text, 'utf8')
 
-  // TODO: embed a README file in here for the choose-a-license metadata
-  // because we still need to attribute this work that we're consuming
+  // embed the license alongside the generated license payload
+  const chooseALicenseLicense = path.join(chooseALicense, 'LICENSE.md')
+  const licenseDestination = path.join(
+    outRoot,
+    'static',
+    'LICENSE.choosealicense.md'
+  )
 
-  // sweep up the ChooseALicense directory, it's no longer needed here
+  const licenseText = fs.readFileSync(chooseALicenseLicense, 'utf8')
+  const licenseWithHeader = `GitHub Desktop uses licensing information provided by choosealicense.com.
+
+The bundle in available-licenses.json has been generated from a source list provided at https://github.com/github/choosealicense.com, which is made available under the below license:
+
+------------
+
+${licenseText}`
+
+  fs.writeFileSync(licenseDestination, licenseWithHeader, 'utf8')
+
+  // sweep up the choosealicense directory as the important bits have been bundled in the app
   fs.removeSync(chooseALicense)
 }

--- a/script/build.ts
+++ b/script/build.ts
@@ -22,16 +22,9 @@ interface IChooseALicense {
 }
 
 export interface ILicense {
-  /** The human-readable name. */
   readonly name: string
-
-  /** Is the license featured? */
   readonly featured: boolean
-
-  /** The actual text of the license. */
   readonly body: string
-
-  /** Whether to hide the license from the standard list */
   readonly hidden: boolean
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,6 +2917,12 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+front-matter@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-2.3.0.tgz#7203af896ce357ee04e2aa45169ea91ed7f67504"
+  dependencies:
+    js-yaml "^3.10.0"
+
 fs-extra-p@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.5.0.tgz#b79f3f3fcc0b5e57b7e7caeb06159f958ef15fe8"


### PR DESCRIPTION
Once upon a time, we merged #727 which bundled a collection of licenses in a submodule with the app and parsed them out to display to the user in a list, and things were good.

Fast forward to today, and we're dealing with a really complex `renderer.js` file which weighs in at over 1.4MB. This matters because there might be opportunities for us to defer work that's occurring as part of initializing the app.

One of the places I started looking was the report in #4355 and one thing stood out - esprima.js

<img width="690" src="https://user-images.githubusercontent.com/359239/38075811-60212da0-337f-11e8-8334-a44b2bc80c19.png">

It's parsed size is 137,268 bytes, or 9% of the 1,464,048 parsed bytes of the renderer file. That's alot.

And what are we using it for? This is what `front-matter` is using under the hood, and Desktop uses it to create a list of licenses when you create a new repository:

<img width="473" src="https://user-images.githubusercontent.com/359239/38076183-95cd72c8-3380-11e8-95ee-81d3480b28e9.png">

If you look at the code inside `app/src/ui/add-repository/licenses.ts` you'll see that it's:

 - scanning a directory for files
 - parsing each of these files for the YAML front matter
 - building up and caching the list of licenses

Doing the scanning of licenses at runtime feels inefficient, so this PR moves all this computation into the build script. This means:

 - we compute the license information once, and embed a JSON file in the app containing the metadata
 - we no longer need to include `front-matter` as a runtime dependency
 - we no longer need to include the `choosealicense.com` submodule in the app

TODO: 

 - [x] use async method for reading new JSON file to address lint error
 - [x] ensure we are still bundling the license for choosealicense.com that was previously in the submodule