### PR TITLE
Typescript 2.8.1

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -472,7 +472,18 @@ export abstract class AutocompletingTextInput<
       this.props.onValueChanged(str)
     }
 
-    const caretPosition = this.element!.selectionStart
+    const element = this.element
+
+    if (element === null) {
+      return
+    }
+
+    const caretPosition = element.selectionStart
+
+    if (caretPosition === null) {
+      return
+    }
+
     const requestID = ++this.autocompletionRequestID
     const autocompletionState = await this.attemptAutocompletion(
       str,

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "tslint-config-prettier": "^1.10.0",
     "tslint-microsoft-contrib": "^5.0.3",
     "tslint-react": "^3.5.1",
-    "typescript": "2.7.2",
+    "typescript": "^2.8.1",
     "typescript-eslint-parser": "^14.0.0",
     "webpack": "^3.10.0",
     "webpack-dev-middleware": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6779,9 +6779,9 @@ typescript-eslint-parser@^14.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
[Conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html) are finally upon us!

Upgrading to TypeScript 2.8 gives us `NonNullable<T>` (and much more) thanks to conditional types and I've been waiting for it so that we can clean up a bunch of our array filters. I decided not to implement any of those changes here so that we can keep this PR tightly scoped. I'll open another PR that builds on this for those changes.

The change to `autocompleting-text-input.tsx` was needed because TypeScript updated the type definition of `HTMLInputElement`'s `selectionStart` to be `number | null`. This change does seem to have been reverted in TypeScript master though so we'll see if we can clean it up in the next typescript release.

Other than conditional types (which is A Big Thing™) there's some additional improvements that I don't believe we'll make much use of.