### PR TITLE
Fix several broken links in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ time as the team learns, listens and refines how we work with the community.
 
 ### Code of Conduct
 
-This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
+This project adheres to the Contributor Covenant [code of conduct](../CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
 Please report unacceptable behavior to [opensource+desktop@github.com](mailto:opensource+desktop@github.com).
 
@@ -58,7 +58,7 @@ reports :mag_right:.
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report)
 as you might find out that you don't need to create one. When you are creating
 a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
-Fill out [the required template](./.github/ISSUE_TEMPLATE.md), the information
+Fill out [the required template](ISSUE_TEMPLATE.md), the information
 it asks for helps us resolve issues faster.
 
 #### Before Submitting A Bug Report
@@ -73,7 +73,7 @@ comment to the existing issue if there is extra information you can contribute.
 Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
 Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues)
-and fill out the provided [issue template](./.github/ISSUE_TEMPLATE.md).
+and fill out the provided [issue template](ISSUE_TEMPLATE.md).
 
 The information we are interested in includes:
 
@@ -93,7 +93,7 @@ community understand your suggestion :pencil: and find related suggestions
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion)
 as you might find out that you don't need to create one. When you are creating
 an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
-Fill in [the template](./.github/ISSUE_TEMPLATE.md), including the steps
+Fill in [the template](ISSUE_TEMPLATE.md), including the steps
 that you imagine you would take if the feature you're requesting existed.
 
 #### Before Submitting An Enhancement Suggestion


### PR DESCRIPTION
I noticed while opening an issue moments ago that several links in the Contributing guide are broken. This pull request fixes all broken links.