### PR TITLE
smooth out filtering behaviour

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -413,26 +413,29 @@ export class CompareSidebar extends React.Component<
     this.setState({ filterText: text })
   }
 
+  private clearFilterState = () => {
+    this.setState({
+      selectedBranch: null,
+      filterText: '',
+      compareType: CompareType.None,
+    })
+
+    this.props.dispatcher.loadCompareState(
+      this.props.repository,
+      DisplayHistory
+    )
+  }
+
   private onSelectionChanged = (branch: Branch | null) => {
     if (branch === null) {
-      this.setState({
-        selectedBranch: null,
-        filterText: '',
-        compareType: CompareType.None,
-      })
-
-      this.props.dispatcher.loadCompareState(
-        this.props.repository,
-        DisplayHistory
-      )
-
+      this.clearFilterState()
       return
     } else {
       const { branches } = this.branchState
       const selectedBranch = branches.find(b => b.name === branch.name) || null
 
       if (selectedBranch === null) {
-        this.onSelectionChanged(null)
+        this.clearFilterState()
         return
       }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -436,26 +436,31 @@ export class CompareSidebar extends React.Component<
       return
     }
 
-    const { branches } = this.branchState
-    const selectedBranch = branches.find(b => b.name === branch.name) || null
-
-    if (selectedBranch === null) {
-      this.clearFilterState()
+    if (source.kind === 'filter') {
+      // don't load the comparison state until a selection has been made
+      this.setState({
+        selectedBranch: branch,
+      })
       return
     }
 
-    this.props.dispatcher.loadCompareState(this.props.repository, {
-      kind: CompareType.Behind,
-      comparisonBranch: selectedBranch,
-      ahead: 0,
-      behind: 0,
-      commitSHAs: [],
-    })
+    if (source.kind === 'mouseclick') {
+      const kind = CompareType.Behind
 
-    this.setState({
-      selectedBranch,
-      compareType: CompareType.Behind,
-    })
+      this.props.dispatcher.loadCompareState(this.props.repository, {
+        kind,
+        comparisonBranch: branch,
+        ahead: 0,
+        behind: 0,
+        commitSHAs: [],
+      })
+
+      this.setState({
+        selectedBranch: branch,
+        filterText: branch.name,
+        compareType: kind,
+      })
+    }
   }
 
   private onTextBoxFocused = () => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -446,7 +446,6 @@ export class CompareSidebar extends React.Component<
 
       this.setState({
         selectedBranch,
-        filterText: selectedBranch.name,
         compareType: CompareType.Behind,
       })
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -366,11 +366,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private handleEscape() {
-    this.props.dispatcher.loadCompareState(
-      this.props.repository,
-      DisplayHistory
-    )
-    this.setState({ selectedBranch: null, filterText: '' })
+    this.clearFilterState()
     this.textbox!.blur()
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -21,6 +21,7 @@ import { TabBar } from '../tab-bar'
 import { CompareBranchListItem } from './compare-branch-list-item'
 import { FancyTextBox } from '../lib/fancy-text-box'
 import { OcticonSymbol } from '../octicons'
+import { SelectionSource } from '../lib/filter-list'
 
 const DisplayHistory: IDisplayHistory = {
   kind: CompareType.None,
@@ -426,7 +427,10 @@ export class CompareSidebar extends React.Component<
     )
   }
 
-  private onSelectionChanged = (branch: Branch | null) => {
+  private onSelectionChanged = (
+    branch: Branch | null,
+    source: SelectionSource
+  ) => {
     if (branch === null) {
       this.clearFilterState()
       return

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -430,28 +430,28 @@ export class CompareSidebar extends React.Component<
     if (branch === null) {
       this.clearFilterState()
       return
-    } else {
-      const { branches } = this.branchState
-      const selectedBranch = branches.find(b => b.name === branch.name) || null
-
-      if (selectedBranch === null) {
-        this.clearFilterState()
-        return
-      }
-
-      this.props.dispatcher.loadCompareState(this.props.repository, {
-        kind: CompareType.Behind,
-        comparisonBranch: selectedBranch,
-        ahead: 0,
-        behind: 0,
-        commitSHAs: [],
-      })
-
-      this.setState({
-        selectedBranch,
-        compareType: CompareType.Behind,
-      })
     }
+
+    const { branches } = this.branchState
+    const selectedBranch = branches.find(b => b.name === branch.name) || null
+
+    if (selectedBranch === null) {
+      this.clearFilterState()
+      return
+    }
+
+    this.props.dispatcher.loadCompareState(this.props.repository, {
+      kind: CompareType.Behind,
+      comparisonBranch: selectedBranch,
+      ahead: 0,
+      behind: 0,
+      commitSHAs: [],
+    })
+
+    this.setState({
+      selectedBranch,
+      compareType: CompareType.Behind,
+    })
   }
 
   private onTextBoxFocused = () => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -339,20 +339,25 @@ export class CompareSidebar extends React.Component<
     const key = event.key
 
     if (key === 'Enter') {
-      if (this.state.filterText === '') {
+      if (this.state.filterText.length === 0) {
         this.handleEscape()
       } else {
-        const branch =
-          this.props.repositoryState.branchesState.allBranches.find(
-            branch =>
-              branch.name.toLowerCase() === this.state.filterText.toLowerCase()
-          ) || null
+        if (this.state.selectedBranch == null) {
+          this.props.dispatcher.loadCompareState(
+            this.props.repository,
+            DisplayHistory
+          )
+        } else {
+          this.props.dispatcher.loadCompareState(this.props.repository, {
+            kind: CompareType.Behind,
+            comparisonBranch: this.state.selectedBranch,
+            ahead: 0,
+            behind: 0,
+            commitSHAs: [],
+          })
 
-        this.props.dispatcher.loadCompareState(
-          this.props.repository,
-          DisplayHistory
-        )
-        this.setState({ selectedBranch: branch })
+          this.setState({ filterText: this.state.selectedBranch.name })
+        }
         this.textbox!.blur()
       }
     } else if (key === 'Escape') {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -432,7 +432,7 @@ export class CompareSidebar extends React.Component<
       const selectedBranch = branches.find(b => b.name === branch.name) || null
 
       if (selectedBranch === null) {
-        this.onSelectionChanged(selectedBranch)
+        this.onSelectionChanged(null)
         return
       }
 


### PR DESCRIPTION
This addresses an issue I have with the current filter text setup, which can be best illustrated by this GIF that occurs when I first click into it and click `p` to filter on PRs (I have multiple of them open locally):

![](https://user-images.githubusercontent.com/359239/38221992-bbac4520-3725-11e8-9f57-b31b19fb4b43.gif)

What seems to be happening:

 - inside `FilterList.createStateUpdate` sees that there's some filter text set, so it "selects" the first branch it has filtered

https://github.com/desktop/desktop/blob/4405c3bb22d33b92ed4682072e7e205420c88ef9/app/src/ui/lib/filter-list.tsx#L419-L423

 - as `selectedItem` is now different, `Compare.onSelectionChanged` is fired with the first branch in the filtered list
 - the `Compare` tab sets the filter text to the first branch name updates it's state
 - `FilterList` filters on this new filter text, it matches only one branch, everything else is hidden

TODO:

This is roughly where I want to take it, feel free to clarify things if I've missed some context:

 - [x] updating filter text should show valid branches
 - mouse click on branch in list should
    - [x] compare that branch to the current one
    - [x] update filter text to full name
 - <kbd>Enter</kbd> when focused in filter text should
    - [x] compare with the focused branch in the list
    - [x] update filter text to full name
 - ~~keyboard navigation and <kbd>Enter</kbd> in list~~ the use of a custom textbox here breaks this, punting to another PR as I need to wrap my head around the internals better
