### PR TITLE
"open file in external editor" should provide the full path

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -603,11 +603,10 @@ export class Dispatcher {
   }
 
   /**
-   * Opens a path (can either be a folder representing a repository or the
-   * path to a file) in the external editor selected by the user.
+   * Opens a path in the external editor selected by the user.
    */
-  public async openInExternalEditor(path: string): Promise<void> {
-    return this.appStore._openInExternalEditor(path)
+  public async openInExternalEditor(fullPath: string): Promise<void> {
+    return this.appStore._openInExternalEditor(fullPath)
   }
 
   /**

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -602,7 +602,10 @@ export class Dispatcher {
     }
   }
 
-  /** Opens a Git repository in the user provided program */
+  /**
+   * Opens a path (can either be a folder representing a repository or the
+   * path to a file) in the external editor selected by the user.
+   */
   public async openInExternalEditor(path: string): Promise<void> {
     return this.appStore._openInExternalEditor(path)
   }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -3,13 +3,13 @@ import { pathExists } from '../file-system'
 import { ExternalEditorError, FoundEditor } from './shared'
 
 /**
- * Open a given folder in the desired external editor.
+ * Open a given file or folder in the desired external editor.
  *
- * @param path The folder to pass as an argument when launching the editor.
+ * @param fullPath A folder or file path to pass as an argument when launching the editor.
  * @param editor The external editor to launch.
  */
 export async function launchExternalEditor(
-  path: string,
+  fullPath: string,
   editor: FoundEditor
 ): Promise<void> {
   const editorPath = editor.path
@@ -24,5 +24,5 @@ export async function launchExternalEditor(
     )
   }
 
-  spawn(editorPath, [path])
+  spawn(editorPath, [fullPath])
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2575,7 +2575,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return shell.openExternal(url)
   }
 
-  /** Takes a file path and open it using the user's configured editor */
+  /** Open a path to a repository or file using the user's configured editor */
   public async _openInExternalEditor(fullPath: string): Promise<void> {
     const selectedExternalEditor =
       this.getState().selectedExternalEditor || null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2575,14 +2575,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return shell.openExternal(url)
   }
 
-  /** Takes a repository path and opens it using the user's configured editor */
-  public async _openInExternalEditor(path: string): Promise<void> {
+  /** Takes a file path and open it using the user's configured editor */
+  public async _openInExternalEditor(fullPath: string): Promise<void> {
     const selectedExternalEditor =
       this.getState().selectedExternalEditor || null
 
     try {
       const match = await findEditorOrDefault(selectedExternalEditor)
-      await launchExternalEditor(path, match)
+      await launchExternalEditor(fullPath, match)
     } catch (error) {
       this.emitError(error)
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1355,8 +1355,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.openShell(repository.path)
   }
 
-  private openFileInExternalEditor = (path: string) => {
-    this.props.dispatcher.openInExternalEditor(path)
+  private openFileInExternalEditor = (fullPath: string) => {
+    this.props.dispatcher.openInExternalEditor(fullPath)
   }
 
   private openInExternalEditor = (

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -98,10 +98,11 @@ interface IChangesListProps {
   readonly externalEditorLabel?: string
 
   /**
-   * Called to open a file using the user's configured applications
-   * @param path The path of the file relative to the root of the repository
+   * Callback to open a selected file using the configured external editor
+   *
+   * @param fullPath The full path to the file on disk
    */
-  readonly onOpenInExternalEditor: (path: string) => void
+  readonly onOpenInExternalEditor: (fullPath: string) => void
 }
 
 export class ChangesList extends React.Component<IChangesListProps, {}> {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -226,7 +226,10 @@ export class ChangesList extends React.Component<IChangesListProps, {}> {
       },
       {
         label: openInExternalEditor,
-        action: () => this.props.onOpenInExternalEditor(path),
+        action: () => {
+          const fullPath = Path.join(this.props.repository.path, path)
+          this.props.onOpenInExternalEditor(fullPath)
+        },
         enabled: isSafeExtension && status !== AppFileStatus.Deleted,
       },
       {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -52,10 +52,11 @@ interface IChangesSidebarProps {
   readonly externalEditorLabel?: string
 
   /**
-   * Called to open a file using the user's configured applications
-   * @param path The path of the file relative to the root of the repository
+   * Callback to open a selected file using the configured external editor
+   *
+   * @param fullPath The full path to the file on disk
    */
-  readonly onOpenInExternalEditor: (path: string) => void
+  readonly onOpenInExternalEditor: (fullPath: string) => void
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -40,10 +40,12 @@ interface IRepositoryProps {
   readonly externalEditorLabel?: string
 
   /**
-   * Called to open a file using the user's configured applications
-   * @param path The path of the file relative to the root of the repository
+   * Callback to open a selected file using the configured external editor
+   *
+   * @param fullPath The full path to the file on disk
    */
-  readonly onOpenInExternalEditor: (path: string) => void
+
+  readonly onOpenInExternalEditor: (fullPath: string) => void
 }
 
 const enum Tab {


### PR DESCRIPTION
Found this one while trying to address a merge conflict by editing the file and VS Code would continue to show me a file without merge conflicts. Relates to #4030.

**Repro steps:**

 - have multiple versions of a repository on disk (I'm using `desktop` as an example)
 - use these both in VS Code (Atom does the same thing).
 - modify a file so that it appears in the `Changes` list. For this repro, I've deleted all the lines in `tslint.json`.

<img width="961" src="https://user-images.githubusercontent.com/359239/38231970-68d33f10-3758-11e8-94c3-38bad4ac5c25.png">

 - right-click and select `Open in [External Editor]`

**Expected:**

 - editor is launched, file shown matches expected diff from Desktop (no lines)

**Actual:**

 -  editor is launched, but file is different local clone (original content shown)

If you break into in the `launchExternalEditor` function in `app/src/lib/editors/launch.ts` you'll see the relative file path is passed through to the `spawn` API:

<img width="668" src="https://user-images.githubusercontent.com/359239/38232049-b66d5f8a-3758-11e8-86a5-83b6fbdfe116.png">

It looks like VS Code and Atom are smart enough to find a workspace containing the file, but because it lacks the repository directory it keeps choosing the wrong workspace - leading me to be very confused.



