### PR TITLE
some more compare branches cleanup

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -601,7 +601,7 @@ export enum ComparisonView {
  * The default comparison state is to display the history for the current
  * branch.
  */
-interface IDisplayHistory {
+export interface IDisplayHistory {
   readonly kind: ComparisonView.None
 }
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1153,8 +1153,11 @@ export class Dispatcher {
   /**
    * Initialze the compare state for the current repository.
    */
-  public initializeCompare(repository: Repository) {
-    return this.appStore._initializeCompare(repository)
+  public initializeCompare(
+    repository: Repository,
+    initialAction?: CompareAction
+  ) {
+    return this.appStore._initializeCompare(repository, initialAction)
   }
 
   /**

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -29,6 +29,9 @@ interface ICommitListProps {
   /** The list of known local commits for the current branch */
   readonly localCommitSHAs: ReadonlyArray<string>
 
+  /** The message to display inside the list when no results are displayed */
+  readonly emptyListMessage: string
+
   /** Callback which fires when a commit has been selected in the list */
   readonly onCommitSelected: (commit: Commit) => void
 
@@ -99,7 +102,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
 
   public render() {
     if (this.props.commitSHAs.length === 0) {
-      return <div className="panel blankslate">No history</div>
+      return (
+        <div className="panel blankslate">{this.props.emptyListMessage}</div>
+      )
     }
 
     return (

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -68,6 +68,20 @@ export class CompareSidebar extends React.Component<
     }
   }
 
+  public componentWillReceiveProps(nextProps: ICompareSidebarProps) {
+    const hasFormStateChanged =
+      nextProps.compareState.formState.kind !==
+      this.props.compareState.formState.kind
+
+    if (
+      hasFormStateChanged &&
+      nextProps.compareState.formState.kind === ComparisonView.None
+    ) {
+      // the comparison form should be reset to its default state
+      this.setState({ filterText: '', focusedBranch: null })
+    }
+  }
+
   public componentWillMount() {
     this.props.dispatcher.initializeCompare(this.props.repository)
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -136,6 +136,11 @@ export class CompareSidebar extends React.Component<
     const selectedCommit = this.state.selectedCommit
     const commitSHAs = compareState.commitSHAs
 
+    const emptyListMessage =
+      compareState.formState.kind === ComparisonView.None
+        ? 'No history'
+        : 'No commits'
+
     return (
       <CommitList
         gitHubRepository={this.props.repository.gitHubRepository}
@@ -149,6 +154,7 @@ export class CompareSidebar extends React.Component<
         onRevertCommit={this.props.onRevertCommit}
         onCommitSelected={this.onCommitSelected}
         onScroll={this.onScroll}
+        emptyListMessage={emptyListMessage}
       />
     )
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -73,12 +73,17 @@ export class CompareSidebar extends React.Component<
       nextProps.compareState.formState.kind !==
       this.props.compareState.formState.kind
 
-    if (
-      hasFormStateChanged &&
-      nextProps.compareState.formState.kind === ComparisonView.None
-    ) {
+    const newFormState = nextProps.compareState.formState
+
+    if (hasFormStateChanged && newFormState.kind === ComparisonView.None) {
       // the comparison form should be reset to its default state
       this.setState({ filterText: '', focusedBranch: null })
+      return
+    }
+
+    if (!hasFormStateChanged && newFormState.kind !== ComparisonView.None) {
+      // ensure the filter text is in sync with the comparison branch
+      this.setState({ filterText: newFormState.comparisonBranch.name })
     }
   }
 

--- a/app/src/ui/history/sidebar.tsx
+++ b/app/src/ui/history/sidebar.tsx
@@ -64,6 +64,7 @@ export class HistorySidebar extends React.Component<IHistorySidebarProps, {}> {
         localCommitSHAs={this.props.localCommitSHAs}
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+        emptyListMessage={'No history'}
       />
     )
   }


### PR DESCRIPTION
- [x] "No commits" or "No history" shown depending on context
- [x] `checkout` branch now resets compare tab - switch back to history, clear branch and filter text
- [x] filter text is now in sync with the comparison branch when switching `Compare` -> `Commit` -> `Compare` 