### PR TITLE
tidy up a few incorrect annotations

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -879,10 +879,6 @@ export class Dispatcher {
 
   /**
    * Sets the user's preference so that confirmation to discard changes is not asked
-   *
-   * @param {boolean} value
-   * @returns {Promise<void>}
-   * @memberof Dispatcher
    */
   public setConfirmDiscardChangesSetting(value: boolean): Promise<void> {
     return this.appStore._setConfirmDiscardChangesSetting(value)

--- a/app/src/lib/fatal-error.ts
+++ b/app/src/lib/fatal-error.ts
@@ -9,11 +9,11 @@ export function fatalError(msg: string): never {
  * If the type system is bypassed or this method will throw an exception
  * using the second parameter as the message.
  *
- * @param {x}       Placeholder parameter in order to leverage the type
+ * @param x         Placeholder parameter in order to leverage the type
  *                  system. Pass the variable which has been type narrowed
  *                  in an exhaustive check.
  *
- * @param {message} The message to be used in the runtime exception.
+ * @param message   The message to be used in the runtime exception.
  *
  */
 export function assertNever(x: never, message: string): never {

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -81,17 +81,17 @@ export class GitError extends Error {
 /**
  * Shell out to git with the given arguments, at the given path.
  *
- * @param {args}             The arguments to pass to `git`.
+ * @param args             The arguments to pass to `git`.
  *
- * @param {path}             The working directory path for the execution of the
- *                           command.
+ * @param path             The working directory path for the execution of the
+ *                         command.
  *
- * @param {name}             The name for the command based on its caller's
- *                           context. This will be used for performance
- *                           measurements and debugging.
+ * @param name             The name for the command based on its caller's
+ *                         context. This will be used for performance
+ *                         measurements and debugging.
  *
- * @param {options}          Configuration options for the execution of git,
- *                           see IGitExecutionOptions for more information.
+ * @param options          Configuration options for the execution of git,
+ *                         see IGitExecutionOptions for more information.
  *
  * Returns the result. If the command exits with a code not in
  * `successExitCodes` or an error not in `expectedErrors`, a `GitError` will be

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -534,8 +534,8 @@ export class List extends React.Component<IListProps, IListState> {
    * Renders the react-virtualized Grid component and optionally
    * a fake scroll bar component if running on Windows.
    *
-   * @param {width} - The width of the Grid as given by AutoSizer
-   * @param {height} - The height of the Grid as given by AutoSizer
+   * @param width - The width of the Grid as given by AutoSizer
+   * @param height - The height of the Grid as given by AutoSizer
    *
    */
   private renderContents(width: number, height: number) {
@@ -557,8 +557,8 @@ export class List extends React.Component<IListProps, IListState> {
   /**
    * Renders the react-virtualized Grid component
    *
-   * @param {width} - The width of the Grid as given by AutoSizer
-   * @param {height} - The height of the Grid as given by AutoSizer
+   * @param width - The width of the Grid as given by AutoSizer
+   * @param height - The height of the Grid as given by AutoSizer
    */
   private renderGrid(width: number, height: number) {
     let scrollToRow = this.props.scrollToRow
@@ -608,7 +608,7 @@ export class List extends React.Component<IListProps, IListState> {
    * be coupled with styling that hides scroll bars on Grid
    * and accurately positions the fake scroll bar.
    *
-   * @param {height} - The height of the Grid as given by AutoSizer
+   * @param height The height of the Grid as given by AutoSizer
    *
    */
   private renderFakeScroll(height: number) {

--- a/app/src/ui/lib/throttled-scheduler.ts
+++ b/app/src/ui/lib/throttled-scheduler.ts
@@ -6,7 +6,7 @@ export class ThrottledScheduler {
   /**
    * Initialize a new instance of the ThrottledScheduler class
    *
-   * @param {delay} - The minimum interval between invocations
+   * @param delay The minimum interval between invocations
    *                  of callbacks.
    */
   public constructor(delay: number) {


### PR DESCRIPTION
TL;DR: JSDoc [`@param`](http://usejsdoc.org/tags-param.html) syntax allows for an optional `{Type}` parameter before the name:

```js
/**
 * @param {string} somebody
 */
function sayHello(somebody) {
    alert('Hello ' + somebody);
}
```

I found some usages in Desktop were using it to store the parameter name, which leads to some confusion:

<img width="527" src="https://user-images.githubusercontent.com/359239/38346930-7b82df4c-38db-11e8-8a8d-d40a5d7bf692.png">

This also comes up with the intellisense in VSCode at least:

<img width="607" src="https://user-images.githubusercontent.com/359239/38346845-f717d38e-38da-11e8-85ae-2a2f447c2392.png">

We're already getting type annotations for free from TS, so we can skip these and just specify the parameter names.
