### PR TITLE
optimize and reduce the time spent computing ahead/behind info

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "moment": "^2.17.1",
     "mri": "^1.1.0",
     "primer-support": "^4.0.0",
+    "queue": "^4.4.2",
     "react": "^16.2.0",
     "react-addons-shallow-compare": "^15.6.2",
     "react-dom": "^16.2.0",

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -661,7 +661,38 @@ export interface ICompareState {
   /**
    * A local cache of ahead/behind computations to compare other refs to the current branch
    */
-  readonly aheadBehindCache: Map<string, IAheadBehind>
+  readonly aheadBehindCache: ComparisonCache
+}
+
+export class ComparisonCache {
+  backingStore = new Map<string, IAheadBehind>()
+
+  static getKey(from: string, to: string) {
+    return `${from}...${to}`
+  }
+
+  public set(from: string, to: string, value: IAheadBehind) {
+    const key = ComparisonCache.getKey(from, to)
+    this.backingStore.set(key, value)
+  }
+
+  public get(from: string, to: string) {
+    const key = ComparisonCache.getKey(from, to)
+    return this.backingStore.get(key)
+  }
+
+  public has(from: string, to: string) {
+    const key = ComparisonCache.getKey(from, to)
+    return this.backingStore.has(key)
+  }
+
+  public get size() {
+    return this.backingStore.size
+  }
+
+  public clear() {
+    this.backingStore.clear()
+  }
 }
 
 export enum CompareActionKind {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -628,9 +628,6 @@ export interface ICompareState {
   /** The current state of the compare form, based on user input */
   readonly formState: IDisplayHistory | ICompareBranch
 
-  /** A flag to indicate when background Git operations are being performed */
-  readonly isCrunching: boolean
-
   /** The SHAs of commits to render in the compare list */
   readonly commitSHAs: ReadonlyArray<string>
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -653,13 +653,6 @@ export interface ICompareState {
   readonly defaultBranch: Branch | null
 
   /**
-   * The base SHA associated with the current ahead/behind cache.
-   *
-   * When this changes, the cache needs to be invalidated.
-   */
-  readonly baseSha: string | null
-
-  /**
    * A local cache of ahead/behind computations to compare other refs to the current branch
    */
   readonly aheadBehindCache: ComparisonCache

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -627,6 +627,9 @@ export interface ICompareState {
   /** The current state of the compare form, based on user input */
   readonly formState: IDisplayHistory | ICompareBranch
 
+  /** A flag to indicate when background Git operations are being performed */
+  readonly isCrunching: boolean
+
   /** The SHAs of commits to render in the compare list */
   readonly commitSHAs: ReadonlyArray<string>
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -26,6 +26,7 @@ import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { BranchesTab } from '../models/branches-tab'
 import { PullRequest } from '../models/pull-request'
 import { IAuthor } from '../models/author'
+import { ComparisonCache } from './comparison-cache'
 
 export { ICommitMessage }
 
@@ -662,37 +663,6 @@ export interface ICompareState {
    * A local cache of ahead/behind computations to compare other refs to the current branch
    */
   readonly aheadBehindCache: ComparisonCache
-}
-
-export class ComparisonCache {
-  backingStore = new Map<string, IAheadBehind>()
-
-  static getKey(from: string, to: string) {
-    return `${from}...${to}`
-  }
-
-  public set(from: string, to: string, value: IAheadBehind) {
-    const key = ComparisonCache.getKey(from, to)
-    this.backingStore.set(key, value)
-  }
-
-  public get(from: string, to: string) {
-    const key = ComparisonCache.getKey(from, to)
-    return this.backingStore.get(key)
-  }
-
-  public has(from: string, to: string) {
-    const key = ComparisonCache.getKey(from, to)
-    return this.backingStore.has(key)
-  }
-
-  public get size() {
-    return this.backingStore.size
-  }
-
-  public clear() {
-    this.backingStore.clear()
-  }
 }
 
 export enum CompareActionKind {

--- a/app/src/lib/comparison-cache.ts
+++ b/app/src/lib/comparison-cache.ts
@@ -1,0 +1,32 @@
+import { IAheadBehind } from '../models/branch'
+
+export class ComparisonCache {
+  backingStore = new Map<string, IAheadBehind>()
+
+  static getKey(from: string, to: string) {
+    return `${from}...${to}`
+  }
+
+  public set(from: string, to: string, value: IAheadBehind) {
+    const key = ComparisonCache.getKey(from, to)
+    this.backingStore.set(key, value)
+  }
+
+  public get(from: string, to: string) {
+    const key = ComparisonCache.getKey(from, to)
+    return this.backingStore.get(key)
+  }
+
+  public has(from: string, to: string) {
+    const key = ComparisonCache.getKey(from, to)
+    return this.backingStore.has(key)
+  }
+
+  public get size() {
+    return this.backingStore.size
+  }
+
+  public clear() {
+    this.backingStore.clear()
+  }
+}

--- a/app/src/lib/comparison-cache.ts
+++ b/app/src/lib/comparison-cache.ts
@@ -1,9 +1,9 @@
 import { IAheadBehind } from '../models/branch'
 
 export class ComparisonCache {
-  backingStore = new Map<string, IAheadBehind>()
+  private backingStore = new Map<string, IAheadBehind>()
 
-  static getKey(from: string, to: string) {
+  private static getKey(from: string, to: string) {
     return `${from}...${to}`
   }
 

--- a/app/src/lib/comparison-cache.ts
+++ b/app/src/lib/comparison-cache.ts
@@ -14,7 +14,7 @@ export class ComparisonCache {
 
   public get(from: string, to: string) {
     const key = ComparisonCache.getKey(from, to)
-    return this.backingStore.get(key)
+    return this.backingStore.get(key) || null
   }
 
   public has(from: string, to: string) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -723,15 +723,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const updater = new AheadBehindUpdater(
       repository,
-      working => {
+      isCrunching => {
+        log.warn(`[AppStore] isCrunching: ${isCrunching}!`)
         this.updateCompareState(repository, state => ({
-          isCrunching: working,
+          isCrunching,
         }))
+        this.emitUpdate()
       },
-      cache => {
+      aheadBehindCache => {
+        log.warn(`[AppStore] the cache has been updated!`)
         this.updateCompareState(repository, state => ({
-          aheadBehindCache: cache,
+          aheadBehindCache,
         }))
+        this.emitUpdate()
       }
     )
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -448,7 +448,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         allBranches: [],
         recentBranches: [],
         defaultBranch: null,
-        baseSha: null,
       },
       commitAuthor: null,
       gitHubUsers: new Map<string, IGitHubUser>(),
@@ -796,27 +795,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }))
 
     const compareState = state.compareState
-    const { aheadBehindCache, baseSha } = compareState
-
-    const newSha = currentBranch ? currentBranch.tip.sha : ''
-
-    if (baseSha !== newSha) {
-      log.warn(`[Compare] time to start crunching for ${newSha}`)
-
-      aheadBehindCache.clear()
-
-      this.updateCompareState(repository, state => ({
-        aheadBehindCache,
-        baseSha: newSha,
-      }))
-    }
 
     const cachedState = compareState.formState
 
     const action = initialAction ? initialAction : getInitialAction(cachedState)
     this._executeCompare(repository, action)
 
-    if (currentBranch != null && aheadBehindCache.size === 0) {
+    if (currentBranch != null) {
       log.warn('[Compare] computing ahead/behind counts')
 
       let allOtherBranches = [...recentBranches, ...allBranches]

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1710,6 +1710,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this._updateCurrentPullRequest(repository)
     this.updateMenuItemLabels(repository)
+    this._initializeCompare(repository)
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -724,14 +724,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const updater = new AheadBehindUpdater(
       repository,
       isCrunching => {
-        log.warn(`[AppStore] isCrunching: ${isCrunching}!`)
         this.updateCompareState(repository, state => ({
           isCrunching,
         }))
         this.emitUpdate()
       },
       aheadBehindCache => {
-        log.warn(`[AppStore] the cache has been updated!`)
         this.updateCompareState(repository, state => ({
           aheadBehindCache,
         }))

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -23,7 +23,6 @@ import {
   CompareActionKind,
   IDisplayHistory,
   ICompareBranch,
-  ComparisonCache,
 } from '../app-state'
 import { Account } from '../../models/account'
 import { Repository } from '../../models/repository'
@@ -128,6 +127,7 @@ import { PullRequestUpdater } from './helpers/pull-request-updater'
 import * as QueryString from 'querystring'
 import { IRemote, ForkedRemotePrefix } from '../../models/remote'
 import { IAuthor } from '../../models/author'
+import { ComparisonCache } from '../comparison-cache'
 
 /**
  * Enum used by fetch to determine if

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -731,7 +731,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         continue
       }
 
-      const aheadBehind = await gitStore.getAheadBehind(currentBranch.name, sha)
+      const aheadBehind = await gitStore.getAheadBehind(from, sha)
 
       if (aheadBehind != null) {
         cache.set(from, sha, aheadBehind)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -447,7 +447,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       compareState: {
         formState: { kind: ComparisonView.None },
         commitSHAs: [],
-        isCrunching: false,
         aheadBehindCache: new ComparisonCache(),
         allBranches: [],
         recentBranches: [],
@@ -721,21 +720,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const updater = new AheadBehindUpdater(
-      repository,
-      isCrunching => {
-        this.updateCompareState(repository, state => ({
-          isCrunching,
-        }))
-        this.emitUpdate()
-      },
-      aheadBehindCache => {
-        this.updateCompareState(repository, state => ({
-          aheadBehindCache,
-        }))
-        this.emitUpdate()
-      }
-    )
+    const updater = new AheadBehindUpdater(repository, aheadBehindCache => {
+      this.updateCompareState(repository, state => ({
+        aheadBehindCache,
+      }))
+      this.emitUpdate()
+    })
 
     this.currentAheadBehindUpdater = updater
 
@@ -796,8 +786,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._executeCompare(repository, action)
 
     if (currentBranch != null && this.currentAheadBehindUpdater != null) {
-      log.warn('[Compare] computing ahead/behind counts')
-
       let allOtherBranches = [...recentBranches, ...allBranches]
 
       if (defaultBranch != null) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -711,6 +711,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     currentBranch: Branch,
     branches: ReadonlyArray<Branch>
   ): Promise<void> {
+    console.time('encrunchening')
+
     log.warn(`[Compare] - beginning crunching for ${currentBranch.name}`)
 
     this.updateCompareState(repository, state => ({
@@ -755,6 +757,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }))
 
     log.warn(`[Compare] - ending crunching for ${currentBranch.name}`)
+
+    console.timeEnd('encrunchening')
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -721,11 +721,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const updater = new AheadBehindUpdater(repository, cache => {
-      this.updateCompareState(repository, state => ({
-        aheadBehindCache: cache,
-      }))
-    })
+    const updater = new AheadBehindUpdater(
+      repository,
+      working => {
+        this.updateCompareState(repository, state => ({
+          isCrunching: working,
+        }))
+      },
+      cache => {
+        this.updateCompareState(repository, state => ({
+          aheadBehindCache: cache,
+        }))
+      }
+    )
 
     this.currentAheadBehindUpdater = updater
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -804,7 +804,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         allOtherBranches = [defaultBranch, ...allOtherBranches]
       }
 
-      this.currentAheadBehindUpdater.enqueue(currentBranch, allOtherBranches)
+      this.currentAheadBehindUpdater.schedule(currentBranch, allOtherBranches)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -442,6 +442,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       compareState: {
         formState: { kind: ComparisonView.None },
         commitSHAs: [],
+        isCrunching: false,
         aheadBehindCache: new Map<string, IAheadBehind>(),
         allBranches: [],
         recentBranches: [],
@@ -710,6 +711,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     currentBranch: Branch,
     branches: ReadonlyArray<Branch>
   ): Promise<void> {
+    this.updateCompareState(repository, state => ({
+      isCrunching: true,
+    }))
+
     const uniqueBranchSha = new Set<string>(branches.map(b => b.tip.sha))
 
     const gitStore = this.getGitStore(repository)
@@ -740,6 +745,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.emitUpdate()
     }
+
+    this.updateCompareState(repository, state => ({
+      isCrunching: false,
+    }))
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -93,7 +93,7 @@ export class AheadBehindUpdater {
     })
   }
 
-  public enqueue(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
+  public schedule(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
     // remove any queued work to prioritize this new set of tasks
     this.aheadBehindQueue.end()
 

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -116,7 +116,7 @@ export class AheadBehindUpdater {
 
     for (const sha of newRefsToCompare) {
       this.q.push<IAheadBehind | null>(callback =>
-        requestAnimationFrame(() => {
+        requestIdleCallback(() => {
           this.executeTask(from, sha, callback)
         })
       )

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -9,6 +9,7 @@ export class AheadBehindUpdater {
 
   public constructor(
     private repository: Repository,
+    private onPerformingWork: (working: boolean) => void,
     private onCacheUpdate: (cache: ComparisonCache) => void
   ) {}
 
@@ -23,6 +24,7 @@ export class AheadBehindUpdater {
     uniqueBranchSha: Set<string>
   ) {
     this.abortInflightRequests = false
+    this.onPerformingWork(true)
 
     let count = uniqueBranchSha.size
 
@@ -31,6 +33,7 @@ export class AheadBehindUpdater {
         log.debug(
           `[AheadBehindUpdater] - aborting with ${count} branches unresolved`
         )
+        this.onPerformingWork(false)
         break
       }
 
@@ -52,6 +55,8 @@ export class AheadBehindUpdater {
       }
       count -= 1
     }
+
+    this.onPerformingWork(false)
   }
 
   public enqueue(currentBranch: Branch, branches: ReadonlyArray<Branch>) {

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -35,22 +35,18 @@ export class AheadBehindUpdater {
 
   public constructor(
     private repository: Repository,
-    private onPerformingWork: (working: boolean) => void,
     private onCacheUpdate: (cache: ComparisonCache) => void
   ) {}
 
   public start() {
-    this.aheadBehindQueue.on(
-      'success',
-      (result: IAheadBehind | null, job: any) => {
-        if (result != null) {
-          this.onCacheUpdate(this.comparisonCache)
-        }
+    this.aheadBehindQueue.on('success', (result: IAheadBehind | null) => {
+      if (result != null) {
+        this.onCacheUpdate(this.comparisonCache)
       }
-    )
+    })
 
     this.aheadBehindQueue.on('error', (err: Error) => {
-      log.error(
+      log.debug(
         '[AheadBehindUpdater] an error with the queue was reported',
         err
       )
@@ -58,10 +54,8 @@ export class AheadBehindUpdater {
 
     this.aheadBehindQueue.on('end', (err?: Error) => {
       if (err != null) {
-        log.warn(`[AheadBehindUpdater] ended with an error`, err)
+        log.debug(`[AheadBehindUpdater] ended with an error`, err)
       }
-
-      this.onPerformingWork(false)
     })
 
     this.aheadBehindQueue.start()
@@ -105,7 +99,7 @@ export class AheadBehindUpdater {
 
     const newRefsToCompare = new Set<string>(branchesNotInCache)
 
-    log.warn(
+    log.debug(
       `[AheadBehindUpdater] - found ${
         newRefsToCompare.size
       } comparisons to perform`
@@ -114,8 +108,6 @@ export class AheadBehindUpdater {
     if (newRefsToCompare.size === 0) {
       return
     }
-
-    this.onPerformingWork(true)
 
     for (const sha of newRefsToCompare) {
       this.aheadBehindQueue.push<IAheadBehind | null>(callback =>

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -1,0 +1,73 @@
+import { Repository } from '../../../models/repository'
+import { getAheadBehind } from '../../../lib/git'
+import { Branch } from '../../../models/branch'
+import { ComparisonCache } from '../../comparison-cache'
+
+export class AheadBehindUpdater {
+  private comparisonCache = new ComparisonCache()
+  private abortInflightRequests = false
+
+  public constructor(
+    private repository: Repository,
+    private onCacheUpdate: (cache: ComparisonCache) => void
+  ) {}
+
+  public start() {}
+
+  public stop() {
+    this.abortInflightRequests = true
+  }
+
+  private async executeBackgroundCompares(
+    from: string,
+    uniqueBranchSha: Set<string>
+  ) {
+    this.abortInflightRequests = false
+
+    let count = uniqueBranchSha.size
+
+    for (const sha of uniqueBranchSha) {
+      if (this.abortInflightRequests) {
+        log.debug(
+          `[AheadBehindUpdater] - aborting with ${count} branches unresolved`
+        )
+        break
+      }
+
+      if (this.comparisonCache.has(from, sha)) {
+        count -= 1
+        continue
+      }
+
+      const range = `${from}...${sha}`
+      const aheadBehind = await getAheadBehind(this.repository, range)
+
+      if (aheadBehind != null) {
+        this.comparisonCache.set(from, sha, aheadBehind)
+        this.onCacheUpdate(this.comparisonCache)
+      } else {
+        log.debug(
+          `[AheadBehindUpdater] unable to cache '${range}' as no result returned`
+        )
+      }
+      count -= 1
+    }
+  }
+
+  public enqueue(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
+    // signal to abandon any in-flight comparison checks
+    this.abortInflightRequests = true
+
+    const from = currentBranch.tip.sha
+
+    const uncachedBranchShas = branches
+      .map(b => b.tip.sha)
+      .filter(to => !this.comparisonCache.has(from, to))
+
+    const uniqueBranchSha = new Set<string>(uncachedBranchShas)
+
+    log.warn(`[Compare] - found ${uniqueBranchSha.size} comparisons to perform`)
+
+    this.executeBackgroundCompares(from, uniqueBranchSha)
+  }
+}

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -1,11 +1,35 @@
+const queue: (config: QueueConfig) => Queue = require('queue')
+
+interface QueueConfig {
+  // Max number of jobs the queue should process concurrently, defaults to Infinity.
+  readonly concurrency: number
+  // Ensures the queue is always running if jobs are available.
+  // Useful in situations where you are using a queue only for concurrency control.
+  readonly autostart: boolean
+}
+
+interface Queue extends NodeJS.EventEmitter {
+  readonly length: number
+
+  start(): void
+  end(): void
+  push<T>(
+    func: (callback: (error: Error | null, result: T) => void) => void
+  ): void
+}
+
 import { Repository } from '../../../models/repository'
 import { getAheadBehind } from '../../../lib/git'
-import { Branch } from '../../../models/branch'
+import { Branch, IAheadBehind } from '../../../models/branch'
 import { ComparisonCache } from '../../comparison-cache'
 
 export class AheadBehindUpdater {
   private comparisonCache = new ComparisonCache()
-  private abortInflightRequests = false
+
+  private q = queue({
+    concurrency: 1,
+    autostart: true,
+  })
 
   public constructor(
     private repository: Repository,
@@ -13,66 +37,87 @@ export class AheadBehindUpdater {
     private onCacheUpdate: (cache: ComparisonCache) => void
   ) {}
 
-  public start() {}
+  public start() {
+    this.q.on('success', (result: IAheadBehind | null, job: any) => {
+      if (result != null) {
+        this.onCacheUpdate(this.comparisonCache)
+      }
+    })
 
-  public stop() {
-    this.abortInflightRequests = true
+    this.q.on('error', (err: Error) => {
+      log.error(
+        '[AheadBehindUpdater] an error with the queue was reported',
+        err
+      )
+    })
+
+    this.q.on('end', (err?: Error) => {
+      if (err != null) {
+        log.warn(`[AheadBehindUpdater] ended with an error`, err)
+      }
+
+      this.onPerformingWork(false)
+    })
+
+    this.q.start()
   }
 
-  private async executeBackgroundCompares(
+  public stop() {
+    this.q.end()
+  }
+
+  private executeTask = (
     from: string,
-    uniqueBranchSha: Set<string>
-  ) {
-    this.abortInflightRequests = false
-    this.onPerformingWork(true)
+    to: string,
+    callback: (error: Error | null, result: IAheadBehind | null) => void
+  ) => {
+    if (this.comparisonCache.has(from, to)) {
+      return
+    }
 
-    let count = uniqueBranchSha.size
-
-    for (const sha of uniqueBranchSha) {
-      if (this.abortInflightRequests) {
-        log.debug(
-          `[AheadBehindUpdater] - aborting with ${count} branches unresolved`
-        )
-        this.onPerformingWork(false)
-        break
-      }
-
-      if (this.comparisonCache.has(from, sha)) {
-        count -= 1
-        continue
-      }
-
-      const range = `${from}...${sha}`
-      const aheadBehind = await getAheadBehind(this.repository, range)
-
-      if (aheadBehind != null) {
-        this.comparisonCache.set(from, sha, aheadBehind)
-        this.onCacheUpdate(this.comparisonCache)
+    const range = `${from}...${to}`
+    getAheadBehind(this.repository, range).then(result => {
+      if (result != null) {
+        this.comparisonCache.set(from, to, result)
       } else {
         log.debug(
           `[AheadBehindUpdater] unable to cache '${range}' as no result returned`
         )
       }
-      count -= 1
-    }
-
-    this.onPerformingWork(false)
+      callback(null, result)
+    })
   }
 
   public enqueue(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
-    // signal to abandon any in-flight comparison checks
-    this.abortInflightRequests = true
+    // remove any queued work to prioritize this new set of tasks
+    this.q.end()
 
     const from = currentBranch.tip.sha
 
-    const uncachedBranchShas = branches
+    const branchesNotInCache = branches
       .map(b => b.tip.sha)
       .filter(to => !this.comparisonCache.has(from, to))
 
-    const uniqueBranchSha = new Set<string>(uncachedBranchShas)
+    const newRefsToCompare = new Set<string>(branchesNotInCache)
 
-    log.warn(`[Compare] - found ${uniqueBranchSha.size} comparisons to perform`)
+    log.warn(
+      `[AheadBehindUpdater] - found ${
+        newRefsToCompare.size
+      } comparisons to perform`
+    )
 
-    this.executeBackgroundCompares(from, uniqueBranchSha)
+    if (newRefsToCompare.size === 0) {
+      return
+    }
+
+    this.onPerformingWork(true)
+
+    for (const sha of newRefsToCompare) {
+      this.q.push<IAheadBehind | null>(callback =>
+        requestAnimationFrame(() => {
+          this.executeTask(from, sha, callback)
+        })
+      )
+    }
   }
 }

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -1,5 +1,6 @@
 const queue: (config: QueueConfig) => Queue = require('queue')
 
+// eslint-disable-next-line typescript/interface-name-prefix
 interface QueueConfig {
   // Max number of jobs the queue should process concurrently, defaults to Infinity.
   readonly concurrency: number
@@ -8,6 +9,7 @@ interface QueueConfig {
   readonly autostart: boolean
 }
 
+// eslint-disable-next-line typescript/interface-name-prefix
 interface Queue extends NodeJS.EventEmitter {
   readonly length: number
 

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -105,10 +105,6 @@ export class AheadBehindUpdater {
       } comparisons to perform`
     )
 
-    if (newRefsToCompare.size === 0) {
-      return
-    }
-
     for (const sha of newRefsToCompare) {
       this.aheadBehindQueue.push<IAheadBehind | null>(callback =>
         requestIdleCallback(() => {

--- a/app/src/ui/history/compare-branch-list-item.tsx
+++ b/app/src/ui/history/compare-branch-list-item.tsx
@@ -13,7 +13,7 @@ interface ICompareBranchListItemProps {
   /** The characters in the branch name to highlight */
   readonly matches: ReadonlyArray<number>
 
-  readonly aheadBehind?: IAheadBehind
+  readonly aheadBehind: IAheadBehind | null
 }
 
 export class CompareBranchListItem extends React.Component<

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -277,13 +277,17 @@ export class CompareSidebar extends React.Component<
     item: IBranchListItem,
     matches: ReadonlyArray<number>
   ) => {
-    const currentBranchName =
-      this.props.currentBranch != null ? this.props.currentBranch.name : null
+    const currentBranch = this.props.currentBranch
+
+    const currentBranchName = currentBranch != null ? currentBranch.name : null
     const branch = item.branch
 
-    const aheadBehind = this.props.compareState.aheadBehindCache.get(
-      branch.tip.sha
-    )
+    const aheadBehind = currentBranch
+      ? this.props.compareState.aheadBehindCache.get(
+          currentBranch.tip.sha,
+          branch.tip.sha
+        )
+      : undefined
 
     return (
       <CompareBranchListItem

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -111,15 +111,11 @@ export class CompareSidebar extends React.Component<
           : 'Select branch to compare...'
         : undefined
 
-    const symbol = this.props.compareState.isCrunching
-      ? OcticonSymbol.sync
-      : OcticonSymbol.gitBranch
-
     return (
       <div id="compare-view">
         <div className="the-box">
           <FancyTextBox
-            symbol={symbol}
+            symbol={OcticonSymbol.gitBranch}
             type="search"
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -111,11 +111,15 @@ export class CompareSidebar extends React.Component<
           : 'Select branch to compare...'
         : undefined
 
+    const symbol = this.props.compareState.isCrunching
+      ? OcticonSymbol.sync
+      : OcticonSymbol.gitBranch
+
     return (
       <div id="compare-view">
         <div className="the-box">
           <FancyTextBox
-            symbol={OcticonSymbol.gitBranch}
+            symbol={symbol}
             type="search"
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -297,7 +297,7 @@ export class CompareSidebar extends React.Component<
           currentBranch.tip.sha,
           branch.tip.sha
         )
-      : undefined
+      : null
 
     return (
       <CompareBranchListItem

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -500,7 +500,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -753,6 +753,12 @@ qs@~6.5.1:
 querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+queue@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-4.4.2.tgz#5a9733d9a8b8bd1b36e934bc9c55ab89b28e29c7"
+  dependencies:
+    inherits "~2.0.0"
 
 react-addons-shallow-compare@^15.6.2:
   version "15.6.2"


### PR DESCRIPTION
Fixes #4399

Some changes to reduce the work that Desktop does for crunching the ahead/behind counts:

 - [x] a unified `ComparisonCache` which uses the two refs as a lookup key - simplifies the app store work
 - [x] aborting inflight operations when quickly switching branches
 - [x] use `requestIdleCallback` to prioritize this work behind everything else
 - [x] confirm scenarios where the tip changes are triggering crunching
   - [x] after making a new commit
   - [x] after pulling
   - [x] after a merge
 - [x] cleanup `isCrunching` state as this isn't intended to ship as a UI feature
 
There's also a visual cue to indicate when it's working to help with debugging on my end, but I'll pull this out before merging.
