### PR TITLE
add escape hatch to disable hardware acceleration when launching 

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -170,6 +170,13 @@ function setAsDefaultProtocolClient(protocol: string) {
   }
 }
 
+if (process.env.GITHUB_DESKTOP_DISABLE_HARDWARE_ACCELERATION) {
+  log.info(
+    `GITHUB_DESKTOP_DISABLE_HARDWARE_ACCELERATION environment variable set, disabling hardware acceleration`
+  )
+  app.disableHardwareAcceleration()
+}
+
 app.on('ready', () => {
   if (isDuplicateInstance || handlingSquirrelEvent) {
     return

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -118,3 +118,9 @@ are unable to find another cygwin DLL.
 Enabling Mandatory ASLR affects the MSYS2 core library, which is relied upon by Git for Windows to emulate process forking.
 
 **Not supported:** this is an upstream limitation of MSYS2, and it is recommend that you either disable Mandatory ASLR or whitelist all executables under `<Git>\usr\bin` which depend on MSYS2.
+
+### I get a black screen when launching Desktop
+
+Electron enables hardware accelerated graphics by default, but some graphics cards have issues with hardware acceleration which means the application will launch successfully but it will be a black screen.
+
+**Workaround:** if you set the `GITHUB_DESKTOP_DISABLE_HARDWARE_ACCELERATION` environment variable to any value and launch Desktop again it will disable hardware acceleration on launch, so the application is usable.


### PR DESCRIPTION
Fixes #3921

- [x] on launch, if environment variable set run the workaround
- [x] document this workaround
- [x] test it on Windows, confirm it emits a message to the log