### PR TITLE
ensure filter text and selected branch are in sync

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -435,11 +435,6 @@ export class CompareSidebar extends React.Component<
         kind: CompareActionKind.Branch,
         mode: ComparisonView.Behind,
       })
-      this.setState({
-        focusedBranch: null,
-        filterText: '',
-      })
-      return
     }
 
     this.setState({

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -413,7 +413,6 @@ export class CompareSidebar extends React.Component<
   }
 
   private onBranchItemClicked = (branch: Branch) => {
-    console.log('onBranchItemClicked', branch.name)
     this.props.dispatcher.executeCompare(this.props.repository, {
       branch,
       kind: CompareActionKind.Branch,

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -85,7 +85,12 @@ export class CompareSidebar extends React.Component<
 
     if (!hasFormStateChanged && newFormState.kind !== ComparisonView.None) {
       // ensure the filter text is in sync with the comparison branch
-      this.setState({ filterText: newFormState.comparisonBranch.name })
+      const branch = newFormState.comparisonBranch
+
+      this.setState({
+        filterText: branch.name,
+        focusedBranch: branch,
+      })
     }
 
     if (nextProps.sidebarHasFocusWithin !== this.props.sidebarHasFocusWithin) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -404,8 +404,12 @@ export class CompareSidebar extends React.Component<
     this.setState({ filterText: '' })
   }
 
-  private onBranchFilterTextChanged = (text: string) => {
-    this.setState({ filterText: text })
+  private onBranchFilterTextChanged = (filterText: string) => {
+    if (filterText.length === 0) {
+      this.setState({ focusedBranch: null, filterText })
+    } else {
+      this.setState({ filterText })
+    }
   }
 
   private clearFilterState = () => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -20,6 +20,7 @@ import { TabBar } from '../tab-bar'
 import { CompareBranchListItem } from './compare-branch-list-item'
 import { FancyTextBox } from '../lib/fancy-text-box'
 import { OcticonSymbol } from '../octicons'
+import { SelectionSource } from '../lib/filter-list'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -425,7 +426,23 @@ export class CompareSidebar extends React.Component<
     })
   }
 
-  private onSelectionChanged = (branch: Branch | null) => {
+  private onSelectionChanged = (
+    branch: Branch | null,
+    source: SelectionSource
+  ) => {
+    if (source.kind === 'mouseclick' && branch != null) {
+      this.props.dispatcher.executeCompare(this.props.repository, {
+        branch,
+        kind: CompareActionKind.Branch,
+        mode: ComparisonView.Behind,
+      })
+      this.setState({
+        focusedBranch: null,
+        filterText: '',
+      })
+      return
+    }
+
     this.setState({
       focusedBranch: branch,
     })


### PR DESCRIPTION
Found this while testing the latest `compare-branches` changes (aa566445b3d4cff2ac66614b30afcd7a0f8b28ed). Not sure if I'm missing context on these changes, feel free to leave a comment here.

Repro steps:

 - open the compare tab and select a branch to compare
 - clear the filter to see all branches again
 - click to select a different branch

![](https://user-images.githubusercontent.com/359239/38476428-025c72fe-3bf1-11e8-8d19-fc7e7a26e6c7.gif)

Expected behaviour:
  - compare is performed against new branch
  - filter text changes to new branch name

Actual behaviour:
  - compare is not updated
  - filter text stays as old branch name

TODO:

 - [x] compare updates when branch is selected by click
 - [x] filter text now reflects current branch name
 - [x] focused branch is also the new branch when looking at branch list