### PR TITLE
draft of release notes for next beta

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.1.2-beta1",
+  "version": "1.1.2-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -5,7 +5,9 @@
       "[New] Add PowerShell Core support for Windows and macOS - #3791. Thanks @saschanaz!",
       "[Fixed] Error when creating Git LFS progress causes clone to fail - #4307. Thanks @MagicMarvMan!",
       "[Fixed] 'Open File in External Editor' does not use existing window - #4381",
-      "[Improved] Pull request status text now matches format on GitHub website - #3521"
+      "[Fixed] Always ask for confirmation when discarding all changes - #4423",
+      "[Improved] Pull request status text now matches format on GitHub - #3521",
+      "[Improved] Add escape hatch to disable hardware acceleration when launching - #3921"
     ],
     "1.1.2-beta1": [
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,12 @@
 {
   "releases": {
+    "1.1.2-beta2": [
+      "[New] Render bitmap images in diffs - #4367. Thanks @MagicMarvMan!",
+      "[New] Add PowerShell Core support for Windows and macOS - #3791. Thanks @saschanaz!",
+      "[Fixed] Fix lfs log file creation - #4307. Thanks @MagicMarvMan!",
+      "[Fixed] `Open File in External Editor` does not launch existing window - #4381",
+      "[Improved] Pull request status text now matches format on GitHub website - #3521"
+    ],
     "1.1.2-beta1": [
 
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -3,8 +3,8 @@
     "1.1.2-beta2": [
       "[New] Render bitmap images in diffs - #4367. Thanks @MagicMarvMan!",
       "[New] Add PowerShell Core support for Windows and macOS - #3791. Thanks @saschanaz!",
-      "[Fixed] Fix lfs log file creation - #4307. Thanks @MagicMarvMan!",
-      "[Fixed] `Open File in External Editor` does not launch existing window - #4381",
+      "[Fixed] Error when creating Git LFS progress causes clone to fail - #4307. Thanks @MagicMarvMan!",
+      "[Fixed] 'Open File in External Editor' does not use existing window - #4381",
       "[Improved] Pull request status text now matches format on GitHub website - #3521"
     ],
     "1.1.2-beta1": [


### PR DESCRIPTION
We're reviewing the big part of the 1.2 release over in #4182, but it'd be nice to get out another beta with the fixes already on `master` before that lands. ~~I also opened #4411 which is a minor fix for an issue affecting some users trying to open the app on Windows - maybe that can go out?~~

 - [x] merge #4411 and then merge into this branch