### PR TITLE
update node @types to v8

### DIFF
--- a/app/src/ask-pass/ask-pass.ts
+++ b/app/src/ask-pass/ask-pass.ts
@@ -5,7 +5,7 @@ import { TokenStore } from '../lib/stores/token-store'
 export async function responseForPrompt(
   prompt: string
 ): Promise<string | null> {
-  const username: string | undefined = process.env.DESKTOP_USERNAME
+  const username = process.env.DESKTOP_USERNAME
   if (username == null || !username.length) {
     return null
   }
@@ -13,7 +13,7 @@ export async function responseForPrompt(
   if (prompt.startsWith('Username')) {
     return username
   } else if (prompt.startsWith('Password')) {
-    const endpoint: string | undefined = process.env.DESKTOP_ENDPOINT
+    const endpoint = process.env.DESKTOP_ENDPOINT
     if (endpoint == null || !endpoint.length) {
       return null
     }

--- a/app/src/ask-pass/ask-pass.ts
+++ b/app/src/ask-pass/ask-pass.ts
@@ -6,7 +6,7 @@ export async function responseForPrompt(
   prompt: string
 ): Promise<string | null> {
   const username = process.env.DESKTOP_USERNAME
-  if (username == null || !username.length) {
+  if (username == null || username.length === 0) {
     return null
   }
 
@@ -14,7 +14,7 @@ export async function responseForPrompt(
     return username
   } else if (prompt.startsWith('Password')) {
     const endpoint = process.env.DESKTOP_ENDPOINT
-    if (endpoint == null || !endpoint.length) {
+    if (endpoint == null || endpoint.length === 0) {
       return null
     }
 

--- a/app/src/ask-pass/ask-pass.ts
+++ b/app/src/ask-pass/ask-pass.ts
@@ -5,16 +5,16 @@ import { TokenStore } from '../lib/stores/token-store'
 export async function responseForPrompt(
   prompt: string
 ): Promise<string | null> {
-  const username: string | null = process.env.DESKTOP_USERNAME
-  if (!username || !username.length) {
+  const username: string | undefined = process.env.DESKTOP_USERNAME
+  if (username == null || !username.length) {
     return null
   }
 
   if (prompt.startsWith('Username')) {
     return username
   } else if (prompt.startsWith('Password')) {
-    const endpoint: string | null = process.env.DESKTOP_ENDPOINT
-    if (!endpoint || !endpoint.length) {
+    const endpoint: string | undefined = process.env.DESKTOP_ENDPOINT
+    if (endpoint == null || !endpoint.length) {
       return null
     }
 

--- a/app/src/lib/parse-app-url.ts
+++ b/app/src/lib/parse-app-url.ts
@@ -40,6 +40,7 @@ export type URLActionType =
   | IOpenRepositoryFromPathAction
   | IUnknownAction
 
+// eslint-disable-next-line typescript/interface-name-prefix
 interface ParsedUrlQueryWithUndefined {
   // `undefined` is added here to ensure we handle the missing querystring key
   // See https://github.com/Microsoft/TypeScript/issues/13778 for discussion about

--- a/app/src/lib/parse-app-url.ts
+++ b/app/src/lib/parse-app-url.ts
@@ -58,7 +58,7 @@ function getQueryStringValue(
   query: ParsedUrlQueryWithUndefined,
   key: string
 ): string | null {
-  const value = query['key']
+  const value = query[key]
   if (value == null) {
     return null
   }
@@ -111,13 +111,15 @@ export function parseAppURL(url: string): URLActionType {
     const branch = getQueryStringValue(query, 'branch')
     const filepath = getQueryStringValue(query, 'filepath')
 
-    if (pr != null && !/^\d+$/.test(pr)) {
-      return unknown
-    }
+    if (pr != null) {
+      if (!/^\d+$/.test(pr)) {
+        return unknown
+      }
 
-    // we also expect the branch for a forked PR to be a given ref format
-    if (branch != null && !/^pr\/\d+$/.test(branch)) {
-      return unknown
+      // we also expect the branch for a forked PR to be a given ref format
+      if (branch != null && !/^pr\/\d+$/.test(branch)) {
+        return unknown
+      }
     }
 
     if (branch != null && testForInvalidChars(branch)) {

--- a/app/src/lib/parse-app-url.ts
+++ b/app/src/lib/parse-app-url.ts
@@ -13,13 +13,13 @@ export interface IOpenRepositoryFromURLAction {
   readonly url: string
 
   /** the optional branch name which should be checked out. use the default branch otherwise. */
-  readonly branch?: string
+  readonly branch: string | null
 
   /** the pull request number, if pull request originates from a fork of the repository */
-  readonly pr?: string
+  readonly pr: string | null
 
   /** the file to open after cloning the repository */
-  readonly filepath?: string
+  readonly filepath: string | null
 }
 
 export interface IOpenRepositoryFromPathAction {
@@ -40,6 +40,35 @@ export type URLActionType =
   | IOpenRepositoryFromPathAction
   | IUnknownAction
 
+interface ParsedUrlQueryWithUndefined {
+  // `undefined` is added here to ensure we handle the missing querystring key
+  // See https://github.com/Microsoft/TypeScript/issues/13778 for discussion about
+  // why this isn't supported natively in TypeScript
+  [key: string]: string | string[] | undefined
+}
+
+/**
+ * Parse the URL to find a given key in the querystring text.
+ *
+ * @param url The source URL containing querystring key-value pairs
+ * @param key The key to look for in the querystring
+ */
+function getQueryStringValue(
+  query: ParsedUrlQueryWithUndefined,
+  key: string
+): string | null {
+  const value = query['key']
+  if (value == null) {
+    return null
+  }
+
+  if (Array.isArray(value)) {
+    return value[0]
+  }
+
+  return value
+}
+
 export function parseAppURL(url: string): URLActionType {
   const parsedURL = URL.parse(url, true)
   const hostname = parsedURL.hostname
@@ -48,9 +77,16 @@ export function parseAppURL(url: string): URLActionType {
     return unknown
   }
 
+  const query = parsedURL.query
+
   const actionName = hostname.toLowerCase()
   if (actionName === 'oauth') {
-    return { name: 'oauth', code: parsedURL.query.code }
+    const code = getQueryStringValue(query, 'code')
+    if (code != null) {
+      return { name: 'oauth', code }
+    } else {
+      return unknown
+    }
   }
 
   // we require something resembling a URL first
@@ -70,28 +106,21 @@ export function parseAppURL(url: string): URLActionType {
     // suffix the remote URL with `.git`, for backwards compatibility
     const url = `${probablyAURL}.git`
 
-    const queryString = parsedURL.query
+    const pr = getQueryStringValue(query, 'pr')
+    const branch = getQueryStringValue(query, 'branch')
+    const filepath = getQueryStringValue(query, 'filepath')
 
-    const pr = queryString.pr
-    const branch = queryString.branch
-    const filepath = queryString.filepath
-
-    if (pr) {
-      // if anything other than a number is used for the PR value, exit
-      if (!/^\d+$/.test(pr)) {
-        return unknown
-      }
-
-      // we also expect the branch for a forked PR to be a given ref format
-      if (!/^pr\/\d+$/.test(branch)) {
-        return unknown
-      }
+    if (pr != null && !/^\d+$/.test(pr)) {
+      return unknown
     }
 
-    if (branch) {
-      if (testForInvalidChars(branch)) {
-        return unknown
-      }
+    // we also expect the branch for a forked PR to be a given ref format
+    if (branch != null && !/^pr\/\d+$/.test(branch)) {
+      return unknown
+    }
+
+    if (branch != null && testForInvalidChars(branch)) {
+      return unknown
     }
 
     return {

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -167,11 +167,17 @@ async function findHyper(): Promise<string | null> {
     // This regex is designed to get the path to the version-specific Hyper.
     // commandPieces = ['"{installationPath}\app-x.x.x\Hyper.exe"', '"', '{installationPath}\app-x.x.x\Hyper.exe', ...]
     const commandPieces = first.data.match(/(["'])(.*?)\1/)
+    const localAppData = process.env.LocalAppData
+
     const path = commandPieces
       ? commandPieces[2]
-      : process.env.LocalAppData.concat('\\hyper\\Hyper.exe') // fall back to the launcher in install root
+      : localAppData != null ? localAppData.concat('\\hyper\\Hyper.exe') : null // fall back to the launcher in install root
 
-    if (await pathExists(path)) {
+    if (path == null) {
+      log.debug(
+        `[Hyper] LOCALAPPDATA environment variable is unset, aborting fallback behavior`
+      )
+    } else if (await pathExists(path)) {
       return path
     } else {
       log.debug(`[Hyper] registry entry found but does not exist at '${path}'`)

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -157,9 +157,9 @@ async function updateShortcut(): Promise<void> {
 /** Get the path segments in the user's `Path`. */
 async function getPathSegments(): Promise<ReadonlyArray<string>> {
   let powershellPath: string
-  const systemRoot = process.env['SystemRoot']
-  if (systemRoot) {
-    const system32Path = Path.join(process.env.SystemRoot, 'System32')
+  const systemRoot = process.env.SystemRoot
+  if (systemRoot != null) {
+    const system32Path = Path.join(systemRoot, 'System32')
     powershellPath = Path.join(
       system32Path,
       'WindowsPowerShell',

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@types/keytar": "^4.0.0",
     "@types/mocha": "^2.2.48",
     "@types/mri": "^1.1.0",
-    "@types/node": "^7.0.18",
+    "@types/node": "^8.10.4",
     "@types/react": "^16.0.40",
     "@types/react-dom": "^16.0.4",
     "@types/react-transition-group": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,13 +94,13 @@
   version "8.0.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.47.tgz#968e596f91acd59069054558a00708c445ca30c2"
 
-"@types/node@^7.0.18":
-  version "7.0.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.46.tgz#c3dedd25558c676b3d6303e51799abb9c3f8f314"
-
 "@types/node@^8.0.24":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.10.tgz#49bd3637125dea5f55d7d1e8f51efd6cb835e1f7"
+
+"@types/node@^8.10.4":
+  version "8.10.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.4.tgz#d3ca40ee884c853e2b786ee73096726ec59a5b31"
 
 "@types/prop-types@*":
   version "15.5.2"


### PR DESCRIPTION
Turns out we're still working against the Node 7 APIs both in the app and our related tooling. Oops.

This upgrade highlighted two areas where our handling of return values needed to be improved:

 - `process.env` now correctly returns `string | undefined` when indexing into it
 - the result from `URL.parse()` now has a different shape for `query`, which is also an index. This now requires handling `string | string[] | undefined` for querystring terms. 

The second bullet point is a bit contentious, but I poked at this API in Chrome Dev Tools and could trigger these three scenarios:

<img width="604"  src="https://user-images.githubusercontent.com/359239/38535380-8761a430-3cc6-11e8-943f-db89d94e7e99.png">
