### PR TITLE
Add hint in placeholder for required commit message

### DIFF
--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -28,6 +28,9 @@ interface IAutocompletingTextInputProps<ElementType> {
   /** Disabled state for input field. */
   readonly disabled?: boolean
 
+  /** Indicates if input field should be required */
+  readonly isRequired?: boolean
+
   /**
    * Called when the user changes the value in the input field.
    */

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -273,6 +273,7 @@ export abstract class AutocompletingTextInput<
       onBlur: this.onBlur,
       onContextMenu: this.onContextMenu,
       disabled: this.props.disabled,
+      'aria-required': this.props.isRequired ? true : false,
     }
 
     return React.createElement<React.HTMLAttributes<ElementType>, ElementType>(

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -491,6 +491,7 @@ export class CommitMessage extends React.Component<
           {this.renderAvatar()}
 
           <AutocompletingInput
+            isRequired={true}
             className="summary-field"
             placeholder="Summary (required)"
             value={this.state.summary}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -492,7 +492,7 @@ export class CommitMessage extends React.Component<
 
           <AutocompletingInput
             className="summary-field"
-            placeholder="Summary"
+            placeholder="Summary (required)"
             value={this.state.summary}
             onValueChanged={this.onSummaryChanged}
             autocompletionProviders={this.props.autocompletionProviders}


### PR DESCRIPTION
Workaround for feedback reported in #4354 

**Before**
![before](https://user-images.githubusercontent.com/1715082/38585479-a971cb0e-3cdf-11e8-9d9e-4c532d83558f.png)

**After**
![after](https://user-images.githubusercontent.com/1715082/38585490-b04b5116-3cdf-11e8-9176-e8968533a80f.png)
