### PR TITLE
Adds PR usage tracking

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -40,6 +40,9 @@ export interface IDailyMeasures {
 
   /** The number of commits created with one or more co-authors. */
   readonly coAuthoredCommits: number
+
+  /** The number of times the user checks out a branch using the PR menu */
+  readonly prBranchCheckouts: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -294,6 +294,13 @@ export class StatsStore {
     }))
   }
 
+  /** Record that the user checked out a PR branch */
+  public prBranchCheckout(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      prBranchCheckouts: m.prBranchCheckouts + 1,
+    }))
+  }
+
   /** Set whether the user has opted out of stats reporting. */
   public async setOptOut(optOut: boolean): Promise<void> {
     const changed = this.optOut !== optOut

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -29,6 +29,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   partialCommits: 0,
   openShellCount: 0,
   coAuthoredCommits: 0,
+  prBranchCheckouts: 0,
 }
 
 interface ICalculatedStats {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -296,7 +296,7 @@ export class StatsStore {
   }
 
   /** Record that the user checked out a PR branch */
-  public prBranchCheckout(): Promise<void> {
+  public recordPRBranchCheckout(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       prBranchCheckouts: m.prBranchCheckouts + 1,
     }))

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3316,7 +3316,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         )
 
         log.error(error.message)
-        this.emitError(error)
+        return this.emitError(error)
       }
 
       await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3338,6 +3338,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       await this._checkoutBranch(repository, localBranchName)
     }
+
+    this.statsStore.recordPRBranchCheckout()
   }
 
   /**


### PR DESCRIPTION
Fixes #4158 

**Plumbing**
- [x] Add `prBranchCheckouts` field to `IDailyMeasures` in `stats` database
- [x] Add the method, `recordPRBranchCheckout`, to `statsStore`
- [x] Add a new field `co-authored-commit` to `DefaultDailyMeasure` in `statsStore`

**Back-end (Central)**
- [x] Add measure to `desktop_usage_event.rb`
- [x] Update `usage_test.rb`
- [x] Update `fake_desktop_data` in `helper.rb`

**Database**
- [x] Open an issue on _github/analytics_ to get new field pulled into view, update airflow, and update reports

**Other**
- [x] Update the [usage-data page](https://desktop.github.com/usage-data/) on desktop.github.com 

_This depends on PRs in [central](https://github.com/github/central/pull/365), [desktop.github.com](https://github.com/github/desktop.github.com/pull/96), and [analytics](https://github.com/github/analytics/issues/445) being merged._