### PR TITLE
 Remove O(N^2) loop in getStatus

### DIFF
--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -62,7 +62,6 @@ export async function getStatus(
     'getStatus'
   )
 
-  const files = new Array<WorkingDirectoryFileChange>()
   // Map of files keyed on their paths.
   // Note, map maintains insertion order
   const files = new Map<string, WorkingDirectoryFileChange>()

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -63,6 +63,9 @@ export async function getStatus(
   )
 
   const files = new Array<WorkingDirectoryFileChange>()
+  // Map of files keyed on their paths.
+  // Note, map maintains insertion order
+  const files = new Map<string, WorkingDirectoryFileChange>()
 
   let currentBranch: string | undefined = undefined
   let currentUpstreamBranch: string | undefined = undefined
@@ -90,10 +93,7 @@ export async function getStatus(
         // same path, we should ensure that we only draw one entry in the
         // changes list - see if an entry already exists for this path and
         // remove it if found
-        const existingEntry = files.findIndex(p => p.path === entry.path)
-        if (existingEntry > -1) {
-          files.splice(existingEntry, 1)
-        }
+        files.delete(entry.path)
       }
 
       // for now we just poke at the existing summary
@@ -102,7 +102,8 @@ export async function getStatus(
         DiffSelectionType.All
       )
 
-      files.push(
+      files.set(
+        entry.path,
         new WorkingDirectoryFileChange(
           entry.path,
           summary,
@@ -134,7 +135,7 @@ export async function getStatus(
     }
   }
 
-  const workingDirectory = WorkingDirectoryStatus.fromFiles(files)
+  const workingDirectory = WorkingDirectoryStatus.fromFiles([...files.values()])
 
   return {
     currentBranch,

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -221,9 +221,9 @@ export class WorkingDirectoryStatus {
   /**
    * The list of changes in the repository's working directory
    */
-  public readonly files: ReadonlyArray<WorkingDirectoryFileChange> = new Array<
-    WorkingDirectoryFileChange
-  >()
+  public readonly files: ReadonlyArray<WorkingDirectoryFileChange> = []
+
+  private readonly fileIxById = new Map<string, number>()
 
   /**
    * Update the include checkbox state of the form
@@ -244,6 +244,8 @@ export class WorkingDirectoryStatus {
     includeAll: boolean | null
   ) {
     this.files = files
+    files.forEach((f, ix) => this.fileIxById.set(f.id, ix))
+
     this.includeAll = includeAll
   }
 
@@ -257,7 +259,14 @@ export class WorkingDirectoryStatus {
 
   /** Find the file with the given ID. */
   public findFileWithID(id: string): WorkingDirectoryFileChange | null {
-    return this.files.find(f => f.id === id) || null
+    const ix = this.fileIxById.get(id)
+    return ix !== undefined ? this.files[ix] || null : null
+  }
+
+  /** Find the index of the file with the given ID. Returns -1 if not found */
+  public findFileIndexByID(id: string): number {
+    const ix = this.fileIxById.get(id)
+    return ix !== undefined ? ix : -1
   }
 }
 

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -144,15 +144,14 @@ export class FileChange {
   /** the status of the change to the file */
   public readonly status: AppFileStatus
 
+  /** An ID for the file change. */
+  public readonly id: string
+
   public constructor(path: string, status: AppFileStatus, oldPath?: string) {
     this.path = path
     this.status = status
     this.oldPath = oldPath
-  }
-
-  /** An ID for the file change. */
-  public get id(): string {
-    return `${this.status}+${this.path}`
+    this.id = `${this.status}+${this.path}`
   }
 }
 


### PR DESCRIPTION
For each item returned from `git status` we were doing an O(N) lookup (using findIndex) on the array to see if we had already added a file with that path. This change turns that array into a map keyed on the path so that we can perform O(1) lookups instead.

Measurements of a pathological case (10k files) show great improvement:

Before : 1519ms
After: 95.0ms

Additionally this moves us to precomputing file ids once rather than on-demand. We usually call id multiple times during the lifetime of a file (up to 60+ times in fact) so it makes sense to precompute it

Finally this adds a map inside of WorkingDirectory for faster file lookups. The added method is used in #4188 but I've pulled these changes out of that PR because they make sense on there own and are easier to review in isolation.
