### PR TITLE
skip fast-forwarding when there are a lot of eligible local branches

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -131,6 +131,13 @@ export enum FetchType {
   UserInitiatedTask,
 }
 
+/**
+ * As fast-forwarding local branches is proportional to the number of local
+ * branches, and is run after every fetch/push/pull, this is skipped when the
+ * number of eligible branches is greater than a given threshold.
+ */
+const FastForwardBranchesThreshold = 20
+
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
 const defaultSidebarWidth: number = 250
@@ -2175,6 +2182,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
         b.upstream
       )
     })
+
+    if (eligibleBranches.length >= FastForwardBranchesThreshold) {
+      log.info(
+        `skipping fast-forward work because there are ${
+          eligibleBranches.length
+        } local branches - this will run again when there are less than ${FastForwardBranchesThreshold} local branches tracking remotes`
+      )
+      return
+    }
 
     for (const branch of eligibleBranches) {
       const aheadBehind = await getBranchAheadBehind(repository, branch)


### PR DESCRIPTION
Fixes #4392

The case reported by @gemal in #4392 indicates that they are using a repository with **388** local branches which also track upstream branches. This means every fetch/push/pull on that repository will trigger enumerating each branch, running `getBranchAheadBehind` to see if the local branch is behind the remote branch, and then `updateRef` to move it forward if it can be safely moved.

This feature is neat to help users keep their branches up to date, but when each `getBranchAheadBehind` takes over a second and the actions are performed sequentially it becomes less neat:

```
...
info: [ui] Executing getAheadBehind: git rev-list --left-right --count noepayaccess...origin/noepayaccess -- (took 1.251s)
...
```

This PR skips the fast-forward work when there are 20 or more eligible local branches. I chose that number arbitrarily, and could be swayed to make it larger or shorter with actual logic.

The point here is that `fastForwardBranches` is potentially counter-intuitive beyond a certain threshold, and the app disrupts the user's flow because it adds time to the push/pull/fetch action. With this workaround they'll instead need to update the branch when they switch to it, which seems a reasonable compromise until we're able to be smarter in the app around detecting _which_ branches to fast-forward.

I also propose that once we land Compare Branches (which uses `getAheadBehind` heavily but does this using a queue and `requestIdleCallback`) and we're happy that it doesn't adversely affect users in the wild, we can try and apply the lessons learned there to this situation.