### PR TITLE
handle the click event when opening a binary file

### DIFF
--- a/app/src/ui/diff/binary-file.tsx
+++ b/app/src/ui/diff/binary-file.tsx
@@ -5,6 +5,8 @@ import { Repository } from '../../models/repository'
 import { openFile } from '../../lib/open-file'
 import { Dispatcher } from '../../lib/dispatcher/dispatcher'
 
+import { LinkButton } from '../lib/link-button'
+
 interface IBinaryFileProps {
   readonly repository: Repository
   readonly path: string
@@ -13,8 +15,7 @@ interface IBinaryFileProps {
 
 /** represents the default view for a file that we cannot render a diff for */
 export class BinaryFile extends React.Component<IBinaryFileProps, {}> {
-  private handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
+  private open = () => {
     const fullPath = Path.join(this.props.repository.path, this.props.path)
     openFile(fullPath, this.props.dispatcher)
   }
@@ -24,9 +25,9 @@ export class BinaryFile extends React.Component<IBinaryFileProps, {}> {
       <div className="panel binary" id="diff">
         <div className="image-header">This binary file has changed.</div>
         <div className="image-header">
-          <a href="#" onClick={this.handleClick}>
+          <LinkButton onClick={this.open}>
             Open file in external program.
-          </a>
+          </LinkButton>
         </div>
       </div>
     )

--- a/app/src/ui/diff/binary-file.tsx
+++ b/app/src/ui/diff/binary-file.tsx
@@ -14,6 +14,7 @@ interface IBinaryFileProps {
 /** represents the default view for a file that we cannot render a diff for */
 export class BinaryFile extends React.Component<IBinaryFileProps, {}> {
   private handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
     const fullPath = Path.join(this.props.repository.path, this.props.path)
     openFile(fullPath, this.props.dispatcher)
   }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -246,15 +246,6 @@
   padding: 0;
 }
 // ***************************************************************************************************************************
-#diff a {
-  text-decoration: none;
-  margin-left: var(--spacing-half);
-}
-
-#diff a:link {
-  color: (orange);
-}
-
 .panel.image {
   display: flex;
   flex: 1;


### PR DESCRIPTION
Fixes #4446 by:

 - ensuring we `e.preventDefault()` on the link click so it doesn't change the window title
 - switch to `LinkButton` so we get this behaviour for free
 - switch to `LinkButton` to get the `cursor: pointer` style when hovering over a link

**Before:**

<img width="1000" src="https://user-images.githubusercontent.com/359239/38793551-19afd0dc-4195-11e8-906a-01cf10468ca9.png">

**After:**

<img width="998" src="https://user-images.githubusercontent.com/359239/38793631-6c555f82-4195-11e8-8e43-cf0aeb7673de.png">

I suspect this bit of code pre-dates the `LinkButton` creation, and I'm also not sure why there's a custom orange style here for diff links (ping @donokuda @niik to scold my design skills). You can see an existing link in the "No changes" view, which is just a plain `LinkButton`, so I'm going to follow that.

<img width="994"  src="https://user-images.githubusercontent.com/359239/38793619-61cc30e0-4195-11e8-93cb-5afd82478c81.png">

cc @MikeDombo
