### PR TITLE
Don't show option to not show message again when discarding more than one file

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -210,11 +210,6 @@ export enum PopupType {
   DeletePullRequest,
 }
 
-export enum DiscardChangesSource {
-  manualSelection,
-  all,
-}
-
 export type Popup =
   | { type: PopupType.RenameBranch; repository: Repository; branch: Branch }
   | {
@@ -227,7 +222,7 @@ export type Popup =
       type: PopupType.ConfirmDiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
-      source: DiscardChangesSource
+      forceConfirmation: boolean
     }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | { type: PopupType.MergeBranch; repository: Repository }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -2,7 +2,6 @@ import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
 import { IDiff } from '../models/diff'
 import { Repository } from '../models/repository'
-import { IAheadBehind } from './git'
 import { Branch } from '../models/branch'
 import { Tip } from '../models/tip'
 import { Commit } from '../models/commit'
@@ -26,6 +25,7 @@ import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { BranchesTab } from '../models/branches-tab'
 import { PullRequest } from '../models/pull-request'
 import { IAuthor } from '../models/author'
+import { IAheadBehind } from './git'
 
 export { ICommitMessage }
 export { IAheadBehind }
@@ -210,6 +210,11 @@ export enum PopupType {
   DeletePullRequest,
 }
 
+export enum DiscardChangesSource {
+  manualSelection,
+  all,
+}
+
 export type Popup =
   | { type: PopupType.RenameBranch; repository: Repository; branch: Branch }
   | {
@@ -222,6 +227,7 @@ export type Popup =
       type: PopupType.ConfirmDiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
+      source: DiscardChangesSource
     }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | { type: PopupType.MergeBranch; repository: Repository }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -222,7 +222,7 @@ export type Popup =
       type: PopupType.ConfirmDiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
-      showDiscardChangesSetting: boolean
+      showDiscardChangesSetting?: boolean
     }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | { type: PopupType.MergeBranch; repository: Repository }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -2,6 +2,7 @@ import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
 import { IDiff } from '../models/diff'
 import { Repository } from '../models/repository'
+import { IAheadBehind } from './git'
 import { Branch } from '../models/branch'
 import { Tip } from '../models/tip'
 import { Commit } from '../models/commit'
@@ -25,7 +26,6 @@ import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { BranchesTab } from '../models/branches-tab'
 import { PullRequest } from '../models/pull-request'
 import { IAuthor } from '../models/author'
-import { IAheadBehind } from './git'
 
 export { ICommitMessage }
 export { IAheadBehind }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -222,7 +222,7 @@ export type Popup =
       type: PopupType.ConfirmDiscardChanges
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
-      forceConfirmation: boolean
+      showDiscardChangesSetting: boolean
     }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | { type: PopupType.MergeBranch; repository: Repository }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -963,6 +963,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
+            forceConfirmation={popup.forceConfirmation}
             onDismissed={this.onPopupDismissed}
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -963,7 +963,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
-            forceConfirmation={popup.forceConfirmation}
+            showDiscardChangesSetting={popup.showDiscardChangesSetting}
             onDismissed={this.onPopupDismissed}
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -954,6 +954,11 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       case PopupType.ConfirmDiscardChanges:
+        const showSetting =
+          popup.showDiscardChangesSetting === undefined
+            ? true
+            : popup.showDiscardChangesSetting
+
         return (
           <DiscardChanges
             key="discard-changes"
@@ -963,7 +968,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
-            showDiscardChangesSetting={popup.showDiscardChangesSetting}
+            showDiscardChangesSetting={showSetting}
             onDismissed={this.onPopupDismissed}
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -163,7 +163,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         type: PopupType.ConfirmDiscardChanges,
         repository: this.props.repository,
         files: [file],
-        forceConfirmation: false,
+        showDiscardChangesSetting: false,
       })
     }
   }
@@ -174,7 +174,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmDiscardChanges,
       repository: this.props.repository,
-      forceConfirmation: true,
+      showDiscardChangesSetting: true,
       files,
     })
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -3,7 +3,11 @@ import * as React from 'react'
 
 import { ChangesList } from './changes-list'
 import { DiffSelectionType } from '../../models/diff'
-import { IChangesState, PopupType } from '../../lib/app-state'
+import {
+  IChangesState,
+  PopupType,
+  DiscardChangesSource,
+} from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../../lib/dispatcher'
 import { IGitHubUser } from '../../lib/databases'
@@ -163,6 +167,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         type: PopupType.ConfirmDiscardChanges,
         repository: this.props.repository,
         files: [file],
+        source: DiscardChangesSource.manualSelection,
       })
     }
   }
@@ -173,6 +178,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmDiscardChanges,
       repository: this.props.repository,
+      source: DiscardChangesSource.all,
       files,
     })
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -163,7 +163,6 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         type: PopupType.ConfirmDiscardChanges,
         repository: this.props.repository,
         files: [file],
-        showDiscardChangesSetting: false,
       })
     }
   }
@@ -174,7 +173,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmDiscardChanges,
       repository: this.props.repository,
-      showDiscardChangesSetting: true,
+      showDiscardChangesSetting: false,
       files,
     })
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -3,11 +3,7 @@ import * as React from 'react'
 
 import { ChangesList } from './changes-list'
 import { DiffSelectionType } from '../../models/diff'
-import {
-  IChangesState,
-  PopupType,
-  DiscardChangesSource,
-} from '../../lib/app-state'
+import { IChangesState, PopupType } from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../../lib/dispatcher'
 import { IGitHubUser } from '../../lib/databases'
@@ -167,7 +163,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         type: PopupType.ConfirmDiscardChanges,
         repository: this.props.repository,
         files: [file],
-        source: DiscardChangesSource.manualSelection,
+        forceConfirmation: false,
       })
     }
   }
@@ -178,7 +174,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmDiscardChanges,
       repository: this.props.repository,
-      source: DiscardChangesSource.all,
+      forceConfirmation: true,
       files,
     })
   }

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -15,7 +15,7 @@ interface IDiscardChangesProps {
   readonly dispatcher: Dispatcher
   readonly files: ReadonlyArray<WorkingDirectoryFileChange>
   readonly confirmDiscardChanges: boolean
-  readonly forceConfirmation: boolean
+  readonly showDiscardChangesSetting: boolean
   readonly onDismissed: () => void
   readonly onConfirmDiscardChangesChanged: (optOut: boolean) => void
 }
@@ -66,7 +66,7 @@ export class DiscardChanges extends React.Component<
           <p>
             Changes can be restored by retrieving them from the {trashName}.
           </p>
-          {!this.props.forceConfirmation ? (
+          {!this.props.showDiscardChangesSetting ? (
             <Checkbox
               label="Do not show this message again"
               value={

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -9,12 +9,14 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { PathText } from '../lib/path-text'
 import { Monospaced } from '../lib/monospaced'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { DiscardChangesSource } from '../../lib/app-state'
 
 interface IDiscardChangesProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly files: ReadonlyArray<WorkingDirectoryFileChange>
   readonly confirmDiscardChanges: boolean
+  readonly source?: DiscardChangesSource
   readonly onDismissed: () => void
   readonly onConfirmDiscardChangesChanged: (optOut: boolean) => void
 }
@@ -65,7 +67,7 @@ export class DiscardChanges extends React.Component<
           <p>
             Changes can be restored by retrieving them from the {trashName}.
           </p>
-          {this.props.files.length === 1 ? (
+          {this.props.source === DiscardChangesSource.manualSelection ? (
             <Checkbox
               label="Do not show this message again"
               value={

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -65,15 +65,17 @@ export class DiscardChanges extends React.Component<
           <p>
             Changes can be restored by retrieving them from the {trashName}.
           </p>
-          <Checkbox
-            label="Do not show this message again"
-            value={
-              this.state.confirmDiscardChanges
-                ? CheckboxValue.Off
-                : CheckboxValue.On
-            }
-            onChange={this.onCheckboxChanged}
-          />
+          {this.props.files.length === 1 ? (
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.confirmDiscardChanges
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onCheckboxChanged}
+            />
+          ) : null}
         </DialogContent>
 
         <DialogFooter>

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -9,14 +9,13 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { PathText } from '../lib/path-text'
 import { Monospaced } from '../lib/monospaced'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
-import { DiscardChangesSource } from '../../lib/app-state'
 
 interface IDiscardChangesProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly files: ReadonlyArray<WorkingDirectoryFileChange>
   readonly confirmDiscardChanges: boolean
-  readonly source?: DiscardChangesSource
+  readonly forceConfirmation: boolean
   readonly onDismissed: () => void
   readonly onConfirmDiscardChangesChanged: (optOut: boolean) => void
 }
@@ -67,7 +66,7 @@ export class DiscardChanges extends React.Component<
           <p>
             Changes can be restored by retrieving them from the {trashName}.
           </p>
-          {this.props.source === DiscardChangesSource.manualSelection ? (
+          {!this.props.forceConfirmation ? (
             <Checkbox
               label="Do not show this message again"
               value={

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -15,6 +15,11 @@ interface IDiscardChangesProps {
   readonly dispatcher: Dispatcher
   readonly files: ReadonlyArray<WorkingDirectoryFileChange>
   readonly confirmDiscardChanges: boolean
+  /**
+   * Determines whether to show the option
+   * to ask for confirmation when discarding
+   * changes
+   */
   readonly showDiscardChangesSetting: boolean
   readonly onDismissed: () => void
   readonly onConfirmDiscardChangesChanged: (optOut: boolean) => void

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -71,7 +71,7 @@ export class DiscardChanges extends React.Component<
           <p>
             Changes can be restored by retrieving them from the {trashName}.
           </p>
-          {this.renderCheckbox()}
+          {this.renderConfirmDiscardChanges()}
         </DialogContent>
 
         <DialogFooter>
@@ -86,7 +86,7 @@ export class DiscardChanges extends React.Component<
     )
   }
 
-  private renderCheckbox() {
+  private renderConfirmDiscardChanges() {
     if (this.props.showDiscardChangesSetting) {
       return (
         <Checkbox

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -66,17 +66,7 @@ export class DiscardChanges extends React.Component<
           <p>
             Changes can be restored by retrieving them from the {trashName}.
           </p>
-          {!this.props.showDiscardChangesSetting ? (
-            <Checkbox
-              label="Do not show this message again"
-              value={
-                this.state.confirmDiscardChanges
-                  ? CheckboxValue.Off
-                  : CheckboxValue.On
-              }
-              onChange={this.onCheckboxChanged}
-            />
-          ) : null}
+          {this.renderCheckbox()}
         </DialogContent>
 
         <DialogFooter>
@@ -89,6 +79,27 @@ export class DiscardChanges extends React.Component<
         </DialogFooter>
       </Dialog>
     )
+  }
+
+  private renderCheckbox() {
+    if (this.props.showDiscardChangesSetting) {
+      return (
+        <Checkbox
+          label="Do not show this message again"
+          value={
+            this.state.confirmDiscardChanges
+              ? CheckboxValue.Off
+              : CheckboxValue.On
+          }
+          onChange={this.onCheckboxChanged}
+        />
+      )
+    } else {
+      // since we ignore the users option to not show
+      // confirmation, we don't want to show a checkbox
+      // that will have no effect
+      return null
+    }
   }
 
   private renderFileList() {

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -96,7 +96,7 @@ export class DiscardChanges extends React.Component<
               ? CheckboxValue.Off
               : CheckboxValue.On
           }
-          onChange={this.onCheckboxChanged}
+          onChange={this.onConfirmDiscardChangesChanged}
         />
       )
     } else {
@@ -145,7 +145,9 @@ export class DiscardChanges extends React.Component<
     this.props.onDismissed()
   }
 
-  private onCheckboxChanged = (event: React.FormEvent<HTMLInputElement>) => {
+  private onConfirmDiscardChangesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
     const value = !event.currentTarget.checked
 
     this.setState({ confirmDiscardChanges: value })


### PR DESCRIPTION
Addresses a loose-end in #4426.

Before, when discarding all files, we would show the checkbox that disables the confirmation dialog. This doesn't make much sense since that setting is ignored when discarding all files. This PR addresses that by only showing the checkbox when there is exactly one change being discarded.

**Discard**
![discard](https://user-images.githubusercontent.com/1715082/38961415-115711ee-432e-11e8-86e1-a64b913409eb.png)


**Discard All**
![discard_all](https://user-images.githubusercontent.com/1715082/38961421-19802266-432e-11e8-89cb-0ca2acafb9a4.png)

- [x] Update PopupType to include a bit of context on how it's being used
- [x] Move away from using the number of files to determine if we should show option