### PR TITLE
update typescript-eslint-parser to support new syntax in TS 2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "tslint-microsoft-contrib": "^5.0.3",
     "tslint-react": "^3.5.1",
     "typescript": "^2.8.1",
-    "typescript-eslint-parser": "^14.0.0",
+    "typescript-eslint-parser": "^15.0.0",
     "webpack": "^3.10.0",
     "webpack-bundle-analyzer": "^2.11.1",
     "webpack-dev-middleware": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6934,9 +6934,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-14.0.0.tgz#c90a8f541c1d96e5c55e2807c61d154e788520f9"
+typescript-eslint-parser@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-15.0.0.tgz#882fd3d7aabffbab0a7f98d2a59fb9a989c2b37f"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"


### PR DESCRIPTION
Before:

```shellsession
$ yarn lint
yarn run v1.6.0
$ yarn lint:src && yarn lint:prettier
$ yarn tslint && yarn eslint-check && yarn eslint
$ tslint ./{script,tslint-rules}/*.ts ./app/{src,typings,test}/**/*.{ts,tsx}
$ eslint --print-config .eslintrc.* | eslint-config-prettier-check
No rules that are unnecessary or conflict with Prettier were found.
$ ts-node script/eslint.ts
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: ~2.7.1

YOUR TYPESCRIPT VERSION: 2.8.1

Please only submit bug reports when using the officially supported version.

=============

$ ts-node script/prettier.ts
✨  Done in 8.91s.
```

After:

```shellsession
$ yarn lint
yarn run v1.6.0
$ yarn lint:src && yarn lint:prettier
$ yarn tslint && yarn eslint-check && yarn eslint
$ tslint ./{script,tslint-rules}/*.ts ./app/{src,typings,test}/**/*.{ts,tsx}
$ eslint --print-config .eslintrc.* | eslint-config-prettier-check
No rules that are unnecessary or conflict with Prettier were found.
$ ts-node script/eslint.ts

$ ts-node script/prettier.ts
✨  Done in 7.54s.
```
