### PR TITLE
fixed broken CONTRIBUTING.md-link in new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 First and foremost, we’d like to thank you for taking the time to contribute to our project. Before submitting your issue, please follow these steps:
 
 1. Familiarize yourself with our contributing guide:
-	* https://github.com/desktop/desktop/blob/master/CONTRIBUTING.md#contributing-to-github-desktop
+	* https://github.com/desktop/desktop/blob/master/.github/CONTRIBUTING.md#contributing-to-github-desktop
 2. Check if your issue (and sometimes workaround) is in the known-issues doc:
 	* https://github.com/desktop/desktop/blob/master/docs/known-issues.md
 3. Make sure your issue isn’t a duplicate of another issue


### PR DESCRIPTION
I actually just filed it https://github.com/desktop/desktop/issues/4499
but remembered this was easy to fix ...

A little weird that this is under the .github directory. I have no idea why that is. Maybe another hint in the CONTRIBUTING.md file itself would be nice: That its linked from the new issues page?