### PR TITLE
always fast-forward the default branch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2196,12 +2196,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const currentBranchName =
       tip.kind === TipState.Valid ? tip.branch.name : null
 
-    // A branch is only eligible for being fast forwarded if:
-    //  1. It's local.
-    //  2. It's not the current branch.
-    //  3. It has an upstream.
-    //  4. It's not ahead of its upstream.
-
     let eligibleBranches = branches.filter(b =>
       eligibleForFastForward(b, currentBranchName)
     )
@@ -2228,6 +2222,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       const { ahead, behind } = aheadBehind
+      // Only perform the fast forward if the branch is behind it's upstream
+      // branch and has no local commits.
       if (ahead === 0 && behind > 0) {
         // At this point we're guaranteed this is non-null since we've filtered
         // out any branches will null upstreams above when creating

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2201,7 +2201,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     //  2. It's not the current branch.
     //  3. It has an upstream.
     //  4. It's not ahead of its upstream.
-    const eligibleBranches = branches.filter(b => {
+    let eligibleBranches = branches.filter(b => {
       return (
         b.type === BranchType.Local &&
         b.name !== currentBranchName &&
@@ -2211,11 +2211,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (eligibleBranches.length >= FastForwardBranchesThreshold) {
       log.info(
-        `skipping fast-forward work because there are ${
+        `skipping fast-forward for all branches as there are ${
           eligibleBranches.length
         } local branches - this will run again when there are less than ${FastForwardBranchesThreshold} local branches tracking remotes`
       )
-      return
+
+      const defaultBranch = state.branchesState.defaultBranch
+      eligibleBranches = defaultBranch != null ? [defaultBranch] : []
     }
 
     for (const branch of eligibleBranches) {

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -8,6 +8,17 @@ export enum BranchType {
   Remote = 1,
 }
 
+/**
+ * Check if a branch is eligible for beign fast forarded.
+ *
+ * Requirements:
+ *   1. It's local.
+ *   2. It's not the current branch.
+ *   3. It has an upstream.
+ *
+ * @param branch The branch to validate
+ * @param currentBranchName The current branch in the repository
+ */
 export function eligibleForFastForward(
   branch: Branch,
   currentBranchName: string | null

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -8,6 +8,17 @@ export enum BranchType {
   Remote = 1,
 }
 
+export function eligibleForFastForward(
+  branch: Branch,
+  currentBranchName: string | null
+): boolean {
+  return (
+    branch.type === BranchType.Local &&
+    branch.name !== currentBranchName &&
+    branch.upstream != null
+  )
+}
+
 /** A branch as loaded from Git. */
 export class Branch {
   /** The short name of the branch. E.g., `master`. */


### PR DESCRIPTION
This is a follow up to #4447 after I got some feedback that the latest beta wasn't fast-forwarding `master`. We were skipping _all_ branches here for performance reasons, but I think we should handle `master` differently because it saves a lot of friction here like:

 - keeping `master` up-to-date means you don't need to switch to `master`, pull `master`, switch back, and then merge.
 - comparing locally means you don't need to consciously differentiate `origin/master` and `master`
 - the GitHub flow is centered on the default branch, creating new branches will mean you're always working from the latest code