### PR TITLE
Add some UI polish for relationship between branches feature

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -30,7 +30,7 @@ interface ICommitListProps {
   readonly localCommitSHAs: ReadonlyArray<string>
 
   /** The message to display inside the list when no results are displayed */
-  readonly emptyListMessage: string
+  readonly emptyListMessage: JSX.Element | string
 
   /** Callback which fires when a commit has been selected in the list */
   readonly onCommitSelected: (commit: Commit) => void

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -265,7 +265,7 @@ export class CompareSidebar extends React.Component<
       )
     }
 
-    return <div className="merge-message">There are no commits</div>
+    return null
   }
 
   private onTabClicked = (index: number) => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -174,21 +174,26 @@ export class CompareSidebar extends React.Component<
 
     let emptyListMessage
     if (compareState.formState.kind === ComparisonView.Ahead) {
-        const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
-        emptyListMessage = (
-          <p>
-            The compared branch (<Ref>${currentlyComparedBranchName}</Ref>)
-            is up to date with your branch
-          </p>
-        )
+      const currentlyComparedBranchName =
+        compareState.formState.comparisonBranch.name
+
+      emptyListMessage = (
+        <p>
+          The compared branch (<Ref>${currentlyComparedBranchName}</Ref>) is up
+          to date with your branch
+        </p>
+      )
     } else if (compareState.formState.kind === ComparisonView.Behind) {
-        const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
-        emptyListMessage = (
-          <p>
-            Your branch is up to date with the compared branch
-            (<Ref>${currentlyComparedBranchName}</Ref>)
-          </p>
-        )
+      const currentlyComparedBranchName =
+        compareState.formState.comparisonBranch.name
+
+      emptyListMessage = (
+        <p>
+          Your branch is up to date with the compared branch (<Ref>
+            ${currentlyComparedBranchName}
+          </Ref>)
+        </p>
+      )
     } else {
       emptyListMessage = 'No history'
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -173,9 +173,11 @@ export class CompareSidebar extends React.Component<
 
     let emptyListMessage
     if (compareState.formState.kind === ComparisonView.Ahead) {
-        emptyListMessage = 'No commits ahead'
+        const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
+        emptyListMessage = `The branch "${currentlyComparedBranchName}" is up to date with your branch.`
     } else if (compareState.formState.kind === ComparisonView.Behind) {
-        emptyListMessage = 'No commits behind'
+        const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
+        emptyListMessage = `Your branch is up to date with the branch "${currentlyComparedBranchName}".`
     } else {
       emptyListMessage = 'No history'
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -174,10 +174,10 @@ export class CompareSidebar extends React.Component<
     let emptyListMessage
     if (compareState.formState.kind === ComparisonView.Ahead) {
         const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
-        emptyListMessage = `The branch "${currentlyComparedBranchName}" is up to date with your branch.`
+        emptyListMessage = `The compared branch (${currentlyComparedBranchName}) is up to date with your branch.`
     } else if (compareState.formState.kind === ComparisonView.Behind) {
         const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
-        emptyListMessage = `Your branch is up to date with the branch "${currentlyComparedBranchName}".`
+        emptyListMessage = `Your branch is up to date with the compared branch (${currentlyComparedBranchName})`
     } else {
       emptyListMessage = 'No history'
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -172,30 +172,26 @@ export class CompareSidebar extends React.Component<
     const selectedCommit = this.state.selectedCommit
     const commitSHAs = compareState.commitSHAs
 
-    let emptyListMessage
-    if (compareState.formState.kind === ComparisonView.Ahead) {
-      const currentlyComparedBranchName =
-        compareState.formState.comparisonBranch.name
-
-      emptyListMessage = (
-        <p>
-          The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
-          to date with your branch
-        </p>
-      )
-    } else if (compareState.formState.kind === ComparisonView.Behind) {
-      const currentlyComparedBranchName =
-        compareState.formState.comparisonBranch.name
-
-      emptyListMessage = (
-        <p>
-          Your branch is up to date with the compared branch (<Ref>
-            {currentlyComparedBranchName}
-          </Ref>)
-        </p>
-      )
-    } else {
+    let emptyListMessage: string | JSX.Element
+    if (compareState.formState.kind === ComparisonView.None) {
       emptyListMessage = 'No history'
+    } else {
+      const currentlyComparedBranchName =
+        compareState.formState.comparisonBranch.name
+
+      emptyListMessage =
+        compareState.formState.kind === ComparisonView.Ahead ? (
+          <p>
+            The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
+            to date with your branch
+          </p>
+        ) : (
+          <p>
+            Your branch is up to date with the compared branch (<Ref>
+              {currentlyComparedBranchName}
+            </Ref>)
+          </p>
+        )
     }
 
     return (

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -260,7 +260,7 @@ export class CompareSidebar extends React.Component<
           This will merge
           <strong>{` ${count} ${pluralized}`}</strong>
           {` `}from{` `}
-          <strong>{branch.name}</strong>)
+          <strong>{branch.name}</strong>
         </div>
       )
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -152,7 +152,7 @@ export class CompareSidebar extends React.Component<
   private renderCommits() {
     const formState = this.props.compareState.formState
     return (
-      <div className="the-commits">
+      <div className="compare-commit-list">
         {formState.kind === ComparisonView.None
           ? this.renderCommitList()
           : this.renderTabBar(formState)}
@@ -203,7 +203,7 @@ export class CompareSidebar extends React.Component<
   private renderActiveTab() {
     const formState = this.props.compareState.formState
     return (
-      <div className="the-commits">
+      <div className="compare-commit-list">
         {this.renderCommitList()}
         {formState.kind === ComparisonView.Behind
           ? this.renderMergeCallToAction(formState)

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -171,10 +171,14 @@ export class CompareSidebar extends React.Component<
     const selectedCommit = this.state.selectedCommit
     const commitSHAs = compareState.commitSHAs
 
-    const emptyListMessage =
-      compareState.formState.kind === ComparisonView.None
-        ? 'No history'
-        : 'No commits'
+    let emptyListMessage
+    if (compareState.formState.kind === ComparisonView.Ahead) {
+        emptyListMessage = 'No commits ahead'
+    } else if (compareState.formState.kind === ComparisonView.Behind) {
+        emptyListMessage = 'No commits behind'
+    } else {
+      emptyListMessage = 'No history'
+    }
 
     return (
       <CommitList

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -21,6 +21,7 @@ import { CompareBranchListItem } from './compare-branch-list-item'
 import { FancyTextBox } from '../lib/fancy-text-box'
 import { OcticonSymbol } from '../octicons'
 import { SelectionSource } from '../lib/filter-list'
+import { Ref } from '../lib/ref'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -174,10 +175,20 @@ export class CompareSidebar extends React.Component<
     let emptyListMessage
     if (compareState.formState.kind === ComparisonView.Ahead) {
         const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
-        emptyListMessage = `The compared branch (${currentlyComparedBranchName}) is up to date with your branch.`
+        emptyListMessage = (
+          <p>
+            The compared branch (<Ref>${currentlyComparedBranchName}</Ref>)
+            is up to date with your branch
+          </p>
+        )
     } else if (compareState.formState.kind === ComparisonView.Behind) {
         const currentlyComparedBranchName = compareState.formState.comparisonBranch.name
-        emptyListMessage = `Your branch is up to date with the compared branch (${currentlyComparedBranchName})`
+        emptyListMessage = (
+          <p>
+            Your branch is up to date with the compared branch
+            (<Ref>${currentlyComparedBranchName}</Ref>)
+          </p>
+        )
     } else {
       emptyListMessage = 'No history'
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -179,7 +179,7 @@ export class CompareSidebar extends React.Component<
 
       emptyListMessage = (
         <p>
-          The compared branch (<Ref>${currentlyComparedBranchName}</Ref>) is up
+          The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
           to date with your branch
         </p>
       )
@@ -190,7 +190,7 @@ export class CompareSidebar extends React.Component<
       emptyListMessage = (
         <p>
           Your branch is up to date with the compared branch (<Ref>
-            ${currentlyComparedBranchName}
+            {currentlyComparedBranchName}
           </Ref>)
         </p>
       )

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -125,7 +125,7 @@ export class CompareSidebar extends React.Component<
 
     return (
       <div id="compare-view">
-        <div className="the-box">
+        <div className="compare-form">
           <FancyTextBox
             symbol={OcticonSymbol.gitBranch}
             type="search"

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -115,6 +115,7 @@ button {
   align-items: center;
   justify-content: center;
   text-align: center;
+  padding: var(--spacing-half);
 }
 
 // Stretches an element to fill the entire window (such as an overlay)

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -115,7 +115,7 @@ button {
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: var(--spacing-half);
+  padding: var(--spacing);
 }
 
 // Stretches an element to fill the entire window (such as an overlay)

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -62,7 +62,7 @@
     border-bottom: var(--base-border);
   }
 
-  .the-commits {
+  .compare-commit-list {
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -55,7 +55,7 @@
   flex-direction: column;
   flex: 1;
 
-  .the-box {
+  .compare-form {
     background: var(--box-alt-background-color);
     flex: initial;
     padding: var(--spacing-half);


### PR DESCRIPTION
This pull request brings in a few polish items for the [Relationship Between Branches feature](https://github.com/desktop/desktop/issues/3956)

---

### Updated no commit messaging for Behind & Ahead states
_Also removed the "There are no commits" messaging next to the merge button_

I thought the messaging could be improved by explaining why no commits are displayed. Another benefit is a "success" message when someone merges commits from the branch they are comparing against.

📷 **Commits Behind (Before)**

![compare-before-empty](https://user-images.githubusercontent.com/1174461/39146042-7366e052-46ea-11e8-8792-33cf1d3b623a.png)

📷 **Commits Behind (After)**

![compare-master-before-empty](https://user-images.githubusercontent.com/1174461/39149740-02144e8e-46f5-11e8-8b54-52c63e5fd814.png)

📷 **Commits Ahead (Before)**

![compare-ahead-empty](https://user-images.githubusercontent.com/1174461/39149846-50411bd2-46f5-11e8-9b96-4c70448cc50c.png)

📷 **Commits Ahead (After)**

![compare-after-empty](https://user-images.githubusercontent.com/1174461/39149859-5b2d1690-46f5-11e8-9792-566fa0bcbe86.png)

---

### Fix messaging in the merge commit area

1. Removed `)` at the end of the "This will merge..." messaging
2. Remove "There are no commits" message under merge button when current branch is up to date with the compared branch

📷 **Before**

![compare-master-merge-message](https://user-images.githubusercontent.com/1174461/39150173-50743b74-46f6-11e8-918a-446663cd6483.png)

📷 **After**

![compare-master-merge-message](https://user-images.githubusercontent.com/1174461/39150180-599015fc-46f6-11e8-9264-ad4947792526.png)

![compare-master-before-empty](https://user-images.githubusercontent.com/1174461/39150200-6c352aa8-46f6-11e8-82a0-c4ab70f6734f.png)
