### PR TITLE
Wire up select all edit menu item to multi-select lists

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -114,7 +114,11 @@ export function buildDefaultMenu(
       { role: 'cut', label: __DARWIN__ ? 'Cut' : 'Cu&t' },
       { role: 'copy', label: __DARWIN__ ? 'Copy' : '&Copy' },
       { role: 'paste', label: __DARWIN__ ? 'Paste' : '&Paste' },
-      { role: 'selectall', label: __DARWIN__ ? 'Select All' : 'Select &all' },
+      {
+        label: __DARWIN__ ? 'Select All' : 'Select &all',
+        accelerator: 'CmdOrCtrl+A',
+        click: emit('select-all'),
+      },
     ],
   })
 

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -25,3 +25,4 @@ export type MenuEvent =
   | 'open-pull-request'
   | 'install-cli'
   | 'open-external-editor'
+  | 'select-all'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -307,10 +307,12 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
 
     const target = document.activeElement
+    const webContents = remote.getCurrentWebContents()
 
     if (target.dispatchEvent(event)) {
+      webContents.selectAll()
     } else {
-      remote.getCurrentWebContents().unselect()
+      webContents.unselect()
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -298,7 +298,11 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   /**
-   * Handler for the edit menu item 'Select All'.
+   * Handler for the 'select-all' menu event, dispatches
+   * a custom DOM event originating from the element which
+   * currently has keyboard focus. Components have a chance
+   * to intercept this event and implement their own 'select
+   * all' logic.
    */
   private selectAll() {
     const event = new CustomEvent('select-all', {
@@ -306,13 +310,8 @@ export class App extends React.Component<IAppProps, IAppState> {
       cancelable: true,
     })
 
-    const target = document.activeElement
-    const webContents = remote.getCurrentWebContents()
-
-    if (target.dispatchEvent(event)) {
-      webContents.selectAll()
-    } else {
-      webContents.unselect()
+    if (document.activeElement.dispatchEvent(event)) {
+      remote.getCurrentWebContents().selectAll()
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -301,7 +301,17 @@ export class App extends React.Component<IAppProps, IAppState> {
    * Handler for the edit menu item 'Select All'.
    */
   private selectAll() {
-    remote.getCurrentWebContents().selectAll()
+    const event = new CustomEvent('select-all', {
+      bubbles: true,
+      cancelable: true,
+    })
+
+    const target = document.activeElement
+
+    if (target.dispatchEvent(event)) {
+    } else {
+      remote.getCurrentWebContents().unselect()
+    }
   }
 
   private boomtown() {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ipcRenderer } from 'electron'
+import { ipcRenderer, remote } from 'electron'
 import { CSSTransitionGroup } from 'react-transition-group'
 
 import {
@@ -290,9 +290,18 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.props.dispatcher.installCLI()
       case 'open-external-editor':
         return this.openCurrentRepositoryInExternalEditor()
+      case 'select-all':
+        return this.selectAll()
     }
 
     return assertNever(name, `Unknown menu event name: ${name}`)
+  }
+
+  /**
+   * Handler for the edit menu item 'Select All'.
+   */
+  private selectAll() {
+    remote.getCurrentWebContents().selectAll()
   }
 
   private boomtown() {

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -370,7 +370,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     this.list = element
 
-    if (element) {
+    if (element !== null) {
       // This is a custom event that desktop emits through <App />
       // when the user selects the Edit > Select all menu item. We
       // hijack it and select all list items rather than let it bubble
@@ -382,7 +382,7 @@ export class List extends React.Component<IListProps, IListState> {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect()
 
-      if (element) {
+      if (element !== null) {
         this.resizeObserver.observe(element)
       } else {
         this.setState({ width: undefined, height: undefined })

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -58,8 +58,21 @@ export interface IKeyboardSource {
   readonly event: React.KeyboardEvent<any>
 }
 
+/**
+ * Interface describing a user initiated selection of all list
+ * items (usually by clicking the Edit > Select all menu item in
+ * the application window). This is highly specific to GitHub Desktop
+ */
+export interface ISelectAllSource {
+  readonly kind: 'select-all'
+}
+
 /** A type union of possible sources of a selection changed event */
-export type SelectionSource = IMouseClickSource | IHoverSource | IKeyboardSource
+export type SelectionSource =
+  | IMouseClickSource
+  | IHoverSource
+  | IKeyboardSource
+  | ISelectAllSource
 
 export type ClickSource = IMouseClickSource | IKeyboardSource
 
@@ -323,8 +336,48 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
+  private onSelectAll = (event: Event) => {
+    const selectionMode = this.props.selectionMode
+
+    if (selectionMode !== 'range' && selectionMode !== 'multi') {
+      return
+    }
+
+    event.preventDefault()
+
+    if (this.props.rowCount <= 0) {
+      return
+    }
+
+    const source: ISelectAllSource = { kind: 'select-all' }
+    const firstRow = 0
+    const lastRow = this.props.rowCount - 1
+
+    if (this.props.onSelectionChanged) {
+      const newSelection = createSelectionBetween(firstRow, lastRow)
+      this.props.onSelectionChanged(newSelection, source)
+    }
+
+    if (selectionMode === 'range' && this.props.onSelectedRangeChanged) {
+      this.props.onSelectedRangeChanged(firstRow, lastRow, source)
+    }
+  }
+
   private onRef = (element: HTMLDivElement | null) => {
+    if (element === null && this.list !== null) {
+      this.list.removeEventListener('select-all', this.onSelectAll)
+    }
+
     this.list = element
+
+    if (element) {
+      // This is a custom event that desktop emits through <App />
+      // when the user selects the Edit > Select all menu item. We
+      // hijack it and select all list items rather than let it bubble
+      // to electron's default behavior which is to select all selectable
+      // text in the renderer.
+      element.addEventListener('select-all', this.onSelectAll)
+    }
 
     if (this.resizeObserver) {
       this.resizeObserver.disconnect()


### PR DESCRIPTION
Fixes #3821

This is a continuation of #4188 that wires up the "Select All" Edit menu item such that when keyboard focus resides within a List (which supports range or multi selection) the list deals with the event rather than the default electron action which selects all selectable text in the currently focused window.

We do this by moving the handling of the select-all menu item to the renderer and dispatching a custom DOM event to the element where keyboard focus currently resides and letting it bubble. Components then have the option to intercept that event and cancel the default action.