### PR TITLE
Refactor discardChanges

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -193,27 +193,29 @@ export class ChangesList extends React.Component<
     this.props.onDiscardAllChanges(this.props.workingDirectory.files)
   }
 
-  private onDiscardChanges = (paths: string | string[]) => {
+  private onDiscardChanges = (files: ReadonlyArray<string>) => {
     const workingDirectory = this.props.workingDirectory
 
-    if (paths instanceof Array) {
-      const files: WorkingDirectoryFileChange[] = []
-      paths.forEach(path => {
-        const file = workingDirectory.files.find(f => f.path === path)
-        if (file) {
-          files.push(file)
+    if (files.length === 1) {
+      const modifiedFile = workingDirectory.files.find(f => f.path === files[0])
+
+      return modifiedFile && this.props.onDiscardChanges(modifiedFile)
+    } else {
+      const modifiedFiles: Array<WorkingDirectoryFileChange> = []
+
+      modifiedFiles.forEach(file => {
+        const modifiedFile = workingDirectory.files.find(
+          f => f.path === file.path
+        )
+
+        if (modifiedFile !== undefined) {
+          modifiedFiles.push(file)
         }
       })
-      if (files.length) {
-        this.props.onDiscardAllChanges(files)
-      }
-    } else {
-      const file = workingDirectory.files.find(f => f.path === paths)
-      if (!file) {
-        return
-      }
 
-      this.props.onDiscardChanges(file)
+      if (modifiedFiles.length) {
+        this.props.onDiscardAllChanges(modifiedFiles)
+      }
     }
   }
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -208,7 +208,7 @@ export class ChangesList extends React.Component<
       files.forEach(file => {
         const modifiedFile = workingDirectory.files.find(f => f.path === file)
 
-        if (modifiedFile !== undefined) {
+        if (modifiedFile != null) {
           modifiedFiles.push(modifiedFile)
         }
       })

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -205,13 +205,11 @@ export class ChangesList extends React.Component<
     } else {
       const modifiedFiles = new Array<WorkingDirectoryFileChange>()
 
-      modifiedFiles.forEach(file => {
-        const modifiedFile = workingDirectory.files.find(
-          f => f.path === file.path
-        )
+      files.forEach(file => {
+        const modifiedFile = workingDirectory.files.find(f => f.path === file)
 
         if (modifiedFile !== undefined) {
-          modifiedFiles.push(file)
+          modifiedFiles.push(modifiedFile)
         }
       })
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -199,9 +199,11 @@ export class ChangesList extends React.Component<
     if (files.length === 1) {
       const modifiedFile = workingDirectory.files.find(f => f.path === files[0])
 
-      return modifiedFile && this.props.onDiscardChanges(modifiedFile)
+      if (modifiedFile != null) {
+        this.props.onDiscardChanges(modifiedFile)
+      }
     } else {
-      const modifiedFiles: Array<WorkingDirectoryFileChange> = []
+      const modifiedFiles = new Array<WorkingDirectoryFileChange>()
 
       modifiedFiles.forEach(file => {
         const modifiedFile = workingDirectory.files.find(
@@ -213,7 +215,7 @@ export class ChangesList extends React.Component<
         }
       })
 
-      if (modifiedFiles.length) {
+      if (modifiedFiles.length > 0) {
         this.props.onDiscardAllChanges(modifiedFiles)
       }
     }


### PR DESCRIPTION
While working on #4459, I ran into a problem where right-clicking discard changes would not offer the option to never show a confirmation dialog. This is due to the changes introduced over in #4188.

I've updated the function to take a single argument and I’m also checking if there is exactly one file because we want to do what we did before (not fallback to discard all changes). 