### PR TITLE
Automatically add valid and non-existing repository when executed from command line

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -54,7 +54,7 @@ import { FetchType } from '../../lib/stores'
 import { PullRequest } from '../../models/pull-request'
 import { IAuthor } from '../../models/author'
 import { ITrailer } from '../git/interpret-trailers'
-import { isGitRepository } from "../git";
+import { isGitRepository } from '../git'
 
 /**
  * An error handler function.
@@ -854,6 +854,12 @@ export class Dispatcher {
           state.repositories,
           path
         )
+
+        // in case this is valid git repository, there is no need to ask
+        // user for confirmation and it can be added automatically
+        if (!existingRepository && (await isGitRepository(path))) {
+          existingRepository = (await this.addRepositories([path]))[0]
+        }
 
         if (existingRepository) {
           await this.selectRepository(existingRepository)

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -857,8 +857,12 @@ export class Dispatcher {
 
         // in case this is valid git repository, there is no need to ask
         // user for confirmation and it can be added automatically
-        if (!existingRepository && (await isGitRepository(path))) {
-          existingRepository = (await this.addRepositories([path]))[0]
+        if (existingRepository == null) {
+          const isRepository = await isGitRepository(path)
+          if (isRepository) {
+            const addedRepositories = await this.addRepositories([path])
+            existingRepository = addedRepositories[0]
+          }
         }
 
         if (existingRepository) {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -54,6 +54,7 @@ import { FetchType } from '../../lib/stores'
 import { PullRequest } from '../../models/pull-request'
 import { IAuthor } from '../../models/author'
 import { ITrailer } from '../git/interpret-trailers'
+import { isGitRepository } from "../git";
 
 /**
  * An error handler function.
@@ -848,9 +849,8 @@ export class Dispatcher {
         // this ensures we use the repository root, if it is actually a repository
         // otherwise we consider it an untracked repository
         const path = (await validatedRepositoryPath(action.path)) || action.path
-
         const state = this.appStore.getState()
-        const existingRepository = matchExistingRepository(
+        let existingRepository = matchExistingRepository(
           state.repositories,
           path
         )


### PR DESCRIPTION
There are still open topics in #4259 but I believe this is fixing the original issue requested by @gingerbeardman. This change doesn't prompt user to add repo if this is a valid repository.