### PR TITLE
add compare value into cache

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -820,6 +820,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
           commitSHAs: compare.commits.map(commit => commit.sha),
         }))
 
+        const tip = gitStore.tip
+
+        let currentSha: string | null = null
+
+        if (tip.kind === TipState.Valid) {
+          currentSha = tip.branch.tip.sha
+        } else if (tip.kind === TipState.Detached) {
+          currentSha = tip.currentSha
+        }
+
+        if (this.currentAheadBehindUpdater != null && currentSha != null) {
+          const from =
+            action.mode === ComparisonView.Ahead
+              ? comparisonBranch.tip.sha
+              : currentSha
+          const to =
+            action.mode === ComparisonView.Ahead
+              ? currentSha
+              : comparisonBranch.tip.sha
+
+          this.currentAheadBehindUpdater.insert(from, to, aheadBehind)
+        }
+
         return this.emitUpdate()
       }
     } else {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -808,11 +808,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
 
       if (compare !== null) {
+        const { ahead, behind } = compare
+        const aheadBehind = { ahead, behind }
+
         this.updateCompareState(repository, s => ({
           formState: {
             comparisonBranch,
             kind: action.mode,
-            aheadBehind: { ahead: compare.ahead, behind: compare.behind },
+            aheadBehind,
           },
           commitSHAs: compare.commits.map(commit => commit.sha),
         }))

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -88,6 +88,14 @@ export class AheadBehindUpdater {
     })
   }
 
+  public insert(from: string, to: string, value: IAheadBehind) {
+    if (this.comparisonCache.has(from, to)) {
+      return
+    }
+
+    this.comparisonCache.set(from, to, value)
+  }
+
   public schedule(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
     // remove any queued work to prioritize this new set of tasks
     this.aheadBehindQueue.end()


### PR DESCRIPTION
This addresses a UX issue where the cached value when selecting a branch isn't kept around:

From https://github.com/desktop/desktop/pull/4182:

> Sometimes when I switch to a new branch and go to compare mode, the ahead/behinds take a while to load (even though we already calculate them after we click on them). 
>
> ![](https://user-images.githubusercontent.com/1834387/39081506-f6240bb4-44f6-11e8-83c9-a97d39c5f4e1.gif)
>
> after reading the code, that made sense; in fact that wasn't the part that felt off when i was testing; it was the fact that the component was calculating the ahead/behind when i clicked on a compare-branch and then it felt like the branch list component hadn't "remembered". programmatically i get that it's queued and it'll show up soon but still felt weird as a user.

 - ~~[ ] investigate corner case when background caching seems to stop once it gets to the currently selected compare branch??!?!?~~ i think this is just an interaction issue, and will eventually come good
