### PR TITLE
promote the compare tab to the beta channel

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -37,5 +37,5 @@ export function enableMergeTool(): boolean {
 }
 
 export function enableCompareSidebar(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }


### PR DESCRIPTION
This is necessary to ensure users on the beta channel get the new Compare tab.