### PR TITLE
correct menu id to prevent clash with existing compare-branch id

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -112,7 +112,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'repository',
   'create-branch',
   'create-commit',
-  'compare-branch',
+  'compare-to-branch',
   'show-repository-list',
   'show-branches-list',
   'open-working-directory',

--- a/app/src/main-process/menu/menu-ids.ts
+++ b/app/src/main-process/menu/menu-ids.ts
@@ -13,7 +13,7 @@ export type MenuIDs =
   | 'repository'
   | 'create-branch'
   | 'create-commit'
-  | 'compare-branch'
+  | 'compare-to-branch'
   | 'show-repository-list'
   | 'show-branches-list'
   | 'open-working-directory'


### PR DESCRIPTION
Found this while looking at #4526 - 87a19b138f5e617b9b338d9f69b9cba6a738bb34 renamed the menu ID, but we already have a `'compare-branch'` menu ID - so this might cause issues with updating the menu state.

If someone else wants to pick this up, maybe `'compare-branch'`  should also be renamed to indicate it's related to `Compare on GitHub`