### PR TITLE
Added syntax highlighting for java server pages (jsp)

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -29,6 +29,9 @@ import 'codemirror/mode/htmlmixed/htmlmixed'
 extensionMIMEMap.set('.html', 'text/html')
 extensionMIMEMap.set('.htm', 'text/html')
 
+import 'codemirror/mode/htmlembedded/htmlembedded'
+extensionMIMEMap.set('.jsp', 'application/x-jsp')
+
 import 'codemirror/mode/css/css'
 extensionMIMEMap.set('.css', 'text/css')
 extensionMIMEMap.set('.scss', 'text/x-scss')

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R
+JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, JavaServer Pages
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
Fixes #4470 

Added syntax highlighting for java server pages (.jsp)

<img width="956" alt="screen shot 2018-04-26 at 5 15 14 pm" src="https://user-images.githubusercontent.com/343914/39332472-7fae41f6-4975-11e8-912f-ff935eedf20d.png">
