### PR TITLE
Fix typo(s) across the codebase

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -314,22 +314,22 @@ export class StatsStore {
     }))
   }
 
-  /** Record that a merge has been initated from the `compare` sidebar */
-  public recordCompareInitatedMerge(): Promise<void> {
+  /** Record that a merge has been initiated from the `compare` sidebar */
+  public recordCompareInitiatedMerge(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergesInitiatedFromComparison: m.mergesInitiatedFromComparison + 1,
     }))
   }
 
-  /** Record that a merge has been initated from the `Branch -> Update From Default Branch` menu item */
-  public recordMenuInitatedUpdate(): Promise<void> {
+  /** Record that a merge has been initiated from the `Branch -> Update From Default Branch` menu item */
+  public recordMenuInitiatedUpdate(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       updateFromDefaultBranchMenuCount: m.updateFromDefaultBranchMenuCount + 1,
     }))
   }
 
-  /** Record that a merge has been initated from the `Branch -> Merge Into Current Branch` menu item */
-  public recordMenuInitatedMerge(): Promise<void> {
+  /** Record that a merge has been initiated from the `Branch -> Merge Into Current Branch` menu item */
+  public recordMenuInitiatedMerge(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeIntoCurrentBranchMenuCount: m.mergeIntoCurrentBranchMenuCount + 1,
     }))


### PR DESCRIPTION
As I was looking at @nerdneha's https://github.com/desktop/desktop/pull/4531 I found that we have a couple more typos related to the Initiated.

Now we're `Initated` free. 😆 