### PR TITLE
Beta release of RBB lite and multi-select lists

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,9 +1,14 @@
 {
   "releases": {
     "1.1.2-beta4": [
-      "[Fixed] Add support for multiple selection in changes list - #1712. Thanks @icosamuel!",
+      "[New] New Compare tab allowing visualization of the relationship between branches",
+      "[New] Support for selecting more than one file in the changes list - #1712. Thanks @icosamuel!",
       "[Fixed] 'Select All' shortcut now works for changes list - #3821",
-      "[Improved] Always fast-forward the default branch - #4506"
+      "[Fixed] Always fast-forward the default branch - #4506",
+      "[Improved] Always fast-forward the default branch - #4506",
+      "[Improved] Warn when trying to rename a published branch - #4035. Thanks @agisilaos!",
+      "[Improved] Added context menu for files in commit history - #2845. Thanks @crea7or",
+      "[Improved] Discarding all changes always prompts for confirmation - #4459"
     ],
     "1.1.2-beta3": [
       "[Added] Syntax highlighting for Haxe files - #4445. Thanks @Gama11!",

--- a/changelog.json
+++ b/changelog.json
@@ -4,7 +4,6 @@
       "[New] New Compare tab allowing visualization of the relationship between branches",
       "[New] Support for selecting more than one file in the changes list - #1712. Thanks @icosamuel!",
       "[Fixed] 'Select All' shortcut now works for changes list - #3821",
-      "[Fixed] Always fast-forward the default branch - #4506",
       "[Improved] Always fast-forward the default branch - #4506",
       "[Improved] Warn when trying to rename a published branch - #4035. Thanks @agisilaos!",
       "[Improved] Added context menu for files in commit history - #2845. Thanks @crea7or",


### PR DESCRIPTION
After discussing with @nerdneha earlier today we decided that shipping RBB lite and multi-select to beta was the easiest way to get mileage on the changes as well as deliver updates to QA.

There was some concerns earlier about potential stability issues but our (my) take on this is that we'll accept some risk on the beta channel, that's what it's there for. Our need for mileage is high enough that it's important for us to get this to the beta channel as soon as possible.