### PR TITLE
Prevent Octicon from shrinking in rename dialog

### DIFF
--- a/app/styles/ui/_octicons.scss
+++ b/app/styles/ui/_octicons.scss
@@ -6,4 +6,6 @@ svg.octicon {
   Forcing a width of 16px would result in some blurry icons showing up.
   Instead, let's imply width: auto; instead. */
   height: 16px;
+
+  flex-shrink: 0;
 }

--- a/app/styles/ui/_ref.scss
+++ b/app/styles/ui/_ref.scss
@@ -5,4 +5,5 @@
   border: var(--path-segment-background);
   border-radius: var(--border-radius);
   padding: var(--path-segment-padding);
+  word-break: break-all;
 }


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/4564

This PR prevents the octicon from shrinking when inputting a very long branch name.

<img width="748" alt="screen shot 2018-04-30 at 4 30 34 pm" src="https://user-images.githubusercontent.com/1174461/39455333-b9698118-4c94-11e8-855b-45c4466e69f8.png">

**Bonus fix!** This PR also fixes an issue where long branch names breaks outside of the dialog. (classic css.)

**Before**

<img width="769" alt="screen shot 2018-04-30 at 4 04 13 pm" src="https://user-images.githubusercontent.com/1174461/39455247-5060a278-4c94-11e8-983e-8728da9f10f8.png">

**After**

<img src="https://user-images.githubusercontent.com/1174461/39455300-88fd86fa-4c94-11e8-8f08-03b958ae0eae.png" width="450" />
