### PR TITLE
 Fix background color behind octicon when textfield is disabled

### DIFF
--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -29,6 +29,7 @@ export class FancyTextBox extends React.Component<
     const componentCSS = classNames(
       'fancy-text-box-component',
       this.props.className,
+      { disabled: this.props.disabled },
       { focused: this.state.isFocused }
     )
     const octiconCSS = classNames('fancy-octicon')

--- a/app/styles/ui/_fancy-text-box.scss
+++ b/app/styles/ui/_fancy-text-box.scss
@@ -1,7 +1,6 @@
 @import '../mixins';
 
 .fancy-text-box-component {
-  background: var(--background-color);
   display: flex;
   align-items: center;
   border: var(--base-border);

--- a/app/styles/ui/_fancy-text-box.scss
+++ b/app/styles/ui/_fancy-text-box.scss
@@ -1,6 +1,7 @@
 @import '../mixins';
 
 .fancy-text-box-component {
+  background: var(--background-color);
   display: flex;
   align-items: center;
   border: var(--base-border);
@@ -32,5 +33,9 @@
     &:focus {
       box-shadow: none;
     }
+  }
+
+  &.disabled {
+    background: var(--box-alt-background-color);
   }
 }


### PR DESCRIPTION
Fixes #4580 

**Before**

<img width="280" alt="screen shot 2018-05-02 at 3 19 13 pm" src="https://user-images.githubusercontent.com/1174461/39552069-80bb11cc-4e1c-11e8-9d51-e7fd011aedcb.png">

**After**

<img width="266" alt="screen shot 2018-05-02 at 3 16 10 pm" src="https://user-images.githubusercontent.com/1174461/39552198-0ebf4ad8-4e1d-11e8-829c-9c58f748f102.png">
