### PR TITLE
actually get the styling fix for the disabled compare branch selector in

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -117,7 +117,6 @@ export class CompareSidebar extends React.Component<
 
   public render() {
     const formState = this.props.compareState.formState
-    const numBranches = this.props.compareState.allBranches.length
     const placeholderText =
       numBranches <= 1
         ? __DARWIN__
@@ -128,6 +127,7 @@ export class CompareSidebar extends React.Component<
             ? 'Select Branch to Compare...'
             : 'Select branch to compare...'
           : undefined
+    const { allBranches } = this.props.compareState
 
     return (
       <div id="compare-view">
@@ -138,7 +138,7 @@ export class CompareSidebar extends React.Component<
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}
             value={this.state.filterText}
-            disabled={numBranches <= 1}
+            disabled={allBranches.length <= 1}
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -116,18 +116,8 @@ export class CompareSidebar extends React.Component<
   }
 
   public render() {
-    const formState = this.props.compareState.formState
-    const placeholderText =
-      numBranches <= 1
-        ? __DARWIN__
-          ? 'There Are No Branches to Compare'
-          : 'There are no branches to compare'
-        : formState.kind === ComparisonView.None
-          ? __DARWIN__
-            ? 'Select Branch to Compare...'
-            : 'Select branch to compare...'
-          : undefined
     const { allBranches } = this.props.compareState
+    const placeholderText = getPlaceholderText(this.props.compareState)
 
     return (
       <div id="compare-view">
@@ -499,5 +489,19 @@ export class CompareSidebar extends React.Component<
 
   private onTextBoxRef = (textbox: TextBox) => {
     this.textbox = textbox
+  }
+}
+
+function getPlaceholderText(state: ICompareState) {
+  const { allBranches, formState } = state
+
+  if (allBranches.length <= 1) {
+    return __DARWIN__ ? 'No Branches to Compare' : 'No branches to compare'
+  } else if (formState.kind === ComparisonView.None) {
+    return __DARWIN__
+      ? 'Select Branch to Compare...'
+      : 'Select branch to compare...'
+  } else {
+    return undefined
   }
 }


### PR DESCRIPTION
Looks like #4583 was targeting a non-`master` branch, and merging it in  _after_ #4563 means that it hasn't actually made it to `master`.