### PR TITLE
include the account login when emitting this message

### DIFF
--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -213,7 +213,7 @@ export class AccountsStore extends BaseStore {
 async function updatedAccount(account: Account): Promise<Account> {
   if (!account.token) {
     return fatalError(
-      `Cannot update an account which doesn't have a token: ${account}`
+      `Cannot update an account which doesn't have a token: ${account.login}`
     )
   }
 


### PR DESCRIPTION
Found this while looking at #4607:

```
2018-05-05T12:57:23.964Z - warn: [ui] Error refreshing account 'stavrossk'
Error: Cannot update an account which doesn't have a token: [object Object]
...
```

This drops the `[object Object]` mention for the login associated with the error - minor thing given it's on the previous line, but whatevs