### PR TITLE
update access key to address constraint enforced at dev time

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -132,7 +132,7 @@ export function buildDefaultMenu(
         click: emit('create-commit'),
       },
       {
-        label: __DARWIN__ ? 'Compare to Branch' : '&Compare',
+        label: __DARWIN__ ? 'Compare to Branch' : 'C&ompare',
         id: 'compare-to-branch',
         accelerator: 'CmdOrCtrl+2',
         click: emit('compare-to-branch'),


### PR DESCRIPTION
Found this one when I switched over to my Windows VM - running the application up on dev mode would crash with this error:

```
error: [main] Error: Duplicate access key 'C' for item &Compare
    at menuFromElectronMenu (C:\Users\shiftkey\src\desktop\webpack:\app\src\models\app-menu.ts:260:19)
    at menuItemFromElectronMenuItem (C:\Users\shiftkey\src\desktop\webpack:\app\src\models\app-menu.ts:200:40)
    at Array.map (native)
    at Object.menuFromElectronMenu (C:\Users\shiftkey\src\desktop\webpack:\app\src\models\app-menu.ts:251:31)
    at AppWindow.sendAppMenu (C:\Users\shiftkey\src\desktop\webpack:\app\src\main-process\app-window.ts:217:40)
    at EventEmitter.electron_1.ipcMain.on (C:\Users\shiftkey\src\desktop\webpack:\app\src\main-process\main.ts:300:31)
    at emitOne (events.js:115:13)
    at EventEmitter.emit (events.js:210:7)
    at WebContents.<anonymous> (C:\Users\shiftkey\src\desktop\dist\GitHubDesktop-dev-win32-x64\resources\electron.asar\bro
wser\api\web-contents.js:266:13)
    at emitTwo (events.js:125:13)
```

I've traced this to 24f20606d700fd216bc3c0666342f0222cf6fab1 when we changed the tabs from Changes+History to Commit+Compare:

https://github.com/desktop/desktop/blob/617abad4611bc5b3700f2d3bb7d581771b1bc703/app/src/main-process/menu/build-default-menu.ts#L128-L139

They can't both share the same access key, so I've moved Compare to use `o` for now to unblock me.