### PR TITLE
ensure FocusContainer also has key set

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -728,6 +728,7 @@ export class List extends React.Component<IListProps, IListState> {
       <FocusContainer
         className="list-focus-container"
         onKeyDown={this.onKeyDown}
+        key="focus-container"
       >
         <Grid
           aria-label={''}


### PR DESCRIPTION
🌵 **This fix depends on #4618 when running in development mode. Go review that first.** 🌵

This is a warning that React Dev Tools has picked up on Windows when you run up `master`:

<img width="556" alt="screen shot 2018-05-07 at 1 01 29 pm" src="https://user-images.githubusercontent.com/359239/39683247-d48a9ec4-51f7-11e8-828c-ec6b6ea09edb.png">

The `FocusContainer` was added in 2a59ef5a70f1c717a54e4182c0cd7f3b9efd44b1 while we were adding multi-select support in #4188, but there's a difference between macOS and Windows here - we render a "fake" scroll inside the list:

https://github.com/desktop/desktop/blob/617abad4611bc5b3700f2d3bb7d581771b1bc703/app/src/ui/lib/list/list.tsx#L691-L697

Because we can be returning a list of elements from this method, React expects each of them to be named with a distinct `key` attribute so they can be identified. There's more details about this in [the docs](http://fb.me/react-warning-keys).