### PR TITLE
use more granular links when documenting to open a new issue

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,7 +108,7 @@ information you would like to add.
 Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
 Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=feature_request.md)
-and fill out the template.
+and fill out the provided issue template.
 
 Some additional advice:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,8 +72,8 @@ comment to the existing issue if there is extra information you can contribute.
 
 Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
-Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues)
-and fill out the provided [issue template](ISSUE_TEMPLATE.md).
+Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=bug_report.md)
+and fill out the provided issue template.
 
 The information we are interested in includes:
 
@@ -107,14 +107,15 @@ information you would like to add.
 
 Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
-Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues)
-and provide the following information:
+Simply create an issue on the [GitHub Desktop issue tracker](https://github.com/desktop/desktop/issues/new?template=feature_request.md)
+and fill out the template.
 
-* **Use a clear and descriptive title** for the issue to identify the
-  suggestion.
-* **Provide a step-by-step description of the suggested enhancement** in as
-  much detail as possible. This additional context helps the maintainers to
-  understand the enhancement from your perspective
+Some additional advice:
+
+* **Use a clear and descriptive title** for the feature request.
+* **Provide a step-by-step description of the suggested enhancement**.
+  This additional context helps the maintainers understand the enhancement from
+  your perspective
 * **Explain why this enhancement would be useful** to GitHub Desktop users.
 * **Include screenshots and animated GIFs** if relevant to help you demonstrate
   the steps or point out the part of GitHub Desktop which the suggestion is

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ to see if your issue hasn't already been reported (it may also be fixed).
 There is also a list of [known issues](https://github.com/desktop/desktop/blob/master/docs/known-issues.md)
 that are being tracked against Desktop, and some of these issues have workarounds.
 
-If you can't find an issue that matches what you're seeing, open a [new issue](https://github.com/desktop/desktop/issues/new)
-and fill out the template to provide us with enough information to investigate
+If you can't find an issue that matches what you're seeing, open a [new issue](https://github.com/desktop/desktop/issues/new/choose),
+choose the right template and provide us with enough information to investigate
 further.
 
 ## How can I contribute to GitHub Desktop?

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -328,7 +328,7 @@ export function buildDefaultMenu(
   const submitIssueItem: Electron.MenuItemConstructorOptions = {
     label: __DARWIN__ ? 'Report Issue…' : 'Report issue…',
     click() {
-      shell.openExternal('https://github.com/desktop/desktop/issues/new')
+      shell.openExternal('https://github.com/desktop/desktop/issues/new/choose')
     },
   }
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -14,7 +14,7 @@ Each known issue links off to an existing GitHub issue. If you have additional q
 
 ### My issue is not listed here?
 
-Please check the [open](https://github.com/desktop/desktop/labels/bug) and [closed](https://github.com/desktop/desktop/issues?q=is%3Aclosed+label%3Abug) bugs in the issue tracker for the details of your bug. If you can't find it, or if you're not sure, open a [new issue](https://github.com/desktop/desktop/issues/new).
+Please check the [open](https://github.com/desktop/desktop/labels/bug) and [closed](https://github.com/desktop/desktop/issues?q=is%3Aclosed+label%3Abug) bugs in the issue tracker for the details of your bug. If you can't find it, or if you're not sure, open a [new issue](https://github.com/desktop/desktop/issues/new?template=bug_report.md).
 
 ## macOS
 


### PR DESCRIPTION
Now that #4585 is merged, there are two important changes to the issue tracker:

 - the **New Issue** button now navigates to `/issues/new/choose` which displays the available templates :tada:
 - Some of our docs point to `/issues/new`, which is now the empty template. Oh well.

This PR updates all the places where we point to `/issues/new` to be more specific. I also tweaked some words while I was in there.
