### PR TITLE
keep the branch name readable in the compare tab

### DIFF
--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -147,5 +147,9 @@
     display: flex;
     height: 100%;
     flex-direction: column;
+
+    .ref-component {
+      word-break: break-word;
+    }
   }
 }


### PR DESCRIPTION
Found this while poking at the compare tab:

<img width="419" src="https://user-images.githubusercontent.com/359239/39791560-ae2bfc62-537f-11e8-894d-e4b290f01ab9.png">

By default our `.ref-component` uses `word-break: all` to ensure it doesn't overflow, but breaking in the middle of a word doesn't seem optimal when we have space.

**Before**

<img width="285" src="https://user-images.githubusercontent.com/359239/39791598-dee3d2c6-537f-11e8-9dc3-d902ca3461ba.png">

**After**

<img width="283"  src="https://user-images.githubusercontent.com/359239/39791604-e953e016-537f-11e8-969b-8da22e0a1983.png">

