### PR TITLE
Update arm64 instructions

### DIFF
--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -95,6 +95,11 @@ In order to build for arm64, you will need the following:
 on setup there.
 * Instead of running `yarn` to get all required dependencies on your machine, you will
 instead need to run `script/install-arm64-deps.sh`.
+* Before building with `yarn build:dev` or `yarn build:prod`, you will need to
+set the environment variable `TARGET_ARCH` to `arm64` eg:
+```shellsession
+export TARGET_ARCH=arm64
+```
 
 ## Install Yarn
 


### PR DESCRIPTION
When #4198 was added I missed on bit of information when building for arm64, namely that the environment variable `TARGET_ARCH` needs to be set to `arm64` before running `yarn build:dev` or `yarn build:prod`.  This PR adds that information.