### PR TITLE
Add support for WSL shell on Windows 10

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -244,16 +244,10 @@ async function findGitBash(): Promise<string | null> {
  * Check if WSL is installed. When using this function also check the executable exists on the disk.
  */
 async function isWslInstalled(): Promise<boolean> {
-  // First, determine that we are running Windows 10 or greater
-  const winVersion = OS.release()
-  const versionParts = winVersion.split('.')
+  // First, determine that we are running Windows 10
+  const winVersion = OS.release() // Of the form '10.x.x'
 
-  if (versionParts.length == 0 && /^[0-9]+$/.test(versionParts[0])) {
-    return false
-  }
-
-  const majorVersion = Number(versionParts[0])
-  if (majorVersion < 10) {
+  if (!winVersion.startsWith('10.')) {
     return false
   }
 

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -40,6 +40,7 @@ export enum Shell {
   Hyper = 'Hyper',
   GitBash = 'Git Bash',
   Wsl = 'WSL',
+  WslBash = 'WSL Bash',
 }
 ```
 

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -28,6 +28,7 @@ These shells are currently supported:
  - [PowerShell Core](https://github.com/powershell/powershell/)
  - [Hyper](https://hyper.sh/)
  - Git Bash (from [Git for Windows](https://git-for-windows.github.io/))
+ - Windows Subsystem for Linux
 
 These are defined in an enum at the top of the file:
 
@@ -38,6 +39,7 @@ export enum Shell {
   PowerShellCore = 'PowerShell Core',
   Hyper = 'Hyper',
   GitBash = 'Git Bash',
+  Wsl = 'WSL',
 }
 ```
 


### PR DESCRIPTION
Fixes #4641

Currently I'm relying on `C:\Windows\System32` being on the path (reasonable assumption :wink:) because passing `C:\Windows\System32\wsl.exe` to `spawn` doesn't seem to actually launch anything (same for `bash.exe`).