### PR TITLE
attach scopes associated with account when refreshing

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -231,15 +231,15 @@ function toGitHubIsoDateString(date: Date) {
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
-type UserWithTokenScopes = {
+interface IUserWithTokenScopes {
   /**
    * The details associated with the current user
    */
-  user: IAPIUser
+  readonly user: IAPIUser
   /**
    * The list of scopes assigned to the current token
    */
-  scopes: ReadonlyArray<string>
+  readonly scopes: ReadonlyArray<string>
 }
 
 /**
@@ -291,7 +291,7 @@ export class API {
   }
 
   /** Fetch the logged in account and the current scopes associated with the token. */
-  public async fetchAccount(): Promise<UserWithTokenScopes> {
+  public async fetchAccount(): Promise<IUserWithTokenScopes> {
     try {
       const response = await this.request('GET', 'user')
       const user = await parsedResponse<IAPIUser>(response)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -182,7 +182,6 @@ interface IAPIAccessToken {
 /** The partial server response when creating a new authorization on behalf of a user */
 interface IAPIAuthorization {
   readonly token: string
-  readonly scopes: ReadonlyArray<string>
 }
 
 /** The response we receive from fetching mentionables. */
@@ -233,7 +232,13 @@ function toGitHubIsoDateString(date: Date) {
 }
 
 type UserWithTokenScopes = {
+  /**
+   * The details associated with the current user
+   */
   user: IAPIUser
+  /**
+   * The list of scopes assigned to the current token
+   */
   scopes: ReadonlyArray<string>
 }
 

--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -43,6 +43,7 @@ interface IAccount {
   readonly avatarURL: string
   readonly id: number
   readonly name: string
+  readonly scopes?: ReadonlyArray<string>
 }
 
 /** The store for logged in accounts. */
@@ -182,7 +183,8 @@ export class AccountsStore extends BaseStore {
         account.emails,
         account.avatarURL,
         account.id,
-        account.name
+        account.name,
+        account.scopes || []
       )
 
       const key = getKeyForAccount(accountWithoutToken)

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -8,7 +8,7 @@ import { getDotComAPIEndpoint, IAPIEmail } from '../lib/api'
 export class Account {
   /** Create an account which can be used to perform unauthenticated API actions */
   public static anonymous(): Account {
-    return new Account('', getDotComAPIEndpoint(), '', [], '', -1, '')
+    return new Account('', getDotComAPIEndpoint(), '', [], '', -1, '', [])
   }
 
   public constructor(
@@ -25,7 +25,9 @@ export class Account {
     /** The database id for this account */
     public readonly id: number,
     /** The friendly name associated with this account */
-    public readonly name: string
+    public readonly name: string,
+    /** The OAuth scopes associated with the token */
+    public readonly scopes: ReadonlyArray<string>
   ) {}
 
   public withToken(token: string): Account {
@@ -36,7 +38,8 @@ export class Account {
       this.emails,
       this.avatarURL,
       this.id,
-      this.name
+      this.name,
+      this.scopes
     )
   }
 }

--- a/app/test/unit/accounts-store-test.ts
+++ b/app/test/unit/accounts-store-test.ts
@@ -17,7 +17,7 @@ describe('AccountsStore', () => {
     it('contains the added user', async () => {
       const newAccountLogin = 'joan'
       await accountsStore!.addAccount(
-        new Account(newAccountLogin, '', 'deadbeef', [], '', 1, '')
+        new Account(newAccountLogin, '', 'deadbeef', [], '', 1, '', [])
       )
 
       const users = await accountsStore!.getAll()

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -10,7 +10,16 @@ describe('repository-matching', () => {
   describe('matchGitHubRepository', () => {
     it('matches HTTPS URLs', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          []
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -22,7 +31,16 @@ describe('repository-matching', () => {
 
     it('matches HTTPS URLs without the git extension', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          []
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -34,7 +52,16 @@ describe('repository-matching', () => {
 
     it('matches git URLs', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          []
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -46,7 +73,16 @@ describe('repository-matching', () => {
 
     it('matches SSH URLs', () => {
       const accounts = [
-        new Account('alovelace', 'https://api.github.com', '', [], '', 1, ''),
+        new Account(
+          'alovelace',
+          'https://api.github.com',
+          '',
+          [],
+          '',
+          1,
+          '',
+          []
+        ),
       ]
       const repo = matchGitHubRepository(
         accounts,
@@ -65,7 +101,8 @@ describe('repository-matching', () => {
           [],
           '',
           1,
-          ''
+          '',
+          []
         ),
       ]
       const repo = matchGitHubRepository(


### PR DESCRIPTION
This is a bit of groundwork that I uncovered when implementing SSH troubleshooting, and it helps the application to answer this simple question: **what permissions does a token currently have?**

This doesn't cover the actual re-authentication flow, because it will require the user to sign in again and it'd be nice to fit this in around the workflow they're currently performing. If they were using the webflow to sign in, they'd be greeted with a dialog like this: 

<img width="573" src="https://user-images.githubusercontent.com/359239/39905007-7b5db758-551e-11e8-99da-b336a9af10dc.png">

I've marked this as `infrastructure` because there's no user-facing changes in here.