### PR TITLE
improved SSH diagnostics

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "moment": "^2.17.1",
     "mri": "^1.1.0",
     "primer-support": "^4.0.0",
+    "process-exists": "^3.1.0",
     "queue": "^4.4.2",
     "react": "^16.2.0",
     "react-addons-shallow-compare": "^15.6.2",

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -208,6 +208,7 @@ export enum PopupType {
   LFSAttributeMismatch,
   UpstreamAlreadyExists,
   DeletePullRequest,
+  TroubleshootSSH,
 }
 
 export type Popup =
@@ -281,6 +282,10 @@ export type Popup =
       repository: Repository
       branch: Branch
       pullRequest: PullRequest
+    }
+  | {
+      type: PopupType.TroubleshootSSH
+      repository: Repository
     }
 
 export enum FoldoutType {

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -245,6 +245,45 @@ export async function pushNeedsPullHandler(
   return error
 }
 
+export async function sshAuthenticationErrorHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (!dugiteError) {
+    return error
+  }
+
+  const repository = e.metadata.repository
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+
+  if (
+    dugiteError === DugiteError.SSHAuthenticationFailed ||
+    dugiteError === DugiteError.SSHPermissionDenied ||
+    dugiteError === DugiteError.SSHRepositoryNotFound
+  ) {
+    dispatcher.showPopup({
+      type: PopupType.TroubleshootSSH,
+      repository,
+    })
+    return null
+  }
+
+  return error
+}
+
 /**
  * Handler for when we attempt to install the global LFS filters and LFS throws
  * an error.

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -39,3 +39,8 @@ export function enableMergeTool(): boolean {
 export function enableCompareSidebar(): boolean {
   return true
 }
+
+/** Should Desktop use the new troubleshooting flow */
+export function enableSSHTroubleshooting(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/find-executable.ts
+++ b/app/src/lib/find-executable.ts
@@ -1,0 +1,67 @@
+import { spawn } from 'child_process'
+import * as Path from 'path'
+
+export function findExecutableOnPath(
+  executableName: string
+): Promise<string | null> {
+  // adapted from http://stackoverflow.com/a/34953561/1363815
+  if (__WIN32__) {
+    return new Promise<string | null>((resolve, reject) => {
+      const windowsRoot = process.env.SystemRoot || 'C:\\Windows'
+      const wherePath = Path.join(windowsRoot, 'System32', 'where.exe')
+
+      const stdoutChunks = new Array<Buffer>()
+      let totalStdoutLength = 0
+
+      const cp = spawn(wherePath, [executableName])
+
+      cp.stdout.on('data', (chunk: Buffer) => {
+        stdoutChunks.push(chunk)
+        totalStdoutLength += chunk.length
+      })
+
+      cp.on('error', error => {
+        log.warn('Unable to spawn where.exe', error)
+        resolve(null)
+      })
+
+      // `where` will return 0 when the executable
+      // is found under PATH, or 1 if it cannot be found
+      cp.on('close', function(code) {
+        if (code === 0) {
+          const stdout = Buffer.concat(stdoutChunks, totalStdoutLength)
+          resolve(stdout.toString().trim())
+        } else {
+          resolve(null)
+        }
+      })
+    })
+  }
+
+  if (__LINUX__ || __DARWIN__) {
+    return new Promise<string | null>((resolve, reject) => {
+      const cp = spawn('which', [executableName])
+
+      const stdoutChunks = new Array<Buffer>()
+      let totalStdoutLength = 0
+
+      cp.stdout.on('data', (chunk: Buffer) => {
+        stdoutChunks.push(chunk)
+        totalStdoutLength += chunk.length
+      })
+
+      // `which` will return 0 when the executable
+      // is found under PATH, or 1 if it cannot be found
+      cp.on('close', function(code) {
+        if (code === 0) {
+          const stdout = Buffer.concat(stdoutChunks, totalStdoutLength)
+          resolve(stdout.toString().trim())
+        } else {
+          resolve(null)
+        }
+      })
+    })
+  }
+
+  return Promise.resolve(null)
+}

--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -1,5 +1,4 @@
-import { spawn } from 'child_process'
-import * as Path from 'path'
+import { findExecutableOnPath } from './find-executable'
 
 export function isGitOnPath(): Promise<boolean> {
   // Modern versions of macOS ship with a Git shim that guides you through
@@ -9,39 +8,5 @@ export function isGitOnPath(): Promise<boolean> {
     return Promise.resolve(true)
   }
 
-  // adapted from http://stackoverflow.com/a/34953561/1363815
-  if (__WIN32__) {
-    return new Promise<boolean>((resolve, reject) => {
-      const windowsRoot = process.env.SystemRoot || 'C:\\Windows'
-      const wherePath = Path.join(windowsRoot, 'System32', 'where.exe')
-
-      const cp = spawn(wherePath, ['git'])
-
-      cp.on('error', error => {
-        log.warn('Unable to spawn where.exe', error)
-        resolve(false)
-      })
-
-      // `where` will return 0 when the executable
-      // is found under PATH, or 1 if it cannot be found
-      cp.on('close', function(code) {
-        resolve(code === 0)
-      })
-      return
-    })
-  }
-
-  if (__LINUX__) {
-    return new Promise<boolean>((resolve, reject) => {
-      const process = spawn('which', ['git'])
-
-      // `which` will return 0 when the executable
-      // is found under PATH, or 1 if it cannot be found
-      process.on('close', function(code) {
-        resolve(code === 0)
-      })
-    })
-  }
-
-  return Promise.resolve(false)
+  return findExecutableOnPath('git').then(value => value !== null)
 }

--- a/app/src/lib/ssh/index.ts
+++ b/app/src/lib/ssh/index.ts
@@ -1,0 +1,1 @@
+export * from './troubleshooting-log'

--- a/app/src/lib/ssh/ssh-environment.ts
+++ b/app/src/lib/ssh/ssh-environment.ts
@@ -1,0 +1,87 @@
+import * as Path from 'path'
+import { enumerateValues, HKEY, RegistryValueType } from 'registry-js'
+import { pathExists } from 'fs-extra'
+
+import { findExecutableOnPath } from '../find-executable'
+import { getPathSegments } from '../process/win32'
+
+async function findGitForWindowsInstall(): Promise<string | null> {
+  const registryPath = enumerateValues(
+    HKEY.HKEY_LOCAL_MACHINE,
+    'SOFTWARE\\GitForWindows'
+  )
+
+  if (registryPath.length === 0) {
+    return null
+  }
+
+  const installPathEntry = registryPath.find(e => e.name === 'InstallPath')
+  if (installPathEntry && installPathEntry.type === RegistryValueType.REG_SZ) {
+    const path = Path.join(installPathEntry.data, 'git-bash.exe')
+
+    if (await pathExists(path)) {
+      return installPathEntry.data
+    } else {
+      log.debug(
+        `[hasGitForWindowsInstall] registry entry found but git-bash.exe does not exist at '${path}'`
+      )
+    }
+  }
+
+  return null
+}
+
+async function appendToPath(directory: string) {
+  const paths = await getPathSegments()
+  const updatedPaths = [...paths, directory]
+  const path = updatedPaths.join(';')
+
+  const env = Object.assign({}, process.env, { path })
+
+  if (env.Path != null) {
+    // this is a stupid win32 hack because `Path` and `path` are distinct keys
+    // on a Javascript hash, but Windows will choose Path and ignore the other value
+    delete env.Path
+  }
+
+  return env
+}
+
+export async function getSSHEnvironment(executable: string) {
+  // don't even bother checking for macOS as it should be there by default
+  if (__DARWIN__) {
+    return process.env
+  }
+
+  const path = await findExecutableOnPath(executable)
+  if (path != null) {
+    log.debug(
+      `[getSSHEnvironment] found ${executable} on PATH, no need to tweak the environment`
+    )
+    return process.env
+  }
+
+  if (__LINUX__) {
+    log.warn(
+      '[getSSHEnvironment] TODO: what should we be doing for the Linux support?'
+    )
+    return process.env
+  }
+
+  const foundGitInstall = await findGitForWindowsInstall()
+  if (foundGitInstall != null) {
+    const pathToSSHTools = Path.join(foundGitInstall, 'usr', 'bin')
+    return appendToPath(pathToSSHTools)
+  }
+
+  const localGitDir = process.env['LOCAL_GIT_DIRECTORY']
+  if (localGitDir != null) {
+    const pathToSSHTools = Path.join(localGitDir, 'usr', 'bin')
+    return appendToPath(pathToSSHTools)
+  }
+
+  log.warn(
+    '[getSSHEnvironment] unable to find path to the embedded Git installation'
+  )
+  return process.env
+}

--- a/app/src/lib/ssh/ssh-interop.ts
+++ b/app/src/lib/ssh/ssh-interop.ts
@@ -1,0 +1,78 @@
+import { spawn, SpawnOptions } from 'child_process'
+import { getSSHEnvironment } from './ssh-environment'
+
+const processExists = require('process-exists')
+
+type ProcessOutput = {
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+}
+
+function spawnAndComplete(
+  command: string,
+  args: string[],
+  options?: SpawnOptions
+): Promise<ProcessOutput> {
+  return new Promise<ProcessOutput>((resolve, reject) => {
+    const cp = spawn(command, args, options)
+    let totalStdoutLength = 0
+    const stdoutChunks = new Array<Buffer>()
+    cp.stdout.on('data', (chunk: Buffer) => {
+      stdoutChunks.push(chunk)
+      totalStdoutLength += chunk.length
+    })
+
+    let totalStderrLength = 0
+    const stderrChunks = new Array<Buffer>()
+    cp.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk)
+      totalStderrLength += chunk.length
+    })
+
+    cp.on('error', err => {
+      // for unhandled errors raised by the process, let's surface this in the
+      // promise and make the caller handle it
+      reject(err)
+    })
+
+    cp.on('close', (exitCode, signal) => {
+      const stdout = Buffer.concat(stdoutChunks, totalStdoutLength).toString()
+      const stderr = Buffer.concat(stderrChunks, totalStderrLength).toString()
+
+      resolve({
+        exitCode,
+        stdout,
+        stderr,
+      })
+    })
+  })
+}
+
+export async function isSSHAgentRunning(): Promise<boolean> {
+  const running: boolean = await processExists(
+    __WIN32__ ? 'ssh-agent.exe' : 'ssh-agent'
+  )
+  return running
+}
+
+export async function listIdentities(): Promise<ProcessOutput> {
+  return spawnAndComplete('ssh-add', ['-L'])
+}
+
+export function listEnvironmentVariables(): string {
+  return `SSH_AUTH_SOCK=${process.env.SSH_AUTH_SOCK}
+SSH_AGENT_PID=${process.env.SSH_AGENT_PID}`
+}
+
+export async function testSSHConnection(
+  sshUrl: string
+): Promise<ProcessOutput> {
+  const command = 'ssh'
+  const env = await getSSHEnvironment(command)
+  return spawnAndComplete(
+    command,
+    ['-Tv', '-o', `StrictHostKeyChecking=yes`, sshUrl],
+    { env }
+  )
+}

--- a/app/src/lib/ssh/troubleshooting-log.ts
+++ b/app/src/lib/ssh/troubleshooting-log.ts
@@ -4,16 +4,61 @@ import * as moment from 'moment'
 
 import { Repository } from '../../models/repository'
 
-export function generateSSHTroubleshootingLog(
+import { parseRemote } from '../remote-parsing'
+import { getRemotes } from '../git'
+
+import {
+  listEnvironmentVariables,
+  isSSHAgentRunning,
+  listIdentities,
+  testSSHConnection,
+} from './ssh-interop'
+
+export async function generateSSHTroubleshootingLog(
   repository: Repository
 ): Promise<string> {
-  // TODO: - check if ssh-agent is running
-  //       - if not found, Git is not likely to work
+  const remotes = await getRemotes(repository)
 
-  // TODO: - get current environment variables
-  //       - if not found, Git is not likely to work
+  const sshRemoteHosts: Array<string> = []
+  for (const remote of remotes) {
+    const gitRemote = parseRemote(remote.url)
+    if (gitRemote != null && gitRemote.protocol === 'ssh') {
+      sshRemoteHosts.push(gitRemote.hostname)
+    }
+  }
 
-  return Promise.resolve('oops')
+  const sshUrl = `git@${sshRemoteHosts[0]}`
+
+  const sshAgentRunning = await isSSHAgentRunning()
+
+  const firstSection = sshAgentRunning
+    ? 'ssh-agent process is running'
+    : 'ssh-agent process is NOT running'
+  const secondSection = listEnvironmentVariables()
+  const identitiesResult = await listIdentities()
+  const connectResult = await testSSHConnection(sshUrl)
+
+  const output = `# SSH Troubleshooting
+
+## ssh-agent
+${firstSection}
+
+## environment variables
+${secondSection}
+
+## identities
+stdout:
+${identitiesResult.stdout}
+stderr:
+${identitiesResult.stderr}
+
+## ssh test
+stdout:
+${connectResult.stdout}
+stderr:
+${connectResult.stderr}
+`
+  return output
 }
 
 export function saveLogFile(contents: string) {

--- a/app/src/lib/ssh/troubleshooting-log.ts
+++ b/app/src/lib/ssh/troubleshooting-log.ts
@@ -1,0 +1,43 @@
+import { remote } from 'electron'
+import { writeFile } from 'fs'
+import * as moment from 'moment'
+
+import { Repository } from '../../models/repository'
+
+export function generateSSHTroubleshootingLog(
+  repository: Repository
+): Promise<string> {
+  // TODO: - check if ssh-agent is running
+  //       - if not found, Git is not likely to work
+
+  // TODO: - get current environment variables
+  //       - if not found, Git is not likely to work
+
+  return Promise.resolve('oops')
+}
+
+export function saveLogFile(contents: string) {
+  const timestamp = moment().format('YYYYMMDD-HHmmss')
+  const defaultPath = `ssh-output-${timestamp}.txt`
+
+  return new Promise<void>((resolve, reject) => {
+    // TODO: null should be a valid argument here
+    const window: any = null
+    remote.dialog.showSaveDialog(window, { defaultPath }, filename => {
+      if (filename == null) {
+        log.warn(
+          'TODO: filename returned null, this needs to be in the signature'
+        )
+        resolve()
+      } else {
+        writeFile(filename, contents, err => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+      }
+    })
+  })
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -83,6 +83,7 @@ import { CLIInstalled } from './cli-installed'
 import { GenericGitAuthentication } from './generic-git-auth'
 import { ShellError } from './shell'
 import { InitializeLFS, AttributeMismatch } from './lfs'
+import { TroubleshootSSH } from './ssh'
 import { UpstreamAlreadyExists } from './upstream-already-exists'
 import { DeletePullRequest } from './delete-branch/delete-pull-request-dialog'
 
@@ -1204,6 +1205,13 @@ export class App extends React.Component<IAppProps, IAppState> {
             repositories={popup.repositories}
             onDismissed={this.onPopupDismissed}
             onInitialize={this.initializeLFS}
+          />
+        )
+      case PopupType.TroubleshootSSH:
+        return (
+          <TroubleshootSSH
+            repository={popup.repository}
+            onDismissed={this.onPopupDismissed}
           />
         )
       case PopupType.LFSAttributeMismatch:

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -13,6 +13,7 @@ import {
   externalEditorErrorHandler,
   openShellErrorHandler,
   lfsAttributeMismatchHandler,
+  sshAuthenticationErrorHandler,
   defaultErrorHandler,
   missingRepositoryHandler,
   backgroundTaskHandler,
@@ -49,6 +50,8 @@ import {
   enableSourceMaps,
   withSourceMappedStack,
 } from '../lib/source-map-support'
+
+import { enableSSHTroubleshooting } from '../lib/feature-flag'
 
 if (__DEV__) {
   installDevGlobals()
@@ -139,6 +142,9 @@ dispatcher.registerErrorHandler(upstreamAlreadyExistsHandler)
 dispatcher.registerErrorHandler(externalEditorErrorHandler)
 dispatcher.registerErrorHandler(openShellErrorHandler)
 dispatcher.registerErrorHandler(lfsAttributeMismatchHandler)
+if (enableSSHTroubleshooting()) {
+  dispatcher.registerErrorHandler(sshAuthenticationErrorHandler)
+}
 dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)

--- a/app/src/ui/ssh/index.ts
+++ b/app/src/ui/ssh/index.ts
@@ -1,0 +1,1 @@
+export * from './troubleshoot-ssh'

--- a/app/src/ui/ssh/troubleshoot-ssh.tsx
+++ b/app/src/ui/ssh/troubleshoot-ssh.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+
+import { Welcome } from './welcome'
+
+interface ITroubleshootSSHProps {
+  readonly repository: Repository
+  readonly onDismissed: () => void
+}
+
+export class TroubleshootSSH extends React.Component<
+  ITroubleshootSSHProps,
+  {}
+> {
+  public render() {
+    return (
+      <Welcome
+        repository={this.props.repository}
+        onDismissed={this.props.onDismissed}
+      />
+    )
+  }
+}

--- a/app/src/ui/ssh/welcome.tsx
+++ b/app/src/ui/ssh/welcome.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Loading } from '../lib/loading'
+import { generateSSHTroubleshootingLog, saveLogFile } from '../../lib/ssh'
+import { Octicon, OcticonSymbol } from '../octicons'
+
+interface IWelcomeProps {
+  readonly repository: Repository
+  readonly onDismissed: () => void
+}
+
+interface IWelcomeState {
+  readonly isLoading: boolean
+}
+
+export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
+  public constructor(props: IWelcomeProps) {
+    super(props)
+
+    this.state = { isLoading: false }
+  }
+
+  private startTroubleshooting = async () => {
+    this.setState({ isLoading: true })
+
+    const contents = await generateSSHTroubleshootingLog(this.props.repository)
+    await saveLogFile(contents)
+
+    this.setState({ isLoading: false })
+  }
+
+  public render() {
+    const disabled = this.state.isLoading
+
+    return (
+      <Dialog
+        id="troubleshoot-ssh"
+        title="Troubleshoot SSH Authentication"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.startTroubleshooting}
+      >
+        <DialogContent>
+          <p>
+            It looks like you are having an issue connecting to an SSH remote.
+          </p>
+          <p>
+            You can generate a log file about the details of your setup to help
+            with troubleshooting.
+          </p>
+        </DialogContent>
+        <DialogFooter>
+          <ButtonGroup>
+            <Button type="submit" disabled={disabled}>
+              {this.state.isLoading ? (
+                <Loading />
+              ) : (
+                <Octicon symbol={OcticonSymbol.desktopDownload} />
+              )}{' '}
+              Troubleshoot
+            </Button>
+            <Button onClick={this.props.onDismissed}>Cancel</Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -111,6 +111,25 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+buffer-alloc-unsafe@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz#ffe1f67551dd055737de253337bfe853dfab1a6a"
+
+buffer-alloc@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.1.0.tgz#05514d33bf1656d3540c684f65b1202e90eca303"
+  dependencies:
+    buffer-alloc-unsafe "^0.1.0"
+    buffer-fill "^0.1.0"
+
+buffer-fill@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-0.1.1.tgz#76d825c4d6e50e06b7a31eb520c04d08cc235071"
+
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -191,7 +210,7 @@ core-js@^2.4.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
-core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
@@ -211,6 +230,18 @@ cryptiles@3.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
   dependencies:
     boom "5.x.x"
+
+csv-parser@^1.6.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/csv-parser/-/csv-parser-1.12.1.tgz#391e1ef961b1f9dcb4c7c0f82eb450a1bd916158"
+  dependencies:
+    buffer-alloc "^1.1.0"
+    buffer-from "^1.0.0"
+    generate-function "^1.0.1"
+    generate-object-property "^1.0.0"
+    inherits "^2.0.1"
+    minimist "^1.2.0"
+    ndjson "^1.4.0"
 
 cycle@1.0.x:
   version "1.0.3"
@@ -399,6 +430,13 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs-extra@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.0.tgz#0f0afb290bb3deb87978da816fcd3c7797f3a817"
@@ -420,6 +458,23 @@ fs.realpath@^1.0.0:
 fuzzaldrin-plus@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz#832f6489fbe876769459599c914a670ec22947ee"
+
+generate-function@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-1.1.0.tgz#54c21b080192b16d9877779c5bb81666e772365f"
+
+generate-object-property@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  dependencies:
+    is-property "^1.0.0"
+
+get-stream@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -501,9 +556,19 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.0:
+inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+into-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-2.0.1.tgz#db9b003694453eae091d8a5c84cc11507b781d31"
+  dependencies:
+    from2 "^2.1.1"
+
+is-property@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -512,6 +577,10 @@ is-stream@^1.0.1, is-stream@^1.1.0:
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -544,7 +613,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -632,6 +701,10 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
 minipass@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.1.tgz#5ada97538b1027b4cf7213432428578cb564011f"
@@ -673,6 +746,23 @@ nan@2.x:
 nan@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+
+ndjson@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ndjson/-/ndjson-1.5.0.tgz#ae603b36b134bcec347b452422b0bf98d5832ec8"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    minimist "^1.2.0"
+    split2 "^2.1.0"
+    through2 "^2.0.3"
+
+neat-csv@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/neat-csv/-/neat-csv-2.1.0.tgz#06f58360c4c3b955bd467ddc85ae4511a3907a4c"
+  dependencies:
+    csv-parser "^1.6.0"
+    get-stream "^2.1.0"
+    into-stream "^2.0.0"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -723,9 +813,37 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
+pify@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
 primer-support@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/primer-support/-/primer-support-4.3.0.tgz#c470fef8c0bff2ec8a771a0749783c2b388118fe"
+
+process-exists@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/process-exists/-/process-exists-3.1.0.tgz#86cae049e1e7b51382690ec9fd8dfd74ff7a17c8"
+  dependencies:
+    ps-list "^4.0.0"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 progress@^2.0.0:
   version "2.0.0"
@@ -744,6 +862,13 @@ prop-types@^15.5.6, prop-types@^15.6.0:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+ps-list@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-4.1.0.tgz#8ffd6434add37f9dd1a9f19ab1beb42c9db60dae"
+  dependencies:
+    pify "^3.0.0"
+    tasklist "^3.1.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -812,6 +937,18 @@ react@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+readable-stream@^2.0.0, readable-stream@^2.1.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
@@ -869,6 +1006,14 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+sec@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sec/-/sec-1.0.0.tgz#033d60a3ad20ecf2e00940d14f97823465774335"
+
 semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -893,6 +1038,12 @@ source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+split2@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
+  dependencies:
+    through2 "^2.0.2"
+
 sshpk@^1.7.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
@@ -910,6 +1061,12 @@ sshpk@^1.7.0:
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 stringstream@~0.0.5:
   version "0.0.5"
@@ -954,6 +1111,14 @@ tar@^4.0.2:
     mkdirp "^0.5.0"
     yallist "^3.0.2"
 
+tasklist@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tasklist/-/tasklist-3.1.0.tgz#873a98a4e45cbdecfa2c2ee18865353057e63696"
+  dependencies:
+    neat-csv "^2.1.0"
+    pify "^2.2.0"
+    sec "^1.0.0"
+
 temp@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
@@ -964,6 +1129,13 @@ temp@^0.8.3:
 textarea-caret@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/textarea-caret/-/textarea-caret-3.0.2.tgz#f360c48699aa1abf718680a43a31a850665c2caf"
+
+through2@^2.0.2, through2@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
 
 tough-cookie@~2.3.3:
   version "2.3.3"
@@ -999,6 +1171,10 @@ username@^2.3.0:
   dependencies:
     execa "^0.4.0"
     mem "^0.1.0"
+
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
 uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
@@ -1068,6 +1244,10 @@ wordwrap@~0.0.2:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+xtend@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/docs/technical/ssh-troubleshooting.md
+++ b/docs/technical/ssh-troubleshooting.md
@@ -1,0 +1,122 @@
+# SSH Troubleshooting
+
+This document outlines how Desktop inspects the SSH setup to address a number
+of common issues.
+
+## Host Key Verification
+
+As part of initializing the SSH connection, `ssh` will check that it knows
+and trusts the server it is connnecting to. When connecting to an unknown
+host, `ssh` will prompt to ask if you wish to trust this server:
+
+```shellsession
+$ git fetch --progress --prune origin
+The authenticity of host 'github.com (192.30.255.112)' can't be established.
+RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
+Are you sure you want to continue connecting (yes/no)?
+```
+
+Desktop currently doesn't have a way to support interactive processes like
+this, so we need to hook into some configuration options and manually add this
+to the known hosts file that SSH uses.
+
+To avoid the interactive prompt, adding `StrictHostKeyChecking=yes` as an
+option to `ssh` ensures that the Git operation will fail rather than hang
+waiting for user input:
+
+```shellsession
+$ ssh -o StrictHostKeyChecking=yes git@github.com
+```
+
+To trust a new server, you can use `ssh-keygen`:
+
+```shellsession
+$ ssh-keygen github.com >> ~/.ssh/known_hosts
+```
+
+This isn't currently available in `dugite`, but we can leverage either the
+OpenSSH environment that comes with Windows 10 Fall Creators Update (should
+be on `PATH`) or the version that comes with Git for Windows (need to add to
+`PATH`). macOS should have a working SSH setup by default, Linux will likely be
+in trouble if it's not on `PATH`.
+
+## The `ssh-agent` process
+
+The `ssh-agent` process is important to the SSH connection process, and needs
+to be running for the current user to handle SSH authentication on the local
+machine.
+
+If no running `ssh-agent` process is found, Desktop could launch it's own
+instance of the process and ensure it is killed when Desktop exits. *This is
+currently out of scope for the proof-of-concept.*
+
+As part of launching the `ssh-agent` process, it has a number of environment
+variables that help other tools integrate with it:
+
+```shellsession
+$ ssh-agent -s
+SSH_AUTH_SOCK=/var/folders/dc/ww83254d73g8z6lc9y_msm9r0000gn/T//ssh-oerrG9QXPkWr/agent.15063; export SSH_AUTH_SOCK;
+SSH_AGENT_PID=15064; export SSH_AGENT_PID;
+echo Agent pid 15064;
+```
+
+Desktop needs to inspect these and pass them through to Git whenever it needs
+to do anything authentication-related.
+
+## Working with SSH keys
+
+After verifying the SSH server, and confirming a valid `ssh-agent` process is running,
+a valid public/private key pair is required that represents the identity of the user.
+
+We can see the existing keys by running `ssh-add l`:
+
+```
+$ ssh-all -l
+4096 SHA256:V+fJ7HbKo3UindVz0x2XlZcZDr5GAd3p4+Ex7NnCCBI /Users/shiftkey/.ssh/id_rsa_new (RSA)
+```
+
+I'm not aware of any CLI tools for identifying available SSH keys, but we can assume
+with a good degree of confidence that we have pairs of files at `~/.ssh`:
+
+```
+$ ls ~/.ssh/
+id_rsa         id_rsa.pub     id_rsa_new     id_rsa_new.pub known_hosts
+```
+
+Desktop could list these in the application so that a user may add them to the `ssh-agent`
+process.
+
+We can glean some identity information from the public key file - an email address that
+was used when it was created - and the name of the file. This should be enough to help
+the user identify the right key to add.
+
+We can tell if a private key requires a passphrase by the header contents. Here's a key
+that doesn't require a passphrase:
+
+```
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEA3qKD/4PAc6PMb1yCckTduFl5fA1OpURLR5Z+T4xY1JQt3eTM
+```
+
+And this is the header of a key that requires a passphrase:
+
+```
+-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-EDE3-CBC,556C1115CDA822F5
+
+AHi/3++6PEIBv4kfpM57McyoSAAaT2ECxNOA5DRKxJQ9pr2D3aUeMBaBfWGrxd/Q
+```
+
+## Creating a new public/private key pair
+
+If no suitable keys are found, the user should be able to create a new SSH key. This
+can be done from the command line:
+
+```
+ssh-keygen -q -b 4096 -t rsa -N new_passphrase -f output_keyfile
+```
+
+Desktop should use a naming convention to make it clear that it was the source of the key,
+to ensure it doesn't interfere with existing keys from other sources. Something
+like `~/.ssh/github_desktop_[login]` would be radical.


### PR DESCRIPTION
🌵🌵🌵 Depends on #4644 and #4619 🌵🌵🌵

This is a trimmed-down version of #4622 that focuses on better diagnostics - the work in #4622 was great to figure out more about the flow and make troubleshooting even easier, but it needs hardening and figuring out the re-authentication flow to upgrade tokens.

The new flow here is to simply show this dialog:

<img width="576" src="https://user-images.githubusercontent.com/359239/39919131-0a4c50aa-5556-11e8-8462-dd3d1a899e76.png">

Clicking `Troubleshoot` does some work behind the scenes and asks you to save the log file somewhere. This is what the log file contains:

```
# SSH Troubleshooting

## ssh-agent
ssh-agent process is running

## environment variables
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.wXtjjowfcp/Listeners
SSH_AGENT_PID=undefined

## identities
stdout:
The agent has no identities.

stderr:


## ssh test
stdout:

stderr:
OpenSSH_7.6p1, LibreSSL 2.6.2
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 48: Applying options for *
debug1: Connecting to github.com port 22.
...
```

This is currently only available in development mode behind a flag, so users need to opt into it.

 - [ ] test on macOS
 - [ ] test on Windows
 - [ ] test on Linux
 - [ ] rebase after dependent PRs have been merged