### PR TITLE
"Zero Is Not False" And Other Keyboard Adventures

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -442,7 +442,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
         this.canSelectRow
       )
 
-      if (row) {
+      if (row != null) {
         this.onRowClick(row)
       }
     }

--- a/app/src/ui/lib/list/selection.ts
+++ b/app/src/ui/lib/list/selection.ts
@@ -89,11 +89,6 @@ export function findNextSelectableRow(
   const { direction, row } = action
   const wrap = action.wrap === undefined ? true : action.wrap
 
-  // handle specific case from switching from filter text to list
-  if (direction === 'down' && row === -1) {
-    return 0
-  }
-
   // Ensure the row value is in the range between 0 and rowCount - 1
   //
   // If the row falls outside this range, use the direction
@@ -104,6 +99,14 @@ export function findNextSelectableRow(
   //
   let currentRow =
     row < 0 || row >= rowCount ? (direction === 'up' ? rowCount - 1 : 0) : row
+
+  // handle specific case from switching from filter text to list
+  //
+  // locking currentRow to [0,rowCount) above means that the below loops
+  // will skip over the first entry
+  if (direction === 'down' && row === -1) {
+    currentRow = -1
+  }
 
   const delta = direction === 'up' ? -1 : 1
 

--- a/app/src/ui/lib/list/selection.ts
+++ b/app/src/ui/lib/list/selection.ts
@@ -89,6 +89,11 @@ export function findNextSelectableRow(
   const { direction, row } = action
   const wrap = action.wrap === undefined ? true : action.wrap
 
+  // handle specific case from switching from filter text to list
+  if (direction === 'down' && row === -1) {
+    return 0
+  }
+
   // Ensure the row value is in the range between 0 and rowCount - 1
   //
   // If the row falls outside this range, use the direction

--- a/app/test/unit/list-selection-test.ts
+++ b/app/test/unit/list-selection-test.ts
@@ -4,12 +4,23 @@ import { findNextSelectableRow } from '../../src/ui/lib/list/selection'
 
 describe('list-selection', () => {
   describe('findNextSelectableRow', () => {
-    it('returns first row when selecting down from outside range', () => {
-      const selectedRow = findNextSelectableRow(2, {
+    const rowCount = 5
+
+    it('returns first row when selecting down', () => {
+      const lastRow = rowCount - 1
+      const selectedRow = findNextSelectableRow(rowCount, {
         direction: 'down',
-        row: -1,
+        row: lastRow,
       })
       expect(selectedRow).to.equal(0)
+    })
+
+    it('returns last row when selecting up from top', () => {
+      const selectedRow = findNextSelectableRow(rowCount, {
+        direction: 'up',
+        row: 0,
+      })
+      expect(selectedRow).to.equal(4)
     })
   })
 })

--- a/app/test/unit/list-selection-test.ts
+++ b/app/test/unit/list-selection-test.ts
@@ -6,7 +6,15 @@ describe('list-selection', () => {
   describe('findNextSelectableRow', () => {
     const rowCount = 5
 
-    it('returns first row when selecting down', () => {
+    it('returns first row when selecting down outside list (filter text)', () => {
+      const selectedRow = findNextSelectableRow(rowCount, {
+        direction: 'down',
+        row: -1,
+      })
+      expect(selectedRow).to.equal(0)
+    })
+
+    it('returns first row when selecting down from last row', () => {
       const lastRow = rowCount - 1
       const selectedRow = findNextSelectableRow(rowCount, {
         direction: 'down',
@@ -15,7 +23,7 @@ describe('list-selection', () => {
       expect(selectedRow).to.equal(0)
     })
 
-    it('returns last row when selecting up from top', () => {
+    it('returns last row when selecting up from top row', () => {
       const selectedRow = findNextSelectableRow(rowCount, {
         direction: 'up',
         row: 0,

--- a/app/test/unit/list-selection-test.ts
+++ b/app/test/unit/list-selection-test.ts
@@ -14,6 +14,24 @@ describe('list-selection', () => {
       expect(selectedRow).to.equal(0)
     })
 
+    it('returns first selectable row when header is first', () => {
+      const selectedRow = findNextSelectableRow(
+        rowCount,
+        {
+          direction: 'down',
+          row: -1,
+        },
+        row => {
+          if (row === 0) {
+            return false
+          } else {
+            return true
+          }
+        }
+      )
+      expect(selectedRow).to.equal(1)
+    })
+
     it('returns first row when selecting down from last row', () => {
       const lastRow = rowCount - 1
       const selectedRow = findNextSelectableRow(rowCount, {

--- a/app/test/unit/list-selection-test.ts
+++ b/app/test/unit/list-selection-test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai'
+
+import { findNextSelectableRow } from '../../src/ui/lib/list/selection'
+
+describe('list-selection', () => {
+  describe('findNextSelectableRow', () => {
+    it('returns first row when selecting down from outside range', () => {
+      const selectedRow = findNextSelectableRow(2, {
+        direction: 'down',
+        row: -1,
+      })
+      expect(selectedRow).to.equal(0)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #4673:

 - [x] enter when filtering now chooses the top (focused) selection
 - [x] can arrow/up down between the filter box and the PR list
 - [x] fix introduced regression in branch list where first row might be a header