### PR TITLE
add target branch to merge call-to-action

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -258,12 +258,12 @@ export class CompareSidebar extends React.Component<
           Merge into <strong>{this.props.currentBranch.name}</strong>
         </Button>
 
-        {this.renderMergeDetails(formState)}
+        {this.renderMergeDetails(formState, this.props.currentBranch)}
       </div>
     )
   }
 
-  private renderMergeDetails(formState: ICompareBranch) {
+  private renderMergeDetails(formState: ICompareBranch, currentBranch: Branch) {
     const branch = formState.comparisonBranch
     const count = formState.aheadBehind.behind
 
@@ -275,6 +275,8 @@ export class CompareSidebar extends React.Component<
           <strong>{` ${count} ${pluralized}`}</strong>
           {` `}from{` `}
           <strong>{branch.name}</strong>
+          {` `}into{` `}
+          <strong>{currentBranch.name}</strong>
         </div>
       )
     }


### PR DESCRIPTION
Fixes #4689

Before:

<img width="253"  src="https://user-images.githubusercontent.com/359239/40033785-3ec74882-583d-11e8-8544-f561c454065f.png">

After:

<img width="244" alt="screen shot 2018-05-15 at 12 40 36 pm" src="https://user-images.githubusercontent.com/359239/40033816-5da556d6-583d-11e8-8fef-32d00f569a89.png">

This is being tested with a long branch name and with the minimal width, to ensure this is readable.

At full width, this is what the new message looks like:

<img width="546" alt="screen shot 2018-05-15 at 12 42 34 pm" src="https://user-images.githubusercontent.com/359239/40033842-83368b40-583d-11e8-857b-1b4cbd180450.png">
