### PR TITLE
redirect to commit tab when merge conflicts found

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -208,6 +208,7 @@ export enum PopupType {
   LFSAttributeMismatch,
   UpstreamAlreadyExists,
   DeletePullRequest,
+  MergeConflicts,
 }
 
 export type Popup =
@@ -282,6 +283,7 @@ export type Popup =
       branch: Branch
       pullRequest: PullRequest
     }
+  | { type: PopupType.MergeConflicts; repository: Repository }
 
 export enum FoldoutType {
   Repository,

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -246,6 +246,50 @@ export async function pushNeedsPullHandler(
 }
 
 /**
+ * Handler for detecting when a merge conflict is reported to direct the user
+ * to a different dialog than the generic Git error dialog.
+ */
+export async function mergeConflictHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (!dugiteError) {
+    return error
+  }
+
+  if (dugiteError !== DugiteError.MergeConflicts) {
+    return error
+  }
+
+  const repository = e.metadata.repository
+  if (!repository) {
+    return error
+  }
+
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+
+  dispatcher.showPopup({
+    type: PopupType.MergeConflicts,
+    repository,
+  })
+
+  return null
+}
+
+/**
  * Handler for when we attempt to install the global LFS filters and LFS throws
  * an error.
  */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -85,6 +85,7 @@ import { ShellError } from './shell'
 import { InitializeLFS, AttributeMismatch } from './lfs'
 import { UpstreamAlreadyExists } from './upstream-already-exists'
 import { DeletePullRequest } from './delete-branch/delete-pull-request-dialog'
+import { MergeConflictsWarning } from './merge-conflicts'
 
 /** The interval at which we should check for updates. */
 const UpdateCheckInterval = 1000 * 60 * 60 * 4
@@ -1232,6 +1233,14 @@ export class App extends React.Component<IAppProps, IAppState> {
             branch={popup.branch}
             onDismissed={this.onPopupDismissed}
             pullRequest={popup.pullRequest}
+          />
+        )
+      case PopupType.MergeConflicts:
+        return (
+          <MergeConflictsWarning
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            onDismissed={this.onPopupDismissed}
           />
         )
       default:

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -12,6 +12,7 @@ import {
   gitAuthenticationErrorHandler,
   externalEditorErrorHandler,
   openShellErrorHandler,
+  mergeConflictHandler,
   lfsAttributeMismatchHandler,
   defaultErrorHandler,
   missingRepositoryHandler,
@@ -138,6 +139,7 @@ dispatcher.registerErrorHandler(defaultErrorHandler)
 dispatcher.registerErrorHandler(upstreamAlreadyExistsHandler)
 dispatcher.registerErrorHandler(externalEditorErrorHandler)
 dispatcher.registerErrorHandler(openShellErrorHandler)
+dispatcher.registerErrorHandler(mergeConflictHandler)
 dispatcher.registerErrorHandler(lfsAttributeMismatchHandler)
 dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)

--- a/app/src/ui/merge-conflicts/index.ts
+++ b/app/src/ui/merge-conflicts/index.ts
@@ -1,0 +1,1 @@
+export * from './merge-conflicts-warning'

--- a/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dispatcher } from '../../lib/dispatcher'
+import { RepositorySection } from '../../lib/app-state'
+import { Repository } from '../../models/repository'
+
+interface IMergeConflictsWarningProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly onDismissed: () => void
+}
+
+export class MergeConflictsWarning extends React.Component<
+  IMergeConflictsWarningProps,
+  {}
+> {
+  private onSubmit = () => {
+    this.props.dispatcher.changeRepositorySection(
+      this.props.repository,
+      RepositorySection.Changes
+    )
+    this.props.onDismissed()
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="merge-conflicts-warning"
+        title={__DARWIN__ ? 'Merge Conflicts Found' : 'Merge conflicts found'}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+      >
+        <DialogContent>
+          <p>
+            Conflicts were detected as part of the last merge. You will need to
+            view and resolve these conflicts before creating the merge commit.
+          </p>
+        </DialogContent>
+
+        <DialogFooter>
+          <ButtonGroup>
+            <Button type="submit">
+              {__DARWIN__ ? 'View Conflicts' : 'View conflicts'}
+            </Button>
+            <Button onClick={this.props.onDismissed}>
+              {__DARWIN__ ? 'Cancel' : 'Cancel'}
+            </Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
@@ -35,8 +35,8 @@ export class MergeConflictsWarning extends React.Component<
         <DialogContent>
           <p>Conflicts were detected as part of the last merge operation.</p>
           <p>
-            You will need to view and resolve these conflicts before finishing
-            and creating the merge commit.
+            You will need to view and resolve these conflicts via your editor or
+            shell before finishing and creating the merge commit.
           </p>
         </DialogContent>
 

--- a/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
@@ -45,9 +45,7 @@ export class MergeConflictsWarning extends React.Component<
             <Button type="submit">
               {__DARWIN__ ? 'View Conflicts' : 'View conflicts'}
             </Button>
-            <Button onClick={this.props.onDismissed}>
-              {__DARWIN__ ? 'Cancel' : 'Cancel'}
-            </Button>
+            <Button onClick={this.props.onDismissed}>Close</Button>
           </ButtonGroup>
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
@@ -33,9 +33,10 @@ export class MergeConflictsWarning extends React.Component<
         onSubmit={this.onSubmit}
       >
         <DialogContent>
+          <p>Conflicts were detected as part of the last merge operation.</p>
           <p>
-            Conflicts were detected as part of the last merge. You will need to
-            view and resolve these conflicts before creating the merge commit.
+            You will need to view and resolve these conflicts before finishing
+            and creating the merge commit.
           </p>
         </DialogContent>
 


### PR DESCRIPTION

Fixes #4686 

Before:

![merge-conflicts-before](https://user-images.githubusercontent.com/359239/40035300-65f68056-5844-11e8-869c-4715051ef714.gif)

After:

![merge-conflicts-after](https://user-images.githubusercontent.com/359239/40035299-65c6b498-5844-11e8-9b4a-c1049073fc38.gif)

Open to feedback for improvements to the copy and dialog flow - I felt that having an explicit (and default) action to view the conflicts felt better than a single button.


