### PR TITLE
Remove "Discard All Changes..." from File Context Menu

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -272,10 +272,6 @@ export class ChangesList extends React.Component<
               : `Discard ${paths.length} selected changes…`,
         action: () => this.onDiscardChanges(paths),
       },
-      {
-        label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
-        action: () => this.onDiscardAllChanges(),
-      },
       { type: 'separator' },
     ]
 


### PR DESCRIPTION
Reasons:

- This makes it very easy to delete all your work by accident.
- The File Context Menu typically performs actions on a specific file, not on all Files.
- There is currently no undo to 'Discard All Changes...'
-  It does not say 'Discard Changes in All Files'

There is a Context Menu on The [{x} Changed Files] header which provides this same functionality, in a less confusing context.

