### PR TITLE
bring back the hover styles for the app menu

### DIFF
--- a/app/styles/ui/window/_app-menu-bar.scss
+++ b/app/styles/ui/window/_app-menu-bar.scss
@@ -42,5 +42,15 @@
       background: var(--background-color);
       pointer-events: all;
     }
+
+    .menu-item:hover {
+      &:not(.disabled) {
+        --text-color: var(--box-selected-active-text-color);
+        --text-secondary-color: var(--box-selected-active-text-color);
+
+        color: var(--text-color);
+        background-color: var(--box-selected-active-background-color);
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #4636

This was an unfortunate side-effect of #4188 but hasn't made it to `production` yet, so it doesn't need it's own release entry in the changelog.

Before:

![](https://user-images.githubusercontent.com/359239/40092675-e01c5640-5901-11e8-907a-1127a96c5c03.gif)

After:

![](https://user-images.githubusercontent.com/359239/40092760-68f7ebe6-5902-11e8-97dc-ad8af88420c2.gif)

~~I also uncovered a keyboard navigation issue in here while testing - I'll extract another issue with details for reproducing it.~~ EDIT: nevermind, I don't think this was related to the multi-select changes. Keeping an eye on this to see if I can nail down what's wrong with it - basically you can _sometimes_ make the menu disappear/lose focus when you expand the app menu and move left/right between menu items.
