### PR TITLE
blur branch selector when search text is cleared

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -132,6 +132,7 @@ export class CompareSidebar extends React.Component<
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}
+            onSearchCleared={this.onSearchCleared}
           />
         </div>
 
@@ -140,6 +141,14 @@ export class CompareSidebar extends React.Component<
           : this.renderCommits()}
       </div>
     )
+  }
+
+  private onSearchCleared = () => {
+    if (this.textbox != null) {
+      this.textbox.blur()
+    }
+
+    this.setState({ showBranchList: false })
   }
 
   private onBranchesListRef = (branchList: BranchList | null) => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -144,11 +144,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private onSearchCleared = () => {
-    if (this.textbox != null) {
-      this.textbox.blur()
-    }
-
-    this.setState({ showBranchList: false })
+    this.handleEscape()
   }
 
   private onBranchesListRef = (branchList: BranchList | null) => {

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -47,6 +47,7 @@ export class FancyTextBox extends React.Component<
           placeholder={this.props.placeholder}
           onKeyDown={this.props.onKeyDown}
           onValueChanged={this.props.onValueChanged}
+          onSearchCleared={this.props.onSearchCleared}
           tabIndex={this.props.tabIndex}
           ref={this.props.onRef}
         />

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -38,17 +38,9 @@ export class FancyTextBox extends React.Component<
       <div className={componentCSS}>
         <Octicon className={octiconCSS} symbol={this.props.symbol} />
         <TextBox
-          value={this.props.value}
+          {...this.props}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
-          autoFocus={this.props.autoFocus}
-          disabled={this.props.disabled}
-          type={this.props.type}
-          placeholder={this.props.placeholder}
-          onKeyDown={this.props.onKeyDown}
-          onValueChanged={this.props.onValueChanged}
-          onSearchCleared={this.props.onSearchCleared}
-          tabIndex={this.props.tabIndex}
           ref={this.props.onRef}
         />
       </div>

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -38,9 +38,17 @@ export class FancyTextBox extends React.Component<
       <div className={componentCSS}>
         <Octicon className={octiconCSS} symbol={this.props.symbol} />
         <TextBox
-          {...this.props}
+          value={this.props.value}
           onFocus={this.onFocus}
           onBlur={this.onBlur}
+          autoFocus={this.props.autoFocus}
+          disabled={this.props.disabled}
+          type={this.props.type}
+          placeholder={this.props.placeholder}
+          onKeyDown={this.props.onKeyDown}
+          onValueChanged={this.props.onValueChanged}
+          onSearchCleared={this.props.onSearchCleared}
+          tabIndex={this.props.tabIndex}
           ref={this.props.onRef}
         />
       </div>

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -167,7 +167,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     })
   }
 
-  private onSearchTextCleared = (ev: Event) => {
+  private onSearchTextCleared = () => {
     if (this.props.onSearchCleared != null) {
       this.props.onSearchCleared()
     }

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -173,6 +173,17 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     }
   }
 
+  /**
+   * The search event here is a Chrome and Safari specific event that is
+   * only reported for input[type=search] elements.
+   *
+   * Source: http://help.dottoro.com/ljdvxmhr.php
+   *
+   * TODO: can we hook into the warning API of React to report on incorrect usage
+   * when you set a `onSearchCleared` callback prop but don't use a `type=search`
+   * input - because this won't set an event handler.
+   *
+   */
   private onInputRef = (element: HTMLInputElement | null) => {
     if (this.inputElement != null && this.props.type === 'search') {
       this.inputElement.removeEventListener('search', this.onSearchTextCleared)

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -84,6 +84,11 @@ export interface ITextBoxProps {
    * Callback used when the component loses focus.
    */
   readonly onBlur?: () => void
+
+  /**
+   * Callback used when the user has cleared the search text.
+   */
+  readonly onSearchCleared?: () => void
 }
 
 interface ITextBoxState {
@@ -162,8 +167,22 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     })
   }
 
+  private onSearchTextCleared = (ev: Event) => {
+    if (this.props.onSearchCleared != null) {
+      this.props.onSearchCleared()
+    }
+  }
+
   private onInputRef = (element: HTMLInputElement | null) => {
+    if (this.inputElement != null && this.props.type === 'search') {
+      this.inputElement.removeEventListener('search', this.onSearchTextCleared)
+    }
+
     this.inputElement = element
+
+    if (this.inputElement != null && this.props.type === 'search') {
+      this.inputElement.addEventListener('search', this.onSearchTextCleared)
+    }
   }
 
   private renderLabelLink() {


### PR DESCRIPTION
Fixes #4690 

### Clearing filter text before selecting a branch to compare

Before:

![](https://user-images.githubusercontent.com/359239/40097959-6de8a1ee-591c-11e8-8814-09fb0ad19b21.gif)

After:

![](https://user-images.githubusercontent.com/359239/40097958-6dba6694-591c-11e8-82c0-dadf4319a7e4.gif)

### Clearing filter text after selecting a branch to compare

Before:

![](https://user-images.githubusercontent.com/359239/40099745-a705830e-5924-11e8-8306-5c807156380c.gif)

After:

![](https://user-images.githubusercontent.com/359239/40099744-a6d73dc8-5924-11e8-83ef-666cbce3a2b2.gif)

 - [x] tested clearing with only filter text (no branch selected) on macOS
 - [x] tested clearing after selecting branch on macOS
 - [x] tested clearing with only filter text (no branch selected) on Windows
 - [x] tested clearing after selecting branch on Windows
