### PR TITLE
provide this.canSelectRow here to ensure first valid branch is selected

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -258,11 +258,11 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     )
 
     if (next !== null) {
-      this.setState({ selectedRow: next })
-    }
-
-    if (focus) {
-      this.list.focus()
+      this.setState({ selectedRow: next }, () => {
+        if (focus && this.list != null) {
+          this.list.focus()
+        }
+      })
     }
   }
 

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -244,19 +244,25 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   public selectFirstItem(focus: boolean = false) {
-    if (this.list !== null) {
-      const next = findNextSelectableRow(this.state.rows.length, {
+    if (this.list == null) {
+      return
+    }
+
+    const next = findNextSelectableRow(
+      this.state.rows.length,
+      {
         direction: 'down',
         row: -1,
-      })
+      },
+      this.canSelectRow
+    )
 
-      if (next !== null) {
-        this.setState({ selectedRow: next })
-      }
+    if (next !== null) {
+      this.setState({ selectedRow: next })
+    }
 
-      if (focus) {
-        this.list.focus()
-      }
+    if (focus) {
+      this.list.focus()
     }
   }
 

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -244,7 +244,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
   }
 
   public selectFirstItem(focus: boolean = false) {
-    if (this.list == null) {
+    if (this.list === null) {
       return
     }
 
@@ -259,7 +259,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     if (next !== null) {
       this.setState({ selectedRow: next }, () => {
-        if (focus && this.list != null) {
+        if (focus && this.list !== null) {
           this.list.focus()
         }
       })


### PR DESCRIPTION
This fixes a known issue on `1.1.2-beta6` where you're unable to cursor down from the branch selector like you can do in other places within the app (it gets stuck in the header, which isn't a valid row to select).

Before:

![](https://user-images.githubusercontent.com/359239/40160924-88109e4c-59f2-11e8-9e1e-3bd7a851bdde.gif)

After:

![](https://user-images.githubusercontent.com/359239/40161332-ca505ff8-59f3-11e8-9f03-d4442367a164.gif)


 - [x] can move down from filter textbox to branch list
 - [x] fix focus issue - list should be focused after first move, but textbox holds onto it because `setState` is not a blocking function