### PR TITLE
Disable Merge into current branch menu item when there aren't enough branches

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -150,6 +150,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let networkActionInProgress = false
   let tipStateIsUnknown = false
   let branchIsUnborn = false
+  let hasMultipleBranches = false
 
   let hasRemote = false
 
@@ -184,6 +185,8 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     hasRemote = !!selectedState.state.remote
 
     networkActionInProgress = selectedState.state.isPushPullFetchInProgress
+    hasMultipleBranches =
+      selectedState.state.branchesState.allBranches.length > 1
   }
 
   // These are IDs for menu items that are entirely _and only_
@@ -225,7 +228,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       'update-branch',
       onNonDefaultBranch && hasDefaultBranch
     )
-    menuStateBuilder.setEnabled('merge-branch', onBranch)
+    menuStateBuilder.setEnabled('merge-branch', onBranch && hasMultipleBranches)
     menuStateBuilder.setEnabled(
       'compare-branch',
       isHostedOnGitHub && hasPublishedBranch


### PR DESCRIPTION
Fixes #4725 

## Before
**New repo**
<img width="570" alt="screen shot 2018-05-17 at 3 27 00 pm" src="https://user-images.githubusercontent.com/1715082/40202194-d1b96f44-59e6-11e8-8070-64e618a0e73d.png">


## After
**New repo**
<img width="626" alt="after-no-branches" src="https://user-images.githubusercontent.com/1715082/40202074-85b0474e-59e6-11e8-8a35-bc4d10c181be.png">

**New repo after created new branch**
<img width="597" alt="after-created-new-branch" src="https://user-images.githubusercontent.com/1715082/40202108-a3fa465a-59e6-11e8-8f70-b7fa7baf315a.png">

**Existing repo (that already has branches)**
<img width="633" alt="after-with-branches" src="https://user-images.githubusercontent.com/1715082/40202101-9a18e344-59e6-11e8-9893-0e63e294954b.png">

