### PR TITLE
move new error handler behind a feature flag

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -50,6 +50,7 @@ import {
   enableSourceMaps,
   withSourceMappedStack,
 } from '../lib/source-map-support'
+import { enableCompareSidebar } from '../lib/feature-flag'
 
 if (__DEV__) {
   installDevGlobals()
@@ -139,7 +140,9 @@ dispatcher.registerErrorHandler(defaultErrorHandler)
 dispatcher.registerErrorHandler(upstreamAlreadyExistsHandler)
 dispatcher.registerErrorHandler(externalEditorErrorHandler)
 dispatcher.registerErrorHandler(openShellErrorHandler)
-dispatcher.registerErrorHandler(mergeConflictHandler)
+if (enableCompareSidebar()) {
+  dispatcher.registerErrorHandler(mergeConflictHandler)
+}
 dispatcher.registerErrorHandler(lfsAttributeMismatchHandler)
 dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)


### PR DESCRIPTION
We discussed this in https://github.com/desktop/desktop/pull/4694#discussion_r188180199 and I figure we should actually do this so we're consistently rolling out this feature.