### PR TITLE
Use React Fragment to avoid key attributes

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -733,11 +733,9 @@ export class List extends React.Component<IListProps, IListState> {
       <FocusContainer
         className="list-focus-container"
         onKeyDown={this.onKeyDown}
-        key="focus-container"
       >
         <Grid
           aria-label={''}
-          key="grid"
           role={''}
           ref={this.onGridRef}
           autoContainerWidth={true}
@@ -785,7 +783,6 @@ export class List extends React.Component<IListProps, IListState> {
 
     return (
       <div
-        key="fake-scroll"
         className="fake-scroll"
         ref={this.onFakeScrollRef}
         style={{ height }}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -690,7 +690,12 @@ export class List extends React.Component<IListProps, IListState> {
    */
   private renderContents(width: number, height: number) {
     if (__WIN32__) {
-      return [this.renderGrid(width, height), this.renderFakeScroll(height)]
+      return (
+        <>
+          {this.renderGrid(width, height)}
+          {this.renderFakeScroll(height)}
+        </>
+      )
     }
 
     return this.renderGrid(width, height)


### PR DESCRIPTION
Fixes #4638 
As suggested in the issue:
* React Fragment used
* `key` attributes removed