### PR TITLE
lift up compare form state

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -628,6 +628,12 @@ export interface ICompareState {
   /** The current state of the compare form, based on user input */
   readonly formState: IDisplayHistory | ICompareBranch
 
+  /** Whether the branch list should be expanded or hidden */
+  readonly showBranchList: boolean
+
+  /** The text entered into the compare branch filter text box */
+  readonly filterText: string
+
   /** The SHAs of commits to render in the compare list */
   readonly commitSHAs: ReadonlyArray<string>
 
@@ -653,6 +659,14 @@ export interface ICompareState {
    * A local cache of ahead/behind computations to compare other refs to the current branch
    */
   readonly aheadBehindCache: ComparisonCache
+}
+
+export interface ICompareFormUpdate {
+  /** The updated filter text to set */
+  readonly filterText: string
+
+  /** Thew new state of the branches list */
+  readonly showBranchList: boolean
 }
 
 export enum CompareActionKind {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -323,18 +323,11 @@ export enum RepositorySectionTab {
   History,
 }
 
-export type RepositorySection =
-  | { selectedTab: RepositorySectionTab.Changes }
-  | {
-      selectedTab: RepositorySectionTab.History
-      shouldShowBranchesList?: boolean
-    }
-
 export interface IRepositoryState {
   readonly historyState: IHistoryState
   readonly changesState: IChangesState
   readonly compareState: ICompareState
-  readonly selectedSection: RepositorySection
+  readonly selectedSection: RepositorySectionTab
 
   /**
    * The name and email that will be used for the author info

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -11,7 +11,7 @@ import {
 } from '../../models/status'
 import { DiffSelection } from '../../models/diff'
 import {
-  RepositorySection,
+  RepositorySectionTab,
   Popup,
   PopupType,
   Foldout,
@@ -179,7 +179,7 @@ export class Dispatcher {
   /** Change the selected section in the repository. */
   public changeRepositorySection(
     repository: Repository,
-    section: RepositorySection
+    section: RepositorySectionTab
   ): Promise<void> {
     return this.appStore._changeRepositorySection(repository, section)
   }

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -18,6 +18,7 @@ import {
   FoldoutType,
   ImageDiffType,
   CompareAction,
+  ICompareFormUpdate,
 } from '../app-state'
 import { AppStore } from '../stores/app-store'
 import { CloningRepository } from '../../models/cloning-repository'
@@ -1182,6 +1183,14 @@ export class Dispatcher {
    */
   public executeCompare(repository: Repository, action: CompareAction) {
     return this.appStore._executeCompare(repository, action)
+  }
+
+  /** Update the compare form state for the current repository */
+  public updateCompareForm<K extends keyof ICompareFormUpdate>(
+    repository: Repository,
+    newState: Pick<ICompareFormUpdate, K>
+  ) {
+    return this.appStore._updateCompareForm(repository, newState)
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -422,7 +422,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         coAuthors: [],
         showCoAuthoredBy: false,
       },
-      selectedSection: { selectedTab: RepositorySectionTab.Changes },
+      selectedSection: RepositorySectionTab.Changes,
       branchesState: {
         tip: { kind: TipState.Unknown },
         defaultBranch: null,
@@ -1482,14 +1482,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _changeRepositorySection(
     repository: Repository,
-    selectedSection: RepositorySection
+    selectedSection: RepositorySectionTab
   ): Promise<void> {
     this.updateRepositoryState(repository, state => ({ selectedSection }))
     this.emitUpdate()
 
-    if (selectedSection.selectedTab === RepositorySectionTab.History) {
+    if (selectedSection === RepositorySectionTab.History) {
       return this.refreshHistorySection(repository)
-    } else if (selectedSection.selectedTab === RepositorySectionTab.Changes) {
+    } else if (selectedSection === RepositorySectionTab.Changes) {
       return this.refreshChangesSection(repository, {
         includingStatus: true,
         clearPartialState: false,
@@ -1729,9 +1729,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const section = state.selectedSection
     let refreshSectionPromise: Promise<void>
 
-    if (section.selectedTab === RepositorySectionTab.History) {
+    if (section === RepositorySectionTab.History) {
       refreshSectionPromise = this.refreshHistorySection(repository)
-    } else if (section.selectedTab === RepositorySectionTab.Changes) {
+    } else if (section === RepositorySectionTab.Changes) {
       refreshSectionPromise = this.refreshChangesSection(repository, {
         includingStatus: false,
         clearPartialState: false,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -23,7 +23,7 @@ import {
   CompareActionKind,
   IDisplayHistory,
   ICompareBranch,
-  RepositorySection,
+  ICompareFormUpdate,
 } from '../app-state'
 import { Account } from '../../models/account'
 import { Repository } from '../../models/repository'
@@ -434,6 +434,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       },
       compareState: {
         formState: { kind: ComparisonView.None },
+        showBranchList: false,
+        filterText: '',
         commitSHAs: [],
         aheadBehindCache: new ComparisonCache(),
         allBranches: new Array<Branch>(),
@@ -859,6 +861,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     } else {
       return assertNever(action, `Unknown action: ${kind}`)
     }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _updateCompareForm<K extends keyof ICompareFormUpdate>(
+    repository: Repository,
+    newState: Pick<ICompareFormUpdate, K>
+  ) {
+    this.updateCompareState(repository, state => {
+      return merge(state, newState)
+    })
+
+    this.emitUpdate()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -502,10 +502,10 @@ export class App extends React.Component<IAppProps, IAppState> {
       kind: CompareActionKind.History,
     })
 
-    await this.props.dispatcher.changeRepositorySection(state.repository, {
-      selectedTab: RepositorySectionTab.History,
-      shouldShowBranchesList,
-    })
+    await this.props.dispatcher.changeRepositorySection(
+      state.repository,
+      RepositorySectionTab.History
+    )
   }
 
   private showChanges() {
@@ -515,9 +515,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.props.dispatcher.closeCurrentFoldout()
-    this.props.dispatcher.changeRepositorySection(state.repository, {
-      selectedTab: RepositorySectionTab.Changes,
-    })
+    this.props.dispatcher.changeRepositorySection(
+      state.repository,
+      RepositorySectionTab.Changes
+    )
   }
 
   private chooseRepository() {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -490,7 +490,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.showPopup({ type: PopupType.About })
   }
 
-  private async showHistory(shouldShowBranchesList: boolean = false) {
+  private async showHistory(showBranchList: boolean = false) {
     const state = this.state.selectedState
     if (state == null || state.type !== SelectionType.Repository) {
       return
@@ -506,6 +506,11 @@ export class App extends React.Component<IAppProps, IAppState> {
       state.repository,
       RepositorySectionTab.History
     )
+
+    await this.props.dispatcher.updateCompareForm(state.repository, {
+      filterText: '',
+      showBranchList,
+    })
   }
 
   private showChanges() {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -452,15 +452,7 @@ export class CompareSidebar extends React.Component<
 
   private onBranchFilterTextChanged = (filterText: string) => {
     if (filterText.length === 0) {
-      this.setState({ focusedBranch: null, filterText })
-      if (this.props.compareState.formState.kind !== ComparisonView.None) {
-        // ensure any previous filter branch selection is cleared
-        this.props.dispatcher.executeCompare(this.props.repository, {
-          kind: CompareActionKind.History,
-        })
-      }
-    } else {
-      this.setState({ filterText })
+      this.setState({ focusedBranch: null })
     }
 
     this.props.dispatcher.updateCompareForm(this.props.repository, {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -139,17 +139,13 @@ export class CompareSidebar extends React.Component<
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}
-            onSearchCleared={this.onSearchCleared}
+            onSearchCleared={this.handleEscape}
           />
         </div>
 
         {showBranchList ? this.renderFilterList() : this.renderCommits()}
       </div>
     )
-  }
-
-  private onSearchCleared = () => {
-    this.handleEscape()
   }
 
   private onBranchesListRef = (branchList: BranchList | null) => {
@@ -395,7 +391,7 @@ export class CompareSidebar extends React.Component<
     }
   }
 
-  private handleEscape() {
+  private handleEscape = () => {
     this.clearFilterState()
     if (this.textbox) {
       this.textbox.blur()

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -361,7 +361,7 @@ export class CompareSidebar extends React.Component<
     const key = event.key
 
     if (key === 'Enter') {
-      if (this.state.filterText.length === 0) {
+      if (this.props.compareState.filterText.length === 0) {
         this.handleEscape()
       } else {
         if (this.state.focusedBranch == null) {
@@ -375,7 +375,9 @@ export class CompareSidebar extends React.Component<
             mode: ComparisonView.Behind,
           })
 
-          this.setState({ filterText: branch.name })
+          this.props.dispatcher.updateCompareForm(this.props.repository, {
+            filterText: branch.name,
+          })
         }
 
         if (this.textbox) {
@@ -443,7 +445,9 @@ export class CompareSidebar extends React.Component<
     )
 
     await this.viewHistoryForBranch()
-    this.setState({ filterText: '' })
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      filterText: '',
+    })
   }
 
   private onBranchFilterTextChanged = (filterText: string) => {
@@ -458,11 +462,18 @@ export class CompareSidebar extends React.Component<
     } else {
       this.setState({ filterText })
     }
+
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      filterText,
+    })
   }
 
   private clearFilterState = () => {
     this.setState({
       focusedBranch: null,
+    })
+
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
       filterText: '',
     })
 
@@ -477,8 +488,11 @@ export class CompareSidebar extends React.Component<
     })
 
     this.setState({
-      filterText: branch.name,
       focusedBranch: null,
+    })
+
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      filterText: branch.name,
       showBranchList: false,
     })
   }
@@ -501,7 +515,9 @@ export class CompareSidebar extends React.Component<
   }
 
   private onTextBoxFocused = () => {
-    this.setState({ showBranchList: true })
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      showBranchList: true,
+    })
   }
 
   private onTextBoxRef = (textbox: TextBox) => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -123,7 +123,7 @@ export class CompareSidebar extends React.Component<
   }
 
   public render() {
-    const { allBranches } = this.props.compareState
+    const { allBranches, filterText, showBranchList } = this.props.compareState
     const placeholderText = getPlaceholderText(this.props.compareState)
 
     return (
@@ -134,7 +134,7 @@ export class CompareSidebar extends React.Component<
             type="search"
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}
-            value={this.state.filterText}
+            value={filterText}
             disabled={allBranches.length <= 1}
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
@@ -143,9 +143,7 @@ export class CompareSidebar extends React.Component<
           />
         </div>
 
-        {this.state.showBranchList
-          ? this.renderFilterList()
-          : this.renderCommits()}
+        {showBranchList ? this.renderFilterList() : this.renderCommits()}
       </div>
     )
   }
@@ -173,22 +171,24 @@ export class CompareSidebar extends React.Component<
     this.props.dispatcher.executeCompare(this.props.repository, {
       kind: CompareActionKind.History,
     })
+
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      showBranchList: false,
+    })
   }
 
   private renderCommitList() {
-    const compareState = this.props.compareState
+    const { formState, commitSHAs } = this.props.compareState
     const selectedCommit = this.state.selectedCommit
-    const commitSHAs = compareState.commitSHAs
 
     let emptyListMessage: string | JSX.Element
-    if (compareState.formState.kind === ComparisonView.None) {
+    if (formState.kind === ComparisonView.None) {
       emptyListMessage = 'No history'
     } else {
-      const currentlyComparedBranchName =
-        compareState.formState.comparisonBranch.name
+      const currentlyComparedBranchName = formState.comparisonBranch.name
 
       emptyListMessage =
-        compareState.formState.kind === ComparisonView.Ahead ? (
+        formState.kind === ComparisonView.Ahead ? (
           <p>
             The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
             to date with your branch
@@ -233,15 +233,21 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderFilterList() {
-    const compareState = this.props.compareState
+    const {
+      defaultBranch,
+      allBranches,
+      recentBranches,
+      filterText,
+    } = this.props.compareState
+
     return (
       <BranchList
         ref={this.onBranchesListRef}
-        defaultBranch={compareState.defaultBranch}
+        defaultBranch={defaultBranch}
         currentBranch={this.props.currentBranch}
-        allBranches={compareState.allBranches}
-        recentBranches={compareState.recentBranches}
-        filterText={this.state.filterText}
+        allBranches={allBranches}
+        recentBranches={recentBranches}
+        filterText={filterText}
         textbox={this.textbox!}
         selectedBranch={this.state.focusedBranch}
         canCreateNewBranch={false}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -32,12 +32,6 @@ interface ICompareSidebarProps {
   readonly localCommitSHAs: ReadonlyArray<string>
   readonly dispatcher: Dispatcher
   readonly currentBranch: Branch | null
-  readonly sidebarHasFocusWithin: boolean
-
-  /**
-   * A flag from the application to indicate the branches list should be expanded.
-   */
-  readonly shouldShowBranchesList: boolean
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
 }
@@ -49,8 +43,6 @@ interface ICompareSidebarState {
    * For all other cases, use the prop
    */
   readonly focusedBranch: Branch | null
-  readonly filterText: string
-  readonly showBranchList: boolean
   readonly selectedCommit: Commit | null
 }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -62,8 +62,6 @@ export class CompareSidebar extends React.Component<
 
     this.state = {
       focusedBranch: null,
-      filterText: '',
-      showBranchList: props.shouldShowBranchesList,
       selectedCommit: null,
     }
   }
@@ -72,28 +70,31 @@ export class CompareSidebar extends React.Component<
     const newFormState = nextProps.compareState.formState
     const oldFormState = this.props.compareState.formState
 
+    if (this.textbox !== null) {
+      if (
+        !this.props.compareState.showBranchList &&
+        nextProps.compareState.showBranchList
+      ) {
+        // showBranchList changes from false -> true
+        //  -> ensure the textbox has focus
+        this.textbox.focus()
+      } else if (
+        this.props.compareState.showBranchList &&
+        !nextProps.compareState.showBranchList
+      ) {
+        // showBranchList changes from true -> false
+        //  -> ensure the textbox no longer has focus
+        this.textbox.blur()
+      }
+    }
+
     if (
       newFormState.kind !== oldFormState.kind &&
       newFormState.kind === ComparisonView.None
     ) {
-      // reset form to it's default state
-      this.setState(
-        {
-          filterText: '',
-          focusedBranch: null,
-          showBranchList: nextProps.shouldShowBranchesList,
-        },
-        () => {
-          // ensure filter text behaviour matches the prop value
-          if (this.textbox !== null) {
-            if (nextProps.shouldShowBranchesList) {
-              this.textbox.focus()
-            } else {
-              this.textbox.blur()
-            }
-          }
-        }
-      )
+      this.setState({
+        focusedBranch: null,
+      })
       return
     }
 
@@ -105,25 +106,10 @@ export class CompareSidebar extends React.Component<
       const newBranch = newFormState.comparisonBranch
 
       if (oldBranch.name !== newBranch.name) {
-        // ensure the filter text is in sync with the comparison branch
+        // ensure the focused branch is in sync with the chosen branch
         this.setState({
-          filterText: newBranch.name,
           focusedBranch: newBranch,
         })
-      }
-    }
-
-    if (
-      this.props.shouldShowBranchesList !== nextProps.shouldShowBranchesList
-    ) {
-      if (nextProps.shouldShowBranchesList === true) {
-        this.setState({ showBranchList: true })
-      }
-    }
-
-    if (nextProps.sidebarHasFocusWithin !== this.props.sidebarHasFocusWithin) {
-      if (nextProps.sidebarHasFocusWithin === false) {
-        this.setState({ showBranchList: false })
       }
     }
   }
@@ -134,12 +120,6 @@ export class CompareSidebar extends React.Component<
 
   public componentWillUnmount() {
     this.textbox = null
-  }
-
-  public componentDidMount() {
-    if (this.textbox !== null && this.state.showBranchList) {
-      this.textbox.focus()
-    }
   }
 
   public render() {

--- a/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-warning.tsx
@@ -17,9 +17,10 @@ export class MergeConflictsWarning extends React.Component<
   {}
 > {
   private onSubmit = () => {
-    this.props.dispatcher.changeRepositorySection(this.props.repository, {
-      selectedTab: RepositorySectionTab.Changes,
-    })
+    this.props.dispatcher.changeRepositorySection(
+      this.props.repository,
+      RepositorySectionTab.Changes
+    )
     this.props.onDismissed()
   }
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -155,11 +155,6 @@ export class RepositoryView extends React.Component<
   private renderCompareSidebar(): JSX.Element {
     const tip = this.props.state.branchesState.tip
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
-    const selectedSection = this.props.state.selectedSection
-    const shouldShowBranchesList =
-      selectedSection.selectedTab === RepositorySectionTab.History
-        ? selectedSection.shouldShowBranchesList || false
-        : false
 
     return (
       <CompareSidebar
@@ -173,8 +168,6 @@ export class RepositoryView extends React.Component<
         dispatcher={this.props.dispatcher}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
-        sidebarHasFocusWithin={this.state.sidebarHasFocusWithin}
-        shouldShowBranchesList={shouldShowBranchesList}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -13,7 +13,6 @@ import {
   IRepositoryState,
   RepositorySectionTab,
   ImageDiffType,
-  RepositorySection,
 } from '../lib/app-state'
 import { Dispatcher } from '../lib/dispatcher'
 import { IssuesStore, GitHubUserStore } from '../lib/stores'
@@ -77,8 +76,7 @@ export class RepositoryView extends React.Component<
     const hasChanges =
       this.props.state.changesState.workingDirectory.files.length > 0
     const selectedTab =
-      this.props.state.selectedSection.selectedTab ===
-      RepositorySectionTab.Changes
+      this.props.state.selectedSection === RepositorySectionTab.Changes
         ? Tab.Changes
         : Tab.History
 
@@ -184,9 +182,9 @@ export class RepositoryView extends React.Component<
   private renderSidebarContents(): JSX.Element {
     const selectedSection = this.props.state.selectedSection
 
-    if (selectedSection.selectedTab === RepositorySectionTab.Changes) {
+    if (selectedSection === RepositorySectionTab.Changes) {
       return this.renderChangesSidebar()
-    } else if (selectedSection.selectedTab === RepositorySectionTab.History) {
+    } else if (selectedSection === RepositorySectionTab.History) {
       return enableCompareSidebar()
         ? this.renderCompareSidebar()
         : this.renderHistorySidebar()
@@ -223,12 +221,21 @@ export class RepositoryView extends React.Component<
   private onSidebarFocusWithinChanged = (sidebarHasFocusWithin: boolean) => {
     // this lets us know that focus is somewhere within the sidebar
     this.setState({ sidebarHasFocusWithin })
+
+    if (
+      sidebarHasFocusWithin === false &&
+      this.props.state.selectedSection === RepositorySectionTab.History
+    ) {
+      this.props.dispatcher.updateCompareForm(this.props.repository, {
+        showBranchList: false,
+      })
+    }
   }
 
   private renderContent(): JSX.Element | null {
     const selectedSection = this.props.state.selectedSection
 
-    if (selectedSection.selectedTab === RepositorySectionTab.Changes) {
+    if (selectedSection === RepositorySectionTab.Changes) {
       const changesState = this.props.state.changesState
       const selectedFileIDs = changesState.selectedFileIDs
 
@@ -260,7 +267,7 @@ export class RepositoryView extends React.Component<
           />
         )
       }
-    } else if (selectedSection.selectedTab === RepositorySectionTab.History) {
+    } else if (selectedSection === RepositorySectionTab.History) {
       return (
         <History
           repository={this.props.repository}
@@ -298,14 +305,10 @@ export class RepositoryView extends React.Component<
     // about the shift key here, we can get away with that as long
     // as there's only two tabs.
     if (e.ctrlKey && e.key === 'Tab') {
-      const section: RepositorySection =
-        this.props.state.selectedSection.selectedTab ===
-        RepositorySectionTab.History
-          ? { selectedTab: RepositorySectionTab.Changes }
-          : {
-              selectedTab: RepositorySectionTab.History,
-              shouldShowBranchesList: false,
-            }
+      const section =
+        this.props.state.selectedSection === RepositorySectionTab.History
+          ? RepositorySectionTab.Changes
+          : RepositorySectionTab.History
 
       this.props.dispatcher.changeRepositorySection(
         this.props.repository,
@@ -316,13 +319,10 @@ export class RepositoryView extends React.Component<
   }
 
   private onTabClicked = (tab: Tab) => {
-    const section: RepositorySection =
+    const section =
       tab === Tab.History
-        ? {
-            selectedTab: RepositorySectionTab.History,
-            shouldShowBranchesList: false,
-          }
-        : { selectedTab: RepositorySectionTab.Changes }
+        ? RepositorySectionTab.History
+        : RepositorySectionTab.Changes
 
     this.props.dispatcher.changeRepositorySection(
       this.props.repository,

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -131,9 +131,10 @@ describe('AppStore', () => {
 
       // select the repository and show the changes view
       await appStore._selectRepository(repository)
-      await appStore._changeRepositorySection(repository, {
-        selectedTab: RepositorySectionTab.Changes,
-      })
+      await appStore._changeRepositorySection(
+        repository,
+        RepositorySectionTab.Changes
+      )
 
       let state = getAppState(appStore)
       expect(state.localCommitSHAs.length).to.equal(1)


### PR DESCRIPTION
This addresses the edge cases identified in https://github.com/desktop/desktop/pull/4743#issuecomment-390822487 because the component wasn't originally designed to be controlled from menu actions. We had some success in #4702 by introducing better context when switching tabs

```ts
export type RepositorySection =
  | { selectedTab: RepositorySectionTab.Changes }
  | {
      selectedTab: RepositorySectionTab.History
      shouldFocusBranchList?: boolean
    }
```

But this doesn't capture all possible permutations of interactions (for example, you may need to update `shouldFocusBranchList` when you're already on the `History` tab), and this required us to push complexity down into the component which made it harder to reason about (let alone get correct).

![](https://media.giphy.com/media/116a8zosxwA0SI/giphy.gif)

So let's do it right this time and split up these interactions:

 1. Which tab should the app look at?
 2. What should the form state of the comparison be?

This gives the menu actions better control about putting things into the right state, but makes the component a bit more complex in terms of invoking the dispatcher, rather than a simple `setState` - which wasn't actually easier to reason about in some parts.

 - [x] rebase on top of `master` once #4743 has been merged
 - [x] review current changes and cleanup
 - [x] exercise test cases from #4743
 - [x] exercise test cases from #4758

### Interactions to verify

From #4743:

 - [x] with focus on branch filter, key down and up to switch between branch list and filter
 - [x] with focus on branch filter, then **View | Show History** should clear filter text, hide branch list, blur branch filter
 - [x] set some filter text, then **View | Show History** should clear filter text, hide branch list, blur branch filter
 - [x] with focus on branch filter, then **Branch | Compare to Branch** should clear filter text, show branch list, focus branch on filter
 - [x] set some filter text, then **Branch | Compare to Branch** should clear filter text, show branch list, focus branch filter

From #4758:

 - [x] clearing filter text after all text selected should not cause the textbox to blur
 - [x] clearing filter text by deleting one-by-one should not cause the textbox to blur
