### PR TITLE
VSTS tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Travis](https://img.shields.io/travis/desktop/desktop.svg?style=flat-square&label=Travis+CI)](https://travis-ci.org/desktop/desktop)
 [![CircleCI](https://img.shields.io/circleci/project/github/desktop/desktop.svg?style=flat-square&label=CircleCI)](https://circleci.com/gh/desktop/desktop)
 [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/github-windows/desktop/master.svg?style=flat-square&label=AppVeyor&logo=appveyor)](https://ci.appveyor.com/project/github-windows/desktop/branch/master)
+[![VSTS Build Status](https://github.visualstudio.com/_apis/public/build/definitions/845028c2-21f3-4eb1-80b9-215d3e9b1d08/3/badge)](https://github.visualstudio.com/Desktop/_build/index?definitionId=3)
 [![license](https://img.shields.io/github/license/desktop/desktop.svg?style=flat-square)](https://github.com/desktop/desktop/blob/master/LICENSE)
 ![90+% TypeScript](https://img.shields.io/github/languages/top/desktop/desktop.svg?style=flat-square&colorB=green)
 

--- a/vsts.yml
+++ b/vsts.yml
@@ -17,9 +17,6 @@ phases:
   - script: |
       yarn test:setup && yarn test
     name: Test
-  - script: |
-       yarn package
-    name: Package
 
 - phase: Linux
   queue: Hosted Linux Preview
@@ -38,15 +35,12 @@ phases:
     name: Install
   - script: |
        yarn lint && yarn build:prod
-    name: Build 
+    name: Build
   - script: |
        export DISPLAY=':99.0'
        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
        yarn test:setup && yarn test
     name: Test
-  - script: |
-       yarn package
-    name: Package
 
 - phase: macOS
   queue: Hosted macOS Preview
@@ -66,7 +60,3 @@ phases:
   - script: |
       yarn test:setup && yarn test
     name: Test
-  - script: |
-      yarn package
-    name: Package
-


### PR DESCRIPTION
Two tweaks:

 - skip the packaging step to generate builds as part of CI (this was more for my benefit to ensure I'd configured things right, we can drop this for now until I feel confident enough to migrate deployments over)
 - add a build badge - I'd love to have this point to the latest `master` build rather than the latest build, but [the docs](https://docs.microsoft.com/en-us/rest/api/vsts/build/badge/get%20build%20badge%20data?view=vsts-rest-4.1) aren't quite clear on how to structure the URL, and I had to reverse-engineer what ReactiveUI has setup to get this showing. Maybe @damovisa can help when he has a moment :trollface:.
