### PR TITLE
Removes unused feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -31,6 +31,7 @@ export function enableMergeTool(): boolean {
   return enableDevelopmentFeatures()
 }
 
+/** Should the new Compare view be enabled? */
 export function enableCompareSidebar(): boolean {
   return true
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -33,5 +33,5 @@ export function enableMergeTool(): boolean {
 
 /** Should the new Compare view be enabled? */
 export function enableCompareSidebar(): boolean {
-  return true || enableBetaFeatures()
+  return true || enableBetaFeatures() //the second condition is just to get the linter to be quiet
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -22,6 +22,7 @@ function enableDevelopmentFeatures(): boolean {
 }
 
 /** Should the app enable beta features? */
+//@ts-ignore: this will be used again in the future
 function enableBetaFeatures(): boolean {
   return enableDevelopmentFeatures() || __RELEASE_CHANNEL__ === 'beta'
 }
@@ -33,5 +34,5 @@ export function enableMergeTool(): boolean {
 
 /** Should the new Compare view be enabled? */
 export function enableCompareSidebar(): boolean {
-  return true || enableBetaFeatures() //the second condition is just to get the linter to be quiet
+  return true
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -33,5 +33,5 @@ export function enableMergeTool(): boolean {
 
 /** Should the new Compare view be enabled? */
 export function enableCompareSidebar(): boolean {
-  return true
+  return true || enableBetaFeatures()
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -26,11 +26,6 @@ function enableBetaFeatures(): boolean {
   return enableDevelopmentFeatures() || __RELEASE_CHANNEL__ === 'beta'
 }
 
-/** Should the new Compare view be enabled? */
-export function enableCompareBranch(): boolean {
-  return enableBetaFeatures()
-}
-
 /** Should merge tool integration be enabled? */
 export function enableMergeTool(): boolean {
   return enableDevelopmentFeatures()


### PR DESCRIPTION
Noticed that we had two feature flags doing the same thing. The one that I removed was not being used anywhere in the app. I also had to do some linter trickery to get it to leave me alone about the `enableBetaFeatures` function not being used. 

I'm open to other ways of telling the linter to be quiet...