### PR TITLE
extract MergeToAction component from Compare view

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -12,7 +12,6 @@ import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { Dispatcher } from '../../lib/dispatcher'
 import { ThrottledScheduler } from '../lib/throttled-scheduler'
-import { Button } from '../lib/button'
 import { BranchList } from '../branches'
 import { TextBox } from '../lib/text-box'
 import { IBranchListItem } from '../branches/group-branches'
@@ -23,6 +22,8 @@ import { OcticonSymbol } from '../octicons'
 import { SelectionSource } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
 import { Ref } from '../lib/ref'
+
+import { MergeCallToAction } from './merge-call-to-action'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -261,42 +262,14 @@ export class CompareSidebar extends React.Component<
       return null
     }
 
-    const count = formState.aheadBehind.behind
-
     return (
-      <div className="merge-cta">
-        <Button
-          type="submit"
-          disabled={count <= 0}
-          onClick={this.onMergeClicked}
-        >
-          Merge into <strong>{this.props.currentBranch.name}</strong>
-        </Button>
-
-        {this.renderMergeDetails(formState, this.props.currentBranch)}
-      </div>
+      <MergeCallToAction
+        repository={this.props.repository}
+        dispatcher={this.props.dispatcher}
+        currentBranch={this.props.currentBranch}
+        formState={formState}
+      />
     )
-  }
-
-  private renderMergeDetails(formState: ICompareBranch, currentBranch: Branch) {
-    const branch = formState.comparisonBranch
-    const count = formState.aheadBehind.behind
-
-    if (count > 0) {
-      const pluralized = count === 1 ? 'commit' : 'commits'
-      return (
-        <div className="merge-message">
-          This will merge
-          <strong>{` ${count} ${pluralized}`}</strong>
-          {` `}from{` `}
-          <strong>{branch.name}</strong>
-          {` `}into{` `}
-          <strong>{currentBranch.name}</strong>
-        </div>
-      )
-    }
-
-    return null
   }
 
   private onTabClicked = (index: number) => {
@@ -430,25 +403,6 @@ export class CompareSidebar extends React.Component<
     if (commits.length - end <= CloseToBottomThreshold) {
       this.props.dispatcher.loadNextHistoryBatch(this.props.repository)
     }
-  }
-
-  private onMergeClicked = async (event: React.MouseEvent<any>) => {
-    const formState = this.props.compareState.formState
-
-    if (formState.kind === ComparisonView.None) {
-      return
-    }
-
-    this.props.dispatcher.recordCompareInitiatedMerge()
-    await this.props.dispatcher.mergeBranch(
-      this.props.repository,
-      formState.comparisonBranch.name
-    )
-
-    await this.viewHistoryForBranch()
-    this.props.dispatcher.updateCompareForm(this.props.repository, {
-      filterText: '',
-    })
   }
 
   private onBranchFilterTextChanged = (filterText: string) => {

--- a/app/src/ui/history/merge-call-to-action.tsx
+++ b/app/src/ui/history/merge-call-to-action.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+
+import { CompareActionKind, ICompareBranch } from '../../lib/app-state'
+import { Repository } from '../../models/repository'
+import { Branch } from '../../models/branch'
+import { Dispatcher } from '../../lib/dispatcher'
+import { Button } from '../lib/button'
+
+interface IMergeCallToActionProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly currentBranch: Branch
+  readonly formState: ICompareBranch
+}
+
+export class MergeCallToAction extends React.Component<
+  IMergeCallToActionProps,
+  {}
+> {
+  public render() {
+    const count = this.props.formState.aheadBehind.behind
+
+    return (
+      <div className="merge-cta">
+        <Button
+          type="submit"
+          disabled={count <= 0}
+          onClick={this.onMergeClicked}
+        >
+          Merge into <strong>{this.props.currentBranch.name}</strong>
+        </Button>
+
+        {this.renderMergeDetails(
+          this.props.formState,
+          this.props.currentBranch
+        )}
+      </div>
+    )
+  }
+
+  private renderMergeDetails(formState: ICompareBranch, currentBranch: Branch) {
+    const branch = formState.comparisonBranch
+    const count = formState.aheadBehind.behind
+
+    if (count > 0) {
+      const pluralized = count === 1 ? 'commit' : 'commits'
+      return (
+        <div className="merge-message">
+          This will merge
+          <strong>{` ${count} ${pluralized}`}</strong>
+          {` `}from{` `}
+          <strong>{branch.name}</strong>
+          {` `}into{` `}
+          <strong>{currentBranch.name}</strong>
+        </div>
+      )
+    }
+
+    return null
+  }
+
+  private onMergeClicked = async (event: React.MouseEvent<any>) => {
+    const formState = this.props.formState
+
+    this.props.dispatcher.recordCompareInitiatedMerge()
+
+    await this.props.dispatcher.mergeBranch(
+      this.props.repository,
+      formState.comparisonBranch.name
+    )
+
+    this.props.dispatcher.executeCompare(this.props.repository, {
+      kind: CompareActionKind.History,
+    })
+
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      showBranchList: false,
+      filterText: '',
+    })
+  }
+}


### PR DESCRIPTION
As part of #4588 there will likely be some changes to the merge call-to-action, so this is laying the groundwork for some of that by extract it out into it's own component to simplify the `Compare` view a bit.