### PR TITLE
SCSS Cleanup and centralization of hard coded values

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -85,6 +85,7 @@
   // or an item in a tab control header. It's up to each implementation
   // to decide what states to support (active selection, selection, etc).
 
+  --box-background-color: var(--background-color);
   --box-alt-background-color: $gray-100;
 
   /**

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -277,6 +277,19 @@
   --diff-delete-hover-gutter-color: $red-300;
   --diff-delete-hover-text-color: var(--text-color);
 
+  // Syntax highlighting text colors
+  --syntax-variable-color: #6f42c1;
+  --syntax-alt-variable-color: #24292e;
+  --syntax-keyword-color: #d73a49;
+  --syntax-atom-color: #005cc5;
+  --syntax-string-color: #032f62;
+  --syntax-qualifier-color: #6f42c1;
+  --syntax-type-color: #d73a49;
+  --syntax-comment-color: $gray-500;
+  --syntax-tag-color: #22863a;
+  --syntax-attribute-color: #22863a;
+  --syntax-link-color: #032f62;
+
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`
   // specified in `changes/index.tsx`.
   --undo-animation-duration: 500ms;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -14,7 +14,6 @@
 
   --text-color: $gray-900;
   --text-secondary-color: $gray-500;
-  --text-tertiary-color: $gray-400;
   --background-color: $white;
 
   --button-height: 25px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -5,6 +5,12 @@
 // Primer colors, see https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/color-system.scss
 @import '~primer-support/lib/variables/color-system.scss';
 
+// Extracted as a SCSS variable so that we can define the --overlay-background-color
+// on both the :root and the ::backdrop scope. The ::backdrop pseudo-element
+// doesn't inherit :root, see
+// https://bugs.chromium.org/p/chromium/issues/detail?id=594096
+$overlay-background-color: rgba(0, 0, 0, 0.4);
+
 :root {
   --color-new: $green;
   --color-deleted: $red;
@@ -306,7 +312,7 @@
   --form-error-text-color: $red-800;
 
   /** Overlay is used as a background for both modals and foldouts */
-  --overlay-background-color: rgba(0, 0, 0, 0.4);
+  --overlay-background-color: $overlay-background-color;
 
   /** Dialog */
   --dialog-warning-color: $yellow-600;
@@ -325,4 +331,8 @@
 
   // http://easings.net/#easeOutQuint
   --easing-ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+::backdrop {
+  --overlay-background-color: $overlay-background-color;
 }

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -287,7 +287,7 @@
   --syntax-type-color: #d73a49;
   --syntax-comment-color: $gray-500;
   --syntax-tag-color: #22863a;
-  --syntax-attribute-color: #22863a;
+  --syntax-attribute-color: #6f42c1;
   --syntax-link-color: #032f62;
 
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -196,6 +196,9 @@
   --toolbar-button-hover-progress-color: $gray-700;
   --toolbar-dropdown-open-progress-color: $gray-200;
 
+  /** Ahead and behind count bubble in the push/pull/publish button */
+  --toolbar-ahead-behind-background-color: $gray-500;
+
   --tab-bar-height: 29px;
   --tab-bar-active-color: $blue;
   --tab-bar-background-color: $white;
@@ -294,11 +297,6 @@
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`
   // specified in `changes/index.tsx`.
   --undo-animation-duration: 500ms;
-
-  /**
-   * Ahead/behind view
-   */
-  --ahead-behind-background-color: $gray-500;
 
   // Colors for form errors
   --error-color: $red;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -233,6 +233,7 @@
   --diff-text-color: $gray-900;
   --diff-border-color: $gray-200;
   --diff-gutter-color: $gray-200;
+  --diff-gutter-background-color: var(--background-color);
 
   --diff-line-number-color: $gray-700;
   --diff-line-number-column-width: 50px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -173,6 +173,7 @@
   --toolbar-height: 50px;
 
   --toolbar-background-color: $gray-900;
+  --toolbar-border-color: $gray-900;
   --toolbar-text-color: $white;
   --toolbar-text-secondary-color: $gray-300;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -292,6 +292,9 @@
   --form-error-border-color: $red-200;
   --form-error-text-color: $red-800;
 
+  /** Overlay is used as a background for both modals and foldouts */
+  --overlay-background-color: rgba(0, 0, 0, 0.4);
+
   /** Dialog */
   --dialog-warning-color: $yellow-600;
   --dialog-warning-text-color: $yellow-800;

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -7,6 +7,7 @@
 @mixin textboxish {
   border: 1px solid var(--box-border-color);
   border-radius: var(--border-radius);
+  background: var(--box-background-color);
   color: currentColor;
   font-size: var(--font-size);
   font-family: var(--font-family-sans-serif);

--- a/app/styles/ui/_codemirror.scss
+++ b/app/styles/ui/_codemirror.scss
@@ -25,6 +25,15 @@
   background: inherit;
 }
 
+.CodeMirror-simplescroll-horizontal,
+.CodeMirror-simplescroll-vertical {
+  background: var(--box-alt-background-color);
+  div {
+    background: var(--scroll-bar-thumb-background-color);
+    border: none;
+  }
+}
+
 // Windows has custom scroll bars, see _scroll.scss
 @include win32-context {
   .CodeMirror {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -82,9 +82,7 @@ dialog {
   }
 
   &::backdrop {
-    // fallback value until we can get variables to work, see
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=594096
-    background: rgba(0, 0, 0, 0.4);
+    background: var(--overlay-background-color);
     opacity: 1;
   }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -53,7 +53,7 @@ dialog {
       transition: transform 250ms var(--easing-ease-out-back);
 
       &::backdrop {
-        opacity: 0.4;
+        opacity: 1;
         transition: opacity 100ms ease-in;
       }
     }
@@ -64,7 +64,7 @@ dialog {
       pointer-events: none;
 
       &::backdrop {
-        opacity: 0.4;
+        opacity: 1;
       }
     }
 
@@ -82,8 +82,10 @@ dialog {
   }
 
   &::backdrop {
-    background: #000;
-    opacity: 0.4;
+    // fallback value until we can get variables to work, see
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=594096
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 1;
   }
 
   // The dialog embeds a fieldset as the first child of the form element

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -62,6 +62,7 @@
 .diff-line-gutter {
   display: flex;
   height: 100%;
+  background: var(--diff-gutter-background-color);
 
   &.diff-add {
     background: var(--diff-add-gutter-background-color);

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -447,15 +447,15 @@
 // https://github.com/primer/github-syntax-light/blob/5aeffad2559647286080328436156c4904a9785b/lib/github-light.css
 .cm-s-default {
   .cm-variable {
-    color: #6f42c1;
+    color: var(--syntax-variable-color);
   }
 
   .cm-keyword {
-    color: #d73a49;
+    color: var(--syntax-keyword-color);
   }
 
   .cm-atom {
-    color: #005cc5;
+    color: var(--syntax-atom-color);
   }
   .cm-number {
     color: inherit;
@@ -467,25 +467,25 @@
 
   .cm-variable-2,
   .cm-variable-3 {
-    color: #24292e;
+    color: var(--syntax-alt-variable-color);
   }
   .cm-comment,
   .cm-meta {
-    color: $gray-500;
+    color: var(--syntax-comment-color);
   }
   .cm-string,
   .cm-string-2 {
-    color: #032f62;
+    color: var(--syntax-string-color);
 
     &.cm-property {
       color: inherit;
     }
   }
   .cm-qualifier {
-    color: #6f42c1;
+    color: var(--syntax-qualifier-color);
   }
   .cm-type {
-    color: #d73a49;
+    color: var(--syntax-type-color);
   }
   .cm-builtin {
     color: inherit;
@@ -494,17 +494,17 @@
     color: inherit;
   }
   .cm-tag {
-    color: #22863a;
+    color: var(--syntax-tag-color);
   }
   .cm-attribute {
-    color: #6f42c1;
+    color: var(--syntax-attribute-color);
   }
   .cm-hr {
     color: inherit;
   }
   .cm-link {
     text-decoration: underline;
-    color: #032f62;
+    color: var(--syntax-link-color);
   }
 
   // Intra line markings takes precedence over syntax highlighting.
@@ -518,19 +518,19 @@
 
   .cm-m-css {
     &.cm-property {
-      color: #005cc5;
+      color: var(--syntax-atom-color);
     }
   }
 
   .cm-m-shell {
     &.cm-builtin {
-      color: #005cc5;
+      color: var(--syntax-atom-color);
     }
   }
 
   .cm-m-javascript {
     &.cm-type {
-      color: #6f42c1;
+      color: var(--syntax-variable-color);
     }
   }
 }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -177,7 +177,7 @@
   }
 }
 
-.diff-line-selected {
+.CodeMirror pre.CodeMirror-line .diff-line-selected {
   .diff-line-number {
     background: var(--diff-selected-background-color);
     border-color: var(--diff-selected-border-color);
@@ -189,7 +189,7 @@
   }
 }
 
-.diff-line-hover {
+.CodeMirror pre.CodeMirror-line .diff-line-hover {
   .diff-line-number {
     background: var(--diff-hover-background-color);
     border-color: var(--diff-hover-border-color);

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -9,6 +9,7 @@
 .diff-code-mirror .CodeMirror {
   height: 100%;
   color: var(--diff-text-color);
+  background: var(--background-color);
   font-size: var(--font-size-sm);
   font-family: var(--font-family-monospace);
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -96,7 +96,7 @@
   text-align: right;
 }
 
-.diff-add {
+.CodeMirror pre.diff-add {
   background: var(--diff-add-background-color);
   color: var(--diff-add-text-color);
   padding: 0;
@@ -110,7 +110,7 @@
   }
 }
 
-.diff-delete {
+.CodeMirror pre.diff-delete {
   background: var(--diff-delete-background-color);
   color: var(--diff-delete-text-color);
   padding: 0;
@@ -124,7 +124,7 @@
   }
 }
 
-.diff-context {
+.CodeMirror pre.diff-context {
   background: var(--background-color);
   color: var(--diff-context-text-color);
   padding: 0;
@@ -163,7 +163,7 @@
   color: var(--diff-context-text-color);
 }
 
-.diff-hunk {
+.CodeMirror pre.diff-hunk {
   background: var(--diff-hunk-background-color);
   color: var(--diff-hunk-text-color);
   padding: 0;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -126,7 +126,7 @@
 
 .CodeMirror pre.diff-context {
   background: var(--background-color);
-  color: var(--diff-context-text-color);
+  color: var(--diff-text-color);
   padding: 0;
 
   .diff-line-number {
@@ -160,7 +160,7 @@
 }
 
 .cm-diff-context {
-  color: var(--diff-context-text-color);
+  color: var(--diff-text-color);
 }
 
 .CodeMirror pre.diff-hunk {

--- a/app/styles/ui/_fancy-text-box.scss
+++ b/app/styles/ui/_fancy-text-box.scss
@@ -1,7 +1,7 @@
 @import '../mixins';
 
 .fancy-text-box-component {
-  background: var(--background-color);
+  background: var(--box-background-color);
   display: flex;
   align-items: center;
   border: var(--base-border);

--- a/app/styles/ui/_foldout.scss
+++ b/app/styles/ui/_foldout.scss
@@ -12,8 +12,7 @@
       box-shadow: none;
     }
 
-    background: black;
-    opacity: 0.4;
+    background: var(--overlay-background-color);
     height: 100%;
   }
 

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -50,7 +50,7 @@
       @include ellipsis;
 
       .prefix {
-        color: var(--text-tertiary-color);
+        color: var(--text-secondary-color);
       }
 
       /* Used to highlight substring matches in filtered lists */

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -119,6 +119,7 @@
 
     .action-bar {
       padding: var(--spacing-half);
+      background: var(--box-background-color);
 
       // We're not faking being a textbox any more
       cursor: default;

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -63,7 +63,7 @@
 .ahead-behind {
   display: flex;
 
-  background: var(--ahead-behind-background-color);
+  background: var(--toolbar-ahead-behind-background-color);
 
   // Perfectly round semi circle ends with real tight
   // padding on either side. Now in two flavors!

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -3,6 +3,7 @@
 /** A React component holding the main application toolbar component. */
 #desktop-app-toolbar {
   height: var(--toolbar-height);
+  border-bottom: 1px solid var(--toolbar-border-color);
 
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
This PR extracts a few hard-coded values into CSS variables and removes one unused variable and deprecates another seldom used one.

We still have a bunch of hard coded values scattered about but we'll incrementally work towards centralizing where it makes sense.

Our text boxes (textboxish mixin) didn't have a set background color so I've settled on `--box-background-color` (which is the same thing as `--background-color`) for now but I think we might want to split them out and remove the overlap in the future. For now it works well enough though.

I had to introduce one scss variable for the dialog backdrop due to the `::backdrop` pseudo element not inheriting from any element (including `:root`). This lets us encode the opacity of the backdrop for both the foldouts and the dialogs in a single spot.