### PR TITLE
update Prettier to 1.13.0

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -171,7 +171,9 @@ async function findHyper(): Promise<string | null> {
 
     const path = commandPieces
       ? commandPieces[2]
-      : localAppData != null ? localAppData.concat('\\hyper\\Hyper.exe') : null // fall back to the launcher in install root
+      : localAppData != null
+        ? localAppData.concat('\\hyper\\Hyper.exe')
+        : null // fall back to the launcher in install root
 
     if (path == null) {
       log.debug(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -255,7 +255,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     | ((repository: Repository | null) => void)
     | null = null
 
-  private selectedCloneRepositoryTab: CloneRepositoryTab = CloneRepositoryTab.DotCom
+  private selectedCloneRepositoryTab = CloneRepositoryTab.DotCom
 
   private selectedBranchesTab = BranchesTab.Branches
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2156,7 +2156,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const refreshWeight = 0.1
 
         // Scale pull and fetch weights to be between 0 and 0.9.
-        const scale = 1 / (pushWeight + fetchWeight) * (1 - refreshWeight)
+        const scale = (1 / (pushWeight + fetchWeight)) * (1 - refreshWeight)
 
         pushWeight *= scale
         fetchWeight *= scale
@@ -2340,7 +2340,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           const refreshWeight = 0.1
 
           // Scale pull and fetch weights to be between 0 and 0.9.
-          const scale = 1 / (pullWeight + fetchWeight) * (1 - refreshWeight)
+          const scale = (1 / (pullWeight + fetchWeight)) * (1 - refreshWeight)
 
           pullWeight *= scale
           fetchWeight *= scale

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -358,7 +358,9 @@ export function buildDefaultMenu(
 
   const showLogsLabel = __DARWIN__
     ? 'Show Logs in Finder'
-    : __WIN32__ ? 'S&how logs in Explorer' : 'S&how logs in your File Manager'
+    : __WIN32__
+      ? 'S&how logs in Explorer'
+      : 'S&how logs in your File Manager'
 
   const showLogsItem: Electron.MenuItemConstructorOptions = {
     label: showLogsLabel,

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -31,7 +31,9 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
     const icon = isCurrentBranch ? OcticonSymbol.check : OcticonSymbol.gitBranch
     const infoTitle = isCurrentBranch
       ? 'Current branch'
-      : lastCommitDate ? lastCommitDate.toString() : ''
+      : lastCommitDate
+        ? lastCommitDate.toString()
+        : ''
     return (
       <div className="branches-list-item">
         <Octicon className="icon" symbol={icon} />

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -160,7 +160,9 @@ export class ChangesList extends React.Component<
     const includeAll =
       selection === DiffSelectionType.All
         ? true
-        : selection === DiffSelectionType.None ? false : null
+        : selection === DiffSelectionType.None
+          ? false
+          : null
 
     return (
       <ChangedFile
@@ -266,7 +268,9 @@ export class ChangesList extends React.Component<
       {
         label:
           paths.length === 1
-            ? __DARWIN__ ? `Discard Changes…` : `Discard changes…`
+            ? __DARWIN__
+              ? `Discard Changes…`
+              : `Discard changes…`
             : __DARWIN__
               ? `Discard ${paths.length} Selected Changes…`
               : `Discard ${paths.length} selected changes…`,

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -343,8 +343,12 @@ export class CommitMessage extends React.Component<
 
   private get toggleCoAuthorsText(): string {
     return this.props.showCoAuthoredBy
-      ? __DARWIN__ ? 'Remove Co-Authors' : 'Remove co-authors'
-      : __DARWIN__ ? 'Add Co-Authors' : 'Add co-authors'
+      ? __DARWIN__
+        ? 'Remove Co-Authors'
+        : 'Remove co-authors'
+      : __DARWIN__
+        ? 'Add Co-Authors'
+        : 'Add co-authors'
   }
 
   private getAddRemoveCoAuthorsMenuItem(): IMenuItem {

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -19,7 +19,9 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
   public render() {
     const opener = __DARWIN__
       ? 'Finder'
-      : __WIN32__ ? 'Explorer' : 'your File Manager'
+      : __WIN32__
+        ? 'Explorer'
+        : 'your File Manager'
     return (
       <div className="panel blankslate" id="no-changes">
         <img src={BlankSlateImage} className="blankslate-image" />

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -30,7 +30,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
       maxHeight: this.props.maxSize.height - ControlsHeight,
     }
     const percentDiff = (previous: number, current: number) => {
-      const diff = Math.round(100 * (current - previous) / previous)
+      const diff = Math.round((100 * (current - previous)) / previous)
       const sign = diff > 0 ? '+' : ''
       return sign + diff + '%'
     }

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -5,7 +5,9 @@ export const DefaultEditorLabel = __DARWIN__
 
 export const RevealInFileManagerLabel = __DARWIN__
   ? 'Reveal in Finder'
-  : __WIN32__ ? 'Show in Explorer' : 'Show in your File Manager'
+  : __WIN32__
+    ? 'Show in Explorer'
+    : 'Show in your File Manager'
 
 export const OpenWithDefaultProgramLabel = __DARWIN__
   ? 'Open with Default Program'

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -102,7 +102,9 @@ export class RepositoryListItem extends React.Component<
 
     const showRepositoryLabel = __DARWIN__
       ? 'Show in Finder'
-      : __WIN32__ ? 'Show in Explorer' : 'Show in your File Manager'
+      : __WIN32__
+        ? 'Show in Explorer'
+        : 'Show in your File Manager'
 
     const items: ReadonlyArray<IMenuItem> = [
       {

--- a/app/test/unit/progress/clone-test.ts
+++ b/app/test/unit/progress/clone-test.ts
@@ -36,21 +36,21 @@ describe('CloneProgressParser', () => {
         'remote: Compressing objects:  45% (10/22)'
       )
       expect(compressing.kind).to.equal('progress')
-      expect(compressing.percent).to.be.closeTo(10 / 22 * 0.1, 0.01)
+      expect(compressing.percent).to.be.closeTo((10 / 22) * 0.1, 0.01)
 
       const receiving = parser.parse(
         'Receiving objects:  17% (4808/28282), 3.30 MiB | 1.29 MiB/s'
       )
       expect(receiving.kind).to.equal('progress')
-      expect(receiving.percent).to.be.closeTo(0.1 + 4808 / 28282 * 0.6, 0.01)
+      expect(receiving.percent).to.be.closeTo(0.1 + (4808 / 28282) * 0.6, 0.01)
 
       const resolving = parser.parse('Resolving deltas:  89% (18063/20263)')
       expect(resolving.kind).to.equal('progress')
-      expect(resolving.percent).to.be.closeTo(0.7 + 18063 / 20263 * 0.1, 0.01)
+      expect(resolving.percent).to.be.closeTo(0.7 + (18063 / 20263) * 0.1, 0.01)
 
       const checkingOut = parser.parse('Checking out files: 100% (579/579)')
       expect(checkingOut.kind).to.equal('progress')
-      expect(checkingOut.percent).to.be.closeTo(0.8 + 579 / 579 * 0.2, 0.01)
+      expect(checkingOut.percent).to.be.closeTo(0.8 + (579 / 579) * 0.2, 0.01)
     })
 
     it('ignores wrong order', () => {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "node-sass": "^4.7.2",
     "octicons": "^7.0.1",
     "parallel-webpack": "^2.3.0",
-    "prettier": "1.11.1",
+    "prettier": "1.13.0",
     "request": "^2.72.0",
     "rimraf": "^2.5.2",
     "sass-loader": "^7.0.1",

--- a/script/prettier.ts
+++ b/script/prettier.ts
@@ -11,7 +11,12 @@ const root = Path.dirname(__dirname)
 const prettier = process.platform === 'win32' ? 'prettier.cmd' : 'prettier'
 const prettierPath = Path.join(root, 'node_modules', '.bin', prettier)
 
-const args = ['**/*.scss', '--list-different']
+const args = [
+  '**/*.scss',
+  'app/**/*.{ts,tsx}',
+  'script/**/*.ts',
+  '--list-different',
+]
 
 if (shouldFix) {
   args.push('--write')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,9 +5477,9 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-prettier@1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+prettier@1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.0.tgz#054de8d5fb1a4405c845d16183f58a2c301f6f16"
 
 pretty-bytes@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
This jumps us from 1.11.0 over [1.12.0](https://prettier.io/blog/2018/04/11/1.12.0.html) to [1.13.0](https://prettier.io/blog/2018/05/23/1.13.0.html).

TL;DR:

 - support for some new syntax changes coming in TS 2.9
 - better nested ternary indenting
 - better use of parentheses in math expressions
 - unordered lists in markdown now use `-`, not `*` (not enabled for us yet, might follow up with another PR)