### PR TITLE
tweaking the flow of data when updating the repository local state

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1764,6 +1764,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /**
+   * Refresh the local state for a number of repositories in the sidebar
+   *
+   * @param repositories A collection of repositories to check and update
+   * @param fetchRepository Whether to trigger a fetch as part of each repository update
+   */
   private async refreshLocalState(
     repositories: ReadonlyArray<Repository>,
     fetchRepository: boolean = false

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -339,9 +339,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.onDidError(error => this.emitError(error))
 
     this.repositoriesStore.onDidUpdate(async () => {
-      this.repositories = await this.getRefreshedRepositories(
-        await this.repositoriesStore.getAll()
-      )
+      this.repositories = await this.repositoriesStore.getAll()
       this.updateRepositorySelectionAfterRepositoriesChanged()
       this.emitUpdate()
     })
@@ -1753,15 +1751,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._updateCurrentPullRequest(repository)
     this.updateMenuItemLabels(repository)
     this._initializeCompare(repository)
-    this.repositories = await this.getRefreshedRepositories(
-      this.repositories,
-      repository
-    )
+    this.refreshLocalState([repository])
   }
 
   public async refreshAllRepositories() {
-    this.repositories = await this.getRefreshedRepositories(this.repositories)
-    this.emitUpdate()
+    await this.refreshLocalState(this.repositories, true)
   }
 
   /**

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -128,6 +128,15 @@ export class RepositoriesStore extends BaseStore {
     })
   }
 
+  /**
+   * Update the local status of a number of repositories.
+   *
+   * This will compare the work to what's currently cached and only signal
+   * when values have changed.
+   *
+   * @param repositories A collection of repositories to inspect
+   * @param getStatus A function to compute the repository status
+   */
   public async updateLocalStatus(
     repositories: ReadonlyArray<Repository>,
     getStatus: (repository: Repository) => Promise<IRepositoryStatus>

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -4,7 +4,9 @@ import { GitHubRepository } from './github-repository'
 import { IAheadBehind } from './branch'
 
 export interface IRepositoryStatus {
+  /** Whether the repository has uncommitted changes on disk */
   readonly hasChanges: boolean
+  /** The ahead/behind count for the current branch (assumes tracking branch) */
   readonly aheadBehind: IAheadBehind | null
 }
 
@@ -13,13 +15,15 @@ export class Repository {
   public readonly id: number
   /** The working directory of this repository */
   public readonly path: string
+  /** The friendly name for the repository, if a GitHub remote exists, or the directory name of the repository */
   public readonly name: string
+  /** The GitHub API repository details for the current repository, or `null` if the repository has another remote */
   public readonly gitHubRepository: GitHubRepository | null
-
   /** Was the repository missing on disk last we checked? */
   public readonly missing: boolean
-
+  /** The last known state of the ahead/behind count for the current branch (assumes tracking branch) */
   public readonly aheadBehind: IAheadBehind | null
+  /** The last known state for whether there are uncommitted changes for the repository */
   public readonly hasChanges: boolean
 
   public constructor(

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -2,7 +2,11 @@ import * as Path from 'path'
 
 import { GitHubRepository } from './github-repository'
 import { IAheadBehind } from './branch'
-import { WorkingDirectoryFileChange } from './status'
+
+export interface IRepositoryStatus {
+  readonly hasChanges: boolean
+  readonly aheadBehind: IAheadBehind | null
+}
 
 /** A local repository. */
 export class Repository {
@@ -15,16 +19,16 @@ export class Repository {
   /** Was the repository missing on disk last we checked? */
   public readonly missing: boolean
 
-  public aheadBehind: IAheadBehind | null
-  public changedFiles: ReadonlyArray<WorkingDirectoryFileChange> | null
+  public readonly aheadBehind: IAheadBehind | null
+  public readonly hasChanges: boolean
 
   public constructor(
     path: string,
     id: number,
     gitHubRepository: GitHubRepository | null,
     missing: boolean,
-    aheadBehind?: IAheadBehind,
-    changedFiles?: ReadonlyArray<WorkingDirectoryFileChange>
+    hasChanges: boolean = false,
+    aheadBehind: IAheadBehind | null = null
   ) {
     this.path = path
     this.gitHubRepository = gitHubRepository
@@ -32,8 +36,8 @@ export class Repository {
       (gitHubRepository && gitHubRepository.name) || Path.basename(path)
     this.id = id
     this.missing = missing
+    this.hasChanges = hasChanges
     this.aheadBehind = aheadBehind || null
-    this.changedFiles = changedFiles || null
   }
 
   /**
@@ -47,5 +51,16 @@ export class Repository {
       ${this.path}+
       ${this.missing}+
       ${this.name}`
+  }
+
+  public withLocalStatus(status: IRepositoryStatus): Repository {
+    return new Repository(
+      this.path,
+      this.id,
+      this.gitHubRepository,
+      this.missing,
+      status.hasChanges,
+      status.aheadBehind
+    )
   }
 }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -50,9 +50,7 @@ export class RepositoryListItem extends React.Component<
       repository instanceof Repository ? repository.gitHubRepository : null
     let hasChanges = false
     if (repository instanceof Repository) {
-      hasChanges = repository.changedFiles
-        ? repository.changedFiles.length > 0
-        : false
+      hasChanges = repository.hasChanges
     }
     const renderAheadBehindIndicator = () => {
       if (!(repository instanceof Repository) || !repository.aheadBehind) {


### PR DESCRIPTION
**This is targeting #4770 but at the moment I'm opening this up for a review and feedback. I also need to do some testing to ensure I haven't adversely impacted things**

@vanessayuenn this does a bit of cleanup to the flow of data when refreshing the sidebar, based on what I was touching on in this comment thread: https://github.com/desktop/desktop/pull/4770#discussion_r190431032.

The cliff notes:

 - `Repository` now uses a boolean `hasChanges` rather than referencing the array of `WorkingDirectoryChanges` - I don't think we need the count of files here?
 - `Repository` now doesn't have public setters to update properties around the local state - instead you call `Repository.withLocalStatus` and get a new instance
 - `RepositoriesStore` now tracks the local state for each repository in a cache and handles enriching the database instance for the application's needs
 - `AppStore.refreshLocalState` replaces `AppStore. getRefreshedRepositories`, and instead of returning an array of repositories it performs it's Git operations and then calls into `RepositoriesStore` to perform the update

The net effect of this is that we can now use `this.repositoriesStore.onDidUpdate` and `getAll()` again to update `this.repositories` in one spot.