### PR TITLE
cut a new release

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.2.1-beta0",
+  "version": "1.2.1-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,12 @@
 {
   "releases": {
+    "1.2.1-beta1": [
+      "[Added] Add Brackets support for macOS - #4608. Thanks @3raxton!",
+      "[Added] Pull request number and author are included in fuzzy-find filtering - #4653. Thanks @damaneice!",
+      "[Fixed] Decreased the max line length limit - #3740. Thanks @sagaragarwal94!",
+      "[Fixed] Display the differences file size of images - #4380. Thanks @ggajos!",
+      "[Fixed] Updated embedded Git to 2.17.1 to address upstream security issue - #4791"
+    ],
     "1.2.1-beta0": [
 
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,11 +1,11 @@
 {
   "releases": {
     "1.2.1-beta1": [
-      "[Added] Add Brackets support for macOS - #4608. Thanks @3raxton!",
+      "[Added] Brackets support for macOS - #4608. Thanks @3raxton!",
       "[Added] Pull request number and author are included in fuzzy-find filtering - #4653. Thanks @damaneice!",
       "[Fixed] Decreased the max line length limit - #3740. Thanks @sagaragarwal94!",
-      "[Fixed] Display the differences file size of images - #4380. Thanks @ggajos!",
-      "[Fixed] Updated embedded Git to 2.17.1 to address upstream security issue - #4791"
+      "[Fixed] Updated embedded Git to 2.17.1 to address upstream security issue - #4791",
+      "[Improved] Display the difference in file size of an image in the diff view - #4380. Thanks @ggajos!"
     ],
     "1.2.1-beta0": [
 


### PR DESCRIPTION
This depends on #4791, and is relatively urgent because the Git project published an update addressing a security issue with recursive submodule clones (which we do in Desktop).

More details here: https://blogs.msdn.microsoft.com/devops/2018/05/29/announcing-the-may-2018-git-security-vulnerability/