### PR TITLE
downgrade Git to 2.17.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "codemirror-mode-elixir": "1.1.1",
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
-    "dugite": "1.65.0",
+    "dugite": "1.64.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.2.2-beta1",
+  "version": "1.2.2-test1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.2.1",
+  "version": "1.2.2-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -253,8 +253,6 @@ function getDescriptionForError(error: DugiteError): string {
       return 'The object was not found in the Git repository.'
     case DugiteError.OutsideRepository:
       return 'This path is not a valid path inside the repository.'
-    case DugiteError.LockFileAlreadyExists:
-      return 'A lock file already exists in the repository, which blocks this operation from completing.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -242,9 +242,9 @@ dom-matches@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dom-matches/-/dom-matches-2.0.0.tgz#d2728b416a87533980eb089b848d253cf23a758c"
 
-dugite@1.65.0:
-  version "1.65.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.65.0.tgz#43636fb9af9afe701a694f17857d38b56184679c"
+dugite@1.64.0:
+  version "1.64.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.64.0.tgz#60739f9e172fc77eca560e5bac2311d0517ff03b"
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.2.2-beta1": [
+      "[Fixed] Downgrade embedded Git to 2.17.0 due to SChannel issue - #4819"
+    ],
     "1.2.1": [
       "[Added] Brackets support for macOS - #4608. Thanks @3raxton!",
       "[Added] Pull request number and author are included in fuzzy-find filtering - #4653. Thanks @damaneice!",

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,6 @@
 {
   "releases": {
-    "1.2.2-beta1": [
+    "1.2.2-test1": [
       "[Fixed] Downgrade embedded Git to 2.17.0 due to SChannel issue - #4819"
     ],
     "1.2.1": [


### PR DESCRIPTION
This is an interim fix to help confirm there's an outstanding issue with Git for Windows 2.17.1.