### PR TITLE
Release 1.2.2 to production with dugite update

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.2.2-beta1",
+  "version": "1.2.2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,9 @@
 {
   "releases": {
+    "1.2.2": [
+      "[Fixed] Make cURL/schannel default to using the Windows certificate store - #4817",
+      "[Fixed] Restore text selection highlighting in diffs - #4818"
+    ],
     "1.2.2-beta1": [
       "[Fixed] Make cURL/schannel default to using the Windows certificate store - #4817",
       "[Fixed] Text selection highlighting in diffs is back - #4818"


### PR DESCRIPTION
We just released 1.2.2-beta1 to beta and verified the change. This is to release to production.

Changes:
1. Update dugite
See desktop/dugite-native#98
See desktop/dugite#189

2. Restore syntax highlighting for diffs