### PR TITLE
handle and log when updating PRs fails

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -104,7 +104,11 @@ export class PullRequestStore extends TypedBaseStore<GitHubRepository> {
   ): Promise<void> {
     const prs = await this.fetchPullRequestsFromCache(repository)
 
-    await this.fetchAndCachePullRequestStatus(prs, repository, account)
+    try {
+      await this.fetchAndCachePullRequestStatus(prs, repository, account)
+    } catch (e) {
+      log.warn('Error updating pull request statuses', e)
+    }
   }
 
   /** Gets the pull requests against the given repository. */


### PR DESCRIPTION
I stumbled upon this after closing my laptop and changing locations - I had Desktop opened, but for a period of time I was away from internet access. I came back to find a generic `Unable to fetch` dialog and this entry in the dev tools:

<img width="925" alt="screen shot 2018-06-01 at 10 01 27 am" src="https://user-images.githubusercontent.com/359239/40814418-74505d24-6583-11e8-9bba-52a60e8258a7.png">

This correlates to the second `await` in here:

https://github.com/desktop/desktop/blob/f8a69cad4bb3ed51810d3108b5012dcf6d331a27/app/src/lib/stores/pull-request-store.ts#L101-L108

We don't need to prompt the user if this fails for whatever reason, and I've chosen `warn` as the priority here to ensure this is logged (we do this inside `BackgroundFetcher` too).