### PR TITLE
inline AuthorInput.getHintRangeFromCursor to address TypeError

### DIFF
--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -174,17 +174,6 @@ function scanUntil(
   return scanWhile(doc, start, (doc, pos) => !predicate(doc, pos), iter)
 }
 
-/**
- * Given a cursor position, expand it into a range covering as
- * long of an autocompletable string as possible.
- */
-function getHintRangeFromCursor(doc: Doc, cursor: Position) {
-  return {
-    from: scanUntil(doc, cursor, isMarkOrWhitespace, prevPosition),
-    to: scanUntil(doc, cursor, isMarkOrWhitespace, nextPosition),
-  }
-}
-
 function appendTextMarker(
   cm: Editor,
   text: string,
@@ -635,7 +624,10 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
     const doc = cm.getDoc()
     const cursor = doc.getCursor() as Readonly<Position>
 
-    const { from, to } = getHintRangeFromCursor(doc, cursor)
+    // expand the current cursor position into a range covering as
+    // long of an autocompletable string as possible.
+    const from = scanUntil(doc, cursor, isMarkOrWhitespace, prevPosition)
+    const to = scanUntil(doc, cursor, isMarkOrWhitespace, nextPosition)
 
     const word = doc.getRange(from, to)
 


### PR DESCRIPTION
Fixes #4847 by inlining the function.

**Before**:

 - run current `master` with `yarn build:prod` and `yarn start:prod`
 - choose a GitHub repository
 - try and add a co-author
 - :boom: no auto-complete appears, errors in dev tools console

<img width="467" alt="screen shot 2018-06-01 at 5 09 00 pm" src="https://user-images.githubusercontent.com/359239/40826613-867e7fe0-65be-11e8-82b4-a76125704375.png">

Which is this unminified code in `onAutocompleteUser`:

<img width="378" alt="screen shot 2018-06-01 at 5 11 01 pm" src="https://user-images.githubusercontent.com/359239/40826728-d3b96bb2-65be-11e8-8911-62cd4fb594a3.png">

**After**:

 - run this version with `yarn build:prod` and `yarn start:prod`
 - choose a GitHub repository
 - try and add a co-author
 - ✅ auto-complete appears, filtered users listed, no errors in dev tools console

This is the new unminified code for `onAutocompleteUser`:

<img width="534" alt="screen shot 2018-06-01 at 5 32 24 pm" src="https://user-images.githubusercontent.com/359239/40827764-f4c7c706-65c1-11e8-960e-2e5aae2d4907.png">



**Other notes**:

I could reproduce this with the latest webpack (4.10.2 as of writing) but I think this needs to be isolated and submitted to `uglify-es` because that's the component doing the JS mangling here.