### PR TITLE
Update TypeScript to 2.9

### DIFF
--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -20,14 +20,6 @@ import {
 } from './group-branches'
 import { NoBranches } from './no-branches'
 
-/**
- * TS can't parse generic specialization in JSX, so we have to alias it here
- * with the generic type. See https://github.com/Microsoft/TypeScript/issues/6395.
- */
-const BranchesFilterList: new () => FilterList<
-  IBranchListItem
-> = FilterList as any
-
 const RowHeight = 30
 
 interface IBranchListProps {
@@ -172,7 +164,7 @@ export class BranchList extends React.Component<
 
   public render() {
     return (
-      <BranchesFilterList
+      <FilterList<IBranchListItem>
         ref={this.onBranchesFilterListRef}
         className="branches-list"
         rowHeight={RowHeight}

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -17,14 +17,6 @@ interface IPullRequestListItem extends IFilterListItem {
   readonly pullRequest: PullRequest
 }
 
-/**
- * TS can't parse generic specialization in JSX, so we have to alias it here
- * with the generic type. See https://github.com/Microsoft/TypeScript/issues/6395.
- */
-const PullRequestFilterList: new () => FilterList<
-  IPullRequestListItem
-> = FilterList as any
-
 export const RowHeight = 47
 
 interface IPullRequestListProps {
@@ -128,7 +120,7 @@ export class PullRequestList extends React.Component<
 
   public render() {
     return (
-      <PullRequestFilterList
+      <FilterList<IPullRequestListItem>
         className="pull-request-list"
         rowHeight={RowHeight}
         groups={this.state.groupedItems}

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -8,14 +8,6 @@ import { RowHeight } from './pull-request-list'
 
 const FacadeCount = 6
 
-/**
- * TS can't parse generic specialization in JSX, so we have to alias it here
- * with the generic type. See https://github.com/Microsoft/TypeScript/issues/6395.
- */
-const PullRequestsLoadingList: new () => FilterList<
-  IFilterListItem
-> = FilterList as any
-
 const prLoadingItemProps: IPullRequestListItemProps = {
   loading: true,
   author: '',
@@ -51,7 +43,7 @@ export class PullRequestsLoading extends React.Component<{}, {}> {
     ]
 
     return (
-      <PullRequestsLoadingList
+      <FilterList<IFilterListItem>
         className="pull-request-list"
         rowHeight={RowHeight}
         groups={groups}

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -11,14 +11,6 @@ import { FilterList } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
 import { assertNever } from '../../lib/fatal-error'
 
-/**
- * TS can't parse generic specialization in JSX, so we have to alias it here
- * with the generic type. See https://github.com/Microsoft/TypeScript/issues/6395.
- */
-const RepositoryFilterList: new () => FilterList<
-  IRepositoryListItem
-> = FilterList as any
-
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
@@ -127,7 +119,7 @@ export class RepositoriesList extends React.Component<
 
     return (
       <div className="repository-list">
-        <RepositoryFilterList
+        <FilterList<IRepositoryListItem>
           rowHeight={RowHeight}
           selectedItem={selectedItem}
           filterText={this.props.filterText}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
-    "eslint-plugin-typescript": "^0.10.0",
+    "eslint-plugin-typescript": "^0.12.0",
     "express": "^4.15.0",
     "front-matter": "^2.3.0",
     "fs-extra": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "tslint-config-prettier": "^1.10.0",
     "tslint-microsoft-contrib": "^5.0.3",
     "tslint-react": "^3.5.1",
-    "typescript": "^2.8.3",
+    "typescript": "^2.9.1",
     "typescript-eslint-parser": "^15.0.0",
     "webpack": "^4.8.3",
     "webpack-bundle-analyzer": "^2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,9 +2492,9 @@ eslint-plugin-react@^7.7.0:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.0"
 
-eslint-plugin-typescript@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.10.0.tgz#009a8fcaf0ec7bf68f6fb71576df0d84ebd0b114"
+eslint-plugin-typescript@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.12.0.tgz#e23d58cb27fe28e89fc641a1f20e8d862cb99aef"
   dependencies:
     requireindex "~1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,13 +126,7 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.3.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.14.tgz#f90ac6834de172e13ecca430dcb6814744225d36"
-  dependencies:
-    csstype "^2.2.0"
-
-"@types/react@16.3.14":
+"@types/react@*", "@types/react@16.3.14":
   version "16.3.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.14.tgz#f90ac6834de172e13ecca430dcb6814744225d36"
   dependencies:
@@ -7066,9 +7060,9 @@ typescript-eslint-parser@^15.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
 - [What's New?](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#typescript-29)
 - [Breaking Changes](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-29)

I tidied up the workarounds for generic components in JSX to confirm that there's no additional dependencies we need to update aside from `eslint-plugin-typescript`.