### PR TITLE
Show an ellipses only if the confirm popup should be shown

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -47,6 +47,7 @@ interface IChangesListProps {
     trailers?: ReadonlyArray<ITrailer>
   ) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
+  readonly askForConfirmationOnDiscardChanges: boolean
   readonly onDiscardAllChanges: (
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ) => void
@@ -219,6 +220,19 @@ export class ChangesList extends React.Component<
     }
   }
 
+  private getDiscardChangesMenuItemLabel = (files: ReadonlyArray<string>) => {
+    const label =
+      files.length === 1
+        ? __DARWIN__
+          ? `Discard Changes`
+          : `Discard changes`
+        : __DARWIN__
+          ? `Discard ${files.length} Selected Changes`
+          : `Discard ${files.length} selected changes`
+
+    return this.props.askForConfirmationOnDiscardChanges ? `${label}…` : label
+  }
+
   private onContextMenu = (event: React.MouseEvent<any>) => {
     event.preventDefault()
 
@@ -266,14 +280,7 @@ export class ChangesList extends React.Component<
 
     const items: IMenuItem[] = [
       {
-        label:
-          paths.length === 1
-            ? __DARWIN__
-              ? `Discard Changes…`
-              : `Discard changes…`
-            : __DARWIN__
-              ? `Discard ${paths.length} Selected Changes…`
-              : `Discard ${paths.length} selected changes…`,
+        label: this.getDiscardChangesMenuItemLabel(paths),
         action: () => this.onDiscardChanges(paths),
       },
       {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -295,6 +295,9 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onIncludeChanged={this.onIncludeChanged}
           onSelectAll={this.onSelectAll}
           onDiscardChanges={this.onDiscardChanges}
+          askForConfirmationOnDiscardChanges={
+            this.props.askForConfirmationOnDiscardChanges
+          }
           onDiscardAllChanges={this.onDiscardAllChanges}
           onOpenItem={this.onOpenItem}
           onRowClick={this.onChangedItemClick}


### PR DESCRIPTION
This PR fixes #4846 
 
`askForConfirmationOnDiscardChanges` boolean prop was passed to the `ChangesList` component to determine whether ellipses is displayed.

![handle_ellipsis](https://user-images.githubusercontent.com/4126644/40887939-12fe06e8-678b-11e8-9f07-c89b56afb413.gif)
