### PR TITLE
inline forkPullRequestRemoteName to address ReferenceError

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3571,9 +3571,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         "This pull request's clone URL is not populated but should be",
         head.gitHubRepository.cloneURL
       )
-      const remoteName = `${ForkedRemotePrefix}${
-        head.gitHubRepository.owner.login
-      }`
+      const remoteName = ForkedRemotePrefix + head.gitHubRepository.owner.login
+
       const remotes = await getRemotes(repository)
       const remote =
         remotes.find(r => r.name === remoteName) ||

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3571,7 +3571,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         "This pull request's clone URL is not populated but should be",
         head.gitHubRepository.cloneURL
       )
-      const remoteName = `${ForkedRemotePrefix}${head.gitHubRepository.owner.login}`
+      const remoteName = `${ForkedRemotePrefix}${
+        head.gitHubRepository.owner.login
+      }`
       const remotes = await getRemotes(repository)
       const remote =
         remotes.find(r => r.name === remoteName) ||

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3571,9 +3571,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         "This pull request's clone URL is not populated but should be",
         head.gitHubRepository.cloneURL
       )
-      const remoteName = forkPullRequestRemoteName(
-        head.gitHubRepository.owner.login
-      )
+      const remoteName = `${ForkedRemotePrefix}${head.gitHubRepository.owner.login}`
       const remotes = await getRemotes(repository)
       const remote =
         remotes.find(r => r.name === remoteName) ||
@@ -3659,10 +3657,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _recordCompareInitiatedMerge() {
     this.statsStore.recordCompareInitiatedMerge()
   }
-}
-
-function forkPullRequestRemoteName(remoteName: string) {
-  return `${ForkedRemotePrefix}${remoteName}`
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3571,6 +3571,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         "This pull request's clone URL is not populated but should be",
         head.gitHubRepository.cloneURL
       )
+
+      // by convention the remote that Desktop looks for here is prefixed to
+      // differentiate from existing remotes defined by the user
       const remoteName = ForkedRemotePrefix + head.gitHubRepository.owner.login
 
       const remotes = await getRemotes(repository)


### PR DESCRIPTION
Fixes #4842

**Before:**

 - run current `master` with `yarn build:prod` and `yarn start:prod`
 - choose a GitHub repository
 - try and checkout a pull request from a fork 
 - :boom: no checkout, errors in dev tools console

<img width="605" src="https://user-images.githubusercontent.com/359239/40892959-0769d832-67dd-11e8-91d8-8c6fb0d1c103.png">

Spelunk down to find the underlying JS:

<img width="342" src="https://user-images.githubusercontent.com/359239/40892962-116535d4-67dd-11e8-9270-9a2b52453f70.png">

**After:**

 - run this version with `yarn build:prod` and `yarn start:prod`
 - choose a GitHub repository
 - try and checkout a pull request from a fork 
 - ✅ checkout occurs, no errors in dev tools console

This is now the underlying JS:

<img width="577" src="https://user-images.githubusercontent.com/359239/40893013-cc672c2a-67dd-11e8-9a1e-53dbec79aa1e.png">


