### PR TITLE
introduce new props for repository list items

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -75,7 +75,7 @@ export interface IAppState {
   /**
    * A cache of the latest repository state values, keyed by the repository id
    */
-  readonly localRepositoryStateLookup: Map<string, ILocalRepositoryState>
+  readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>
 
   readonly selectedState: PossibleSelections | null
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -1,7 +1,7 @@
 import { Account } from '../models/account'
 import { CommitIdentity } from '../models/commit-identity'
 import { IDiff } from '../models/diff'
-import { Repository } from '../models/repository'
+import { Repository, ILocalRepositoryState } from '../models/repository'
 
 import { Branch, IAheadBehind } from '../models/branch'
 import { Tip } from '../models/tip'
@@ -71,6 +71,11 @@ export interface IAppState {
    * The current list of repositories tracked in the application
    */
   readonly repositories: ReadonlyArray<Repository | CloningRepository>
+
+  /**
+   * A cache of the latest repository state values, keyed by the repository id
+   */
+  readonly localRepositoryStateLookup: Map<string, ILocalRepositoryState>
 
   readonly selectedState: PossibleSelections | null
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -67,6 +67,9 @@ export type PossibleSelections =
 /** All of the shared app state. */
 export interface IAppState {
   readonly accounts: ReadonlyArray<Account>
+  /**
+   * The current list of repositories tracked in the application
+   */
   readonly repositories: ReadonlyArray<Repository | CloningRepository>
 
   readonly selectedState: PossibleSelections | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -568,7 +568,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ...this.repositories,
         ...this.cloningRepositoriesStore.repositories,
       ],
-      localRepositoryStateLookup: new Map<string, ILocalRepositoryState>(),
+      localRepositoryStateLookup: new Map<number, ILocalRepositoryState>(),
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
       appIsFocused: this.appIsFocused,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -199,6 +199,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     string,
     RepositorySettingsStore
   >()
+
+  private readonly localRepositoryStateLookup = new Map<
+    number,
+    ILocalRepositoryState
+  >()
   public readonly gitHubUserStore: GitHubUserStore
   private readonly cloningRepositoriesStore: CloningRepositoriesStore
   private readonly emojiStore: EmojiStore
@@ -568,7 +573,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ...this.repositories,
         ...this.cloningRepositoriesStore.repositories,
       ],
-      localRepositoryStateLookup: new Map<number, ILocalRepositoryState>(),
+      localRepositoryStateLookup: this.localRepositoryStateLookup,
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
       appIsFocused: this.appIsFocused,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -26,7 +26,7 @@ import {
   ICompareFormUpdate,
 } from '../app-state'
 import { Account } from '../../models/account'
-import { Repository } from '../../models/repository'
+import { Repository, ILocalRepositoryState } from '../../models/repository'
 import { GitHubRepository } from '../../models/github-repository'
 import {
   CommittedFileChange,
@@ -568,6 +568,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ...this.repositories,
         ...this.cloningRepositoriesStore.repositories,
       ],
+      localRepositoryStateLookup: new Map<string, ILocalRepositoryState>(),
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
       appIsFocused: this.appIsFocused,

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -1,6 +1,7 @@
 import * as Path from 'path'
 
 import { GitHubRepository } from './github-repository'
+import { IAheadBehind } from './branch'
 
 /** A local repository. */
 export class Repository {
@@ -39,4 +40,19 @@ export class Repository {
       ${this.missing}+
       ${this.name}`
   }
+}
+
+/**
+ * A snapshot for the local state for a given repository
+ */
+export interface ILocalRepositoryState {
+  /**
+   * The ahead/behind count for the current branch, or `null` if no tracking
+   * branch found.
+   */
+  readonly aheadBehind: IAheadBehind | null
+  /**
+   * The number of uncommitted changes currently in the repository.
+   */
+  readonly changedFilesCount: number
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1390,6 +1390,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         selectedRepository={selectedRepository}
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
+        localRepositoryStateLookup={this.state.localRepositoryStateLookup}
         onRemoveRepository={this.removeRepository}
         onOpenInShell={this.openInShell}
         onShowRepository={this.showRepository}

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -18,6 +18,11 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly changedFilesCount: number
 }
 
+const fallbackValue = {
+  changedFilesCount: 0,
+  aheadBehind: null,
+}
+
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: Map<number, ILocalRepositoryState>
@@ -63,13 +68,15 @@ export function groupRepositories(
     repositories.sort((x, y) => caseInsensitiveCompare(x.name, y.name))
     const items: ReadonlyArray<IRepositoryListItem> = repositories.map(r => {
       const nameCount = names.get(r.name) || 0
+      const { aheadBehind, changedFilesCount } =
+        localRepositoryStateLookup.get(r.id) || fallbackValue
       return {
         text: [r.name],
         id: r.id.toString(),
         repository: r,
         needsDisambiguation: nameCount > 1,
-        aheadBehind: null,
-        changedFilesCount: 0,
+        aheadBehind,
+        changedFilesCount,
       }
     })
 

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -3,6 +3,7 @@ import { CloningRepository } from '../../models/cloning-repository'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { caseInsensitiveCompare } from '../../lib/compare'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
+import { IAheadBehind } from '../../models/branch'
 
 export type RepositoryGroupIdentifier = 'github' | 'enterprise' | 'other'
 
@@ -13,6 +14,8 @@ export interface IRepositoryListItem extends IFilterListItem {
   readonly id: string
   readonly repository: Repositoryish
   readonly needsDisambiguation: boolean
+  readonly aheadBehind: IAheadBehind | null
+  readonly changedFilesCount: number
 }
 
 export function groupRepositories(
@@ -64,6 +67,8 @@ export function groupRepositories(
         id: r.id.toString(),
         repository: r,
         needsDisambiguation: nameCount > 1,
+        aheadBehind: null,
+        changedFilesCount: 0,
       }
     })
 

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -20,7 +20,7 @@ export interface IRepositoryListItem extends IFilterListItem {
 
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
-  localRepositoryStateLookup: Map<string, ILocalRepositoryState>
+  localRepositoryStateLookup: Map<number, ILocalRepositoryState>
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem>> {
   const grouped = new Map<RepositoryGroupIdentifier, Repositoryish[]>()
   for (const repository of repositories) {

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -1,4 +1,4 @@
-import { Repository } from '../../models/repository'
+import { Repository, ILocalRepositoryState } from '../../models/repository'
 import { CloningRepository } from '../../models/cloning-repository'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { caseInsensitiveCompare } from '../../lib/compare'
@@ -19,7 +19,8 @@ export interface IRepositoryListItem extends IFilterListItem {
 }
 
 export function groupRepositories(
-  repositories: ReadonlyArray<Repositoryish>
+  repositories: ReadonlyArray<Repositoryish>,
+  localRepositoryStateLookup: Map<string, ILocalRepositoryState>
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem>> {
   const grouped = new Map<RepositoryGroupIdentifier, Repositoryish[]>()
   for (const repository of repositories) {

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -10,6 +10,7 @@ import {
 import { FilterList } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
 import { assertNever } from '../../lib/fatal-error'
+import { ILocalRepositoryState } from '../../models/repository'
 
 /**
  * TS can't parse generic specialization in JSX, so we have to alias it here
@@ -22,6 +23,9 @@ const RepositoryFilterList: new () => FilterList<
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
+
+  /** A cache of the latest repository state values, keyed by the repository id */
+  readonly localRepositoryStateLookup: Map<string, ILocalRepositoryState>
 
   /** Called when a repository has been selected. */
   readonly onSelectionChanged: (repository: Repositoryish) => void
@@ -107,7 +111,10 @@ export class RepositoriesList extends React.Component<
       return this.noRepositories()
     }
 
-    const groups = groupRepositories(this.props.repositories)
+    const groups = groupRepositories(
+      this.props.repositories,
+      this.props.localRepositoryStateLookup
+    )
 
     let selectedItem: IRepositoryListItem | null = null
     const selectedRepository = this.props.selectedRepository

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -25,7 +25,7 @@ interface IRepositoriesListProps {
   readonly repositories: ReadonlyArray<Repositoryish>
 
   /** A cache of the latest repository state values, keyed by the repository id */
-  readonly localRepositoryStateLookup: Map<string, ILocalRepositoryState>
+  readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>
 
   /** Called when a repository has been selected. */
   readonly onSelectionChanged: (repository: Repositoryish) => void

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -28,7 +28,7 @@ describe('repository list grouping', () => {
     ),
   ]
 
-  const cache = new Map<string, ILocalRepositoryState>()
+  const cache = new Map<number, ILocalRepositoryState>()
 
   it('groups repositories by GitHub/Enterprise/Other', () => {
     const grouped = groupRepositories(repositories, cache)

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 
 import { groupRepositories } from '../../src/ui/repositories-list/group-repositories'
-import { Repository } from '../../src/models/repository'
+import { Repository, ILocalRepositoryState } from '../../src/models/repository'
 import { GitHubRepository } from '../../src/models/github-repository'
 import { Owner } from '../../src/models/owner'
 import { getDotComAPIEndpoint } from '../../src/lib/api'
@@ -28,8 +28,10 @@ describe('repository list grouping', () => {
     ),
   ]
 
+  const cache = new Map<string, ILocalRepositoryState>()
+
   it('groups repositories by GitHub/Enterprise/Other', () => {
-    const grouped = groupRepositories(repositories)
+    const grouped = groupRepositories(repositories, cache)
     expect(grouped.length).to.equal(3)
 
     expect(grouped[0].identifier).to.equal('github')
@@ -68,7 +70,10 @@ describe('repository list grouping', () => {
     )
     const repoZ = new Repository('z', 3, null, false)
 
-    const grouped = groupRepositories([repoC, repoB, repoZ, repoD, repoA])
+    const grouped = groupRepositories(
+      [repoC, repoB, repoZ, repoD, repoA],
+      cache
+    )
     expect(grouped.length).to.equal(2)
 
     expect(grouped[0].identifier).to.equal('github')
@@ -119,7 +124,7 @@ describe('repository list grouping', () => {
       false
     )
 
-    const grouped = groupRepositories([repoA, repoB, repoC])
+    const grouped = groupRepositories([repoA, repoB, repoC], cache)
     expect(grouped.length).to.equal(1)
 
     expect(grouped[0].identifier).to.equal('github')


### PR DESCRIPTION
This is some groundwork to land #4770:

 - a new `localRepositoryStateLookup` in `AppState` to map repositories (by their numeric id) to the local state, without needing to poke at the `GitStore` inside components
 - the new properties to display in the UI are now found in `IRepositoryListItem` - this is a more appropriate place than the repository model, as this is what we use to represent UI-specific data
 - `groupRepositories` - the function used to build up the listed repositories - this now uses the new lookup to populate these objects as part of rendering

I've avoided pulling in the computation and UI updates from #4770, but you can update this local cache in `AppStore` by using a snippet like this:

```ts
    const lookup = this.localRepositoryStateLookup
    const gitStore = this.getGitStore(repository)
    const status = await gitStore.loadStatus()
    if (status != null) {
      const changedFilesCount = status.workingDirectory.files.length
      const aheadBehind = gitStore.aheadBehind
      lookup.set(repository.id, { aheadBehind, changedFilesCount })
    }

    this.emitUpdate()
```

