### PR TITLE
this error is logged, don't report to the user

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -67,7 +67,6 @@ export class PullRequestStore extends TypedBaseStore<GitHubRepository> {
       this.emitUpdate(githubRepo)
     } catch (error) {
       log.warn(`Error refreshing pull requests for '${repository.name}'`, error)
-      this.emitError(error)
     } finally {
       this.updateActiveFetchCount(githubRepo, Decrement)
     }


### PR DESCRIPTION
Fixes #4866 by not interrupting the user when an unexpected network error happens - this is logged as well, so it doesn't seem important to also interrupt the user for this background work.