### PR TITLE
add support for running unit tests with Chrome Dev Tools shown

### DIFF
--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -166,18 +166,8 @@ problems.
 ## Running tests
 
 - `yarn test` - Runs all unit and integration tests
-- `yarn test:unit` - Runs all unit tests
+- `yarn test:unit` - Runs all unit tests (add `--debug` to open Chrome Dev Tools while running tests)
 - `yarn test:integration` - Runs all integration tests
-
-**Pro Tip:** If you're only interested in the results of a single test and don't
-wish to run the entire test suite to see it you can pass along a search string
-in order to only run the tests that match that string.
-
-```shellsession
-$ yarn test:unit -- --grep CloneProgressParser
-```
-
-This example will run all test names containing `CloneProgressParser`.
 
 ## Debugging
 

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -52,6 +52,12 @@ const electronMochaArgs = [
   'app/test/unit/**/*.{ts,tsx}',
 ]
 
+const shouldDebug = process.argv.indexOf('--debug') > -1
+
+if (shouldDebug) {
+  electronMochaArgs.push('--debug')
+}
+
 let exitCode = -1
 
 if (process.platform === 'linux') {


### PR DESCRIPTION
Want to poke at your unit tests while authoring them? Here's a quick way to get access to the Chrome Dev Tools when running tests. Simply add a `debugger` statement at the start of the test to get CDT to break there, then you can step through the tests like it was the live app.

I've updated the docs to mention this, and also remove the `--grep` tip that's no longer relevant since we moved to a different way to running these tests in #4136. **Let me know if that's something you still want back, and we can open a tracking issue to investigate.**
