### PR TITLE
Change "restart now" to "restart GitHub Desktop"

### DIFF
--- a/app/src/ui/updates/update-available.tsx
+++ b/app/src/ui/updates/update-available.tsx
@@ -26,7 +26,9 @@ export class UpdateAvailable extends React.Component<
           installed at the next launch. See{' '}
           <LinkButton uri={this.props.releaseNotesLink}>what's new</LinkButton>{' '}
           or{' '}
-          <LinkButton onClick={this.updateNow}>restart GitHub now</LinkButton>.
+          <LinkButton onClick={this.updateNow}>
+            restart GitHub Desktop now
+          </LinkButton>.
         </span>
 
         <a className="close" onClick={this.dismiss}>

--- a/app/src/ui/updates/update-available.tsx
+++ b/app/src/ui/updates/update-available.tsx
@@ -25,7 +25,8 @@ export class UpdateAvailable extends React.Component<
           An updated version of GitHub Desktop is available and will be
           installed at the next launch. See{' '}
           <LinkButton uri={this.props.releaseNotesLink}>what's new</LinkButton>{' '}
-          or <LinkButton onClick={this.updateNow}>restart GitHub now</LinkButton>.
+          or{' '}
+          <LinkButton onClick={this.updateNow}>restart GitHub now</LinkButton>.
         </span>
 
         <a className="close" onClick={this.dismiss}>

--- a/app/src/ui/updates/update-available.tsx
+++ b/app/src/ui/updates/update-available.tsx
@@ -25,7 +25,7 @@ export class UpdateAvailable extends React.Component<
           An updated version of GitHub Desktop is available and will be
           installed at the next launch. See{' '}
           <LinkButton uri={this.props.releaseNotesLink}>what's new</LinkButton>{' '}
-          or <LinkButton onClick={this.updateNow}>restart now</LinkButton>.
+          or <LinkButton onClick={this.updateNow}>restart GitHub now</LinkButton>.
         </span>
 
         <a className="close" onClick={this.dismiss}>

--- a/app/src/ui/updates/update-available.tsx
+++ b/app/src/ui/updates/update-available.tsx
@@ -27,7 +27,7 @@ export class UpdateAvailable extends React.Component<
           <LinkButton uri={this.props.releaseNotesLink}>what's new</LinkButton>{' '}
           or{' '}
           <LinkButton onClick={this.updateNow}>
-            restart GitHub Desktop now
+            restart GitHub Desktop
           </LinkButton>.
         </span>
 


### PR DESCRIPTION
Specifies that you will restart GitHub Desktop and not your computer when there is an update available.
Closes #4891 