### PR TITLE
Only show overflow shadow when description overflows

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -41,6 +41,21 @@
     .commit-summary-description {
       padding-right: 100px;
     }
+
+    // When the description area can be, but isn't yet, expanded
+    // we'll add a small shadow towards the bottom to hint that
+    // there's more content available.
+    &:not(.expanded) {
+      .commit-summary-description:before {
+        content: '';
+        background: var(--box-overflow-shadow-background);
+        position: absolute;
+        height: 30px;
+        bottom: 0px;
+        width: 100%;
+        pointer-events: none;
+      }
+    }
   }
 }
 
@@ -76,16 +91,6 @@
     // The extra pixel makes the space align up with the commit list.
     max-height: 61px;
     flex: 1;
-
-    &:before {
-      content: '';
-      background: var(--box-overflow-shadow-background);
-      position: absolute;
-      height: 30px;
-      bottom: 0px;
-      width: 100%;
-      pointer-events: none;
-    }
   }
 
   // Enable text selection inside the title and description elements.


### PR DESCRIPTION
This fixes a bug where we'd always add an overflow shadow regardless of whether the description contents actually overflowed its container or not.

### Before

![screen shot 2018-06-08 at 15 26 12](https://user-images.githubusercontent.com/634063/41160762-f0fd6dbe-6b30-11e8-9e08-4a8a94f206e6.png)

### After

![screen shot 2018-06-08 at 15 31 25](https://user-images.githubusercontent.com/634063/41160818-0c69c930-6b31-11e8-8b46-9f1c1165a8ae.png)

Extracted from #4849 for stand-alone review.