### PR TITLE
Extract toolbar badge variables and sync ahead/behind with pr badge

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -221,8 +221,14 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --toolbar-button-hover-progress-color: $gray-700;
   --toolbar-dropdown-open-progress-color: $gray-200;
 
-  /** Ahead and behind count bubble in the push/pull/publish button */
-  --toolbar-ahead-behind-background-color: $gray-500;
+  /**
+    * Background color for badges inside of toolbar buttons.
+    * Examples of badges are the ahead/behind bubble in the
+    * push/pull button and the PR badge in the branch drop
+    * down button.
+    */
+  --toolbar-badge-background-color: $gray-600;
+  --toolbar-badge-active-background-color: $gray-200;
 
   --tab-bar-height: 29px;
   --tab-bar-active-color: $blue;

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -1,9 +1,9 @@
 .toolbar-dropdown.open .pr-badge {
-  background: $gray-200;
+  background: var(--toolbar-badge-active-background-color);
 }
 
 .toolbar-dropdown:not(.open) .pr-badge {
-  background: $gray-700;
+  background: var(--toolbar-badge-background-color);
 }
 
 .pr-badge {

--- a/app/styles/ui/toolbar/_toolbar.scss
+++ b/app/styles/ui/toolbar/_toolbar.scss
@@ -64,7 +64,7 @@
 .ahead-behind {
   display: flex;
 
-  background: var(--toolbar-ahead-behind-background-color);
+  background: var(--toolbar-badge-background-color);
 
   // Perfectly round semi circle ends with real tight
   // padding on either side. Now in two flavors!


### PR DESCRIPTION
Prior to this we had two different colors for the PR badge background and the ahead/behind counter in the toolbar, gray-700 and gray-500. This standardizes them to both be gray-600.

Additionally this introduces a new variable for the background color of the PR badge when the dropdown is open.

This is extracted from #4849 for easier reviewing