### PR TITLE
Custom styled select components for all platforms

### DIFF
--- a/app/styles/ui/_select.scss
+++ b/app/styles/ui/_select.scss
@@ -10,27 +10,26 @@
     margin-bottom: var(--spacing-third);
   }
 
-  // Select boxes look absolutely horrible on Windows so we'll make them
-  // look as good as we possibly can. There's nothing we can do about the
-  // drop down itself but at least we can style the base element a bit.
-  @include win32 {
-    select {
-      // Get rid of all default UA styling, we can do better
-      -webkit-appearance: none;
+  // Custom styles for select components because a) they look horrible
+  // on Windows and b) because we need them to inherit colors and other
+  // appearance from our global variables. Therefore we treat them more
+  // or less exactly as a text box.
+  select {
+    // Get rid of all default UA styling, we can do better
+    -webkit-appearance: none;
 
-      // Make the select look like a text box.
-      @include textboxish;
-      @include textboxish-disabled;
+    // Make the select look like a text box.
+    @include textboxish;
+    @include textboxish-disabled;
 
-      // Add back the arrow that got removed with appearance: none.
-      // This is a custom version of the triangle-down octicon that was
-      // adapted to be 8 by 5px. The gif is in 2x and the background-size
-      // scales it back down so that we can have crisp arrows on high-dpi
-      // displays. The path is M 0,0 4,5 8,0 Z and the color is #6a737d.
-      background-image: url('data:image/gif;base64,R0lGODlhEAAKAMQAAGpzff///8PHy6arsXqCi46UnN7g4vHy8/v7+253gYuSmm12gO/w8dve4Pz8/KassniAicfLzwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAAAAAAALAAAAAAQAAoAAAUw4ACMZFk+TmGugIIEB8GSEBPcRjIvze1HM4FvKDI9hsNUyYUcxka1JjLHkzYFwmYIADs=');
-      background-size: 8px 5px;
-      background-repeat: no-repeat;
-      background-position: right var(--spacing-half) center;
-    }
+    // Add back the arrow that got removed with appearance: none.
+    // This is a custom version of the triangle-down octicon that was
+    // adapted to be 8 by 5px. The gif is in 2x and the background-size
+    // scales it back down so that we can have crisp arrows on high-dpi
+    // displays. The path is M 0,0 4,5 8,0 Z and the color is #6a737d.
+    background-image: url('data:image/gif;base64,R0lGODlhEAAKAMQAAGpzff///8PHy6arsXqCi46UnN7g4vHy8/v7+253gYuSmm12gO/w8dve4Pz8/KassniAicfLzwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAAAAAAALAAAAAAQAAoAAAUw4ACMZFk+TmGugIIEB8GSEBPcRjIvze1HM4FvKDI9hsNUyYUcxka1JjLHkzYFwmYIADs=');
+    background-size: 8px 5px;
+    background-repeat: no-repeat;
+    background-position: right var(--spacing-half) center;
   }
 }

--- a/app/styles/ui/_select.scss
+++ b/app/styles/ui/_select.scss
@@ -15,21 +15,11 @@
   // appearance from our global variables. Therefore we treat them more
   // or less exactly as a text box.
   select {
-    // Get rid of all default UA styling, we can do better
-    -webkit-appearance: none;
-
     // Make the select look like a text box.
     @include textboxish;
     @include textboxish-disabled;
 
-    // Add back the arrow that got removed with appearance: none.
-    // This is a custom version of the triangle-down octicon that was
-    // adapted to be 8 by 5px. The gif is in 2x and the background-size
-    // scales it back down so that we can have crisp arrows on high-dpi
-    // displays. The path is M 0,0 4,5 8,0 Z and the color is #6a737d.
-    background-image: url('data:image/gif;base64,R0lGODlhEAAKAMQAAGpzff///8PHy6arsXqCi46UnN7g4vHy8/v7+253gYuSmm12gO/w8dve4Pz8/KassniAicfLzwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAAAAAAALAAAAAAQAAoAAAUw4ACMZFk+TmGugIIEB8GSEBPcRjIvze1HM4FvKDI9hsNUyYUcxka1JjLHkzYFwmYIADs=');
-    background-size: 8px 5px;
-    background-repeat: no-repeat;
-    background-position: right var(--spacing-half) center;
+    // Don't include the default padding from textboxish, it's too much
+    padding: 0;
   }
 }


### PR DESCRIPTION
We've previously had custom style select components for Windows but with the advent of #4849 we're going to need to style these components based on what theme is currently active so I've decided to switch to custom styling for all platforms.

# Before macOS

![screen shot 2018-06-08 at 16 40 31](https://user-images.githubusercontent.com/634063/41164738-2bdb86fe-6b3c-11e8-918c-2c7781be4fb2.png)


# After macOS

![screen shot 2018-06-08 at 16 40 19](https://user-images.githubusercontent.com/634063/41164758-376ee506-6b3c-11e8-9fb4-03013e4d5150.png)

# After macOS dark theme (bonus screenshot)

![screen shot 2018-06-08 at 16 39 55](https://user-images.githubusercontent.com/634063/41164772-40e3d858-6b3c-11e8-8ac5-6834a685edf1.png)

On Windows nothing really changes except we get a little less aesthetically pleasing down arrow now that we're not rendering it ourselves. The upside is that the arrow will automatically inherit the foreground color of the select box.

Extracted from #4849 for easier reviewing.