### PR TITLE
Reuse link button variables for co-authors toggle

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -31,6 +31,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --button-focus-border-color: $blue-600;
 
   --link-button-color: $blue;
+  --link-button-hover-color: $blue-600;
 
   --secondary-button-background: $gray-000;
   --secondary-button-hover-background: $white;

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -45,18 +45,18 @@
   }
 
   .co-authors-toggle {
-    color: $gray-500;
+    color: var(--text-secondary-color);
 
     &:hover {
-      color: $gray-900;
+      color: var(--text-color);
     }
   }
 
   &.with-co-authors .co-authors-toggle {
-    color: $blue-400;
+    color: var(--link-button-color);
 
     &:hover {
-      color: $blue-600;
+      color: var(--link-button-hover-color);
     }
   }
 


### PR DESCRIPTION
The co-author toggle button is, for basically all intents and purposes, a link button. If anything we could talk about changing the name of the variable but let's not deal with that right now.

Extracted from #4849 for easier reviewing