### PR TITLE
Show the local path of selected repository as a tooltip

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1457,13 +1457,13 @@ export class App extends React.Component<IAppProps, IAppState> {
       title = __DARWIN__ ? 'No Repositories' : 'No repositories'
     }
 
-    const tooltip = repository ? repository.path : undefined
-
     const isOpen =
       this.state.currentFoldout &&
       this.state.currentFoldout.type === FoldoutType.Repository
 
     const currentState: DropdownState = isOpen ? 'open' : 'closed'
+
+    const tooltip = repository && !isOpen ? repository.path : undefined
 
     const foldoutStyle: React.CSSProperties = {
       position: 'absolute',

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1457,6 +1457,8 @@ export class App extends React.Component<IAppProps, IAppState> {
       title = __DARWIN__ ? 'No Repositories' : 'No repositories'
     }
 
+    const tooltip = repository ? repository.path : undefined
+
     const isOpen =
       this.state.currentFoldout &&
       this.state.currentFoldout.type === FoldoutType.Repository
@@ -1476,6 +1478,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         icon={icon}
         title={title}
         description={__DARWIN__ ? 'Current Repository' : 'Current repository'}
+        tooltip={tooltip}
         foldoutStyle={foldoutStyle}
         onDropdownStateChanged={this.onRepositoryDropdownStateChanged}
         dropdownContentRenderer={this.renderRepositoryList}


### PR DESCRIPTION
This change resolves #4922 

If there's selected repository, a tooltip that shows the local path of the repository will be appeared on the toolbar button.