### PR TITLE
Support .Cake Highlights

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -121,6 +121,7 @@ const modes: ReadonlyArray<IModeDefinition> = [
       '.scala': 'text/x-scala',
       '.sc': 'text/x-scala',
       '.cs': 'text/x-csharp',
+      '.cake': 'text/x-csharp',
       '.java': 'text/x-java',
       '.c': 'text/x-c',
       '.h': 'text/x-c',


### PR DESCRIPTION
The .cake extension is used for C# Make Builds. https://github.com/cake-build/cake