### PR TITLE
bump package to address lint warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ branches:
 
 language: node_js
 node_js:
-  - "8.9.0"
+  - "8.11.0"
 
 cache:
   yarn: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform:
   - x64
 
 environment:
-  nodejs_version: "8.11.3"
+  nodejs_version: "8.11"
 
 cache:
   - .eslintcache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform:
   - x64
 
 environment:
-  nodejs_version: "8.11.0"
+  nodejs_version: "8.11.3"
 
 cache:
   - .eslintcache

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform:
   - x64
 
 environment:
-  nodejs_version: "8.9.0"
+  nodejs_version: "8.11.0"
 
 cache:
   - .eslintcache

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
     - brew update
     # uninstall Node 6 which is shipped by default on Circle
     - brew uninstall node
-    # install latest Node LTS (8.9.3 as of writing)
+    # install latest Node LTS (8.11.* as of writing)
     - brew install node@8 --force
     # everything is terrible, but we must march on
     - brew link --overwrite node@8 --force

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -6,13 +6,13 @@ You will need to install these tools on your machine:
 
 ### macOS
 
- - [Node.js v8.9.0](https://nodejs.org/dist/v8.9.0/)
+ - [Node.js v8.11.2](https://nodejs.org/dist/v8.11.2/)
  - [Python 2.7](https://www.python.org/downloads/mac-osx/)
  - Xcode and Xcode Command Line Tools (Xcode -> Preferences -> Downloads)
 
 ### Windows
 
- - [Node.js v8.9.0](https://nodejs.org/dist/v8.9.0/)
+ - [Node.js v8.11.2](https://nodejs.org/dist/v8.11.2/)
     - *Make sure you allow the Node.js installer to add node to the PATH.*
  - [Python 2.7](https://www.python.org/downloads/windows/)
     - *Let Python install into the default suggested path (`c:\Python27`), otherwise you'll have
@@ -32,7 +32,7 @@ You will need to install these tools on your machine:
 
 ### Fedora 26
 
-First, add the NodeJS package repository.
+First, add the NodeJS package repository for 8.x.
 
 ```shellsession
 $ curl --silent --location https://rpm.nodesource.com/setup_8.x | sudo bash -
@@ -67,7 +67,7 @@ First, install curl:
 $ sudo apt install curl
 ```
 
-Then add the NodeJS package repository:
+Then add the NodeJS package repository for 8.x:
 
 ```shellsession
 $ curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
@@ -123,7 +123,7 @@ versions look similar to the below output:
 
 ```shellsession
 $ node -v
-v8.10.0
+v8.11.2
 
 $ yarn -v
 1.5.1

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "tslint-microsoft-contrib": "^5.0.3",
     "tslint-react": "^3.5.1",
     "typescript": "^2.9.1",
-    "typescript-eslint-parser": "^15.0.0",
+    "typescript-eslint-parser": "^16.0.0",
     "webpack": "^4.8.3",
     "webpack-bundle-analyzer": "^2.13.0",
     "webpack-dev-middleware": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 8",
+    "node": ">= 8.10",
     "yarn": ">= 1.5.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7242,9 +7242,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-15.0.0.tgz#882fd3d7aabffbab0a7f98d2a59fb9a989c2b37f"
+typescript-eslint-parser@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.0.tgz#14a9ab75932b15af919602faef553c6f0487f352"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"


### PR DESCRIPTION
I thought I'd caught this as part of #4854 but CI builds now report the classic "you're using a newer version of TS" message when linting:

```sh
$ yarn lint
yarn run v1.5.1
$ yarn lint:src && yarn lint:prettier
$ yarn tslint && yarn eslint-check && yarn eslint
$ tslint -p .
$ eslint --print-config .eslintrc.* | eslint-config-prettier-check
No rules that are unnecessary or conflict with Prettier were found.
$ ts-node script/eslint.ts
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: ~2.8.1

YOUR TYPESCRIPT VERSION: 2.9.1

Please only submit bug reports when using the officially supported version.

=============
...
```

I _sometimes_ see this warning when linting locally, but not always. Maybe something is being stored in `.eslintcache`. I'm not hugely worried about that for now.

`typescript-eslint-parser` has shipped [an update](https://github.com/eslint/typescript-eslint-parser/releases/tag/v16.0.0) which supports TS 2.9, so this should address the CI warnings.

 - [x] bump package
 - [x] refresh CI builds so they are all using `8.11.x` 
 - [x] upgrade root `package.json` to indicate that you need a recent version of Node
 - [x] update setup docs to ensure they too refer to a recent version of Node
 - [x] allow 1 week for @desktop/core and @desktop/comrades to upgrade their dev environments