### PR TITLE
Themeable colors for application menus on Windows/Linux

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -2,3 +2,8 @@ singleQuote: true
 trailingComma: es5
 semi: false
 proseWrap: always
+
+overrides:
+- files: "*.scss"
+  options:
+    printWidth: 200

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -223,6 +223,23 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --toolbar-dropdown-open-progress-color: $gray-200;
 
   /**
+   * App menu bar colors (Windows/Linux only)
+   */
+  --app-menu-button-color: var(--toolbar-text-color);
+  --app-menu-button-hover-color: var(--toolbar-button-hover-color);
+  --app-menu-button-hover-background-color: var(
+    --toolbar-button-hover-background-color
+  );
+  --app-menu-button-active-color: var(--toolbar-button-active-color);
+  --app-menu-button-active-background-color: var(
+    --toolbar-button-active-background-color
+  );
+  --app-menu-pane-color: var(--text-color);
+  --app-menu-pane-secondary-color: var(--text-secondary-color);
+  --app-menu-pane-background-color: var(
+    --toolbar-button-active-background-color
+  );
+  /**
     * Background color for badges inside of toolbar buttons.
     * Examples of badges are the ahead/behind bubble in the
     * push/pull button and the PR badge in the branch drop

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -239,6 +239,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --app-menu-pane-background-color: var(
     --toolbar-button-active-background-color
   );
+  --app-menu-divider-color: var(--box-border-color);
+
   /**
     * Background color for badges inside of toolbar buttons.
     * Examples of badges are the ahead/behind bubble in the

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -42,11 +42,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // Typography
   //
   // Font, line-height, and color for body text, headings, and more.
-  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-    'Helvetica Neue', Arial, sans-serif;
-  --font-family-monospace: Menlo, Monaco, Consolas, 'Liberation Mono',
-    'Courier New', monospace;
+  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Arial, sans-serif;
+  --font-family-monospace: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   /**
    * Font weight to use for semibold text
@@ -99,12 +96,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * Background color for skeleton or "loading" boxes
    */
   --box-skeleton-background-color: $gray-200;
-  --skeleton-background-gradient: -webkit-linear-gradient(
-    left,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.5) 50%,
-    rgba(255, 255, 255, 0) 100%
-  );
+  --skeleton-background-gradient: -webkit-linear-gradient(left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0) 100%);
 
   /**
    * Border color for boxes.
@@ -162,12 +154,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * for use when content can be expanded through other means than
    * scrolling.
    */
-  --box-overflow-shadow-background: linear-gradient(
-    180deg,
-    rgba($white, 0) 0%,
-    rgba($white, 1) 90%,
-    rgba($white, 1) 100%
-  );
+  --box-overflow-shadow-background: linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%);
 
   /**
    * The height of the title bar area on Win32 platforms
@@ -227,18 +214,12 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    */
   --app-menu-button-color: var(--toolbar-text-color);
   --app-menu-button-hover-color: var(--toolbar-button-hover-color);
-  --app-menu-button-hover-background-color: var(
-    --toolbar-button-hover-background-color
-  );
+  --app-menu-button-hover-background-color: var(--toolbar-button-hover-background-color);
   --app-menu-button-active-color: var(--toolbar-button-active-color);
-  --app-menu-button-active-background-color: var(
-    --toolbar-button-active-background-color
-  );
+  --app-menu-button-active-background-color: var(--toolbar-button-active-background-color);
   --app-menu-pane-color: var(--text-color);
   --app-menu-pane-secondary-color: var(--text-secondary-color);
-  --app-menu-pane-background-color: var(
-    --toolbar-button-active-background-color
-  );
+  --app-menu-pane-background-color: var(--toolbar-button-active-background-color);
   --app-menu-divider-color: var(--box-border-color);
 
   /**

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -163,17 +163,17 @@ body.theme-dark {
   /**
     * App menu bar colors (Windows/Linux only)
     */
-    --app-menu-button-color: var(--toolbar-text-color);
-    --app-menu-button-hover-color: var(--toolbar-button-hover-color);
-    --app-menu-button-hover-background-color: var(
-      --toolbar-button-hover-background-color
-    );
-    --app-menu-button-active-color: var(--text-color);
-    --app-menu-button-active-background-color: $gray-800;
-    --app-menu-pane-color: var(--text-color);
-    --app-menu-pane-secondary-color: var(--text-secondary-color);
-    --app-menu-pane-background-color: $gray-800;
-    --app-menu-divider-color: $gray-600;
+  --app-menu-button-color: var(--toolbar-text-color);
+  --app-menu-button-hover-color: var(--toolbar-button-hover-color);
+  --app-menu-button-hover-background-color: var(
+    --toolbar-button-hover-background-color
+  );
+  --app-menu-button-active-color: var(--text-color);
+  --app-menu-button-active-background-color: $gray-800;
+  --app-menu-pane-color: var(--text-color);
+  --app-menu-pane-secondary-color: var(--text-secondary-color);
+  --app-menu-pane-background-color: $gray-800;
+  --app-menu-divider-color: $gray-600;
 
   /**
    * Background color for badges inside of toolbar buttons.

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -161,6 +161,19 @@ body.theme-dark {
   --toolbar-dropdown-open-progress-color: $gray-200;
 
   /**
+    * App menu bar colors (Windows/Linux only)
+    */
+    --app-menu-button-color: var(--toolbar-text-color);
+    --app-menu-button-hover-color: var(--toolbar-button-hover-color);
+    --app-menu-button-hover-background-color: var(
+      --toolbar-button-hover-background-color
+    );
+    --app-menu-button-active-color: var(--text-color);
+    --app-menu-button-active-background-color: $gray-800;
+    --app-menu-pane-color: var(--text-color);
+    --app-menu-pane-secondary-color: var(--text-secondary-color);
+    --app-menu-pane-background-color: $gray-800;
+  /**
    * Background color for badges inside of toolbar buttons.
    * Examples of badges are the ahead/behind bubble in the
    * push/pull button and the PR badge in the branch drop

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -173,6 +173,8 @@ body.theme-dark {
     --app-menu-pane-color: var(--text-color);
     --app-menu-pane-secondary-color: var(--text-secondary-color);
     --app-menu-pane-background-color: $gray-800;
+    --app-menu-divider-color: $gray-600;
+
   /**
    * Background color for badges inside of toolbar buttons.
    * Examples of badges are the ahead/behind bubble in the

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -60,12 +60,7 @@ body.theme-dark {
    * Background color for skeleton or "loading" boxes
    */
   --box-skeleton-background-color: $gray-700;
-  --skeleton-background-gradient: -webkit-linear-gradient(
-    left,
-    rgba(36, 41, 46, 0) 0%,
-    rgba(36, 41, 46, 0.5) 50%,
-    rgba(36, 41, 46, 0) 100%
-  );
+  --skeleton-background-gradient: -webkit-linear-gradient(left, rgba(36, 41, 46, 0) 0%, rgba(36, 41, 46, 0.5) 50%, rgba(36, 41, 46, 0) 100%);
 
   /**
    * Border color for boxes.
@@ -123,12 +118,7 @@ body.theme-dark {
    * for use when content can be expanded through other means than
    * scrolling.
    */
-  --box-overflow-shadow-background: linear-gradient(
-    180deg,
-    rgba($gray-900, 0) 0%,
-    rgba($gray-900, 1) 90%,
-    rgba($gray-900, 1) 100%
-  );
+  --box-overflow-shadow-background: linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%);
 
   --base-border: 1px solid var(--box-border-color);
 
@@ -165,9 +155,7 @@ body.theme-dark {
     */
   --app-menu-button-color: var(--toolbar-text-color);
   --app-menu-button-hover-color: var(--toolbar-button-hover-color);
-  --app-menu-button-hover-background-color: var(
-    --toolbar-button-hover-background-color
-  );
+  --app-menu-button-hover-background-color: var(--toolbar-button-hover-background-color);
   --app-menu-button-active-color: var(--text-color);
   --app-menu-button-active-background-color: $gray-800;
   --app-menu-pane-color: var(--text-color);

--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -116,6 +116,6 @@
     width: 100%;
     border: none;
     height: 1px;
-    border-bottom: var(--base-border);
+    border-bottom: 1px solid var(--app-menu-divider-color);
   }
 }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -71,8 +71,7 @@ dialog {
     &-leave-active {
       opacity: 0.01;
       transform: scale(0.25);
-      transition: opacity 100ms ease-in,
-        transform 100ms var(--easing-ease-in-back);
+      transition: opacity 100ms ease-in, transform 100ms var(--easing-ease-in-back);
 
       &::backdrop {
         opacity: 0.01;
@@ -136,10 +135,7 @@ dialog {
       // Ensure that the dialog contents always have room for the icon,
       // account for two double spacers at top and bottom plus the 5px
       // icon offset (margin-top) and the size of the icon itself.
-      min-height: calc(
-        var(--spacing-double) * 2 + var(--spacing-half) +
-          var(--dialog-icon-size)
-      );
+      min-height: calc(var(--spacing-double) * 2 + var(--spacing-half) + var(--dialog-icon-size));
 
       // We're creating an opaque 24 by 24px div with the background color
       // that we want the icon to appear in and then apply the icon path

--- a/app/styles/ui/_progress.scss
+++ b/app/styles/ui/_progress.scss
@@ -12,13 +12,7 @@ progress {
   }
 
   &:indeterminate {
-    background-image: -webkit-linear-gradient(
-      -45deg,
-      transparent 33%,
-      var(--text-color) 33%,
-      var(--text-color) 66%,
-      transparent 66%
-    );
+    background-image: -webkit-linear-gradient(-45deg, transparent 33%, var(--text-color) 33%, var(--text-color) 66%, transparent 66%);
     background-size: 25px 10px, 100% 100%, 100% 100%;
 
     -webkit-animation: progress-indeterminate-animation 5s linear infinite;

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -91,11 +91,7 @@
         width: 100%;
         bottom: 0px;
         height: 5px;
-        background: linear-gradient(
-          to bottom,
-          rgba(0, 0, 0, 0) 0%,
-          rgba(0, 0, 0, 0.1) 100%
-        );
+        background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);
         border-bottom: var(--base-border);
       }
     }

--- a/app/styles/ui/window/_app-menu-bar.scss
+++ b/app/styles/ui/window/_app-menu-bar.scss
@@ -10,12 +10,19 @@
     }
   }
 
+  .toolbar-dropdown.open > .toolbar-button > button {
+    background-color: var(--app-menu-button-active-background-color);
+    color: var(--app-menu-button-active-color);
+  }
+
   .toolbar-dropdown:not(.open) > .toolbar-button > button {
-    color: var(--toolbar-text-color);
+    color: var(--app-menu-button-color);
+    background: transparent;
 
     &:hover,
     &:focus {
-      color: var(--toolbar-button-color);
+      color: var(--app-menu-button-hover-color);
+      background: var(--app-menu-button-hover-background-color);
     }
   }
 
@@ -39,7 +46,14 @@
     pointer-events: none;
 
     .menu-pane {
+      --background-color: var(--app-menu-pane-background-color);
       background: var(--background-color);
+
+      --text-color: var(--app-menu-pane-color);
+      color: var(--text-color);
+
+      --text-secondary-color: var(--app-menu-pane-secondary-color);
+
       pointer-events: all;
     }
 


### PR DESCRIPTION
The current setup for the menu bars on Windows/Linux was using the exact same styles as for the toolbar dropdowns which works great in the light theme and not so much in the dark theme.

This PR puts in place variables which by default inherit the toolbar colors and is customizeable in other themes.

### Dark theme (before)
![ghd-windows-menus-dark-before](https://user-images.githubusercontent.com/634063/41470949-76baf198-70b2-11e8-93d3-c32a3c742bd7.png)


### Dark theme (after)
![ghd-windows-menus-dark](https://user-images.githubusercontent.com/634063/41470797-06355cba-70b2-11e8-98d5-b210809990eb.png)

### Light theme (no change)
![ghd-windows-menus-light](https://user-images.githubusercontent.com/634063/41470812-11290f72-70b2-11e8-8efa-48240476ac1e.png)