### PR TITLE
let the user compare when a second branch exists

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -137,7 +137,7 @@ export class CompareSidebar extends React.Component<
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}
             value={filterText}
-            disabled={allBranches.length <= 1}
+            disabled={allBranches.length < 1}
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}
@@ -475,7 +475,7 @@ export class CompareSidebar extends React.Component<
 function getPlaceholderText(state: ICompareState) {
   const { allBranches, formState } = state
 
-  if (allBranches.length <= 1) {
+  if (allBranches.length < 1) {
     return __DARWIN__ ? 'No Branches to Compare' : 'No branches to compare'
   } else if (formState.kind === ComparisonView.None) {
     return __DARWIN__


### PR DESCRIPTION
Fixes #4947
Fixes #4730

Existing behaviour on a repository with two branches (`master` is published, `things-to-compare` is then created without publishing):

<img width="657"  src="https://user-images.githubusercontent.com/359239/41476703-b4f67ac8-7098-11e8-8d90-5134c76bebd9.png">

New behaviour introduced by this PR:

<img width="522"  src="https://user-images.githubusercontent.com/359239/41476740-cece0240-7098-11e8-91e2-b17ee20d2365.png">

You can then select and see the other branch in the list:

<img width="551" src="https://user-images.githubusercontent.com/359239/41476769-e0c6ba3c-7098-11e8-8730-bdec685df07a.png">
