### PR TITLE
Enable compare branch selector if there are 1 or more branches

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -137,7 +137,7 @@ export class CompareSidebar extends React.Component<
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}
             value={filterText}
-            disabled={allBranches.length <= 1}
+            disabled={allBranches.length === 0}
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}


### PR DESCRIPTION
Fixes  #4947 

The issue was we used `compareState.allBranches`, which is 1 less than `branchesState.allBranches`, to enable the branch selector. This is incorrect since because we filter `master` out of `compareState.allBranches`. This means that we should be checking `x === 0` instead of `x <= 1`. In other words if `compareState.allBranches === 0` there is still 1 branch.

Maybe `allBranches` isn't a good name here?

![2018-06-15 10 36 31](https://user-images.githubusercontent.com/1715082/41476732-03b98e9a-7088-11e8-85ef-0e60cc34d4fc.gif)
