### PR TITLE
Add support for WebStorm editor

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -14,6 +14,7 @@ export enum ExternalEditor {
   RubyMine = 'RubyMine',
   TextMate = 'TextMate',
   Brackets = 'Brackets',
+  WebStorm = 'WebStorm',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -47,6 +48,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Brackets) {
     return ExternalEditor.Brackets
   }
+  if (label === ExternalEditor.WebStorm) {
+    return ExternalEditor.WebStorm
+  }
   return null
 }
 
@@ -77,6 +81,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.macromates.TextMate']
     case ExternalEditor.Brackets:
       return ['io.brackets.appshell']
+    case ExternalEditor.WebStorm:
+      return ['com.jetbrains.WebStorm']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -113,6 +119,8 @@ function getExecutableShim(
       return Path.join(installPath, 'Contents', 'Resources', 'mate')
     case ExternalEditor.Brackets:
       return Path.join(installPath, 'Contents', 'MacOS', 'Brackets')
+    case ExternalEditor.WebStorm:
+      return Path.join(installPath, 'Contents', 'MacOS', 'WebStorm')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -158,6 +166,7 @@ export async function getAvailableEditors(): Promise<
     rubyMinePath,
     textMatePath,
     bracketsPath,
+    webStormPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),
@@ -169,6 +178,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.RubyMine),
     findApplication(ExternalEditor.TextMate),
     findApplication(ExternalEditor.Brackets),
+    findApplication(ExternalEditor.WebStorm),
   ])
 
   if (atomPath) {
@@ -212,6 +222,10 @@ export async function getAvailableEditors(): Promise<
 
   if (bracketsPath) {
     results.push({ editor: ExternalEditor.Brackets, path: bracketsPath })
+  }
+
+  if (webStormPath) {
+    results.push({ editor: ExternalEditor.WebStorm, path: webStormPath })
   }
 
   return results

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -1,7 +1,7 @@
 # "Open External Editor" integration
 
 GitHub Desktop supports the user choosing an external program to open their
-local repositories, and this is available from the top-level **Repository** menu 
+local repositories, and this is available from the top-level **Repository** menu
 or when right-clicking on a repository in the sidebar.
 
 ### My favourite editor XYZ isn't supported!
@@ -212,10 +212,11 @@ These editors are currently supported:
  - [PhpStorm](https://www.jetbrains.com/phpstorm/)
  - [RubyMine](https://www.jetbrains.com/rubymine/)
  - [TextMate](https://macromates.com)
- - [Brackets](http://brackets.io/) 
+ - [Brackets](http://brackets.io/)
      - To use Brackets the Command Line shortcut must be installed.
        - This can be done by opening Brackets, choosing File > Install Command Line Shortcut
-       
+ - [WebStorm](https://www.jetbrains.com/webstorm/)
+
 These are defined in an enum at the top of the file:
 
 ```ts
@@ -231,6 +232,7 @@ export enum ExternalEditor {
   RubyMine = 'RubyMine',
   TextMate = 'TextMate',
   Brackets = 'Brackets',
+  WebStorm = 'WebStorm',
 }
 ```
 


### PR DESCRIPTION
### What is the issue?

As outlined in #4841 desktop does not support opening files in WebStorm.

### What have we done?

I have taken inspiration from the [docs](https://github.com/desktop/desktop/blob/master/docs/technical/editor-integration.md) and followed the guidelines to add the support for [WebStorm](https://www.jetbrains.com/webstorm/) editor. I have also updated the docs file to include the WebStorm editor.

### How can we test?

It is tedious but if you want to confirm expected behavior, you can follow the following steps.

1. Install WebStorm editor
2. Clone and checkout this branch.
3. Boot up the development environment
4. Change your editor to WebStorm - Preferences > Advance > Editor - change to WebStorm.
5. Make a file change in the repository you are on
6. Highlight the file and choose to "open in WebStorm"

_Expected Outcome:_ The file should be opened in webstorm

closes #4841