### PR TITLE
emulate colour blindness at development time

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -407,14 +407,24 @@ function createWindow() {
   const window = new AppWindow()
 
   if (__DEV__) {
-    const installer = require('electron-devtools-installer')
+    const {
+      default: installExtension,
+      REACT_DEVELOPER_TOOLS,
+      REACT_PERF,
+    } = require('electron-devtools-installer')
+
     require('electron-debug')({ showDevTools: true })
 
-    const extensions = ['REACT_DEVELOPER_TOOLS', 'REACT_PERF']
+    const ChromeLens = {
+      id: 'idikgljglpfilbhaboonnpnnincjhjkd',
+      electron: '>=1.2.1',
+    }
 
-    for (const name of extensions) {
+    const extensions = [REACT_DEVELOPER_TOOLS, REACT_PERF, ChromeLens]
+
+    for (const extension of extensions) {
       try {
-        installer.default(installer[name])
+        installExtension(extension)
       } catch (e) {}
     }
   }


### PR DESCRIPTION
Following on from #4913 I started looking for ways to "see" how Desktop looks when emulating various colour blindness. We already have hooks for enabling dev tools in development mode, so this PR tidies up that code and adds support for ChromeLens.

This is how it looks with the new extension enabled:

<img width="1201" src="https://user-images.githubusercontent.com/359239/41550975-c282c29a-7300-11e8-9f1e-eab12476a015.png">

Note that the `Run accessibility checks` doesn't work in Desktop, and crashes with this error:

```
TypeError: Cannot read property 'valid' of null
    at axs.AuditRule.test [as test_] (chrome-extension://chromelensaudit/axs_testing.js:2359:32)
    at axs.AuditRule.run (chrome-extension://chromelensaudit/axs_testing.js:2069:39)
    at Object.axs.Audit.run (chrome-extension://chromelensaudit/axs_testing.js:2212:29)
    at run (chrome-extension://chromelensaudit/run_axs.js:189:30)
    at chrome-extension://chromelensaudit/run_axs.js:215:1
    at runContentScript (app/Contents/Resources/electron.asar/renderer/content-scripts-injector.js:23:26)
    at EventEmitter.<anonymous> (app/Contents/Resources/electron.asar/renderer/content-scripts-injector.js:77:35)
    at emitMany (events.js:146:13)
    at EventEmitter.emit (events.js:223:7)

Version: 1.2.3
OS: Mac OS 10.13.5
```

This is the expected behaviour:

<img width="551" src="https://user-images.githubusercontent.com/359239/41551038-fe6c6072-7300-11e8-810a-d603801791c2.png">

But I'm not that worried about that - DevTron in theory has accessibility checks built in, and the value for this extension is the visual testing. Maybe there's a better extension out there, but for now this is a pretty handy help when developing locally.