### PR TITLE
Enforce named highlighter chunks in prod

### DIFF
--- a/app/webpack.common.js
+++ b/app/webpack.common.js
@@ -153,6 +153,7 @@ const highlighterConfig = merge({}, commonConfig, {
     chunkFilename: 'highlighter/[name].js',
   },
   optimization: {
+    namedChunks: true,
     splitChunks: {
       cacheGroups: {
         modes: {


### PR DESCRIPTION
The latest beta revealed a problem with our setup of named chunks for the async/incremental loading of syntax highlighting modes where the chunks would get persisted to disk using the name we gave them but imported using their chunk ids.