### PR TITLE
Update diverging notification banner text (NDDB)

### DIFF
--- a/app/src/ui/notification/new-commits-banner.tsx
+++ b/app/src/ui/notification/new-commits-banner.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Ref } from '../lib/ref'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Branch } from '../../models/branch'
+import { LinkButton } from '../lib/link-button';
 
 interface INewCommitsBannerProps {
   /**
@@ -41,8 +42,9 @@ export class NewCommitsBanner extends React.Component<
               behind <Ref>{this.props.baseBranch.name}</Ref>.
             </p>
 
-            <p className="notification-banner-content-body">
-              You can view these commits using the form below.
+            {/* TODO: chat with Will about this LinkButton */}
+            <p>
+              <LinkButton>View these commits</LinkButton>
             </p>
           </div>
         </div>

--- a/app/src/ui/notification/new-commits-banner.tsx
+++ b/app/src/ui/notification/new-commits-banner.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { Ref } from '../lib/ref'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Branch } from '../../models/branch'
-import { LinkButton } from '../lib/link-button';
 
 interface INewCommitsBannerProps {
   /**
@@ -37,14 +36,9 @@ export class NewCommitsBanner extends React.Component<
         <div className="notification-banner-content">
           <div>
             <p>
-              Your branch is{' '}
+              We have noticed that your branch is{' '}
               <strong>{this.props.commitsBehindBaseBranch} commits</strong>{' '}
               behind <Ref>{this.props.baseBranch.name}</Ref>.
-            </p>
-
-            {/* TODO: chat with Will about this LinkButton */}
-            <p>
-              <LinkButton>View these commits</LinkButton>
             </p>
           </div>
         </div>


### PR DESCRIPTION
This pull request updates iterates on the text shown for the diverging banner:

**Before:**
<img width="270" alt="screen shot 2018-06-19 at 11 52 16 am" src="https://user-images.githubusercontent.com/1174461/41618175-43d494f2-73b7-11e8-8f4a-79a0df1db946.png">

**After:**
<img width="318" alt="screen shot 2018-06-19 at 11 50 47 am" src="https://user-images.githubusercontent.com/1174461/41618081-0e4c6120-73b7-11e8-9170-4369e9b24489.png">

I removed the second line since I felt like it made the dialog take up more space than needed. I didn't think "You can view these commits..." was particularly helpful, and I'd rather leave it open for people to use their existing Desktop workflow of either choosing "Update from default branch..." or "Merge into current branch" from the branch menu instead. Since we're planning on adding the "View commits" and "Merge..." action button later on, I don't expect removing the second sentence to have any long-lasting negative impacts.

If we feel like we should have some sort of action, I've explored using a link action to view the commits (but we should consider making that part of the feature functional):

<img width="272" alt="screen shot 2018-06-19 at 11 57 46 am" src="https://user-images.githubusercontent.com/1174461/41618428-00d3a7fa-73b8-11e8-8c87-f8994353f22b.png">
