### PR TITLE
remove context menu needs to hint if a dialog will be shown

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1394,6 +1394,9 @@ export class App extends React.Component<IAppProps, IAppState> {
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
         localRepositoryStateLookup={this.state.localRepositoryStateLookup}
+        askForConfirmationOnRemoveRepository={
+          this.state.askForConfirmationOnRepositoryRemoval
+        }
         onRemoveRepository={this.removeRepository}
         onOpenInShell={this.openInShell}
         onShowRepository={this.showRepository}

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -22,6 +22,9 @@ interface IRepositoriesListProps {
   /** Called when a repository has been selected. */
   readonly onSelectionChanged: (repository: Repositoryish) => void
 
+  /** Whether the user has enabled the setting to confirm removing a repository from the app */
+  readonly askForConfirmationOnRemoveRepository: boolean
+
   /** Called when the repository should be removed. */
   readonly onRemoveRepository: (repository: Repositoryish) => void
 
@@ -61,6 +64,9 @@ export class RepositoriesList extends React.Component<
         key={repository.id}
         repository={repository}
         needsDisambiguation={item.needsDisambiguation}
+        askForConfirmationOnRemoveRepository={
+          this.props.askForConfirmationOnRemoveRepository
+        }
         onRemoveRepository={this.props.onRemoveRepository}
         onShowRepository={this.props.onShowRepository}
         onOpenInShell={this.props.onOpenInShell}

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -14,6 +14,9 @@ const defaultEditorLabel = __DARWIN__
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
 
+  /** Whether the user has enabled the setting to confirm removing a repository from the app */
+  readonly askForConfirmationOnRemoveRepository: boolean
+
   /** Called when the repository should be removed. */
   readonly onRemoveRepository: (repository: Repositoryish) => void
 
@@ -124,7 +127,9 @@ export class RepositoryListItem extends React.Component<
       },
       { type: 'separator' },
       {
-        label: 'Remove',
+        label: this.props.askForConfirmationOnRemoveRepository
+          ? 'Remove…'
+          : 'Remove',
         action: this.removeRepository,
       },
     ]


### PR DESCRIPTION
Found this one while testing #4703 and realised that we need to make this action reflect what we did in #4855.

By default Desktop should show ellipses here to indicate it will pop a dialog:

<img width="283" src="https://user-images.githubusercontent.com/359239/41664001-1bdc254a-747b-11e8-9c30-11297e30b64c.png">

But if you turn that off, it'll drop the ellipses to indicate no dialog will be shown:

<img width="293" src="https://user-images.githubusercontent.com/359239/41664026-27f7e094-747b-11e8-807a-5cce0b0e396c.png">
