### PR TITLE
Adds ability to track banner dismissals (NDDB)

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1228,4 +1228,11 @@ export class Dispatcher {
   public setSelectedTheme(theme: ApplicationTheme) {
     return this.appStore._setSelectedTheme(theme)
   }
+
+  /**
+   * The number of times the user dismisses the diverged branch notification
+   */
+  public recordDivergingBranchBannerDismissal() {
+    return this.appStore._recordDivergingBranchBannerDismissal()
+  }
 }

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -58,6 +58,21 @@ export interface IDailyMeasures {
 
   /** The number of times the user checks out a branch using the PR menu */
   readonly prBranchCheckouts: number
+
+  /** The number of times the user dismisses the diverged branch notification */
+  readonly divergingBranchBannerDismissal: number
+
+  /** The number of times the user merges from the diverged branch notification merge CTA button */
+  readonly divergingBranchBannerInitatedMerge: number
+
+  /** The number of times the user compares from the diverged branch notification compare CTA button */
+  readonly divergingBranchBannerInitiatedCompare: number
+
+  /**
+   * The number of times the user merges from the compare view after getting to that state
+   * from the diverged branch notification compare CTA button
+   */
+  readonly divergingBranchBannerInfluencedCompare: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -36,6 +36,10 @@ const DefaultDailyMeasures: IDailyMeasures = {
   updateFromDefaultBranchMenuCount: 0,
   mergeIntoCurrentBranchMenuCount: 0,
   prBranchCheckouts: 0,
+  divergingBranchBannerDismissal: 0,
+  divergingBranchBannerInitatedMerge: 0,
+  divergingBranchBannerInitiatedCompare: 0,
+  divergingBranchBannerInfluencedCompare: 0,
 }
 
 interface ICalculatedStats {
@@ -366,6 +370,40 @@ export class StatsStore {
   /** Has the user opted out of stats reporting? */
   public getOptOut(): boolean {
     return this.optOut
+  }
+
+  /** Record that user dismissed diverging branch notification */
+  public async recordDivergingBranchBannerDismissal(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      divergingBranchBannerDismissal: m.divergingBranchBannerDismissal + 1,
+    }))
+  }
+
+  /** Record that user initiated a merge from within the notification banner */
+  public async recordDivergingBranchBannerInitatedMerge(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      divergingBranchBannerInitatedMerge:
+        m.divergingBranchBannerInitatedMerge + 1,
+    }))
+  }
+
+  /** Record that user initiated a compare from within the notification banner */
+  public async recordDivergingBranchBannerInitiatedCompare(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      divergingBranchBannerInitiatedCompare:
+        m.divergingBranchBannerInitiatedCompare + 1,
+    }))
+  }
+
+  /**
+   * Record that user initiated a merge after getting to compare view
+   * from within notificatio banner
+   */
+  public async recordDivergingBranchBannerInfluencedCompare(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      divergingBranchBannerInfluencedCompare:
+        m.divergingBranchBannerInfluencedCompare + 1,
+    }))
   }
 
   /** Post some data to our stats endpoint. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3742,6 +3742,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return Promise.resolve()
   }
+
+  /**
+   * The number of times the user dismisses the diverged branch notification
+   */
+  public _recordDivergingBranchBannerDismissal() {
+    this.statsStore.recordDivergingBranchBannerDismissal()
+  }
 }
 
 function forkPullRequestRemoteName(remoteName: string) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -510,6 +510,7 @@ export class CompareSidebar extends React.Component<
 
   private onNotificationBannerDismissed = () => {
     this.props.dispatcher.setDivergingBranchBannerVisibility(false)
+    this.props.dispatcher.recordDivergingBranchBannerDismissal()
   }
 }
 


### PR DESCRIPTION
This PR wires up the `divergingBranchBannerDismissal` metric defined in #4883.

🌵 🌵 🌵 
This PR depends on ~#4874~ and ~#4983~ being merged first. 
🌵 🌵 🌵 