### PR TITLE
Dark alternative colors for author input tags

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -157,6 +157,12 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --box-overflow-shadow-background: linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%);
 
   /**
+   * Author input (co-authors)
+   */
+  --co-author-tag-background-color: $blue-000;
+  --co-author-tag-border-color: $blue-200;
+
+  /**
    * The height of the title bar area on Win32 platforms
    * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
   */

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -120,6 +120,12 @@ body.theme-dark {
    */
   --box-overflow-shadow-background: linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%);
 
+  /**
+   * Author input (co-authors)
+   */
+  --co-author-tag-background-color: $blue-800;
+  --co-author-tag-border-color: $blue-700;
+
   --base-border: 1px solid var(--box-border-color);
 
   --shadow-color: rgba(black, 0.5);

--- a/app/styles/ui/_author-input.scss
+++ b/app/styles/ui/_author-input.scss
@@ -24,8 +24,8 @@
 
     .handle {
       border-radius: 3px;
-      border: 1px solid #c3e1ff;
-      background: #f0f8ff;
+      border: 1px solid var(--co-author-tag-border-color);
+      background: var(--co-author-tag-background-color);
       padding: 1px 1px;
       margin: 0px 2px;
 


### PR DESCRIPTION
Fixes #4979 

![screen shot 2018-06-21 at 18 14 23](https://user-images.githubusercontent.com/634063/41731600-12b65d6e-757f-11e8-9659-dbb8c2554a09.png)
