### PR TITLE
refresh the "selected commit" component

### DIFF
--- a/app/src/ui/history/index.ts
+++ b/app/src/ui/history/index.ts
@@ -1,2 +1,2 @@
-export { History } from './history'
+export { SelectedCommit } from './selected-commit'
 export { CompareSidebar } from './compare'

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -8,24 +8,22 @@ import { Repository } from '../../models/repository'
 import { CommittedFileChange, FileChange } from '../../models/status'
 import { Commit } from '../../models/commit'
 import { Dispatcher } from '../../lib/dispatcher'
-import {
-  IHistoryState as IAppHistoryState,
-  ImageDiffType,
-} from '../../lib/app-state'
+import { ImageDiffType } from '../../lib/app-state'
 import { encodePathAsUrl } from '../../lib/path'
 import { ThrottledScheduler } from '../lib/throttled-scheduler'
 import { IGitHubUser } from '../../lib/databases'
 import { Resizable } from '../resizable'
 import { openFile } from '../../lib/open-file'
+import { IDiff } from '../../models/diff'
 
 interface ISelectedCommitProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
-  readonly history: IAppHistoryState
   readonly emoji: Map<string, string>
-  readonly commit: Commit | null
+  readonly selectedCommit: Commit | null
   readonly changedFiles: ReadonlyArray<CommittedFileChange>
   readonly selectedFile: CommittedFileChange | null
+  readonly currentDiff: IDiff | null
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly imageDiffType: ImageDiffType
@@ -67,8 +65,12 @@ export class SelectedCommit extends React.Component<
 
   public componentWillUpdate(nextProps: ISelectedCommitProps) {
     // reset isExpanded if we're switching commits.
-    const currentValue = this.props.commit ? this.props.commit.sha : undefined
-    const nextValue = nextProps.commit ? nextProps.commit.sha : undefined
+    const currentValue = this.props.selectedCommit
+      ? this.props.selectedCommit.sha
+      : undefined
+    const nextValue = nextProps.selectedCommit
+      ? nextProps.selectedCommit.sha
+      : undefined
 
     if ((currentValue || nextValue) && currentValue !== nextValue) {
       if (this.state.isExpanded) {
@@ -83,7 +85,7 @@ export class SelectedCommit extends React.Component<
 
   private renderDiff() {
     const file = this.props.selectedFile
-    const diff = this.props.history.diff
+    const diff = this.props.currentDiff
 
     if (file == null || diff == null) {
       // don't show both 'empty' messages
@@ -168,7 +170,7 @@ export class SelectedCommit extends React.Component<
   }
 
   public render() {
-    const commit = this.props.commit
+    const commit = this.props.selectedCommit
 
     if (commit == null) {
       return <NoCommitSelected />

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -76,7 +76,7 @@ export class SelectedCommit extends React.Component<
     this.loadChangedFilesScheduler.clear()
   }
 
-  private renderDiff(commit: Commit | null) {
+  private renderDiff() {
     const files = this.props.history.changedFiles
     const file = this.props.history.selection.file
     const diff = this.props.history.diff
@@ -183,7 +183,7 @@ export class SelectedCommit extends React.Component<
           >
             {this.renderFileList()}
           </Resizable>
-          {this.renderDiff(commit)}
+          {this.renderDiff()}
         </div>
       </div>
     )

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -18,7 +18,7 @@ import { IGitHubUser } from '../../lib/databases'
 import { Resizable } from '../resizable'
 import { openFile } from '../../lib/open-file'
 
-interface IHistoryProps {
+interface ISelectedCommitProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly history: IAppHistoryState
@@ -37,15 +37,18 @@ interface IHistoryProps {
   readonly onOpenInExternalEditor: (path: string) => void
 }
 
-interface IHistoryState {
+interface ISelectedCommitState {
   readonly isExpanded: boolean
 }
 
 /** The History component. Contains the commit list, commit summary, and diff. */
-export class History extends React.Component<IHistoryProps, IHistoryState> {
+export class SelectedCommit extends React.Component<
+  ISelectedCommitProps,
+  ISelectedCommitState
+> {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
 
-  public constructor(props: IHistoryProps) {
+  public constructor(props: ISelectedCommitProps) {
     super(props)
 
     this.state = {
@@ -60,7 +63,7 @@ export class History extends React.Component<IHistoryProps, IHistoryState> {
     )
   }
 
-  public componentWillUpdate(nextProps: IHistoryProps) {
+  public componentWillUpdate(nextProps: ISelectedCommitProps) {
     // Reset isExpanded if we're switching commits.
     if (nextProps.history.selection.sha !== this.props.history.selection.sha) {
       if (this.state.isExpanded) {

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -24,6 +24,8 @@ interface ISelectedCommitProps {
   readonly history: IAppHistoryState
   readonly emoji: Map<string, string>
   readonly commit: Commit | null
+  readonly changedFiles: ReadonlyArray<CommittedFileChange>
+  readonly selectedFile: CommittedFileChange | null
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly imageDiffType: ImageDiffType
@@ -80,13 +82,13 @@ export class SelectedCommit extends React.Component<
   }
 
   private renderDiff() {
-    const files = this.props.history.changedFiles
-    const file = this.props.history.selection.file
+    const file = this.props.selectedFile
     const diff = this.props.history.diff
 
-    if (!diff || !file) {
+    if (file == null || diff == null) {
       // don't show both 'empty' messages
-      const message = files.length === 0 ? '' : 'No file selected'
+      const message =
+        this.props.changedFiles.length === 0 ? '' : 'No file selected'
 
       return (
         <div className="panel blankslate" id="diff">
@@ -111,7 +113,7 @@ export class SelectedCommit extends React.Component<
     return (
       <CommitSummary
         commit={commit}
-        files={this.props.history.changedFiles}
+        files={this.props.changedFiles}
         emoji={this.props.emoji}
         repository={this.props.repository}
         gitHubUsers={this.props.gitHubUsers}
@@ -134,7 +136,7 @@ export class SelectedCommit extends React.Component<
   }
 
   private renderFileList() {
-    const files = this.props.history.changedFiles
+    const files = this.props.changedFiles
     if (files.length === 0) {
       return <div className="fill-window">No files in commit</div>
     }
@@ -146,7 +148,7 @@ export class SelectedCommit extends React.Component<
       <FileList
         files={files}
         onSelectedFileChanged={this.onFileSelected}
-        selectedFile={this.props.history.selection.file}
+        selectedFile={this.props.selectedFile}
         availableWidth={availableWidth}
         onOpenItem={this.onOpenItem}
         externalEditorLabel={this.props.externalEditorLabel}

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -23,7 +23,7 @@ interface ISelectedCommitProps {
   readonly dispatcher: Dispatcher
   readonly history: IAppHistoryState
   readonly emoji: Map<string, string>
-  readonly commits: Map<string, Commit>
+  readonly commit: Commit | null
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly imageDiffType: ImageDiffType
@@ -64,8 +64,11 @@ export class SelectedCommit extends React.Component<
   }
 
   public componentWillUpdate(nextProps: ISelectedCommitProps) {
-    // Reset isExpanded if we're switching commits.
-    if (nextProps.history.selection.sha !== this.props.history.selection.sha) {
+    // reset isExpanded if we're switching commits.
+    const currentValue = this.props.commit ? this.props.commit.sha : undefined
+    const nextValue = nextProps.commit ? nextProps.commit.sha : undefined
+
+    if ((currentValue || nextValue) && currentValue !== nextValue) {
       if (this.state.isExpanded) {
         this.setState({ isExpanded: false })
       }
@@ -163,10 +166,9 @@ export class SelectedCommit extends React.Component<
   }
 
   public render() {
-    const sha = this.props.history.selection.sha
-    const commit = sha ? this.props.commits.get(sha) || null : null
+    const commit = this.props.commit
 
-    if (!sha || !commit) {
+    if (commit == null) {
       return <NoCommitSelected />
     }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -26,7 +26,7 @@ interface ISelectedCommitProps {
   readonly currentDiff: IDiff | null
   readonly commitSummaryWidth: number
   readonly gitHubUsers: Map<string, IGitHubUser>
-  readonly imageDiffType: ImageDiffType
+  readonly selectedDiffType: ImageDiffType
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
 
@@ -102,7 +102,7 @@ export class SelectedCommit extends React.Component<
     return (
       <Diff
         repository={this.props.repository}
-        imageDiffType={this.props.imageDiffType}
+        imageDiffType={this.props.selectedDiffType}
         file={file}
         diff={diff}
         readOnly={true}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -7,7 +7,7 @@ import { Changes, ChangesSidebar } from './changes'
 import { NoChanges } from './changes/no-changes'
 import { MultipleSelection } from './changes/multiple-selection'
 import { FilesChangedBadge } from './changes/files-changed-badge'
-import { History, CompareSidebar } from './history'
+import { SelectedCommit, CompareSidebar } from './history'
 import { Resizable } from './resizable'
 import { TabBar } from './tab-bar'
 import {
@@ -267,7 +267,7 @@ export class RepositoryView extends React.Component<
       }
     } else if (selectedSection === RepositorySectionTab.History) {
       return (
-        <History
+        <SelectedCommit
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
           history={this.props.state.historyState}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -266,13 +266,18 @@ export class RepositoryView extends React.Component<
         )
       }
     } else if (selectedSection === RepositorySectionTab.History) {
+      const sha = this.props.state.historyState.selection.sha
+
+      const commit =
+        sha != null ? this.props.state.commitLookup.get(sha) || null : null
+
       return (
         <SelectedCommit
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
           history={this.props.state.historyState}
+          commit={commit}
           emoji={this.props.emoji}
-          commits={this.props.state.commitLookup}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}
           imageDiffType={this.props.imageDiffType}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -270,17 +270,17 @@ export class RepositoryView extends React.Component<
 
       const sha = historyState.selection.sha
 
-      const commit =
+      const selectedCommit =
         sha != null ? this.props.state.commitLookup.get(sha) || null : null
 
       return (
         <SelectedCommit
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
-          history={historyState}
-          commit={commit}
+          selectedCommit={selectedCommit}
           changedFiles={historyState.changedFiles}
           selectedFile={historyState.selection.file}
+          currentDiff={historyState.diff}
           emoji={this.props.emoji}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -266,7 +266,9 @@ export class RepositoryView extends React.Component<
         )
       }
     } else if (selectedSection === RepositorySectionTab.History) {
-      const sha = this.props.state.historyState.selection.sha
+      const { historyState } = this.props.state
+
+      const sha = historyState.selection.sha
 
       const commit =
         sha != null ? this.props.state.commitLookup.get(sha) || null : null
@@ -275,8 +277,10 @@ export class RepositoryView extends React.Component<
         <SelectedCommit
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
-          history={this.props.state.historyState}
+          history={historyState}
           commit={commit}
+          changedFiles={historyState.changedFiles}
+          selectedFile={historyState.selection.file}
           emoji={this.props.emoji}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -284,7 +284,7 @@ export class RepositoryView extends React.Component<
           emoji={this.props.emoji}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}
-          imageDiffType={this.props.imageDiffType}
+          selectedDiffType={this.props.imageDiffType}
           externalEditorLabel={this.props.externalEditorLabel}
           onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         />


### PR DESCRIPTION
This component, which represents the commit view when you're looking at the history view, suffers from a couple of problems:

 - it's poorly named
 - it's coupled to `IHistoryState` and the history components are being deprecated (see #4987)

So this PR updates the component to try and simplify the component itself so that it makes more sense.

No functional changes yet around the shape of data, just ergonomics and lifting up state wherever we can. 