### PR TITLE
ensure native modules are in sync with current version of electron

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 1.8.3
+target = 1.8.7
 arch = x64


### PR DESCRIPTION
In #4695 I neglected to also bump this file, which is used when `npm`/`yarn` build their native modules, to ensure they bind to the right version of V8. We should get this in and published to beta to ensure there's no last-minute issues with things that rely on this:

 - reading credentials (`keytar`) 
 - installing the CLI tools (`runas`)
 - listing the available editors and shells (`registry-js`)