### PR TITLE
compile scripts as part of CI builds to catch regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "yarn test:unit && yarn test:script && yarn test:integration",
     "test:setup": "ts-node script/test-setup.ts",
     "test:review": "ts-node script/test-review.ts",
-    "postinstall": "cd app && yarn install --force && cd .. && git submodule update --recursive --init && yarn compile:tslint",
+    "postinstall": "cd app && yarn install --force && cd .. && git submodule update --recursive --init && yarn compile:tslint && yarn compile:script",
     "start": "cross-env NODE_ENV=development node script/start",
     "start:prod": "cross-env NODE_ENV=production node script/start",
     "compile:dev": "cross-env NODE_ENV=development parallel-webpack --config app/webpack.development.js",

--- a/script/build.ts
+++ b/script/build.ts
@@ -124,11 +124,17 @@ function packageApp(
   }
 
   const toPackageArch = (targetArch: string | undefined): packager.arch => {
+    if (targetArch === undefined) {
+      return 'x64'
+    }
+
     if (targetArch === 'arm64' || targetArch === 'x64') {
       return targetArch
     }
 
-    return 'x64'
+    throw new Error(
+      `Building Desktop for architecture '${targetArch}'  is not supported`
+    )
   }
 
   const options: packager.Options & IPackageAdditionalOptions = {

--- a/script/build.ts
+++ b/script/build.ts
@@ -123,10 +123,18 @@ function packageApp(
     )
   }
 
+  const toPackageArch = (targetArch: string | undefined): packager.arch => {
+    if (targetArch === 'arm64' || targetArch === 'x64') {
+      return targetArch
+    }
+
+    return 'x64'
+  }
+
   const options: packager.Options & IPackageAdditionalOptions = {
     name: getExecutableName(),
     platform: toPackagePlatform(process.platform),
-    arch: process.env.TARGET_ARCH || 'x64',
+    arch: toPackageArch(process.env.TARGET_ARCH),
     asar: false, // TODO: Probably wanna enable this down the road.
     out: getDistRoot(),
     icon: path.join(projectRoot, 'app', 'static', 'logos', 'icon-logo'),

--- a/script/review-logs.ts
+++ b/script/review-logs.ts
@@ -8,7 +8,13 @@ import { getExecutableName } from './dist-info'
 
 function getUserDataPath() {
   if (process.platform === 'win32') {
-    return path.join(process.env.APPDATA, getExecutableName())
+    if (process.env.APPDATA) {
+      return path.join(process.env.APPDATA, getExecutableName())
+    } else {
+      throw new Error(
+        `Unable to find the application data directory on Windows :(`
+      )
+    }
   } else if (process.platform === 'darwin') {
     const home = os.homedir()
     return path.join(home, 'Library', 'Application Support', getProductName())

--- a/script/tsconfig.json
+++ b/script/tsconfig.json
@@ -3,14 +3,12 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es6",
-    "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "strictNullChecks": true,
     "sourceMap": false,
-    "noEmit": true
+    "noEmit": true,
+    "strict": true,
   },
   "compileOnSave": false
 }

--- a/vsts.yml
+++ b/vsts.yml
@@ -10,7 +10,7 @@ phases:
       versionSpec: "1.5.1"
   - script: |
        yarn install --force
-    name: Dependencies
+    name: Install
   - script: |
       yarn lint && yarn build:prod
     name: Build
@@ -53,7 +53,7 @@ phases:
       versionSpec: "1.5.1"
   - script: |
       yarn install --force
-    name: Dependencies
+    name: Install
   - script: |
        yarn lint && yarn build:prod
     name: Build


### PR DESCRIPTION
Turns out there are some lingering Typescript errors lurking in our infrastructure scripts:

```sh
$ tsc -p script
script/build.ts:126:9 - error TS2322: Type '{ name: string; platform: "darwin" | "linux" | "win32"; arch: string; asar: false; out: string; i...' is not assignable to type 'Options & IPackageAdditionalOptions'.
  Type '{ name: string; platform: "darwin" | "linux" | "win32"; arch: string; asar: false; out: string; i...' is not assignable to type 'Options'.
    Types of property 'arch' are incompatible.
      Type 'string' is not assignable to type '"all" | "ia32" | "x64" | "armv7l" | "arm64" | arch[] | undefined'.

126   const options: packager.Options & IPackageAdditionalOptions = {
            ~~~~~~~


script/review-logs.ts:11:22 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.

11     return path.join(process.env.APPDATA, getExecutableName())
                        ~~~~~~~~~~~~~~~~~~~


error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This PR ensures we check our scripts as part of CI, so that we can catch regressions earlier.
