### PR TITLE
bump the limit for `git status` to 20MB of raw output

### DIFF
--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -59,7 +59,8 @@ export async function getStatus(
   const result = await git(
     ['status', '--untracked-files=all', '--branch', '--porcelain=2', '-z'],
     repository.path,
-    'getStatus'
+    'getStatus',
+    { maxBuffer: 20 * 1024 * 1024 }
   )
 
   // Map of files keyed on their paths.


### PR DESCRIPTION
Addresses a known bottleneck from Git output as reported in #2449

This bottleneck seems to come up when you have a lot of untracked files (thousands) so it'd be nice to pause here and think about whether there's a better solution to bumping up this constraint.