### PR TITLE
oops, not quite ready for NDDB

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -172,7 +172,7 @@ export class CompareSidebar extends React.Component<
 
   private renderNotificationBanner() {
     if (!enableNotificationOfBranchUpdates()) {
-      return
+      return null
     }
 
     if (!this.props.isDivergingBranchBannerVisible) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -172,7 +172,7 @@ export class CompareSidebar extends React.Component<
 
   private renderNotificationBanner() {
     if (
-      !enableNotificationOfBranchUpdates ||
+      !enableNotificationOfBranchUpdates &&
       !this.props.isDivergingBranchBannerVisible
     ) {
       return null

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -171,7 +171,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderNotificationBanner() {
-    if (!enableNotificationOfBranchUpdates) {
+    if (!enableNotificationOfBranchUpdates()) {
       return
     }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -171,10 +171,11 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderNotificationBanner() {
-    if (
-      !enableNotificationOfBranchUpdates &&
-      !this.props.isDivergingBranchBannerVisible
-    ) {
+    if (!enableNotificationOfBranchUpdates) {
+      return
+    }
+
+    if (!this.props.isDivergingBranchBannerVisible) {
       return null
     }
 


### PR DESCRIPTION
If you've just updated to 1.2.4 you might have seen a message like this in the compare view:

<img width="587" alt="screen shot 2018-06-25 at 12 29 48 pm" src="https://user-images.githubusercontent.com/359239/41859871-8a796340-7873-11e8-9f67-0c5c959a99dd.png">

This is something that we're _close_ to shipping, called **Notifications of Diverging from Default Branch** and summarized in https://github.com/desktop/desktop/issues/4646, but we want to properly bake it on beta and get feedback before it goes out to the world.

This PR should ensure the new dialog isn't shown:

 - [x] confirm locally that this isn't rendered for `production`