### PR TITLE
introduce label to track theme-related reports

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -158,6 +158,7 @@ pull requests.
 | `Windows` | [search](https://github.com/desktop/desktop/labels/Windows)  | Issues specific to Windows users |
 | `codemirror` | [search](https://github.com/desktop/desktop/labels/codemirror)  | Issues related to our use of [CodeMirror](https://codemirror.net/) that may require upstream fixes |
 | `electron` | [search](https://github.com/desktop/desktop/labels/electron) | Issues related to our use of [Electron](https://electron.atom.io) that may require upstream fixes |
+| `themes` | [search](https://github.com/desktop/desktop/labels/themes) | Issues related the light or dark themes that ship in Desktop |
 
 #### Topics
 


### PR DESCRIPTION
We're starting to get feedback about the Dark Theme™ and I figure this can do with a specialized label to help us track these issues separate to bug reports and enhancements.