### PR TITLE
Reposition notification banner CTA

### DIFF
--- a/app/src/ui/notification/new-commits-banner.tsx
+++ b/app/src/ui/notification/new-commits-banner.tsx
@@ -53,7 +53,7 @@ export class NewCommitsBanner extends React.Component<
             </p>
           </div>
           <div className="notification-banner-cta">
-            <Button onClick={this.onComparedClicked}>Compare</Button>
+            <Button onClick={this.onComparedClicked}>View commits</Button>
           </div>
         </div>
 

--- a/app/src/ui/notification/new-commits-banner.tsx
+++ b/app/src/ui/notification/new-commits-banner.tsx
@@ -52,6 +52,9 @@ export class NewCommitsBanner extends React.Component<
               behind <Ref>{this.props.baseBranch.name}</Ref>.
             </p>
           </div>
+          <div className="notification-banner-cta">
+            <Button onClick={this.onComparedClicked}>Compare</Button>
+          </div>
         </div>
 
         <a
@@ -61,9 +64,6 @@ export class NewCommitsBanner extends React.Component<
         >
           <Octicon symbol={OcticonSymbol.x} />
         </a>
-        <div className="notification-banner-cta">
-          <Button onClick={this.onComparedClicked}>Compare</Button>
-        </div>
       </div>
     )
   }

--- a/app/styles/ui/_notification-banner.scss
+++ b/app/styles/ui/_notification-banner.scss
@@ -95,5 +95,5 @@
 }
 
 .notification-banner-cta {
-  padding-top: 5px;
+  padding-top: var(--spacing-half);
 }

--- a/app/styles/ui/_notification-banner.scss
+++ b/app/styles/ui/_notification-banner.scss
@@ -19,6 +19,7 @@
 
   &-content {
     display: flex;
+    flex-wrap: wrap;
 
     p {
       flex-grow: 1;
@@ -91,4 +92,8 @@
 
 .notification-banner-content-body {
   color: var(--text-secondary-color);
+}
+
+.notification-banner-cta {
+  padding-top: 5px;
 }


### PR DESCRIPTION
This bumps the button on the notification banner down so it doesn't look all broken! 

_Targets the `i-wanna-compare` branch in #5034_

|Before|After|
|---|---|
|<img width="248" alt="screen shot 2018-06-26 at 2 08 51 pm" src="https://user-images.githubusercontent.com/10404068/41939404-8ee48d06-794a-11e8-885c-937bc1175404.png">|<img width="245" alt="screen shot 2018-06-26 at 2 23 15 pm" src="https://user-images.githubusercontent.com/10404068/41940101-853c3f40-794c-11e8-9c52-55c920438bad.png">|