### PR TITLE
keep compare tab in sync with selection

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -342,7 +342,7 @@ export enum RepositorySectionTab {
 }
 
 export interface IRepositoryState {
-  readonly selection: ICommitSelection
+  readonly commitSelection: ICommitSelection
   readonly changesState: IChangesState
   readonly compareState: ICompareState
   readonly selectedSection: RepositorySectionTab

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -562,21 +562,16 @@ export interface IBranchesState {
 }
 
 export interface ICommitSelection {
-  /**
-   * The commit currently selected in the app
-   */
+  /** The commit currently selected in the app */
   readonly sha: string | null
-  /**
-   * The list of files associated with the current commit
-   */
+
+  /** The list of files associated with the current commit */
   readonly changedFiles: ReadonlyArray<CommittedFileChange>
-  /**
-   * The selected file inside the selected commit
-   */
+
+  /** The selected file inside the selected commit */
   readonly file: CommittedFileChange | null
-  /**
-   * The diff of the currently-sel
-   */
+
+  /** The diff of the currently-selected file */
   readonly diff: IDiff | null
 }
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -693,6 +693,12 @@ export enum CompareActionKind {
   Branch = 'Branch',
 }
 
+export interface ICompareToBranch {
+  readonly kind: CompareActionKind.Branch
+  readonly branch: Branch
+  readonly mode: ComparisonView.Ahead | ComparisonView.Behind
+}
+
 /**
  * An action to send to the application store to update the compare state
  */
@@ -700,8 +706,4 @@ export type CompareAction =
   | {
       readonly kind: CompareActionKind.History
     }
-  | {
-      readonly kind: CompareActionKind.Branch
-      readonly branch: Branch
-      readonly mode: ComparisonView.Ahead | ComparisonView.Behind
-    }
+  | ICompareToBranch

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -342,7 +342,7 @@ export enum RepositorySectionTab {
 }
 
 export interface IRepositoryState {
-  readonly historyState: IHistoryState
+  readonly selection: ICommitSelection
   readonly changesState: IChangesState
   readonly compareState: ICompareState
   readonly selectedSection: RepositorySectionTab
@@ -561,19 +561,10 @@ export interface IBranchesState {
   readonly currentPullRequest: PullRequest | null
 }
 
-export interface IHistorySelection {
+export interface ICommitSelection {
   readonly sha: string | null
   readonly file: CommittedFileChange | null
-}
-
-export interface IHistoryState {
-  readonly selection: IHistorySelection
-
-  /** The ordered SHAs. */
-  readonly history: ReadonlyArray<string>
-
   readonly changedFiles: ReadonlyArray<CommittedFileChange>
-
   readonly diff: IDiff | null
 }
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -562,9 +562,21 @@ export interface IBranchesState {
 }
 
 export interface ICommitSelection {
+  /**
+   * The commit currently selected in the app
+   */
   readonly sha: string | null
-  readonly file: CommittedFileChange | null
+  /**
+   * The list of files associated with the current commit
+   */
   readonly changedFiles: ReadonlyArray<CommittedFileChange>
+  /**
+   * The selected file inside the selected commit
+   */
+  readonly file: CommittedFileChange | null
+  /**
+   * The diff of the currently-sel
+   */
   readonly diff: IDiff | null
 }
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -121,8 +121,8 @@ export class Dispatcher {
   }
 
   /** Load the next batch of history for the repository. */
-  public loadNextHistoryBatch(repository: Repository): Promise<void> {
-    return this.appStore._loadNextHistoryBatch(repository)
+  public loadNextCommitBatch(repository: Repository): Promise<void> {
+    return this.appStore._loadNextCommitBatch(repository)
   }
 
   /** Load the changed files for the current history selection. */
@@ -141,11 +141,11 @@ export class Dispatcher {
    *            the history list, represented as a SHA-1 hash
    *            digest. This should match exactly that of Commit.Sha
    */
-  public changeHistoryCommitSelection(
+  public changeCommitSelection(
     repository: Repository,
     sha: string
   ): Promise<void> {
-    return this.appStore._changeHistoryCommitSelection(repository, sha)
+    return this.appStore._changeCommitSelection(repository, sha)
   }
 
   /**
@@ -156,11 +156,11 @@ export class Dispatcher {
    * @param file A FileChange instance among those available in
    *            IHistoryState.changedFiles
    */
-  public changeHistoryFileSelection(
+  public changeFileSelection(
     repository: Repository,
     file: CommittedFileChange
   ): Promise<void> {
-    return this.appStore._changeHistoryFileSelection(repository, file)
+    return this.appStore._changeFileSelection(repository, file)
   }
 
   /** Set the repository filter text. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1977,8 +1977,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       await gitStore.loadLocalCommits(tip.branch)
     }
 
-    // TODO: is this necessary to do still?
-
     return this.updateOrSelectFirstCommit(
       repository,
       state.compareState.commitSHAs

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -904,14 +904,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { ahead, behind } = compare
     const aheadBehind = { ahead, behind }
 
+    const commitSHAs = compare.commits.map(commit => commit.sha)
+
     this.updateCompareState(repository, s => ({
       formState: {
         comparisonBranch,
         kind: action.mode,
         aheadBehind,
       },
-      commitSHAs: compare.commits.map(commit => commit.sha),
       filterText: comparisonBranch.name,
+      commitSHAs,
     }))
 
     const tip = gitStore.tip
@@ -936,6 +938,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.currentAheadBehindUpdater.insert(from, to, aheadBehind)
     }
+
+    this.updateSelectedCommit(repository, commitSHAs)
 
     return this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -850,7 +850,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return
       }
 
-      this.updateCompareState(repository, state => ({
+      this.updateCompareState(repository, () => ({
         formState: {
           kind: ComparisonView.None,
         },
@@ -2706,13 +2706,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (selectedCommit === commit.sha) {
       // clear the selection of this commit in the history view
       this.updateRepositoryState(repository, state => {
-        const selection = {
-          sha: null,
-          file: null,
-          changedFiles: [],
-          diff: null,
+        return {
+          selection: {
+            sha: null,
+            file: null,
+            changedFiles: [],
+            diff: null,
+          },
         }
-        return { selection }
       })
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -709,7 +709,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  private updateSelectedCommit(
+  private updateOrSelectFirstCommit(
     repository: Repository,
     commitSHAs: ReadonlyArray<string>
   ) {
@@ -877,6 +877,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
           },
           commitSHAs: commits,
         }))
+
+        this.updateOrSelectFirstCommit(repository, commits)
+
         return this.emitUpdate()
       }
     } else if (action.kind === CompareActionKind.Branch) {
@@ -950,7 +953,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.currentAheadBehindUpdater.insert(from, to, aheadBehind)
     }
 
-    this.updateSelectedCommit(repository, commitSHAs)
+    this.updateOrSelectFirstCommit(repository, commitSHAs)
 
     return this.emitUpdate()
   }
@@ -1945,7 +1948,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     // TODO: is this necessary to do still?
 
-    return this.updateSelectedCommit(repository, state.compareState.commitSHAs)
+    return this.updateOrSelectFirstCommit(
+      repository,
+      state.compareState.commitSHAs
+    )
   }
 
   private async refreshAuthor(repository: Repository): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -694,10 +694,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     commitSHAs: ReadonlyArray<string>
   ) {
     const state = this.getRepositoryState(repository)
-    const commits = state.compareState.commitSHAs
     let selectedSHA = state.selection.sha
     if (selectedSHA != null) {
-      const index = commits.findIndex(sha => sha === selectedSHA)
+      const index = commitSHAs.findIndex(sha => sha === selectedSHA)
       // Our selected SHA is not in this list, so clear the selection in the app state
       if (index < 0) {
         selectedSHA = null
@@ -712,8 +711,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    if (selectedSHA == null && commits.length > 0) {
-      this._changeCommitSelection(repository, commits[0])
+    if (selectedSHA == null && commitSHAs.length > 0) {
+      this._changeCommitSelection(repository, commitSHAs[0])
       this._loadChangedFilesForCurrentSelection(repository)
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -706,7 +706,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     if (newSelection.sha == null && commits.length > 0) {
-      this._changeHistoryCommitSelection(repository, commits[0])
+      this._changeCommitSelection(repository, commits[0])
       this._loadChangedFilesForCurrentSelection(repository)
     }
 
@@ -935,7 +935,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _loadNextHistoryBatch(repository: Repository): Promise<void> {
+  public async _loadNextCommitBatch(repository: Repository): Promise<void> {
     const gitStore = this.getGitStore(repository)
 
     const state = this.getRepositoryState(repository)
@@ -1004,12 +1004,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     if (selectionOrFirstFile.file) {
-      this._changeHistoryFileSelection(repository, selectionOrFirstFile.file)
+      this._changeFileSelection(repository, selectionOrFirstFile.file)
     }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _changeHistoryCommitSelection(
+  public async _changeCommitSelection(
     repository: Repository,
     sha: string
   ): Promise<void> {
@@ -1032,7 +1032,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _changeHistoryFileSelection(
+  public async _changeFileSelection(
     repository: Repository,
     file: CommittedFileChange
   ): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1,7 +1,6 @@
 import { ipcRenderer, remote } from 'electron'
 import {
   IRepositoryState,
-  IHistoryState,
   IAppState,
   RepositorySectionTab,
   IChangesState,
@@ -425,13 +424,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private getInitialRepositoryState(): IRepositoryState {
     return {
-      historyState: {
-        selection: {
-          sha: null,
-          file: null,
-        },
+      selection: {
+        sha: null,
+        file: null,
         changedFiles: new Array<CommittedFileChange>(),
-        history: new Array<string>(),
         diff: null,
       },
       changesState: {
@@ -503,17 +499,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const currentState = this.getRepositoryState(repository)
     const newValues = fn(currentState)
     this.repositoryState.set(repository.hash, merge(currentState, newValues))
-  }
-
-  private updateHistoryState<K extends keyof IHistoryState>(
-    repository: Repository,
-    fn: (historyState: IHistoryState) => Pick<IHistoryState, K>
-  ) {
-    this.updateRepositoryState(repository, state => {
-      const historyState = state.historyState
-      const newValues = fn(historyState)
-      return { historyState: merge(historyState, newValues) }
-    })
   }
 
   private updateCompareState<K extends keyof ICompareState>(
@@ -623,10 +608,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private onGitStoreUpdated(repository: Repository, gitStore: GitStore) {
-    this.updateHistoryState(repository, state => ({
-      history: gitStore.history,
-    }))
-
     this.updateBranchesState(repository, state => ({
       tip: gitStore.tip,
       defaultBranch: gitStore.defaultBranch,
@@ -707,23 +688,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.getGitStore(repository)
     await gitStore.loadHistory()
 
-    const state = this.getRepositoryState(repository).historyState
+    const state = this.getRepositoryState(repository)
     let newSelection = state.selection
-    const history = state.history
+    const commits = state.compareState.commitSHAs
     const selectedSHA = state.selection.sha
     if (selectedSHA) {
-      const index = history.findIndex(sha => sha === selectedSHA)
+      const index = commits.findIndex(sha => sha === selectedSHA)
       // Our selected SHA disappeared, so clear the selection.
       if (index < 0) {
         newSelection = {
           sha: null,
           file: null,
+          changedFiles: [],
+          diff: null,
         }
       }
     }
 
-    if (!newSelection.sha && history.length > 0) {
-      this._changeHistoryCommitSelection(repository, history[0])
+    if (newSelection.sha == null && commits.length > 0) {
+      this._changeHistoryCommitSelection(repository, commits[0])
       this._loadChangedFilesForCurrentSelection(repository)
     }
 
@@ -868,8 +851,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (action.kind === CompareActionKind.History) {
       await gitStore.loadHistory()
 
-      const repoState = this.getRepositoryState(repository).historyState
-      const commits = repoState.history
+      const repoState = this.getRepositoryState(repository)
+      const commits = repoState.compareState.commitSHAs
 
       this.updateCompareState(repository, state => ({
         formState: {
@@ -978,7 +961,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository
   ): Promise<void> {
     const state = this.getRepositoryState(repository)
-    const selection = state.historyState.selection
+    const { selection } = state
     const currentSHA = selection.sha
     if (!currentSHA) {
       return
@@ -995,7 +978,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // The selection could have changed between when we started loading the
     // changed files and we finished. We might wanna store the changed files per
     // SHA/path.
-    if (currentSHA !== state.historyState.selection.sha) {
+    if (currentSHA !== state.selection.sha) {
       return
     }
 
@@ -1010,9 +993,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const selectionOrFirstFile = {
       file: firstFileOrDefault,
       sha: selection.sha,
+      changedFiles,
+      diff: null,
     }
 
-    this.updateHistoryState(repository, state => ({ changedFiles }))
+    this.updateRepositoryState(repository, state => ({
+      selection: selectionOrFirstFile,
+    }))
 
     this.emitUpdate()
 
@@ -1026,16 +1013,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     sha: string
   ): Promise<void> {
-    this.updateHistoryState(repository, state => {
+    this.updateRepositoryState(repository, state => {
       const commitChanged = state.selection.sha !== sha
       const changedFiles = commitChanged
         ? new Array<CommittedFileChange>()
-        : state.changedFiles
+        : state.selection.changedFiles
       const file = commitChanged ? null : state.selection.file
-      const selection = { sha, file }
-      const diff = null
-
-      return { selection, changedFiles, diff }
+      const selection = { sha, file, diff: null, changedFiles }
+      return { selection }
     })
     this.emitUpdate()
   }
@@ -1051,15 +1036,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     file: CommittedFileChange
   ): Promise<void> {
-    this.updateHistoryState(repository, state => {
-      const selection = { sha: state.selection.sha, file }
-      const diff = null
-      return { selection, diff }
+    this.updateRepositoryState(repository, state => {
+      const selection = {
+        sha: state.selection.sha,
+        changedFiles: state.selection.changedFiles,
+        file,
+        diff: null,
+      }
+      return { selection }
     })
     this.emitUpdate()
 
     const stateBeforeLoad = this.getRepositoryState(repository)
-    const sha = stateBeforeLoad.historyState.selection.sha
+    const sha = stateBeforeLoad.selection.sha
 
     if (!sha) {
       if (__DEV__) {
@@ -1076,22 +1065,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const stateAfterLoad = this.getRepositoryState(repository)
 
     // A whole bunch of things could have happened since we initiated the diff load
-    if (
-      stateAfterLoad.historyState.selection.sha !==
-      stateBeforeLoad.historyState.selection.sha
-    ) {
+    if (stateAfterLoad.selection.sha !== stateBeforeLoad.selection.sha) {
       return
     }
-    if (!stateAfterLoad.historyState.selection.file) {
+    if (!stateAfterLoad.selection.file) {
       return
     }
-    if (stateAfterLoad.historyState.selection.file.id !== file.id) {
+    if (stateAfterLoad.selection.file.id !== file.id) {
       return
     }
 
-    this.updateHistoryState(repository, state => {
-      const selection = { sha: state.selection.sha, file }
-      return { selection, diff }
+    this.updateRepositoryState(repository, state => {
+      const selection = {
+        sha: state.selection.sha,
+        changedFiles: state.selection.changedFiles,
+        file,
+        diff,
+      }
+      return { selection }
     })
 
     this.emitUpdate()
@@ -2714,12 +2705,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await gitStore.undoCommit(commit)
 
     const state = this.getRepositoryState(repository)
-    const selectedCommit = state.historyState.selection.sha
+    const selectedCommit = state.selection.sha
 
     if (selectedCommit === commit.sha) {
       // clear the selection of this commit in the history view
-      this.updateHistoryState(repository, state => {
-        const selection = { sha: null, file: null }
+      this.updateRepositoryState(repository, state => {
+        const selection = {
+          sha: null,
+          file: null,
+          changedFiles: [],
+          diff: null,
+        }
         return { selection }
       })
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -917,16 +917,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    this.updateCompareState(repository, () => ({
-      formState: {
-        comparisonBranch,
-        kind: action.mode,
-        aheadBehind,
-      },
-      commitSHAs: compare.commits.map(commit => commit.sha),
-      filterText: comparisonBranch.name,
-    }))
-
     const { ahead, behind } = compare
     const aheadBehind = { ahead, behind }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -853,20 +853,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const kind = action.kind
 
     if (action.kind === CompareActionKind.History) {
+      // load initial group of commits for current branch
       const commits = await gitStore.loadCommitBatch('HEAD')
 
-      if (commits == null) {
-        log.warn('unable to get any commits, wtf?!?!?!')
-        return
+      if (commits != null) {
+        this.updateCompareState(repository, () => ({
+          formState: {
+            kind: ComparisonView.None,
+          },
+          commitSHAs: commits,
+        }))
+        return this.emitUpdate()
       }
-
-      this.updateCompareState(repository, () => ({
-        formState: {
-          kind: ComparisonView.None,
-        },
-        commitSHAs: commits,
-      }))
-      return this.emitUpdate()
     } else if (action.kind === CompareActionKind.Branch) {
       return this.updateCompareToBranch(repository, action)
     } else {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -679,14 +679,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return store
   }
 
-  /**
-   * TODO:
-   * This is some legacy code that no longer works with the new Compare tab.
-   * Need to investigate porting this to "refresh" the Compare tab state.
-   */
   private async _loadHistory(repository: Repository): Promise<void> {
-    const gitStore = this.getGitStore(repository)
-    await gitStore.loadHistory()
+    // TODO: if we're no longer loading history here what are we doing?
 
     const state = this.getRepositoryState(repository)
     let newSelection = state.selection
@@ -849,10 +843,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const kind = action.kind
 
     if (action.kind === CompareActionKind.History) {
-      await gitStore.loadHistory()
+      const commits = await gitStore.loadCommitBatch('HEAD')
 
-      const repoState = this.getRepositoryState(repository)
-      const commits = repoState.compareState.commitSHAs
+      if (commits == null) {
+        log.warn('unable to get any commits, wtf?!?!?!')
+        return
+      }
 
       this.updateCompareState(repository, state => ({
         formState: {
@@ -3386,7 +3382,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.updateRevertProgress(repo, null)
 
-      return gitStore.loadHistory()
+      // TODO: what's the equivalent for the compare tab?
+      // This might be re-computed when we switch back, in which case we can :fire:
+      // it to the ground.
+      //return gitStore.loadHistory()
     })
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -694,16 +694,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     commitSHAs: ReadonlyArray<string>
   ) {
     const state = this.getRepositoryState(repository)
-    let newSelection = state.selection
     const commits = state.compareState.commitSHAs
-    const selectedSHA = newSelection.sha
-    if (newSelection.sha != null) {
+    let selectedSHA = state.selection.sha
+    if (selectedSHA != null) {
       const index = commits.findIndex(sha => sha === selectedSHA)
       // Our selected SHA is not in this list, so clear the selection in the app state
       if (index < 0) {
+        selectedSHA = null
         this.updateRepositoryState(repository, () => ({
           selection: {
-            sha: null,
+            sha: selectedSHA,
             file: null,
             changedFiles: [],
             diff: null,
@@ -712,7 +712,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    if (newSelection.sha == null && commits.length > 0) {
+    if (selectedSHA == null && commits.length > 0) {
       this._changeCommitSelection(repository, commits[0])
       this._loadChangedFilesForCurrentSelection(repository)
     }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -428,7 +428,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private onCommitSelected = (commit: Commit) => {
-    this.props.dispatcher.changeHistoryCommitSelection(
+    this.props.dispatcher.changeCommitSelection(
       this.props.repository,
       commit.sha
     )
@@ -461,7 +461,7 @@ export class CompareSidebar extends React.Component<
       }
 
       this.loadingMoreCommitsPromise = this.props.dispatcher
-        .loadNextHistoryBatch(this.props.repository)
+        .loadNextCommitBatch(this.props.repository)
         .then(() => {
           // deferring unsetting this flag to some time _after_ the commits
           // have been appended to prevent eagerly adding more commits due

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -40,6 +40,7 @@ interface ICompareSidebarProps {
   readonly localCommitSHAs: ReadonlyArray<string>
   readonly dispatcher: Dispatcher
   readonly currentBranch: Branch | null
+  readonly selectedCommitSha: string | null
   readonly isDivergingBranchBannerVisible: boolean
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
@@ -52,7 +53,6 @@ interface ICompareSidebarState {
    * For all other cases, use the prop
    */
   readonly focusedBranch: Branch | null
-  readonly selectedCommit: Commit | null
 
   /**
    * Flag that tracks whether the user interacted with one of the notification's
@@ -78,7 +78,6 @@ export class CompareSidebar extends React.Component<
 
     this.state = {
       focusedBranch: null,
-      selectedCommit: null,
       hasConsumedNotification: false,
     }
   }
@@ -229,7 +228,6 @@ export class CompareSidebar extends React.Component<
 
   private renderCommitList() {
     const { formState, commitSHAs } = this.props.compareState
-    const selectedCommit = this.state.selectedCommit
 
     let emptyListMessage: string | JSX.Element
     if (formState.kind === ComparisonView.None) {
@@ -257,7 +255,7 @@ export class CompareSidebar extends React.Component<
         gitHubRepository={this.props.repository.gitHubRepository}
         commitLookup={this.props.commitLookup}
         commitSHAs={commitSHAs}
-        selectedSHA={selectedCommit !== null ? selectedCommit.sha : null}
+        selectedSHA={this.props.selectedCommitSha}
         gitHubUsers={this.props.gitHubUsers}
         localCommitSHAs={this.props.localCommitSHAs}
         emoji={this.props.emoji}
@@ -438,8 +436,6 @@ export class CompareSidebar extends React.Component<
         this.props.repository
       )
     })
-
-    this.setState({ selectedCommit: commit })
   }
 
   private onScroll = (start: number, end: number) => {

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -57,7 +57,7 @@ export class SelectedCommit extends React.Component<
   }
 
   private onFileSelected = (file: FileChange) => {
-    this.props.dispatcher.changeHistoryFileSelection(
+    this.props.dispatcher.changeFileSelection(
       this.props.repository,
       file as CommittedFileChange
     )

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -266,9 +266,9 @@ export class RepositoryView extends React.Component<
         )
       }
     } else if (selectedSection === RepositorySectionTab.History) {
-      const { historyState } = this.props.state
+      const { selection } = this.props.state
 
-      const sha = historyState.selection.sha
+      const sha = selection.sha
 
       const selectedCommit =
         sha != null ? this.props.state.commitLookup.get(sha) || null : null
@@ -278,9 +278,9 @@ export class RepositoryView extends React.Component<
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
           selectedCommit={selectedCommit}
-          changedFiles={historyState.changedFiles}
-          selectedFile={historyState.selection.file}
-          currentDiff={historyState.diff}
+          changedFiles={selection.changedFiles}
+          selectedFile={selection.file}
+          currentDiff={selection.diff}
           emoji={this.props.emoji}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -164,6 +164,7 @@ export class RepositoryView extends React.Component<
       <CompareSidebar
         repository={this.props.repository}
         compareState={this.props.state.compareState}
+        selectedCommitSha={this.props.state.selection.sha}
         currentBranch={currentBranch}
         gitHubUsers={this.props.state.gitHubUsers}
         emoji={this.props.emoji}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -164,7 +164,7 @@ export class RepositoryView extends React.Component<
       <CompareSidebar
         repository={this.props.repository}
         compareState={this.props.state.compareState}
-        selectedCommitSha={this.props.state.selection.sha}
+        selectedCommitSha={this.props.state.commitSelection.sha}
         currentBranch={currentBranch}
         gitHubUsers={this.props.state.gitHubUsers}
         emoji={this.props.emoji}
@@ -267,21 +267,23 @@ export class RepositoryView extends React.Component<
         )
       }
     } else if (selectedSection === RepositorySectionTab.History) {
-      const { selection } = this.props.state
+      const { commitSelection } = this.props.state
 
-      const sha = selection.sha
+      const sha = commitSelection.sha
 
       const selectedCommit =
         sha != null ? this.props.state.commitLookup.get(sha) || null : null
+
+      const { changedFiles, file, diff } = commitSelection
 
       return (
         <SelectedCommit
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
           selectedCommit={selectedCommit}
-          changedFiles={selection.changedFiles}
-          selectedFile={selection.file}
-          currentDiff={selection.diff}
+          changedFiles={changedFiles}
+          selectedFile={file}
+          currentDiff={diff}
           emoji={this.props.emoji}
           commitSummaryWidth={this.props.commitSummaryWidth}
           gitHubUsers={this.props.state.gitHubUsers}


### PR DESCRIPTION
This PR removes the last vestiges of `IHistoryState` by moving selection into a root `ICommitSelection` state and ensuring the Compare tab uses it when displaying it's list of commits. This helps us close out some selection-related bugs that have been lurking for a while.

Fixes #4985
Fixes #5069

- [x] confirm #4985 is fixed
- [x] confirm #5069 is fixed
- [x] 📝 all the public members (old and new)
- [x] :fire: any last History-related code
- test various scenarios
   - [x] when viewing history - scrolling populates with older commits, history remains preserved
   - [x] when viewing history - scroll, select commit, change tabs, return -> commit remains selected
   - [x] when viewing history - scroll, select commit, switch to other app, return -> commit remains selected
   - [x] when viewing compare - scroll, select commit, change tabs, return -> commit remains selected
   - [x] when viewing history - select commit, then compare branch -> first ahead commit selected
   - [x] when viewing history - select commit, then compare branch which is not ahead -> no commit selected
   - [x] when viewing compare - select commit, then switch back to history -> first commit selected