### PR TITLE
Add user research label

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -159,6 +159,7 @@ pull requests.
 | `codemirror` | [search](https://github.com/desktop/desktop/labels/codemirror)  | Issues related to our use of [CodeMirror](https://codemirror.net/) that may require upstream fixes |
 | `electron` | [search](https://github.com/desktop/desktop/labels/electron) | Issues related to our use of [Electron](https://electron.atom.io) that may require upstream fixes |
 | `themes` | [search](https://github.com/desktop/desktop/labels/themes) | Issues related the light or dark themes that ship in Desktop |
+| `user-research` | [search](https://github.com/desktop/desktop/labels/user-research) | Issues that might benefit from user interviews, validations, and/or usability testing |
 
 #### Topics
 


### PR DESCRIPTION
Some issues are more usability-related than others and would benefit from user research. This could take the form of interviews, observation, usability testing, or other methods, but I think it'll be helpful to organize them so we know areas of potential focus for UX research. This doesn't mean we'll necessarily incorporate every one into our upcoming user research plans, but rather that they've been identified as reasonable to include and will be available for inclusion in those efforts.