### PR TITLE
support default branch detection for non-GitHub repositories

### DIFF
--- a/app/src/lib/git/refs.ts
+++ b/app/src/lib/git/refs.ts
@@ -1,3 +1,6 @@
+import { git } from './core'
+import { Repository } from '../../models/repository'
+
 /**
  * Format a local branch in the ref syntax, ensuring situations when the branch
  * is ambiguous are handled.
@@ -18,4 +21,25 @@ export function formatAsLocalRef(name: string): string {
     // - include this to ensure the ref is fully qualified.
     return `refs/heads/${name}`
   }
+}
+
+export async function getSymbolicRef(
+  repository: Repository,
+  ref: string
+): Promise<string | null> {
+  const result = await git(
+    ['symbolic-ref', '-q', ref],
+    repository.path,
+    'getSymbolicRef',
+    {
+      successExitCodes: new Set([0, 128]),
+    }
+  )
+
+  if (result.exitCode === 128) {
+    // ref was not a symbolic ref or ref does not exist
+    return null
+  }
+
+  return result.stdout.trim()
 }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -54,6 +54,7 @@ import {
   getAheadBehind,
   revRange,
   revSymmetricDifference,
+  getSymbolicRef,
 } from '../git'
 import { IGitAccount } from '../git/authentication'
 import { RetryAction, RetryActionType } from '../retry-actions'
@@ -358,11 +359,33 @@ export class GitStore extends BaseStore {
     return allBranchesWithUpstream
   }
 
-  private refreshDefaultBranch() {
-    let defaultBranchName: string | null = 'master'
-    const gitHubRepository = this.repository.gitHubRepository
+  private async refreshDefaultBranch() {
+    let defaultBranchName: string | null = null
+
+    const { gitHubRepository } = this.repository
     if (gitHubRepository && gitHubRepository.defaultBranch) {
       defaultBranchName = gitHubRepository.defaultBranch
+    } else if (this.remote != null) {
+      // the Git server should use [remote]/HEAD to advertise
+      // it's default branch, so see if it exists and matches
+      // a valid branch on the remote and attempt to use that
+      const remoteNamespace = `refs/remotes/${this.remote.name}/`
+
+      const match = await getSymbolicRef(
+        this.repository,
+        `${remoteNamespace}HEAD`
+      )
+
+      if (match != null && match.startsWith(remoteNamespace)) {
+        // strip out everything related to the remote because this
+        // is likely to be a tracked branch locally
+        // e.g. `master`, `develop`, etc
+        defaultBranchName = match.substr(remoteNamespace.length)
+      }
+    }
+
+    if (defaultBranchName == null) {
+      defaultBranchName = 'master'
     }
 
     if (defaultBranchName) {


### PR DESCRIPTION
Fixes #4937

I wanted this to be a careful change so I focused on this flow:

 - use`git symbolic-ref refs/remotes/{remote}/HEAD` and ensuring that points to a valid ref
 - strip the returned `refs/remotes/{remote}/{branch}` to just `{branch}` to match the conventions for GitHub default branch detection
 - fallback to `master` if this doesn't work

With this change, the default branch now lights up in the list:

<img width="488" src="https://user-images.githubusercontent.com/359239/42105567-2733654c-7ba7-11e8-9fe2-7476dd2f3d4b.png">

And the menu items are now enabled for non-default branches:

<img width="322" src="https://user-images.githubusercontent.com/359239/42105628-6dcd927a-7ba7-11e8-84dc-557be9c1b8af.png">

And the default branch still inherits the "cannot rename, cannot delete" convention in the app:

<img width="456" src="https://user-images.githubusercontent.com/359239/42105643-7fef70a4-7ba7-11e8-8cd5-1c7cc1b649b6.png">

FYI: I'm using [this repo](https://gitlab.com/gitlab-org/gitter/webapp) for testing, for whoever ends up reviewing this.