### PR TITLE
Change primary button back to blue

### DIFF
--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -16,11 +16,6 @@ body.theme-dark {
   --text-secondary-color: $gray-400;
   --background-color: $gray-900;
 
-  --button-background: black;
-  --button-hover-background: darken($gray-900, 5%);
-  --button-text-color: $white;
-  --button-focus-border-color: $blue-600;
-
   --link-button-color: lighten($blue-400, 3%);
   --link-button-hover-color: $blue-400;
 

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -16,6 +16,11 @@ body.theme-dark {
   --text-secondary-color: $gray-400;
   --background-color: $gray-900;
 
+  --button-background: $blue;
+  --button-hover-background: lighten($blue, 5%);
+  --button-text-color: $white;
+  --button-focus-border-color: $blue-600;
+
   --link-button-color: lighten($blue-400, 3%);
   --link-button-hover-color: $blue-400;
 


### PR DESCRIPTION
This changes the primary button color in dark theme from the black background back to a blue background ⚫️ ➡️ 🔵 

|Before|After|
|---|---|
|<img width="249" alt="screen shot 2018-06-29 at 2 51 22 pm" src="https://user-images.githubusercontent.com/10404068/42116395-ecfbba32-7bab-11e8-9b8c-db94fa70a879.png">|<img width="249" alt="screen shot 2018-06-29 at 2 52 10 pm" src="https://user-images.githubusercontent.com/10404068/42116431-0981037e-7bac-11e8-86f6-abcbefc8017b.png">|



Closes https://github.com/desktop/desktop/issues/5070