### PR TITLE
move open issues about integrations to their own label

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -160,6 +160,7 @@ pull requests.
 | `electron` | [search](https://github.com/desktop/desktop/labels/electron) | Issues related to our use of [Electron](https://electron.atom.io) that may require upstream fixes |
 | `themes` | [search](https://github.com/desktop/desktop/labels/themes) | Issues related the light or dark themes that ship in Desktop |
 | `user-research` | [search](https://github.com/desktop/desktop/labels/user-research) | Issues that might benefit from user interviews, validations, and/or usability testing |
+| `integrations` | [search](https://github.com/desktop/desktop/labels/integrations) | Issues related to editor and shell integrations that ship in Desktop |
 
 #### Topics
 


### PR DESCRIPTION
We currently group issues related to external integrations - in particular shells and editors - under the generic `enhancement` label.

I'd like to move this to a separate label for a couple of reasons:

 - many of these open issues are requests for supporting new tools, and don't require changes to the core to support
 - these can be picked up by people who want to contribute to Desktop, so separating them out from other feature requests will help to emphasize these when used with the `help-wanted` label

Some examples of issues affected by this change:

 - #4825 - Add Xcode to list of supported 'open in' editors
 - #4785 - Add support for launching Emacs.app as "Open in External Editor" entry
 - #4641 - Add support for WSL Bash on Windows 10 

These issues are less further along, and probably require some changes to the core if we decide to proceed, and could also use this new label:

 - #5083 - Allow adding custom editor commands as "External Editor" option
 - #4465  - experiment with supporting advanced editor flow through config 