### PR TITLE
relax checks for merge commits by GitHub Enterprise

### DIFF
--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -118,7 +118,7 @@ export class Commit {
 
     if (this.committer.name === 'GitHub Enterprise') {
       const host = new URL(endpoint).host.toLowerCase()
-      return email === `noreply@${host}`
+      return email.endsWith(`@${host}`)
     }
 
     return false


### PR DESCRIPTION
Fixes #4329 as Enterprise administrators can change this email address from `noreply@` to whatever, and we don't have a way to detect this from the API as mentioned [here](https://github.com/desktop/desktop/issues/4329#issuecomment-376058517) so we should just check that the email associated with the commit comes from the same domain.

