### PR TITLE
Flip button order

### DIFF
--- a/app/src/ui/notification/new-commits-banner.tsx
+++ b/app/src/ui/notification/new-commits-banner.tsx
@@ -65,15 +65,15 @@ export class NewCommitsBanner extends React.Component<
             </p>
           </div>
           <div>
+            <Button className="small-button" onClick={this.onComparedClicked}>
+              View commits
+            </Button>
             <Button
               className="small-button"
               type="submit"
               onClick={this.onMergeClicked}
             >
               Merge...
-            </Button>
-            <Button className="small-button" onClick={this.onComparedClicked}>
-              View commits
             </Button>
           </div>
         </div>


### PR DESCRIPTION
This flips the button order back to `View commits` & `Merge...`. Got flipped around when I removed `ButtonGroup` from the other PR 🤦‍♀️ 

cc @iAmWillShepherd @donokuda 