### PR TITLE
bump react-virtualized to latest version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,7 @@
     "react-addons-shallow-compare": "^15.6.2",
     "react-dom": "^16.3.2",
     "react-transition-group": "^1.2.0",
-    "react-virtualized": "^9.18.5",
+    "react-virtualized": "^9.20.0",
     "registry-js": "^1.0.7",
     "runas": "^3.1.1",
     "source-map-support": "^0.4.15",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -732,6 +732,10 @@ react-dom@^16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
 react-transition-group@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
@@ -742,15 +746,16 @@ react-transition-group@^1.2.0:
     prop-types "^15.5.6"
     warning "^3.0.0"
 
-react-virtualized@^9.18.5:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
+react-virtualized@^9.20.0:
+  version "9.20.0"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.20.0.tgz#b024992cc857c1a1b2884a019ac52ed686cd690b"
   dependencies:
     babel-runtime "^6.26.0"
     classnames "^2.2.3"
     dom-helpers "^2.4.0 || ^3.0.0"
     loose-envify "^1.3.0"
     prop-types "^15.6.0"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.3.2:
   version "16.3.2"


### PR DESCRIPTION
This upgrades us to a version that works with the new React APIs for async rendering, so it's one less issue reported by strict mode in #4369.

 - [x] test on macOS
 - [x] test on Windows
 - [x] test on Linux