### PR TITLE
Repository list badge style tweaks and tweaks for dark theme

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -254,6 +254,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --list-item-badge-background-color: $gray-200;
   --list-item-selected-badge-color: $gray-900;
   --list-item-selected-badge-background-color: $gray-300;
+  --list-item-selected-active-badge-color: $gray-900;
+  --list-item-selected-active-badge-background-color: $white;
+
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -245,6 +245,13 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --tab-bar-count-color: var(--text-color);
   --tab-bar-count-background-color: $gray-200;
 
+  /**
+    * Badge colors when used inside of list items.
+    * Example of this is the change indicators inside
+    * of the repository list.
+    */
+  --list-item-badge-color: $gray-800;
+  --list-item-badge-background-color: $gray-200;
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -252,6 +252,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
     */
   --list-item-badge-color: $gray-800;
   --list-item-badge-background-color: $gray-200;
+  --list-item-selected-badge-color: $gray-900;
+  --list-item-selected-badge-background-color: $gray-300;
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
 

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -186,6 +186,18 @@ body.theme-dark {
   --tab-bar-count-background-color: $gray-700;
 
   /**
+    * Badge colors when used inside of list items.
+    * Example of this is the change indicators inside
+    * of the repository list.
+    */
+  --list-item-badge-color: var(--text-color);
+  --list-item-badge-background-color: $gray-600;
+  --list-item-selected-badge-color: $white;
+  --list-item-selected-badge-background-color: $gray-500;
+  --list-item-selected-active-badge-color: $gray-900;
+  --list-item-selected-active-badge-background-color: $white;
+
+  /**
    * Toast notifications are shown temporarily for things like the zoom
    * percentage changing or the app toggling between full screen and normal
    * window mode.

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -187,7 +187,7 @@ body.theme-dark {
 
   /**
     * Badge colors when used inside of list items.
-    * Example of this is the change indicators inside
+    * Example of this is the ahead/behind indicators inside
     * of the repository list.
     */
   --list-item-badge-color: var(--text-color);

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -108,3 +108,16 @@
     text-align: center;
   }
 }
+
+.list-focus-container {
+  /** Ahead/behind badge colors when list item is selected but not focused */
+  .list-item.selected {
+    .repository-list-item {
+      .ahead-behind {
+        background: var(--list-item-selected-badge-background-color);
+        color: var(--list-item-selected-badge-color);
+      }
+    }
+  }
+
+}

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -75,7 +75,8 @@
 
     .ahead-behind {
       height: 16px;
-      background: $gray-200;
+      background: var(--list-item-badge-background-color);
+      color: var(--list-item-badge-color);
       align-items: center;
       margin-left: auto;
 
@@ -92,7 +93,6 @@
       }
 
       .octicon {
-        color: var(--text-secondary-color) !important;
         margin: 0;
         height: 20px;
         width: 12px;

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -120,4 +120,15 @@
     }
   }
 
+  &.focus-within {
+    /** Ahead/behind badge colors when list item is selected and focused */
+    .list-item.selected {
+      .repository-list-item {
+        .ahead-behind {
+          background: var(--list-item-selected-active-badge-background-color);
+          color: var(--list-item-selected-active-badge-color);
+        }
+      }
+    }
+  }
 }

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -130,5 +130,9 @@
         }
       }
     }
+
+    .change-indicator {
+      color: var(--text-color);
+    }
   }
 }


### PR DESCRIPTION
PR #2259 added support for displaying more information in the repository list. This included adding an indicator bubble and a badge to repository list items. These new elements weren't modified to work in the dark theme and the bubble was not styled appropriately for when a selected list item had focus (blue on blue).

This PR addresses these issues by adding a new set of variables for badges inside of list items.

### Before

![screen shot 2018-07-04 at 16 15 08](https://user-images.githubusercontent.com/634063/42282114-c7556410-7fa5-11e8-962c-cb0a75a95366.png)

The arrow inside of the selected item is too bright, the indicator bubble is hidden because it's got the same color as the background.

![screen shot 2018-07-04 at 16 14 20](https://user-images.githubusercontent.com/634063/42282116-c7754528-7fa5-11e8-96d0-7eeaa1f57730.png)

Same issue with the indicator plus the badges are too bright.

### After

![screen shot 2018-07-04 at 16 21 58](https://user-images.githubusercontent.com/634063/42282325-69d5b118-7fa6-11e8-9ca1-e838e79f1543.png)
![screen shot 2018-07-04 at 16 21 32](https://user-images.githubusercontent.com/634063/42282326-69f48688-7fa6-11e8-8b9a-cd2f13b2e0ec.png)
