### PR TITLE
test deploy with updated scripts

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.2.7-beta0",
+  "version": "1.2.7-test1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.2.7-test1": [
+      "Sanity check deployment for refactored scripts"
+    ],
     "1.2.7-beta0": [
       "[Fixed] Visual indicator for upcoming feature should not be shown - #5026"
     ],


### PR DESCRIPTION
Now that #3675 has landed, this deployment ensures that we're still able to cut releases from `master`.