### PR TITLE
ensure `github` CLI launches under WSL

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.3.3-beta1",
+  "version": "1.3.3-test10",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.3.3-test6",
+  "version": "1.3.3-test7",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -66,7 +66,11 @@ function getBinPath(): string {
 
 function resolveVersionedPath(binPath: string, relativePath: string): string {
   const appFolder = Path.resolve(process.execPath, '..')
-  return Path.relative(binPath, Path.join(appFolder, relativePath))
+  const computedPath = Path.relative(
+    binPath,
+    Path.join(appFolder, relativePath)
+  )
+  return Path.normalize(computedPath)
 }
 
 /**

--- a/app/static/win32/github.sh
+++ b/app/static/win32/github.sh
@@ -2,7 +2,26 @@
 
 CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
 ELECTRON="$CONTENTS/GitHubDesktop.exe"
-CLI="$CONTENTS/Resources/app/cli.js"
+
+if grep -q Microsoft /proc/version; then
+	if [ -x /bin/wslpath ]; then
+		# On recent WSL builds, we just need to set WSLENV so that
+		# ELECTRON_RUN_AS_NODE is visible to the win32 process
+		export WSLENV=ELECTRON_RUN_AS_NODE/w:$WSLENV
+		CLI=$(wslpath -m "$CONTENTS/resources/app/cli.js")
+	else
+		# If running under older WSL, don't pass cli.js to Electron as
+		# environment vars cannot be transferred from WSL to Windows
+		# See: https://github.com/Microsoft/BashOnWindows/issues/1363
+		#      https://github.com/Microsoft/BashOnWindows/issues/1494
+		"$ELECTRON" "$@"
+		exit $?
+	fi
+elif [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
+	CLI=$(cygpath -m "$CONTENTS/resources/app/cli.js")
+else
+	CLI="$CONTENTS/resources/app/cli.js"
+fi
 
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.3.3-test7": [
+      "Testing command line integration changes to support WSL"
+    ],
     "1.3.3-test6": [
       "Testing infrastructure changes"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.3.3-test10": [
+      "Testing command line integration changes to support WSL"
+    ],
     "1.3.3-beta1": [
       "[Fixed] Maximize and restore app on Windows does not fill available space - #5033",
       "[Fixed] 'Clone repository' menu item label is obscured on Windows - #5348. Thanks @Daniel-McCarthy!",


### PR DESCRIPTION
Fixes #4998 

There's two parts to this PR:

 1.  our shim for launching Desktop from bash-esque environments at `%LOCALAPPDATA%\GitHubDesktop\bin\github` has a mix of forward slashes and backslashes

<img width="547" src="https://user-images.githubusercontent.com/359239/42398263-8cf2f616-813f-11e8-99ed-cede4e90608a.png">

I think this needs to be normalized to `/` everywhere but I suspect node is going to keep using `\` because it's Windows. 

2. the launcher doesn't have any checks for it's environment, and based on what VSCode is doing in [their launcher script](https://github.com/Microsoft/vscode/blob/master/resources/win32/bin/code.sh) I think we should do the same.



 - [ ] cut a test release, confirm the shim is generated in the correct format
 - [ ] confirm the `github` launcher works in WSL
 - [ ] confirm the `github` launcher works in Git Bash
 - [ ] confirm the `github` launcher works in PowerShell
 - [ ] confirm the `github` launcher works in CMD
