### PR TITLE
Prepping PR #5053 for review

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -495,7 +495,11 @@ export class GitStore extends BaseStore {
     // directory for the next stage. Doing doing a `git checkout -- .` here
     // isn't suitable because we should preserve the other working directory
     // changes.
-    const status = await getStatus(repository)
+
+    const status = await this.performFailableOperation(() =>
+      getStatus(this.repository)
+    )
+
     if (status == null) {
       return
     }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -273,16 +273,18 @@ export class CreateRepository extends React.Component<
       this.props.dispatcher.postError(e)
     }
 
-    try {
-      const status = await getStatus(repository)
-      if (status == null) {
-        log.error(
+    const status = await getStatus(repository)
+    if (status === null) {
+      this.props.dispatcher.postError(
+        new Error(
           `createRepository: unable to get status for repository at ${fullPath}`
         )
-        // TODO: this feels hacky too
-        return
-      }
+      )
 
+      return
+    }
+
+    try {
       const wd = status.workingDirectory
       const files = wd.files
       if (files.length > 0) {

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -84,8 +84,8 @@ describe('git/status', () => {
       expect(files[1].path).to.equal('docs/OVERVIEW.md')
     })
 
-    it('Does not fail when a large number of changes have been made', async () => {
-      const numFiles = 10000
+    it.only('Handles at least 25k untracked files without failing', async () => {
+      const numFiles = 25000
       const basePath = repository!.path
 
       await mkdir(basePath)

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -11,6 +11,10 @@ import {
   setupEmptyRepository,
 } from '../../helpers/repositories'
 import { AppFileStatus } from '../../../src/models/status'
+import * as temp from 'temp'
+
+const _temp = temp.track()
+const mkdir = _temp.mkdir
 
 describe('git/status', () => {
   let repository: Repository | null = null
@@ -78,6 +82,26 @@ describe('git/status', () => {
       expect(files[1].status).to.equal(AppFileStatus.Copied)
       expect(files[1].oldPath).to.equal('CONTRIBUTING.md')
       expect(files[1].path).to.equal('docs/OVERVIEW.md')
+    })
+
+    it.only('returns null when result size is greater than max buffer size', async () => {
+      const numFiles = 10000
+      const basePath = repository!.path
+
+      await mkdir(basePath)
+
+      // create a lot of files
+      const promises = []
+      for (let i = 0; i < numFiles; i++) {
+        promises.push(
+          FSE.writeFile(path.join(basePath, `test-file-${i}`), 'Hey there\n')
+        )
+      }
+      await Promise.all(promises)
+
+      const status = await getStatusOrThrow(repository!)
+      const files = status.workingDirectory.files
+      expect(files.length).to.equal(numFiles)
     })
   })
 })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -84,7 +84,7 @@ describe('git/status', () => {
       expect(files[1].path).to.equal('docs/OVERVIEW.md')
     })
 
-    it.only('returns null when result size is greater than max buffer size', async () => {
+    it('Does not fail when a large number of changes have been made', async () => {
       const numFiles = 10000
       const basePath = repository!.path
 

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -84,7 +84,7 @@ describe('git/status', () => {
       expect(files[1].path).to.equal('docs/OVERVIEW.md')
     })
 
-    it.only('Handles at least 25k untracked files without failing', async () => {
+    it('Handles at least 25k untracked files without failing', async () => {
       const numFiles = 25000
       const basePath = repository!.path
 

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -84,8 +84,8 @@ describe('git/status', () => {
       expect(files[1].path).to.equal('docs/OVERVIEW.md')
     })
 
-    it('Handles at least 25k untracked files without failing', async () => {
-      const numFiles = 25000
+    it('Handles at least 10k untracked files without failing', async () => {
+      const numFiles = 10000
       const basePath = repository!.path
 
       await mkdir(basePath)


### PR DESCRIPTION
* Wraps the call to `getStatus` inside of `performFailableOperation` in `GitStore` to make sure all errors are handled correctly
* No longer re-logs the error condition; pushing the error to the UI instead now (the actual message hasn't been updated)
* Adds a test to make sure 10k files won't cause an error

~- [ ] Figure out a way to test 100k files without the test timing out~


xref: https://github.com/desktop/desktop/pull/5053