### PR TITLE
Fix contrast of Markdown headers in dark mode

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -355,6 +355,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --syntax-tag-color: #22863a;
   --syntax-attribute-color: #6f42c1;
   --syntax-link-color: #032f62;
+  --syntax-header-color: #032f62;
 
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`
   // specified in `changes/index.tsx`.

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -355,7 +355,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --syntax-tag-color: #22863a;
   --syntax-attribute-color: #6f42c1;
   --syntax-link-color: #032f62;
-  --syntax-header-color: #032f62;
+  --syntax-header-color: #0000FF;
 
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`
   // specified in `changes/index.tsx`.

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -355,7 +355,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --syntax-tag-color: #22863a;
   --syntax-attribute-color: #6f42c1;
   --syntax-link-color: #032f62;
-  --syntax-header-color: #0000FF;
+  --syntax-header-color: #0000ff;
 
   // Note that this duration *must* match the `UndoCommitAnimationTimeout`
   // specified in `changes/index.tsx`.

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -278,7 +278,7 @@ body.theme-dark {
   --syntax-attribute-color: $purple-300;
   --syntax-link-color: $blue-300;
   --syntax-header-color: $red-300;
-  
+
   // Colors for form errors
   --error-color: $red;
   --form-error-background: darken($red-900, 3%);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -277,7 +277,8 @@ body.theme-dark {
   --syntax-tag-color: $green-400;
   --syntax-attribute-color: $purple-300;
   --syntax-link-color: $blue-300;
-
+  --syntax-header-color: $red-300;
+  
   // Colors for form errors
   --error-color: $red;
   --form-error-background: darken($red-900, 3%);

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -521,6 +521,9 @@
     text-decoration: underline;
     color: var(--syntax-link-color);
   }
+  .cm-header {
+    color: var(--syntax-header-color);
+  }
 
   // Intra line markings takes precedence over syntax highlighting.
   .cm-diff-delete-inner {


### PR DESCRIPTION
I kicked off this PR with the changes @shiftkey proposed in #5133. It's definitely an improvement but I would love to know what @niik, @donokuda, @ampinsk think about it. 

## Before
### Light Mode
<img width="265" alt="screen shot 2018-07-12 at 02 18 03" src="https://user-images.githubusercontent.com/10944108/42604130-df33a2de-8579-11e8-8e4e-b69d9df938be.png">

### Dark Mode
![42470890-bb2aae4c-8370-11e8-93b3-720760e088ef](https://user-images.githubusercontent.com/10944108/42603848-3dfdfb22-8578-11e8-9151-7419b27f52d8.png)

## After 
### Light Mode
<img width="267" alt="screen shot 2018-07-12 at 02 17 34" src="https://user-images.githubusercontent.com/10944108/42604164-07ccd742-857a-11e8-92fc-9f9d43fb11db.png">

### Dark Mode
<img width="282" alt="screen shot 2018-07-12 at 02 00 54" src="https://user-images.githubusercontent.com/10944108/42603801-f8843e12-8577-11e8-9cf7-a7232d0ef7dd.png">

Fixes: #5133