### PR TITLE
For all intents and purposes, that's a button

### DIFF
--- a/app/src/ui/diff/diff-line-gutter.tsx
+++ b/app/src/ui/diff/diff-line-gutter.tsx
@@ -279,7 +279,7 @@ export class DiffLineGutter extends React.Component<
   }
 
   public render() {
-    let role =
+    const role =
       !this.props.readOnly && this.props.line.isIncludeableLine()
         ? 'button'
         : undefined

--- a/app/src/ui/diff/diff-line-gutter.tsx
+++ b/app/src/ui/diff/diff-line-gutter.tsx
@@ -279,8 +279,17 @@ export class DiffLineGutter extends React.Component<
   }
 
   public render() {
+    let role =
+      !this.props.readOnly && this.props.line.isIncludeableLine()
+        ? 'button'
+        : undefined
+
     return (
-      <span className={this.getLineClass()} ref={this.applyEventHandlers}>
+      <span
+        className={this.getLineClass()}
+        ref={this.applyEventHandlers}
+        role={role}
+      >
         <span className="diff-line-number before">
           {this.props.line.oldLineNumber || ' '}
         </span>

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -84,6 +84,19 @@
     border-right: 4px solid var(--diff-border-color);
   }
 
+  .diff-line-number {
+    cursor: default;
+  }
+
+  &.diff-add,
+  &.diff-delete {
+    &:not(.read-only) {
+      .diff-line-number {
+        cursor: pointer;
+      }
+    }
+  }
+
   &.read-only .after {
     border-right-width: 1px;
   }


### PR DESCRIPTION
This was something I found as part of #5150, our clickable diff gutters weren't marked as being buttons so the activity tracking wouldn't react to clicking on them.

This PR fixes that and also adds some CSS to ensure that the cursor isn't a text-selection cursor when hovering over the diff gutter.