### PR TITLE
drop usage of fuzzy-find options (these were not applied)

### DIFF
--- a/app/src/lib/fuzzy-find.ts
+++ b/app/src/lib/fuzzy-find.ts
@@ -2,14 +2,8 @@ import * as fuzzAldrin from 'fuzzaldrin-plus'
 
 import { compareDescending } from './compare'
 
-const options: fuzzAldrin.IFilterOptions = {
-  allowErrors: true,
-  isPath: true,
-  pathSeparator: '-',
-}
-
 function score(str: string, query: string, maxScore: number) {
-  return fuzzAldrin.score(str, query, undefined, options) / maxScore
+  return fuzzAldrin.score(str, query) / maxScore
 }
 
 export interface IMatches {
@@ -38,7 +32,7 @@ export function match<T, _K extends keyof T>(
       const matches: Array<ReadonlyArray<number>> = []
       const itemTextArray = getKey(item)
       itemTextArray.forEach(text => {
-        matches.push(fuzzAldrin.match(text, query, undefined, options))
+        matches.push(fuzzAldrin.match(text, query))
       })
 
       return {


### PR DESCRIPTION
This relates to #5152 as we discovered these options weren't being applied when invoking `fuzzaldrin-plus`. I tried porting them to the correct options API but this changed the behaviour in strange ways, so until we complete that upgrade and figure it out I'm going to tidy these up to reflect the current reality.