### PR TITLE
bump for deprecated electron-packager API

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@types/classnames": "^2.2.2",
     "@types/clean-webpack-plugin": "^0.1.2",
     "@types/codemirror": "0.0.55",
-    "@types/electron-packager": "^10.1.0",
+    "@types/electron-packager": "^12.0.0",
     "@types/electron-winstaller": "^2.6.0",
     "@types/event-kit": "^1.2.28",
     "@types/express": "^4.11.0",

--- a/script/build.ts
+++ b/script/build.ts
@@ -187,13 +187,13 @@ function packageApp(
     },
   }
 
-  packager(options, (err: Error, appPaths: string | string[]) => {
-    if (err) {
-      callback(err, appPaths)
-    } else {
+  packager(options)
+    .then((appPaths: string | string[]) => {
       callback(null, appPaths)
-    }
-  })
+    })
+    .catch((err: Error) => {
+      callback(err, [])
+    })
 }
 
 function removeAndCopy(source: string, destination: string) {

--- a/script/build.ts
+++ b/script/build.ts
@@ -75,7 +75,7 @@ if (process.platform === 'darwin' && process.env.CIRCLECI && !isFork) {
 }
 
 console.log('Updating our licenses dump…')
-updateLicenseDump(err => {
+updateLicenseDump(async err => {
   if (err) {
     console.error(
       'Error updating the license dump. This is fatal for a published build.'
@@ -88,14 +88,13 @@ updateLicenseDump(err => {
   }
 
   console.log('Packaging…')
-  packageApp((err, appPaths) => {
-    if (err) {
-      console.error(err)
-      process.exit(1)
-    } else {
-      console.log(`Built to ${appPaths}`)
-    }
-  })
+  try {
+    const appPaths = await packageApp()
+    console.log(`Built to ${appPaths}`)
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
 })
 
 /**
@@ -110,9 +109,7 @@ interface IPackageAdditionalOptions {
   }>
 }
 
-function packageApp(
-  callback: (error: Error | null, appPaths: string | string[]) => void
-) {
+function packageApp() {
   // not sure if this is needed anywhere, so I'm just going to inline it here
   // for now and see what the future brings...
   const toPackagePlatform = (platform: NodeJS.Platform) => {
@@ -187,13 +184,7 @@ function packageApp(
     },
   }
 
-  packager(options)
-    .then((appPaths: string | string[]) => {
-      callback(null, appPaths)
-    })
-    .catch((err: Error) => {
-      callback(err, [])
-    })
+  return packager(options)
 }
 
 function removeAndCopy(source: string, destination: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,9 +57,9 @@
   dependencies:
     "@types/node" "*"
 
-"@types/electron-packager@^10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@types/electron-packager/-/electron-packager-10.1.0.tgz#8d61ef76a2676936c59d14392a9c0c1853405953"
+"@types/electron-packager@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@types/electron-packager/-/electron-packager-12.0.0.tgz#acbcf3c5895c1eeda3d2a325c2feeded6a639b1f"
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Since #5136 was merged you might notice a warning like this when doing a `yarn build:*`:

```
Packaging…
WARNING: The callback-based version of packager() is deprecated and will be removed in a future major version, please convert to the Promise version or use the nodeify module.
Packaging app for platform darwin x64 using electron v2.0.5
```

This is because `electron-packager` is moving away from a callback-based API to using promises. I bumped the `@types/electron-packager` declarations in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27200 to add this new API, and now the build script can use it too.

This was a chance to :fire: some of the callback usage in this area while I also made this change.