### PR TITLE
"Discard Changes" menu item assumes you want to discard your selected items

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -6,6 +6,7 @@ import { Octicon } from '../octicons'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 interface IChangedFileProps {
+  readonly id: string
   readonly path: string
   readonly status: AppFileStatus
   readonly oldPath?: string

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -16,6 +16,7 @@ interface IChangedFileProps {
 
   /** Callback called when user right-clicks on an item */
   readonly onContextMenu: (
+    id: string,
     path: string,
     status: AppFileStatus,
     event: React.MouseEvent<HTMLDivElement>
@@ -83,6 +84,11 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
   }
 
   private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    this.props.onContextMenu(this.props.path, this.props.status, event)
+    this.props.onContextMenu(
+      this.props.id,
+      this.props.path,
+      this.props.status,
+      event
+    )
   }
 }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -267,7 +267,7 @@ export class ChangesList extends React.Component<
     const paths = new Array<string>()
     const extensions = new Set<string>()
 
-    this.props.selectedFileIDs.forEach(fileID => {
+    const addItemToArray = (fileID: string) => {
       const newFile = wd.findFileWithID(fileID)
       if (newFile) {
         selectedFiles.push(newFile)
@@ -278,7 +278,17 @@ export class ChangesList extends React.Component<
           extensions.add(extension)
         }
       }
-    })
+    }
+
+    if (this.props.selectedFileIDs.includes(id)) {
+      // user has selected a file inside an existing selection
+      // -> they may want to discard multiple changes
+      this.props.selectedFileIDs.forEach(addItemToArray)
+    } else {
+      // this is outside their previous selection
+      // -> they just want to discard the selected file
+      addItemToArray(id)
+    }
 
     const items: IMenuItem[] = [
       {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -249,6 +249,7 @@ export class ChangesList extends React.Component<
   }
 
   private onItemContextMenu = (
+    id: string,
     path: string,
     status: AppFileStatus,
     event: React.MouseEvent<HTMLDivElement>

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -167,6 +167,7 @@ export class ChangesList extends React.Component<
 
     return (
       <ChangedFile
+        id={file.id}
         path={file.path}
         status={file.status}
         oldPath={file.oldPath}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -282,11 +282,11 @@ export class ChangesList extends React.Component<
 
     if (this.props.selectedFileIDs.includes(id)) {
       // user has selected a file inside an existing selection
-      // -> they may want to discard multiple changes
+      // -> context menu entries should be applied to all selected files
       this.props.selectedFileIDs.forEach(addItemToArray)
     } else {
       // this is outside their previous selection
-      // -> they just want to discard the selected file
+      // -> context menu entries should be applied to just this file
       addItemToArray(id)
     }
 


### PR DESCRIPTION
Fixes #4788 

## Current behaviour

Here's some example scenarios where the app currently doesn't discard the right files. The lack of a confirmation dialog makes this worse, because you don't see the files are different when discarding.

#### Select a single file, then right-click discard on a different file

![](https://user-images.githubusercontent.com/359239/42896869-9c261b64-8a94-11e8-83d2-7753381641d1.gif)

#### Select a group of files, then right-click discard on a different file

![](https://user-images.githubusercontent.com/359239/42896868-9c188f4e-8a94-11e8-8de8-e2b98c592052.gif)

## This PR

#### Select a single file, then right-click discard on a different file

![](https://user-images.githubusercontent.com/359239/42897151-7bd0c8cc-8a95-11e8-921a-2b2cecee0b93.gif)

#### Select a group of files, then right-click discard on a different file

![](https://user-images.githubusercontent.com/359239/42897150-7bc13934-8a95-11e8-90c5-16b993f093c8.gif)
