### PR TITLE
mute unit tests that depend on the network

### DIFF
--- a/app/test/unit/find-account-test.ts
+++ b/app/test/unit/find-account-test.ts
@@ -4,7 +4,10 @@ import { Account } from '../../src/models/account'
 import { findAccountForRemoteURL } from '../../src/lib/find-account'
 import { getDotComAPIEndpoint, getEnterpriseAPIURL } from '../../src/lib/api'
 
-describe('findAccountForRemoteURL', () => {
+// these tests are running against the real GitHub API and are rate-limited
+// to 60 requests per hour on an IP address - disabling these for now until
+// we can get proper unit tests in place
+describe.skip('findAccountForRemoteURL', () => {
   const accounts: ReadonlyArray<Account> = [
     new Account(
       'joan',


### PR DESCRIPTION
In my eagerness to merge #5149 I overlooked that some of these tests depend on `canAccessRepository` - which actually hits the GitHub API.

https://github.com/desktop/desktop/blob/56b1fe71f59d3f59202f5949ebc48af606e5f89c/app/src/lib/find-account.ts#L10-L22

I had some failing tests in #5187 which were unrelated to the change:

```
  327 passing (35s)
  2 pending
  2 failing
  1) findAccountForRemoteURL
       finds the anonymous account for public GitHub owner/name repository:
      AssertionError: expected null to not equal null
      + expected - actual
      at Context.it (C:\projects\desktop\app\test\unit\find-account-test.ts:48:28)
      at <anonymous>
  2) findAccountForRemoteURL
       finds the account for GitHub owner/name repository:
      AssertionError: expected null to not equal null
      + expected - actual
      at Context.it (C:\projects\desktop\app\test\unit\find-account-test.ts:63:28)
      at <anonymous>
```

What I believe is happening is the GitHub API is rate-limiting the CI agents IP addresses, which means these tests fail incorrectly, and are not actually unit tests in the classic sense.

I'm going to mute all these tests for now with a note because I think we discussed this a bit in #4362 which is still in progress.