### PR TITLE
only perform ahead/behind comparisons when the branch selector is open

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -964,6 +964,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (compareState.showBranchList) {
       this.currentAheadBehindUpdater.schedule(
         currentBranch,
+        compareState.defaultBranch,
         compareState.recentBranches,
         compareState.allBranches
       )

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -952,16 +952,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const currentBranch = branchesState.tip.branch
-    if (currentBranch == null) {
-      return
-    }
-
-    if (this.currentAheadBehindUpdater == null) {
+    if (this.currentAheadBehindUpdater ==== null) {
       return
     }
 
     if (compareState.showBranchList) {
+      const currentBranch = branchesState.tip.branch
+
       this.currentAheadBehindUpdater.schedule(
         currentBranch,
         compareState.defaultBranch,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -851,10 +851,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const action =
       initialAction != null ? initialAction : getInitialAction(cachedState)
     this._executeCompare(repository, action)
-
-    if (currentBranch != null && this.currentAheadBehindUpdater != null) {
-      this.currentAheadBehindUpdater.schedule(currentBranch, allBranches)
-    }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -949,6 +945,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
 
     this.emitUpdate()
+
+    const { branchesState, compareState } = this.getRepositoryState(repository)
+
+    if (branchesState.tip.kind !== TipState.Valid) {
+      return
+    }
+
+    const currentBranch = branchesState.tip.branch
+    if (currentBranch == null) {
+      return
+    }
+
+    if (this.currentAheadBehindUpdater == null) {
+      return
+    }
+
+    if (compareState.showBranchList) {
+      this.currentAheadBehindUpdater.schedule(
+        currentBranch,
+        compareState.allBranches
+      )
+    } else {
+      this.currentAheadBehindUpdater.clear()
+    }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -964,6 +964,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (compareState.showBranchList) {
       this.currentAheadBehindUpdater.schedule(
         currentBranch,
+        compareState.recentBranches,
         compareState.allBranches
       )
     } else {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -814,7 +814,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    this.updateCompareState(repository, state => ({
+    this.updateCompareState(repository, () => ({
       allBranches,
       recentBranches,
       defaultBranch,
@@ -867,7 +867,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const repoState = this.getRepositoryState(repository).historyState
       const commits = repoState.history
 
-      this.updateCompareState(repository, state => ({
+      this.updateCompareState(repository, () => ({
         formState: {
           kind: ComparisonView.None,
         },
@@ -895,7 +895,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const { ahead, behind } = compare
         const aheadBehind = { ahead, behind }
 
-        this.updateCompareState(repository, s => ({
+        this.updateCompareState(repository, () => ({
           formState: {
             comparisonBranch,
             kind: action.mode,
@@ -988,7 +988,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return
       }
 
-      this.updateCompareState(repository, state => ({
+      this.updateCompareState(repository, () => ({
         commitSHAs: commits.concat(newCommits),
       }))
       this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -952,7 +952,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (this.currentAheadBehindUpdater ==== null) {
+    if (this.currentAheadBehindUpdater === null) {
       return
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -742,7 +742,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const updater = new AheadBehindUpdater(repository, aheadBehindCache => {
-      this.updateCompareState(repository, state => ({
+      this.updateCompareState(repository, () => ({
         aheadBehindCache,
       }))
       this.emitUpdate()

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -108,7 +108,9 @@ export class AheadBehindUpdater {
    * the current repository, where they haven't been already computed
    *
    * @param currentBranch The current branch of the repository
-   * @param branches All known branches in the repository
+   * @param defaultBranch The default branch (if defined)
+   * @param recentBranches Recent branches in the repository
+   * @param allBranches All known branches in the repository
    */
   public schedule(
     currentBranch: Branch,

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -130,9 +130,8 @@ export class AheadBehindUpdater {
 
     const otherBranches = [...recentBranches, ...allBranches]
 
-    const branches = defaultBranch
-      ? [defaultBranch, ...otherBranches]
-      : otherBranches
+    const branches =
+      defaultBranch !== null ? [defaultBranch, ...otherBranches] : otherBranches
 
     const newRefsToCompare = new Set<string>(filterBranchesNotInCache(branches))
 

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -96,9 +96,22 @@ export class AheadBehindUpdater {
     this.comparisonCache.set(from, to, value)
   }
 
-  public schedule(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
-    // remove any queued work to prioritize this new set of tasks
+  /**
+   * Stop processing any ahead/behind computations for the current repository
+   */
+  public clear() {
     this.aheadBehindQueue.end()
+  }
+
+  /**
+   * Schedule ahead/behind computations for all available branches in
+   * the current repository, where they haven't been already computed
+   *
+   * @param currentBranch The current branch of the repository
+   * @param branches All known branches in the repository
+   */
+  public schedule(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
+    this.clear()
 
     const from = currentBranch.tip.sha
 

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -110,14 +110,25 @@ export class AheadBehindUpdater {
    * @param currentBranch The current branch of the repository
    * @param branches All known branches in the repository
    */
-  public schedule(currentBranch: Branch, branches: ReadonlyArray<Branch>) {
+  public schedule(
+    currentBranch: Branch,
+    recentBranches: ReadonlyArray<Branch>,
+    allBranches: ReadonlyArray<Branch>
+  ) {
     this.clear()
 
     const from = currentBranch.tip.sha
 
-    const branchesNotInCache = branches
-      .map(b => b.tip.sha)
-      .filter(to => !this.comparisonCache.has(from, to))
+    const filterBranchesNotInCache = (branches: ReadonlyArray<Branch>) => {
+      return branches
+        .map(b => b.tip.sha)
+        .filter(to => !this.comparisonCache.has(from, to))
+    }
+
+    const branchesNotInCache = [
+      ...filterBranchesNotInCache(recentBranches),
+      ...filterBranchesNotInCache(allBranches),
+    ]
 
     const newRefsToCompare = new Set<string>(branchesNotInCache)
 

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -112,6 +112,7 @@ export class AheadBehindUpdater {
    */
   public schedule(
     currentBranch: Branch,
+    defaultBranch: Branch | null,
     recentBranches: ReadonlyArray<Branch>,
     allBranches: ReadonlyArray<Branch>
   ) {
@@ -125,12 +126,13 @@ export class AheadBehindUpdater {
         .filter(to => !this.comparisonCache.has(from, to))
     }
 
-    const branchesNotInCache = [
-      ...filterBranchesNotInCache(recentBranches),
-      ...filterBranchesNotInCache(allBranches),
-    ]
+    const otherBranches = [...recentBranches, ...allBranches]
 
-    const newRefsToCompare = new Set<string>(branchesNotInCache)
+    const branches = defaultBranch
+      ? [defaultBranch, ...otherBranches]
+      : otherBranches
+
+    const newRefsToCompare = new Set<string>(filterBranchesNotInCache(branches))
 
     log.debug(
       `[AheadBehindUpdater] - found ${

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -137,6 +137,12 @@ export class CompareSidebar extends React.Component<
 
   public componentWillUnmount() {
     this.textbox = null
+
+    // by hiding the branch list here when the component is torn down
+    // we ensure any ahead/behind computation work is discarded
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      showBranchList: false,
+    })
   }
 
   public render() {


### PR DESCRIPTION
This fixes #5142 by using the compare form state to determine when to crunch these stats.

That's the core of this chunk of code in `_updateCompareForm`:

```ts
    if (compareState.showBranchList) {
      this.currentAheadBehindUpdater.schedule(
        currentBranch,
        compareState.defaultBranch,
        compareState.recentBranches,
        compareState.allBranches
      )
    } else {
      this.currentAheadBehindUpdater.clear()
    }
```

 - when the branch list is shown, queue up work to do based on `requestIdleCallback` rules
 - when the branch list is hidden, stop doing work

I also ensured we prioritized the default branch and recent branches before the rest, so you see items filled in from the top.