### PR TITLE
Adds a feature flag for in-app-release notes

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -41,3 +41,7 @@ export function enableNotificationOfBranchUpdates(): boolean {
 export function enableRepoInfoIndicators(): boolean {
   return enableBetaFeatures()
 }
+
+export function enableInAppReleaseNotes(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1635,11 +1635,13 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (!this.state.isUpdateAvailableBannerVisible) {
       return null
     }
+    const releaseNotesUri = 'https://desktop.github.com/release-notes/'
 
     return (
       <UpdateAvailable
         dispatcher={this.props.dispatcher}
         newRelease={updateStore.state.newRelease}
+        releaseNotesLink={releaseNotesUri}
         onDismissed={this.onUpdateAvailableDismissed}
       />
     )

--- a/app/src/ui/updates/update-available.tsx
+++ b/app/src/ui/updates/update-available.tsx
@@ -7,10 +7,12 @@ import { PopupType } from '../../lib/app-state'
 import { shell } from '../../lib/app-shell'
 
 import { ReleaseSummary } from '../../models/release-notes'
+import { enableInAppReleaseNotes } from '../../lib/feature-flag'
 
 interface IUpdateAvailableProps {
   readonly dispatcher: Dispatcher
   readonly newRelease: ReleaseSummary | null
+  readonly releaseNotesLink: string
   readonly onDismissed: () => void
 }
 
@@ -30,7 +32,14 @@ export class UpdateAvailable extends React.Component<
         <span>
           An updated version of GitHub Desktop is available and will be
           installed at the next launch. See{' '}
-          <LinkButton onClick={this.showReleaseNotes}>what's new</LinkButton> or{' '}
+          {enableInAppReleaseNotes() ? (
+            <LinkButton onClick={this.showReleaseNotes}>what's new</LinkButton>
+          ) : (
+            <LinkButton uri={this.props.releaseNotesLink}>
+              what's new
+            </LinkButton>
+          )}{' '}
+          or{' '}
           <LinkButton onClick={this.updateNow}>
             restart GitHub Desktop
           </LinkButton>.


### PR DESCRIPTION
Put release notes behind a feature flag so we can iterate without affecting our users.