### PR TITLE
add metric for detecting when user encounters a merge conflict

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1204,6 +1204,13 @@ export class Dispatcher {
   }
 
   /**
+   * Increments the `mergeConflictDetectedCount` metric
+   */
+  public recordMergeConflictDetected() {
+    return this.appStore._recordMergeConflictDetected()
+  }
+
+  /**
    * Increments the `mergeIntoCurrentBranchMenuCount` metric
    */
   public recordMenuInitiatedMerge() {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1204,10 +1204,17 @@ export class Dispatcher {
   }
 
   /**
-   * Increments the `mergeConflictDetectedCount` metric
+   * Increments the `mergeConflictFromPullCount` metric
    */
-  public recordMergeConflictDetected() {
-    return this.appStore._recordMergeConflictDetected()
+  public recordMergeConflictFromPull() {
+    return this.appStore._recordMergeConflictFromPull()
+  }
+
+  /**
+   * Increments the `mergeConflictFromExplicitMergeCount` metric
+   */
+  public recordMergeConflictFromExplicitMerge() {
+    return this.appStore._recordMergeConflictFromExplicitMerge()
   }
 
   /**

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -281,11 +281,16 @@ export async function mergeConflictHandler(
     return error
   }
 
-  if (e.metadata.command) {
-    if (e.metadata.command === 'pull') {
-      dispatcher.recordMergeConflictFromPull()
-    } else if (e.metadata.command === 'merge') {
-      dispatcher.recordMergeConflictFromExplicitMerge()
+  const command = e.metadata.command
+
+  if (command != null) {
+    switch (command) {
+      case 'pull':
+        dispatcher.recordMergeConflictFromPull()
+        break
+      case 'merge':
+        dispatcher.recordMergeConflictFromExplicitMerge()
+        break
     }
   }
 

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -281,7 +281,13 @@ export async function mergeConflictHandler(
     return error
   }
 
-  dispatcher.recordMergeConflictDetected()
+  if (e.metadata.command) {
+    if (e.metadata.command === 'pull') {
+      dispatcher.recordMergeConflictFromPull()
+    } else if (e.metadata.command === 'merge') {
+      dispatcher.recordMergeConflictFromExplicitMerge()
+    }
+  }
 
   dispatcher.showPopup({
     type: PopupType.MergeConflicts,

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -281,6 +281,8 @@ export async function mergeConflictHandler(
     return error
   }
 
+  dispatcher.recordMergeConflictDetected()
+
   dispatcher.showPopup({
     type: PopupType.MergeConflicts,
     repository,

--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -3,6 +3,9 @@ import { CloningRepository } from '../models/cloning-repository'
 import { RetryAction } from './retry-actions'
 
 export interface IErrorMetadata {
+  /** The first argument passed to `git` which triggered this error */
+  readonly command?: string
+
   /** Was the action which caused this error part of a background task? */
   readonly backgroundTask?: boolean
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -93,6 +93,9 @@ export interface IDailyMeasures {
 
   /** Whether or not the app has been interacted with during the current reporting window */
   readonly active: boolean
+
+  /** The number of times a merge in Desktop has resulted in conflicts that the user needs to resolve */
+  readonly mergeConflictDetected: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -94,8 +94,11 @@ export interface IDailyMeasures {
   /** Whether or not the app has been interacted with during the current reporting window */
   readonly active: boolean
 
-  /** The number of times a merge in Desktop has resulted in conflicts that the user needs to resolve */
-  readonly mergeConflictDetected: number
+  /** The number of times a `git pull` initiated by Desktop resulted in a merge conflict for the user */
+  readonly mergeConflictFromPullCount: number
+
+  /** The number of times a `git merge` initiated by Desktop resulted in a merge conflict for the user */
+  readonly mergeConflictFromExplicitMergeCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -49,6 +49,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   enterprisePushCount: 0,
   externalPushCount: 0,
   active: false,
+  mergeConflictDetected: 0,
 }
 
 interface ICalculatedStats {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -381,6 +381,13 @@ export class StatsStore {
     }))
   }
 
+  /** Record that conflicts were detected by a merge initiated by Desktop */
+  public recordMergeConflictDetected(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      mergeConflictDetected: m.mergeConflictDetected + 1,
+    }))
+  }
+
   /** Record that a merge has been initiated from the `Branch -> Merge Into Current Branch` menu item */
   public recordMenuInitiatedMerge(): Promise<void> {
     return this.updateDailyMeasures(m => ({

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -49,7 +49,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   enterprisePushCount: 0,
   externalPushCount: 0,
   active: false,
-  mergeConflictDetected: 0,
+  mergeConflictFromPullCount: 0,
+  mergeConflictFromExplicitMergeCount: 0,
 }
 
 interface ICalculatedStats {
@@ -382,9 +383,17 @@ export class StatsStore {
   }
 
   /** Record that conflicts were detected by a merge initiated by Desktop */
-  public recordMergeConflictDetected(): Promise<void> {
+  public recordMergeConflictFromPull(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      mergeConflictDetected: m.mergeConflictDetected + 1,
+      mergeConflictFromPullCount: m.mergeConflictFromPullCount + 1,
+    }))
+  }
+
+  /** Record that conflicts were detected by a merge initiated by Desktop */
+  public recordMergeConflictFromExplicitMerge(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      mergeConflictFromExplicitMergeCount:
+        m.mergeConflictFromExplicitMergeCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2518,7 +2518,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
                   value: progress.value * pullWeight,
                 })
               }),
-            { retryAction }
+            { command: 'pull', retryAction }
           )
 
           const refreshStartProgress = pullWeight + fetchWeight

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3799,10 +3799,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
-   * Increments the `mergeConflictDetectedCount` metric
+   * Increments the `mergeConflictFromPullCount` metric
    */
-  public _recordMergeConflictDetected() {
-    this.statsStore.recordMergeConflictDetected()
+  public _recordMergeConflictFromPull() {
+    this.statsStore.recordMergeConflictFromPull()
+  }
+
+  /**
+   * Increments the `mergeConflictFromExplicitMergeCount` metric
+   */
+  public _recordMergeConflictFromExplicitMerge() {
+    this.statsStore.recordMergeConflictFromExplicitMerge()
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3799,6 +3799,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
+   * Increments the `mergeConflictDetectedCount` metric
+   */
+  public _recordMergeConflictDetected() {
+    this.statsStore.recordMergeConflictDetected()
+  }
+
+  /**
    * Increments the `mergeIntoCurrentBranchMenuCount` metric
    */
   public _recordMenuInitiatedMerge() {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1104,7 +1104,9 @@ export class GitStore extends BaseStore {
 
   /** Merge the named branch into the current branch. */
   public merge(branch: string): Promise<void> {
-    return this.performFailableOperation(() => merge(this.repository, branch))
+    return this.performFailableOperation(() => merge(this.repository, branch), {
+      command: 'merge',
+    })
   }
 
   /** Changes the URL for the remote that matches the given name  */


### PR DESCRIPTION
Closes #5201 

 - [x] get 👍 for new `mergeConflictFromPullCount` and `mergeConflictFromExplicitMergeCount` metric name (cc @telliott27 @billygriffin for :eyes:)
 - [x] get PR for required backend changes up, reviewed and merged - https://github.com/github/central/pull/390
 - [ ] get PR for required website changes up, reviewed and merged - https://github.com/github/desktop.github.com/pull/109