### PR TITLE
ensure commit message is cleared after successful commit

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -45,7 +45,7 @@ interface IChangesListProps {
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
-  ) => Promise<boolean>
+  ) => Promise<void>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly onDiscardAllChanges: (

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -38,7 +38,7 @@ interface ICommitMessageProps {
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
-  ) => Promise<boolean>
+  ) => Promise<void>
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly gitHubUser: IGitHubUser | null
@@ -216,10 +216,6 @@ export class CommitMessage extends React.Component<
     }
   }
 
-  private clearCommitMessage() {
-    this.setState({ summary: '', description: null })
-  }
-
   private onSummaryChanged = (summary: string) => {
     this.setState({ summary })
   }
@@ -252,15 +248,7 @@ export class CommitMessage extends React.Component<
 
     const trailers = this.getCoAuthorTrailers()
 
-    const commitCreated = await this.props.onCreateCommit(
-      summary,
-      description,
-      trailers
-    )
-
-    if (commitCreated) {
-      this.clearCommitMessage()
-    }
+    await this.props.onCreateCommit(summary, description, trailers)
   }
 
   private canCommit(): boolean {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -117,12 +117,16 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
   ): Promise<void> => {
-    await this.props.dispatcher.commitIncludedChanges(
+    const commitCreated = await this.props.dispatcher.commitIncludedChanges(
       this.props.repository,
       summary,
       description,
       trailers
     )
+
+    if (commitCreated) {
+      this.props.dispatcher.setCommitMessage(this.props.repository, null)
+    }
   }
 
   private onFileSelectionChanged = (rows: ReadonlyArray<number>) => {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -112,12 +112,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
   }
 
-  private onCreateCommit = (
+  private onCreateCommit = async (
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
-  ): Promise<boolean> => {
-    return this.props.dispatcher.commitIncludedChanges(
+  ): Promise<void> => {
+    await this.props.dispatcher.commitIncludedChanges(
       this.props.repository,
       summary,
       description,


### PR DESCRIPTION
Fixes #4046 by moving the responsibility to cleanup higher in the component tree, and clearing the `AppStore` state (which flows back down to the commit form).

For those reviewing, I recommend using a very large repository after #5053 is merged because the problem is clear when it takes a long time for the app to make the commit, giving you more time to switch to the History tab and show it doesn't tidy up as expected.