### PR TITLE
updated setup.md

### DIFF
--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -64,7 +64,7 @@ $ sudo ln -s `find /usr/lib64/ -type f -name "libreadline.so.7.0"` /usr/lib64/li
 First, install curl:
 
 ```shellsession
-$ sudo apt install curl
+$ sudo apt install curl gnupg
 ```
 
 Then add the NodeJS package repository for 8.x:

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -61,7 +61,7 @@ $ sudo ln -s `find /usr/lib64/ -type f -name "libreadline.so.7.0"` /usr/lib64/li
 
 ### Ubuntu 16.04
 
-First, install curl:
+First, install curl and a GPG program:
 
 ```shellsession
 $ sudo apt install curl gnupg


### PR DESCRIPTION
added gnupg which is required by nodejs script on ubuntu 16.04

```
+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
(23) Failed writing body
Error executing command, exiting

```
![screenshot_20180722_215057](https://user-images.githubusercontent.com/4529442/43047736-79572b9c-8df9-11e8-83ed-6d4c26664597.png)
