### PR TITLE
Add Kitty support for macOs

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -9,6 +9,7 @@ export enum Shell {
   Hyper = 'Hyper',
   iTerm2 = 'iTerm2',
   PowerShellCore = 'PowerShell Core',
+  Kitty = 'Kitty',
 }
 
 export const Default = Shell.Terminal
@@ -30,6 +31,10 @@ export function parse(label: string): Shell {
     return Shell.PowerShellCore
   }
 
+  if (label === Shell.Kitty) {
+    return Shell.Kitty
+  }
+
   return Default
 }
 
@@ -43,6 +48,8 @@ function getBundleID(shell: Shell): string {
       return 'co.zeit.hyper'
     case Shell.PowerShellCore:
       return 'com.microsoft.powershell'
+    case Shell.Kitty:
+        return 'net.kovidgoyal.kitty'
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -66,11 +73,13 @@ export async function getAvailableShells(): Promise<
     hyperPath,
     iTermPath,
     powerShellCorePath,
+    kittyPath,
   ] = await Promise.all([
     getShellPath(Shell.Terminal),
     getShellPath(Shell.Hyper),
     getShellPath(Shell.iTerm2),
     getShellPath(Shell.PowerShellCore),
+    getShellPath(Shell.Kitty),
   ])
 
   const shells: Array<IFoundShell<Shell>> = []
@@ -88,6 +97,10 @@ export async function getAvailableShells(): Promise<
 
   if (powerShellCorePath) {
     shells.push({ shell: Shell.PowerShellCore, path: powerShellCorePath })
+  }
+
+  if (kittyPath) {
+    shells.push({ shell: Shell.Kitty, path: kittyPath })
   }
 
   return shells


### PR DESCRIPTION
Hey,

I use kitty and saw #5162 suggestion. So I went ahead and added support for it as its growing a terminal. 


Heres the link to kitty if you wish to download it. https://github.com/kovidgoyal/kitty/releases

Hope the first of many prs and also great docs.

## Screenshot Gif

![d](https://user-images.githubusercontent.com/6218780/43106227-b60aff6a-8ecf-11e8-9622-8ebf2c21ccc5.gif)
