### PR TITLE
refine background fetching by throttling better

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1439,7 +1439,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdateNow()
 
     this.accountsStore.refresh()
-    this.refreshAllRepositories()
+    this.refreshAllIndicators()
   }
 
   private async getSelectedExternalEditor(): Promise<ExternalEditor | null> {
@@ -1898,14 +1898,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._updateCurrentPullRequest(repository)
     this.updateMenuItemLabels(repository)
     this._initializeCompare(repository)
-    this.refreshRepositoryState([repository])
+    this.refreshIndicators([repository])
   }
 
-  public refreshAllRepositories() {
-    return this.refreshRepositoryState(this.repositories)
+  public refreshAllIndicators() {
+    return this.refreshIndicators(this.repositories)
   }
 
-  private async refreshRepositoryState(
+  private async refreshIndicators(
     repositories: ReadonlyArray<Repository>
   ): Promise<void> {
     if (!enableRepoInfoIndicators()) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -185,8 +185,10 @@ const imageDiffTypeKey = 'image-diff-type'
 
 const shellKey = 'shell'
 
-// background fetching should not occur more than once every two minutes
-const BackgroundFetchMinimumInterval = 2 * 60 * 1000
+// background fetching should occur hourly when Desktop is active, but this
+// lower interval ensures user interactions like switching repositories and
+// switching between apps does not result in excessive fetching in the app
+const BackgroundFetchMinimumInterval = 30 * 60 * 1000
 
 export class AppStore extends TypedBaseStore<IAppState> {
   private accounts: ReadonlyArray<Account> = new Array<Account>()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -153,7 +153,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       )
 
       window.setInterval(() => {
-        this.props.appStore.refreshAllRepositories()
+        this.props.appStore.refreshAllIndicators()
       }, updateRepoInfoInterval)
     })
 


### PR DESCRIPTION
This PR addresses two common ways that you can introduce excessive background fetching, as part of investigating #1128:

 - switching between repositories in the same Desktop session
 - switching between Desktop and another app frequently

To see these details for yourself into this run up a development version of `master` with these changes:

```diff
diff --git a/app/src/lib/stores/app-store.ts b/app/src/lib/stores/app-store.ts
index 4dd782b3e..439607161 100644
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1300,6 +1300,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private shouldBackgroundFetch(repository: Repository): boolean {
+    log.warn(`shouldBackgroundFetch fires for ${repository.name}`)
+
     const gitStore = this.getGitStore(repository)
     const lastFetched = gitStore.lastFetched
 
@@ -1309,16 +1311,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const now = new Date()
     const timeSinceFetch = now.getTime() - lastFetched.getTime()
+    const timeInSeconds = Math.floor(timeSinceFetch / 1000)
 
     if (timeSinceFetch < BackgroundFetchMinimumInterval) {
-      const timeInSeconds = Math.floor(timeSinceFetch / 1000)
-
-      log.debug(
+      log.warn(
         `skipping background fetch as repository was fetched ${timeInSeconds}s ago`
       )
       return false
     }
 
+    log.warn(
+      `doing the background fetch as it was last fetched ${timeInSeconds}s ago`
+    )
+
     return true
   }
 
@@ -1912,6 +1917,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    log.warn(
+      `refreshRepositoryIndicators fires for ${repositories.length} entries`
+    )
+
     const promises = []
 
     for (const repo of repositories) {
diff --git a/app/src/lib/stores/helpers/background-fetcher.ts b/app/src/lib/stores/helpers/background-fetcher.ts
index 461a0bdb9..3588135be 100644
--- a/app/src/lib/stores/helpers/background-fetcher.ts
+++ b/app/src/lib/stores/helpers/background-fetcher.ts
@@ -87,17 +87,22 @@ export class BackgroundFetcher {
   private async performAndScheduleFetch(
     repository: GitHubRepository
   ): Promise<void> {
+    log.warn(`performAndScheduleFetch is firing for ${repository.fullName}`)
+
     if (this.stopped) {
       return
     }
 
     const shouldFetch = this.shouldPerformFetch(this.repository)
     if (shouldFetch) {
+      log.warn(`we are doing the fetch`)
       try {
         await this.fetch(this.repository)
       } catch (e) {
         log.error('Error performing periodic fetch', e)
       }
+    } else {
+      log.warn(`we did not do the fetch`)
     }
 
     if (this.stopped) {
```

You should see these two sets of messages when either switching between apps or switching between repositories:

- when switching between repositories, the background fetcher is created for the current repository and queried to see if it should fetch:

<img width="429" src="https://user-images.githubusercontent.com/359239/43162113-689a3c96-8f60-11e8-9adb-3de77ef88465.png">

 - when you switch between apps, the sidebar indicators are updated for the current repository:

<img width="672" src="https://user-images.githubusercontent.com/359239/43162081-5215c5da-8f60-11e8-9174-71addc68af7a.png">

Both of these fetches, while considered "background" can be run if the repository hasn't been fetched in the last two minutes. That threshold was added in #3403 because we weren't really doing any checks. I think we should go even higher now, so this PR moves us up to 30mins for any background fetching.

@vanessayuenn just an FYI: I found myself renaming these methods to indicate they're related "indicators" in the sidebar, rather than the current name, because it helped me to navigate the code better. Let me know if you have any feels on this.