### PR TITLE
fix regression with clearing commit message

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -722,7 +722,7 @@ export class GitStore extends BaseStore {
   }
 
   /**
-   * The commit message to use based on the contex of the repository, e.g., the
+   * The commit message to use based on the context of the repository, e.g., the
    * message from a recently undone commit.
    */
   public get contextualCommitMessage(): ICommitMessage | null {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -45,7 +45,7 @@ interface IChangesListProps {
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
-  ) => Promise<void>
+  ) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly onDiscardAllChanges: (

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -224,8 +224,16 @@ export class CommitMessage extends React.Component<
     this.setState({ description })
   }
 
-  private onSubmit = () => {
-    this.createCommit()
+  private clearCommitMessage() {
+    this.setState({ summary: '', description: null })
+  }
+
+  private onSubmit = async () => {
+    const commitCreated = await this.createCommit()
+
+    if (commitCreated) {
+      this.clearCommitMessage()
+    }
   }
 
   private getCoAuthorTrailers() {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -38,7 +38,7 @@ interface ICommitMessageProps {
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
-  ) => Promise<void>
+  ) => Promise<boolean>
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly gitHubUser: IGitHubUser | null
@@ -239,16 +239,16 @@ export class CommitMessage extends React.Component<
     }))
   }
 
-  private async createCommit() {
+  private async createCommit(): Promise<boolean> {
     const { summary, description } = this.state
 
     if (!this.canCommit()) {
-      return
+      return false
     }
 
     const trailers = this.getCoAuthorTrailers()
 
-    await this.props.onCreateCommit(summary, description, trailers)
+    return await this.props.onCreateCommit(summary, description, trailers)
   }
 
   private canCommit(): boolean {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -116,7 +116,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     const commitCreated = await this.props.dispatcher.commitIncludedChanges(
       this.props.repository,
       summary,
@@ -127,6 +127,8 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     if (commitCreated) {
       this.props.dispatcher.setCommitMessage(this.props.repository, null)
     }
+
+    return commitCreated
   }
 
   private onFileSelectionChanged = (rows: ReadonlyArray<number>) => {


### PR DESCRIPTION
@iAmWillShepherd identified that the latest 1.3.0 beta doesn't clear the commit in the normal scenario because of #5208.

I dug into this and uncovered:

 - my assumption that `GitStore` was the source of truth for this commit message isn't correct
 - `GitStore` is only updated when the component is unmounted (due to switching tabs or switching repositories)
 - because `GitStore` keeps sending `null` message to the component in the normal scenario, the component ignores this in favour of it's local state

So we need to do both "clean up local state" and "clean up `GitStore` state" to cover both scenarios. Sigh.