### PR TITLE
update changelog generation for production release

### DIFF
--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -119,7 +119,7 @@ export function getChangelogEntriesSince(previousVersion: string): string[] {
       continue
     }
 
-    if (prop.endsWith('-beta1')) {
+    if (prop.endsWith('-beta0')) {
       // by convention we push the production updates out to beta
       // to ensure both channels are up to date
       continue

--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -7,6 +7,8 @@ import { fetchPR, IAPIPR } from './api'
 const PlaceholderChangeType = '???'
 const OfficialOwner = 'desktop'
 
+const ChangelogEntryRegex = /^\[(new|fixed|improved|removed|added)\]\s(.*)/i
+
 interface IParsedCommit {
   readonly prID: number
   readonly owner: string
@@ -125,7 +127,11 @@ export function getChangelogEntriesSince(previousVersion: string): string[] {
 
     const entries: string[] = releases[prop]
     if (entries != null) {
-      existingChangelog.push(...entries)
+      const validEntries = entries.filter(e => {
+        const match = ChangelogEntryRegex.exec(e)
+        return match != null
+      })
+      existingChangelog.push(...validEntries)
     }
   }
   return existingChangelog

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -95,7 +95,6 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
     if (channel === 'production') {
       const existingChangelog = getChangelogEntriesSince(previousVersion)
       const entries = new Array<string>(
-        ...changelogEntries,
         ...existingChangelog
       )
       printInstructions(nextVersion, entries)

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -94,10 +94,10 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
 
     if (channel === 'production') {
       const existingChangelog = getChangelogEntriesSince(previousVersion)
-      const entries = new Array<string>(...existingChangelog)
+      const entries = [...existingChangelog]
       printInstructions(nextVersion, entries)
     } else if (channel === 'beta') {
-      const entries = new Array<string>(...changelogEntries)
+      const entries = [...changelogEntries]
       printInstructions(nextVersion, entries)
     }
   }

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -94,9 +94,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
 
     if (channel === 'production') {
       const existingChangelog = getChangelogEntriesSince(previousVersion)
-      const entries = new Array<string>(
-        ...existingChangelog
-      )
+      const entries = new Array<string>(...existingChangelog)
       printInstructions(nextVersion, entries)
     } else if (channel === 'beta') {
       const entries = new Array<string>(...changelogEntries)


### PR DESCRIPTION
This PR adds some tweaks that I've made to the release notes generation for production releases.

It assumes:

 - all PRs on `master` were recently published to beta
   - this means we can skip scanning the changelog again to check for new entries
   - this was problematic because we'd edit items and remove entries, and this list would bring them back again
 - `-beta0` is the special beta upgrade to ensure the latest changes are in the beta channel, and can be skipped from future releases
   - not sure why we excluded `-beta1` instead 🤷‍♂️ 
 - only include changelog entries that match the expected format e.g. `[New]`
   - this ensures we exclude test releases, which are more relaxed and don't adhere to this format
