### PR TITLE
revert fix for commit message persisting after switching apps/tabs

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -216,6 +216,10 @@ export class CommitMessage extends React.Component<
     }
   }
 
+  private clearCommitMessage() {
+    this.setState({ summary: '', description: null })
+  }
+
   private onSummaryChanged = (summary: string) => {
     this.setState({ summary })
   }
@@ -224,16 +228,8 @@ export class CommitMessage extends React.Component<
     this.setState({ description })
   }
 
-  private clearCommitMessage() {
-    this.setState({ summary: '', description: null })
-  }
-
-  private onSubmit = async () => {
-    const commitCreated = await this.createCommit()
-
-    if (commitCreated) {
-      this.clearCommitMessage()
-    }
+  private onSubmit = () => {
+    this.createCommit()
   }
 
   private getCoAuthorTrailers() {
@@ -247,16 +243,24 @@ export class CommitMessage extends React.Component<
     }))
   }
 
-  private async createCommit(): Promise<boolean> {
+  private async createCommit() {
     const { summary, description } = this.state
 
     if (!this.canCommit()) {
-      return false
+      return
     }
 
     const trailers = this.getCoAuthorTrailers()
 
-    return await this.props.onCreateCommit(summary, description, trailers)
+    const commitCreated = await this.props.onCreateCommit(
+      summary,
+      description,
+      trailers
+    )
+
+    if (commitCreated) {
+      this.clearCommitMessage()
+    }
   }
 
   private canCommit(): boolean {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -112,23 +112,17 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
   }
 
-  private onCreateCommit = async (
+  private onCreateCommit = (
     summary: string,
     description: string | null,
     trailers?: ReadonlyArray<ITrailer>
   ): Promise<boolean> => {
-    const commitCreated = await this.props.dispatcher.commitIncludedChanges(
+    return this.props.dispatcher.commitIncludedChanges(
       this.props.repository,
       summary,
       description,
       trailers
     )
-
-    if (commitCreated) {
-      this.props.dispatcher.setCommitMessage(this.props.repository, null)
-    }
-
-    return commitCreated
   }
 
   private onFileSelectionChanged = (rows: ReadonlyArray<number>) => {


### PR DESCRIPTION
This reverts the core of #5233 because of unexpected side-effects around re-rendering and combining the exiting rules for handling props changes as well as internal state.

Given this is very important to the default flow, as well as likely affecting workflows like "Undo Commit", I'm going to revert to the 1.2.6 behaviour of persisting the commit summary and description in these corner cases reported in #4046 until I get a chance to wrap this code in some automated tests.