### PR TITLE
add .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+python 2.7
+nodejs 8.11.2


### PR DESCRIPTION
I like to use [asdf](https://github.com/asdf-vm/asdf) for version management. This file lets you

```shellsession
$ asdf install
```

to get the specififed version of node and python.

(is there anything else we should add to this file?)