### PR TITLE
bugfix for background checks not being aware of missing repositories

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.3.1-beta1",
+  "version": "1.3.1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.3.1-beta0",
+  "version": "1.3.1-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1933,11 +1933,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
             })
           }
 
-          // confirm the repository is still present after that last operation
-          if (repo.missing) {
-            return
-          }
-
           const status = await gitStore.performFailableOperation(() => {
             return gitStore.loadStatus()
           })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer, remote } from 'electron'
+import { pathExists } from 'fs-extra'
 import {
   IRepositoryState,
   IAppState,
@@ -1919,6 +1920,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     for (const repo of eligibleRepositories) {
       promises.push(
         this.withAuthenticatingUser(repo, async (repo, account) => {
+          const exists = await pathExists(repo.path)
+          if (!exists) {
+            return
+          }
+
           const gitStore = this.getGitStore(repo)
           const lookup = this.localRepositoryStateLookup
           if (this.shouldBackgroundFetch(repo)) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1914,12 +1914,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const promises = []
 
-    for (const repo of repositories) {
+    const eligibleRepositories = repositories.filter(repo => !repo.missing)
 
-      if (repo.missing) {
-        continue
-      }
-
+    for (const repo of eligibleRepositories) {
       promises.push(
         this.withAuthenticatingUser(repo, async (repo, account) => {
           const gitStore = this.getGitStore(repo)
@@ -1930,6 +1927,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             })
           }
 
+          // confirm the repository is still present after that last operation
           if (repo.missing) {
             return
           }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1933,11 +1933,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
             })
           }
 
-          const status = await gitStore.performFailableOperation(() => {
-            return gitStore.loadStatus()
-          })
-
-          if (status != null) {
+          const status = await gitStore.loadStatus()
+          if (status !== null) {
             lookup.set(repo.id, {
               aheadBehind: gitStore.aheadBehind,
               changedFilesCount: status.workingDirectory.files.length,

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.3.1": [
+      "[Fixed] Background Git operations on missing repositories are not handled as expected - #5282"
+    ],
     "1.3.1-beta1": [
       "[Fixed] Background Git operations on missing repositories are not handled as expected - #5282"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.3.1-beta1": [
+      "[Fixed] Background Git operations on missing repositories are not handled as expected - #5282"
+    ],
     "1.3.1-beta0": [
       "[New] Notification displayed in History tab when the base branch moves ahead of the current branch - #4768",
       "[New] Repository list displays uncommitted changes count and ahead/behind information - #2259 #5095",


### PR DESCRIPTION
Fixes #5282 

 - [x] skip background checks when repository is already marked as missing
 - [x] skip background check if directory is missing from disk (don't set to missing)
 - [x] changelog and publish to beta
 - [x] changelog and publish to production