### PR TITLE
fix for missing .git directory from a tracked repository

### DIFF
--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -2,8 +2,11 @@ import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
 
 type ProcessOutput = {
+  /** The contents of stdout received from the spawned process */
   output: Buffer
+  /** The contents of stderr received from the spawned process */
   error: Buffer
+  /** The exit code returned by the spawned process */
   exitCode: number
 }
 

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -4,6 +4,7 @@ import * as GitPerf from '../../ui/lib/git-perf'
 type ProcessOutput = {
   output: Buffer
   error: Buffer
+  exitCode: number
 }
 
 /**
@@ -81,6 +82,7 @@ export function spawnAndComplete(
             resolve({
               output: stdout,
               error: stderr,
+              exitCode: code,
             })
             return
           } else {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -75,7 +75,7 @@ export async function getStatus(
     log.debug(
       `'git status' returned 128 for '${
         repository.path
-      }' and is likely missing it's .git directory`
+      }' and is likely missing its .git directory`
     )
     return null
   }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -67,7 +67,8 @@ export async function getStatus(
   const result = await spawnAndComplete(
     ['status', '--untracked-files=all', '--branch', '--porcelain=2', '-z'],
     repository.path,
-    'getStatus'
+    'getStatus',
+    new Set<number>([0, 128])
   )
 
   if (result.output.length > MaxStatusBufferSize) {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -71,6 +71,15 @@ export async function getStatus(
     new Set<number>([0, 128])
   )
 
+  if (result.exitCode === 128) {
+    log.debug(
+      `'git status' returned 128 for '${
+        repository.path
+      }' and is likely missing it's .git directory`
+    )
+    return null
+  }
+
   if (result.output.length > MaxStatusBufferSize) {
     log.error(
       `'git status' emitted ${

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -68,7 +68,7 @@ export async function getStatus(
     ['status', '--untracked-files=all', '--branch', '--porcelain=2', '-z'],
     repository.path,
     'getStatus',
-    new Set<number>([0, 128])
+    new Set([0, 128])
   )
 
   if (result.exitCode === 128) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1899,14 +1899,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._updateCurrentPullRequest(repository)
     this.updateMenuItemLabels(repository)
     this._initializeCompare(repository)
-    this.refreshRepositoryState([repository])
+    this.refreshIndicatorsForRepositories([repository])
   }
 
   public refreshAllRepositories() {
-    return this.refreshRepositoryState(this.repositories)
+    return this.refreshIndicatorsForRepositories(this.repositories)
   }
 
-  private async refreshRepositoryState(
+  private async refreshIndicatorsForRepositories(
     repositories: ReadonlyArray<Repository>
   ): Promise<void> {
     if (!enableRepoInfoIndicators()) {
@@ -1918,30 +1918,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const eligibleRepositories = repositories.filter(repo => !repo.missing)
 
     for (const repo of eligibleRepositories) {
-      promises.push(
-        this.withAuthenticatingUser(repo, async (repo, account) => {
-          const exists = await pathExists(repo.path)
-          if (!exists) {
-            return
-          }
-
-          const gitStore = this.getGitStore(repo)
-          const lookup = this.localRepositoryStateLookup
-          if (this.shouldBackgroundFetch(repo)) {
-            await gitStore.performFailableOperation(() => {
-              return gitStore.fetch(account, true)
-            })
-          }
-
-          const status = await gitStore.loadStatus()
-          if (status !== null) {
-            lookup.set(repo.id, {
-              aheadBehind: gitStore.aheadBehind,
-              changedFilesCount: status.workingDirectory.files.length,
-            })
-          }
-        })
-      )
+      promises.push(this.refreshIndicatorForRepository(repo))
     }
 
     await Promise.all(promises)

--- a/app/test/unit/git/for-each-ref-test.ts
+++ b/app/test/unit/git/for-each-ref-test.ts
@@ -3,7 +3,7 @@ import { Repository } from '../../../src/models/repository'
 import {
   setupFixtureRepository,
   setupEmptyRepository,
-  mkdirSync,
+  setupEmptyDirectory,
 } from '../../helpers/repositories'
 import { getBranches } from '../../../src/lib/git/for-each-ref'
 import { BranchType } from '../../../src/models/branch'
@@ -61,9 +61,7 @@ describe('git/for-each-ref', () => {
     })
 
     it('should return empty list for directory without a .git directory', async () => {
-      const emptyDir = mkdirSync('no-repo-here')
-      const repo = new Repository(emptyDir, -1, null, false)
-
+      const repo = setupEmptyDirectory()
       const status = await getBranches(repo)
       expect(status).eql([])
     })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -9,7 +9,7 @@ import { getStatusOrThrow } from '../../helpers/status'
 import {
   setupFixtureRepository,
   setupEmptyRepository,
-  mkdirSync,
+  setupEmptyDirectory,
 } from '../../helpers/repositories'
 import { AppFileStatus } from '../../../src/models/status'
 import * as temp from 'temp'
@@ -107,9 +107,7 @@ describe('git/status', () => {
     })
 
     it('returns null for directory without a .git directory', async () => {
-      const emptyDir = mkdirSync('no-repo-here')
-      repository = new Repository(emptyDir, -1, null, false)
-
+      repository = setupEmptyDirectory()
       const status = await getStatus(repository)
       expect(status).is.null
     })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -9,9 +9,11 @@ import { getStatusOrThrow } from '../../helpers/status'
 import {
   setupFixtureRepository,
   setupEmptyRepository,
+  mkdirSync,
 } from '../../helpers/repositories'
 import { AppFileStatus } from '../../../src/models/status'
 import * as temp from 'temp'
+import { getStatus } from '../../../src/lib/git'
 
 const _temp = temp.track()
 const mkdir = _temp.mkdir
@@ -102,6 +104,14 @@ describe('git/status', () => {
       const status = await getStatusOrThrow(repository!)
       const files = status.workingDirectory.files
       expect(files.length).to.equal(numFiles)
+    })
+
+    it('returns null for directory without a .git directory', async () => {
+      const emptyDir = mkdirSync('no-repo-here')
+      repository = new Repository(emptyDir, -1, null, false)
+
+      const status = await getStatus(repository)
+      expect(status).is.null
     })
   })
 })


### PR DESCRIPTION
Fixes #5291 by:

 - reordering the checks for updating the repository indicators because of this call stack:

<img width="457" src="https://user-images.githubusercontent.com/359239/43458524-ecbf76c2-94a0-11e8-9bd3-abe0a94c9ca0.png">

This code path shows that `withAuthenticatingUser` can indirectly call `getRemotes` (which requires a valid Git repository) before we do a `getStatus`, which causes the error initially reported.

 - teach `getStatus` about exit code 128

By reordering the checks so that `git status` fires before `git fetch` we now also need to check for exit code 128 there. This required returning the exit code from the spawned process response, and handling that correctly. I've added some debug logging to this code path so it doesn't pollute the file logs excessively.