### PR TITLE
teach getRemotes about handling this error code instead of failing fast

### DIFF
--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -7,6 +7,9 @@ import { findDefaultRemote } from '../stores/helpers/find-default-remote'
 export async function getRemotes(
   repository: Repository
 ): Promise<ReadonlyArray<IRemote>> {
+  // TODO: use expectedErrors here to handle a specific error
+  // see https://github.com/desktop/desktop/pull/5299#discussion_r206603442 for
+  // discussion about what needs to change
   const result = await git(['remote', '-v'], repository.path, 'getRemotes', {
     successExitCodes: new Set([0, 128]),
   })

--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -8,7 +8,7 @@ export async function getRemotes(
   repository: Repository
 ): Promise<ReadonlyArray<IRemote>> {
   const result = await git(['remote', '-v'], repository.path, 'getRemotes', {
-    successExitCodes: new Set<number>([0, 128]),
+    successExitCodes: new Set([0, 128]),
   })
 
   if (result.exitCode === 128) {

--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -7,7 +7,14 @@ import { findDefaultRemote } from '../stores/helpers/find-default-remote'
 export async function getRemotes(
   repository: Repository
 ): Promise<ReadonlyArray<IRemote>> {
-  const result = await git(['remote', '-v'], repository.path, 'getRemotes')
+  const result = await git(['remote', '-v'], repository.path, 'getRemotes', {
+    successExitCodes: new Set<number>([0, 128]),
+  })
+
+  if (result.exitCode === 128) {
+    return []
+  }
+
   const output = result.stdout
   const lines = output.split('\n')
   const remotes = lines

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -73,6 +73,16 @@ export async function setupEmptyRepository(): Promise<Repository> {
 }
 
 /**
+ * Initialize a new, empty folder that is incorrectly associated with a Git
+ * repository. This should only be used to test error handling of the Git
+ * interactions.
+ */
+export function setupEmptyDirectory(): Repository {
+  const repoPath = _temp.mkdirSync('no-repository-here')
+  return new Repository(repoPath, -1, null, false)
+}
+
+/**
  * Setup a repository and create a merge conflict
  *
  * @returns the new local repository

--- a/app/test/unit/git/remote-test.ts
+++ b/app/test/unit/git/remote-test.ts
@@ -10,7 +10,7 @@ import {
 import {
   setupFixtureRepository,
   setupEmptyRepository,
-  mkdirSync,
+  setupEmptyDirectory,
 } from '../../helpers/repositories'
 
 describe('git/remote', () => {
@@ -35,8 +35,7 @@ describe('git/remote', () => {
     })
 
     it('returns empty array for directory without a .git directory', async () => {
-      const emptyDir = mkdirSync('no-repo-here')
-      const repository = new Repository(emptyDir, -1, null, false)
+      const repository = setupEmptyDirectory()
 
       const status = await getRemotes(repository)
       expect(status).eql([])

--- a/app/test/unit/git/remote-test.ts
+++ b/app/test/unit/git/remote-test.ts
@@ -10,6 +10,7 @@ import {
 import {
   setupFixtureRepository,
   setupEmptyRepository,
+  mkdirSync,
 } from '../../helpers/repositories'
 
 describe('git/remote', () => {
@@ -31,6 +32,14 @@ describe('git/remote', () => {
 
       expect(result[1].name).to.equal('origin')
       expect(result[1].url.endsWith(nwo)).to.equal(true)
+    })
+
+    it('returns empty array for directory without a .git directory', async () => {
+      const emptyDir = mkdirSync('no-repo-here')
+      const repository = new Repository(emptyDir, -1, null, false)
+
+      const status = await getRemotes(repository)
+      expect(status).eql([])
     })
   })
 


### PR DESCRIPTION
This is related to exercising #5297 and the steps to reproduce this are roughly:

 - add a repository to Desktop
 - switch to a different repository in the list
 - rename the `.git` directory to something else
 - open Desktop again
 - change to the problem repository
 - :boom:

Inside [`AppStore._refreshRepository`](https://github.com/desktop/desktop/blob/7fc541877d02c0245ebcf4c791bbfce32a4c6fad/app/src/lib/stores/app-store.ts#L1864) there are a bunch of Git operations that assume the `missing` flag is in the right state when it runs.

My testing shows these two operations did not handle this "folder exists but it's not a Git repository" scenario:

 - [`GitStore.loadBranches()`](https://github.com/desktop/desktop/blob/7fc541877d02c0245ebcf4c791bbfce32a4c6fad/app/src/lib/stores/app-store.ts#L1875)
 - [`GitStore.loadRemotes()`](https://github.com/desktop/desktop/blob/7fc541877d02c0245ebcf4c791bbfce32a4c6fad/app/src/lib/stores/app-store.ts#L1892)

I'm going to address the first one in a separate up PR because the app is currently in a loop and doesn't set the repository to `missing=true` , but this fix here was easier to address because:

 - 128 is the generic error code for "no Git repository here, yo"
 - if this error code is encountered, we can just return an empty array of remotes
