### PR TITLE
teach getBranches to exit early if folder isn't a Git repository

### DIFF
--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -41,8 +41,14 @@ export async function getBranches(
   const result = await git(
     ['for-each-ref', `--format=${format}`, ...prefixes],
     repository.path,
-    'getBranches'
+    'getBranches',
+    { successExitCodes: new Set([0, 128]) }
   )
+
+  if (result.exitCode === 128) {
+    return []
+  }
+
   const names = result.stdout
   const lines = names.split(delimiterString)
 

--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -38,6 +38,9 @@ export async function getBranches(
     prefixes = ['refs/heads', 'refs/remotes']
   }
 
+  // TODO: use expectedErrors here to handle a specific error
+  // see https://github.com/desktop/desktop/pull/5299#discussion_r206603442 for
+  // discussion about what needs to change
   const result = await git(
     ['for-each-ref', `--format=${format}`, ...prefixes],
     repository.path,

--- a/app/test/unit/git/for-each-ref-test.ts
+++ b/app/test/unit/git/for-each-ref-test.ts
@@ -3,6 +3,7 @@ import { Repository } from '../../../src/models/repository'
 import {
   setupFixtureRepository,
   setupEmptyRepository,
+  mkdirSync,
 } from '../../helpers/repositories'
 import { getBranches } from '../../../src/lib/git/for-each-ref'
 import { BranchType } from '../../../src/models/branch'
@@ -57,6 +58,14 @@ describe('git/for-each-ref', () => {
       const repo = await setupEmptyRepository()
       const branches = await getBranches(repo)
       expect(branches.length).to.equal(0)
+    })
+
+    it('should return empty list for directory without a .git directory', async () => {
+      const emptyDir = mkdirSync('no-repo-here')
+      const repo = new Repository(emptyDir, -1, null, false)
+
+      const status = await getBranches(repo)
+      expect(status).eql([])
     })
   })
 })


### PR DESCRIPTION
In the similar vein as #5298, `getBranches` is happily run against a folder that doesn't contain a `.git` directory. For safety's sake, we can just exit early and return an empty array of branches.