### PR TITLE
check the on-disk state before performing Git operations

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -176,7 +176,7 @@ export class Dispatcher {
   }
 
   /** Load the working directory status. */
-  public loadStatus(repository: Repository): Promise<void> {
+  public loadStatus(repository: Repository): Promise<boolean> {
     return this.appStore._loadStatus(repository)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1866,6 +1866,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    // if the repository path doesn't exist on disk,
+    // set the flag and don't try anything Git-related
+    const exists = await pathExists(repository.path)
+    if (!exists) {
+      this._updateRepositoryMissing(repository, true)
+      return
+    }
+
     const state = this.getRepositoryState(repository)
     const gitStore = this.getGitStore(repository)
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1553,12 +1553,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _loadStatus(
     repository: Repository,
     clearPartialState: boolean = false
-  ): Promise<void> {
+  ): Promise<boolean> {
     const gitStore = this.getGitStore(repository)
     const status = await gitStore.loadStatus()
 
     if (!status) {
-      return
+      return false
     }
 
     this.updateChangesState(repository, state => {
@@ -1625,6 +1625,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     this.updateChangesDiffForCurrentSelection(repository)
+
+    return true
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */


### PR DESCRIPTION
~~🌵 🌵 🌵 **depends on #5299 and #5298 and #5297, go review those first** 🌵  🌵  🌵~~

Fixes #5289 by adding guard checks inside `AppStore._refreshRepository`.

 - [x] merge `master` once dependent fixes have been merged
 
Test matrix to cover as part of reviewing:

*All of these start with the user adding a problem repository to Desktop*

 - Scenario The First 
   - user selects this repository in Desktop
   - user renames directory outside Desktop
   - user switches back to Desktop
   - 💥 ❓ 

 - Scenario The Second 
   - user selects another repository in Desktop
   - user renames directory outside Desktop
   - user switches back to Desktop
   - user selects problem repository
   -  💥 ❓ 


 - Scenario The Third 
   - user selects this repository in Desktop
   - user renames `.git` directory outside Desktop
   - user switches back to Desktop
   - 💥 ❓ 

 - Scenario The Fourth
   - user selects another repository in Desktop
   - user renames `.git` directory outside Desktop
   - user switches back to Desktop
   - user selects problem repository
   -  💥 ❓ 


I'd love to avoid calling this so often, but we can review the work being done in here after ensuring we handle these corner cases about the underlying filesystem.