### PR TITLE
disable repository indicators to reduce Git overhead

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1917,7 +1917,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const eligibleRepositories = repositories.filter(repo => !repo.missing)
 
     if (eligibleRepositories.length > 15) {
-      log.info(`repository indicators have been disabled while we make this more performant`)
+      log.info(
+        `repository indicators have been disabled as you have ${
+          eligibleRepositories.length
+        } while we reduce the overhead of the computation work`
+      )
+      return
     }
 
     for (const repo of eligibleRepositories) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1916,6 +1916,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const eligibleRepositories = repositories.filter(repo => !repo.missing)
 
+    if (eligibleRepositories.length > 15) {
+      log.info(`repository indicators have been disabled while we make this more performant`)
+    }
+
     for (const repo of eligibleRepositories) {
       promises.push(this.refreshIndicatorForRepository(repo))
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -95,7 +95,7 @@ const UpdateCheckInterval = 1000 * 60 * 60 * 4
 
 const SendStatsInterval = 1000 * 60 * 60 * 4
 
-const updateRepoInfoInterval = 1000 * 60 * 5
+const updateRepoInfoInterval = 1000 * 60 * 15
 
 interface IAppProps {
   readonly dispatcher: Dispatcher


### PR DESCRIPTION
This is some mitigation for the issue reported in #5310 because we don't really do any sort of throttling for the background indicators.

The setup is basically:

 - check for all the non-missing repositories
 - create a promise for each and store them in an array
 - await all the work

I wanted to for loop over these so they were done sequentially https://github.com/desktop/desktop/pull/4770#discussion_r198161555 but it looks like we ended with a `Promise.all` which fires them all concurrently and creates a large amount of Git work.

The log file attached here is pretty indicative of the worst case this can introduce: https://github.com/desktop/desktop/issues/5310#issuecomment-409612073

I've also set this to run every 15 minutes to reduce the overhead further.


