### PR TITLE
invalidate the cache if a repository is now missing

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1930,18 +1930,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const promises = []
 
-    const eligibleRepositories = repositories.filter(repo => !repo.missing)
-
-    if (eligibleRepositories.length > 15) {
+    if (repositories.length > 15) {
       log.info(
         `repository indicators have been disabled as you have ${
-          eligibleRepositories.length
+          repositories.length
         } while we reduce the overhead of the computation work`
       )
       return
     }
 
-    for (const repo of eligibleRepositories) {
+    for (const repo of repositories) {
       promises.push(this.refreshIndicatorForRepository(repo))
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1953,6 +1953,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private async refreshIndicatorForRepository(repository: Repository) {
     const lookup = this.localRepositoryStateLookup
 
+    if (repository.missing) {
+      lookup.delete(repository.id)
+      return
+    }
+
     const exists = await pathExists(repository.path)
     if (!exists) {
       lookup.delete(repository.id)


### PR DESCRIPTION
This addresses a minor UX issue where a valid repository has changed, but is then removed:

<img width="364" src="https://user-images.githubusercontent.com/359239/43544741-4581ebe6-95aa-11e8-8549-2f9ff109b313.png">

By invalidating the cache we avoid requiring the React component to be updated.