### PR TITLE
await each refresh operation inside the loop

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1928,8 +1928,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const promises = []
-
     const eligibleRepositories = repositories.filter(repo => !repo.missing)
 
     if (eligibleRepositories.length > 15) {
@@ -1942,10 +1940,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     for (const repo of eligibleRepositories) {
-      promises.push(this.refreshIndicatorForRepository(repo))
+      await this.refreshIndicatorForRepository(repo)
     }
-
-    await Promise.all(promises)
 
     this.emitUpdate()
   }


### PR DESCRIPTION
This avoids one of the scenarios identified in #5310 about launching 100+ promises containing Git operations as part of the refresh indicators step. This moves us to creating and awaiting them sequentially, which might take longer overall but that's okay - it's supposed to be background work.