### PR TITLE
tidy up custom Electron declarations

### DIFF
--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -215,31 +215,6 @@ declare namespace Electron {
       type: 'string'
     ): AppleActionOnDoubleClickPref
   }
-
-  interface WebviewTag extends HTMLElement {
-    // Copied from https://github.com/electron/electron-typescript-definitions/pull/81
-    // until we can upgrade to a version of Electron which includes the fix.
-    addEventListener<K extends keyof HTMLElementEventMap>(
-      type: K,
-      listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
-      useCapture?: boolean
-    ): void
-    addEventListener(
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      useCapture?: boolean
-    ): void
-    removeEventListener<K extends keyof HTMLElementEventMap>(
-      type: K,
-      listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any,
-      useCapture?: boolean
-    ): void
-    removeEventListener(
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      useCapture?: boolean
-    ): void
-  }
 }
 
 // https://wicg.github.io/ResizeObserver/#resizeobserverentry


### PR DESCRIPTION
I couldn't find any usage of this in our codebase, but this seems to be available in Electron 2.x now so we can :fire: this bit of code.