### PR TITLE
measure how long the background work takes on each run

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1949,7 +1949,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const delta = performance.now() - startTime
       const timeInSeconds = (delta / 1000).toFixed(3)
       log.info(
-        `Background fetch for ${repositories.length} repositories took ${timeInSeconds}sec`
+        `Background fetch for ${
+          repositories.length
+        } repositories took ${timeInSeconds}sec`
       )
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1939,8 +1939,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    const startTime = performance && performance.now ? performance.now() : null
+
     for (const repo of repositories) {
       await this.refreshIndicatorForRepository(repo)
+    }
+
+    if (startTime && repositories.length > 1) {
+      const delta = performance.now() - startTime
+      const timeInSeconds = (delta / 1000).toFixed(3)
+      log.info(
+        `Background fetch for ${repositories.length} repositories took ${timeInSeconds}sec`
+      )
     }
 
     this.emitUpdate()


### PR DESCRIPTION
Fetches can take a while for active repositories, and this is likely an O(N) operation, so I'd like to see some aggregation here about how long our background work takes to perform.

For example, I have 100 `desktop/desktop` clones in this one benchmark and each of them takes ~20 seconds to complete:

```
Executing fetch: git -c credential.helper= fetch --progress --prune origin (took 21.092s)
```

21 sec * 100 fetches = 2100 sec == 35 minutes, which is extreme, but identifying these cases in the wild will help us with tuning our background work better based on user feedback.
