### PR TITLE
update the ahead/behind info for the current branch after a fetch

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -788,6 +788,20 @@ export class GitStore extends BaseStore {
         progressCallback
       )
     }
+
+    // check the upstream ref against the current branch to see if there are
+    // any new commits available
+    if (this.tip.kind === TipState.Valid) {
+      const currentBranch = this.tip.branch
+      if (currentBranch.remote && currentBranch.upstream) {
+        const range = revSymmetricDifference(
+          currentBranch.name,
+          currentBranch.upstream
+        )
+        this._aheadBehind = await getAheadBehind(this.repository, range)
+        this.emitUpdate()
+      }
+    }
   }
 
   /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -793,7 +793,7 @@ export class GitStore extends BaseStore {
     // any new commits available
     if (this.tip.kind === TipState.Valid) {
       const currentBranch = this.tip.branch
-      if (currentBranch.remote && currentBranch.upstream) {
+      if (currentBranch.remote !== null && currentBranch.upstream !== null) {
         const range = revSymmetricDifference(
           currentBranch.name,
           currentBranch.upstream


### PR DESCRIPTION
This bypasses the need for us to `loadStatus` again when background fetching: https://github.com/desktop/desktop/issues/5312#issuecomment-410239974