### PR TITLE
Fix for file menu pane cut off on Windows

### DIFF
--- a/app/styles/ui/_app-menu.scss
+++ b/app/styles/ui/_app-menu.scss
@@ -26,7 +26,7 @@
   }
 
   &.menu-pane-file {
-    width: 200px;
+    width: 205px;
   }
 
   // Open panes (except the first one) should have a border on their


### PR DESCRIPTION
This change is in response to the problem mentioned in Issue #4721. In the comments for that issue it  is suggested that the text should remain the same and that the menu pane should be made wider to fit each option.

To fix this I have increased the width of the file menu pane by 5 pixels. In my tests this is the absolute minimum amount for "Clone Repository..." to show in full and not be cut off on Windows 10.
Currently I am not able to test this in any other Windows OS.

In case this is not the ideal solution to this problem I would be happy to make changes.

![desktop3](https://user-images.githubusercontent.com/4957200/43755994-340bd534-99d8-11e8-8bad-e513918019ad.png)
