### PR TITLE
bump electron-builder to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
     "electron": "2.0.5",
-    "electron-builder": "20.19.2",
+    "electron-builder": "20.27.1",
     "electron-mocha": "^6.0.1",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,7 +507,7 @@ ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.0.1, ajv@^6.5.0, ajv@^6.5.1:
+ajv@^6.0.1, ajv@^6.5.0, ajv@^6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
   dependencies:
@@ -591,13 +591,38 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-builder-bin@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.10.3.tgz#ab4d7b1a3bf4005dea16bf0b184077b3136f8ae9"
+app-builder-bin@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.1.1.tgz#02c6adfbfa3c09404a23ff7874d2cab5a8fcb9ca"
 
-app-builder-bin@1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-1.11.1.tgz#33741167f2873cf76805c9557b62caac8ede017b"
+app-builder-lib@20.27.1, app-builder-lib@~20.27.0:
+  version "20.27.1"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.27.1.tgz#02d5da95cc68256ec3812999e9686d7f6dfdfcc1"
+  dependencies:
+    "7zip-bin" "~4.0.2"
+    app-builder-bin "2.1.1"
+    async-exit-hook "^2.0.1"
+    bluebird-lst "^1.0.5"
+    builder-util "6.0.0"
+    builder-util-runtime "4.4.1"
+    chromium-pickle-js "^0.2.0"
+    debug "^3.1.0"
+    ejs "^2.6.1"
+    electron-osx-sign "0.4.10"
+    electron-publish "20.27.0"
+    fs-extra-p "^4.6.1"
+    hosted-git-info "^2.7.1"
+    is-ci "^1.1.0"
+    isbinaryfile "^3.0.3"
+    js-yaml "^3.12.0"
+    lazy-val "^1.0.3"
+    minimatch "^3.0.4"
+    normalize-package-data "^2.4.0"
+    plist "^3.0.1"
+    read-config-file "3.1.0"
+    sanitize-filename "^1.6.1"
+    semver "^5.5.0"
+    temp-file "^3.1.3"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -1414,9 +1439,24 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
 buffer-crc32@^0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.0.0"
@@ -1442,42 +1482,23 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
-builder-util-runtime@4.4.0, builder-util-runtime@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.4.0.tgz#1f486819df12a04abfa128fe082e7c54edda0ef7"
+builder-util-runtime@4.4.1, builder-util-runtime@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-4.4.1.tgz#2770d03241e51fde46acacc7ed3ed8a9f45f02cb"
   dependencies:
     bluebird-lst "^1.0.5"
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@5.13.2:
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.13.2.tgz#58b43b5b2c4acdeb9d4994b47152acdb111683ea"
+builder-util@6.0.0, builder-util@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-6.0.0.tgz#5f4941c096778758d8c186ef95eaa0e8b536cab8"
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
+    app-builder-bin "2.1.1"
     bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.4.0"
-    chalk "^2.4.1"
-    debug "^3.1.0"
-    fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    semver "^5.5.0"
-    source-map-support "^0.5.6"
-    stat-mode "^0.2.2"
-    temp-file "^3.1.3"
-
-builder-util@^5.13.1, builder-util@^5.13.2:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.15.0.tgz#e8381a67bfd1de17e45ea9f1dec26317169a30f3"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.11.1"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.4.0"
+    builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
@@ -2405,13 +2426,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dmg-builder@4.11.6:
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-4.11.6.tgz#ea686a487376b9288ffb306e0db6b6c8a9b7ed86"
+dmg-builder@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-5.2.0.tgz#93d0c327fdd536794d8b7cf4fb16d1748ed8d9cf"
   dependencies:
+    app-builder-lib "~20.27.0"
     bluebird-lst "^1.0.5"
-    builder-util "^5.13.2"
-    electron-builder-lib "~20.19.1"
+    builder-util "~6.0.0"
     fs-extra-p "^4.6.1"
     iconv-lite "^0.4.23"
     js-yaml "^3.12.0"
@@ -2527,52 +2548,20 @@ ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
 
-electron-builder-lib@20.19.2, electron-builder-lib@~20.19.1:
-  version "20.19.2"
-  resolved "https://registry.yarnpkg.com/electron-builder-lib/-/electron-builder-lib-20.19.2.tgz#1ad1053f8e02c87a5f949fec575fe55a8dff4b8b"
+electron-builder@20.27.1:
+  version "20.27.1"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.27.1.tgz#f3405280b5c5c5b2c7c0e8c6ac4c0d6b63375573"
   dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "1.10.3"
-    async-exit-hook "^2.0.1"
+    app-builder-lib "20.27.1"
     bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
-    builder-util-runtime "4.4.0"
-    chromium-pickle-js "^0.2.0"
-    debug "^3.1.0"
-    ejs "^2.6.1"
-    electron-osx-sign "0.4.10"
-    electron-publish "20.19.0"
-    env-paths "^1.0.0"
-    fs-extra-p "^4.6.1"
-    hosted-git-info "^2.6.1"
-    is-ci "^1.1.0"
-    isbinaryfile "^3.0.2"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    minimatch "^3.0.4"
-    normalize-package-data "^2.4.0"
-    plist "^3.0.1"
-    read-config-file "3.0.2"
-    sanitize-filename "^1.6.1"
-    semver "^5.5.0"
-    stream-json "^1.1.0"
-    sumchecker "^2.0.2"
-    temp-file "^3.1.3"
-
-electron-builder@20.19.2:
-  version "20.19.2"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.19.2.tgz#0c782ddbefa17192278963ab58c461b3a13dc99c"
-  dependencies:
-    bluebird-lst "^1.0.5"
-    builder-util "5.13.2"
-    builder-util-runtime "4.4.0"
+    builder-util "6.0.0"
+    builder-util-runtime "4.4.1"
     chalk "^2.4.1"
-    dmg-builder "4.11.6"
-    electron-builder-lib "20.19.2"
+    dmg-builder "5.2.0"
     fs-extra-p "^4.6.1"
     is-ci "^1.1.0"
     lazy-val "^1.0.3"
-    read-config-file "3.0.2"
+    read-config-file "3.1.0"
     sanitize-filename "^1.6.1"
     update-notifier "^2.5.0"
     yargs "^12.0.1"
@@ -2666,13 +2655,13 @@ electron-packager@^12.0.0:
     semver "^5.3.0"
     yargs-parser "^10.0.0"
 
-electron-publish@20.19.0:
-  version "20.19.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.19.0.tgz#5d272ba4d4a8b54da8770505da4bcbf460662394"
+electron-publish@20.27.0:
+  version "20.27.0"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.27.0.tgz#0f44befa800b94458c78a8f63a4bc9109c5b5b10"
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "^5.13.1"
-    builder-util-runtime "^4.4.0"
+    builder-util "~6.0.0"
+    builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     fs-extra-p "^4.6.1"
     lazy-val "^1.0.3"
@@ -3811,7 +3800,7 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-hosted-git-info@^2.6.1:
+hosted-git-info@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
@@ -4312,6 +4301,12 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 isbinaryfile@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.2.tgz#4a3e974ec0cba9004d3fc6cde7209ea69368a621"
+
+isbinaryfile@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
+  dependencies:
+    buffer-alloc "^1.2.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -6130,11 +6125,11 @@ rcedit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-1.0.0.tgz#43309ecbc8814f3582fca6b751748cfad66a16a2"
 
-read-config-file@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.0.2.tgz#3866666a8772d350cfbfe9a4b26187df34883c56"
+read-config-file@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.0.tgz#d433283c76f32204d6995542e4a04723db9e8308"
   dependencies:
-    ajv "^6.5.1"
+    ajv "^6.5.2"
     ajv-keywords "^3.2.0"
     bluebird-lst "^1.0.5"
     dotenv "^6.0.0"
@@ -7015,10 +7010,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-chain@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.0.3.tgz#9155237a719c8bb2de883c2d1af66d1546f910c9"
-
 stream-each@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
@@ -7035,12 +7026,6 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
-
-stream-json@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.1.0.tgz#0a91e84e3cfb017f2446d9023025694982c99e89"
-  dependencies:
-    stream-chain "^2.0.3"
 
 stream-shift@^1.0.0:
   version "1.0.0"
@@ -7149,7 +7134,7 @@ sumchecker@^1.2.0:
     debug "^2.2.0"
     es6-promise "^4.0.5"
 
-sumchecker@^2.0.1, sumchecker@^2.0.2:
+sumchecker@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
   dependencies:


### PR DESCRIPTION
Important Linux-specific fixes for Desktop:

 - AppImage should set the correct task bar icon - (as of v20.26.0)
 - Include main category for inferred DEB desktop entries (as of v20.24.5)