### PR TITLE
defer initial refresh of repository indicators, enable this again for everyone

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1952,15 +1952,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (repositories.length > 15) {
-      log.info(
-        `repository indicators have been disabled while we investigate reducing the overhead of the computation work as you have ${
-          repositories.length
-        } tracked repositories`
-      )
-      return
-    }
-
     const startTime = performance && performance.now ? performance.now() : null
 
     for (const repo of repositories) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1464,7 +1464,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdateNow()
 
     this.accountsStore.refresh()
-    this.refreshAllIndicators()
   }
 
   private async getSelectedExternalEditor(): Promise<ExternalEditor | null> {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -90,12 +90,15 @@ import { MergeConflictsWarning } from './merge-conflicts'
 import { AppTheme } from './app-theme'
 import { ApplicationTheme } from './lib/application-theme'
 
+const minuteInMilliseconds = 1000 * 60
+
 /** The interval at which we should check for updates. */
 const UpdateCheckInterval = 1000 * 60 * 60 * 4
 
 const SendStatsInterval = 1000 * 60 * 60 * 4
 
-const updateRepoInfoInterval = 1000 * 60 * 15
+const initialTimeoutForRepositoryIndicators = 2 * minuteInMilliseconds
+const updateRepoInfoInterval = 15 * minuteInMilliseconds
 
 interface IAppProps {
   readonly dispatcher: Dispatcher
@@ -152,9 +155,15 @@ export class App extends React.Component<IAppProps, IAppState> {
         { timeout: ReadyDelay }
       )
 
-      window.setInterval(() => {
-        this.props.appStore.refreshAllIndicators()
-      }, updateRepoInfoInterval)
+      const initialTimeout = window.setTimeout(async () => {
+        window.clearTimeout(initialTimeout)
+
+        await this.props.appStore.refreshAllIndicators()
+
+        window.setInterval(() => {
+          this.props.appStore.refreshAllIndicators()
+        }, updateRepoInfoInterval)
+      }, initialTimeoutForRepositoryIndicators)
     })
 
     this.state = props.appStore.getState()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -126,6 +126,8 @@ export class App extends React.Component<IAppProps, IAppState> {
    */
   private lastKeyPressed: string | null = null
 
+  private updateIntervalHandle: number
+
   /**
    * Gets a value indicating whether or not we're currently showing a
    * modal dialog such as the preferences, or an error dialog.
@@ -160,7 +162,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         await this.props.appStore.refreshAllIndicators()
 
-        window.setInterval(() => {
+        this.updateIntervalHandle = window.setInterval(() => {
           this.props.appStore.refreshAllIndicators()
         }, UpdateRepositoryIndicatorInterval)
       }, InitialRepositoryIndicatorTimeout)
@@ -230,6 +232,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         })
       }
     )
+  }
+
+  public componentWillUnmount() {
+    window.clearInterval(this.updateIntervalHandle)
   }
 
   private performDeferredLaunchActions() {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -90,15 +90,15 @@ import { MergeConflictsWarning } from './merge-conflicts'
 import { AppTheme } from './app-theme'
 import { ApplicationTheme } from './lib/application-theme'
 
-const minuteInMilliseconds = 1000 * 60
+const MinuteInMilliseconds = 1000 * 60
 
 /** The interval at which we should check for updates. */
 const UpdateCheckInterval = 1000 * 60 * 60 * 4
 
 const SendStatsInterval = 1000 * 60 * 60 * 4
 
-const initialTimeoutForRepositoryIndicators = 2 * minuteInMilliseconds
-const updateRepoInfoInterval = 15 * minuteInMilliseconds
+const InitialRepositoryIndicatorTimeout = 2 * MinuteInMilliseconds
+const UpdateRepositoryIndicatorInterval = 15 * MinuteInMilliseconds
 
 interface IAppProps {
   readonly dispatcher: Dispatcher
@@ -162,8 +162,8 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         window.setInterval(() => {
           this.props.appStore.refreshAllIndicators()
-        }, updateRepoInfoInterval)
-      }, initialTimeoutForRepositoryIndicators)
+        }, UpdateRepositoryIndicatorInterval)
+      }, InitialRepositoryIndicatorTimeout)
     })
 
     this.state = props.appStore.getState()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -126,7 +126,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    */
   private lastKeyPressed: string | null = null
 
-  private updateIntervalHandle: number
+  private updateIntervalHandle?: number
 
   /**
    * Gets a value indicating whether or not we're currently showing a


### PR DESCRIPTION
This change moved the initial fire-and-forget promise from inside `AppStore.loadInitialState()` to refresh indicators to a `setTimeout` that fires 2 minutes after the initial state is loaded.

When dealing with a large number of tracked repositories in Desktop, this ensures work around the active repository is prioritized over the background fetching and status checks of repositories that are not visible

We also want to avoid setting the `setInterval` timer until after the initial refresh has completed. A `fetch` on a dormant repository can take significant time due to network latency or number of refs/objects to download, but subsequent `fetch` operations will be quicker. And because we do this serially now to avoid creating too many background Git processes, this overall background work will take longer.