### PR TITLE
fix keyboard navigation triggering dual checkouts

### DIFF
--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -360,6 +360,14 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
       return
     }
 
+    if (event.key === 'Enter' && this.canSelectRow(row)) {
+      // this event is handled in List.onKeyDown (which fires List.toggleSelection)
+      // so we can ignore this event here to prevent the double "onRowClick"
+      // event from firing
+      event.preventDefault()
+      return
+    }
+
     const rowCount = this.state.rows.length
 
     const firstSelectableRow = findNextSelectableRow(


### PR DESCRIPTION
A fix for one of the known scenarios reported in #4938 

As `FilterList` is used in a bunch of places, we need to ensure they are not affected by this change:

 - [x] test branches list works as expected when using keyboard navigation and <kbd>Enter</kbd> to checkout a branch
 - [x] test PR list works as expected when using keyboard navigation and <kbd>Enter</kbd> to checkout a PR
 - [x] test compare tab works as expected when using keyboard navigation and <kbd>Enter</kbd> to choose a branch to compare
 - [x] test repository list works as expected when using keyboard navigation and <kbd>Enter</kbd> to switch repositories
