### PR TITLE
avoid double checkout when opening a PR in Desktop

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -58,6 +58,7 @@ import { IAuthor } from '../../models/author'
 import { ITrailer } from '../git/interpret-trailers'
 import { isGitRepository } from '../git'
 import { ApplicationTheme } from '../../ui/lib/application-theme'
+import { TipState } from '../../models/tip'
 
 /**
  * An error handler function.
@@ -954,7 +955,17 @@ export class Dispatcher {
     }
 
     if (branch != null) {
-      await this.checkoutBranch(repository, branch)
+      let shouldCheckoutBranch = true
+
+      const { tip } = state.branchesState
+
+      if (tip.kind === TipState.Valid) {
+        shouldCheckoutBranch = tip.branch.nameWithoutRemote !== branch
+      }
+
+      if (shouldCheckoutBranch) {
+        await this.checkoutBranch(repository, branch)
+      }
     }
 
     if (filepath != null) {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -840,12 +840,8 @@ export class Dispatcher {
         break
 
       case 'open-repository-from-url':
-        const { pr, url, branch } = action
-        // a forked PR will provide both these values, despite the branch not existing
-        // in the repository - drop the branch argument in this case so a clone will
-        // checkout the default branch when it clones
-        const branchToClone = pr && branch ? null : branch || null
-        const repository = await this.openRepository(url, branchToClone)
+        const { url } = action
+        const repository = await this.openRepository(url)
         if (repository) {
           this.handleCloneInDesktopOptions(repository, action)
         } else {
@@ -976,10 +972,7 @@ export class Dispatcher {
     }
   }
 
-  private async openRepository(
-    url: string,
-    branch: string | null
-  ): Promise<Repository | null> {
+  private async openRepository(url: string): Promise<Repository | null> {
     const state = this.appStore.getState()
     const repositories = state.repositories
     const existingRepository = repositories.find(r => {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -843,7 +843,7 @@ export class Dispatcher {
         const { url } = action
         const repository = await this.openRepository(url)
         if (repository) {
-          this.handleCloneInDesktopOptions(repository, action)
+          await this.handleCloneInDesktopOptions(repository, action)
         } else {
           log.warn(
             `Open Repository from URL failed, did not find repository: ${url} - payload: ${JSON.stringify(

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -936,8 +936,9 @@ export class Dispatcher {
       await this.fetchRefspec(repository, `pull/${pr}/head:${branch}`)
     }
 
+    const state = this.appStore.getRepositoryState(repository)
+
     if (pr == null && branch != null) {
-      const state = this.appStore.getRepositoryState(repository)
       const branches = state.branchesState.allBranches
 
       // I don't want to invoke Git functionality from the dispatcher, which

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -995,21 +995,16 @@ export class Dispatcher {
     })
 
     if (existingRepository) {
-      const repo = await this.selectRepository(existingRepository)
-      if (!repo || !branch) {
-        return repo
-      }
-
-      return this.checkoutBranch(repo, branch)
-    } else {
-      return this.appStore._startOpenInDesktop(() => {
-        this.changeCloneRepositoriesTab(CloneRepositoryTab.Generic)
-        this.showPopup({
-          type: PopupType.CloneRepository,
-          initialURL: url,
-        })
-      })
+      return await this.selectRepository(existingRepository)
     }
+
+    return this.appStore._startOpenInDesktop(() => {
+      this.changeCloneRepositoriesTab(CloneRepositoryTab.Generic)
+      this.showPopup({
+        type: PopupType.CloneRepository,
+        initialURL: url,
+      })
+    })
   }
 
   /**


### PR DESCRIPTION
While investigating #4938 I found another code path that's a potential race condition:

 - app receives URL from browser about repository to clone and checkout a branch
 - app finds existing repository **and checks out the branch**
 - app processes arguments attached to URL to ensure the ref exists before checkout
 - app **checks out the same branch again** 
 - :boom:

This PR tidies up this flow by skipping that first checkout and also doing a sanity check when the second checkout occurs to see if the branch is already in the correct state. 

Most of the time when I tripped the "fatal: Unable to create '/path/to/repo/.git/index.lock': File exists." error on checkout, the action before was a `git status`. I think the `--no-optional-locks` added in a recent version of Git will also help here to ensure `git status` avoids clashing with operations that need to lock the index (we're doing more of this in the background with `1.3.0`) but I'll test out in a follow-up PR.