### PR TITLE
we don't need getStatus to always lock the index

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -41,3 +41,8 @@ export function enableNotificationOfBranchUpdates(): boolean {
 export function enableRepoInfoIndicators(): boolean {
   return true
 }
+
+/** Should `git status` use --no-optional-locks to assist with concurrent usage */
+export function enableStatusWithoutOptionalLocks(): boolean {
+  return enableBetaFeatures()
+}


### PR DESCRIPTION
From the docs for [`git status`](https://github.com/git/git/blob/master/Documentation/git-status.txt#L408):

```
BACKGROUND REFRESH
------------------

By default, `git status` will automatically refresh the index, updating
the cached stat information from the working tree and writing out the
result. Writing out the updated index is an optimization that isn't
strictly necessary (`status` computes the values for itself, but writing
them out is just to save subsequent programs from repeating our
computation). When `status` is run in the background, the lock held
during the write may conflict with other simultaneous processes, causing
them to fail. Scripts running `status` in the background should consider
using `git --no-optional-locks status` (see linkgit:git[1] for details).
```

We should totally do this, particularly as:

 - this fits with the description of new background work introduced by `1.3.0`
 - is potentially related to #4938 (which precedes `1.3.0`)

I'd love to give this time to test thoroughly (as `git status` is very important to Desktop) to ensure it doesn't affect existing functionality too