### PR TITLE
Add accelerator to Exit menu on non-macOS

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -99,7 +99,12 @@ export function buildDefaultMenu(
         click: emit('show-preferences'),
       },
       separator,
-      { role: 'quit' }
+      {
+        label: 'E&xit',
+        id: 'exit',
+        accelerator: 'Alt+F4',
+        click: emit('quit'),
+      }
     )
   }
 

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -27,3 +27,4 @@ export type MenuEvent =
   | 'install-cli'
   | 'open-external-editor'
   | 'select-all'
+  | 'quit'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -324,6 +324,9 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.openCurrentRepositoryInExternalEditor()
       case 'select-all':
         return this.selectAll()
+      case 'quit':
+        remote.app.quit()
+        return
     }
 
     return assertNever(name, `Unknown menu event name: ${name}`)


### PR DESCRIPTION
Fixes #6507 

The "quit" role in Electron's MenuItem on Windows is a bit lacking, it doesn't correctly set the accelerator to 'x' (the underline under the menu item that tells you the key to press), and it doesn't list "Alt-F4" as the shortcut. Since we don't really need Quit as a Special Menu Item (unlike "services" in macOS for example), we can just implement this ourselves and give it the right decoration.

## To Test:

1. Open Desktop
1. Hit Alt-F to open the File Menu
1. Hit 'x' to exit