### PR TITLE
Added error for publishing repo w/ non-existent org

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -374,11 +374,8 @@ export class API {
       return await parsedResponse<IAPIRepository>(response)
     } catch (e) {
       if (e instanceof APIError) {
-        const orgsList: ReadonlyArray<IAPIUser> | null = await this.fetchOrgs()
-        if (orgsList && org) {
-          if (orgsList.indexOf(org) === -1) {
-            throw new Error(`Organization "${org.login}" Not Found`)
-          }
+        if (org !== null) {
+          throw new Error(`Organization "${org.login}" Not Found`)
         }
         throw e
       }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -374,6 +374,12 @@ export class API {
       return await parsedResponse<IAPIRepository>(response)
     } catch (e) {
       if (e instanceof APIError) {
+        const orgsList: ReadonlyArray<IAPIUser> | null = await this.fetchOrgs()
+        if (orgsList && org) {
+          if (orgsList.indexOf(org) === -1) {
+            throw new Error(`Organization "${org.login}" Not Found`)
+          }
+        }
         throw e
       }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -375,7 +375,11 @@ export class API {
     } catch (e) {
       if (e instanceof APIError) {
         if (org !== null) {
-          throw new Error(`Organization "${org.login}" Not Found`)
+          throw new Error(
+            `Unable to create repository for organization '${
+              org.login
+            }'. Verify it exists and that you have permission to create a repository there.`
+          )
         }
         throw e
       }


### PR DESCRIPTION
As the docs say, open pull requests early. I figured would open this and see what others think.

This pull request is in response to Issue #3764. Although it does not cover all the suggestions in it, it is meant to solve the issue of the vague "Not Found" error when attempting to publish a repository with an organization that has been renamed or deleted. This change intends to make a very clear error that specifically tells the user that it is the organization that was not able to be found and shows the name of the organization to review.

I am certainly open to feedback and would be happy to make changes as needed. I am new both to this project and the conventions of this language, so I am sure there are better ways of doing things.

