### PR TITLE
experimenting with tuning ts-node usage to speed up tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,6 @@ build_script:
   - yarn build:prod
 
 test_script:
-  - node --version
   - yarn test:setup
   - ./script/test-appveyor.bat
 

--- a/script/test-appveyor.bat
+++ b/script/test-appveyor.bat
@@ -1,2 +1,2 @@
-npm test
+yarn test
 set APPVEYOR_TEST_RESULT=%ERRORLEVEL%

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -13,6 +13,8 @@ const environmentVariables = {
   TEST_ENV: '1',
   // ensuring Electron doesn't attach to the current console session (Windows only)
   ELECTRON_NO_ATTACH_CONSOLE: '1',
+  // speed up ts-node usage by using the new transpile-only module
+  TS_NODE_TRANSPILE_ONLY: 'true',
 }
 
 const env = { ...process.env, ...environmentVariables }

--- a/script/unit-tests.ts
+++ b/script/unit-tests.ts
@@ -13,7 +13,7 @@ const environmentVariables = {
   TEST_ENV: '1',
   // ensuring Electron doesn't attach to the current console session (Windows only)
   ELECTRON_NO_ATTACH_CONSOLE: '1',
-  // speed up ts-node usage by using the new transpile-only module
+  // speed up ts-node usage by using the new transpile-only mode
   TS_NODE_TRANSPILE_ONLY: 'true',
 }
 


### PR DESCRIPTION
Currently our unit tests seem to spend a significant time transpiling on some platforms, e.g. [AppVeyor](https://ci.appveyor.com/project/github-windows/desktop/build/10153):

```
  ...

  331 passing (39s)
  8 pending
Done in 413.07s.
```

And [VSTS (Windows agent)](https://github.visualstudio.com/Desktop/_build/results?buildId=4566&view=logs):

```
[92m [0m[32m 331 passing[0m[90m (49s)[0m
 [36m [0m[36m 8 pending[0m
... 
Done in 449.09s.
```

We've upgraded `ts-node` recently, so perhaps there's some flags we need to set in here. An obvious one I was just looking at was `--transpileOnly`:

> `-T`, `--transpileOnly` Use TypeScript's faster `transpileModule` (`TS_NODE_TRANSPILE_ONLY`, default: `false`)

I'll update this with more research and digging.
