### PR TITLE
fix CircleCI build so that it correctly reports lint errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,7 @@ jobs:
             - ./node_modules
       - run:
           name: Lint and validate changelog
-          command: |
-            yarn lint
-            yarn validate-changelog
+          command: yarn lint && yarn validate-changelog
       - run:
           name: Build
           command: yarn build:prod


### PR DESCRIPTION
🎶 One of these things is not like the other 🎶

<img width="720" src="https://user-images.githubusercontent.com/359239/44148381-8b7a0100-a06e-11e8-81af-9207024bb000.png">

This was a linting error that CircleCI did detect, but note the exit code is fine:

<img width="1327" src="https://user-images.githubusercontent.com/359239/44148471-ea45c9bc-a06e-11e8-8acd-72a5f3a70963.png">

That's because bash scripts, made up of multiple commands, will by default continue on to the next instructions and then return the exit code at the end of the script (so whatever the last command set).

https://github.com/desktop/desktop/blob/4589ea4ff366d34e3fb9344c71b2244b7bba993b/.circleci/config.yml#L37-L41

We need to do something like what Travis does, and fail as soon as any step returns a non-zero exit code:

https://github.com/desktop/desktop/blob/4589ea4ff366d34e3fb9344c71b2244b7bba993b/.travis.yml#L55-L57

 - [x] [CircleCI build passes](https://circleci.com/gh/desktop/desktop/5030?), all others fail
 - [x] update CircleCI config, [see it now fail](https://circleci.com/gh/desktop/desktop/5032)
 - [x] fix the lint issue and confirm [build remains green](https://circleci.com/gh/desktop/desktop/5033)
 - [x] rebase branch to remove the lint changes