### PR TITLE
cloning message uses remote repo name not file destination

### DIFF
--- a/app/src/models/cloning-repository.ts
+++ b/app/src/models/cloning-repository.ts
@@ -14,7 +14,7 @@ export class CloningRepository {
   }
 
   public get name(): string {
-    return Path.basename(this.path)
+    return Path.basename(this.url, '.git')
   }
 
   /**


### PR DESCRIPTION
In the message displayed during cloning of a remote repo the app will now use the repo name from the original url being cloned not the name of the destination folder.

In response to issue #3938 this tiny pull request is a very different approach to fixing the repo name displayed during cloning than the previous PR https://github.com/desktop/desktop/pull/4364

I acknowledge this could use more testing, but it's a very different approach from the previous PR and I wanted to run it by the maintainers first. Totally open to the idea that I'm missing something.

@outofambit 