### PR TITLE
Clear Displayed Publish Repository Error on change of tab

### DIFF
--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -247,13 +247,12 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   }
 
   private onTabClicked = (index: PublishTab) => {
-    // Clear the selected org since dot com and Enterprise will have a different
-    // set of orgs.
-    const settings = { ...this.state.publishSettings, org: null }
-    this.setState({ currentTab: index, publishSettings: settings })
-
     const isTabChanging = index !== this.state.currentTab
     if (isTabChanging) {
+      // Clear the selected org since dot com and Enterprise will have a different
+      // set of orgs.
+      const settings = { ...this.state.publishSettings, org: null }
+      this.setState({ currentTab: index, publishSettings: settings })
       // Swap the current stored error from the active tab with the error from
       // the inactive tab. So that each tab saves and displays their own error.
       const temporaryError: Error | null = this.state.error

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -47,6 +47,13 @@ interface IPublishState {
    */
   readonly error: Error | null
 
+  /**
+   * The error pertaining to the tab the user is not
+   * actively using. It is swapped when the user changes
+   * the current tab.
+   */
+  readonly inactiveTabError: Error | null
+
   /** Is the repository currently being published? */
   readonly publishing: boolean
 }
@@ -76,6 +83,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       currentTab: startingTab,
       publishSettings,
       error: null,
+      inactiveTabError: null,
       publishing: false,
     }
   }
@@ -243,7 +251,14 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     // set of orgs.
     const settings = { ...this.state.publishSettings, org: null }
     this.setState({ currentTab: index, publishSettings: settings })
-    // Clear any errors now that the context has been changed.
-    this.setState({ error: null })
+
+    const isTabChanging = index !== this.state.currentTab
+    if (isTabChanging) {
+      // Swap the current stored error from the active tab with the error from
+      // the inactive tab. So that each tab saves and displays their own error.
+      const temporaryError: Error | null = this.state.error
+      this.setState({ error: this.state.inactiveTabError })
+      this.setState({ inactiveTabError: temporaryError })
+    }
   }
 }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -243,5 +243,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     // set of orgs.
     const settings = { ...this.state.publishSettings, org: null }
     this.setState({ currentTab: index, publishSettings: settings })
+    // Clear any errors now that the context has been changed.
+    this.setState({ error: null })
   }
 }


### PR DESCRIPTION
This pull request is in response to Issue #3764 and #3089. Among the suggestions was clearing errors when switching tabs. However, I figured this would be a good opportunity to discuss such a change.

The intent of this change is to stop showing an error in the Publish Repository window when the user has changed tabs and the error from their attempt to publish is no longer related to the current context.

While it makes sense to clear an error such as an issue publishing with the selected organization, it may not make as much sense with errors that may persist the immediate context (such as warning that internet issues may have prevented the publishing).

Therefore, I figured it would be great to discuss :

- If this would be a welcomed change in the first place.
- If there is a better way to implement such a change.
- If a different approach entirely would be preferable (such as an individual solution to individual errors)

(Additionally, in regard to consistency, this is not something that seems to occur in the Clone Repository window. For example, if you type a single character for the URL in Clone a Repository, you will get a "The destination already exists" error that does not clear on deleting the url or switching tabs. However, I feel like it would make sense to do so in that case as well.)