### PR TITLE
Start blocking the ability to add local bare repositories

### DIFF
--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -55,26 +55,19 @@ export async function getTopLevelWorkingDirectory(
 export async function checkIfRepositoryIsBare(
   path: string
 ): Promise<boolean | null> {
-  let result
-
   try {
-    result = await git(
+    const result = await git(
       ['rev-parse', '--is-bare-repository'],
       path,
       'checkIfRepositoryIsBare'
     )
+    return result.stdout.trim() === 'true'
   } catch (e) {
     if (e.message.includes('not a git repository')) {
       return null
     }
 
     throw e
-  }
-
-  if (result === null) {
-    return null
-  } else {
-    return result.stdout === 'true\n'
   }
 }
 

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -52,6 +52,32 @@ export async function getTopLevelWorkingDirectory(
   return Path.resolve(path, relativePath)
 }
 
+export async function checkIfRepositoryIsBare(
+  path: string
+): Promise<boolean | null> {
+  let result
+
+  try {
+    result = await git(
+      ['rev-parse', '--is-bare-repository'],
+      path,
+      'checkIfRepositoryIsBare'
+    )
+  } catch (e) {
+    if (e.message.includes('not a git repository')) {
+      return null
+    }
+
+    throw e
+  }
+
+  if (result === null) {
+    return null
+  } else {
+    return result.stdout === 'true\n'
+  }
+}
+
 /** Is the path a git repository? */
 export async function isGitRepository(path: string): Promise<boolean> {
   return (await getTopLevelWorkingDirectory(path)) !== null

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -52,6 +52,13 @@ export async function getTopLevelWorkingDirectory(
   return Path.resolve(path, relativePath)
 }
 
+/**
+ * Checks if the repository at a path is bare.
+ *
+ * @param path The path to the Git repository to check.
+ *
+ * @returns null if the path provided does not contain a Git repository.
+ */
 export async function isBareRepository(path: string): Promise<boolean | null> {
   try {
     const result = await git(

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -59,7 +59,7 @@ export async function getTopLevelWorkingDirectory(
  *
  * @returns null if the path provided does not contain a Git repository.
  */
-export async function isBareRepository(path: string): Promise<boolean | null> {
+export async function isBareRepository(path: string): Promise<boolean> {
   try {
     const result = await git(
       ['rev-parse', '--is-bare-repository'],
@@ -69,7 +69,7 @@ export async function isBareRepository(path: string): Promise<boolean | null> {
     return result.stdout.trim() === 'true'
   } catch (e) {
     if (e.message.includes('not a git repository')) {
-      return null
+      return false
     }
 
     throw e

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -52,14 +52,12 @@ export async function getTopLevelWorkingDirectory(
   return Path.resolve(path, relativePath)
 }
 
-export async function checkIfRepositoryIsBare(
-  path: string
-): Promise<boolean | null> {
+export async function isBareRepository(path: string): Promise<boolean | null> {
   try {
     const result = await git(
       ['rev-parse', '--is-bare-repository'],
       path,
-      'checkIfRepositoryIsBare'
+      'isBareRepository'
     )
     return result.stdout.trim() === 'true'
   } catch (e) {

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -55,9 +55,9 @@ export async function getTopLevelWorkingDirectory(
 /**
  * Checks if the repository at a path is bare.
  *
- * @param path The path to the Git repository to check.
+ * @param path The path to the repository to check. An error will be thrown if the path does not exist on disk.
  *
- * @returns null if the path provided does not contain a Git repository.
+ * @returns true if the path contains a bare Git repository. Returns false if it is not bare or is not a Git repository.
  */
 export async function isBareRepository(path: string): Promise<boolean> {
   try {

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -86,7 +86,7 @@ export class AddExistingRepository extends React.Component<
     }
 
     const isBare = await isBareRepository(this.state.path)
-    if (isBare !== null && isBare === true) {
+    if (isBare === true) {
       this.setState({ isRepositoryBare: true })
       return
     }
@@ -183,7 +183,7 @@ export class AddExistingRepository extends React.Component<
 
     const path = directory[0]
     const isRepository = await isGitRepository(path)
-    const isRepositoryBare = (await isBareRepository(path)) || false
+    const isRepositoryBare = await isBareRepository(path)
 
     this.setState({
       path,

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { Dispatcher } from '../../lib/dispatcher'
 import { isGitRepository } from '../../lib/git'
-import { checkIfRepositoryIsBare } from '../../lib/git'
+import { isBareRepository } from '../../lib/git'
 import { Button } from '../lib/button'
 import { ButtonGroup } from '../lib/button-group'
 import { TextBox } from '../lib/text-box'
@@ -49,7 +49,7 @@ interface IAddExistingRepositoryState {
    * flickering for our users as they type in a path.
    */
   readonly showNonGitRepositoryWarning: boolean
-  readonly isBareRepository: boolean
+  readonly isRepositoryBare: boolean
 }
 
 /** The component for adding an existing local repository. */
@@ -66,7 +66,7 @@ export class AddExistingRepository extends React.Component<
       path,
       isRepository: false,
       showNonGitRepositoryWarning: false,
-      isBareRepository: false,
+      isRepositoryBare: false,
     }
   }
 
@@ -85,14 +85,14 @@ export class AddExistingRepository extends React.Component<
       return
     }
 
-    const isBare = await checkIfRepositoryIsBare(this.state.path)
+    const isBare = await isBareRepository(this.state.path)
     if (isBare !== null && isBare === true) {
-      this.setState({ isBareRepository: true })
+      this.setState({ isRepositoryBare: true })
       return
     }
 
     this.setState({ isRepository, showNonGitRepositoryWarning: !isRepository })
-    this.setState({ isBareRepository: false })
+    this.setState({ isRepositoryBare: false })
   }
 
   private renderWarning() {
@@ -100,7 +100,7 @@ export class AddExistingRepository extends React.Component<
       return null
     }
 
-    if (this.state.isBareRepository) {
+    if (this.state.isRepositoryBare) {
       return (
         <Row className="warning-helper-text">
           <Octicon symbol={OcticonSymbol.alert} />
@@ -132,7 +132,7 @@ export class AddExistingRepository extends React.Component<
     const disabled =
       this.state.path.length === 0 ||
       !this.state.isRepository ||
-      this.state.isBareRepository
+      this.state.isRepositoryBare
 
     return (
       <Dialog
@@ -183,7 +183,7 @@ export class AddExistingRepository extends React.Component<
 
     const path = directory[0]
     const isRepository = await isGitRepository(path)
-    const isBareRepositoryResult = await checkIfRepositoryIsBare(path)
+    const isBareRepositoryResult = await isBareRepository(path)
     let isBareRepository: boolean = false
 
     if (isBareRepositoryResult !== null) {
@@ -193,8 +193,8 @@ export class AddExistingRepository extends React.Component<
     this.setState({
       path,
       isRepository,
-      showNonGitRepositoryWarning: !isRepository || isBareRepository,
-      isBareRepository,
+      showNonGitRepositoryWarning: !isRepository || isRepositoryBare,
+      isRepositoryBare,
     })
   }
 

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -183,12 +183,7 @@ export class AddExistingRepository extends React.Component<
 
     const path = directory[0]
     const isRepository = await isGitRepository(path)
-    const isBareRepositoryResult = await isBareRepository(path)
-    let isBareRepository: boolean = false
-
-    if (isBareRepositoryResult !== null) {
-      isBareRepository = isBareRepositoryResult
-    }
+    const isRepositoryBare = (await isBareRepository(path)) || false
 
     this.setState({
       path,

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -51,10 +51,10 @@ describe('git/rev-parse', () => {
       expect(result).is.true
     })
 
-    it('returns null for empty directory', async () => {
+    it('returns false for empty directory', async () => {
       const path = await mkdirSync('no-actual-repository-here')
       const result = await isBareRepository(path)
-      expect(result).is.null
+      expect(result).is.false
     })
 
     it('throws error for missing directory', async () => {

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -7,9 +7,15 @@ import { Repository } from '../../../src/models/repository'
 import {
   isGitRepository,
   getTopLevelWorkingDirectory,
+  checkIfRepositoryIsBare,
 } from '../../../src/lib/git/rev-parse'
 import { git } from '../../../src/lib/git/core'
-import { setupFixtureRepository, mkdirSync } from '../../helpers/repositories'
+import {
+  setupFixtureRepository,
+  mkdirSync,
+  setupEmptyRepository,
+} from '../../helpers/repositories'
+import { GitProcess } from 'dugite'
 
 describe('git/rev-parse', () => {
   let repository: Repository | null = null
@@ -28,6 +34,46 @@ describe('git/rev-parse', () => {
     it('should return false for a directory', async () => {
       const result = await isGitRepository(path.dirname(repository!.path))
       expect(result).to.equal(false)
+    })
+  })
+
+  describe('isBareRepository', () => {
+    it('returns false for default initialized repository', async () => {
+      const repository = await setupEmptyRepository()
+      const result = await checkIfRepositoryIsBare(repository.path)
+      expect(result).is.false
+    })
+
+    it('returns true for initialized bare repository', async () => {
+      const path = await mkdirSync('no-repository-here')
+      await GitProcess.exec(['init', '--bare'], path)
+      const result = await checkIfRepositoryIsBare(path)
+      expect(result).is.true
+    })
+
+    it('returns false for empty directory', async () => {
+      const path = await mkdirSync('no-actual-repository-here')
+      let errorThrown = false
+      try {
+        await checkIfRepositoryIsBare(path)
+      } catch {
+        errorThrown = true
+      }
+
+      expect(errorThrown).is.true
+    })
+
+    it('throws error for missing directory', async () => {
+      const rootPath = await mkdirSync('no-actual-repository-here')
+      const missingPath = path.join(rootPath, 'missing-folder')
+      let errorThrown = false
+      try {
+        await checkIfRepositoryIsBare(missingPath)
+      } catch {
+        errorThrown = true
+      }
+
+      expect(errorThrown).is.true
     })
   })
 

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -7,7 +7,7 @@ import { Repository } from '../../../src/models/repository'
 import {
   isGitRepository,
   getTopLevelWorkingDirectory,
-  checkIfRepositoryIsBare,
+  isBareRepository,
 } from '../../../src/lib/git/rev-parse'
 import { git } from '../../../src/lib/git/core'
 import {
@@ -40,20 +40,20 @@ describe('git/rev-parse', () => {
   describe('isBareRepository', () => {
     it('returns false for default initialized repository', async () => {
       const repository = await setupEmptyRepository()
-      const result = await checkIfRepositoryIsBare(repository.path)
+      const result = await isBareRepository(repository.path)
       expect(result).is.false
     })
 
     it('returns true for initialized bare repository', async () => {
       const path = await mkdirSync('no-repository-here')
       await GitProcess.exec(['init', '--bare'], path)
-      const result = await checkIfRepositoryIsBare(path)
+      const result = await isBareRepository(path)
       expect(result).is.true
     })
 
     it('returns null for empty directory', async () => {
       const path = await mkdirSync('no-actual-repository-here')
-      const result = await checkIfRepositoryIsBare(path)
+      const result = await isBareRepository(path)
       expect(result).is.null
     })
 
@@ -62,7 +62,7 @@ describe('git/rev-parse', () => {
       const missingPath = path.join(rootPath, 'missing-folder')
       let errorThrown = false
       try {
-        await checkIfRepositoryIsBare(missingPath)
+        await isBareRepository(missingPath)
       } catch {
         errorThrown = true
       }

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -51,16 +51,10 @@ describe('git/rev-parse', () => {
       expect(result).is.true
     })
 
-    it('returns false for empty directory', async () => {
+    it('returns null for empty directory', async () => {
       const path = await mkdirSync('no-actual-repository-here')
-      let errorThrown = false
-      try {
-        await checkIfRepositoryIsBare(path)
-      } catch {
-        errorThrown = true
-      }
-
-      expect(errorThrown).is.true
+      const result = await checkIfRepositoryIsBare(path)
+      expect(result).is.null
     })
 
     it('throws error for missing directory', async () => {


### PR DESCRIPTION
This pull request is in response to Issue #4293. The intention is to stop allowing bare repositories from being added via GitHub Desktop as they are not currently supported. To do so, a function that checks if the repository is bare has been added. Additionally, the Add-Existing-Repository dialogue now uses the added function to check for a bare repository and displays a warning and disables the add button.

I am still new to this project and a number of the technologies involved in it so there is likely plenty room for improvement. I am more than happy to make changes to my implementation. I suspect it can be simplified, especially where it deals with `boolean | null` types.
