### PR TITLE
refactor config tests to control HOME environment variable

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -17,12 +17,18 @@ export function getGlobalConfigValue(name: string): Promise<string | null> {
 /** Set the local config value by name. */
 export async function setGlobalConfigValue(
   name: string,
-  value: string
+  value: string,
+  env?: {
+    HOME: string
+  }
 ): Promise<void> {
+  const options = env ? { env } : undefined
+
   await git(
     ['config', '--global', '--replace-all', name, value],
     __dirname,
-    'setGlobalConfigValue'
+    'setGlobalConfigValue',
+    options
   )
 }
 
@@ -51,11 +57,15 @@ async function getConfigValueInPath(
 }
 
 /** Get the path to the global git config. */
-export async function getGlobalConfigPath(): Promise<string | null> {
+export async function getGlobalConfigPath(env?: {
+  HOME: string
+}): Promise<string | null> {
+  const options = env ? { env } : undefined
   const result = await git(
     ['config', '--global', '--list', '--show-origin', '--name-only', '-z'],
     __dirname,
-    'getGlobalConfigPath'
+    'getGlobalConfigPath',
+    options
   )
   const segments = result.stdout.split('\0')
   if (segments.length < 1) {

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -10,8 +10,13 @@ export function getConfigValue(
 }
 
 /** Look up a global config value by name. */
-export function getGlobalConfigValue(name: string): Promise<string | null> {
-  return getConfigValueInPath(name, null)
+export function getGlobalConfigValue(
+  name: string,
+  env?: {
+    HOME: string
+  }
+): Promise<string | null> {
+  return getConfigValueInPath(name, null, env)
 }
 
 /** Set the local config value by name. */
@@ -34,7 +39,10 @@ export async function setGlobalConfigValue(
 
 async function getConfigValueInPath(
   name: string,
-  path: string | null
+  path: string | null,
+  env?: {
+    HOME: string
+  }
 ): Promise<string | null> {
   const flags = ['config', '-z']
   if (!path) {
@@ -45,7 +53,9 @@ async function getConfigValueInPath(
 
   const result = await git(flags, path || __dirname, 'getConfigValueInPath', {
     successExitCodes: new Set([0, 1]),
+    env,
   })
+
   // Git exits with 1 if the value isn't found. That's OK.
   if (result.exitCode === 1) {
     return null

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -1,5 +1,6 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
+import { normalize } from 'path'
 
 /** Look up a config value by name in the repository. */
 export function getConfigValue(
@@ -92,7 +93,7 @@ export async function getGlobalConfigPath(env?: {
     return null
   }
 
-  return path[1]
+  return normalize(path[1])
 }
 
 export interface IMergeTool {

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai'
+import { GitProcess } from 'dugite'
+import * as Path from 'path'
 
 import { Repository } from '../../../src/models/repository'
 import {
@@ -7,8 +9,7 @@ import {
   getGlobalConfigValue,
   setGlobalConfigValue,
 } from '../../../src/lib/git'
-import { GitProcess } from 'dugite'
-import { setupFixtureRepository } from '../../helpers/repositories'
+import { setupFixtureRepository, mkdirSync } from '../../helpers/repositories'
 
 describe('git/config', () => {
   let repository: Repository | null = null
@@ -33,39 +34,47 @@ describe('git/config', () => {
     })
   })
 
-  describe('getGlobalConfigPath', () => {
-    it('gets the config path', async () => {
-      const path = await getGlobalConfigPath()
-      expect(path).not.to.equal(null)
-      expect(path!.length).to.be.greaterThan(0)
-    })
-  })
+  describe('global config', () => {
+    const HOME = mkdirSync('global-config-here')
+    const env = { HOME }
+    const expectedConfigPath = Path.normalize(Path.join(HOME, '.gitconfig'))
+    const configArgsForTestConfig = ['config', '-f', expectedConfigPath]
 
-  describe('setGlobalConfigValue', () => {
-    const key = 'foo.bar'
+    describe('getGlobalConfigPath', () => {
+      beforeEach(async () => {
+        // getGlobalConfigPath requires at least one entry, so the
+        // test needs to setup an existing config value
+        await GitProcess.exec(
+          [...configArgsForTestConfig, 'user.name', 'bar'],
+          __dirname
+        )
+      })
 
-    beforeEach(async () => {
-      await GitProcess.exec(
-        ['config', '--add', '--global', key, 'first'],
-        __dirname
-      )
-      await GitProcess.exec(
-        ['config', '--add', '--global', key, 'second'],
-        __dirname
-      )
-    })
-
-    it('will replace all entries for a global value', async () => {
-      await setGlobalConfigValue(key, 'the correct value')
-      const value = await getGlobalConfigValue(key)
-      expect(value).to.equal('the correct value')
+      it('gets the config path', async () => {
+        const path = await getGlobalConfigPath(env)
+        expect(path).to.equal(expectedConfigPath)
+      })
     })
 
-    afterEach(async () => {
-      await GitProcess.exec(
-        ['config', '--unset-all', '--global', key],
-        __dirname
-      )
+    describe('setGlobalConfigValue', () => {
+      const key = 'foo.bar'
+
+      beforeEach(async () => {
+        await GitProcess.exec(
+          [...configArgsForTestConfig, '--add', key, 'first'],
+          __dirname
+        )
+        await GitProcess.exec(
+          [...configArgsForTestConfig, '--add', key, 'second'],
+          __dirname
+        )
+      })
+
+      it('will replace all entries for a global value', async () => {
+        await setGlobalConfigValue(key, 'the correct value', env)
+        const value = await getGlobalConfigValue(key, env)
+        expect(value).to.equal('the correct value')
+      })
     })
   })
 })

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -38,16 +38,13 @@ describe('git/config', () => {
     const HOME = mkdirSync('global-config-here')
     const env = { HOME }
     const expectedConfigPath = Path.normalize(Path.join(HOME, '.gitconfig'))
-    const configArgsForTestConfig = ['config', '-f', expectedConfigPath]
+    const baseArgs = ['config', '-f', expectedConfigPath]
 
     describe('getGlobalConfigPath', () => {
       beforeEach(async () => {
         // getGlobalConfigPath requires at least one entry, so the
         // test needs to setup an existing config value
-        await GitProcess.exec(
-          [...configArgsForTestConfig, 'user.name', 'bar'],
-          __dirname
-        )
+        await GitProcess.exec([...baseArgs, 'user.name', 'bar'], __dirname)
       })
 
       it('gets the config path', async () => {
@@ -60,14 +57,8 @@ describe('git/config', () => {
       const key = 'foo.bar'
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          [...configArgsForTestConfig, '--add', key, 'first'],
-          __dirname
-        )
-        await GitProcess.exec(
-          [...configArgsForTestConfig, '--add', key, 'second'],
-          __dirname
-        )
+        await GitProcess.exec([...baseArgs, '--add', key, 'first'], __dirname)
+        await GitProcess.exec([...baseArgs, '--add', key, 'second'], __dirname)
       })
 
       it('will replace all entries for a global value', async () => {


### PR DESCRIPTION
The Jest PR #5427 identified some tests that touch the global config, and this is suboptimal for a couple of reasons:

 - inconsistent setup between CI environments - not every environment provides it
 - tests should not be modifying the user's global config as a result of running tests

This PR refactors the `config.ts` to support controlling the `HOME` environment variable, which Git should be using to read the global config. This also updates the `config-tests.ts` that touch the global config to now use a temporary directory.