### PR TITLE
bump electron to latest stable 

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 2.0.5
+target = 2.0.8
 arch = x64

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "2.0.5",
+    "electron": "2.0.8",
     "electron-builder": "20.27.1",
     "electron-mocha": "^6.0.1",
     "electron-packager": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,9 +2704,9 @@ electron-winstaller@2.5.2:
     lodash.template "^4.2.2"
     temp "^0.8.3"
 
-electron@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.5.tgz#6045db011e2547062a36e8c5da84d4982f434fc0"
+electron@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
You might have seen [this blog post](https://electronjs.org/blog/web-preferences-fix) in the last couple of days about vulnerability `CVE-2018-15685`. **GitHub Desktop is not vulnerable to this issue, as we already have the recommended mitigation in place.**

Nevertheless, there was a [security alert](https://blog.github.com/2017-11-16-introducing-security-alerts-on-github/) about this, and I saw we were a couple of minor releases behind. This PR catches us up to what is available upstream:

 - [x] scan [v2.0.6](https://github.com/electron/electron/releases/tag/v2.0.6), [v2.0.7](https://github.com/electron/electron/releases/tag/v2.0.7) and [v2.0.8](https://github.com/electron/electron/releases/tag/v2.0.8) release notes to identify changes to test
 - [x] test app on Windows
 - [x] test app on macOS
 - [x] test app on Linux