### PR TITLE
Don't hide commit details when commit summary description is expanded.

### DIFF
--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -9,12 +9,6 @@
   // Necessary so that the diff doesn't expand
   // beyond the width of the history
   min-width: 0;
-
-  &.expanded {
-    #commit-details {
-      display: none;
-    }
-  }
 }
 
 #commit-summary-container {


### PR DESCRIPTION
This is in response to issue #5446.

It's a simple fix that greatly improves usability.

Previous behavior (summary description collapsed):

![before change collapsed](https://user-images.githubusercontent.com/29365565/44623209-c1c39980-a87d-11e8-8375-7316e61566b8.PNG)

Previous behavior (summary description expanded):

![before change expanded](https://user-images.githubusercontent.com/29365565/44623210-c38d5d00-a87d-11e8-8123-f4d075a5405d.PNG)

Note that the expanded description unnecessarily obscures the details of the commit.

New behavior (summary description expanded):

![after change expanded](https://user-images.githubusercontent.com/29365565/44623218-ddc73b00-a87d-11e8-8dc5-76fd88032b74.PNG)

The previous collapsed behavior is unchanged.

Now the expanded description only takes up as much space as it needs. A description that is large enough will still obscure the details (and will itself scroll if it is larger than the viewport).

A further improvement could include a maximum height restriction for the description (like 25%, 50%, 75%) so that the details are always visible in any circumstance, but that requires further discussion.