### PR TITLE
add explicit dependencies to libcurl and libsecret when packaging for deb and RPM

### DIFF
--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -20,6 +20,8 @@ deb:
     - libnss3
     # dugite-native dependencies
     - libcurl3
+    # keytar dependencies
+    - libsecret-1-0
 rpm:
   depends:
     # default Electron dependencies
@@ -28,3 +30,5 @@ rpm:
     - libnotify
     # dugite-native dependencies
     - libcurl
+    # keytar dependencies
+    - libsecret

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -9,3 +9,22 @@ linux:
     - rpm
     - AppImage
   maintainer: 'GitHub, Inc <opensource+desktop@github.com>'
+deb:
+  depends:
+    # default Electron dependencies
+    - gconf2
+    - gconf-service
+    - libnotify4
+    - libappindicator1
+    - libxtst6
+    - libnss3
+    # dugite-native dependencies
+    - libcurl3
+rpm:
+  depends:
+    # default Electron dependencies
+    - libXScrnSaver
+    - libappindicator
+    - libnotify
+    # dugite-native dependencies
+    - libcurl


### PR DESCRIPTION
~~🌵 🌵 🌵 🌵 **depends on #5388, go review that first** 🌵 🌵 🌵 🌵~~ 

As part of #5388 we've switched over the embedded Git to target `curl`, and the [list of shared libraries](https://github.com/desktop/dugite-native/pull/102#issuecomment-407065593) that `dugite-native` needs to function looks like this:

```
 0x0000000000000001 (NEEDED)             Shared library: [libcurl.so.4]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
```

This PR makes the `libcurl.so.4` shared library an explicit dependency, which is available in in different upstream packages dependent on the source. The other packages in the list are the defaults that `electron-builder` generates, which we still need.

 - [x] identify packages containing `libsecret-1.so.0` and add them to the list

cc @immackay who has been looking after the Arch Linux packaging