### PR TITLE
skip fallback cache key if no match found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
             # when lock file changes, use increasingly general patterns to restore cache
             - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
             - yarn-packages-v1-{{ .Branch }}-
-            - yarn-packages-v1-
       - run:
           name: Install dependencies
           command: yarn install --force


### PR DESCRIPTION
This fixes the scenario where an electron bump like #5462 gets cached in `node_modules`, and subsequent builds from new branches are unable to roll back to an earlier version of Electron:

```sh
#!/bin/bash --login
yarn install --force
yarn install v1.9.4
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 📃  Rebuilding all packages...
error /Users/distiller/Desktop/desktop/node_modules/electron: Command failed.
Exit code: 1
Command: node install.js
Arguments: 
Directory: /Users/distiller/Desktop/desktop/node_modules/electron
Output:
/Users/distiller/Desktop/desktop/node_modules/electron/install.js:47
  throw err
  ^

Error: EEXIST: file already exists, symlink 'Versions/Current/Electron Framework' -> '/Users/distiller/Desktop/desktop/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Electron Framework'
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Exited with code 1
```

Previously we'd just bust the cache from the admin portal, but they seem to have removed that as part of the Circle CI 2.0 migration, so for the moment let's keep caches scoped to branches and the `yarn.lock` key.