### PR TITLE
Revert workaround for tooltip issue on Windows, closes #3362

### DIFF
--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -83,7 +83,8 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
 
     return (
       <button
-        aria-label={title}
+        aria-label={name}
+        title={title}
         tabIndex={-1}
         className={className}
         onClick={onClick}


### PR DESCRIPTION
This reverts commit 42c83b723c769b947d9b8313c8eee84f743bc02e and closes #3362. The upstream electron issue [electron/electron#9943](https://github.com/electron/electron/issues/9943) has been fixed.