### PR TITLE
Disable affected menu items when on detached HEAD

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -145,6 +145,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let repositorySelected = false
   let onNonDefaultBranch = false
   let onBranch = false
+  let onDetachedHead = false
   let hasDefaultBranch = false
   let hasPublishedBranch = false
   let networkActionInProgress = false
@@ -163,6 +164,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     hasDefaultBranch = Boolean(defaultBranch)
 
     onBranch = tip.kind === TipState.Valid
+    onDetachedHead = tip.kind === TipState.Detached
     tipStateIsUnknown = tip.kind === TipState.Unknown
     branchIsUnborn = tip.kind === TipState.Unborn
 
@@ -216,15 +218,15 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.setEnabled(
       'rename-branch',
-      onNonDefaultBranch && !branchIsUnborn
+      onNonDefaultBranch && !branchIsUnborn && !onDetachedHead
     )
     menuStateBuilder.setEnabled(
       'delete-branch',
-      onNonDefaultBranch && !branchIsUnborn
+      onNonDefaultBranch && !branchIsUnborn && !onDetachedHead
     )
     menuStateBuilder.setEnabled(
       'update-branch',
-      onNonDefaultBranch && hasDefaultBranch
+      onNonDefaultBranch && hasDefaultBranch && !onDetachedHead
     )
     menuStateBuilder.setEnabled('merge-branch', onBranch)
     menuStateBuilder.setEnabled(
@@ -235,7 +237,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     menuStateBuilder.setEnabled('view-repository-on-github', isHostedOnGitHub)
     menuStateBuilder.setEnabled(
       'create-pull-request',
-      isHostedOnGitHub && !branchIsUnborn
+      isHostedOnGitHub && !branchIsUnborn && !onDetachedHead
     )
     menuStateBuilder.setEnabled(
       'push',
@@ -249,6 +251,8 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       'create-branch',
       !tipStateIsUnknown && !branchIsUnborn
     )
+
+    menuStateBuilder.setEnabled('compare-to-branch', !onDetachedHead)
 
     if (
       selectedState &&


### PR DESCRIPTION
Noticed this when looking into https://github.com/desktop/desktop/issues/788. This does **NOT** address the core problem mentioned in that issue but similarly addresses concerns of confusion that can arise when you are on a detached head. There are menu items under the branch drop down that currently do nothing when in this state.