### PR TITLE
use the RichText component when rendering release notes

### DIFF
--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -177,7 +177,7 @@ export class Tokenizer {
     let nextIndex = this.scanForEndOfWord(text, index)
     let maybeMention = text.slice(index, nextIndex)
 
-    // release notes add a ! to the very last user
+    // release notes add a ! to the very last user, or use , to separate users
     if (maybeMention.endsWith('!') || maybeMention.endsWith(',')) {
       nextIndex -= 1
       maybeMention = text.slice(index, nextIndex)

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -141,6 +141,12 @@ export class Tokenizer {
       maybeIssue = text.slice(index, nextIndex)
     }
 
+    // release notes may add a full stop as part of formatting the entry
+    if (maybeIssue.endsWith('.')) {
+      nextIndex -= 1
+      maybeIssue = text.slice(index, nextIndex)
+    }
+
     if (!/^#\d+$/.test(maybeIssue)) {
       return null
     }
@@ -168,8 +174,15 @@ export class Tokenizer {
       return null
     }
 
-    const nextIndex = this.scanForEndOfWord(text, index)
-    const maybeMention = text.slice(index, nextIndex)
+    let nextIndex = this.scanForEndOfWord(text, index)
+    let maybeMention = text.slice(index, nextIndex)
+
+    // release notes add a ! to the very last user
+    if (maybeMention.endsWith('!') || maybeMention.endsWith(',')) {
+      nextIndex -= 1
+      maybeMention = text.slice(index, nextIndex)
+    }
+
     if (!/^@[a-zA-Z0-9\-]+$/.test(maybeMention)) {
       return null
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1275,6 +1275,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.ReleaseNotes:
         return (
           <ReleaseNotes
+            emoji={this.state.emoji}
             newRelease={popup.newRelease}
             onDismissed={this.onPopupDismissed}
           />

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -14,6 +14,7 @@ import { DialogHeader } from '../dialog/header'
 
 import { RichText } from '../lib/rich-text'
 import { Repository } from '../../models/repository'
+import { getDotComAPIEndpoint } from '../../lib/api'
 
 const repository = new Repository(
   '',
@@ -24,7 +25,7 @@ const repository = new Repository(
     owner: {
       id: null,
       login: 'desktop',
-      endpoint: 'https://api.github.com/',
+      endpoint: getDotComAPIEndpoint(),
       hash: '',
     },
     private: false,
@@ -32,7 +33,7 @@ const repository = new Repository(
     htmlURL: 'https://github.com/desktop/desktop',
     defaultBranch: 'master',
     cloneURL: 'https://github.com/desktop/desktop',
-    endpoint: 'https://api.github.com/',
+    endpoint: getDotComAPIEndpoint(),
     fullName: 'desktop/desktop',
     fork: false,
     hash: '',

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -8,10 +8,37 @@ import { ReleaseNote, ReleaseSummary } from '../../models/release-notes'
 import { updateStore } from '../lib/update-store'
 import { ButtonGroup } from '../lib/button-group'
 import { Button } from '../lib/button'
-import { LinkButton } from '../lib/link-button'
 
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { DialogHeader } from '../dialog/header'
+
+import { RichText } from '../lib/rich-text'
+import { Repository } from '../../models/repository'
+
+const repository = new Repository(
+  '',
+  -1,
+  {
+    dbID: null,
+    name: 'desktop',
+    owner: {
+      id: null,
+      login: 'desktop',
+      endpoint: 'https://api.github.com/',
+      hash: '',
+    },
+    private: false,
+    parent: null,
+    htmlURL: 'https://github.com/desktop/desktop',
+    defaultBranch: 'master',
+    cloneURL: 'https://github.com/desktop/desktop',
+    endpoint: 'https://api.github.com/',
+    fullName: 'desktop/desktop',
+    fork: false,
+    hash: '',
+  },
+  true
+)
 
 const ReleaseNoteHeaderLeftUri = encodePathAsUrl(
   __dirname,
@@ -22,57 +49,9 @@ const ReleaseNoteHeaderRightUri = encodePathAsUrl(
   'static/release-note-header-right.svg'
 )
 
-const externalContributionRe = /^(.*)(#\d+)(.*)(@[a-zA-Z0-9\-]+)!(.*)$/
-const otherContributionRe = /^(.*)(#\d+)(.*)$/
-
-function desktopIssueUrl(numberWithHash: string): string {
-  return `https://github.com/desktop/desktop/issues/${numberWithHash.substr(1)}`
-}
-
-function accountUrl(name: string): string {
-  return `https://github.com/${name.substr(1)}`
-}
-
-function renderLineItem(note: string): (JSX.Element | string)[] | string {
-  const externalContribution = externalContributionRe.exec(note)
-  if (externalContribution) {
-    const issueNumber = externalContribution[2]
-    const issueUrl = desktopIssueUrl(issueNumber)
-    const mention = externalContribution[4]
-    const mentionUrl = accountUrl(issueNumber)
-
-    return [
-      externalContribution[1],
-      <LinkButton key={2} uri={issueUrl}>
-        {issueNumber}
-      </LinkButton>,
-      externalContribution[3],
-      <LinkButton key={4} uri={mentionUrl}>
-        {mention}
-      </LinkButton>,
-      externalContribution[5],
-    ]
-  }
-
-  const otherContribution = otherContributionRe.exec(note)
-  if (otherContribution) {
-    const issueNumber = otherContribution[2]
-    const issueUrl = desktopIssueUrl(issueNumber)
-
-    return [
-      otherContribution[1],
-      <LinkButton key={2} uri={issueUrl}>
-        {issueNumber}
-      </LinkButton>,
-      otherContribution[3],
-    ]
-  }
-
-  return note
-}
-
 interface IReleaseNotesProps {
   readonly onDismissed: () => void
+  readonly emoji: Map<string, string>
   readonly newRelease: ReleaseSummary
 }
 
@@ -110,7 +89,16 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     const options = new Array<JSX.Element>()
 
     for (const [i, entry] of releaseEntries.entries()) {
-      options.push(<li key={i}>{renderLineItem(entry.message)}</li>)
+      options.push(
+        <li key={i}>
+          <RichText
+            text={entry.message}
+            emoji={this.props.emoji}
+            renderUrlsAsLinks={true}
+            repository={repository}
+          />
+        </li>
+      )
     }
 
     return (

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -189,7 +189,7 @@ describe('Tokenizer', () => {
       )
     })
 
-    it('renders link when sqaush and merge', () => {
+    it('renders link when squash and merge', () => {
       const id = 5203
       const expectedUri = `${htmlURL}/issues/${id}`
       const text = `Update README.md (#5203)`

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -211,6 +211,111 @@ describe('Tokenizer', () => {
       expect(results[2].text).to.equal(')')
     })
 
+    it('renders link and author mention when parsing release notes', () => {
+      const id = 5348
+      const expectedUri = `${htmlURL}/issues/${id}`
+      const text = `'Clone repository' menu item label is obscured on Windows - #5348. Thanks @Daniel-McCarthy!`
+
+      const tokenizer = new Tokenizer(emoji, repository)
+      const results = tokenizer.tokenize(text)
+      expect(results.length).to.equal(5)
+
+      expect(results[0].kind).to.equal(TokenType.Text)
+      expect(results[0].text).to.equal(
+        `'Clone repository' menu item label is obscured on Windows - `
+      )
+
+      expect(results[1].kind).to.equal(TokenType.Link)
+      const issueLink = results[1] as HyperlinkMatch
+
+      expect(issueLink.text).to.equal('#5348')
+      expect(issueLink.url).to.equal(expectedUri)
+
+      expect(results[2].kind).to.equal(TokenType.Text)
+      expect(results[2].text).to.equal('. Thanks ')
+
+      expect(results[3].kind).to.equal(TokenType.Link)
+      const userLink = results[3] as HyperlinkMatch
+
+      expect(userLink.text).to.equal('@Daniel-McCarthy')
+      expect(userLink.url).to.equal('https://github.com/Daniel-McCarthy')
+
+      expect(results[4].kind).to.equal(TokenType.Text)
+      expect(results[4].text).to.equal(`!`)
+    })
+
+    it('renders multiple issue links and mentions', () => {
+      const firstId = 3174
+      const firstExpectedUrl = `${htmlURL}/issues/${firstId}`
+      const secondId = 3184
+      const secondExpectedUrl = `${htmlURL}/issues/${secondId}`
+      const thirdId = 3207
+      const thirdExpectedUrl = `${htmlURL}/issues/${thirdId}`
+      const text =
+        'Assorted changelog typos - #3174 #3184 #3207. Thanks @strafe, @alanaasmaa and @jt2k!'
+
+      const tokenizer = new Tokenizer(emoji, repository)
+      const results = tokenizer.tokenize(text)
+      expect(results.length).to.equal(13)
+
+      expect(results[0].kind).to.equal(TokenType.Text)
+      expect(results[0].text).to.equal('Assorted changelog typos - ')
+
+      expect(results[1].kind).to.equal(TokenType.Link)
+      const firstIssueLink = results[1] as HyperlinkMatch
+
+      expect(firstIssueLink.text).to.equal('#3174')
+      expect(firstIssueLink.url).to.equal(firstExpectedUrl)
+
+      expect(results[2].kind).to.equal(TokenType.Text)
+      expect(results[2].text).to.equal(' ')
+
+      expect(results[3].kind).to.equal(TokenType.Link)
+      const secondIssueLink = results[3] as HyperlinkMatch
+
+      expect(secondIssueLink.text).to.equal('#3184')
+      expect(secondIssueLink.url).to.equal(secondExpectedUrl)
+
+      expect(results[4].kind).to.equal(TokenType.Text)
+      expect(results[4].text).to.equal(' ')
+
+      expect(results[5].kind).to.equal(TokenType.Link)
+      const thirdIssueLink = results[5] as HyperlinkMatch
+
+      expect(thirdIssueLink.text).to.equal('#3207')
+      expect(thirdIssueLink.url).to.equal(thirdExpectedUrl)
+
+      expect(results[6].kind).to.equal(TokenType.Text)
+      expect(results[6].text).to.equal('. Thanks ')
+
+      expect(results[7].kind).to.equal(TokenType.Link)
+      const firstUserLink = results[7] as HyperlinkMatch
+
+      expect(firstUserLink.text).to.equal('@strafe')
+      expect(firstUserLink.url).to.equal('https://github.com/strafe')
+
+      expect(results[8].kind).to.equal(TokenType.Text)
+      expect(results[8].text).to.equal(', ')
+
+      expect(results[9].kind).to.equal(TokenType.Link)
+      const secondUserLink = results[9] as HyperlinkMatch
+
+      expect(secondUserLink.text).to.equal('@alanaasmaa')
+      expect(secondUserLink.url).to.equal('https://github.com/alanaasmaa')
+
+      expect(results[10].kind).to.equal(TokenType.Text)
+      expect(results[10].text).to.equal(' and ')
+
+      expect(results[11].kind).to.equal(TokenType.Link)
+      const thirdUserLink = results[11] as HyperlinkMatch
+
+      expect(thirdUserLink.text).to.equal('@jt2k')
+      expect(thirdUserLink.url).to.equal('https://github.com/jt2k')
+
+      expect(results[12].kind).to.equal(TokenType.Text)
+      expect(results[12].text).to.equal(`!`)
+    })
+
     it('converts full URL to issue shorthand', () => {
       const text = `Note: we keep a "black list" of authentication methods for which we do
 not want to enable http.emptyAuth automatically. A white list would be


### PR DESCRIPTION
This PR supersedes #5494 and instead uses our current `RichText` component. I caught a couple of corner cases with our release notes that I added tests for while I was in here.

<img width="586" src="https://user-images.githubusercontent.com/359239/44798365-a01d2780-ab87-11e8-9ff5-03f1eeda0843.png">

One caveat: `RichText` relies on the `repository` prop being set to render links (because it was rendering things inside the repository view and needs to know the GitHub API details), which might have been why I avoided it initially. Not sure how I feel about stubbing a `Repository` like I have in here, but It Work™ and I think I can follow up by isolating the fields that the component _actually_ needs here.
