### PR TITLE
some tweaks to jest's default behaviour

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,17 @@ module.exports = {
     '!**/node_modules/**',
     '!**/vendor/**',
     '!**/*.d.*',
+    // skip coverage of test scripts
+    '!app/test/**/*',
+    // ignore scripts
+    '!script/**/*',
+    // not focused on testing these areas currently
+    '!app/src/ask-pass/**/*',
+    '!app/src/cli/**/*',
+    '!app/src/crash/**/*',
+    '!app/src/highlighter/**/*',
+    // ignore index files
+    '!**/index.ts',
   ],
   globals: {
     'ts-jest': {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "cli": "ts-node --require ./app/test/globals.ts --require ./app/src/cli/dev-commands-global.ts app/src/cli/main.ts",
     "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe --auto-servernum -- mocha -t 30000 --require ts-node/register app/test/integration/*.ts",
-    "test:unit": "cross-env ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron ./node_modules/jest/bin/jest --config ./jest.config.js",
+    "test:unit": "cross-env ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron ./node_modules/jest/bin/jest --silent --config ./jest.config.js",
     "test:unit:cov": "yarn test:unit --coverage",
     "test:script": "mocha -P ./tsonfig.json -t 10000 --require ts-node/register script/changelog/test/*.ts",
     "test": "yarn test:unit --runInBand && yarn test:script && yarn test:integration",


### PR DESCRIPTION
This PR adds a couple of changes on top of #5427:

 - provide `--silent` by default to suppress these console messages that occur in the test output

```
...
 PASS  app/test/unit/git/remote-test.ts
 PASS  app/test/unit/stats-store-test.ts
  ● Console

    console.warn app/node_modules/dexie/dist/dexie.js:1541
      Another connection wants to delete database 'TestStatsDatabase'. Closing db now to resume the delete request.

 PASS  app/test/unit/git/for-each-ref-test.ts
 PASS  app/test/unit/git/reset-test.ts
 PASS  app/test/unit/validated-repository-path-test.ts
 PASS  app/test/unit/infer-comparison-branch-test.ts
 PASS  app/test/unit/repositories-store-test.ts
  ● Console

    console.warn app/node_modules/dexie/dist/dexie.js:1541
      Another connection wants to delete database 'TestRepositoriesDatabase'. Closing db now to resume the delete request.
    console.warn app/node_modules/dexie/dist/dexie.js:1541
      Another connection wants to delete database 'TestRepositoriesDatabase'. Closing db now to resume the delete request.
    console.warn app/node_modules/dexie/dist/dexie.js:1541
      Another connection wants to delete database 'TestRepositoriesDatabase'. Closing db now to resume the delete request.

 PASS  app/test/unit/text-token-parser-test.ts
...
```

 - add more exclusions to the `collectCoverageFrom` array for areas that we're not interested in currently

Currently on `master` our stats look like this:

```
-------------------------------------------|----------|----------|----------|----------|-------------------|
File                                       |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------------------------------|----------|----------|----------|----------|-------------------|
All files                                  |    22.94 |    14.63 |     17.1 |    22.95 |                   |
```

With this PR, there's not much change (but it better reflects reality of what we need to test):

```
-------------------------------------|----------|----------|----------|----------|-------------------|
File                                 |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------------------------|----------|----------|----------|----------|-------------------|
All files                            |    22.56 |    14.83 |    16.88 |    22.59 |                   |
```

