### PR TITLE
Show border when commit description is expanded.

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -120,7 +120,7 @@ function messageEquals(x: Commit, y: Commit) {
 export class CommitSummary extends React.Component<
   ICommitSummaryProps,
   ICommitSummaryState
-  > {
+> {
   private descriptionScrollViewRef: HTMLDivElement | null = null
   private readonly resizeObserver: ResizeObserver | null = null
   private updateOverflowTimeoutId: number | null = null
@@ -154,7 +154,8 @@ export class CommitSummary extends React.Component<
 
   private onResized = () => {
     if (this.descriptionRef) {
-      const descriptionBottom = this.descriptionRef.getBoundingClientRect().bottom
+      const descriptionBottom = this.descriptionRef.getBoundingClientRect()
+        .bottom
       this.props.onDescriptionBottomChanged(descriptionBottom)
     }
 
@@ -297,7 +298,7 @@ export class CommitSummary extends React.Component<
       expanded: this.props.isExpanded,
       collapsed: !this.props.isExpanded,
       'has-expander': this.props.isExpanded || this.state.isOverflowed,
-      'hide-description-border': this.props.hideDescriptionBorder
+      'hide-description-border': this.props.hideDescriptionBorder,
     })
 
     return (

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -28,6 +28,10 @@ interface ICommitSummaryProps {
   readonly isExpanded: boolean
 
   readonly onExpandChanged: (isExpanded: boolean) => void
+
+  readonly onDescriptionBottomChanged: (descriptionBottom: Number) => void
+
+  readonly hideDescriptionBorder: boolean
 }
 
 interface ICommitSummaryState {
@@ -116,10 +120,11 @@ function messageEquals(x: Commit, y: Commit) {
 export class CommitSummary extends React.Component<
   ICommitSummaryProps,
   ICommitSummaryState
-> {
+  > {
   private descriptionScrollViewRef: HTMLDivElement | null = null
   private readonly resizeObserver: ResizeObserver | null = null
   private updateOverflowTimeoutId: number | null = null
+  private descriptionRef: HTMLDivElement | null = null
 
   public constructor(props: ICommitSummaryProps) {
     super(props)
@@ -148,6 +153,11 @@ export class CommitSummary extends React.Component<
   }
 
   private onResized = () => {
+    if (this.descriptionRef) {
+      const descriptionBottom = this.descriptionRef.getBoundingClientRect().bottom
+      this.props.onDescriptionBottomChanged(descriptionBottom)
+    }
+
     if (this.props.isExpanded) {
       return
     }
@@ -167,6 +177,10 @@ export class CommitSummary extends React.Component<
         this.setState({ isOverflowed: false })
       }
     }
+  }
+
+  private onDescriptionRef = (ref: HTMLDivElement | null) => {
+    this.descriptionRef = ref
   }
 
   private renderExpander() {
@@ -252,7 +266,10 @@ export class CommitSummary extends React.Component<
     }
 
     return (
-      <div className="commit-summary-description-container">
+      <div
+        className="commit-summary-description-container"
+        ref={this.onDescriptionRef}
+      >
         <div
           className="commit-summary-description-scroll-view"
           ref={this.onDescriptionScrollViewRef}
@@ -280,6 +297,7 @@ export class CommitSummary extends React.Component<
       expanded: this.props.isExpanded,
       collapsed: !this.props.isExpanded,
       'has-expander': this.props.isExpanded || this.state.isOverflowed,
+      'hide-description-border': this.props.hideDescriptionBorder
     })
 
     return (

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -46,7 +46,7 @@ interface ISelectedCommitState {
 export class SelectedCommit extends React.Component<
   ISelectedCommitProps,
   ISelectedCommitState
-  > {
+> {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
   private historyRef: HTMLDivElement | null = null
 
@@ -55,7 +55,7 @@ export class SelectedCommit extends React.Component<
 
     this.state = {
       isExpanded: false,
-      hideDescriptionBorder: false
+      hideDescriptionBorder: false,
     }
   }
 
@@ -141,7 +141,9 @@ export class SelectedCommit extends React.Component<
   private onDescriptionBottomChanged = (descriptionBottom: Number) => {
     if (this.historyRef) {
       const historyBottom = this.historyRef.getBoundingClientRect().bottom
-      this.setState({ hideDescriptionBorder: descriptionBottom >= historyBottom })
+      this.setState({
+        hideDescriptionBorder: descriptionBottom >= historyBottom,
+      })
     }
   }
 
@@ -195,11 +197,7 @@ export class SelectedCommit extends React.Component<
     const className = this.state.isExpanded ? 'expanded' : 'collapsed'
 
     return (
-      <div
-        id="history"
-        ref={this.onHistoryRef}
-        className={className}
-      >
+      <div id="history" ref={this.onHistoryRef} className={className}>
         {this.renderCommitSummary(commit)}
         <div id="commit-details">
           <Resizable

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -39,20 +39,23 @@ interface ISelectedCommitProps {
 
 interface ISelectedCommitState {
   readonly isExpanded: boolean
+  readonly hideDescriptionBorder: boolean
 }
 
 /** The History component. Contains the commit list, commit summary, and diff. */
 export class SelectedCommit extends React.Component<
   ISelectedCommitProps,
   ISelectedCommitState
-> {
+  > {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
+  private historyRef: HTMLDivElement | null = null
 
   public constructor(props: ISelectedCommitProps) {
     super(props)
 
     this.state = {
       isExpanded: false,
+      hideDescriptionBorder: false
     }
   }
 
@@ -61,6 +64,10 @@ export class SelectedCommit extends React.Component<
       this.props.repository,
       file as CommittedFileChange
     )
+  }
+
+  private onHistoryRef = (ref: HTMLDivElement | null) => {
+    this.historyRef = ref
   }
 
   public componentWillUpdate(nextProps: ISelectedCommitProps) {
@@ -121,12 +128,21 @@ export class SelectedCommit extends React.Component<
         gitHubUsers={this.props.gitHubUsers}
         onExpandChanged={this.onExpandChanged}
         isExpanded={this.state.isExpanded}
+        onDescriptionBottomChanged={this.onDescriptionBottomChanged}
+        hideDescriptionBorder={this.state.hideDescriptionBorder}
       />
     )
   }
 
   private onExpandChanged = (isExpanded: boolean) => {
     this.setState({ isExpanded })
+  }
+
+  private onDescriptionBottomChanged = (descriptionBottom: Number) => {
+    if (this.historyRef) {
+      const historyBottom = this.historyRef.getBoundingClientRect().bottom
+      this.setState({ hideDescriptionBorder: descriptionBottom >= historyBottom })
+    }
   }
 
   private onCommitSummaryReset = () => {
@@ -179,7 +195,11 @@ export class SelectedCommit extends React.Component<
     const className = this.state.isExpanded ? 'expanded' : 'collapsed'
 
     return (
-      <div id="history" className={className}>
+      <div
+        id="history"
+        ref={this.onHistoryRef}
+        className={className}
+      >
         {this.renderCommitSummary(commit)}
         <div id="commit-details">
           <Resizable

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -33,6 +33,12 @@
     }
   }
 
+  &.hide-description-border {
+    .commit-summary-description-container {
+      border-bottom: none;
+    }
+  }
+
   &.has-expander {
     .commit-summary-description {
       padding-right: 100px;

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -82,7 +82,6 @@
 
   &-description-container {
     display: flex;
-
     // So that we have something to position the expander against
     position: relative;
     border-bottom: var(--base-border);
@@ -103,6 +102,7 @@
       -webkit-user-select: text;
       user-select: text;
     }
+
     span {
       cursor: text;
     }
@@ -131,7 +131,6 @@
     display: flex;
     flex-direction: row;
     min-width: 0;
-
     margin-right: var(--spacing);
     font-size: var(--font-size-sm);
 

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -23,10 +23,6 @@
   }
 
   &.expanded {
-    .commit-summary-description-container {
-      border-bottom: none;
-    }
-
     .commit-summary-description-scroll-view {
       max-height: none;
       overflow: auto;


### PR DESCRIPTION
Fixes #5506.

Previously the border between the description and the file list was not displayed when a long description was expanded:

![previous behavior 01](https://user-images.githubusercontent.com/29365565/44821908-d28d4b80-abac-11e8-9be6-59d7b6faffa8.PNG)

Now the border is shown after expansion:

![new behaviour 01](https://user-images.githubusercontent.com/29365565/44821915-d6b96900-abac-11e8-948d-02afca4d0640.PNG)

A super long description that takes up the whole page will have it's border hidden (the original behavior before #5471):

![new behaviour 02](https://user-images.githubusercontent.com/29365565/44821928-e5078500-abac-11e8-8e8c-b49daf755f09.PNG)

Please disregard the solid black line across the bottom of the images, they are artifacts from Windows Snipping Tool (I need to find a window screenshot tool for Windows that is as elegant as the one built in to macOS, that one even adds a fancy drop shadow).

Let me know if there are any problems, or if you've got any suggestions for this fix, thanks!