### PR TITLE
Verify Clone-Repository path on focus

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -53,7 +53,7 @@ interface ICloneRepositoryState {
   /** The local path to clone to. */
   readonly path: string
 
-  /** A copy of the initial local path to clone to. */
+  /** The a copy of the default path value to compare if the current path is a different directory. */
   readonly initialPath: string
 
   /** Are we currently trying to load the entered repository? */

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -53,6 +53,9 @@ interface ICloneRepositoryState {
   /** The local path to clone to. */
   readonly path: string
 
+  /** A copy of the initial local path to clone to. */
+  readonly initialPath: string
+
   /** Are we currently trying to load the entered repository? */
   readonly loading: boolean
 
@@ -76,9 +79,11 @@ export class CloneRepository extends React.Component<
   public constructor(props: ICloneRepositoryProps) {
     super(props)
 
+    const defaultDirectory = getDefaultDir()
     this.state = {
       url: this.props.initialURL || '',
-      path: getDefaultDir(),
+      path: defaultDirectory,
+      initialPath: defaultDirectory,
       loading: false,
       error: null,
       lastParsedIdentifier: null,

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -387,7 +387,7 @@ export class CloneRepository extends React.Component<
   private onWindowFocus = () => {
     // Verify the path after focus has been regained in case changes have been made.
     const isDefaultPath =
-      this.state.initialPath === this.state.path.replace(/\/$/g, '')
+      this.state.initialPath === this.state.path
     const isURLNotEntered = this.state.url === ''
 
     if (isDefaultPath && isURLNotEntered) {

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -97,6 +97,8 @@ export class CloneRepository extends React.Component<
     if (initialURL) {
       this.updateUrl(initialURL)
     }
+
+    window.addEventListener('focus', this.onFocus)
   }
 
   public render() {
@@ -371,5 +373,12 @@ export class CloneRepository extends React.Component<
     this.props.onDismissed()
 
     setDefaultDir(Path.resolve(path, '..'))
+  }
+
+  private onFocus = () => {
+    // Verify the path after focus has been regained in case changes have been made.
+    if (this.state.url !== ``) {
+      this.updateAndValidatePath(this.state.path)
+    }
   }
 }

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -382,7 +382,18 @@ export class CloneRepository extends React.Component<
 
   private onFocus = () => {
     // Verify the path after focus has been regained in case changes have been made.
-    if (this.state.url !== ``) {
+    const isDefaultPath =
+      this.state.initialPath === this.state.path.replace(/\/$/g, '')
+    const isURLNotEntered = this.state.url === ''
+
+    if (isDefaultPath && isURLNotEntered) {
+      if (
+        this.state.error !== null &&
+        this.state.error.name === DestinationExistsErrorName
+      ) {
+        this.setState({ error: null })
+      }
+    } else {
       this.updateAndValidatePath(this.state.path)
     }
   }

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -53,7 +53,15 @@ interface ICloneRepositoryState {
   /** The local path to clone to. */
   readonly path: string
 
-  /** The a copy of the default path value to compare if the current path is a different directory. */
+  /** A copy of the path state field which is set when the component initializes.
+   *
+   *  This value, as opposed to the path state variable, doesn't change for the
+   *  lifetime of the component. Used to keep track of whether the user has
+   *  modified the path state field which influences whether we show a
+   *  warning about the directory already existing or not.
+   *
+   *  See the onWindowFocus method for more information.
+   */
   readonly initialPath: string
 
   /** Are we currently trying to load the entered repository? */

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -103,7 +103,11 @@ export class CloneRepository extends React.Component<
       this.updateUrl(initialURL)
     }
 
-    window.addEventListener('focus', this.onFocus)
+    window.addEventListener('focus', this.onWindowFocus)
+  }
+  
+  public componentWillUnmount() {
+    window.removeEventListener('focus', this.onWindowFocus)
   }
 
   public render() {
@@ -380,7 +384,7 @@ export class CloneRepository extends React.Component<
     setDefaultDir(Path.resolve(path, '..'))
   }
 
-  private onFocus = () => {
+  private onWindowFocus = () => {
     // Verify the path after focus has been regained in case changes have been made.
     const isDefaultPath =
       this.state.initialPath === this.state.path.replace(/\/$/g, '')

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -105,7 +105,7 @@ export class CloneRepository extends React.Component<
 
     window.addEventListener('focus', this.onWindowFocus)
   }
-  
+
   public componentWillUnmount() {
     window.removeEventListener('focus', this.onWindowFocus)
   }
@@ -386,8 +386,7 @@ export class CloneRepository extends React.Component<
 
   private onWindowFocus = () => {
     // Verify the path after focus has been regained in case changes have been made.
-    const isDefaultPath =
-      this.state.initialPath === this.state.path
+    const isDefaultPath = this.state.initialPath === this.state.path
     const isURLNotEntered = this.state.url === ''
 
     if (isDefaultPath && isURLNotEntered) {


### PR DESCRIPTION
This pull request is in response to Issue #4678. It aims to prevent displaying the DestinationAlreadyExists error when the path has been deleted since selecting it. Additionally, it will display the error if the path has been created after it was selected.

However, there is a current upside and drawback to the current implementation.
- If a repository to clone is selected, the path will be checked on refocus to determine if it exists and will clear or throw the destination exists error.
    
    1. This prevents continuing to display the destination exists error when they have since deleted the folder.

    2. This prevents cloning into a folder that now exists but did not when the path was selected.

- It will not verify when a repository has not been selected.

    1. This stops the error from being thrown on the initial screen. Since the default path exists, if the user opens the dialog, switches to another window, and switches back, the DestinationAlreadyExists error would throw before they have done anything.

    2. However, this means that it will not automatically clear the error when a repository has not been selected yet.


Therefore, I would love suggestions on how to improve this. I would love to have it be able to clear the error when a repository is not selected while continuing to not throw the error on the default screen before a user has changed anything.
