### PR TITLE
fix 10k file test on appveyor

### DIFF
--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -86,25 +86,30 @@ describe('git/status', () => {
       expect(files[1].path).to.equal('docs/OVERVIEW.md')
     })
 
-    it('Handles at least 10k untracked files without failing', async () => {
-      const numFiles = 10000
-      const basePath = repository!.path
+    it(
+      'Handles at least 10k untracked files without failing',
+      async () => {
+        const numFiles = 10000
+        const basePath = repository!.path
 
-      await mkdir(basePath)
+        await mkdir(basePath)
 
-      // create a lot of files
-      const promises = []
-      for (let i = 0; i < numFiles; i++) {
-        promises.push(
-          FSE.writeFile(path.join(basePath, `test-file-${i}`), 'Hey there\n')
-        )
-      }
-      await Promise.all(promises)
+        // create a lot of files
+        const promises = []
+        for (let i = 0; i < numFiles; i++) {
+          promises.push(
+            FSE.writeFile(path.join(basePath, `test-file-${i}`), 'Hey there\n')
+          )
+        }
+        await Promise.all(promises)
 
-      const status = await getStatusOrThrow(repository!)
-      const files = status.workingDirectory.files
-      expect(files.length).to.equal(numFiles)
-    })
+        const status = await getStatusOrThrow(repository!)
+        const files = status.workingDirectory.files
+        expect(files.length).to.equal(numFiles)
+      },
+      // needs a little extra time on CI
+      25000
+    )
 
     it('returns null for directory without a .git directory', async () => {
       repository = setupEmptyDirectory()

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "cli": "ts-node --require ./app/test/globals.ts --require ./app/src/cli/dev-commands-global.ts app/src/cli/main.ts",
     "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 xvfb-maybe --auto-servernum -- mocha -t 30000 --require ts-node/register app/test/integration/*.ts",
-    "test:unit": "cross-env ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron ./node_modules/jest/bin/jest --silent --config ./jest.config.js",
+    "test:unit": "cross-env ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron ./node_modules/jest/bin/jest --detectOpenHandles --silent --config ./jest.config.js",
     "test:unit:cov": "yarn test:unit --coverage",
     "test:script": "mocha -P ./tsonfig.json -t 10000 --require ts-node/register script/changelog/test/*.ts",
     "test": "yarn test:unit --runInBand && yarn test:script && yarn test:integration",


### PR DESCRIPTION
fixes #5527 

The solution for this ended up being [`--detectOpenHandles`](https://jestjs.io/docs/en/cli.html#detectopenhandles), which gave me reliable failures for the 10k untracked file test. This test was only failing because it timed out, so I increased the time limit for that one test.

thanks @shiftkey and @streeter!