### PR TITLE
add analytics for how user leverages merge hint to merge

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -19,6 +19,7 @@ import {
   ImageDiffType,
   CompareAction,
   ICompareFormUpdate,
+  MergeResultStatus,
 } from '../app-state'
 import { AppStore } from '../stores/app-store'
 import { CloningRepository } from '../../models/cloning-repository'
@@ -569,8 +570,12 @@ export class Dispatcher {
   }
 
   /** Merge the named branch into the current branch. */
-  public mergeBranch(repository: Repository, branch: string): Promise<void> {
-    return this.appStore._mergeBranch(repository, branch)
+  public mergeBranch(
+    repository: Repository,
+    branch: string,
+    mergeStatus: MergeResultStatus | null
+  ): Promise<void> {
+    return this.appStore._mergeBranch(repository, branch, mergeStatus)
   }
 
   /** Record the given launch stats. */

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -91,6 +91,12 @@ export interface IDailyMeasures {
   /** The number of times the users pushes to a generic remote */
   readonly externalPushCount: number
 
+  /** The number of times the user has merged after seeing the conflict warning */
+  readonly userProceededAfterConflictsWarning: number
+
+  /** The number of times the user has merged after seeing the 'no conflicts' warning */
+  readonly userProceededAfterNoConflictsHint: number
+
   /** Whether or not the app has been interacted with during the current reporting window */
   readonly active: boolean
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -91,11 +91,14 @@ export interface IDailyMeasures {
   /** The number of times the users pushes to a generic remote */
   readonly externalPushCount: number
 
-  /** The number of times the user has merged after seeing the conflict warning */
-  readonly proceededAfterConflictsWarningCount: number
+  /** The number of times the user merged before seeing the result of the merge hint */
+  readonly mergedWithLoadingHintCount: number
 
-  /** The number of times the user has merged after seeing the 'no conflicts' warning */
-  readonly proceededAfterNoConflictsHintCount: number
+  /** The number of times the user has merged after seeing the 'no conflicts' merge hint */
+  readonly mergedWithCleanMergeHintCount: number
+
+  /** The number of times the user has merged after seeing the 'you have XX conflicted files' warning */
+  readonly mergedWithConflictWarningHintCount: number
 
   /** Whether or not the app has been interacted with during the current reporting window */
   readonly active: boolean

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -92,10 +92,10 @@ export interface IDailyMeasures {
   readonly externalPushCount: number
 
   /** The number of times the user has merged after seeing the conflict warning */
-  readonly userProceededAfterConflictsWarning: number
+  readonly proceededAfterConflictsWarningCount: number
 
   /** The number of times the user has merged after seeing the 'no conflicts' warning */
-  readonly userProceededAfterNoConflictsHint: number
+  readonly proceededAfterNoConflictsHintCount: number
 
   /** Whether or not the app has been interacted with during the current reporting window */
   readonly active: boolean

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -51,8 +51,9 @@ const DefaultDailyMeasures: IDailyMeasures = {
   active: false,
   mergeConflictFromPullCount: 0,
   mergeConflictFromExplicitMergeCount: 0,
-  proceededAfterNoConflictsHintCount: 0,
-  proceededAfterConflictsWarningCount: 0,
+  mergedWithLoadingHintCount: 0,
+  mergedWithCleanMergeHintCount: 0,
+  mergedWithConflictWarningHintCount: 0,
 }
 
 interface ICalculatedStats {
@@ -505,18 +506,24 @@ export class StatsStore {
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
-  public async recordUserProccededAfterConflictWarning(): Promise<void> {
+  public async recordUserProccededWhileLoading(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      proceededAfterConflictsWarningCount:
-        m.proceededAfterConflictsWarningCount + 1,
+      mergedWithLoadingHintCount: m.mergedWithLoadingHintCount + 1,
     }))
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
   public async recordMergeHintSuccessAndUserProceeded(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      proceededAfterNoConflictsHintCount:
-        m.proceededAfterNoConflictsHintCount + 1,
+      mergedWithCleanMergeHintCount: m.mergedWithCleanMergeHintCount + 1,
+    }))
+  }
+
+  /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
+  public async recordUserProccededAfterConflictWarning(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      mergedWithConflictWarningHintCount:
+        m.mergedWithConflictWarningHintCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -51,6 +51,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   active: false,
   mergeConflictFromPullCount: 0,
   mergeConflictFromExplicitMergeCount: 0,
+  userProceededAfterConflictsWarning: 0,
+  userProceededAfterNoConflictsHint: 0,
 }
 
 interface ICalculatedStats {
@@ -499,6 +501,22 @@ export class StatsStore {
   public async recordPushToGenericRemote(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       externalPushCount: m.externalPushCount + 1,
+    }))
+  }
+
+  /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
+  public async recordUserProccededAfterConflictWarning(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      userProceededAfterConflictsWarning:
+        m.userProceededAfterConflictsWarning + 1,
+    }))
+  }
+
+  /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
+  public async recordMergeHintSuccessAndUserProceeded(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      userProceededAfterNoConflictsHint:
+        m.userProceededAfterNoConflictsHint + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -51,8 +51,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   active: false,
   mergeConflictFromPullCount: 0,
   mergeConflictFromExplicitMergeCount: 0,
-  userProceededAfterConflictsWarning: 0,
-  userProceededAfterNoConflictsHint: 0,
+  proceededAfterNoConflictsHintCount: 0,
+  proceededAfterConflictsWarningCount: 0,
 }
 
 interface ICalculatedStats {
@@ -507,16 +507,16 @@ export class StatsStore {
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
   public async recordUserProccededAfterConflictWarning(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      userProceededAfterConflictsWarning:
-        m.userProceededAfterConflictsWarning + 1,
+      proceededAfterConflictsWarningCount:
+        m.proceededAfterConflictsWarningCount + 1,
     }))
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
   public async recordMergeHintSuccessAndUserProceeded(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      userProceededAfterNoConflictsHint:
-        m.userProceededAfterNoConflictsHint + 1,
+      proceededAfterNoConflictsHintCount:
+        m.proceededAfterNoConflictsHintCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -506,7 +506,7 @@ export class StatsStore {
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
-  public async recordUserProccededWhileLoading(): Promise<void> {
+  public async recordUserProceededWhileLoading(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergedWithLoadingHintCount: m.mergedWithLoadingHintCount + 1,
     }))
@@ -520,7 +520,7 @@ export class StatsStore {
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
-  public async recordUserProccededAfterConflictWarning(): Promise<void> {
+  public async recordUserProceededAfterConflictWarning(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergedWithConflictWarningHintCount:
         m.mergedWithConflictWarningHintCount + 1,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3120,6 +3120,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordMergeHintSuccessAndUserProceeded()
       } else if (mergeStatus.kind === MergeResultKind.Conflicts) {
         this.statsStore.recordUserProccededAfterConflictWarning()
+      } else if (mergeStatus.kind === MergeResultKind.Loading) {
+        this.statsStore.recordUserProccededWhileLoading()
       }
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3119,9 +3119,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (mergeStatus.kind === MergeResultKind.Clean) {
         this.statsStore.recordMergeHintSuccessAndUserProceeded()
       } else if (mergeStatus.kind === MergeResultKind.Conflicts) {
-        this.statsStore.recordUserProccededAfterConflictWarning()
+        this.statsStore.recordUserProceededAfterConflictWarning()
       } else if (mergeStatus.kind === MergeResultKind.Loading) {
-        this.statsStore.recordUserProccededWhileLoading()
+        this.statsStore.recordUserProceededWhileLoading()
       }
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -25,6 +25,7 @@ import {
   ICompareBranch,
   ICompareFormUpdate,
   ICompareToBranch,
+  MergeResultStatus,
 } from '../app-state'
 import { Account } from '../../models/account'
 import {
@@ -3109,9 +3110,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public async _mergeBranch(
     repository: Repository,
-    branch: string
+    branch: string,
+    mergeStatus: MergeResultStatus | null
   ): Promise<void> {
     const gitStore = this.getGitStore(repository)
+
+    if (mergeStatus !== null) {
+      if (mergeStatus.kind === MergeResultKind.Clean) {
+        this.statsStore.recordMergeHintSuccessAndUserProceeded()
+      } else if (mergeStatus.kind === MergeResultKind.Conflicts) {
+        this.statsStore.recordUserProccededAfterConflictWarning()
+      }
+    }
+
     await gitStore.merge(branch)
 
     return this._refreshRepository(repository)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -387,17 +387,26 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private updateBranch() {
-    const state = this.state.selectedState
-    if (state == null || state.type !== SelectionType.Repository) {
+    const { selectedState } = this.state
+    if (
+      selectedState == null ||
+      selectedState.type !== SelectionType.Repository
+    ) {
       return
     }
 
-    const defaultBranch = state.state.branchesState.defaultBranch
+    const { state } = selectedState
+    const defaultBranch = state.branchesState.defaultBranch
     if (!defaultBranch) {
       return
     }
 
-    this.props.dispatcher.mergeBranch(state.repository, defaultBranch.name)
+    const { mergeStatus } = state.compareState
+    this.props.dispatcher.mergeBranch(
+      selectedState.repository,
+      defaultBranch.name,
+      mergeStatus
+    )
   }
 
   private mergeBranch() {

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -121,11 +121,15 @@ export class MergeCallToActionWithConflicts extends React.Component<
   }
 
   private onMergeClicked = async () => {
-    const { comparisonBranch, repository } = this.props
+    const { comparisonBranch, repository, mergeStatus } = this.props
 
     this.props.dispatcher.recordCompareInitiatedMerge()
 
-    await this.props.dispatcher.mergeBranch(repository, comparisonBranch.name)
+    await this.props.dispatcher.mergeBranch(
+      repository,
+      comparisonBranch.name,
+      mergeStatus
+    )
 
     this.props.dispatcher.executeCompare(repository, {
       kind: CompareActionKind.History,

--- a/app/src/ui/history/merge-call-to-action.tsx
+++ b/app/src/ui/history/merge-call-to-action.tsx
@@ -75,7 +75,8 @@ export class MergeCallToAction extends React.Component<
 
     await this.props.dispatcher.mergeBranch(
       this.props.repository,
-      formState.comparisonBranch.name
+      formState.comparisonBranch.name,
+      null
     )
 
     this.props.dispatcher.executeCompare(this.props.repository, {

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -324,7 +324,11 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       return
     }
 
-    this.props.dispatcher.mergeBranch(this.props.repository, branch.name)
+    this.props.dispatcher.mergeBranch(
+      this.props.repository,
+      branch.name,
+      this.state.mergeStatus
+    )
     this.props.dispatcher.closePopup()
   }
 


### PR DESCRIPTION
I'm not sure whether this entirely resolves (it doesn't completely) #5394 but I think this is two key metrics which will help us understand the impact of the new merge hint.

This PR checks **at merge time** what hint was shown to the user:

 - `proceededAfterNoConflictsHintCount` - the number of times a user merged with the "no conflicts" hint shown
 - `proceededAfterConflictsWarningCount` - the number of times a user merged with the "you have X conflicted files" metric

We already have some insight into how the user is initiating the merge flow (we aggregate these up into "total merges" which isn't quite accurate) but these two metrics show how many actually complete the flow and perform the merge to update their repository.

We don't report on the number of conflicted files shown by the dialog because we don't have a good story about sending those sorts of metrics, but we have that data available on `mergeStatus`.

This also requires changes to Central and `desktop.github.com`, but I'm opening this up for discussion to see whether it's on the right track.

- [x] Update Central: https://github.com/github/central/pull/397
- [x] Update marketing site: https://github.com/github/desktop.github.com/pull/115
- [x] Update metrics doc: https://github.com/desktop/desktop/pull/5556

cc @billygriffin @telliott27