### PR TITLE
Fix ordering of branches

### DIFF
--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -130,8 +130,8 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
         <p className="merge-info">
           {this.renderMergeStatusMessage(
             mergeStatus,
-            currentBranch,
             selectedBranch,
+            currentBranch,
             commitCount
           )}
         </p>


### PR DESCRIPTION
This is a <sub>tiny</sub> pull request that fixes the ordering of the branches in the merge dialog box:

🖼 **Screenshots**

(Compare the text in the footer of the dialog to the text in the compare column to the left)

**Before**
![screen shot 2018-09-05 at 2 11 40 pm](https://user-images.githubusercontent.com/1174461/45121608-81cea300-b116-11e8-82d8-f3b6d0ef7c0e.png)

**After**
![screen shot 2018-09-05 at 2 14 34 pm](https://user-images.githubusercontent.com/1174461/45121607-81cea300-b116-11e8-85ad-34e397f89399.png)
