### PR TITLE
release notes dialog spacing tweaks

### DIFF
--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -120,9 +120,11 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   private drawSingleColumnLayout(release: ReleaseSummary): JSX.Element {
     return (
       <div className="container">
-        {this.renderList(release.bugfixes, 'Bugfixes')}
-        {this.renderList(release.enhancements, 'Enhancements')}
-        {this.renderList(release.other, 'Other')}
+        <div className="column">
+          {this.renderList(release.bugfixes, 'Bugfixes')}
+          {this.renderList(release.enhancements, 'Enhancements')}
+          {this.renderList(release.other, 'Other')}
+        </div>
       </div>
     )
   }

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -62,7 +62,7 @@
 
     .column {
       flex: 1 1 275px;
-      max-width: 70%;
+      max-width: 75%;
       margin: 0 calc(var(--spacing) * 1.5);
 
       .section {

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -61,7 +61,8 @@
     justify-content: space-around;
 
     .column {
-      flex: 0 1 275px;
+      flex: 1 1 275px;
+      max-width: 70%;
       margin: 0 calc(var(--spacing) * 1.5);
 
       .section {

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -55,21 +55,17 @@
     max-height: 200px;
     display: flex;
     flex-direction: row;
-    padding-left: var(--spacing-double);
-    padding-right: var(--spacing-double);
-    margin-top: var(--spacing);
+    padding-left: var(--spacing-triple);
+    padding-right: var(--spacing-triple);
     overflow: scroll;
+    justify-content: space-around;
 
     .column {
-      width: 275px;
-
-      &:first-of-type {
-        margin-right: var(--spacing);
-      }
+      flex: 0 1 275px;
+      margin: 0 calc(var(--spacing) * 1.5);
 
       .section {
-        margin-top: var(--spacing);
-
+        margin: var(--spacing-double) 0;
         .header {
           font-size: 12px;
           font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
did a little design tweaking based on talking with @donokuda. mostly just paddings/margins.

<img width="636" alt="two columns" src="https://user-images.githubusercontent.com/964912/45126857-58b80d80-b12a-11e8-9642-fd582ff41ffd.png">

<img width="641" alt="one column" src="https://user-images.githubusercontent.com/964912/45126874-67062980-b12a-11e8-83a2-43a1ead16323.png">
