### PR TITLE
ensure the old layout is fine for users until they see the new merge hint

### DIFF
--- a/app/src/ui/history/merge-call-to-action.tsx
+++ b/app/src/ui/history/merge-call-to-action.tsx
@@ -50,7 +50,7 @@ export class MergeCallToAction extends React.Component<
     if (count > 0) {
       const pluralized = count === 1 ? 'commit' : 'commits'
       return (
-        <div className="merge-message">
+        <div className="merge-message merge-message-legacy">
           This will merge
           <strong>{` ${count} ${pluralized}`}</strong>
           {` `}

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -84,6 +84,11 @@
     }
   }
 
+  // this style can be removed once we enable the merge hint for everyone
+  .merge-message-legacy {
+    margin-top: var(--spacing);
+  }
+
   .merge-cta {
     border-top: var(--base-border);
     display: flex;


### PR DESCRIPTION
This PR ensures the existing message (which will be default until we enable the feature flag) still looks fine.

To test this out, checkout `display-merge-status-in-compare-tab` and disable the feature flag:

```diff
diff --git a/app/src/lib/feature-flag.ts b/app/src/lib/feature-flag.ts
index 1572bf5e0..7b46277b5 100644
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -44,7 +44,7 @@ export function enableRepoInfoIndicators(): boolean {
 
 /** Should the app try and detect conflicts before the user stumbles into them? */
 export function enableMergeConflictDetection(): boolean {
-  return enableDevelopmentFeatures()
+  return false
 }
 
 /** Should `git status` use --no-optional-locks to assist with concurrent usage */
```

Run it up locally and you'll see it looks more squashed compared to what we've currently shipped:

<img width="642" alt="screen shot 2018-09-07 at 10 00 45 am" src="https://user-images.githubusercontent.com/359239/45220744-a09f7780-b285-11e8-8e42-84938a86fe26.png">

This PR adds back that top margin, and indicates it can be cleaned up when we're happy with this feature:

<img width="270" alt="screen shot 2018-09-07 at 10 04 16 am" src="https://user-images.githubusercontent.com/359239/45220743-a09f7780-b285-11e8-9f31-b478979d687d.png">

cc @desktop/design for :eyes: and ideas on how to manage styles that are tied to feature flags like this.
