### PR TITLE
the first 1.4.0 beta

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.4.0-beta0",
+  "version": "1.4.0-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,16 @@
 {
   "releases": {
+    "1.4.0-beta1": [
+      "[New] Release notes for update are now displayed within Desktop - #2774",
+      "[New] Detect merge conflicts when comparing branches - #4588",
+      "[Fixed] Avoid double checkout when opening a PR in Desktop - #5375",
+      "[Fixed] Clear Displayed Publish Repository Error on change of tab - #5422. Thanks @Daniel-McCarthy!",
+      "[Fixed] Disable affected menu items when on detached HEAD - #5500. Thanks @say25!",
+      "[Fixed] Show border when commit description is expanded. - #5506. Thanks @aryyya!",
+      "[Fixed] Validate hostname when cloning a URL - #4154",
+      "[Improved] Avoid using getDefaultRemote where possible - #5399",
+      "[Improved] We don't need getStatus to always lock the index - #5376"
+    ],
     "1.4.0-beta0": [
     ],
     "1.3.5": [

--- a/changelog.json
+++ b/changelog.json
@@ -7,7 +7,7 @@
       "[Fixed] Clear error in Publish repository dialog on change of tab - #5422. Thanks @Daniel-McCarthy!",
       "[Fixed] Disable affected menu items when on detached HEAD - #5500. Thanks @say25!",
       "[Fixed] Show border when commit description is expanded. - #5506. Thanks @aryyya!",
-      "[Fixed] Clone URL with matching GitHub repository would incorrectly choose GitHub repository - #4154",
+      "[Fixed] GitLab URL which corresponds to GitHub repository of same name cloned GitHub repository - #4154",
       "[Improved] avoid multiple lookups of default remote - #5399",
       "[Improved] skip optional locks when checking status of repository - #5376"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.4.0-beta1": [
-      "[New] Release notes for update are now displayed within Desktop - #2774",
+      "[New] When an update is available for GitHub Desktop, the release notes can be viewed in Desktop - #2774",
       "[New] Detect merge conflicts when comparing branches - #4588",
       "[Fixed] Avoid double checkout warning when opening a pull request in Desktop - #5375",
       "[Fixed] Clear error in Publish repository dialog on change of tab - #5422. Thanks @Daniel-McCarthy!",

--- a/changelog.json
+++ b/changelog.json
@@ -3,13 +3,13 @@
     "1.4.0-beta1": [
       "[New] Release notes for update are now displayed within Desktop - #2774",
       "[New] Detect merge conflicts when comparing branches - #4588",
-      "[Fixed] Avoid double checkout when opening a PR in Desktop - #5375",
-      "[Fixed] Clear Displayed Publish Repository Error on change of tab - #5422. Thanks @Daniel-McCarthy!",
+      "[Fixed] Avoid double checkout warning when opening a pull request in Desktop - #5375",
+      "[Fixed] Clear error in Publish repository dialog on change of tab - #5422. Thanks @Daniel-McCarthy!",
       "[Fixed] Disable affected menu items when on detached HEAD - #5500. Thanks @say25!",
       "[Fixed] Show border when commit description is expanded. - #5506. Thanks @aryyya!",
-      "[Fixed] Validate hostname when cloning a URL - #4154",
-      "[Improved] Avoid using getDefaultRemote where possible - #5399",
-      "[Improved] We don't need getStatus to always lock the index - #5376"
+      "[Fixed] Clone URL with matching GitHub repository would incorrectly choose GitHub repository - #4154",
+      "[Improved] avoid multiple lookups of default remote - #5399",
+      "[Improved] skip optional locks when checking status of repository - #5376"
     ],
     "1.4.0-beta0": [
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -4,7 +4,7 @@
       "[New] When an update is available for GitHub Desktop, the release notes can be viewed in Desktop - #2774",
       "[New] Detect merge conflicts when comparing branches - #4588",
       "[Fixed] Avoid double checkout warning when opening a pull request in Desktop - #5375",
-      "[Fixed] Clear error in Publish repository dialog on change of tab - #5422. Thanks @Daniel-McCarthy!",
+      "[Fixed] Error when publishing repository is now associated with the right tab - #5422. Thanks @Daniel-McCarthy!",
       "[Fixed] Disable affected menu items when on detached HEAD - #5500. Thanks @say25!",
       "[Fixed] Show border when commit description is expanded. - #5506. Thanks @aryyya!",
       "[Fixed] GitLab URL which corresponds to GitHub repository of same name cloned GitHub repository - #4154",

--- a/changelog.json
+++ b/changelog.json
@@ -6,7 +6,7 @@
       "[Fixed] Avoid double checkout warning when opening a pull request in Desktop - #5375",
       "[Fixed] Error when publishing repository is now associated with the right tab - #5422. Thanks @Daniel-McCarthy!",
       "[Fixed] Disable affected menu items when on detached HEAD - #5500. Thanks @say25!",
-      "[Fixed] Show border when commit description is expanded. - #5506. Thanks @aryyya!",
+      "[Fixed] Show border when commit description is expanded - #5506. Thanks @aryyya!",
       "[Fixed] GitLab URL which corresponds to GitHub repository of same name cloned GitHub repository - #4154",
       "[Improved] avoid multiple lookups of default remote - #5399",
       "[Improved] skip optional locks when checking status of repository - #5376"

--- a/changelog.json
+++ b/changelog.json
@@ -8,8 +8,8 @@
       "[Fixed] Disable affected menu items when on detached HEAD - #5500. Thanks @say25!",
       "[Fixed] Show border when commit description is expanded - #5506. Thanks @aryyya!",
       "[Fixed] GitLab URL which corresponds to GitHub repository of same name cloned GitHub repository - #4154",
-      "[Improved] avoid multiple lookups of default remote - #5399",
-      "[Improved] skip optional locks when checking status of repository - #5376"
+      "[Improved] Avoid multiple lookups of default remote - #5399",
+      "[Improved] Skip optional locks when checking status of repository - #5376"
     ],
     "1.4.0-beta0": [
     ],


### PR DESCRIPTION
This changelog contains three features which are currently beta-only:

 - in-app release notes - #3601 
 - the merge conflict hint dialog - #5495
 - skip optional locks when doing `git status` - #5376

We need to ensure that, if we're happy to ship these features, that their corresponding entries in `feature-flag.ts` are enabled for everyone before we update `production`.

 - [x] #5495 and it's depdendent PRs are merged into `master`
 - [x] 👍 on release notes
