### PR TITLE
specify the old space limit when performing the production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "cross-env NODE_ENV=development ts-node -P script/tsconfig.json script/start.ts",
     "start:prod": "cross-env NODE_ENV=production ts-node -P script/tsconfig.json script/start.ts",
     "compile:dev": "cross-env NODE_ENV=development parallel-webpack --config app/webpack.development.ts",
-    "compile:prod": "cross-env NODE_ENV=production parallel-webpack --config app/webpack.production.ts",
+    "compile:prod": "cross-env NODE_ENV=production NODE_OPTIONS='--max_old_space_size=4096' parallel-webpack --config app/webpack.production.ts",
     "build:dev": "yarn compile:dev && cross-env NODE_ENV=development ts-node -P script/tsconfig.json script/build.ts",
     "build:prod": "yarn compile:prod && cross-env NODE_ENV=production ts-node -P script/tsconfig.json script/build.ts",
     "package": "ts-node -P script/tsconfig.json script/package.ts",


### PR DESCRIPTION
This change passes in a V8 flag when performing the webpack production build to set a limit on the old heap size. This was affecting the Windows CI agents, which have a 4GB RAM limit and the `compile:prod` step was ending up in an OOM state after spending significant time in GC.

I've run a number of builds with this change and haven't seen the VSTS or AppVeyor Windows agents fail the first attempt at building the `renderer` stage, which means the Windows builds are now faster:

  - VSTS
     - `build:prod` on current `master` took ~430sec to handle the OOM and restart
     - with this PR it now takes ~160sec
  - Appveyor
     - `build:prod` on current `master` took ~320sec to handle the OOM and restart
     - with this PR it now takes ~170sec

Hat tip to @niik for the idea rather than undertaking bigger changes.