### PR TITLE
don't show merge hint when branch can be fast-forwarded

### DIFF
--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -35,22 +35,30 @@ export class MergeCallToActionWithConflicts extends React.Component<
 
     const disabled = commitsBehind <= 0 || cannotMergeBranch
 
+    const mergeDetails = commitsBehind > 0 ? this.renderMergeStatus() : null
+
     return (
       <div className="merge-cta">
         <Button type="submit" disabled={disabled} onClick={this.onMergeClicked}>
           Merge into <strong>{this.props.currentBranch.name}</strong>
         </Button>
 
-        <div className="merge-status-component">
-          <MergeStatusHeader status={this.props.mergeStatus} />
+        {mergeDetails}
+      </div>
+    )
+  }
 
-          {this.renderMergeDetails(
-            this.props.currentBranch,
-            this.props.comparisonBranch,
-            this.props.mergeStatus,
-            commitsBehind
-          )}
-        </div>
+  private renderMergeStatus() {
+    return (
+      <div className="merge-status-component">
+        <MergeStatusHeader status={this.props.mergeStatus} />
+
+        {this.renderMergeDetails(
+          this.props.currentBranch,
+          this.props.comparisonBranch,
+          this.props.mergeStatus,
+          this.props.commitsBehind
+        )}
       </div>
     )
   }


### PR DESCRIPTION
This fixes a corner case where you are comparing to a branch that can be fast-forwarded (so no commits behind), and there's no point displaying any new UI (because we disable the merge button).

Current behaviour (1.3.5):

<img width="276" src="https://user-images.githubusercontent.com/359239/45308831-c54f5580-b4f8-11e8-99db-768ab029c6a1.png">

Current behaviour (1.4.0-beta2):

<img width="302" src="https://user-images.githubusercontent.com/359239/45308845-ca140980-b4f8-11e8-98a2-8442807f16b8.png">

New behaviour:

<img width="295" src="https://user-images.githubusercontent.com/359239/45308852-cf715400-b4f8-11e8-9e98-c68331062222.png">


