### PR TITLE
avoid the merge-tree operation work in some cases

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -987,7 +987,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return this.currentMergeTreePromise
       }
 
-      if (tip.kind === TipState.Valid) {
+      if (tip.kind === TipState.Valid && aheadBehind.behind > 0) {
         const mergeTreePromise = promiseWithMinimumTimeout(
           () => mergeTree(repository, tip.branch, action.branch),
           500

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -991,13 +991,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const mergeTreePromise = promiseWithMinimumTimeout(
           () => mergeTree(repository, tip.branch, action.branch),
           500
-        ).then(mergeStatus => {
-          this.updateCompareState(repository, () => ({
-            mergeStatus,
-          }))
+        )
+          .catch(err => {
+            log.warn(
+              `Error occurred while trying to merge ${tip.branch.name} (${
+                tip.branch.tip.sha
+              }) and ${action.branch.name} (${action.branch.tip.sha})`,
+              err
+            )
+            return null
+          })
+          .then(mergeStatus => {
+            this.updateCompareState(repository, () => ({
+              mergeStatus,
+            }))
 
-          this.emitUpdate()
-        })
+            this.emitUpdate()
+          })
 
         const cleanup = () => {
           this.currentMergeTreePromise = null

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -61,7 +61,11 @@ export class MergeCallToActionWithConflicts extends React.Component<
     mergeStatus: MergeResultStatus | null,
     behindCount: number
   ) {
-    if (mergeStatus === null || mergeStatus.kind === MergeResultKind.Loading) {
+    if (mergeStatus === null) {
+      return null
+    }
+
+    if (mergeStatus.kind === MergeResultKind.Loading) {
       return this.renderLoadingMergeMessage()
     }
     if (mergeStatus.kind === MergeResultKind.Clean) {

--- a/app/src/ui/history/merge-status-header.tsx
+++ b/app/src/ui/history/merge-status-header.tsx
@@ -20,7 +20,11 @@ export class MergeStatusHeader extends React.Component<
 > {
   public render() {
     const { status } = this.props
-    const state = status === null ? MergeResultKind.Loading : status.kind
+    if (status === null) {
+      return null
+    }
+
+    const state = status.kind
 
     return (
       <div className="merge-status-icon-container">


### PR DESCRIPTION
This relates to #5581 and investigating #5582 but tweaks some of the merge hint flow:

 - we skip performing the `mergeTree` action if the merge operation is a fast-forward only. In this case we disable the merge button anyway, so there's no point crunching any further data
 - we handle any unexpected errors from `mergeTree` and clear the `mergeStatus` state
 - when `mergeStatus` is null, we don't show any UI - this should help with some of the confusion we've heard from early beta testers