### PR TITLE
Warn user if branch exists on remote when creating branch

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -40,7 +40,7 @@ enum StartPoint {
 
 interface ICreateBranchState {
   readonly currentError: Error | null
-  readonly currentWarning: string | null
+  readonly currentWarning: JSX.Element | null
   readonly proposedName: string
   readonly sanitizedName: string
   readonly startPoint: StartPoint
@@ -304,12 +304,15 @@ export class CreateBranch extends React.Component<
       ) > -1
 
     const currentError = alreadyExists
-      ? new Error(`A branch named ${sanitizedName} already exists`)
+      ? new Error(`
+        A branch named ${sanitizedName} already exists`)
       : null
 
-    const currentWarning = alreadyExistsOnRemote
-      ? `A branch named ${sanitizedName} already exists on remote`
-      : null
+    const currentWarning = alreadyExistsOnRemote ? (
+      <p>
+        A branch named <Ref>{sanitizedName}</Ref> already exists on remote
+      </p>
+    ) : null
 
     this.setState({
       proposedName: name,

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../../lib/dispatcher'
 import { sanitizedBranchName } from '../../lib/sanitize-branch'
-import { Branch } from '../../models/branch'
+import { Branch, BranchType } from '../../models/branch'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Ref } from '../lib/ref'
@@ -299,8 +299,10 @@ export class CreateBranch extends React.Component<
 
     const alreadyExistsOnRemote =
       this.props.allBranches.findIndex(
-        b => b.name === sanitizedName && b.remote !== null
+        b =>
+          b.nameWithoutRemote === sanitizedName && b.type === BranchType.Remote
       ) > -1
+
     const currentError = alreadyExists
       ? new Error(`A branch named ${sanitizedName} already exists`)
       : null

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -56,16 +56,16 @@ export function renderBranchNameExistsOnRemoteWarning(
       b => b.nameWithoutRemote === sanitizedName && b.type === BranchType.Remote
     ) > -1
 
-  if (alreadyExistsOnRemote) {
-    return (
-      <Row className="warning-helper-text">
-        <Octicon symbol={OcticonSymbol.alert} />
-        <p>
-          A branch named <Ref>{sanitizedName}</Ref> already exists on remote.
-        </p>
-      </Row>
-    )
-  } else {
+  if (alreadyExistsOnRemote === false) {
     return null
   }
+
+  return (
+    <Row className="warning-helper-text">
+      <Octicon symbol={OcticonSymbol.alert} />
+      <p>
+        A branch named <Ref>{sanitizedName}</Ref> already exists on remote.
+      </p>
+    </Row>
+  )
 }

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Branch } from '../../models/branch'
+import { Branch, BranchType } from '../../models/branch'
 
 import { Row } from './row'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -39,6 +39,29 @@ export function renderBranchHasRemoteWarning(branch: Branch) {
         <p>
           This branch is tracking <Ref>{branch.upstream}</Ref> and renaming this
           branch will not change the branch name on the remote.
+        </p>
+      </Row>
+    )
+  } else {
+    return null
+  }
+}
+
+export function renderBranchNameExistsOnRemoteWarning(
+  sanitizedName: string,
+  branches: ReadonlyArray<Branch>
+) {
+  const alreadyExistsOnRemote =
+    branches.findIndex(
+      b => b.nameWithoutRemote === sanitizedName && b.type === BranchType.Remote
+    ) > -1
+
+  if (alreadyExistsOnRemote) {
+    return (
+      <Row className="warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+        <p>
+          A branch named <Ref>{sanitizedName}</Ref> already exists on remote.
         </p>
       </Row>
     )

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -64,7 +64,7 @@ export function renderBranchNameExistsOnRemoteWarning(
     <Row className="warning-helper-text">
       <Octicon symbol={OcticonSymbol.alert} />
       <p>
-        A branch named <Ref>{sanitizedName}</Ref> already exists on remote.
+        A branch named <Ref>{sanitizedName}</Ref> already exists on the remote.
       </p>
     </Row>
   )


### PR DESCRIPTION
Fixes #5141 

It was suggested to warn a user when attempting to create a branch with a name that already exists on remote.

Previously it already could notify and block a user from creating a branch when it existed locally. Now it can also give a to inform the user that the branch already exists on remote while allowing them to still create their local branch.
___
One matter I felt should be discussed is the design:

- The `create-branch-dialog` already allows a warning to be displayed, however it tells things like when an entered name will be sanitized and changed. This should still display and not be overwritten to display a branch exists warning.
- With this pull request, 0-2 warnings can be displayed at a time. The branch exists warning will not effect the above mentioned warnings and will be displayed additionally.

With that said, it may look _odd_ having two separate warnings and symbols. Currently this is how it behaves. Though I can change it to display both warnings, but only one symbol if both warnings are showing at once. But I would see what others think.
___
Here is what it looks like currently with 2 warnings displayed:
![image](https://user-images.githubusercontent.com/4957200/45331076-5ab90c80-b52e-11e8-8708-3c3509594785.png)

