### PR TITLE
Adding SSH Tests

### DIFF
--- a/app/test/unit/parse-app-url-test.ts
+++ b/app/test/unit/parse-app-url-test.ts
@@ -24,7 +24,7 @@ describe('parseAppURL', () => {
     })
   })
 
-  describe('openRepo', () => {
+  describe('openRepoViaHttps', () => {
     it('returns right name', () => {
       const result = parseAppURL(
         'github-mac://openRepo/https://github.com/desktop/desktop'

--- a/app/test/unit/parse-app-url-test.ts
+++ b/app/test/unit/parse-app-url-test.ts
@@ -131,9 +131,7 @@ describe('parseAppURL', () => {
       expect(result.name).to.equal('open-repository-from-url')
 
       const openRepo = result as IOpenRepositoryFromURLAction
-      expect(openRepo.url).to.equal(
-        'git@github.com/octokit/octokit.net.git'
-      )
+      expect(openRepo.url).to.equal('git@github.com/octokit/octokit.net.git')
       expect(openRepo.branch).to.equal('pr/1569')
       expect(openRepo.pr).to.equal('1569')
     })
@@ -160,9 +158,7 @@ describe('parseAppURL', () => {
       expect(result.name).to.equal('open-repository-from-url')
 
       const openRepo = result as IOpenRepositoryFromURLAction
-      expect(openRepo.url).to.equal(
-        'git@github.com/octokit/octokit.net.git'
-      )
+      expect(openRepo.url).to.equal('git@github.com/octokit/octokit.net.git')
       expect(openRepo.branch).to.equal('master')
       expect(openRepo.filepath).to.equal(
         'Octokit.Reactive/Octokit.Reactive.csproj'

--- a/app/test/unit/parse-app-url-test.ts
+++ b/app/test/unit/parse-app-url-test.ts
@@ -97,6 +97,79 @@ describe('parseAppURL', () => {
     })
   })
 
+  describe('openRepoViaSsh', () => {
+    it('returns right name', () => {
+      const result = parseAppURL(
+        'github-mac://openRepo/git@github.com/desktop/desktop'
+      )
+      expect(result.name).to.equal('open-repository-from-url')
+
+      const openRepo = result as IOpenRepositoryFromURLAction
+      expect(openRepo.url).to.equal('git@github.com/desktop/desktop.git')
+    })
+
+    it('returns unknown when no remote defined', () => {
+      const result = parseAppURL('github-mac://openRepo/')
+      expect(result.name).to.equal('unknown')
+    })
+
+    it('adds branch name if set', () => {
+      const result = parseAppURL(
+        'github-mac://openRepo/git@github.com/desktop/desktop?branch=cancel-2fa-flow'
+      )
+      expect(result.name).to.equal('open-repository-from-url')
+
+      const openRepo = result as IOpenRepositoryFromURLAction
+      expect(openRepo.url).to.equal('git@github.com/desktop/desktop.git')
+      expect(openRepo.branch).to.equal('cancel-2fa-flow')
+    })
+
+    it('adds pull request ID if found', () => {
+      const result = parseAppURL(
+        'github-mac://openRepo/git@github.com/octokit/octokit.net?branch=pr%2F1569&pr=1569'
+      )
+      expect(result.name).to.equal('open-repository-from-url')
+
+      const openRepo = result as IOpenRepositoryFromURLAction
+      expect(openRepo.url).to.equal(
+        'git@github.com/octokit/octokit.net.git'
+      )
+      expect(openRepo.branch).to.equal('pr/1569')
+      expect(openRepo.pr).to.equal('1569')
+    })
+
+    it('returns unknown for unexpected pull request input', () => {
+      const result = parseAppURL(
+        'github-mac://openRepo/git@github.com/octokit/octokit.net?branch=bar&pr=foo'
+      )
+      expect(result.name).to.equal('unknown')
+    })
+
+    it('returns unknown for invalid branch name', () => {
+      // branch=<>
+      const result = parseAppURL(
+        'github-mac://openRepo/git@github.com/octokit/octokit.net?branch=%3C%3E'
+      )
+      expect(result.name).to.equal('unknown')
+    })
+
+    it('adds file path if found', () => {
+      const result = parseAppURL(
+        'github-mac://openRepo/git@github.com/octokit/octokit.net?branch=master&filepath=Octokit.Reactive%2FOctokit.Reactive.csproj'
+      )
+      expect(result.name).to.equal('open-repository-from-url')
+
+      const openRepo = result as IOpenRepositoryFromURLAction
+      expect(openRepo.url).to.equal(
+        'git@github.com/octokit/octokit.net.git'
+      )
+      expect(openRepo.branch).to.equal('master')
+      expect(openRepo.filepath).to.equal(
+        'Octokit.Reactive/Octokit.Reactive.csproj'
+      )
+    })
+  })
+
   describe('openLocalRepo', () => {
     it('parses local paths', () => {
       const path = __WIN32__

--- a/app/test/unit/parse-app-url-test.ts
+++ b/app/test/unit/parse-app-url-test.ts
@@ -24,7 +24,7 @@ describe('parseAppURL', () => {
     })
   })
 
-  describe('openRepoViaHttps', () => {
+  describe('openRepo via HTTPS', () => {
     it('returns right name', () => {
       const result = parseAppURL(
         'github-mac://openRepo/https://github.com/desktop/desktop'
@@ -97,7 +97,7 @@ describe('parseAppURL', () => {
     })
   })
 
-  describe('openRepoViaSsh', () => {
+  describe('openRepo via SSH', () => {
     it('returns right name', () => {
       const result = parseAppURL(
         'github-mac://openRepo/git@github.com/desktop/desktop'


### PR DESCRIPTION
Saw https://github.com/desktop/desktop/pull/5576 and remembered how I typically clone via URL with SSH. 

I had realized there were no tests so I thought I would add them. Tests are the same as the set I renamed to `openRepoViaHttps` with different URL strings.