### PR TITLE
use the default scrolling to avoid rendering issue on Windows

### DIFF
--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -57,7 +57,7 @@
     flex-direction: row;
     padding-left: var(--spacing-triple);
     padding-right: var(--spacing-triple);
-    overflow: scroll;
+    overflow: auto;
     justify-content: space-around;
 
     .column {


### PR DESCRIPTION
Fixes this comment: https://github.com/desktop/desktop/pull/3601#issuecomment-420137311

If you would like to test this out yourself, the [`fix-overflow-style-for-windows-testing`](https://github.com/desktop/desktop/tree/fix-overflow-style-for-windows-testing) branch is setup for local testing.

**Note:** all screenshots show scrolling (to indicate that the overflow content is still visible) and also the lack of the visual artefact. This was a bit of a timesaver rather than GIF-ing them all.

Windows (default theme):

<img width="622" src="https://user-images.githubusercontent.com/359239/45358273-54af4400-b59f-11e8-9592-ea7125e2ca84.png">

Windows (dark theme):

<img width="610" src="https://user-images.githubusercontent.com/359239/45358269-50832680-b59f-11e8-824d-381af92671ba.png">

macOS (default theme):

<img width="610" src="https://user-images.githubusercontent.com/359239/45358556-2847f780-b5a0-11e8-8052-51f5fff12173.png">

macOS (dark theme):

<img width="630" src="https://user-images.githubusercontent.com/359239/45358537-19f9db80-b5a0-11e8-828f-66402ed4fce1.png">


