### PR TITLE
enable upcoming features for all users

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -44,12 +44,12 @@ export function enableRepoInfoIndicators(): boolean {
 
 /** Should the app try and detect conflicts before the user stumbles into them? */
 export function enableMergeConflictDetection(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 /** Should the app display the new release notes dialog? */
 export function enableInAppReleaseNotes(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 /** Should `git status` use --no-optional-locks to assist with concurrent usage */


### PR DESCRIPTION
I've left `enableStatusWithoutOptionalLocks()` enabled for just beta users because I don't believe it completely resolves our problems around handling `index.lock` - see #908 for more details.

Also, the last time we rolled out a change to `getStatus` it uncovered some corner cases, so I'd like more time and QA on this work. So for now, we just need to drop the mention of this entry in the finalized release notes:

```
"[Improved] Skip optional locks when checking status of repository - #5376"
```


