### PR TITLE
Branch names no longer allow starting with a plus

### DIFF
--- a/app/src/lib/sanitize-branch.ts
+++ b/app/src/lib/sanitize-branch.ts
@@ -6,7 +6,7 @@ const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]+|@{|\.\.+|^\.|\.$|\
 
 /** Sanitize a proposed branch name by replacing illegal characters. */
 export function sanitizedBranchName(name: string): string {
-  return name.replace(invalidCharacterRegex, '-').replace(/^[-\+]/g, '')
+  return name.replace(invalidCharacterRegex, '-').replace(/^[-\+]*/g, '')
 }
 
 /** Validate a branch does not contain any invalid characters */

--- a/app/src/lib/sanitize-branch.ts
+++ b/app/src/lib/sanitize-branch.ts
@@ -6,7 +6,7 @@ const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]+|@{|\.\.+|^\.|\.$|\
 
 /** Sanitize a proposed branch name by replacing illegal characters. */
 export function sanitizedBranchName(name: string): string {
-  return name.replace(invalidCharacterRegex, '-').replace(/^-/g, '')
+  return name.replace(invalidCharacterRegex, '-').replace(/^[-\+]/g, '')
 }
 
 /** Validate a branch does not contain any invalid characters */

--- a/app/test/unit/sanitize-test-name-test.ts
+++ b/app/test/unit/sanitize-test-name-test.ts
@@ -21,6 +21,12 @@ describe('sanitizedBranchName', () => {
     expect(result).to.equal('hello-')
   })
 
+  it('does not allow name to start with plus', () => {
+    const branchName = '+but-can-still-keep-the-rest'
+    const result = sanitizedBranchName(branchName)
+    expect(result).to.equal('but-can-still-keep-the-rest')
+  })
+
   it('does not allow name to end in `.lock`', () => {
     const branchName = 'foo.lock.lock'
     const result = sanitizedBranchName(branchName)

--- a/app/test/unit/sanitize-test-name-test.ts
+++ b/app/test/unit/sanitize-test-name-test.ts
@@ -27,6 +27,12 @@ describe('sanitizedBranchName', () => {
     expect(result).to.equal('but-can-still-keep-the-rest')
   })
 
+  it('does not allow name to start with minus', () => {
+    const branchName = '-but-can-still-keep-the-rest'
+    const result = sanitizedBranchName(branchName)
+    expect(result).to.equal('but-can-still-keep-the-rest')
+  })
+
   it('does not allow name to end in `.lock`', () => {
     const branchName = 'foo.lock.lock'
     const result = sanitizedBranchName(branchName)

--- a/app/test/unit/sanitize-test-name-test.ts
+++ b/app/test/unit/sanitize-test-name-test.ts
@@ -22,13 +22,13 @@ describe('sanitizedBranchName', () => {
   })
 
   it('does not allow name to start with plus', () => {
-    const branchName = '+but-can-still-keep-the-rest'
+    const branchName = '++but-can-still-keep-the-rest'
     const result = sanitizedBranchName(branchName)
     expect(result).to.equal('but-can-still-keep-the-rest')
   })
 
   it('does not allow name to start with minus', () => {
-    const branchName = '-but-can-still-keep-the-rest'
+    const branchName = '--but-can-still-keep-the-rest'
     const result = sanitizedBranchName(branchName)
     expect(result).to.equal('but-can-still-keep-the-rest')
   })


### PR DESCRIPTION
Fixes #5594. This is in response to an issue mentioning getting fatal "invalid refspec" errors when creating a branch that begins with +. (For example `+` or `+A`)

Branch names like `A+B` are allowed and do not result in this error. Therefore I have updated the branch name sanitization regular expression to replace '+' if it is the beginning character (and not replace it if it is anywhere after the first character).

This is the behavior with these changes:
![peek 2018-09-11 14-41](https://user-images.githubusercontent.com/4957200/45390968-de363480-b5e6-11e8-8286-eb3392a25aa4.gif)

___
On the original Issue there is discussion about potentially adding to or updating warnings regarding invalid branch names. I have added more details about the current behavior. If there's any changes needed regarding that matter I would be happy to add them in this or a follow up pull request.
___
I have additionally added two unit tests. Branch names already were not allowed to start with `-`. However, there was no unit test verifying this functionality. I have added one, and one that verifies the same for the `+` at the start of a name.

I found two more things worth mentioning related to these unit tests:
- The name of the unit test file is `sanitize-test-name-test`. However, this is somewhat confusing. Perhaps it should be named `sanitize-branch-name-test`?
- `sanitize-test-name-test` only tests branch names. There does not appear to be any tests for sanitizing repository names. I would be happy to add some as a follow up to this pull request.
