### PR TITLE
improved error handling when checking the merge base of a missing reference

### DIFF
--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -29,12 +29,14 @@ export async function getMergeBase(
     repository.path,
     'merge-base',
     {
-      // 1 is returned if a common ancestor cannot be resolved
-      successExitCodes: new Set([0, 1]),
+      // - 1 is returned if a common ancestor cannot be resolved
+      // - 128 is returned if a ref cannot be found
+      //   "warning: ignoring broken ref refs/remotes/origin/master."
+      successExitCodes: new Set([0, 1, 128]),
     }
   )
 
-  if (process.exitCode === 1) {
+  if (process.exitCode === 1 || process.exitCode === 128) {
     return null
   }
 

--- a/app/test/unit/git/merge-test.ts
+++ b/app/test/unit/git/merge-test.ts
@@ -67,5 +67,22 @@ describe('git/merge', () => {
       const ref = await getMergeBase(repository, first.tip.sha, second.tip.sha)
       expect(ref).is.null
     })
+
+    it('returns null when the branches do not have a common ancestor', async () => {
+      const repository = await setupEmptyRepository()
+
+      // create the first commit
+      await GitProcess.exec(
+        ['commit', '--allow-empty', '-m', `first commit on master`],
+        repository.path
+      )
+
+      const ref = await getMergeBase(
+        repository,
+        'master',
+        'origin/some-unknown-branch'
+      )
+      expect(ref).is.null
+    })
   })
 })

--- a/app/test/unit/git/merge-test.ts
+++ b/app/test/unit/git/merge-test.ts
@@ -68,7 +68,7 @@ describe('git/merge', () => {
       expect(ref).is.null
     })
 
-    it('returns null when the branches do not have a common ancestor', async () => {
+    it('returns null when a ref cannot be found', async () => {
       const repository = await setupEmptyRepository()
 
       // create the first commit


### PR DESCRIPTION
Found this one while investigating #5596

```
2018-09-10T03:28:41.053Z - error: [ui] `git merge-base master origin/master` exited with an unexpected code: 128.
warning: ignoring broken ref refs/remotes/origin/master.
fatal: Not a valid object name origin/master
```

 - [x] add failing test
 - [x] handle and return `null` to indicate it cannot be resolved