### PR TITLE
bump to latest 2.0.x version of Electron

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 2.0.5
+target = 2.0.8
 arch = x64

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 2.0.8
+target = 2.0.9
 arch = x64

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "2.0.8",
+    "electron": "2.0.9",
     "electron-builder": "20.27.1",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "2.0.5",
+    "electron": "2.0.8",
     "electron-builder": "20.27.1",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3008,9 +3008,9 @@ electron-winstaller@2.5.2:
     lodash.template "^4.2.2"
     temp "^0.8.3"
 
-electron@2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
+electron@2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.9.tgz#dfc863d653fa3a2dd4fea0c63303df9c0e33c602"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3008,9 +3008,9 @@ electron-winstaller@2.5.2:
     lodash.template "^4.2.2"
     temp "^0.8.3"
 
-electron@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.5.tgz#6045db011e2547062a36e8c5da84d4982f434fc0"
+electron@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
It looks like Electron 3.0 is close to landing, so making the jump up to the latest stable release of Electron 2 will help with testing once we decide to dip our toes into the next major versions of Node and Chromium:

 - [x] exploratory testing on macOS
 - [x] exploratory testing on Windows
 - [x] exploratory testing on Ubuntu 18.04