### PR TITLE
upgrade node-sass to a version that supports Node 10

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -12,32 +12,32 @@
 $overlay-background-color: rgba(0, 0, 0, 0.4);
 
 :root {
-  --color-new: $green;
-  --color-deleted: $red;
-  --color-modified: $yellow-700;
-  --color-renamed: $blue;
-  --color-conflicted: $orange;
+  --color-new: #{$green};
+  --color-deleted: #{$red};
+  --color-modified: #{$yellow-700};
+  --color-renamed: #{$blue};
+  --color-conflicted: #{$orange};
 
-  --text-color: $gray-900;
-  --text-secondary-color: $gray-500;
-  --background-color: $white;
+  --text-color: #{$gray-900};
+  --text-secondary-color: #{$gray-500};
+  --background-color: #{$white};
 
   --button-height: 25px;
 
-  --button-background: $blue;
+  --button-background: #{$blue};
   --button-border-radius: 2px;
-  --button-hover-background: lighten($blue, 5%);
-  --button-text-color: $white;
-  --button-focus-border-color: $blue-600;
+  --button-hover-background: #{lighten($blue, 5%)};
+  --button-text-color: #{$white};
+  --button-focus-border-color: #{$blue-600};
 
-  --link-button-color: $blue;
-  --link-button-hover-color: $blue-600;
+  --link-button-color: #{$blue};
+  --link-button-hover-color: #{$blue-600};
 
-  --secondary-button-background: $gray-000;
-  --secondary-button-hover-background: $white;
+  --secondary-button-background: #{$gray-000};
+  --secondary-button-hover-background: #{$white};
   --secondary-button-text-color: var(--text-color);
-  --secondary-button-focus-shadow-color: rgba($gray-200, 0.75);
-  --secondary-button-focus-border-color: $gray-300;
+  --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};
+  --secondary-button-focus-border-color: #{$gray-300};
 
   // Typography
   //
@@ -90,19 +90,19 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // to decide what states to support (active selection, selection, etc).
 
   --box-background-color: var(--background-color);
-  --box-alt-background-color: $gray-100;
+  --box-alt-background-color: #{$gray-100};
 
   /**
    * Background color for skeleton or "loading" boxes
    */
-  --box-skeleton-background-color: $gray-200;
+  --box-skeleton-background-color: #{$gray-200};
   --skeleton-background-gradient: -webkit-linear-gradient(left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0) 100%);
 
   /**
    * Border color for boxes.
    */
-  --box-border-color: $gray-200;
-  --box-border-accent-color: $blue;
+  --box-border-color: #{$gray-200};
+  --box-border-accent-color: #{$blue};
 
   /**
    * Background color for selected boxes without keyboard focus
@@ -115,7 +115,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * implement a hover state since this will conflict with
    * selection and active selection
    */
-  --box-hover-text-color: $gray-900;
+  --box-hover-text-color: #{$gray-900};
 
   /**
    * Background color for when a user hovers over a boxe with a
@@ -127,47 +127,47 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   /**
    * Text color for selected boxes without keyboard focus
    */
-  --box-selected-text-color: $gray-900;
+  --box-selected-text-color: #{$gray-900};
 
   /**
    * Border color for selected boxes without keyboard focus
    */
-  --box-selected-border-color: $gray-400;
+  --box-selected-border-color: #{$gray-400};
 
   /**
    * Background color for selected boxes with active keyboard focus
    */
-  --box-selected-active-background-color: $blue;
+  --box-selected-active-background-color: #{$blue};
 
   /**
    * Text color for selected boxes with active keyboard focus
    */
-  --box-selected-active-text-color: $white;
+  --box-selected-active-text-color: #{$white};
 
   /**
    * Border color for selected boxes with active keyboard focus
    */
-  --box-selected-active-border-color: $gray-400;
+  --box-selected-active-border-color: #{$gray-400};
 
   /**
    * Gradient used to indicate that content is overflowing, intended
    * for use when content can be expanded through other means than
    * scrolling.
    */
-  --box-overflow-shadow-background: linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%);
+  --box-overflow-shadow-background: #{linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%)};
 
   /**
    * Author input (co-authors)
    */
-  --co-author-tag-background-color: $blue-000;
-  --co-author-tag-border-color: $blue-200;
+  --co-author-tag-background-color: #{$blue-000};
+  --co-author-tag-border-color: #{$blue-200};
 
   /**
    * The height of the title bar area on Win32 platforms
    * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
   */
   --win32-title-bar-height: 28px;
-  --win32-title-bar-background-color: $gray-900;
+  --win32-title-bar-background-color: #{$gray-900};
 
   /**
    * The height of the title bar area on darwin platforms
@@ -190,30 +190,30 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --toolbar-height: 50px;
 
-  --toolbar-background-color: $gray-900;
-  --toolbar-border-color: $gray-900;
-  --toolbar-text-color: $white;
-  --toolbar-text-secondary-color: $gray-300;
+  --toolbar-background-color: #{$gray-900};
+  --toolbar-border-color: #{$gray-900};
+  --toolbar-text-color: #{$white};
+  --toolbar-text-secondary-color: #{$gray-300};
 
   --toolbar-button-color: var(--toolbar-text-color);
   --toolbar-button-background-color: transparent;
   --toolbar-button-border-color: black;
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
-  --toolbar-button-hover-color: $white;
-  --toolbar-button-hover-background-color: $gray-800;
+  --toolbar-button-hover-color: #{$white};
+  --toolbar-button-hover-background-color: #{$gray-800};
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: $gray-800;
+  --toolbar-button-focus-background-color: #{$gray-800};
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);
   --toolbar-button-active-border-color: var(--background-color);
 
-  --toolbar-button-progress-color: $gray-800;
-  --toolbar-button-focus-progress-color: $gray-700;
-  --toolbar-button-hover-progress-color: $gray-700;
-  --toolbar-dropdown-open-progress-color: $gray-200;
+  --toolbar-button-progress-color: #{$gray-800};
+  --toolbar-button-focus-progress-color: #{$gray-700};
+  --toolbar-button-hover-progress-color: #{$gray-700};
+  --toolbar-dropdown-open-progress-color: #{$gray-200};
 
   /**
    * App menu bar colors (Windows/Linux only)
@@ -234,28 +234,28 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
     * push/pull button and the PR badge in the branch drop
     * down button.
     */
-  --toolbar-badge-background-color: $gray-600;
-  --toolbar-badge-active-background-color: $gray-200;
+  --toolbar-badge-background-color: #{$gray-600};
+  --toolbar-badge-active-background-color: #{$gray-200};
 
   --tab-bar-height: 29px;
-  --tab-bar-active-color: $blue;
-  --tab-bar-background-color: $white;
+  --tab-bar-active-color: #{$blue};
+  --tab-bar-background-color: #{$white};
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);
-  --tab-bar-count-background-color: $gray-200;
+  --tab-bar-count-background-color: #{$gray-200};
 
   /**
     * Badge colors when used inside of list items.
     * Example of this is the change indicators inside
     * of the repository list.
     */
-  --list-item-badge-color: $gray-800;
-  --list-item-badge-background-color: $gray-200;
-  --list-item-selected-badge-color: $gray-900;
-  --list-item-selected-badge-background-color: $gray-300;
-  --list-item-selected-active-badge-color: $gray-900;
-  --list-item-selected-active-badge-background-color: $white;
+  --list-item-badge-color: #{$gray-800};
+  --list-item-badge-background-color: #{$gray-200};
+  --list-item-selected-badge-color: #{$gray-900};
+  --list-item-selected-badge-background-color: #{$gray-300};
+  --list-item-selected-active-badge-color: #{$gray-900};
+  --list-item-selected-active-badge-background-color: #{$white};
 
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
@@ -277,17 +277,17 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * percentage changing or the app toggling between full screen and normal
    * window mode.
    */
-  --toast-notification-color: $gray-000;
-  --toast-notification-background-color: rgba($gray-900, 0.6);
+  --toast-notification-color: #{$gray-000};
+  --toast-notification-background-color: #{rgba($gray-900, 0.6)};
 
   /** The highlight color used for focus rings and focus box shadows */
-  --focus-color: $blue;
+  --focus-color: #{$blue};
 
   /**
    * Variables for form elements
    */
   --text-field-height: 25px;
-  --text-field-focus-shadow-color: rgba($blue, 0.25);
+  --text-field-focus-shadow-color: #{rgba($blue, 0.25)};
 
   /**
    * Diff view
@@ -295,52 +295,52 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --diff-line-padding-y: 2px;
 
-  --diff-text-color: $gray-900;
-  --diff-border-color: $gray-200;
-  --diff-gutter-color: $gray-200;
+  --diff-text-color: #{$gray-900};
+  --diff-border-color: #{$gray-200};
+  --diff-gutter-color: #{$gray-200};
   --diff-gutter-background-color: var(--background-color);
 
-  --diff-line-number-color: $gray-700;
+  --diff-line-number-color: #{$gray-700};
   --diff-line-number-column-width: 50px;
 
-  --diff-selected-background-color: $blue-400;
-  --diff-selected-border-color: $blue-600;
-  --diff-selected-gutter-color: $blue-600;
+  --diff-selected-background-color: #{$blue-400};
+  --diff-selected-border-color: #{$blue-600};
+  --diff-selected-gutter-color: #{$blue-600};
   --diff-selected-text-color: var(--background-color);
 
-  --diff-add-background-color: darken($green-000, 2%);
-  --diff-add-border-color: $green-300;
-  --diff-add-gutter-color: $green-300;
-  --diff-add-gutter-background-color: darken($green-100, 3%);
+  --diff-add-background-color: #{darken($green-000, 2%)};
+  --diff-add-border-color: #{$green-300};
+  --diff-add-gutter-color: #{$green-300};
+  --diff-add-gutter-background-color: #{darken($green-100, 3%)};
   --diff-add-inner-background-color: #acf2bd;
-  --diff-add-text-color: var(--diff-text-color);
 
-  --diff-delete-background-color: $red-000;
-  --diff-delete-border-color: $red-200;
-  --diff-delete-gutter-color: $red-200;
-  --diff-delete-gutter-background-color: $red-100;
+  --diff-add-text-color: var(--diff-text-color);
+  --diff-delete-background-color: #{$red-000};
+  --diff-delete-border-color: #{$red-200};
+  --diff-delete-gutter-color: #{$red-200};
+  --diff-delete-gutter-background-color: #{$red-100};
   --diff-delete-inner-background-color: #fdb8c0;
   --diff-delete-text-color: var(--diff-text-color);
 
-  --diff-hunk-background-color: $blue-000;
-  --diff-hunk-border-color: $blue-200;
-  --diff-hunk-gutter-color: darken($blue-200, 5%);
-  --diff-hunk-gutter-background-color: $blue-100;
-  --diff-hunk-text-color: $gray;
+  --diff-hunk-background-color: #{$blue-000};
+  --diff-hunk-border-color: #{$blue-200};
+  --diff-hunk-gutter-color: #{darken($blue-200, 5%)};
+  --diff-hunk-gutter-background-color: #{$blue-100};
+  --diff-hunk-text-color: #{$gray};
 
-  --diff-hover-background-color: $blue-300;
-  --diff-hover-border-color: $blue-400;
-  --diff-hover-gutter-color: $blue-400;
+  --diff-hover-background-color: #{$blue-300};
+  --diff-hover-border-color: #{$blue-400};
+  --diff-hover-gutter-color: #{$blue-400};
   --diff-hover-text-color: var(--background-color);
 
-  --diff-add-hover-background-color: $green-300;
-  --diff-add-hover-border-color: $green-400;
-  --diff-add-hover-gutter-color: $green-400;
+  --diff-add-hover-background-color: #{$green-300};
+  --diff-add-hover-border-color: #{$green-400};
+  --diff-add-hover-gutter-color: #{$green-400};
   --diff-add-hover-text-color: var(--text-color);
 
-  --diff-delete-hover-background-color: $red-200;
-  --diff-delete-hover-border-color: $red-300;
-  --diff-delete-hover-gutter-color: $red-300;
+  --diff-delete-hover-background-color: #{$red-200};
+  --diff-delete-hover-border-color: #{$red-300};
+  --diff-delete-hover-gutter-color: #{$red-300};
   --diff-delete-hover-text-color: var(--text-color);
 
   // Syntax highlighting text colors
@@ -351,7 +351,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --syntax-string-color: #032f62;
   --syntax-qualifier-color: #6f42c1;
   --syntax-type-color: #d73a49;
-  --syntax-comment-color: $gray-500;
+  --syntax-comment-color: #{$gray-500};
   --syntax-tag-color: #22863a;
   --syntax-attribute-color: #6f42c1;
   --syntax-link-color: #032f62;
@@ -362,25 +362,25 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --undo-animation-duration: 500ms;
 
   // Colors for form errors
-  --error-color: $red;
-  --form-error-background: $red-100;
-  --form-error-border-color: $red-200;
-  --form-error-text-color: $red-800;
+  --error-color: #{$red};
+  --form-error-background: #{$red-100};
+  --form-error-border-color: #{$red-200};
+  --form-error-text-color: #{$red-800};
 
   /** Overlay is used as a background for both modals and foldouts */
-  --overlay-background-color: $overlay-background-color;
+  --overlay-background-color: #{$overlay-background-color};
 
   /** Dialog */
-  --dialog-warning-color: $yellow-600;
-  --dialog-error-color: $red;
+  --dialog-warning-color: #{$yellow-600};
+  --dialog-error-color: #{$red};
 
   /** Inline paths and code */
-  --path-segment-background: $blue-000;
+  --path-segment-background: #{$blue-000};
   --path-segment-padding: var(--spacing-third);
 
   /** Diverging notification banner colors */
-  --notification-banner-background: $blue-000;
-  --notification-banner-border-color: $blue-200;
+  --notification-banner-background: #{$blue-000};
+  --notification-banner-border-color: #{$blue-200};
   --notification-ref-background: rgba(255, 255, 255, 0.75);
 
   // http://easings.net/#easeOutBack
@@ -394,5 +394,5 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 }
 
 ::backdrop {
-  --overlay-background-color: $overlay-background-color;
+  --overlay-background-color: #{$overlay-background-color};
 }

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -6,29 +6,29 @@
 @import '~primer-support/lib/variables/color-system.scss';
 
 body.theme-dark {
-  --color-new: $green;
-  --color-deleted: $red;
-  --color-modified: $yellow-700;
-  --color-renamed: $blue;
-  --color-conflicted: $orange;
+  --color-new: #{$green};
+  --color-deleted: #{$red};
+  --color-modified: #{$yellow-700};
+  --color-renamed: #{$blue};
+  --color-conflicted: #{$orange};
 
-  --text-color: $gray-300;
-  --text-secondary-color: $gray-400;
-  --background-color: $gray-900;
+  --text-color: #{$gray-300};
+  --text-secondary-color: #{$gray-400};
+  --background-color: #{$gray-900};
 
-  --button-background: $blue;
-  --button-hover-background: lighten($blue, 5%);
-  --button-text-color: $white;
-  --button-focus-border-color: $blue-600;
+  --button-background: #{$blue};
+  --button-hover-background: #{lighten($blue, 5%)};
+  --button-text-color: #{$white};
+  --button-focus-border-color: #{$blue-600};
 
-  --link-button-color: lighten($blue-400, 3%);
-  --link-button-hover-color: $blue-400;
+  --link-button-color: #{lighten($blue-400, 3%)};
+  --link-button-hover-color: #{$blue-400};
 
-  --secondary-button-background: $gray-800;
+  --secondary-button-background: #{$gray-800};
   --secondary-button-hover-background: var(--secondary-button-background);
   --secondary-button-text-color: var(--text-color);
-  --secondary-button-focus-shadow-color: rgba($gray-200, 0.75);
-  --secondary-button-focus-border-color: $gray-300;
+  --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};
+  --secondary-button-focus-border-color: #{$gray-300};
 
   /**
    * Background color for custom scroll bars.
@@ -53,25 +53,25 @@ body.theme-dark {
   // or an item in a tab control header. It's up to each implementation
   // to decide what states to support (active selection, selection, etc).
 
-  --box-background-color: darken($gray-900, 3%);
-  --box-alt-background-color: $gray-800;
+  --box-background-color: #{darken($gray-900, 3%)};
+  --box-alt-background-color: #{$gray-800};
 
   /**
    * Background color for skeleton or "loading" boxes
    */
-  --box-skeleton-background-color: $gray-700;
+  --box-skeleton-background-color: #{$gray-700};
   --skeleton-background-gradient: -webkit-linear-gradient(left, rgba(36, 41, 46, 0) 0%, rgba(36, 41, 46, 0.5) 50%, rgba(36, 41, 46, 0) 100%);
 
   /**
    * Border color for boxes.
    */
   --box-border-color: #141414;
-  --box-border-accent-color: $blue;
+  --box-border-accent-color: #{$blue};
 
   /**
    * Background color for selected boxes without keyboard focus
    */
-  --box-selected-background-color: $gray-700;
+  --box-selected-background-color: #{$gray-700};
 
   /**
    * Text color for when a user hovers over a boxe with a
@@ -96,42 +96,42 @@ body.theme-dark {
   /**
    * Border color for selected boxes without keyboard focus
    */
-  --box-selected-border-color: $gray-400;
+  --box-selected-border-color: #{$gray-400};
 
   /**
    * Background color for selected boxes with active keyboard focus
    */
-  --box-selected-active-background-color: $blue;
+  --box-selected-active-background-color: #{$blue};
 
   /**
    * Text color for selected boxes with active keyboard focus
    */
-  --box-selected-active-text-color: $white;
+  --box-selected-active-text-color: #{$white};
 
   /**
    * Border color for selected boxes with active keyboard focus
    */
-  --box-selected-active-border-color: $gray-400;
+  --box-selected-active-border-color: #{$gray-400};
 
   /**
    * Gradient used to indicate that content is overflowing, intended
    * for use when content can be expanded through other means than
    * scrolling.
    */
-  --box-overflow-shadow-background: linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%);
+  --box-overflow-shadow-background: #{linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%)};
 
   /**
    * Author input (co-authors)
    */
-  --co-author-tag-background-color: $blue-800;
-  --co-author-tag-border-color: $blue-700;
+  --co-author-tag-background-color: #{$blue-800};
+  --co-author-tag-border-color: #{$blue-700};
 
   --base-border: 1px solid var(--box-border-color);
 
-  --shadow-color: rgba(black, 0.5);
+  --shadow-color: #{rgba(black, 0.5)};
   --base-box-shadow: 0 2px 7px var(--shadow-color);
 
-  --toolbar-background-color: darken($gray-900, 3%);
+  --toolbar-background-color: #{darken($gray-900, 3%)};
   --toolbar-border-color: var(--box-border-color);
   --toolbar-text-color: var(--text-color);
   --toolbar-text-secondary-color: var(--text-secondary-color);
@@ -141,20 +141,20 @@ body.theme-dark {
   --toolbar-button-border-color: var(--box-border-color);
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
-  --toolbar-button-hover-color: $white;
-  --toolbar-button-hover-background-color: $gray-800;
+  --toolbar-button-hover-color: #{$white};
+  --toolbar-button-hover-background-color: #{$gray-800};
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: $gray-800;
+  --toolbar-button-focus-background-color: #{$gray-800};
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);
   --toolbar-button-active-border-color: var(--box-border-color);
 
-  --toolbar-button-progress-color: $gray-800;
-  --toolbar-button-focus-progress-color: $gray-700;
-  --toolbar-button-hover-progress-color: $gray-700;
-  --toolbar-dropdown-open-progress-color: $gray-200;
+  --toolbar-button-progress-color: #{$gray-800};
+  --toolbar-button-focus-progress-color: #{$gray-700};
+  --toolbar-button-hover-progress-color: #{$gray-700};
+  --toolbar-dropdown-open-progress-color: #{$gray-200};
 
   /**
     * App menu bar colors (Windows/Linux only)
@@ -163,11 +163,11 @@ body.theme-dark {
   --app-menu-button-hover-color: var(--toolbar-button-hover-color);
   --app-menu-button-hover-background-color: var(--toolbar-button-hover-background-color);
   --app-menu-button-active-color: var(--text-color);
-  --app-menu-button-active-background-color: $gray-800;
+  --app-menu-button-active-background-color: #{$gray-800};
   --app-menu-pane-color: var(--text-color);
   --app-menu-pane-secondary-color: var(--text-secondary-color);
-  --app-menu-pane-background-color: $gray-800;
-  --app-menu-divider-color: $gray-600;
+  --app-menu-pane-background-color: #{$gray-800};
+  --app-menu-divider-color: #{$gray-600};
 
   /**
    * Background color for badges inside of toolbar buttons.
@@ -175,15 +175,15 @@ body.theme-dark {
    * push/pull button and the PR badge in the branch drop
    * down button.
    */
-  --toolbar-badge-background-color: $gray-700;
-  --toolbar-badge-active-background-color: $gray-700;
+  --toolbar-badge-background-color: #{$gray-700};
+  --toolbar-badge-active-background-color: #{$gray-700};
 
-  --tab-bar-active-color: $blue;
+  --tab-bar-active-color: #{$blue};
   --tab-bar-background-color: var(--box-background-color);
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);
-  --tab-bar-count-background-color: $gray-700;
+  --tab-bar-count-background-color: #{$gray-700};
 
   /**
     * Badge colors when used inside of list items.
@@ -191,11 +191,11 @@ body.theme-dark {
     * of the repository list.
     */
   --list-item-badge-color: var(--text-color);
-  --list-item-badge-background-color: $gray-600;
-  --list-item-selected-badge-color: $white;
-  --list-item-selected-badge-background-color: $gray-500;
-  --list-item-selected-active-badge-color: $gray-900;
-  --list-item-selected-active-badge-background-color: $white;
+  --list-item-badge-background-color: #{$gray-600};
+  --list-item-selected-badge-color: #{$white};
+  --list-item-selected-badge-background-color: #{$gray-500};
+  --list-item-selected-active-badge-color: #{$gray-900};
+  --list-item-selected-active-badge-background-color: #{$white};
 
   /**
    * Toast notifications are shown temporarily for things like the zoom
@@ -203,106 +203,106 @@ body.theme-dark {
    * window mode.
    */
   --toast-notification-color: var(--text-color);
-  --toast-notification-background-color: rgba(black, 0.8);
+  --toast-notification-background-color: #{rgba(black, 0.8)};
 
   /** The highlight color used for focus rings and focus box shadows */
-  --focus-color: $blue;
+  --focus-color: #{$blue};
 
   /**
    * Variables for form elements
    */
-  --text-field-focus-shadow-color: rgba($blue, 0.25);
+  --text-field-focus-shadow-color: #{rgba($blue, 0.25)};
 
   /**
    * Diff view
    */
 
   --diff-text-color: var(--text-color);
-  --diff-border-color: $gray-800;
-  --diff-gutter-color: $gray-800;
-  --diff-gutter-background-color: darken($gray-900, 3%);
+  --diff-border-color: #{$gray-800};
+  --diff-gutter-color: #{$gray-800};
+  --diff-gutter-background-color: #{darken($gray-900, 3%)};
 
   --diff-line-number-color: var(--text-secondary-color);
   --diff-line-number-column-width: 50px;
 
-  --diff-selected-background-color: $blue-700;
-  --diff-selected-border-color: $blue-600;
-  --diff-selected-gutter-color: $blue-600;
+  --diff-selected-background-color: #{$blue-700};
+  --diff-selected-border-color: #{$blue-600};
+  --diff-selected-gutter-color: #{$blue-600};
   --diff-selected-text-color: var(--text-color);
 
-  --diff-add-background-color: darken($green-900, 3%);
-  --diff-add-border-color: darken($green-900, 2%);
-  --diff-add-gutter-color: darken($green-900, 2%);
-  --diff-add-gutter-background-color: darken($green-900, 8%);
-  --diff-add-inner-background-color: $green-600;
+  --diff-add-background-color: #{darken($green-900, 3%)};
+  --diff-add-border-color: #{darken($green-900, 2%)};
+  --diff-add-gutter-color: #{darken($green-900, 2%)};
+  --diff-add-gutter-background-color: #{darken($green-900, 8%)};
+  --diff-add-inner-background-color: #{$green-600};
   --diff-add-text-color: var(--diff-text-color);
 
-  --diff-delete-background-color: darken($red-900, 15%);
-  --diff-delete-border-color: darken($red-900, 10%);
-  --diff-delete-gutter-color: darken($red-900, 10%);
-  --diff-delete-gutter-background-color: darken($red-900, 20%);
-  --diff-delete-inner-background-color: $red-700;
-  --diff-delete-text-color: $red-100;
+  --diff-delete-background-color: #{darken($red-900, 15%)};
+  --diff-delete-border-color: #{darken($red-900, 10%)};
+  --diff-delete-gutter-color: #{darken($red-900, 10%)};
+  --diff-delete-gutter-background-color: #{darken($red-900, 20%)};
+  --diff-delete-inner-background-color: #{$red-700};
+  --diff-delete-text-color: #{$red-100};
 
-  --diff-hunk-background-color: darken($gray-900, 3%);
-  --diff-hunk-border-color: lighten($gray-900, 3%);
-  --diff-hunk-gutter-color: lighten($gray-900, 3%);
-  --diff-hunk-gutter-background-color: darken($gray-900, 6%);
+  --diff-hunk-background-color: #{darken($gray-900, 3%)};
+  --diff-hunk-border-color: #{lighten($gray-900, 3%)};
+  --diff-hunk-gutter-color: #{lighten($gray-900, 3%)};
+  --diff-hunk-gutter-background-color: #{darken($gray-900, 6%)};
   --diff-hunk-text-color: var(--text-secondary-color);
 
-  --diff-hover-background-color: $blue-500;
-  --diff-hover-border-color: $blue-400;
-  --diff-hover-gutter-color: $blue-400;
+  --diff-hover-background-color: #{$blue-500};
+  --diff-hover-border-color: #{$blue-400};
+  --diff-hover-gutter-color: #{$blue-400};
   --diff-hover-text-color: var(--diff-text-color);
 
-  --diff-add-hover-background-color: $green-900;
-  --diff-add-hover-border-color: $green-700;
-  --diff-add-hover-gutter-color: $green-700;
+  --diff-add-hover-background-color: #{$green-900};
+  --diff-add-hover-border-color: #{$green-700};
+  --diff-add-hover-gutter-color: #{$green-700};
   --diff-add-hover-text-color: var(--text-color);
 
-  --diff-delete-hover-background-color: $red-800;
-  --diff-delete-hover-border-color: $red-700;
-  --diff-delete-hover-gutter-color: $red-700;
+  --diff-delete-hover-background-color: #{$red-800};
+  --diff-delete-hover-border-color: #{$red-700};
+  --diff-delete-hover-gutter-color: #{$red-700};
   --diff-delete-hover-text-color: var(--text-color);
 
   // Syntax highlighting text colors
-  --syntax-variable-color: $purple-300;
-  --syntax-alt-variable-color: $blue-300;
-  --syntax-keyword-color: $red-300;
-  --syntax-atom-color: $blue-300;
-  --syntax-string-color: $orange-300;
-  --syntax-qualifier-color: $purple-300;
-  --syntax-type-color: $red-300;
-  --syntax-comment-color: $gray-400;
-  --syntax-tag-color: $green-400;
-  --syntax-attribute-color: $purple-300;
-  --syntax-link-color: $blue-300;
-  --syntax-header-color: $red-300;
+  --syntax-variable-color: #{$purple-300};
+  --syntax-alt-variable-color: #{$blue-300};
+  --syntax-keyword-color: #{$red-300};
+  --syntax-atom-color: #{$blue-300};
+  --syntax-string-color: #{$orange-300};
+  --syntax-qualifier-color: #{$purple-300};
+  --syntax-type-color: #{$red-300};
+  --syntax-comment-color: #{$gray-400};
+  --syntax-tag-color: #{$green-400};
+  --syntax-attribute-color: #{$purple-300};
+  --syntax-link-color: #{$blue-300};
+  --syntax-header-color: #{$red-300};
 
   // Colors for form errors
-  --error-color: $red;
-  --form-error-background: darken($red-900, 3%);
-  --form-error-border-color: $red-900;
+  --error-color: #{$red};
+  --form-error-background: #{darken($red-900, 3%)};
+  --form-error-border-color: #{$red-900};
   --form-error-text-color: var(--text-color);
 
   /** Overlay is used as a background for both modals and foldouts */
   --overlay-background-color: rgba(0, 0, 0, 0.5);
 
   /** Dialog */
-  --dialog-warning-color: $yellow-600;
-  --dialog-error-color: $red-600;
+  --dialog-warning-color: #{$yellow-600};
+  --dialog-error-color: #{$red-600};
 
   /** Inline paths and code */
-  --path-segment-background: $gray-700;
+  --path-segment-background: #{$gray-700};
 
   .blankslate-image {
     filter: #{'invert()'} grayscale(1) brightness(8) contrast(0.6);
   }
 
   /** Diverging notification banner colors */
-  --notification-banner-background: $gray-800;
-  --notification-banner-border-color: $gray-700;
-  --notification-ref-background: $gray-700;
+  --notification-banner-background: #{$gray-800};
+  --notification-banner-border-color: #{$gray-700};
+  --notification-ref-background: #{$gray-700};
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -91,7 +91,7 @@
         width: 100%;
         bottom: 0px;
         height: 5px;
-        background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);
+        background: linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 0.1) 100%);
         border-bottom: var(--base-border);
       }
     }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "legal-eagle": "0.16.0",
     "mini-css-extract-plugin": "^0.4.0",
     "mocha": "^5.2.0",
-    "node-sass": "^4.7.2",
+    "node-sass": "^4.9.3",
     "octicons": "^7.0.1",
     "parallel-webpack": "^2.3.0",
     "prettier": "^1.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,6 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -3913,16 +3909,6 @@ gaze@^1.0.0, gaze@~1.1.2:
   dependencies:
     globule "^1.0.0"
 
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
-
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -4088,15 +4074,6 @@ har-schema@^1.0.5:
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
-har-validator@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
-  dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    is-my-json-valid "^2.12.4"
-    pinkie-promise "^2.0.0"
 
 har-validator@~4.2.1:
   version "4.2.1"
@@ -4674,15 +4651,6 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
-is-my-json-valid@^2.12.4:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz#3da98914a70a22f0a8563ef1511a246c6fc55471"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -4754,10 +4722,6 @@ is-promise@^2.1.0:
 is-promise@~1, is-promise@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-1.0.1.tgz#31573761c057e33c2e91aab9e96da08cefbe76e5"
-
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -5399,10 +5363,6 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -6030,9 +5990,9 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+nan@^2.10.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
 
 nan@^2.9.2:
   version "2.10.0"
@@ -6099,19 +6059,18 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-gyp@^3.3.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
+node-gyp@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
   dependencies:
     fstream "^1.0.0"
     glob "^7.0.3"
     graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
     mkdirp "^0.5.0"
     nopt "2 || 3"
     npmlog "0 || 1 || 2 || 3 || 4"
     osenv "0"
-    request "2"
+    request "^2.87.0"
     rimraf "2"
     semver "~5.3.0"
     tar "^2.0.0"
@@ -6196,9 +6155,9 @@ node-pre-gyp@^0.9.0:
     semver "^5.3.0"
     tar "^4"
 
-node-sass@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.7.2.tgz#9366778ba1469eb01438a9e8592f4262bcb6794e"
+node-sass@^4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.3.tgz#f407cf3d66f78308bb1e346b24fa428703196224"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -6212,10 +6171,10 @@ node-sass@^4.7.2:
     lodash.mergewith "^4.6.0"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.3.2"
-    node-gyp "^3.3.1"
+    nan "^2.10.0"
+    node-gyp "^3.8.0"
     npmlog "^4.0.0"
-    request "~2.79.0"
+    request "2.87.0"
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
@@ -7159,10 +7118,6 @@ qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@~6.3.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
-
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
@@ -7532,7 +7487,32 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2, request@^2.45.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
+request@2.87.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
+request@^2.45.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -7583,31 +7563,6 @@ request@^2.87.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
-
-request@~2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
 
 request@~2.81.0:
   version "2.81.0"
@@ -8759,10 +8714,6 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
-
-tunnel-agent@~0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
> "This will be easy," I think to myself as I `yarn upgrade --latest node-sass`. "There's a version out that supports Node 10, and life will be much simpler!"

This started a couple of months ago, when I'd heard @nerdneha having troubles with building Desktop on Node 10. I found #5204 which fixed one issue, but my earlier attempt to fix this in #5205 lead to something shocking - an app devoid of colour.

<img width="969" src="https://user-images.githubusercontent.com/359239/45549153-29299500-b7fd-11e8-8143-1a9e408c9a9c.png">

What did I break? What happened to the beautiful app? This was supposed to be a minor version change! I put this aside, questioning everything and contemplating joining a monastery again (probably the Trappist ones) and went about my life.

The Node 10 issue came up again earlier in the week, and I had another look at this with fresh eyes and lots of Google tabs. The actual problem was that I wasn't seeing the values from `primer-support` inserted into our CSS:

<img width="909"  src="https://user-images.githubusercontent.com/359239/45549251-90474980-b7fd-11e8-8b2f-8b738577ba8e.png">

Same thing with the crash view:

<img width="904" src="https://user-images.githubusercontent.com/359239/45549250-90474980-b7fd-11e8-9ed1-44e6e600bd35.png">

After much digging I find that `node-sass` [`v4.8.0`](https://github.com/sass/node-sass/releases/tag/v4.8.0) mentions upgrading to [Futura](https://github.com/sass/libsass/releases/tag/3.5.0) - the release name for `libsass` 3.5 which corresponds to SASS 3.5.

I switch over to the SASS [release notes](http://sass-lang.com/documentation/file.SASS_CHANGELOG.html) and find this gem:

<img width="636" src="https://user-images.githubusercontent.com/359239/45549429-25e2d900-b7fe-11e8-8af5-33bc7a6eae31.png">

So yes, a cascading series of "minor" updates broke previously-working code with no warnings about the change in behaviour! 

![](https://media.giphy.com/media/FJDeqfp4QZXmE/giphy.gif)

I've updated all the affected rules to use the recommended `#{}` token to ensure our generated stylesheet matches what we were previously generating, but if someone wants to figure out The Correct Way™ to consume `primer-support` styles without these kludges I'm happy to jam on them with it.

But for the moment, with this PR **I'm now able to build Desktop on Node 10 on macOS** (I'll confirm the others as I go through testing out this PR).

 - [x] test `start` and `start:prod` on macOS
 - [x] test `start` and `start:prod` on Windows 
 - [x] test `start` and `start:prod` on Ubuntu 18.04