### PR TITLE
fix overflow CSS for dialog boxes with dark theme on Windows

### DIFF
--- a/app/styles/ui/_acknowledgements.scss
+++ b/app/styles/ui/_acknowledgements.scss
@@ -3,7 +3,7 @@
 
   .dialog-content {
     height: 300px;
-    overflow: scroll;
+    overflow: auto;
 
     .license-text {
       font-family: var(--font-family-monospace);

--- a/app/styles/ui/_acknowledgements.scss
+++ b/app/styles/ui/_acknowledgements.scss
@@ -3,7 +3,7 @@
 
   .dialog-content {
     height: 300px;
-    overflow: auto;
+    overflow: scroll hidden;
 
     .license-text {
       font-family: var(--font-family-monospace);

--- a/app/styles/ui/_terms-and-conditions.scss
+++ b/app/styles/ui/_terms-and-conditions.scss
@@ -3,7 +3,7 @@
 
   .dialog-content {
     height: 250px;
-    overflow: scroll;
+    overflow: auto;
 
     p,
     ol,

--- a/app/styles/ui/_terms-and-conditions.scss
+++ b/app/styles/ui/_terms-and-conditions.scss
@@ -3,7 +3,7 @@
 
   .dialog-content {
     height: 250px;
-    overflow: auto;
+    overflow: scroll hidden;
 
     p,
     ol,

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -57,7 +57,7 @@
     flex-direction: row;
     padding-left: var(--spacing-triple);
     padding-right: var(--spacing-triple);
-    overflow: scroll hidden;
+    overflow: auto hidden;
     justify-content: space-around;
 
     .column {

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -57,7 +57,7 @@
     flex-direction: row;
     padding-left: var(--spacing-triple);
     padding-right: var(--spacing-triple);
-    overflow: auto;
+    overflow: scroll hidden;
     justify-content: space-around;
 
     .column {


### PR DESCRIPTION
Fixes #5629 

Changes overflow: scroll to overflow: auto in _acknowledgements.scss and _terms-and-conditions.scss
This commit aims to fix issue #5629 by removing the horizontal scrollbar.