### PR TITLE
Added compare-to-branch to MenuIDs

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -102,6 +102,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'delete-branch',
   'preferences',
   'update-branch',
+  'compare-to-branch',
   'merge-branch',
   'view-repository-on-github',
   'compare-on-github',


### PR DESCRIPTION
Fixes issue where 'Compare to branch' menu option was visible on macOS with modals open. https://github.com/desktop/desktop/issues/5603#issue-359122944

