### PR TITLE
fix codedov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,15 +7,15 @@ coverage:
   precision: 1
   round: nearest
   # thresholds for red to green color coding
-  range: '10...100'
+  range: '10...80'
 
   status:
     project:
       default:
         # compares coverage to the base branch
         target: auto
-        # if it drops by 25%, send a fail status
-        threshhold: 25
+        # if it drops by 10%, send a fail status
+        threshhold: 10%
         # only send statuses for prs, not all commits
         base: pr
     patch: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ codecov:
 
 coverage:
   precision: 1
-  round: nearest
+  round: down
   # thresholds for red to green color coding
   range: '10...80'
 
@@ -15,7 +15,7 @@ coverage:
         # compares coverage to the base branch
         target: auto
         # if it drops by 10%, send a fail status
-        threshhold: 10%
+        threshhold: 15%
         # only send statuses for prs, not all commits
         base: pr
     patch: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,8 +14,8 @@ coverage:
       default:
         # compares coverage to the base branch
         target: auto
-        # if it drops by 10%, send a fail status
-        threshhold: 50%
+        # if it drops by 20%, send a fail status
+        threshold: 20%
         # only send statuses for prs, not all commits
         base: pr
     patch: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ codecov:
 
 coverage:
   precision: 1
-  round: down
+  round: nearest
   # thresholds for red to green color coding
   range: '10...80'
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,3 +22,12 @@ coverage:
     changes: no
 
 comment: off
+
+# not sure what this does, but its the default!
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,7 +15,7 @@ coverage:
         # compares coverage to the base branch
         target: auto
         # if it drops by 10%, send a fail status
-        threshhold: 15%
+        threshhold: 50%
         # only send statuses for prs, not all commits
         base: pr
     patch: no


### PR DESCRIPTION
Turns out i misspelled a key in the codecov yaml and their validator didn't catch it.

~threshhold~ **threshold**

also twiddled with a few numbers and added in the parsers section with the default values since i no longer trust their yaml parsing to handle that for me