### PR TITLE
Disable commit button when commit summary is only spaces

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -470,7 +470,10 @@ export class CommitMessage extends React.Component<
 
   public render() {
     const branchName = this.props.branch ? this.props.branch : 'master'
-    const buttonEnabled = this.canCommit() && !this.props.isCommitting
+
+    const isSummaryWhiteSpace = this.state.summary.match(/^\s+$/g)
+    const buttonEnabled =
+      this.canCommit() && !this.props.isCommitting && !isSummaryWhiteSpace
 
     const loading = this.props.isCommitting ? <Loading /> : undefined
     const className = classNames({


### PR DESCRIPTION
This pull request is in response to Issue #1485. Currently when a commit summary is only a space, or several spaces, an error is generated and the commit is not created. To avoid this, I have made it disable the commit button when the summary is only spaces.

![peek 2018-09-18 18-48](https://user-images.githubusercontent.com/4957200/45723797-99774400-bb78-11e8-98f8-8e141257e8b6.gif)
___
Above shows how the commit button behaves with the changes I have implemented. Here is an explanation of what occurs:
- If the commit summary is empty, only a space, or multiple spaces, then the commit button will be disabled and not allow the user to create the commit, which would have resulted in an error.
- If the commit summary starts with a non-space character then the commit button will be enabled and allow the user to create the commit.
- If the user enters one or more spaces followed by a non-space character ('    Test'), then the commit button will enable and the commit summary will be created without the preceding spaces ('Test').
___
In regards to the user experience with this change, I do not foresee it to be too confusing since entering any non-space character enables the commit button. 

However, this is definitely a place to consider how the design for this should work. If there are suggestions for alternative or additional behavior I would be happy to explore them.