### PR TITLE
Simplify Branch constructor with parameter properties

### DIFF
--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -41,15 +41,16 @@ export function eligibleForFastForward(
   )
 }
 
-/**
- * A branch as loaded from Git.
- *
- * @param name The short name of the branch. E.g., `master`.
- * @param upstream The remote-prefixed upstream name. E.g., `origin/master`.
- * @param tip The commit associated with this branch
- * @param type The type of branch, e.g., local or remote.
- */
+/** A branch as loaded from Git. */
 export class Branch {
+  /**
+   * A branch as loaded from Git.
+   *
+   * @param name The short name of the branch. E.g., `master`.
+   * @param upstream The remote-prefixed upstream name. E.g., `origin/master`.
+   * @param tip The commit associated with this branch
+   * @param type The type of branch, e.g., local or remote.
+   */
   public constructor(
     public readonly name: string,
     public readonly upstream: string | null,

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -41,16 +41,19 @@ export function eligibleForFastForward(
   )
 }
 
-/** A branch as loaded from Git. */
+/** 
+ * A branch as loaded from Git.
+ * 
+ * @param name The short name of the branch. E.g., `master`.
+ * @param upstream The remote-prefixed upstream name. E.g., `origin/master`.
+ * @param tip The commit associated with this branch
+ * @param type The type of branch, e.g., local or remote.
+ */
 export class Branch {
   public constructor(
-    /** The short name of the branch. E.g., `master`. */
     public readonly name: string,
-    /** The remote-prefixed upstream name. E.g., `origin/master`. */
     public readonly upstream: string | null,
-    /** The commit associated with this branch */
     public readonly tip: Commit,
-    /** The type of branch, e.g., local or remote. */
     public readonly type: BranchType
   ) {}
 

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -41,9 +41,9 @@ export function eligibleForFastForward(
   )
 }
 
-/** 
+/**
  * A branch as loaded from Git.
- * 
+ *
  * @param name The short name of the branch. E.g., `master`.
  * @param upstream The remote-prefixed upstream name. E.g., `origin/master`.
  * @param tip The commit associated with this branch

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -43,29 +43,16 @@ export function eligibleForFastForward(
 
 /** A branch as loaded from Git. */
 export class Branch {
-  /** The short name of the branch. E.g., `master`. */
-  public readonly name: string
-
-  /** The remote-prefixed upstream name. E.g., `origin/master`. */
-  public readonly upstream: string | null
-
-  /** The type of branch, e.g., local or remote. */
-  public readonly type: BranchType
-
-  /** The commit associated with this branch */
-  public readonly tip: Commit
-
   public constructor(
-    name: string,
-    upstream: string | null,
-    tip: Commit,
-    type: BranchType
-  ) {
-    this.name = name
-    this.upstream = upstream
-    this.tip = tip
-    this.type = type
-  }
+    /** The short name of the branch. E.g., `master`. */
+    public readonly name: string,
+    /** The remote-prefixed upstream name. E.g., `origin/master`. */
+    public readonly upstream: string | null,
+    /** The commit associated with this branch */
+    public readonly tip: Commit,
+    /** The type of branch, e.g., local or remote. */
+    public readonly type: BranchType
+  ) {}
 
   /** The name of the upstream's remote. */
   public get remote(): string | null {


### PR DESCRIPTION
Issue #4272 suggests to clean-up and refactor the `app/src/models/` files by making use of Typescript parameter properties. I have made changes to the `models/branch` file in order to reduce some redundancy via this feature.

The Issue also mentions recommending taking things one file at a time in regards to the `/models/` folder. If these changes are fitting then I would be happy to continue to another of the files after this pull request.