### PR TITLE
switch from inline comments to normal jsdoc

### DIFF
--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -11,20 +11,24 @@ export class Account {
     return new Account('', getDotComAPIEndpoint(), '', [], '', -1, '')
   }
 
+  /**
+   * Create an instance of an account
+   *
+   * @param login The login name for this account
+   * @param endpoint The server for this account - GitHub or a GitHub Enterprise instance
+   * @param token The access token used to perform operations on behalf of this account
+   * @param emails The current list of email addresses associated with the account
+   * @param avatarURL The profile URL to render for this account
+   * @param id The database id for this account
+   * @param name The friendly name associated with this account
+   */
   public constructor(
-    /** The login name for this account  */
     public readonly login: string,
-    /** The server for this account - GitHub or a GitHub Enterprise instance */
     public readonly endpoint: string,
-    /** The access token used to perform operations on behalf of this account */
     public readonly token: string,
-    /** The current list of email addresses associated with the account */
     public readonly emails: ReadonlyArray<IAPIEmail>,
-    /** The profile URL to render for this account */
     public readonly avatarURL: string,
-    /** The database id for this account */
     public readonly id: number,
-    /** The friendly name associated with this account */
     public readonly name: string
   ) {}
 


### PR DESCRIPTION
Related to #5697 and in particular this comment https://github.com/desktop/desktop/pull/5697#issuecomment-423339885.

I went back to the file used in the original PR #4243 and tested how this is inferred using VSCode (like before), and it works in the constructor:

<img width="703"  src="https://user-images.githubusercontent.com/359239/45882768-8a191600-bd85-11e8-9098-4f62eb7de926.png">

And also works when inspecting the field outside the constructor, but still within the class:

<img width="367"  src="https://user-images.githubusercontent.com/359239/45882767-8a191600-bd85-11e8-9e92-bff97ab29422.png">

And somewhere else in the codebase:

<img width="847"  src="https://user-images.githubusercontent.com/359239/45882769-8a191600-bd85-11e8-9fdd-78e81678459a.png">

cc @Daniel-McCarthy 
