### PR TITLE
Add to max height of .commit-summary-description-scroll-view to accom…

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -90,7 +90,7 @@
   &-description-scroll-view {
     overflow: hidden;
     // The extra pixel makes the space align up with the commit list.
-    max-height: 61px;
+    max-height: 69px;
     flex: 1;
   }
 


### PR DESCRIPTION
…modate 3 lines when the description is not expanded.

This fixes #5700.

When a description has 3 lines, expansion is no longer necessary:

![3 line commit](https://user-images.githubusercontent.com/29365565/45908839-7389b380-bdb3-11e8-8118-3a807236dde0.PNG)

If it has 4+ lines, expansion is optional and the white shadow makes it obvious:

![4 line commit](https://user-images.githubusercontent.com/29365565/45908860-92884580-bdb3-11e8-9406-0d24ba4f4a48.PNG)

Much nicer.