### PR TITLE
Git diff check sparingly

### DIFF
--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -23,6 +23,18 @@ export interface IStatusEntry {
   readonly oldPath?: string
 }
 
+export function isIStatusHeader(
+  statusItem: StatusItem
+): statusItem is IStatusHeader {
+  return (<IStatusHeader>statusItem).kind === 'header'
+}
+
+export function isIStatusEntry(
+  statusItem: StatusItem
+): statusItem is IStatusEntry {
+  return (<IStatusEntry>statusItem).kind === 'entry'
+}
+
 const ChangedEntryType = '1'
 const RenamedOrCopiedEntryType = '2'
 const UnmergedEntryType = 'u'


### PR DESCRIPTION
Currently, #5683 runs a `git diff --check` every time we call `getStatus()`, even when there are no conflicted files. This PR refactors `getStatus()` so we can determine if we need to `git diff --check` earlier on, and only do so when needed.