### PR TITLE
push isDivergingBranchBannerVisible down into repository state

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -190,8 +190,6 @@ export interface IAppState {
   /** The currently selected tab for the Branches foldout. */
   readonly selectedBranchesTab: BranchesTab
 
-  /** Show the diverging notification banner */
-  readonly isDivergingBranchBannerVisible: boolean
   /** The currently selected appearance (aka theme) */
   readonly selectedTheme: ApplicationTheme
 }
@@ -648,6 +646,9 @@ export interface ICompareBranch {
 }
 
 export interface ICompareState {
+  /** Show the diverging notification banner */
+  readonly isDivergingBranchBannerVisible: boolean
+
   /** The current state of the compare form, based on user input */
   readonly formState: IDisplayHistory | ICompareBranch
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -471,8 +471,14 @@ export class Dispatcher {
   /**
    * Set the divering branch notification banner's visibility
    */
-  public setDivergingBranchBannerVisibility(isVisible: boolean) {
-    return this.appStore._setDivergingBranchBannerVisibility(isVisible)
+  public setDivergingBranchBannerVisibility(
+    repository: Repository,
+    isVisible: boolean
+  ) {
+    return this.appStore._setDivergingBranchBannerVisibility(
+      repository,
+      isVisible
+    )
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -666,26 +666,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
       },
     }))
 
-    // we only want to show the banner when the the number
-    // commits behind has changed since the last it was visible
-    if (
-      inferredBranch !== null &&
-      aheadBehindOfInferredBranch !== null &&
-      aheadBehindOfInferredBranch.behind > 0
-    ) {
+    if (inferredBranch !== null) {
+      const currentCount = getBehindCount(aheadBehindOfInferredBranch)
+
       const prevInferredBranchState =
         state.compareState.inferredComparisonBranch
-      if (
-        prevInferredBranchState.aheadBehind === null ||
-        prevInferredBranchState.aheadBehind.behind !==
-          aheadBehindOfInferredBranch.behind
-      ) {
-        this._setDivergingBranchBannerVisibility(repository, true)
-      }
-    } else if (
-      inferComparisonBranch !== null ||
-      aheadBehindOfInferredBranch === null
-    ) {
+
+      const previousCount = getBehindCount(prevInferredBranchState.aheadBehind)
+
+      // we only want to show the banner when the the number
+      // commits behind has changed since the last it was visible
+      const countChanged = currentCount > 0 && previousCount !== currentCount
+      this._setDivergingBranchBannerVisibility(repository, countChanged)
+    } else {
       this._setDivergingBranchBannerVisibility(repository, false)
     }
 
@@ -3864,4 +3857,12 @@ function getInitialAction(
     branch: cachedState.comparisonBranch,
     mode: cachedState.kind,
   }
+}
+
+function getBehindCount(aheadBehind: IAheadBehind | null): number {
+  if (aheadBehind === null) {
+    return 0
+  }
+
+  return aheadBehind.behind
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -667,12 +667,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }))
 
     if (inferredBranch !== null) {
-      const currentCount = getBehindCount(aheadBehindOfInferredBranch)
+      const currentCount = getBehindOrDefault(aheadBehindOfInferredBranch)
 
       const prevInferredBranchState =
         state.compareState.inferredComparisonBranch
 
-      const previousCount = getBehindCount(prevInferredBranchState.aheadBehind)
+      const previousCount = getBehindOrDefault(
+        prevInferredBranchState.aheadBehind
+      )
 
       // we only want to show the banner when the the number
       // commits behind has changed since the last it was visible
@@ -3859,7 +3861,10 @@ function getInitialAction(
   }
 }
 
-function getBehindCount(aheadBehind: IAheadBehind | null): number {
+/**
+ * Get the behind count (or 0) of the ahead/behind counter
+ */
+function getBehindOrDefault(aheadBehind: IAheadBehind | null): number {
   if (aheadBehind === null) {
     return 0
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -269,7 +269,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.Light
-  private isDivergingBranchBannerVisible = false
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -470,7 +469,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repositoryFilterText: this.repositoryFilterText,
       selectedCloneRepositoryTab: this.selectedCloneRepositoryTab,
       selectedBranchesTab: this.selectedBranchesTab,
-      isDivergingBranchBannerVisible: this.isDivergingBranchBannerVisible,
       selectedTheme: this.selectedTheme,
     }
   }
@@ -682,13 +680,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
         prevInferredBranchState.aheadBehind.behind !==
           aheadBehindOfInferredBranch.behind
       ) {
-        this._setDivergingBranchBannerVisibility(true)
+        this._setDivergingBranchBannerVisibility(repository, true)
       }
     } else if (
       inferComparisonBranch !== null ||
       aheadBehindOfInferredBranch === null
     ) {
-      this._setDivergingBranchBannerVisibility(false)
+      this._setDivergingBranchBannerVisibility(repository, false)
     }
 
     const cachedState = compareState.formState
@@ -3097,9 +3095,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  public _setDivergingBranchBannerVisibility(visible: boolean) {
-    if (this.isDivergingBranchBannerVisible !== visible) {
-      this.isDivergingBranchBannerVisible = visible
+  public _setDivergingBranchBannerVisibility(
+    repository: Repository,
+    visible: boolean
+  ) {
+    const state = this.repositoryStateCache.get(repository)
+    const { compareState } = state
+
+    if (compareState.isDivergingBranchBannerVisible !== visible) {
+      this.repositoryStateCache.updateCompareState(repository, () => ({
+        isDivergingBranchBannerVisible: visible,
+      }))
 
       if (visible) {
         this.statsStore.recordDivergingBranchBannerDisplayed()

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -116,6 +116,7 @@ function getInitialRepositoryState(): IRepositoryState {
       isLoadingPullRequests: false,
     },
     compareState: {
+      isDivergingBranchBannerVisible: false,
       formState: { kind: ComparisonView.None },
       mergeStatus: null,
       showBranchList: false,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1726,7 +1726,6 @@ export class App extends React.Component<IAppProps, IAppState> {
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}
           onOpenInExternalEditor={this.openFileInExternalEditor}
-          isDivergingBranchBannerVisible={state.isDivergingBranchBannerVisible}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -45,7 +45,6 @@ interface ICompareSidebarProps {
   readonly dispatcher: Dispatcher
   readonly currentBranch: Branch | null
   readonly selectedCommitSha: string | null
-  readonly isDivergingBranchBannerVisible: boolean
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
 }
@@ -195,7 +194,7 @@ export class CompareSidebar extends React.Component<
       return null
     }
 
-    if (!this.props.isDivergingBranchBannerVisible) {
+    if (!this.props.compareState.isDivergingBranchBannerVisible) {
       return null
     }
 
@@ -570,7 +569,10 @@ export class CompareSidebar extends React.Component<
   }
 
   private onNotificationBannerDismissed = (reason: DismissalReason) => {
-    this.props.dispatcher.setDivergingBranchBannerVisibility(false)
+    this.props.dispatcher.setDivergingBranchBannerVisibility(
+      this.props.repository,
+      false
+    )
     this.props.dispatcher.recordDivergingBranchBannerDismissal()
 
     switch (reason) {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -49,12 +49,6 @@ interface IRepositoryViewProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
-
-  /**
-   * Determines if the notification banner and associated dot
-   * on this history tab will be rendered
-   */
-  readonly isDivergingBranchBannerVisible: boolean
 }
 
 interface IRepositoryViewState {
@@ -105,7 +99,7 @@ export class RepositoryView extends React.Component<
         <div className="with-indicator">
           <span>History</span>
           {enableNotificationOfBranchUpdates() &&
-          this.props.isDivergingBranchBannerVisible ? (
+          this.props.state.compareState.isDivergingBranchBannerVisible ? (
             <Octicon
               className="indicator"
               symbol={OcticonSymbol.primitiveDot}
@@ -173,9 +167,6 @@ export class RepositoryView extends React.Component<
         dispatcher={this.props.dispatcher}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
-        isDivergingBranchBannerVisible={
-          this.props.isDivergingBranchBannerVisible
-        }
       />
     )
   }


### PR DESCRIPTION
As part of reviewing the current application state I noticed that we define `isDivergingBranchBannerVisible` as global state, but then plumb it down into the Repository and Compare components. This was different to how we track the other related state in `ICompareState`, which is tracked per-repository. This might be confusing to people unfamiliar with the code, and potentially a source of confusing behaviour that we're unpacking in #5301.

The first commit is the refactor, and the second commit is my attempt to clarify the flow while I was touching callers to this code. 

Why do that? In current `master` we had this check:

```ts
    } else if (
      inferComparisonBranch !== null ||
      aheadBehindOfInferredBranch === null
    ) {
```

`inferComparisonBranch` is actually the name of the function we're currently in, rather than some sort of variable assigned inside the function.

<img width="550" src="https://user-images.githubusercontent.com/359239/45954353-2d1a9b80-bfe3-11e8-8a5a-cd8aaae6a46c.png">

That won't ever be `null`, and I wasn't sure what it was supposed to be, so I tried to update the flow to reflect what I think should be happening in here.