### PR TITLE
respect the protocol of a detected GitHub repository

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -41,6 +41,7 @@ const NoteURL = 'https://desktop.github.com/'
  */
 export interface IAPIRepository {
   readonly clone_url: string
+  readonly ssh_url: string
   readonly html_url: string
   readonly name: string
   readonly owner: IAPIUser

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -11,6 +11,7 @@ import { Account } from '../../models/account'
 import {
   IRepositoryIdentifier,
   parseRepositoryIdentifier,
+  parseRemote,
 } from '../../lib/remote-parsing'
 import { findAccountForRemoteURL } from '../../lib/find-account'
 import { API } from '../../lib/api'
@@ -356,7 +357,14 @@ export class CloneRepository extends React.Component<
       const api = API.fromAccount(account)
       const repo = await api.fetchRepository(identifier.owner, identifier.name)
       if (repo) {
-        url = repo.clone_url
+        // respect the user's preference if they pasted an SSH URL into the
+        // Clone Generic Repository tab
+        const parsedUrl = parseRemote(url)
+        if (parsedUrl && parsedUrl.protocol === 'ssh') {
+          url = repo.ssh_url
+        } else {
+          url = repo.clone_url
+        }
       }
     }
 

--- a/app/test/unit/repositories-clone-grouping-test.ts
+++ b/app/test/unit/repositories-clone-grouping-test.ts
@@ -38,6 +38,7 @@ describe('clone repository grouping', () => {
     const repositories: Array<IAPIRepository> = [
       {
         clone_url: '',
+        ssh_url: '',
         html_url: '',
         name: 'some-repo',
         owner: users.shiftkey,
@@ -49,6 +50,7 @@ describe('clone repository grouping', () => {
       },
       {
         clone_url: '',
+        ssh_url: '',
         html_url: '',
         name: 'octokit.net',
         owner: users.octokit,
@@ -60,6 +62,7 @@ describe('clone repository grouping', () => {
       },
       {
         clone_url: '',
+        ssh_url: '',
         html_url: '',
         name: 'desktop',
         owner: users.desktop,

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -37,6 +37,7 @@ describe('RepositoriesStore', () => {
   describe('updating a GitHub repository', () => {
     const gitHubRepo: IAPIRepository = {
       clone_url: 'https://github.com/my-user/my-repo',
+      ssh_url: 'git@github.com:my-user/my-repo.git',
       html_url: 'https://github.com/my-user/my-repo',
       name: 'my-repo',
       owner: {


### PR DESCRIPTION
Related discussion: https://github.com/desktop/desktop/issues/5713#issuecomment-423983796

I settled on this approach for users who pasted the SSH URL for GitHub repositories into the Clone URL tab:

<img width="458" src="https://user-images.githubusercontent.com/359239/45957188-d022e380-bfea-11e8-94cc-c920e8c90f17.png">

Currently we will detect this is a GitHub remote and switch to the HTTPS URL, which we do because we support HTTPS authentication natively in the app. But for users who have their SSH setup and want to use SSH authentication, swapping this out from underneath them feels unfriendly and confusing.
