### PR TITLE
Format numbers by their locale

### DIFF
--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -105,7 +105,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
     if (ahead > 0) {
       content.push(
         <span key="ahead">
-          {ahead}
+          {ahead.toLocaleString()}
           <Octicon symbol={OcticonSymbol.arrowSmallUp} />
         </span>
       )
@@ -114,7 +114,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
     if (behind > 0) {
       content.push(
         <span key="behind">
-          {behind}
+          {behind.toLocaleString()}
           <Octicon symbol={OcticonSymbol.arrowSmallDown} />
         </span>
       )


### PR DESCRIPTION
Fixes #1245

Related issue: https://github.com/electron/electron/issues/9247

I took a shot in the dark on this, but I understand that using the `toLocaleString` function may not be sufficient, so it would be great if we can discuss the reasons why it's not sufficient or better approaches to formatting large numbers.

### Before

<img width="285" alt="screen shot 2018-09-24 at 9 09 34 pm" src="https://user-images.githubusercontent.com/1715082/45988758-2a995f80-c03e-11e8-9bbb-b8fb5b7e8592.png">

### After

<img width="334" alt="screen shot 2018-09-24 at 3 08 41 pm" src="https://user-images.githubusercontent.com/1715082/45979366-7d5e2180-c014-11e8-9cd0-691489d7fd9a.png">

cc @desktop/engineering 
