### PR TITLE
Refactored models/pull-request constructors with parameter properties

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3548,7 +3548,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const baseURL = `${gitHubRepository.htmlURL}/pull/${
-      currentPullRequest.number
+      currentPullRequest.pullRequestNumber
     }`
 
     await this._openInBrowser(baseURL)
@@ -3782,7 +3782,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       const gitStore = this.getGitStore(repository)
 
-      const localBranchName = `pr/${pullRequest.number}`
+      const localBranchName = `pr/${pullRequest.pullRequestNumber}`
       const doesBranchExist =
         gitStore.allBranches.find(branch => branch.name === localBranchName) !=
         null

--- a/app/src/lib/stores/helpers/pull-request-updater.ts
+++ b/app/src/lib/stores/helpers/pull-request-updater.ts
@@ -127,7 +127,7 @@ export class PullRequestUpdater {
         status.state === 'failure'
       ) {
         this.currentPullRequests = this.currentPullRequests.filter(
-          p => p.number !== status.pullRequestNumber
+          p => p.pullRequestNumber !== status.pullRequestNumber
         )
       }
     }

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -2,27 +2,17 @@ import { APIRefState } from '../lib/api'
 import { GitHubRepository } from './github-repository'
 
 export class PullRequestRef {
-  /** The name of the ref. */
-  public readonly ref: string
-
-  /** The SHA of the ref. */
-  public readonly sha: string
-
   /**
-   * The GitHub repository in which this ref lives. It could be null if the
-   * repository was deleted after the PR was opened.
+   * @param ref The name of the ref.
+   * @param sha The SHA of the ref.
+   * @param gitHubRepository The GitHub repository in which this ref lives. It could be null if the
+   *                         repository was deleted after the PR was opened.
    */
-  public readonly gitHubRepository: GitHubRepository | null
-
   public constructor(
-    ref: string,
-    sha: string,
-    gitHubRepository: GitHubRepository | null
-  ) {
-    this.ref = ref
-    this.sha = sha
-    this.gitHubRepository = gitHubRepository
-  }
+    public readonly ref: string,
+    public readonly sha: string,
+    public readonly gitHubRepository: GitHubRepository | null
+  ) {}
 }
 
 /** The commit status and metadata for a given ref */
@@ -33,81 +23,42 @@ export interface ICommitStatus {
 }
 
 export class PullRequestStatus {
-  /** The pull request this status is associated with */
-  public readonly pullRequestNumber: number
-
-  /** The status' state. */
-  public readonly state: APIRefState
-
-  /** The number of statuses represented in this combined status. */
-  public readonly totalCount: number
-
-  /** The SHA for which this status applies. */
-  public readonly sha: string
-
-  /** The list of all statuses for a specific ref. */
-  public readonly statuses: ReadonlyArray<ICommitStatus>
-
+  /**
+   * @param pullRequestNumber The pull request this status is associated with.
+   * @param state The status' state.
+   * @param totalCount The number of statuses represented in this combined status.
+   * @param sha The SHA for which this status applies.
+   * @param statuses The list of all statuses for a specific ref.
+   */
   public constructor(
-    pullRequestNumber: number,
-    state: APIRefState,
-    totalCount: number,
-    sha: string,
-    statuses: ReadonlyArray<ICommitStatus>
-  ) {
-    this.pullRequestNumber = pullRequestNumber
-    this.state = state
-    this.totalCount = totalCount
-    this.sha = sha
-    this.statuses = statuses
-  }
+    public readonly pullRequestNumber: number,
+    public readonly state: APIRefState,
+    public readonly totalCount: number,
+    public readonly sha: string,
+    public readonly statuses: ReadonlyArray<ICommitStatus>
+  ) {}
 }
 
 export class PullRequest {
-  /** The database ID. */
-  public readonly id: number
-
-  /** The date on which the PR was created. */
-  public readonly created: Date
-
-  /** The title of the PR. */
-  public readonly title: string
-
-  /** The number. */
-  public readonly pullRequestNumber: number
-
-  /** The ref from which the pull request's changes are coming. */
-  public readonly head: PullRequestRef
-
-  /** The ref which the pull request is targetting. */
-  public readonly base: PullRequestRef
-
-  /** The author's login. */
-  public readonly author: string
-
   /**
-   * The status of the PR. This will be `null` if we haven't looked up its
-   * status yet or if an error occurred while looking it up.
+   * @param id The database ID.
+   * @param created The date on which the PR was created.
+   * @param status The status of the PR. This will be `null` if we haven't looked up its
+   *               status yet or if an error occurred while looking it up.
+   * @param title The title of the PR.
+   * @param number The number.
+   * @param head The ref from which the pull request's changes are coming.
+   * @param base The ref which the pull request is targetting.
+   * @param author The author's login.
    */
-  public readonly status: PullRequestStatus | null
-
   public constructor(
-    id: number,
-    created: Date,
-    status: PullRequestStatus | null,
-    title: string,
-    pullRequestNumber: number,
-    head: PullRequestRef,
-    base: PullRequestRef,
-    author: string
-  ) {
-    this.id = id
-    this.created = created
-    this.status = status
-    this.title = title
-    this.pullRequestNumber = pullRequestNumber
-    this.head = head
-    this.base = base
-    this.author = author
-  }
+    public readonly id: number,
+    public readonly created: Date,
+    public readonly status: PullRequestStatus | null,
+    public readonly title: string,
+    public readonly pullRequestNumber: number,
+    public readonly head: PullRequestRef,
+    public readonly base: PullRequestRef,
+    public readonly author: string
+  ) {}
 }

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -74,7 +74,7 @@ export class PullRequest {
   public readonly title: string
 
   /** The number. */
-  public readonly number: number
+  public readonly pullRequestNumber: number
 
   /** The ref from which the pull request's changes are coming. */
   public readonly head: PullRequestRef
@@ -96,7 +96,7 @@ export class PullRequest {
     created: Date,
     status: PullRequestStatus | null,
     title: string,
-    number_: number,
+    pullRequestNumber: number,
     head: PullRequestRef,
     base: PullRequestRef,
     author: string
@@ -105,7 +105,7 @@ export class PullRequest {
     this.created = created
     this.status = status
     this.title = title
-    this.number = number_
+    this.pullRequestNumber = pullRequestNumber
     this.head = head
     this.base = base
     this.author = author

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -158,7 +158,7 @@ export class PullRequestList extends React.Component<
     const status =
       pr.status != null
         ? new PullRequestStatus(
-            pr.number,
+            pr.pullRequestNumber,
             pr.status.state,
             pr.status.totalCount,
             pr.status.sha,
@@ -169,7 +169,7 @@ export class PullRequestList extends React.Component<
     return (
       <PullRequestListItem
         title={pr.title}
-        number={pr.number}
+        number={pr.pullRequestNumber}
         created={pr.created}
         author={pr.author}
         status={status}
@@ -199,7 +199,7 @@ export class PullRequestList extends React.Component<
 
 function getSubtitle(pr: PullRequest) {
   const timeAgo = moment(pr.created).fromNow()
-  return `#${pr.number} opened ${timeAgo} by ${pr.author}`
+  return `#${pr.pullRequestNumber} opened ${timeAgo} by ${pr.author}`
 }
 
 function createListItems(
@@ -207,7 +207,7 @@ function createListItems(
 ): IFilterListGroup<IPullRequestListItem> {
   const items = pullRequests.map(pr => ({
     text: [pr.title, getSubtitle(pr)],
-    id: pr.number.toString(),
+    id: pr.pullRequestNumber.toString(),
     pullRequest: pr,
   }))
 
@@ -222,6 +222,8 @@ function findItemForPullRequest(
   pullRequest: PullRequest
 ): IPullRequestListItem | null {
   return (
-    group.items.find(i => i.pullRequest.number === pullRequest.number) || null
+    group.items.find(
+      i => i.pullRequest.pullRequestNumber === pullRequest.pullRequestNumber
+    ) || null
   )
 }

--- a/app/src/ui/delete-branch/delete-pull-request-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-pull-request-dialog.tsx
@@ -33,7 +33,7 @@ export class DeletePullRequest extends React.Component<IDeleteBranchProps, {}> {
           <p>
             If{' '}
             <LinkButton onClick={this.openPullRequest}>
-              #{this.props.pullRequest.number}
+              #{this.props.pullRequest.pullRequestNumber}
             </LinkButton>{' '}
             has been merged, you can also remove the remote branch on GitHub.
           </p>

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -162,6 +162,6 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       return null
     }
 
-    return <PullRequestBadge number={pr.number} status={pr.status} />
+    return <PullRequestBadge number={pr.pullRequestNumber} status={pr.status} />
   }
 }


### PR DESCRIPTION
This is continuing off Issue #4272. It has updated the models/pull-request file with parameter properties. 

As discussed here [(comment)](https://github.com/desktop/desktop/issues/4272#issuecomment-424106301), the `models/pull-request` needed an additional change in order to use parameter properties. The result is that the variable name `number` has been changed to `pullRequestNumber` to avoid linting issues with the name matching a type.