### PR TITLE
Update Discard-Changes-Dialog text when discarding all changes

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -241,6 +241,7 @@ export type Popup =
       repository: Repository
       files: ReadonlyArray<WorkingDirectoryFileChange>
       showDiscardChangesSetting?: boolean
+      discardingAllChanges?: boolean
     }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | {

--- a/app/src/lib/platform-case.ts
+++ b/app/src/lib/platform-case.ts
@@ -1,0 +1,14 @@
+/** Convert input string to current platform's text case preference. */
+export function toPlatformCase(inputText: string): string {
+  inputText = inputText.toLowerCase()
+
+  if (__DARWIN__) {
+    // Capitalize the first letter of every word.
+    inputText = inputText.replace(/\b[a-z]/gi, $1 => $1.toUpperCase())
+  } else {
+    // Capitalize the first letter of the first word.
+    inputText = inputText.replace(/\b[a-z]/i, $1 => $1.toUpperCase())
+  }
+
+  return inputText
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1018,6 +1018,10 @@ export class App extends React.Component<IAppProps, IAppState> {
           popup.showDiscardChangesSetting === undefined
             ? true
             : popup.showDiscardChangesSetting
+        const discardingAllChanges =
+          popup.discardingAllChanges === undefined
+            ? false
+            : popup.discardingAllChanges
 
         return (
           <DiscardChanges
@@ -1029,6 +1033,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               this.state.askForConfirmationOnDiscardChanges
             }
             showDiscardChangesSetting={showSetting}
+            discardingAllChanges={discardingAllChanges}
             onDismissed={this.onPopupDismissed}
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -50,7 +50,7 @@ interface IChangesListProps {
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly onDiscardAllChanges: (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
-    dontDisplayAsAll?: boolean
+    isDiscardingAllChanges?: boolean
   ) => void
 
   /**
@@ -218,15 +218,12 @@ export class ChangesList extends React.Component<
       })
 
       if (modifiedFiles.length > 0) {
-        if (modifiedFiles.length === workingDirectory.files.length) {
-          // Display Discard Changes popup as Display All Changes since all
-          // modified files are selected.
-          this.props.onDiscardAllChanges(modifiedFiles)
-        } else {
-          // Display Discard Changes popup without displaying showing as
-          // Discard All Changes.
-          this.props.onDiscardAllChanges(modifiedFiles, true)
-        }
+        // DiscardAllChanges can also be used for discarding several selected changes.
+        // Therefore, we update the pop up to reflect whether or not it is "all" changes.
+        const discardingAllChanges =
+          modifiedFiles.length === workingDirectory.files.length
+
+        this.props.onDiscardAllChanges(modifiedFiles, discardingAllChanges)
       }
     }
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -49,7 +49,8 @@ interface IChangesListProps {
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly onDiscardAllChanges: (
-    files: ReadonlyArray<WorkingDirectoryFileChange>
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    dontDisplayAsAll?: boolean
   ) => void
 
   /**
@@ -217,7 +218,15 @@ export class ChangesList extends React.Component<
       })
 
       if (modifiedFiles.length > 0) {
-        this.props.onDiscardAllChanges(modifiedFiles)
+        if (modifiedFiles.length === workingDirectory.files.length) {
+          // Display Discard Changes popup as Display All Changes since all
+          // modified files are selected.
+          this.props.onDiscardAllChanges(modifiedFiles)
+        } else {
+          // Display Discard Changes popup without displaying showing as
+          // Discard All Changes.
+          this.props.onDiscardAllChanges(modifiedFiles, true)
+        }
       }
     }
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -168,12 +168,16 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   }
 
   private onDiscardAllChanges = (
-    files: ReadonlyArray<WorkingDirectoryFileChange>
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    dontDisplayAsAll?: boolean
   ) => {
+    const discardingAllChanges =
+      dontDisplayAsAll === undefined ? true : dontDisplayAsAll === false
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmDiscardChanges,
       repository: this.props.repository,
       showDiscardChangesSetting: false,
+      discardingAllChanges: discardingAllChanges,
       files,
     })
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -169,15 +169,13 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
 
   private onDiscardAllChanges = (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
-    dontDisplayAsAll?: boolean
+    isDiscardingAllChanges: boolean = true
   ) => {
-    const discardingAllChanges =
-      dontDisplayAsAll === undefined ? true : dontDisplayAsAll === false
     this.props.dispatcher.showPopup({
       type: PopupType.ConfirmDiscardChanges,
       repository: this.props.repository,
       showDiscardChangesSetting: false,
-      discardingAllChanges: discardingAllChanges,
+      discardingAllChanges: isDiscardingAllChanges,
       files,
     })
   }

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -58,11 +58,19 @@ export class DiscardChanges extends React.Component<
   }
 
   public render() {
+    const discardingAllChanges = this.props.discardingAllChanges
+
     return (
       <Dialog
         id="discard-changes"
         title={
-          __DARWIN__ ? 'Confirm Discard Changes' : 'Confirm discard changes'
+          discardingAllChanges
+            ? __DARWIN__
+              ? 'Confirm Discard All Changes'
+              : 'Confirm discard all changes'
+            : __DARWIN__
+              ? 'Confirm Discard Changes'
+              : 'Confirm discard changes'
         }
         onDismissed={this.props.onDismissed}
         type="warning"
@@ -80,7 +88,13 @@ export class DiscardChanges extends React.Component<
           <ButtonGroup destructive={true}>
             <Button type="submit">Cancel</Button>
             <Button onClick={this.discard}>
-              {__DARWIN__ ? 'Discard Changes' : 'Discard changes'}
+              {discardingAllChanges
+                ? __DARWIN__
+                  ? 'Discard All Changes'
+                  : 'Discard all changes'
+                : __DARWIN__
+                  ? 'Discard Changes'
+                  : 'Discard changes'}
             </Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -21,6 +21,7 @@ interface IDiscardChangesProps {
    * to ask for confirmation when discarding
    * changes
    */
+  readonly discardingAllChanges: boolean
   readonly showDiscardChangesSetting: boolean
   readonly onDismissed: () => void
   readonly onConfirmDiscardChangesChanged: (optOut: boolean) => void

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -10,6 +10,7 @@ import { PathText } from '../lib/path-text'
 import { Monospaced } from '../lib/monospaced'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { TrashNameLabel } from '../lib/context-menu'
+import { toPlatformCase } from '../../lib/platform-case'
 
 interface IDiscardChangesProps {
   readonly repository: Repository
@@ -65,12 +66,8 @@ export class DiscardChanges extends React.Component<
         id="discard-changes"
         title={
           discardingAllChanges
-            ? __DARWIN__
-              ? 'Confirm Discard All Changes'
-              : 'Confirm discard all changes'
-            : __DARWIN__
-              ? 'Confirm Discard Changes'
-              : 'Confirm discard changes'
+            ? toPlatformCase('Confirm Discard All Changes')
+            : toPlatformCase('Confirm Discard Changes')
         }
         onDismissed={this.props.onDismissed}
         type="warning"
@@ -89,12 +86,8 @@ export class DiscardChanges extends React.Component<
             <Button type="submit">Cancel</Button>
             <Button onClick={this.discard}>
               {discardingAllChanges
-                ? __DARWIN__
-                  ? 'Discard All Changes'
-                  : 'Discard all changes'
-                : __DARWIN__
-                  ? 'Discard Changes'
-                  : 'Discard changes'}
+                ? toPlatformCase('Discard All Changes')
+                : toPlatformCase('Discard Changes')}
             </Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/test/unit/platform-case-test.ts
+++ b/app/test/unit/platform-case-test.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai'
+import { toPlatformCase } from '../../src/lib/platform-case'
+
+describe('string to platform case', () => {
+  it('convert string to detected platform text case', () => {
+    if (__DARWIN__) {
+      const result = toPlatformCase(' this should be title case.')
+      expect(result).to.equal(' This Should Be Title Case.')
+    } else {
+      const result = toPlatformCase(' this should be sentence case.')
+      expect(result).to.equal(' This should be sentence case.')
+    }
+  })
+})


### PR DESCRIPTION
This is in response to Issue #5690. It recommends updating the `Discard-Changes-Dialog` title and confirmation button when discarding all changes. This is to notify the user more clearly for situations where they have accidentally selected "Discard All Changes..." instead of "Discard Change..." or "Discard # Selected Changes..."
___
This is what the dialog would look like when clicking "Discard All Changes...":
![image](https://user-images.githubusercontent.com/4957200/46044338-1c9c1b00-c0e0-11e8-841b-1b1e321ff4a4.png)
___
In regards to the implementation of this change, I suspect there may be a simpler way to inform the dialog when the user is attempting to discard all changes. To do this, a boolean was passed to the PopupType so that it could be sent to the dialog via props.

- As an extra note, selecting "Discard Change" or selecting multiple modified files (but not all of them) to discard, the dialog will display as it normally does. However, if one selects all of the modified files and uses "Discard # Selected Files" it will display the Discard All Changes text.