### PR TITLE
disable Lock integration

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,0 @@
-# Configuration for lock-threads - https://github.com/dessant/lock-threads
-daysUntilLock: 60
-lockLabel: locked-due-to-inactivity
-lockComment: false
-setLockReason: true
-# Proposals need to be handled separately to normal issues
-exemptLabels: ['future-proposal']


### PR DESCRIPTION
This was mentioned out in #5743 and indicates that the [Lock](https://github.com/apps/lock) GitHub App isn't doing what it's supposed to be:

>  I'm not a huge fan of your auto-close bot, who assumes any ticket not replied to must be resolved so I aim to keep this ticket alive until an answer can be reached one way or another lest others stumble across it, auto-closed in a few months, with no discernable resolution.

This isn't the first time I've heard this feedback, and I'm in agreement that this can lead to a bad first impression for someone new to the project.

I'm going to put together a script to unlock and unlabel issues/PRs that were caught up in this, but I'm also keen to hear the feedback from others about this bit of automation. I've already uninstalled the GitHub App to prevent any further issues being marked like this.

TODO:

 - [x] unlock issues  marked with `locked-due-to-inactivity`
 - [x] unlabel issues marked with `locked-due-to-inactivity`
 - [x] remove `locked-due-to-inactivity` label
