### PR TITLE
Revert "refresh repository after revert"

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3436,7 +3436,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
 
       this.updateRevertProgress(repo, null)
-      await this._refreshRepository(repository)
+
+      // TODO: what's the equivalent for the compare tab?
+      // This might be re-computed when we switch back, in which case we can :fire:
+      // it to the ground.
+      //return gitStore.loadHistory()
     })
   }
 


### PR DESCRIPTION
Reverts desktop/desktop#5722.

It was marked for 1.4.2, so I'd prefer to leave it out of 1.4.1 release

@billygriffin does that seem fair to you?

cc @shiftkey 