### PR TITLE
Linux Shells: add Terminator, MATE Terminal, Terminology

### DIFF
--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -5,7 +5,7 @@ import { IFoundShell } from './found-shell'
 
 export enum Shell {
   Gnome = 'GNOME Terminal',
-  Mate  = 'MATE Terminal',
+  Mate = 'MATE Terminal',
   Tilix = 'Tilix',
   Terminator = 'Terminator',
   Urxvt = 'URxvt',

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -5,7 +5,9 @@ import { IFoundShell } from './found-shell'
 
 export enum Shell {
   Gnome = 'GNOME Terminal',
+  Mate  = 'MATE Terminal',
   Tilix = 'Tilix',
+  Terminator = 'Terminator',
   Urxvt = 'URxvt',
   Konsole = 'Konsole',
   Xterm = 'XTerm',
@@ -18,8 +20,16 @@ export function parse(label: string): Shell {
     return Shell.Gnome
   }
 
+  if (label === Shell.Mate) {
+    return Shell.Mate
+  }
+
   if (label === Shell.Tilix) {
     return Shell.Tilix
+  }
+
+  if (label === Shell.Terminator) {
+    return Shell.Terminator
   }
 
   if (label === Shell.Urxvt) {
@@ -45,8 +55,12 @@ function getShellPath(shell: Shell): Promise<string | null> {
   switch (shell) {
     case Shell.Gnome:
       return getPathIfAvailable('/usr/bin/gnome-terminal')
+    case Shell.Mate:
+      return getPathIfAvailable('/usr/bin/mate-terminal')
     case Shell.Tilix:
       return getPathIfAvailable('/usr/bin/tilix')
+    case Shell.Terminator:
+      return getPathIfAvailable('/usr/bin/terminator')
     case Shell.Urxvt:
       return getPathIfAvailable('/usr/bin/urxvt')
     case Shell.Konsole:
@@ -63,13 +77,17 @@ export async function getAvailableShells(): Promise<
 > {
   const [
     gnomeTerminalPath,
+    mateTerminalPath,
     tilixPath,
+    terminatorPath,
     urxvtPath,
     konsolePath,
     xtermPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
+    getShellPath(Shell.Mate),
     getShellPath(Shell.Tilix),
+    getShellPath(Shell.Terminator),
     getShellPath(Shell.Urxvt),
     getShellPath(Shell.Konsole),
     getShellPath(Shell.Xterm),
@@ -80,8 +98,16 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Gnome, path: gnomeTerminalPath })
   }
 
+  if (mateTerminalPath) {
+    shells.push({ shell: Shell.Mate, path: mateTerminalPath })
+  }
+
   if (tilixPath) {
     shells.push({ shell: Shell.Tilix, path: tilixPath })
+  }
+
+  if (terminatorPath) {
+    shells.push({ shell: Shell.Terminator, path: terminatorPath })
   }
 
   if (urxvtPath) {
@@ -105,15 +131,17 @@ export function launch(
 ): ChildProcess {
   const shell = foundShell.shell
   switch (shell) {
+    case Shell.Gnome:
+    case Shell.Mate:
+    case Shell.Tilix:
+    case Shell.Terminator:
+      return spawn(foundShell.path, ['--working-directory', path])
     case Shell.Urxvt:
       return spawn(foundShell.path, ['-cd', path])
     case Shell.Konsole:
       return spawn(foundShell.path, ['--workdir', path])
     case Shell.Xterm:
       return spawn(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
-    case Shell.Tilix:
-    case Shell.Gnome:
-      return spawn(foundShell.path, ['--working-directory', path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -11,6 +11,7 @@ export enum Shell {
   Urxvt = 'URxvt',
   Konsole = 'Konsole',
   Xterm = 'XTerm',
+  Terminology = 'Terminology',
 }
 
 export const Default = Shell.Gnome
@@ -44,6 +45,10 @@ export function parse(label: string): Shell {
     return Shell.Xterm
   }
 
+  if (label === Shell.Terminology) {
+    return Shell.Terminology
+  }
+
   return Default
 }
 
@@ -67,6 +72,8 @@ function getShellPath(shell: Shell): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/konsole')
     case Shell.Xterm:
       return getPathIfAvailable('/usr/bin/xterm')
+    case Shell.Terminology:
+      return getPathIfAvailable('/usr/bin/terminology')
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -83,6 +90,7 @@ export async function getAvailableShells(): Promise<
     urxvtPath,
     konsolePath,
     xtermPath,
+    terminologyPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.Mate),
@@ -91,6 +99,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Urxvt),
     getShellPath(Shell.Konsole),
     getShellPath(Shell.Xterm),
+    getShellPath(Shell.Terminology),
   ])
 
   const shells: Array<IFoundShell<Shell>> = []
@@ -122,6 +131,10 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Xterm, path: xtermPath })
   }
 
+  if (terminologyPath) {
+    shells.push({ shell: Shell.Terminology, path: terminologyPath })
+  }
+
   return shells
 }
 
@@ -142,6 +155,8 @@ export function launch(
       return spawn(foundShell.path, ['--workdir', path])
     case Shell.Xterm:
       return spawn(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
+    case Shell.Terminology:
+      return spawn(foundShell.path, ['-d', path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -209,7 +209,9 @@ The source for the Linux shell integration is found in [`app/src/lib/shells/linu
 These shells are currently supported:
 
  - [GNOME Terminal](https://help.gnome.org/users/gnome-terminal/stable/)
+ - [MATE Terminal](https://github.com/mate-desktop/mate-terminal)
  - [Tilix](https://github.com/gnunn1/tilix)
+ - [Terminator](https://gnometerminator.blogspot.com)
  - [Rxvt Unicode](http://software.schmorp.de/pkg/rxvt-unicode.html)
  - [Konsole](https://konsole.kde.org/)
  - [XTerm](http://invisible-island.net/xterm/)

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -219,7 +219,9 @@ These are defined in an enum at the top of the file:
 ```ts
 export enum Shell {
   Gnome = 'GNOME Terminal',
+  Mate  = 'MATE Terminal',
   Tilix = 'Tilix',
+  Terminator = 'Terminator',
   Urxvt = 'URxvt',
   Konsole = 'Konsole',
   Xterm = 'XTerm',
@@ -250,13 +252,17 @@ export async function getAvailableShells(): Promise<
 > {
   const [
     gnomeTerminalPath,
+    mateTerminalPath,
     tilixPath,
+    terminatorPath,
     urxvtPath,
     konsolePath,
     xtermPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
+    getShellPath(Shell.Mate),
     getShellPath(Shell.Tilix),
+    getShellPath(Shell.Terminator),
     getShellPath(Shell.Urxvt),
     getShellPath(Shell.Konsole),
     getShellPath(Shell.Xterm),
@@ -283,15 +289,17 @@ export function launch(
 ): ChildProcess {
   const shell = foundShell.shell
   switch (shell) {
+    case Shell.Gnome:
+    case Shell.Mate:
+    case Shell.Tilix:
+    case Shell.Terminator:
+      return spawn(foundShell.path, ['--working-directory', path])
     case Shell.Urxvt:
       return spawn(foundShell.path, ['-cd', path])
     case Shell.Konsole:
       return spawn(foundShell.path, ['--workdir', path])
     case Shell.Xterm:
       return spawn(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
-    case Shell.Tilix:
-    case Shell.Gnome:
-      return spawn(foundShell.path, ['--working-directory', path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -215,6 +215,7 @@ These shells are currently supported:
  - [Rxvt Unicode](http://software.schmorp.de/pkg/rxvt-unicode.html)
  - [Konsole](https://konsole.kde.org/)
  - [XTerm](http://invisible-island.net/xterm/)
+ - [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)
 
 These are defined in an enum at the top of the file:
 
@@ -227,6 +228,7 @@ export enum Shell {
   Urxvt = 'URxvt',
   Konsole = 'Konsole',
   Xterm = 'XTerm',
+  Terminology = 'Terminology',
 }
 ```
 
@@ -260,6 +262,7 @@ export async function getAvailableShells(): Promise<
     urxvtPath,
     konsolePath,
     xtermPath,
+    terminologyPath,
   ] = await Promise.all([
     getShellPath(Shell.Gnome),
     getShellPath(Shell.Mate),
@@ -268,6 +271,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Urxvt),
     getShellPath(Shell.Konsole),
     getShellPath(Shell.Xterm),
+    getShellPath(Shell.Terminology),
   ])
 
   ...
@@ -302,6 +306,8 @@ export function launch(
       return spawn(foundShell.path, ['--workdir', path])
     case Shell.Xterm:
       return spawn(foundShell.path, ['-e', '/bin/bash'], { cwd: path })
+    case Shell.Terminology:
+      return spawn(foundShell.path, ['-d', path])
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }


### PR DESCRIPTION
### What is the issue?

GitHub Desktop is missing support for the following shells:
- [MATE Terminal](https://github.com/mate-desktop/mate-terminal)
- [Terminator](https://gnometerminator.blogspot.com/p/introduction.html)
- [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)
- [xfce terminal](https://git.xfce.org/apps/xfce4-terminal/about/)
- [Guake Terminal](http://guake-project.org)
- [st: Simple Terminal](http://st.suckless.org)

### What have we done

Followed the guidelines in the [documentation](https://github.com/desktop/desktop/blob/master/docs/technical/shell-integration.md) to add support for the the following terminal emulators:
- [MATE Terminal](https://github.com/mate-desktop/mate-terminal)
- [Terminator](https://gnometerminator.blogspot.com/p/introduction.html)
- [Terminology](https://www.enlightenment.org/docs/apps/terminology.md)

I can add support for the remaining if you're interested.

### How can we test?

1. Install the shells (see below)
2. Clone this branch (`git clone --single-branch -b terminator https://github.com/joaomlneto/desktop`)
3. Boot up the development environment (`cd desktop && yarn && yarn build:dev && yarn start`)
4. Change shell in the preferences pane
5. Open repository in terminal

---

### Installing the shells

#### Terminator
Terminator is available in most package repositories
```
sudo apt install terminator
```

#### Terminology
Terminology is available in most package repositories
```
sudo apt install terminology
```

#### MATE Terminal
This is bundled by default in the MATE desktop environment (MATE is a Gnome 2 fork).

It is available in most distros package repositories (though I haven't tried installing it manually when using a different desktop environment -- probably installs a *bazillion* other packages):
```
sudo apt install mate-terminal
```