### PR TITLE
Add product vision doc and roadmap to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ uses [React](https://facebook.github.io/react/).
 
 ![GitHub Desktop screenshot - Windows](https://cloud.githubusercontent.com/assets/359239/26094502/a1f56d02-3a5d-11e7-8799-23c7ba5e5106.png)
 
+## Is GitHub Desktop right for me? What are the primary areas of focus?
+
+[This document](https://github.com/desktop/desktop/blob/master/docs/process/what-is-desktop.md) describes the focus of GitHub Desktop and who the product is most useful for.
+
+And to see what the team is working on currently and in the near future, check out the [GitHub Desktop roadmap](https://github.com/desktop/desktop/blob/master/docs/process/roadmap.md).
+
 ## Where can I get it?
 
 Download the official installer for your operating system:

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ uses [React](https://facebook.github.io/react/).
 
 ![GitHub Desktop screenshot - Windows](https://cloud.githubusercontent.com/assets/359239/26094502/a1f56d02-3a5d-11e7-8799-23c7ba5e5106.png)
 
-## Is GitHub Desktop right for me? What are the primary areas of focus?
-
-[This document](https://github.com/desktop/desktop/blob/master/docs/process/what-is-desktop.md) describes the focus of GitHub Desktop and who the product is most useful for.
-
-And to see what the team is working on currently and in the near future, check out the [GitHub Desktop roadmap](https://github.com/desktop/desktop/blob/master/docs/process/roadmap.md).
-
 ## Where can I get it?
 
 Download the official installer for your operating system:
@@ -48,6 +42,12 @@ beta channel to get access to early builds of Desktop:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
+ 
+## Is GitHub Desktop right for me? What are the primary areas of focus?
+
+[This document](https://github.com/desktop/desktop/blob/master/docs/process/what-is-desktop.md) describes the focus of GitHub Desktop and who the product is most useful for.
+
+And to see what the team is working on currently and in the near future, check out the [GitHub Desktop roadmap](https://github.com/desktop/desktop/blob/master/docs/process/roadmap.md).
 
 ## I have a problem with GitHub Desktop
 


### PR DESCRIPTION
I thought it'd be useful to give people a high level product view from the main repo page. Open to verbiage suggestions here if this doesn't seem quite right.