### PR TITLE
Fix Overflow value of T&C and License Notices dialogs

### DIFF
--- a/app/styles/ui/_acknowledgements.scss
+++ b/app/styles/ui/_acknowledgements.scss
@@ -3,7 +3,8 @@
 
   .dialog-content {
     height: 300px;
-    overflow: scroll hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 
     .license-text {
       font-family: var(--font-family-monospace);

--- a/app/styles/ui/_terms-and-conditions.scss
+++ b/app/styles/ui/_terms-and-conditions.scss
@@ -3,7 +3,8 @@
 
   .dialog-content {
     height: 250px;
-    overflow: scroll hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 
     p,
     ol,


### PR DESCRIPTION
Fixes #5756 

• Changes `overflow: scroll hidden;` to `overflow-x: hidden; overflow-y: auto;` in _acknowledgements.scss and _terms-and-conditions.scss
• This commit aims to fix issue #5756 by fixing the overflow attribute values by separating the specification for x and y  scroll.

See the screenshots -
– **Before**:
Notices:
<img width="703" alt="1" src="https://user-images.githubusercontent.com/4612840/46120980-aa126480-c1df-11e8-89e6-e17e23392fde.png">
T&C:
<img width="620" alt="2" src="https://user-images.githubusercontent.com/4612840/46120988-aed71880-c1df-11e8-871e-bd2a30604e43.png">

– **After**:
Notices:
<img width="586" alt="termsandconditionsdialog" src="https://user-images.githubusercontent.com/4612840/46120998-c2827f00-c1df-11e8-835f-862e7304e8ab.png">
T&C:
<img width="614" alt="licenceandopensourcenoticesdialog" src="https://user-images.githubusercontent.com/4612840/46121004-cadaba00-c1df-11e8-8811-46eef0c3a590.png">
