### PR TITLE
Refactored models/commit-identity constructor with parameter properties

### DIFF
--- a/app/src/models/commit-identity.ts
+++ b/app/src/models/commit-identity.ts
@@ -3,8 +3,6 @@
  * info in a commit.
  */
 export class CommitIdentity {
-  public readonly tzOffset: number
-
   /**
    * Parses a Git ident string (GIT_AUTHOR_IDENT or GIT_COMMITTER_IDENT)
    * into a commit identity. Returns null if string could not be parsed.
@@ -51,8 +49,6 @@ export class CommitIdentity {
     public readonly name: string,
     public readonly email: string,
     public readonly date: Date,
-    tzOffset?: number
-  ) {
-    this.tzOffset = tzOffset || new Date().getTimezoneOffset()
-  }
+    public readonly tzOffset: number = new Date().getTimezoneOffset()
+  ) {}
 }

--- a/app/src/models/commit-identity.ts
+++ b/app/src/models/commit-identity.ts
@@ -3,9 +3,6 @@
  * info in a commit.
  */
 export class CommitIdentity {
-  public readonly name: string
-  public readonly email: string
-  public readonly date: Date
   public readonly tzOffset: number
 
   /**
@@ -51,14 +48,11 @@ export class CommitIdentity {
   }
 
   public constructor(
-    name: string,
-    email: string,
-    date: Date,
+    public readonly name: string,
+    public readonly email: string,
+    public readonly date: Date,
     tzOffset?: number
   ) {
-    this.name = name
-    this.email = email
-    this.date = date
     this.tzOffset = tzOffset || new Date().getTimezoneOffset()
   }
 }


### PR DESCRIPTION
This is continuing off Issue #4272. It has updated the `models/commit-identity` file with parameter properties.

This one contains a property that was defined in the constructor with an optional argument and had a default value in case the argument was not supplied. This has also been simplified via constructor parameter properties and should simulate the behavior.