### PR TITLE
Clicking History tab should default to commit history list

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -329,5 +329,9 @@ export class RepositoryView extends React.Component<
       this.props.repository,
       section
     )
+
+    this.props.dispatcher.updateCompareForm(this.props.repository, {
+      showBranchList: false,
+    })
   }
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -329,9 +329,10 @@ export class RepositoryView extends React.Component<
       this.props.repository,
       section
     )
-
-    this.props.dispatcher.updateCompareForm(this.props.repository, {
-      showBranchList: false,
-    })
+    if (!!section) {
+      this.props.dispatcher.updateCompareForm(this.props.repository, {
+        showBranchList: false,
+      })
+    }
   }
 }


### PR DESCRIPTION
Sets showBranchList to false when clicking on a new tab. This should resolve #5736