### PR TITLE
Add repository path to "Remove repository" dialog (#5805)

### DIFF
--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -3,6 +3,7 @@ import { ButtonGroup } from '../lib/button-group'
 import { Button } from '../lib/button'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Ref } from '../lib/ref'
 import { Repository } from '../../models/repository'
 import { TrashNameLabel } from '../lib/context-menu'
 
@@ -68,7 +69,7 @@ export class ConfirmRemoveRepository extends React.Component<
           <p className="description">
             The repository will be removed from GitHub Desktop:
             <br />
-            {this.props.repository.path}
+            <Ref>{this.props.repository.path}</Ref>
           </p>
 
           <div>

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -66,7 +66,9 @@ export class ConfirmRemoveRepository extends React.Component<
             "?
           </p>
           <p className="description">
-            The repository will be removed from GitHub Desktop.
+            The repository will be removed from GitHub Desktop:
+            <br />
+            {this.props.repository.path}
           </p>
 
           <div>


### PR DESCRIPTION
This adds the path of the repository to the "Remove repository" dialog to remove any confusion and ensure the user knows which repository is in play. This is especially relevant when removing files from disk is selected.

See #5805 for details. Here's a screenshot of this branch:
![image](https://user-images.githubusercontent.com/454813/46431928-08c56a00-c71b-11e8-91d1-43ea1c9fa73b.png)