### PR TITLE
add number of conflict markers to status

### DIFF
--- a/app/src/lib/git/diff-check.ts
+++ b/app/src/lib/git/diff-check.ts
@@ -4,11 +4,11 @@ import { getCaptures } from '../helpers/regex'
 /**
  * returns a list of files with conflict markers present
  * @param repositoryPath filepath to repository
- * @returns set of filepaths with conflict markers
+ * @returns filepaths with their number of conflicted markers
  */
 export async function getFilesWithConflictMarkers(
   repositoryPath: string
-): Promise<Set<string>> {
+): Promise<Map<string, number>> {
   // git operation
   const args = ['diff', '--check']
   const { output } = await spawnAndComplete(
@@ -20,13 +20,18 @@ export async function getFilesWithConflictMarkers(
 
   // result parsing
   const outputStr = output.toString('utf8')
-  const flatSet = new Set<string>()
   const captures = await getCaptures(outputStr, fileNameCaptureRe)
-  captures.forEach(match =>
-    // fileNameCaptureRe only has one capture
-    flatSet.add(match[0])
+  if (captures.length === 0) {
+    return new Map<string, number>()
+  }
+  // flatten the list (only does one level deep)
+  const flatCaptures = captures.reduce((acc, val) => acc.concat(val))
+  // count number of occurences
+  const counted = flatCaptures.reduce(
+    (acc, val) => acc.set(val, (acc.get(val) || 0) + 1),
+    new Map<string, number>()
   )
-  return flatSet
+  return counted
 }
 
 /**

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -133,7 +133,7 @@ export async function getStatus(
     es => mapStatus(es.statusCode).kind === 'conflicted'
   )
     ? await getFilesWithConflictMarkers(repository.path)
-    : new Set<string>()
+    : new Map<string, number>()
 
   // Map of files keyed on their paths.
   const files = entries.reduce(
@@ -176,7 +176,7 @@ export async function getStatus(
 function buildStatusMap(
   files: Map<string, WorkingDirectoryFileChange>,
   entry: IStatusEntry,
-  filesWithConflictMarkers: Set<string>
+  filesWithConflictMarkers: Map<string, number>
 ): Map<string, WorkingDirectoryFileChange> {
   const status = mapStatus(entry.statusCode)
 
@@ -213,7 +213,8 @@ function buildStatusMap(
       entry.path,
       summary,
       selection,
-      entry.oldPath
+      entry.oldPath,
+      filesWithConflictMarkers.get(entry.path)
     )
   )
   return files

--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -2,16 +2,16 @@
  * get all regex captures within a body of text
  * @param text string to search
  * @param re regex to search with. must have global option and one capture
- * @returns set of strings captured by supplied regex
+ * @returns ararys of strings captured by supplied regex
  */
 export async function getCaptures(
   text: string,
   re: RegExp
-): Promise<Set<Array<string>>> {
+): Promise<ReadonlyArray<Array<string>>> {
   const matches = await getMatches(text, re)
   const captures = matches.reduce(
-    (captures, match) => captures.add(match.slice(1)),
-    new Set<Array<string>>()
+    (acc, match) => acc.concat([match.slice(1)]),
+    new Array<Array<string>>()
   )
   return captures
 }

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -162,14 +162,16 @@ export class WorkingDirectoryFileChange extends FileChange {
   /**
    * @param path The relative path to the file in the repository.
    * @param status The status of the change to the file.
-   * @param oldPath The original path in the case of a renamed file.
    * @param selection Contains the selection details for this file - all, nothing or partial.
+   * @param oldPath The original path in the case of a renamed file.
+   * @param conflictMarkers The number of conflict markers found in this file
    */
   public constructor(
     path: string,
     status: AppFileStatus,
     public readonly selection: DiffSelection,
-    oldPath?: string
+    oldPath?: string,
+    public readonly conflictMarkers: number = 0
   ) {
     super(path, status, oldPath)
   }

--- a/app/test/unit/git/diff-check-test.ts
+++ b/app/test/unit/git/diff-check-test.ts
@@ -17,7 +17,7 @@ describe('getFilesWithConflictMarkers', () => {
 
     it('finds one conflicted file', async () => {
       expect(await getFilesWithConflictMarkers(repository.path)).toEqual(
-        new Set<string>(['foo'])
+        new Map([['foo', 3]])
       )
     })
   })
@@ -28,7 +28,7 @@ describe('getFilesWithConflictMarkers', () => {
     })
     it('finds multiple conflicted files', async () => {
       expect(await getFilesWithConflictMarkers(repository.path)).toEqual(
-        new Set<string>(['foo', 'bar', 'baz'])
+        new Map([['bar', 3], ['baz', 3], ['foo', 3]])
       )
     })
   })
@@ -40,7 +40,7 @@ describe('getFilesWithConflictMarkers', () => {
 
     it('finds one conflicted file', async () => {
       expect(await getFilesWithConflictMarkers(repository.path)).toEqual(
-        new Set<string>([])
+        new Map()
       )
     })
   })

--- a/app/test/unit/helpers/regex-test.ts
+++ b/app/test/unit/helpers/regex-test.ts
@@ -10,20 +10,18 @@ describe('getCaptures()', () => {
       bodyOfText = `capture me!:matching:capture me too!\nalso capture me!:matching:also capture me too!\n`
     })
     it('returns all captures', async () => {
-      expect(await subject()).toEqual(
-        new Set<Array<string>>([
-          ['capture me!', 'capture me too!'],
-          ['also capture me!', 'also capture me too!'],
-        ])
-      )
+      expect(await subject()).toEqual([
+        ['capture me!', 'capture me too!'],
+        ['also capture me!', 'also capture me too!'],
+      ])
     })
   })
   describe('with no matches', () => {
     beforeAll(() => {
       bodyOfText = ' '
     })
-    it('returns empty set', async () => {
-      expect(await subject()).toEqual(new Set<Array<string>>())
+    it('returns empty array', async () => {
+      expect(await subject()).toEqual([])
     })
   })
 })


### PR DESCRIPTION
## Overview

This PR refactors to `getFilesWithConflictMarkers` to return a `Map` instead of a `Set`. The new `Map` has keys of the filepaths and values that count the number of conflict markers in that file. This will be used to display the _number of conflicts in a file_ in the merge conflict resolution UI.

## Implementation details

* refactored `getCaptures` to return and `Array` instead of a `Set` so its more general purpose. and works for my case 😂
* refactored `getStatus` to use this new data structure
* add `conflictMarkers` property to `WorkingDirectoryFileChange`

## Timeline

I will merge this on Friday, Oct 5, barring any major blockers.