### PR TITLE
Allow Resetting HEAD from History View

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -450,6 +450,14 @@ export class Dispatcher {
     return this.appStore._revertCommit(repository, commit)
   }
 
+  /** Revert the commit with the given SHA */
+  public resetHeadToCommit(
+    repository: Repository,
+    commit: Commit
+  ): Promise<void> {
+    return this.appStore._resetHeadToCommit(repository, commit)
+  }
+
   /**
    * Set the width of the repository sidebar to the given
    * value. This affects the changes and history sidebar

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3450,6 +3450,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _resetHeadToCommit(
+    repository: Repository,
+    commit: Commit
+  ): Promise<void> {
+    return this.withAuthenticatingUser(repository, async repo => {
+      const gitStore = this.getGitStore(repo)
+
+      await gitStore.resetHeadToCommit(repo, commit)
+
+      this.updateRevertProgress(repo, null)
+      await this._refreshRepository(repository)
+    })
+  }
+
   public async promptForGenericGitAuthentication(
     repository: Repository | CloningRepository,
     retryAction: RetryAction

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1243,7 +1243,7 @@ export class GitStore extends BaseStore {
     commit: Commit
   ): Promise<void> {
     await this.performFailableOperation(() =>
-      reset(repository, GitResetMode.Hard, commit.sha)
+      reset(repository, GitResetMode.Soft, commit.sha)
     )
 
     this.emitUpdate()

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1237,6 +1237,18 @@ export class GitStore extends BaseStore {
     this.emitUpdate()
   }
 
+  /** Reverts the commit with the given SHA */
+  public async resetHeadToCommit(
+    repository: Repository,
+    commit: Commit
+  ): Promise<void> {
+    await this.performFailableOperation(() =>
+      reset(repository, GitResetMode.Hard, commit.sha)
+    )
+
+    this.emitUpdate()
+  }
+
   /**
    * Get the merge message in the repository. This will resolve to null if the
    * repository isn't in the middle of a merge.

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -18,6 +18,7 @@ interface ICommitProps {
   readonly emoji: Map<string, string>
   readonly isLocal: boolean
   readonly onRevertCommit?: (commit: Commit) => void
+  readonly onResetHeadToCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
 }
@@ -116,6 +117,16 @@ export class CommitListItem extends React.Component<
         action: () => {
           if (this.props.onRevertCommit) {
             this.props.onRevertCommit(this.props.commit)
+          }
+        },
+      },
+      {
+        label: __DARWIN__
+          ? 'Reset HEAD To This Commit'
+          : 'Reset HEAD to this commit',
+        action: () => {
+          if (this.props.onResetHeadToCommit) {
+            this.props.onResetHeadToCommit(this.props.commit)
           }
         },
       },

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -41,6 +41,9 @@ interface ICommitListProps {
   /** Callback to fire to revert a given commit in the current repository */
   readonly onRevertCommit: (commit: Commit) => void
 
+  /** Callback to fire to reset head of a branch to a commit in the current repository */
+  readonly onResetHeadToCommit: (commit: Commit) => void
+
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
 }
@@ -71,6 +74,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}
         onRevertCommit={this.props.onRevertCommit}
+        onResetHeadToCommit={this.props.onResetHeadToCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -46,6 +46,7 @@ interface ICompareSidebarProps {
   readonly currentBranch: Branch | null
   readonly selectedCommitSha: string | null
   readonly onRevertCommit: (commit: Commit) => void
+  readonly onResetHeadToCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
 }
 
@@ -274,6 +275,7 @@ export class CompareSidebar extends React.Component<
         emoji={this.props.emoji}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onRevertCommit={this.props.onRevertCommit}
+        onResetHeadToCommit={this.props.onResetHeadToCommit}
         onCommitSelected={this.onCommitSelected}
         onScroll={this.onScroll}
         emptyListMessage={emptyListMessage}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -166,6 +166,7 @@ export class RepositoryView extends React.Component<
         localCommitSHAs={this.props.state.localCommitSHAs}
         dispatcher={this.props.dispatcher}
         onRevertCommit={this.onRevertCommit}
+        onResetHeadToCommit={this.onResetHeadToCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
@@ -299,6 +300,10 @@ export class RepositoryView extends React.Component<
 
   private onRevertCommit = (commit: Commit) => {
     this.props.dispatcher.revertCommit(this.props.repository, commit)
+  }
+
+  private onResetHeadToCommit = (commit: Commit) => {
+    this.props.dispatcher.resetHeadToCommit(this.props.repository, commit)
   }
 
   private onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
Fixes https://github.com/desktop/desktop/issues/5860

When on a branch I typically like to jump back in time. I reset my head to a particular commit in order to do so. This makes my workflow easier 😃.

I chose to go with `Soft` mode because you can always right click discard changes afterwards. I generally find myself wishing to go back a few commits to merge a typo commit or something of a similar sort.

![image](https://user-images.githubusercontent.com/7467062/46559189-23cbe180-c8b5-11e8-89e8-565925f3dd46.png)
