### PR TITLE
fixes issue #3030 by checking for an empty field

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -416,7 +416,7 @@ export class CreateRepository extends React.Component<
   private renderGitRepositoryWarning() {
     const isRepo = this.state.isRepository
 
-    if (this.state.path.length && !isRepo) {
+    if ((this.state.path.length && !isRepo) || this.state.path.length === 0) {
       return null
     }
 


### PR DESCRIPTION
This PR fixes issue #3030 by checking for an empty directory when conditionally rendering the warning.