### PR TITLE
`Install and Restart` button should be default button in Release Notes modal

### DIFF
--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -174,10 +174,10 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         <DialogContent>{contents}</DialogContent>
         <DialogFooter>
           <ButtonGroup destructive={true}>
-            <Button type="submit">Close</Button>
-            <Button onClick={this.updateNow}>
+            <Button type="submit" onClick={this.updateNow}>
               {__DARWIN__ ? 'Install and Restart' : 'Install and restart'}
             </Button>
+            <Button>Close</Button>
           </ButtonGroup>
         </DialogFooter>
       </Dialog>


### PR DESCRIPTION
This was a quick fix to #5827 ! To highlight the button `Install and Restart` I added `type="submit"` as an attribute

This is a destructive button so it will default to close when the `Enter` key is pressed. 