### PR TITLE
fix emoji autocompleter updating

### DIFF
--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -77,11 +77,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   private receiveProps(props: IChangesSidebarProps) {
     if (
       this.autocompletionProviders === null ||
+      this.props.emoji.size === 0 ||
       props.repository.hash !== this.props.repository.hash ||
       props.accounts !== this.props.accounts
     ) {
       const autocompletionProviders: IAutocompletionProvider<any>[] = [
-        new EmojiAutocompletionProvider(this.props.emoji),
+        new EmojiAutocompletionProvider(props.emoji),
       ]
 
       // Issues autocompletion is only available for GitHub repositories.


### PR DESCRIPTION
#5723 exposed a bug in the sidebar component where it would not load a new emoji set into the emoji autocompletion provider. this PR updates that logic to load a new emoji set _only_ when the current emoji set is empty