### PR TITLE
avoid unnecessarily reloading history

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -662,6 +662,9 @@ export interface ICompareState {
   /** The text entered into the compare branch filter text box */
   readonly filterText: string
 
+  /** The SHA associated with the most recent history state */
+  readonly tip: string | null
+
   /** The SHAs of commits to render in the compare list */
   readonly commitSHAs: ReadonlyArray<string>
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -728,13 +728,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const { formState, commitSHAs } = compareState
       const previousTip = compareState.tip
 
-      const tipHasChanged =
+      const tipIsUnchanged =
         currentSha !== null &&
         previousTip !== null &&
         currentSha === previousTip
 
       if (
-        tipHasChanged &&
+        tipIsUnchanged &&
         formState.kind === ComparisonView.None &&
         commitSHAs.length > 0
       ) {

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -118,6 +118,7 @@ function getInitialRepositoryState(): IRepositoryState {
     compareState: {
       isDivergingBranchBannerVisible: false,
       formState: { kind: ComparisonView.None },
+      tip: null,
       mergeStatus: null,
       showBranchList: false,
       filterText: '',


### PR DESCRIPTION
Fixes #5470 by checking the current state of the history tab.

We're interested in checking these three conditions:

 - we're still viewing the history tab
 - the tip commit (where the history starts) is unchanged
 - there are commits already shown 

To test this: 
 - switch to the history tab
 - scroll down so a second page of commits is loaded in
 - select an item in that second page, so we can demonstrate scrolling and selection

On current `master`, when you switch away and return to Desktop, the app will forget everything and revert to choosing the first commit. With this PR, the selected commit and scroll position should be remembered (because we no longer re-populate History).