### PR TITLE
add commit selection API to RepositoryStateCache and tidy up

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -556,7 +556,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ? new Array<CommittedFileChange>()
         : state.changedFiles
       const file = commitChanged ? null : state.file
-      return { sha, file, diff: null, changedFiles }
+      return { sha, file, changedFiles, diff: null }
     })
 
     this.emitUpdate()
@@ -956,24 +956,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ? changedFiles[0]
         : commitSelection.file
 
-    const selectionOrFirstFile = {
-      file: firstFileOrDefault,
-      sha: commitSelection.sha,
-      changedFiles,
-      diff: null,
-    }
-
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       file: firstFileOrDefault,
-      sha: commitSelection.sha,
       changedFiles,
       diff: null,
     }))
 
     this.emitUpdate()
 
-    if (selectionOrFirstFile.file) {
-      this._changeFileSelection(repository, selectionOrFirstFile.file)
+    if (firstFileOrDefault !== null) {
+      this._changeFileSelection(repository, firstFileOrDefault)
     }
   }
 
@@ -988,15 +980,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     file: CommittedFileChange
   ): Promise<void> {
-    this.repositoryStateCache.updateCommitSelection(repository, state => {
-      const { sha, changedFiles } = state
-      return {
-        sha,
-        changedFiles,
-        file,
-        diff: null,
-      }
-    })
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      file,
+      diff: null,
+    }))
     this.emitUpdate()
 
     const stateBeforeLoad = this.repositoryStateCache.get(repository)
@@ -1029,15 +1016,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    this.repositoryStateCache.updateCommitSelection(repository, state => {
-      const { sha, changedFiles } = state
-      return {
-        sha,
-        changedFiles,
-        file,
-        diff,
-      }
-    })
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      diff,
+    }))
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -550,14 +550,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     sha: string
   ): Promise<void> {
-    this.repositoryStateCache.updateCommitSelection(repository, state => {
-      const commitChanged = state.sha !== sha
-      const changedFiles = commitChanged
-        ? new Array<CommittedFileChange>()
-        : state.changedFiles
-      const file = commitChanged ? null : state.file
-      return { sha, file, changedFiles, diff: null }
-    })
+    const { commitSelection } = this.repositoryStateCache.get(repository)
+
+    if (commitSelection.sha === sha) {
+      return
+    }
+
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      sha,
+      file: null,
+      changedFiles: [],
+      diff: null,
+    }))
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -537,13 +537,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private clearSelectedCommit(repository: Repository) {
-    this.repositoryStateCache.update(repository, () => ({
-      commitSelection: {
-        sha: null,
-        file: null,
-        changedFiles: [],
-        diff: null,
-      },
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      sha: null,
+      file: null,
+      changedFiles: [],
+      diff: null,
     }))
   }
 
@@ -552,14 +550,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     sha: string
   ): Promise<void> {
-    this.repositoryStateCache.update(repository, state => {
-      const commitChanged = state.commitSelection.sha !== sha
+    this.repositoryStateCache.updateCommitSelection(repository, state => {
+      const commitChanged = state.sha !== sha
       const changedFiles = commitChanged
         ? new Array<CommittedFileChange>()
-        : state.commitSelection.changedFiles
-      const file = commitChanged ? null : state.commitSelection.file
-      const commitSelection = { sha, file, diff: null, changedFiles }
-      return { commitSelection }
+        : state.changedFiles
+      const file = commitChanged ? null : state.file
+      return { sha, file, diff: null, changedFiles }
     })
 
     this.emitUpdate()
@@ -966,8 +963,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       diff: null,
     }
 
-    this.repositoryStateCache.update(repository, () => ({
-      commitSelection: selectionOrFirstFile,
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      file: firstFileOrDefault,
+      sha: commitSelection.sha,
+      changedFiles,
+      diff: null,
     }))
 
     this.emitUpdate()
@@ -988,15 +988,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     file: CommittedFileChange
   ): Promise<void> {
-    this.repositoryStateCache.update(repository, state => {
-      const { sha, changedFiles } = state.commitSelection
-      const commitSelection = {
+    this.repositoryStateCache.updateCommitSelection(repository, state => {
+      const { sha, changedFiles } = state
+      return {
         sha,
         changedFiles,
         file,
         diff: null,
       }
-      return { commitSelection }
     })
     this.emitUpdate()
 
@@ -1030,15 +1029,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    this.repositoryStateCache.update(repository, state => {
-      const { sha, changedFiles } = state.commitSelection
-      const commitSelection = {
+    this.repositoryStateCache.updateCommitSelection(repository, state => {
+      const { sha, changedFiles } = state
+      return {
         sha,
         changedFiles,
         file,
         diff,
       }
-      return { commitSelection }
     })
 
     this.emitUpdate()

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -15,6 +15,7 @@ import {
   ICompareState,
   IRepositoryState,
   RepositorySectionTab,
+  ICommitSelection,
 } from '../app-state'
 import { ComparisonCache } from '../comparison-cache'
 import { IGitHubUser } from '../databases'
@@ -71,6 +72,17 @@ export class RepositoryStateCache {
       const changesState = state.changesState
       const newState = merge(changesState, fn(changesState))
       return { changesState: newState }
+    })
+  }
+
+  public updateCommitSelection<K extends keyof ICommitSelection>(
+    repository: Repository,
+    fn: (state: ICommitSelection) => Pick<ICommitSelection, K>
+  ) {
+    this.update(repository, state => {
+      const { commitSelection } = state
+      const newState = merge(commitSelection, fn(commitSelection))
+      return { commitSelection: newState }
     })
   }
 


### PR DESCRIPTION
The `commitSelection` state object is very old, and it never got the `Pick<T>` treatment like other parts of `IRepositoryState`, so every time we need to update it we need to provide the whole object. This has lead to some complex and potentially confusing code.

This PR introduces a `updateCommitSelection` helper function which allows us to cleanup our existing usages to just update the fields that are changed.