### PR TITLE
Add new repo button in repository dropdown

### DIFF
--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -15,6 +15,8 @@ import { enableRepoInfoIndicators } from '../../lib/feature-flag'
 import { Dispatcher } from '../../lib/dispatcher'
 import { Button } from '../lib/button'
 import { Octicon, OcticonSymbol } from '../octicons'
+import { showContextualMenu } from '../main-process-proxy'
+import { IMenuItem } from '../../lib/menu-item'
 
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
@@ -169,12 +171,42 @@ export class RepositoriesList extends React.Component<
 
   private renderPostFilter = () => {
     return (
-      <Button className="new-repository-button">
+      <Button
+        className="new-repository-button"
+        onClick={this.onNewRepositoryButtonClick}
+      >
         {__DARWIN__ ? 'Add' : 'Add'}
         <Octicon symbol={OcticonSymbol.triangleDown} />
       </Button>
     )
   }
+
+  private onNewRepositoryButtonClick = () => {
+    const items: IMenuItem[] = [
+      {
+        label: __DARWIN__ ? 'Clone Repository…' : 'Clone repository…',
+        action: this.onCloneRepository,
+      },
+      {
+        label: __DARWIN__
+          ? 'Add Existing Repository…'
+          : 'Add existing repository…',
+        action: this.onAddExistingRepository,
+      },
+      {
+        label: __DARWIN__ ? 'Create New Repository…' : 'Create new repository…',
+        action: this.onCreateNewRepository,
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
+  private onCloneRepository = () => {}
+
+  private onAddExistingRepository = () => {}
+
+  private onCreateNewRepository = () => {}
 
   private noRepositories() {
     return (

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -17,6 +17,7 @@ import { Button } from '../lib/button'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { showContextualMenu } from '../main-process-proxy'
 import { IMenuItem } from '../../lib/menu-item'
+import { PopupType } from '../../lib/app-state'
 
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
@@ -202,11 +203,20 @@ export class RepositoriesList extends React.Component<
     showContextualMenu(items)
   }
 
-  private onCloneRepository = () => {}
+  private onCloneRepository = () => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.CloneRepository,
+      initialURL: null,
+    })
+  }
 
-  private onAddExistingRepository = () => {}
+  private onAddExistingRepository = () => {
+    this.props.dispatcher.showPopup({ type: PopupType.AddRepository })
+  }
 
-  private onCreateNewRepository = () => {}
+  private onCreateNewRepository = () => {
+    this.props.dispatcher.showPopup({ type: PopupType.CreateRepository })
+  }
 
   private noRepositories() {
     return (

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -176,7 +176,7 @@ export class RepositoriesList extends React.Component<
         className="new-repository-button"
         onClick={this.onNewRepositoryButtonClick}
       >
-        {__DARWIN__ ? 'Add' : 'Add'}
+        Add
         <Octicon symbol={OcticonSymbol.triangleDown} />
       </Button>
     )

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -13,6 +13,8 @@ import { assertNever } from '../../lib/fatal-error'
 import { ILocalRepositoryState } from '../../models/repository'
 import { enableRepoInfoIndicators } from '../../lib/feature-flag'
 import { Dispatcher } from '../../lib/dispatcher'
+import { Button } from '../lib/button'
+import { Octicon, OcticonSymbol } from '../octicons'
 
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
@@ -154,6 +156,7 @@ export class RepositoriesList extends React.Component<
           renderItem={this.renderItem}
           renderGroupHeader={this.renderGroupHeader}
           onItemClick={this.onItemClick}
+          renderPostFilter={this.renderPostFilter}
           groups={groups}
           invalidationProps={{
             repositories: this.props.repositories,
@@ -161,6 +164,15 @@ export class RepositoriesList extends React.Component<
           }}
         />
       </div>
+    )
+  }
+
+  private renderPostFilter = () => {
+    return (
+      <Button className="new-repository-button">
+        {__DARWIN__ ? 'Add' : 'Add'}
+        <Octicon symbol={OcticonSymbol.triangleDown} />
+      </Button>
     )
   }
 

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -225,16 +225,6 @@
       white-space: nowrap;
     }
   }
-
-  .filter-list-filter-field {
-    padding-right: 0;
-  }
-
-  // We need to beat Row's style at the specificity game :|
-  button.new-branch-button {
-    align-self: center;
-    margin-right: var(--spacing);
-  }
 }
 
 .no-pull-requests {

--- a/app/styles/ui/_filter-list.scss
+++ b/app/styles/ui/_filter-list.scss
@@ -7,8 +7,8 @@
 
   min-width: inherit;
 
-  &-filter-field {
-    padding: var(--spacing);
+  .filter-field-row {
+    margin: var(--spacing);
   }
 
   &-container {

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -103,6 +103,8 @@
   .new-repository-button {
     .octicon {
       margin-left: 5px;
+      width: 9px;
+      height: 13px;
     }
   }
 

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -100,6 +100,12 @@
     }
   }
 
+  .new-repository-button {
+    .octicon {
+      margin-left: 5px;
+    }
+  }
+
   .sidebar-message {
     display: flex;
     flex: 1;


### PR DESCRIPTION
We've heard in research and feedback that users often look in the repository dropdown for a way to add repositories. This adds an "add" dropdown button to the repository sidebar similar to what we have in the branches dropdown to hopefully alleviate that problem.

<img src="https://user-images.githubusercontent.com/634063/46813314-c6cda100-cd76-11e8-8309-6e8c3b2653a9.png" width="410" />

<img width="500" alt="screen shot 2018-10-11 at 16 59 58" src="https://user-images.githubusercontent.com/634063/46813533-2cba2880-cd77-11e8-96e8-77caac7a6586.png">

This addresses one part of #5566 and I plan to tackle the blank slate view when filtering in a follow-up PR.