### PR TITLE
extract GitStoreCache from AppStore to manage state

### DIFF
--- a/app/src/lib/stores/git-store-cache.ts
+++ b/app/src/lib/stores/git-store-cache.ts
@@ -1,0 +1,44 @@
+import { GitStore } from './git-store'
+import { Repository } from '../../models/repository'
+import { IAppShell } from '../app-shell'
+import { Commit } from '../../models/commit'
+
+export class GitStoreCache {
+  /** GitStores keyed by their hash. */
+  private readonly gitStores = new Map<string, GitStore>()
+
+  public constructor(
+    private readonly shell: IAppShell,
+    private readonly onGitStoreUpdated: (
+      repository: Repository,
+      gitStore: GitStore
+    ) => void,
+    private readonly onDidLoadNewCommits: (
+      repository: Repository,
+      commits: ReadonlyArray<Commit>
+    ) => void,
+    private readonly onDidError: (error: Error) => void
+  ) {}
+
+  public remove(repository: Repository) {
+    if (this.gitStores.has(repository.hash)) {
+      this.gitStores.delete(repository.hash)
+    }
+  }
+
+  public get(repository: Repository): GitStore {
+    let gitStore = this.gitStores.get(repository.hash)
+    if (!gitStore) {
+      gitStore = new GitStore(repository, this.shell)
+      gitStore.onDidUpdate(() => this.onGitStoreUpdated(repository, gitStore!))
+      gitStore.onDidLoadNewCommits(commits =>
+        this.onDidLoadNewCommits(repository, commits)
+      )
+      gitStore.onDidError(error => this.onDidError(error))
+
+      this.gitStores.set(repository.hash, gitStore)
+    }
+
+    return gitStore
+  }
+}


### PR DESCRIPTION
Following on from #5564 and `RepositoryStoreCache`, `AppStore` also manages the lifetimes of the `GitStore` instances we create. We can extract these out to be managed by another component.

 - [ ] add tests