### PR TITLE
Fix Changelog Text Overflow in client dialog

### DIFF
--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -57,7 +57,8 @@
     flex-direction: row;
     padding-left: var(--spacing-triple);
     padding-right: var(--spacing-triple);
-    overflow: auto hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     justify-content: space-around;
 
     .column {


### PR DESCRIPTION
Fixes #5854 
• Changes overflow: scroll hidden; to overflow-x: hidden; overflow-y: auto; in _release-notes.scss
• This commit aims to fix issue #5854 by fixing the overflow attribute values by separating the specification for x and y scroll.

This fix also relates to #5760 