### PR TITLE
don't render the merge status when there are no commits to merge

### DIFF
--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -119,7 +119,8 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       currentBranch == null ||
       selectedBranch == null ||
       currentBranch.name === selectedBranch.name ||
-      commitCount == null
+      commitCount == null ||
+      commitCount === 0
     ) {
       return null
     }


### PR DESCRIPTION
Fixes #5890

Current `master` build when you create a new branch and try to merge it into the default branch (note that merge is disabled):

<img width="506" src="https://user-images.githubusercontent.com/359239/46920513-c119ca80-cfc5-11e8-9307-884ec8b8eca3.png">

With this change:

<img width="520" src="https://user-images.githubusercontent.com/359239/46920517-c9720580-cfc5-11e8-9627-d0c189e4a9f3.png">
