### PR TITLE
add tests for symbolicRef and fix regression

### DIFF
--- a/app/src/lib/git/refs.ts
+++ b/app/src/lib/git/refs.ts
@@ -45,12 +45,15 @@ export async function getSymbolicRef(
     repository.path,
     'getSymbolicRef',
     {
-      successExitCodes: new Set([0, 128]),
+      //  - 1 is the exit code that Git throws in quiet mode when the ref is not a
+      //    symbolic ref
+      //  - 128 is the generic error code that Git returns when it can't find
+      //    something
+      successExitCodes: new Set([0, 1, 128]),
     }
   )
 
-  if (result.exitCode === 128) {
-    // ref was not a symbolic ref or ref does not exist
+  if (result.exitCode === 1 || result.exitCode === 128) {
     return null
   }
 

--- a/app/test/unit/git/ref-test.ts
+++ b/app/test/unit/git/ref-test.ts
@@ -1,19 +1,36 @@
 import { expect } from 'chai'
-import { formatAsLocalRef } from '../../../src/lib/git/refs'
+import { formatAsLocalRef, getSymbolicRef } from '../../../src/lib/git/refs'
+import { setupEmptyRepository } from '../../helpers/repositories'
 
 describe('git/refs', () => {
-  it('formats the common branch syntax', () => {
-    const result = formatAsLocalRef('master')
-    expect(result).to.equal('refs/heads/master')
+  describe('formatAsLocalRef', () => {
+    it('formats the common branch syntax', () => {
+      const result = formatAsLocalRef('master')
+      expect(result).to.equal('refs/heads/master')
+    })
+
+    it('formats an explicit heads/ prefix', () => {
+      const result = formatAsLocalRef('heads/something-important')
+      expect(result).to.equal('refs/heads/something-important')
+    })
+
+    it('formats when a remote name is included', () => {
+      const result = formatAsLocalRef('heads/Microsoft/master')
+      expect(result).to.equal('refs/heads/Microsoft/master')
+    })
   })
 
-  it('formats an explicit heads/ prefix', () => {
-    const result = formatAsLocalRef('heads/something-important')
-    expect(result).to.equal('refs/heads/something-important')
-  })
+  describe('getSymbolicRef', () => {
+    it('resolves a valid symbolic ref', async () => {
+      const repo = await setupEmptyRepository()
+      const ref = await getSymbolicRef(repo, 'HEAD')
+      expect(ref).equals('refs/heads/master')
+    })
 
-  it('formats when a remote name is included', () => {
-    const result = formatAsLocalRef('heads/Microsoft/master')
-    expect(result).to.equal('refs/heads/Microsoft/master')
+    it('does not resolve a missing ref', async () => {
+      const repo = await setupEmptyRepository()
+      const ref = await getSymbolicRef(repo, 'FOO')
+      expect(ref).is.null
+    })
   })
 })


### PR DESCRIPTION
Found this while investigating #5905. The user is seeing a lot of these messages:

```
2018-10-16T12:12:43.347Z - error: [ui] `git symbolic-ref -q refs/remotes/org/HEAD` exited with an unexpected code: 1.
```

`git symbolic-ref` was added in #5073 to better detect the default branch but it looks like the Git internals have changed - I was expecting `128` as the error code when it can't resolve a symbolic ref but it looks like `1` is now what's returned.

 - [x] add tests to verify regression
 - [x] fix regression