### PR TITLE
add createMergeCommit and refactor out commit error handling logic

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -48,11 +48,11 @@ export async function createMergeCommit(
   // do the same thing.
   await unstageAll(repository)
   await stageFiles(repository, files)
-  await git(
-    ['commit', '--no-edit'],
-    repository.path,
-    'createMergeCommit'
-  ).catch(logCommitError)
+  try {
+    await git(['commit', '--no-edit'], repository.path, 'createMergeCommit')
+  } catch (e) {
+    logCommitError(e)
+  }
 }
 
 /**

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -64,11 +64,8 @@ function logCommitError(e: Error): void {
   if (e instanceof GitError) {
     const output = e.result.stderr.trim()
 
-    let standardError = ''
-    if (output.length > 0) {
-      standardError = `, with output: '${output}'`
-    }
-    const exitCode = e.result.exitCode
+    const standardError = output.length > 0 ? `, with output: '${output}'` : ''
+    const { exitCode } = e.result
     const error = new Error(
       `Commit failed - exit code ${exitCode} received${standardError}`
     )

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -57,7 +57,8 @@ export async function createMergeCommit(
 
 /**
  * Commit failures could come from a pre-commit hook rejection.
- * So display a bit more context than we otherwise would.
+ * So display a bit more context than we otherwise would,
+ * then re-raise the error.
  */
 function logCommitError(e: Error): void {
   if (e instanceof GitError) {

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -44,21 +44,15 @@ export async function createCommit(
 export async function createMergeCommit(
   repository: Repository,
   files: ReadonlyArray<WorkingDirectoryFileChange>
-): Promise<boolean> {
+): Promise<void> {
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
   // do the same thing.
   await unstageAll(repository)
-
   await stageFiles(repository, files)
-
-  try {
-    await git(['commit'], repository.path, 'createMergeCommit')
-    return true
-  } catch (e) {
-    handleCommitError(e)
-    return false
-  }
+  await git(['commit'], repository.path, 'createMergeCommit').catch(
+    handleCommitError
+  )
 }
 
 /**

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -4,6 +4,13 @@ import { Repository } from '../../models/repository'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { unstageAll } from './reset'
 
+/**
+ * Create a commit
+ *
+ * @param repository repository to execute merge in
+ * @param message commit message
+ * @param files files to commit
+ */
 export async function createCommit(
   repository: Repository,
   message: string,
@@ -22,23 +29,57 @@ export async function createCommit(
     })
     return true
   } catch (e) {
-    // Commit failures could come from a pre-commit hook rejection. So display
-    // a bit more context than we otherwise would.
-    if (e instanceof GitError) {
-      const output = e.result.stderr.trim()
+    handleCommitError(e)
+    return false
+  }
+}
 
-      let standardError = ''
-      if (output.length > 0) {
-        standardError = `, with output: '${output}'`
-      }
-      const exitCode = e.result.exitCode
-      const error = new Error(
-        `Commit failed - exit code ${exitCode} received${standardError}`
-      )
-      error.name = 'commit-failed'
-      throw error
-    } else {
-      throw e
+/**
+ * Creates a commit to finish an in-progress merge
+ * assumes that all conflicts have already been resolved
+ *
+ * @param repository repository to execute merge in
+ * @param files files to commit
+ */
+export async function createMergeCommit(
+  repository: Repository,
+  files: ReadonlyArray<WorkingDirectoryFileChange>
+): Promise<boolean> {
+  // Clear the staging area, our diffs reflect the difference between the
+  // working directory and the last commit (if any) so our commits should
+  // do the same thing.
+  await unstageAll(repository)
+
+  await stageFiles(repository, files)
+
+  try {
+    await git(['commit'], repository.path, 'createMergeCommit')
+    return true
+  } catch (e) {
+    handleCommitError(e)
+    return false
+  }
+}
+
+/**
+ * Commit failures could come from a pre-commit hook rejection.
+ * So display a bit more context than we otherwise would.
+ */
+function handleCommitError(e: Error): void {
+  if (e instanceof GitError) {
+    const output = e.result.stderr.trim()
+
+    let standardError = ''
+    if (output.length > 0) {
+      standardError = `, with output: '${output}'`
     }
+    const exitCode = e.result.exitCode
+    const error = new Error(
+      `Commit failed - exit code ${exitCode} received${standardError}`
+    )
+    error.name = 'commit-failed'
+    throw error
+  } else {
+    throw e
   }
 }

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -5,8 +5,6 @@ import { WorkingDirectoryFileChange } from '../../models/status'
 import { unstageAll } from './reset'
 
 /**
- * Create a commit
- *
  * @param repository repository to execute merge in
  * @param message commit message
  * @param files files to commit

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -46,9 +46,9 @@ export async function createMergeCommit(
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
   // do the same thing.
-  await unstageAll(repository)
-  await stageFiles(repository, files)
   try {
+    await unstageAll(repository)
+    await stageFiles(repository, files)
     await git(['commit', '--no-edit'], repository.path, 'createMergeCommit')
   } catch (e) {
     logCommitError(e)

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -50,9 +50,11 @@ export async function createMergeCommit(
   // do the same thing.
   await unstageAll(repository)
   await stageFiles(repository, files)
-  await git(['commit'], repository.path, 'createMergeCommit').catch(
-    handleCommitError
-  )
+  await git(
+    ['commit', '--no-edit'],
+    repository.path,
+    'createMergeCommit'
+  ).catch(handleCommitError)
 }
 
 /**

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -27,7 +27,7 @@ export async function createCommit(
     })
     return true
   } catch (e) {
-    handleCommitError(e)
+    logCommitError(e)
     return false
   }
 }
@@ -52,14 +52,14 @@ export async function createMergeCommit(
     ['commit', '--no-edit'],
     repository.path,
     'createMergeCommit'
-  ).catch(handleCommitError)
+  ).catch(logCommitError)
 }
 
 /**
  * Commit failures could come from a pre-commit hook rejection.
  * So display a bit more context than we otherwise would.
  */
-function handleCommitError(e: Error): void {
+function logCommitError(e: Error): void {
   if (e instanceof GitError) {
     const output = e.result.stderr.trim()
 

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -1,8 +1,6 @@
 import * as path from 'path'
 import * as FSE from 'fs-extra'
 
-import { expect } from 'chai'
-
 import { Repository } from '../../../src/models/repository'
 import {
   createCommit,
@@ -57,17 +55,17 @@ describe('git/commit', () => {
 
       let status = await getStatusOrThrow(repository!)
       let files = status.workingDirectory.files
-      expect(files.length).to.equal(1)
+      expect(files.length).toEqual(1)
 
       await createCommit(repository!, 'Special commit', files)
 
       status = await getStatusOrThrow(repository!)
       files = status.workingDirectory.files
-      expect(files.length).to.equal(0)
+      expect(files.length).toEqual(0)
 
       const commits = await getCommits(repository!, 'HEAD', 100)
-      expect(commits.length).to.equal(6)
-      expect(commits[0].summary).to.equal('Special commit')
+      expect(commits.length).toEqual(6)
+      expect(commits[0].summary).toEqual('Special commit')
     })
 
     it('commit does not strip commentary by default', async () => {
@@ -78,7 +76,7 @@ describe('git/commit', () => {
 
       const status = await getStatusOrThrow(repository!)
       const files = status.workingDirectory.files
-      expect(files.length).to.equal(1)
+      expect(files.length).toEqual(1)
 
       const message = `Special commit
 
@@ -87,9 +85,9 @@ describe('git/commit', () => {
       await createCommit(repository!, message, files)
 
       const commit = await getCommit(repository!, 'HEAD')
-      expect(commit).to.not.be.null
-      expect(commit!.summary).to.equal('Special commit')
-      expect(commit!.body).to.equal('# this is a comment\n')
+      expect(commit).not.toBeNull()
+      expect(commit!.summary).toEqual('Special commit')
+      expect(commit!.body).toEqual('# this is a comment\n')
     })
 
     it('can commit for empty repository', async () => {
@@ -101,7 +99,7 @@ describe('git/commit', () => {
       const status = await getStatusOrThrow(repo)
       const files = status.workingDirectory.files
 
-      expect(files.length).to.equal(2)
+      expect(files.length).toEqual(2)
 
       const allChanges = [
         files[0].withIncludeAll(true),
@@ -116,13 +114,13 @@ describe('git/commit', () => {
 
       const statusAfter = await getStatusOrThrow(repo)
 
-      expect(statusAfter.workingDirectory.files.length).to.equal(0)
+      expect(statusAfter.workingDirectory.files.length).toEqual(0)
 
       const history = await getCommits(repo, 'HEAD', 2)
 
-      expect(history.length).to.equal(1)
-      expect(history[0].summary).to.equal('added two files')
-      expect(history[0].body).to.equal('this is a description\n')
+      expect(history.length).toEqual(1)
+      expect(history[0].summary).toEqual('added two files')
+      expect(history[0].body).toEqual('this is a description\n')
     })
 
     it('can commit renames', async () => {
@@ -137,7 +135,7 @@ describe('git/commit', () => {
       const status = await getStatusOrThrow(repo)
       const files = status.workingDirectory.files
 
-      expect(files.length).to.equal(1)
+      expect(files.length).toEqual(1)
 
       await createCommit(repo, 'renamed a file', [
         files[0].withIncludeAll(true),
@@ -145,7 +143,7 @@ describe('git/commit', () => {
 
       const statusAfter = await getStatusOrThrow(repo)
 
-      expect(statusAfter.workingDirectory.files.length).to.equal(0)
+      expect(statusAfter.workingDirectory.files.length).toEqual(0)
     })
   })
 
@@ -176,24 +174,24 @@ describe('git/commit', () => {
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
-      expect(newTip.sha).to.not.equal(previousTip.sha)
-      expect(newTip.summary).to.equal('title')
+      expect(newTip.sha).not.toEqual(previousTip.sha)
+      expect(newTip.summary).toEqual('title')
 
       // verify that the contents of this new commit are just the new file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
-      expect(changedFiles.length).to.equal(1)
-      expect(changedFiles[0].path).to.equal(newFileName)
+      expect(changedFiles.length).toEqual(1)
+      expect(changedFiles[0].path).toEqual(newFileName)
 
       // verify that changes remain for this new file
       const status = await getStatusOrThrow(repository!)
-      expect(status.workingDirectory.files.length).to.equal(4)
+      expect(status.workingDirectory.files.length).toEqual(4)
 
       // verify that the file is now tracked
       const fileChange = status!.workingDirectory.files.find(
         f => f.path === newFileName
       )
-      expect(fileChange).to.not.be.undefined
-      expect(fileChange!.status).to.equal(AppFileStatus.Modified)
+      expect(fileChange).not.toBeUndefined()
+      expect(fileChange!.status).toEqual(AppFileStatus.Modified)
     })
 
     it('can commit second hunk from modified file', async () => {
@@ -227,24 +225,24 @@ describe('git/commit', () => {
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
-      expect(newTip.sha).to.not.equal(previousTip.sha)
-      expect(newTip.summary).to.equal('title')
+      expect(newTip.sha).not.toEqual(previousTip.sha)
+      expect(newTip.summary).toEqual('title')
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
-      expect(changedFiles.length).to.equal(1)
-      expect(changedFiles[0].path).to.equal(modifiedFile)
+      expect(changedFiles.length).toEqual(1)
+      expect(changedFiles[0].path).toEqual(modifiedFile)
 
       // verify that changes remain for this modified file
       const status = await getStatusOrThrow(repository!)
-      expect(status.workingDirectory.files.length).to.equal(4)
+      expect(status.workingDirectory.files.length).toEqual(4)
 
       // verify that the file is still marked as modified
       const fileChange = status.workingDirectory.files.find(
         f => f.path === modifiedFile
       )
-      expect(fileChange).to.not.be.undefined
-      expect(fileChange!.status).to.equal(AppFileStatus.Modified)
+      expect(fileChange).not.toBeUndefined()
+      expect(fileChange!.status).toEqual(AppFileStatus.Modified)
     })
 
     it('can commit single delete from modified file', async () => {
@@ -280,13 +278,13 @@ describe('git/commit', () => {
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
-      expect(newTip.sha).to.not.equal(previousTip.sha)
-      expect(newTip.summary).to.equal('title')
+      expect(newTip.sha).not.toEqual(previousTip.sha)
+      expect(newTip.summary).toEqual('title')
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
-      expect(changedFiles.length).to.equal(1)
-      expect(changedFiles[0].path).to.equal(fileName)
+      expect(changedFiles.length).toEqual(1)
+      expect(changedFiles[0].path).toEqual(fileName)
     })
 
     it('can commit multiple hunks from modified file', async () => {
@@ -324,24 +322,24 @@ describe('git/commit', () => {
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
-      expect(newTip.sha).to.not.equal(previousTip.sha)
-      expect(newTip.summary).to.equal('title')
+      expect(newTip.sha).not.toEqual(previousTip.sha)
+      expect(newTip.summary).toEqual('title')
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
-      expect(changedFiles.length).to.equal(1)
-      expect(changedFiles[0].path).to.equal(modifiedFile)
+      expect(changedFiles.length).toEqual(1)
+      expect(changedFiles[0].path).toEqual(modifiedFile)
 
       // verify that changes remain for this modified file
       const status = await getStatusOrThrow(repository!)
-      expect(status.workingDirectory.files.length).to.equal(4)
+      expect(status.workingDirectory.files.length).toEqual(4)
 
       // verify that the file is still marked as modified
       const fileChange = status.workingDirectory.files.find(
         f => f.path === modifiedFile
       )
-      expect(fileChange).to.not.be.undefined
-      expect(fileChange!.status).to.equal(AppFileStatus.Modified)
+      expect(fileChange).not.toBeUndefined()
+      expect(fileChange!.status).toEqual(AppFileStatus.Modified)
     })
 
     it('can commit some lines from deleted file', async () => {
@@ -364,24 +362,24 @@ describe('git/commit', () => {
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
-      expect(newTip.sha).to.not.equal(previousTip.sha)
-      expect(newTip.summary).to.equal('title')
+      expect(newTip.sha).not.toEqual(previousTip.sha)
+      expect(newTip.summary).toEqual('title')
 
       // verify that the contents of this new commit are just the new file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
-      expect(changedFiles.length).to.equal(1)
-      expect(changedFiles[0].path).to.equal(deletedFile)
+      expect(changedFiles.length).toEqual(1)
+      expect(changedFiles[0].path).toEqual(deletedFile)
 
       // verify that changes remain for this new file
       const status = await getStatusOrThrow(repository!)
-      expect(status.workingDirectory.files.length).to.equal(4)
+      expect(status.workingDirectory.files.length).toEqual(4)
 
       // verify that the file is now tracked
       const fileChange = status.workingDirectory.files.find(
         f => f.path === deletedFile
       )
-      expect(fileChange).to.not.be.undefined
-      expect(fileChange!.status).to.equal(AppFileStatus.Deleted)
+      expect(fileChange).not.toBeUndefined()
+      expect(fileChange!.status).toEqual(AppFileStatus.Deleted)
     })
 
     it('can commit renames with modifications', async () => {
@@ -398,7 +396,7 @@ describe('git/commit', () => {
       const status = await getStatusOrThrow(repo)
       const files = status.workingDirectory.files
 
-      expect(files.length).to.equal(1)
+      expect(files.length).toEqual(1)
 
       await createCommit(repo, 'renamed a file', [
         files[0].withIncludeAll(true),
@@ -406,7 +404,7 @@ describe('git/commit', () => {
 
       const statusAfter = await getStatusOrThrow(repo)
 
-      expect(statusAfter.workingDirectory.files.length).to.equal(0)
+      expect(statusAfter.workingDirectory.files.length).toEqual(0)
     })
 
     // The scenario here is that the user has staged a rename (probably using git mv)
@@ -426,9 +424,9 @@ describe('git/commit', () => {
       const status = await getStatusOrThrow(repo)
       const files = status.workingDirectory.files
 
-      expect(files.length).to.equal(1)
-      expect(files[0].path).to.contain('bar')
-      expect(files[0].status).to.equal(AppFileStatus.Renamed)
+      expect(files.length).toEqual(1)
+      expect(files[0].path).toContain('bar')
+      expect(files[0].status).toEqual(AppFileStatus.Renamed)
 
       const selection = files[0].selection
         .withSelectNone()
@@ -440,16 +438,16 @@ describe('git/commit', () => {
 
       const statusAfter = await getStatusOrThrow(repo)
 
-      expect(statusAfter.workingDirectory.files.length).to.equal(1)
+      expect(statusAfter.workingDirectory.files.length).toEqual(1)
 
       const diff = await getTextDiff(
         repo,
         statusAfter.workingDirectory.files[0]
       )
 
-      expect(diff.hunks.length).to.equal(1)
-      expect(diff.hunks[0].lines.length).to.equal(4)
-      expect(diff.hunks[0].lines[3].text).to.equal('+line3')
+      expect(diff.hunks.length).toEqual(1)
+      expect(diff.hunks[0].lines.length).toEqual(4)
+      expect(diff.hunks[0].lines[3].text).toEqual('+line3')
     })
   })
 
@@ -461,23 +459,23 @@ describe('git/commit', () => {
       const inMerge = await FSE.pathExists(
         path.join(repo.path, '.git', 'MERGE_HEAD')
       )
-      expect(inMerge).to.equal(true)
+      expect(inMerge).toEqual(true)
 
       await FSE.writeFile(filePath, 'b1b2')
 
       const status = await getStatusOrThrow(repo)
       const files = status.workingDirectory.files
 
-      expect(files.length).to.equal(1)
-      expect(files[0].path).to.equal('foo')
-      expect(files[0].status).to.equal(AppFileStatus.Resolved)
+      expect(files.length).toEqual(1)
+      expect(files[0].path).toEqual('foo')
+      expect(files[0].status).toEqual(AppFileStatus.Resolved)
 
       const selection = files[0].selection.withSelectAll()
       const selectedFile = files[0].withSelection(selection)
       await createCommit(repo, 'Merge commit!', [selectedFile])
 
       const commits = await getCommits(repo, 'HEAD', 5)
-      expect(commits[0].parentSHAs.length).to.equal(2)
+      expect(commits[0].parentSHAs.length).toEqual(2)
     })
   })
 
@@ -501,9 +499,9 @@ describe('git/commit', () => {
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files
 
-      expect(files.length).to.equal(1)
-      expect(files[0].path).to.contain('second')
-      expect(files[0].status).to.equal(AppFileStatus.New)
+      expect(files.length).toEqual(1)
+      expect(files[0].path).toContain('second')
+      expect(files[0].status).toEqual(AppFileStatus.New)
 
       const toCommit = status.workingDirectory.withIncludeAllFiles(true)
 
@@ -511,11 +509,11 @@ describe('git/commit', () => {
 
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files
-      expect(files).to.be.empty
+      expect(files).toHaveLength(0)
 
       const commit = await getCommit(repo, 'HEAD')
-      expect(commit).to.not.be.null
-      expect(commit!.summary).to.equal('commit everything')
+      expect(commit).not.toBeNull()
+      expect(commit!.summary).toEqual('commit everything')
     })
 
     it('can commit when a delete is staged and the untracked file exists', async () => {
@@ -537,9 +535,9 @@ describe('git/commit', () => {
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files
 
-      expect(files.length).to.equal(1)
-      expect(files[0].path).to.contain('first')
-      expect(files[0].status).to.equal(AppFileStatus.New)
+      expect(files.length).toEqual(1)
+      expect(files[0].path).toContain('first')
+      expect(files[0].status).toEqual(AppFileStatus.New)
 
       const toCommit = status!.workingDirectory.withIncludeAllFiles(true)
 
@@ -547,11 +545,11 @@ describe('git/commit', () => {
 
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files
-      expect(files).to.be.empty
+      expect(files).toHaveLength(0)
 
       const commit = await getCommit(repo, 'HEAD')
-      expect(commit).to.not.be.null
-      expect(commit!.summary).to.equal('commit again!')
+      expect(commit).not.toBeNull()
+      expect(commit!.summary).toEqual('commit again!')
     })
   })
 })


### PR DESCRIPTION
to support #5809 

I need a way to commit without supplying a string as one is automatically filled in by git, as it does when committing a resolved merge.

Bonuses:
* added some docs
* refactored out specialized error handling from `createCommit` into its own function for use in both commit methods
* converted `git/commit` tests to use `jest`'s `expect` (I needed jest's error throwing matchers for my test)

_I would like to merge this Thursday, October, 18th_