### PR TITLE
better ways to compare URLs

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -934,6 +934,10 @@ export class Dispatcher {
       await this.fetchRefspec(repository, `pull/${pr}/head:${branch}`)
     }
 
+    // ensure a fresh clone repository has it's in-memory state
+    // up-to-date before performing the "Clone in Desktop" steps
+    await this.appStore._refreshRepository(repository)
+
     const state = this.repositoryStateManager.get(repository)
 
     if (pr == null && branch != null) {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -31,7 +31,10 @@ import { GitHubRepository } from '../../models/github-repository'
 import { ICommitMessage } from '../stores/git-store'
 import { executeMenuItem } from '../../ui/main-process-proxy'
 import { AppMenu, ExecutableMenuItem } from '../../models/app-menu'
-import { matchExistingRepository } from '../../lib/repository-matching'
+import {
+  matchExistingRepository,
+  urlMatchesCloneURL,
+} from '../../lib/repository-matching'
 import { ILaunchStats, StatsStore } from '../stats'
 import { fatalError, assertNever } from '../fatal-error'
 import { isGitOnPath } from '../is-git-on-path'
@@ -979,7 +982,7 @@ export class Dispatcher {
         if (!gitHubRepository) {
           return false
         }
-        return gitHubRepository.cloneURL === url
+        return urlMatchesCloneURL(url, gitHubRepository)
       } else {
         return false
       }

--- a/app/src/lib/repository-matching.ts
+++ b/app/src/lib/repository-matching.ts
@@ -6,7 +6,7 @@ import { Repository } from '../models/repository'
 import { Account } from '../models/account'
 import { IRemote } from '../models/remote'
 import { getHTMLURL } from './api'
-import { parseRemote } from './remote-parsing'
+import { parseRemote, parseRepositoryIdentifier } from './remote-parsing'
 import { caseInsensitiveEquals } from './compare'
 import { GitHubRepository } from '../models/github-repository'
 
@@ -146,5 +146,31 @@ export function urlMatchesRemote(url: string | null, remote: IRemote): boolean {
   return (
     caseInsensitiveEquals(remoteUrl.owner, cloneUrl.owner) &&
     caseInsensitiveEquals(remoteUrl.name, cloneUrl.name)
+  )
+}
+
+/**
+ * Match a URL-like string to the Clone URL of a GitHub Repository
+ *
+ * @param url A remote-like URL to verify against the existing information
+ * @param gitHubRepository GitHub API details for a repository
+ */
+export function urlMatchesCloneURL(
+  url: string,
+  gitHubRepository: GitHubRepository
+): boolean {
+  if (gitHubRepository.cloneURL === null) {
+    return false
+  }
+
+  const firstIdentifier = parseRepositoryIdentifier(gitHubRepository.cloneURL)
+  const secondIdentifier = parseRepositoryIdentifier(url)
+
+  return (
+    firstIdentifier !== null &&
+    secondIdentifier !== null &&
+    firstIdentifier.hostname === secondIdentifier.hostname &&
+    firstIdentifier.owner === secondIdentifier.owner &&
+    firstIdentifier.name === secondIdentifier.name
   )
 }

--- a/app/src/lib/stores/helpers/infer-comparison-branch.ts
+++ b/app/src/lib/stores/helpers/infer-comparison-branch.ts
@@ -4,6 +4,7 @@ import { GitHubRepository } from '../../../models/github-repository'
 import { IRemote } from '../../../models/remote'
 import { Repository } from '../../../models/repository'
 import { ComparisonCache } from '../../comparison-cache'
+import { urlMatchesCloneURL } from '../../repository-matching'
 
 type RemotesGetter = (repository: Repository) => Promise<ReadonlyArray<IRemote>>
 
@@ -129,7 +130,7 @@ async function getDefaultBranchOfForkedGitHubRepo(
   }
 
   const remotes = await getRemotes(repository)
-  const remote = remotes.find(r => r.url === parentRepo.cloneURL)
+  const remote = remotes.find(r => urlMatchesCloneURL(r.url, parentRepo))
 
   if (remote === undefined) {
     log.warn(`Could not find remote with URL ${parentRepo.cloneURL}.`)

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -31,10 +31,18 @@ function createTestBranch(
 }
 
 function createTestGhRepo(
-  name: string,
+  owner: string,
   defaultBranch: string | null = null,
   parent: GitHubRepository | null = null
 ) {
+  if (owner.indexOf('/') !== -1) {
+    throw new Error(
+      'Providing a slash in the repository name is no longer supported, please update your test'
+    )
+  }
+
+  const cloneURL = `https://github.com/${owner}/my-cool-repo.git`
+
   return new GitHubRepository(
     name,
     new Owner('', '', null),
@@ -46,7 +54,7 @@ function createTestGhRepo(
         ? defaultBranch.split('/')[1]
         : defaultBranch
     }`,
-    `${name.indexOf('/') !== -1 ? name.split('/')[1] : name}.git`,
+    cloneURL,
     parent
   )
 }

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -1,5 +1,3 @@
-import { expect } from 'chai'
-
 import {
   matchGitHubRepository,
   urlMatchesRemote,
@@ -18,8 +16,8 @@ describe('repository-matching', () => {
         accounts,
         'https://github.com/someuser/somerepo.git'
       )!
-      expect(repo.name).to.equal('somerepo')
-      expect(repo.owner).to.equal('someuser')
+      expect(repo.name).toEqual('somerepo')
+      expect(repo.owner).toEqual('someuser')
     })
 
     it('matches HTTPS URLs without the git extension', () => {
@@ -30,8 +28,8 @@ describe('repository-matching', () => {
         accounts,
         'https://github.com/someuser/somerepo'
       )!
-      expect(repo.name).to.equal('somerepo')
-      expect(repo.owner).to.equal('someuser')
+      expect(repo.name).toBe('somerepo')
+      expect(repo.owner).toBe('someuser')
     })
 
     it('matches git URLs', () => {
@@ -42,8 +40,8 @@ describe('repository-matching', () => {
         accounts,
         'git:github.com/someuser/somerepo.git'
       )!
-      expect(repo.name).to.equal('somerepo')
-      expect(repo.owner).to.equal('someuser')
+      expect(repo.name).toBe('somerepo')
+      expect(repo.owner).toBe('someuser')
     })
 
     it('matches SSH URLs', () => {
@@ -54,8 +52,8 @@ describe('repository-matching', () => {
         accounts,
         'git@github.com:someuser/somerepo.git'
       )!
-      expect(repo.name).to.equal('somerepo')
-      expect(repo.owner).to.equal('someuser')
+      expect(repo.name).toBe('somerepo')
+      expect(repo.owner).toBe('someuser')
     })
 
     it(`doesn't match if there aren't any users with that endpoint`, () => {
@@ -74,7 +72,7 @@ describe('repository-matching', () => {
         accounts,
         'https://github.com/someuser/somerepo.git'
       )
-      expect(repo).to.equal(null)
+      expect(repo).toBeNull()
     })
   })
 
@@ -90,27 +88,27 @@ describe('repository-matching', () => {
       }
 
       it('does not match null', () => {
-        expect(urlMatchesRemote(null, remoteWithSuffix)).is.false
+        expect(urlMatchesRemote(null, remoteWithSuffix)).toBe(false)
       })
 
       it('matches cloneURL from API', () => {
         const cloneURL = 'https://github.com/shiftkey/desktop.git'
-        expect(urlMatchesRemote(cloneURL, remoteWithSuffix)).is.true
+        expect(urlMatchesRemote(cloneURL, remoteWithSuffix)).toBe(true)
       })
 
       it('matches cloneURL from API without suffix', () => {
         const cloneURL = 'https://github.com/shiftkey/desktop.git'
-        expect(urlMatchesRemote(cloneURL, remote)).is.true
+        expect(urlMatchesRemote(cloneURL, remote)).toBe(true)
       })
 
       it('matches htmlURL from API', () => {
         const htmlURL = 'https://github.com/shiftkey/desktop'
-        expect(urlMatchesRemote(htmlURL, remoteWithSuffix)).is.true
+        expect(urlMatchesRemote(htmlURL, remoteWithSuffix)).toBe(true)
       })
 
       it('matches htmlURL from API without suffix', () => {
         const htmlURL = 'https://github.com/shiftkey/desktop'
-        expect(urlMatchesRemote(htmlURL, remote)).is.true
+        expect(urlMatchesRemote(htmlURL, remote)).toBe(true)
       })
     })
 
@@ -120,16 +118,16 @@ describe('repository-matching', () => {
         url: 'git@github.com:shiftkey/desktop.git',
       }
       it('does not match null', () => {
-        expect(urlMatchesRemote(null, remote)).to.be.false
+        expect(urlMatchesRemote(null, remote)).toBe(false)
       })
 
       it('matches cloneURL from API', () => {
         const cloneURL = 'https://github.com/shiftkey/desktop.git'
-        expect(urlMatchesRemote(cloneURL, remote)).to.be.true
+        expect(urlMatchesRemote(cloneURL, remote)).toBe(true)
       })
       it('matches htmlURL from API', () => {
         const htmlURL = 'https://github.com/shiftkey/desktop'
-        expect(urlMatchesRemote(htmlURL, remote)).to.be.true
+        expect(urlMatchesRemote(htmlURL, remote)).toBe(true)
       })
     })
   })
@@ -181,13 +179,13 @@ describe('repository-matching', () => {
           'https://github.com/shiftkey/desktop.git',
           repository
         )
-      ).is.true
+      ).toBe(true)
     })
 
     it(`returns true when URL doesn't have a .git suffix`, () => {
       expect(
         urlMatchesCloneURL('https://github.com/shiftkey/desktop', repository)
-      ).is.true
+      ).toBe(true)
     })
 
     it(`returns false when URL belongs to a different owner`, () => {
@@ -196,7 +194,7 @@ describe('repository-matching', () => {
           'https://github.com/outofambit/desktop.git',
           repository
         )
-      ).is.false
+      ).toBe(false)
     })
 
     it(`returns false if GitHub repository does't have a cloneURL set`, () => {
@@ -205,7 +203,7 @@ describe('repository-matching', () => {
           'https://github.com/shiftkey/desktop',
           repositoryWithoutCloneURL
         )
-      ).is.false
+      ).toBe(false)
     })
   })
 })

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -3,8 +3,10 @@ import { expect } from 'chai'
 import {
   matchGitHubRepository,
   urlMatchesRemote,
+  urlMatchesCloneURL,
 } from '../../src/lib/repository-matching'
 import { Account } from '../../src/models/account'
+import { GitHubRepository } from '../../src/models/github-repository'
 
 describe('repository-matching', () => {
   describe('matchGitHubRepository', () => {
@@ -129,6 +131,81 @@ describe('repository-matching', () => {
         const htmlURL = 'https://github.com/shiftkey/desktop'
         expect(urlMatchesRemote(htmlURL, remote)).to.be.true
       })
+    })
+  })
+
+  describe('cloneUrlMatches', () => {
+    const repository: GitHubRepository = {
+      dbID: 1,
+      name: 'desktop',
+      fullName: 'shiftkey/desktop',
+      cloneURL: 'https://github.com/shiftkey/desktop.git',
+      owner: {
+        login: 'shiftkey',
+        id: 1234,
+        endpoint: 'https://api.github.com/',
+        hash: 'whatever',
+      },
+      private: false,
+      htmlURL: 'https://github.com/shiftkey/desktop',
+      defaultBranch: 'master',
+      parent: null,
+      endpoint: 'https://api.github.com/',
+      fork: true,
+      hash: 'whatever',
+    }
+
+    const repositoryWithoutCloneURL: GitHubRepository = {
+      dbID: 1,
+      name: 'desktop',
+      fullName: 'shiftkey/desktop',
+      cloneURL: null,
+      owner: {
+        login: 'shiftkey',
+        id: 1234,
+        endpoint: 'https://api.github.com/',
+        hash: 'whatever',
+      },
+      private: false,
+      htmlURL: 'https://github.com/shiftkey/desktop',
+      defaultBranch: 'master',
+      parent: null,
+      endpoint: 'https://api.github.com/',
+      fork: true,
+      hash: 'whatever',
+    }
+
+    it('returns true for exact match', () => {
+      expect(
+        urlMatchesCloneURL(
+          'https://github.com/shiftkey/desktop.git',
+          repository
+        )
+      ).is.true
+    })
+
+    it(`returns true when URL doesn't have a .git suffix`, () => {
+      expect(
+        urlMatchesCloneURL('https://github.com/shiftkey/desktop', repository)
+      ).is.true
+    })
+
+    it(`returns false when URL belongs to a different owner`, () => {
+      expect(
+        urlMatchesCloneURL(
+          'https://github.com/outofambit/desktop.git',
+          repository
+        )
+      ).is.false
+    })
+
+    it(`returns false if GitHub repository does't have a cloneURL set`, () => {
+      expect(
+        urlMatchesCloneURL(
+          'https://github.com/shiftkey/desktop',
+          repositoryWithoutCloneURL
+        )
+      ).is.false
     })
   })
 })


### PR DESCRIPTION
Fixes #5913 

I want to verify other places where we use `gitHubRepository.cloneURL` and ensure we're not comparing incorrectly there too.

 - [x] add new API for matching repository URLs
 - [x] fix known regression
 - [x] scan codebase for other candidates, review API