### PR TITLE
Add Copy File Path button to the context menu of file list

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -353,7 +353,6 @@ export class ChangesList extends React.Component<
           const fullPath = Path.join(this.props.repository.path, path)
           clipboard.writeText(fullPath)
         },
-        enabled: status !== AppFileStatus.Deleted,
       },
       {
         label: RevealInFileManagerLabel,

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -21,6 +21,7 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import {
   isSafeFileExtension,
   DefaultEditorLabel,
+  CopyFilePathLabel,
   RevealInFileManagerLabel,
   OpenWithDefaultProgramLabel,
 } from '../lib/context-menu'
@@ -29,6 +30,7 @@ import { ChangedFile } from './changed-file'
 import { IAutocompletionProvider } from '../autocompletion'
 import { showContextualMenu } from '../main-process-proxy'
 import { arrayEquals } from '../../lib/equality'
+import { clipboard } from 'electron'
 
 const RowHeight = 29
 
@@ -345,6 +347,14 @@ export class ChangesList extends React.Component<
 
     items.push(
       { type: 'separator' },
+      {
+        label: CopyFilePathLabel,
+        action: () => {
+          const fullPath = Path.join(this.props.repository.path, path)
+          clipboard.writeText(fullPath)
+        },
+        enabled: status !== AppFileStatus.Deleted,
+      },
       {
         label: RevealInFileManagerLabel,
         action: () => revealInFileManager(this.props.repository, path),

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -137,7 +137,6 @@ export class FileList extends React.Component<IFileListProps, {}> {
       {
         label: CopyFilePathLabel,
         action: () => clipboard.writeText(fullPath),
-        enabled: fileExistsOnDisk,
       },
       {
         label: RevealInFileManagerLabel,

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -9,6 +9,7 @@ import { Repository } from '../../models/repository'
 import { PathLabel } from '../lib/path-label'
 import {
   isSafeFileExtension,
+  CopyFilePathLabel,
   DefaultEditorLabel,
   RevealInFileManagerLabel,
   OpenWithDefaultProgramLabel,
@@ -17,6 +18,7 @@ import { List } from '../lib/list'
 
 import { Octicon } from '../octicons'
 import { showContextualMenu } from '../main-process-proxy'
+import { clipboard } from 'electron'
 
 interface IFileListProps {
   readonly files: ReadonlyArray<FileChange>
@@ -132,6 +134,11 @@ export class FileList extends React.Component<IFileListProps, {}> {
       : DefaultEditorLabel
 
     const items = [
+      {
+        label: CopyFilePathLabel,
+        action: () => clipboard.writeText(fullPath),
+        enabled: fileExistsOnDisk,
+      },
       {
         label: RevealInFileManagerLabel,
         action: () => revealInFileManager(this.props.repository, filePath),

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -1,5 +1,7 @@
 const RestrictedFileExtensions = ['.cmd', '.exe', '.bat', '.sh']
-export const CopyFilePathLabel = __DARWIN__ ? 'Copy File Path' : 'Copy file path'
+export const CopyFilePathLabel = __DARWIN__
+  ? 'Copy File Path'
+  : 'Copy file path'
 
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -1,5 +1,5 @@
 const RestrictedFileExtensions = ['.cmd', '.exe', '.bat', '.sh']
-export const CopyFilePathLabel = 'Copy File Path'
+export const CopyFilePathLabel = __DARWIN__ ? 'Copy File Path' : 'Copy file path'
 
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -1,4 +1,6 @@
 const RestrictedFileExtensions = ['.cmd', '.exe', '.bat', '.sh']
+export const CopyFilePathLabel = 'Copy File Path'
+
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
   : 'Open in external editor'


### PR DESCRIPTION
This adds a 'Copy File Path' button in the file list context menu in both Changes and History tabs. When click the button, it will copy the fullpath of the selected file to your clipboard.

- [x] add copy button in Changes tab

- [x] add copy button in History tab

Fixes #2944

Here are the GIFs which show the behavior:

|Changes tab|History tab|
|---|---|
|![2](https://user-images.githubusercontent.com/12688422/47055768-10454280-d1f4-11e8-925f-a4af69205f5e.gif)|![1](https://user-images.githubusercontent.com/12688422/47055764-09b6cb00-d1f4-11e8-9eef-00bd08b547b0.gif)|