### PR TITLE
Added optional Automatic "sync" after commit feature

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -172,6 +172,9 @@ export interface IAppState {
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnDiscardChanges: boolean
 
+  /** Whether we should automatically sync after a commit. */
+  readonly willInitiateSyncAfterCommit: boolean
+
   /** The external editor to use when opening repositories */
   readonly selectedExternalEditor?: ExternalEditor
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -907,6 +907,13 @@ export class Dispatcher {
   }
 
   /**
+   * Sets the user's preference to control whether to automatically sync after a commit.
+   */
+  public setInitiateSyncAfterCommitSetting(value: boolean): Promise<void> {
+    return this.appStore._setInitiateSyncAfterCommitSetting(value)
+  }
+
+  /**
    * Sets the user's preference for an external program to open repositories in.
    */
   public setExternalEditor(editor: ExternalEditor): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -180,8 +180,10 @@ const commitSummaryWidthConfigKey: string = 'commit-summary-width'
 
 const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
+const initiateSyncAfterCommitDefault: boolean = false
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
+const initiateSyncAfterCommitKey: string = 'initiateSyncAfterCommit'
 
 const externalEditorKey: string = 'externalEditor'
 
@@ -253,6 +255,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private isUpdateAvailableBannerVisible: boolean = false
   private confirmRepoRemoval: boolean = confirmRepoRemovalDefault
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
+  private initiateSyncAfterCommit: boolean = initiateSyncAfterCommitDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
 
   private selectedExternalEditor?: ExternalEditor
@@ -480,6 +483,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       isUpdateAvailableBannerVisible: this.isUpdateAvailableBannerVisible,
       askForConfirmationOnRepositoryRemoval: this.confirmRepoRemoval,
       askForConfirmationOnDiscardChanges: this.confirmDiscardChanges,
+      willInitiateSyncAfterCommit: this.initiateSyncAfterCommit,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
       selectedShell: this.selectedShell,
@@ -1372,6 +1376,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       confirmDiscardChangesValue === null
         ? confirmDiscardChangesDefault
         : confirmDiscardChangesValue === '1'
+
+    const initiateSyncAfterCommitValue = localStorage.getItem(
+      initiateSyncAfterCommitKey
+    )
+
+    this.initiateSyncAfterCommit =
+      initiateSyncAfterCommitValue === null
+        ? initiateSyncAfterCommitDefault
+        : initiateSyncAfterCommitValue === '1'
 
     const externalEditorValue = await this.getSelectedExternalEditor()
     if (externalEditorValue) {
@@ -3176,6 +3189,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmDiscardChanges = value
 
     localStorage.setItem(confirmDiscardChangesKey, value ? '1' : '0')
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _setInitiateSyncAfterCommitSetting(value: boolean): Promise<void> {
+    this.initiateSyncAfterCommit = value
+
+    localStorage.setItem(initiateSyncAfterCommitKey, value ? '1' : '0')
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1741,6 +1741,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           askForConfirmationOnDiscardChanges={
             state.askForConfirmationOnDiscardChanges
           }
+          willInitiateSyncAfterCommit={state.willInitiateSyncAfterCommit}
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}
           onOpenInExternalEditor={this.openFileInExternalEditor}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1063,6 +1063,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
+            initiateSyncAfterCommit={this.state.willInitiateSyncAfterCommit}
             selectedExternalEditor={this.state.selectedExternalEditor}
             optOutOfUsageTracking={this.props.appStore.getStatsOptOut()}
             enterpriseAccount={this.getEnterpriseAccount()}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1726,6 +1726,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (selectedState.type === SelectionType.Repository) {
       const externalEditorLabel = state.selectedExternalEditor
 
+      const remoteName = selectedState.state.remote
+        ? selectedState.state.remote.name
+        : null
+
       return (
         <RepositoryView
           repository={selectedState.repository}
@@ -1745,6 +1749,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}
           onOpenInExternalEditor={this.openFileInExternalEditor}
+          remoteName={remoteName}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -104,6 +104,7 @@ interface IChangesListProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
+  readonly remoteName: string | null
 }
 
 interface IChangesState {
@@ -425,6 +426,7 @@ export class ChangesList extends React.Component<
           }
           singleFileCommit={singleFileCommit}
           willInitiateSyncOnCommit={this.props.willInitiateSyncOnCommit}
+          remoteName={this.props.remoteName}
         />
       </div>
     )

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -48,6 +48,7 @@ interface IChangesListProps {
   ) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly willInitiateSyncOnCommit: boolean
   readonly onDiscardAllChanges: (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     isDiscardingAllChanges?: boolean
@@ -423,6 +424,7 @@ export class ChangesList extends React.Component<
               : 'Summary (required)'
           }
           singleFileCommit={singleFileCommit}
+          willInitiateSyncOnCommit={this.props.willInitiateSyncOnCommit}
         />
       </div>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -67,6 +67,7 @@ interface ICommitMessageProps {
    * the user has chosen to do so.
    */
   readonly coAuthors: ReadonlyArray<IAuthor>
+  readonly remoteName: string | null
 }
 
 interface ICommitMessageState {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -51,6 +51,7 @@ interface ICommitMessageProps {
   readonly isCommitting: boolean
   readonly placeholder: string
   readonly singleFileCommit: boolean
+  readonly willInitiateSyncOnCommit: boolean
 
   /**
    * Whether or not to show a field for adding co-authors to

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -231,8 +231,13 @@ export class CommitMessage extends React.Component<
     this.setState({ description })
   }
 
-  private onSubmit = () => {
+  private onSubmit = async () => {
     this.createCommit()
+
+    if (this.props.willInitiateSyncOnCommit) {
+      await this.props.dispatcher.pull(this.props.repository)
+      this.props.dispatcher.push(this.props.repository)
+    }
   }
 
   private getCoAuthorTrailers() {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -235,9 +235,13 @@ export class CommitMessage extends React.Component<
   private onSubmit = async () => {
     this.createCommit()
 
-    if (this.props.willInitiateSyncOnCommit) {
-      await this.props.dispatcher.pull(this.props.repository)
-      this.props.dispatcher.push(this.props.repository)
+    const initiateSyncOnCommit = this.props.willInitiateSyncOnCommit
+    const remoteExists = this.props.remoteName != null
+
+    if (initiateSyncOnCommit && remoteExists) {
+      const repository = this.props.repository
+      await this.props.dispatcher.pull(repository)
+      this.props.dispatcher.push(repository)
     }
   }
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -58,6 +58,7 @@ interface IChangesSidebarProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
+  readonly remoteName: string | null
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -319,6 +320,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           coAuthors={this.props.changes.coAuthors}
           externalEditorLabel={this.props.externalEditorLabel}
           onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+          remoteName={this.props.remoteName}
         />
         {this.renderMostRecentLocalCommit()}
       </div>

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -47,6 +47,7 @@ interface IChangesSidebarProps {
   readonly isPushPullFetchInProgress: boolean
   readonly gitHubUserStore: GitHubUserStore
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly willInitiateSyncAfterCommit: boolean
   readonly accounts: ReadonlyArray<Account>
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
@@ -302,6 +303,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
             this.props.askForConfirmationOnDiscardChanges
           }
           onDiscardAllChanges={this.onDiscardAllChanges}
+          willInitiateSyncOnCommit={this.props.willInitiateSyncAfterCommit}
           onOpenItem={this.onOpenItem}
           onRowClick={this.onChangedItemClick}
           commitAuthor={this.props.commitAuthor}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -15,6 +15,7 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly initiateSyncAfterCommit: boolean
   readonly availableEditors: ReadonlyArray<ExternalEditor>
   readonly selectedExternalEditor?: ExternalEditor
   readonly availableShells: ReadonlyArray<Shell>
@@ -22,6 +23,7 @@ interface IAdvancedPreferencesProps {
   readonly onOptOutofReportingchanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
   readonly onConfirmRepositoryRemovalChanged: (checked: boolean) => void
+  readonly onInitiateSyncAfterCommitChanged: (checked: boolean) => void
   readonly onSelectedEditorChanged: (editor: ExternalEditor) => void
   readonly onSelectedShellChanged: (shell: Shell) => void
 
@@ -36,6 +38,7 @@ interface IAdvancedPreferencesState {
   readonly selectedShell: Shell
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly initiateSyncAfterCommit: boolean
 }
 
 export class Advanced extends React.Component<
@@ -49,6 +52,7 @@ export class Advanced extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      initiateSyncAfterCommit: this.props.initiateSyncAfterCommit,
       selectedExternalEditor: this.props.selectedExternalEditor,
       selectedShell: this.props.selectedShell,
     }
@@ -108,6 +112,15 @@ export class Advanced extends React.Component<
 
     this.setState({ confirmRepositoryRemoval: value })
     this.props.onConfirmRepositoryRemovalChanged(value)
+  }
+
+  private onInitiateSyncAfterCommitChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ initiateSyncAfterCommit: value })
+    this.props.onInitiateSyncAfterCommitChanged(value)
   }
 
   private onSelectedEditorChanged = (
@@ -258,6 +271,17 @@ export class Advanced extends React.Component<
                 : CheckboxValue.Off
             }
             onChange={this.onConfirmDiscardChangesChanged}
+          />
+        </Row>
+        <Row>
+          <Checkbox
+            label="Automatically sync after creating a commit."
+            value={
+              this.state.initiateSyncAfterCommit
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onInitiateSyncAfterCommitChanged}
           />
         </Row>
       </DialogContent>

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -33,6 +33,7 @@ interface IPreferencesProps {
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly initiateSyncAfterCommit: boolean
   readonly selectedExternalEditor?: ExternalEditor
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
@@ -46,6 +47,7 @@ interface IPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly initiateSyncAfterCommit: boolean
   readonly availableEditors: ReadonlyArray<ExternalEditor>
   readonly selectedExternalEditor?: ExternalEditor
   readonly availableShells: ReadonlyArray<Shell>
@@ -70,6 +72,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
+      initiateSyncAfterCommit: false,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
       selectedShell: this.props.selectedShell,
@@ -116,6 +119,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      initiateSyncAfterCommit: this.props.initiateSyncAfterCommit,
       availableShells,
       availableEditors,
       mergeTool,
@@ -220,6 +224,7 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             confirmRepositoryRemoval={this.state.confirmRepositoryRemoval}
             confirmDiscardChanges={this.state.confirmDiscardChanges}
+            initiateSyncAfterCommit={this.state.initiateSyncAfterCommit}
             availableEditors={this.state.availableEditors}
             selectedExternalEditor={this.state.selectedExternalEditor}
             onOptOutofReportingchanged={this.onOptOutofReportingChanged}
@@ -227,6 +232,9 @@ export class Preferences extends React.Component<
               this.onConfirmRepositoryRemovalChanged
             }
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
+            onInitiateSyncAfterCommitChanged={
+              this.onInitiateSyncAfterCommitChanged
+            }
             onSelectedEditorChanged={this.onSelectedEditorChanged}
             availableShells={this.state.availableShells}
             selectedShell={this.state.selectedShell}
@@ -252,6 +260,10 @@ export class Preferences extends React.Component<
 
   private onConfirmDiscardChangesChanged = (value: boolean) => {
     this.setState({ confirmDiscardChanges: value })
+  }
+
+  private onInitiateSyncAfterCommitChanged = (value: boolean) => {
+    this.setState({ initiateSyncAfterCommit: value })
   }
 
   private onCommitterNameChanged = (committerName: string) => {
@@ -326,6 +338,9 @@ export class Preferences extends React.Component<
     await this.props.dispatcher.setShell(this.state.selectedShell)
     await this.props.dispatcher.setConfirmDiscardChangesSetting(
       this.state.confirmDiscardChanges
+    )
+    await this.props.dispatcher.setInitiateSyncAfterCommitSetting(
+      this.state.initiateSyncAfterCommit
     )
 
     const mergeTool = this.state.mergeTool

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -50,6 +50,7 @@ interface IRepositoryViewProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
+  readonly remoteName: string | null
 }
 
 interface IRepositoryViewState {
@@ -148,6 +149,7 @@ export class RepositoryView extends React.Component<
         accounts={this.props.accounts}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+        remoteName={this.props.remoteName}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -38,6 +38,7 @@ interface IRepositoryViewProps {
   readonly onViewCommitOnGitHub: (SHA: string) => void
   readonly imageDiffType: ImageDiffType
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly willInitiateSyncAfterCommit: boolean
   readonly accounts: ReadonlyArray<Account>
 
   /** The name of the currently selected external editor */
@@ -143,6 +144,7 @@ export class RepositoryView extends React.Component<
         askForConfirmationOnDiscardChanges={
           this.props.askForConfirmationOnDiscardChanges
         }
+        willInitiateSyncAfterCommit={this.props.willInitiateSyncAfterCommit}
         accounts={this.props.accounts}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}


### PR DESCRIPTION
Fixes #2191. The Issue this addresses the lack of a feature that allows to optionally sync immediately after creating a commit. This feature was available in the native Mac version of GitHub Desktop but was not brought into the Electron Desktop program.

Previously this feature appeared to use a toggle in the `Edit` dropdown. However, there appears to be no precedent for such functionality in Electron Desktop yet, so it has instead been implemented as an option in the Advanced tab of Preferences, and defaults to disabled.

I'd love any potential feedback on this to improve my implementation or address any potential concerns. In my tests it seems to work as expected. If there is a merge conflict or some other error that the user has to deal with manually they will have to address it. Otherwise it should push the new commit without any need to do so manually as long as the setting is enabled.