### PR TITLE
focus coverage rules only on app code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,6 +18,8 @@ coverage:
         threshold: 20%
         # only send statuses for prs, not all commits
         base: pr
+        # only include coverage in "app/src/" folder
+        paths: 'app/src/'
     patch: no
     changes: no
 


### PR DESCRIPTION
I think this fixes the occasional Codecov issue when a commit changes files outside the application source: https://github.com/desktop/desktop/issues/5511#issuecomment-430296298