### PR TITLE
codified section about where to start a release from

### DIFF
--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -118,20 +118,19 @@ Here's an example of the previous changelog draft after it has been edited:
 }
 ```
 
-Once you've pushed up the version update and the changelog changes, you're ready to release! Get the others on the team to :thumbsup: in a PR if you're not sure. Note that any version change that does not have an associated changelog entry will not successfully release.
+Create a new branch off `master` to represent the work that will be released to users. Add your new changelog entries and version update, and push this branch to GitHub. This becomes the release branch, and lets other maintainers continue to merge into `master` without affecting your release.
+
+If a maintainer would like to backport a pull request to the next release, it is their responsibilty to co-ordinate with the release owner and ensure they are fine with accepting this work.
+
+Once your release branch is ready to review and ship, add the `ready-for-review` label and ask the other maintainers to review and approve the changes!
 
 ### 3. Releasing
 
-When you feel ready to start the deployment, run this command in Chat:
+When you are ready to start the deployment, run this command in chat (where `X.Y.Z-release` is the name of your release branch):
 
 ```
-.release! desktop/YOUR_BRANCH to {production|beta|test}
+.release! desktop/X.Y.Z-release to {production|beta|test}
 ```
-
-If you are releasing from master, YOUR_BRANCH is unnecessary; write:
-```
-.release! desktop to {production|beta|test}
-``` 
 
 We're using `.release` with a bang so that we don't have to wait for any current CI on the branch to finish. This might feel a little wrong, but it's OK since making the release itself will also run CI.
 

--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -118,7 +118,17 @@ Here's an example of the previous changelog draft after it has been edited:
 }
 ```
 
-Create a new branch off `master` to represent the work that will be released to users. Add your new changelog entries and version update, and push this branch to GitHub. This becomes the release branch, and lets other maintainers continue to merge into `master` without affecting your release.
+Create a new branch to represent the work that will be released to users:
+
+ - for `beta` releases, branch from `master` to ensure the latest changes are published
+ - for `production` releases, branch from the latest beta tag
+    - to find this tag: `git tag | grep 'beta' | sort -r | head -n 1`
+
+If you are creating a new beta release, the `yarn draft-release beta` command will help you find the new release entries for the changelog.
+
+If you are create a new `production` release, you should just use the previous `beta` changelog entires.
+
+Add your new changelog entries to `changelog.json`, update the version in `app/package.json`, commit the changes, and push this branch to GitHub. This becomes the release branch, and lets other maintainers continue to merge into `master` without affecting your release.
 
 If a maintainer would like to backport a pull request to the next release, it is their responsibilty to co-ordinate with the release owner and ensure they are fine with accepting this work.
 

--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -126,7 +126,7 @@ Create a new branch to represent the work that will be released to users:
 
 If you are creating a new beta release, the `yarn draft-release beta` command will help you find the new release entries for the changelog.
 
-If you are create a new `production` release, you should just use the previous `beta` changelog entires.
+If you are create a new `production` release, you should just combine and sort the previous `beta` changelog entries.
 
 Add your new changelog entries to `changelog.json`, update the version in `app/package.json`, commit the changes, and push this branch to GitHub. This becomes the release branch, and lets other maintainers continue to merge into `master` without affecting your release.
 


### PR DESCRIPTION
@outofambit and I had a chat earlier about where we land on the "release from master" or "release from a branch" debate.

I think our workflow from the last few updates should be codified to indicate that the release owner should cut a branch from `master` which is then released to users, rather than having options.

This has a few benefits:

 - other maintainers can continue to review and merge PRs once that release branch is cut, knowing it won't be shipped to users by accident
 - if a hotfix needs to be expedited after the release branch is cut, a maintainer can target the release branch and work with the release owner to get it included (if the release owner is on board)
 - release branch is only opened to generate the release notes - so it's not a long-lived branch and should not be involved with typical workflows

