### PR TITLE
expand on how we plan and co-ordinate releases

### DIFF
--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -40,7 +40,7 @@ Pull Requests associated with bugfixes or unplanned work can be opened early,
 but **should not** be assigned a milestone until after they have been reviewed and
 approved.
 
-This gives the maintainers a chance to propose when this should land, based on
+This gives the maintainers a chance to propose when the pull request should land, based on
 these factors:
 
  - **priority** - Some bugs are more harmful (and affect more users) than

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -57,7 +57,7 @@ current milestone.
 Once a milestone is agreed upon, and it is assigned by a maintainer, the Pull
 Request can be merged by a maintainer when the milestone corresponds with the
 current release. The reviewer should also ensure any issues linked in the
-milestone are also assigned to the same milestone, for traceability.
+pull request are also assigned to the same milestone, for traceability.
 
 > **TODO: (BF)** this feels like something to automate:
 >

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -32,16 +32,18 @@ milestone defined as soon as possible, to indicate the anticipated release and
 help track.
 
 These pull requests should also be behind a feature flag, so we can control when
-the feature is enabled for users. If you are running the GitHub Desktop
+a feature is enabled for users. If you are using the GitHub Desktop
 [beta channel](https://github.com/desktop/desktop#beta-channel)
-you are able to help test and provide feedback about these features early.
+you will be able to help test and provide feedback about these features early.
 
 ### Bugfixes
 
 Pull Requests associated with bugfixes or unplanned work can be opened early,
-but should not have a milestone assigned until after it has been reviewed and
-approved. This gives the maintainers a chance to propose when this should land,
-based on these factors:
+but **should not** be assigned a milestone until after it has been reviewed and
+approved.
+
+This gives the maintainers a chance to propose when this should land, based on
+these factors:
 
  - **priority** - Some bugs are more harmful (and affect more users) than
    others...
@@ -49,16 +51,17 @@ based on these factors:
    go?
  - **timing** - Are we close to a release? Maybe it can wait a couple of days...
 
-We do this as late as possible in the review process to give the maintainers
-a chance to discuss when this should be merged, and sometimes the work required
-to review a pull request can take it beyond the current milestone.
+We do this as late as possible in the lifetime of the pull request to give the
+maintainers an opportunity to discuss when this should be merged, and sometimes
+the time and effort required to review a pull request can take it beyond the
+current milestone.
 
 Once a milestone is agreed upon, and it is assigned by a maintainer, the Pull
-Request can be merged by a maintainer at the appropriate time. The reviewer
-should also ensure any issues linked in the milestone are also assigned to the
-same milestone, for traceability.
+Request can be merged by a maintainer when the milestone corresponds with the
+current release. The reviewer should also ensure any issues linked in the
+milestone are also assigned to the same milestone, for traceability.
 
-> **TODO:** this feels like something to automate:
+> **TODO: (BF)** this feels like something to automate:
 >
 > The reviewer should also ensure any issues linked in the milestone are also
 assigned to the same milestone, for traceability.

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -13,7 +13,7 @@ We organize releases in two ways - marketing and milestones:
       - **for example: 1.4, 1.5, etc.**
  - Milestone releases are used to track issues and pull requests associated
    with a marketing release, and can be followed along on GitHub
-      - **e.g. 1.4.1, 1.4.2, 1.5.0, etc**
+      - **for example: 1.4.1, 1.4.2, 1.5.0, etc.**
 
 We aim to ship updates to production approximately every two weeks, to ensure a continuous
 flow of improvements to our users. Track our progress in the [current milestones](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open).

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -11,12 +11,13 @@ We organize releases in two ways - marketing and milestones:
  - Marketing releases are what we use to represent planned features, and are
    high-level goals
       - **for example: 1.4, 1.5, etc.**
- - Milestone releases are used to track issues and pull requests associated
-   with a marketing release, and can be followed along on GitHub
+ - Milestones are used to track issues and pull requests associated with a
+   marketing release, and can be [followed on GitHub](https://github.com/desktop/desktop/milestones)
       - **for example: 1.4.1, 1.4.2, 1.5.0, etc.**
 
-We aim to ship updates to production approximately every two weeks, to ensure a continuous
-flow of improvements to our users. Track our progress in the [current milestones](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open).
+We aim to ship updates to production approximately every two weeks, to ensure a
+continuous flow of improvements to our users. Track our progress in the
+[current milestones](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open).
 
 ## Scheduling Pull Requests
 
@@ -29,19 +30,28 @@ Pull Requests associated with features for our marketing releases should have a
 milestone defined as soon as possible, to indicate the anticipated release and
 help track.
 
-These pull requests should also be behind a feature flag, so we can control when
-a feature is enabled for users. If you are using the GitHub Desktop
+Pull requests for new features should leverage feature flags, so we can control
+when a feature is made available to users. If you are using the GitHub Desktop
 [beta channel](https://github.com/desktop/desktop#beta-channel)
-you will be able to help test and provide feedback about these features early.
+you will be able to help test and provide feedback about upcoming features
+before they are made available to everyone.
 
 ### Bugfixes
 
 Pull Requests associated with bugfixes or unplanned work can be opened early,
-but **should not** be assigned a milestone until after they have been reviewed and
-approved.
+but **should not** be assigned a milestone until after they have been reviewed
+and approved.
 
-This gives the maintainers a chance to propose when the pull request should land, based on
-these factors:
+We do this as late as possible in the lifetime of the pull request to give the
+maintainers an opportunity to discuss when this should be merged, and sometimes
+the time and effort required to review a pull request can take it beyond the
+current milestone.
+
+The reviewer who approves the pull request may assign a milestone at the same
+time to propose when this pull request should be merged, and optionally add a
+comment to provice context around their choice.
+
+These factors can be used when deciding on the chosen milestone:
 
  - **priority** - Some bugs are more harmful (and affect more users) than
    others...
@@ -49,20 +59,16 @@ these factors:
    go?
  - **timing** - Are we close to a release? Maybe it can wait a couple of days...
 
-We do this as late as possible in the lifetime of the pull request to give the
-maintainers an opportunity to discuss when this should be merged, and sometimes
-the time and effort required to review a pull request can take it beyond the
-current milestone.
+During the 24-hour approval window for merged pull request other maintainers may
+discuss the proposed milestone (or just :thumbsup: to acknowledege and agree
+with the proposed milestone).
 
-Once a milestone is agreed upon, and it is assigned by a maintainer, the Pull
-Request can be merged by a maintainer when the milestone corresponds with the
-current release. The reviewer should also ensure any issues linked in the
-pull request are also assigned to the same milestone, for traceability.
+Once the 24-hour approval window has expired the pull request can be merged by a
+maintainer when the milestone corresponds with the current release.
 
-> **TODO: (BF)** this feels like something to automate:
->
-> The reviewer should also ensure any issues linked in the milestone are also
-assigned to the same milestone, for traceability.
+The maintainer merging the pull request should also ensure any issues linked in
+the pull request description (which will be auto-closed when merging) are also
+assigned to the same milestone.
 
 ### Community Contributions
 

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -10,7 +10,7 @@ We organize releases in two ways - marketing and milestones:
 
  - Marketing releases are what we use to represent planned features, and are
    high-level goals
-      - **e.g. 1.4, 1.5, etc**
+      - **for example: 1.4, 1.5, etc.**
  - Milestone releases are used to track issues and pull requests associated
    with a marketing release, and can be followed along on GitHub
       - **e.g. 1.4.1, 1.4.2, 1.5.0, etc**

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -30,9 +30,9 @@ Pull Requests associated with features for our marketing releases should have a
 milestone defined as soon as possible, to indicate the anticipated release and
 help track.
 
-Pull requests for new features should leverage feature flags, so we can control
-when a feature is made available to users. If you are using the GitHub Desktop
-[beta channel](https://github.com/desktop/desktop#beta-channel)
+Pull requests for new features should leverage [feature flags](https://github.com/desktop/desktop/blob/master/docs/technical/feature-flagging.md),
+so we can control when a feature is made available to users. If you are using
+the GitHub Desktop [beta channel](https://github.com/desktop/desktop#beta-channel)
 you will be able to help test and provide feedback about upcoming features
 before they are made available to everyone.
 

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -15,7 +15,7 @@ We organize releases in two ways - marketing and milestones:
    with a marketing release, and can be followed along on GitHub
       - **e.g. 1.4.1, 1.4.2, 1.5.0, etc**
 
-We aim to ship updates to production every two weeks, to ensure a continuous
+We aim to ship updates to production approximately every two weeks, to ensure a continuous
 flow of improvements to our users. Track our progress in the [current milestones](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open).
 
 ## Scheduling Pull Requests

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -11,7 +11,7 @@ We organize releases in two ways - marketing and milestones:
  - Marketing releases are what we use to represent planned features, and are
    high-level goals
       - **e.g. 1.4, 1.5, etc**
- - Milestones releases are used to track issues and pull requests associated
+ - Milestone releases are used to track issues and pull requests associated
    with a marketing release, and can be followed along on GitHub
       - **e.g. 1.4.1, 1.4.2, 1.5.0, etc**
 

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -37,7 +37,7 @@ you will be able to help test and provide feedback about these features early.
 ### Bugfixes
 
 Pull Requests associated with bugfixes or unplanned work can be opened early,
-but **should not** be assigned a milestone until after it has been reviewed and
+but **should not** be assigned a milestone until after they have been reviewed and
 approved.
 
 This gives the maintainers a chance to propose when this should land, based on

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -16,9 +16,7 @@ We organize releases in two ways - marketing and milestones:
       - **e.g. 1.4.1, 1.4.2, 1.5.0, etc**
 
 We aim to ship updates to production every two weeks, to ensure a continuous
-flow of improvements to our users. You can follow along with the latest
-milestones [here](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open)
-to track our progress.
+flow of improvements to our users. Track our progress in the [current milestones](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open).
 
 ## Scheduling Pull Requests
 

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -21,7 +21,7 @@ flow of improvements to our users. Track our progress in the [current milestones
 ## Scheduling Pull Requests
 
 Pull Requests for user-facing changes should have a milestone associated with
-it, to indicate when it should be merged.
+them, to indicate when they should be merged.
 
 ### Features
 

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -11,8 +11,8 @@ We organize releases in two ways - marketing and milestones:
  - Marketing releases are what we use to represent planned features, and are
    high-level goals
       - **for example: 1.4, 1.5, etc.**
- - Milestones are used to track issues and pull requests associated with a
-   marketing release, and can be [followed on GitHub](https://github.com/desktop/desktop/milestones)
+ - Milestones are used to track issues and pull requests associated with an
+   upcoming release, and can be [followed on GitHub](https://github.com/desktop/desktop/milestones)
       - **for example: 1.4.1, 1.4.2, 1.5.0, etc.**
 
 We aim to ship updates to production approximately every two weeks, to ensure a

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -1,7 +1,70 @@
 # Release Planning
 
-We plan work at two levels of granularity: first at the marketing release level (1.1, 1.2, etc.) and then at the milestone level. Marketing releases are made up of multiple milestones. Milestones should contain roughly a month’s worth of work.
+This document outlines our process for planning and scheduling releases, so you
+can familiarize yourself with the flow of work from opening an issue to seeing
+it published in a release.
 
-We’ll release updates as needed or when a milestone is completed.
+## Releases
 
-Large features and user-visible changes are feature-flagged, to be unflagged in the next marketing release. Beta and dev builds will have all feature flags enabled.
+We organize releases in two ways - marketing and milestones:
+
+ - Marketing releases are what we use to represent planned features, and are
+   high-level goals
+      - **e.g. 1.4, 1.5, etc**
+ - Milestones releases are used to track issues and pull requests associated
+   with a marketing release, and can be followed along on GitHub
+      - **e.g. 1.4.1, 1.4.2, 1.5.0, etc**
+
+We aim to ship updates to production every two weeks, to ensure a continuous
+flow of improvements to our users. You can follow along with the latest
+milestones [here](https://github.com/desktop/desktop/milestones?direction=desc&sort=completeness&state=open)
+to track our progress.
+
+## Scheduling Pull Requests
+
+Pull Requests for user-facing changes should have a milestone associated with
+it, to indicate when it should be merged.
+
+### Features
+
+Pull Requests associated with features for our marketing releases should have a
+milestone defined as soon as possible, to indicate the anticipated release and
+help track.
+
+These pull requests should also be behind a feature flag, so we can control when
+the feature is enabled for users. If you are running the GitHub Desktop
+[beta channel](https://github.com/desktop/desktop#beta-channel)
+you are able to help test and provide feedback about these features early.
+
+### Bugfixes
+
+Pull Requests associated with bugfixes or unplanned work can be opened early,
+but should not have a milestone assigned until after it has been reviewed and
+approved. This gives the maintainers a chance to propose when this should land,
+based on these factors:
+
+ - **priority** - Some bugs are more harmful (and affect more users) than
+   others...
+ - **impact** - Does this need time on the `beta` channel to verify it's good to
+   go?
+ - **timing** - Are we close to a release? Maybe it can wait a couple of days...
+
+We do this as late as possible in the review process to give the maintainers
+a chance to discuss when this should be merged, and sometimes the work required
+to review a pull request can take it beyond the current milestone.
+
+Once a milestone is agreed upon, and it is assigned by a maintainer, the Pull
+Request can be merged by a maintainer at the appropriate time. The reviewer
+should also ensure any issues linked in the milestone are also assigned to the
+same milestone, for traceability.
+
+> **TODO:** this feels like something to automate:
+>
+> The reviewer should also ensure any issues linked in the milestone are also
+assigned to the same milestone, for traceability.
+
+### Community Contributions
+
+Similiar to bugfixes, community PRs and features should not have a milestone
+assigned until they have been reviewed and approved, and should go through the
+same process.


### PR DESCRIPTION
Updating this document to better reflect what we do currently and how we can be clearer about the work that's underway.

In a nutshell:

 - we use "marketing releases" to track upcoming features, and GitHub milestones to track the team's work
 - PRs related to feature work should be assigned a milestone when opened by the author (to indicate they have a defined goal)
 - PRs for bugfixes and community features should be assigned a milestone by a maintainer after they've been reviewed and approved (so we have a chance to discuss when the right time is to merge)

For most items, "the next release" will be the answer to the question "when will this go out?", but this gives us breathing space to work better asynchronously.