### PR TITLE
remove newlines to make hash values easier to read

### DIFF
--- a/app/src/models/github-repository.ts
+++ b/app/src/models/github-repository.ts
@@ -58,13 +58,9 @@ export class GitHubRepository {
    * Objects with the same hash are guaranteed to be structurally equal.
    */
   public get hash(): string {
-    return `${this.dbID}+
-      ${this.defaultBranch}+
-      ${this.private}+
-      ${this.cloneURL}+
-      ${this.name}+
-      ${this.htmlURL}+
-      ${this.owner.hash}+
-      ${this.parent && this.parent.hash}`
+    return `${this.dbID}+${this.defaultBranch}+${this.private}+${
+      this.cloneURL
+    }+${this.name}+${this.htmlURL}+${this.owner.hash}+${this.parent &&
+      this.parent.hash}`
   }
 }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -38,11 +38,9 @@ export class Repository {
    * Objects with the same hash are guaranteed to be structurally equal.
    */
   public get hash(): string {
-    return `${this.id}+
-      ${this.gitHubRepository && this.gitHubRepository.hash}+
-      ${this.path}+
-      ${this.missing}+
-      ${this.name}`
+    return `${this.id}+${this.gitHubRepository && this.gitHubRepository.hash}+${
+      this.path
+    }+${this.missing}+${this.name}`
   }
 }
 


### PR DESCRIPTION
If you find yourself in the React dev tools and look at the keys we use to store `IRepositoryState` or `GitStore` entries, you might notice this weirdness:

<img width="261" src="https://user-images.githubusercontent.com/359239/47223370-88943b00-d38f-11e8-9191-c8aacbc00f9b.png">
<img width="255" src="https://user-images.githubusercontent.com/359239/47223372-88943b00-d38f-11e8-9b6b-2f5fe3f2a5c4.png">

This is because how we structured these template literals meant a cheeky newline was added after each `+`.

With this change they look a bit less intimidating:

<img width="242" src="https://user-images.githubusercontent.com/359239/47223511-d7da6b80-d38f-11e8-8797-42062b0fb9e0.png">
<img width="240" src="https://user-images.githubusercontent.com/359239/47223512-d8730200-d38f-11e8-995f-37a5918512bc.png">

These hashes are not stored between sessions, so this should be a safe change to push out with an update.
