### PR TITLE
add some packaging improvements for Linux

### DIFF
--- a/docs/contributing/linux-testing-and-you.md
+++ b/docs/contributing/linux-testing-and-you.md
@@ -14,7 +14,7 @@ The goals for this testing process are:
 
 ## Testing Release Candidates
 
-Release Candidate installers can be found on [**@shiftkey's**](https://github.com/shiftkey) [fork](https://github.com/shiftkey/desktop), listed under the [Releases](https://github.com/shiftkey/desktop/releases) tab. The current installer formats supported are Debian, RPM and AppImage.
+Release Candidate installers can be found on [**@shiftkey's**](https://github.com/shiftkey) [fork](https://github.com/shiftkey/desktop), listed under the [Releases](https://github.com/shiftkey/desktop/releases) tab. The current installer formats supported are Debian, RPM, AppImage and Snap.
 
 [@shiftkey](https://github.com/shiftkey) aims to make new installers available soon after the main Desktop project tags and publishes a new update. To receive notifications when new installers are published, [subscribe](https://github.com/shiftkey/desktop/subscription) to [**@shiftkey's**](https://github.com/shiftkey) fork of the repository.
 

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
     "electron": "2.0.9",
-    "electron-builder": "20.27.1",
+    "electron-builder": "20.28.4",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"
   }

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -7,6 +7,7 @@ linux:
   target:
     - deb
     - rpm
+    - snap
     - AppImage
   maintainer: 'GitHub, Inc <opensource+desktop@github.com>'
 deb:
@@ -19,7 +20,7 @@ deb:
     - libxtst6
     - libnss3
     # dugite-native dependencies
-    - libcurl3
+    - libcurl3 | libcurl4
     # keytar dependencies
     - libsecret-1-0
 rpm:
@@ -32,3 +33,12 @@ rpm:
     - libcurl
     # keytar dependencies
     - libsecret
+snap:
+  confinement: 'classic'
+  stagePackages:
+    - default
+    - libcurl3
+    - libsecret-1-0
+    - openssh-client
+  plugs:
+    - password-manager-service

--- a/script/electron-builder-linux.yml
+++ b/script/electron-builder-linux.yml
@@ -11,6 +11,8 @@ linux:
     - AppImage
   maintainer: 'GitHub, Inc <opensource+desktop@github.com>'
 deb:
+  afterInstall: './script/linux-after-install.sh'
+  afterRemove: './script/linux-after-remove.sh'
   depends:
     # default Electron dependencies
     - gconf2

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+INSTALL_DIR="/opt/${productFilename}"
+SCRIPT="#!/bin/sh
+export PATH=$INSTALL_DIR:\$PATH"
+
+case "$1" in
+    configure)
+      echo "$SCRIPT" > ${PROFILE_D_FILE};
+      . ${PROFILE_D_FILE};
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+      echo "postinst called with unknown argument \`$1'" >&2
+      exit 1
+    ;;
+esac
+
+exit 0

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+
+case "$1" in
+    purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+      echo "#!/bin/sh" > ${PROFILE_D_FILE};
+      . ${PROFILE_D_FILE};
+      rm ${PROFILE_D_FILE};
+    ;;
+
+    *)
+      echo "postrm called with unknown argument \`$1'" >&2
+      exit 1
+    ;;
+esac
+
+exit 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,39 +915,39 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-builder-bin@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.1.1.tgz#02c6adfbfa3c09404a23ff7874d2cab5a8fcb9ca"
-  integrity sha512-ye0fQcG/msVKJcHBOZOfXf8kIkHoY+1ZYpWyFH/jyeNRwlsdBQCmg0A+pbbTyvjiet9XQzPVA7s21oyRhUixRQ==
+app-builder-bin@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.1.2.tgz#528ce8e543aa595210c9595f91bdf5638cecd79b"
+  integrity sha512-PZJspzAqB0+z60OalXChP9I05BzODd/ffDz6RvTmDG3qclr7YrnpqzvPF+T7vGVtk2nN7syuveTQROJfXcB8xA==
 
-app-builder-lib@20.27.1, app-builder-lib@~20.27.0:
-  version "20.27.1"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.27.1.tgz#02d5da95cc68256ec3812999e9686d7f6dfdfcc1"
-  integrity sha512-nuGl5s6dGp0lbLfM3Ef/tst3ZAeKznBb+SB0zNjHR8chbU7338451y7TfDXkcLQVkvMivfhwIRlUCyN/sH5KKA==
+app-builder-lib@20.28.4, app-builder-lib@~20.28.3:
+  version "20.28.4"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.28.4.tgz#0bee3366364c65d17a2aaab75b30bb10df76ece5"
+  integrity sha512-RY4/NJs1HCFWAOpLMivuDzbesU5VyaZVKuQllxgCNZ56+ihgO5aGexla2DVjG/bBQleWfF3DPnEsF3sbZPlpHw==
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "2.1.1"
+    app-builder-bin "2.1.2"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.5"
-    builder-util "6.0.0"
+    builder-util "6.1.3"
     builder-util-runtime "4.4.1"
     chromium-pickle-js "^0.2.0"
     debug "^3.1.0"
     ejs "^2.6.1"
     electron-osx-sign "0.4.10"
-    electron-publish "20.27.0"
+    electron-publish "20.28.3"
     fs-extra-p "^4.6.1"
     hosted-git-info "^2.7.1"
-    is-ci "^1.1.0"
+    is-ci "^1.2.0"
     isbinaryfile "^3.0.3"
     js-yaml "^3.12.0"
     lazy-val "^1.0.3"
     minimatch "^3.0.4"
     normalize-package-data "^2.4.0"
     plist "^3.0.1"
-    read-config-file "3.1.0"
+    read-config-file "3.1.2"
     sanitize-filename "^1.6.1"
-    semver "^5.5.0"
+    semver "^5.5.1"
     temp-file "^3.1.3"
 
 append-transform@^1.0.0:
@@ -2101,23 +2101,23 @@ builder-util-runtime@4.4.1, builder-util-runtime@^4.4.1:
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
 
-builder-util@6.0.0, builder-util@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-6.0.0.tgz#5f4941c096778758d8c186ef95eaa0e8b536cab8"
-  integrity sha512-PPwBEQa8zNcgd0ht2IozdD9QDdrADSl/TkceGcErkT7By1v8LLcomBAThm+t+0Ebm7q6JJbdL2SShM6wbXRCUg==
+builder-util@6.1.3, builder-util@~6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-6.1.3.tgz#6bd3a5253c99afa31e3574e6fc3b796e218f8cfd"
+  integrity sha512-MXeARNff9KHlzJYGJcAhLI/tpE57PmUnleaYfL22IE+viRt192Yr3wQL444ztsA+LUHJ8d12moUoG00jh1hfLA==
   dependencies:
     "7zip-bin" "~4.0.2"
-    app-builder-bin "2.1.1"
+    app-builder-bin "2.1.2"
     bluebird-lst "^1.0.5"
     builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
+    is-ci "^1.2.0"
     js-yaml "^3.12.0"
     lazy-val "^1.0.3"
-    semver "^5.5.0"
-    source-map-support "^0.5.6"
+    semver "^5.5.1"
+    source-map-support "^0.5.9"
     stat-mode "^0.2.2"
     temp-file "^3.1.3"
 
@@ -2388,6 +2388,11 @@ ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
   integrity sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==
+
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -3299,16 +3304,16 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dmg-builder@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-5.2.0.tgz#93d0c327fdd536794d8b7cf4fb16d1748ed8d9cf"
-  integrity sha512-0doOlH/Lew4St3X5UwEyuj763sDa4GIJPBDr/0hDywPn06atclRO36Bf6oEy9BEp7YaNV5aoaOfH3l8SBBacYQ==
+dmg-builder@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-5.3.1.tgz#b4d66d1dd010e1c9e7a5787bf1369e8157cac3cf"
+  integrity sha512-/+vtqlgvTtha/4Gc76XIRKS2KzYO58sTWXhZ/kgfNr05ZXY6bIw26v7xDu8ZBpTYnfWI09JRZTMv1yIXT/vvfg==
   dependencies:
-    app-builder-lib "~20.27.0"
+    app-builder-lib "~20.28.3"
     bluebird-lst "^1.0.5"
-    builder-util "~6.0.0"
+    builder-util "~6.1.3"
     fs-extra-p "^4.6.1"
-    iconv-lite "^0.4.23"
+    iconv-lite "^0.4.24"
     js-yaml "^3.12.0"
     parse-color "^1.0.0"
     sanitize-filename "^1.6.1"
@@ -3450,21 +3455,21 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
-electron-builder@20.27.1:
-  version "20.27.1"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.27.1.tgz#f3405280b5c5c5b2c7c0e8c6ac4c0d6b63375573"
-  integrity sha512-jsrUX2t8Yx8n5lVzIZ7AOMGlSYSb2iZhD+BX1DQ9H0O2FNDhWBNRfQQyj0mM2slNsk+5RWpK8FpOOsn5Z8BIqw==
+electron-builder@20.28.4:
+  version "20.28.4"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.28.4.tgz#c9355b92b0971d51aaed0c945d2944bac41e9fbf"
+  integrity sha512-JMOzMfx9BrC9SJr6+UacuvQZmuodL02Zua8iFn0l5bv32GkWcNj1D6FwybV33BpsmdQ8sF1SkQj+7L+FEIxang==
   dependencies:
-    app-builder-lib "20.27.1"
+    app-builder-lib "20.28.4"
     bluebird-lst "^1.0.5"
-    builder-util "6.0.0"
+    builder-util "6.1.3"
     builder-util-runtime "4.4.1"
     chalk "^2.4.1"
-    dmg-builder "5.2.0"
+    dmg-builder "5.3.1"
     fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
+    is-ci "^1.2.0"
     lazy-val "^1.0.3"
-    read-config-file "3.1.0"
+    read-config-file "3.1.2"
     sanitize-filename "^1.6.1"
     update-notifier "^2.5.0"
     yargs "^12.0.1"
@@ -3554,13 +3559,13 @@ electron-packager@^12.0.0:
     semver "^5.3.0"
     yargs-parser "^10.0.0"
 
-electron-publish@20.27.0:
-  version "20.27.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.27.0.tgz#0f44befa800b94458c78a8f63a4bc9109c5b5b10"
-  integrity sha512-bmyA9PbXeYDoh2S3Q5Rcs/AT3XUKxPnx0aChfy/qbsPBc/DtZirKuHh8B9SVjo8nK9wqm531rempyEOh3LAkDw==
+electron-publish@20.28.3:
+  version "20.28.3"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-20.28.3.tgz#0cc360ecaffd16e22780ee1630e0bd88fe6395e2"
+  integrity sha512-/2t5zk9EKgH7p7rFZ+ynTKLmpKGF9bktMP2UR6u4bbPz9w4r3WEUbPOeZ1TLqUCAqdfZECcj4ThjrlcAJTghCA==
   dependencies:
     bluebird-lst "^1.0.5"
-    builder-util "~6.0.0"
+    builder-util "~6.1.3"
     builder-util-runtime "^4.4.1"
     chalk "^2.4.1"
     fs-extra-p "^4.6.1"
@@ -5207,10 +5212,17 @@ iconv-lite@0.4.19, iconv-lite@^0.4.17:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
-iconv-lite@0.4.23, iconv-lite@^0.4.23:
+iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -5468,12 +5480,19 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
   integrity sha1-hut1OSgF3cM69xySoO7fdO52BLI=
 
-is-ci@^1.0.10, is-ci@^1.1.0:
+is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   integrity sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==
   dependencies:
     ci-info "^1.0.0"
+
+is-ci@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -8620,10 +8639,10 @@ rcedit@^1.0.0:
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-1.0.0.tgz#43309ecbc8814f3582fca6b751748cfad66a16a2"
   integrity sha512-W7DNa34x/3OgWyDHsI172AG/Lr/lZ+PkavFkHj0QhhkBRcV9QTmRJE1tDKrWkx8XHPSBsmZkNv9OKue6pncLFQ==
 
-read-config-file@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.0.tgz#d433283c76f32204d6995542e4a04723db9e8308"
-  integrity sha512-z3VTrR9fgFu+Ll6MhTdtxbPFBKNGKgzYYnRjOcZvQeE/zwJTjPYVrps0ATgaSWU2/BnucUg3knP+Oz4zo9vEoA==
+read-config-file@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-3.1.2.tgz#9b299cb7a2bcec1511a4c22e71620df0a2e3b896"
+  integrity sha512-QCATYzlYHvmWps/W/eP7rcKuhYRYZg5XKeXFxSJRIXvn+KSw1+Ntz2et1aBz5TrEpawGrxWZ7zBipj+/v0xwWQ==
   dependencies:
     ajv "^6.5.2"
     ajv-keywords "^3.2.0"
@@ -9335,6 +9354,11 @@ semver@^5.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
   integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
 
+semver@^5.5.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -9628,6 +9652,14 @@ source-map-support@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   integrity sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
This upstreams some PRs that I've been able to use when packaging Desktop for Linux:

 - add support for generating a Snap package - https://github.com/shiftkey/desktop/pull/64
 - add Desktop to `PATH` when installing the `deb` package - https://github.com/shiftkey/desktop/pull/69
 - ensure the `snap` build can access the password manager - https://github.com/shiftkey/desktop/pull/70

Thanks to @flexiondotorg and @bb441db for their help with these!