### PR TITLE
run status without optional locks for all users

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -54,5 +54,5 @@ export function enableInAppReleaseNotes(): boolean {
 
 /** Should `git status` use --no-optional-locks to assist with concurrent usage */
 export function enableStatusWithoutOptionalLocks(): boolean {
-  return enableBetaFeatures()
+  return true
 }


### PR DESCRIPTION
We rolled this out in `release-1.4.0-beta1` and I've not heard any problems with it from our beta users, so I'd like to propose rolling this out more broadly in a future update.

I see outstanding issues like #5438 and #4938 which are `priority-2` and I believe will be aided by this change (I often hit this when trying to checkout a branch or a PR, and I haven't seen this on `beta` in a while).