### PR TITLE
allow DialogHeader to take a custom title element

### DIFF
--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -4,8 +4,9 @@ import { Octicon, OcticonSymbol } from '../octicons'
 interface IDialogHeaderProps {
   /**
    * The dialog title text. Will be rendered top and center in a dialog.
+   * You can also pass a function that returns an element for custom styling.
    */
-  readonly title: string
+  readonly title: string | (() => JSX.Element)
 
   /**
    * An optional id for the h1 element that contains the title of this
@@ -68,6 +69,16 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
     )
   }
 
+  private renderTitle() {
+    return (
+      <h1 id={this.props.titleId}>
+        {typeof this.props.title === 'string'
+          ? this.props.title
+          : this.props.title()}
+      </h1>
+    )
+  }
+
   public render() {
     const spinner = this.props.loading ? (
       <Octicon className="icon spin" symbol={OcticonSymbol.sync} />
@@ -75,7 +86,7 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
 
     return (
       <header className="dialog-header">
-        <h1 id={this.props.titleId}>{this.props.title}</h1>
+        {this.renderTitle()}
         {spinner}
         {this.renderCloseButton()}
         {this.props.children}

--- a/app/src/ui/dialog/header.tsx
+++ b/app/src/ui/dialog/header.tsx
@@ -4,9 +4,9 @@ import { Octicon, OcticonSymbol } from '../octicons'
 interface IDialogHeaderProps {
   /**
    * The dialog title text. Will be rendered top and center in a dialog.
-   * You can also pass a function that returns an element for custom styling.
+   * You can also pass JSX for custom styling
    */
-  readonly title: string | (() => JSX.Element)
+  readonly title: string | JSX.Element
 
   /**
    * An optional id for the h1 element that contains the title of this
@@ -70,13 +70,7 @@ export class DialogHeader extends React.Component<IDialogHeaderProps, {}> {
   }
 
   private renderTitle() {
-    return (
-      <h1 id={this.props.titleId}>
-        {typeof this.props.title === 'string'
-          ? this.props.title
-          : this.props.title()}
-      </h1>
-    )
+    return <h1 id={this.props.titleId}>{this.props.title}</h1>
   }
 
   public render() {


### PR DESCRIPTION
_In support of #5809 and #5930_

Currently, `DialogHeader` only allows a string to be passed for the title, but this doesn't allow for designs like

<img width="882" alt="custom title example" src="https://user-images.githubusercontent.com/964912/47248670-c6f61e00-d3c0-11e8-8ad0-ca54d296e7f2.png">

which requires some different tag structure than a single string.

This PR allows `DialogHeader` to accept a function that renders a `JSX.Element` to be used in place of a string.

cc @JQuinnie @ampinsk @iAmWillShepherd 