### PR TITLE
Add branch merge dialog for directional merge flow

### DIFF
--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -305,16 +305,16 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
           />
         </DialogContent>
         <DialogFooter>
+          {enableMergeConflictDetection()
+            ? this.renderNewMergeInfo()
+            : this.renderOldMergeMessage()}
+          <br />
           <ButtonGroup>
             <Button type="submit" disabled={disabled}>
               Merge <strong>{selectedBranch ? selectedBranch.name : ''}</strong>{' '}
               into <strong>{currentBranch ? currentBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>
-
-          {enableMergeConflictDetection()
-            ? this.renderNewMergeInfo()
-            : this.renderOldMergeMessage()}
         </DialogFooter>
       </Dialog>
     )

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -307,8 +307,8 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
         <DialogFooter>
           <ButtonGroup>
             <Button type="submit" disabled={disabled}>
-              Merge into{' '}
-              <strong>{currentBranch ? currentBranch.name : ''}</strong>
+              Merge <strong>{selectedBranch ? selectedBranch.name : ''}</strong>{' '}
+              into <strong>{currentBranch ? currentBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>
 


### PR DESCRIPTION
This PR fixes issue #5930 with context below;

> The directional merge flow is not as obvious as it could be. It should be perfectly clear which branch you're merging into which branch.

Two changes were made to make it more obvious as to which branch (_selected branch_) is getting merged into what (_current branch_);
1. Updated the merge text dialog to include selected branch merge into current branch.
2. Moved the merge text dialog above the **Merge** button.

**Before the Change**
<img width="400" alt="issue5930-before-merge" src="https://user-images.githubusercontent.com/29465981/47250877-20714380-d3e7-11e8-8d94-2062a2472a20.png">
<img width="400" alt="issue5930-before-conflict" src="https://user-images.githubusercontent.com/29465981/47250884-4991d400-d3e7-11e8-84eb-2de230ca8098.png">

**After the Change**
<img width="400" alt="issue5930-after-merge" src="https://user-images.githubusercontent.com/29465981/47250892-72b26480-d3e7-11e8-98e0-1f1546bb4397.png">
<img width="400" alt="issue5930-after-conflict" src="https://user-images.githubusercontent.com/29465981/47250893-7514be80-d3e7-11e8-970f-cfc5adb31628.png">

NOTES:
- The horizontal rule around the octicons (green check and orange warning) is a part of the styling for class `merge-status-icon-container` so therefore I did not make any updates to those scss files.
- Also along the lines of styling (which I did not mess with), I noticed that there is quite a bit of space at the top of the dialog/button combo... found in class `dialog-footer` with a padding of 20px.
- As for the **RISK** mentioned in #5930 I can make a separate PR to work with the styling of when the branch name is longer than fixed width of modal... might take more a little more time for research.

Please let me know if I need to pull in any of the styling concerns in the Notes section for this PR.
