### PR TITLE
Repository name is now sanitized on publish

### DIFF
--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -7,6 +7,8 @@ import { DialogContent } from '../dialog'
 import { Row } from '../lib/row'
 import { merge } from '../../lib/merge'
 import { caseInsensitiveCompare } from '../../lib/compare'
+import { sanitizedRepositoryName } from '../add-repository/sanitized-repository-name'
+import { Octicon, OcticonSymbol } from '../octicons'
 
 interface IPublishRepositoryProps {
   /** The user to use for publishing. */
@@ -150,6 +152,8 @@ export class PublishRepository extends React.Component<
           />
         </Row>
 
+        {this.renderSanitizedName()}
+
         <Row>
           <TextBox
             label="Description"
@@ -171,6 +175,20 @@ export class PublishRepository extends React.Component<
 
         {this.renderOrgs()}
       </DialogContent>
+    )
+  }
+
+  private renderSanitizedName() {
+    const sanitizedName = sanitizedRepositoryName(this.props.settings.name)
+    if (this.props.settings.name === sanitizedName) {
+      return null
+    }
+
+    return (
+      <Row className="warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+        Will be created as {sanitizedName}
+      </Row>
     )
   }
 }

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -47,10 +47,14 @@ export class PublishRepository extends React.Component<
   IPublishRepositoryProps,
   IPublishRepositoryState
 > {
+  /** The repository name entered by the user. It has not yet been sanitized. */
+  private name: string
+
   public constructor(props: IPublishRepositoryProps) {
     super(props)
 
     this.state = { orgs: [] }
+    this.name = props.settings.name
   }
 
   public async componentWillMount() {
@@ -81,6 +85,9 @@ export class PublishRepository extends React.Component<
   }
 
   private onNameChange = (name: string) => {
+    this.name = name
+
+    name = sanitizedRepositoryName(name)
     this.updateSettings({ name })
   }
 
@@ -146,7 +153,7 @@ export class PublishRepository extends React.Component<
         <Row>
           <TextBox
             label="Name"
-            value={this.props.settings.name}
+            value={this.name}
             autoFocus={true}
             onValueChanged={this.onNameChange}
           />
@@ -179,8 +186,8 @@ export class PublishRepository extends React.Component<
   }
 
   private renderSanitizedName() {
-    const sanitizedName = sanitizedRepositoryName(this.props.settings.name)
-    if (this.props.settings.name === sanitizedName) {
+    const sanitizedName = this.props.settings.name
+    if (this.name === sanitizedName) {
       return null
     }
 


### PR DESCRIPTION
Fixes #3090. This is in response to an issue reporting the ability to enter characters such as emojis as the repository name in the `Publish Repository` dialog. Although the `Create Repository` dialog sanitizes the user entered name to filter out illegal characters, the `Publish Repository` dialog gives an opportunity to modify the name of to be published without sanitization, giving an opportunity to enter illegal characters.

To solve this, I have included the pre-existing repository sanitization functionality in the `Publish Repository` dialog. This is both in the form of a warning that displays what the new name will be, and the dialog using the new sanitized name instead.
___
The new functionality can be seen here:
![peek 2018-10-04 15-07](https://user-images.githubusercontent.com/4957200/46500418-6b386c00-c7e8-11e8-88fb-97d8beba1920.gif)
___
Additionally, while testing these changes I noticed that the sanitization function will replace an emoji such as 🐓 with two dashes instead of one. I am not quite sure why this is the case currently. It is somewhat unrelated, but I figured I would mention it.
