### PR TITLE
add a localStorage abstraction to tidy up our parsing work

### DIFF
--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -1,0 +1,64 @@
+/**
+ * Returns the value for the provided key from local storage interpreted as a
+ * boolean or the provided `defaultValue` if the key doesn't exist.
+ *
+ * @param key local storage entry to find
+ * @param defaultValue fallback value if key not found
+ */
+export function getBoolean(key: string, defaultValue = false): boolean {
+  const value = localStorage.getItem(key)
+  if (value === null) {
+    return defaultValue
+  }
+
+  const intValue = parseInt(value, 10)
+  return intValue === 1
+}
+
+/**
+ * Set the provided key in local storage to a boolean value, or update the
+ * existing value if a key is already defined.
+ *
+ * `true` and `false` will be encoded as the string '1' or '0' respectively.
+ *
+ * @param key local storage entry to update
+ * @param value the boolean to set
+ */
+export function setBoolean(key: string, value: boolean) {
+  localStorage.setItem(key, value ? '1' : '0')
+}
+
+/**
+ * Retrieve a numeric value from a given local storage entry.
+ *
+ * Returns `0` if a valid number is not found in this key
+ *
+ * @param key local storage entry to read
+ * @param defaultValue fallback value if key not found
+ */
+export function getNumber(key: string, defaultValue = 0): number {
+  const numberAsText = localStorage.getItem(key)
+  let value = 0
+  if (numberAsText && numberAsText.length > 0) {
+    value = parseInt(numberAsText, 10)
+  }
+
+  if (isNaN(value)) {
+    return defaultValue
+  }
+
+  return value
+}
+
+/**
+ * Set the provided key in local storage to a numeric value, or update the
+ * existing value if a key is already defined.
+ *
+ * Stores the string representation of the number.
+ *
+ * @param key local storage entry to update
+ * @param value the number to set
+ */
+export function setNumber(key: string, value: number) {
+  localStorage.setItem(key, value.toString())
+}

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -52,11 +52,12 @@ export function setBoolean(key: string, value: boolean) {
  */
 export function getNumber(key: string, defaultValue = 0): number {
   const numberAsText = localStorage.getItem(key)
-  let value = 0
-  if (numberAsText && numberAsText.length > 0) {
-    value = parseInt(numberAsText, 10)
+
+  if (numberAsText === null || numberAsText.length === 0) {
+    return defaultValue
   }
 
+  const value = parseInt(numberAsText, 10)
   if (isNaN(value)) {
     return defaultValue
   }

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -11,13 +11,15 @@ export function getBoolean(key: string, defaultValue = false): boolean {
     return defaultValue
   }
 
-  const intValue = parseInt(value, 10)
-
-  if (isNaN(intValue)) {
-    return defaultValue
+  if (value === '1' || value === 'true') {
+    return true
   }
 
-  return intValue === 1
+  if (value === '0' || value === 'false') {
+    return false
+  }
+
+  return defaultValue
 }
 
 /**

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -29,12 +29,12 @@ export function setBoolean(key: string, value: boolean) {
 }
 
 /**
- * Retrieve a numeric value from a given local storage entry.
- *
- * Returns `0` if a valid number is not found in this key
+ * Retrieve a `number` value from a given local storage entry if found, or the
+ * provided `defaultValue` if the key doesn't exist or if the value cannot be
+ * convered into a number
  *
  * @param key local storage entry to read
- * @param defaultValue fallback value if key not found
+ * @param defaultValue fallback value if unable to find key or valid value
  */
 export function getNumber(key: string, defaultValue = 0): number {
   const numberAsText = localStorage.getItem(key)

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -12,6 +12,11 @@ export function getBoolean(key: string, defaultValue = false): boolean {
   }
 
   const intValue = parseInt(value, 10)
+
+  if (isNaN(intValue)) {
+    return defaultValue
+  }
+
   return intValue === 1
 }
 

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -5,7 +5,12 @@
  * @param key local storage entry to find
  * @param defaultValue fallback value if key not found
  */
-export function getBoolean(key: string, defaultValue = false): boolean {
+export function getBoolean(key: string): boolean | undefined
+export function getBoolean(key: string, defaultValue: boolean): boolean
+export function getBoolean(
+  key: string,
+  defaultValue?: boolean
+): boolean | undefined {
   const value = localStorage.getItem(key)
   if (value === null) {
     return defaultValue
@@ -50,7 +55,12 @@ export function setBoolean(key: string, value: boolean) {
  * @param key local storage entry to read
  * @param defaultValue fallback value if unable to find key or valid value
  */
-export function getNumber(key: string, defaultValue = 0): number {
+export function getNumber(key: string): number | undefined
+export function getNumber(key: string, defaultValue: number): number
+export function getNumber(
+  key: string,
+  defaultValue?: number
+): number | undefined {
   const numberAsText = localStorage.getItem(key)
 
   if (numberAsText === null || numberAsText.length === 0) {

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -11,6 +11,13 @@ export function getBoolean(key: string, defaultValue = false): boolean {
     return defaultValue
   }
 
+  // NOTE:
+  // 'true' and 'false' were acceptable values for controlling feature flags
+  // but it required users to set them manually, and were not documented well in
+  // the codebase
+  // For now we can check these values for compatibility, but we could drop
+  // these at some point in the future
+
   if (value === '1' || value === 'true') {
     return true
   }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -786,7 +786,8 @@ function createLocalStorageTimestamp(key: string) {
  * be converted into a number this method will return null.
  */
 function getLocalStorageTimestamp(key: string): number | null {
-  return getNumber(key) || null
+  const timestamp = getNumber(key)
+  return timestamp === undefined ? null : timestamp
 }
 
 /**

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -240,7 +240,7 @@ export class StatsStore {
 
   /** Should the app report its daily stats? */
   private shouldReportDailyStats(): boolean {
-    const lastDate = getNumber(LastDailyStatsReportKey)
+    const lastDate = getNumber(LastDailyStatsReportKey, 0)
     const now = Date.now()
     return now - lastDate > DailyStatsReportInterval
   }
@@ -786,8 +786,7 @@ function createLocalStorageTimestamp(key: string) {
  * be converted into a number this method will return null.
  */
 function getLocalStorageTimestamp(key: string): number | null {
-  const value = getNumber(key)
-  return value === 0 ? null : value
+  return getNumber(key) || null
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1449,7 +1449,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     if (newSelectedRepository === null && this.repositories.length > 0) {
-      const lastSelectedID = getNumber(LastSelectedRepositoryIDKey)
+      const lastSelectedID = getNumber(LastSelectedRepositoryIDKey, 0)
       if (lastSelectedID > 0) {
         newSelectedRepository =
           this.repositories.find(r => r.id === lastSelectedID) || null

--- a/app/src/lib/welcome.ts
+++ b/app/src/lib/welcome.ts
@@ -1,3 +1,5 @@
+import { getBoolean, setBoolean } from './local-storage'
+
 /** The `localStorage` key for whether we've shown the Welcome flow yet. */
 const HasShownWelcomeFlowKey = 'has-shown-welcome-flow'
 
@@ -5,18 +7,12 @@ const HasShownWelcomeFlowKey = 'has-shown-welcome-flow'
  * Check if the current user has completed the welcome flow.
  */
 export function hasShownWelcomeFlow(): boolean {
-  const hasShownWelcomeFlow = localStorage.getItem(HasShownWelcomeFlowKey)
-  if (!hasShownWelcomeFlow) {
-    return false
-  }
-
-  const value = parseInt(hasShownWelcomeFlow, 10)
-  return value === 1
+  return getBoolean(HasShownWelcomeFlowKey, false)
 }
 
 /**
  * Update local storage to indicate the welcome flow has been completed.
  */
 export function markWelcomeFlowComplete() {
-  localStorage.setItem(HasShownWelcomeFlowKey, '1')
+  setBoolean(HasShownWelcomeFlowKey, true)
 }

--- a/app/src/ui/lib/features.ts
+++ b/app/src/ui/lib/features.ts
@@ -1,18 +1,10 @@
+import { getBoolean } from '../../lib/local-storage'
+
 function getFeatureOverride(
   featureName: string,
   defaultValue: boolean
 ): boolean {
-  const override = localStorage.getItem(`features/${featureName}`)
-
-  if (override) {
-    if (override === '1' || override === 'true') {
-      return true
-    } else if (override === '0' || override === 'false') {
-      return false
-    }
-  }
-
-  return defaultValue
+  return getBoolean(`features/${featureName}`, defaultValue)
 }
 
 function featureFlag(

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -47,7 +47,7 @@ class UpdateStore {
   private userInitiatedUpdate = true
 
   public constructor() {
-    const lastSuccessfulCheckTime = getNumber(lastSuccessfulCheckKey)
+    const lastSuccessfulCheckTime = getNumber(lastSuccessfulCheckKey, 0)
 
     if (lastSuccessfulCheckTime > 0) {
       this.lastSuccessfulCheck = new Date(lastSuccessfulCheckTime)

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -13,6 +13,7 @@ import { parseError } from '../../lib/squirrel-error-parser'
 
 import { ReleaseSummary } from '../../models/release-notes'
 import { generateReleaseSummary } from '../../lib/release-notes'
+import { setNumber, getNumber } from '../../lib/local-storage'
 
 /** The states the auto updater can be in. */
 export enum UpdateStatus {
@@ -46,16 +47,10 @@ class UpdateStore {
   private userInitiatedUpdate = true
 
   public constructor() {
-    const lastSuccessfulCheckValue = localStorage.getItem(
-      lastSuccessfulCheckKey
-    )
+    const lastSuccessfulCheckTime = getNumber(lastSuccessfulCheckKey)
 
-    if (lastSuccessfulCheckValue) {
-      const lastSuccessfulCheckTime = parseInt(lastSuccessfulCheckValue, 10)
-
-      if (!isNaN(lastSuccessfulCheckTime)) {
-        this.lastSuccessfulCheck = new Date(lastSuccessfulCheckTime)
-      }
+    if (lastSuccessfulCheckTime > 0) {
+      this.lastSuccessfulCheck = new Date(lastSuccessfulCheckTime)
     }
 
     autoUpdater.on('error', this.onAutoUpdaterError)
@@ -81,10 +76,8 @@ class UpdateStore {
 
   private touchLastChecked() {
     const now = new Date()
-    const persistedValue = now.getTime().toString()
-
     this.lastSuccessfulCheck = now
-    localStorage.setItem(lastSuccessfulCheckKey, persistedValue)
+    setNumber(lastSuccessfulCheckKey, now.getTime())
   }
 
   private onAutoUpdaterError = (error: Error) => {

--- a/app/test/setup-test-framework.ts
+++ b/app/test/setup-test-framework.ts
@@ -1,2 +1,4 @@
 // set test timeout to 10s
 jest.setTimeout(10000)
+
+import 'jest-localstorage-mock'

--- a/app/test/unit/local-storage-test.ts
+++ b/app/test/unit/local-storage-test.ts
@@ -6,45 +6,78 @@ import {
 } from '../../src/lib/local-storage'
 
 describe('local storage', () => {
-  describe('working with booleans', () => {
-    const key = 'some-boolean-key'
+  const booleanKey = 'some-boolean-key'
+  const numberKey = 'some-number-key'
 
-    it('can round-trip a true value', () => {
+  describe('setBoolean', () => {
+    it('round-trips a true value', () => {
       const expected = true
-
-      setBoolean(key, expected)
-
-      expect(getBoolean(key)).toEqual(expected)
+      setBoolean(booleanKey, expected)
+      expect(getBoolean(booleanKey)).toEqual(expected)
     })
 
-    it('returns default value when malformed string encountered', () => {
-      localStorage.setItem(key, 'blahblahblah')
-      const defaultValue = true
-
-      const actual = getBoolean(key, defaultValue)
-
-      expect(actual).toEqual(defaultValue)
+    it('round-trips a false value', () => {
+      const expected = false
+      setBoolean(booleanKey, expected)
+      expect(getBoolean(booleanKey)).toEqual(expected)
     })
   })
 
-  describe('working with numbers', () => {
-    const key = 'some-number-key'
-
-    it('can round-trip a true value', () => {
-      const expected = 12345
-
-      setNumber(key, expected)
-
-      expect(getNumber(key)).toEqual(expected)
-    })
-
+  describe('getBoolean parsing', () => {
     it('returns default value when malformed string encountered', () => {
-      localStorage.setItem(key, 'blahblahblah')
-      const defaultValue = 3456
+      localStorage.setItem(booleanKey, 'blahblahblah')
+      const defaultValue = true
 
-      const actual = getNumber(key, defaultValue)
+      const actual = getBoolean(booleanKey, defaultValue)
 
       expect(actual).toEqual(defaultValue)
+    })
+
+    it('returns false if found and ignores default value', () => {
+      localStorage.setItem(booleanKey, '0')
+
+      const actual = getBoolean(booleanKey, true)
+
+      expect(actual).toEqual(false)
+    })
+  })
+
+  describe('setNumber', () => {
+    it('round-trip a valid number', () => {
+      const expected = 12345
+
+      setNumber(numberKey, expected)
+
+      expect(getNumber(numberKey)).toEqual(expected)
+    })
+
+    it('round-trip zero and ignore default value', () => {
+      const expected = 0
+      const defaultNumber = 1234
+
+      setNumber(numberKey, expected)
+
+      expect(getNumber(numberKey, defaultNumber)).toEqual(expected)
+    })
+  })
+
+  describe('getNumber parsing', () => {
+    it('returns default value when malformed string encountered', () => {
+      localStorage.setItem(numberKey, 'blahblahblah')
+      const defaultValue = 3456
+
+      const actual = getNumber(numberKey, defaultValue)
+
+      expect(actual).toEqual(defaultValue)
+    })
+
+    it('returns zero if found and ignores default value', () => {
+      localStorage.setItem(numberKey, '0')
+      const defaultValue = 3456
+
+      const actual = getNumber(numberKey, defaultValue)
+
+      expect(actual).toEqual(0)
     })
   })
 })

--- a/app/test/unit/local-storage-test.ts
+++ b/app/test/unit/local-storage-test.ts
@@ -28,6 +28,14 @@ describe('local storage', () => {
   })
 
   describe('getBoolean parsing', () => {
+    it('returns default value when no key found', () => {
+      const defaultValue = true
+
+      const actual = getBoolean(booleanKey, defaultValue)
+
+      expect(actual).toEqual(defaultValue)
+    })
+
     it('returns default value when malformed string encountered', () => {
       localStorage.setItem(booleanKey, 'blahblahblah')
       const defaultValue = true
@@ -83,6 +91,12 @@ describe('local storage', () => {
   })
 
   describe('getNumber parsing', () => {
+    it('returns default value when no key found', () => {
+      const defaultValue = 3456
+      const actual = getNumber(numberKey, defaultValue)
+      expect(actual).toEqual(defaultValue)
+    })
+
     it('returns default value when malformed string encountered', () => {
       localStorage.setItem(numberKey, 'blahblahblah')
       const defaultValue = 3456

--- a/app/test/unit/local-storage-test.ts
+++ b/app/test/unit/local-storage-test.ts
@@ -1,0 +1,50 @@
+import {
+  setBoolean,
+  getBoolean,
+  setNumber,
+  getNumber,
+} from '../../src/lib/local-storage'
+
+describe('local storage', () => {
+  describe('working with booleans', () => {
+    const key = 'some-boolean-key'
+
+    it('can round-trip a true value', () => {
+      const expected = true
+
+      setBoolean(key, expected)
+
+      expect(getBoolean(key)).toEqual(expected)
+    })
+
+    it('returns default value when malformed string encountered', () => {
+      localStorage.setItem(key, 'blahblahblah')
+      const defaultValue = true
+
+      const actual = getBoolean(key, defaultValue)
+
+      expect(actual).toEqual(defaultValue)
+    })
+  })
+
+  describe('working with numbers', () => {
+    const key = 'some-number-key'
+
+    it('can round-trip a true value', () => {
+      const expected = 12345
+
+      setNumber(key, expected)
+
+      expect(getNumber(key)).toEqual(expected)
+    })
+
+    it('returns default value when malformed string encountered', () => {
+      localStorage.setItem(key, 'blahblahblah')
+      const defaultValue = 3456
+
+      const actual = getNumber(key, defaultValue)
+
+      expect(actual).toEqual(defaultValue)
+    })
+  })
+})

--- a/app/test/unit/local-storage-test.ts
+++ b/app/test/unit/local-storage-test.ts
@@ -40,6 +40,23 @@ describe('local storage', () => {
 
       expect(actual).toEqual(false)
     })
+
+    it(`can parse the string 'true' if found`, () => {
+      localStorage.setItem(booleanKey, 'true')
+
+      const actual = getBoolean(booleanKey)
+
+      expect(actual).toEqual(true)
+    })
+
+    it(`can parse the string 'false' if found`, () => {
+      localStorage.setItem(booleanKey, 'false')
+      const defaultValue = true
+
+      const actual = getBoolean(booleanKey, defaultValue)
+
+      expect(actual).toEqual(false)
+    })
   })
 
   describe('setNumber', () => {

--- a/app/test/unit/local-storage-test.ts
+++ b/app/test/unit/local-storage-test.ts
@@ -9,6 +9,10 @@ describe('local storage', () => {
   const booleanKey = 'some-boolean-key'
   const numberKey = 'some-number-key'
 
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   describe('setBoolean', () => {
     it('round-trips a true value', () => {
       const expected = true

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "glob": "^7.1.2",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^23.5.0",
+    "jest-localstorage-mock": "^2.3.0",
     "json-pretty": "^0.0.1",
     "klaw-sync": "^3.0.0",
     "legal-eagle": "0.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6062,6 +6062,11 @@ jest-leak-detector@^23.5.0:
   dependencies:
     pretty-format "^23.5.0"
 
+jest-localstorage-mock@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.3.0.tgz#86eda98d5af3aed687aebf11dbab3ca0f8fe66ff"
+  integrity sha512-Lk+awEPuIz0PSERHtnsXyMVLvf/4mZ3sZBEjKG5sJHvey2/i2JfQmmb/NHhialMbHXZILBORzuH64YXhWGlLsQ==
+
 jest-matcher-utils@^23.5.0:
   version "23.5.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz#0e2ea67744cab78c9ab15011c4d888bdd3e49e2a"


### PR DESCRIPTION
I've got a PR on the way which interacts with local storage, but I'm opening this PR in advance because I found myself writing this code again:

 - reading and writing a `boolean` to `localStorage`
 - reading and writing a `number` to `localStorage`

`localStorage` only deals with strings, so we have various parsing code sprinkled around to convert between strings and boolean/number values.

This centralizes those rules and makes our current usage a bit easier to follow.

 - [x] add unit tests for new APIs