### PR TITLE
Update merge dialog to display truncation on long branch names

### DIFF
--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -308,7 +308,6 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
           {enableMergeConflictDetection()
             ? this.renderNewMergeInfo()
             : this.renderOldMergeMessage()}
-          <br />
           <ButtonGroup>
             <Button type="submit" disabled={disabled}>
               Merge <strong>{selectedBranch ? selectedBranch.name : ''}</strong>{' '}

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -263,7 +263,6 @@ dialog {
 
     border-top: var(--base-border);
     padding: var(--spacing-double);
-    padding-top: 0;
 
     .button-group {
       display: flex;

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -63,4 +63,10 @@ dialog#merge {
   .merge-status-component {
     margin-top: var(--spacing);
   }
+
+  .merge-status-icon-container {
+    &:after {
+      border-bottom: 0;
+    }
+  }
 }

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -62,7 +62,7 @@ dialog#merge {
   }
 
   .merge-status-component {
-    margin-top: var(--spacing);
+    margin-top: 0;
   }
 
   .merge-status-icon-container {

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -58,6 +58,7 @@
 dialog#merge {
   .merge-info {
     margin-top: var(--spacing-half);
+    margin-bottom: var(--spacing);
   }
 
   .merge-status-component {


### PR DESCRIPTION
PR fixes #5930 and #5970 

### Background
This PR is addressing both issues above;
- the **risks** section of issue #5930 
  - >Branch names can be an arbitrary length, so it's worth thinking about how to present a longer branch names in a fixed width window.
- issue #5970 
  - >A long branch name should be truncated in both locations (modal surface and changes tab) where we show a merge hint.

Currently a work in progress, will update with more info as I move along. Thanks.
