### PR TITLE
help improve our release notes by writing them earlier

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,13 @@ If an issue doesn't exist for this pull request (PR) to address, please open one
 ## Description
 
 -
+
+## Release notes
+
+<!--
+If this is related to a user-facing change and should be added to the release notes, please add a summary of the change.
+
+For changes related to documentation or techical debt, just add `no-notes` to indicate this can be skipped.
+-->
+
+Notes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ If an issue doesn't exist for this pull request (PR) to address, please open one
 ## Release notes
 
 <!--
-If this is related to a feature, bugfix or improvement, please add a summary of the change so it can be featured in the releaase notes.
+If this is related to a feature, bugfix or improvement, please add a summary of the change so it can be featured in the release notes.
 
 If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,14 @@ If an issue doesn't exist for this pull request (PR) to address, please open one
 ## Release notes
 
 <!--
-If this is related to a feature, bugfix or improvement, please add a summary of the change so it can be featured in the release notes.
+If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.
+
+Some examples:
+
+  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
+  - Fixes problem with commit being reset when switching between History and Changes tabs 
+  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
+  - Improves status parsing performance when handling thousands of changed files
 
 If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,9 +15,9 @@ If an issue doesn't exist for this pull request (PR) to address, please open one
 ## Release notes
 
 <!--
-If this is related to a user-facing change and should be added to the release notes, please add a summary of the change.
+If this is related to a feature, bugfix or improvement, please add a summary of the change so it can be featured in the releaase notes.
 
-For changes related to documentation or techical debt, just add `no-notes` to indicate this can be skipped.
+If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
 -->
 
 Notes:


### PR DESCRIPTION
## Overview

A suggestion to improve the workflow for new contributions

## Description

This adds a new section to the pull request template (inspired by the Electron repository) to help curate better release notes earlier in the process.

Why?

 - our release notes generator currently just dumps a list of every PR that was merged - I think we can distinguish better between "this PR should be in the release notes" and "this change doesn't affect end users"
 - writing the release notes later means important context may be forgotten, and makes writing the release notes a more time-consuming task than it should be
 - our release notes generator looks in the PR body for linked issues, so it's easy for us to add an additional lookup for this `notes: [blah]` line to decide whether or not to omit it

For the moment I'm going to keep the `infrastructure` around to help us track reviews unrelated to user-facing work, but I'm pondering on different ways to prioritize reviews (maybe the granularity should be on what the PR is affecting - `docs`/`infrastructure`/`tech-debt`/???)

## Release notes

Notes: no-notes