### PR TITLE
cleanup metadata support to help with providing support for merge conflicts

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -312,13 +312,13 @@ export type Popup =
       type: PopupType.MergeConflicts
       repository: Repository
       currentBranch: string
-      comparisonBranch: string
+      theirBranch: string
     }
   | {
       type: PopupType.AbortMerge
       repository: Repository
       currentBranch: string
-      comparisonBranch: string
+      theirBranch: string
     }
 
 export enum FoldoutType {

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -295,21 +295,17 @@ export async function mergeConflictHandler(
       break
   }
 
-  if (gitContext.kind === 'merge') {
-    const { tip, branch } = gitContext
-    if (tip == null || tip.kind !== TipState.Valid) {
-      return error
-    }
-
-    dispatcher.showPopup({
-      type: PopupType.MergeConflicts,
-      repository,
-      currentBranch: tip.branch.name,
-      comparisonBranch: branch,
-    })
-  } else {
-    // TODO: what should we display if this is a pull?
+  const { tip, branch } = gitContext
+  if (tip == null || tip.kind !== TipState.Valid) {
+    return error
   }
+
+  dispatcher.showPopup({
+    type: PopupType.MergeConflicts,
+    repository,
+    currentBranch: tip.branch.name,
+    comparisonBranch: branch,
+  })
 
   return null
 }

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -295,7 +295,7 @@ export async function mergeConflictHandler(
       break
   }
 
-  const { tip, branch } = gitContext
+  const { tip, theirBranch } = gitContext
   if (tip == null || tip.kind !== TipState.Valid) {
     return error
   }
@@ -304,7 +304,7 @@ export async function mergeConflictHandler(
     type: PopupType.MergeConflicts,
     repository,
     currentBranch: tip.branch.name,
-    comparisonBranch: branch,
+    theirBranch,
   })
 
   return null

--- a/app/src/lib/dispatcher/error-handlers.ts
+++ b/app/src/lib/dispatcher/error-handlers.ts
@@ -273,7 +273,7 @@ export async function mergeConflictHandler(
     return error
   }
 
-  const { command, tip, repository } = e.metadata
+  const { command, tip, repository, context } = e.metadata
   if (repository == null) {
     return error
   }
@@ -297,14 +297,15 @@ export async function mergeConflictHandler(
     return error
   }
 
-  // TODO: where can we get this from?
-  const branch = 'my-cool-branch'
+  if (context == null || context.kind !== 'merge') {
+    return error
+  }
 
   dispatcher.showPopup({
     type: PopupType.MergeConflicts,
     repository,
     currentBranch: tip.branch.name,
-    comparisonBranch: branch,
+    comparisonBranch: context.branch,
   })
 
   return null

--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -1,6 +1,7 @@
 import { Repository } from '../models/repository'
 import { CloningRepository } from '../models/cloning-repository'
 import { RetryAction } from './retry-actions'
+import { Tip } from '../models/tip'
 
 export interface IErrorMetadata {
   /** The first argument passed to `git` which triggered this error */
@@ -14,6 +15,9 @@ export interface IErrorMetadata {
 
   /** The action to retry if applicable. */
   readonly retryAction?: RetryAction
+
+  /** The tip of the repository at the time of the action */
+  readonly tip?: Tip
 }
 
 /** An error which contains additional metadata. */

--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -1,21 +1,9 @@
 import { Repository } from '../models/repository'
 import { CloningRepository } from '../models/cloning-repository'
 import { RetryAction } from './retry-actions'
-import { Tip } from '../models/tip'
-
-type MergeErrorContext = {
-  kind: 'merge'
-  /** the branch passed to Git as part of the merge operation */
-  branch: string
-}
-
-/** A custom shape of data for actions to provide to help with error handling */
-type IErrorContext = MergeErrorContext
+import { IGitErrorContext } from './git-error-context'
 
 export interface IErrorMetadata {
-  /** The first argument passed to `git` which triggered this error */
-  readonly command?: string
-
   /** Was the action which caused this error part of a background task? */
   readonly backgroundTask?: boolean
 
@@ -25,11 +13,8 @@ export interface IErrorMetadata {
   /** The action to retry if applicable. */
   readonly retryAction?: RetryAction
 
-  /** The tip of the repository at the time of the action */
-  readonly tip?: Tip
-
   /** Additional context that specific actions can provide fields for */
-  readonly context?: IErrorContext
+  readonly gitContext?: IGitErrorContext
 }
 
 /** An error which contains additional metadata. */

--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -3,6 +3,15 @@ import { CloningRepository } from '../models/cloning-repository'
 import { RetryAction } from './retry-actions'
 import { Tip } from '../models/tip'
 
+type MergeErrorContext = {
+  kind: 'merge'
+  /** the branch passed to Git as part of the merge operation */
+  branch: string
+}
+
+/** A custom shape of data for actions to provide to help with error handling */
+type IErrorContext = MergeErrorContext
+
 export interface IErrorMetadata {
   /** The first argument passed to `git` which triggered this error */
   readonly command?: string
@@ -18,6 +27,9 @@ export interface IErrorMetadata {
 
   /** The tip of the repository at the time of the action */
   readonly tip?: Tip
+
+  /** Additional context that specific actions can provide fields for */
+  readonly context?: IErrorContext
 }
 
 /** An error which contains additional metadata. */

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -1,6 +1,6 @@
 import { Tip } from '../models/tip'
 
-type MergeConflictsErrorContext = {
+export type MergeConflictsErrorContext = {
   /** The Git operation that triggered the conflicted state */
   readonly kind: 'merge' | 'pull'
   /** The tip of the repository at the time of the merge operation */

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -1,0 +1,16 @@
+import { Tip } from '../models/tip'
+
+type MergeErrorContext = {
+  kind: 'merge'
+  /** The tip of the repository at the time of the merge operation */
+  readonly tip?: Tip
+  /** the branch passed to Git as part of the merge operation */
+  branch: string
+}
+
+type PullErrorContext = {
+  kind: 'pull'
+}
+
+/** A custom shape of data for actions to provide to help with error handling */
+export type IGitErrorContext = MergeErrorContext | PullErrorContext

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -1,16 +1,13 @@
 import { Tip } from '../models/tip'
 
-type MergeErrorContext = {
-  kind: 'merge'
+type MergeConflictsErrorContext = {
+  /** The Git operation that triggered the conflicted state */
+  readonly kind: 'merge' | 'pull'
   /** The tip of the repository at the time of the merge operation */
   readonly tip?: Tip
   /** the branch passed to Git as part of the merge operation */
-  branch: string
-}
-
-type PullErrorContext = {
-  kind: 'pull'
+  readonly branch: string
 }
 
 /** A custom shape of data for actions to provide to help with error handling */
-export type IGitErrorContext = MergeErrorContext | PullErrorContext
+export type IGitErrorContext = MergeConflictsErrorContext

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -5,8 +5,8 @@ export type MergeConflictsErrorContext = {
   readonly kind: 'merge' | 'pull'
   /** The tip of the repository at the time of the merge operation */
   readonly tip?: Tip
-  /** the branch passed to Git as part of the merge operation */
-  readonly branch: string
+  /** The branch currently being merged into the current branch, "their" in Git terminology */
+  readonly theirBranch: string
 }
 
 /** A custom shape of data for actions to provide to help with error handling */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2607,7 +2607,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           gitContext = {
             kind: 'pull',
             tip,
-            branch: tip.branch.upstream,
+            theirBranch: tip.branch.upstream,
           }
         }
 
@@ -3101,7 +3101,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       gitContext: {
         kind: 'merge',
         tip,
-        branch,
+        theirBranch: branch,
       },
     })
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -165,6 +165,7 @@ import { validatedRepositoryPath } from './helpers/validated-repository-path'
 import { RepositoryStateCache } from './repository-state-cache'
 import { readEmoji } from '../read-emoji'
 import { GitStoreCache } from './git-store-cache'
+import { IErrorMetadata } from '../error-with-metadata'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -3085,7 +3086,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { tip } = gitStore
-    const errorMetadata = { tip }
+    const errorMetadata: IErrorMetadata = {
+      tip,
+      context: {
+        kind: 'merge',
+        branch,
+      },
+    }
 
     await gitStore.performFailableOperation(
       () => gitStore.merge(branch),

--- a/app/src/ui/abort-merge/abort-merge-warning.tsx
+++ b/app/src/ui/abort-merge/abort-merge-warning.tsx
@@ -12,7 +12,7 @@ interface IAbortMergeWarningProps {
   readonly repository: Repository
   readonly onDismissed: () => void
   readonly currentBranch: string
-  readonly comparisonBranch: string
+  readonly theirBranch: string
 }
 
 const titleString = 'Confirm abort merge'
@@ -43,7 +43,7 @@ export class AbortMergeWarning extends React.Component<
       type: PopupType.MergeConflicts,
       repository: this.props.repository,
       currentBranch: this.props.currentBranch,
-      comparisonBranch: this.props.comparisonBranch,
+      theirBranch: this.props.theirBranch,
     })
   }
 
@@ -61,7 +61,7 @@ export class AbortMergeWarning extends React.Component<
           <div className="column-left">
             <p>
               {'Are you sure you want to abort merging '}
-              <strong>{this.props.comparisonBranch}</strong>
+              <strong>{this.props.theirBranch}</strong>
               {' into '}
               <strong>{this.props.currentBranch}</strong>?
             </p>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1350,7 +1350,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               externalEditorName={this.state.selectedExternalEditor}
               openRepositoryInShell={this.openInShell}
               currentBranch={popup.currentBranch}
-              comparisonBranch={popup.comparisonBranch}
+              theirBranch={popup.theirBranch}
             />
           )
         } else {
@@ -1388,7 +1388,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               repository={popup.repository}
               onDismissed={this.onPopupDismissed}
               currentBranch={popup.currentBranch}
-              comparisonBranch={popup.comparisonBranch}
+              theirBranch={popup.theirBranch}
             />
           )
         }

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -23,7 +23,7 @@ interface IMergeConflictsDialogProps {
   readonly externalEditorName?: string
   readonly openRepositoryInShell: (repository: Repository) => void
   readonly currentBranch: string
-  readonly comparisonBranch: string
+  readonly theirBranch: string
 }
 
 const submitButtonString = 'Commit merge'
@@ -67,7 +67,7 @@ export class MergeConflictsDialog extends React.Component<
         type: PopupType.AbortMerge,
         repository: this.props.repository,
         currentBranch: this.props.currentBranch,
-        comparisonBranch: this.props.comparisonBranch,
+        theirBranch: this.props.theirBranch,
       })
     }
   }
@@ -201,7 +201,7 @@ export class MergeConflictsDialog extends React.Component<
     )
     const titleString = this.titleString(
       this.props.currentBranch,
-      this.props.comparisonBranch
+      this.props.theirBranch
     )
     const tooltipString = anyConflictedFiles
       ? 'Resolve all changes before merging'

--- a/docs/technical/error-reporting.md
+++ b/docs/technical/error-reporting.md
@@ -68,15 +68,23 @@ That will present the generic error dialog to the user.
 +-------------------------+
 ```
 
-### Subclasses
+### `Error` subclasses
 
-We have a couple `Error` subclasses which we use to provide more context to
-error handlers:
+We define some `Error` subclasses that are used in the codebase use to provide
+more context to error handlers:
 
 * [`GitError`](https://github.com/desktop/desktop/blob/75445ea61177347b2df08e846aae30e637d5f1de/app/src/lib/git/core.ts#L62) -
-All errors coming from git should be `GitError`s.
+wraps a raw `Error` raise by `dugite` with additional git information.
 * [`ErrorWithMetadata`](https://github.com/desktop/desktop/blob/75445ea61177347b2df08e846aae30e637d5f1de/app/src/lib/error-with-metadata.ts) -
-Wraps an existing `Error` with additional metadata.
+wraps an existing `Error` with additional metadata.
 
-`ErrorWithMetadata` instances can provide a [`RetryAction`](https://github.com/desktop/desktop/blob/75445ea61177347b2df08e846aae30e637d5f1de/app/src/lib/retry-actions.ts)
-which gives error handlers the ability to retry whatever action caused the error.
+In addition to the global information like the repository associated with the
+error, `ErrorWithMetadata` supports providing additional details:
+
+ - a [`RetryAction`](https://github.com/desktop/desktop/blob/75445ea61177347b2df08e846aae30e637d5f1de/app/src/lib/retry-actions.ts)
+  can be set to let the user retry the action that previously failed, allowing
+  error handlers the ability to retry whatever action caused the error.
+ - a [`IGitErrorContext`](https://github.com/desktop/desktop/blob/c60350c52daeab04fe9e8743c5a5079bc87daa0e/app/src/lib/git-error-context.ts)
+  can be set to add custom details about the Git operation that failed, so that
+  error handlers have more context to provide the user about how to recover
+


### PR DESCRIPTION
This PR moves the error handling for merge conflicts back into `dispatcher.ts`, and makes some changes to the internals to help support the scenario needed in #5809 about being able to pass additional metadata to the dialog we need to show.

I also refreshed the relevant docs section to indicate This Is How We Should Pass Information To Error Handlers™ In The Future™:

 - [x] update the `pull` error handler to also provide this required metadata