### PR TITLE
extract labels to it's own document and refresh

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,11 +12,11 @@ time as the team learns, listens and refines how we work with the community.
 
 #### Table Of Contents
 
-[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+- [What should I know before I get started?](#what-should-i-know-before-i-get-started)
   * [Code of Conduct](#code-of-conduct)
   * [The Roadmap](#the-roadmap)
 
-[How Can I Contribute?](#how-can-i-contribute)
+- [How Can I Contribute?](#how-can-i-contribute)
   * [Reporting Bugs](#reporting-bugs)
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Help Wanted](#help-wanted)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,6 +21,8 @@ time as the team learns, listens and refines how we work with the community.
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Help Wanted](#help-wanted)
 
+- [Process Documentation](#process-documentation)
+
 ## What should I know before I get started?
 
 ### Code of Conduct
@@ -138,3 +140,14 @@ interested in the issue.
 ### Set Up Your Machine
 
 Start [here](https://github.com/desktop/desktop/blob/master/docs/contributing/setup.md).
+
+
+## Process Documentation
+
+These documents are useful resources for contributors  to learn more about the project and how it is run:
+
+ - [Teams](https://github.com/desktop/desktop/blob/master/docs/process/teams.md)
+ - [Release Planning](https://github.com/desktop/desktop/blob/master/docs/process/release-planning.md)
+ - [Issue Triage](https://github.com/desktop/desktop/blob/master/docs/process/issue-triage.md)
+ - [Issue and Pull Request Labels](https://github.com/desktop/desktop/blob/master/docs/process/labels.md)
+ - [Pull Request Triage](https://github.com/desktop/desktop/blob/master/docs/process/pull-request-triage.md)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,9 +21,6 @@ time as the team learns, listens and refines how we work with the community.
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Help Wanted](#help-wanted)
 
-[Additional Notes](#additional-notes)
-  * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
-
 ## What should I know before I get started?
 
 ### Code of Conduct
@@ -141,42 +138,3 @@ interested in the issue.
 ### Set Up Your Machine
 
 Start [here](https://github.com/desktop/desktop/blob/master/docs/contributing/setup.md).
-
-## Additional Notes
-
-### Issue and Pull Request Labels
-
-This section lists the labels we use to help us track and manage issues and
-pull requests.
-
-#### Type of Issue and Issue State
-
-| Label name | :mag_right: | Description |
-| --- | --- | --- |
-| `enhancement` | [search](https://github.com/desktop/desktop/labels/enhancement) | Feature requests |
-| `bug` | [search](https://github.com/desktop/desktop/labels/bug)  | Confirmed bugs or reports that are very likely to be bugs |
-| `more-information-needed` | [search](https://github.com/desktop/desktop/labels/more-information-needed) | More information needs to be collected about these problems or feature requests (e.g. steps to reproduce) |
-| `reviewer-needs-to-reproduce` | [search](https://github.com/desktop/desktop/labels/reviewer-needs-to-reproduce)  | Potential bugs that still need to be reliably reproduced by a reviewer |
-| `stale` | [search](https://github.com/desktop/desktop/labels/stale) | Issues that are inactive and marked to be closed |
-| `macOS` | [search](https://github.com/desktop/desktop/labels/macOS)  | Issues specific to macOS users |
-| `Windows` | [search](https://github.com/desktop/desktop/labels/Windows)  | Issues specific to Windows users |
-| `codemirror` | [search](https://github.com/desktop/desktop/labels/codemirror)  | Issues related to our use of [CodeMirror](https://codemirror.net/) that may require upstream fixes |
-| `electron` | [search](https://github.com/desktop/desktop/labels/electron) | Issues related to our use of [Electron](https://electron.atom.io) that may require upstream fixes |
-| `themes` | [search](https://github.com/desktop/desktop/labels/themes) | Issues related the light or dark themes that ship in Desktop |
-| `user-research` | [search](https://github.com/desktop/desktop/labels/user-research) | Issues that might benefit from user interviews, validations, and/or usability testing |
-| `integrations` | [search](https://github.com/desktop/desktop/labels/integrations) | Issues related to editor and shell integrations that ship in Desktop |
-
-#### Topics
-
-| Label name | :mag_right: | Description |
-| --- | --- | --- |
-| `help wanted` | [search](https://github.com/desktop/desktop/labels/help%20wanted)  | Issues marked as ideal for external contributors |
-| `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions |
-| `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require design input from the core team before the work can be started |
-
-#### Workflow
-
-| Label name | :mag_right: | Description |
-| --- | --- | --- |
-| `infrastructure` | [search](https://github.com/desktop/desktop/labels/infrastructure) | Pull requests not related to the core application - documentation, dependencies, tooling, etc |
-| `ready-for-review` | [search](https://github.com/desktop/desktop/labels/ready-for-review)  | Pull Requests that are ready to be reviewed by the maintainers |

--- a/docs/process/labels.md
+++ b/docs/process/labels.md
@@ -1,0 +1,38 @@
+## Additional Notes
+
+### Issue and Pull Request Labels
+
+This section lists the labels we use to help us track and manage issues and
+pull requests.
+
+#### Type of Issue and Issue State
+
+| Label name | :mag_right: | Description |
+| --- | --- | --- |
+| `enhancement` | [search](https://github.com/desktop/desktop/labels/enhancement) | Feature requests |
+| `bug` | [search](https://github.com/desktop/desktop/labels/bug)  | Confirmed bugs or reports that are very likely to be bugs |
+| `more-information-needed` | [search](https://github.com/desktop/desktop/labels/more-information-needed) | More information needs to be collected about these problems or feature requests (e.g. steps to reproduce) |
+| `reviewer-needs-to-reproduce` | [search](https://github.com/desktop/desktop/labels/reviewer-needs-to-reproduce)  | Potential bugs that still need to be reliably reproduced by a reviewer |
+| `stale` | [search](https://github.com/desktop/desktop/labels/stale) | Issues that are inactive and marked to be closed |
+| `macOS` | [search](https://github.com/desktop/desktop/labels/macOS)  | Issues specific to macOS users |
+| `Windows` | [search](https://github.com/desktop/desktop/labels/Windows)  | Issues specific to Windows users |
+| `codemirror` | [search](https://github.com/desktop/desktop/labels/codemirror)  | Issues related to our use of [CodeMirror](https://codemirror.net/) that may require upstream fixes |
+| `electron` | [search](https://github.com/desktop/desktop/labels/electron) | Issues related to our use of [Electron](https://electron.atom.io) that may require upstream fixes |
+| `themes` | [search](https://github.com/desktop/desktop/labels/themes) | Issues related the light or dark themes that ship in Desktop |
+| `user-research` | [search](https://github.com/desktop/desktop/labels/user-research) | Issues that might benefit from user interviews, validations, and/or usability testing |
+| `integrations` | [search](https://github.com/desktop/desktop/labels/integrations) | Issues related to editor and shell integrations that ship in Desktop |
+
+#### Topics
+
+| Label name | :mag_right: | Description |
+| --- | --- | --- |
+| `help wanted` | [search](https://github.com/desktop/desktop/labels/help%20wanted)  | Issues marked as ideal for external contributors |
+| `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions |
+| `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require design input from the core team before the work can be started |
+
+#### Workflow
+
+| Label name | :mag_right: | Description |
+| --- | --- | --- |
+| `infrastructure` | [search](https://github.com/desktop/desktop/labels/infrastructure) | Pull requests not related to the core application - documentation, dependencies, tooling, etc |
+| `ready-for-review` | [search](https://github.com/desktop/desktop/labels/ready-for-review)  | Pull Requests that are ready to be reviewed by the maintainers |

--- a/docs/process/labels.md
+++ b/docs/process/labels.md
@@ -1,38 +1,121 @@
-## Additional Notes
+# Issue and Pull Request Labels
 
-### Issue and Pull Request Labels
+This section outlines the labels currently used in the project, and adds context
+about what each label represents.
 
-This section lists the labels we use to help us track and manage issues and
-pull requests.
+## Common labels
 
-#### Type of Issue and Issue State
+These labels are used for both issues and pull requests, and are assigned to
+help understand the type of work involved.
 
-| Label name | :mag_right: | Description |
-| --- | --- | --- |
-| `enhancement` | [search](https://github.com/desktop/desktop/labels/enhancement) | Feature requests |
-| `bug` | [search](https://github.com/desktop/desktop/labels/bug)  | Confirmed bugs or reports that are very likely to be bugs |
-| `more-information-needed` | [search](https://github.com/desktop/desktop/labels/more-information-needed) | More information needs to be collected about these problems or feature requests (e.g. steps to reproduce) |
-| `reviewer-needs-to-reproduce` | [search](https://github.com/desktop/desktop/labels/reviewer-needs-to-reproduce)  | Potential bugs that still need to be reliably reproduced by a reviewer |
-| `stale` | [search](https://github.com/desktop/desktop/labels/stale) | Issues that are inactive and marked to be closed |
-| `macOS` | [search](https://github.com/desktop/desktop/labels/macOS)  | Issues specific to macOS users |
-| `Windows` | [search](https://github.com/desktop/desktop/labels/Windows)  | Issues specific to Windows users |
-| `codemirror` | [search](https://github.com/desktop/desktop/labels/codemirror)  | Issues related to our use of [CodeMirror](https://codemirror.net/) that may require upstream fixes |
-| `electron` | [search](https://github.com/desktop/desktop/labels/electron) | Issues related to our use of [Electron](https://electron.atom.io) that may require upstream fixes |
-| `themes` | [search](https://github.com/desktop/desktop/labels/themes) | Issues related the light or dark themes that ship in Desktop |
-| `user-research` | [search](https://github.com/desktop/desktop/labels/user-research) | Issues that might benefit from user interviews, validations, and/or usability testing |
-| `integrations` | [search](https://github.com/desktop/desktop/labels/integrations) | Issues related to editor and shell integrations that ship in Desktop |
+|                               | Label name       | Description |
+| ----------------------------- | -----------------| ----------- |
+| [:mag_right:][docs]           | `docs`           | Issues and pull requests related to documentation work on the project |
+| [:mag_right:][infrastructure] | `infrastructure` | Issues and pull requests related to scripts and tooling for GitHub Desktop |
+| [:mag_right:][tech-debt]      | `tech-debt`      | Issues and pull requests related to addressing technical debt or improving the codebase |
 
-#### Topics
+## Issue-specific labels
 
-| Label name | :mag_right: | Description |
-| --- | --- | --- |
-| `help wanted` | [search](https://github.com/desktop/desktop/labels/help%20wanted)  | Issues marked as ideal for external contributors |
-| `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions |
-| `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require design input from the core team before the work can be started |
+This section is organized into sub-groups, as groups of labels relate to
+specific work being done in the issue tracker.
 
-#### Workflow
+### Issue triage
 
-| Label name | :mag_right: | Description |
-| --- | --- | --- |
-| `infrastructure` | [search](https://github.com/desktop/desktop/labels/infrastructure) | Pull requests not related to the core application - documentation, dependencies, tooling, etc |
-| `ready-for-review` | [search](https://github.com/desktop/desktop/labels/ready-for-review)  | Pull Requests that are ready to be reviewed by the maintainers |
+The triage process is how the maintainers process incoming issues and prioritize
+the work required to address the feedback raised. These labels help us to track
+the flow of an issue through this process
+
+|                                        | Label name                  | Description |
+| -------------------------------------- | ----------------------------| ----------- |
+| [:mag_right:][bug]                     | `bug`                     | Confirmed bugs or reports that are very likely to be bugs |
+| [:mag_right:][enhancement]             | `enhancement`             | |
+| [:mag_right:][investigation-needed]    | `investigation-needed`    | Likely bugs, but haven't been reliably reproduced by a reviewer |
+| [:mag_right:][more-information-needed] | `more-information-needed` | The submitter needs to provide more information about the issue |
+| [:mag_right:][priority-1]              | `priority-1`              | Major bug affecting large population and inhibiting their work |
+| [:mag_right:][priority-2]              | `priority-2`              | Bug that affects more than a few users in a meaningful way but doesn't prevent core functions |
+| [:mag_right:][priority-3]              | `priority-3`              | Bugs that affect small number of users and/or relatively cosmetic in nature |
+
+### External contributions
+
+We use these labels to identify work that is ideal for external contributors to
+get involved with.
+
+|                                 | Label name         |  Description |
+| ------------------------------- | ------------------ |  ----------- |
+| [:mag_right:][good first issue] | `good first issue` | Issues marked as ideal for a brand new contributor to start with |
+| [:mag_right:][help wanted]      | `help wanted`      | Issues marked as ideal for external contributors |
+
+### Planning
+
+We use these labels to track tasks outside the usual flow of addressing bugs or
+implementing features:
+
+|                                   | Label name           |  Description |
+| --------------------------------- | -------------------- |  ----------- |
+| [:mag_right:][meta]               | `meta`               | Issues used to co-ordinate tasks or discuss a feature before the required work is captured |
+| [:mag_right:][user-research]      | `user-research`      | Issues that may benefit from user interviews, validations, and/or usability testing |
+| [:mag_right:][needs-design-input] | `needs-design-input` | Issues that require design input from the core team before the work can be started |
+
+### Specialized areas
+
+We use these labels to identify issues related to a specific area or the app,
+or a specicif subset of users
+
+|                             | Label name     | Description |
+| --------------------------- | -------------- | ----------- |
+| [:mag_right:][codemirror]   | `codemirror`   | Issues related to our use of [CodeMirror](https://codemirror.net/) that may require upstream fixes |
+| [:mag_right:][electron]     | `electron`     | Issues related to our use of [Electron](https://electronjs.org) that may need updates to Electron or upstream fixes |
+| [:mag_right:][integrations] | `integrations` | Issues related to editor and shell integrations that ship in Desktop |
+| [:mag_right:][performance]  | `performance`  | Relating to things affecting performance |
+| [:mag_right:][themes]       | `themes`       | Issues related the light or dark themes that ship in Desktop |
+| [:mag_right:][website]      | `website`      | Issues that relate to external websites and require co-ordination to resolve |
+
+### Environments
+
+Sometimes issues are isolated to a specific operating system. We use these
+labels to help identify these issues, so maintainers with that setup - or
+experience with that setup - can easily find them in the issue tracker.
+
+|                        | Label name | Description |
+| ---------------------- | ---------- | ----------- |
+| [:mag_right:][linux]   | `linux`    |  Issues specific to Desktop usage on Linux |
+| [:mag_right:][macOS]   | `macOS`    |  Issues specific to Desktop usage on macOS |
+| [:mag_right:][windows] | `windows`  | Issues specific Desktop usage on Windows |
+
+
+## Pull Request-specific labels
+
+These labels should only be assigned to pull requests, and are intended to help
+reviewers navigate the open contributions to identify how best to spend their
+time:
+
+|                                 | Label name         | Description |
+| ------------------------------- | ------------------ | ----------- |
+| [:mag_right:][ready-for-review] | `ready-for-review` | Pull Requests that are ready to be reviewed by the maintainers |
+
+
+[bug]: https://github.com/desktop/desktop/labels/bug
+[codemirror]: https://github.com/desktop/desktop/labels/codemirror
+[docs]: https://github.com/desktop/desktop/labels/docs
+[electron]: https://github.com/desktop/desktop/labels/electron
+[enhancement]: https://github.com/desktop/desktop/labels/enhancement
+[good first issue]: https://github.com/desktop/desktop/labels/good%20first%20issue
+[help wanted]: https://github.com/desktop/desktop/labels/help%20wanted
+[infrastructure]: https://github.com/desktop/desktop/labels/infrastructure
+[integrations]: https://github.com/desktop/desktop/labels/integrations
+[investigation-needed]: https://github.com/desktop/desktop/labels/investigation-needed
+[linux]: https://github.com/desktop/desktop/labels/linux
+[macOS]: https://github.com/desktop/desktop/labels/macOS
+[meta]: https://github.com/desktop/desktop/labels/meta
+[more-information-needed]: https://github.com/desktop/desktop/labels/more-information-needed
+[needs-design-input]: https://github.com/desktop/desktop/labels/needs-design-input
+[performance]: https://github.com/desktop/desktop/labels/performance
+[priority-1]: https://github.com/desktop/desktop/labels/priority-1
+[priority-2]: https://github.com/desktop/desktop/labels/priority-2
+[priority-3]: https://github.com/desktop/desktop/labels/priority-3
+[ready-for-review]: https://github.com/desktop/desktop/labels/ready-for-review
+[tech-debt]: https://github.com/desktop/desktop/labels/tech-debt
+[themes]: https://github.com/desktop/desktop/labels/themes
+[user-research]: https://github.com/desktop/desktop/labels/user-research
+[website]: https://github.com/desktop/desktop/labels/website
+[windows]: https://github.com/desktop/desktop/labels/windows

--- a/docs/process/labels.md
+++ b/docs/process/labels.md
@@ -78,8 +78,8 @@ experience with that setup - can easily find them in the issue tracker.
 
 |                        | Label name | Description |
 | ---------------------- | ---------- | ----------- |
-| [:mag_right:][linux]   | `linux`    |  Issues specific to Desktop usage on Linux |
-| [:mag_right:][macOS]   | `macOS`    |  Issues specific to Desktop usage on macOS |
+| [:mag_right:][linux]   | `linux`    | Issues specific to Desktop usage on Linux |
+| [:mag_right:][macOS]   | `macOS`    | Issues specific to Desktop usage on macOS |
 | [:mag_right:][windows] | `windows`  | Issues specific Desktop usage on Windows |
 
 

--- a/docs/process/labels.md
+++ b/docs/process/labels.md
@@ -59,7 +59,7 @@ implementing features:
 ### Specialized areas
 
 We use these labels to identify issues related to a specific area or the app,
-or a specicif subset of users
+or a specific subset of users:
 
 |                             | Label name     | Description |
 | --------------------------- | -------------- | ----------- |


### PR DESCRIPTION
## Overview

As part of thinking about #5994 I found myself using different labels to indicate what pull requests were about, i.e. `docs`, `infrastructure`, `tech-debt`, etc. This made me realise it was a chance to refresh our documented list of labels, because it's not been updated for a while.

## Description

[**Updated CONTRIBUTING doc**](https://github.com/desktop/desktop/blob/issue-labels/.github/CONTRIBUTING.md)


[**New 'Issues and Pull Request Labels' doc**](https://github.com/desktop/desktop/blob/issue-labels/docs/process/labels.md)

In a nutshell:

- I moved these out from the bottom of `CONTRIBUTING.md` to their own document
- I organized the document by how we use the labels (because anyone can browse [this page](https://github.com/desktop/desktop/labels), I wanted this document to show the logical groupings of labels)
- I changed the layout to make the Markdown tables 1000% more maintainable
- I refreshed the list with updated and new labels
- ~~label names are now standardized to use `-` instead of spaces (I think this only affects `help wanted` and `good first issue`)~~ reverted because GitHub The Website likes these labels to have spaces and doesn't acknowledge others
- label names are now also standardized to use all lowercase letters (aside from `macOS` which I still feel should be named to `macos` but it looks _weird_).

I avoided documenting `future-proposal` because I think we want that to go away eventually, and I'm also open to new descriptions for any of these from people who care.

TODO:

 - [x] scan rest of repository to find `help wanted` and `good first issue` links to update