### PR TITLE
tweak Azure Pipelines config to mirror other build platforms

### DIFF
--- a/vsts.yml
+++ b/vsts.yml
@@ -4,8 +4,8 @@ trigger:
     include:
       - master
       - __release-*
-      
-# initialize submodules before running build jobs      
+
+# initialize submodules before running build jobs
 resources:
   repositories:
     - repository: self

--- a/vsts.yml
+++ b/vsts.yml
@@ -4,6 +4,13 @@ trigger:
     include:
       - master
       - __release-*
+      
+# initialize submodules before running build jobs      
+resources:
+  repositories:
+    - repository: self
+      checkoutOptions:
+        submodules: true
 
 jobs:
   - job: Windows

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,3 +1,10 @@
+trigger:
+  batch: true
+  branches:
+    include:
+      - master
+      - __release-.*
+
 jobs:
   - job: Windows
     pool:

--- a/vsts.yml
+++ b/vsts.yml
@@ -3,7 +3,7 @@ trigger:
   branches:
     include:
       - master
-      - __release-.*
+      - __release-*
 
 jobs:
   - job: Windows


### PR DESCRIPTION
## Overview

Currently we've setup Azure Pipelines without any triggers, which means it's running lots of builds by default. I've spotted it running two builds whenever a PR from a local branch is updated (one for the branch being updated, the second to validate the pull request, but they're both the same commit ID so it's rather wasteful).

## Description

[This documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=vsts&tabs=yaml) shows the syntax for defining the triggers, and in particular:

> If you set `batch` to `true`, when a build is running, the system waits until the build is completed, then queues another build of all changes that have not yet been built.

So here's the constraints I've added:

 - batching builds, to avoid wasted builds when a branch is churning due to lots of pushes
 - only building specific branches (matches how we have Appveyor/Circle/Travis configured)

## Release notes

Notes: no-notes
