### PR TITLE
revert this tracing as it affects local production builds

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -43,19 +43,14 @@ import {
 } from '../app/package-info'
 
 import { getReleaseChannel, getDistRoot, getExecutableName } from './dist-info'
-import { getSha, isRunningOnFork, isCircleCI } from './build-platforms'
+import { isRunningOnFork, isCircleCI } from './build-platforms'
 
 const projectRoot = path.join(__dirname, '..')
 const outRoot = path.join(projectRoot, 'out')
 
 const isPublishableBuild = getReleaseChannel() !== 'development'
 
-// don't call `getSha` when not on CI
-if (isPublishableBuild) {
-  console.log(`Building for ${getReleaseChannel()} from commit id ${getSha()}…`)
-} else {
-  console.log(`Building for ${getReleaseChannel()}`)
-}
+console.log(`Building for ${getReleaseChannel()}…`)
 
 console.log('Removing old distribution…')
 fs.removeSync(getDistRoot())


### PR DESCRIPTION
## Overview

#6004 helped unblock `yarn build:dev` locally but `yarn build:prod` locally (which sets `NODE_ENV=production`) still falls through to call `getSha`, as mentioned in https://github.com/desktop/desktop/pull/6003#issuecomment-433289489.

We weren't doing that tracing before #5663, so let's just put current `master` back to that state.

## Release notes

Notes: no-notes
