### PR TITLE
Fixes links for finding help-wanted

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -133,7 +133,7 @@ external contributors to pick up. These tasks:
  - have a narrow scope and/or easy reproduction steps
  - can be worked on independent of other tasks
 
-These issues will be labelled as [`help wanted`](https://github.com/desktop/desktop/labels/help%20wanted)
+These issues will be labelled as [`help-wanted`](https://github.com/desktop/desktop/labels/help-wanted)
 in the repository. If you are interested in contributing to the project, please
 comment on the issue to let the core team (and the community) know you are
 interested in the issue.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -170,7 +170,7 @@ pull requests.
 
 | Label name | :mag_right: | Description |
 | --- | --- | --- |
-| `help wanted` | [search](https://github.com/desktop/desktop/labels/help%20wanted)  | Issues marked as ideal for external contributors |
+| `help-wanted` | [search](https://github.com/desktop/desktop/labels/help-wanted)  | Issues marked as ideal for external contributors |
 | `tech-debt` | [search](https://github.com/desktop/desktop/labels/tech-debt) | Issues related to code or architecture decisions |
 | `needs-design-input` | [search](https://github.com/desktop/desktop/labels/needs-design-input)  | Issues that require design input from the core team before the work can be started |
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The [CONTRIBUTING.md](./.github/CONTRIBUTING.md) document will help you get setu
 familiar with the source. The [documentation](docs/) folder also contains more
 resources relevant to the project.
 
-If you're looking for something to work on, check out the [help wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22) label.
+If you're looking for something to work on, check out the [help wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help-wanted%22) label.
 
 ## More Resources
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The [CONTRIBUTING.md](./.github/CONTRIBUTING.md) document will help you get setu
 familiar with the source. The [documentation](docs/) folder also contains more
 resources relevant to the project.
 
-If you're looking for something to work on, check out the [help wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help-wanted%22) label.
+If you're looking for something to work on, check out the [help-wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help-wanted%22) label.
 
 ## More Resources
 


### PR DESCRIPTION
## Overview
Fixes a bug: When I navigate on the README and CONTRIBUTING page, if I click on the help wanted links, they reveals 0 labels because the label is `help-wanted` not `help wanted`. 

## Description

I've changed the links to replace the space `help wanted` and instead have a dash `help-wanted`

## Release notes
This feature fixes documentation but is not user facing. I don't think this needs to go in the release notes. 