### PR TITLE
successful merge banner

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -151,6 +151,9 @@ export interface IAppState {
   /** Whether we should show the update banner */
   readonly isUpdateAvailableBannerVisible: boolean
 
+  /** Whether we should show the merge success banner */
+  readonly successfulMergeBannerState: SuccessfulMergeBannerState
+
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnRepositoryRemoval: boolean
 
@@ -526,3 +529,10 @@ export interface ICompareToBranch {
  * An action to send to the application store to update the compare state
  */
 export type CompareAction = IViewHistory | ICompareToBranch
+
+export type SuccessfulMergeBannerState =
+  | {
+      currentBranch: string
+      theirBranch: string
+    }
+  | false

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -530,9 +530,7 @@ export interface ICompareToBranch {
  */
 export type CompareAction = IViewHistory | ICompareToBranch
 
-export type SuccessfulMergeBannerState =
-  | {
-      currentBranch: string
-      theirBranch: string
-    }
-  | false
+export type SuccessfulMergeBannerState = {
+  currentBranch: string
+  theirBranch: string
+} | null

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -17,6 +17,7 @@ import {
   CompareAction,
   ICompareFormUpdate,
   MergeResultStatus,
+  SuccessfulMergeBannerState,
 } from '../app-state'
 import { AppStore } from '../stores/app-store'
 import { CloningRepository } from '../../models/cloning-repository'
@@ -470,6 +471,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set the successful merge banner's state
+   */
+  public setSuccessfulMergeBannerState(state: SuccessfulMergeBannerState) {
+    return this.appStore._setSuccessfulMergeBannerState(state)
+  }
+
+  /**
    * Set the divering branch notification banner's visibility
    */
   public setDivergingBranchBannerVisibility(
@@ -628,7 +636,10 @@ export class Dispatcher {
     if (gitFound || ignoreWarning) {
       this.appStore._openShell(path)
     } else {
-      this.appStore._showPopup({ type: PopupType.InstallGit, path })
+      this.appStore._showPopup({
+        type: PopupType.InstallGit,
+        path,
+      })
     }
   }
 

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -9,7 +9,7 @@ import { spawnAndComplete } from './spawn'
 export async function merge(
   repository: Repository,
   branch: string
-): Promise<void | true> {
+): Promise<true> {
   await git(['merge', branch], repository.path, 'merge')
   return true
 }

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -9,8 +9,9 @@ import { spawnAndComplete } from './spawn'
 export async function merge(
   repository: Repository,
   branch: string
-): Promise<void> {
+): Promise<void | true> {
   await git(['merge', branch], repository.path, 'merge')
+  return true
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -257,7 +257,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private windowState: WindowState
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false
-  private successfulMergeBannerState: SuccessfulMergeBannerState = false
+  private successfulMergeBannerState: SuccessfulMergeBannerState = null
   private confirmRepoRemoval: boolean = confirmRepoRemovalDefault
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3079,13 +3079,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    if ((await gitStore.merge(branch)) === true) {
-      const currentBranchName =
-        gitStore.tip.kind === TipState.Valid
-          ? gitStore.tip.branch.name
-          : 'unknown branch'
+    const mergeSuccessful = await gitStore.merge(branch)
+    const { tip } = gitStore
+
+    if (mergeSuccessful && tip.kind === TipState.Valid) {
       this._setSuccessfulMergeBannerState({
-        currentBranch: currentBranchName,
+        currentBranch: tip.branch.name,
         theirBranch: branch,
       })
     }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1114,7 +1114,7 @@ export class GitStore extends BaseStore {
   }
 
   /** Merge the named branch into the current branch. */
-  public merge(branch: string): Promise<void | true> {
+  public merge(branch: string): Promise<true | undefined> {
     return this.performFailableOperation(() => merge(this.repository, branch), {
       command: 'merge',
     })

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1114,7 +1114,7 @@ export class GitStore extends BaseStore {
   }
 
   /** Merge the named branch into the current branch. */
-  public merge(branch: string): Promise<void> {
+  public merge(branch: string): Promise<void | true> {
     return this.performFailableOperation(() => merge(this.repository, branch), {
       command: 'merge',
     })

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -993,7 +993,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setUpdateBannerVisibility(false)
 
   private onSuccessfulMergeDismissed = () =>
-    this.props.dispatcher.setSuccessfulMergeBannerState(false)
+    this.props.dispatcher.setSuccessfulMergeBannerState(null)
 
   private currentPopupContent(): JSX.Element | null {
     // Hide any dialogs while we're displaying an error
@@ -1680,7 +1680,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   // we currently only render one banner at a time
   private renderBanner(): JSX.Element | null {
-    if (this.state.successfulMergeBannerState !== false) {
+    if (this.state.successfulMergeBannerState !== null) {
       return this.renderSuccessfulMergeBanner(
         this.state.successfulMergeBannerState
       )
@@ -1706,7 +1706,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   private renderSuccessfulMergeBanner(
     successfulMergeBannerState: SuccessfulMergeBannerState
   ) {
-    if (successfulMergeBannerState === false) {
+    if (successfulMergeBannerState === null) {
       return null
     }
     return (

--- a/app/src/ui/banners/index.ts
+++ b/app/src/ui/banners/index.ts
@@ -1,0 +1,1 @@
+export { SuccessfulMerge } from './successful-merge'

--- a/app/src/ui/banners/successful-merge.tsx
+++ b/app/src/ui/banners/successful-merge.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { Octicon, OcticonSymbol } from '../octicons'
+
+interface ISuccessfulMergeProps {
+  readonly currentBranch: string
+  readonly theirBranch: string
+  readonly onDismissed: () => void
+}
+
+export class SuccessfulMerge extends React.Component<
+  ISuccessfulMergeProps,
+  {}
+> {
+  private timeoutId: NodeJS.Timer | null = null
+
+  public render() {
+    return (
+      <div id="successful-merge" className="active">
+        <div className="green-circle">
+          <Octicon className="check-icon" symbol={OcticonSymbol.check} />
+        </div>
+        {'Successfully merged '}
+        <strong>{this.props.theirBranch}</strong>
+        {' into '}
+        <strong>{this.props.currentBranch}</strong>
+        <a className="close" onClick={this.dismiss}>
+          <Octicon symbol={OcticonSymbol.x} />
+        </a>
+      </div>
+    )
+  }
+
+  public componentDidMount = () => {
+    this.timeoutId = setTimeout(() => {
+      this.dismiss()
+    }, 3250)
+  }
+
+  public componentWillUnmount = () => {
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId)
+    }
+  }
+
+  private dismiss = () => {
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/banners/successful-merge.tsx
+++ b/app/src/ui/banners/successful-merge.tsx
@@ -19,10 +19,12 @@ export class SuccessfulMerge extends React.Component<
         <div className="green-circle">
           <Octicon className="check-icon" symbol={OcticonSymbol.check} />
         </div>
-        {'Successfully merged '}
-        <strong>{this.props.theirBranch}</strong>
-        {' into '}
-        <strong>{this.props.currentBranch}</strong>
+        <span>
+          {'Successfully merged '}
+          <strong>{this.props.theirBranch}</strong>
+          {' into '}
+          <strong>{this.props.currentBranch}</strong>
+        </span>
         <a className="close" onClick={this.dismiss}>
           <Octicon symbol={OcticonSymbol.x} />
         </a>

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -41,6 +41,7 @@
 @import 'ui/checkbox';
 @import 'ui/errors';
 @import 'ui/dialog';
+@import 'ui/banners';
 @import 'ui/add-repository';
 @import 'ui/discard-changes';
 @import 'ui/filter-list';

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -1,0 +1,1 @@
+@import 'banners/successful-merge';

--- a/app/styles/ui/banners/_successful-merge.scss
+++ b/app/styles/ui/banners/_successful-merge.scss
@@ -1,0 +1,53 @@
+#successful-merge {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  align-content: center;
+  align-items: center;
+  justify-content: left;
+  padding-left: var(--spacing);
+  border-bottom: var(--base-border);
+
+  height: 0px;
+  transition: height 0.25s;
+  // Prevents the notification banner from decreasing its height
+  // when a large diff is rendered.
+  flex: none;
+
+  &.active {
+    height: 30px;
+  }
+
+  .green-circle {
+    background-color: var(--color-new);
+    color: var(--background-color);
+    border-radius: 50%;
+    height: 16px;
+    width: 16px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: var(--spacing);
+  }
+
+  .close {
+    position: absolute;
+    right: var(--spacing);
+    border: 0;
+    height: 16px;
+    width: 16px;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+
+    color: var(--text-secondary-color);
+
+    &:hover {
+      color: var(--text-color);
+    }
+
+    &:focus {
+      outline: 0;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #5851**

Adds a banner that appears when the user completes a merge.

screenshot:

<img width="979" alt="success banner" src="https://user-images.githubusercontent.com/964912/47606365-65890d00-d9c7-11e8-858c-7d41c8698a7e.png">

in action:

![great success](https://user-images.githubusercontent.com/964912/47606360-5bffa500-d9c7-11e8-8c97-e2623b62163d.gif)

## Description

- This PR will need to be updated once #5809 is merged to make sure we cover all ways of merging
- This required more reworking of the git-related parts of the codebase than i would have liked, so if there alternate approaches, I'm all ears
- This PR _doesn't_ attempt to make a banner management system as we only have two banners currently. (As we add more we'll have to cross that bridge.)

## Release notes

Notes: Displays merge success banner
