### PR TITLE
use a while loop in regex helpers

### DIFF
--- a/app/src/lib/git/diff-check.ts
+++ b/app/src/lib/git/diff-check.ts
@@ -20,7 +20,7 @@ export async function getFilesWithConflictMarkers(
 
   // result parsing
   const outputStr = output.toString('utf8')
-  const captures = await getCaptures(outputStr, fileNameCaptureRe)
+  const captures = getCaptures(outputStr, fileNameCaptureRe)
   if (captures.length === 0) {
     return new Map<string, number>()
   }

--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -4,11 +4,11 @@
  * @param re regex to search with. must have global option and one capture
  * @returns ararys of strings captured by supplied regex
  */
-export async function getCaptures(
+export function getCaptures(
   text: string,
   re: RegExp
-): Promise<ReadonlyArray<Array<string>>> {
-  const matches = await getMatches(text, re)
+): ReadonlyArray<Array<string>> {
+  const matches = getMatches(text, re)
   const captures = matches.reduce(
     (acc, match) => acc.concat([match.slice(1)]),
     new Array<Array<string>>()
@@ -22,20 +22,13 @@ export async function getCaptures(
  * @param re regex to search with. must have global option
  * @returns set of strings captured by supplied regex
  */
-export async function getMatches(
-  text: string,
-  re: RegExp
-): Promise<Array<RegExpExecArray>> {
+export function getMatches(text: string, re: RegExp): Array<RegExpExecArray> {
   const matches = new Array<RegExpExecArray>()
-  const getNextMatch = () =>
-    new Promise(resolve => {
-      const match = re.exec(text)
-      if (match !== null) {
-        matches.push(match)
-        resolve(getNextMatch())
-      }
-      resolve(matches)
-    })
-  await getNextMatch()
+  let match = re.exec(text)
+
+  while (match !== null) {
+    matches.push(match)
+    match = re.exec(text)
+  }
   return matches
 }

--- a/app/test/unit/helpers/regex-test.ts
+++ b/app/test/unit/helpers/regex-test.ts
@@ -9,8 +9,8 @@ describe('getCaptures()', () => {
     beforeAll(() => {
       bodyOfText = `capture me!:matching:capture me too!\nalso capture me!:matching:also capture me too!\n`
     })
-    it('returns all captures', async () => {
-      expect(await subject()).toEqual([
+    it('returns all captures', () => {
+      expect(subject()).toEqual([
         ['capture me!', 'capture me too!'],
         ['also capture me!', 'also capture me too!'],
       ])
@@ -20,8 +20,8 @@ describe('getCaptures()', () => {
     beforeAll(() => {
       bodyOfText = ' '
     })
-    it('returns empty array', async () => {
-      expect(await subject()).toEqual([])
+    it('returns empty array', () => {
+      expect(subject()).toEqual([])
     })
   })
 })


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
fixes a bug found in https://github.com/desktop/desktop/pull/5809#issuecomment-433543734

## Description

- removes use of recursion from `getMatches` and co
- also, @iAmWillShepherd was right :)

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: no-notes
