### PR TITLE
Update SCSS styling on merge modal

### DIFF
--- a/app/styles/ui/_filter-list.scss
+++ b/app/styles/ui/_filter-list.scss
@@ -7,10 +7,6 @@
 
   min-width: inherit;
 
-  .filter-field-row {
-    margin: var(--spacing);
-  }
-
   &-container {
     display: flex;
     flex: 1;

--- a/app/styles/ui/_filter-list.scss
+++ b/app/styles/ui/_filter-list.scss
@@ -7,6 +7,10 @@
 
   min-width: inherit;
 
+  .filter-field-row {
+    padding: var(--spacing);
+  }
+
   &-container {
     display: flex;
     flex: 1;


### PR DESCRIPTION
## Fixing SCSS for merge modal

**Closes #5998**

## Description

- @ampinsk was very correct with which commit caused this. I was originally planning to revert the change but I saw that it would have no effect.
<img width="1440" alt="screen shot 2018-10-27 at 2 06 53 pm" src="https://user-images.githubusercontent.com/18089817/47607908-52406680-d9f4-11e8-9716-622aeacd1868.png">
- seeing that the crossed line for padding I decided to remove the class entirely

- After this change, the merge modal has returned to looking like this.
<img width="502" alt="screen shot 2018-10-27 at 1 52 20 pm" src="https://user-images.githubusercontent.com/18089817/47607955-e8748c80-d9f4-11e8-8a1b-da72da63d49a.png">

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: no-notes
