### PR TITLE
Improve single file commit summary to match GitHub.com

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -31,6 +31,7 @@ import { IAutocompletionProvider } from '../autocompletion'
 import { showContextualMenu } from '../main-process-proxy'
 import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
+import * as path from 'path'
 
 const RowHeight = 29
 
@@ -428,7 +429,7 @@ export class ChangesList extends React.Component<
           coAuthors={this.props.coAuthors}
           placeholder={
             singleFileCommit
-              ? `Update ${filesSelected[0].path}`
+              ? `Update ${path.parse(filesSelected[0].path).base}`
               : 'Summary (required)'
           }
           singleFileCommit={singleFileCommit}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -31,7 +31,7 @@ import { IAutocompletionProvider } from '../autocompletion'
 import { showContextualMenu } from '../main-process-proxy'
 import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
-import * as path from 'path'
+import { basename } from 'path'
 
 const RowHeight = 29
 
@@ -430,10 +430,10 @@ export class ChangesList extends React.Component<
           placeholder={
             singleFileCommit
               ? filesSelected[0].status === AppFileStatus.New
-                ? `Create ${path.parse(filesSelected[0].path).base}`
+                ? `Create ${basename(filesSelected[0].path)}`
                 : filesSelected[0].status === AppFileStatus.Deleted
-                  ? `Delete ${path.parse(filesSelected[0].path).base}`
-                  : `Update ${path.parse(filesSelected[0].path).base}`
+                  ? `Delete ${basename(filesSelected[0].path)}`
+                  : `Update ${basename(filesSelected[0].path)}`
               : 'Summary (required)'
           }
           singleFileCommit={singleFileCommit}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -429,7 +429,11 @@ export class ChangesList extends React.Component<
           coAuthors={this.props.coAuthors}
           placeholder={
             singleFileCommit
-              ? `Update ${path.parse(filesSelected[0].path).base}`
+              ? filesSelected[0].status === AppFileStatus.New
+                ? `Create ${path.parse(filesSelected[0].path).base}`
+                : filesSelected[0].status === AppFileStatus.Deleted
+                  ? `Delete ${path.parse(filesSelected[0].path).base}`
+                  : `Update ${path.parse(filesSelected[0].path).base}`
               : 'Summary (required)'
           }
           singleFileCommit={singleFileCommit}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -378,6 +378,31 @@ export class ChangesList extends React.Component<
     showContextualMenu(items)
   }
 
+  private getPlaceholderMessage(
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    singleFileCommit: boolean
+  ) {
+    if (!singleFileCommit) {
+      return 'Summary (required)'
+    }
+
+    const firstFile = files[0]
+    const fileName = basename(firstFile.path)
+
+    switch (firstFile.status) {
+      case AppFileStatus.New:
+        return `Create ${fileName}`
+      case AppFileStatus.Deleted:
+        return `Delete ${fileName}`
+      default:
+        // TODO:
+        // this doesn't feel like a great message for AppFileStatus.Copied or
+        // AppFileStatus.Renamed but without more insight (and whether this
+        // affects other parts of the flow) we can just default to this for now
+        return `Update ${fileName}`
+    }
+  }
+
   public render() {
     const fileList = this.props.workingDirectory.files
     const fileCount = fileList.length
@@ -427,15 +452,10 @@ export class ChangesList extends React.Component<
           isCommitting={this.props.isCommitting}
           showCoAuthoredBy={this.props.showCoAuthoredBy}
           coAuthors={this.props.coAuthors}
-          placeholder={
+          placeholder={this.getPlaceholderMessage(
+            filesSelected,
             singleFileCommit
-              ? filesSelected[0].status === AppFileStatus.New
-                ? `Create ${basename(filesSelected[0].path)}`
-                : filesSelected[0].status === AppFileStatus.Deleted
-                  ? `Delete ${basename(filesSelected[0].path)}`
-                  : `Update ${basename(filesSelected[0].path)}`
-              : 'Summary (required)'
-          }
+          )}
           singleFileCommit={singleFileCommit}
         />
       </div>


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #6017**

## Description

- Updates the default single file commit summary to show the file name and not the rest of the path.
- Updates the default single file commit summary to show "Create" and "Delete" in addition to "Update" depending on the type of changes being committed.

Preview of the changes being made:
![image](https://user-images.githubusercontent.com/4957200/47618384-7ce7f900-daa0-11e8-8508-0f22f16cf97b.png)
## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: Updated the default commit summary to match GitHub.com more closely.
