### PR TITLE
rename VSTS config to Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,82 @@
+jobs:
+  - job: Windows
+    pool:
+      vmImage: vs2017-win2016
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '8.11.1'
+      - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+        inputs:
+          versionSpec: '1.5.1'
+      - script: |
+          yarn install --force
+        name: Install
+      - script: |
+          yarn build:prod
+        name: Build
+      - script: |
+          yarn test:setup && yarn test
+        name: Test
+
+  - job: Linux
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsecret-1-dev xvfb fakeroot dpkg rpm xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '8.11.1'
+      - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+        inputs:
+          versionSpec: '1.5.1'
+      - script: |
+          yarn install --force
+        name: Install
+      - script: |
+          yarn build:prod
+        name: Build
+      - script: |
+          export DISPLAY=':99.0'
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          yarn test:setup && yarn test
+        name: Test
+
+  - job: macOS
+    pool:
+      vmImage: xcode9-macos10.13
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '8.11.1'
+      - script: |
+          yarn install --force
+        name: Install
+      - script: |
+          yarn build:prod
+        name: Build
+      - script: |
+          yarn test:setup && yarn test
+        name: Test
+
+  - job: Lint
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libsecret-1-dev
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '8.11.1'
+      - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+        inputs:
+          versionSpec: '1.5.1'
+      - script: |
+          yarn install --force
+        name: Install
+      - script: |
+          yarn lint
+        name: Lint

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,3 +1,6 @@
+# DO NOT MAKE CHANGES TO THIS CONFIG AS IT WILL BE OBSOLETED SOON
+# MAKE ANY REQUIRED CHANGES TO azure-pipelines.yml INSTEAD
+
 jobs:
   - job: Windows
     pool:


### PR DESCRIPTION
## Overview

VSTS was rebranded a while ago to Azure DevOps and so this PR cleans up the last mention of it in our codebase. cc @chrisrpatterson 

## Description

After this PR is merged, I will:

 - in the admin portal, switch the CI build config over to point to this path
 - wait a couple of days to confirm new builds work and active PRs are NOT affected (in which case I'll point it back to `vsts.yml`)
 - open a new PR to remove `vsts.yml` from version control

## Release notes

Notes: no-notes
