### PR TITLE
Update title of merge dialog to match label in top-level menu

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1075,7 +1075,14 @@ export class App extends React.Component<IAppProps, IAppState> {
         const state = this.props.repositoryStateManager.get(repository)
 
         const tip = state.branchesState.tip
-        const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
+
+        // we should never get in this state since we disable the menu
+        // item in a detatched HEAD state, this check is so TSC is happy
+        if (tip.kind !== TipState.Valid) {
+          return null
+        }
+
+        const currentBranch = tip.branch
 
         return (
           <Merge

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -19,6 +19,8 @@ import { MergeResultKind } from '../../models/merge'
 import { MergeStatusHeader } from '../history/merge-status-header'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
+import { DialogHeader } from '../dialog/header'
+import { Ref } from '../lib/ref'
 
 interface IMergeProps {
   readonly dispatcher: Dispatcher
@@ -292,14 +294,16 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     return (
       <Dialog
         id="merge"
-        title={
-          __DARWIN__
-            ? `Merge Into ${currentBranchName}`
-            : `Merge into ${currentBranchName}`
-        }
         onDismissed={this.props.onDismissed}
         onSubmit={this.merge}
       >
+        <DialogHeader title={` `} dismissable={true}>
+          <div className={''}>
+            <p>
+              Merge into <Ref>{currentBranchName}</Ref>
+            </p>
+          </div>
+        </DialogHeader>
         <DialogContent>
           <BranchList
             allBranches={this.props.allBranches}

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -282,14 +282,14 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       this.state.mergeStatus.kind === MergeResultKind.Invalid
 
     const disabled = invalidBranchState || cannotMergeBranch
-
+    const currentBranchName = this.props.currentBranch!.name
     return (
       <Dialog
         id="merge"
         title={
           __DARWIN__
-            ? `Merge Into ${this.props.currentBranch}`
-            : `Merge into ${this.props.currentBranch}`
+            ? `Merge Into ${currentBranchName}`
+            : `Merge into ${currentBranchName}`
         }
         onDismissed={this.props.onDismissed}
         onSubmit={this.merge}

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -298,7 +298,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       >
         <DialogHeader
           title={
-            <div className={'merge-dialog-header'}>
+            <div className="merge-dialog-header">
               Merge into <b>{currentBranchName}</b>
             </div>
           }

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -29,9 +29,9 @@ interface IMergeProps {
   readonly defaultBranch: Branch | null
 
   /**
-   * The currently checked out branch or null if HEAD is detached
+   * The currently checked out branch
    */
-  readonly currentBranch: Branch | null
+  readonly currentBranch: Branch
 
   /**
    * See IBranchesState.allBranches

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -287,7 +287,9 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       <Dialog
         id="merge"
         title={
-          __DARWIN__ ? 'Merge Into Current Branch' : 'Merge into current branch'
+          __DARWIN__
+            ? `Merge Into ${this.props.currentBranch}`
+            : `Merge into ${this.props.currentBranch}`
         }
         onDismissed={this.props.onDismissed}
         onSubmit={this.merge}

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -303,6 +303,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
             </div>
           }
           dismissable={true}
+          onDismissed={this.props.onDismissed}
         />
         <DialogContent>
           <BranchList

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -282,7 +282,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       this.state.mergeStatus.kind === MergeResultKind.Invalid
 
     const disabled = invalidBranchState || cannotMergeBranch
-    const currentBranchName = this.props.currentBranch!.name
+    const currentBranchName = this.props.currentBranch.name
     return (
       <Dialog
         id="merge"

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -20,7 +20,6 @@ import { MergeStatusHeader } from '../history/merge-status-header'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { DialogHeader } from '../dialog/header'
-import { Ref } from '../lib/ref'
 
 interface IMergeProps {
   readonly dispatcher: Dispatcher
@@ -297,13 +296,14 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
         onDismissed={this.props.onDismissed}
         onSubmit={this.merge}
       >
-        <DialogHeader title={` `} dismissable={true}>
-          <div className={''}>
-            <p>
-              Merge into <Ref>{currentBranchName}</Ref>
-            </p>
-          </div>
-        </DialogHeader>
+        <DialogHeader
+          title={
+            <div className={'merge-dialog-header'}>
+              Merge into <b>{currentBranchName}</b>
+            </div>
+          }
+          dismissable={true}
+        />
         <DialogContent>
           <BranchList
             allBranches={this.props.allBranches}

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -18,6 +18,7 @@ import { MergeResultStatus } from '../../lib/app-state'
 import { MergeResultKind } from '../../models/merge'
 import { MergeStatusHeader } from '../history/merge-status-header'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
+import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 
 interface IMergeProps {
   readonly dispatcher: Dispatcher
@@ -282,7 +283,12 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       this.state.mergeStatus.kind === MergeResultKind.Invalid
 
     const disabled = invalidBranchState || cannotMergeBranch
-    const currentBranchName = this.props.currentBranch.name
+
+    // the amount of characters to allow before we truncate was chosen arbitrarily
+    const currentBranchName = truncateWithEllipsis(
+      this.props.currentBranch.name,
+      40
+    )
     return (
       <Dialog
         id="merge"

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -286,7 +286,9 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     return (
       <Dialog
         id="merge"
-        title={__DARWIN__ ? 'Merge Branch' : 'Merge branch'}
+        title={
+          __DARWIN__ ? 'Merge Into Current Branch' : 'Merge into current branch'
+        }
         onDismissed={this.props.onDismissed}
         onSubmit={this.merge}
       >

--- a/app/styles/ui/dialogs/_merge.scss
+++ b/app/styles/ui/dialogs/_merge.scss
@@ -44,4 +44,8 @@ dialog#merge {
       padding: var(--spacing-half);
     }
   }
+
+  .merge-dialog-header {
+    font-weight: var(--font-weight-light);
+  }
 }


### PR DESCRIPTION
Related to: https://github.com/desktop/desktop/issues/5555

@ampinsk and I discusses the state of the merge dialog title and the proposed changes from https://github.com/desktop/desktop/issues/5555#issuecomment-429963614. I felt we were being overly redundant since the same information was being presented in 2 other places on the dialog and that we were deviating from how all out other dialogs are titled (essentially what we expect you to do). We both agreed that we could approach this by updating the title of the dialog to match that in the menu or only call out the current branch (Merge into `master`). This PR is for the first option because we can always iterate to the one that includes the branch name.

**Before**
<img width="453" alt="screen shot 2018-10-29 at 2 13 45 pm" src="https://user-images.githubusercontent.com/1715082/47674300-f822db00-db84-11e8-8db6-9b9ec893c4dc.png">

**After**
<img width="453" alt="screen shot 2018-10-29 at 4 28 24 pm" src="https://user-images.githubusercontent.com/1715082/47681520-b3546f80-db97-11e8-9ade-e1d950981187.png">

_Long branch name_
<img width="453" alt="screen shot 2018-10-29 at 4 30 11 pm" src="https://user-images.githubusercontent.com/1715082/47681609-ee56a300-db97-11e8-88aa-25ebc291447f.png">

