### PR TITLE
Add support for Visual SlickEdit as an external editor

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -16,6 +16,7 @@ export enum ExternalEditor {
   Brackets = 'Brackets',
   WebStorm = 'WebStorm',
   Typora = 'Typora',
+  SlickEdit = 'Visual SlickEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -55,6 +56,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Typora) {
     return ExternalEditor.Typora
   }
+  if (label === ExternalEditor.SlickEdit) {
+    return ExternalEditor.SlickEdit
+  }
   return null
 }
 
@@ -89,6 +93,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.jetbrains.WebStorm']
     case ExternalEditor.Typora:
       return ['abnerworks.Typora']
+    case ExternalEditor.SlickEdit:
+      return ['com.slickedit.SlickEditPro2018','com.slickedit.SlickEditPro2017','com.slickedit.SlickEditPro2016','com.slickedit.SlickEditPro2015']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -129,6 +135,8 @@ function getExecutableShim(
       return Path.join(installPath, 'Contents', 'MacOS', 'WebStorm')
     case ExternalEditor.Typora:
       return Path.join(installPath, 'Contents', 'MacOS', 'Typora')
+    case ExternalEditor.SlickEdit:
+      return Path.join(installPath, 'Contents', 'MacOS', 'vs')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -176,6 +184,7 @@ export async function getAvailableEditors(): Promise<
     bracketsPath,
     webStormPath,
     typoraPath,
+    slickeditPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),
@@ -189,6 +198,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.Brackets),
     findApplication(ExternalEditor.WebStorm),
     findApplication(ExternalEditor.Typora),
+    findApplication(ExternalEditor.SlickEdit),
   ])
 
   if (atomPath) {
@@ -240,6 +250,10 @@ export async function getAvailableEditors(): Promise<
 
   if (typoraPath) {
     results.push({ editor: ExternalEditor.Typora, path: typoraPath })
+  }
+
+  if (slickeditPath) {
+    results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
   }
 
   return results

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -16,7 +16,7 @@ export enum ExternalEditor {
   Brackets = 'Brackets',
   WebStorm = 'WebStorm',
   Typora = 'Typora',
-  SlickEdit = 'Visual SlickEdit',
+  SlickEdit = 'SlickEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -94,7 +94,12 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
     case ExternalEditor.Typora:
       return ['abnerworks.Typora']
     case ExternalEditor.SlickEdit:
-      return ['com.slickedit.SlickEditPro2018','com.slickedit.SlickEditPro2017','com.slickedit.SlickEditPro2016','com.slickedit.SlickEditPro2015']
+      return [
+        'com.slickedit.SlickEditPro2018',
+        'com.slickedit.SlickEditPro2017',
+        'com.slickedit.SlickEditPro2016',
+        'com.slickedit.SlickEditPro2015',
+      ]
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -44,7 +44,7 @@ async function getPathIfAvailable(path: string): Promise<string | null> {
   return (await pathExists(path)) ? path : null
 }
 
-function getEditorPath(editor: ExternalEditor): Promise<string | null> {
+async function getEditorPath(editor: ExternalEditor): Promise<string | null> {
   switch (editor) {
     case ExternalEditor.Atom:
       return getPathIfAvailable('/usr/bin/atom')
@@ -64,14 +64,12 @@ function getEditorPath(editor: ExternalEditor): Promise<string | null> {
         '/opt/slickedit-pro2015/bin/vs',
       ]
       for (const possiblePath of possiblePaths) {
-        const slickeditPath = getPathIfAvailable(possiblePath)
+        const slickeditPath = await getPathIfAvailable(possiblePath)
         if (slickeditPath) {
           return slickeditPath
         }
       }
-      return new Promise<string | null>((resolve, reject) => {
-        resolve(null)
-      })
+      return null
     default:
       return assertNever(editor, `Unknown editor: ${editor}`)
   }

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -9,6 +9,7 @@ export enum ExternalEditor {
   VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
   SublimeText = 'Sublime Text',
   Typora = 'Typora',
+  SlickEdit = 'Visual SlickEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -32,6 +33,10 @@ export function parse(label: string): ExternalEditor | null {
     return ExternalEditor.Typora
   }
 
+  if (label === ExternalEditor.SlickEdit) {
+    return ExternalEditor.SlickEdit
+  }
+
   return null
 }
 
@@ -51,6 +56,23 @@ function getEditorPath(editor: ExternalEditor): Promise<string | null> {
       return getPathIfAvailable('/usr/bin/subl')
     case ExternalEditor.Typora:
       return getPathIfAvailable('/usr/bin/typora')
+    case ExternalEditor.SlickEdit:
+      var slickeditPath
+      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2018/bin/vs')
+      if (slickeditPath) {
+        return slickeditPath
+      }
+      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2017/bin/vs')
+      if (slickeditPath) {
+        return slickeditPath
+      }
+      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2016/bin/vs')
+      if (slickeditPath) {
+        return slickeditPath
+      }
+      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2015/bin/vs')
+      // SlickEdit Pro 2015 is the last one we look for, so return that path no matter what
+      return slickeditPath
     default:
       return assertNever(editor, `Unknown editor: ${editor}`)
   }
@@ -67,12 +89,14 @@ export async function getAvailableEditors(): Promise<
     codeInsidersPath,
     sublimePath,
     typoraPath,
+    slickeditPath,
   ] = await Promise.all([
     getEditorPath(ExternalEditor.Atom),
     getEditorPath(ExternalEditor.VisualStudioCode),
     getEditorPath(ExternalEditor.VisualStudioCodeInsiders),
     getEditorPath(ExternalEditor.SublimeText),
     getEditorPath(ExternalEditor.Typora),
+    getEditorPath(ExternalEditor.SlickEdit),
   ])
 
   if (atomPath) {
@@ -96,6 +120,10 @@ export async function getAvailableEditors(): Promise<
 
   if (typoraPath) {
     results.push({ editor: ExternalEditor.Typora, path: typoraPath })
+  }
+
+  if (slickeditPath) {
+    results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
   }
 
   return results

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -9,7 +9,7 @@ export enum ExternalEditor {
   VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
   SublimeText = 'Sublime Text',
   Typora = 'Typora',
-  SlickEdit = 'Visual SlickEdit',
+  SlickEdit = 'SlickEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -57,22 +57,21 @@ function getEditorPath(editor: ExternalEditor): Promise<string | null> {
     case ExternalEditor.Typora:
       return getPathIfAvailable('/usr/bin/typora')
     case ExternalEditor.SlickEdit:
-      var slickeditPath
-      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2018/bin/vs')
-      if (slickeditPath) {
-        return slickeditPath
+      const possiblePaths = [
+        '/opt/slickedit-pro2018/bin/vs',
+        '/opt/slickedit-pro2017/bin/vs',
+        '/opt/slickedit-pro2016/bin/vs',
+        '/opt/slickedit-pro2015/bin/vs',
+      ]
+      for (const possiblePath of possiblePaths) {
+        const slickeditPath = getPathIfAvailable(possiblePath)
+        if (slickeditPath) {
+          return slickeditPath
+        }
       }
-      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2017/bin/vs')
-      if (slickeditPath) {
-        return slickeditPath
-      }
-      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2016/bin/vs')
-      if (slickeditPath) {
-        return slickeditPath
-      }
-      slickeditPath = getPathIfAvailable('/opt/slickedit-pro2015/bin/vs')
-      // SlickEdit Pro 2015 is the last one we look for, so return that path no matter what
-      return slickeditPath
+      return new Promise<string | null>((resolve, reject) => {
+        resolve(null)
+      })
     default:
       return assertNever(editor, `Unknown editor: ${editor}`)
   }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -19,6 +19,7 @@ export enum ExternalEditor {
   SublimeText = 'Sublime Text',
   CFBuilder = 'ColdFusion Builder',
   Typora = 'Typora',
+  SlickEdit = 'Visual SlickEdit'
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -39,6 +40,9 @@ export function parse(label: string): ExternalEditor | null {
   }
   if (label === ExternalEditor.Typora) {
     return ExternalEditor.Typora
+  }
+  if (label === ExternalEditor.SlickEdit) {
+    return ExternalEditor.SlickEdit
   }
 
   return null
@@ -156,6 +160,15 @@ function getRegistryKeys(
             'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
         },
       ]
+    case ExternalEditor.SlickEdit:
+      return [
+        // 64-bit version of Visual SlickEdit Pro 2018
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18406187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+      ]
 
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
@@ -185,6 +198,8 @@ function getExecutableShim(
       return Path.join(installLocation, 'CFBuilder.exe')
     case ExternalEditor.Typora:
       return Path.join(installLocation, 'bin', 'typora.exe')
+    case ExternalEditor.SlickEdit:
+      return Path.join(installLocation, 'win', 'vs.exe')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -227,6 +242,8 @@ function isExpectedInstallation(
       )
     case ExternalEditor.Typora:
       return displayName.startsWith('Typora') && publisher === 'typora.io'
+    case ExternalEditor.SlickEdit:
+      return displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.'
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -312,6 +329,13 @@ function extractApplicationInformation(
     return { displayName, publisher, installLocation }
   }
 
+  if (editor === ExternalEditor.SlickEdit) {
+    const displayName = getKeyOrEmpty(keys, 'DisplayName')
+    const publisher = getKeyOrEmpty(keys, 'Publisher')
+    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
+    return { displayName, publisher, installLocation }
+  }
+
   return assertNever(editor, `Unknown external editor: ${editor}`)
 }
 
@@ -369,6 +393,7 @@ export async function getAvailableEditors(): Promise<
     sublimePath,
     cfBuilderPath,
     typoraPath,
+    slickeditPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.VisualStudioCode),
@@ -376,6 +401,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.SublimeText),
     findApplication(ExternalEditor.CFBuilder),
     findApplication(ExternalEditor.Typora),
+    findApplication(ExternalEditor.SlickEdit),
   ])
 
   if (atomPath) {
@@ -417,6 +443,13 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.Typora,
       path: typoraPath,
+    })
+  }
+
+  if (slickeditPath) {
+    results.push({
+      editor: ExternalEditor.SlickEdit,
+      path: slickeditPath,
     })
   }
 

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -19,7 +19,7 @@ export enum ExternalEditor {
   SublimeText = 'Sublime Text',
   CFBuilder = 'ColdFusion Builder',
   Typora = 'Typora',
-  SlickEdit = 'Visual SlickEdit',
+  SlickEdit = 'SlickEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -162,67 +162,67 @@ function getRegistryKeys(
       ]
     case ExternalEditor.SlickEdit:
       return [
-        // 64-bit version of Visual SlickEdit Pro 2018
+        // 64-bit version of SlickEdit Pro 2018
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18406187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 32-bit version of Visual SlickEdit Pro 2018
+        // 32-bit version of SlickEdit Pro 2018
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18006187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Standard 2018
+        // 64-bit version of SlickEdit Standard 2018
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18606187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 32-bit version of Visual SlickEdit Standard 2018
+        // 32-bit version of SlickEdit Standard 2018
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18206187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Pro 2017
+        // 64-bit version of SlickEdit Pro 2017
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15406187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 32-bit version of Visual SlickEdit Pro 2017
+        // 32-bit version of SlickEdit Pro 2017
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15006187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Pro 2016 (21.0.1)
+        // 64-bit version of SlickEdit Pro 2016 (21.0.1)
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10C06187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Pro 2016 (21.0.0)
+        // 64-bit version of SlickEdit Pro 2016 (21.0.0)
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10406187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Pro 2015 (20.0.3)
+        // 64-bit version of SlickEdit Pro 2015 (20.0.3)
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0DC06187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Pro 2015 (20.0.2)
+        // 64-bit version of SlickEdit Pro 2015 (20.0.2)
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0D406187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
-        // 64-bit version of Visual SlickEdit Pro 2014 (19.0.2)
+        // 64-bit version of SlickEdit Pro 2014 (19.0.2)
         {
           key: HKEY.HKEY_LOCAL_MACHINE,
           subKey:

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -168,6 +168,66 @@ function getRegistryKeys(
           subKey:
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18406187-F49E-4822-CAF2-1D25C0C83BA2}',
         },
+        // 32-bit version of Visual SlickEdit Pro 2018
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18006187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Standard 2018
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18606187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 32-bit version of Visual SlickEdit Standard 2018
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18206187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Pro 2017
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15406187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 32-bit version of Visual SlickEdit Pro 2017
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15006187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Pro 2016 (21.0.1)
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10C06187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Pro 2016 (21.0.0)
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10406187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Pro 2015 (20.0.3)
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0DC06187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Pro 2015 (20.0.2)
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0D406187-F49E-4822-CAF2-1D25C0C83BA2}',
+        },
+        // 64-bit version of Visual SlickEdit Pro 2014 (19.0.2)
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}',
+        },
       ]
 
     default:

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -303,7 +303,9 @@ function isExpectedInstallation(
     case ExternalEditor.Typora:
       return displayName.startsWith('Typora') && publisher === 'typora.io'
     case ExternalEditor.SlickEdit:
-      return displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.'
+      return (
+        displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.'
+      )
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -19,7 +19,7 @@ export enum ExternalEditor {
   SublimeText = 'Sublime Text',
   CFBuilder = 'ColdFusion Builder',
   Typora = 'Typora',
-  SlickEdit = 'Visual SlickEdit'
+  SlickEdit = 'Visual SlickEdit',
 }
 
 export function parse(label: string): ExternalEditor | null {

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -29,6 +29,7 @@ These editors are currently supported:
  - [Sublime Text](https://www.sublimetext.com/)
  - [ColdFusion Builder](https://www.adobe.com/products/coldfusion-builder.html)
  - [Typora](https://typora.io/)
+ - [SlickEdit](https://www.slickedit.com)
 
 These are defined in an enum at the top of the file:
 
@@ -40,6 +41,7 @@ export enum ExternalEditor {
   SublimeText = 'Sublime Text',
   CFBuilder = 'ColdFusion Builder',
   Typora = 'Typora',
+  SlickEdit = 'SlickEdit',
 }
 ```
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -221,6 +221,7 @@ These editors are currently supported:
        - This can be done by opening Brackets, choosing File > Install Command Line Shortcut
  - [WebStorm](https://www.jetbrains.com/webstorm/)
  - [Typora](https://typora.io/)
+ - [SlickEdit](https://www.slickedit.com)
 
 These are defined in an enum at the top of the file:
 
@@ -239,6 +240,7 @@ export enum ExternalEditor {
   Brackets = 'Brackets',
   WebStorm = 'WebStorm',
   Typora = 'Typora',
+  SlickEdit = 'SlickEdit',
 }
 ```
 
@@ -323,6 +325,7 @@ These editors are currently supported:
  - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
  - [Sublime Text](https://www.sublimetext.com/)
  - [Typora](https://typora.io/)
+ - [SlickEdit](https://www.slickedit.com)
 
 These are defined in an enum at the top of the file:
 
@@ -333,6 +336,7 @@ export enum ExternalEditor {
   VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
   SublimeText = 'Sublime Text',
   Typora = 'Typora',
+  SlickEdit = 'SlickEdit',
 }
 ```
 


### PR DESCRIPTION
## Overview

**Closes #6029**

## Description

- Add support for recent versions of Visual SlickEdit for Windows, Linux & Mac
- On Windows, not all minor releases will be detected

## Release notes

- Add support for recent versions of Visual SlickEdit for Windows, Linux & Mac

Notes:
