### PR TITLE
add support for debugging jest tests in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": [
+        "--silent",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env":{
+        "ELECTRON_RUN_AS_NODE": "1"
+      },
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": [
+        "--silent",
+        "--config",
+        "${workspaceFolder}/jest.config.js",
+        "${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env":{
+        "ELECTRON_RUN_AS_NODE": "1"
+      },
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+    },
+  ]
+}


### PR DESCRIPTION
## Overview

This PR re-adds support for being able to debug Desktop's unit tests inside VSCode. 

There's two parts to supporting this in VSCode:

 - the node runtime to attach to - in this case we're using our local version of Electron
 - the program to run - we'll use `jest` with our existing unit test config

When you launch the tests, VSCode's terminal will appear and the rest of the experience looks familiar if you've run the tests from the command line:

<img width="1141" src="https://user-images.githubusercontent.com/359239/47730490-03d3d780-dc41-11e8-8165-2d913e750030.png">

But to see the real magic, set a breakpoint inside a test (the gutter to the left of the numbers) like this:

<img width="678" src="https://user-images.githubusercontent.com/359239/47730580-3b428400-dc41-11e8-8347-3d13c654210f.png">

At some point after that, the tests should break on the breakpoint you just defined:

<img width="664" src="https://user-images.githubusercontent.com/359239/47730581-3b428400-dc41-11e8-8687-03942e10c1bb.png">

You then have access to the variables and stack trace in the left sidebar:

<img width="283"  src="https://user-images.githubusercontent.com/359239/47730676-6331e780-dc41-11e8-964e-6af975430c5f.png">

## Description

In a nutshell, you now have two options:

 - `Jest All` to run all unit tests (the equivalent of `yarn test:unit` from the command line)
 - `Jest Current` to run all unit tests in the current file

I'd recommend `Jest Current` when working on tests, as that avoids running the whole test suite.

If you try and `Jest Current` from a file that doesn't contain any tests, you'll see an error like this:

<img width="684" src="https://user-images.githubusercontent.com/359239/47730375-c8390d80-dc40-11e8-817e-ccfa91ae19b5.png">

You can set breakpoints anywhere in the code, but be careful where you `Jest Current` from.

I haven't had a chance to confirm this works the same on Windows, but I think it'll be fine...

## Release notes

Notes: no-notes
 