### PR TITLE
refactor commit message state handling

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -360,12 +360,6 @@ export interface IChangesState {
 
   readonly diff: IDiff | null
 
-  /**
-   * The commit message to use based on the context of the repository, e.g., the
-   * message from a recently undone commit.
-   */
-  readonly contextualCommitMessage: ICommitMessage | null
-
   /** The commit message for a work-in-progress commit in the changes view. */
   readonly commitMessage: ICommitMessage | null
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2835,11 +2835,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.clearSelectedCommit(repository)
     }
 
-    await gitStore.setCommitMessage({
-      summary: commit.summary,
-      description: commit.body,
-    })
-
     return this._refreshRepository(repository)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -513,7 +513,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoryStateCache.updateChangesState(repository, () => ({
       commitMessage: gitStore.commitMessage,
-      contextualCommitMessage: gitStore.contextualCommitMessage,
       showCoAuthoredBy: gitStore.showCoAuthoredBy,
       coAuthors: gitStore.coAuthors,
     }))
@@ -1901,7 +1900,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       gitStore.loadRemotes(),
       gitStore.updateLastFetched(),
       this.refreshAuthor(repository),
-      gitStore.loadContextualCommitMessage(),
       refreshSectionPromise,
     ])
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2835,6 +2835,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.clearSelectedCommit(repository)
     }
 
+    await gitStore.setCommitMessage({
+      summary: commit.summary,
+      description: commit.body,
+    })
+
     return this._refreshRepository(repository)
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -18,7 +18,6 @@ import { ComparisonMode } from '../app-state'
 
 import { IAppShell } from '../app-shell'
 import { ErrorWithMetadata, IErrorMetadata } from '../error-with-metadata'
-import { structuralEquals } from '../../lib/equality'
 import { compare } from '../../lib/compare'
 import { queueWorkHigh } from '../../lib/queue-work'
 
@@ -104,8 +103,6 @@ export class GitStore extends BaseStore {
   private _localCommitSHAs: ReadonlyArray<string> = []
 
   private _commitMessage: ICommitMessage | null = null
-
-  private _contextualCommitMessage: ICommitMessage | null = null
 
   private _showCoAuthoredBy: boolean = false
 
@@ -718,14 +715,6 @@ export class GitStore extends BaseStore {
   }
 
   /**
-   * The commit message to use based on the context of the repository, e.g., the
-   * message from a recently undone commit.
-   */
-  public get contextualCommitMessage(): ICommitMessage | null {
-    return this._contextualCommitMessage
-  }
-
-  /**
    * Gets a value indicating whether the user has chosen to
    * hide or show the co-authors field in the commit message
    * component
@@ -1214,25 +1203,6 @@ export class GitStore extends BaseStore {
     })
   }
 
-  /** Load the contextual commit message if there is one. */
-  public async loadContextualCommitMessage(): Promise<void> {
-    const message = await this.getMergeMessage()
-    const existingMessage = this._contextualCommitMessage
-    // In the case where we're in the middle of a merge, we're gonna keep
-    // finding the same merge message over and over. We don't need to keep
-    // telling the world.
-    if (
-      existingMessage &&
-      message &&
-      structuralEquals(existingMessage, message)
-    ) {
-      return
-    }
-
-    this._contextualCommitMessage = message
-    this.emitUpdate()
-  }
-
   /** Reverts the commit with the given SHA */
   public async revertCommit(
     repository: Repository,
@@ -1245,43 +1215,6 @@ export class GitStore extends BaseStore {
     )
 
     this.emitUpdate()
-  }
-
-  /**
-   * Get the merge message in the repository. This will resolve to null if the
-   * repository isn't in the middle of a merge.
-   */
-  private async getMergeMessage(): Promise<ICommitMessage | null> {
-    const messagePath = Path.join(this.repository.path, '.git', 'MERGE_MSG')
-    return new Promise<ICommitMessage | null>((resolve, reject) => {
-      Fs.readFile(messagePath, 'utf8', (err, data) => {
-        if (err || !data.length) {
-          resolve(null)
-        } else {
-          const pieces = data.match(/(.*)\n\n([\S\s]*)/m)
-          if (!pieces || pieces.length < 3) {
-            resolve(null)
-            return
-          }
-
-          // exclude any commented-out lines from the MERGE_MSG body
-          let description: string | null = pieces[2]
-            .split('\n')
-            .filter(line => line[0] !== '#')
-            .join('\n')
-
-          // join with no elements will return an empty string
-          if (description.length === 0) {
-            description = null
-          }
-
-          resolve({
-            summary: pieces[1],
-            description,
-          })
-        }
-      })
-    })
   }
 
   public async openMergeTool(path: string): Promise<void> {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -544,7 +544,7 @@ export class GitStore extends BaseStore {
       }
     }
 
-    this._contextualCommitMessage = {
+    this._commitMessage = {
       summary: commit.summary,
       description: commit.body,
     }
@@ -578,7 +578,7 @@ export class GitStore extends BaseStore {
 
     // This is the happy path, nothing more for us to do
     if (coAuthorTrailers.length === 0) {
-      this._contextualCommitMessage = {
+      this._commitMessage = {
         summary: commit.summary,
         description: commit.body,
       }
@@ -649,7 +649,7 @@ export class GitStore extends BaseStore {
 
     const newBody = lines.join('\n').trim()
 
-    this._contextualCommitMessage = {
+    this._commitMessage = {
       summary: commit.summary,
       description: newBody,
     }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -112,7 +112,6 @@ function getInitialRepositoryState(): IRepositoryState {
       ),
       selectedFileIDs: [],
       diff: null,
-      contextualCommitMessage: null,
       commitMessage: null,
       coAuthors: [],
       showCoAuthoredBy: false,

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -73,7 +73,6 @@ interface IChangesListProps {
    */
   readonly onRowClick?: (row: number, source: ClickSource) => void
   readonly commitMessage: ICommitMessage | null
-  readonly contextualCommitMessage: ICommitMessage | null
 
   /** The autocompletion providers available to the repository. */
   readonly autocompletionProviders: ReadonlyArray<IAutocompletionProvider<any>>
@@ -421,7 +420,6 @@ export class ChangesList extends React.Component<
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
           commitMessage={this.props.commitMessage}
-          contextualCommitMessage={this.props.contextualCommitMessage}
           autocompletionProviders={this.props.autocompletionProviders}
           isCommitting={this.props.isCommitting}
           showCoAuthoredBy={this.props.showCoAuthoredBy}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -432,6 +432,7 @@ export class ChangesList extends React.Component<
               : 'Summary (required)'
           }
           singleFileCommit={singleFileCommit}
+          key={this.props.repository.id}
         />
       </div>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -14,7 +14,6 @@ import { Repository } from '../../models/repository'
 import { Button } from '../lib/button'
 import { Avatar } from '../lib/avatar'
 import { Loading } from '../lib/loading'
-import { structuralEquals } from '../../lib/equality'
 import { generateGravatarUrl } from '../../lib/gravatar'
 import { AuthorInput } from '../lib/author-input'
 import { FocusContainer } from '../lib/focus-container'
@@ -109,19 +108,17 @@ export class CommitMessage extends React.Component<
   public constructor(props: ICommitMessageProps) {
     super(props)
 
+    const { commitMessage } = this.props
+
     this.state = {
-      summary: '',
-      description: '',
-      lastContextualCommitMessage: null,
+      summary: commitMessage ? commitMessage.summary : '',
+      description: commitMessage ? commitMessage.description : null,
+      lastContextualCommitMessage: this.props.contextualCommitMessage,
       userAutocompletionProvider: findUserAutoCompleteProvider(
         props.autocompletionProviders
       ),
       descriptionObscured: false,
     }
-  }
-
-  public componentWillMount() {
-    this.receiveProps(this.props, true)
   }
 
   public componentWillUnmount() {
@@ -130,90 +127,23 @@ export class CommitMessage extends React.Component<
     this.props.dispatcher.setCommitMessage(this.props.repository, this.state)
   }
 
-  public componentWillReceiveProps(nextProps: ICommitMessageProps) {
-    this.receiveProps(nextProps, false)
-  }
-
-  private receiveProps(nextProps: ICommitMessageProps, initializing: boolean) {
-    // If we're switching away from one repository to another we'll persist
-    // our commit message in the dispatcher.
-    if (nextProps.repository.id !== this.props.repository.id) {
-      this.props.dispatcher.setCommitMessage(this.props.repository, this.state)
-    }
-
+  public componentDidUpdate(prevProps: ICommitMessageProps) {
     if (
-      nextProps.autocompletionProviders !== this.props.autocompletionProviders
+      this.props.autocompletionProviders !== prevProps.autocompletionProviders
     ) {
       this.setState({
         userAutocompletionProvider: findUserAutoCompleteProvider(
-          nextProps.autocompletionProviders
+          this.props.autocompletionProviders
         ),
       })
     }
-
-    // This is rather gnarly. We want to persist the commit message (summary,
-    // and description) in the dispatcher on a per-repository level (git-store).
-    //
-    // Our dispatcher is asynchronous and only emits and update on animation
-    // frames. This is a great thing for performance but it gets real messy
-    // when you throw text boxes into the mix. If we went for a traditional
-    // approach of persisting the textbox values in the dispatcher and updating
-    // the virtual dom when we get new props there's an interim state which
-    // means that the browser can't keep track of the cursor for us, see:
-    //
-    //   http://stackoverflow.com/a/28922465
-    //
-    // So in order to work around that we keep the text values in the component
-    // state. Whenever they get updated we submit the update to the dispatcher
-    // but we disregard the message that flows to us on the subsequent animation
-    // frame unless we have switched repositories.
-    //
-    // Then there's the case when we're being mounted (think switching between
-    // history and changes tabs. In that case we have to rely on what's in the
-    // dispatcher since we don't have any state of our own.
-
-    const nextContextualCommitMessage = nextProps.contextualCommitMessage
-    const lastContextualCommitMessage = this.state.lastContextualCommitMessage
-    // If the contextual commit message changed, we'll use it as our commit
-    // message.
     if (
-      nextContextualCommitMessage &&
-      (!lastContextualCommitMessage ||
-        !structuralEquals(
-          nextContextualCommitMessage,
-          lastContextualCommitMessage
-        ))
+      this.props.commitMessage &&
+      prevProps.commitMessage != this.props.commitMessage
     ) {
       this.setState({
-        summary: nextContextualCommitMessage.summary,
-        description: nextContextualCommitMessage.description,
-        lastContextualCommitMessage: nextContextualCommitMessage,
-      })
-    } else if (
-      initializing ||
-      this.props.repository.id !== nextProps.repository.id
-    ) {
-      // We're either initializing (ie being mounted) or someone has switched
-      // repositories. If we receive a message we'll take it
-      if (nextProps.commitMessage) {
-        // Don't update dispatcher here, we're receiving it, could cause never-
-        // ending loop.
-        this.setState({
-          summary: nextProps.commitMessage.summary,
-          description: nextProps.commitMessage.description,
-          lastContextualCommitMessage: nextContextualCommitMessage,
-        })
-      } else {
-        // No message, assume clean slate
-        this.setState({
-          summary: '',
-          description: null,
-          lastContextualCommitMessage: nextContextualCommitMessage,
-        })
-      }
-    } else {
-      this.setState({
-        lastContextualCommitMessage: nextContextualCommitMessage,
+        summary: this.props.commitMessage.summary,
+        description: this.props.commitMessage.description,
       })
     }
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -137,6 +137,15 @@ export class CommitMessage extends React.Component<
         ),
       })
     }
+    if (
+      this.props.commitMessage &&
+      prevProps.commitMessage != this.props.commitMessage
+    ) {
+      this.setState({
+        summary: this.props.commitMessage.summary,
+        description: this.props.commitMessage.description,
+      })
+    }
   }
 
   private clearCommitMessage() {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -22,6 +22,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { ITrailer } from '../../lib/git/interpret-trailers'
 import { IAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
+import { shallowEquals } from '../../lib/equality'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -132,17 +133,14 @@ export class CommitMessage extends React.Component<
         ),
       })
     }
-    if (prevProps.commitMessage !== this.props.commitMessage) {
+    if (!shallowEquals(prevProps.commitMessage, this.props.commitMessage)) {
       if (this.props.commitMessage) {
         this.setState({
           summary: this.props.commitMessage.summary,
           description: this.props.commitMessage.description,
         })
       } else {
-        this.setState({
-          summary: '',
-          description: null,
-        })
+        this.setState({ summary: '', description: null })
       }
     }
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -137,14 +137,18 @@ export class CommitMessage extends React.Component<
         ),
       })
     }
-    if (
-      this.props.commitMessage &&
-      prevProps.commitMessage != this.props.commitMessage
-    ) {
-      this.setState({
-        summary: this.props.commitMessage.summary,
-        description: this.props.commitMessage.description,
-      })
+    if (prevProps.commitMessage != this.props.commitMessage) {
+      if (this.props.commitMessage) {
+        this.setState({
+          summary: this.props.commitMessage.summary,
+          description: this.props.commitMessage.description,
+        })
+      } else {
+        this.setState({
+          summary: '',
+          description: null,
+        })
+      }
     }
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -137,7 +137,7 @@ export class CommitMessage extends React.Component<
         ),
       })
     }
-    if (prevProps.commitMessage != this.props.commitMessage) {
+    if (prevProps.commitMessage !== this.props.commitMessage) {
       if (this.props.commitMessage) {
         this.setState({
           summary: this.props.commitMessage.summary,

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -43,7 +43,6 @@ interface ICommitMessageProps {
   readonly gitHubUser: IGitHubUser | null
   readonly anyFilesSelected: boolean
   readonly commitMessage: ICommitMessage | null
-  readonly contextualCommitMessage: ICommitMessage | null
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly autocompletionProviders: ReadonlyArray<IAutocompletionProvider<any>>
@@ -70,9 +69,6 @@ interface ICommitMessageProps {
 interface ICommitMessageState {
   readonly summary: string
   readonly description: string | null
-
-  /** The last contextual commit message we've received. */
-  readonly lastContextualCommitMessage: ICommitMessage | null
 
   readonly userAutocompletionProvider: UserAutocompletionProvider | null
 
@@ -113,7 +109,6 @@ export class CommitMessage extends React.Component<
     this.state = {
       summary: commitMessage ? commitMessage.summary : '',
       description: commitMessage ? commitMessage.description : null,
-      lastContextualCommitMessage: this.props.contextualCommitMessage,
       userAutocompletionProvider: findUserAutoCompleteProvider(
         props.autocompletionProviders
       ),

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -137,15 +137,6 @@ export class CommitMessage extends React.Component<
         ),
       })
     }
-    if (
-      this.props.commitMessage &&
-      prevProps.commitMessage != this.props.commitMessage
-    ) {
-      this.setState({
-        summary: this.props.commitMessage.summary,
-        description: this.props.commitMessage.description,
-      })
-    }
   }
 
   private clearCommitMessage() {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -309,7 +309,6 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           branch={this.props.branch}
           gitHubUser={user}
           commitMessage={this.props.changes.commitMessage}
-          contextualCommitMessage={this.props.changes.contextualCommitMessage}
           autocompletionProviders={this.autocompletionProviders!}
           availableWidth={this.props.availableWidth}
           onIgnore={this.onIgnore}

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -6,7 +6,6 @@ import { shell } from '../helpers/test-app-shell'
 import {
   setupEmptyRepository,
   setupFixtureRepository,
-  setupConflictedRepo,
 } from '../helpers/repositories'
 import { GitStore } from '../../src/lib/stores'
 import { AppFileStatus } from '../../src/models/status'
@@ -186,18 +185,6 @@ describe('GitStore', () => {
       )
       expect(result.stdout.length).toEqual(0)
     })
-  })
-
-  it('hides commented out lines from MERGE_MSG', async () => {
-    const repo = await setupConflictedRepo()
-    const gitStore = new GitStore(repo, shell)
-
-    await gitStore.loadContextualCommitMessage()
-
-    const context = gitStore.contextualCommitMessage
-    expect(context).not.toBeNull()
-    expect(context!.summary).toEqual(`Merge branch 'master' into other-branch`)
-    expect(context!.description).toBeNull()
   })
 
   describe('repository with HEAD file', () => {

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai'
 import * as FSE from 'fs-extra'
 import * as Path from 'path'
 import { GitProcess } from 'dugite'
@@ -26,9 +25,9 @@ describe('GitStore', () => {
 
       const commits = await gitStore.loadCommitBatch('HEAD')
 
-      expect(commits).is.not.null
-      expect(commits!.length).equals(100)
-      expect(commits![0]).equals('708a46eac512c7b2486da2247f116d11a100b611')
+      expect(commits).not.toBeNull()
+      expect(commits).toHaveLength(100)
+      expect(commits![0]).toEqual('708a46eac512c7b2486da2247f116d11a100b611')
     })
   })
 
@@ -57,9 +56,9 @@ describe('GitStore', () => {
     let status = await getStatusOrThrow(repo)
     let files = status.workingDirectory.files
 
-    expect(files.length).to.equal(2)
-    expect(files[0].path).to.equal('README.md')
-    expect(files[0].status).to.equal(AppFileStatus.Modified)
+    expect(files).toHaveLength(2)
+    expect(files[0].path).toEqual('README.md')
+    expect(files[0].status).toEqual(AppFileStatus.Modified)
 
     // discard the LICENSE.md file
     await gitStore.discardChanges([files[1]])
@@ -67,7 +66,7 @@ describe('GitStore', () => {
     status = await getStatusOrThrow(repo)
     files = status.workingDirectory.files
 
-    expect(files.length).to.equal(1)
+    expect(files).toHaveLength(1)
   })
 
   it('can discard a renamed file', async () => {
@@ -94,7 +93,7 @@ describe('GitStore', () => {
     const status = await getStatusOrThrow(repo)
     const files = status.workingDirectory.files
 
-    expect(files.length).to.equal(0)
+    expect(files).toHaveLength(0)
   })
 
   describe('undo first commit', () => {
@@ -115,20 +114,20 @@ describe('GitStore', () => {
       await GitProcess.exec(['commit', '-m', commitMessage], repo.path)
 
       firstCommit = await getCommit(repo!, 'master')
-      expect(firstCommit).to.not.equal(null)
-      expect(firstCommit!.parentSHAs.length).to.equal(0)
+      expect(firstCommit).not.toBeNull()
+      expect(firstCommit!.parentSHAs).toHaveLength(0)
     })
 
     it('reports the repository is unborn', async () => {
       const gitStore = new GitStore(repo!, shell)
 
       await gitStore.loadStatus()
-      expect(gitStore.tip.kind).to.equal(TipState.Valid)
+      expect(gitStore.tip.kind).toEqual(TipState.Valid)
 
       await gitStore.undoCommit(firstCommit!)
 
       const after = await getStatusOrThrow(repo!)
-      expect(after.currentTip).to.be.undefined
+      expect(after.currentTip).toBeUndefined()
     })
 
     it('pre-fills the commit message', async () => {
@@ -137,8 +136,8 @@ describe('GitStore', () => {
       await gitStore.undoCommit(firstCommit!)
 
       const context = gitStore.contextualCommitMessage
-      expect(context).to.not.be.null
-      expect(context!.summary).to.equal(commitMessage)
+      expect(context).not.toBeNull()
+      expect(context!.summary).toEqual(commitMessage)
     })
 
     it('clears the undo commit dialog', async () => {
@@ -149,16 +148,16 @@ describe('GitStore', () => {
       const tip = gitStore.tip as IValidBranch
       await gitStore.loadLocalCommits(tip.branch)
 
-      expect(gitStore.localCommitSHAs.length).to.equal(1)
+      expect(gitStore.localCommitSHAs).toHaveLength(1)
 
       await gitStore.undoCommit(firstCommit!)
 
       await gitStore.loadStatus()
-      expect(gitStore.tip.kind).to.equal(TipState.Unborn)
+      expect(gitStore.tip.kind).toEqual(TipState.Unborn)
 
       await gitStore.loadLocalCommits(null)
 
-      expect(gitStore.localCommitSHAs).to.be.empty
+      expect(gitStore.localCommitSHAs).toHaveLength(0)
     })
 
     it('has no staged files', async () => {
@@ -169,7 +168,7 @@ describe('GitStore', () => {
       const tip = gitStore.tip as IValidBranch
       await gitStore.loadLocalCommits(tip.branch)
 
-      expect(gitStore.localCommitSHAs.length).to.equal(1)
+      expect(gitStore.localCommitSHAs.length).toEqual(1)
 
       await gitStore.undoCommit(firstCommit!)
 
@@ -185,7 +184,7 @@ describe('GitStore', () => {
         ],
         repo!.path
       )
-      expect(result.stdout.length).to.equal(0)
+      expect(result.stdout.length).toEqual(0)
     })
   })
 
@@ -196,9 +195,9 @@ describe('GitStore', () => {
     await gitStore.loadContextualCommitMessage()
 
     const context = gitStore.contextualCommitMessage
-    expect(context).to.not.be.null
-    expect(context!.summary).to.equal(`Merge branch 'master' into other-branch`)
-    expect(context!.description).to.be.null
+    expect(context).not.toBeNull()
+    expect(context!.summary).toEqual(`Merge branch 'master' into other-branch`)
+    expect(context!.description).toBeNull()
   })
 
   describe('repository with HEAD file', () => {
@@ -214,13 +213,13 @@ describe('GitStore', () => {
 
       let status = await getStatusOrThrow(repo!)
       let files = status.workingDirectory.files
-      expect(files.length).to.equal(1)
+      expect(files.length).toEqual(1)
 
       await gitStore.discardChanges([files[0]])
 
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files
-      expect(files.length).to.equal(0)
+      expect(files.length).toEqual(0)
     })
   })
 })

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -135,9 +135,9 @@ describe('GitStore', () => {
 
       await gitStore.undoCommit(firstCommit!)
 
-      const context = gitStore.contextualCommitMessage
-      expect(context).not.toBeNull()
-      expect(context!.summary).toEqual(commitMessage)
+      const newCommitMessage = gitStore.commitMessage
+      expect(newCommitMessage).not.toBeNull()
+      expect(newCommitMessage!.summary).toEqual(commitMessage)
     })
 
     it('clears the undo commit dialog', async () => {


### PR DESCRIPTION
## Overview

_supports #6049 and #6013_

This PR refactors our handling of commit message state so that it can be successfully cleared from the `dispatcher`. It also removes the `CommitMessage` components reliance on deprecated lifecycle methods.

**This PR will allow us to reset the commit message in the UI via the existing dispatcher method 'setCommitMessage' (which currently doesn't work in all cases).**

## Description

- removes deprecated [`componentWillMount`](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount) from `CommitMessage` component
- removes deprecated [`componentWillReceiveProps`](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops) from `CommitMessage` component
- (mostly) centralizes commitMessage state in `gitStore`
- uses a `key` to manage un-mounting and mounting a new `CommitMessage` 

## User Flows tested

- undoing commits with and without coauthors
- switching repositories and not losing commit message drafts
- committing

## Release notes

Notes: no-notes
