### PR TITLE
just some regrets about regexes 

### DIFF
--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -23,6 +23,12 @@ export function getCaptures(
  * @returns set of strings captured by supplied regex
  */
 export function getMatches(text: string, re: RegExp): Array<RegExpExecArray> {
+  if (re.global === false) {
+    throw new Error(
+      'A regex has been provided that is not marked as global, and has the potential to execute forever if it finds a match'
+    )
+  }
+
   const matches = new Array<RegExpExecArray>()
   let match = re.exec(text)
 

--- a/app/test/unit/helpers/regex-test.ts
+++ b/app/test/unit/helpers/regex-test.ts
@@ -24,4 +24,10 @@ describe('getCaptures()', () => {
       expect(subject()).toEqual([])
     })
   })
+
+  it('will error when a non-global regex is provided', () => {
+    const regex = /(.+):matching:(.+)/
+    bodyOfText = `capture me!:matching:capture me too!\nalso capture me!:matching:also capture me too!\n`
+    expect(() => getCaptures(bodyOfText, regex)).toThrow()
+  })
 })


### PR DESCRIPTION
## Overview

As part of improving some of our Git LFS plumbing I found myself writing this simple code to parse a regex:

```ts
export async function getLFSPaths(
  repository: Repository
): Promise<ReadonlyArray<string>> {
  const { stdout } = await getLfsTrackOutput(repository)
  const trackExpressionRegex = /\s*(.*)\s\(.*\)\n/

  const matches = new Array<string>()
  let match = trackExpressionRegex.exec(stdout)

  while (match !== null && match.length === 2) {
    const expression = match[1]
    matches.push(expression)
    match = trackExpressionRegex.exec(stdout)
  }
  return matches
}
```

Notice the bug? It's on this line:

```ts
const trackExpressionRegex = /\s*(.*)\s\(.*\)\n/
```

This regex has not been defined with a `/g`, and so the loop of asking for results will run forever, because it'll keep providing the same "first match". You can see it if you run this new test I added:

<img width="1016" src="https://user-images.githubusercontent.com/359239/47747299-d26e0280-dc66-11e8-96f8-1126a85d9ea5.png">

Or to describe it visually, here's the regex without `/g` on [regex101.com](https://regex101.com/):

<img width="699" src="https://user-images.githubusercontent.com/359239/47747550-53c59500-dc67-11e8-928e-043755199811.png">

And here's the same regex but with `/g` set:

<img width="698" src="https://user-images.githubusercontent.com/359239/47747551-53c59500-dc67-11e8-8877-cfc02f684e19.png">

## Description

The fix I will submit after I see this PR explode in a fire of flaming builds looks like this:

```diff
diff --git a/app/src/lib/helpers/regex.ts b/app/src/lib/helpers/regex.ts
index 2d1f80af3..bb2779b86 100644
--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -23,6 +23,12 @@ export function getCaptures(
  * @returns set of strings captured by supplied regex
  */
 export function getMatches(text: string, re: RegExp): Array<RegExpExecArray> {
+  if (re.global === false) {
+    throw new Error(
+      'A regex has been provided that is not marked as global, and has the potential to execute forever if it finds a match'
+    )
+  }
+
   const matches = new Array<RegExpExecArray>()
   let match = re.exec(text)
 
```

This might seem contentious, but I'd like to prevent others from accidentally running into this the same performance issue as I did at development time, and the API does suggest match**es** so we should expect a global regex anyway.

## Release notes
Notes: no-notes
