### PR TITLE
handle really long banner messages

### DIFF
--- a/app/src/ui/banners/successful-merge.tsx
+++ b/app/src/ui/banners/successful-merge.tsx
@@ -37,9 +37,9 @@ export class SuccessfulMerge extends React.Component<
   }
 
   public componentDidMount = () => {
-    // this.timeoutId = setTimeout(() => {
-    //   this.dismiss()
-    // }, 3250)
+    this.timeoutId = setTimeout(() => {
+      this.dismiss()
+    }, 3250)
   }
 
   public componentWillUnmount = () => {

--- a/app/src/ui/banners/successful-merge.tsx
+++ b/app/src/ui/banners/successful-merge.tsx
@@ -19,23 +19,27 @@ export class SuccessfulMerge extends React.Component<
         <div className="green-circle">
           <Octicon className="check-icon" symbol={OcticonSymbol.check} />
         </div>
-        <span>
-          {'Successfully merged '}
-          <strong>{this.props.theirBranch}</strong>
-          {' into '}
-          <strong>{this.props.currentBranch}</strong>
-        </span>
-        <a className="close" onClick={this.dismiss}>
-          <Octicon symbol={OcticonSymbol.x} />
-        </a>
+        <div className="banner-message">
+          <span>
+            {'Successfully merged '}
+            <strong>{this.props.theirBranch}</strong>
+            {' into '}
+            <strong>{this.props.currentBranch}</strong>
+          </span>
+        </div>
+        <div className="close">
+          <a onClick={this.dismiss}>
+            <Octicon symbol={OcticonSymbol.x} />
+          </a>
+        </div>
       </div>
     )
   }
 
   public componentDidMount = () => {
-    this.timeoutId = setTimeout(() => {
-      this.dismiss()
-    }, 3250)
+    // this.timeoutId = setTimeout(() => {
+    //   this.dismiss()
+    // }, 3250)
   }
 
   public componentWillUnmount = () => {

--- a/app/styles/ui/banners/_successful-merge.scss
+++ b/app/styles/ui/banners/_successful-merge.scss
@@ -1,6 +1,7 @@
 #successful-merge {
   position: relative;
   display: flex;
+  flex-wrap: nowrap;
   overflow: hidden;
   align-content: center;
   align-items: center;
@@ -13,6 +14,18 @@
   // Prevents the notification banner from decreasing its height
   // when a large diff is rendered.
   flex: none;
+
+  .banner-message {
+    span {
+      max-width: 100%;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    overflow-x: hidden;
+    display: flex;
+    flex: 1 1 auto;
+  }
 
   &.active {
     height: 30px;
@@ -28,16 +41,19 @@
     justify-content: center;
     align-items: center;
     margin-right: var(--spacing);
+    display: flex;
+    flex-shrink: 0;
+    flex-grow: 0;
   }
 
   .close {
-    position: absolute;
-    right: var(--spacing);
-    border: 0;
-    height: 16px;
+    display: flex;
+    flex-shrink: 0;
+    flex-grow: 0;
     width: 16px;
-    margin: 0;
-    padding: 0;
+    height: 16px;
+    margin-right: var(--spacing);
+    margin-left: var(--spacing);
     background: transparent;
 
     color: var(--text-secondary-color);


### PR DESCRIPTION
## Overview

**Closes bug reported in https://github.com/desktop/desktop/pull/6011#issuecomment-434457344**

## Description

- css redo to truncate long banner message

<img width="983" alt="screen shot 2018-10-30 at 5 02 26 pm" src="https://user-images.githubusercontent.com/964912/47758385-0c8bd400-dc68-11e8-92d1-0d669441fe49.png">


## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: no-notes
