### PR TITLE
add some new Git APIs to improve our Git LFS support

### DIFF
--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -50,10 +50,24 @@ export async function isTrackedByLFS(
   path: string
 ): Promise<boolean> {
   const { stdout } = await git(
-    ['check-attr', '-a', path],
+    ['check-attr', 'filter', path],
     repository.path,
     'checkAttrForLFS'
   )
+
+  // "git check-attr -a" will output every filter it can find in .gitattributes
+  // and it looks like this:
+  //
+  // README.md: diff: lfs
+  // README.md: merge: lfs
+  // README.md: text: unset
+  // README.md: filter: lfs
+  //
+  // To verify git-lfs this test will just focus on that last row, "filter",
+  // and the value associated with it. If nothing is found in .gitattributes
+  // the output will look like this
+  //
+  // README.md: filter: unspecified
 
   const lfsFilterRegex = /(.*): filter: lfs/
 

--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -1,5 +1,6 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
+import { caseInsensitiveCompare } from '../compare'
 
 /** Install the global LFS filters. */
 export async function installGlobalLFSFilters(force: boolean): Promise<void> {
@@ -33,4 +34,39 @@ export async function isUsingLFS(repository: Repository): Promise<boolean> {
     env,
   })
   return result.stdout.length > 0
+}
+
+/**
+ * Check if a provided file path is being tracked by Git LFS
+ *
+ * This uses the Git plumbing to read the .gitattributes file
+ * for any LFS-related rules that are set for the file
+ *
+ * @param repository repository with
+ * @param path relative file path in the repository
+ */
+export async function isTrackedByLFS(
+  repository: Repository,
+  path: string
+): Promise<boolean> {
+  const { stdout } = await git(
+    ['check-attr', '-a', path],
+    repository.path,
+    'checkAttrForLFS'
+  )
+
+  const lfsFilterRegex = /(.*): filter: lfs/
+
+  const match = lfsFilterRegex.exec(stdout)
+
+  if (match == null || match.length !== 2) {
+    return false
+  }
+
+  const fileName = match[1]
+  if (caseInsensitiveCompare(fileName, path) !== 0) {
+    return false
+  }
+
+  return true
 }

--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -84,3 +84,27 @@ export async function isTrackedByLFS(
 
   return true
 }
+
+/**
+ * Query a Git repository and filter the set of provided relative paths to see
+ * which are not covered by the current Git LFS configuration.
+ *
+ * @param repository
+ * @param filePaths List of relative paths in the repository
+ */
+export async function filesNotTrackedByLFS(
+  repository: Repository,
+  filePaths: ReadonlyArray<string>
+): Promise<ReadonlyArray<string>> {
+  const filesNotTrackedByGitLFS = new Array<string>()
+
+  for (const file of filePaths) {
+    const isTracked = await isTrackedByLFS(repository, file)
+
+    if (!isTracked) {
+      filesNotTrackedByGitLFS.push(file)
+    }
+  }
+
+  return filesNotTrackedByGitLFS
+}

--- a/app/test/unit/git/lfs-test.ts
+++ b/app/test/unit/git/lfs-test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import { Repository } from '../../../src/models/repository'
 import { GitProcess } from 'dugite'
@@ -11,7 +10,7 @@ describe('git-lfs', () => {
       const repository = new Repository(path, -1, null, false)
 
       const usingLFS = await isUsingLFS(repository)
-      expect(usingLFS).to.equal(false)
+      expect(usingLFS).toBe(false)
     })
 
     it('returns true if LFS is tracking a path', async () => {
@@ -21,7 +20,7 @@ describe('git-lfs', () => {
       await GitProcess.exec(['lfs', 'track', '*.psd'], repository.path)
 
       const usingLFS = await isUsingLFS(repository)
-      expect(usingLFS).to.equal(true)
+      expect(usingLFS).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Overview

As part of #6013 we uncovered that we lack some context about how a repository is configured for Git LFS. In particular we didn't know whether a file would be tracked by Git LFS, so this PR adds support for doing this in two ways:

 - directly querying a repository and passing a relative path
 - a convenience function that takes in a list of relative paths and will return only the files not covered by Git LFS

Shout out to @Daniel-McCarthy for digging into this and helping uncover the gaps with how we detect our Git LFS support, and shout out to @ttaylorr for pointing me to `git check-attr` to help with the underlying querying of the Git repository.

## Description

The internals for this are split into two parts:

 - `isTrackedByLFS` - checking a file path is covered by Git LFS
 - `filesNotTrackedByLFS` - pass it a list of files, get back only those which aren't covered by Git LFS

For the workflows in #6013 I think callers should be fine with what `filesNotTrackedByLFS` provides. @Daniel-McCarthy let me know if this makes sense for what you're building out.

There's a few tests covering this currently to help guide the API, but I didn't want to spend too much time on it in case it's not what we need for #6013. As we get to the bottom of #6013 I imagine we'll bake in more tests.

## Release notes

Notes: no-notes
