### PR TITLE
ensure status after aborting a merge reflects reality

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -595,8 +595,9 @@ export class Dispatcher {
     return this.appStore._mergeBranch(repository, branch, mergeStatus)
   }
 
-  public abortMerge(repository: Repository) {
-    return this.appStore._abortMerge(repository)
+  public async abortMerge(repository: Repository) {
+    await this.appStore._abortMerge(repository)
+    await this.appStore._loadStatus(repository)
   }
 
   public createMergeCommit(


### PR DESCRIPTION
## Overview

**Closes #6052**

This PR ensures the changes tab is updated after aborting a merge, rather than relying on switching tabs to trigger the refresh.

## Release notes

Notes: no-notes
