### PR TITLE
kill off unnecessary margin inside compare tab branch list

### DIFF
--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -53,6 +53,10 @@
   flex-direction: column;
   flex: 1;
 
+  .filter-list .filter-field-row {
+    margin: 0;
+  }
+
   .compare-form {
     background: var(--box-alt-background-color);
     flex: initial;


### PR DESCRIPTION
## Overview

**Closes #6058**

## Description

Now it looks like this:

<img width="271" alt="screen shot 2018-10-31 at 2 59 26 pm" src="https://user-images.githubusercontent.com/359239/47808715-bed1a300-dd1d-11e8-92d5-327adb7df3a0.png">

The root cause of this was

 - `FilterList` always rendering this row, even if neither of these placeholders render something:

```ts
<Row className="filter-field-row">
  {this.props.filterTextBox === undefined ? this.renderTextBox() : null}
  {this.props.renderPostFilter ? this.props.renderPostFilter() : null}
</Row>
```

 - the default styles added in b8a600971305c0f99ae5632de946ab883f25e05e assigning a margin to this empty `div`, so it takes up space even without any child elements.
 
## Release notes

Notes: no-notes
