### PR TITLE
Bump to Electron 2.0.13

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 2.0.9
+target = 2.0.13
 arch = x64

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "2.0.9",
+    "electron": "2.0.13",
     "electron-builder": "20.28.4",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3589,10 +3589,10 @@ electron-winstaller@2.5.2:
     lodash.template "^4.2.2"
     temp "^0.8.3"
 
-electron@2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.9.tgz#dfc863d653fa3a2dd4fea0c63303df9c0e33c602"
-  integrity sha512-xRefYuz6C65ahX8vDwIJxr1Y5ffFa106dugZEbl23yLKfrAG01lh5csBJ9hJwCBPLHp2zj/9PGoJ8dt5zlzOvQ==
+electron@2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.13.tgz#db3949cf4d9d4569be0cec010624746793a406c9"
+  integrity sha512-8ouYaLsp0F4sPI7QKgJkkJhrwj1JPSnBwbz6HHA9l6u7WofEt94lV+gHw71KJrDl7UaIkFwlSjyhIjG8lIZqxw==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #6068**
**Fixes #5287**

## Description

- Bumps from Electron 2.0.9 to 2.0.13 (bug fixes, documentation fixes mostly)
   1. [2.0.10 Release Notes](https://github.com/electron/electron/releases/tag/v2.0.10)
   1. [2.0.11 Release Notes](https://github.com/electron/electron/releases/tag/v2.0.11)
   1. [2.0.12 Release Notes](https://github.com/electron/electron/releases/tag/v2.0.12)
   1. [2.0.13 Release Notes](https://github.com/electron/electron/releases/tag/v2.0.13)

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: No notes