### PR TITLE
add support for reporting a binary file is in a conflicted state

### DIFF
--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -138,6 +138,15 @@ export function iconForStatus(status: AppFileStatus): OcticonSymbol {
   return assertNever(status, `Unknown file status ${status}`)
 }
 
+export type ConflictStatus =
+  | {
+      readonly kind: 'text'
+      readonly conflictMarkerCount: number
+    }
+  | {
+      readonly kind: 'binary'
+    }
+
 /** encapsulate changes to a file associated with a commit */
 export class FileChange {
   /** An ID for the file change. */
@@ -171,7 +180,7 @@ export class WorkingDirectoryFileChange extends FileChange {
     status: AppFileStatus,
     public readonly selection: DiffSelection,
     oldPath?: string,
-    public readonly conflictMarkers: number = 0
+    public readonly conflictStatus: ConflictStatus | null = null
   ) {
     super(path, status, oldPath)
   }
@@ -192,7 +201,7 @@ export class WorkingDirectoryFileChange extends FileChange {
       this.status,
       selection,
       this.oldPath,
-      this.conflictMarkers
+      this.conflictStatus
     )
   }
 }

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -32,13 +32,13 @@ export enum GitStatusEntry {
 
 /** The file status as represented in GitHub Desktop. */
 export enum AppFileStatus {
-  New,
-  Modified,
-  Deleted,
-  Copied,
-  Renamed,
-  Conflicted,
-  Resolved,
+  New = 'New',
+  Modified = 'Modified',
+  Deleted = 'Deleted',
+  Copied = 'Copied',
+  Renamed = 'Renamed',
+  Conflicted = 'Conflicted',
+  Resolved = 'Resolved',
 }
 
 /** The porcelain status for an ordinary changed entry */

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -11,6 +11,7 @@ import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
   AppFileStatus,
+  ConflictStatus,
 } from '../../models/status'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { PathText } from '../lib/path-text'
@@ -133,27 +134,33 @@ export class MergeConflictsDialog extends React.Component<
 
   private renderConflictedFile(
     path: string,
-    conflicts: number,
+    conflictStatus: ConflictStatus,
     editorName: string | undefined,
     onOpenEditorClick: () => void
   ): JSX.Element {
-    const humanReadableConflicts = this.calculateConflicts(conflicts)
-    const message =
-      humanReadableConflicts === 1
-        ? `1 conflict`
-        : `${humanReadableConflicts} conflicts`
-    return (
-      <li className="unmerged-file-status-conflicts">
-        <Octicon symbol={OcticonSymbol.fileCode} className="file-octicon" />
-        <div className="column-left">
-          <PathText path={path} availableWidth={200} />
-          <div className="file-conflicts-status">{message}</div>
-        </div>
-        <Button onClick={onOpenEditorClick}>
-          {this.editorButtonString(editorName)}
-        </Button>
-      </li>
-    )
+    if (conflictStatus.kind === 'binary') {
+      return <div>TODO</div>
+    } else {
+      const humanReadableConflicts = this.calculateConflicts(
+        conflictStatus.conflictMarkerCount
+      )
+      const message =
+        humanReadableConflicts === 1
+          ? `1 conflict`
+          : `${humanReadableConflicts} conflicts`
+      return (
+        <li className="unmerged-file-status-conflicts">
+          <Octicon symbol={OcticonSymbol.fileCode} className="file-octicon" />
+          <div className="column-left">
+            <PathText path={path} availableWidth={200} />
+            <div className="file-conflicts-status">{message}</div>
+          </div>
+          <Button onClick={onOpenEditorClick}>
+            {this.editorButtonString(editorName)}
+          </Button>
+        </li>
+      )
+    }
   }
 
   private renderUnmergedFile(
@@ -165,9 +172,15 @@ export class MergeConflictsDialog extends React.Component<
       case AppFileStatus.Resolved:
         return this.renderResolvedFile(file.path)
       case AppFileStatus.Conflicted:
+        if (file.conflictStatus === null) {
+          throw new Error(
+            'Invalid state - a conflicted file should have conflicted status set'
+          )
+        }
+
         return this.renderConflictedFile(
           file.path,
-          file.conflictMarkers,
+          file.conflictStatus,
           editorName,
           () =>
             this.props.openFileInExternalEditor(join(repositoryPath, file.path))

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -137,10 +137,8 @@ export class MergeConflictsDialog extends React.Component<
     conflictStatus: ConflictStatus,
     editorName: string | undefined,
     onOpenEditorClick: () => void
-  ): JSX.Element {
-    if (conflictStatus.kind === 'binary') {
-      return <div>TODO</div>
-    } else {
+  ): JSX.Element | null {
+    if (conflictStatus.kind === 'text') {
       const humanReadableConflicts = this.calculateConflicts(
         conflictStatus.conflictMarkerCount
       )
@@ -161,6 +159,7 @@ export class MergeConflictsDialog extends React.Component<
         </li>
       )
     }
+    return null
   }
 
   private renderUnmergedFile(


### PR DESCRIPTION
## Overview

While I dig into #6063 about the Git internals, this PR helps to adapt the shape of the data returned by `getStatus` - using a number to represent the conflicted files isn't helpful for binary files, so I've created a new shape:

```ts
export type ConflictStatus =
  | {
      readonly kind: 'text'
      readonly conflictMarkerCount: number
    }
  | {
      readonly kind: 'binary'
    }
```

## Description

- This PR just adapts the existing code to the new shape of data - we're not surfacing binary conflicted files currently, and they'll continue to be marked as "resolved" in the app
- I've not done any of the UI work around how this affects the conflict resolution flow, but there's a placeholder list entry now to support when we are able to bubble these up.
- I'm not a fan of the `throw new Error` I've added in here to ensure an unrepresentable state is not encountered, but it'd be cool to maybe figure that out once I've gotten #6063 ready for review
 - 38c3a2ce7 converts `AppFileStatus` to string enums for readability, but it also results in a bit less JS being emitted because it no longer uses numbers for the backing store

<img width="1561" src="https://user-images.githubusercontent.com/359239/47861728-33feb000-ddd2-11e8-81c5-8bc6807d2925.png">

## Release notes

Notes: no-notes
