### PR TITLE
Disable Compare on GitHub menu item when no repository is selected

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -288,6 +288,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     menuStateBuilder.disable('push')
     menuStateBuilder.disable('pull')
     menuStateBuilder.disable('compare-to-branch')
+    menuStateBuilder.disable('compare-on-github')
   }
   return menuStateBuilder
 }


### PR DESCRIPTION
Seems like we've missed this menu item. It's currently enabled even when no repository is selected (i.e. when there are no repositories added to the app).