### PR TITLE
add keyboard shortcut for reverse tab order to ignore list

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -724,8 +724,8 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
       cursorBlinkRate: -1,
       lineWrapping: true,
       mode: { name: DiffSyntaxMode.ModeName },
-      // Make sure CodeMirror doesn't capture Tab and thus destroy tab navigation
-      extraKeys: { Tab: false },
+      // Make sure CodeMirror doesn't capture Tab (and Shift-Tab) and thus destroy tab navigation
+      extraKeys: { Tab: false, 'Shift-Tab': false },
       scrollbarStyle: __DARWIN__ ? 'simple' : 'native',
       styleSelectedText: true,
       lineSeparator: '\n',


### PR DESCRIPTION

## Overview

This supersedes the original PR #5991 with an official way to get Codemirror to ignore certain key combinations.

**Closes #2794**

## Description

I'll just defer to @niik's comment here about it https://github.com/desktop/desktop/pull/5991#issuecomment-435323385

## Release notes

Notes: Fixes counter-clockwise tab order by configuring diff to ignore keyboard shortcut
