### PR TITLE
tidy up log message to provide better context

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -862,12 +862,12 @@ export class Dispatcher {
 
       case 'open-repository-from-url':
         const { url } = action
-        const repository = await this.openRepository(url)
+        const repository = await this.openOrCloneRepository(url)
         if (repository) {
           await this.handleCloneInDesktopOptions(repository, action)
         } else {
           log.warn(
-            `Open Repository from URL failed, did not find repository: ${url} - payload: ${JSON.stringify(
+            `Open Repository from URL failed, did not find or clone repository: ${url} - payload: ${JSON.stringify(
               action
             )}`
           )
@@ -998,7 +998,7 @@ export class Dispatcher {
     }
   }
 
-  private async openRepository(url: string): Promise<Repository | null> {
+  private async openOrCloneRepository(url: string): Promise<Repository | null> {
     const state = this.appStore.getState()
     const repositories = state.repositories
     const existingRepository = repositories.find(r => {


### PR DESCRIPTION
## Overview

While investigating #6070 I noticed that an error message in here wasn't clear:

```
2018-11-02T01:10:58.257Z - warn: [ui] Open Repository from URL failed, did not find repository: [url] - payload: [json]
```

## Description

This change tidies up two things - the name of the function, and the message being logged if the flow ends without a valid repository.

When a user clicks "Open in Desktop" in the browser we want to either:

 - find the tracked repository in Desktop that corresponds to this remote URL
 - clone down a new repository if one isn't found

The message is intended to show that the app got this event from the browser and wasn't able to complete successfully, providing the payload it received for additional diagnostics. There should be extra context before this message if there were underlying errors (a failed clone, for example) unless the user chose to avoid the clone operation.

## Release notes

Notes: no-notes
