### PR TITLE
Add Branch List and Pull Request List filter text persistence

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -175,6 +175,9 @@ export interface IAppState {
   /** The current branch filter text. */
   readonly branchFilterText: string
 
+  /** The current pull request filter text. */
+  readonly pullRequestFilterText: string
+
   /** The currently selected tab for Clone Repository. */
   readonly selectedCloneRepositoryTab: CloneRepositoryTab
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -172,6 +172,9 @@ export interface IAppState {
   /** The current repository filter text. */
   readonly repositoryFilterText: string
 
+  /** The current branch filter text. */
+  readonly branchFilterText: string
+
   /** The currently selected tab for Clone Repository. */
   readonly selectedCloneRepositoryTab: CloneRepositoryTab
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -172,12 +172,6 @@ export interface IAppState {
   /** The current repository filter text. */
   readonly repositoryFilterText: string
 
-  /** The current branch filter text. */
-  readonly branchFilterText: string
-
-  /** The current pull request filter text. */
-  readonly pullRequestFilterText: string
-
   /** The currently selected tab for Clone Repository. */
   readonly selectedCloneRepositoryTab: CloneRepositoryTab
 
@@ -304,6 +298,12 @@ export interface IRepositoryState {
    * null if no such operation is in flight.
    */
   readonly revertProgress: IRevertProgress | null
+
+  /** The current branch filter text. */
+  readonly branchFilterText: string
+
+  /** The current pull request filter text. */
+  readonly pullRequestFilterText: string
 }
 
 export interface IBranchesState {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -173,6 +173,11 @@ export class Dispatcher {
     return this.appStore._setRepositoryFilterText(text)
   }
 
+  /** Set the branch filter text. */
+  public setBranchFilterText(text: string): Promise<void> {
+    return this.appStore._setBranchFilterText(text)
+  }
+
   /** Select the repository. */
   public selectRepository(
     repository: Repository | CloningRepository

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -174,13 +174,19 @@ export class Dispatcher {
   }
 
   /** Set the branch filter text. */
-  public setBranchFilterText(text: string): Promise<void> {
-    return this.appStore._setBranchFilterText(text)
+  public setBranchFilterText(
+    repository: Repository,
+    text: string
+  ): Promise<void> {
+    return this.appStore._setBranchFilterText(repository, text)
   }
 
   /** Set the branch filter text. */
-  public setPullRequestFilterText(text: string): Promise<void> {
-    return this.appStore._setPullRequestFilterText(text)
+  public setPullRequestFilterText(
+    repository: Repository,
+    text: string
+  ): Promise<void> {
+    return this.appStore._setPullRequestFilterText(repository, text)
   }
 
   /** Select the repository. */

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -178,6 +178,11 @@ export class Dispatcher {
     return this.appStore._setBranchFilterText(text)
   }
 
+  /** Set the branch filter text. */
+  public setPullRequestFilterText(text: string): Promise<void> {
+    return this.appStore._setPullRequestFilterText(text)
+  }
+
   /** Select the repository. */
   public selectRepository(
     repository: Repository | CloningRepository

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -277,6 +277,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** The current branch filter text */
   private branchFilterText: string = ''
 
+  /** The current pull request filter text */
+  private pullRequestFilterText: string = ''
+
   private currentMergeTreePromise: Promise<void> | null = null
 
   /** The function to resolve the current Open in Desktop flow. */
@@ -500,6 +503,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
       branchFilterText: this.branchFilterText,
+      pullRequestFilterText: this.pullRequestFilterText,
       selectedCloneRepositoryTab: this.selectedCloneRepositoryTab,
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
@@ -1008,6 +1012,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _setBranchFilterText(text: string): Promise<void> {
     this.branchFilterText = text
+    this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _setPullRequestFilterText(text: string): Promise<void> {
+    this.pullRequestFilterText = text
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -274,6 +274,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** The current repository filter text */
   private repositoryFilterText: string = ''
 
+  /** The current branch filter text */
+  private branchFilterText: string = ''
+
   private currentMergeTreePromise: Promise<void> | null = null
 
   /** The function to resolve the current Open in Desktop flow. */
@@ -496,6 +499,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       imageDiffType: this.imageDiffType,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
+      branchFilterText: this.branchFilterText,
       selectedCloneRepositoryTab: this.selectedCloneRepositoryTab,
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
@@ -998,6 +1002,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _setRepositoryFilterText(text: string): Promise<void> {
     this.repositoryFilterText = text
+    this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _setBranchFilterText(text: string): Promise<void> {
+    this.branchFilterText = text
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -274,12 +274,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** The current repository filter text */
   private repositoryFilterText: string = ''
 
-  /** The current branch filter text */
-  private branchFilterText: string = ''
-
-  /** The current pull request filter text */
-  private pullRequestFilterText: string = ''
-
   private currentMergeTreePromise: Promise<void> | null = null
 
   /** The function to resolve the current Open in Desktop flow. */
@@ -502,8 +496,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       imageDiffType: this.imageDiffType,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
-      branchFilterText: this.branchFilterText,
-      pullRequestFilterText: this.pullRequestFilterText,
       selectedCloneRepositoryTab: this.selectedCloneRepositoryTab,
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
@@ -1010,14 +1002,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _setBranchFilterText(text: string): Promise<void> {
-    this.branchFilterText = text
+  public async _setBranchFilterText(
+    repository: Repository,
+    text: string
+  ): Promise<void> {
+    this.repositoryStateCache.update(repository, () => ({
+      branchFilterText: text,
+    }))
     this.emitUpdate()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _setPullRequestFilterText(text: string): Promise<void> {
-    this.pullRequestFilterText = text
+  public async _setPullRequestFilterText(
+    repository: Repository,
+    text: string
+  ): Promise<void> {
+    this.repositoryStateCache.update(repository, () => ({
+      pullRequestFilterText: text,
+    }))
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -155,5 +155,7 @@ function getInitialRepositoryState(): IRepositoryState {
     checkoutProgress: null,
     pushPullFetchProgress: null,
     revertProgress: null,
+    branchFilterText: '',
+    pullRequestFilterText: '',
   }
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1738,6 +1738,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const repository = selection.repository
     const branchesState = selection.state.branchesState
+    const branchFilterText = this.state.branchFilterText
 
     return (
       <BranchDropdown
@@ -1750,6 +1751,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         pullRequests={branchesState.openPullRequests}
         currentPullRequest={branchesState.currentPullRequest}
         isLoadingPullRequests={branchesState.isLoadingPullRequests}
+        branchFilterText={branchFilterText}
       />
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1738,8 +1738,6 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const repository = selection.repository
     const branchesState = selection.state.branchesState
-    const branchFilterText = this.state.branchFilterText
-    const pullRequestFilterText = this.state.pullRequestFilterText
 
     return (
       <BranchDropdown
@@ -1752,8 +1750,6 @@ export class App extends React.Component<IAppProps, IAppState> {
         pullRequests={branchesState.openPullRequests}
         currentPullRequest={branchesState.currentPullRequest}
         isLoadingPullRequests={branchesState.isLoadingPullRequests}
-        branchFilterText={branchFilterText}
-        pullRequestFilterText={pullRequestFilterText}
       />
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1739,6 +1739,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     const repository = selection.repository
     const branchesState = selection.state.branchesState
     const branchFilterText = this.state.branchFilterText
+    const pullRequestFilterText = this.state.pullRequestFilterText
 
     return (
       <BranchDropdown
@@ -1752,6 +1753,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         currentPullRequest={branchesState.currentPullRequest}
         isLoadingPullRequests={branchesState.isLoadingPullRequests}
         branchFilterText={branchFilterText}
+        pullRequestFilterText={pullRequestFilterText}
       />
     )
   }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -37,6 +37,7 @@ interface IBranchesContainerProps {
   readonly recentBranches: ReadonlyArray<Branch>
   readonly pullRequests: ReadonlyArray<PullRequest>
   readonly branchFilterText: string
+  readonly pullRequestFilterText: string
 
   /** The pull request associated with the current branch. */
   readonly currentPullRequest: PullRequest | null
@@ -63,8 +64,8 @@ export class BranchesContainer extends React.Component<
     this.state = {
       selectedBranch: props.currentBranch,
       selectedPullRequest: props.currentPullRequest,
-      pullRequestFilterText: '',
       branchFilterText: props.branchFilterText,
+      pullRequestFilterText: props.pullRequestFilterText,
     }
   }
 
@@ -242,6 +243,7 @@ export class BranchesContainer extends React.Component<
 
   private onPullRequestFilterTextChanged = (text: string) => {
     this.setState({ pullRequestFilterText: text })
+    this.props.dispatcher.setPullRequestFilterText(text)
   }
 
   private onPullRequestSelectionChanged = (

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -36,6 +36,7 @@ interface IBranchesContainerProps {
   readonly currentBranch: Branch | null
   readonly recentBranches: ReadonlyArray<Branch>
   readonly pullRequests: ReadonlyArray<PullRequest>
+  readonly branchFilterText: string
 
   /** The pull request associated with the current branch. */
   readonly currentPullRequest: PullRequest | null
@@ -62,8 +63,8 @@ export class BranchesContainer extends React.Component<
     this.state = {
       selectedBranch: props.currentBranch,
       selectedPullRequest: props.currentPullRequest,
-      branchFilterText: '',
       pullRequestFilterText: '',
+      branchFilterText: props.branchFilterText,
     }
   }
 
@@ -223,6 +224,7 @@ export class BranchesContainer extends React.Component<
 
   private onBranchFilterTextChanged = (text: string) => {
     this.setState({ branchFilterText: text })
+    this.props.dispatcher.setBranchFilterText(text)
   }
 
   private onCreateBranchWithName = (name: string) => {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -225,7 +225,6 @@ export class BranchesContainer extends React.Component<
 
   private onBranchFilterTextChanged = (text: string) => {
     this.setState({ branchFilterText: text })
-    this.props.dispatcher.setBranchFilterText(this.props.repository, text)
   }
 
   private onCreateBranchWithName = (name: string) => {
@@ -243,7 +242,6 @@ export class BranchesContainer extends React.Component<
 
   private onPullRequestFilterTextChanged = (text: string) => {
     this.setState({ pullRequestFilterText: text })
-    this.props.dispatcher.setPullRequestFilterText(this.props.repository, text)
   }
 
   private onPullRequestSelectionChanged = (
@@ -265,5 +263,16 @@ export class BranchesContainer extends React.Component<
     )
 
     this.onPullRequestSelectionChanged(pullRequest)
+  }
+
+  public componentWillUnmount() {
+    this.props.dispatcher.setBranchFilterText(
+      this.props.repository,
+      this.state.branchFilterText
+    )
+    this.props.dispatcher.setPullRequestFilterText(
+      this.props.repository,
+      this.state.pullRequestFilterText
+    )
   }
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -225,7 +225,7 @@ export class BranchesContainer extends React.Component<
 
   private onBranchFilterTextChanged = (text: string) => {
     this.setState({ branchFilterText: text })
-    this.props.dispatcher.setBranchFilterText(text)
+    this.props.dispatcher.setBranchFilterText(this.props.repository, text)
   }
 
   private onCreateBranchWithName = (name: string) => {
@@ -243,7 +243,7 @@ export class BranchesContainer extends React.Component<
 
   private onPullRequestFilterTextChanged = (text: string) => {
     this.setState({ pullRequestFilterText: text })
-    this.props.dispatcher.setPullRequestFilterText(text)
+    this.props.dispatcher.setPullRequestFilterText(this.props.repository, text)
   }
 
   private onPullRequestSelectionChanged = (

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -44,6 +44,9 @@ interface IBranchDropdownProps {
 
   /** Text used to filter the branches list. */
   readonly branchFilterText: string
+
+  /** Text used to filter the pull request list. */
+  readonly pullRequestFilterText: string
 }
 
 /**
@@ -70,6 +73,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
         branchFilterText={this.props.branchFilterText}
+        pullRequestFilterText={this.props.pullRequestFilterText}
       />
     )
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -41,6 +41,9 @@ interface IBranchDropdownProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
+
+  /** Text used to filter the branches list. */
+  readonly branchFilterText: string
 }
 
 /**
@@ -66,6 +69,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         pullRequests={this.props.pullRequests}
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
+        branchFilterText={this.props.branchFilterText}
       />
     )
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -41,12 +41,6 @@ interface IBranchDropdownProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
-
-  /** Text used to filter the branches list. */
-  readonly branchFilterText: string
-
-  /** Text used to filter the pull request list. */
-  readonly pullRequestFilterText: string
 }
 
 /**
@@ -72,8 +66,8 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         pullRequests={this.props.pullRequests}
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
-        branchFilterText={this.props.branchFilterText}
-        pullRequestFilterText={this.props.pullRequestFilterText}
+        branchFilterText={repositoryState.branchFilterText}
+        pullRequestFilterText={repositoryState.pullRequestFilterText}
       />
     )
   }


### PR DESCRIPTION
## Overview


**Closes #6002**

## Description

- Filter text for both the Branches list and Pull Request list will now persist when closing and reopening the drop-down foldout.

Behavior with this change:
![peek 2018-11-04 18-50](https://user-images.githubusercontent.com/4957200/47972668-0a5cb780-e064-11e8-95be-902378032f4f.gif)

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: Branch and Pull Request list filters are retained when re-opening the list foldout.
