### PR TITLE
return commit id from commit and merge operations

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2510,7 +2510,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async isCommitting(
     repository: Repository,
-    fn: () => Promise<boolean | undefined>
+    fn: () => Promise<string | undefined>
   ): Promise<boolean | undefined> {
     const state = this.repositoryStateCache.get(repository)
     // ensure the user doesn't try and commit again
@@ -2524,7 +2524,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     try {
-      return await fn()
+      const sha = await fn()
+      return sha !== undefined
     } finally {
       this.repositoryStateCache.update(repository, () => ({
         isCommitting: false,
@@ -3116,7 +3117,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
-    return await gitStore.performFailableOperation(() =>
+    await gitStore.performFailableOperation(() =>
       createMergeCommit(repository, files)
     )
   }

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -68,6 +68,7 @@ describe('git/commit', () => {
       const commits = await getCommits(repository!, 'HEAD', 100)
       expect(commits.length).toEqual(6)
       expect(commits[0].summary).toEqual('Special commit')
+      expect(commits[0].sha.substring(0, 7)).toEqual(sha)
     })
 
     it('commit does not strip commentary by default', async () => {
@@ -91,6 +92,7 @@ describe('git/commit', () => {
       expect(commit).not.toBeNull()
       expect(commit!.summary).toEqual('Special commit')
       expect(commit!.body).toEqual('# this is a comment\n')
+      expect(commit!.sha.substring(0, 7)).toEqual(sha)
     })
 
     it('can commit for empty repository', async () => {
@@ -182,6 +184,7 @@ describe('git/commit', () => {
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
       expect(newTip.sha).not.toEqual(previousTip.sha)
       expect(newTip.summary).toEqual('title')
+      expect(newTip.sha.substring(0, 7)).toEqual(sha)
 
       // verify that the contents of this new commit are just the new file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
@@ -288,6 +291,7 @@ describe('git/commit', () => {
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
       expect(newTip.sha).not.toEqual(previousTip.sha)
       expect(newTip.summary).toEqual('title')
+      expect(newTip.sha.substring(0, 7)).toEqual(sha)
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
@@ -333,6 +337,7 @@ describe('git/commit', () => {
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
       expect(newTip.sha).not.toEqual(previousTip.sha)
       expect(newTip.summary).toEqual('title')
+      expect(newTip.sha.substring(0, 7)).toEqual(sha)
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
@@ -374,6 +379,7 @@ describe('git/commit', () => {
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
       expect(newTip.sha).not.toEqual(previousTip.sha)
       expect(newTip.summary).toEqual('title')
+      expect(newTip.sha.substring(0, 7)).toEqual(sha)
 
       // verify that the contents of this new commit are just the new file
       const changedFiles = await getChangedFiles(repository!, newTip.sha)
@@ -416,6 +422,7 @@ describe('git/commit', () => {
       const statusAfter = await getStatusOrThrow(repo)
 
       expect(statusAfter.workingDirectory.files.length).toEqual(0)
+      expect(statusAfter.currentTip!.substring(0, 7)).toEqual(sha)
     })
 
     // The scenario here is that the user has staged a rename (probably using git mv)
@@ -491,6 +498,7 @@ describe('git/commit', () => {
 
       const commits = await getCommits(repo, 'HEAD', 5)
       expect(commits[0].parentSHAs.length).toEqual(2)
+      expect(commits[0]!.sha.substring(0, 7)).toEqual(sha)
     })
   })
 
@@ -602,6 +610,7 @@ describe('git/commit', () => {
       const commit = await getCommit(repo, 'HEAD')
       expect(commit).not.toBeNull()
       expect(commit!.summary).toEqual('commit again!')
+      expect(commit!.sha.substring(0, 7)).toEqual(sha)
     })
   })
 })

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -58,7 +58,8 @@ describe('git/commit', () => {
       let files = status.workingDirectory.files
       expect(files.length).toEqual(1)
 
-      await createCommit(repository!, 'Special commit', files)
+      const sha = await createCommit(repository!, 'Special commit', files)
+      expect(sha).toHaveLength(7)
 
       status = await getStatusOrThrow(repository!)
       files = status.workingDirectory.files
@@ -83,7 +84,8 @@ describe('git/commit', () => {
 
 # this is a comment`
 
-      await createCommit(repository!, message, files)
+      const sha = await createCommit(repository!, message, files)
+      expect(sha).toHaveLength(7)
 
       const commit = await getCommit(repository!, 'HEAD')
       expect(commit).not.toBeNull()
@@ -107,11 +109,12 @@ describe('git/commit', () => {
         files[1].withIncludeAll(true),
       ]
 
-      await createCommit(
+      const sha = await createCommit(
         repo,
         'added two files\n\nthis is a description',
         allChanges
       )
+      expect(sha).toEqual('(root-commit)')
 
       const statusAfter = await getStatusOrThrow(repo)
 
@@ -138,9 +141,10 @@ describe('git/commit', () => {
 
       expect(files.length).toEqual(1)
 
-      await createCommit(repo, 'renamed a file', [
+      const sha = await createCommit(repo, 'renamed a file', [
         files[0].withIncludeAll(true),
       ])
+      expect(sha).toHaveLength(7)
 
       const statusAfter = await getStatusOrThrow(repo)
 
@@ -171,7 +175,8 @@ describe('git/commit', () => {
       )
 
       // commit just this change, ignore everything else
-      await createCommit(repository!, 'title', [file])
+      const sha = await createCommit(repository!, 'title', [file])
+      expect(sha).toHaveLength(7)
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
@@ -222,7 +227,8 @@ describe('git/commit', () => {
       const updatedFile = file.withSelection(selection)
 
       // commit just this change, ignore everything else
-      await createCommit(repository!, 'title', [updatedFile])
+      const sha = await createCommit(repository!, 'title', [updatedFile])
+      expect(sha).toHaveLength(7)
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
@@ -275,7 +281,8 @@ describe('git/commit', () => {
       )
 
       // commit just this change, ignore everything else
-      await createCommit(repository!, 'title', [file])
+      const sha = await createCommit(repository!, 'title', [file])
+      expect(sha).toHaveLength(7)
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
@@ -319,7 +326,8 @@ describe('git/commit', () => {
       )
 
       // commit just this change, ignore everything else
-      await createCommit(repository!, 'title', [updatedFile])
+      const sha = await createCommit(repository!, 'title', [updatedFile])
+      expect(sha).toHaveLength(7)
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
@@ -359,7 +367,8 @@ describe('git/commit', () => {
       )
 
       // commit just this change, ignore everything else
-      await createCommit(repository!, 'title', [file])
+      const sha = await createCommit(repository!, 'title', [file])
+      expect(sha).toHaveLength(7)
 
       // verify that the HEAD of the repository has moved
       const newTip = (await getCommits(repository!, 'HEAD', 1))[0]
@@ -399,9 +408,10 @@ describe('git/commit', () => {
 
       expect(files.length).toEqual(1)
 
-      await createCommit(repo, 'renamed a file', [
+      const sha = await createCommit(repo, 'renamed a file', [
         files[0].withIncludeAll(true),
       ])
+      expect(sha).toHaveLength(7)
 
       const statusAfter = await getStatusOrThrow(repo)
 
@@ -435,7 +445,10 @@ describe('git/commit', () => {
 
       const partiallySelectedFile = files[0].withSelection(selection)
 
-      await createCommit(repo, 'renamed a file', [partiallySelectedFile])
+      const sha = await createCommit(repo, 'renamed a file', [
+        partiallySelectedFile,
+      ])
+      expect(sha).toHaveLength(7)
 
       const statusAfter = await getStatusOrThrow(repo)
 
@@ -473,7 +486,8 @@ describe('git/commit', () => {
 
       const selection = files[0].selection.withSelectAll()
       const selectedFile = files[0].withSelection(selection)
-      await createCommit(repo, 'Merge commit!', [selectedFile])
+      const sha = await createCommit(repo, 'Merge commit!', [selectedFile])
+      expect(sha).toHaveLength(7)
 
       const commits = await getCommits(repo, 'HEAD', 5)
       expect(commits[0].parentSHAs.length).toEqual(2)
@@ -488,8 +502,12 @@ describe('git/commit', () => {
       })
       it('creates a merge commit', async () => {
         const status = await getStatusOrThrow(repository)
-        await createMergeCommit(repository, status.workingDirectory.files)
+        const sha = await createMergeCommit(
+          repository,
+          status.workingDirectory.files
+        )
         const newStatus = await getStatusOrThrow(repository)
+        expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(0)
       })
     })
@@ -537,7 +555,8 @@ describe('git/commit', () => {
 
       const toCommit = status.workingDirectory.withIncludeAllFiles(true)
 
-      await createCommit(repo, 'commit everything', toCommit.files)
+      const sha = await createCommit(repo, 'commit everything', toCommit.files)
+      expect(sha).toEqual('(root-commit)')
 
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files
@@ -573,7 +592,8 @@ describe('git/commit', () => {
 
       const toCommit = status!.workingDirectory.withIncludeAllFiles(true)
 
-      await createCommit(repo, 'commit again!', toCommit.files)
+      const sha = await createCommit(repo, 'commit again!', toCommit.files)
+      expect(sha).toHaveLength(7)
 
       status = await getStatusOrThrow(repo)
       files = status.workingDirectory.files


### PR DESCRIPTION
## Overview
Have `createCommit` and `createMergeCommit` return SHAs instead of boolean or null.

**Closes #5923**

## Description
- Have `createCommit` and `createMergeCommit` return SHAs instead of boolean or null.
- Add Unit Tests

## Release notes

Notes: No notes
