### PR TITLE
address React runtime error

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -67,11 +67,14 @@ export class BranchesContainer extends React.Component<
     }
   }
 
-  public render() {
-    const branchName = this.props.currentBranch
+  private getBranchName = (): string => {
+    return this.props.currentBranch
       ? this.props.currentBranch.name
       : this.props.defaultBranch || 'master'
+  }
 
+  public render() {
+    const branchName = this.getBranchName()
     return (
       <div className="branches-container">
         {this.renderTabBar()}


### PR DESCRIPTION
## Overview

I found this while testing `master` with a fresh repository in a detached HEAD state and trying to open the branch selector:

```
error: [main] Invariant Violation: Objects are not valid as a React child (found: object with keys {name, upstream, tip, type}). If you meant to render a collection of children, use an array instead.
    in strong (created by BranchesContainer)
    in span (created by BranchesContainer)
    in button (created by Button)
    in Button (created by BranchesContainer)
    in div (created by Row)
    in Row (created by BranchesContainer)
    in div (created by BranchesContainer)
    ...
```


## Description

The root cause of the issue is this line:

```tsx
              Choose a branch to merge into <strong>{branchName}</strong>
```

`branchName` is defined like this:

```ts
  const branchName = this.props.currentBranch
      ? this.props.currentBranch.name
      : this.props.defaultBranch || 'master'
```

I believe the goal here was to define `branchName` as a string, but `defaultBranch` is a `Branch` object, which means `branchName` is `string | Branch`, and React doesn't know how to render this object and crashes hard.

 - [x] extract function and confirm compiler error
 - [ ] rewrite function to be more readable and ensure it always returns a `string`

## Release notes

This was introduced in #5977 and is shipped in the 1.5.0 betas but not available in production yet.

Notes: no-notes
