### PR TITLE
ensure creating branch with detached HEAD does not revert to default branch

### DIFF
--- a/app/src/lib/create-branch.ts
+++ b/app/src/lib/create-branch.ts
@@ -1,0 +1,35 @@
+import { TipState, Tip } from '../models/tip'
+import { StartPoint, Branch } from '../models/branch'
+
+type BranchInfo = {
+  readonly tip: Tip
+  readonly defaultBranch: Branch | null
+}
+
+export function getStartPoint(
+  props: BranchInfo,
+  preferred: StartPoint
+): StartPoint {
+  if (preferred === StartPoint.DefaultBranch && props.defaultBranch) {
+    return preferred
+  }
+
+  if (
+    preferred === StartPoint.CurrentBranch &&
+    props.tip.kind === TipState.Valid
+  ) {
+    return preferred
+  }
+
+  if (preferred === StartPoint.Head) {
+    return preferred
+  }
+
+  if (props.defaultBranch) {
+    return StartPoint.DefaultBranch
+  } else if (props.tip.kind === TipState.Valid) {
+    return StartPoint.CurrentBranch
+  } else {
+    return StartPoint.Head
+  }
+}

--- a/app/src/lib/create-branch.ts
+++ b/app/src/lib/create-branch.ts
@@ -10,6 +10,10 @@ export function getStartPoint(
   props: BranchInfo,
   preferred: StartPoint
 ): StartPoint {
+  if (props.tip.kind === TipState.Detached) {
+    return StartPoint.Head
+  }
+
   if (preferred === StartPoint.DefaultBranch && props.defaultBranch) {
     return preferred
   }

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -19,6 +19,13 @@ export interface ICompareResult extends IAheadBehind {
   readonly commits: ReadonlyArray<Commit>
 }
 
+/** Default rules for where to create a branch from */
+export enum StartPoint {
+  CurrentBranch = 'CurrentBranch',
+  DefaultBranch = 'DefaultBranch',
+  Head = 'Head',
+}
+
 /**
  * Check if a branch is eligible for beign fast forarded.
  *

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../../lib/dispatcher'
 import { sanitizedBranchName } from '../../lib/sanitize-branch'
-import { Branch } from '../../models/branch'
+import { Branch, StartPoint } from '../../models/branch'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Ref } from '../lib/ref'
@@ -23,6 +23,7 @@ import {
   renderBranchNameWarning,
   renderBranchNameExistsOnRemoteWarning,
 } from '../lib/branch-name-warnings'
+import { getStartPoint } from '../../lib/create-branch'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -32,12 +33,6 @@ interface ICreateBranchProps {
   readonly defaultBranch: Branch | null
   readonly allBranches: ReadonlyArray<Branch>
   readonly initialName: string
-}
-
-enum StartPoint {
-  CurrentBranch,
-  DefaultBranch,
-  Head,
 }
 
 interface ICreateBranchState {
@@ -78,34 +73,6 @@ interface ICreateBranchState {
 enum SelectedBranch {
   DefaultBranch = 0,
   CurrentBranch = 1,
-}
-
-function getStartPoint(
-  props: ICreateBranchProps,
-  preferred: StartPoint
-): StartPoint {
-  if (preferred === StartPoint.DefaultBranch && props.defaultBranch) {
-    return preferred
-  }
-
-  if (
-    preferred === StartPoint.CurrentBranch &&
-    props.tip.kind === TipState.Valid
-  ) {
-    return preferred
-  }
-
-  if (preferred === StartPoint.Head) {
-    return preferred
-  }
-
-  if (props.defaultBranch) {
-    return StartPoint.DefaultBranch
-  } else if (props.tip.kind === TipState.Valid) {
-    return StartPoint.CurrentBranch
-  } else {
-    return StartPoint.Head
-  }
 }
 
 /** The Create Branch component. */

--- a/app/test/unit/create-branch-test.ts
+++ b/app/test/unit/create-branch-test.ts
@@ -1,0 +1,114 @@
+import { getStartPoint } from '../../src/lib/create-branch'
+import { TipState, IValidBranch, IDetachedHead } from '../../src/models/tip'
+import { BranchType, StartPoint } from '../../src/models/branch'
+
+const stubAuthor = {
+  name: 'Brendan Forster',
+  email: 'brendan@example.com',
+  date: new Date(),
+  tzOffset: 0,
+}
+
+const stubTip = {
+  sha: 'deadbeef',
+  summary: 'some commit',
+  body: '',
+  coAuthors: [],
+  author: stubAuthor,
+  committer: stubAuthor,
+  authoredByCommitter: true,
+  parentSHAs: [],
+  trailers: [],
+  isWebFlowCommitter: false,
+}
+
+const defaultBranch = {
+  name: 'my-default-branch',
+  upstream: null,
+  tip: stubTip,
+  type: BranchType.Local,
+  remote: null,
+  upstreamWithoutRemote: null,
+  nameWithoutRemote: 'my-default-branch',
+}
+
+const someOtherBranch = {
+  name: 'some-other-branch',
+  upstream: null,
+  tip: stubTip,
+  type: BranchType.Local,
+  remote: null,
+  upstreamWithoutRemote: null,
+  nameWithoutRemote: 'some-other-branch',
+}
+
+describe('create-branch/getStartPoint', () => {
+  describe('for default branch', () => {
+    const tip: IValidBranch = {
+      kind: TipState.Valid,
+      branch: defaultBranch,
+    }
+
+    const action = (startPoint: StartPoint) => {
+      return getStartPoint({ tip, defaultBranch }, startPoint)
+    }
+
+    it('returns current HEAD when HEAD requested', () => {
+      expect(action(StartPoint.Head)).toBe(StartPoint.Head)
+    })
+
+    it('chooses current branch when current branch requested', () => {
+      expect(action(StartPoint.CurrentBranch)).toBe(StartPoint.CurrentBranch)
+    })
+
+    it('chooses default branch when default branch requested', () => {
+      expect(action(StartPoint.DefaultBranch)).toBe(StartPoint.DefaultBranch)
+    })
+  })
+
+  describe('for a non-default branch', () => {
+    const tip: IValidBranch = {
+      kind: TipState.Valid,
+      branch: someOtherBranch,
+    }
+
+    const action = (startPoint: StartPoint) => {
+      return getStartPoint({ tip, defaultBranch }, startPoint)
+    }
+
+    it('returns current HEAD when HEAD requested', () => {
+      expect(action(StartPoint.Head)).toBe(StartPoint.Head)
+    })
+
+    it('chooses current branch when current branch requested', () => {
+      expect(action(StartPoint.CurrentBranch)).toBe(StartPoint.CurrentBranch)
+    })
+
+    it('chooses default branch when default branch requested', () => {
+      expect(action(StartPoint.DefaultBranch)).toBe(StartPoint.DefaultBranch)
+    })
+  })
+
+  describe('for detached HEAD', () => {
+    const tip: IDetachedHead = {
+      kind: TipState.Detached,
+      currentSha: 'deadbeef',
+    }
+
+    const action = (startPoint: StartPoint) => {
+      return getStartPoint({ tip, defaultBranch }, startPoint)
+    }
+
+    it('returns current HEAD when HEAD requested', () => {
+      expect(action(StartPoint.Head)).toBe(StartPoint.Head)
+    })
+
+    it('returns current HEAD when current branch requested', () => {
+      expect(action(StartPoint.CurrentBranch)).toBe(StartPoint.DefaultBranch)
+    })
+
+    it('returns current HEAD when default branch requested', () => {
+      expect(action(StartPoint.DefaultBranch)).toBe(StartPoint.DefaultBranch)
+    })
+  })
+})

--- a/app/test/unit/create-branch-test.ts
+++ b/app/test/unit/create-branch-test.ts
@@ -104,11 +104,11 @@ describe('create-branch/getStartPoint', () => {
     })
 
     it('returns current HEAD when current branch requested', () => {
-      expect(action(StartPoint.CurrentBranch)).toBe(StartPoint.DefaultBranch)
+      expect(action(StartPoint.CurrentBranch)).toBe(StartPoint.Head)
     })
 
     it('returns current HEAD when default branch requested', () => {
-      expect(action(StartPoint.DefaultBranch)).toBe(StartPoint.DefaultBranch)
+      expect(action(StartPoint.DefaultBranch)).toBe(StartPoint.Head)
     })
   })
 })


### PR DESCRIPTION
## Overview

~~🌵🌵🌵🌵 **Builds upon #6100, go review that first**  🌵🌵🌵🌵~~

**Closes #6085**

## Description

This PR does a few things around the original bug:

- extract function from inside component - 6fc99d6
- wrap it in tests to catch regressions  - a599356
- make the tests fail so that we can see the bug - 87ec4b1
- finally, fix the bug by respecting when the repository is in detached HEAD - e463cd4


## TODO

 - [x] rebase branch on `master` once #6100 is merged

## Release notes

Notes: Creating a branch when in detached HEAD state no longer reverts to using the default branch
