### PR TITLE
avoid resolving conflicts using "Open in External Editor" flow if no editors found

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -163,6 +163,16 @@ export interface IAppState {
   /** The external editor to use when opening repositories */
   readonly selectedExternalEditor?: ExternalEditor
 
+  /**
+   * A cached entry representing an external editor found on the user's machine:
+   *
+   *  - If the `selectedExternalEditor` can be found, choose that
+   *  - Otherwise, if any editors found, this will be set to the first value
+   *    based on the search order in `app/src/lib/editors/{platform}.ts`
+   *  - If no editors found, this will remain `null`
+   */
+  readonly resolvedExternalEditor: ExternalEditor | null
+
   /** What type of visual diff mode we should use to compare images */
   readonly imageDiffType: ImageDiffType
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1241,6 +1241,10 @@ export class Dispatcher {
     return this.appStore._updateCompareForm(repository, newState)
   }
 
+  public resolveCurrentEditor() {
+    return this.appStore._resolveCurrentEditor()
+  }
+
   /**
    * Updates the application state to indicate a conflict is in-progress
    * as a result of a pull and increments the relevant metric.

--- a/app/src/lib/editors/lookup.ts
+++ b/app/src/lib/editors/lookup.ts
@@ -49,14 +49,11 @@ export async function getAvailableEditors(): Promise<
  * be found (i.e. it has been removed).
  */
 export async function findEditorOrDefault(
-  name: string | null
-): Promise<IFoundEditor<ExternalEditor>> {
+  name?: string
+): Promise<IFoundEditor<ExternalEditor> | null> {
   const editors = await getAvailableEditors()
   if (editors.length === 0) {
-    throw new ExternalEditorError(
-      'No suitable editors installed for GitHub Desktop to launch. Install Atom for your platform and restart GitHub Desktop to try again.',
-      { suggestAtom: true }
-    )
+    return null
   }
 
   if (name) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -271,6 +271,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private selectedExternalEditor?: ExternalEditor
 
+  private resolvedExternalEditor: ExternalEditor | null = null
+
   /** The user's preferred shell. */
   private selectedShell = DefaultShell
 
@@ -499,6 +501,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       imageDiffType: this.imageDiffType,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
+      resolvedExternalEditor: this.resolvedExternalEditor,
       selectedCloneRepositoryTab: this.selectedCloneRepositoryTab,
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4026,6 +4026,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return Promise.resolve()
   }
+
+  public async _resolveCurrentEditor() {
+    const match = await findEditorOrDefault(this.selectedExternalEditor)
+    const resolvedExternalEditor = match != null ? match.editor : null
+    if (this.resolvedExternalEditor != resolvedExternalEditor) {
+      this.resolvedExternalEditor = resolvedExternalEditor
+      this.emitUpdate()
+    }
+  }
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4030,7 +4030,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _resolveCurrentEditor() {
     const match = await findEditorOrDefault(this.selectedExternalEditor)
     const resolvedExternalEditor = match != null ? match.editor : null
-    if (this.resolvedExternalEditor != resolvedExternalEditor) {
+    if (this.resolvedExternalEditor !== resolvedExternalEditor) {
       this.resolvedExternalEditor = resolvedExternalEditor
       this.emitUpdate()
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1358,7 +1358,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               status={workingDirectoryStatus}
               onDismissed={this.onPopupDismissed}
               openFileInExternalEditor={this.openFileInExternalEditor}
-              externalEditorName={this.state.selectedExternalEditor}
+              selectedExternalEditor={this.state.selectedExternalEditor}
               openRepositoryInShell={this.openInShell}
               ourBranch={popup.ourBranch}
               theirBranch={popup.theirBranch}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1356,7 +1356,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               workingDirectory={workingDirectory}
               onDismissed={this.onPopupDismissed}
               openFileInExternalEditor={this.openFileInExternalEditor}
-              selectedExternalEditor={this.state.selectedExternalEditor}
+              resolvedExternalEditor={this.state.resolvedExternalEditor}
               openRepositoryInShell={this.openInShell}
               ourBranch={popup.ourBranch}
               theirBranch={popup.theirBranch}

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -65,7 +65,7 @@ export class MergeConflictsDialog extends React.Component<
   IMergeConflictsDialogProps,
   IMergeConflictsDialogState
 > {
-  constructor(props: IMergeConflictsDialogProps) {
+  public constructor(props: IMergeConflictsDialogProps) {
     super(props)
 
     this.state = { foundExternalEditor: null }

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -17,7 +17,6 @@ import { PathText } from '../lib/path-text'
 import { DialogHeader } from '../dialog/header'
 import { ConflictFileStatus } from '../../models/conflicts'
 import { LinkButton } from '../lib/link-button'
-import { findEditorOrDefault } from '../../lib/editors'
 
 interface IMergeConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -25,15 +24,11 @@ interface IMergeConflictsDialogProps {
   readonly workingDirectory: WorkingDirectoryStatus
   readonly onDismissed: () => void
   readonly openFileInExternalEditor: (path: string) => void
-  readonly selectedExternalEditor?: string
+  readonly resolvedExternalEditor: string | null
   readonly openRepositoryInShell: (repository: Repository) => void
   readonly ourBranch: string
   /* `undefined` when we didn't know the branch at the beginning of this flow */
   readonly theirBranch?: string
-}
-
-interface IMergeConflictsDialogState {
-  readonly foundExternalEditor: string | null
 }
 
 /**
@@ -199,9 +194,9 @@ export class MergeConflictsDialog extends React.Component<
           ? `1 conflict`
           : `${humanReadableConflicts} conflicts`
 
-      const disabled = this.state.foundExternalEditor === null
+      const disabled = this.props.resolvedExternalEditor === null
 
-      const tooltip = editorButtonTooltip(this.state.foundExternalEditor)
+      const tooltip = editorButtonTooltip(this.props.resolvedExternalEditor)
 
       return (
         <li className="unmerged-file-status-conflicts">
@@ -215,7 +210,7 @@ export class MergeConflictsDialog extends React.Component<
             disabled={disabled}
             tooltip={tooltip}
           >
-            {editorButtonString(this.state.foundExternalEditor)}
+            {editorButtonString(this.props.resolvedExternalEditor)}
           </Button>
         </li>
       )

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -55,6 +55,24 @@ function getUnmergedFiles(status: WorkingDirectoryStatus) {
   )
 }
 
+function editorButtonString(editorName: string | null): string {
+  const defaultEditorString = 'editor'
+  return `Open in ${editorName || defaultEditorString}`
+}
+
+function editorButtonTooltip(editorName: string | null): string | undefined {
+  if (editorName !== null) {
+    // no need to render a tooltip if we have a known editor
+    return
+  }
+
+  if (__DARWIN__) {
+    return `No editor configured in Preferences > Advanced`
+  } else {
+    return `No editor configured in Options > Advanced`
+  }
+}
+
 const submitButtonString = 'Commit merge'
 const cancelButtonString = 'Abort merge'
 
@@ -133,11 +151,6 @@ export class MergeConflictsDialog extends React.Component<
     )
   }
 
-  private editorButtonString(editorName: string | undefined) {
-    const defaultEditorString = 'editor'
-    return `Open in ${editorName || defaultEditorString}`
-  }
-
   private openThisRepositoryInShell = () =>
     this.props.openRepositoryInShell(this.props.repository)
 
@@ -182,12 +195,9 @@ export class MergeConflictsDialog extends React.Component<
           ? `1 conflict`
           : `${humanReadableConflicts} conflicts`
 
-      const button =
-        this.state.foundExternalEditor != null ? (
-          <Button onClick={onOpenEditorClick}>
-            {this.editorButtonString(this.state.foundExternalEditor)}
-          </Button>
-        ) : null
+      const disabled = this.state.foundExternalEditor === null
+
+      const tooltip = editorButtonTooltip(this.state.foundExternalEditor)
 
       return (
         <li className="unmerged-file-status-conflicts">
@@ -196,7 +206,13 @@ export class MergeConflictsDialog extends React.Component<
             <PathText path={path} availableWidth={200} />
             <div className="file-conflicts-status">{message}</div>
           </div>
-          {button}
+          <Button
+            onClick={onOpenEditorClick}
+            disabled={disabled}
+            tooltip={tooltip}
+          >
+            {editorButtonString(this.state.foundExternalEditor)}
+          </Button>
         </li>
       )
     }

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -76,18 +76,10 @@ const cancelButtonString = 'Abort merge'
  */
 export class MergeConflictsDialog extends React.Component<
   IMergeConflictsDialogProps,
-  IMergeConflictsDialogState
+  {}
 > {
-  public constructor(props: IMergeConflictsDialogProps) {
-    super(props)
-
-    this.state = { foundExternalEditor: null }
-  }
-
   public async componentDidMount() {
-    const match = await findEditorOrDefault(this.props.selectedExternalEditor)
-    const foundExternalEditor = match != null ? match.editor : null
-    this.setState({ foundExternalEditor })
+    this.props.dispatcher.resolveCurrentEditor()
   }
 
   /**


### PR DESCRIPTION
## Overview

**Closes #6060**

## Description

- [x] lift error out of `findEditorOrDefault`, make `App` responsible for that, and return `null` if no editors can be found
 - [x] update `MergeConflictsDialog` to resolve the editor after mounting, and not show the button if the editor cannot be found
 - [x] test happy path when an editor can be found -> user can resolve conflicts in editor
 - [x] test sad path when not editors can be found  -> buttons are disabled

## Release notes

This is related to a new feature that hasn't yet made it to production

Notes: no-notes
