### PR TITLE
Spacing and timing tweaks

### DIFF
--- a/app/src/ui/banners/successful-merge.tsx
+++ b/app/src/ui/banners/successful-merge.tsx
@@ -39,7 +39,7 @@ export class SuccessfulMerge extends React.Component<
   public componentDidMount = () => {
     this.timeoutId = setTimeout(() => {
       this.dismiss()
-    }, 3250)
+    }, 5000)
   }
 
   public componentWillUnmount = () => {

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -4,14 +4,14 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  width: 300px;
+  width: 350px;
 
   & > .tab-bar {
     border-top: var(--base-border);
   }
 
   .branches-list {
-    width: 300px;
+    width: 350px;
   }
 }
 

--- a/app/styles/ui/banners/_successful-merge.scss
+++ b/app/styles/ui/banners/_successful-merge.scss
@@ -46,6 +46,11 @@
     flex-grow: 0;
   }
 
+  .check-icon {
+    height: 12px;
+    width: 12px;
+  }
+
   .close {
     display: flex;
     flex-shrink: 0;

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -38,7 +38,7 @@ dialog#merge-conflicts-list {
     }
 
     li:last-of-type {
-      margin-bottom: calc(var(--spacing) * 5);
+      margin-bottom: calc(var(--spacing) * 2);
     }
 
     li.unmerged-file-status-resolved,
@@ -66,6 +66,7 @@ dialog#merge-conflicts-list {
       button:last-child,
       .green-circle:last-child {
         margin-left: auto;
+        margin-top: var(--spacing);
         flex-shrink: 0;
         flex: 0 1 auto;
       }


### PR DESCRIPTION
This addresses a few small changes in bulk

Adjustments to the success banner:
- Slows down the success banner dismissing (Closes #6106)
- Decrease size of check icon (Also closes #6106)

_Following up on animation in a separate PR_

![kapture 2018-11-06 at 12 58 06](https://user-images.githubusercontent.com/10404068/48093378-0ba4f600-e1c4-11e8-8f7d-9bec96a3ac78.gif)


Spacing adjustments on conflicts dialog

![screen shot 2018-11-06 at 11 21 43 am](https://user-images.githubusercontent.com/10404068/48093414-18c1e500-e1c4-11e8-91d3-f7a48a39f099.png)


Widen branch menu (Closes #6099)

<img src="https://user-images.githubusercontent.com/10404068/48093430-1f505c80-e1c4-11e8-9165-9f670149a7f5.png" width="300" />


cc @donokuda @billygriffin @outofambit @tierninho 
