### PR TITLE
use getStatus to detect conflicted repository state

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -223,8 +223,9 @@ export enum RepositorySectionTab {
 /**
  * Stores information about a merge conflict when it occurs
  */
-interface IConflictState {
-  readonly branch: Branch
+export interface IConflictState {
+  readonly currentBranch: string
+  readonly currentTip: string
 }
 
 export interface IRepositoryState {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1234,7 +1234,6 @@ export class Dispatcher {
    * as a result of a pull and increments the relevant metric.
    */
   public mergeConflictDetectedFromPull() {
-    this.appStore._mergeConflictDetected()
     return this.statsStore.recordMergeConflictFromPull()
   }
 
@@ -1243,7 +1242,6 @@ export class Dispatcher {
    * as a result of a merge and increments the relevant metric.
    */
   public mergeConflictDetectedFromExplicitMerge() {
-    this.appStore._mergeConflictDetected()
     return this.statsStore.recordMergeConflictFromExplicitMerge()
   }
 

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -1341,18 +1341,4 @@ export class Dispatcher {
   public recordAddExistingRepository() {
     this.statsStore.recordAddExistingRepository()
   }
-
-  /**
-   * Increments the `recordMergeSuccesfulAfterConflicts` metric
-   */
-  public recordMergeSuccesfulAfterConflicts() {
-    return this.statsStore.recordMergeSuccesAfterConflicts()
-  }
-
-  /**
-   * Increments the `recordMergeAbortedAfterConflicts` metric
-   */
-  public recordMergeAbortedAfterConflicts() {
-    return this.statsStore.recordMergeAbortedAfterConflicts()
-  }
 }

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -1,3 +1,6 @@
+import * as FSE from 'fs-extra'
+import * as Path from 'path'
+
 import { git } from './core'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
@@ -89,4 +92,13 @@ export async function mergeTree(
  */
 export async function abortMerge(repository: Repository): Promise<void> {
   await git(['merge', '--abort'], repository.path, 'abortMerge')
+}
+
+/**
+ * Check the `.git/MERGE_HEAD` file exists in a repository to confirm
+ * that it is in a conflicted state.
+ */
+export async function isMergeHeadSet(repository: Repository): Promise<boolean> {
+  const path = Path.join(repository.path, '.git', 'MERGE_HEAD')
+  return FSE.pathExists(path)
 }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -26,6 +26,7 @@ import {
   ConflictFileStatus,
   ConflictedFile,
 } from '../../models/conflicts'
+import { isMergeHeadSet } from './merge'
 
 /**
  * V8 has a limit on the size of string it can create (~256MB), and unless we want to
@@ -53,6 +54,9 @@ export interface IStatusResult {
 
   /** true if the repository exists at the given location */
   readonly exists: boolean
+
+  /** true if repository is in a conflicted state */
+  readonly mergeHeadFound: boolean
 
   /** the absolute path to the repository's working directory */
   readonly workingDirectory: WorkingDirectoryStatus
@@ -217,12 +221,15 @@ export async function getStatus(
 
   const workingDirectory = WorkingDirectoryStatus.fromFiles([...files.values()])
 
+  const mergeHeadFound = await isMergeHeadSet(repository)
+
   return {
     currentBranch,
     currentTip,
     currentUpstreamBranch,
     branchAheadBehind,
     exists: true,
+    mergeHeadFound,
     workingDirectory,
   }
 }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -711,7 +711,7 @@ export class StatsStore {
   }
 
   /** Record when a conflicted merge was successfully completed by the user */
-  public async recordMergeSuccesAfterConflicts(): Promise<void> {
+  public async recordMergeSuccessAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeSuccessAfterConflictsCount: m.mergeSuccessAfterConflictsCount + 1,
     }))

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4048,6 +4048,9 @@ function getBehindOrDefault(aheadBehind: IAheadBehind | null): number {
   return aheadBehind.behind
 }
 
+/**
+ * Convert the received status information into a conflict state
+ */
 function getConflictState(status: IStatusResult): IConflictState | null {
   if (!status.mergeHeadFound) {
     return null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1564,7 +1564,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         currentBranchName != null &&
         previousBranchName !== currentBranchName
 
-      // The branch name has changed -> the merge must have been aborted
+      // The branch name has changed while remaining conflicted -> the merge must have been aborted
       if (branchNameChanged) {
         this.statsStore.recordMergeAbortedAfterConflicts()
         return { conflictState: newConflictState }
@@ -1572,7 +1572,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       const previousTip =
         prevConflictState != null ? prevConflictState.currentTip : null
-      const currentTip = status.currentTip
+      const { currentTip } = status
 
       const tipChanged =
         previousTip != null && currentTip != null && previousTip !== currentTip

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1581,7 +1581,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // the repository is no longer conflicted, what do we think happened?
         if (tipChanged) {
           // the tip has changed -> merge conflict created
-          this.statsStore.recordMergeSuccesAfterConflicts()
+          this.statsStore.recordMergeSuccessAfterConflicts()
         } else {
           // the tip has not changed -> merge conflict aborted
           this.statsStore.recordMergeAbortedAfterConflicts()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4016,35 +4016,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return Promise.resolve()
   }
-
-  /**
-   * Sets conflict state with a non-null value
-   *
-   * The presence of a non-null value signifies
-   * that the repository is in a conflicted state
-   */
-  public _mergeConflictDetected() {
-    const selection = this.getSelectedState()
-
-    if (selection === null || selection.type !== SelectionType.Repository) {
-      return
-    }
-
-    const { tip } = selection.state.branchesState
-
-    if (tip.kind !== TipState.Valid) {
-      return
-    }
-
-    const repository = selection.repository
-
-    this.repositoryStateCache.updateChangesState(repository, () => ({
-      conflictState: {
-        branch: tip.branch,
-      },
-    }))
-    this.emitUpdate()
-  }
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1548,16 +1548,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoryStateCache.updateChangesState(repository, state => {
       const prevConflictState = state.conflictState
-      const newConflictStatus = getConflictStatus(status)
+      const newConflictState = getConflictState(status)
 
-      if (prevConflictState == null && newConflictStatus == null) {
+      if (prevConflictState == null && newConflictState == null) {
         return { conflictState: null }
       }
 
       const previousBranchName =
         prevConflictState != null ? prevConflictState.currentBranch : null
       const currentBranchName =
-        newConflictStatus != null ? newConflictStatus.currentBranch : null
+        newConflictState != null ? newConflictState.currentBranch : null
 
       const branchNameChanged =
         previousBranchName != null &&
@@ -1572,7 +1572,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const previousTip =
         prevConflictState != null ? prevConflictState.currentTip : null
       const currentTip =
-        newConflictStatus != null ? newConflictStatus.currentTip : null
+        newConflictState != null ? newConflictState.currentTip : null
 
       const tipChanged =
         previousTip != null && currentTip != null && previousTip !== currentTip
@@ -1586,7 +1586,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordMergeSuccesAfterConflicts()
       }
 
-      return { conflictState: newConflictStatus }
+      return { conflictState: newConflictState }
     })
 
     this._triggerMergeConflictsFlow(repository)
@@ -4048,17 +4048,13 @@ function getBehindOrDefault(aheadBehind: IAheadBehind | null): number {
   return aheadBehind.behind
 }
 
-function getConflictStatus(status: IStatusResult): IConflictState | null {
+function getConflictState(status: IStatusResult): IConflictState | null {
   if (!status.mergeHeadFound) {
     return null
   }
 
   const { currentBranch, currentTip } = status
-  if (currentBranch == null) {
-    return null
-  }
-
-  if (currentTip == null) {
+  if (currentBranch == null || currentTip == null) {
     return null
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1570,20 +1570,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return { conflictState: newConflictState }
       }
 
-      const previousTip =
-        prevConflictState != null ? prevConflictState.currentTip : null
       const { currentTip } = status
 
-      const tipChanged =
-        previousTip != null && currentTip != null && previousTip !== currentTip
+      // if the repository is no longer conflicted, what do we think happened?
+      if (
+        prevConflictState != null &&
+        newConflictState == null &&
+        currentTip != null
+      ) {
+        const previousTip = prevConflictState.currentTip
 
-      if (prevConflictState != null && newConflictState == null) {
-        // the repository is no longer conflicted, what do we think happened?
-        if (tipChanged) {
-          // the tip has changed -> merge conflict created
+        if (previousTip !== currentTip) {
           this.statsStore.recordMergeSuccessAfterConflicts()
         } else {
-          // the tip has not changed -> merge conflict aborted
           this.statsStore.recordMergeAbortedAfterConflicts()
         }
       }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1564,26 +1564,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
         currentBranchName != null &&
         previousBranchName !== currentBranchName
 
-      // The branch name has changed, so the merge must have been aborted
+      // The branch name has changed -> the merge must have been aborted
       if (branchNameChanged) {
         this.statsStore.recordMergeAbortedAfterConflicts()
+        return { conflictState: newConflictState }
       }
 
       const previousTip =
         prevConflictState != null ? prevConflictState.currentTip : null
-      const currentTip =
-        newConflictState != null ? newConflictState.currentTip : null
+      const currentTip = status.currentTip
 
       const tipChanged =
         previousTip != null && currentTip != null && previousTip !== currentTip
 
-      // TODO: what are we actually trying to do?
-
-      if (!tipChanged) {
-        // if the tip is the same, no merge commit was created
-        this.statsStore.recordMergeAbortedAfterConflicts()
-      } else {
-        this.statsStore.recordMergeSuccesAfterConflicts()
+      if (prevConflictState != null && newConflictState == null) {
+        // the repository is no longer conflicted, what do we think happened?
+        if (tipChanged) {
+          // the tip has changed -> merge conflict created
+          this.statsStore.recordMergeSuccesAfterConflicts()
+        } else {
+          // the tip has not changed -> merge conflict aborted
+          this.statsStore.recordMergeAbortedAfterConflicts()
+        }
       }
 
       return { conflictState: newConflictState }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1339,15 +1339,13 @@ export class App extends React.Component<IAppProps, IAppState> {
           ) {
             return null
           }
-          const workingDirectoryStatus =
-            selectedState.state.changesState.workingDirectory
-          // double check that this repository is actually in merge
-          const isInConflictedMerge = workingDirectoryStatus.files.some(
-            file =>
-              file.status === AppFileStatus.Conflicted ||
-              file.status === AppFileStatus.Resolved
-          )
-          if (!isInConflictedMerge) {
+
+          const {
+            workingDirectory,
+            conflictState,
+          } = selectedState.state.changesState
+
+          if (conflictState === null) {
             return null
           }
 
@@ -1355,7 +1353,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             <MergeConflictsDialog
               dispatcher={this.props.dispatcher}
               repository={popup.repository}
-              status={workingDirectoryStatus}
+              workingDirectory={workingDirectory}
               onDismissed={this.onPopupDismissed}
               openFileInExternalEditor={this.openFileInExternalEditor}
               externalEditorName={this.state.selectedExternalEditor}

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -21,7 +21,7 @@ import { LinkButton } from '../lib/link-button'
 interface IMergeConflictsDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
-  readonly status: WorkingDirectoryStatus
+  readonly workingDirectory: WorkingDirectoryStatus
   readonly onDismissed: () => void
   readonly openFileInExternalEditor: (path: string) => void
   readonly externalEditorName?: string
@@ -47,7 +47,7 @@ export class MergeConflictsDialog extends React.Component<
   private onSubmit = async () => {
     await this.props.dispatcher.createMergeCommit(
       this.props.repository,
-      this.props.status.files
+      this.props.workingDirectory.files
     )
     this.props.dispatcher.setCommitMessage(this.props.repository, null)
     this.props.dispatcher.changeRepositorySection(
@@ -212,7 +212,7 @@ export class MergeConflictsDialog extends React.Component<
   }
 
   private getUnmergedFiles() {
-    return this.props.status.files.filter(
+    return this.props.workingDirectory.files.filter(
       file =>
         file.status === AppFileStatus.Conflicted ||
         file.status === AppFileStatus.Resolved


### PR DESCRIPTION
## Overview

It's late, I can't sleep, and I'm restless from watching the news so I figure now is a great time to open a PR that changes how we detect merge conflicts in the app :tada:

This was started in #6082 but I wanted to move it out from there for more explicit discussion as it touches the core parts of conflict resolution flow.

## Description

Currently we look at the output of `git status` to see which files are conflicted, but if a user decides to stage files outside the app (whether they're resolved or not) the conflict status markers are forgotten by `git status`, so it's possible for Desktop to "forget" it's in the middle of a conflict.

This affects #6082 but also other scenarios that weren't the happy path flow, like the user addressing conflicts in the app but not completing the process by committing before switching back to Desktop.

Instead of relying on `git status` output, this PR switches us over to look for `.git/MERGE_HEAD` in the repository to identify when conflicts need to be resolved.

The flow of this information is then like this:

 - `getStatus` has a new field `mergeHeadFound` that indicates whether it found `MERGE_HEAD`
 - within `AppStore._loadStatus` we compute the new conflicted state for the repository (`getConflictStatus()`)
 - we update the repository state with the conflict information, as well as related stats ~~(still needs some cleanup)~~
 - inside `AppStore._triggerMergeConflictsFlow` we then check the current state of conflicts
 - we use this detail to display the merge conflicts dialog (if required)

This also removes some `_mergeConflictDetected()` which would set the conflicted state, but didn't use `git status` - this centralizes the responsibility to `AppStore._loadStatus()`

TODO:

 - [x] refactor the stats flow to reflect the desired behaviour
 - [x] a bunch more testing

## Release notes

Notes: no-notes
