### PR TITLE
UI changes to handle binary files when conflicted

### DIFF
--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -150,7 +150,6 @@ export class MergeConflictsDialog extends React.Component<
   private renderConflictedFile(
     path: string,
     conflictStatus: ConflictFileStatus,
-    editorName: string | undefined,
     onOpenEditorClick: () => void
   ): JSX.Element | null {
     switch (conflictStatus.kind) {
@@ -170,7 +169,7 @@ export class MergeConflictsDialog extends React.Component<
               <div className="file-conflicts-status">{message}</div>
             </div>
             <Button onClick={onOpenEditorClick}>
-              {this.editorButtonString(editorName)}
+              {this.editorButtonString(this.props.externalEditorName)}
             </Button>
           </li>
         )
@@ -195,9 +194,7 @@ export class MergeConflictsDialog extends React.Component<
   }
 
   private renderUnmergedFile(
-    file: WorkingDirectoryFileChange,
-    editorName: string | undefined,
-    repositoryPath: string
+    file: WorkingDirectoryFileChange
   ): JSX.Element | null {
     switch (file.status) {
       case AppFileStatus.Resolved:
@@ -209,12 +206,10 @@ export class MergeConflictsDialog extends React.Component<
           )
         }
 
-        return this.renderConflictedFile(
-          file.path,
-          file.conflictStatus,
-          editorName,
-          () =>
-            this.props.openFileInExternalEditor(join(repositoryPath, file.path))
+        return this.renderConflictedFile(file.path, file.conflictStatus, () =>
+          this.props.openFileInExternalEditor(
+            join(this.props.repository.path, file.path)
+          )
         )
       default:
         return null
@@ -222,13 +217,11 @@ export class MergeConflictsDialog extends React.Component<
   }
 
   private renderUnmergedFiles(
-    files: ReadonlyArray<WorkingDirectoryFileChange>,
-    editorName: string | undefined,
-    repositoryPath: string
+    files: ReadonlyArray<WorkingDirectoryFileChange>
   ) {
     return (
       <ul className="unmerged-file-statuses">
-        {files.map(f => this.renderUnmergedFile(f, editorName, repositoryPath))}
+        {files.map(f => this.renderUnmergedFile(f))}
       </ul>
     )
   }
@@ -265,11 +258,7 @@ export class MergeConflictsDialog extends React.Component<
     return (
       <>
         {this.renderUnmergedFilesSummary(conflictedFilesCount)}
-        {this.renderUnmergedFiles(
-          unmergedFiles,
-          this.props.externalEditorName,
-          this.props.repository.path
-        )}
+        {this.renderUnmergedFiles(unmergedFiles)}
         {this.renderShellLink(this.openThisRepositoryInShell)}
       </>
     )

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -252,9 +252,12 @@ export class MergeConflictsDialog extends React.Component<
   ): JSX.Element {
     if (unmergedFiles.length === 0) {
       return (
-        <>
-          <span>All conflicts resolved</span>
-        </>
+        <div className="all-conflicts-resolved">
+          <div className="green-circle">
+            <Octicon symbol={OcticonSymbol.check} />
+          </div>
+          <div className="message">All conflicts resolved</div>
+        </div>
       )
     }
 

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -222,7 +222,7 @@ export class MergeConflictsDialog extends React.Component<
   }
 
   private renderUnmergedFiles(
-    files: Array<WorkingDirectoryFileChange>,
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
     editorName: string | undefined,
     repositoryPath: string
   ) {
@@ -250,11 +250,37 @@ export class MergeConflictsDialog extends React.Component<
     return <h3 className="summary">{message}</h3>
   }
 
+  private renderContent(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
+    conflictedFilesCount: number
+  ): JSX.Element {
+    if (unmergedFiles.length === 0) {
+      return (
+        <>
+          <span>All conflicts resolved</span>
+        </>
+      )
+    }
+
+    return (
+      <>
+        {this.renderUnmergedFilesSummary(conflictedFilesCount)}
+        {this.renderUnmergedFiles(
+          unmergedFiles,
+          this.props.externalEditorName,
+          this.props.repository.path
+        )}
+        {this.renderShellLink(this.openThisRepositoryInShell)}
+      </>
+    )
+  }
+
   public render() {
     const unmergedFiles = this.getUnmergedFiles()
     const conflictedFilesCount = unmergedFiles.filter(
       f => f.status === AppFileStatus.Conflicted
     ).length
+
     const headerTitle = this.renderHeaderTitle(
       this.props.ourBranch,
       this.props.theirBranch
@@ -263,6 +289,7 @@ export class MergeConflictsDialog extends React.Component<
       conflictedFilesCount > 0
         ? 'Resolve all changes before merging'
         : undefined
+
     return (
       <Dialog
         id="merge-conflicts-list"
@@ -272,13 +299,7 @@ export class MergeConflictsDialog extends React.Component<
       >
         <DialogHeader title={headerTitle} dismissable={false} />
         <DialogContent>
-          {this.renderUnmergedFilesSummary(conflictedFilesCount)}
-          {this.renderUnmergedFiles(
-            unmergedFiles,
-            this.props.externalEditorName,
-            this.props.repository.path
-          )}
-          {this.renderShellLink(this.openThisRepositoryInShell)}
+          {this.renderContent(unmergedFiles, conflictedFilesCount)}
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -246,19 +246,23 @@ export class MergeConflictsDialog extends React.Component<
     return <h3 className="summary">{message}</h3>
   }
 
+  private renderAllResolved() {
+    return (
+      <div className="all-conflicts-resolved">
+        <div className="green-circle">
+          <Octicon symbol={OcticonSymbol.check} />
+        </div>
+        <div className="message">All conflicts resolved</div>
+      </div>
+    )
+  }
+
   private renderContent(
     unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
     conflictedFilesCount: number
   ): JSX.Element {
     if (unmergedFiles.length === 0) {
-      return (
-        <div className="all-conflicts-resolved">
-          <div className="green-circle">
-            <Octicon symbol={OcticonSymbol.check} />
-          </div>
-          <div className="message">All conflicts resolved</div>
-        </div>
-      )
+      return this.renderAllResolved()
     }
 
     return (

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -90,9 +90,11 @@ dialog#merge-conflicts-list {
   .all-conflicts-resolved {
     display: flex;
     flex-flow: row nowrap;
+    padding: var(--spacing) 0 var(--spacing-double);
 
     .message {
       padding-left: var(--spacing);
+      padding-top: var(--spacing-third);
     }
   }
 

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -75,8 +75,15 @@ dialog#merge-conflicts-list {
     .unmerged-file-status-resolved .file-conflicts-status {
       color: $green;
     }
-    .unmerged-file-status-conflicts .file-conflicts-status {
-      color: $orange;
+
+    .unmerged-file-status-conflicts {
+      .file-conflicts-status {
+        color: $orange;
+      }
+
+      .command-line-hint {
+        color: $gray;
+      }
     }
   }
 

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -87,6 +87,15 @@ dialog#merge-conflicts-list {
     }
   }
 
+  .all-conflicts-resolved {
+    display: flex;
+    flex-flow: row nowrap;
+
+    .message {
+      padding-left: var(--spacing);
+    }
+  }
+
   .cli-link {
     a {
       color: $blue;


### PR DESCRIPTION
## Overview

**Closes #6066**

This improves how we display binary files - which do not contain conflict markers and have a different flow to resolve them - in the new merge conflict dialog.

## Description

This PR closes out the last parts of #6066:

 - conflicted binary diff files are now listed as conflicted and do not encourage you to open them in an editor

<img width="521" src="https://user-images.githubusercontent.com/359239/48138520-df987c00-e27a-11e8-9454-dacbede330fc.png">

 - because binary files need to be staged to be resolved - removing the conflicted markers and potentially removing them from the working directory completely - the dialog needs to show something if it cannot find any conflicted files

<img width="536" src="https://user-images.githubusercontent.com/359239/48138500-d3142380-e27a-11e8-8999-0e0b1360df9d.png">

TODO: 

 - [x] rebase on top of `master` once #6116 has been merged
 - [x] retarget PR to 1.5.0 release branch 

## Release notes

Notes: no-notes
