### PR TITLE
changelog for 1.5.0-beta4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.5.0-beta3",
+  "version": "1.5.0-beta4",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -3,7 +3,7 @@
     "1.5.0-beta4": [
       "[Fixed] \"Compare on GitHub\" menu item not disabled when a repository is not selected - #6078",
       "[Fixed] Diff viewer blocks keyboard navigation using reverse tab order - #2794",
-      "[Improved] \"Publish Repository\" dialog handling emoji characters - #5980. Thanks @WaleedAshraf!"
+      "[Improved] \"Publish Repository\" dialog handles emoji characters - #5980. Thanks @WaleedAshraf!"
     ],
     "1.5.0-beta3": [
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "1.5.0-beta4": [
+      "[Fixed] \"Compare on GitHub\" menu item not disabled when a repository is not selected - #6078",
+      "[Fixed] Diff viewer does block keyboard navigation using reverse tab order - #2794",
+      "[Improved] \"Publish Repository\" dialog handling emoji characters - #5980. Thanks @WaleedAshraf!"
+    ],
     "1.5.0-beta3": [
     ],
     "1.5.0-beta2": [

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.5.0-beta4": [
-      "[Fixed] \"Compare on GitHub\" menu item not disabled when a repository is not selected - #6078",
+      "[Fixed] \"Compare on GitHub\" menu item enabled when no repository is selected - #6078",
       "[Fixed] Diff viewer blocks keyboard navigation using reverse tab order - #2794",
       "[Improved] \"Publish Repository\" dialog handles emoji characters - #5980. Thanks @WaleedAshraf!"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -2,7 +2,7 @@
   "releases": {
     "1.5.0-beta4": [
       "[Fixed] \"Compare on GitHub\" menu item not disabled when a repository is not selected - #6078",
-      "[Fixed] Diff viewer does block keyboard navigation using reverse tab order - #2794",
+      "[Fixed] Diff viewer blocks keyboard navigation using reverse tab order - #2794",
       "[Improved] \"Publish Repository\" dialog handling emoji characters - #5980. Thanks @WaleedAshraf!"
     ],
     "1.5.0-beta3": [


### PR DESCRIPTION
There are two outstanding PRs for the beta tomorrow - #6113 and #6122 - but I don't think those relate to existing features so they can be omitted from the changelog.