### PR TITLE
generate HTML bundle of coverage stats by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,7 @@ module.exports = {
     // ignore index files
     '!**/index.ts',
   ],
-  coverageReporters: ['text-summary', 'json'],
+  coverageReporters: ['text-summary', 'json', 'html'],
   globals: {
     'ts-jest': {
       useBabelrc: true,


### PR DESCRIPTION
## Overview

Working on #6125 and adding some more tests, I find myself tweaking the jest config so I can look at a the details of the coverage for the test run.

Currently you only see the summary in the console, and a JSON bundle is generated with CI builds.

```
=============================== Coverage summary ===============================
Statements   : 29.62% ( 5024/16960 )
Branches     : 14.44% ( 1165/8068 )
Functions    : 16.48% ( 582/3531 )
Lines        : 29.77% ( 4988/16753 )
================================================================================
```

This is great for seeing the overall details, but I want to dig into the areas I'm working on and track what they're coverage looks like.

## Description

With this change, after running `yarn test:unit:cov` locally you'll see a `coverage` folder on disk:

```
$ ls coverage
base.css		index.html		models			sort-arrow-sprite.png
block-navigation.js	lib			prettify.css		sorter.js
coverage-final.json	main-process		prettify.js		ui
```

If you open `coverage/index.html` you'll see the detailed stats, and can click into the relevant area of the codebase you're interested in:

<img width="906" src="https://user-images.githubusercontent.com/359239/48201343-4465dc00-e338-11e8-9bc4-cd705c12e950.png">

## Release notes

Notes: no-notes
