### PR TITLE
add experimental support for v2 of the Git wire protocol

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -51,3 +51,8 @@ export function enableRecurseSubmodulesFlag(): boolean {
 export function enableMergeConflictsDialog(): boolean {
   return true
 }
+
+/** Should the app set protocol.version=2 for any fetch/push/pull/clone operation? */
+export function enableGitProtocolVersionTwo(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -78,8 +78,10 @@ export async function deleteBranch(
   )
 
   if (branchExistsOnRemote) {
+    const networkArguments = gitNetworkArguments(account)
+
     const args = [
-      ...gitNetworkArguments,
+      ...networkArguments,
       'push',
       remote,
       `:${branch.nameWithoutRemote}`,
@@ -101,8 +103,10 @@ async function checkIfBranchExistsOnRemote(
   account: IGitAccount | null,
   remote: string
 ): Promise<boolean> {
+  const networkArguments = gitNetworkArguments(account)
+
   const args = [
-    ...gitNetworkArguments,
+    ...networkArguments,
     'ls-remote',
     '--heads',
     remote,

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -78,7 +78,7 @@ export async function deleteBranch(
   )
 
   if (branchExistsOnRemote) {
-    const networkArguments = gitNetworkArguments(account)
+    const networkArguments = await gitNetworkArguments(repository, account)
 
     const args = [
       ...networkArguments,
@@ -103,7 +103,7 @@ async function checkIfBranchExistsOnRemote(
   account: IGitAccount | null,
   remote: string
 ): Promise<boolean> {
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   const args = [
     ...networkArguments,

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -12,12 +12,13 @@ import { enableRecurseSubmodulesFlag } from '../feature-flag'
 
 export type ProgressCallback = (progress: ICheckoutProgress) => void
 
-function getCheckoutArgs(
+async function getCheckoutArgs(
+  repository: Repository,
   branch: Branch,
   account: IGitAccount | null,
   progressCallback?: ProgressCallback
 ) {
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   const baseArgs =
     progressCallback != null
@@ -88,7 +89,12 @@ export async function checkoutBranch(
     progressCallback({ kind, title, value: 0, targetBranch })
   }
 
-  const args = getCheckoutArgs(branch, account, progressCallback)
+  const args = await getCheckoutArgs(
+    repository,
+    branch,
+    account,
+    progressCallback
+  )
 
   await git(args, repository.path, 'checkoutBranch', opts)
 }

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -12,11 +12,17 @@ import { enableRecurseSubmodulesFlag } from '../feature-flag'
 
 export type ProgressCallback = (progress: ICheckoutProgress) => void
 
-function getCheckoutArgs(branch: Branch, progressCallback?: ProgressCallback) {
+function getCheckoutArgs(
+  branch: Branch,
+  account: IGitAccount | null,
+  progressCallback?: ProgressCallback
+) {
+  const networkArguments = gitNetworkArguments(account)
+
   const baseArgs =
     progressCallback != null
-      ? [...gitNetworkArguments, 'checkout', '--progress']
-      : [...gitNetworkArguments, 'checkout']
+      ? [...networkArguments, 'checkout', '--progress']
+      : [...networkArguments, 'checkout']
 
   if (enableRecurseSubmodulesFlag()) {
     return branch.type === BranchType.Remote
@@ -82,7 +88,7 @@ export async function checkoutBranch(
     progressCallback({ kind, title, value: 0, targetBranch })
   }
 
-  const args = getCheckoutArgs(branch, progressCallback)
+  const args = getCheckoutArgs(branch, account, progressCallback)
 
   await git(args, repository.path, 'checkoutBranch', opts)
 }

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -30,7 +30,7 @@ export async function clone(
   options: CloneOptions,
   progressCallback?: (progress: ICloneProgress) => void
 ): Promise<void> {
-  const networkArguments = gitNetworkArguments(options.account)
+  const networkArguments = await gitNetworkArguments(null, options.account)
 
   const env = envForAuthentication(options.account)
 

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -30,9 +30,11 @@ export async function clone(
   options: CloneOptions,
   progressCallback?: (progress: ICloneProgress) => void
 ): Promise<void> {
+  const networkArguments = gitNetworkArguments(options.account)
+
   const env = envForAuthentication(options.account)
 
-  const args = [...gitNetworkArguments, 'clone', '--recursive']
+  const args = [...networkArguments, 'clone', '--recursive']
 
   let opts: IGitExecutionOptions = { env }
 

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -322,6 +322,7 @@ export async function gitNetworkArguments(
       : getGlobalConfigValue(name)
 
   if (protocolVersion !== null) {
+    // protocol.version is already set, we should not override it with our own
     return baseArgs
   }
 

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -316,12 +316,12 @@ export async function gitNetworkArguments(
 
   if (repository != null) {
     const protocolVersion = await getConfigValue(repository, 'protocol.version')
-    if (protocolVersion === '1') {
+    if (protocolVersion !== null) {
       return baseArgs
     }
   } else {
     const protocolVersion = await getGlobalConfigValue('protocol.version')
-    if (protocolVersion === '1') {
+    if (protocolVersion !== null) {
       return baseArgs
     }
   }

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -314,16 +314,15 @@ export async function gitNetworkArguments(
     return baseArgs
   }
 
-  if (repository != null) {
-    const protocolVersion = await getConfigValue(repository, 'protocol.version')
-    if (protocolVersion !== null) {
-      return baseArgs
-    }
-  } else {
-    const protocolVersion = await getGlobalConfigValue('protocol.version')
-    if (protocolVersion !== null) {
-      return baseArgs
-    }
+  const name = 'protocol.version'
+
+  const protocolVersion =
+    repository != null
+      ? await getConfigValue(repository, name)
+      : getGlobalConfigValue(name)
+
+  if (protocolVersion !== null) {
+    return baseArgs
   }
 
   // opt in for v2 of the Git Wire protocol for GitHub repositories

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -297,6 +297,7 @@ export function gitNetworkArguments(
   const isDotComAccount = account.endpoint === getDotComAPIEndpoint()
 
   if (isDotComAccount) {
+    // opt in for v2 of the Git Wire protocol for GitHub repositories
     return [...baseArgs, '-c', 'protocol.version=2']
   } else {
     return baseArgs

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -6,12 +6,13 @@ import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 
-function getFetchArgs(
+async function getFetchArgs(
+  repository: Repository,
   remote: string,
   account: IGitAccount | null,
   progressCallback?: (progress: IFetchProgress) => void
 ) {
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   if (enableRecurseSubmodulesFlag()) {
     return progressCallback != null
@@ -93,7 +94,7 @@ export async function fetch(
     progressCallback({ kind, title, value: 0, remote })
   }
 
-  const args = getFetchArgs(remote, account, progressCallback)
+  const args = await getFetchArgs(repository, remote, account, progressCallback)
   await git(args, repository.path, 'fetch', opts)
 }
 
@@ -109,7 +110,7 @@ export async function fetchRefspec(
     env: envForAuthentication(account),
   }
 
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   const args = [...networkArguments, 'fetch', remote, refspec]
 

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -8,12 +8,15 @@ import { enableRecurseSubmodulesFlag } from '../feature-flag'
 
 function getFetchArgs(
   remote: string,
+  account: IGitAccount | null,
   progressCallback?: (progress: IFetchProgress) => void
 ) {
+  const networkArguments = gitNetworkArguments(account)
+
   if (enableRecurseSubmodulesFlag()) {
     return progressCallback != null
       ? [
-          ...gitNetworkArguments,
+          ...networkArguments,
           'fetch',
           '--progress',
           '--prune',
@@ -21,7 +24,7 @@ function getFetchArgs(
           remote,
         ]
       : [
-          ...gitNetworkArguments,
+          ...networkArguments,
           'fetch',
           '--prune',
           '--recurse-submodules=on-demand',
@@ -29,8 +32,8 @@ function getFetchArgs(
         ]
   } else {
     return progressCallback != null
-      ? [...gitNetworkArguments, 'fetch', '--progress', '--prune', remote]
-      : [...gitNetworkArguments, 'fetch', '--prune', remote]
+      ? [...networkArguments, 'fetch', '--progress', '--prune', remote]
+      : [...networkArguments, 'fetch', '--prune', remote]
   }
 }
 
@@ -90,7 +93,7 @@ export async function fetch(
     progressCallback({ kind, title, value: 0, remote })
   }
 
-  const args = getFetchArgs(remote, progressCallback)
+  const args = getFetchArgs(remote, account, progressCallback)
   await git(args, repository.path, 'fetch', opts)
 }
 
@@ -106,7 +109,9 @@ export async function fetchRefspec(
     env: envForAuthentication(account),
   }
 
-  const args = [...gitNetworkArguments, 'fetch', remote, refspec]
+  const networkArguments = gitNetworkArguments(account)
+
+  const args = [...networkArguments, 'fetch', remote, refspec]
 
   await git(args, repository.path, 'fetchRefspec', options)
 }

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -13,12 +13,15 @@ import { enableRecurseSubmodulesFlag } from '../feature-flag'
 
 function getPullArgs(
   remote: string,
+  account: IGitAccount | null,
   progressCallback?: (progress: IPullProgress) => void
 ) {
+  const networkArguments = gitNetworkArguments(account)
+
   if (enableRecurseSubmodulesFlag()) {
     return progressCallback != null
       ? [
-          ...gitNetworkArguments,
+          ...networkArguments,
           'pull',
           '--no-rebase',
           '--recurse-submodules',
@@ -26,7 +29,7 @@ function getPullArgs(
           remote,
         ]
       : [
-          ...gitNetworkArguments,
+          ...networkArguments,
           'pull',
           '--no-rebase',
           '--recurse-submodules',
@@ -34,8 +37,8 @@ function getPullArgs(
         ]
   } else {
     return progressCallback != null
-      ? [...gitNetworkArguments, 'pull', '--no-rebase', '--progress', remote]
-      : [...gitNetworkArguments, 'pull', '--no-rebase', remote]
+      ? [...networkArguments, 'pull', '--no-rebase', '--progress', remote]
+      : [...networkArguments, 'pull', '--no-rebase', remote]
   }
 }
 
@@ -94,7 +97,7 @@ export async function pull(
     progressCallback({ kind, title, value: 0, remote })
   }
 
-  const args = getPullArgs(remote, progressCallback)
+  const args = getPullArgs(remote, account, progressCallback)
   const result = await git(args, repository.path, 'pull', opts)
 
   if (result.gitErrorDescription) {

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -11,12 +11,13 @@ import { PullProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication, AuthenticationErrors } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 
-function getPullArgs(
+async function getPullArgs(
+  repository: Repository,
   remote: string,
   account: IGitAccount | null,
   progressCallback?: (progress: IPullProgress) => void
 ) {
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   if (enableRecurseSubmodulesFlag()) {
     return progressCallback != null
@@ -97,7 +98,7 @@ export async function pull(
     progressCallback({ kind, title, value: 0, remote })
   }
 
-  const args = getPullArgs(remote, account, progressCallback)
+  const args = await getPullArgs(repository, remote, account, progressCallback)
   const result = await git(args, repository.path, 'pull', opts)
 
   if (result.gitErrorDescription) {

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -40,7 +40,7 @@ export async function push(
   remoteBranch: string | null,
   progressCallback?: (progress: IPushProgress) => void
 ): Promise<void> {
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   const args = [
     ...networkArguments,

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -40,8 +40,10 @@ export async function push(
   remoteBranch: string | null,
   progressCallback?: (progress: IPushProgress) => void
 ): Promise<void> {
+  const networkArguments = gitNetworkArguments(account)
+
   const args = [
-    ...gitNetworkArguments,
+    ...networkArguments,
     'push',
     remote,
     remoteBranch ? `${localBranch}:${remoteBranch}` : localBranch,

--- a/app/src/lib/git/revert.ts
+++ b/app/src/lib/git/revert.ts
@@ -23,7 +23,7 @@ export async function revertCommit(
   account: IGitAccount | null,
   progressCallback?: (progress: IRevertProgress) => void
 ) {
-  const networkArguments = gitNetworkArguments(account)
+  const networkArguments = await gitNetworkArguments(repository, account)
 
   const args = [...networkArguments, 'revert']
   if (commit.parentSHAs.length > 1) {

--- a/app/src/lib/git/revert.ts
+++ b/app/src/lib/git/revert.ts
@@ -23,7 +23,9 @@ export async function revertCommit(
   account: IGitAccount | null,
   progressCallback?: (progress: IRevertProgress) => void
 ) {
-  const args = [...gitNetworkArguments, 'revert']
+  const networkArguments = gitNetworkArguments(account)
+
+  const args = [...networkArguments, 'revert']
   if (commit.parentSHAs.length > 1) {
     args.push('-m', '1')
   }


### PR DESCRIPTION
## Overview

GitHub just enabled support for v2 of the wire protocol on it's repositories, which helps clients and servers save on network traffic: https://blog.github.com/changelog/2018-11-08-git-protocol-v2-support/

## Description

This PR enables Desktop to opt-in for the new behaviour and start testing it out ourselves (currently development mode only).

This checks it is working with a GitHub repository, and for now won't consider GitHub Enterprise repositories (because they need to receive this with a future update, and we don't have a good way to detect this support) and non-GitHub repositories.

There is a way to enable this via config yourself if you're on Git 2.18 or later:

```shellsession
$ git config --global protocol.version 2
```

Alternatively you can use `--local` instead of `--global` to enable it for a specific repository.

More details about wire protocol changes itself can be found here: https://opensource.googleblog.com/2018/05/introducing-git-protocol-version-2.html

TODO:

 - [x] add config check to respect if `protocol.version` is set to `1` to indicate they have set themselves to the old version.

## Release notes

Notes: Opt-in for v2 of the Git Wire protocol for GitHub repositories
