### PR TITLE
hide branches list when launching merge branch dialog

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -211,6 +211,7 @@ export class BranchesContainer extends React.Component<
   }
 
   private onMergeClick = () => {
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     this.props.dispatcher.showPopup({
       type: PopupType.MergeBranch,
       repository: this.props.repository,


### PR DESCRIPTION
## Overview

**Closes #6115**

## Description

Easy fix - we hide the branch foldout before we show the dialog

## Release notes

Notes: no-notes
