### PR TITLE
Release Notes for 1.5.0 beta 5

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.5.0-beta4",
+  "version": "1.5.0-beta5",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.5.0-beta5": [
+
+    ],
     "1.5.0-beta4": [
       "[Fixed] \"Compare on GitHub\" menu item enabled when no repository is selected - #6078",
       "[Fixed] Diff viewer blocks keyboard navigation using reverse tab order - #2794",


### PR DESCRIPTION
## Overview

It's Friday, and we're publishing a new beta release!

![](https://user-images.githubusercontent.com/359239/48280760-f67dd080-e42a-11e8-8579-e6621342e9b1.gif)

## Description

The `draft-release` script suggested these potential entries:

```
    "[Fixed] Add flag to createMergeCommit to be consistent with Git CLI - #6134",
    "[Fixed] Detect and prompt users to use command line for text file merge conflicts without markers - #6123",
    "[Fixed] Hide branches list when launching merge branch dialog - #6115"
```

These are all related to new features coming in `1.5.0`, so I'm going to omit them for now and ask y'all to chime in with your thoughts about #6084. I got some feedback about adding channel-specific info to PRs which would help with automating release notes better because we'd know ahead of time what channels should know about which changes (currently we try and avoid listing beta fixes for upcoming features).

TODO:

 - [x] approve the (empty) changelog
 - [x] publish to beta
 - [x] create release branch from tag

## Release notes

Notes: no-notes
