### PR TITLE
1.5.0 Release

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.5.0-beta5",
+  "version": "1.5.0",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.5.0-beta4",
+  "version": "1.5.0-beta5",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.5.0",
+  "version": "1.5.1-beta0",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -64,5 +64,5 @@ export function enableRecurseSubmodulesFlag(): boolean {
 
 /** Should the app use the MergeConflictsDialog component and flow? */
 export function enableMergeConflictsDialog(): boolean {
-  return enableBetaFeatures()
+  return true
 }

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -228,7 +228,7 @@
 }
 
 .no-pull-requests {
-  width: 300px;
+  width: 350px;
   display: flex;
   flex-direction: column;
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,7 @@
 {
   "releases": {
+    "1.5.1-beta0": [
+    ],
     "1.5.0": [
       "[New] Clone, create, or add repositories right from the repository dropdown - #5878",
       "[New] Drag-and-drop to add local repositories from macOS tray icon - #5048",
@@ -24,7 +26,6 @@
       "[Improved] Update license and .gitignore templates for initializing a new repository - #6024. Thanks @say25!"
     ],
     "1.5.0-beta5": [
-
     ],
     "1.5.0-beta4": [
       "[Fixed] \"Compare on GitHub\" menu item enabled when no repository is selected - #6078",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,28 @@
 {
   "releases": {
+    "1.5.0": [
+      "[New] Repository switcher has a convenient \"Add\" button to add other repositories - #5878",
+      "[New] macOS tray icon now supports drag-and-drop to add local repositories - #5048",
+      "[Added] Resolve merge conflicts through a guided flow - #5400",
+      "[Added] Allow merging branches directly from branch dropdown - #5929. Thanks @bruncun!",
+      "[Added] Commit file list now has \"Copy File Path\" context menu action - #2944. Thanks @Amabel!",
+      "[Added] Keyboard shortcut for \"Rename Branch\" menu item - #5964. Thanks @agisilaos!",
+      "[Added] Notify users when a merge is successfully completed - #5851",
+      "[Fixed] \"Compare on GitHub\" menu item enabled when no repository is selected - #6078",
+      "[Fixed] Diff viewer blocks keyboard navigation using reverse tab order - #2794",
+      "[Fixed] Launching Desktop from browser always asks to clone repository - #5913",
+      "[Fixed] Publish dialog displayed on push when repository is already published - #5936",
+      "[Improved] \"Publish Repository\" dialog handles emoji characters - #5980. Thanks @WaleedAshraf!",
+      "[Improved] Avoid repository checks when no path is specified in \"Create Repository\" dialog - #5828. Thanks @JakeHL!",
+      "[Improved] Clarify the direction of merging branches - #5930. Thanks @JQuinnie!",
+      "[Improved] Default commit summary more explanatory and consistent with GitHub.com - #6017. Thanks @Daniel-McCarthy!",
+      "[Improved] Display a more informative message on merge dialog when branch is up to date - #5890",
+      "[Improved] Getting a repository's status only blocks other operations when absolutely necessary - #5952",
+      "[Improved] Merge dialog displays current branch in header - #6027",
+      "[Improved] Sanitize repository name before publishing to GitHub - #3090. Thanks @Daniel-McCarthy!",
+      "[Improved] Show the branch name in \"Update From Default Branch\" menu item - #3018. Thanks @a-golovanov!",
+      "[Improved] Updated license and .gitignore templates for initializing a new repository - #6024. Thanks @say25!"
+    ],
     "1.5.0-beta5": [
 
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.5.0-beta5": [
+
+    ],
     "1.5.0-beta4": [
       "[Fixed] \"Compare on GitHub\" menu item enabled when no repository is selected - #6078",
       "[Fixed] Diff viewer blocks keyboard navigation using reverse tab order - #2794",

--- a/changelog.json
+++ b/changelog.json
@@ -1,8 +1,8 @@
 {
   "releases": {
     "1.5.0": [
-      "[New] Repository switcher has a convenient \"Add\" button to add other repositories - #5878",
-      "[New] macOS tray icon now supports drag-and-drop to add local repositories - #5048",
+      "[New] Clone, create, or add repositories right from the repository dropdown - #5878",
+      "[New] Drag-and-drop to add local repositories from macOS tray icon - #5048",
       "[Added] Resolve merge conflicts through a guided flow - #5400",
       "[Added] Allow merging branches directly from branch dropdown - #5929. Thanks @bruncun!",
       "[Added] Commit file list now has \"Copy File Path\" context menu action - #2944. Thanks @Amabel!",
@@ -18,10 +18,10 @@
       "[Improved] Default commit summary more explanatory and consistent with GitHub.com - #6017. Thanks @Daniel-McCarthy!",
       "[Improved] Display a more informative message on merge dialog when branch is up to date - #5890",
       "[Improved] Getting a repository's status only blocks other operations when absolutely necessary - #5952",
-      "[Improved] Merge dialog displays current branch in header - #6027",
+      "[Improved] Display current branch in header of merge dialog - #6027",
       "[Improved] Sanitize repository name before publishing to GitHub - #3090. Thanks @Daniel-McCarthy!",
       "[Improved] Show the branch name in \"Update From Default Branch\" menu item - #3018. Thanks @a-golovanov!",
-      "[Improved] Updated license and .gitignore templates for initializing a new repository - #6024. Thanks @say25!"
+      "[Improved] Update license and .gitignore templates for initializing a new repository - #6024. Thanks @say25!"
     ],
     "1.5.0-beta5": [
 


### PR DESCRIPTION
## Overview

Adding the release notes for the 1.5.0 release.

If there are any additional changes that need to be made available for 1.5.0, please open a PR targeting `1-5-0-release-branch`. **Do not push non-release-notes changes directly to this branch.**

## Description

- [x] approve release notes
- [x] publish to `production` (Wedesday 8am PST) 
- [x] publish `1.5.1-beta0` to `beta` (once production is shipped and smoke tested)

## Release notes

Notes: no-notes
