### PR TITLE
additional status conflict testing

### DIFF
--- a/app/src/models/conflicts.ts
+++ b/app/src/models/conflicts.ts
@@ -8,25 +8,29 @@ import { GitStatusEntry, UnmergedEntry } from './status'
  * binary, which need to be reviewed by the user and a decision made.
  */
 export type ConflictFileStatus =
-  | {
-      readonly kind: 'text'
-      /**
-       *  This number should be greater than zero
-       *  or null if the file has a non-markered conflict (like added vs removed)
-       */
-      readonly conflictMarkerCount: number | null
-      /** The state of the file in the current branch */
-      readonly us?: GitStatusEntry
-      /** THe state of the file in the other branch */
-      readonly them?: GitStatusEntry
-    }
-  | {
-      readonly kind: 'binary'
-      /** The state of the file in the current branch */
-      readonly us: GitStatusEntry
-      /** THe state of the file in the other branch */
-      readonly them: GitStatusEntry
-    }
+  | IConflictTextFileStatus
+  | IConflictBinaryFileStatus
+
+export interface IConflictTextFileStatus {
+  readonly kind: 'text'
+  /**
+   *  This number should be greater than zero
+   *  or null if the file has a non-markered conflict (like added vs removed)
+   */
+  readonly conflictMarkerCount: number | null
+  /** The state of the file in the current branch */
+  readonly us?: GitStatusEntry
+  /** THe state of the file in the other branch */
+  readonly them?: GitStatusEntry
+}
+
+export interface IConflictBinaryFileStatus {
+  readonly kind: 'binary'
+  /** The state of the file in the current branch */
+  readonly us: GitStatusEntry
+  /** THe state of the file in the other branch */
+  readonly them: GitStatusEntry
+}
 
 /**
  * Meshing together the path and status information for a conflicted file,

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -135,20 +135,12 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
     Path.join(repo.path, 'foo'),
     Path.join(repo.path, 'bar'),
     Path.join(repo.path, 'baz'),
-    Path.join(repo.path, 'cow'),
-    Path.join(repo.path, 'cat'),
   ]
 
   await FSE.writeFile(filePaths[0], 'b0')
   await FSE.writeFile(filePaths[1], 'b0')
-  await FSE.writeFile(filePaths[2], 'b0')
   await GitProcess.exec(
-    [
-      'add',
-      Path.basename(filePaths[0]),
-      Path.basename(filePaths[1]),
-      Path.basename(filePaths[2]),
-    ],
+    ['add', Path.basename(filePaths[0]), Path.basename(filePaths[1])],
     repo.path
   )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
@@ -156,14 +148,10 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   await GitProcess.exec(['branch', 'other-branch'], repo.path)
 
   await FSE.writeFile(filePaths[0], 'b1')
-  await FSE.writeFile(filePaths[3], 'b1')
+  await FSE.writeFile(filePaths[2], 'b1')
   await GitProcess.exec(['rm', Path.basename(filePaths[1])], repo.path)
   await GitProcess.exec(
-    ['mv', Path.basename(filePaths[2]), Path.basename(filePaths[4])],
-    repo.path
-  )
-  await GitProcess.exec(
-    ['add', Path.basename(filePaths[0]), Path.basename(filePaths[3])],
+    ['add', Path.basename(filePaths[0]), Path.basename(filePaths[2])],
     repo.path
   )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
@@ -173,16 +161,13 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   await FSE.writeFile(filePaths[0], 'b2')
   await FSE.writeFile(filePaths[1], 'b2')
   await FSE.writeFile(filePaths[2], 'b2')
-  await FSE.writeFile(filePaths[3], 'b2')
-  await FSE.writeFile(filePaths[4], 'b2')
+
   await GitProcess.exec(
     [
       'add',
       Path.basename(filePaths[0]),
       Path.basename(filePaths[1]),
       Path.basename(filePaths[2]),
-      Path.basename(filePaths[3]),
-      Path.basename(filePaths[4]),
     ],
     repo.path
   )

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -135,6 +135,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
     Path.join(repo.path, 'foo'),
     Path.join(repo.path, 'bar'),
     Path.join(repo.path, 'baz'),
+    Path.join(repo.path, 'cat'),
   ]
 
   await FSE.writeFile(filePaths[0], 'b0')
@@ -149,9 +150,15 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
 
   await FSE.writeFile(filePaths[0], 'b1')
   await FSE.writeFile(filePaths[2], 'b1')
+  await FSE.writeFile(filePaths[3], 'b1')
   await GitProcess.exec(['rm', Path.basename(filePaths[1])], repo.path)
   await GitProcess.exec(
-    ['add', Path.basename(filePaths[0]), Path.basename(filePaths[2])],
+    [
+      'add',
+      Path.basename(filePaths[0]),
+      Path.basename(filePaths[2]),
+      Path.basename(filePaths[3]),
+    ],
     repo.path
   )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
@@ -161,6 +168,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   await FSE.writeFile(filePaths[0], 'b2')
   await FSE.writeFile(filePaths[1], 'b2')
   await FSE.writeFile(filePaths[2], 'b2')
+  await FSE.writeFile(filePaths[3], 'b2')
 
   await GitProcess.exec(
     [
@@ -168,6 +176,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
       Path.basename(filePaths[0]),
       Path.basename(filePaths[1]),
       Path.basename(filePaths[2]),
+      Path.basename(filePaths[3]),
     ],
     repo.path
   )

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -135,20 +135,37 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
     Path.join(repo.path, 'foo'),
     Path.join(repo.path, 'bar'),
     Path.join(repo.path, 'baz'),
+    Path.join(repo.path, 'cow'),
+    Path.join(repo.path, 'cat'),
   ]
 
-  await FSE.writeFile(filePaths[0], '')
-  await FSE.writeFile(filePaths[1], '')
-  await FSE.writeFile(filePaths[2], '')
-  await GitProcess.exec(['add', 'foo', 'bar', 'baz'], repo.path)
+  await FSE.writeFile(filePaths[0], 'b0')
+  await FSE.writeFile(filePaths[1], 'b0')
+  await FSE.writeFile(filePaths[2], 'b0')
+  await GitProcess.exec(
+    [
+      'add',
+      Path.basename(filePaths[0]),
+      Path.basename(filePaths[1]),
+      Path.basename(filePaths[2]),
+    ],
+    repo.path
+  )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
 
   await GitProcess.exec(['branch', 'other-branch'], repo.path)
 
   await FSE.writeFile(filePaths[0], 'b1')
-  await FSE.writeFile(filePaths[1], 'b1')
-  await FSE.writeFile(filePaths[2], 'b1')
-  await GitProcess.exec(['add', 'foo', 'bar', 'baz'], repo.path)
+  await FSE.writeFile(filePaths[3], 'b1')
+  await GitProcess.exec(['rm', Path.basename(filePaths[1])], repo.path)
+  await GitProcess.exec(
+    ['mv', Path.basename(filePaths[2]), Path.basename(filePaths[4])],
+    repo.path
+  )
+  await GitProcess.exec(
+    ['add', Path.basename(filePaths[0]), Path.basename(filePaths[3])],
+    repo.path
+  )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
 
   await GitProcess.exec(['checkout', 'other-branch'], repo.path)
@@ -156,7 +173,19 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   await FSE.writeFile(filePaths[0], 'b2')
   await FSE.writeFile(filePaths[1], 'b2')
   await FSE.writeFile(filePaths[2], 'b2')
-  await GitProcess.exec(['add', 'foo', 'bar', 'baz'], repo.path)
+  await FSE.writeFile(filePaths[3], 'b2')
+  await FSE.writeFile(filePaths[4], 'b2')
+  await GitProcess.exec(
+    [
+      'add',
+      Path.basename(filePaths[0]),
+      Path.basename(filePaths[1]),
+      Path.basename(filePaths[2]),
+      Path.basename(filePaths[3]),
+      Path.basename(filePaths[4]),
+    ],
+    repo.path
+  )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
 
   await GitProcess.exec(['merge', 'master'], repo.path)

--- a/app/test/unit/git/diff-check-test.ts
+++ b/app/test/unit/git/diff-check-test.ts
@@ -28,7 +28,7 @@ describe('getFilesWithConflictMarkers', () => {
     })
     it('finds multiple conflicted files', async () => {
       expect(await getFilesWithConflictMarkers(repository.path)).toEqual(
-        new Map([['cow', 3], ['foo', 3]])
+        new Map([['baz', 3], ['foo', 3]])
       )
     })
   })

--- a/app/test/unit/git/diff-check-test.ts
+++ b/app/test/unit/git/diff-check-test.ts
@@ -28,7 +28,7 @@ describe('getFilesWithConflictMarkers', () => {
     })
     it('finds multiple conflicted files', async () => {
       expect(await getFilesWithConflictMarkers(repository.path)).toEqual(
-        new Map([['bar', 3], ['baz', 3], ['foo', 3]])
+        new Map([['cow', 3], ['foo', 3]])
       )
     })
   })

--- a/app/test/unit/git/diff-check-test.ts
+++ b/app/test/unit/git/diff-check-test.ts
@@ -28,7 +28,7 @@ describe('getFilesWithConflictMarkers', () => {
     })
     it('finds multiple conflicted files', async () => {
       expect(await getFilesWithConflictMarkers(repository.path)).toEqual(
-        new Map([['baz', 3], ['foo', 3]])
+        new Map([['baz', 3], ['cat', 3], ['foo', 3]])
       )
     })
   })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -14,6 +14,7 @@ import {
 import { AppFileStatus } from '../../../src/models/status'
 import * as temp from 'temp'
 import { getStatus } from '../../../src/lib/git'
+import { IConflictTextFileStatus } from '../../../src/models/conflicts'
 
 const _temp = temp.track()
 const mkdir = _temp.mkdir
@@ -33,16 +34,23 @@ describe('git/status', () => {
       it('parses conflicted files', async () => {
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(5)
-        const file = files.find(f => f.path === 'foo')
-        expect(file!.status).toBe(AppFileStatus.Conflicted)
+        expect(files).toHaveLength(3)
+        expect(
+          files.filter(f => f.status === AppFileStatus.Conflicted)
+        ).toHaveLength(3)
+        const barFileConfclictStatus = files.find(f => f.path === 'bar')!
+          .conflictStatus as IConflictTextFileStatus
+        expect(barFileConfclictStatus.conflictMarkerCount).toBeNull()
       })
 
       it('parses resolved files', async () => {
         await FSE.writeFile(filePath, 'b1b2')
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(5)
+        expect(files).toHaveLength(3)
+        expect(
+          files.filter(f => f.status === AppFileStatus.Conflicted)
+        ).toHaveLength(2)
         const file = files.find(f => f.path === 'foo')
         expect(file!.status).toBe(AppFileStatus.Resolved)
       })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -31,13 +31,32 @@ describe('git/status', () => {
         filePath = path.join(repository.path, 'foo')
       })
 
-      it('parses conflicted files', async () => {
+      it('parses conflicted files with markers', async () => {
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(3)
+        expect(files).toHaveLength(4)
+        const conflictedFiles = files.filter(
+          f => f.status === AppFileStatus.Conflicted
+        )
+        expect(conflictedFiles).toHaveLength(4)
+        const fooFileConfclictStatus = files.find(f => f.path === 'foo')!
+          .conflictStatus as IConflictTextFileStatus
+        expect(fooFileConfclictStatus.conflictMarkerCount).not.toBeNull()
+        const bazFileConfclictStatus = files.find(f => f.path === 'baz')!
+          .conflictStatus as IConflictTextFileStatus
+        expect(bazFileConfclictStatus.conflictMarkerCount).not.toBeNull()
+        const catFileConfclictStatus = files.find(f => f.path === 'cat')!
+          .conflictStatus as IConflictTextFileStatus
+        expect(catFileConfclictStatus.conflictMarkerCount).not.toBeNull()
+      })
+
+      it('parses conflicted files without markers', async () => {
+        const status = await getStatusOrThrow(repository!)
+        const files = status.workingDirectory.files
+        expect(files).toHaveLength(4)
         expect(
           files.filter(f => f.status === AppFileStatus.Conflicted)
-        ).toHaveLength(3)
+        ).toHaveLength(4)
         const barFileConfclictStatus = files.find(f => f.path === 'bar')!
           .conflictStatus as IConflictTextFileStatus
         expect(barFileConfclictStatus.conflictMarkerCount).toBeNull()
@@ -47,10 +66,10 @@ describe('git/status', () => {
         await FSE.writeFile(filePath, 'b1b2')
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(3)
+        expect(files).toHaveLength(4)
         expect(
           files.filter(f => f.status === AppFileStatus.Conflicted)
-        ).toHaveLength(2)
+        ).toHaveLength(3)
         const file = files.find(f => f.path === 'foo')
         expect(file!.status).toBe(AppFileStatus.Resolved)
       })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -9,7 +9,6 @@ import {
   setupFixtureRepository,
   setupEmptyRepository,
   setupEmptyDirectory,
-  setupConflictedRepo,
   setupConflictedRepoWithMultipleFiles,
 } from '../../helpers/repositories'
 import { AppFileStatus } from '../../../src/models/status'

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -10,6 +10,7 @@ import {
   setupEmptyRepository,
   setupEmptyDirectory,
   setupConflictedRepo,
+  setupConflictedRepoWithMultipleFiles,
 } from '../../helpers/repositories'
 import { AppFileStatus } from '../../../src/models/status'
 import * as temp from 'temp'
@@ -26,26 +27,25 @@ describe('git/status', () => {
       let filePath: string
 
       beforeEach(async () => {
-        repository = await setupConflictedRepo()
+        repository = await setupConflictedRepoWithMultipleFiles()
         filePath = path.join(repository.path, 'foo')
       })
 
       it('parses conflicted files', async () => {
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(1)
-
-        const file = files[0]
-        expect(file.status).toBe(AppFileStatus.Conflicted)
+        expect(files).toHaveLength(5)
+        const file = files.find(f => f.path === 'foo')
+        expect(file!.status).toBe(AppFileStatus.Conflicted)
       })
 
       it('parses resolved files', async () => {
         await FSE.writeFile(filePath, 'b1b2')
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(1)
-        const file = files[0]
-        expect(file.status).toBe(AppFileStatus.Resolved)
+        expect(files).toHaveLength(5)
+        const file = files.find(f => f.path === 'foo')
+        expect(file!.status).toBe(AppFileStatus.Resolved)
       })
     })
 


### PR DESCRIPTION
## Overview

In wrapping up #6133, I thought it would be good to throw a little more test coverage on our handling of different merge conflict file types, since one of our existing unit tests helped me chase down an edge case.

## Description

- `setupConflictedRepoWithMultipleFiles` now offers four different file conflict types (`A`/`A`, `U`/`U`, `D`/`M`, `M`/`M`)
- `status-test.tsx` has been updated to use this fixture
- `diff-check-test.tsx` has been updated to use this fixture
- had to do a little type munging to get the `expect`s i wanted 😕

## Release notes

This is definitely not user-facing

Notes: no-notes
