### PR TITLE
Fix empty PR view width

### DIFF
--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -228,7 +228,7 @@
 }
 
 .no-pull-requests {
-  width: 300px;
+  width: 350px;
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
Missed this spot when we widened the branch panel in another PR

|Before|After|
|---|---|
|![screen shot 2018-11-09 at 12 49 19 pm](https://user-images.githubusercontent.com/10404068/48287550-178bf480-e41e-11e8-97c5-843e2c533d98.png)|![screen shot 2018-11-09 at 12 49 29 pm](https://user-images.githubusercontent.com/10404068/48287551-178bf480-e41e-11e8-8f7a-24f7c494fac9.png)|
