### PR TITLE
Win32 LaunchEditor use Shell for .CMD files

### DIFF
--- a/app/src/lib/editors/found-editor.ts
+++ b/app/src/lib/editors/found-editor.ts
@@ -1,4 +1,5 @@
 export interface IFoundEditor<T> {
   readonly editor: T
   readonly path: string
+  readonly usesShell?: boolean
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -18,11 +18,14 @@ export async function launchExternalEditor(
     const label = __DARWIN__ ? 'Preferences' : 'Options'
     throw new ExternalEditorError(
       `Could not find executable for '${editor.editor}' at path '${
-        editor.path
+      editor.path
       }'.  Please open ${label} and select an available editor.`,
       { openPreferences: true }
     )
   }
-
-  spawn(editorPath, [fullPath])
+  if (editor.usesShell) {
+    spawn(`"${editorPath}"`, [`"${fullPath}"`], { shell: true })
+  } else {
+    spawn(editorPath, [fullPath])
+  }
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -18,7 +18,7 @@ export async function launchExternalEditor(
     const label = __DARWIN__ ? 'Preferences' : 'Options'
     throw new ExternalEditorError(
       `Could not find executable for '${editor.editor}' at path '${
-      editor.path
+        editor.path
       }'.  Please open ${label} and select an available editor.`,
       { openPreferences: true }
     )

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -16,7 +16,7 @@ export function parse(label: string): ExternalEditor | null {
 
   throw new Error(
     `Platform not currently supported for resolving editors: ${
-      process.platform
+    process.platform
     }`
   )
 }
@@ -33,6 +33,10 @@ export type FoundEditor = {
    * The executable associated with the editor to launch
    */
   path: string
+  /**
+   * the editor requires a shell spawn to launch
+   */
+  usesShell?: boolean
 }
 
 interface IErrorMetadata {

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -16,7 +16,7 @@ export function parse(label: string): ExternalEditor | null {
 
   throw new Error(
     `Platform not currently supported for resolving editors: ${
-    process.platform
+      process.platform
     }`
   )
 }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -174,11 +174,11 @@ function getExecutableShim(
 ): string {
   switch (editor) {
     case ExternalEditor.Atom:
-      return Path.join(installLocation, 'bin', 'atom.cmd')
+      return Path.join(installLocation, 'bin', 'atom.cmd') // remember, CMD must 'useShell'
     case ExternalEditor.VisualStudioCode:
-      return Path.join(installLocation, 'bin', 'code.cmd')
+      return Path.join(installLocation, 'bin', 'code.cmd') // remember, CMD must 'useShell'
     case ExternalEditor.VisualStudioCodeInsiders:
-      return Path.join(installLocation, 'bin', 'code-insiders.cmd')
+      return Path.join(installLocation, 'bin', 'code-insiders.cmd') // remember, CMD must 'useShell'
     case ExternalEditor.SublimeText:
       return Path.join(installLocation, 'subl.exe')
     case ExternalEditor.CFBuilder:
@@ -359,7 +359,7 @@ async function findApplication(editor: ExternalEditor): Promise<string | null> {
  */
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-> {
+  > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
   const [
@@ -382,6 +382,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.Atom,
       path: atomPath,
+      usesShell: true
     })
   }
 
@@ -389,6 +390,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.VisualStudioCode,
       path: codePath,
+      usesShell: true
     })
   }
 
@@ -396,6 +398,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.VisualStudioCodeInsiders,
       path: codeInsidersPath,
+      usesShell: true
     })
   }
 
@@ -403,6 +406,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.SublimeText,
       path: sublimePath,
+      usesShell: false
     })
   }
 
@@ -410,6 +414,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.CFBuilder,
       path: cfBuilderPath,
+      usesShell: false
     })
   }
 
@@ -417,6 +422,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.Typora,
       path: typoraPath,
+      usesShell: false
     })
   }
 

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -359,7 +359,7 @@ async function findApplication(editor: ExternalEditor): Promise<string | null> {
  */
 export async function getAvailableEditors(): Promise<
   ReadonlyArray<IFoundEditor<ExternalEditor>>
-  > {
+> {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
   const [
@@ -382,7 +382,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.Atom,
       path: atomPath,
-      usesShell: true
+      usesShell: true,
     })
   }
 
@@ -390,7 +390,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.VisualStudioCode,
       path: codePath,
-      usesShell: true
+      usesShell: true,
     })
   }
 
@@ -398,7 +398,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.VisualStudioCodeInsiders,
       path: codeInsidersPath,
-      usesShell: true
+      usesShell: true,
     })
   }
 
@@ -406,7 +406,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.SublimeText,
       path: sublimePath,
-      usesShell: false
+      usesShell: false,
     })
   }
 
@@ -414,7 +414,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.CFBuilder,
       path: cfBuilderPath,
-      usesShell: false
+      usesShell: false,
     })
   }
 
@@ -422,7 +422,7 @@ export async function getAvailableEditors(): Promise<
     results.push({
       editor: ExternalEditor.Typora,
       path: typoraPath,
-      usesShell: false
+      usesShell: false,
     })
   }
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -174,7 +174,7 @@ function isExpectedInstallation(
 }
 ```
 
-### Step 3: Launch the program
+### Step 3: Determine the program to launch
 
 Now that Desktop knows the program is the one it expects, it can use the
 install location to then find the executable to launch. Many editors provide a
@@ -198,6 +198,30 @@ function getExecutableShim(
 
 Desktop will confirm this file exists on disk before launching - if it's
 missing or lost it won't let you launch the external editor.
+
+If the external editor utilizes a CMD.EXE shell script to launch, Desktop
+needs to know this in order to properly launch the CMD.EXE shell.  This is 
+done by setting the property `usesShell: true` in `getAvailableEditors`.
+
+```ts
+export async function getAvailableEditors(): Promise<
+  ReadonlyArray<IFoundEditor<ExternalEditor>>
+> {
+  ...
+
+  if (codePath) {
+    results.push({
+      editor: ExternalEditor.VisualStudioCode,
+      path: codePath,
+      usesShell: true,
+    })
+  }
+
+  ...
+
+  return results
+}
+```
 
 ## macOS
 


### PR DESCRIPTION
## Overview

Addresses issues #5933, #5655, #4246, #4277, all regarding the commands for opening the repository, or a file, in an external editor, and that editor choice requiring use of a shell script to be spawned and there being spaces in the path to the editor, often in the user account in the case of Atom.

## Description

The listed issues stem from issues in Node JS `spawn` function which doesn't always handle execution of shell scripts correctly.  If both the file path to the shell script file, and an argument being passed to the script include spaces, the spawn does not work, but without any error.

I have added the `usesShell` property to `IFoundEditor` to indicate when the editor uses a shell script and needs to be spawned accordingly.  `getAvailableEditors` arbitrarily adds `usesShell: true` for the editors known to use a shell script when spawned.   `launchExternalEditor` is then altered to detect the `usesShell` property and use a different set of arguments for the spawn, to include the spawn option `shell: true`, along with quotation of the arguments.

## Release notes

 - fixes 'Open In External Editor' for Atom/VS Code on Windows when paths contain spaces.

Notes:

FYI, this is as much work as I have ever done in TypeScript or even JavaScript for that matter.  Please excuse me if I have failed to follow any normal conventions.  It could be possible that additional commenting could be utilized to help insure future additions to the editors list will result in the added editors working correctly.
