### PR TITLE
indicate that we expect this error to occur to avoid it polluting the dev tools

### DIFF
--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -2,6 +2,7 @@ import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
 import { git } from './core'
+import { GitError } from 'dugite'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { MergeResult, MergeResultKind } from '../../models/merge'
@@ -13,7 +14,9 @@ export async function merge(
   repository: Repository,
   branch: string
 ): Promise<true> {
-  await git(['merge', branch], repository.path, 'merge')
+  await git(['merge', branch], repository.path, 'merge', {
+    expectedErrors: new Set([GitError.MergeConflicts]),
+  })
   return true
 }
 

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -1,7 +1,7 @@
 import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
-import { git, parseCommitSHA } from './core'
+import { git } from './core'
 import { GitError } from 'dugite'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
@@ -13,11 +13,11 @@ import { spawnAndComplete } from './spawn'
 export async function merge(
   repository: Repository,
   branch: string
-): Promise<string> {
+): Promise<boolean> {
   const result = await git(['merge', branch], repository.path, 'merge', {
     expectedErrors: new Set([GitError.MergeConflicts]),
   })
-  return parseCommitSHA(result)
+  return result.exitCode === 0
 }
 
 /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1103,7 +1103,7 @@ export class GitStore extends BaseStore {
   }
 
   /** Merge the named branch into the current branch. */
-  public merge(branch: string): Promise<string | undefined> {
+  public merge(branch: string): Promise<boolean | undefined> {
     return this.performFailableOperation(() => merge(this.repository, branch), {
       gitContext: {
         kind: 'merge',


### PR DESCRIPTION
## Overview

While investigating a potential bug we were getting feedback about this error in the dev tools:

<img width="882" src="https://user-images.githubusercontent.com/359239/48430406-a44bf080-e745-11e8-9107-4f1bb17c2658.png">

This PR tidies up that warning, because it's a known case and wasn't related to the root cause of the issue.

## Description

We have an `expectedErrors` argument that can be provided when invoking Git to indicate what known errors we expect. This was initially put in place to identify the known ways an operation might fail, and make clear cases that Git encounters which we should handle.

This error is expected and pushed into the error handling pipeline, so we can't set it as expected to kill off the noise in the dev tools.

## Release notes

Notes: no-notes
