### PR TITLE
add a unified commit context shape to combine related data

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -22,7 +22,7 @@ import {
 import { AppStore } from '../stores/app-store'
 import { CloningRepository } from '../../models/cloning-repository'
 import { Branch } from '../../models/branch'
-import { Commit } from '../../models/commit'
+import { Commit, ICommitContext } from '../../models/commit'
 import { ExternalEditor } from '../../lib/editors'
 import { IAPIUser } from '../../lib/api'
 import { GitHubRepository } from '../../models/github-repository'
@@ -57,7 +57,6 @@ import { BranchesTab } from '../../models/branches-tab'
 import { FetchType } from '../../models/fetch'
 import { PullRequest } from '../../models/pull-request'
 import { IAuthor } from '../../models/author'
-import { ITrailer } from '../git/interpret-trailers'
 import { isGitRepository } from '../git'
 import { ApplicationTheme } from '../../ui/lib/application-theme'
 import { TipState } from '../../models/tip'
@@ -208,16 +207,9 @@ export class Dispatcher {
    */
   public async commitIncludedChanges(
     repository: Repository,
-    summary: string,
-    description: string | null,
-    trailers?: ReadonlyArray<ITrailer>
+    context: ICommitContext
   ): Promise<boolean> {
-    return this.appStore._commitIncludedChanges(
-      repository,
-      summary,
-      description,
-      trailers
-    )
+    return this.appStore._commitIncludedChanges(repository, context)
   }
 
   /** Change the file's includedness. */

--- a/app/src/lib/format-commit-message.ts
+++ b/app/src/lib/format-commit-message.ts
@@ -1,5 +1,6 @@
-import { ITrailer, mergeTrailers } from './git/interpret-trailers'
+import { mergeTrailers } from './git/interpret-trailers'
 import { Repository } from '../models/repository'
+import { ICommitContext } from '../models/commit'
 
 /**
  * Formats a summary and a description into a git-friendly
@@ -16,10 +17,10 @@ import { Repository } from '../models/repository'
  */
 export async function formatCommitMessage(
   repository: Repository,
-  summary: string,
-  description: string | null,
-  trailers?: ReadonlyArray<ITrailer>
+  context: ICommitContext
 ) {
+  const { summary, description, trailers } = context
+
   // Git always trim whitespace at the end of commit messages
   // so we concatenate the summary with the description, ensuring
   // that they're separated by two newlines. If we don't have a

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -22,7 +22,7 @@ import {
 import { BranchesTab } from '../../models/branches-tab'
 import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloningRepository } from '../../models/cloning-repository'
-import { Commit } from '../../models/commit'
+import { Commit, ICommitContext } from '../../models/commit'
 import {
   DiffSelection,
   DiffSelectionType,
@@ -122,7 +122,6 @@ import {
   getWorkingDirectoryDiff,
   isCoAuthoredByTrailer,
   mergeTree,
-  ITrailer,
   pull as pullRepo,
   push as pushRepo,
   renameBranch,
@@ -1775,9 +1774,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _commitIncludedChanges(
     repository: Repository,
-    summary: string,
-    description: string | null,
-    trailers?: ReadonlyArray<ITrailer>
+    context: ICommitContext
   ): Promise<boolean> {
     const state = this.repositoryStateCache.get(repository)
     const files = state.changesState.workingDirectory.files
@@ -1789,12 +1786,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const result = await this.isCommitting(repository, () => {
       return gitStore.performFailableOperation(async () => {
-        const message = await formatCommitMessage(
-          repository,
-          summary,
-          description,
-          trailers
-        )
+        const message = await formatCommitMessage(repository, context)
         return createCommit(repository, message, selectedFiles)
       })
     })
@@ -1809,6 +1801,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.statsStore.recordPartialCommit()
       }
 
+      const { trailers } = context
       if (trailers != null && trailers.some(isCoAuthoredByTrailer)) {
         this.statsStore.recordCoAuthoredCommit()
       }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1802,7 +1802,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       const { trailers } = context
-      if (trailers != null && trailers.some(isCoAuthoredByTrailer)) {
+      if (trailers !== undefined && trailers.some(isCoAuthoredByTrailer)) {
         this.statsStore.recordCoAuthoredCommit()
       }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -561,12 +561,10 @@ export class GitStore extends BaseStore {
 
     // git-interpret-trailers is really only made for working
     // with full commit messages so let's start with that
-    const message = await formatCommitMessage(
-      repository,
-      commit.summary,
-      commit.body,
-      []
-    )
+    const message = await formatCommitMessage(repository, {
+      summary: commit.summary,
+      description: commit.body,
+    })
 
     // Next we extract any co-authored-by trailers we
     // can find. We use interpret-trailers for this

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -15,7 +15,7 @@ export interface ICommitContext {
    */
   readonly description: string | null
   /**
-   * Trailers representing co-author information (optional)
+   * An optional array of commit trailers (for example Co-Authored-By trailers) which will be appended to the commit message in accordance with the Git trailer configuration.
    */
   readonly trailers?: ReadonlyArray<ITrailer>
 }

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -6,8 +6,17 @@ import { getDotComAPIEndpoint } from '../lib/api'
 
 /** Grouping of information required to create a commit */
 export interface ICommitContext {
+  /**
+   * The summary of the commit message (required)
+   */
   readonly summary: string
+  /**
+   * Additional details for the commit message (optional)
+   */
   readonly description: string | null
+  /**
+   * Trailers representing co-author information (optional)
+   */
   readonly trailers?: ReadonlyArray<ITrailer>
 }
 

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -4,6 +4,13 @@ import { GitAuthor } from './git-author'
 import { GitHubRepository } from './github-repository'
 import { getDotComAPIEndpoint } from '../lib/api'
 
+/** Grouping of information required to create a commit */
+export interface ICommitContext {
+  readonly summary: string
+  readonly description: string | null
+  readonly trailers?: ReadonlyArray<ITrailer>
+}
+
 /**
  * Extract any Co-Authored-By trailers from an array of arbitrary
  * trailers.

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -3,7 +3,6 @@ import * as Path from 'path'
 
 import { IGitHubUser } from '../../lib/databases'
 import { Dispatcher } from '../../lib/dispatcher'
-import { ITrailer } from '../../lib/git/interpret-trailers'
 import { IMenuItem } from '../../lib/menu-item'
 import { revealInFileManager } from '../../lib/app-shell'
 import {
@@ -32,6 +31,7 @@ import { showContextualMenu } from '../main-process-proxy'
 import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
 import { basename } from 'path'
+import { ICommitContext } from '../../models/commit'
 
 const RowHeight = 29
 
@@ -44,11 +44,7 @@ interface IChangesListProps {
   readonly onFileSelectionChanged: (rows: ReadonlyArray<number>) => void
   readonly onIncludeChanged: (path: string, include: boolean) => void
   readonly onSelectAll: (selectAll: boolean) => void
-  readonly onCreateCommit: (
-    summary: string,
-    description: string | null,
-    trailers?: ReadonlyArray<ITrailer>
-  ) => Promise<boolean>
+  readonly onCreateCommit: (context: ICommitContext) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly onDiscardAllChanges: (

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -19,10 +19,10 @@ import { AuthorInput } from '../lib/author-input'
 import { FocusContainer } from '../lib/focus-container'
 import { showContextualMenu } from '../main-process-proxy'
 import { Octicon, OcticonSymbol } from '../octicons'
-import { ITrailer } from '../../lib/git/interpret-trailers'
 import { IAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
 import { shallowEquals } from '../../lib/equality'
+import { ICommitContext } from '../../models/commit'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -34,11 +34,7 @@ const addAuthorIcon = new OcticonSymbol(
 )
 
 interface ICommitMessageProps {
-  readonly onCreateCommit: (
-    summary: string,
-    description: string | null,
-    trailers?: ReadonlyArray<ITrailer>
-  ) => Promise<boolean>
+  readonly onCreateCommit: (context: ICommitContext) => Promise<boolean>
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly gitHubUser: IGitHubUser | null
@@ -181,14 +177,18 @@ export class CommitMessage extends React.Component<
 
     const trailers = this.getCoAuthorTrailers()
 
-    const commitCreated = await this.props.onCreateCommit(
-      // allow single file commit without summary
+    const summaryOrPlaceholder =
       this.props.singleFileCommit && !this.state.summary
         ? this.props.placeholder
-        : summary,
+        : summary
+
+    const commitContext = {
+      summary: summaryOrPlaceholder,
       description,
-      trailers
-    )
+      trailers,
+    }
+
+    const commitCreated = await this.props.onCreateCommit(commitContext)
 
     if (commitCreated) {
       this.clearCommitMessage()

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -9,7 +9,7 @@ import { Dispatcher } from '../../lib/dispatcher'
 import { IGitHubUser } from '../../lib/databases'
 import { IssuesStore, GitHubUserStore } from '../../lib/stores'
 import { CommitIdentity } from '../../models/commit-identity'
-import { Commit } from '../../models/commit'
+import { Commit, ICommitContext } from '../../models/commit'
 import { UndoCommit } from './undo-commit'
 import {
   IAutocompletionProvider,
@@ -21,7 +21,6 @@ import { ClickSource } from '../lib/list'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { CSSTransitionGroup } from 'react-transition-group'
 import { openFile } from '../../lib/open-file'
-import { ITrailer } from '../../lib/git/interpret-trailers'
 import { Account } from '../../models/account'
 import { PopupType } from '../../models/popup'
 
@@ -114,16 +113,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
   }
 
-  private onCreateCommit = (
-    summary: string,
-    description: string | null,
-    trailers?: ReadonlyArray<ITrailer>
-  ): Promise<boolean> => {
+  private onCreateCommit = (context: ICommitContext): Promise<boolean> => {
     return this.props.dispatcher.commitIncludedChanges(
       this.props.repository,
-      summary,
-      description,
-      trailers
+      context
     )
   }
 

--- a/app/test/unit/format-commit-message.ts
+++ b/app/test/unit/format-commit-message.ts
@@ -7,27 +7,33 @@ describe('formatCommitMessage', () => {
   it('always adds trailing newline', async () => {
     const repo = await setupEmptyRepository()
 
-    expect(await formatCommitMessage(repo, 'test', null)).to.equal('test\n')
-    expect(await formatCommitMessage(repo, 'test', 'test')).to.equal(
-      'test\n\ntest\n'
-    )
+    expect(
+      await formatCommitMessage(repo, { summary: 'test', description: null })
+    ).to.equal('test\n')
+    expect(
+      await formatCommitMessage(repo, { summary: 'test', description: 'test' })
+    ).to.equal('test\n\ntest\n')
   })
 
   it('omits description when null', async () => {
     const repo = await setupEmptyRepository()
-    expect(await formatCommitMessage(repo, 'test', null)).to.equal('test\n')
+    expect(
+      await formatCommitMessage(repo, { summary: 'test', description: null })
+    ).to.equal('test\n')
   })
 
   it('omits description when empty string', async () => {
     const repo = await setupEmptyRepository()
-    expect(await formatCommitMessage(repo, 'test', '')).to.equal('test\n')
+    expect(
+      await formatCommitMessage(repo, { summary: 'test', description: '' })
+    ).to.equal('test\n')
   })
 
   it('adds two newlines between summary and description', async () => {
     const repo = await setupEmptyRepository()
-    expect(await formatCommitMessage(repo, 'foo', 'bar')).to.equal(
-      'foo\n\nbar\n'
-    )
+    expect(
+      await formatCommitMessage(repo, { summary: 'foo', description: 'bar' })
+    ).to.equal('foo\n\nbar\n')
   })
 
   it('appends trailers to a summary-only message', async () => {
@@ -36,7 +42,13 @@ describe('formatCommitMessage', () => {
       { token: 'Co-Authored-By', value: 'Markus Olsson <niik@github.com>' },
       { token: 'Signed-Off-By', value: 'nerdneha <nerdneha@github.com>' },
     ]
-    expect(await formatCommitMessage(repo, 'foo', null, trailers)).to.equal(
+    expect(
+      await formatCommitMessage(repo, {
+        summary: 'foo',
+        description: null,
+        trailers,
+      })
+    ).to.equal(
       'foo\n\n' +
         'Co-Authored-By: Markus Olsson <niik@github.com>\n' +
         'Signed-Off-By: nerdneha <nerdneha@github.com>\n'
@@ -49,7 +61,13 @@ describe('formatCommitMessage', () => {
       { token: 'Co-Authored-By', value: 'Markus Olsson <niik@github.com>' },
       { token: 'Signed-Off-By', value: 'nerdneha <nerdneha@github.com>' },
     ]
-    expect(await formatCommitMessage(repo, 'foo', 'bar', trailers)).to.equal(
+    expect(
+      await formatCommitMessage(repo, {
+        summary: 'foo',
+        description: 'bar',
+        trailers,
+      })
+    ).to.equal(
       'foo\n\nbar\n\n' +
         'Co-Authored-By: Markus Olsson <niik@github.com>\n' +
         'Signed-Off-By: nerdneha <nerdneha@github.com>\n'
@@ -64,12 +82,11 @@ describe('formatCommitMessage', () => {
       { token: 'Signed-Off-By', value: 'nerdneha <nerdneha@github.com>' },
     ]
     expect(
-      await formatCommitMessage(
-        repo,
-        'foo',
-        'Co-Authored-By: Markus Olsson <niik@github.com>',
-        trailers
-      )
+      await formatCommitMessage(repo, {
+        summary: 'foo',
+        description: 'Co-Authored-By: Markus Olsson <niik@github.com>',
+        trailers,
+      })
     ).to.equal(
       'foo\n\n' +
         'Co-Authored-By: Markus Olsson <niik@github.com>\n' +
@@ -85,13 +102,12 @@ describe('formatCommitMessage', () => {
     ]
 
     expect(
-      await formatCommitMessage(
-        repo,
-        'foo',
+      await formatCommitMessage(repo, {
+        summary: 'foo',
         // note the lack of space after :
-        'Co-Authored-By:Markus Olsson <niik@github.com>',
-        trailers
-      )
+        description: 'Co-Authored-By:Markus Olsson <niik@github.com>',
+        trailers,
+      })
     ).to.equal(
       'foo\n\n' +
         'Co-Authored-By: Markus Olsson <niik@github.com>\n' +


### PR DESCRIPTION
## Overview

This came up in a review of #6013 as it replicated the pattern elsewhere in the codebase of defining the same three parameters to represent a commit message: https://github.com/desktop/desktop/pull/6013#discussion_r228990995

## Description

To generate a commit message, we need to flow these fields around to eventually reach `formatCommitMessage`:

```ts
const message = await formatCommitMessage(
  repository,
  summary,
  description,
  trailers
)
```

Instead, this PR combines these three fields into a single `ICommitContext` to clean up this replication:

```ts
const message = await formatCommitMessage(repository, context)
```

Another benefit of this PR is that it tidies up places where we had to import `ITrailer` because we'd have to annotate the parameters to each function:

```ts
import { ITrailer } from '../git/interpret-trailers'
```

And we'd have to ensure these parameters were all consistent:

```ts
  public async commitIncludedChanges(
    repository: Repository,
    summary: string,
    description: string | null,
    trailers?: ReadonlyArray<ITrailer>
  ): Promise<boolean> {
```

## Release notes

Notes: no-notes
