### PR TITLE
simplify LFS check to avoid string encoding issues

### DIFF
--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -1,6 +1,5 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
-import { caseInsensitiveCompare } from '../compare'
 
 /** Install the global LFS filters. */
 export async function installGlobalLFSFilters(force: boolean): Promise<void> {
@@ -69,20 +68,11 @@ export async function isTrackedByLFS(
   //
   // README.md: filter: unspecified
 
-  const lfsFilterRegex = /(.*): filter: lfs/
+  const lfsFilterRegex = /: filter: lfs/
 
   const match = lfsFilterRegex.exec(stdout)
 
-  if (match == null || match.length !== 2) {
-    return false
-  }
-
-  const fileName = match[1]
-  if (caseInsensitiveCompare(fileName, path) !== 0) {
-    return false
-  }
-
-  return true
+  return match !== null
 }
 
 /**

--- a/app/test/unit/git/lfs-test.ts
+++ b/app/test/unit/git/lfs-test.ts
@@ -58,6 +58,20 @@ describe('git-lfs', () => {
       const found = await isTrackedByLFS(repository, file)
       expect(found).toBe(true)
     })
+
+    it('returns true after tracking file with character issues in Git LFS', async () => {
+      const repository = await setupEmptyRepository()
+
+      const file =
+        'Top Ten Worst Repositories to host on GitHub - Carlos Martín Nieto.md'
+      const readme = Path.join(repository.path, file)
+      await writeFile(readme, 'Hello world!')
+
+      await GitProcess.exec(['lfs', 'track', '*.md'], repository.path)
+
+      const found = await isTrackedByLFS(repository, file)
+      expect(found).toBe(true)
+    })
   })
 
   describe('filesNotTrackedByLFS', () => {


### PR DESCRIPTION
## Overview

This was suggested when I originally implemented the LFS checks in https://github.com/desktop/desktop/pull/6053#discussion_r229903903 and I found a test case that was not correctly recognised as being handled by Git LFS.

This will also help with the correctness of #6013.

## Description

The file was a talk from @carlosmn which was great because of the special character in the `Martín` in his name meant the JS string the app passed to Git looked like this:

```
Top Ten Worst Repositories to host on GitHub - Carlos Martín Nieto.mp4
```

And it also meant that Git wrapped the file it emitted in quote marks and generated some unexpected characters:

```
"Top Ten Worst Repositories to host on GitHub - Carlos Mart\303\255n Nieto.mp4": filter: lfs↵
```

And the regex found this string:

```
"Top Ten Worst Repositories to host on GitHub - Carlos Mart\303\255n Nieto.mp4"
```

Which clearly doesn't match my input string.

For the sake of moving things along rather than digging into encodings, I'm going to trust Git LFS when it emits an entry here, and avoid the pitfalls of strings being emitted by Git.

Moral of the story: sometimes you should listen to @ttaylorr

## TODO

 - [x] add a unit test that failed with the old test but passes after the fix

## Release notes

This is some plumbing related to an upcoming feature, and isn't user facing yet.

Notes: no-notes
