### PR TITLE
add previous value to ping payload to differentiate between scenarios

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -248,7 +248,7 @@ export class StatsStore {
     // If the user has set an opt out value but we haven't sent the ping yet,
     // give it a shot now.
     if (!getBoolean(HasSentOptInPingKey, false)) {
-      this.sendOptInStatusPing(!this.optOut, storedValue || null)
+      this.sendOptInStatusPing(!this.optOut, storedValue)
     }
 
     this.enableUiActivityMonitoring()
@@ -601,7 +601,7 @@ export class StatsStore {
 
     this.optOut = optOut
 
-    const previousValue = getBoolean(StatsOptOutKey) || null
+    const previousValue = getBoolean(StatsOptOutKey)
 
     setBoolean(StatsOptOutKey, optOut)
 
@@ -772,14 +772,16 @@ export class StatsStore {
    */
   private async sendOptInStatusPing(
     optIn: boolean,
-    previousValue: boolean | null
+    previousValue?: boolean
   ): Promise<void> {
     const direction = optIn ? 'in' : 'out'
+    const previousValueOrNull =
+      previousValue === undefined ? null : previousValue
     try {
       const response = await this.post({
         eventType: 'ping',
         optIn,
-        previousValue,
+        previousValue: previousValueOrNull,
       })
       if (!response.ok) {
         throw new Error(


### PR DESCRIPTION
## Overview

I was discussing with @billygriffin the onboarding experience and the reasons for sending this ping event when the user opts in or opts out of sending usage stats, but we spotted a gap in the design of the payload.

## Description

We realised we couldn't differentiate between these two scenarios a user in Desktop might do:

 - user installs the app, on first launch is asked whether they consent to sending usage stats, checks box to agree
 - user installs the app, did not consent, then some time later opens Options/Preferences, agrees to opt-in to sending usage stats, and presses Save to update their stats

Currently both of these actions send the same ping event with `{ optIn: true }` in the payload, but we'd like to be able to distinguish between them. The first scenario is an important step as part of onboarding new users, and the second is one an existing GitHub Desktop user would perform. We'd like to identify and understand any underlying trends around this area.

To distinguish between these two, I've added a `previousValue` field to the payload:

 - for the new user choosing whether or not to submit usage stats, `previousValue` will be `null` to indicate no previous choice had been set
 - for the existing user choosing to change their preference, `previousValue` will be the value found in local storage

## Release notes

Notes: no-notes
