### PR TITLE
added focus on close button to license modal

### DIFF
--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -160,7 +160,9 @@ export class Acknowledgements extends React.Component<
 
         <DialogFooter>
           <ButtonGroup>
-            <Button type="submit" onButtonRef={this.onCloseButtonRef}>Close</Button>
+            <Button type="submit" onButtonRef={this.onCloseButtonRef}>
+              Close
+            </Button>
           </ButtonGroup>
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -38,6 +38,13 @@ export class Acknowledgements extends React.Component<
   IAcknowledgementsProps,
   IAcknowledgementsState
 > {
+  private dialogContainerRef: HTMLDivElement | null = null
+  private closeButtonRef: HTMLButtonElement | null = null
+
+  private onCloseButtonRef = (element: HTMLButtonElement | null) => {
+    this.closeButtonRef = element
+  }
+
   public constructor(props: IAcknowledgementsProps) {
     super(props)
 
@@ -61,6 +68,18 @@ export class Acknowledgements extends React.Component<
 
       this.setState({ licenses: parsed })
     })
+
+    // When the dialog is mounted it automatically moves focus to the first
+    // focusable element which in this case is a link to an external site. We don't
+    // want that so let's just reset it.
+    if (this.dialogContainerRef) {
+      this.dialogContainerRef.scrollTop = 0
+    }
+
+    // And let's just move focus to the close button.
+    if (this.closeButtonRef) {
+      this.closeButtonRef.focus()
+    }
   }
 
   private renderLicenses(licenses: Licenses) {
@@ -141,7 +160,7 @@ export class Acknowledgements extends React.Component<
 
         <DialogFooter>
           <ButtonGroup>
-            <Button type="submit">Close</Button>
+            <Button type="submit" onButtonRef={this.onCloseButtonRef}>Close</Button>
           </ButtonGroup>
         </DialogFooter>
       </Dialog>


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #6137**

## Description

- The close button is now in focus on the 'License and Open Source Notes' modal within the 'About Github Desktop' modal. Old behavior would open new window on enter key press inside the modal, new behavior closes the modal. I used the code and comments from the T&C file for consistency.

New behavior:
1. Open "About GitHub Desktop"
2. Click on "License and Open Source Notices"
3. Click Enter/Return
4. "Close" button invoked and the modal closes.

Any changes needed let me know! Thanks

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: no notes
