### PR TITLE
auto recover missing repository

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -246,9 +246,7 @@ export class Dispatcher {
    * Refresh the repository. This would be used, e.g., when the app gains focus.
    */
   public refreshRepository(repository: Repository): Promise<void> {
-    return repository.missing
-      ? this.appStore._attemptRecoverMissingRepository(repository)
-      : this.appStore._refreshRepository(repository)
+    return this.appStore._refreshOrRecoverRepository(repository)
   }
 
   /** Show the popup. This will close any current popup. */

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -246,7 +246,9 @@ export class Dispatcher {
    * Refresh the repository. This would be used, e.g., when the app gains focus.
    */
   public refreshRepository(repository: Repository): Promise<void> {
-    return this.appStore._refreshRepository(repository)
+    return repository.missing
+      ? this.appStore._attemptRecoverMissingRepository(repository)
+      : this.appStore._refreshRepository(repository)
   }
 
   /** Show the popup. This will close any current popup. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1895,7 +1895,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _attemptRecoverMissingRepository(
+  public async _refreshOrRecoverRepository(
     repository: Repository
   ): Promise<void> {
     // if repository is missing, try checking if it has been restored
@@ -1905,6 +1905,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // repository has been restored, attempt to refresh it now.
         return this._refreshRepository(updatedRepository)
       }
+    } else {
+      return this._refreshRepository(repository)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1089,13 +1089,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return Promise.resolve(null)
     }
 
-    return this._selectRepository_refreshTasks(
+    return this._selectRepositoryRefreshTasks(
       refreshedRepository,
       previouslySelectedRepository
     )
   }
 
-  private async _selectRepository_refreshTasks(
+  // finish `_selectRepository`s refresh tasks
+  private async _selectRepositoryRefreshTasks(
     repository: Repository,
     previouslySelectedRepository: Repository | CloningRepository | null
   ): Promise<Repository | null> {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -161,8 +161,11 @@ ipcRenderer.on('focus', () => {
   const { selectedState } = appStore.getState()
 
   // Refresh the currently selected repository on focus (if
-  // we have a selected repository).
-  if (selectedState && selectedState.type === SelectionType.Repository) {
+  // we have a selected repository, that is not cloning).
+  if (
+    selectedState &&
+    !(selectedState.type === SelectionType.CloningRepository)
+  ) {
     dispatcher.refreshRepository(selectedState.repository)
   }
 

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -6,17 +6,35 @@ import { Repository } from '../models/repository'
 
 import { Button } from './lib/button'
 import { Row } from './lib/row'
+import { isGitRepository } from '../lib/git'
 
 interface IMissingRepositoryProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
 }
 
+// The maximum value that can be used in setInterval or
+// setTimeout without it overflowing (2 ^ 31 - 1). See
+//  http://stackoverflow.com/a/16314807
+const MAX_INTERVAL = 2147483647
+
+const recoveryDelayLong = 10000
+const recoveryDelayShort = 1000
+
 /** The view displayed when a repository is missing. */
 export class MissingRepository extends React.Component<
   IMissingRepositoryProps,
   {}
 > {
+  private timer: number | null = null
+
+  private clearTimer() {
+    if (this.timer) {
+      window.clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
   public render() {
     const buttons = new Array<JSX.Element>()
     buttons.push(
@@ -39,6 +57,8 @@ export class MissingRepository extends React.Component<
       </Button>
     )
 
+    this.awaitAutoRecovery(recoveryDelayShort) // attempt auto recovery, or set timer to try again later
+
     return (
       <UiView id="missing-repository-view">
         <div className="title-container">
@@ -60,10 +80,12 @@ export class MissingRepository extends React.Component<
   }
 
   private remove = () => {
+    this.clearTimer()
     this.props.dispatcher.removeRepositories([this.props.repository], false)
   }
 
   private locate = () => {
+    this.clearTimer()
     this.props.dispatcher.relocateRepository(this.props.repository)
   }
 
@@ -78,6 +100,7 @@ export class MissingRepository extends React.Component<
       return
     }
 
+    this.clearTimer()
     try {
       await this.props.dispatcher.cloneAgain(
         cloneURL,
@@ -85,6 +108,48 @@ export class MissingRepository extends React.Component<
       )
     } catch (error) {
       this.props.dispatcher.postError(error)
+    }
+  }
+
+  private awaitAutoRecovery(timeout: number) {
+    // set a timeout to wait to attempt an auto recovery
+    this.clearTimer()
+    this.timer = window.setTimeout(
+      this.attemptAutoRecovery,
+      Math.min(timeout, MAX_INTERVAL)
+    )
+  }
+
+  private readonly attemptAutoRecovery = () => {
+    this.AutoRecovery()
+  }
+
+  public componentWillUnmount() {
+    this.clearTimer()
+  }
+
+  private async AutoRecovery() {
+    if (this.timer && this.props.repository.missing) {
+      // do attempt to recover the missing repository, unless timer has been cleared
+      // if not, set timeout to try again
+
+      if (await isGitRepository(this.props.repository.path)) {
+        // a git repository was found on the original path
+        if (
+          (await this.props.dispatcher.updateRepositoryMissing(
+            this.props.repository,
+            false
+          )).missing
+        ) {
+          this.awaitAutoRecovery(recoveryDelayLong)
+        } else {
+          this.clearTimer() // repository is no longer missing
+        }
+      } else {
+        this.awaitAutoRecovery(recoveryDelayLong)
+      }
+    } else if (this.timer) {
+      this.clearTimer() // clear timer as repository is not marked missing ??
     }
   }
 }

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { pathExists } from 'fs-extra'
 
 import { UiView } from './ui-view'
 import { Dispatcher } from '../lib/dispatcher'
@@ -25,7 +26,7 @@ const recoveryDelayShort = 1000
 export class MissingRepository extends React.Component<
   IMissingRepositoryProps,
   {}
-> {
+  > {
   private timer: number | null = null
 
   private clearTimer() {
@@ -133,7 +134,8 @@ export class MissingRepository extends React.Component<
       // do attempt to recover the missing repository, unless timer has been cleared
       // if not, set timeout to try again
 
-      if (await isGitRepository(this.props.repository.path)) {
+      // first test the repository path for existence, then test if the existing path is a git repository
+      if (await pathExists(this.props.repository.path) ? await isGitRepository(this.props.repository.path) : false) {
         // a git repository was found on the original path
         if (
           (await this.props.dispatcher.updateRepositoryMissing(

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { pathExists } from 'fs-extra'
 
 import { UiView } from './ui-view'
 import { Dispatcher } from '../lib/dispatcher'
@@ -7,35 +6,17 @@ import { Repository } from '../models/repository'
 
 import { Button } from './lib/button'
 import { Row } from './lib/row'
-import { isGitRepository } from '../lib/git'
 
 interface IMissingRepositoryProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
 }
 
-// The maximum value that can be used in setInterval or
-// setTimeout without it overflowing (2 ^ 31 - 1). See
-//  http://stackoverflow.com/a/16314807
-const MAX_INTERVAL = 2147483647
-
-const recoveryDelayLong = 10000
-const recoveryDelayShort = 1000
-
 /** The view displayed when a repository is missing. */
 export class MissingRepository extends React.Component<
   IMissingRepositoryProps,
   {}
 > {
-  private timer: number | null = null
-
-  private clearTimer() {
-    if (this.timer) {
-      window.clearTimeout(this.timer)
-      this.timer = null
-    }
-  }
-
   public render() {
     const buttons = new Array<JSX.Element>()
     buttons.push(
@@ -64,8 +45,6 @@ export class MissingRepository extends React.Component<
       </Button>
     )
 
-    this.awaitAutoRecovery(recoveryDelayShort) // attempt auto recovery, or set timer to try again later
-
     return (
       <UiView id="missing-repository-view">
         <div className="title-container">
@@ -91,12 +70,10 @@ export class MissingRepository extends React.Component<
   }
 
   private remove = () => {
-    this.clearTimer()
     this.props.dispatcher.removeRepositories([this.props.repository], false)
   }
 
   private locate = () => {
-    this.clearTimer()
     this.props.dispatcher.relocateRepository(this.props.repository)
   }
 
@@ -111,7 +88,6 @@ export class MissingRepository extends React.Component<
       return
     }
 
-    this.clearTimer()
     try {
       await this.props.dispatcher.cloneAgain(
         cloneURL,
@@ -119,53 +95,6 @@ export class MissingRepository extends React.Component<
       )
     } catch (error) {
       this.props.dispatcher.postError(error)
-    }
-  }
-
-  private awaitAutoRecovery(timeout: number) {
-    // set a timeout to wait to attempt an auto recovery
-    this.clearTimer()
-    this.timer = window.setTimeout(
-      this.attemptAutoRecovery,
-      Math.min(timeout, MAX_INTERVAL)
-    )
-  }
-
-  private readonly attemptAutoRecovery = () => {
-    this.AutoRecovery()
-  }
-
-  public componentWillUnmount() {
-    this.clearTimer()
-  }
-
-  private async AutoRecovery() {
-    if (this.timer && this.props.repository.missing) {
-      // do attempt to recover the missing repository, unless timer has been cleared
-      // if not, set timeout to try again
-
-      // first test the repository path for existence, then test if the existing path is a git repository
-      if (
-        (await pathExists(this.props.repository.path))
-          ? await isGitRepository(this.props.repository.path)
-          : false
-      ) {
-        // a git repository was found on the original path
-        if (
-          (await this.props.dispatcher.updateRepositoryMissing(
-            this.props.repository,
-            false
-          )).missing
-        ) {
-          this.awaitAutoRecovery(recoveryDelayLong)
-        } else {
-          this.clearTimer() // repository is no longer missing
-        }
-      } else {
-        this.awaitAutoRecovery(recoveryDelayLong)
-      }
-    } else if (this.timer) {
-      this.clearTimer() // clear timer as repository is not marked missing ??
     }
   }
 }

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -26,7 +26,7 @@ const recoveryDelayShort = 1000
 export class MissingRepository extends React.Component<
   IMissingRepositoryProps,
   {}
-  > {
+> {
   private timer: number | null = null
 
   private clearTimer() {
@@ -135,7 +135,11 @@ export class MissingRepository extends React.Component<
       // if not, set timeout to try again
 
       // first test the repository path for existence, then test if the existing path is a git repository
-      if (await pathExists(this.props.repository.path) ? await isGitRepository(this.props.repository.path) : false) {
+      if (
+        (await pathExists(this.props.repository.path))
+          ? await isGitRepository(this.props.repository.path)
+          : false
+      ) {
         // a git repository was found on the original path
         if (
           (await this.props.dispatcher.updateRepositoryMissing(

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -39,6 +39,12 @@ export class MissingRepository extends React.Component<
   public render() {
     const buttons = new Array<JSX.Element>()
     buttons.push(
+      <Button key="refresh" onClick={this.refresh}>
+        Refresh
+      </Button>
+    )
+
+    buttons.push(
       <Button key="locate" onClick={this.locate} type="submit">
         Locate…
       </Button>
@@ -78,6 +84,10 @@ export class MissingRepository extends React.Component<
   private canCloneAgain() {
     const gitHubRepository = this.props.repository.gitHubRepository
     return gitHubRepository && gitHubRepository.cloneURL
+  }
+
+  private refresh = () => {
+    this.props.dispatcher.refreshRepository(this.props.repository)
   }
 
   private remove = () => {

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -6,6 +6,7 @@ import { Repository } from '../models/repository'
 
 import { Button } from './lib/button'
 import { Row } from './lib/row'
+import { LinkButton } from './lib/link-button'
 
 interface IMissingRepositoryProps {
   readonly dispatcher: Dispatcher
@@ -20,8 +21,8 @@ export class MissingRepository extends React.Component<
   public render() {
     const buttons = new Array<JSX.Element>()
     buttons.push(
-      <Button key="refresh" onClick={this.refresh}>
-        Refresh
+      <Button key="check-again" onClick={this.checkAgain}>
+        Check Again
       </Button>
     )
 
@@ -51,7 +52,8 @@ export class MissingRepository extends React.Component<
           <div className="title">Can't find "{this.props.repository.name}"</div>
           <div className="details">
             It was last seen at{' '}
-            <span className="path">{this.props.repository.path}</span>
+            <span className="path">{this.props.repository.path}</span>.{' '}
+            <LinkButton onClick={this.checkAgain}>Check&nbsp;again.</LinkButton>
           </div>
         </div>
 
@@ -65,7 +67,7 @@ export class MissingRepository extends React.Component<
     return gitHubRepository && gitHubRepository.cloneURL
   }
 
-  private refresh = () => {
+  private checkAgain = () => {
     this.props.dispatcher.refreshRepository(this.props.repository)
   }
 

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -21,12 +21,6 @@ export class MissingRepository extends React.Component<
   public render() {
     const buttons = new Array<JSX.Element>()
     buttons.push(
-      <Button key="check-again" onClick={this.checkAgain}>
-        Check Again
-      </Button>
-    )
-
-    buttons.push(
       <Button key="locate" onClick={this.locate} type="submit">
         Locate…
       </Button>

--- a/app/styles/ui/_missing-repository-view.scss
+++ b/app/styles/ui/_missing-repository-view.scss
@@ -49,6 +49,7 @@
   .details {
     margin-top: var(--spacing);
     margin-bottom: var(--spacing);
+    text-align: center;
 
     .path {
       font-family: var(--font-family-monospace);


### PR DESCRIPTION
## Overview

Addresses issues #4264, #5734.  Attempts to recover the repository where it was last known to be, automatically. 

## Description

Updates to 'missing-repository' to trigger a rechecking of the repository state after a delay, and repetitively with a delay while the repository remains in the missing state.  Technically every action the user performs while the missing repository view is up, triggers a rechecking of the repository, after a delay.

## Release notes
 - no notes

Notes:
On a network environment, some operations may become hesitant depending on the order of events or something.
