### PR TITLE
Add workaround to allow toggling between diff modes

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -283,7 +283,7 @@
   .tab-bar {
     width: 350px;
     margin: 10px auto 0;
-    // Workaround to allow toggling between different modes until 
+    // Workaround to allow toggling between different modes until
     // root issue with DPI scaling is addressed, see https://github.com/desktop/desktop/issues/2480
     z-index: 0;
   }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -283,6 +283,9 @@
   .tab-bar {
     width: 350px;
     margin: 10px auto 0;
+    // Workaround to allow toggling between different modes until 
+    // root issue with DPI scaling is addressed, see https://github.com/desktop/desktop/issues/2480
+    z-index: 0;
   }
 
   .image-diff-previous {


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Workaround to allow toggling between different modes in issue #2480**

## Description

When a large image gets drawn out of the diff panel (due to DPI scaling being larger than 100%) it prevents switching the diff mode because the image renders above tab bar. While this doesn't fix the DPI image scaling issue, it does allow someone to be able to toggle the diff modes.

Before:
<img width="596" alt="githubdiffbefore" src="https://user-images.githubusercontent.com/1302542/48679693-77db0e80-eb61-11e8-8cdb-6d6ae3f6d737.png">

After:
<img width="596" alt="githubdiffafter" src="https://user-images.githubusercontent.com/1302542/48679699-7dd0ef80-eb61-11e8-960e-c127f9b0deff.png">

Tested via the developer tools before making the edit.

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: Fixes problem where large image prevent toggling of diff modes in Windows when DPI scaling settings are larger than 100%
