### PR TITLE
Hide overflowed content

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -76,6 +76,9 @@
     // Fake that we're a text-box
     cursor: text;
 
+    // Hide overflowed content
+    overflow: hidden;
+
     &.focus-within {
       outline: none;
       border-color: var(--focus-color);


### PR DESCRIPTION
## Overview
A small PR :eyes:

Give overflow property to container so that the highlight edge shows.

## Description

**Before:**
![2018-11-13 6 41 50](https://user-images.githubusercontent.com/13250888/48690061-66047480-ec10-11e8-879e-7f7afe478c5b.png)
![2018-11-13 6 41 53](https://user-images.githubusercontent.com/13250888/48690062-669d0b00-ec10-11e8-83cd-ef2c6343541b.png)

**After:**
![2018-11-13 6 41 34](https://user-images.githubusercontent.com/13250888/48690070-6b61bf00-ec10-11e8-8ab0-29553ee8e5c2.png)
![2018-11-13 6 41 40](https://user-images.githubusercontent.com/13250888/48690071-6b61bf00-ec10-11e8-9627-ea98e80223b3.png)

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:
