### PR TITLE
Updating usage metrics to connect to GitHub usage

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -682,8 +682,11 @@ export class Dispatcher {
   }
 
   /** Set whether the user has opted out of stats reporting. */
-  public setStatsOptOut(optOut: boolean): Promise<void> {
-    return this.appStore.setStatsOptOut(optOut)
+  public setStatsOptOut(
+    optOut: boolean,
+    userViewedPrompt: boolean
+  ): Promise<void> {
+    return this.appStore.setStatsOptOut(optOut, userViewedPrompt)
   }
 
   public markUsageStatsNoteSeen() {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -686,6 +686,10 @@ export class Dispatcher {
     return this.appStore.setStatsOptOut(optOut)
   }
 
+  public markUsageStatsNoteSeen() {
+    this.appStore.markUsageStatsNoteSeen()
+  }
+
   /**
    * Clear any in-flight sign in state and return to the
    * initial (no sign-in) state.

--- a/app/src/lib/stats/index.ts
+++ b/app/src/lib/stats/index.ts
@@ -1,3 +1,7 @@
 export { StatsDatabase, ILaunchStats } from './stats-database'
 export { StatsStore, SamplesURL } from './stats-store'
 export { getGUID } from './get-guid'
+export {
+  hasSeenUsageStatsNote,
+  markUsageStatsNoteSeen,
+} from './usage-stats-change'

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -591,14 +591,17 @@ export class StatsStore {
   }
 
   /** Set whether the user has opted out of stats reporting. */
-  public async setOptOut(optOut: boolean): Promise<void> {
+  public async setOptOut(
+    optOut: boolean,
+    userViewedPrompt: boolean
+  ): Promise<void> {
     const changed = this.optOut !== optOut
 
     this.optOut = optOut
 
     setBoolean(StatsOptOutKey, optOut)
 
-    if (changed) {
+    if (changed || userViewedPrompt) {
       await this.sendOptInStatusPing(!optOut)
     }
   }

--- a/app/src/lib/stats/usage-stats-change.ts
+++ b/app/src/lib/stats/usage-stats-change.ts
@@ -1,0 +1,22 @@
+/** The `localStorage` for whether we've shown the usage stats change notice. */
+const HasSeenUsageStatsNoteKey = 'has-seen-usage-stats-note'
+
+/**
+ * Check if the current user has acknowledged the usage stats change
+ */
+export function hasSeenUsageStatsNote(): boolean {
+  const hasSeenUsageStatsNote = localStorage.getItem(HasSeenUsageStatsNoteKey)
+  if (!hasSeenUsageStatsNote) {
+    return false
+  }
+
+  const value = parseInt(hasSeenUsageStatsNote, 10)
+  return value === 1
+}
+
+/**
+ * Update local storage to indicate the usage stats dialog has been seen
+ */
+export function markUsageStatsNoteSeen() {
+  localStorage.setItem(HasSeenUsageStatsNoteKey, '1')
+}

--- a/app/src/lib/stats/usage-stats-change.ts
+++ b/app/src/lib/stats/usage-stats-change.ts
@@ -1,3 +1,5 @@
+import { getBoolean, setBoolean } from '../local-storage'
+
 /** The `localStorage` for whether we've shown the usage stats change notice. */
 const HasSeenUsageStatsNoteKey = 'has-seen-usage-stats-note'
 
@@ -5,18 +7,12 @@ const HasSeenUsageStatsNoteKey = 'has-seen-usage-stats-note'
  * Check if the current user has acknowledged the usage stats change
  */
 export function hasSeenUsageStatsNote(): boolean {
-  const hasSeenUsageStatsNote = localStorage.getItem(HasSeenUsageStatsNoteKey)
-  if (!hasSeenUsageStatsNote) {
-    return false
-  }
-
-  const value = parseInt(hasSeenUsageStatsNote, 10)
-  return value === 1
+  return getBoolean(HasSeenUsageStatsNoteKey, false)
 }
 
 /**
  * Update local storage to indicate the usage stats dialog has been seen
  */
 export function markUsageStatsNoteSeen() {
-  localStorage.setItem(HasSeenUsageStatsNoteKey, '1')
+  setBoolean(HasSeenUsageStatsNoteKey, true)
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3224,8 +3224,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** Set whether the user has opted out of stats reporting. */
-  public async setStatsOptOut(optOut: boolean): Promise<void> {
-    await this.statsStore.setOptOut(optOut)
+  public async setStatsOptOut(
+    optOut: boolean,
+    userViewedPrompt: boolean
+  ): Promise<void> {
+    await this.statsStore.setOptOut(optOut, userViewedPrompt)
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -153,7 +153,12 @@ import {
   parse as parseShell,
   Shell,
 } from '../shells'
-import { ILaunchStats, StatsStore, hasSeenUsageStatsNote } from '../stats'
+import {
+  ILaunchStats,
+  StatsStore,
+  markUsageStatsNoteSeen,
+  hasSeenUsageStatsNote,
+} from '../stats'
 import { hasShownWelcomeFlow, markWelcomeFlowComplete } from '../welcome'
 import { getWindowState, WindowState } from '../window-state'
 import { TypedBaseStore } from './base-store'
@@ -3224,6 +3229,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await this.statsStore.setOptOut(optOut)
 
     this.emitUpdate()
+  }
+
+  public async markUsageStatsNoteSeen(): Promise<void> {
+    markUsageStatsNoteSeen()
   }
 
   public _setConfirmRepositoryRemovalSetting(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -153,7 +153,7 @@ import {
   parse as parseShell,
   Shell,
 } from '../shells'
-import { ILaunchStats, StatsStore } from '../stats'
+import { ILaunchStats, StatsStore, hasSeenUsageStatsNote } from '../stats'
 import { hasShownWelcomeFlow, markWelcomeFlowComplete } from '../welcome'
 import { getWindowState, WindowState } from '../window-state'
 import { TypedBaseStore } from './base-store'
@@ -3306,6 +3306,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public _reportStats() {
+    // ensure the user has seen and acknowledged the current usage stats setting
+    if (!hasSeenUsageStatsNote()) {
+      this._showPopup({ type: PopupType.UsageReportingChanges })
+      return Promise.resolve()
+    }
+
     return this.statsStore.reportStats(this.accounts, this.repositories)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3016,7 +3016,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _endWelcomeFlow(): Promise<void> {
     this.showWelcomeFlow = false
-
     this.emitUpdate()
 
     markWelcomeFlowComplete()
@@ -3231,7 +3230,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  public async markUsageStatsNoteSeen(): Promise<void> {
+  public markUsageStatsNoteSeen() {
     markUsageStatsNoteSeen()
   }
 
@@ -3316,7 +3315,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _reportStats() {
     // ensure the user has seen and acknowledged the current usage stats setting
-    if (!hasSeenUsageStatsNote()) {
+    if (!this.showWelcomeFlow && !hasSeenUsageStatsNote()) {
       this._showPopup({ type: PopupType.UsageReportingChanges })
       return Promise.resolve()
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -38,6 +38,7 @@ export enum PopupType {
   DeletePullRequest,
   MergeConflicts,
   AbortMerge,
+  UsageReportingChanges,
 }
 
 export type Popup =
@@ -133,3 +134,4 @@ export type Popup =
       ourBranch: string
       theirBranch?: string
     }
+  | { type: PopupType.UsageReportingChanges }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -19,7 +19,7 @@ import { RetryAction } from '../models/retry-actions'
 import { shouldRenderApplicationMenu } from './lib/features'
 import { matchExistingRepository } from '../lib/repository-matching'
 import { getDotComAPIEndpoint } from '../lib/api'
-import { ILaunchStats, SamplesURL, markUsageStatsNoteSeen } from '../lib/stats'
+import { ILaunchStats, SamplesURL } from '../lib/stats'
 import { getVersion, getName } from './lib/app-proxy'
 import { getOS } from '../lib/get-os'
 import { validatedRepositoryPath } from '../lib/stores/helpers/validated-repository-path'
@@ -1423,8 +1423,8 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private onUsageReportingDismissed = (optOut: boolean) => {
     this.props.appStore.setStatsOptOut(optOut)
+    this.props.appStore.markUsageStatsNoteSeen()
     this.onPopupDismissed()
-    markUsageStatsNoteSeen()
     this.props.appStore._reportStats()
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1422,7 +1422,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private onUsageReportingDismissed = (optOut: boolean) => {
-    this.props.appStore.setStatsOptOut(optOut)
+    this.props.appStore.setStatsOptOut(optOut, true)
     this.props.appStore.markUsageStatsNoteSeen()
     this.onPopupDismissed()
     this.props.appStore._reportStats()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -19,13 +19,11 @@ import { RetryAction } from '../models/retry-actions'
 import { shouldRenderApplicationMenu } from './lib/features'
 import { matchExistingRepository } from '../lib/repository-matching'
 import { getDotComAPIEndpoint } from '../lib/api'
-import { ILaunchStats } from '../lib/stats'
+import { ILaunchStats, SamplesURL, markUsageStatsNoteSeen } from '../lib/stats'
 import { getVersion, getName } from './lib/app-proxy'
 import { getOS } from '../lib/get-os'
 import { validatedRepositoryPath } from '../lib/stores/helpers/validated-repository-path'
-
 import { MenuEvent } from '../main-process/menu'
-
 import { Repository } from '../models/repository'
 import { Branch } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
@@ -95,6 +93,7 @@ import { enableMergeConflictsDialog } from '../lib/feature-flag'
 import { AppFileStatus } from '../models/status'
 import { PopupType, Popup } from '../models/popup'
 import { SuccessfulMerge } from './banners'
+import { UsageStatsChange } from './usage-stats-change'
 
 const MinuteInMilliseconds = 1000 * 60
 
@@ -1409,9 +1408,28 @@ export class App extends React.Component<IAppProps, IAppState> {
           )
         }
         return null
+      case PopupType.UsageReportingChanges:
+        return (
+          <UsageStatsChange
+            onOpenUsageDataUrl={this.openUsageDataUrl}
+            onDismissed={this.onUsageReportingDismissed}
+          />
+        )
+
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
+  }
+
+  private onUsageReportingDismissed = (optOut: boolean) => {
+    this.props.appStore.setStatsOptOut(optOut)
+    this.onPopupDismissed()
+    markUsageStatsNoteSeen()
+    this.props.appStore._reportStats()
+  }
+
+  private openUsageDataUrl = () => {
+    this.props.dispatcher.openInBrowser(SamplesURL)
   }
 
   private onUpdateExistingUpstreamRemote = (repository: Repository) => {

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -132,7 +132,7 @@ export class Advanced extends React.Component<
     return (
       <span>
         Help GitHub Desktop improve by submitting{' '}
-        <LinkButton uri={SamplesURL}>anonymous usage data</LinkButton>
+        <LinkButton uri={SamplesURL}>usage data</LinkButton>
       </span>
     )
   }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -128,7 +128,7 @@ export class Advanced extends React.Component<
     this.props.onSelectedShellChanged(value)
   }
 
-  public reportDesktopUsageLabel() {
+  private reportDesktopUsageLabel() {
     return (
       <span>
         Help GitHub Desktop improve by submitting{' '}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -132,7 +132,7 @@ export class Advanced extends React.Component<
     return (
       <span>
         Help GitHub Desktop improve by submitting{' '}
-        <LinkButton uri={SamplesURL}>usage data</LinkButton>
+        <LinkButton uri={SamplesURL}>usage stats</LinkButton>
       </span>
     )
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -313,7 +313,10 @@ export class Preferences extends React.Component<
   private onSave = async () => {
     await setGlobalConfigValue('user.name', this.state.committerName)
     await setGlobalConfigValue('user.email', this.state.committerEmail)
-    await this.props.dispatcher.setStatsOptOut(this.state.optOutOfUsageTracking)
+    await this.props.dispatcher.setStatsOptOut(
+      this.state.optOutOfUsageTracking,
+      false
+    )
     await this.props.dispatcher.setConfirmRepoRemovalSetting(
       this.state.confirmRepositoryRemoval
     )

--- a/app/src/ui/usage-stats-change/index.ts
+++ b/app/src/ui/usage-stats-change/index.ts
@@ -1,0 +1,1 @@
+export { UsageStatsChange } from './usage-stats-change'

--- a/app/src/ui/usage-stats-change/usage-stats-change.tsx
+++ b/app/src/ui/usage-stats-change/usage-stats-change.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { ButtonGroup } from '../lib/button-group'
+import { Button } from '../lib/button'
+import { Row } from '../lib/row'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { Ref } from '../lib/ref'
+
+interface IUsageStatsChangeProps {
+  readonly onDismissed: (optOut: boolean) => void
+  readonly onOpenUsageDataUrl: () => void
+}
+
+interface IUsageStatsChangeState {
+  readonly optOutOfUsageTracking: boolean
+}
+
+/**
+ * The dialog shown if the user has not seen the details about how our usage
+ * tracking has changed
+ */
+export class UsageStatsChange extends React.Component<
+  IUsageStatsChangeProps,
+  IUsageStatsChangeState
+> {
+  public constructor(props: IUsageStatsChangeProps) {
+    super(props)
+
+    this.state = {
+      optOutOfUsageTracking: false,
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="usage-reporting"
+        title={
+          __DARWIN__ ? 'Usage Reporting Changes' : 'Usage reporting changes'
+        }
+        dismissable={false}
+        onDismissed={this.onDismissed}
+        onSubmit={this.onDismissed}
+        type="normal"
+      >
+        <DialogContent>
+          <Row>
+            GitHub Desktop has introduced a change around how it reports usage
+            stats, to help us better understand how our GitHub users get value
+            from Desktop:
+          </Row>
+          <Row>
+            <ul>
+              <li>
+                <span>
+                  <strong>If you are signed into a GitHub account</strong>, your
+                  GitHub.com account ID will be included in the periodic usage
+                  stats.
+                </span>
+              </li>
+              <li>
+                <span>
+                  <strong>
+                    If you are only signed into a GitHub Enterprise account, or
+                    only using Desktop with non-GitHub remotes
+                  </strong>
+                  , nothing is going to change.
+                </span>
+              </li>
+            </ul>
+          </Row>
+          <Row className="selection">
+            <Checkbox
+              label="Help GitHub Desktop improve by submitting usage data"
+              value={
+                this.state.optOutOfUsageTracking
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onReportingOptOutChanged}
+            />
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <ButtonGroup>
+            <Button type="submit">Save</Button>
+            <Button onClick={this.viewMoreInfo}>
+              {' '}
+              {__DARWIN__ ? 'More Info' : 'More info'}
+            </Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onReportingOptOutChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+    this.setState({ optOutOfUsageTracking: value })
+  }
+
+  private onDismissed = () => {
+    this.props.onDismissed(this.state.optOutOfUsageTracking)
+  }
+
+  private viewMoreInfo = () => {
+    this.props.onOpenUsageDataUrl()
+  }
+}

--- a/app/src/ui/usage-stats-change/usage-stats-change.tsx
+++ b/app/src/ui/usage-stats-change/usage-stats-change.tsx
@@ -71,7 +71,7 @@ export class UsageStatsChange extends React.Component<
           </Row>
           <Row className="selection">
             <Checkbox
-              label="Help GitHub Desktop improve by submitting usage data"
+              label="Help GitHub Desktop improve by submitting usage stats"
               value={
                 this.state.optOutOfUsageTracking
                   ? CheckboxValue.Off

--- a/app/src/ui/usage-stats-change/usage-stats-change.tsx
+++ b/app/src/ui/usage-stats-change/usage-stats-change.tsx
@@ -4,7 +4,6 @@ import { ButtonGroup } from '../lib/button-group'
 import { Button } from '../lib/button'
 import { Row } from '../lib/row'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
-import { Ref } from '../lib/ref'
 
 interface IUsageStatsChangeProps {
   readonly onDismissed: (optOut: boolean) => void
@@ -83,7 +82,7 @@ export class UsageStatsChange extends React.Component<
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>
-            <Button type="submit">Save</Button>
+            <Button type="submit">Continue</Button>
             <Button onClick={this.viewMoreInfo}>
               {' '}
               {__DARWIN__ ? 'More Info' : 'More info'}

--- a/app/src/ui/welcome/usage-opt-out.tsx
+++ b/app/src/ui/welcome/usage-opt-out.tsx
@@ -71,6 +71,8 @@ export class UsageOptOut extends React.Component<
 
   private finish = () => {
     this.props.dispatcher.setStatsOptOut(this.state.newOptOutValue)
+    // new users do not need to see the usage notes warning
+    this.props.dispatcher.markUsageStatsNoteSeen()
     this.props.done()
   }
 }

--- a/app/src/ui/welcome/usage-opt-out.tsx
+++ b/app/src/ui/welcome/usage-opt-out.tsx
@@ -37,13 +37,13 @@ export class UsageOptOut extends React.Component<
 
         <p>
           Would you like to help us improve GitHub Desktop by periodically
-          submitting <LinkButton uri={SamplesURL}>usage data</LinkButton>?
+          submitting <LinkButton uri={SamplesURL}>usage stats</LinkButton>?
         </p>
 
         <Form onSubmit={this.finish}>
           <Row>
             <Checkbox
-              label="Yes, submit periodic usage data"
+              label="Yes, submit periodic usage stats"
               value={
                 this.state.newOptOutValue ? CheckboxValue.Off : CheckboxValue.On
               }

--- a/app/src/ui/welcome/usage-opt-out.tsx
+++ b/app/src/ui/welcome/usage-opt-out.tsx
@@ -70,7 +70,7 @@ export class UsageOptOut extends React.Component<
   }
 
   private finish = () => {
-    this.props.dispatcher.setStatsOptOut(this.state.newOptOutValue)
+    this.props.dispatcher.setStatsOptOut(this.state.newOptOutValue, true)
     // new users do not need to see the usage notes warning
     this.props.dispatcher.markUsageStatsNoteSeen()
     this.props.done()

--- a/app/src/ui/welcome/usage-opt-out.tsx
+++ b/app/src/ui/welcome/usage-opt-out.tsx
@@ -37,14 +37,13 @@ export class UsageOptOut extends React.Component<
 
         <p>
           Would you like to help us improve GitHub Desktop by periodically
-          submitting{' '}
-          <LinkButton uri={SamplesURL}>anonymous usage data</LinkButton>?
+          submitting <LinkButton uri={SamplesURL}>usage data</LinkButton>?
         </p>
 
         <Form onSubmit={this.finish}>
           <Row>
             <Checkbox
-              label="Yes, submit anonymized usage data"
+              label="Yes, submit periodic usage data"
               value={
                 this.state.newOptOutValue ? CheckboxValue.Off : CheckboxValue.On
               }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -5,6 +5,7 @@
 @import 'dialogs/publish-repository';
 @import 'dialogs/repository-settings';
 @import 'dialogs/release-notes';
+@import 'dialogs/usage-reporting';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to

--- a/app/styles/ui/dialogs/_usage-reporting.scss
+++ b/app/styles/ui/dialogs/_usage-reporting.scss
@@ -1,0 +1,8 @@
+#usage-reporting {
+  .ref-component {
+    word-break: break-word;
+  }
+  .checkbox-component {
+    margin-left: auto;
+  }
+}


### PR DESCRIPTION
This PR affects how we generate and submit usage metrics, and we want to be transparent about what it means technically and for the product. Here are some details around why we're making this change and why we believe it will lead to a better product for our users.

## Context

If you've been following the GitHub Desktop repository for a while, you probably noticed recent pull requests to add analytics for new features in GitHub Desktop, such as [the dark theme](https://github.com/desktop/desktop/pull/4932), the [Notifications of Diverging from Default Branch](https://github.com/desktop/desktop/issues/4883) prompts, and the new [merge conflicts flow](https://github.com/desktop/desktop/issues/5394). We’ve been rolling these out alongside features to help us understand how they’re being used in the wild and if they're solving the problems that we're attempting to solve for users.

In tandem with user research, metrics like these help us answer questions like:

- **What OS are our users running GitHub Desktop on?** This helps us be aware of whether users are on recent OS versions, or whether we have a significant user base on older versions.
- **How are they using GitHub Desktop?** Users might be happy to just use GitHub Desktop for viewing their repository alongside the command line, or they might be making lots of commits and pushing to GitHub without needing to use the command line.
- **Is GitHub Desktop fast to launch?** GitHub Desktop is intended to enhance the productivity of its users, and we believe performance is an important piece of delivering the best experience possible.
- **How are new features in GitHub Desktop being used?** High or growing usage of features suggests we’re building the right things for GitHub Desktop’s target audience, but declining or low usage of features might suggest we need to investigate what didn’t work.
- **Is GitHub Desktop improving people's ability to collaborate?** There are various metrics here, but essentially we want to measure things that help us understand whether GitHub Desktop is reducing friction to users' ability to collaborate effectively.

## A Gap in our Understanding

Historically we anonymized the usage statistics submitted. This meant we had no insight into our users' developer journeys, workflows, or preferences, aside from whether they had signed into GitHub Desktop with a GitHub or GitHub Enterprise account.

This has prevented the team and other groups inside GitHub from being able to answer questions like:

- Does GitHub Desktop help users gain new skills and experience as developers?
- Is GitHub Desktop helping people contribute to projects on GitHub?
- How can we better support people's end to end workflows from GitHub Desktop to GitHub.com?

While we do support connecting to other Git remotes, GitHub Desktop is primarily a GitHub product, and we’d love to be able to answer these questions so we can make GitHub and GitHub Desktop better for both our current and future users. We're also conscious of potential concerns around collecting additional metrics, and therefore we only look at aggregate data and trends as opposed to data from any specific individual.

For reference, you can see examples of the usage statistics we currently submit on the GitHub Desktop website: https://desktop.github.com/usage-data/. This is currently being refreshed in co-ordination with this PR.

## Changes to how we report usage statistics

An upcoming update will show a dialog to users explaining these changes and what it means for you:

<img width="639" src="https://user-images.githubusercontent.com/359239/48722870-7fe78c80-ebfb-11e8-8360-e483f8e4cb5f.png">

#### If you opt out from sending usage stats in GitHub Desktop:

This change does not affect you. We’d love for you to opt-in and participate so we can incorporate your workflows into our decisions, but we will continue to respect this setting in GitHub Desktop.

#### If you opt in to sending usage stats in GitHub Desktop, and...

- **You are signed into a GitHub account:** GitHub Desktop will add a `user_id` field containing your GitHub account id with each usage report. On our usage reporting backend, we can use this to identify the user associated with it, and pass that on to our analytics backend.
- **You are only signed into a GitHub Enterprise account:** this change does not affect you. We will continue to use the anonymized identifier `guid` when submitting usage reports.
- **You are not signed into either a GitHub or GitHub Enterprise account:** this change does not affect you. We will continue to use the anonymized identifier `guid` when submitting usage reports.
