### PR TITLE
Focus branch selector when comparing to branch from menu

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -90,24 +90,6 @@ export class CompareSidebar extends React.Component<
     const newFormState = nextProps.compareState.formState
     const oldFormState = this.props.compareState.formState
 
-    if (this.textbox !== null) {
-      if (
-        !this.props.compareState.showBranchList &&
-        nextProps.compareState.showBranchList
-      ) {
-        // showBranchList changes from false -> true
-        //  -> ensure the textbox has focus
-        this.textbox.focus()
-      } else if (
-        this.props.compareState.showBranchList &&
-        !nextProps.compareState.showBranchList
-      ) {
-        // showBranchList changes from true -> false
-        //  -> ensure the textbox no longer has focus
-        this.textbox.blur()
-      }
-    }
-
     if (
       newFormState.kind !== oldFormState.kind &&
       newFormState.kind === HistoryTabMode.History
@@ -130,6 +112,18 @@ export class CompareSidebar extends React.Component<
         this.setState({
           focusedBranch: newBranch,
         })
+      }
+    }
+  }
+
+  public componentDidUpdate(prevProps: ICompareSidebarProps) {
+    const { showBranchList } = this.props.compareState
+
+    if (this.textbox !== null) {
+      if (showBranchList) {
+        this.textbox.focus()
+      } else if (!showBranchList) {
+        this.textbox.blur()
       }
     }
   }


### PR DESCRIPTION
Fixes #5600

Fixed by moving DOM updates to [componentDidUpdate](https://reactjs.org/docs/react-component.html#componentdidupdate) lifecycle hook and getting rid of the previous state check.

**Before**
![2018-11-19 13 45 09](https://user-images.githubusercontent.com/1715082/48730995-8e38a700-ec01-11e8-8121-8dab4a9f6600.gif)

**After**
![2018-11-19 13 44 22](https://user-images.githubusercontent.com/1715082/48730985-87119900-ec01-11e8-88d9-1f604bbf8ab6.gif)


