### PR TITLE
extract functions living under the models folder

### DIFF
--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -2,7 +2,7 @@ import { AppFileStatusKind } from '../models/status'
 import { assertNever } from './fatal-error'
 
 /**
- * Convert a given FileStatus value to a human-readable string to be
+ * Convert a given `AppFileStatusKind` value to a human-readable string to be
  * presented to users which describes the state of a file.
  *
  * Typically this will be the same value as that of the enum key.

--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -1,0 +1,31 @@
+import { AppFileStatusKind } from '../models/status'
+import { assertNever } from './fatal-error'
+
+/**
+ * Convert a given FileStatus value to a human-readable string to be
+ * presented to users which describes the state of a file.
+ *
+ * Typically this will be the same value as that of the enum key.
+ *
+ * Used in file lists.
+ */
+export function mapStatus(status: AppFileStatusKind): string {
+  switch (status) {
+    case AppFileStatusKind.New:
+      return 'New'
+    case AppFileStatusKind.Modified:
+      return 'Modified'
+    case AppFileStatusKind.Deleted:
+      return 'Deleted'
+    case AppFileStatusKind.Renamed:
+      return 'Renamed'
+    case AppFileStatusKind.Conflicted:
+      return 'Conflicted'
+    case AppFileStatusKind.Resolved:
+      return 'Resolved'
+    case AppFileStatusKind.Copied:
+      return 'Copied'
+  }
+
+  return assertNever(status, `Unknown file status ${status}`)
+}

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -1,6 +1,4 @@
 import { DiffSelection, DiffSelectionType } from './diff'
-import { OcticonSymbol } from '../ui/octicons'
-import { assertNever } from '../lib/fatal-error'
 import { ConflictFileStatus } from './conflicts'
 
 /**
@@ -100,62 +98,6 @@ export type FileEntry =
   | RenamedOrCopiedEntry
   | UnmergedEntry
   | UntrackedEntry
-
-/**
- * Convert a given FileStatus value to a human-readable string to be
- * presented to users which describes the state of a file.
- *
- * Typically this will be the same value as that of the enum key.
- *
- * Used in file lists.
- */
-export function mapStatus(status: AppFileStatusKind): string {
-  switch (status) {
-    case AppFileStatusKind.New:
-      return 'New'
-    case AppFileStatusKind.Modified:
-      return 'Modified'
-    case AppFileStatusKind.Deleted:
-      return 'Deleted'
-    case AppFileStatusKind.Renamed:
-      return 'Renamed'
-    case AppFileStatusKind.Conflicted:
-      return 'Conflicted'
-    case AppFileStatusKind.Resolved:
-      return 'Resolved'
-    case AppFileStatusKind.Copied:
-      return 'Copied'
-  }
-
-  return assertNever(status, `Unknown file status ${status}`)
-}
-
-/**
- * Converts a given FileStatus value to an Octicon symbol
- * presented to users when displaying the file path.
- *
- * Used in file lists.
- */
-export function iconForStatus(status: AppFileStatusKind): OcticonSymbol {
-  switch (status) {
-    case AppFileStatusKind.New:
-      return OcticonSymbol.diffAdded
-    case AppFileStatusKind.Modified:
-      return OcticonSymbol.diffModified
-    case AppFileStatusKind.Deleted:
-      return OcticonSymbol.diffRemoved
-    case AppFileStatusKind.Renamed:
-      return OcticonSymbol.diffRenamed
-    case AppFileStatusKind.Conflicted:
-      return OcticonSymbol.alert
-    case AppFileStatusKind.Resolved:
-      return OcticonSymbol.check
-    case AppFileStatusKind.Copied:
-      return OcticonSymbol.diffAdded
-  }
-
-  return assertNever(status, `Unknown file status ${status}`)
-}
 
 /** encapsulate changes to a file associated with a commit */
 export class FileChange {

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -1,15 +1,11 @@
 import * as React from 'react'
 import { PathLabel } from '../lib/path-label'
-import {
-  AppFileStatus,
-  mapStatus,
-  iconForStatus,
-  AppFileStatusKind,
-} from '../../models/status'
+import { AppFileStatus, AppFileStatusKind } from '../../models/status'
 import { IDiff, DiffType } from '../../models/diff'
-import { Octicon, OcticonSymbol } from '../octicons'
+import { Octicon, OcticonSymbol, iconForStatus } from '../octicons'
 import { Button } from '../lib/button'
 import { enableMergeTool } from '../../lib/feature-flag'
+import { mapStatus } from '../../lib/status'
 
 interface IChangedFileDetailsProps {
   readonly path: string

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 
-import { AppFileStatus, mapStatus, iconForStatus } from '../../models/status'
+import { AppFileStatus } from '../../models/status'
 import { PathLabel } from '../lib/path-label'
-import { Octicon } from '../octicons'
+import { Octicon, iconForStatus } from '../octicons'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { mapStatus } from '../../lib/status'
 
 interface IChangedFileProps {
   readonly id: string

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -3,7 +3,7 @@ import * as Path from 'path'
 import { pathExists } from 'fs-extra'
 import { revealInFileManager } from '../../lib/app-shell'
 
-import { FileChange, mapStatus, iconForStatus } from '../../models/status'
+import { FileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
 
 import { PathLabel } from '../lib/path-label'
@@ -16,9 +16,10 @@ import {
 } from '../lib/context-menu'
 import { List } from '../lib/list'
 
-import { Octicon } from '../octicons'
+import { Octicon, iconForStatus } from '../octicons'
 import { showContextualMenu } from '../main-process-proxy'
 import { clipboard } from 'electron'
+import { mapStatus } from '../../lib/status'
 
 interface IFileListProps {
   readonly files: ReadonlyArray<FileChange>

--- a/app/src/ui/octicons/index.ts
+++ b/app/src/ui/octicons/index.ts
@@ -1,3 +1,4 @@
 export { Octicon } from './octicon'
 export { OcticonSymbol } from './octicons.generated'
 export { iconForRepository } from './repository'
+export { iconForStatus } from './status'

--- a/app/src/ui/octicons/status.ts
+++ b/app/src/ui/octicons/status.ts
@@ -1,0 +1,30 @@
+import { AppFileStatusKind } from '../../models/status'
+import { OcticonSymbol } from './octicons.generated'
+import { assertNever } from '../../lib/fatal-error'
+
+/**
+ * Converts a given FileStatus value to an Octicon symbol
+ * presented to users when displaying the file path.
+ *
+ * Used in file lists.
+ */
+export function iconForStatus(status: AppFileStatusKind): OcticonSymbol {
+  switch (status) {
+    case AppFileStatusKind.New:
+      return OcticonSymbol.diffAdded
+    case AppFileStatusKind.Modified:
+      return OcticonSymbol.diffModified
+    case AppFileStatusKind.Deleted:
+      return OcticonSymbol.diffRemoved
+    case AppFileStatusKind.Renamed:
+      return OcticonSymbol.diffRenamed
+    case AppFileStatusKind.Conflicted:
+      return OcticonSymbol.alert
+    case AppFileStatusKind.Resolved:
+      return OcticonSymbol.check
+    case AppFileStatusKind.Copied:
+      return OcticonSymbol.diffAdded
+  }
+
+  return assertNever(status, `Unknown file status ${status}`)
+}

--- a/app/src/ui/octicons/status.ts
+++ b/app/src/ui/octicons/status.ts
@@ -3,7 +3,7 @@ import { OcticonSymbol } from './octicons.generated'
 import { assertNever } from '../../lib/fatal-error'
 
 /**
- * Converts a given FileStatus value to an Octicon symbol
+ * Converts a given `AppFileStatusKind` value to an Octicon symbol
  * presented to users when displaying the file path.
  *
  * Used in file lists.


### PR DESCRIPTION
## Overview

A bit of cleanup done in isolation of #6214 - these two helper functions should live somewhere else.

## Description

- `mapStatus` - for converting an `AppFileStatusKind` into a string - is now under `app/src/lib/status.ts`

- `iconForStatus ` - for converting an `AppFileStatusKind` into an `OcticonSymbol` - is now under `app/src/ui/octicons/status.ts`

## Release notes

Notes: no-notes
