### PR TITLE
Update roadmap post-release

### DIFF
--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -2,22 +2,43 @@
 
 The following are the larger areas of upcoming work the GitHub Desktop team intends to explore. This is not inclusive of everything we're working on, and it's not written in stone. We'll continue to update it as our priorities evolve.
 
-### Onboarding
+#### Onboarding
   
-- Evaluate and improve onboarding for new users: [#5686](https://github.com/desktop/desktop/issues/5686)
-- Measuring success: [#5549](https://github.com/desktop/desktop/issues/5549)
-  
-### Merge conflicts handling
+- Improve onboarding for new users: [#5686](https://github.com/desktop/desktop/issues/5686)
+- Measuring success: [#5549](https://github.com/desktop/desktop/issues/5549) + usability testing
 
-- Improve how Desktop handles merge conflicts: [#5400](https://github.com/desktop/desktop/issues/5400)
-- Measuring success: [#5394](https://github.com/desktop/desktop/issues/5394)
-
-### Support rebase workflows
+#### Support rebase workflows
 
 - Improve rebase workflows: [#5953](https://github.com/desktop/desktop/issues/5953)
 - Measuring success: TBD alongside the work + usability testing
+
+#### Accessibility improvements
+
+- To be further defined, but we want to prioritize scoping a chunk of work on improving accessibility for our users
+
+#### Working with uncommitted changes
+
+- Improve workflows when you have uncommitted changes: https://github.com/desktop/desktop/issues/6107
+- Measuring success: TBD alongside the work + usability testing
+
+#### Branch list grows with merged & deleted branches making it difficult to find those you care about
+
+- Prune branches after they've been deleted: https://github.com/desktop/desktop/issues/750
+- Measuring success: TBD alongside the work + usability testing
+
+#### Users behind corporate proxies cannot clone without manual setup
+
+- Help people get set up correctly if they're behind a proxy: https://github.com/desktop/desktop/issues/2789
+- Measuring success: TBD alongside the work
+
+## Shipped in previous releases
   
-### Merge workflow iteration
+#### Merge conflicts handling (1.5)
+
+- Improve how Desktop handles merge conflicts: [#5400](https://github.com/desktop/desktop/issues/5400)
+- Measuring success: [#5394](https://github.com/desktop/desktop/issues/5394)
+  
+#### Merge workflow iteration (1.5)
 
 - Evaluate and improve merge flow end-to-end: [#5555](https://github.com/desktop/desktop/issues/5555)
 - Usability testing for merging


### PR DESCRIPTION
This is not time sensitive. I did a few things here:

1. Added the things that were previously on the roadmap and shipped in 1.5 to a past category. I'm not wedded to it, but it might be a helpful way to have a place to come back to to revisit the features that shipped in the past few releases at any given time and evaluate success (especially if we have associated metrics).

2. Added upcoming areas of exploration to the roadmap to make it a bit more robust and communicative. Because a few of the things are earlier in the process there's not a ton of amplifying info (like Accessibility), but I think that may be ok. Open to other opinions.

3. Altered formatting somewhat to make it more readable to me (if others don't feel like it is, please say so).
