### PR TITLE
simplify travis config to avoid unnecessary work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ notifications:
 
 dist: trusty
 
-sudo: false
-
 os: linux
 compiler: clang
 
@@ -21,15 +19,6 @@ addons:
       # this package is essential for testing Electron in a headless fashion
       # https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
       - xvfb
-      # packages required for electron-installer-debian
-      - fakeroot
-      - dpkg
-      # packages required for electron-installer-redhat
-      - rpm
-      # packages required for electron-installer-appimage
-      - xz-utils
-      - xorriso
-      - zsync
 
 branches:
   only:


### PR DESCRIPTION
## Overview

We don't do any packaging work as part of the Travis builds, so there's some chance here to simplify the build.

## Description

- Travis is unifying their Linux infrastructure to a VM-based infrastructure and `sudo: false` (which was used to indicate that you wanted to run in a container) is now ignored - https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures has more details, and I think we're fine to just go with the defaults of The Platform™
 - the removed packages were needed for `electron-installer-*` but we no longer have those packages around - we're using `electron-builder` instead

## Release notes

Notes: no-notes
