### PR TITLE
Fixed broken maintainers line in Teams doc

### DIFF
--- a/docs/process/teams.md
+++ b/docs/process/teams.md
@@ -10,8 +10,7 @@ These are good teams to start with for general communication and questions. (Mem
 
 | Team | Purpose |
 |:--|:--|
-| `@desktop/maintainers` | The people designing, 
-ing, and driving GitHub Desktop. Includes all groups below. |
+| `@desktop/maintainers` | The people designing, developing, and driving GitHub Desktop. Includes all groups below. |
 | `@desktop/comrades` | Community members with a track record of activity in the Desktop project |
 
 ## Special-purpose Teams


### PR DESCRIPTION
## Overview


**Closes #6256**

## Description

- Changes the maintainers line to display as one line and fixes the "developing" typo.

Before:
![image](https://user-images.githubusercontent.com/4957200/48849040-21412080-ed6b-11e8-9fb3-72b3a3f9553b.png)

After:
![image](https://user-images.githubusercontent.com/4957200/48849098-433aa300-ed6b-11e8-8971-9b9ae35838bc.png)


## Release notes

Notes: no-notes
