### PR TITLE
spaces in filenames are problematic for profile scripts

### DIFF
--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -9,8 +9,8 @@ export PATH=$INSTALL_DIR:\$PATH"
 
 case "$1" in
     configure)
-      echo "$SCRIPT" > ${PROFILE_D_FILE};
-      . ${PROFILE_D_FILE};
+      echo "$SCRIPT" > "${PROFILE_D_FILE}";
+      . "${PROFILE_D_FILE}";
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -4,8 +4,8 @@ set -e
 
 PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
-SCRIPT="#!/bin/sh
-export PATH=$INSTALL_DIR:\$PATH"
+SCRIPT=$"#!/bin/sh
+export PATH=\"$INSTALL_DIR:\$PATH\""
 
 case "$1" in
     configure)

--- a/script/linux-after-install.sh
+++ b/script/linux-after-install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 INSTALL_DIR="/opt/${productFilename}"
 SCRIPT="#!/bin/sh
 export PATH=$INSTALL_DIR:\$PATH"

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -5,9 +5,9 @@ PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-      echo "#!/bin/sh" > ${PROFILE_D_FILE};
-      . ${PROFILE_D_FILE};
-      rm ${PROFILE_D_FILE};
+      echo "#!/bin/sh" > "${PROFILE_D_FILE}";
+      . "${PROFILE_D_FILE}";
+      rm "${PROFILE_D_FILE}";
     ;;
 
     *)

--- a/script/linux-after-remove.sh
+++ b/script/linux-after-remove.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-PROFILE_D_FILE="/etc/profile.d/${productFilename}.sh"
+PROFILE_D_FILE="/etc/profile.d/github-desktop.sh"
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
## Overview

This is the upstreamed version of https://github.com/shiftkey/desktop/pull/87 which addresses a Linux-specific issue with the Debian installer

## Description

- I updated the product name of the package in the Linux fork to `GitHub Desktop` (it was previously `GitHubDesktop` without a space
 - This uncovered that the generated profile script had a filename with a space in it
 - And it also uncovered that the generated script (which adds the install directory to `PATH`) had a space that wasn't handled properly either

## Release notes

Notes: no-notes
