### PR TITLE
Fixed react devtools warning about unique keys for new MergeConflicts…

### DIFF
--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -228,7 +228,7 @@ export class MergeConflictsDialog extends React.Component<
       )
     }
     return content !== null ? (
-      <li className="unmerged-file-status-conflicts">
+      <li key={path} className="unmerged-file-status-conflicts">
         <Octicon symbol={OcticonSymbol.fileCode} className="file-octicon" />
         {content}
       </li>


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #6186**

## Description

- Try to remove react devtools warning:
```
Warning: Each child in an array or iterator should have a unique "key" prop.

Check the render method of `MergeConflictsDialog`. See https://fb.me/react-warning-keys for more information.
    in li (created by MergeConflictsDialog)
    in MergeConflictsDialog (created by App)
    in CSSTransitionGroupChild (created by TransitionGroup)
    in div (created by TransitionGroup)
    in TransitionGroup (created by CSSTransitionGroup)
    in CSSTransitionGroup (created by App)
    in div (created by App)
    in div (created by App)
    in App
```
