### PR TITLE
Image preview fix for dpi scaling issue

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -386,6 +386,7 @@
 
   .slider {
     align-self: center;
+    z-index: 0;
   }
 
   .sizing-container {
@@ -429,6 +430,7 @@
 
   .slider {
     align-self: center;
+    z-index: 0;
   }
 
   .sizing-container {

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -71,4 +71,5 @@
   display: flex;
   flex-grow: 1;
   min-width: 0;
+  overflow: overlay;
 }


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #2480**

## Description

When a large image gets drawn out of the diff panel (due to DPI scaling being larger than 100%) and overlaps the top menu. This fixes the issue where it breaks out of the container and also allows for the slider to render above the image.

![48798075-d45d3b80-ecd1-11e8-8795-a1a4af686581](https://user-images.githubusercontent.com/1302542/48880779-f1803000-eddf-11e8-9bd1-3a438d499d21.gif)

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: 
 - Fixes problem where large images render above the top bar in Windows when DPI scaling settings are larger than 100%
 - Fixes problem where sliders for swipe & onion skin modes are below image in Windows when DPI scaling settings are larger than 100%
 - Improves preview of newly added large images by allowing scrolling to the preview
