### PR TITLE
Add integration for JetBrains Webstorm 

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -230,7 +230,7 @@ function getRegistryKeys(
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}',
         },
       ]
-      case ExternalEditor.Webstorm:
+    case ExternalEditor.Webstorm:
       return [
         // 32-bit version of WebStorm
         {
@@ -319,7 +319,9 @@ function isExpectedInstallation(
         displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.'
       )
     case ExternalEditor.Webstorm:
-      return displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.'
+      return (
+        displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.'
+      )
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -20,6 +20,7 @@ export enum ExternalEditor {
   CFBuilder = 'ColdFusion Builder',
   Typora = 'Typora',
   SlickEdit = 'SlickEdit',
+  Webstorm = 'JetBrains Webstorm',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -229,6 +230,15 @@ function getRegistryKeys(
             'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}',
         },
       ]
+      case ExternalEditor.Webstorm:
+      return [
+        // 32-bit version of WebStorm
+        {
+          key: HKEY.HKEY_LOCAL_MACHINE,
+          subKey:
+            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2018.3',
+        },
+      ]
 
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
@@ -260,6 +270,8 @@ function getExecutableShim(
       return Path.join(installLocation, 'bin', 'typora.exe')
     case ExternalEditor.SlickEdit:
       return Path.join(installLocation, 'win', 'vs.exe')
+    case ExternalEditor.Webstorm:
+      return Path.join(installLocation, 'bin', 'webstorm.exe')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -306,6 +318,8 @@ function isExpectedInstallation(
       return (
         displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.'
       )
+    case ExternalEditor.Webstorm:
+      return displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.'
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -395,6 +409,36 @@ function extractApplicationInformation(
     const displayName = getKeyOrEmpty(keys, 'DisplayName')
     const publisher = getKeyOrEmpty(keys, 'Publisher')
     const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
+    return { displayName, publisher, installLocation }
+  }
+
+  if (editor === ExternalEditor.Webstorm) {
+    let displayName = ''
+    let publisher = ''
+    let installLocation = ''
+
+    for (const item of keys) {
+      // NOTE:
+      // Webstorm adds the current release number to the end of the Display Name, below checks for "WebStorm"
+      if (
+        item.name === 'DisplayName' &&
+        item.type === RegistryValueType.REG_SZ &&
+        item.data.startsWith('WebStorm ')
+      ) {
+        displayName = 'WebStorm'
+      } else if (
+        item.name === 'Publisher' &&
+        item.type === RegistryValueType.REG_SZ
+      ) {
+        publisher = item.data
+      } else if (
+        item.name === 'InstallLocation' &&
+        item.type === RegistryValueType.REG_SZ
+      ) {
+        installLocation = item.data
+      }
+    }
+
     return { displayName, publisher, installLocation }
   }
 


### PR DESCRIPTION
## Overview
<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #6077**

## Description

- Adds support for JetBrains Webstorm as an editor integration.

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:
- Adds support for JetBrains Webstorm as an editor integration.