### PR TITLE
Make list scroll to selected item on mount

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -263,6 +263,12 @@ export class List extends React.Component<IListProps, IListState> {
   public constructor(props: IListProps) {
     super(props)
 
+    // If we have a selected row when we're about to mount
+    // we'll scroll to it immediately.
+    if (props.selectedRows.length > 0) {
+      this.scrollToRow = props.selectedRows[0]
+    }
+
     this.state = {}
 
     const ResizeObserverClass: typeof ResizeObserver = (window as any)


### PR DESCRIPTION
## Overview

This was originally part of #6278 but I'm extracting it to a separate PR for easier review.

Makes the list component scroll to its selected item on mount (if a selection exists). An example of this would be if a user has a bunch of repositories added and opens the repository tab. In its current state the current repository could be beneath the fold. With this change we're ensuring that it's at least scrolled into view.

This is important in #6278 because we're now persisting selections across tabs in the clone dialog.

## Release notes

no-notes