### PR TITLE
Hover states on list items and tabs

### DIFF
--- a/app/src/ui/lib/list/list-row.tsx
+++ b/app/src/ui/lib/list/list-row.tsx
@@ -37,6 +37,13 @@ interface IListRowProps {
 
   /** callback to fire when the row receives a keyboard event */
   readonly onRowKeyDown: (index: number, e: React.KeyboardEvent<any>) => void
+
+  /**
+   * Whether or not this list row is going to be selectable either through
+   * keyboard navigation, pointer clicks, or both. This is used to determine
+   * whether or not to present a hover state for the list row.
+   */
+  readonly selectable: boolean
 }
 
 export class ListRow extends React.Component<IListRowProps, {}> {
@@ -58,7 +65,11 @@ export class ListRow extends React.Component<IListRowProps, {}> {
 
   public render() {
     const selected = this.props.selected
-    const className = classNames('list-item', { selected })
+    const className = classNames(
+      'list-item',
+      { selected },
+      { 'not-selectable': this.props.selectable === false }
+    )
     const role = this.props.ariaMode === 'menu' ? 'menuitem' : 'option'
 
     // react-virtualized gives us an explicit pixel width for rows, but that

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -639,6 +639,7 @@ export class List extends React.Component<IListProps, IListState> {
         style={params.style}
         tabIndex={tabIndex}
         children={element}
+        selectable={selectable}
       />
     )
   }

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -157,12 +157,6 @@ button {
   }
 }
 
-.list-item {
-  &:hover {
-    background: var(--list-item-hover-background-color);
-  }
-}
-
 .brutalism {
   background: salmon;
 }

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -157,6 +157,12 @@ button {
   }
 }
 
+.list-item {
+  &:hover {
+    background: var(--list-item-hover-background-color);
+  }
+}
+
 .brutalism {
   background: salmon;
 }

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -256,6 +256,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --list-item-selected-badge-background-color: $gray-300;
   --list-item-selected-active-badge-color: $gray-900;
   --list-item-selected-active-badge-background-color: $white;
+  --list-item-hover-background-color: $gray-100;
 
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -240,6 +240,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --tab-bar-height: 29px;
   --tab-bar-active-color: $blue;
   --tab-bar-background-color: $white;
+  --tab-bar-hover-background-color: $gray-100;
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -180,6 +180,7 @@ body.theme-dark {
 
   --tab-bar-active-color: $blue;
   --tab-bar-background-color: var(--box-background-color);
+  --tab-bar-hover-background-color: $gray-800;
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -196,6 +196,7 @@ body.theme-dark {
   --list-item-selected-badge-background-color: $gray-500;
   --list-item-selected-active-badge-color: $gray-900;
   --list-item-selected-active-badge-background-color: $white;
+  --list-item-hover-background-color: $gray-800;
 
   /**
    * Toast notifications are shown temporarily for things like the zoom

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -93,7 +93,7 @@
     outline: none;
   }
 
-  &:hover {
+  &:not(.not-selectable):hover {
     background: var(--list-item-hover-background-color);
   }
 }

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -92,4 +92,8 @@
   &:focus {
     outline: none;
   }
+
+  &:hover {
+    background: var(--list-item-hover-background-color);
+  }
 }

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -41,6 +41,10 @@
       box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
     }
 
+    &:hover {
+      background: var(--tab-bar-hover-background-color);
+    }
+
     .with-indicator {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Overview

Fixes https://github.com/desktop/desktop/issues/5030

This adds a hover state to all list items in both light and dark mode:
- Uncommitted changes
- Commit history
- File list
- Repo list
- Branches list

And to tabs in:
- Changes panel
- Branches panel

Light mode:

![hover-state-list](https://user-images.githubusercontent.com/10404068/49190703-5b409280-f328-11e8-9aaa-db2d0f3b87a9.gif)

Dark mode:

![hover-state-dark](https://user-images.githubusercontent.com/10404068/49190704-5b409280-f328-11e8-9e75-af28b5d4e00c.gif)

The only problem I've run into and can't figure out how to address is the hover style is also applied to these header items:

![screen shot 2018-11-28 at 4 09 19 pm](https://user-images.githubusercontent.com/10404068/49190706-5b409280-f328-11e8-9626-be5aebda517c.png)

