### PR TITLE
Display warning if existing readme file will be overwritten

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -51,3 +51,8 @@ export function enableMergeConflictsDialog(): boolean {
 export function enableGitProtocolVersionTwo(): boolean {
   return enableDevelopmentFeatures()
 }
+
+export function enableReadmeOverwriteWarning(): boolean {
+  // return enableBetaFeatures()
+  return false
+}

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -133,6 +133,12 @@ export class CreateRepository extends React.Component<
       this.state.name
     )
     this.setState({ readMeExists })
+
+    window.addEventListener('focus', this.onWindowFocus)
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('focus', this.onWindowFocus)
   }
 
   private onPathChanged = async (path: string) => {
@@ -582,5 +588,15 @@ export class CreateRepository extends React.Component<
         </DialogFooter>
       </Dialog>
     )
+  }
+
+  private onWindowFocus = async () => {
+    // Verify whether or not a ReadMe.md file exists at the chosen directory
+    // in case one has been added or removed and the warning can be displayed.
+    const readMeExists = await this.doesReadMeExist(
+      this.state.path,
+      this.state.name
+    )
+    this.setState({ readMeExists })
   }
 }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -28,6 +28,7 @@ import { Dialog, DialogContent, DialogFooter, DialogError } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
 import { PopupType } from '../../models/popup'
+import { Ref } from '../lib/ref'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -470,6 +471,25 @@ export class CreateRepository extends React.Component<
     )
   }
 
+  private renderReadmeOverwriteWarning() {
+    if (
+      this.state.createWithReadme === false ||
+      this.state.readMeExists === false
+    ) {
+      return null
+    }
+
+    return (
+      <Row className="warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+        <p>
+          This directory contains a <Ref>ReadMe.md</Ref> file already. Checking
+          this box will result in the existing file being overwritten.
+        </p>
+      </Row>
+    )
+  }
+
   private onAddRepositoryClicked = () => {
     return this.props.dispatcher.showPopup({
       type: PopupType.AddRepository,
@@ -545,6 +565,7 @@ export class CreateRepository extends React.Component<
               onChange={this.onCreateWithReadmeChange}
             />
           </Row>
+          {this.renderReadmeOverwriteWarning()}
 
           {this.renderGitIgnores()}
           {this.renderLicenses()}

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -29,6 +29,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
 import { PopupType } from '../../models/popup'
 import { Ref } from '../lib/ref'
+import { enableReadmeOverwriteWarning } from '../../lib/feature-flag'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -145,7 +146,9 @@ export class CreateRepository extends React.Component<
   }
 
   private onNameChanged = async (name: string) => {
-    await this.updateReadMeExists(this.state.path, name)
+    if (enableReadmeOverwriteWarning()) {
+      await this.updateReadMeExists(this.state.path, name)
+    }
 
     this.setState({ name })
   }
@@ -461,6 +464,10 @@ export class CreateRepository extends React.Component<
   }
 
   private renderReadmeOverwriteWarning() {
+    if (!enableReadmeOverwriteWarning()) {
+      return null
+    }
+
     if (
       this.state.createWithReadme === false ||
       this.state.readMeExists === false
@@ -576,6 +583,8 @@ export class CreateRepository extends React.Component<
   private onWindowFocus = async () => {
     // Verify whether or not a README.md file exists at the chosen directory
     // in case one has been added or removed and the warning can be displayed.
-    await this.updateReadMeExists(this.state.path, this.state.name)
+    if (enableReadmeOverwriteWarning()) {
+      await this.updateReadMeExists(this.state.path, this.state.name)
+    }
   }
 }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -76,6 +76,13 @@ interface ICreateRepositoryState {
 
   /** The license to include in the repository. */
   readonly license: string
+
+  /**
+   * Whether or not a ReadMe.md file already exists in the
+   * directory that may be overwritten by initializing with
+   * a new ReadMe.md
+   */
+  readonly readMeExists: boolean
 }
 
 /** The Create New Repository component. */
@@ -106,6 +113,7 @@ export class CreateRepository extends React.Component<
       license: NoLicenseValue.name,
       isValidPath: null,
       isRepository: false,
+      readMeExists: false,
     }
   }
 

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -128,11 +128,7 @@ export class CreateRepository extends React.Component<
     const isRepository = await isGitRepository(this.state.path)
     this.setState({ isRepository })
 
-    const readMeExists = await this.doesReadMeExist(
-      this.state.path,
-      this.state.name
-    )
-    this.setState({ readMeExists })
+    await this.updateReadMeExists(this.state.path, this.state.name)
 
     window.addEventListener('focus', this.onWindowFocus)
   }
@@ -143,15 +139,15 @@ export class CreateRepository extends React.Component<
 
   private onPathChanged = async (path: string) => {
     const isRepository = await isGitRepository(path)
-    const readMeExists = await this.doesReadMeExist(path, this.state.name)
+    await this.updateReadMeExists(path, this.state.name)
 
-    this.setState({ isRepository, path, readMeExists, isValidPath: null })
+    this.setState({ isRepository, path, isValidPath: null })
   }
 
   private onNameChanged = async (name: string) => {
-    const readMeExists = await this.doesReadMeExist(this.state.path, name)
+    await this.updateReadMeExists(this.state.path, name)
 
-    this.setState({ name, readMeExists })
+    this.setState({ name })
   }
 
   private onDescriptionChanged = (description: string) => {
@@ -173,9 +169,10 @@ export class CreateRepository extends React.Component<
     this.setState({ isRepository, path })
   }
 
-  private async doesReadMeExist(path: string, name: string) {
+  private async updateReadMeExists(path: string, name: string) {
     const fullPath = Path.join(path, sanitizedRepositoryName(name), 'README.md')
-    return await FSE.pathExists(fullPath)
+    const readMeExists = await FSE.pathExists(fullPath)
+    this.setState({ readMeExists })
   }
 
   private resolveRepositoryRoot = async (): Promise<string> => {
@@ -579,10 +576,6 @@ export class CreateRepository extends React.Component<
   private onWindowFocus = async () => {
     // Verify whether or not a README.md file exists at the chosen directory
     // in case one has been added or removed and the warning can be displayed.
-    const readMeExists = await this.doesReadMeExist(
-      this.state.path,
-      this.state.name
-    )
-    this.setState({ readMeExists })
+    await this.updateReadMeExists(this.state.path, this.state.name)
   }
 }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -79,9 +79,9 @@ interface ICreateRepositoryState {
   readonly license: string
 
   /**
-   * Whether or not a ReadMe.md file already exists in the
+   * Whether or not a README.md file already exists in the
    * directory that may be overwritten by initializing with
-   * a new ReadMe.md
+   * a new README.md.
    */
   readonly readMeExists: boolean
 }
@@ -475,7 +475,7 @@ export class CreateRepository extends React.Component<
       <Row className="warning-helper-text">
         <Octicon symbol={OcticonSymbol.alert} />
         <p>
-          This directory contains a <Ref>ReadMe.md</Ref> file already. Checking
+          This directory contains a <Ref>README.md</Ref> file already. Checking
           this box will result in the existing file being overwritten.
         </p>
       </Row>
@@ -577,7 +577,7 @@ export class CreateRepository extends React.Component<
   }
 
   private onWindowFocus = async () => {
-    // Verify whether or not a ReadMe.md file exists at the chosen directory
+    // Verify whether or not a README.md file exists at the chosen directory
     // in case one has been added or removed and the warning can be displayed.
     const readMeExists = await this.doesReadMeExist(
       this.state.path,

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -174,22 +174,8 @@ export class CreateRepository extends React.Component<
   }
 
   private async doesReadMeExist(path: string, name: string) {
-    try {
-      const fullPath = Path.join(path, sanitizedRepositoryName(name))
-      const directoryFileNames = await FSE.readdir(fullPath)
-
-      if (
-        directoryFileNames != null &&
-        directoryFileNames.length !== 0 &&
-        directoryFileNames.some(fileName => /^ReadMe.md$/i.test(fileName))
-      ) {
-        return true
-      }
-
-      return false
-    } catch (error) {
-      return false
-    }
+    const fullPath = Path.join(path, sanitizedRepositoryName(name), 'README.md')
+    return await FSE.pathExists(fullPath)
   }
 
   private resolveRepositoryRoot = async (): Promise<string> => {


### PR DESCRIPTION
## Overview

**Addresses #6294**
(Does not close the issue since this is the initial change where more may follow.)

## Description

- Adds a warning to the `Create-Repository` dialog when a `ReadMe.md` file exists in the new repository directory that will be overwritten. (When Initialize repository with a ReadMe checkbox is set)

If a user already had a `ReadMe.md` file in the directory they are creating a repository in and had set it to initialize with a readme, there was no notice that the existing readme file will be overwritten, potentially causing a loss of work.

![image](https://user-images.githubusercontent.com/4957200/49321380-ad221d80-f4cc-11e8-8e97-3207386283db.png)

Edit: Ready for review.

## Release notes

Notes: A warning is now displayed if a readme file exists and will be overwritten during repository creation.
