### PR TITLE
Fix odd filtering behavior after switching tabs in the clone dialog

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -106,6 +106,12 @@ export class CloneRepository extends React.Component<
     })
   }
 
+  public componentDidUpdate() {
+    if (this.state.shouldClearFilter) {
+      this.setState({ shouldClearFilter: false })
+    }
+  }
+
   public componentDidMount() {
     const initialURL = this.props.initialURL
     if (initialURL) {


### PR DESCRIPTION
## Overview

#3787 added a mechanism for clearing the filter text inside the GitHub.com and Enterprise tabs in the clone dialog when switching between them as a workaround to us not accurately persisting state when switching between tabs (fixed by #6278). That solution consisted of setting a special flag `shouldClearFilter` when the clone dialog received updated props that indicated a change in tabs.

That flag was then forwarded to the `CloneGithubRepository` component which, when receiving a truthy value in that property would clear its filter text in the components internal state.

The problem with this is that if the dialog component doesn't receive any updated props after the user has switched tabs the dialog will keep the `shouldClearFilter` set to true causing the tab to clear the filter on each update.

While this condition has existed since #3787 landed it's not been triggered up until now because prior to #5931 filtering did not trigger the parent component (dialog) to update since the selected repository wouldn't change until the user actually clicked on it whereas now it changes to the best match while filtering.

This problem will cease to exist once #6278 lands with per-tab state but this will work around the problem until then by explicitly clearing the `shouldClearFilter` flag after the dialog component has updated.

### Steps to reproduce

1. Open the clone dialog, switch to the URL tab
2. Switch back to either the GitHub.com or the Enterprise tab
3. Start typing randomly in the filter text box

The filter text will skip characters and spontaneously clear itself.

![2018-12-06 20-36-13 2018-12-06 20_37_14](https://user-images.githubusercontent.com/634063/49607593-be6c9d80-f996-11e8-8ea4-90219c611fbe.gif)


## Release notes

no-notes (bug introduced in beta, never hit production)