### PR TITLE
Fix for "directory not empty" error when no repository selected

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -24,9 +24,6 @@ import { CloneGithubRepository } from './clone-github-repository'
 import { assertNever } from '../../lib/fatal-error'
 import { CallToAction } from '../lib/call-to-action'
 
-/** The name for the error when the destination already exists. */
-const DestinationExistsErrorName = 'DestinationExistsError'
-
 interface ICloneRepositoryProps {
   readonly dispatcher: Dispatcher
   readonly onDismissed: () => void
@@ -161,7 +158,7 @@ export class CloneRepository extends React.Component<
       this.state.url.length === 0 ||
       this.state.path.length === 0 ||
       this.state.loading ||
-      (!!error && error.name === DestinationExistsErrorName)
+      !!error
 
     return (
       <DialogFooter>

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -179,6 +179,10 @@ export class CloneRepository extends React.Component<
     this.props.onTabSelected(tab)
   }
 
+  private onPathChanged = (path: string) => {
+    this.setState({ path }, this.validatePath)
+  }
+
   private renderActiveTab() {
     const tab = this.props.selectedTab
 
@@ -188,7 +192,7 @@ export class CloneRepository extends React.Component<
           <CloneGenericRepository
             path={this.state.path}
             url={this.state.url}
-            onPathChanged={this.updateAndValidatePath}
+            onPathChanged={this.onPathChanged}
             onUrlChanged={this.updateUrl}
             onChooseDirectory={this.onChooseDirectory}
           />
@@ -204,7 +208,7 @@ export class CloneRepository extends React.Component<
             <CloneGithubRepository
               path={this.state.path}
               account={account}
-              onPathChanged={this.updateAndValidatePath}
+              onPathChanged={this.onPathChanged}
               onGitHubRepositorySelected={this.updateUrl}
               onChooseDirectory={this.onChooseDirectory}
               shouldClearFilter={this.state.shouldClearFilter}
@@ -266,11 +270,26 @@ export class CloneRepository extends React.Component<
     this.props.dispatcher.showEnterpriseSignInDialog()
   }
 
-  private updateAndValidatePath = async (path: string) => {
-    this.setState({ path })
+  private validatePath = async () => {
+    const { path } = this.state
+    const isDefaultPath = this.state.initialPath === this.state.path
+    const isURLNotEntered = this.state.url === ''
 
-    const pathValidation = await this.validateEmptyFolder(path)
-    this.setState({ error: pathValidation })
+    if (isDefaultPath && isURLNotEntered) {
+      if (this.state.error) {
+        this.setState({ error: null })
+      }
+    } else {
+      const pathValidation = await this.validateEmptyFolder(path)
+
+      // If the path has changed while we check we don't care
+      // about the result
+      if (this.state.path !== path) {
+        return
+      }
+
+      this.setState({ error: pathValidation, path })
+    }
   }
 
   private onChooseDirectory = async () => {
@@ -287,7 +306,7 @@ export class CloneRepository extends React.Component<
       ? Path.join(directories[0], lastParsedIdentifier.name)
       : directories[0]
 
-    this.updateAndValidatePath(directory)
+    this.setState({ path: directory, error: null }, this.validatePath)
 
     return directory
   }
@@ -310,12 +329,15 @@ export class CloneRepository extends React.Component<
       newPath = this.state.path
     }
 
-    this.setState({
-      url,
-      lastParsedIdentifier: parsed,
-    })
-
-    this.updateAndValidatePath(newPath)
+    this.setState(
+      {
+        url,
+        lastParsedIdentifier: parsed,
+        path: newPath,
+        error: null,
+      },
+      this.validatePath
+    )
   }
 
   private async validateEmptyFolder(path: string): Promise<null | Error> {
@@ -409,19 +431,9 @@ export class CloneRepository extends React.Component<
   }
 
   private onWindowFocus = () => {
-    // Verify the path after focus has been regained in case changes have been made.
-    const isDefaultPath = this.state.initialPath === this.state.path
-    const isURLNotEntered = this.state.url === ''
-
-    if (isDefaultPath && isURLNotEntered) {
-      if (
-        this.state.error !== null &&
-        this.state.error.name === DestinationExistsErrorName
-      ) {
-        this.setState({ error: null })
-      }
-    } else {
-      this.updateAndValidatePath(this.state.path)
-    }
+    // Verify the path after focus has been regained in
+    // case the directory or directory contents has been
+    // created/removed/altered while the user wasn't in-app.
+    this.validatePath()
   }
 }

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -276,13 +276,11 @@ export class CloneRepository extends React.Component<
     } else {
       const pathValidation = await this.validateEmptyFolder(path)
 
-      // If the path has changed while we check we don't care
-      // about the result
-      if (this.state.path !== path) {
-        return
+      // We only care about the result if the path hasn't
+      // changed since we went async
+      if (this.state.path === path) {
+        this.setState({ error: pathValidation, path })
       }
-
-      this.setState({ error: pathValidation, path })
     }
   }
 

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -265,9 +265,9 @@ export class CloneRepository extends React.Component<
   }
 
   private validatePath = async () => {
-    const { path, initialPath } = this.state
+    const { path, initialPath, url } = this.state
     const isDefaultPath = initialPath === path
-    const isURLNotEntered = this.state.url === ''
+    const isURLNotEntered = url === ''
 
     if (isDefaultPath && isURLNotEntered) {
       if (this.state.error) {

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -265,8 +265,8 @@ export class CloneRepository extends React.Component<
   }
 
   private validatePath = async () => {
-    const { path } = this.state
-    const isDefaultPath = this.state.initialPath === this.state.path
+    const { path, initialPath } = this.state
+    const isDefaultPath = initialPath === path
     const isURLNotEntered = this.state.url === ''
 
     if (isDefaultPath && isURLNotEntered) {

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -153,12 +153,9 @@ export class CloneRepository extends React.Component<
       return null
     }
 
-    const error = this.state.error
+    const { error, url, path, loading } = this.state
     const disabled =
-      this.state.url.length === 0 ||
-      this.state.path.length === 0 ||
-      this.state.loading ||
-      !!error
+      url.length === 0 || path.length === 0 || loading || error !== null
 
     return (
       <DialogFooter>

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -326,7 +326,6 @@ export class CloneRepository extends React.Component<
         url,
         lastParsedIdentifier: parsed,
         path: newPath,
-        error: null,
       },
       this.validatePath
     )


### PR DESCRIPTION
## Overview

When filtering until there are no more results in the clone dialog you'll get an error stating that the directory isn't empty even though no repository is selected and the path points to your default clone directory.

<img width="484" alt="image" src="https://user-images.githubusercontent.com/634063/49609274-4a80c400-f99b-11e8-8824-4cf6a4d0e24b.png">

This bug has existed for a while but was only made visible more recently when #5931 was merged due to us now receiving updates whenever the selected item changes, not just when a list item is clicked.

## Description

The `updateUrl` function is called by the tab components whenever the selected item changes. It parses the url, figures out what the clone path should be, and then calls `updateAndValidatePath` to persist that path and run some validation on it. The problem here is that `updateAndValidatePath` requires access to the `url` state property to function, the same property that has just been updated through `setState` by the `updateUrl` function. `setState` is not synchronous but rather buffers and coalesces changes until the next appropriate render cycle so when the `updateAndValidatePath` tried to access the `url` state variable it was seeing the value as it was prior to the `setState` call in `updateUrl`.

This PR fixes the problem by having all callsites which update `url` also update the path variable and then use the callback functionality of `setState` to invoke the new (renamed) `validatePath` function _once the state change has been finalised_.

## Release notes

no-notes (the bug only exists on beta, never hit production).