### PR TITLE
Add merge conflicts iteration to roadmap

### DIFF
--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -7,6 +7,11 @@ The following are the larger areas of upcoming work the GitHub Desktop team inte
 - Improve onboarding for new users: [#5686](https://github.com/desktop/desktop/issues/5686)
 - Measuring success: [#5549](https://github.com/desktop/desktop/issues/5549) + usability testing
 
+#### Merge conflicts iteration
+
+- Iterate on initial merge conflicts ship: [#6213](https://github.com/desktop/desktop/issues/6213)
+- Measuring success: [#6388](https://github.com/desktop/desktop/issues/6388)
+
 #### Support rebase workflows
 
 - Improve rebase workflows: [#5953](https://github.com/desktop/desktop/issues/5953)


### PR DESCRIPTION
Iterating on our 1.5 release for v2 of merge conflicts has become quite large, and therefore I'd like it to be reflected in our roadmap.