### PR TITLE
Merge conflicts dialog visual updates

### DIFF
--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -217,6 +217,7 @@ export class MergeConflictsDialog extends React.Component<
             onClick={onOpenEditorClick}
             disabled={disabled}
             tooltip={tooltip}
+            className="small-button"
           >
             {editorButtonString(this.props.resolvedExternalEditor)}
           </Button>

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -165,11 +165,10 @@ export class MergeConflictsDialog extends React.Component<
   private renderShellLink(openThisRepositoryInShell: () => void): JSX.Element {
     return (
       <div className="cli-link">
-        You can also{' '}
         <LinkButton onClick={openThisRepositoryInShell}>
-          open the command line
+          Open in command line,
         </LinkButton>{' '}
-        to resolve
+        your tool of choice, or close to resolve manually.
       </div>
     )
   }

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -29,7 +29,7 @@ dialog#merge-conflicts-list {
   ul {
     list-style: none;
     padding: 0;
-    max-height: 200px;
+    max-height: 285px;
     overflow-y: auto;
 
     li {


### PR DESCRIPTION
Closes #6377 

This changes a couple of small visual things: 

1. Updates the small text on the modal
2. Uses the small button size instead of the normal button size on `Open in [editor` buttons
3. Increases the max height of the file list

<img width="1003" alt="screen shot 2018-12-11 at 1 58 05 pm" src="https://user-images.githubusercontent.com/10404068/49833691-22a0b000-fd4f-11e8-8058-5e4b028372cf.png">