### PR TITLE
Previous opt in value

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -263,7 +263,7 @@ export class StatsStore implements IStatsStore {
     // If the user has set an opt out value but we haven't sent the ping yet,
     // give it a shot now.
     if (!getBoolean(HasSentOptInPingKey, false)) {
-      this.sendOptInStatusPing(!this.optOut, storedValue)
+      this.sendOptInStatusPing(this.optOut, storedValue)
     }
 
     this.enableUiActivityMonitoring()
@@ -650,7 +650,7 @@ export class StatsStore implements IStatsStore {
     setBoolean(StatsOptOutKey, optOut)
 
     if (changed || userViewedPrompt) {
-      await this.sendOptInStatusPing(!optOut, previousValue)
+      await this.sendOptInStatusPing(optOut, previousValue)
     }
   }
 
@@ -813,19 +813,31 @@ export class StatsStore implements IStatsStore {
 
   /**
    * Send opt-in ping with details of previous stored value (if known)
+   *
+   * @param optOut        Whether or not the user has opted
+   *                      out of usage reporting.
+   * @param previousValue The raw, current value stored for the
+   *                      "stats-opt-out" localStorage key, or
+   *                      undefined if no previously stored value
+   *                      exists.
    */
   private async sendOptInStatusPing(
-    optIn: boolean,
+    optOut: boolean,
     previousValue?: boolean
   ): Promise<void> {
+    // The analytics pipeline expects us to submit `optIn` but we
+    // track `optOut` so we need to invert the value before we send
+    // it.
+    const optIn = !optOut
+    const previousOptInValue =
+      previousValue === undefined ? null : !previousValue
     const direction = optIn ? 'in' : 'out'
-    const previousValueOrNull =
-      previousValue === undefined ? null : previousValue
+
     try {
       const response = await this.post({
         eventType: 'ping',
         optIn,
-        previousValue: previousValueOrNull,
+        previousOptInValue,
       })
       if (!response.ok) {
         throw new Error(

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -823,7 +823,7 @@ export class StatsStore implements IStatsStore {
    */
   private async sendOptInStatusPing(
     optOut: boolean,
-    previousValue?: boolean
+    previousValue: boolean | undefined
   ): Promise<void> {
     // The analytics pipeline expects us to submit `optIn` but we
     // track `optOut` so we need to invert the value before we send


### PR DESCRIPTION
## Overview

There's confusion around the `previousValue` added in https://github.com/desktop/desktop/pull/6215. The `previousValue` was the inverse of the `optIn` value sent by the clients so if a user had previously opted **in** the subsequent opt-**out** event would look like

```json
{
  "optIn": false,
  "previousValue": false
}
```

In other words, this payload signifies that the user **has changed** their preference but the double negative makes it hard to reason about so after discussing it with @nerdneha we concluded that it would be worth it to correct this before we ship to production.

This PR replaces `previousValue` with a new `previousOptInValue` property that will be sent going forward.

## Release notes

no-notes

cc @nerdneha @billygriffin @telliott27 @iAmWillShepherd @outofambit 