### PR TITLE
Reorder the repository list's Add button options

### DIFF
--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -186,14 +186,14 @@ export class RepositoriesList extends React.Component<
         action: this.onCloneRepository,
       },
       {
+        label: __DARWIN__ ? 'Create New Repository…' : 'Create new repository…',
+        action: this.onCreateNewRepository,
+      },
+      {
         label: __DARWIN__
           ? 'Add Existing Repository…'
           : 'Add existing repository…',
         action: this.onAddExistingRepository,
-      },
-      {
-        label: __DARWIN__ ? 'Create New Repository…' : 'Create new repository…',
-        action: this.onCreateNewRepository,
       },
     ]
 


### PR DESCRIPTION
## Overview

Part of the UX and workflow changes described in #6365.
Closes https://github.com/desktop/desktop/issues/6396

## Description

In the repository list, reordered the Add button's option list to be "Clone, Create, Add" instead of "Clone, Add, Create".
Before:
![Before](https://i.imgur.com/oDc3J1i.png)
After:
![After](https://i.imgur.com/nR4G4QR.png)

## Release notes

no-notes