### PR TITLE
fix feature flag for readme overwrite warning

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -53,6 +53,5 @@ export function enableGitProtocolVersionTwo(): boolean {
 }
 
 export function enableReadmeOverwriteWarning(): boolean {
-  // return enableBetaFeatures()
-  return false
+  return enableBetaFeatures()
 }


### PR DESCRIPTION
## Overview

in #6338 i botched the feature flag to be beta-only. (it was left off for everything.) this fixes that.