### PR TITLE
Adds metrics to track selected terminal emulator and text editor

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -37,6 +37,8 @@ const FirstPushToGitHubAtKey = 'first-push-to-github-at'
 const FirstNonDefaultBranchCheckoutAtKey =
   'first-non-default-branch-checkout-at'
 const WelcomeWizardSignInMethodKey = 'welcome-wizard-sign-in-method'
+const terminalEmulatorKey = 'shell'
+const textEditorKey: string = 'externalEditor'
 
 /** How often daily stats should be submitted (i.e., 24 hours). */
 const DailyStatsReportInterval = 1000 * 60 * 60 * 24
@@ -222,6 +224,12 @@ interface ICalculatedStats {
    * appearance as set at time of stats submission.
    */
   readonly theme: string
+
+  /** The selected terminal emulator at the time of stats submission */
+  readonly selectedTerminalEmulator: string
+
+  /** The selected text editor at the time of stats submission */
+  readonly selectedTextEditor: string
 
   readonly eventType: 'usage'
 }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -388,6 +388,8 @@ export class StatsStore implements IStatsStore {
       osVersion: getOS(),
       platform: process.platform,
       theme: getPersistedThemeName(),
+      selectedTerminalEmulator,
+      selectedTextEditor,
       ...launchStats,
       ...dailyMeasures,
       ...userType,

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -378,6 +378,9 @@ export class StatsStore implements IStatsStore {
     const userType = this.determineUserType(accounts)
     const repositoryCounts = this.categorizedRepositoryCounts(repositories)
     const onboardingStats = this.getOnboardingStats()
+    const selectedTerminalEmulator =
+      localStorage.getItem(terminalEmulatorKey) || 'none'
+    const selectedTextEditor = localStorage.getItem(textEditorKey) || 'none'
 
     return {
       eventType: 'usage',

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -10,18 +10,18 @@ These are general metrics about users that are aggregated to understand general 
 
 | Metric | Description | Justification |
 |:--|:--|:--|
+| `dotComAccount` | Flag that is set if the user is logged in with a GitHub.com account | Informs us on the percentage of people who use Desktop with GitHub.com, so we can more accurately prioritize GitHub workflows in Desktop. |
+| `enterpriseAccount` | Flag that is set if the user is logged in with a GitHub Enterprise account. | Informs us on the percentage of people who use Desktop with an Enterprise instance of GitHub, so we can more accurately prioritize Enterprise-related bugs. |
 | `eventType` | Always set to usage. | Specifies that this data is related to GitHub Desktop usage, so we can filter it correctly in our analytics. |
-| `version` | The version of Desktop. | To visualize update rates and performance metrics for each version of Desktop, so we can track whether users are staying up-to-date and which older versions are active. |
+| `gitHubRepositoryCount` | The number of GitHub repositories. | To understand the typical number of repositories tracked in Desktop that are hosted on GitHub, so we can more accurately prioritize GitHub workflows in Desktop. |
+| `guid` | The unique ID of a Desktop installation. | This allows us to aggregate metrics across multiple days, so we can understand how many people use Desktop per week or per month, and how many people use a particular feature per month.  |
 | `osVersion` | The OS version. | To identify the most common versions of operating systems people use Desktop on, so we can more accurately prioritize version-specific bugs. |
 | `platform` | The OS. | To understand which platforms are most popular among people who use Desktop, so we can more accurately prioritize platform-specific bugs.  |
 | `repositoryCount` | The total number of tracked repositories in Desktop. | To understand the typical number of repositories tracked in Desktop, so we can make appropriate decisions in terms of performance and UI. |
-| `gitHubRepositoryCount` | The number of GitHub repositories. | To understand the typical number of repositories tracked in Desktop that are hosted on GitHub, so we can more accurately prioritize GitHub workflows in Desktop. |
-| `guid` | The unique ID of a Desktop installation. | This allows us to aggregate metrics across multiple days, so we can understand how many people use Desktop per week or per month, and how many people use a particular feature per month.  |
-| `dotComAccount` | Flag that is set if the user is logged in with a GitHub.com account | Informs us on the percentage of people who use Desktop with GitHub.com, so we can more accurately prioritize GitHub workflows in Desktop. |
-| `enterpriseAccount` | Flag that is set if the user is logged in with a GitHub Enterprise account. | Informs us on the percentage of people who use Desktop with an Enterprise instance of GitHub, so we can more accurately prioritize Enterprise-related bugs. |
-| `theme` | The name of the currently selected theme/application appearance as set at time of stats submission. | To understand usage patterns of the Dark Theme feature, so we can more accurately prioritize theme-related bugs. |
 | `selectedTerminalEmulator` | The name of the currently selected terminal emulator at the time of stats submission. | |
 | `selectedTextEditor` | The name of the currently selected text editor at the time of stats submission. | |
+| `theme` | The name of the currently selected theme/application appearance as set at time of stats submission. | To understand usage patterns of the Dark Theme feature, so we can more accurately prioritize theme-related bugs. |
+| `version` | The version of Desktop. | To visualize update rates and performance metrics for each version of Desktop, so we can track whether users are staying up-to-date and which older versions are active. |
 
 ## Measures
 These are general metrics about feature usage and specific feature behaviors. These help us understand our users' mental map of the application, hypothesize pain points within the application, and aid in feature and bugfix planning so that we can improve workflows that are more likely to benefit users.
@@ -29,34 +29,34 @@ These are general metrics about feature usage and specific feature behaviors. Th
 <!-- The `active` field is marked with an `*` because it's actually a dimension that was defined as a measure. Since it is represented in source that way, it is mimiced in this doc. -->
 | Metric | Description | Justification |
 |:--|:--|:--|
-| `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
-| `openShellCount` | The number of times the user has opened a shell from the app. | To understand if people need to use the command line because of missing features. |
-| `partialCommits` | The number of partial commits. | To understand usage patterns of commits made in Desktop. |
-| `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
+| `active*` | Flag indicating whether the app has been interacted with during the current reporting window. | To identify users who are actively using Desktop versus those who have it open but never interact with it. |
 | `branchComparisons` | The number of times a branch is compared to an arbitrary branch. | To understand usage patterns around the compare branches feature. |
+| `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
+| `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
 | `defaultBranchComparisons` | The number of times a branch is compared to the default branch. | To understand usage patterns around the compare branches feature. |
-| `mergesInitiatedFromComparison` | The number of times a merge is initiated in the `compare` sidebar. | To understand usage patterns around the compare branches feature. |
-| `updateFromDefaultBranchMenuCount` | The number of times the `Branch -> Update From Default Branch` menu item is used. | To understand usage patterns around the compare branches feature. |
-| `mergeIntoCurrentBranchMenuCount` | The number of times the `Branch -> Merge Into Current Branch` menu item is used. | To understand usage patterns around the compare branches feature. |
-| `prBranchCheckouts` | The number of times the user checks out a branch using the PR menu. | To understand usage patterns around the PR checkout menu. |
-| `repoWithIndicatorClicked` | The numbers of times a repo with indicators is clicked on repo list view. | To understand usage patterns around the repository indicators feature. |
-| `repoWithoutIndicatorClicked` | The numbers of times a repo without indicators is clicked on repo list view.  | To understand usage patterns around the repository indicators feature. |
 | `divergingBranchBannerDismissal` | The number of times the user dismisses the diverged branch notification. | To understand usage patterns around the notification of diverging from the default branch feature. |
+| `divergingBranchBannerDisplayed` | The number of times the diverged branch notification is displayed. | To understand usage patterns around the notification of diverging from the default branch feature. |
+| `divergingBranchBannerInfluencedMerge` | The number of times the user merges from the compare view after getting to that state from the diverged branch notification compare CTA button. | To understand usage patterns around the notification of diverging from the default branch feature. |
 | `divergingBranchBannerInitatedMerge` | The number of times the user merges from the diverged branch notification merge CTA button. | To understand usage patterns around the notification of diverging from the default branch feature. |
 | `divergingBranchBannerInitiatedCompare` | The number of times the user compares from the diverged branch notification compare CTA button. | To understand usage patterns around the notification of diverging from the default branch feature. |
-| `divergingBranchBannerInfluencedMerge` | The number of times the user merges from the compare view after getting to that state from the diverged branch notification compare CTA button. | To understand usage patterns around the notification of diverging from the default branch feature. |
-| `divergingBranchBannerDisplayed` | The number of times the diverged branch notification is displayed. | To understand usage patterns around the notification of diverging from the default branch feature. |
-| `active*` | Flag indicating whether the app has been interacted with during the current reporting window. | To identify users who are actively using Desktop versus those who have it open but never interact with it. |
-| `mainReadyTime` | The time (in milliseconds) it takes from when our main process code is first loaded until the app `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
+| `dotcomCommits` | The number of time the user made a commit to a repo hosted on Github.com. | To understand the total percentage of commits made to GitHub repos compared to GitHub Enterprise and other remotes to help prioritize our work and focus areas |
+| `enterpriseCommits` | The number of times the user made a commit to a repo hosted on a GitHub Enterprise instance. | To understand the total percentage of commits made to GitHub Enterprise repos to help prioritize our work associated with enterprise use of GitHub Desktop compared to GitHub |
 | `loadTime` | The time (in milliseconds) it takes from when loading begins to loading end. | To make sure new versions of Desktop are not regressing on performance. |
-| `rendererReadyTime` | The time (in milliseconds) it takes from when our renderer process code is first loaded until the renderer `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
-| `mergeConflictFromPullCount` | The number of times a `git pull` initiated by Desktop resulted in a merge conflict for the user. | To understand how often people encounter a merge conflict in Desktop. |
+| `mainReadyTime` | The time (in milliseconds) it takes from when our main process code is first loaded until the app `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
+| `mergeAbortedAfterConflictsCount` | The number of times the user aborts a merge after a merge conflict. | To understand the frequency of merges that are never completed after attempting to merge and hitting a merge conflict |
 | `mergeConflictFromExplicitMergeCount` | The number of times a `git merge` initiated by Desktop resulted in a merge conflict for the user. | To understand how often people encounter a merge conflict in Desktop. |
-| `mergedWithLoadingHintCount` | The number of times the user merged before seeing the result of the merge hint. | To understand how many people are merging before learning whether there will be conflicts or not |
+| `mergeConflictFromPullCount` | The number of times a `git pull` initiated by Desktop resulted in a merge conflict for the user. | To understand how often people encounter a merge conflict in Desktop. |
 | `mergedWithCleanMergeHintCount` | The number of times the user has merged after seeing the 'no conflicts' merge hint. | To understand how many "clean" merges there are |
 | `mergedWithConflictWarningHintCount` | The number of times the user has merged after seeing the 'you have XX conflicted files' warning. | To understand how frequently people are merging even though they know there will be conflicts |
+| `mergedWithLoadingHintCount` | The number of times the user merged before seeing the result of the merge hint. | To understand how many people are merging before learning whether there will be conflicts or not |
+| `mergeIntoCurrentBranchMenuCount` | The number of times the `Branch -> Merge Into Current Branch` menu item is used. | To understand usage patterns around the compare branches feature. |
+| `mergesInitiatedFromComparison` | The number of times a merge is initiated in the `compare` sidebar. | To understand usage patterns around the compare branches feature. |
 | `mergeSuccessAfterConflictsCount` | The number of times the user successfully completes a merge after a merge conflict. | To understand how effectively users are able to resolve conflicts and complete their merge successfully |
-| `mergeAbortedAfterConflictsCount` | The number of times the user aborts a merge after a merge conflict. | To understand the frequency of merges that are never completed after attempting to merge and hitting a merge conflict |
+| `openShellCount` | The number of times the user has opened a shell from the app. | To understand if people need to use the command line because of missing features. |
+| `partialCommits` | The number of partial commits. | To understand usage patterns of commits made in Desktop. |
+| `prBranchCheckouts` | The number of times the user checks out a branch using the PR menu. | To understand usage patterns around the PR checkout menu. |
+| `rendererReadyTime` | The time (in milliseconds) it takes from when our renderer process code is first loaded until the renderer `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
+| `repoWithIndicatorClicked` | The numbers of times a repo with indicators is clicked on repo list view. | To understand usage patterns around the repository indicators feature. |
+| `repoWithoutIndicatorClicked` | The numbers of times a repo without indicators is clicked on repo list view.  | To understand usage patterns around the repository indicators feature. |
 | `unattributedCommits` | The number of commits that will go unattributed to GitHub users. | To understand how frequently commits in GitHub Desktop are unattributed and how highly we should prioritize design for those instances |
-| `enterpriseCommits` | The number of times the user made a commit to a repo hosted on a GitHub Enterprise instance. | To understand the total percentage of commits made to GitHub Enterprise repos to help prioritize our work associated with enterprise use of GitHub Desktop compared to GitHub |
-| `dotcomCommits` | The number of time the user made a commit to a repo hosted on Github.com. | To understand the total percentage of commits made to GitHub repos compared to GitHub Enterprise and other remotes to help prioritize our work and focus areas |
+| `updateFromDefaultBranchMenuCount` | The number of times the `Branch -> Update From Default Branch` menu item is used. | To understand usage patterns around the compare branches feature. |

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -10,6 +10,7 @@ These are general metrics about users that are aggregated to understand general 
 
 | Metric | Description | Justification |
 |:--|:--|:--|
+| `eventType` | Always set to usage. | Specifies that this data is related to GitHub Desktop usage, so we can filter it correctly in our analytics. |
 | `version` | The version of Desktop. | To visualize update rates and performance metrics for each version of Desktop, so we can track whether users are staying up-to-date and which older versions are active. |
 | `osVersion` | The OS version. | To identify the most common versions of operating systems people use Desktop on, so we can more accurately prioritize version-specific bugs. |
 | `platform` | The OS. | To understand which platforms are most popular among people who use Desktop, so we can more accurately prioritize platform-specific bugs.  |
@@ -19,7 +20,6 @@ These are general metrics about users that are aggregated to understand general 
 | `dotComAccount` | Flag that is set if the user is logged in with a GitHub.com account | Informs us on the percentage of people who use Desktop with GitHub.com, so we can more accurately prioritize GitHub workflows in Desktop. |
 | `enterpriseAccount` | Flag that is set if the user is logged in with a GitHub Enterprise account. | Informs us on the percentage of people who use Desktop with an Enterprise instance of GitHub, so we can more accurately prioritize Enterprise-related bugs. |
 | `theme` | The name of the currently selected theme/application appearance as set at time of stats submission. | To understand usage patterns of the Dark Theme feature, so we can more accurately prioritize theme-related bugs. |
-| `eventType` | Always set to usage. | Specifies that this data is related to GitHub Desktop usage, so we can filter it correctly in our analytics. |
 
 ## Measures
 These are general metrics about feature usage and specific feature behaviors. These help us understand our users' mental map of the application, hypothesize pain points within the application, and aid in feature and bugfix planning so that we can improve workflows that are more likely to benefit users.

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -20,6 +20,8 @@ These are general metrics about users that are aggregated to understand general 
 | `dotComAccount` | Flag that is set if the user is logged in with a GitHub.com account | Informs us on the percentage of people who use Desktop with GitHub.com, so we can more accurately prioritize GitHub workflows in Desktop. |
 | `enterpriseAccount` | Flag that is set if the user is logged in with a GitHub Enterprise account. | Informs us on the percentage of people who use Desktop with an Enterprise instance of GitHub, so we can more accurately prioritize Enterprise-related bugs. |
 | `theme` | The name of the currently selected theme/application appearance as set at time of stats submission. | To understand usage patterns of the Dark Theme feature, so we can more accurately prioritize theme-related bugs. |
+| `selectedTerminalEmulator` | The name of the currently selected terminal emulator at the time of stats submission. | |
+| `selectedTextEditor` | The name of the currently selected text editor at the time of stats submission. | |
 
 ## Measures
 These are general metrics about feature usage and specific feature behaviors. These help us understand our users' mental map of the application, hypothesize pain points within the application, and aid in feature and bugfix planning so that we can improve workflows that are more likely to benefit users.

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -18,8 +18,8 @@ These are general metrics about users that are aggregated to understand general 
 | `osVersion` | The OS version. | To identify the most common versions of operating systems people use Desktop on, so we can more accurately prioritize version-specific bugs. |
 | `platform` | The OS. | To understand which platforms are most popular among people who use Desktop, so we can more accurately prioritize platform-specific bugs.  |
 | `repositoryCount` | The total number of tracked repositories in Desktop. | To understand the typical number of repositories tracked in Desktop, so we can make appropriate decisions in terms of performance and UI. |
-| `selectedTerminalEmulator` | The name of the currently selected terminal emulator at the time of stats submission. | |
-| `selectedTextEditor` | The name of the currently selected text editor at the time of stats submission. | |
+| `selectedTerminalEmulator` | The name of the currently selected terminal emulator at the time of stats submission. | To understand what percentage of people have a shell detected and what the most common ones are as certain features allow for opening in shell. |
+| `selectedTextEditor` | The name of the currently selected text editor at the time of stats submission. | To understand what percentage of people have an editor detected and what the most common ones are as certain features send users to their editor. |
 | `theme` | The name of the currently selected theme/application appearance as set at time of stats submission. | To understand usage patterns of the Dark Theme feature, so we can more accurately prioritize theme-related bugs. |
 | `version` | The version of Desktop. | To visualize update rates and performance metrics for each version of Desktop, so we can track whether users are staying up-to-date and which older versions are active. |
 


### PR DESCRIPTION
⚠️ ⚠️ ⚠️  The PRs linked in the **Todo** section need to be merged/deployed too ⚠️ ⚠️ ⚠️ 

Fixes #5431

This PR adds the following metrics:
1. `selectedTerminalEmulator`
1. `selectedTextEditor`

**Todo**
- [x] Request that @desktop/analytics update views and dashboard - https://github.com/github/analytics/issues/812
- [x] Update central - https://github.com/github/central/pull/421
- [x] Update marketing site - https://github.com/github/desktop.github.com/pull/122
- [x] Update metrics doc - https://github.com/desktop/desktop/pull/6416/commits/c0ee4f7710a8797a1da803ce8c8db023eacef23e