### PR TITLE
Commit conflicted files warning

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -494,6 +494,13 @@ export class Dispatcher {
   }
 
   /**
+   * Clear (close) the successful merge banner
+   */
+  public clearMergeConflictsBanner() {
+    return this.appStore._setMergeConflictsBannerState(null)
+  }
+
+  /**
    * Set the divering branch notification banner's visibility
    */
   public setDivergingBranchBannerVisibility(

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -41,6 +41,7 @@ export enum PopupType {
   AbortMerge,
   OversizedFiles,
   UsageReportingChanges,
+  CommitConflictsWarning,
 }
 
 export type Popup =
@@ -143,3 +144,8 @@ export type Popup =
       repository: Repository
     }
   | { type: PopupType.UsageReportingChanges }
+  | {
+      type: PopupType.CommitConflictsWarning
+      repository: Repository
+      context: ICommitContext
+    }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -146,7 +146,10 @@ export type Popup =
   | { type: PopupType.UsageReportingChanges }
   | {
       type: PopupType.CommitConflictsWarning
+      /** files that were selected for committing that are also conflicted */
       files: ReadonlyArray<WorkingDirectoryFileChange>
+      /** repository user is committing in */
       repository: Repository
+      /** information for completing the commit */
       context: ICommitContext
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -146,6 +146,7 @@ export type Popup =
   | { type: PopupType.UsageReportingChanges }
   | {
       type: PopupType.CommitConflictsWarning
+      files: ReadonlyArray<WorkingDirectoryFileChange>
       repository: Repository
       context: ICommitContext
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -85,7 +85,7 @@ import { InitializeLFS, AttributeMismatch } from './lfs'
 import { UpstreamAlreadyExists } from './upstream-already-exists'
 import { ReleaseNotes } from './release-notes'
 import { DeletePullRequest } from './delete-branch/delete-pull-request-dialog'
-import { MergeConflictsDialog } from './merge-conflicts'
+import { MergeConflictsDialog, CommitConflictsWarning } from './merge-conflicts'
 import { AppTheme } from './app-theme'
 import { ApplicationTheme } from './lib/application-theme'
 import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
@@ -1431,7 +1431,15 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={this.onUsageReportingDismissed}
           />
         )
-
+      case PopupType.CommitConflictsWarning:
+        return (
+          <CommitConflictsWarning
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            context={popup.context}
+            onDismissed={this.onPopupDismissed}
+          />
+        )
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1435,6 +1435,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <CommitConflictsWarning
             dispatcher={this.props.dispatcher}
+            files={popup.files}
             repository={popup.repository}
             context={popup.context}
             onDismissed={this.onPopupDismissed}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -144,15 +144,16 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       }
     }
 
-    const anyConflictedFilesSelected = this.props.changes.workingDirectory.files.some(
+    const conflictedFilesSelected = this.props.changes.workingDirectory.files.filter(
       f =>
         isConflictedFile(f.status) &&
         f.selection.getSelectionType() !== DiffSelectionType.None
     )
 
-    if (anyConflictedFilesSelected) {
+    if (conflictedFilesSelected.length > 0) {
       this.props.dispatcher.showPopup({
         type: PopupType.CommitConflictsWarning,
+        files: conflictedFilesSelected,
         repository: this.props.repository,
         context,
       })

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -26,6 +26,7 @@ import { PopupType } from '../../models/popup'
 import { enableFileSizeWarningCheck } from '../../lib/feature-flag'
 import { filesNotTrackedByLFS } from '../../lib/git/lfs'
 import { getLargeFilePaths } from '../../lib/large-files'
+import { isConflictedFile } from '../../lib/status'
 
 /**
  * The timeout for the animation of the enter/leave animation for Undo.
@@ -141,6 +142,21 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
 
         return false
       }
+    }
+
+    const anyConflictedFilesSelected = this.props.changes.workingDirectory.files.some(
+      f =>
+        isConflictedFile(f.status) &&
+        f.selection.getSelectionType() !== DiffSelectionType.None
+    )
+
+    if (anyConflictedFilesSelected) {
+      this.props.dispatcher.showPopup({
+        type: PopupType.CommitConflictsWarning,
+        repository: this.props.repository,
+        context,
+      })
+      return false
     }
 
     return this.props.dispatcher.commitIncludedChanges(

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -144,6 +144,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       }
     }
 
+    // which of the files selected for committing are conflicted?
     const conflictedFilesSelected = this.props.changes.workingDirectory.files.filter(
       f =>
         isConflictedFile(f.status) &&

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -1,0 +1,69 @@
+/** tslint:disable:button-group-order */
+
+import * as React from 'react'
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dispatcher } from '../../lib/dispatcher'
+import { Repository } from '../../models/repository'
+import { DialogHeader } from '../dialog/header'
+import { ICommitContext } from '../../models/commit'
+import { Octicon, OcticonSymbol } from '../octicons'
+
+interface ICommitConflictsWarningProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly context: ICommitContext
+  readonly onDismissed: () => void
+}
+
+/**
+ * Modal to tell the user their merge encountered conflicts
+ */
+export class CommitConflictsWarning extends React.Component<
+  ICommitConflictsWarningProps,
+  {}
+> {
+  private onCancel = () => {
+    this.props.onDismissed()
+  }
+
+  private onSubmit = async () => {
+    this.props.onDismissed()
+    await this.props.dispatcher.commitIncludedChanges(
+      this.props.repository,
+      this.props.context
+    )
+    this.props.dispatcher.setCommitMessage(this.props.repository, {
+      summary: '',
+      description: '',
+    })
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="merge-conflicts-list"
+        dismissable={false}
+        onDismissed={this.onCancel}
+        onSubmit={this.onSubmit}
+      >
+        <DialogHeader
+          title={'Confirm commit files with conflict markers'}
+          dismissable={false}
+        />
+        <DialogContent>
+          <Octicon className="alert-icon" symbol={OcticonSymbol.alert} />
+          If you choose to commit, you'll be committing conflict markers into
+          your repository. Are you sure you want to commit conflict markers?
+        </DialogContent>
+        <DialogFooter>
+          <ButtonGroup>
+            <Button onClick={this.onCancel}>Cancel</Button>
+            <Button type="submit">Yes, commit files</Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -7,9 +7,12 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Dispatcher } from '../../lib/dispatcher'
 import { Repository } from '../../models/repository'
 import { ICommitContext } from '../../models/commit'
+import { WorkingDirectoryFileChange } from '../../models/status'
+import { PathText } from '../lib/path-text'
 
 interface ICommitConflictsWarningProps {
   readonly dispatcher: Dispatcher
+  readonly files: ReadonlyArray<WorkingDirectoryFileChange>
   readonly repository: Repository
   readonly context: ICommitContext
   readonly onDismissed: () => void
@@ -39,6 +42,16 @@ export class CommitConflictsWarning extends React.Component<
     })
   }
 
+  private renderFiles(files: ReadonlyArray<WorkingDirectoryFileChange>) {
+    return (
+      <p>
+        {files.map(f => (
+          <PathText path={f.path} />
+        ))}
+      </p>
+    )
+  }
+
   public render() {
     return (
       <Dialog
@@ -46,15 +59,16 @@ export class CommitConflictsWarning extends React.Component<
         dismissable={false}
         onDismissed={this.onCancel}
         onSubmit={this.onSubmit}
-        title={'Confirm commit files with conflict markers'}
+        title={'Confirm committing conflicted files'}
         type={'warning'}
       >
         <DialogContent>
           <p>
-            If you choose to commit, you'll be committing conflict markers into
-            your repository.
+            If you choose to commit, you’ll be committing the following
+            conflicted files into your repository:
           </p>
-          <p>Are you sure you want to commit conflict markers?</p>
+          {this.renderFiles(this.props.files)}
+          <p>Are you sure you want to commit these conflicted files?</p>
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -1,4 +1,4 @@
-/** tslint:disable:button-group-order */
+// tslint:disable:button-group-order
 
 import * as React from 'react'
 import { Button } from '../lib/button'

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -9,6 +9,7 @@ import { Repository } from '../../models/repository'
 import { ICommitContext } from '../../models/commit'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { PathText } from '../lib/path-text'
+import { Monospaced } from '../lib/monospaced'
 
 interface ICommitConflictsWarningProps {
   readonly dispatcher: Dispatcher
@@ -46,7 +47,9 @@ export class CommitConflictsWarning extends React.Component<
     return (
       <p>
         {files.map(f => (
-          <PathText path={f.path} />
+          <Monospaced>
+            <PathText path={f.path} key={f.path} />
+          </Monospaced>
         ))}
       </p>
     )

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -39,7 +39,7 @@ export class CommitConflictsWarning extends React.Component<
       this.props.repository,
       this.props.context
     )
-    this.props.dispatcher.setMergeConflictsBannerState(null)
+    this.props.dispatcher.clearMergeConflictsBanner()
     this.props.dispatcher.setCommitMessage(this.props.repository, {
       summary: '',
       description: '',

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -13,8 +13,11 @@ import { Monospaced } from '../lib/monospaced'
 
 interface ICommitConflictsWarningProps {
   readonly dispatcher: Dispatcher
+  /** files that were selected for committing that are also conflicted */
   readonly files: ReadonlyArray<WorkingDirectoryFileChange>
+  /** repository user is committing in */
   readonly repository: Repository
+  /** information for completing the commit */
   readonly context: ICommitContext
   readonly onDismissed: () => void
 }

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -47,8 +47,8 @@ export class CommitConflictsWarning extends React.Component<
     return (
       <p>
         {files.map(f => (
-          <Monospaced>
-            <PathText path={f.path} key={f.path} />
+          <Monospaced key={f.path}>
+            <PathText path={f.path} />
           </Monospaced>
         ))}
       </p>

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -6,9 +6,7 @@ import { ButtonGroup } from '../lib/button-group'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Dispatcher } from '../../lib/dispatcher'
 import { Repository } from '../../models/repository'
-import { DialogHeader } from '../dialog/header'
 import { ICommitContext } from '../../models/commit'
-import { Octicon, OcticonSymbol } from '../octicons'
 
 interface ICommitConflictsWarningProps {
   readonly dispatcher: Dispatcher
@@ -34,6 +32,7 @@ export class CommitConflictsWarning extends React.Component<
       this.props.repository,
       this.props.context
     )
+    this.props.dispatcher.setMergeConflictsBannerState(null)
     this.props.dispatcher.setCommitMessage(this.props.repository, {
       summary: '',
       description: '',
@@ -43,19 +42,19 @@ export class CommitConflictsWarning extends React.Component<
   public render() {
     return (
       <Dialog
-        id="merge-conflicts-list"
+        id="commit-conflict-markers-warning"
         dismissable={false}
         onDismissed={this.onCancel}
         onSubmit={this.onSubmit}
+        title={'Confirm commit files with conflict markers'}
+        type={'warning'}
       >
-        <DialogHeader
-          title={'Confirm commit files with conflict markers'}
-          dismissable={false}
-        />
         <DialogContent>
-          <Octicon className="alert-icon" symbol={OcticonSymbol.alert} />
-          If you choose to commit, you'll be committing conflict markers into
-          your repository. Are you sure you want to commit conflict markers?
+          <p>
+            If you choose to commit, you'll be committing conflict markers into
+            your repository.
+          </p>
+          <p>Are you sure you want to commit conflict markers?</p>
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>

--- a/app/src/ui/merge-conflicts/index.ts
+++ b/app/src/ui/merge-conflicts/index.ts
@@ -1,1 +1,2 @@
 export * from './merge-conflicts-dialog'
+export * from './commit-conflicts-warning'


### PR DESCRIPTION
## Overview

Closes #6381 

## Description

![committing conflicted files warning](https://user-images.githubusercontent.com/964912/49977486-5caeb500-fefb-11e8-9e0a-21f8fd202850.gif)


## Release notes

Notes: Warn users when before committing unresolved merge conflicts 
