### PR TITLE
clear merge conflicts banner after there are no more conflicted files

### DIFF
--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -152,6 +152,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     )
 
     if (conflictedFilesLeft.length === 0) {
+      this.props.dispatcher.clearMergeConflictsBanner()
       this.props.dispatcher.recordUnguidedConflictedMergeCompletion()
     }
 


### PR DESCRIPTION
## Overview

Currently, the Merge Conflicts Banner is only hidden after going through the Committing Conflicted Files Warning. this PR adds the command to clear the banner after there are no more conflicted files left to be committed.
