### PR TITLE
Cloneable filter list

### DIFF
--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -6,18 +6,8 @@ import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Button } from '../lib/button'
 import { Loading } from '../lib/loading'
-import { Octicon, OcticonSymbol } from '../octicons'
-import { FilterList } from '../lib/filter-list'
 import { IAPIRepository } from '../../lib/api'
-import { IFilterListGroup } from '../lib/filter-list'
-import { IMatches } from '../../lib/fuzzy-find'
-import {
-  IClonableRepositoryListItem,
-  groupRepositories,
-  YourRepositoriesIdentifier,
-} from './group-repositories'
-import { HighlightText } from '../lib/highlight-text'
-import memoizeOne from 'memoize-one'
+import { CloneableRepositoryFilterList } from './cloneable-repository-filter-list'
 
 interface ICloneGithubRepositoryProps {
   /** The account to clone from. */
@@ -75,75 +65,9 @@ interface ICloneGithubRepositoryProps {
   readonly onRefreshRepositories: (account: Account) => void
 }
 
-const RowHeight = 31
-
-/**
- * Iterate over all groups until a list item is found that matches
- * the clone url of the provided repository.
- */
-function findMatchingListItem(
-  groups: ReadonlyArray<IFilterListGroup<IClonableRepositoryListItem>>,
-  selectedRepository: IAPIRepository | null
-) {
-  if (selectedRepository !== null) {
-    for (const group of groups) {
-      for (const item of group.items) {
-        if (item.url === selectedRepository.clone_url) {
-          return item
-        }
-      }
-    }
-  }
-
-  return null
-}
-
 export class CloneGithubRepository extends React.PureComponent<
   ICloneGithubRepositoryProps
 > {
-  /**
-   * A memoized function for grouping repositories for display
-   * in the FilterList. The group will not be recomputed as long
-   * as the provided list of repositories is equal to the last
-   * time the method was called (reference equality).
-   */
-  private getRepositoryGroups = memoizeOne(
-    (repositories: ReadonlyArray<IAPIRepository> | null) =>
-      this.props.repositories === null
-        ? []
-        : groupRepositories(this.props.repositories, this.props.account.login)
-  )
-
-  /**
-   * A memoized function for finding the selected list item based
-   * on a IAPIRepository instance. The selected item will not be
-   * recomputed as long as the provided list of repositories and
-   * the selected data object is equal to the last time the method
-   * was called (reference equality).
-   *
-   * See findMatchingListItem for more details.
-   */
-  private getSelectedListItem = memoizeOne(findMatchingListItem)
-
-  public componentDidMount() {
-    if (this.props.repositories === null) {
-      this.refreshRepositories()
-    }
-  }
-
-  public componentDidUpdate(prevProps: ICloneGithubRepositoryProps) {
-    if (
-      prevProps.repositories !== this.props.repositories &&
-      this.props.repositories === null
-    ) {
-      this.refreshRepositories()
-    }
-  }
-
-  private refreshRepositories = () => {
-    this.props.onRefreshRepositories(this.props.account)
-  }
-
   public render() {
     return (
       <DialogContent className="clone-github-repository-content">
@@ -154,7 +78,7 @@ export class CloneGithubRepository extends React.PureComponent<
             value={this.props.path}
             label={__DARWIN__ ? 'Local Path' : 'Local path'}
             placeholder="repository path"
-            onValueChanged={this.onPathChanged}
+            onValueChanged={this.props.onPathChanged}
           />
           <Button onClick={this.props.onChooseDirectory}>Choose…</Button>
         </Row>
@@ -174,90 +98,17 @@ export class CloneGithubRepository extends React.PureComponent<
       )
     }
 
-    const groups = this.getRepositoryGroups(this.props.repositories)
-    const selectedItem = this.getSelectedListItem(
-      groups,
-      this.props.selectedItem
-    )
-
     return (
-      <FilterList<IClonableRepositoryListItem>
-        className="clone-github-repo"
-        rowHeight={RowHeight}
-        selectedItem={selectedItem}
-        renderItem={this.renderItem}
-        renderGroupHeader={this.renderGroupHeader}
-        onSelectionChanged={this.onSelectionChanged}
-        invalidationProps={groups}
-        groups={groups}
+      <CloneableRepositoryFilterList
+        account={this.props.account}
+        selectedItem={this.props.selectedItem}
+        onSelectionChanged={this.props.onSelectionChanged}
+        loading={this.props.loading}
+        repositories={this.props.repositories}
         filterText={this.props.filterText}
         onFilterTextChanged={this.props.onFilterTextChanged}
-        renderNoItems={this.noMatchingRepositories}
-        renderPostFilter={this.renderPostFilter}
+        onRefreshRepositories={this.props.onRefreshRepositories}
       />
-    )
-  }
-
-  private renderPostFilter = () => {
-    return (
-      <Button
-        disabled={this.props.loading}
-        onClick={this.refreshRepositories}
-        tooltip="Refresh the list of repositories"
-      >
-        <Octicon
-          symbol={OcticonSymbol.sync}
-          className={this.props.loading ? 'spin' : undefined}
-        />
-      </Button>
-    )
-  }
-
-  private noMatchingRepositories = function() {
-    return (
-      <div className="no-results-found">
-        Sorry, I can't find that repository.
-      </div>
-    )
-  }
-
-  private onSelectionChanged = (item: IClonableRepositoryListItem | null) => {
-    if (item === null || this.props.repositories === null) {
-      this.props.onSelectionChanged(null)
-    } else {
-      this.props.onSelectionChanged(
-        this.props.repositories.find(r => r.clone_url === item.url) || null
-      )
-    }
-  }
-
-  private onPathChanged = (path: string) => {
-    this.props.onPathChanged(path)
-  }
-
-  private renderGroupHeader = (identifier: string) => {
-    let header = identifier
-    if (identifier === YourRepositoriesIdentifier) {
-      header = __DARWIN__ ? 'Your Repositories' : 'Your repositories'
-    }
-    return (
-      <div className="clone-repository-list-content clone-repository-list-group-header">
-        {header}
-      </div>
-    )
-  }
-
-  private renderItem = (
-    item: IClonableRepositoryListItem,
-    matches: IMatches
-  ) => {
-    return (
-      <div className="clone-repository-list-item">
-        <Octicon className="icon" symbol={item.icon} />
-        <div className="name" title={item.text[0]}>
-          <HighlightText text={item.text[0]} highlight={matches.title} />
-        </div>
-      </div>
     )
   }
 }

--- a/app/src/ui/clone-repository/clone-github-repository.tsx
+++ b/app/src/ui/clone-repository/clone-github-repository.tsx
@@ -5,7 +5,6 @@ import { DialogContent } from '../dialog'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Button } from '../lib/button'
-import { Loading } from '../lib/loading'
 import { IAPIRepository } from '../../lib/api'
 import { CloneableRepositoryFilterList } from './cloneable-repository-filter-list'
 
@@ -71,7 +70,18 @@ export class CloneGithubRepository extends React.PureComponent<
   public render() {
     return (
       <DialogContent className="clone-github-repository-content">
-        <Row>{this.renderRepositoryList()}</Row>
+        <Row>
+          <CloneableRepositoryFilterList
+            account={this.props.account}
+            selectedItem={this.props.selectedItem}
+            onSelectionChanged={this.props.onSelectionChanged}
+            loading={this.props.loading}
+            repositories={this.props.repositories}
+            filterText={this.props.filterText}
+            onFilterTextChanged={this.props.onFilterTextChanged}
+            onRefreshRepositories={this.props.onRefreshRepositories}
+          />
+        </Row>
 
         <Row className="local-path-field">
           <TextBox
@@ -83,32 +93,6 @@ export class CloneGithubRepository extends React.PureComponent<
           <Button onClick={this.props.onChooseDirectory}>Choose…</Button>
         </Row>
       </DialogContent>
-    )
-  }
-
-  private renderRepositoryList() {
-    if (
-      this.props.loading &&
-      (this.props.repositories === null || this.props.repositories.length === 0)
-    ) {
-      return (
-        <div className="clone-github-repo clone-loading">
-          <Loading /> Loading repositories…
-        </div>
-      )
-    }
-
-    return (
-      <CloneableRepositoryFilterList
-        account={this.props.account}
-        selectedItem={this.props.selectedItem}
-        onSelectionChanged={this.props.onSelectionChanged}
-        loading={this.props.loading}
-        repositories={this.props.repositories}
-        filterText={this.props.filterText}
-        onFilterTextChanged={this.props.onFilterTextChanged}
-        onRefreshRepositories={this.props.onRefreshRepositories}
-      />
     )
   }
 }

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -129,7 +129,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
 
   /**
    * A memoized function for finding the selected list item based
-   * on a IAPIRepository instance. The selected item will not be
+   * on an IAPIRepository instance. The selected item will not be
    * recomputed as long as the provided list of repositories and
    * the selected data object is equal to the last time the method
    * was called (reference equality).

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -13,6 +13,7 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { HighlightText } from '../lib/highlight-text'
 import { Loading } from '../lib/loading'
+import { ClickSource } from '../lib/list'
 
 interface ICloneableRepositoryFilterListProps {
   /** The account to clone from. */
@@ -57,6 +58,21 @@ interface ICloneableRepositoryFilterListProps {
    * available for cloning.
    */
   readonly onRefreshRepositories: (account: Account) => void
+
+  /**
+   * This function will be called when a pointer device is pressed and then
+   * released on a selectable row. Note that this follows the conventions
+   * of button elements such that pressing Enter or Space on a keyboard
+   * while focused on a particular row will also trigger this event. Consumers
+   * can differentiate between the two using the source parameter.
+   *
+   * Consumers of this event do _not_ have to call event.preventDefault,
+   * when this event is subscribed to the list will automatically call it.
+   */
+  readonly onItemClicked?: (
+    repository: IAPIRepository,
+    source: ClickSource
+  ) => void
 }
 
 const RowHeight = 31
@@ -172,8 +188,26 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
         onFilterTextChanged={this.props.onFilterTextChanged}
         renderNoItems={this.renderNoMatchingRepositories}
         renderPostFilter={this.renderPostFilter}
+        onItemClick={this.props.onItemClicked ? this.onItemClick : undefined}
       />
     )
+  }
+
+  private onItemClick = (
+    item: IClonableRepositoryListItem,
+    source: ClickSource
+  ) => {
+    const { onItemClicked, repositories } = this.props
+
+    if (onItemClicked === undefined || repositories === null) {
+      return
+    }
+
+    const selectedItem = findRepositoryForListItem(repositories, item)
+
+    if (selectedItem !== null) {
+      onItemClicked(selectedItem, source)
+    }
   }
 
   private onSelectionChanged = (item: IClonableRepositoryListItem | null) => {

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react'
+import { Account } from '../../models/account'
+import { FilterList, IFilterListGroup } from '../lib/filter-list'
+import { IAPIRepository } from '../../lib/api'
+import {
+  IClonableRepositoryListItem,
+  groupRepositories,
+  YourRepositoriesIdentifier,
+} from './group-repositories'
+import memoizeOne from 'memoize-one'
+import { Button } from '../lib/button'
+import { IMatches } from '../../lib/fuzzy-find'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { HighlightText } from '../lib/highlight-text'
+import { Loading } from '../lib/loading'
+
+interface ICloneableRepositoryFilterListProps {
+  /** The account to clone from. */
+  readonly account: Account
+
+  /**
+   * The currently selected repository, or null if no repository
+   * is selected.
+   */
+  readonly selectedItem: IAPIRepository | null
+
+  /** Called when a repository is selected. */
+  readonly onSelectionChanged: (selectedItem: IAPIRepository | null) => void
+
+  /**
+   * The list of repositories that the account has explicit permissions
+   * to access, or null if no repositories has been loaded yet.
+   */
+  readonly repositories: ReadonlyArray<IAPIRepository> | null
+
+  /**
+   * Whether or not the list of repositories is currently being loaded
+   * by the API Repositories Store. This determines whether the loading
+   * indicator is shown or not.
+   */
+  readonly loading: boolean
+
+  /**
+   * The contents of the filter text box used to filter the list of
+   * repositories.
+   */
+  readonly filterText: string
+
+  /**
+   * Called when the filter text is changed by the user entering a new
+   * value in the filter text box.
+   */
+  readonly onFilterTextChanged: (filterText: string) => void
+
+  /**
+   * Called when the user requests a refresh of the repositories
+   * available for cloning.
+   */
+  readonly onRefreshRepositories: (account: Account) => void
+}
+
+const RowHeight = 31
+
+/**
+ * Iterate over all groups until a list item is found that matches
+ * the clone url of the provided repository.
+ */
+function findMatchingListItem(
+  groups: ReadonlyArray<IFilterListGroup<IClonableRepositoryListItem>>,
+  selectedRepository: IAPIRepository | null
+) {
+  if (selectedRepository !== null) {
+    for (const group of groups) {
+      for (const item of group.items) {
+        if (item.url === selectedRepository.clone_url) {
+          return item
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+export class CloneableRepositoryFilterList extends React.PureComponent<
+  ICloneableRepositoryFilterListProps
+> {
+  /**
+   * A memoized function for grouping repositories for display
+   * in the FilterList. The group will not be recomputed as long
+   * as the provided list of repositories is equal to the last
+   * time the method was called (reference equality).
+   */
+  private getRepositoryGroups = memoizeOne(
+    (repositories: ReadonlyArray<IAPIRepository> | null) =>
+      this.props.repositories === null
+        ? []
+        : groupRepositories(this.props.repositories, this.props.account.login)
+  )
+
+  /**
+   * A memoized function for finding the selected list item based
+   * on a IAPIRepository instance. The selected item will not be
+   * recomputed as long as the provided list of repositories and
+   * the selected data object is equal to the last time the method
+   * was called (reference equality).
+   *
+   * See findMatchingListItem for more details.
+   */
+  private getSelectedListItem = memoizeOne(findMatchingListItem)
+
+  public componentDidMount() {
+    if (this.props.repositories === null) {
+      this.refreshRepositories()
+    }
+  }
+
+  public componentDidUpdate(prevProps: ICloneableRepositoryFilterListProps) {
+    if (
+      prevProps.repositories !== this.props.repositories &&
+      this.props.repositories === null
+    ) {
+      this.refreshRepositories()
+    }
+  }
+
+  private refreshRepositories = () => {
+    this.props.onRefreshRepositories(this.props.account)
+  }
+
+  public render() {
+    if (
+      this.props.loading &&
+      (this.props.repositories === null || this.props.repositories.length === 0)
+    ) {
+      return (
+        <div className="clone-github-repo clone-loading">
+          <Loading /> Loading repositories…
+        </div>
+      )
+    }
+
+    const groups = this.getRepositoryGroups(this.props.repositories)
+    const selectedItem = this.getSelectedListItem(
+      groups,
+      this.props.selectedItem
+    )
+
+    return (
+      <FilterList<IClonableRepositoryListItem>
+        className="clone-github-repo"
+        rowHeight={RowHeight}
+        selectedItem={selectedItem}
+        renderItem={this.renderItem}
+        renderGroupHeader={this.renderGroupHeader}
+        onSelectionChanged={this.onSelectionChanged}
+        invalidationProps={groups}
+        groups={groups}
+        filterText={this.props.filterText}
+        onFilterTextChanged={this.props.onFilterTextChanged}
+        renderNoItems={this.renderNoMatchingRepositories}
+        renderPostFilter={this.renderPostFilter}
+      />
+    )
+  }
+
+  private onSelectionChanged = (item: IClonableRepositoryListItem | null) => {
+    if (item === null || this.props.repositories === null) {
+      this.props.onSelectionChanged(null)
+    } else {
+      this.props.onSelectionChanged(
+        this.props.repositories.find(r => r.clone_url === item.url) || null
+      )
+    }
+  }
+
+  private renderGroupHeader = (identifier: string) => {
+    let header = identifier
+    if (identifier === YourRepositoriesIdentifier) {
+      header = __DARWIN__ ? 'Your Repositories' : 'Your repositories'
+    }
+    return (
+      <div className="clone-repository-list-content clone-repository-list-group-header">
+        {header}
+      </div>
+    )
+  }
+
+  private renderItem = (
+    item: IClonableRepositoryListItem,
+    matches: IMatches
+  ) => {
+    return (
+      <div className="clone-repository-list-item">
+        <Octicon className="icon" symbol={item.icon} />
+        <div className="name" title={item.text[0]}>
+          <HighlightText text={item.text[0]} highlight={matches.title} />
+        </div>
+      </div>
+    )
+  }
+
+  private renderPostFilter = () => {
+    return (
+      <Button
+        disabled={this.props.loading}
+        onClick={this.refreshRepositories}
+        tooltip="Refresh the list of repositories"
+      >
+        <Octicon
+          symbol={OcticonSymbol.sync}
+          className={this.props.loading ? 'spin' : undefined}
+        />
+      </Button>
+    )
+  }
+
+  private renderNoMatchingRepositories = function() {
+    return (
+      <div className="no-results-found">
+        Sorry, I can't find that repository.
+      </div>
+    )
+  }
+}

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -82,6 +82,18 @@ function findMatchingListItem(
   return null
 }
 
+/**
+ * Attempt to locate the source IAPIRepository instance given
+ * an ICloneableRepositoryList item using clone_url for the
+ * equality comparison.
+ */
+function findRepositoryForListItem(
+  repositories: ReadonlyArray<IAPIRepository>,
+  listItem: IClonableRepositoryListItem
+) {
+  return repositories.find(r => r.clone_url === listItem.url) || null
+}
+
 export class CloneableRepositoryFilterList extends React.PureComponent<
   ICloneableRepositoryFilterListProps
 > {
@@ -169,7 +181,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
       this.props.onSelectionChanged(null)
     } else {
       this.props.onSelectionChanged(
-        this.props.repositories.find(r => r.clone_url === item.url) || null
+        findRepositoryForListItem(this.props.repositories, item)
       )
     }
   }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -5,6 +5,7 @@ import {
   List,
   SelectionSource as ListSelectionSource,
   findNextSelectableRow,
+  ClickSource,
 } from '../lib/list'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -71,8 +72,20 @@ interface IFilterListProps<T extends IFilterListItem> {
   /** Called to render content before/above the filter and list. */
   readonly renderPreList?: () => JSX.Element | null
 
-  /** Called when an item is clicked. */
-  readonly onItemClick?: (item: T) => void
+  /**
+   * This function will be called when a pointer device is pressed and then
+   * released on a selectable row. Note that this follows the conventions
+   * of button elements such that pressing Enter or Space on a keyboard
+   * while focused on a particular row will also trigger this event. Consumers
+   * can differentiate between the two using the source parameter.
+   *
+   * Note that this event handler will not be called for keyboard events
+   * if event.preventDefault was called in the onRowKeyDown event handler.
+   *
+   * Consumers of this event do _not_ have to call event.preventDefault,
+   * when this event is subscribed to the list will automatically call it.
+   */
+  readonly onItemClick?: (item: T, source: ClickSource) => void
 
   /**
    * This function will be called when the selection changes as a result of a
@@ -344,12 +357,12 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
     return row.kind === 'item'
   }
 
-  private onRowClick = (index: number) => {
+  private onRowClick = (index: number, source: ClickSource) => {
     if (this.props.onItemClick) {
       const row = this.state.rows[index]
 
       if (row.kind === 'item') {
-        this.props.onItemClick(row.item)
+        this.props.onItemClick(row.item, source)
       }
     }
   }
@@ -458,7 +471,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
       )
 
       if (row != null) {
-        this.onRowClick(row)
+        this.onRowClick(row, { kind: 'keyboard', event })
       }
     }
   }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -80,7 +80,7 @@ interface IFilterListProps<T extends IFilterListItem> {
    * can differentiate between the two using the source parameter.
    *
    * Note that this event handler will not be called for keyboard events
-   * if event.preventDefault was called in the onRowKeyDown event handler.
+   * if `event.preventDefault()` was called in the onRowKeyDown event handler.
    *
    * Consumers of this event do _not_ have to call event.preventDefault,
    * when this event is subscribed to the list will automatically call it.

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -82,7 +82,7 @@ interface IListProps {
    * can differentiate between the two using the source parameter.
    *
    * Note that this event handler will not be called for keyboard events
-   * if event.preventDefault was called in the onRowKeyDown event handler.
+   * if `event.preventDefault()` was called in the onRowKeyDown event handler.
    *
    * Consumers of this event do _not_ have to call event.preventDefault,
    * when this event is subscribed to the list will automatically call it.

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -67,3 +67,4 @@
 @import 'ui/fancy-text-box';
 @import 'ui/notification-banner';
 @import 'ui/merge-status';
+@import 'ui/cloneable-repository-filter-list';

--- a/app/styles/ui/_add-repository.scss
+++ b/app/styles/ui/_add-repository.scss
@@ -64,19 +64,4 @@
     border-top: var(--base-border);
     padding: var(--spacing-double);
   }
-
-  .clone-loading {
-    display: flex;
-    color: var(--text-secondary-color);
-    align-items: center;
-    flex-direction: column;
-    justify-content: center;
-    text-align: center;
-    width: 100%;
-
-    .octicon {
-      fill: var(--text-secondary-color);
-      margin-right: var(--spacing-half);
-    }
-  }
 }

--- a/app/styles/ui/_cloneable-repository-filter-list.scss
+++ b/app/styles/ui/_cloneable-repository-filter-list.scss
@@ -1,0 +1,19 @@
+.filter-list.clone-github-repo {
+  .no-items {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    text-align: center;
+    margin: var(--spacing-double);
+    width: 100%;
+
+    .octicon {
+      fill: var(--text-secondary-color);
+      margin-right: var(--spacing-half);
+    }
+
+    &.loading {
+      color: var(--text-secondary-color);
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR is part of #6365 but extracted here to be reviewed separately from it in order to cut down on the review burden.

## Description

Extracts the logic required to present a list of 'cloneable' repositories from the `CloneGitHubRepository` component into a separate `CloneableRepositoryFilterList` component which can be reused in the upcoming blank slate (see #6365).

This is a pretty straightforward refactor with the exception of updating the `onItemClick` `FilterList` callback to pass along the `ClickSource` from the underlying `List`. This isn't strictly necessary for this PR but it will be used in #6365 and even if it hadn't been I still think it's a good idea for the `FilterList` to be as compatible with `List` as possible.

## Release notes

no-notes