### PR TITLE
Add link to all release notes in the release notes dialog

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -12,6 +12,7 @@ import { Disposable } from 'event-kit'
 import { Loading } from '../lib/loading'
 import { RelativeTime } from '../relative-time'
 import { assertNever } from '../../lib/fatal-error'
+import { ReleaseNotesUri } from '../lib/releases'
 
 interface IAboutProps {
   /**
@@ -42,8 +43,6 @@ interface IAboutProps {
 interface IAboutState {
   readonly updateState: IUpdateState
 }
-
-const releaseNotesUri = 'https://desktop.github.com/release-notes/'
 
 /**
  * A dialog that presents information about the
@@ -246,7 +245,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
     const name = this.props.applicationName
     const version = this.props.applicationVersion
     const releaseNotesLink = (
-      <LinkButton uri={releaseNotesUri}>release notes</LinkButton>
+      <LinkButton uri={ReleaseNotesUri}>release notes</LinkButton>
     )
 
     return (

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -8,6 +8,7 @@ import { shell } from '../../lib/app-shell'
 
 import { ReleaseSummary } from '../../models/release-notes'
 import { Banner } from './banner'
+import { ReleaseNotesUri } from '../lib/releases'
 
 interface IUpdateAvailableProps {
   readonly dispatcher: Dispatcher
@@ -48,8 +49,7 @@ export class UpdateAvailable extends React.Component<
     if (this.props.newRelease == null) {
       // if, for some reason we're not able to render the release notes we
       // should redirect the user to the website so we do _something_
-      const releaseNotesUri = 'https://desktop.github.com/release-notes/'
-      shell.openExternal(releaseNotesUri)
+      shell.openExternal(ReleaseNotesUri)
     } else {
       this.props.dispatcher.showPopup({
         type: PopupType.ReleaseNotes,

--- a/app/src/ui/lib/releases.ts
+++ b/app/src/ui/lib/releases.ts
@@ -1,0 +1,1 @@
+export const ReleaseNotesUri = 'https://desktop.github.com/release-notes/'

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -17,6 +17,7 @@ import { RichText } from '../lib/rich-text'
 import { Repository } from '../../models/repository'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { shell } from '../../lib/app-shell'
+import { ReleaseNotesUri } from '../lib/releases'
 
 // HACK: This is needed because the `Rich`Text` component
 // needs to know what repo to link issues against.
@@ -194,7 +195,6 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   }
 
   private showAllReleaseNotes = () => {
-    const releaseNotesUri = 'https://desktop.github.com/release-notes/'
-    shell.openExternal(releaseNotesUri)
+    shell.openExternal(ReleaseNotesUri)
   }
 }

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -8,6 +8,7 @@ import { ReleaseNote, ReleaseSummary } from '../../models/release-notes'
 import { updateStore } from '../lib/update-store'
 import { ButtonGroup } from '../lib/button-group'
 import { Button } from '../lib/button'
+import { LinkButton } from '../lib/link-button'
 
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { DialogHeader } from '../dialog/header'
@@ -15,6 +16,7 @@ import { DialogHeader } from '../dialog/header'
 import { RichText } from '../lib/rich-text'
 import { Repository } from '../../models/repository'
 import { getDotComAPIEndpoint } from '../../lib/api'
+import { shell } from '../../lib/app-shell'
 
 // HACK: This is needed because the `Rich`Text` component
 // needs to know what repo to link issues against.
@@ -173,6 +175,9 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
 
         <DialogContent>{contents}</DialogContent>
         <DialogFooter>
+          <LinkButton onClick={this.showAllReleaseNotes}>
+            View all release notes
+          </LinkButton>
           <ButtonGroup destructive={true}>
             <Button type="submit">Close</Button>
             <Button onClick={this.updateNow}>
@@ -186,5 +191,10 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
 
   private updateNow = () => {
     updateStore.quitAndInstallUpdate()
+  }
+
+  private showAllReleaseNotes = () => {
+    const releaseNotesUri = 'https://desktop.github.com/release-notes/'
+    shell.openExternal(releaseNotesUri)
   }
 }

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -41,6 +41,11 @@
     }
   }
 
+  .dialog-footer {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
   ul {
     list-style: none;
     padding-left: 0;


### PR DESCRIPTION
## Overview
<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes https://github.com/desktop/desktop/issues/5605**

## Description

Adds a link to all release notes in to the release notes dialog, as discussed in https://github.com/desktop/desktop/issues/5605

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:

Adds a link to all release notes in to the release notes dialog
