### PR TITLE
Fix displayed color for conflict status

### DIFF
--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -14,8 +14,8 @@ import { assertNever } from './fatal-error'
  *
  * Used in file lists.
  */
-export function mapStatus(status: AppFileStatusKind): string {
-  switch (status) {
+export function mapStatus(status: AppFileStatus): string {
+  switch (status.kind) {
     case AppFileStatusKind.New:
       return 'New'
     case AppFileStatusKind.Modified:
@@ -25,6 +25,11 @@ export function mapStatus(status: AppFileStatusKind): string {
     case AppFileStatusKind.Renamed:
       return 'Renamed'
     case AppFileStatusKind.Conflicted:
+      if (status.lookForConflictMarkers) {
+        const conflictsCount = status.conflictMarkerCount
+        return conflictsCount > 0 ? 'Conflicted' : 'Resolved'
+      }
+
       return 'Conflicted'
     case AppFileStatusKind.Copied:
       return 'Copied'

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -22,7 +22,7 @@ export class ChangedFileDetails extends React.Component<
 > {
   public render() {
     const status = this.props.status
-    const fileStatus = mapStatus(status.kind)
+    const fileStatus = mapStatus(status)
 
     return (
       <div className="header">

--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -43,7 +43,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
 
   public render() {
     const status = this.props.status
-    const fileStatus = mapStatus(status.kind)
+    const fileStatus = mapStatus(status)
 
     const listItemPadding = 10 * 2
     const checkboxWidth = 20

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -58,7 +58,7 @@ export class FileList extends React.Component<IFileListProps, {}> {
   private renderFile = (row: number) => {
     const file = this.props.files[row]
     const status = file.status
-    const fileStatus = mapStatus(status.kind)
+    const fileStatus = mapStatus(status)
 
     const listItemPadding = 10 * 2
     const statusWidth = 16


### PR DESCRIPTION
Fixes #6423

**Before**
![Before](https://user-images.githubusercontent.com/14828183/50022904-86ff8180-ff92-11e8-9b29-02f3ed860df9.png)

**After**
<img width="1409" alt="screen shot 2018-12-18 at 1 47 43 pm" src="https://user-images.githubusercontent.com/1715082/50179270-322e7480-02cc-11e9-9cb1-196a0bb3a063.png">
