### PR TITLE
Don't show "Still Conflicted Warning" when all conflicts are resolved

### DIFF
--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -163,6 +163,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     const conflictedFilesSelected = this.props.changes.workingDirectory.files.filter(
       f =>
         isConflictedFile(f.status) &&
+        hasUnresolvedConflicts(f.status) &&
         f.selection.getSelectionType() !== DiffSelectionType.None
     )
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -18,7 +18,10 @@ import {
   UserAutocompletionProvider,
 } from '../autocompletion'
 import { ClickSource } from '../lib/list'
-import { WorkingDirectoryFileChange } from '../../models/status'
+import {
+  WorkingDirectoryFileChange,
+  ConflictedFileStatus,
+} from '../../models/status'
 import { CSSTransitionGroup } from 'react-transition-group'
 import { openFile } from '../../lib/open-file'
 import { Account } from '../../models/account'
@@ -375,4 +378,14 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       </div>
     )
   }
+}
+
+function hasUnresolvedConflicts(status: ConflictedFileStatus) {
+  if (!status.lookForConflictMarkers) {
+    // binary file doesn't contain markers
+    return true
+  }
+
+  // text file will have conflict markers removed
+  return status.conflictMarkerCount > 0
 }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -381,6 +381,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   }
 }
 
+/**
+ * Determine if we have a `ManualConflict` type
+ * or conflict markers
+ */
 function hasUnresolvedConflicts(status: ConflictedFileStatus) {
   if (!status.lookForConflictMarkers) {
     // binary file doesn't contain markers


### PR DESCRIPTION
Fixes #6451

**After**
![2018-12-18 16 36 04](https://user-images.githubusercontent.com/1715082/50187251-239f8780-02e3-11e9-87de-c336283cb1a5.gif)

No release notes necessary.
