### PR TITLE
check for invalid rows and emit a warning into devtools

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -431,7 +431,7 @@ export class List extends React.Component<IListProps, IListState> {
         return
       }
 
-      const rowCount = this.props.rowCount
+      const { rowCount } = this.props
 
       if (row < 0 || row >= rowCount) {
         log.debug(
@@ -933,7 +933,7 @@ export class List extends React.Component<IListProps, IListState> {
         }
 
         if (this.props.onSelectedRowChanged) {
-          const rowCount = this.props.rowCount
+          const { rowCount } = this.props
 
           if (row < 0 || row >= rowCount) {
             log.debug(

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -427,9 +427,20 @@ export class List extends React.Component<IListProps, IListState> {
 
   private toggleSelection = (event: React.KeyboardEvent<any>) => {
     this.props.selectedRows.forEach(row => {
-      if (this.props.onRowClick) {
-        this.props.onRowClick(row, { kind: 'keyboard', event })
+      if (!this.props.onRowClick) {
+        return
       }
+
+      const rowCount = this.props.rowCount
+
+      if (row < 0 || row >= rowCount) {
+        log.debug(
+          `[List.toggleSelection] unable to onRowClick for row ${row} as it is outside the bounds of the array [0, ${rowCount}]`
+        )
+        return
+      }
+
+      this.props.onRowClick(row, { kind: 'keyboard', event })
     })
   }
 
@@ -919,6 +930,15 @@ export class List extends React.Component<IListProps, IListState> {
 
   private onRowClick = (row: number, event: React.MouseEvent<any>) => {
     if (this.canSelectRow(row) && this.props.onRowClick) {
+      const rowCount = this.props.rowCount
+
+      if (row < 0 || row >= rowCount) {
+        log.debug(
+          `[List.onRowClick] unable to onRowClick for row ${row} as it is outside the bounds of the array [0, ${rowCount}]`
+        )
+        return
+      }
+
       this.props.onRowClick(row, { kind: 'mouseclick', event })
     }
   }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -527,6 +527,15 @@ export class List extends React.Component<IListProps, IListState> {
       }
 
       if (this.props.onSelectedRowChanged) {
+        const rowCount = this.props.rowCount
+
+        if (newRow < 0 || newRow >= rowCount) {
+          log.debug(
+            `[List.moveSelection] unable to onSelectedRowChanged for row '${newRow}' as it is outside the bounds of the array [0, ${rowCount}]`
+          )
+          return
+        }
+
         this.props.onSelectedRowChanged(newRow, {
           kind: 'keyboard',
           event,
@@ -915,13 +924,24 @@ export class List extends React.Component<IListProps, IListState> {
         if (this.props.onSelectionChanged) {
           this.props.onSelectionChanged([row], { kind: 'mouseclick', event })
         }
+
         if (this.props.onSelectedRangeChanged) {
           this.props.onSelectedRangeChanged(row, row, {
             kind: 'mouseclick',
             event,
           })
         }
+
         if (this.props.onSelectedRowChanged) {
+          const rowCount = this.props.rowCount
+
+          if (row < 0 || row >= rowCount) {
+            log.debug(
+              `[List.onRowMouseDown] unable to onSelectedRowChanged for row '${row}' as it is outside the bounds of the array [0, ${rowCount}]`
+            )
+            return
+          }
+
           this.props.onSelectedRowChanged(row, { kind: 'mouseclick', event })
         }
       }


### PR DESCRIPTION
## Overview

**Closes #5266**

## Description

Because of the lack of details about the underlying issue, this PR turns this unhandled error into a dev-time log message with more details about why it's getting into that state.

The original issue was reported in `FilterList`, but as we have a few places that render a `List` and hook into these props I think `List` is a better place to capture it.

@desktop/engineering I'd love any thoughts or ideas you have about getting to the bottom of how we're ending up in this state that we can pull into this PR.

## Release notes

Notes: no-notes
