### PR TITLE
don't include untracked files in merge commit

### DIFF
--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -8,6 +8,7 @@ import { Repository } from '../../models/repository'
 import {
   WorkingDirectoryFileChange,
   CommittedFileChange,
+  WorkingDirectoryStatus,
 } from '../../models/status'
 import { DiffSelection, ImageDiffType } from '../../models/diff'
 import {
@@ -633,15 +634,18 @@ export class Dispatcher {
    * commits an in-flight merge and shows a banner if successful
    *
    * @param repository
-   * @param files files to commit. should be all of them in the repository
+   * @param workingDirectory
    * @param successfulMergeBannerState information for banner to be displayed if merge is successful
    */
-  public async createMergeCommit(
+  public async finishConflictedMerge(
     repository: Repository,
-    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    workingDirectory: WorkingDirectoryStatus,
     successfulMergeBannerState: SuccessfulMergeBannerState
   ) {
-    const result = await this.appStore._createMergeCommit(repository, files)
+    const result = await this.appStore._finishConflictedMerge(
+      repository,
+      workingDirectory
+    )
     if (result !== undefined) {
       this.appStore._setSuccessfulMergeBannerState(successfulMergeBannerState)
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -43,6 +43,7 @@ import {
   CommittedFileChange,
   WorkingDirectoryFileChange,
   WorkingDirectoryStatus,
+  AppFileStatusKind,
 } from '../../models/status'
 import { TipState } from '../../models/tip'
 import { ICommitMessage } from '../../models/commit-message'
@@ -3099,13 +3100,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _createMergeCommit(
+  public async _finishConflictedMerge(
     repository: Repository,
-    files: ReadonlyArray<WorkingDirectoryFileChange>
+    workingDirectory: WorkingDirectoryStatus
   ): Promise<string | undefined> {
+    // filter out untracked files so we don't commit them
+    const trackedFiles = workingDirectory.files.filter(f => {
+      return f.status.kind !== AppFileStatusKind.Untracked
+    })
     const gitStore = this.gitStoreCache.get(repository)
     return await gitStore.performFailableOperation(() =>
-      createMergeCommit(repository, files)
+      createMergeCommit(repository, trackedFiles)
     )
   }
 

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -104,9 +104,14 @@ export class MergeConflictsDialog extends React.Component<
    *  commits the merge displays the repository changes tab and dismisses the modal
    */
   private onSubmit = async () => {
+    // filter out untracked files so we don't commit them
+    const trackedFiles = this.props.workingDirectory.files.filter(f => {
+      return f.status.kind !== AppFileStatusKind.Untracked
+    })
+
     await this.props.dispatcher.createMergeCommit(
       this.props.repository,
-      this.props.workingDirectory.files,
+      trackedFiles,
       {
         ourBranch: this.props.ourBranch,
         theirBranch: this.props.theirBranch,

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -104,14 +104,9 @@ export class MergeConflictsDialog extends React.Component<
    *  commits the merge displays the repository changes tab and dismisses the modal
    */
   private onSubmit = async () => {
-    // filter out untracked files so we don't commit them
-    const trackedFiles = this.props.workingDirectory.files.filter(f => {
-      return f.status.kind !== AppFileStatusKind.Untracked
-    })
-
-    await this.props.dispatcher.createMergeCommit(
+    await this.props.dispatcher.finishConflictedMerge(
       this.props.repository,
-      trackedFiles,
+      this.props.workingDirectory,
       {
         ourBranch: this.props.ourBranch,
         theirBranch: this.props.theirBranch,

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -136,6 +136,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
     Path.join(repo.path, 'bar'),
     Path.join(repo.path, 'baz'),
     Path.join(repo.path, 'cat'),
+    Path.join(repo.path, 'dog'),
   ]
 
   await FSE.writeFile(filePaths[0], 'b0')
@@ -181,6 +182,8 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
     repo.path
   )
   await GitProcess.exec(['commit', '-m', 'Commit'], repo.path)
+
+  await FSE.writeFile(filePaths[4], 'touch')
 
   await GitProcess.exec(['merge', 'master'], repo.path)
 

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -94,7 +94,7 @@ describe('AppStore', () => {
   it('can select a repository', async () => {
     const appStore = await createAppStore()
 
-    const repo = await setupConflictedRepoWithMultipleFiles()
+    const repo = await setupEmptyRepository()
 
     await appStore._selectRepository(repo)
 
@@ -184,10 +184,10 @@ describe('AppStore', () => {
     it('commits tracked files', async () => {
       await appStore._finishConflictedMerge(repo, status.workingDirectory)
       const newStatus = await getStatusOrThrow(repo)
-      const changedFiles = newStatus.workingDirectory.files.filter(
+      const trackedFiles = newStatus.workingDirectory.files.filter(
         f => f.status.kind !== AppFileStatusKind.Untracked
       )
-      expect(changedFiles).toHaveLength(0)
+      expect(trackedFiles).toHaveLength(0)
     })
     it('leaves untracked files untracked', async () => {
       await appStore._finishConflictedMerge(repo, status.workingDirectory)

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -19,7 +19,10 @@ import {
   TestRepositoriesDatabase,
   TestPullRequestDatabase,
 } from '../helpers/databases'
-import { setupEmptyRepository } from '../helpers/repositories'
+import {
+  setupEmptyRepository,
+  setupConflictedRepoWithMultipleFiles,
+} from '../helpers/repositories'
 import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
 
 import { StatsStore } from '../../src/lib/stats'
@@ -31,10 +34,12 @@ import {
 } from '../../src/lib/app-state'
 import { Repository } from '../../src/models/repository'
 import { Commit } from '../../src/models/commit'
-import { getCommit } from '../../src/lib/git'
+import { getCommit, IStatusResult } from '../../src/lib/git'
 import { TestActivityMonitor } from '../helpers/test-activity-monitor'
 import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cache'
 import { ApiRepositoriesStore } from '../../src/lib/stores/api-repositories-store'
+import { getStatusOrThrow } from '../helpers/status'
+import { AppFileStatusKind } from '../../src/models/status'
 
 // enable mocked version
 jest.mock('../../src/lib/window-state')
@@ -89,7 +94,7 @@ describe('AppStore', () => {
   it('can select a repository', async () => {
     const appStore = await createAppStore()
 
-    const repo = await setupEmptyRepository()
+    const repo = await setupConflictedRepoWithMultipleFiles()
 
     await appStore._selectRepository(repo)
 
@@ -164,6 +169,33 @@ describe('AppStore', () => {
 
       state = getAppState(appStore)
       expect(state.localCommitSHAs).toHaveLength(0)
+    })
+  })
+  describe('_finishConflictedMerge', () => {
+    let appStore: AppStore, repo: Repository, status: IStatusResult
+
+    beforeEach(async () => {
+      appStore = await createAppStore()
+      repo = await setupConflictedRepoWithMultipleFiles()
+      await appStore._selectRepository(repo)
+      status = await getStatusOrThrow(repo)
+    })
+
+    it('commits tracked files', async () => {
+      await appStore._finishConflictedMerge(repo, status.workingDirectory)
+      const newStatus = await getStatusOrThrow(repo)
+      const changedFiles = newStatus.workingDirectory.files.filter(
+        f => f.status.kind !== AppFileStatusKind.Untracked
+      )
+      expect(changedFiles).toHaveLength(0)
+    })
+    it('leaves untracked files untracked', async () => {
+      await appStore._finishConflictedMerge(repo, status.workingDirectory)
+      const newStatus = await getStatusOrThrow(repo)
+      const untrackedfiles = newStatus.workingDirectory.files.filter(
+        f => f.status.kind === AppFileStatusKind.Untracked
+      )
+      expect(untrackedfiles).toHaveLength(1)
     })
   })
 })

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -523,10 +523,10 @@ describe('git/commit', () => {
       })
       it('creates a merge commit', async () => {
         const status = await getStatusOrThrow(repository)
-        const sha = await createMergeCommit(
-          repository,
-          status.workingDirectory.files
+        const untrackedFiles = status.workingDirectory.files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
         )
+        const sha = await createMergeCommit(repository, untrackedFiles)
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(0)

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -523,10 +523,10 @@ describe('git/commit', () => {
       })
       it('creates a merge commit', async () => {
         const status = await getStatusOrThrow(repository)
-        const untrackedFiles = status.workingDirectory.files.filter(
+        const trackedFiles = status.workingDirectory.files.filter(
           f => f.status.kind !== AppFileStatusKind.Untracked
         )
-        const sha = await createMergeCommit(repository, untrackedFiles)
+        const sha = await createMergeCommit(repository, trackedFiles)
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(0)

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -37,7 +37,7 @@ describe('git/status', () => {
       it('parses conflicted files with markers', async () => {
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(4)
+        expect(files).toHaveLength(5)
         const conflictedFiles = files.filter(
           f => f.status.kind === AppFileStatusKind.Conflicted
         )
@@ -86,7 +86,7 @@ describe('git/status', () => {
       it('parses conflicted files without markers', async () => {
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
-        expect(files).toHaveLength(4)
+        expect(files).toHaveLength(5)
         expect(
           files.filter(f => f.status.kind === AppFileStatusKind.Conflicted)
         ).toHaveLength(4)
@@ -109,7 +109,7 @@ describe('git/status', () => {
         const status = await getStatusOrThrow(repository!)
         const files = status.workingDirectory.files
 
-        expect(files).toHaveLength(4)
+        expect(files).toHaveLength(5)
 
         // all files are now considered conflicted
         expect(


### PR DESCRIPTION
~~🌵 🌵 **waiting on #6468** 🌵 🌵~~

## Overview

closes #6411

## Description

- refactors component's click handler and `AppStore`/`Dispatcher`'s `createMergeCommit` into more semantic `finishConflictedMerge`
- adds a little logic to prevent committing untracked files during merge conflict resolution
- adds untracked file to conflicted repo fixture (and fix broken tests as a result)
- adds regression test 🎉 

## Release notes

Notes: Leave untracked files uncommitted during merge conflict resolution
