### PR TITLE
Repository list memoization

### DIFF
--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -25,7 +25,7 @@ const fallbackValue = {
 
 export function groupRepositories(
   repositories: ReadonlyArray<Repositoryish>,
-  localRepositoryStateLookup: Map<number, ILocalRepositoryState>
+  localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem>> {
   const grouped = new Map<RepositoryGroupIdentifier, Repositoryish[]>()
   for (const repository of repositories) {

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -7,7 +7,7 @@ import {
   Repositoryish,
   RepositoryGroupIdentifier,
 } from './group-repositories'
-import { FilterList } from '../lib/filter-list'
+import { FilterList, IFilterListGroup } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
 import { assertNever } from '../../lib/fatal-error'
 import { ILocalRepositoryState } from '../../models/repository'

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -17,6 +17,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { showContextualMenu } from '../main-process-proxy'
 import { IMenuItem } from '../../lib/menu-item'
 import { PopupType } from '../../models/popup'
+import memoizeOne from 'memoize-one'
 
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -68,6 +68,22 @@ export class RepositoriesList extends React.Component<
   IRepositoriesListProps,
   {}
 > {
+  /**
+   * A memoized function for grouping repositories for display
+   * in the FilterList. The group will not be recomputed as long
+   * as the provided list of repositories is equal to the last
+   * time the method was called (reference equality).
+   */
+  private getRepositoryGroups = memoizeOne(
+    (
+      repositories: ReadonlyArray<Repositoryish> | null,
+      localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
+    ) =>
+      repositories === null
+        ? []
+        : groupRepositories(repositories, localRepositoryStateLookup)
+  )
+
   private renderItem = (item: IRepositoryListItem, matches: IMatches) => {
     const repository = item.repository
     return (
@@ -128,7 +144,7 @@ export class RepositoriesList extends React.Component<
       return this.noRepositories()
     }
 
-    const groups = groupRepositories(
+    const groups = this.getRepositoryGroups(
       this.props.repositories,
       this.props.localRepositoryStateLookup
     )

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -23,7 +23,10 @@ interface IRepositoriesListProps {
   readonly repositories: ReadonlyArray<Repositoryish>
 
   /** A cache of the latest repository state values, keyed by the repository id */
-  readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>
+  readonly localRepositoryStateLookup: ReadonlyMap<
+    number,
+    ILocalRepositoryState
+  >
 
   /** Called when a repository has been selected. */
   readonly onSelectionChanged: (repository: Repositoryish) => void


### PR DESCRIPTION
## Overview

Noticed this as I was working on https://github.com/desktop/desktop/pull/6475. We were recalculating the repository groups and repository list items on each render even if the repository list or selected item hadn't changed. This is likely of little consequence performance wise since people won't have all that many repositories but since we have a pattern for solving this exact problem now established in https://github.com/desktop/desktop/pull/6278 I figured we might as well use it here as well.

## Description

See the "Memoization" section in the body of https://github.com/desktop/desktop/pull/6278 for details on the pattern itself.

## Release notes

no-notes