### PR TITLE
Cloneable filter list tidy up

### DIFF
--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -121,10 +121,8 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
    * time the method was called (reference equality).
    */
   private getRepositoryGroups = memoizeOne(
-    (repositories: ReadonlyArray<IAPIRepository> | null) =>
-      this.props.repositories === null
-        ? []
-        : groupRepositories(this.props.repositories, this.props.account.login)
+    (repositories: ReadonlyArray<IAPIRepository> | null, login: string) =>
+      repositories === null ? [] : groupRepositories(repositories, login)
   )
 
   /**
@@ -158,7 +156,11 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
   }
 
   public render() {
-    const groups = this.getRepositoryGroups(this.props.repositories)
+    const groups = this.getRepositoryGroups(
+      this.props.repositories,
+      this.props.account.login
+    )
+
     const selectedItem = this.getSelectedListItem(
       groups,
       this.props.selectedItem

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -156,21 +156,16 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
   }
 
   public render() {
-    const groups = this.getRepositoryGroups(
-      this.props.repositories,
-      this.props.account.login
-    )
+    const { repositories, account, selectedItem } = this.props
 
-    const selectedItem = this.getSelectedListItem(
-      groups,
-      this.props.selectedItem
-    )
+    const groups = this.getRepositoryGroups(repositories, account.login)
+    const selectedListItem = this.getSelectedListItem(groups, selectedItem)
 
     return (
       <FilterList<IClonableRepositoryListItem>
         className="clone-github-repo"
         rowHeight={RowHeight}
-        selectedItem={selectedItem}
+        selectedItem={selectedListItem}
         renderItem={this.renderItem}
         renderGroupHeader={this.renderGroupHeader}
         onSelectionChanged={this.onSelectionChanged}


### PR DESCRIPTION
## Overview

While working on #6476 I noticed this little error of mine in the `CloneableRepositoryFilterList` component where I wasn't using the values passed into the memoization function but instead used the instance props. In real world usage this doesn't matter at all since they will always be the same in this particular instance but it's still worth cleaning up.

The memoization function also wasn't using the login as a dependency for when to invalidate the cache which shouldn't matter in this particular case either but certainly isn't correct and worth fixing.

## Release notes

no-notes