### PR TITLE
Remember Scroll Positions in History and Changes Lists

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -54,7 +54,7 @@ interface IChangesListProps {
     isDiscardingAllChanges?: boolean
   ) => void
   readonly onChangesListScrolled: (rowNumber: number) => void
-  readonly changesListScroll: number
+  readonly changesListScrollTop: number
 
   /**
    * Called to open a file it its default application
@@ -439,7 +439,7 @@ export class ChangesList extends React.Component<
           invalidationProps={this.props.workingDirectory}
           onRowClick={this.props.onRowClick}
           onScroll={this.onScroll}
-          setScrollTop={this.props.changesListScroll}
+          setScrollTop={this.props.changesListScrollTop}
         />
 
         <CommitMessage

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -53,7 +53,11 @@ interface IChangesListProps {
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     isDiscardingAllChanges?: boolean
   ) => void
+
+  /** Callback that fires on page scroll to pass the new scrollTop location */
   readonly onChangesListScrolled: (rowNumber: number) => void
+
+  /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly changesListScrollTop: number
 
   /**

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -55,7 +55,7 @@ interface IChangesListProps {
   ) => void
 
   /** Callback that fires on page scroll to pass the new scrollTop location */
-  readonly onChangesListScrolled: (rowNumber: number) => void
+  readonly onChangesListScrolled: (scrollTop: number) => void
 
   /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly changesListScrollTop: number

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -53,6 +53,8 @@ interface IChangesListProps {
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     isDiscardingAllChanges?: boolean
   ) => void
+  readonly onChangesListScrolled: (rowNumber: number) => void
+  readonly changesListScroll: number
 
   /**
    * Called to open a file it its default application
@@ -399,6 +401,10 @@ export class ChangesList extends React.Component<
     }
   }
 
+  private onScroll = (scrollTop: number, clientHeight: number) => {
+    this.props.onChangesListScrolled(scrollTop)
+  }
+
   public render() {
     const fileList = this.props.workingDirectory.files
     const fileCount = fileList.length
@@ -432,6 +438,8 @@ export class ChangesList extends React.Component<
           onSelectionChanged={this.props.onFileSelectionChanged}
           invalidationProps={this.props.workingDirectory}
           onRowClick={this.props.onRowClick}
+          onScroll={this.onScroll}
+          setScrollTop={this.props.changesListScroll}
         />
 
         <CommitMessage

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -65,6 +65,8 @@ interface IChangesSidebarProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
+  readonly onChangesListScrolled: (rowNumber: number) => void
+  readonly changesListScroll: number
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -374,6 +376,8 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           coAuthors={this.props.changes.coAuthors}
           externalEditorLabel={this.props.externalEditorLabel}
           onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+          onChangesListScrolled={this.props.onChangesListScrolled}
+          changesListScroll={this.props.changesListScroll}
         />
         {this.renderMostRecentLocalCommit()}
       </div>

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -66,7 +66,7 @@ interface IChangesSidebarProps {
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
   readonly onChangesListScrolled: (rowNumber: number) => void
-  readonly changesListScroll: number
+  readonly changesListScrollTop: number
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -377,7 +377,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           externalEditorLabel={this.props.externalEditorLabel}
           onOpenInExternalEditor={this.props.onOpenInExternalEditor}
           onChangesListScrolled={this.props.onChangesListScrolled}
-          changesListScroll={this.props.changesListScroll}
+          changesListScrollTop={this.props.changesListScrollTop}
         />
         {this.renderMostRecentLocalCommit()}
       </div>

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -65,7 +65,7 @@ interface IChangesSidebarProps {
    * @param fullPath The full path to the file on disk
    */
   readonly onOpenInExternalEditor: (fullPath: string) => void
-  readonly onChangesListScrolled: (rowNumber: number) => void
+  readonly onChangesListScrolled: (scrollTop: number) => void
   readonly changesListScrollTop: number
 }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -45,7 +45,7 @@ interface ICommitListProps {
   readonly onViewCommitOnGitHub: (sha: string) => void
 
   /** Callback that fires on page scroll to pass the new scrollTop location */
-  readonly onCompareListScrolled: (rowNumber: number) => void
+  readonly onCompareListScrolled: (scrollTop: number) => void
 
   /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly compareListScrollTop: number

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -43,6 +43,9 @@ interface ICommitListProps {
 
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
+
+  readonly onCompareListScrolled: (rowNumber: number) => void
+  readonly compareListScroll: number
 }
 
 /** A component which displays the list of commits. */
@@ -89,6 +92,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const top = Math.floor(scrollTop / RowHeight)
     const bottom = top + numberOfRows
     this.props.onScroll(top, bottom)
+
+    // Store new scroll value so the scroll position will be remembered.
+    this.props.onCompareListScrolled(scrollTop)
   }
 
   private rowForSHA(sha_: string | null): number {
@@ -120,6 +126,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
             commits: this.props.commitSHAs,
             gitHubUsers: this.props.gitHubUsers,
           }}
+          setScrollTop={this.props.compareListScroll}
         />
       </div>
     )

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -45,7 +45,7 @@ interface ICommitListProps {
   readonly onViewCommitOnGitHub: (sha: string) => void
 
   readonly onCompareListScrolled: (rowNumber: number) => void
-  readonly compareListScroll: number
+  readonly compareListScrollTop: number
 }
 
 /** A component which displays the list of commits. */
@@ -126,7 +126,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
             commits: this.props.commitSHAs,
             gitHubUsers: this.props.gitHubUsers,
           }}
-          setScrollTop={this.props.compareListScroll}
+          setScrollTop={this.props.compareListScrollTop}
         />
       </div>
     )

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -44,7 +44,10 @@ interface ICommitListProps {
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
 
+  /** Callback that fires on page scroll to pass the new scrollTop location */
   readonly onCompareListScrolled: (rowNumber: number) => void
+
+  /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly compareListScrollTop: number
 }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -44,8 +44,11 @@ interface ICommitListProps {
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
 
-  /** Callback that fires on page scroll to pass the new scrollTop location */
-  readonly onCompareListScrolled: (scrollTop: number) => void
+  /**
+   * Optional callback that fires on page scroll in order to allow passing
+   * a new scrollTop value up to the parent component for storing.
+   */
+  readonly onCompareListScrolled?: (scrollTop: number) => void
 
   /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly compareListScrollTop: number
@@ -96,8 +99,10 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const bottom = top + numberOfRows
     this.props.onScroll(top, bottom)
 
-    // Store new scroll value so the scroll position will be remembered.
-    this.props.onCompareListScrolled(scrollTop)
+    // Pass new scroll value so the scroll position will be remembered (if the callback has been supplied).
+    if (this.props.onCompareListScrolled != null) {
+      this.props.onCompareListScrolled(scrollTop)
+    }
   }
 
   private rowForSHA(sha_: string | null): number {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -43,7 +43,7 @@ interface ICompareSidebarProps {
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (rowNumber: number) => void
-  readonly compareListScroll: number
+  readonly compareListScrollTop: number
 }
 
 interface ICompareSidebarState {
@@ -265,7 +265,7 @@ export class CompareSidebar extends React.Component<
         onScroll={this.onScroll}
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
-        compareListScroll={this.props.compareListScroll}
+        compareListScrollTop={this.props.compareListScrollTop}
       />
     )
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -42,7 +42,7 @@ interface ICompareSidebarProps {
   readonly selectedCommitSha: string | null
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
-  readonly onCompareListScrolled: (rowNumber: number) => void
+  readonly onCompareListScrolled: (scrollTop: number) => void
   readonly compareListScrollTop: number
 }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -42,6 +42,8 @@ interface ICompareSidebarProps {
   readonly selectedCommitSha: string | null
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
+  readonly onCompareListScrolled: (rowNumber: number) => void
+  readonly compareListScroll: number
 }
 
 interface ICompareSidebarState {
@@ -262,6 +264,8 @@ export class CompareSidebar extends React.Component<
         onCommitSelected={this.onCommitSelected}
         onScroll={this.onScroll}
         emptyListMessage={emptyListMessage}
+        onCompareListScrolled={this.props.onCompareListScrolled}
+        compareListScroll={this.props.compareListScroll}
       />
     )
   }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -735,9 +735,6 @@ export class List extends React.Component<IListProps, IListState> {
     }
     this.scrollToRow = -1
 
-    const scrollTop =
-      this.props.setScrollTop !== undefined ? this.props.setScrollTop : 0
-
     // The currently selected list item is focusable but if
     // there's no focused item (and there's items to switch between)
     // the list itself needs to be focusable so that you can reach
@@ -764,7 +761,7 @@ export class List extends React.Component<IListProps, IListState> {
           cellRenderer={this.renderRow}
           onScroll={this.onScroll}
           scrollToRow={scrollToRow}
-          scrollTop={scrollTop}
+          scrollTop={this.props.setScrollTop}
           overscanRowCount={4}
           style={this.gridStyle}
           tabIndex={tabIndex}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -204,6 +204,12 @@ interface IListProps {
   readonly focusOnHover?: boolean
 
   readonly ariaMode?: 'list' | 'menu'
+
+  /**
+   * The number of pixels from the top of the list indicating
+   * where to scroll do on rendering of the list.
+   */
+  readonly setScrollTop?: number
 }
 
 interface IListState {
@@ -729,6 +735,9 @@ export class List extends React.Component<IListProps, IListState> {
     }
     this.scrollToRow = -1
 
+    const scrollTop =
+      this.props.setScrollTop !== undefined ? this.props.setScrollTop : 0
+
     // The currently selected list item is focusable but if
     // there's no focused item (and there's items to switch between)
     // the list itself needs to be focusable so that you can reach
@@ -755,6 +764,7 @@ export class List extends React.Component<IListProps, IListState> {
           cellRenderer={this.renderRow}
           onScroll={this.onScroll}
           scrollToRow={scrollToRow}
+          scrollTop={scrollTop}
           overscanRowCount={4}
           style={this.gridStyle}
           tabIndex={tabIndex}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -73,12 +73,12 @@ export class RepositoryView extends React.Component<
     }
   }
 
-  private onChangesListScrolled = (rowNumber: number) => {
-    this.setState({ changesListScrollTop: rowNumber })
+  private onChangesListScrolled = (scrollTop: number) => {
+    this.setState({ changesListScrollTop: scrollTop })
   }
 
-  private onCompareListScrolled = (rowNumber: number) => {
-    this.setState({ compareListScrollTop: rowNumber })
+  private onCompareListScrolled = (scrollTop: number) => {
+    this.setState({ compareListScrollTop: scrollTop })
   }
 
   private renderChangesBadge(): JSX.Element | null {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -50,6 +50,7 @@ interface IRepositoryViewProps {
 
 interface IRepositoryViewState {
   readonly sidebarHasFocusWithin: boolean
+  readonly changesListScroll: number
 }
 
 const enum Tab {
@@ -66,7 +67,12 @@ export class RepositoryView extends React.Component<
 
     this.state = {
       sidebarHasFocusWithin: false,
+      changesListScroll: 0,
     }
+  }
+
+  private onChangesListScrolled = (rowNumber: number) => {
+    this.setState({ changesListScroll: rowNumber })
   }
 
   private renderChangesBadge(): JSX.Element | null {
@@ -143,6 +149,8 @@ export class RepositoryView extends React.Component<
         accounts={this.props.accounts}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+        onChangesListScrolled={this.onChangesListScrolled}
+        changesListScroll={this.state.changesListScroll}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -51,6 +51,7 @@ interface IRepositoryViewProps {
 interface IRepositoryViewState {
   readonly sidebarHasFocusWithin: boolean
   readonly changesListScroll: number
+  readonly compareListScroll: number
 }
 
 const enum Tab {
@@ -68,11 +69,16 @@ export class RepositoryView extends React.Component<
     this.state = {
       sidebarHasFocusWithin: false,
       changesListScroll: 0,
+      compareListScroll: 0,
     }
   }
 
   private onChangesListScrolled = (rowNumber: number) => {
     this.setState({ changesListScroll: rowNumber })
+  }
+
+  private onCompareListScrolled = (rowNumber: number) => {
+    this.setState({ compareListScroll: rowNumber })
   }
 
   private renderChangesBadge(): JSX.Element | null {
@@ -172,6 +178,8 @@ export class RepositoryView extends React.Component<
         dispatcher={this.props.dispatcher}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+        onCompareListScrolled={this.onCompareListScrolled}
+        compareListScroll={this.state.compareListScroll}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -50,8 +50,8 @@ interface IRepositoryViewProps {
 
 interface IRepositoryViewState {
   readonly sidebarHasFocusWithin: boolean
-  readonly changesListScroll: number
-  readonly compareListScroll: number
+  readonly changesListScrollTop: number
+  readonly compareListScrollTop: number
 }
 
 const enum Tab {
@@ -68,17 +68,17 @@ export class RepositoryView extends React.Component<
 
     this.state = {
       sidebarHasFocusWithin: false,
-      changesListScroll: 0,
-      compareListScroll: 0,
+      changesListScrollTop: 0,
+      compareListScrollTop: 0,
     }
   }
 
   private onChangesListScrolled = (rowNumber: number) => {
-    this.setState({ changesListScroll: rowNumber })
+    this.setState({ changesListScrollTop: rowNumber })
   }
 
   private onCompareListScrolled = (rowNumber: number) => {
-    this.setState({ compareListScroll: rowNumber })
+    this.setState({ compareListScrollTop: rowNumber })
   }
 
   private renderChangesBadge(): JSX.Element | null {
@@ -156,7 +156,7 @@ export class RepositoryView extends React.Component<
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onChangesListScrolled={this.onChangesListScrolled}
-        changesListScroll={this.state.changesListScroll}
+        changesListScrollTop={this.state.changesListScrollTop}
       />
     )
   }
@@ -179,7 +179,7 @@ export class RepositoryView extends React.Component<
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onCompareListScrolled={this.onCompareListScrolled}
-        compareListScroll={this.state.compareListScroll}
+        compareListScrollTop={this.state.compareListScrollTop}
       />
     )
   }


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes #5177**
**Closes #5059**

## Description

- Scroll positions for the Commit History list and the File Changes list will both be remembered. This allows you to switch between the History and Changes tabs without scroll resetting to the top each time.

Before:
![peek 2018-12-22 11-27](https://user-images.githubusercontent.com/4957200/50377093-c2c2c880-05dc-11e9-95a5-5f956b795e6d.gif)

After:
![peek 2018-12-22 11-02](https://user-images.githubusercontent.com/4957200/50377039-c144d080-05db-11e9-8302-c5afcf2ae46e.gif)

- One potential additional change that can be done would be to save the positions in the Repository state, so that your positions will be remembered between switching to different repositories.

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: Scroll position is now remembered when switching between History and Changes tabs.
