### PR TITLE
upgrade to Typescript 3.2

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -762,11 +762,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
         return
       }
 
+      const newState: IDisplayHistory = {
+        kind: HistoryTabMode.History,
+      }
+
       this.repositoryStateCache.updateCompareState(repository, () => ({
         tip: currentSha,
-        formState: {
-          kind: HistoryTabMode.History,
-        },
+        formState: newState,
         commitSHAs: commits,
         filterText: '',
         showBranchList: false,
@@ -814,13 +816,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const commitSHAs = compare.commits.map(commit => commit.sha)
 
+    const newState: ICompareBranch = {
+      kind: HistoryTabMode.Compare,
+      comparisonBranch,
+      comparisonMode: action.comparisonMode,
+      aheadBehind,
+    }
+
     this.repositoryStateCache.updateCompareState(repository, s => ({
-      formState: {
-        kind: HistoryTabMode.Compare,
-        comparisonBranch,
-        comparisonMode: action.comparisonMode,
-        aheadBehind,
-      },
+      formState: newState,
       filterText: comparisonBranch.name,
       commitSHAs,
     }))
@@ -848,8 +852,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.currentAheadBehindUpdater.insert(from, to, aheadBehind)
     }
 
+    const loadingMerge: MergeResultStatus = { kind: MergeResultKind.Loading }
+
     this.repositoryStateCache.updateCompareState(repository, () => ({
-      mergeStatus: { kind: MergeResultKind.Loading },
+      mergeStatus: loadingMerge,
     }))
 
     this.emitUpdate()

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -382,7 +382,7 @@ export class CloneRepository extends React.Component<
     if (tab === CloneRepositoryTab.DotCom) {
       this.setState(
         prevState => ({
-          dotComTabState: merge<IGitHubTabState, keyof IBaseTabState>(
+          dotComTabState: merge<IGitHubTabState, K>(
             prevState.dotComTabState,
             state
           ),
@@ -392,7 +392,7 @@ export class CloneRepository extends React.Component<
     } else if (tab === CloneRepositoryTab.Enterprise) {
       this.setState(
         prevState => ({
-          enterpriseTabState: merge<IGitHubTabState, keyof IBaseTabState>(
+          enterpriseTabState: merge<IGitHubTabState, K>(
             prevState.enterpriseTabState,
             state
           ),
@@ -402,10 +402,7 @@ export class CloneRepository extends React.Component<
     } else if (tab === CloneRepositoryTab.Generic) {
       this.setState(
         prevState => ({
-          urlTabState: merge<IUrlTabState, keyof IBaseTabState>(
-            prevState.urlTabState,
-            state
-          ),
+          urlTabState: merge<IUrlTabState, K>(prevState.urlTabState, state),
         }),
         callback
       )

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -8,7 +8,7 @@ import {
   AppFileStatusKind,
 } from '../../src/models/status'
 import { DiffSelection, DiffSelectionType } from '../../src/models/diff'
-import { HistoryTabMode } from '../../src/lib/app-state'
+import { HistoryTabMode, IDisplayHistory } from '../../src/lib/app-state'
 import { IGitHubUser } from '../../src/lib/databases'
 
 function createSampleGitHubRepository() {
@@ -122,10 +122,12 @@ describe('RepositoryStateCache', () => {
     const cache = new RepositoryStateCache(defaultGetUsersFunc)
 
     cache.updateCompareState(repository, () => {
+      const newState: IDisplayHistory = {
+        kind: HistoryTabMode.History,
+      }
+
       return {
-        formState: {
-          kind: HistoryTabMode.History,
-        },
+        formState: newState,
         filterText,
         commitSHAs: ['deadbeef'],
       }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "tslint-config-prettier": "^1.14.0",
     "tslint-microsoft-contrib": "^5.2.1",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.1.1",
+    "typescript": "^3.2.0",
     "typescript-eslint-parser": "^20.0.0",
     "typescript-tslint-plugin": "^0.0.6",
     "webpack": "^4.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10762,10 +10762,10 @@ typescript-tslint-plugin@^0.0.6:
     minimatch "^3.0.4"
     vscode-languageserver "^5.1.0"
 
-typescript@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.21"


### PR DESCRIPTION
## Overview

VSCode is now using TS 3.2 by default, so you might encounter errors if you haven't forced VSCode to use the workspace version. I looked into what had changed between TS 3.1 and 3.2 and this was the minimum work to get things compiling again - looks like some changes to how type inference works with `Pick`.

## Release notes

Notes: no-notes
