### PR TITLE
ignore any xml file generated to be read by junit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ app/node_modules/
 .eslintcache
 *.iml
 .envrc
-junit.xml
+junit*.xml


### PR DESCRIPTION
## Overview

If you run `yarn test:integration` locally you'll see this file created. 

```
~/src/desktop> git status                                                                                                            ±[●][development]
On branch development
Your branch is up to date with 'origin/development'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	junit-testresults.xml

nothing added to commit but untracked files present (use "git add" to track)
```


This PR ensure it isn't accidentally added to version control.

## Release notes

Notes: no-notes
