### PR TITLE
Give arrow shown in the path for renamed/copied files some margins

### DIFF
--- a/app/src/ui/lib/path-label.tsx
+++ b/app/src/ui/lib/path-label.tsx
@@ -26,7 +26,7 @@ const ResizeArrowPadding = 10
 export class PathLabel extends React.Component<IPathLabelProps, {}> {
   public render() {
     const props: React.HTMLProps<HTMLLabelElement> = {
-      className: 'path',
+      className: 'path-label-component',
     }
 
     const { status } = this.props

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -31,6 +31,7 @@
 @import 'ui/foldout';
 @import 'ui/preferences';
 @import 'ui/path-text';
+@import 'ui/path-label';
 @import 'ui/configure-git-user';
 @import 'ui/form';
 @import 'ui/text-box';

--- a/app/styles/ui/_file-list.scss
+++ b/app/styles/ui/_file-list.scss
@@ -48,11 +48,6 @@
       margin-right: var(--spacing-half);
     }
 
-    .rename-arrow {
-      flex: 1;
-      flex-shrink: 0;
-    }
-
     .octicon {
       vertical-align: text-bottom;
     }

--- a/app/styles/ui/_file-list.scss
+++ b/app/styles/ui/_file-list.scss
@@ -40,14 +40,6 @@
       flex-shrink: 0;
     }
 
-    .path {
-      display: flex;
-      flex-direction: row;
-      flex-grow: 1;
-      min-width: 0;
-      margin-right: var(--spacing-half);
-    }
-
     .octicon {
       vertical-align: text-bottom;
     }

--- a/app/styles/ui/_path-label.scss
+++ b/app/styles/ui/_path-label.scss
@@ -1,0 +1,12 @@
+.path-label-component {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  align-self: center;
+  min-width: 0;
+  margin-right: var(--spacing-half);
+
+  .rename-arrow {
+    margin: 0 var(--spacing-half);
+  }
+}

--- a/app/styles/ui/_path-text.scss
+++ b/app/styles/ui/_path-text.scss
@@ -7,7 +7,3 @@
     color: var(--text-secondary-color);
   }
 }
-
-.rename-arrow {
-  margin: 0 var(--spacing-half);
-}

--- a/app/styles/ui/_path-text.scss
+++ b/app/styles/ui/_path-text.scss
@@ -7,3 +7,7 @@
     color: var(--text-secondary-color);
   }
 }
+
+.rename-arrow {
+  margin: 0 10px;
+}

--- a/app/styles/ui/_path-text.scss
+++ b/app/styles/ui/_path-text.scss
@@ -9,5 +9,5 @@
 }
 
 .rename-arrow {
-  margin: 0 10px;
+  margin: 0 var(--spacing-half);
 }

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -19,13 +19,6 @@
 
     padding: var(--spacing-half) var(--spacing);
 
-    .path {
-      flex-grow: 1;
-      align-self: center;
-      display: flex;
-      min-width: 0;
-    }
-
     @include octicon-status;
 
     .octicon {


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Closes https://github.com/desktop/desktop/issues/5114**

## Description

In the discussions for https://github.com/desktop/desktop/issues/5114 the last comment was to give the rename/copy arrow a fixed margin in the spots that it's used. The proposed change does that, and things look like this with it in place (note both the renamed files in the sidebar, and the file details header):
![after](https://user-images.githubusercontent.com/3772093/50568318-df5daf80-0d04-11e9-9731-365c87e8a67c.gif)

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:
- Gives arrow shown in the path for renamed/copied files some margins