### PR TITLE
Fix image overlapping menu

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -279,6 +279,9 @@
   display: flex;
   flex: 1;
   padding-top: 10px;
+  // Workaround so images stay within diff view until
+  // root issue with DPI scaling is addressed, see https://github.com/desktop/desktop/issues/2480
+  overflow: hidden;
 
   .tab-bar {
     width: 350px;


### PR DESCRIPTION
## Overview

<!--
What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one to allow for discussion before opening this PR.
(You can open a new issue at https://github.com/desktop/desktop/issues/new/choose)
-->
**Workaround to not have image overlap the menu until the root issue is fixed with the DPI scaling issue in #2480**

## Description

- When a large image gets drawn out of the diff panel (due to DPI scaling being larger than 100%) and overlaps the top menu. This prevents the image from overlapping the menu until the root issue with the DPI scaling is fixed. Unlike #6265 this will not add a scroll bar to the container.

![githubmenuoverlap](https://user-images.githubusercontent.com/1302542/50569667-18b01280-0d39-11e9-951d-bd4c4f73952e.gif)


## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: Fixes problem where large image overlaps menu in Windows when DPI scaling settings are larger than 100%