### PR TITLE
CommitMessages - Better Handle Nulls

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -402,7 +402,7 @@ export interface IChangesState {
   readonly diff: IDiff | null
 
   /** The commit message for a work-in-progress commit in the changes view. */
-  readonly commitMessage: ICommitMessage | null
+  readonly commitMessage: ICommitMessage
 
   /**
    * Whether or not to show a field for adding co-authors to

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -561,7 +561,7 @@ export class Dispatcher {
    */
   public setCommitMessage(
     repository: Repository,
-    message: ICommitMessage | null
+    message: ICommitMessage
   ): Promise<void> {
     return this.appStore._setCommitMessage(repository, message)
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3015,7 +3015,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _setCommitMessage(
     repository: Repository,
-    message: ICommitMessage | null
+    message: ICommitMessage
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
     return gitStore.setCommitMessage(message)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -16,7 +16,10 @@ import { Tip, TipState } from '../../models/tip'
 import { Commit } from '../../models/commit'
 import { IRemote } from '../../models/remote'
 import { IFetchProgress, IRevertProgress } from '../../models/progress'
-import { ICommitMessage } from '../../models/commit-message'
+import {
+  ICommitMessage,
+  DefaultCommitMessage,
+} from '../../models/commit-message'
 import { ComparisonMode } from '../app-state'
 
 import { IAppShell } from '../app-shell'
@@ -105,7 +108,7 @@ export class GitStore extends BaseStore {
 
   private _localCommitSHAs: ReadonlyArray<string> = []
 
-  private _commitMessage: ICommitMessage | null = null
+  private _commitMessage: ICommitMessage = DefaultCommitMessage
 
   private _showCoAuthoredBy: boolean = false
 
@@ -712,7 +715,7 @@ export class GitStore extends BaseStore {
   }
 
   /** The commit message for a work-in-progress commit in the changes view. */
-  public get commitMessage(): ICommitMessage | null {
+  public get commitMessage(): ICommitMessage {
     return this._commitMessage
   }
 
@@ -1072,14 +1075,8 @@ export class GitStore extends BaseStore {
     this.emitUpdate()
   }
 
-  public setCommitMessage(message: ICommitMessage | null): Promise<void> {
-    this._commitMessage =
-      message === null
-        ? {
-            summary: '',
-            description: '',
-          }
-        : message
+  public setCommitMessage(message: ICommitMessage): Promise<void> {
+    this._commitMessage = message
 
     this.emitUpdate()
     return Promise.resolve()

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1073,7 +1073,14 @@ export class GitStore extends BaseStore {
   }
 
   public setCommitMessage(message: ICommitMessage | null): Promise<void> {
-    this._commitMessage = message
+    this._commitMessage =
+      message === null
+        ? {
+            summary: '',
+            description: '',
+          }
+        : message
+
     this.emitUpdate()
     return Promise.resolve()
   }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -20,6 +20,7 @@ import {
 import { ComparisonCache } from '../comparison-cache'
 import { IGitHubUser } from '../databases'
 import { merge } from '../merge'
+import { DefaultCommitMessage } from '../../models/commit-message'
 
 export class RepositoryStateCache {
   private readonly repositoryState = new Map<string, IRepositoryState>()
@@ -112,7 +113,7 @@ function getInitialRepositoryState(): IRepositoryState {
       ),
       selectedFileIDs: [],
       diff: null,
-      commitMessage: null,
+      commitMessage: DefaultCommitMessage,
       coAuthors: [],
       showCoAuthoredBy: false,
       conflictState: null,

--- a/app/src/models/commit-message.ts
+++ b/app/src/models/commit-message.ts
@@ -3,3 +3,8 @@ export interface ICommitMessage {
   readonly summary: string
   readonly description: string | null
 }
+
+export const DefaultCommitMessage: ICommitMessage = {
+  summary: '',
+  description: '',
+}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -71,7 +71,7 @@ interface IChangesListProps {
    * List Props for documentation.
    */
   readonly onRowClick?: (row: number, source: ClickSource) => void
-  readonly commitMessage: ICommitMessage | null
+  readonly commitMessage: ICommitMessage
 
   /** The autocompletion providers available to the repository. */
   readonly autocompletionProviders: ReadonlyArray<IAutocompletionProvider<any>>

--- a/app/src/ui/changes/oversized-files-warning.tsx
+++ b/app/src/ui/changes/oversized-files-warning.tsx
@@ -99,9 +99,6 @@ export class OversizedFiles extends React.Component<IOversizedFilesProps> {
       this.props.context
     )
 
-    this.props.dispatcher.setCommitMessage(this.props.repository, {
-      summary: '',
-      description: '',
-    })
+    this.props.dispatcher.setCommitMessage(this.props.repository, null)
   }
 }

--- a/app/src/ui/changes/oversized-files-warning.tsx
+++ b/app/src/ui/changes/oversized-files-warning.tsx
@@ -8,6 +8,7 @@ import { PathText } from '../lib/path-text'
 import { Dispatcher } from '../../lib/dispatcher'
 import { Repository } from '../../models/repository'
 import { ICommitContext } from '../../models/commit'
+import { DefaultCommitMessage } from '../../models/commit-message'
 
 const GitLFSWebsiteURL =
   'https://help.github.com/articles/versioning-large-files/'
@@ -99,6 +100,9 @@ export class OversizedFiles extends React.Component<IOversizedFilesProps> {
       this.props.context
     )
 
-    this.props.dispatcher.setCommitMessage(this.props.repository, null)
+    this.props.dispatcher.setCommitMessage(
+      this.props.repository,
+      DefaultCommitMessage
+    )
   }
 }

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -40,10 +40,7 @@ export class CommitConflictsWarning extends React.Component<
       this.props.context
     )
     this.props.dispatcher.clearMergeConflictsBanner()
-    this.props.dispatcher.setCommitMessage(this.props.repository, {
-      summary: '',
-      description: '',
-    })
+    this.props.dispatcher.setCommitMessage(this.props.repository, null)
   }
 
   private renderFiles(files: ReadonlyArray<WorkingDirectoryFileChange>) {

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -10,6 +10,7 @@ import { ICommitContext } from '../../models/commit'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { PathText } from '../lib/path-text'
 import { Monospaced } from '../lib/monospaced'
+import { DefaultCommitMessage } from '../../models/commit-message'
 
 interface ICommitConflictsWarningProps {
   readonly dispatcher: Dispatcher
@@ -40,7 +41,10 @@ export class CommitConflictsWarning extends React.Component<
       this.props.context
     )
     this.props.dispatcher.clearMergeConflictsBanner()
-    this.props.dispatcher.setCommitMessage(this.props.repository, null)
+    this.props.dispatcher.setCommitMessage(
+      this.props.repository,
+      DefaultCommitMessage
+    )
   }
 
   private renderFiles(files: ReadonlyArray<WorkingDirectoryFileChange>) {

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -18,6 +18,7 @@ import { PathText } from '../lib/path-text'
 import { DialogHeader } from '../dialog/header'
 import { LinkButton } from '../lib/link-button'
 import { isConflictedFile } from '../../lib/status'
+import { DefaultCommitMessage } from '../../models/commit-message'
 
 interface IMergeConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -112,7 +113,10 @@ export class MergeConflictsDialog extends React.Component<
         theirBranch: this.props.theirBranch,
       }
     )
-    this.props.dispatcher.setCommitMessage(this.props.repository, null)
+    this.props.dispatcher.setCommitMessage(
+      this.props.repository,
+      DefaultCommitMessage
+    )
     this.props.dispatcher.changeRepositorySection(
       this.props.repository,
       RepositorySectionTab.Changes

--- a/app/test/unit/stores/updates/changes-state-helper.ts
+++ b/app/test/unit/stores/updates/changes-state-helper.ts
@@ -2,6 +2,7 @@ import { IChangesState } from '../../../../src/lib/app-state'
 import { WorkingDirectoryStatus } from '../../../../src/models/status'
 import { merge } from '../../../../src/lib/merge'
 import { IStatusResult } from '../../../../src/lib/git'
+import { DefaultCommitMessage } from '../../../../src/models/commit-message'
 
 export function createState<K extends keyof IChangesState>(
   pick: Pick<IChangesState, K>
@@ -10,7 +11,7 @@ export function createState<K extends keyof IChangesState>(
     workingDirectory: WorkingDirectoryStatus.fromFiles([]),
     selectedFileIDs: [],
     diff: null,
-    commitMessage: null,
+    commitMessage: DefaultCommitMessage,
     showCoAuthoredBy: false,
     coAuthors: [],
     conflictState: null,


### PR DESCRIPTION
## Overview

**Closes #6378**

## Description

- Handles null in a way we don't have to remember `''` vs `null`

## Release notes

Notes: no-notes