### PR TITLE
restore eslint ignore file and ignore generated coverage folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+# these folders contain scripts to add enhance the code coverage reports and are
+# already ignored by .gitignore but because they live under app and script they
+# will be included when linting unless they are excluded here
+app/coverage
+script/coverage

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
-# these folders contain scripts to add enhance the code coverage reports and are
-# already ignored by .gitignore but because they live under app and script they
-# will be included when linting unless they are excluded here
+# These folders contain scripts to enhance the code coverage reports and are
+# already ignored by .gitignore, but because they live under app and script they
+# might be included when linting
 app/coverage
 script/coverage


### PR DESCRIPTION
## Overview

After the work in #6518  and #6517 I noticed that I would get some eslint errors that should be ignored.

## Description

```
~/src/desktop> yarn eslint                                                                                                                                      ±[development]
yarn run v1.12.3
$ eslint --cache --rulesdir ./eslint-rules "./{script,eslint-rules,tslint-rules}/**/*.{j,t}s{,x}" "./app/{src,typings,test}/**/*.{j,t}s{,x}" "./changelog.json"

/Users/shiftkey/src/desktop/script/coverage/block-navigation.js
   1:1  error  Use the global form of 'use strict'       strict
   1:1  error  Unexpected var, use let or const instead  no-var
   ...

/Users/shiftkey/src/desktop/script/coverage/prettify.js
  1:1      error  Use the global form of 'use strict'       strict
  1:52     error  Unexpected var, use let or const instead  no-var
  ...  

/Users/shiftkey/src/desktop/script/coverage/sorter.js
    1:1   error  Use the global form of 'use strict'       strict
    1:1   error  Unexpected var, use let or const instead  no-var
    ...

✖ 235 problems (235 errors, 0 warnings)
  183 errors and 0 warnings potentially fixable with the `--fix` option.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

These files are part of the HTML report generated by jest when you run `yarn test:unit:cov` or the new `yarn test:script:cov` command, and should not be linted.

## Release notes

Notes: no-notes
