### PR TITLE
ensure we await the value read from global config

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -319,7 +319,7 @@ export async function gitNetworkArguments(
   const protocolVersion =
     repository != null
       ? await getConfigValue(repository, name)
-      : getGlobalConfigValue(name)
+      : await getGlobalConfigValue(name)
 
   if (protocolVersion !== null) {
     // protocol.version is already set, we should not override it with our own


### PR DESCRIPTION
## Overview

After reviewing some code I stumbled upon the changes from #6142 and noticed there was a subtle bug with the behaviour.

## Description

Here's the hint:

<img width="459" src="https://user-images.githubusercontent.com/359239/50729423-aca22580-110f-11e9-8614-4191cae34dc2.png">

While this code is intended to run for every Git network operation the impact is currently negligible because:

  - the feature flag means it's only available in development mode (release builds have this code stripped out)
  - it doesn't wait to resolve the `Promise<string | null>` when checking the global config path (e.g. when performing a clone), and then compared it to `null` on the next line, which means it would retain the default behaviour of not setting `protocol.version=2`

With this fix, the type inference is sane again:

<img width="341" src="https://user-images.githubusercontent.com/359239/50729424-aca22580-110f-11e9-8948-766988155a50.png">

## Release notes

This is only enabled in development mode currently, so doesn't need to be listed for end users

Notes: no-notes
