### PR TITLE
ignore handled Enter event in FocusContainer keydown event handler

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -360,7 +360,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private handleKeyDown = (event: React.KeyboardEvent<any>) => {
+  private onKeyDown = (event: React.KeyboardEvent<any>) => {
     this.props.selectedRows.forEach(row => {
       if (this.props.onRowKeyDown) {
         this.props.onRowKeyDown(row, event)
@@ -681,7 +681,7 @@ export class List extends React.Component<IListProps, IListState> {
         ref={this.onRef}
         id={this.props.id}
         className="list"
-        onKeyDown={this.handleKeyDown}
+        onKeyDown={this.onKeyDown}
         role={role}
         aria-activedescendant={activeDescendant}
       >

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -398,7 +398,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private onRowKeyDown = (
+  private handleRowKeyDown = (
     rowIndex: number,
     event: React.KeyboardEvent<any>
   ) => {
@@ -418,7 +418,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<any>) => {
+  private handleFocusContainerKeyDown = (event: React.KeyboardEvent<any>) => {
     if (
       !event.defaultPrevented &&
       (event.key === 'Enter' || event.key === ' ')
@@ -636,7 +636,7 @@ export class List extends React.Component<IListProps, IListState> {
         selected={selected}
         ariaMode={this.props.ariaMode}
         onRowClick={this.onRowClick}
-        onRowKeyDown={this.onRowKeyDown}
+        onRowKeyDown={this.handleRowKeyDown}
         onRowMouseDown={this.onRowMouseDown}
         onRowMouseOver={this.onRowMouseOver}
         style={params.style}
@@ -742,7 +742,7 @@ export class List extends React.Component<IListProps, IListState> {
     return (
       <FocusContainer
         className="list-focus-container"
-        onKeyDown={this.onKeyDown}
+        onKeyDown={this.handleFocusContainerKeyDown}
       >
         <Grid
           aria-label={''}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -419,7 +419,10 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private onKeyDown = (event: React.KeyboardEvent<any>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
+    if (
+      !event.defaultPrevented &&
+      (event.key === 'Enter' || event.key === ' ')
+    ) {
       this.toggleSelection(event)
       event.preventDefault()
     }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -398,7 +398,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private handleRowKeyDown = (
+  private onRowKeyDown = (
     rowIndex: number,
     event: React.KeyboardEvent<any>
   ) => {
@@ -418,7 +418,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private handleFocusContainerKeyDown = (event: React.KeyboardEvent<any>) => {
+  private onFocusContainerKeyDown = (event: React.KeyboardEvent<any>) => {
     if (
       !event.defaultPrevented &&
       (event.key === 'Enter' || event.key === ' ')
@@ -636,7 +636,7 @@ export class List extends React.Component<IListProps, IListState> {
         selected={selected}
         ariaMode={this.props.ariaMode}
         onRowClick={this.onRowClick}
-        onRowKeyDown={this.handleRowKeyDown}
+        onRowKeyDown={this.onRowKeyDown}
         onRowMouseDown={this.onRowMouseDown}
         onRowMouseOver={this.onRowMouseOver}
         style={params.style}
@@ -742,7 +742,7 @@ export class List extends React.Component<IListProps, IListState> {
     return (
       <FocusContainer
         className="list-focus-container"
-        onKeyDown={this.handleFocusContainerKeyDown}
+        onKeyDown={this.onFocusContainerKeyDown}
       >
         <Grid
           aria-label={''}


### PR DESCRIPTION
## Overview

**Closes #5344**

The easiest way to test this is to use the "Open in Shell" menu item on Windows **using only keyboard navigation** - you should seeing two instances of the desired shell launch, which can be traced back to this event handling.

## Description

I've been wrestling with this one for a while, but after plodding through the event handlers yet again I think I've stumbled upon the best solution for this.

First, I first need to walk through the bug itself. Have a read of [event bubbling](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture) as that's relevant to the behaviour we're currently seeing.

 1. user uses keyboard navigation to expand menu and select an menu item to execute
 2. user presses <kbd>Enter</kbd>

3. [`List.onRowKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/lib/list/list.tsx#L401) fires - this is the event handler attached to each `ListRow` component inside the `Grid`
     - this invokes [`MenuPane.onRowKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/app-menu/menu-pane.tsx#L220) as it's the active row
     - which then invokes [`AppMenu.onItemKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/app-menu/app-menu.tsx#L168)
     - this doesn't handle the event 🙅‍♂️ 
     - back in `List.onRowKeyDown` we check that <kbd>Enter</kbd> [has not been handled](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/lib/list/list.tsx#L412-L418) and `toggleSelection` fires
     - `List.toggleSelection` fires the `onRowClick` prop for `List`
     - ... which runs `MenuPane.onRowClick` 
     - ... which runs `AppMenu.onItemClicked`
     - which performs the IPC call to execute the menu item :ok:
 
4. [`List.onKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/lib/list/list.tsx#L421) fires - this is the click handler for the `FocusContainer` that wraps the `Grid`
     - this checks for <kbd>Enter</kbd> or the space key and runs `toggleSelection` again
     - `List.toggleSelection` fires the `onRowClick` prop for `List`
     - ... which runs `MenuPane.onRowClick` 
     - ... which runs `AppMenu.onItemClicked`
     - which performs the IPC call to execute the menu item again  ❌ 

 5. finally [`List.handleKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/lib/list/list.tsx#L363) fires - this is the click handler for the `div` which hosts the contents
     - this again invokes [`MenuPane.onRowKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/app-menu/menu-pane.tsx#L220) because the row is considered "selected" due to the hover state
     - which again invokes [`AppMenu.onItemKeyDown`](https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/app-menu/app-menu.tsx#L168)
     - which still doesn't handle the event 🙅‍♂️  

The MDN docs about [event bubbling](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture) talk about using `event.stopPropagation()` to prevent the parent elements from handling events, but I feel this is heavy-handed and goes against the way we've been designing these components.

Instead I think the fix here is ensure that `List.onKeyDown` event handler ignores the event if `defaultPrevented` has been set. We do this inside `List.handleKeyDown` and `List.onRowKeyDown`, so I think this was just an oversight whenever we were making changes in here.

https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/lib/list/list.tsx#L370-L374

https://github.com/desktop/desktop/blob/f4efc0af4ef610f9abcc91403aa8f5547282fd0f/app/src/ui/lib/list/list.tsx#L412-L418

Of course, this event handler was implemented as part of multi-select support in #4188 so I want to confirm there are no side effects from this before we can close it out.

 - [x] test multi-select in Changes list with keyboard navigation only
 
## Release notes

Notes: fixed keyboard event handling in app menu on Windows
