### PR TITLE
change feature flag for large file size warning to enable for everyone

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -44,7 +44,7 @@ export function enableRecurseSubmodulesFlag(): boolean {
 
 /** Should the app check and warn the user about committing large files? */
 export function enableFileSizeWarningCheck(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 /** Should the app set protocol.version=2 for any fetch/push/pull/clone operation? */


### PR DESCRIPTION
## Overview

enable #6013 for everyone!

cc @Daniel-McCarthy :D

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: no-notes

