### PR TITLE
Increase contrast on input placeholder color in dark mode

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -157,6 +157,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --box-overflow-shadow-background: linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%);
 
   /**
+   * Placeholder color for input boxes
+   */
+  --box-placeholder-color: $gray-500;
+
+  /**
    * Author input (co-authors)
    */
   --co-author-tag-background-color: $blue-000;

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -17,6 +17,10 @@
   &:focus {
     @include textboxish-focus-styles;
   }
+
+  &::-webkit-input-placeholder {
+    color: var(--box-placeholder-color);
+  }
 }
 
 @mixin textboxish-focus-styles {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -121,6 +121,11 @@ body.theme-dark {
   --box-overflow-shadow-background: linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%);
 
   /**
+   * Placeholder color for input boxes
+   */
+  --box-placeholder-color: $gray-400;
+
+  /**
    * Author input (co-authors)
    */
   --co-author-tag-background-color: $blue-800;


### PR DESCRIPTION
## Overview

Closes https://github.com/desktop/desktop/issues/5978

## Description

This increases the color contrast on input placeholder text in dark mode by giving the placeholder text a custom color.

|Before|After|
|---|---|
|<img width="259" alt="screen shot 2019-01-08 at 1 31 48 pm" src="https://user-images.githubusercontent.com/10404068/50860326-7a303c80-134a-11e9-9594-6bb6eb546c25.png">|<img width="259" alt="screen shot 2019-01-08 at 1 32 42 pm" src="https://user-images.githubusercontent.com/10404068/50860327-7b616980-134a-11e9-8e31-8ff8a93d29cd.png">|






## Release notes
- Fixes color contrast on input placeholder text in dark mode

