### PR TITLE
detect no-op merges and don't show merge success banner

### DIFF
--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -14,11 +14,23 @@ export async function merge(
   repository: Repository,
   branch: string
 ): Promise<boolean> {
-  const result = await git(['merge', branch], repository.path, 'merge', {
-    expectedErrors: new Set([GitError.MergeConflicts]),
-  })
-  return result.exitCode === 0
+  const { exitCode, stdout } = await git(
+    ['merge', branch],
+    repository.path,
+    'merge',
+    {
+      expectedErrors: new Set([GitError.MergeConflicts]),
+    }
+  )
+
+  if (exitCode === 0 && stdout !== noopMergeMessage) {
+    return true
+  } else {
+    return false
+  }
 }
+
+const noopMergeMessage = 'Already up to date.\n'
 
 /**
  * Find the base commit between two commit-ish identifiers

--- a/app/test/unit/git/merge-test.ts
+++ b/app/test/unit/git/merge-test.ts
@@ -1,4 +1,9 @@
-import { abortMerge, getMergeBase, getBranches } from '../../../src/lib/git'
+import {
+  abortMerge,
+  getMergeBase,
+  getBranches,
+  merge,
+} from '../../../src/lib/git'
 import {
   setupEmptyRepository,
   setupFixtureRepository,
@@ -8,6 +13,30 @@ import { GitProcess } from 'dugite'
 import { Repository } from '../../../src/models/repository'
 
 describe('git/merge', () => {
+  describe('merge', () => {
+    describe('and is successful', () => {
+      let repository: Repository
+      beforeEach(async () => {
+        const path = await setupFixtureRepository('merge-base-test')
+        repository = new Repository(path, -1, null, false)
+      })
+      it('returns true', async () => {
+        expect(await merge(repository, 'dev')).toBe(true)
+      })
+    })
+    describe('and is a noop', () => {
+      let repository: Repository
+      beforeEach(async () => {
+        const path = await setupFixtureRepository('merge-base-test')
+        repository = new Repository(path, -1, null, false)
+        await merge(repository, 'dev')
+      })
+      it('returns false', async () => {
+        expect(await merge(repository, 'dev')).toBe(false)
+      })
+    })
+  })
+
   describe('getMergeBase', () => {
     it('returns the common ancestor of two branches', async () => {
       const path = await setupFixtureRepository('merge-base-test')


### PR DESCRIPTION
## Overview

Closes #6282

## Description

- add parsing for no-op merges to `merge` so it doesn't return `true` for them
- add tests

## Release notes

Notes: Fix false positives for successful merge banner
