### PR TITLE
add action dropdown to merge conflicts dialog

### DIFF
--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -63,7 +63,16 @@ dialog#merge-conflicts-list {
         }
       }
 
-      button:last-child,
+      .action-buttons {
+        margin-left: auto;
+        margin-top: var(--spacing);
+        flex-shrink: 0;
+        flex: 0 1 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
       .green-circle:last-child {
         margin-left: auto;
         margin-top: var(--spacing);


### PR DESCRIPTION
## Overview

closes #6385 

## Description

![action dropdown in merge conflict dialog](https://user-images.githubusercontent.com/964912/50919026-a0131b00-13f6-11e9-92ad-9ed50f3c5283.gif)


## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes: Add options to open files with other programs from "Merge Conflicts" dialog
