### PR TITLE
fix all the places where the blank slate overflows

### DIFF
--- a/app/styles/ui/_blank-slate.scss
+++ b/app/styles/ui/_blank-slate.scss
@@ -173,6 +173,7 @@
 // full width of the container (minus padding).
 .foldout .blankslate-image {
   width: 100%;
+  min-width: auto;
 }
 
 // When there's not enough space to show the blankslate

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -116,6 +116,7 @@
     .blankslate-image {
       margin: 0 auto;
       max-width: 300px;
+      min-width: auto;
     }
 
     .title {


### PR DESCRIPTION
## Overview

**Closes #6555**

## Description

### Repository List

Existing behaviour:

<img width="471" src="https://user-images.githubusercontent.com/359239/50926127-a1f6d180-142a-11e9-90eb-aa2f982025f0.png">

New behaviour:

<img width="377" src="https://user-images.githubusercontent.com/359239/50926128-a1f6d180-142a-11e9-8122-1b39e6649fd6.png">

New behaviour at full width:

<img width="526" src="https://user-images.githubusercontent.com/359239/50926130-a1f6d180-142a-11e9-9b62-27c7cfecf910.png">

### Branches

Before:

<img width="648" src="https://user-images.githubusercontent.com/359239/50932696-c22f8c00-143c-11e9-9a2a-4ea5e6d15bd3.png">
This PR:

<img width="598" src="https://user-images.githubusercontent.com/359239/50932694-c22f8c00-143c-11e9-9a17-0622fdf0b45b.png">


### Pull Requests

Before:
<img width="762"  src="https://user-images.githubusercontent.com/359239/50932697-c2c82280-143c-11e9-90e8-9debfc27737e.png">

This PR:
<img width="591" src="https://user-images.githubusercontent.com/359239/50932695-c22f8c00-143c-11e9-886f-bc119923b180.png">

## Release notes

Notes: [beta] - fixed issue with blank slate image overflowing the repository list
