### PR TITLE
remove lookForConflictMarkers from conflict file status models

### DIFF
--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -81,7 +81,6 @@ function parseConflictedState(
       return {
         kind: AppFileStatusKind.Conflicted,
         entry,
-        lookForConflictMarkers: true,
         conflictMarkerCount: addedConflictsLeft,
       }
     case UnmergedEntrySummary.BothModified:
@@ -89,14 +88,12 @@ function parseConflictedState(
       return {
         kind: AppFileStatusKind.Conflicted,
         entry,
-        lookForConflictMarkers: true,
         conflictMarkerCount: modifedConflictsLeft,
       }
     default:
       return {
         kind: AppFileStatusKind.Conflicted,
         entry,
-        lookForConflictMarkers: false,
       }
   }
 }

--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -3,6 +3,8 @@ import {
   AppFileStatus,
   ConflictedFileStatus,
   WorkingDirectoryStatus,
+  isManualConflict,
+  isConflictWithMarkers,
 } from '../models/status'
 import { assertNever } from './fatal-error'
 
@@ -26,7 +28,7 @@ export function mapStatus(status: AppFileStatus): string {
     case AppFileStatusKind.Renamed:
       return 'Renamed'
     case AppFileStatusKind.Conflicted:
-      if (status.lookForConflictMarkers) {
+      if (isConflictWithMarkers(status)) {
         const conflictsCount = status.conflictMarkerCount
         return conflictsCount > 0 ? 'Conflicted' : 'Resolved'
       }
@@ -55,4 +57,18 @@ export function hasConflictedFiles(
   workingDirectoryStatus: WorkingDirectoryStatus
 ): boolean {
   return workingDirectoryStatus.files.some(f => isConflictedFile(f.status))
+}
+
+/**
+ * Determine if we have a `ManualConflict` type
+ * or conflict markers
+ */
+export function hasUnresolvedConflicts(status: ConflictedFileStatus) {
+  if (isManualConflict(status)) {
+    // binary file doesn't contain markers
+    return true
+  }
+
+  // text file will have conflict markers removed
+  return status.conflictMarkerCount > 0
 }

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -55,7 +55,6 @@ export type CopiedOrRenamedFileStatus = {
 type ConflictsWithMarkers = {
   kind: AppFileStatusKind.Conflicted
   entry: TextConflictEntry
-  lookForConflictMarkers: true
   conflictMarkerCount: number
 }
 
@@ -66,11 +65,31 @@ type ConflictsWithMarkers = {
 type ManualConflict = {
   kind: AppFileStatusKind.Conflicted
   entry: ManualConflictEntry
-  lookForConflictMarkers: false
 }
 
 /** Union of potential conflict scenarios the application should handle */
 export type ConflictedFileStatus = ConflictsWithMarkers | ManualConflict
+
+/** Custom typeguard to differentiate ConflictsWithMarkers from other Conflict types */
+export function isConflictedFileStatus(
+  appFileStatus: AppFileStatus
+): appFileStatus is ConflictedFileStatus {
+  return appFileStatus.kind === AppFileStatusKind.Conflicted
+}
+
+/** Custom typeguard to differentiate ConflictsWithMarkers from other Conflict types */
+export function isConflictWithMarkers(
+  conflictedFileStatus: ConflictedFileStatus
+): conflictedFileStatus is ConflictsWithMarkers {
+  return conflictedFileStatus.hasOwnProperty('conflictMarkerCount')
+}
+
+/** Custom typeguard to differentiate ManualConflict from other Conflict types */
+export function isManualConflict(
+  conflictedFileStatus: ConflictedFileStatus
+): conflictedFileStatus is ManualConflict {
+  return !conflictedFileStatus.hasOwnProperty('conflictMarkerCount')
+}
 
 /** Denotes an untracked file in the working directory) */
 export type UntrackedFileStatus = { kind: AppFileStatusKind.Untracked }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -18,10 +18,7 @@ import {
   UserAutocompletionProvider,
 } from '../autocompletion'
 import { ClickSource } from '../lib/list'
-import {
-  WorkingDirectoryFileChange,
-  ConflictedFileStatus,
-} from '../../models/status'
+import { WorkingDirectoryFileChange } from '../../models/status'
 import { CSSTransitionGroup } from 'react-transition-group'
 import { openFile } from '../../lib/open-file'
 import { Account } from '../../models/account'
@@ -29,7 +26,7 @@ import { PopupType } from '../../models/popup'
 import { enableFileSizeWarningCheck } from '../../lib/feature-flag'
 import { filesNotTrackedByLFS } from '../../lib/git/lfs'
 import { getLargeFilePaths } from '../../lib/large-files'
-import { isConflictedFile } from '../../lib/status'
+import { isConflictedFile, hasUnresolvedConflicts } from '../../lib/status'
 
 /**
  * The timeout for the animation of the enter/leave animation for Undo.
@@ -379,18 +376,4 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       </div>
     )
   }
-}
-
-/**
- * Determine if we have a `ManualConflict` type
- * or conflict markers
- */
-function hasUnresolvedConflicts(status: ConflictedFileStatus) {
-  if (!status.lookForConflictMarkers) {
-    // binary file doesn't contain markers
-    return true
-  }
-
-  // text file will have conflict markers removed
-  return status.conflictMarkerCount > 0
 }

--- a/app/src/ui/octicons/status.ts
+++ b/app/src/ui/octicons/status.ts
@@ -1,4 +1,8 @@
-import { AppFileStatusKind, AppFileStatus } from '../../models/status'
+import {
+  AppFileStatusKind,
+  AppFileStatus,
+  isConflictWithMarkers,
+} from '../../models/status'
 import { OcticonSymbol } from './octicons.generated'
 import { assertNever } from '../../lib/fatal-error'
 
@@ -20,7 +24,7 @@ export function iconForStatus(status: AppFileStatus): OcticonSymbol {
     case AppFileStatusKind.Renamed:
       return OcticonSymbol.diffRenamed
     case AppFileStatusKind.Conflicted:
-      if (status.lookForConflictMarkers) {
+      if (isConflictWithMarkers(status)) {
         const conflictsCount = status.conflictMarkerCount
         return conflictsCount > 0 ? OcticonSymbol.alert : OcticonSymbol.check
       }

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -500,7 +500,6 @@ describe('git/commit', () => {
           them: GitStatusEntry.UpdatedButUnmerged,
           us: GitStatusEntry.UpdatedButUnmerged,
         },
-        lookForConflictMarkers: true,
         conflictMarkerCount: 0,
       })
 

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -52,7 +52,6 @@ describe('git/status', () => {
             them: GitStatusEntry.UpdatedButUnmerged,
             us: GitStatusEntry.UpdatedButUnmerged,
           },
-          lookForConflictMarkers: true,
           conflictMarkerCount: 3,
         })
 
@@ -65,7 +64,6 @@ describe('git/status', () => {
             them: GitStatusEntry.Added,
             us: GitStatusEntry.Added,
           },
-          lookForConflictMarkers: true,
           conflictMarkerCount: 3,
         })
 
@@ -78,7 +76,6 @@ describe('git/status', () => {
             them: GitStatusEntry.Added,
             us: GitStatusEntry.Added,
           },
-          lookForConflictMarkers: true,
           conflictMarkerCount: 3,
         })
       })
@@ -100,7 +97,6 @@ describe('git/status', () => {
             us: GitStatusEntry.UpdatedButUnmerged,
             them: GitStatusEntry.Deleted,
           },
-          lookForConflictMarkers: false,
         })
       })
 
@@ -125,7 +121,6 @@ describe('git/status', () => {
             them: GitStatusEntry.UpdatedButUnmerged,
             us: GitStatusEntry.UpdatedButUnmerged,
           },
-          lookForConflictMarkers: true,
           conflictMarkerCount: 0,
         })
       })


### PR DESCRIPTION
## Overview

continuation of #6214 to support #6062

## Description

- removed `lookForConflictMarkers` field from conflicted status model  in favor of user-defined typeguards
- centralized logic for determining conflicted and resolved files

## Release notes

<!--
If this is related to a feature, bugfix or improvement, please add a summary of the change to assist with drafting the release notes when this pull request is merged.

Some examples:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs 
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

If you don't believe this change needs to be mentioned in the release notes, write "no-notes" to indicate this can be skipped.
-->

Notes:  no-notes
