### PR TITLE
Change "sign into" to "sign in to" in welcome flow

### DIFF
--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -36,7 +36,7 @@ export class Start extends React.Component<IStartProps, {}> {
 
         <div>
           <LinkButton className="welcome-button" onClick={this.signInToDotCom}>
-            Sign into GitHub.com
+            Sign in to GitHub.com
           </LinkButton>
         </div>
 
@@ -45,7 +45,7 @@ export class Start extends React.Component<IStartProps, {}> {
             className="welcome-button"
             onClick={this.signInToEnterprise}
           >
-            Sign into GitHub Enterprise
+            Sign in to GitHub Enterprise
           </LinkButton>
         </div>
 


### PR DESCRIPTION
## Overview

Addresses part of #6583 

## Description

This updates "Sign into" to "Sign in to" during the welcome flow when you have the option to either sign in to GitHub.com or Enterprise.

## Release notes

None