### PR TITLE
Don't show a create PR action for default branch

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -303,7 +303,6 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
   private renderRemoteAction() {
     const { remote, aheadBehind, branchesState } = this.props.repositoryState
-    const { tip, defaultBranch } = branchesState
     const { tip, defaultBranch, currentPullRequest } = branchesState
 
     if (tip.kind !== TipState.Valid) {
@@ -330,7 +329,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
     const isGitHub = this.props.repository.gitHubRepository !== null
     const hasOpenPullRequest = currentPullRequest !== null
     const isDefaultBranch =
-      defaultBranch === null ? false : tip.branch.name === defaultBranch.name
+      defaultBranch !== null && tip.branch.name === defaultBranch.name
 
     if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
       return this.renderCreatePullRequestAction(tip)

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -388,10 +388,9 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     const description = (
       <>
-        The branch you're currently on (<Ref>{tip.branch.name}</Ref>) hasn't
-        been published to the remote yet. By publishing it{' '}
-        {isGitHub ? 'to GitHub' : ''} you can share it,{' '}
-        {isGitHub ? 'open a pull request, ' : ''}
+        The current branch (<Ref>{tip.branch.name}</Ref>) hasn't been published
+        to the remote yet. By publishing it {isGitHub ? 'to GitHub' : ''} you
+        can share it, {isGitHub ? 'open a pull request, ' : ''}
         and collaborate with others.
       </>
     )

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -303,7 +303,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
   private renderRemoteAction() {
     const { remote, aheadBehind, branchesState } = this.props.repositoryState
-    const { tip } = branchesState
+    const { tip, defaultBranch } = branchesState
 
     if (tip.kind !== TipState.Valid) {
       return null
@@ -328,8 +328,10 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     const isGitHub = this.props.repository.gitHubRepository !== null
     const hasOpenPullRequest = branchesState.currentPullRequest !== null
+    const isDefaultBranch =
+      defaultBranch === null ? false : tip.branch.name === defaultBranch.name
 
-    if (isGitHub && !hasOpenPullRequest) {
+    if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
       return this.renderCreatePullRequestAction(tip)
     }
 

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -304,6 +304,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
   private renderRemoteAction() {
     const { remote, aheadBehind, branchesState } = this.props.repositoryState
     const { tip, defaultBranch } = branchesState
+    const { tip, defaultBranch, currentPullRequest } = branchesState
 
     if (tip.kind !== TipState.Valid) {
       return null
@@ -327,7 +328,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
     }
 
     const isGitHub = this.props.repository.gitHubRepository !== null
-    const hasOpenPullRequest = branchesState.currentPullRequest !== null
+    const hasOpenPullRequest = currentPullRequest !== null
     const isDefaultBranch =
       defaultBranch === null ? false : tip.branch.name === defaultBranch.name
 


### PR DESCRIPTION
## Overview

#6445 added an action to create a pull request when the current branch is published and in sync but failed to take into account whether the current branch was also the default branch leading to us encouraging users to create a PR for the default branch.

This excludes the Create PR action for the default branch and polishes the language a little bit.

## Release notes

no-notes
