### PR TITLE
extract functions to format and remove &'s from menu labels

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -23,6 +23,19 @@ const BlankSlateImage = encodePathAsUrl(
   'static/empty-no-file-selected.svg'
 )
 
+function formatMenuItemLabel(text: string) {
+  if (__WIN32__ || __LINUX__) {
+    return text.replace('&', '')
+  }
+
+  return text
+}
+
+function formatParentMenuLabel(menuItem: IMenuItemInfo) {
+  const parentMenusText = menuItem.parentMenuLabels.join(' -> ')
+  return formatMenuItemLabel(parentMenusText)
+}
+
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 
 interface INoChangesProps {
@@ -203,7 +216,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
   }
 
   private renderDiscoverabilityElements(menuItem: IMenuItemInfo) {
-    const parentMenusText = menuItem.parentMenuLabels.join(' -> ')
+    const parentMenusText = formatParentMenuLabel(menuItem)
 
     return (
       <>
@@ -235,7 +248,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
         description={description}
         discoverabilityContent={this.renderDiscoverabilityElements(menuItem)}
         menuItemId={itemId}
-        buttonText={menuItem.label}
+        buttonText={formatMenuItemLabel(menuItem.label)}
         disabled={!menuItem.enabled}
       />
     )


### PR DESCRIPTION
## Overview

**Closes #6596**

## Description

`1.6.0-beta2` on Windows:

<img width="641" alt="screen shot 2019-01-11 at 3 27 52 pm" src="https://user-images.githubusercontent.com/359239/51055211-95eb4b00-15b5-11e9-8aa1-081cf2fc59b8.png">

This PR:

<img width="687" alt="screen shot 2019-01-11 at 3 27 27 pm" src="https://user-images.githubusercontent.com/359239/51055210-95eb4b00-15b5-11e9-8652-f6451a433145.png">

## Release notes

Notes: Addressed formatting issue with displaying shortcuts in new "no changes" view
