### PR TITLE
manualConflictResolution and stageManualConflictResolution

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -70,6 +70,10 @@ export async function createMergeCommit(
       const file = files.find(f => f.path === path)
       if (file !== undefined) {
         await stageManualConflictResolution(repository, file, resolution)
+      } else {
+        log.error(
+          `couldn't find file ${path} even though there's a manual resolution for it`
+        )
       }
     }
 
@@ -122,11 +126,11 @@ async function stageManualConflictResolution(
   const { status } = file
   // if somehow the file isn't in a conflicted state
   if (!isConflictedFileStatus(status)) {
-    console.error(`tried to manually resolve unconflicted file (${file.path})`)
+    log.error(`tried to manually resolve unconflicted file (${file.path})`)
     return false
   }
   if (!isManualConflict(status)) {
-    console.error(
+    log.error(
       `tried to manually resolve conflicted file with markers (${file.path})`
     )
     return false

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -120,6 +120,14 @@ export async function createMergeCommit(
   }
 }
 
+/**
+ * Stages a file with the given manual resolution method. Useful for resolving binary conflicts at commit-time.
+ *
+ * @param repository
+ * @param file conflicted file to stage
+ * @param manualResolution method to resolve the conflict of file
+ * @returns true if successful, false if something went wrong
+ */
 async function stageManualConflictResolution(
   repository: Repository,
   file: WorkingDirectoryFileChange,

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -82,8 +82,10 @@ export async function createMergeCommit(
     await stageFiles(repository, otherFiles)
     const result = await git(
       [
-        'commit', // no-edit here ensures the app does not accidentally invoke the user's editor
-        '--no-edit', // By default Git merge commits do not contain any commentary (which
+        'commit',
+        // no-edit here ensures the app does not accidentally invoke the user's editor
+        '--no-edit',
+        // By default Git merge commits do not contain any commentary (which
         // are lines prefixed with `#`). This works because the Git CLI will
         // prompt the user to edit the file in `.git/COMMIT_MSG` before
         // committing, and then it will run `--cleanup=strip`.

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1876,8 +1876,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private async recoverMissingRepository(
     repository: Repository
   ): Promise<Repository> {
-    /* 
-        if the repository is marked missing, check to see if the file path exists, 
+    /*
+        if the repository is marked missing, check to see if the file path exists,
         and if so then see if git recognizes the path as a valid repository,
         and if so, reset the missing status as its been restored
       */

--- a/app/src/models/manual-conflict-resolution.ts
+++ b/app/src/models/manual-conflict-resolution.ts
@@ -1,0 +1,8 @@
+export enum ManualConflictResolutionKind {
+  theirs = 'theirs',
+  ours = 'ours',
+}
+
+export type ManualConflictResolution =
+  | ManualConflictResolutionKind.theirs
+  | ManualConflictResolutionKind.ours

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -561,7 +561,7 @@ describe('git/commit', () => {
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)
       })
-      it('keeps files chosen to be added and commits', async () => {
+      it('deletes files chosen to be removed and commits', async () => {
         const status = await getStatusOrThrow(repository)
         const trackedFiles = status.workingDirectory.files.filter(
           f => f.status.kind !== AppFileStatusKind.Untracked


### PR DESCRIPTION
## Overview

supports #6062 

## Description

- new `ManualConflictResolution` model
- allow `createMergeCommit` to take these as an argument and apply them in the merge process
- tests
- much stolen/borrowed from @shiftkey's spike on this

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
