### PR TITLE
Change merge hint and merge button order

### DIFF
--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -25,7 +25,7 @@ interface IMergeCallToActionWithConflictsProps {
 export class MergeCallToActionWithConflicts extends React.Component<
   IMergeCallToActionWithConflictsProps,
   {}
-  > {
+> {
   public render() {
     const { commitsBehind } = this.props
 

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -25,7 +25,7 @@ interface IMergeCallToActionWithConflictsProps {
 export class MergeCallToActionWithConflicts extends React.Component<
   IMergeCallToActionWithConflictsProps,
   {}
-> {
+  > {
   public render() {
     const { commitsBehind } = this.props
 
@@ -39,11 +39,11 @@ export class MergeCallToActionWithConflicts extends React.Component<
 
     return (
       <div className="merge-cta">
+        {mergeDetails}
+
         <Button type="submit" disabled={disabled} onClick={this.onMergeClicked}>
           Merge into <strong>{this.props.currentBranch.name}</strong>
         </Button>
-
-        {mergeDetails}
       </div>
     )
   }

--- a/app/src/ui/history/merge-call-to-action.tsx
+++ b/app/src/ui/history/merge-call-to-action.tsx
@@ -21,7 +21,7 @@ interface IMergeCallToActionProps {
 export class MergeCallToAction extends React.Component<
   IMergeCallToActionProps,
   {}
-  > {
+> {
   public render() {
     const count = this.props.formState.aheadBehind.behind
 

--- a/app/src/ui/history/merge-call-to-action.tsx
+++ b/app/src/ui/history/merge-call-to-action.tsx
@@ -21,12 +21,17 @@ interface IMergeCallToActionProps {
 export class MergeCallToAction extends React.Component<
   IMergeCallToActionProps,
   {}
-> {
+  > {
   public render() {
     const count = this.props.formState.aheadBehind.behind
 
     return (
       <div className="merge-cta">
+        {this.renderMergeDetails(
+          this.props.formState,
+          this.props.currentBranch
+        )}
+
         <Button
           type="submit"
           disabled={count <= 0}
@@ -34,11 +39,6 @@ export class MergeCallToAction extends React.Component<
         >
           Merge into <strong>{this.props.currentBranch.name}</strong>
         </Button>
-
-        {this.renderMergeDetails(
-          this.props.formState,
-          this.props.currentBranch
-        )}
       </div>
     )
   }

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -54,7 +54,7 @@
   }
 
   .merge-message {
-    padding-bottom: 10px;
+    padding-bottom: var(--spacing);
   }
 }
 

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -17,7 +17,6 @@
 
     &:after {
       display: block;
-      border-bottom: var(--base-border);
       content: '';
       position: absolute;
       z-index: 0;
@@ -52,6 +51,10 @@
     strong {
       color: var(--text-color);
     }
+  }
+
+  .merge-message {
+    padding-bottom: 10px;
   }
 }
 

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -1,6 +1,4 @@
 .merge-status-component {
-  margin-top: var(--spacing-third);
-
   .merge-status-icon-container {
     height: 20px;
     position: relative;
@@ -13,16 +11,6 @@
       box-sizing: content-box;
       position: relative;
       z-index: 1;
-    }
-
-    &:after {
-      display: block;
-      content: '';
-      position: absolute;
-      z-index: 0;
-      display: block;
-      width: 100%;
-      top: var(--spacing);
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes #6467 

## Description
This changes the order of merge elements in order to be in sync with what is in the merge modal.

![image](https://user-images.githubusercontent.com/24607388/51130023-4498c100-182c-11e9-891d-09c266af79b5.png)

However, as you can see, I just changed the order by now, but it looks like there is some styling needed, but I'm unsure about what is expected...
