### PR TITLE
extract and isolate error handling from GitStore internals

### DIFF
--- a/app/src/lib/stores/error-handling.ts
+++ b/app/src/lib/stores/error-handling.ts
@@ -1,0 +1,33 @@
+import { Repository } from '../../models/repository'
+import { IErrorMetadata, ErrorWithMetadata } from '../error-with-metadata'
+
+/**
+ * Create a handler for an operation that might fail, to wrap an asynchronous
+ * operation and return a default value if the operation does not succeed
+ *
+ * @param repository the repository associated with the operation, so that the
+ *                   error handling can provide context
+ * @param emitError  the callback to fire to handle the error
+ */
+export function createFailableOperationHandler(
+  repository: Repository,
+  emitError: (error: Error) => void
+) {
+  return async function handleFailableOperation<T>(
+    fn: () => Promise<T>,
+    errorMetadata?: IErrorMetadata
+  ): Promise<T | undefined> {
+    try {
+      const result = await fn()
+      return result
+    } catch (e) {
+      e = new ErrorWithMetadata(e, {
+        repository,
+        ...errorMetadata,
+      })
+
+      emitError(e)
+      return undefined
+    }
+  }
+}

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -64,7 +64,6 @@ import {
   getSymbolicRef,
   getConfigValue,
   removeRemote,
-  abortMerge,
 } from '../git'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import { UpstreamAlreadyExistsError } from './upstream-already-exists-error'
@@ -1248,11 +1247,6 @@ export class GitStore extends BaseStore {
         theirBranch: branch,
       },
     })
-  }
-
-  /** Abort the merge against the current repository */
-  public abortMerge(): Promise<void> {
-    return this.withErrorHandling(() => abortMerge(this.repository))
   }
 
   /** Changes the URL for the remote that matches the given name  */

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -23,7 +23,7 @@ import {
 import { ComparisonMode } from '../app-state'
 
 import { IAppShell } from '../app-shell'
-import { ErrorWithMetadata, IErrorMetadata } from '../error-with-metadata'
+import { IErrorMetadata } from '../error-with-metadata'
 import { compare } from '../../lib/compare'
 import { queueWorkHigh } from '../../lib/queue-work'
 
@@ -64,6 +64,7 @@ import {
   getSymbolicRef,
   getConfigValue,
   removeRemote,
+  abortMerge,
 } from '../git'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import { UpstreamAlreadyExistsError } from './upstream-already-exists-error'
@@ -82,6 +83,7 @@ import { enablePullWithRebase, enableStashing } from '../feature-flag'
 import { getStashes, getStashedFiles } from '../git/stash'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { PullRequest } from '../../models/pull-request'
+import { createFailableOperationHandler } from './error-handling'
 
 /** The number of commits to load from history per batch. */
 const CommitBatchSize = 100
@@ -136,11 +138,21 @@ export class GitStore extends BaseStore {
 
   private _stashEntryCount = 0
 
+  private readonly withErrorHandling: <T>(
+    fn: () => Promise<T>,
+    errorMetadata?: IErrorMetadata | undefined
+  ) => Promise<T | undefined>
+
   public constructor(repository: Repository, shell: IAppShell) {
     super()
 
     this.repository = repository
     this.shell = shell
+
+    this.withErrorHandling = createFailableOperationHandler(
+      this.repository,
+      this.emitError
+    )
   }
 
   private emitNewCommitsLoaded(commits: ReadonlyArray<Commit>) {
@@ -171,7 +183,7 @@ export class GitStore extends BaseStore {
 
     const range = revRange('HEAD', mergeBase)
 
-    const commits = await this.performFailableOperation(() =>
+    const commits = await this.withErrorHandling(() =>
       getCommits(this.repository, range, CommitBatchSize)
     )
     if (commits == null) {
@@ -217,7 +229,7 @@ export class GitStore extends BaseStore {
 
     this.requestsInFight.add(requestKey)
 
-    const commits = await this.performFailableOperation(() =>
+    const commits = await this.withErrorHandling(() =>
       getCommits(this.repository, `${lastSHA}^`, CommitBatchSize)
     )
     if (!commits) {
@@ -243,7 +255,7 @@ export class GitStore extends BaseStore {
 
     this.requestsInFight.add(requestKey)
 
-    const commits = await this.performFailableOperation(() =>
+    const commits = await this.withErrorHandling(() =>
       getCommits(this.repository, commitish, CommitBatchSize)
     )
 
@@ -264,8 +276,8 @@ export class GitStore extends BaseStore {
   /** Load all the branches. */
   public async loadBranches() {
     const [localAndRemoteBranches, recentBranchNames] = await Promise.all([
-      this.performFailableOperation(() => getBranches(this.repository)) || [],
-      this.performFailableOperation(() =>
+      this.withErrorHandling(() => getBranches(this.repository)) || [],
+      this.withErrorHandling(() =>
         getRecentBranches(this.repository, RecentBranchesLimit)
       ),
     ])
@@ -465,11 +477,11 @@ export class GitStore extends BaseStore {
     let localCommits: ReadonlyArray<Commit> | undefined
     if (branch.upstream) {
       const range = revRange(branch.upstream, branch.name)
-      localCommits = await this.performFailableOperation(() =>
+      localCommits = await this.withErrorHandling(() =>
         getCommits(this.repository, range, CommitBatchSize)
       )
     } else {
-      localCommits = await this.performFailableOperation(() =>
+      localCommits = await this.withErrorHandling(() =>
         getCommits(this.repository, 'HEAD', CommitBatchSize, [
           '--not',
           '--remotes',
@@ -518,7 +530,7 @@ export class GitStore extends BaseStore {
     // isn't suitable because we should preserve the other working directory
     // changes.
 
-    const status = await this.performFailableOperation(() =>
+    const status = await this.withErrorHandling(() =>
       getStatus(this.repository)
     )
 
@@ -556,7 +568,7 @@ export class GitStore extends BaseStore {
   public async undoCommit(commit: Commit): Promise<void> {
     // For an initial commit, just delete the reference but leave HEAD. This
     // will make the branch unborn again.
-    const success = await this.performFailableOperation(() =>
+    const success = await this.withErrorHandling(() =>
       commit.parentSHAs.length === 0
         ? this.undoFirstCommit(this.repository)
         : reset(this.repository, GitResetMode.Mixed, commit.parentSHAs[0])
@@ -722,31 +734,6 @@ export class GitStore extends BaseStore {
     }
   }
 
-  /**
-   * Perform an operation that may fail by throwing an error. If an error is
-   * thrown, catch it and emit it, and return `undefined`.
-   *
-   * @param errorMetadata - The metadata which should be attached to any errors
-   *                        that are thrown.
-   */
-  public async performFailableOperation<T>(
-    fn: () => Promise<T>,
-    errorMetadata?: IErrorMetadata
-  ): Promise<T | undefined> {
-    try {
-      const result = await fn()
-      return result
-    } catch (e) {
-      e = new ErrorWithMetadata(e, {
-        repository: this.repository,
-        ...errorMetadata,
-      })
-
-      this.emitError(e)
-      return undefined
-    }
-  }
-
   /** The commit message for a work-in-progress commit in the changes view. */
   public get commitMessage(): ICommitMessage {
     return this._commitMessage
@@ -882,7 +869,7 @@ export class GitStore extends BaseStore {
       type: RetryActionType.Fetch,
       repository: this.repository,
     }
-    await this.performFailableOperation(
+    await this.withErrorHandling(
       () => {
         return fetchRepo(this.repository, account, remote, progressCallback)
       },
@@ -907,14 +894,14 @@ export class GitStore extends BaseStore {
     const remotes = await getRemotes(this.repository)
 
     for (const remote of remotes) {
-      await this.performFailableOperation(() =>
+      await this.withErrorHandling(() =>
         fetchRefspec(this.repository, account, remote.name, refspec)
       )
     }
   }
 
   public async loadStatus(): Promise<IStatusResult | null> {
-    const status = await this.performFailableOperation(() =>
+    const status = await this.withErrorHandling(() =>
       getStatus(this.repository)
     )
 
@@ -963,7 +950,7 @@ export class GitStore extends BaseStore {
       return Promise.resolve(cachedCommit)
     }
 
-    const foundCommit = await this.performFailableOperation(() =>
+    const foundCommit = await this.withErrorHandling(() =>
       getCommit(this.repository, sha)
     )
 
@@ -1137,7 +1124,7 @@ export class GitStore extends BaseStore {
       parent.cloneURL
     )
 
-    await this.performFailableOperation(() =>
+    await this.withErrorHandling(() =>
       addRemote(this.repository, UpstreamRemoteName, url)
     )
     this._upstreamRemote = { name: UpstreamRemoteName, url }
@@ -1254,7 +1241,7 @@ export class GitStore extends BaseStore {
 
     const currentBranch = this.tip.branch.name
 
-    return this.performFailableOperation(() => merge(this.repository, branch), {
+    return this.withErrorHandling(() => merge(this.repository, branch), {
       gitContext: {
         kind: 'merge',
         currentBranch,
@@ -1263,11 +1250,14 @@ export class GitStore extends BaseStore {
     })
   }
 
+  /** Abort the merge against the current repository */
+  public abortMerge(): Promise<void> {
+    return this.withErrorHandling(() => abortMerge(this.repository))
+  }
+
   /** Changes the URL for the remote that matches the given name  */
   public async setRemoteURL(name: string, url: string): Promise<void> {
-    await this.performFailableOperation(() =>
-      setRemoteURL(this.repository, name, url)
-    )
+    await this.withErrorHandling(() => setRemoteURL(this.repository, name, url))
     await this.loadRemotes()
 
     this.emitUpdate()
@@ -1343,7 +1333,7 @@ export class GitStore extends BaseStore {
     //
     // 3. Checkout all the files that we've discarded that existed in the previous
     //    commit from the index.
-    await this.performFailableOperation(async () => {
+    await this.withErrorHandling(async () => {
       await resetSubmodulePaths(this.repository, submodulePaths)
       await resetPaths(
         this.repository,
@@ -1362,7 +1352,7 @@ export class GitStore extends BaseStore {
     account: IGitAccount | null,
     progressCallback?: (fetchProgress: IRevertProgress) => void
   ): Promise<void> {
-    await this.performFailableOperation(() =>
+    await this.withErrorHandling(() =>
       revertCommit(repository, commit, account, progressCallback)
     )
 
@@ -1370,9 +1360,7 @@ export class GitStore extends BaseStore {
   }
 
   public async openMergeTool(path: string): Promise<void> {
-    await this.performFailableOperation(() =>
-      openMergeTool(this.repository, path)
-    )
+    await this.withErrorHandling(() => openMergeTool(this.repository, path))
   }
 
   /**
@@ -1393,7 +1381,7 @@ export class GitStore extends BaseStore {
       parent.cloneURL
     )
 
-    await this.performFailableOperation(() =>
+    await this.withErrorHandling(() =>
       setRemoteURL(this.repository, UpstreamRemoteName, url)
     )
   }

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -1,7 +1,6 @@
 import * as moment from 'moment'
 import { BranchPruner } from '../../src/lib/stores/helpers/branch-pruner'
 import { Repository } from '../../src/models/repository'
-import { GitStoreCache } from '../../src/lib/stores/git-store-cache'
 import { RepositoriesStore, GitStore } from '../../src/lib/stores'
 import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cache'
 import { setupFixtureRepository } from '../helpers/repositories'
@@ -12,23 +11,12 @@ import { IGitHubUser } from '../../src/lib/databases'
 import { IAPIRepository } from '../../src/lib/api'
 
 describe('BranchPruner', () => {
-  const onGitStoreUpdated = () => {}
-  const onDidLoadNewCommits = () => {}
-  const onDidError = () => {}
-
-  let gitStoreCache: GitStoreCache
   let repositoriesStore: RepositoriesStore
   let repositoriesStateCache: RepositoryStateCache
   let onPruneCompleted: jest.Mock<(repository: Repository) => Promise<void>>
+  let onEmitError: jest.Mock<(error: Error) => void>
 
   beforeEach(async () => {
-    gitStoreCache = new GitStoreCache(
-      shell,
-      onGitStoreUpdated,
-      onDidLoadNewCommits,
-      onDidError
-    )
-
     const repositoriesDb = new TestRepositoriesDatabase()
     await repositoriesDb.reset()
     repositoriesStore = new RepositoriesStore(repositoriesDb)
@@ -49,10 +37,10 @@ describe('BranchPruner', () => {
     )
     const branchPruner = new BranchPruner(
       repo,
-      gitStoreCache,
       repositoriesStore,
       repositoriesStateCache,
-      onPruneCompleted
+      onPruneCompleted,
+      onEmitError
     )
 
     const branchesBeforePruning = await getBranchesFromGit(repo)
@@ -74,10 +62,10 @@ describe('BranchPruner', () => {
     )
     const branchPruner = new BranchPruner(
       repo,
-      gitStoreCache,
       repositoriesStore,
       repositoriesStateCache,
-      onPruneCompleted
+      onPruneCompleted,
+      onEmitError
     )
 
     await branchPruner.start()
@@ -105,10 +93,10 @@ describe('BranchPruner', () => {
     )
     const branchPruner = new BranchPruner(
       repo,
-      gitStoreCache,
       repositoriesStore,
       repositoriesStateCache,
-      onPruneCompleted
+      onPruneCompleted,
+      onEmitError
     )
 
     const branchesBeforePruning = await getBranchesFromGit(repo)
@@ -130,10 +118,10 @@ describe('BranchPruner', () => {
     )
     const branchPruner = new BranchPruner(
       repo,
-      gitStoreCache,
       repositoriesStore,
       repositoriesStateCache,
-      onPruneCompleted
+      onPruneCompleted,
+      onEmitError
     )
 
     const branchesBeforePruning = await getBranchesFromGit(repo)
@@ -155,10 +143,10 @@ describe('BranchPruner', () => {
     )
     const branchPruner = new BranchPruner(
       repo,
-      gitStoreCache,
       repositoriesStore,
       repositoriesStateCache,
-      onPruneCompleted
+      onPruneCompleted,
+      onEmitError
     )
 
     await branchPruner.start()


### PR DESCRIPTION
## Overview

**First part of #6595**

Currently the default error handling has been owned by `GitStore`, but as we've moved towards running Git operations outside of a `GitStore` (because we don't need to cache the result), there has been some confusion about the right way to leverage the inbuilt error handling so that unhandled errors do not bring down the app.

## Description

This PR extracts the logic for `GitStore.createFailableOperationHandler` into it's own module, and provides a more familiar `withErrorHandling` function in the places where this is currently used.

## Release notes

Notes: no-notes
