### PR TITLE
Blankslate action transitions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -41,6 +41,7 @@
     "queue": "^4.4.2",
     "react": "^16.3.2",
     "react-addons-shallow-compare": "^15.6.2",
+    "react-css-transition-replace": "^3.0.3",
     "react-dom": "^16.3.2",
     "react-transition-group": "^1.2.0",
     "react-virtualized": "^9.20.0",

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -555,6 +555,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
       <>
         <ReactCSSTransitionReplace
           transitionAppear={false}
+          overflowHidden={false}
           transitionName="action"
           component="div"
           className="actions primary"

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -604,8 +604,8 @@ export class NoChanges extends React.Component<
           transitionName="action"
           component="div"
           className="actions primary"
-          transitionEnterTimeout={500}
-          transitionLeaveTimeout={250}
+          transitionEnterTimeout={750}
+          transitionLeaveTimeout={500}
         >
           {this.renderRemoteAction()}
         </ReactCSSTransitionReplace>

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as classNames from 'classnames'
+import * as ReactCSSTransitionReplace from 'react-css-transition-replace'
 
 import { encodePathAsUrl } from '../../lib/path'
 import { revealInFileManager } from '../../lib/app-shell'
@@ -358,6 +359,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     return (
       <MenuBackedBlankslateAction
+        key="publish-repository-action"
         title="Publish your repository to GitHub"
         description="This repository is currently only available on your local machine. By publishing it on GitHub you can share it, and collaborate with others."
         discoverabilityContent={discoverabilityContent}
@@ -403,6 +405,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     return (
       <MenuBackedBlankslateAction
+        key="publish-branch-action"
         title="Publish your branch"
         menuItemId={itemId}
         description={description}
@@ -451,6 +454,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     return (
       <MenuBackedBlankslateAction
+        key="pull-branch-action"
         title={title}
         menuItemId={itemId}
         description={description}
@@ -500,6 +504,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     return (
       <MenuBackedBlankslateAction
+        key="push-branch-action"
         title={title}
         menuItemId={itemId}
         description={description}
@@ -533,6 +538,7 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
 
     return (
       <MenuBackedBlankslateAction
+        key="create-pr-action"
         title={title}
         menuItemId={itemId}
         description={description}
@@ -545,15 +551,18 @@ export class NoChanges extends React.Component<INoChangesProps, {}> {
   }
 
   private renderActions() {
-    const remoteAction = this.renderRemoteAction()
-    const remoteActions =
-      remoteAction === null || remoteAction === undefined ? null : (
-        <div className="actions primary">{remoteAction}</div>
-      )
-
     return (
       <>
-        {remoteActions}
+        <ReactCSSTransitionReplace
+          transitionAppear={false}
+          transitionName="action"
+          component="div"
+          className="actions primary"
+          transitionEnterTimeout={500}
+          transitionLeaveTimeout={250}
+        >
+          {this.renderRemoteAction()}
+        </ReactCSSTransitionReplace>
         <div className="actions">
           {this.renderOpenInExternalEditor()}
           {this.renderShowInFinderAction()}

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -107,6 +107,15 @@ interface IMenuItemInfo {
 }
 
 interface INoChangesState {
+  /**
+   * Whether or not to enable the slide in and
+   * slide out transitions for the remote actions.
+   *
+   * Disabled initially and enabled 500ms after
+   * component mounting in order to provide instant
+   * loading of the remote action when the view is
+   * initially appearing.
+   */
   readonly enableTransitions: boolean
 }
 
@@ -163,6 +172,10 @@ export class NoChanges extends React.Component<
       : buildMenuItemInfoMap(menu)
   )
 
+  /**
+   * ID for the timer that's activated when the component
+   * mounts. See componentDidMount/componenWillUnmount.
+   */
   private transitionTimer: number | null = null
 
   public constructor(props: INoChangesProps) {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -243,6 +243,7 @@ export class RepositoryView extends React.Component<
       ) {
         return (
           <NoChanges
+            key={this.props.repository.id}
             appMenu={this.props.appMenu}
             repository={this.props.repository}
             repositoryState={this.props.state}

--- a/app/styles/ui/changes/_no-changes.scss
+++ b/app/styles/ui/changes/_no-changes.scss
@@ -55,7 +55,6 @@
 
     &.primary {
       margin-bottom: var(--spacing);
-      overflow: hidden;
     }
   }
 
@@ -66,7 +65,7 @@
   .action-leave.action-leave-active {
     opacity: 0;
     transform: translate3d(100%, 0, 0);
-    transition: opacity 250ms ease-in, transform 250ms ease-in;
+    transition: opacity 200ms ease-in, transform 250ms var(--easing-ease-in-back);
   }
 
   .action-enter {
@@ -77,7 +76,7 @@
   .action-enter.action-enter-active {
     opacity: 1;
     transform: translate3d(0, 0, 0);
-    transition: opacity 250ms ease-in 250ms, transform 250ms ease-in 250ms;
+    transition: opacity 200ms ease-in 250ms, transform 250ms var(--easing-ease-out-back) 250ms;
   }
 
   .action-height {

--- a/app/styles/ui/changes/_no-changes.scss
+++ b/app/styles/ui/changes/_no-changes.scss
@@ -76,11 +76,11 @@
   .action-enter.action-enter-active {
     opacity: 1;
     transform: translate3d(0, 0, 0);
-    transition: opacity 200ms ease-in 250ms, transform 250ms var(--easing-ease-out-back) 250ms;
+    transition: opacity 200ms ease-in 500ms, transform 250ms var(--easing-ease-out-back) 500ms;
   }
 
   .action-height {
-    transition: height 250ms ease-in-out;
+    transition: height 250ms ease-out 250ms;
   }
 
   /** Lessen the padding at 1.5x zoom and above  **/

--- a/app/styles/ui/changes/_no-changes.scss
+++ b/app/styles/ui/changes/_no-changes.scss
@@ -55,7 +55,33 @@
 
     &.primary {
       margin-bottom: var(--spacing);
+      overflow: hidden;
     }
+  }
+
+  .action-leave {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+  .action-leave.action-leave-active {
+    opacity: 0;
+    transform: translate3d(100%, 0, 0);
+    transition: opacity 250ms ease-in, transform 250ms ease-in;
+  }
+
+  .action-enter {
+    opacity: 0;
+    transform: translate3d(-100%, 0, 0);
+  }
+
+  .action-enter.action-enter-active {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition: opacity 250ms ease-in 250ms, transform 250ms ease-in 250ms;
+  }
+
+  .action-height {
+    transition: height 250ms ease-in-out;
   }
 
   /** Lessen the padding at 1.5x zoom and above  **/

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
   integrity sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=
 
+"@babel/runtime@^7.1.2":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
+  integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 accessibility-developer-tools@^2.11.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz#3da0cce9d6ec6373964b84f35db7cfc3df7ab514"
@@ -288,6 +295,13 @@ dom-classlist@^1.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
   integrity sha1-MgPgf+0he9H0JLAZc1WC/Deyglo=
+
+dom-helpers@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-matches@^2.0.0:
   version "2.0.0"
@@ -865,6 +879,14 @@ prop-types@^15.5.6, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -904,6 +926,16 @@ react-addons-shallow-compare@^15.6.2:
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
+
+react-css-transition-replace@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-css-transition-replace/-/react-css-transition-replace-3.0.3.tgz#23d3ed17f54e41435c0485300adb75d2e6e24aad"
+  integrity sha512-+EaY+UpHfIZuHF4IfNjQoJmL1zeewxF9P/y6q9hsAN1RTb3x+QRUTldmO4/24q2nGFYEkH+xHF5eAMEAVLYf9Q==
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.3.1"
+    prop-types "^15.6.1"
+    warning "^3.0.0"
 
 react-dom@^16.3.2:
   version "16.3.2"
@@ -957,6 +989,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
   integrity sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 registry-js@^1.0.7:
   version "1.0.7"

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@types/mri": "^1.1.0",
     "@types/node": "^8.10.4",
     "@types/react": "^16.3.16",
+    "@types/react-css-transition-replace": "^2.1.3",
     "@types/react-dom": "^16.0.5",
     "@types/react-transition-group": "1.1.1",
     "@types/react-virtualized": "^9.7.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,6 +348,29 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
   integrity sha512-pQRkAVoxiuUrLq8+CDwiQX4pTCep/PmmNgBbjIwnnsd/HoYjGpR81+FFPE030lvNXgR0haaAU6eoRtztWDE4Xw==
 
+"@types/react-addons-css-transition-group@*":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-addons-css-transition-group/-/react-addons-css-transition-group-15.0.5.tgz#73665af6b8efb47730ab583ead4bed5373dae686"
+  integrity sha512-UIJt5HQDOzRI7AOmnGnc2OZA0N3p7r6yMsxZ3T0+dyGPB3zWiKOPKrMkJr9tyuY3kHKPm26GyihcJKNJdMY8CQ==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-addons-transition-group" "*"
+
+"@types/react-addons-transition-group@*":
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-addons-transition-group/-/react-addons-transition-group-15.0.3.tgz#b1ed2a8218a0f9f3b3d6bf8f75f0aff24abb9605"
+  integrity sha512-aNZpcbSkQmm12VJRm0VOGEj7yYnx2V+614X+0US9MrR42jiehIiQIMjgfW5bUxxjNNUIhfJ5LD0EC9MaRz8XKw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-css-transition-replace@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/react-css-transition-replace/-/react-css-transition-replace-2.1.3.tgz#d85923c3fe0522b7c90e96d94a8d5944716b246b"
+  integrity sha512-o9uDsBEaEFbbCcCexaIYXPWCzw/pwT4GB2UMrBPuCpUteoueGHFJXTI7or4tOymla4+hkcw8gkzXM8FQMmbVIA==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-addons-css-transition-group" "*"
+
 "@types/react-dom@^16.0.5":
   version "16.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"


### PR DESCRIPTION
## Overview

This adds enter and exit transitions for the remote action part of the no-changes blank slate (see #6445).

![no-local-changes-transitions-hq](https://user-images.githubusercontent.com/634063/51138795-57b68b80-1842-11e9-99c0-107d1192c94f.gif)


## Description

Prior to this PR all actions appearing or exiting did so immediately making it hard to spot when the result of one action (publish for example) was complete and replaced with another (i.e. create PR).

Whenever a remote action (push, pull, publish, create PR) appears the container hosting it will animate its height to fit the new contents after which the action will slide in from the right with a slight bounce effect. When that action is replaced by another the old action will animate with a slight bounce and slide off to the right.

## Release notes

no-notes

cc @desktop/design just FYI as we don't have a whole lot of animations in the app right now but we've been talking forever about using them more.