### PR TITLE
A repository doesn't need to have a remote to be pushed

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -154,8 +154,6 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let tipStateIsUnknown = false
   let branchIsUnborn = false
 
-  let hasRemote = false
-
   if (selectedState && selectedState.type === SelectionType.Repository) {
     repositorySelected = true
 
@@ -184,8 +182,6 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     } else {
       onNonDefaultBranch = true
     }
-
-    hasRemote = !!selectedState.state.remote
 
     networkActionInProgress = selectedState.state.isPushPullFetchInProgress
   }
@@ -244,7 +240,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     )
     menuStateBuilder.setEnabled(
       'push',
-      hasRemote && !branchIsUnborn && !networkActionInProgress
+      !branchIsUnborn && !networkActionInProgress
     )
     menuStateBuilder.setEnabled(
       'pull',


### PR DESCRIPTION
Fixes #6598.

The 'push' menu item is used for pushing, publishing a branch, and also publishing a repository. Definitely confusing and something we should look into improving but for now it's blocking the release so I've changed the conditions under which the push menu item is disabled to not care about whether the repository has a remote or not.

The slight side effect of this is that the menu item label will still be 'push' and not 'publish repository' or something similar but I think that's a small price to pay for unblocking the release.

Clicking on the 'Push' menu item on a repository with no remote will trigger the publish flow.