### PR TITLE
[WIP] Custom tooltip experiment

### DIFF
--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -371,6 +371,7 @@ export class MergeConflictsDialog extends React.Component<
               type="submit"
               disabled={conflictedFilesCount > 0}
               tooltip={tooltipString}
+              className="tooltip tooltip-s"
             >
               {submitButtonString}
             </Button>

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -114,7 +114,7 @@ export class RepositoryListItem extends React.Component<
           ) : null}
         </div>
         <Octicon symbol={iconForRepository(repository)} />
-        <div className="name" title={repoTooltip}>
+        <div className="name tooltip tooltip-se" title={repoTooltip}>
           {prefix ? <span className="prefix">{prefix}</span> : null}
           <HighlightText
             text={repository.name}

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -68,4 +68,4 @@
 @import 'ui/notification-banner';
 @import 'ui/merge-status';
 @import 'ui/cloneable-repository-filter-list';
-@import 'ui/tooltip'
+@import 'ui/tooltip';

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -68,3 +68,4 @@
 @import 'ui/notification-banner';
 @import 'ui/merge-status';
 @import 'ui/cloneable-repository-filter-list';
+@import 'ui/tooltip'

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -30,7 +30,9 @@
   }
 
   &:disabled {
-    opacity: 0.6;
+    background-color: $gray-200 !important;
+    border-color: $gray-200 !important;
+    color: $gray-500 !important;
   }
 
   .octicon {

--- a/app/styles/ui/_tooltip.scss
+++ b/app/styles/ui/_tooltip.scss
@@ -1,0 +1,97 @@
+.tooltip {
+  position: relative;
+  overflow: visible !important;
+}
+
+.tooltip::after {
+  position: absolute;
+  z-index: 1000000;
+  display: none;
+  padding: 10px;
+  -webkit-font-smoothing: subpixel-antialiased;
+  color: white;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: break-word;
+  white-space: pre;
+  pointer-events: none;
+  content: attr(title);
+  background: black;
+  border-radius: 3px;
+  opacity: 0;
+}
+
+// This is the tooltip arrow
+.tooltip::before {
+  position: absolute;
+  z-index: 1000001;
+  display: none;
+  width: 0;
+  height: 0;
+  color: black;
+  pointer-events: none;
+  content: "";
+  border: 6px solid transparent;
+  opacity: 0;
+}
+
+// delay animation for tooltip
+@keyframes tooltip-appear {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+// This will indicate when we'll activate the tooltip
+.tooltip:hover,
+.tooltip:active,
+.tooltip:focus {
+  &::before,
+  &::after {
+    display: inline-block;
+    text-decoration: none;
+    animation-name: tooltip-appear;
+    animation-duration: .2s;
+    animation-fill-mode: forwards;
+    animation-timing-function: ease-in;
+    animation-delay: 0;
+  }
+}
+
+// Tooltipped south
+.tooltip-s,
+.tooltip-se,
+.tooltip-sw {
+  &::after {
+    top: 100%;
+    right: 50%;
+    margin-top: 6px;
+  }
+
+  &::before {
+    top: auto;
+    right: 50%;
+    bottom: -7px;
+    margin-right: 6px;
+    border-bottom-color: black;
+  }
+}
+
+.tooltip-se {
+  &::after {
+    right: auto;
+    left: 50%;
+    margin-left: -20px;
+  }
+}
+
+.tooltip-sw::after {
+  margin-right: -20px;
+}

--- a/app/styles/ui/_tooltip.scss
+++ b/app/styles/ui/_tooltip.scss
@@ -19,7 +19,7 @@
   white-space: pre;
   pointer-events: none;
   content: attr(title);
-  background: black;
+  background: $black;
   border-radius: 3px;
   opacity: 0;
 }


### PR DESCRIPTION
## Overview

We've been discussing the possibility of adding our own custom tooltips instead of using native tooltips lately. In some downtime, I tried getting it started, based mostly on [Primer tooltips](https://github.com/primer/primer/tree/master/modules/primer-tooltips). I ran into some trouble on disabled buttons (since disabled buttons use opacity, it was also dimming the tooltips) so this also restyles disabled buttons. This is definitely buggy, and there are probably a ton of ways to implement this, but this is just to get us started. If you want to try them, they work on the disabled merge button in the merge conflicts modal, and on the repo list.

**On repo list:**

<img width="338" alt="screen shot 2019-01-14 at 2 25 29 pm" src="https://user-images.githubusercontent.com/10404068/51145203-08536980-1808-11e9-9429-fd0169838811.png">

**On merge conflicts modal disabled button:**

<img width="401" alt="screen shot 2019-01-14 at 2 25 08 pm" src="https://user-images.githubusercontent.com/10404068/51145204-08536980-1808-11e9-821a-c12a372355a1.png">



