### PR TITLE
add manual resolutions to appState

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -33,6 +33,7 @@ import { ComparisonCache } from './comparison-cache'
 
 import { ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
+import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 
 export enum SelectionType {
   Repository,
@@ -257,6 +258,7 @@ export enum RepositorySectionTab {
 export interface IConflictState {
   readonly currentBranch: string
   readonly currentTip: string
+  readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 
 export interface IRepositoryState {

--- a/app/src/lib/dispatcher/dispatcher.ts
+++ b/app/src/lib/dispatcher/dispatcher.ts
@@ -64,6 +64,7 @@ import { ApplicationTheme } from '../../ui/lib/application-theme'
 import { TipState } from '../../models/tip'
 import { RepositoryStateCache } from '../stores/repository-state-cache'
 import { Popup, PopupType } from '../../models/popup'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 
 /**
  * An error handler function.
@@ -1291,6 +1292,21 @@ export class Dispatcher {
 
   public resolveCurrentEditor() {
     return this.appStore._resolveCurrentEditor()
+  }
+
+  /**
+   *  update the manual resolution method for a file
+   */
+  public updateManualConflictResolution(
+    repository: Repository,
+    path: string,
+    manualResolution: ManualConflictResolution | null
+  ) {
+    return this.appStore._updateManualConflictResolution(
+      repository,
+      path,
+      manualResolution
+    )
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -180,6 +180,7 @@ import {
   updateChangedFiles,
   updateConflictState,
 } from './updates/changes-state'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -4082,8 +4083,40 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.emitUpdate()
     }
   }
-}
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _updateManualConflictResolution(
+    repository: Repository,
+    path: string,
+    manualResolution: ManualConflictResolution | null
+  ) {
+    this.repositoryStateCache.updateChangesState(repository, state => {
+      const { conflictState } = state
+
+      if (conflictState === null) {
+        // not currently in a conflict, whatever
+        return { conflictState }
+      }
+
+      const updatedManualResolutions = new Map(conflictState.manualResolutions)
+
+      if (manualResolution !== null) {
+        updatedManualResolutions.set(path, manualResolution)
+      } else {
+        updatedManualResolutions.delete(path)
+      }
+
+      return {
+        conflictState: {
+          ...conflictState,
+          manualResolutions: updatedManualResolutions,
+        },
+      }
+    })
+
+    this.emitUpdate()
+  }
+}
 /**
  * Map the cached state of the compare view to an action
  * to perform which is then used to compute the compare

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -7,6 +7,7 @@ import { IChangesState, IConflictState } from '../../app-state'
 import { DiffSelectionType, IDiff } from '../../../models/diff'
 import { caseInsensitiveCompare } from '../../compare'
 import { IStatsStore } from '../../stats/stats-store'
+import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 
 /**
  * Internal shape of the return value from this response because the compiler
@@ -92,7 +93,10 @@ export function updateChangedFiles(
 /**
  * Convert the received status information into a conflict state
  */
-function getConflictState(status: IStatusResult): IConflictState | null {
+function getConflictState(
+  status: IStatusResult,
+  manualResolutions: Map<string, ManualConflictResolution>
+): IConflictState | null {
   if (!status.mergeHeadFound) {
     return null
   }
@@ -105,6 +109,7 @@ function getConflictState(status: IStatusResult): IConflictState | null {
   return {
     currentBranch,
     currentTip,
+    manualResolutions,
   }
 }
 
@@ -114,7 +119,12 @@ export function updateConflictState(
   statsStore: IStatsStore
 ): IConflictState | null {
   const prevConflictState = state.conflictState
-  const newConflictState = getConflictState(status)
+
+  const manualResolutions = prevConflictState
+    ? prevConflictState.manualResolutions
+    : new Map<string, ManualConflictResolution>()
+
+  const newConflictState = getConflictState(status, manualResolutions)
 
   if (prevConflictState == null && newConflictState == null) {
     return null


### PR DESCRIPTION
~~🌵 🌵 #6606 must be reviewed and merged before this PR can be merged 🌵 🌵~~

## Overview

supports #6062 

## Description

- adds manual resolutions to `appState`
- adds method for updating via `Dispatcher`
- adds logic into `updateConflictState` to manage updating and resetting stored manual resolutions
