### PR TITLE
New and untracked are pretty much the same thing

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -232,7 +232,10 @@ async function getImageDiff(
       current = await getWorkingDirectoryImage(repository, file)
     }
 
-    if (file.status.kind !== AppFileStatusKind.New) {
+    if (
+      file.status.kind !== AppFileStatusKind.New &&
+      file.status.kind !== AppFileStatusKind.Untracked
+    ) {
       // If we have file.oldPath that means it's a rename so we'll
       // look for that file.
       previous = await getBlobImage(
@@ -248,7 +251,10 @@ async function getImageDiff(
     }
 
     // File status can't be conflicted for a file in a commit
-    if (file.status.kind !== AppFileStatusKind.New) {
+    if (
+      file.status.kind !== AppFileStatusKind.New &&
+      file.status.kind !== AppFileStatusKind.Untracked
+    ) {
       // TODO: commitish^ won't work for the first commit
       //
       // If we have file.oldPath that means it's a rename so we'll


### PR DESCRIPTION
## Overview

#6480 added a new `AppFileStatus`, `UntrackedFileStatus` which is nearly identical to `AppFileStatusKind.New` in that they both tell us that the file isn't in the repository yet. The `getImageDiff` method was not updated to account for this new status and therefore threw an exception which went unhandled by the image diff component causing the behavior seen in #6625.

**Closes #6625**

## Release notes

no-notes