### PR TITLE
reshow overflow to fix #6459

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -76,9 +76,6 @@
     // Fake that we're a text-box
     cursor: text;
 
-    // Hide overflowed content
-    overflow: hidden;
-
     &.focus-within {
       outline: none;
       border-color: var(--focus-color);


### PR DESCRIPTION
## Overview

fix #6459 

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: Fix partial hiding of autocomplete panels in commit message field.
