### PR TITLE
1.6.0-beta3 release notes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.0-beta2",
+  "version": "1.6.0-beta3",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "1.6.0-beta3": [
+      "[Fixed] Autocomplete selection does not overflow text area - #6459",
+      "[Fixed] No local changes views incorrectly rendering ampersands - #6596",
+      "[Improved] Capitalization of menu items on macOS - #6469"
+    ],
     "1.6.0-beta2": [
       "[New] \"No local changes\" view makes it easy to find and accomplish common actions - #6445",
       "[Fixed] Automatically locate a missing repository when it cannot be found - #6228. Thanks @msftrncs!",


### PR DESCRIPTION
## Overview

One last beta before the slated 1.6.0 launch on Thursday.

## Description

- [x] get approval for release notes
- [x] :shipit:

## Release notes

Notes: no-notes
