### PR TITLE
Keeping organization when switching tabs on publish repository modal

### DIFF
--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -82,14 +82,14 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     const startingTabState = {
       publishSettings: { ...publishSettings },
-      error: null
+      error: null,
     }
 
     this.state = {
       currentTab: startingTab,
       dotComTabState: { ...startingTabState },
       enterpriseTabState: { ...startingTabState },
-      publishing: false
+      publishing: false,
     }
   }
 
@@ -270,16 +270,18 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   }
 
   private getCurrentTabState = () =>
-      this.state.currentTab === PublishTab.DotCom ? this.state.dotComTabState : this.state.enterpriseTabState
+    this.state.currentTab === PublishTab.DotCom
+      ? this.state.dotComTabState
+      : this.state.enterpriseTabState
 
   private setTabState = (tabState: IPublishTabState) => {
     if (this.state.currentTab === PublishTab.DotCom) {
       this.setState({
-        dotComTabState: { ...tabState }
+        dotComTabState: { ...tabState },
       })
     } else {
       this.setState({
-        enterpriseTabState: { ...tabState }
+        enterpriseTabState: { ...tabState },
       })
     }
   }
@@ -287,14 +289,14 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   private setCurrentTabSettings = (settings: IPublishRepositorySettings) => {
     this.setTabState({
       ...this.getCurrentTabState(),
-      publishSettings: { ...settings }
+      publishSettings: { ...settings },
     })
   }
 
   private setCurrentTabError = (error: Error | null) => {
     this.setTabState({
       ...this.getCurrentTabState(),
-      error: error
+      error: error,
     })
   }
 }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -249,8 +249,6 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   private onTabClicked = (index: PublishTab) => {
     const isTabChanging = index !== this.state.currentTab
     if (isTabChanging) {
-      // Clear the selected org since dot com and Enterprise will have a different
-      // set of orgs.
       const settings = { ...this.state.publishSettings }
       this.setState({ currentTab: index, publishSettings: settings })
       // Swap the current stored error from the active tab with the error from

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -128,7 +128,6 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     try {
       const description = await getGitDescription(this.props.repository.path)
-      console.log(description)
       const settings = {
         ...currentTabState.publishSettings,
         description,

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -251,7 +251,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     if (isTabChanging) {
       // Clear the selected org since dot com and Enterprise will have a different
       // set of orgs.
-      const settings = { ...this.state.publishSettings, org: null }
+      const settings = { ...this.state.publishSettings }
       this.setState({ currentTab: index, publishSettings: settings })
       // Swap the current stored error from the active tab with the error from
       // the inactive tab. So that each tab saves and displays their own error.


### PR DESCRIPTION
This is my first PR to the project.

![](https://d1wuojemv4s7aw.cloudfront.net/items/001m0s3y2F0I1j3b320t/Screen%20Recording%202019-01-15%20at%2006.21%20PM.gif)

closes https://github.com/desktop/desktop/issues/6546