### PR TITLE
Move Create PR action behind beta feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -64,3 +64,15 @@ export function enableReadmeOverwriteWarning(): boolean {
 export function enableNewNoChangesBlankslate(): boolean {
   return true
 }
+
+/**
+ * Whether or not to activate the "Create PR" blankslate action.
+ *
+ * The state of the feature as of writing this is that the underlying
+ * data source required to power this feature is not reliable enough
+ * and needs looking at so we aren't ready to move this to production
+ * just yet.
+ */
+export function enableNoChangesCreatePRBlankslateAction(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -6,7 +6,10 @@ import { encodePathAsUrl } from '../../lib/path'
 import { revealInFileManager } from '../../lib/app-shell'
 import { Repository } from '../../models/repository'
 import { LinkButton } from '../lib/link-button'
-import { enableNewNoChangesBlankslate } from '../../lib/feature-flag'
+import {
+  enableNewNoChangesBlankslate,
+  enableNoChangesCreatePRBlankslateAction,
+} from '../../lib/feature-flag'
 import { MenuIDs } from '../../main-process/menu'
 import { IMenu, MenuItem } from '../../models/app-menu'
 import memoizeOne from 'memoize-one'
@@ -369,13 +372,15 @@ export class NoChanges extends React.Component<
       return this.renderPushBranchAction(tip, remote, aheadBehind)
     }
 
-    const isGitHub = this.props.repository.gitHubRepository !== null
-    const hasOpenPullRequest = currentPullRequest !== null
-    const isDefaultBranch =
-      defaultBranch !== null && tip.branch.name === defaultBranch.name
+    if (enableNoChangesCreatePRBlankslateAction()) {
+      const isGitHub = this.props.repository.gitHubRepository !== null
+      const hasOpenPullRequest = currentPullRequest !== null
+      const isDefaultBranch =
+        defaultBranch !== null && tip.branch.name === defaultBranch.name
 
-    if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
-      return this.renderCreatePullRequestAction(tip)
+      if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
+        return this.renderCreatePullRequestAction(tip)
+      }
     }
 
     return null


### PR DESCRIPTION
## Overview

This hides the "Create PR" blank slate action behind a beta feature flag. After using it for a while it has become evident that the underlying data source is not suitable for determining whether or not the current branch has a PR associated with it or not and we'll need to take a step back and look at ways to improve that.

I'm intending to investigate solutions for this after the 1.6 release has gone out but for now we can't ship this to production.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
