### PR TITLE
embed the SHA in the About view in development mode

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -249,6 +249,8 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       <LinkButton uri={releaseNotesUri}>release notes</LinkButton>
     )
 
+    const versionText = __DEV__ ? `Build ${version}` : `Version ${version}`
+
     return (
       <Dialog
         id="about"
@@ -267,7 +269,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
               className="version-text"
               onClick={this.onClickVersion}
             >
-              Version {version}
+              {versionText}
             </LinkButton>{' '}
             ({releaseNotesLink})
           </p>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1284,12 +1284,14 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       case PopupType.About:
+        const version = __DEV__ ? __SHA__.substr(0, 10) : getVersion()
+
         return (
           <About
             key="about"
             onDismissed={this.onPopupDismissed}
             applicationName={getName()}
-            applicationVersion={getVersion()}
+            applicationVersion={version}
             onCheckForUpdates={this.onCheckForUpdates}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}


### PR DESCRIPTION
## Overview

This one a small change mostly for @tierninho's benefit when he's testing PRs locally.

Currently, if you run the app from source (`yarn build:dev && yarn start`) the About view shows the version (which likely was from the last release and not very accurate):

<img width="474" src="https://user-images.githubusercontent.com/359239/51345723-0e4c8300-1a72-11e9-9b71-31b44e3c6e04.png">

With this change, the About view now shows `Build` rather than `Version`, alongside the abbreviated commit SHA:

<img width="472" src="https://user-images.githubusercontent.com/359239/51345889-903cac00-1a72-11e9-86a2-e08dd2be3255.png">

It still has the same "click to copy the version to clipboard" behaviour as before, so that you can quickly paste the build commit ID into an issue or PR when leaving feedback.

## Release notes

Notes: no-notes
