### PR TITLE
Only render NoChanges when there are.. no changes

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -265,13 +265,13 @@ export class RepositoryView extends React.Component<
           />
         )
       } else {
-        if (selectedFileIDs.length === 0) {
+        if (selectedFileIDs.length === 0 || diff === null) {
           return null
         }
 
         const selectedFile = workingDirectory.findFileWithID(selectedFileIDs[0])
 
-        if (selectedFile === null || diff === null) {
+        if (selectedFile === null) {
           return null
         }
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -245,18 +245,14 @@ export class RepositoryView extends React.Component<
     const selectedSection = this.props.state.selectedSection
 
     if (selectedSection === RepositorySectionTab.Changes) {
-      const changesState = this.props.state.changesState
-      const selectedFileIDs = changesState.selectedFileIDs
+      const { changesState } = this.props.state
+      const { workingDirectory, selectedFileIDs, diff } = changesState
 
       if (selectedFileIDs.length > 1) {
         return <MultipleSelection count={selectedFileIDs.length} />
       }
 
-      if (
-        changesState.workingDirectory.files.length === 0 ||
-        selectedFileIDs.length === 0 ||
-        changesState.diff === null
-      ) {
+      if (workingDirectory.files.length === 0) {
         return (
           <NoChanges
             key={this.props.repository.id}
@@ -269,10 +265,13 @@ export class RepositoryView extends React.Component<
           />
         )
       } else {
-        const workingDirectory = changesState.workingDirectory
+        if (selectedFileIDs.length === 0) {
+          return null
+        }
+
         const selectedFile = workingDirectory.findFileWithID(selectedFileIDs[0])
 
-        if (!selectedFile) {
+        if (selectedFile === null || diff === null) {
           return null
         }
 
@@ -281,7 +280,7 @@ export class RepositoryView extends React.Component<
             repository={this.props.repository}
             dispatcher={this.props.dispatcher}
             file={selectedFile}
-            diff={changesState.diff}
+            diff={diff}
             imageDiffType={this.props.imageDiffType}
           />
         )


### PR DESCRIPTION
## Overview

Apparently we've been using the `NoChanges` component as a fallback component while we're waiting for the Diff to load. It's been this way since forever but the last release with the redesigned no changes blank slate made it more noticeable, especially on slower environments.

This PR ensures that we're only rendering the `NoChanges` component when there are, in fact, no changes.

**Closes #6658**

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: `[Fix] Don't show the no local changes view when switching between changed files`