### PR TITLE
upgrade node-sass, address SASS breaking changes

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -12,32 +12,32 @@
 $overlay-background-color: rgba(0, 0, 0, 0.4);
 
 :root {
-  --color-new: $green;
-  --color-deleted: $red;
-  --color-modified: $yellow-700;
-  --color-renamed: $blue;
-  --color-conflicted: $orange;
+  --color-new: #{$green};
+  --color-deleted: #{$red};
+  --color-modified: #{$yellow-700};
+  --color-renamed: #{$blue};
+  --color-conflicted: #{$orange};
 
-  --text-color: $gray-900;
-  --text-secondary-color: $gray-500;
-  --background-color: $white;
+  --text-color: #{$gray-900};
+  --text-secondary-color: #{$gray-500};
+  --background-color: #{$white};
 
   --button-height: 25px;
 
-  --button-background: $blue;
+  --button-background: #{$blue};
   --button-border-radius: 2px;
-  --button-hover-background: lighten($blue, 5%);
-  --button-text-color: $white;
-  --button-focus-border-color: $blue-600;
+  --button-hover-background: #{lighten($blue, 5%)};
+  --button-text-color: #{$white};
+  --button-focus-border-color: #{$blue-600};
 
-  --link-button-color: $blue;
-  --link-button-hover-color: $blue-600;
+  --link-button-color: #{$blue};
+  --link-button-hover-color: #{$blue-600};
 
-  --secondary-button-background: $gray-000;
-  --secondary-button-hover-background: $white;
+  --secondary-button-background: #{$gray-000};
+  --secondary-button-hover-background: #{$white};
   --secondary-button-text-color: var(--text-color);
-  --secondary-button-focus-shadow-color: rgba($gray-200, 0.75);
-  --secondary-button-focus-border-color: $gray-300;
+  --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};
+  --secondary-button-focus-border-color: #{$gray-300};
 
   // Typography
   //
@@ -90,19 +90,19 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // to decide what states to support (active selection, selection, etc).
 
   --box-background-color: var(--background-color);
-  --box-alt-background-color: $gray-100;
+  --box-alt-background-color: #{$gray-100};
 
   /**
    * Background color for skeleton or "loading" boxes
    */
-  --box-skeleton-background-color: $gray-200;
+  --box-skeleton-background-color: #{$gray-200};
   --skeleton-background-gradient: -webkit-linear-gradient(left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0) 100%);
 
   /**
    * Border color for boxes.
    */
-  --box-border-color: $gray-200;
-  --box-border-accent-color: $blue;
+  --box-border-color: #{$gray-200};
+  --box-border-accent-color: #{$blue};
 
   /**
    * Background color for selected boxes without keyboard focus
@@ -115,7 +115,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * implement a hover state since this will conflict with
    * selection and active selection
    */
-  --box-hover-text-color: $gray-900;
+  --box-hover-text-color: #{$gray-900};
 
   /**
    * Background color for when a user hovers over a boxe with a
@@ -127,52 +127,52 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   /**
    * Text color for selected boxes without keyboard focus
    */
-  --box-selected-text-color: $gray-900;
+  --box-selected-text-color: #{$gray-900};
 
   /**
    * Border color for selected boxes without keyboard focus
    */
-  --box-selected-border-color: $gray-400;
+  --box-selected-border-color: #{$gray-400};
 
   /**
    * Background color for selected boxes with active keyboard focus
    */
-  --box-selected-active-background-color: $blue;
+  --box-selected-active-background-color: #{$blue};
 
   /**
    * Text color for selected boxes with active keyboard focus
    */
-  --box-selected-active-text-color: $white;
+  --box-selected-active-text-color: #{$white};
 
   /**
    * Border color for selected boxes with active keyboard focus
    */
-  --box-selected-active-border-color: $gray-400;
+  --box-selected-active-border-color: #{$gray-400};
 
   /**
    * Gradient used to indicate that content is overflowing, intended
    * for use when content can be expanded through other means than
    * scrolling.
    */
-  --box-overflow-shadow-background: linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%);
+  --box-overflow-shadow-background: #{linear-gradient(180deg, rgba($white, 0) 0%, rgba($white, 1) 90%, rgba($white, 1) 100%)};
 
   /**
    * Placeholder color for input boxes
    */
-  --box-placeholder-color: $gray-500;
+  --box-placeholder-color: #{$gray-500};
 
   /**
    * Author input (co-authors)
    */
-  --co-author-tag-background-color: $blue-000;
-  --co-author-tag-border-color: $blue-200;
+  --co-author-tag-background-color: #{$blue-000};
+  --co-author-tag-border-color: #{$blue-200};
 
   /**
    * The height of the title bar area on Win32 platforms
    * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
   */
   --win32-title-bar-height: 28px;
-  --win32-title-bar-background-color: $gray-900;
+  --win32-title-bar-background-color: #{$gray-900};
 
   /**
    * The height of the title bar area on darwin platforms
@@ -195,30 +195,30 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --toolbar-height: 50px;
 
-  --toolbar-background-color: $gray-900;
-  --toolbar-border-color: $gray-900;
-  --toolbar-text-color: $white;
-  --toolbar-text-secondary-color: $gray-300;
+  --toolbar-background-color: #{$gray-900};
+  --toolbar-border-color: #{$gray-900};
+  --toolbar-text-color: #{$white};
+  --toolbar-text-secondary-color: #{$gray-300};
 
   --toolbar-button-color: var(--toolbar-text-color);
   --toolbar-button-background-color: transparent;
   --toolbar-button-border-color: black;
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
-  --toolbar-button-hover-color: $white;
-  --toolbar-button-hover-background-color: $gray-800;
+  --toolbar-button-hover-color: #{$white};
+  --toolbar-button-hover-background-color: #{$gray-800};
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: $gray-800;
+  --toolbar-button-focus-background-color: #{$gray-800};
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);
   --toolbar-button-active-border-color: var(--background-color);
 
-  --toolbar-button-progress-color: $gray-800;
-  --toolbar-button-focus-progress-color: $gray-700;
-  --toolbar-button-hover-progress-color: $gray-700;
-  --toolbar-dropdown-open-progress-color: $gray-200;
+  --toolbar-button-progress-color: #{$gray-800};
+  --toolbar-button-focus-progress-color: #{$gray-700};
+  --toolbar-button-hover-progress-color: #{$gray-700};
+  --toolbar-dropdown-open-progress-color: #{$gray-200};
 
   /**
    * App menu bar colors (Windows/Linux only)
@@ -239,30 +239,30 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
     * push/pull button and the PR badge in the branch drop
     * down button.
     */
-  --toolbar-badge-background-color: $gray-600;
-  --toolbar-badge-active-background-color: $gray-200;
+  --toolbar-badge-background-color: #{$gray-600};
+  --toolbar-badge-active-background-color: #{$gray-200};
 
   --tab-bar-height: 29px;
-  --tab-bar-active-color: $blue;
-  --tab-bar-background-color: $white;
-  --tab-bar-hover-background-color: $gray-100;
+  --tab-bar-active-color: #{$blue};
+  --tab-bar-background-color: #{$white};
+  --tab-bar-hover-background-color: #{$gray-100};
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);
-  --tab-bar-count-background-color: $gray-200;
+  --tab-bar-count-background-color: #{$gray-200};
 
   /**
     * Badge colors when used inside of list items.
     * Example of this is the change indicators inside
     * of the repository list.
     */
-  --list-item-badge-color: $gray-800;
-  --list-item-badge-background-color: $gray-200;
-  --list-item-selected-badge-color: $gray-900;
-  --list-item-selected-badge-background-color: $gray-300;
-  --list-item-selected-active-badge-color: $gray-900;
-  --list-item-selected-active-badge-background-color: $white;
-  --list-item-hover-background-color: $gray-100;
+  --list-item-badge-color: #{$gray-800};
+  --list-item-badge-background-color: #{$gray-200};
+  --list-item-selected-badge-color: #{$gray-900};
+  --list-item-selected-badge-background-color: #{$gray-300};
+  --list-item-selected-active-badge-color: #{$gray-900};
+  --list-item-selected-active-badge-background-color: #{$white};
+  --list-item-hover-background-color: #{$gray-100};
 
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
@@ -284,26 +284,26 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * percentage changing or the app toggling between full screen and normal
    * window mode.
    */
-  --toast-notification-color: $gray-000;
-  --toast-notification-background-color: rgba($gray-900, 0.6);
+  --toast-notification-color: #{$gray-000};
+  --toast-notification-background-color: #{rgba($gray-900, 0.6)};
 
-  --tip-box-background-color: rgba($blue-500, 0.06);
-  --tip-box-border-color: $blue-200;
+  --tip-box-background-color: #{rgba($blue-500, 0.06)};
+  --tip-box-border-color: #{$blue-200};
 
   /** The highlight color used for focus rings and focus box shadows */
-  --focus-color: $blue;
+  --focus-color: #{$blue};
 
   /**
    * Variables for form elements
    */
   --text-field-height: 25px;
-  --text-field-focus-shadow-color: rgba($blue, 0.25);
+  --text-field-focus-shadow-color: #{rgba($blue, 0.25)};
 
   /**
    * Blankslate actions, see `BlankslateAction` component.
    */
-  --primary-blankslate-action-background: $blue-000;
-  --primary-blankslate-action-border-color: $blue-200;
+  --primary-blankslate-action-background: #{$blue-000};
+  --primary-blankslate-action-border-color: #{$blue-200};
 
   /**
    * Diff view
@@ -311,52 +311,52 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --diff-line-padding-y: 2px;
 
-  --diff-text-color: $gray-900;
-  --diff-border-color: $gray-200;
-  --diff-gutter-color: $gray-200;
+  --diff-text-color: #{$gray-900};
+  --diff-border-color: #{$gray-200};
+  --diff-gutter-color: #{$gray-200};
   --diff-gutter-background-color: var(--background-color);
 
-  --diff-line-number-color: $gray-700;
+  --diff-line-number-color: #{$gray-700};
   --diff-line-number-column-width: 50px;
 
-  --diff-selected-background-color: $blue-400;
-  --diff-selected-border-color: $blue-600;
-  --diff-selected-gutter-color: $blue-600;
+  --diff-selected-background-color: #{$blue-400};
+  --diff-selected-border-color: #{$blue-600};
+  --diff-selected-gutter-color: #{$blue-600};
   --diff-selected-text-color: var(--background-color);
 
-  --diff-add-background-color: darken($green-000, 2%);
-  --diff-add-border-color: $green-300;
-  --diff-add-gutter-color: $green-300;
-  --diff-add-gutter-background-color: darken($green-100, 3%);
+  --diff-add-background-color: #{darken($green-000, 2%)};
+  --diff-add-border-color: #{$green-300};
+  --diff-add-gutter-color: #{$green-300};
+  --diff-add-gutter-background-color: #{darken($green-100, 3%)};
   --diff-add-inner-background-color: #acf2bd;
-  --diff-add-text-color: var(--diff-text-color);
 
-  --diff-delete-background-color: $red-000;
-  --diff-delete-border-color: $red-200;
-  --diff-delete-gutter-color: $red-200;
-  --diff-delete-gutter-background-color: $red-100;
+  --diff-add-text-color: var(--diff-text-color);
+  --diff-delete-background-color: #{$red-000};
+  --diff-delete-border-color: #{$red-200};
+  --diff-delete-gutter-color: #{$red-200};
+  --diff-delete-gutter-background-color: #{$red-100};
   --diff-delete-inner-background-color: #fdb8c0;
   --diff-delete-text-color: var(--diff-text-color);
 
-  --diff-hunk-background-color: $blue-000;
-  --diff-hunk-border-color: $blue-200;
-  --diff-hunk-gutter-color: darken($blue-200, 5%);
-  --diff-hunk-gutter-background-color: $blue-100;
-  --diff-hunk-text-color: $gray;
+  --diff-hunk-background-color: #{$blue-000};
+  --diff-hunk-border-color: #{$blue-200};
+  --diff-hunk-gutter-color: #{darken($blue-200, 5%)};
+  --diff-hunk-gutter-background-color: #{$blue-100};
+  --diff-hunk-text-color: #{$gray};
 
-  --diff-hover-background-color: $blue-300;
-  --diff-hover-border-color: $blue-400;
-  --diff-hover-gutter-color: $blue-400;
+  --diff-hover-background-color: #{$blue-300};
+  --diff-hover-border-color: #{$blue-400};
+  --diff-hover-gutter-color: #{$blue-400};
   --diff-hover-text-color: var(--background-color);
 
-  --diff-add-hover-background-color: $green-300;
-  --diff-add-hover-border-color: $green-400;
-  --diff-add-hover-gutter-color: $green-400;
+  --diff-add-hover-background-color: #{$green-300};
+  --diff-add-hover-border-color: #{$green-400};
+  --diff-add-hover-gutter-color: #{$green-400};
   --diff-add-hover-text-color: var(--text-color);
 
-  --diff-delete-hover-background-color: $red-200;
-  --diff-delete-hover-border-color: $red-300;
-  --diff-delete-hover-gutter-color: $red-300;
+  --diff-delete-hover-background-color: #{$red-200};
+  --diff-delete-hover-border-color: #{$red-300};
+  --diff-delete-hover-gutter-color: #{$red-300};
   --diff-delete-hover-text-color: var(--text-color);
 
   // Syntax highlighting text colors
@@ -367,7 +367,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --syntax-string-color: #032f62;
   --syntax-qualifier-color: #6f42c1;
   --syntax-type-color: #d73a49;
-  --syntax-comment-color: $gray-500;
+  --syntax-comment-color: #{$gray-500};
   --syntax-tag-color: #22863a;
   --syntax-attribute-color: #6f42c1;
   --syntax-link-color: #032f62;
@@ -378,25 +378,25 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --undo-animation-duration: 500ms;
 
   // Colors for form errors
-  --error-color: $red;
-  --form-error-background: $red-100;
-  --form-error-border-color: $red-200;
-  --form-error-text-color: $red-800;
+  --error-color: #{$red};
+  --form-error-background: #{$red-100};
+  --form-error-border-color: #{$red-200};
+  --form-error-text-color: #{$red-800};
 
   /** Overlay is used as a background for both modals and foldouts */
-  --overlay-background-color: $overlay-background-color;
+  --overlay-background-color: #{$overlay-background-color};
 
   /** Dialog */
-  --dialog-warning-color: $yellow-600;
-  --dialog-error-color: $red;
+  --dialog-warning-color: #{$yellow-600};
+  --dialog-error-color: #{$red};
 
   /** Inline paths and code */
-  --path-segment-background: $blue-000;
+  --path-segment-background: #{$blue-000};
   --path-segment-padding: var(--spacing-third);
 
   /** Diverging notification banner colors */
-  --notification-banner-background: $blue-000;
-  --notification-banner-border-color: $blue-200;
+  --notification-banner-background: #{$blue-000};
+  --notification-banner-border-color: #{$blue-200};
   --notification-ref-background: rgba(255, 255, 255, 0.75);
 
   // http://easings.net/#easeOutBack
@@ -410,5 +410,5 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 }
 
 ::backdrop {
-  --overlay-background-color: $overlay-background-color;
+  --overlay-background-color: #{$overlay-background-color};
 }

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -6,29 +6,29 @@
 @import '~primer-support/lib/variables/color-system.scss';
 
 body.theme-dark {
-  --color-new: $green;
-  --color-deleted: $red;
-  --color-modified: $yellow-700;
-  --color-renamed: $blue;
-  --color-conflicted: $orange;
+  --color-new: #{$green};
+  --color-deleted: #{$red};
+  --color-modified: #{$yellow-700};
+  --color-renamed: #{$blue};
+  --color-conflicted: #{$orange};
 
-  --text-color: $gray-300;
-  --text-secondary-color: $gray-400;
-  --background-color: $gray-900;
+  --text-color: #{$gray-300};
+  --text-secondary-color: #{$gray-400};
+  --background-color: #{$gray-900};
 
-  --button-background: $blue;
-  --button-hover-background: lighten($blue, 5%);
-  --button-text-color: $white;
-  --button-focus-border-color: $blue-600;
+  --button-background: #{$blue};
+  --button-hover-background: #{lighten($blue, 5%)};
+  --button-text-color: #{$white};
+  --button-focus-border-color: #{$blue-600};
 
-  --link-button-color: lighten($blue-400, 3%);
-  --link-button-hover-color: $blue-400;
+  --link-button-color: #{lighten($blue-400, 3%)};
+  --link-button-hover-color: #{$blue-400};
 
-  --secondary-button-background: $gray-800;
+  --secondary-button-background: #{$gray-800};
   --secondary-button-hover-background: var(--secondary-button-background);
   --secondary-button-text-color: var(--text-color);
-  --secondary-button-focus-shadow-color: rgba($gray-200, 0.75);
-  --secondary-button-focus-border-color: $gray-300;
+  --secondary-button-focus-shadow-color: #{rgba($gray-200, 0.75)};
+  --secondary-button-focus-border-color: #{$gray-300};
 
   /**
    * Background color for custom scroll bars.
@@ -53,25 +53,25 @@ body.theme-dark {
   // or an item in a tab control header. It's up to each implementation
   // to decide what states to support (active selection, selection, etc).
 
-  --box-background-color: darken($gray-900, 3%);
-  --box-alt-background-color: $gray-800;
+  --box-background-color: #{darken($gray-900, 3%)};
+  --box-alt-background-color: #{$gray-800};
 
   /**
    * Background color for skeleton or "loading" boxes
    */
-  --box-skeleton-background-color: $gray-700;
+  --box-skeleton-background-color: #{$gray-700};
   --skeleton-background-gradient: -webkit-linear-gradient(left, rgba(36, 41, 46, 0) 0%, rgba(36, 41, 46, 0.5) 50%, rgba(36, 41, 46, 0) 100%);
 
   /**
    * Border color for boxes.
    */
   --box-border-color: #141414;
-  --box-border-accent-color: $blue;
+  --box-border-accent-color: #{$blue};
 
   /**
    * Background color for selected boxes without keyboard focus
    */
-  --box-selected-background-color: $gray-700;
+  --box-selected-background-color: #{$gray-700};
 
   /**
    * Text color for when a user hovers over a boxe with a
@@ -96,47 +96,47 @@ body.theme-dark {
   /**
    * Border color for selected boxes without keyboard focus
    */
-  --box-selected-border-color: $gray-400;
+  --box-selected-border-color: #{$gray-400};
 
   /**
    * Background color for selected boxes with active keyboard focus
    */
-  --box-selected-active-background-color: $blue;
+  --box-selected-active-background-color: #{$blue};
 
   /**
    * Text color for selected boxes with active keyboard focus
    */
-  --box-selected-active-text-color: $white;
+  --box-selected-active-text-color: #{$white};
 
   /**
    * Border color for selected boxes with active keyboard focus
    */
-  --box-selected-active-border-color: $gray-400;
+  --box-selected-active-border-color: #{$gray-400};
 
   /**
    * Gradient used to indicate that content is overflowing, intended
    * for use when content can be expanded through other means than
    * scrolling.
    */
-  --box-overflow-shadow-background: linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%);
+  --box-overflow-shadow-background: #{linear-gradient(180deg, rgba($gray-900, 0) 0%, rgba($gray-900, 1) 90%, rgba($gray-900, 1) 100%)};
 
   /**
    * Placeholder color for input boxes
    */
-  --box-placeholder-color: $gray-400;
+  --box-placeholder-color: #{$gray-400};
 
   /**
    * Author input (co-authors)
    */
-  --co-author-tag-background-color: $blue-800;
-  --co-author-tag-border-color: $blue-700;
+  --co-author-tag-background-color: #{$blue-800};
+  --co-author-tag-border-color: #{$blue-700};
 
   --base-border: 1px solid var(--box-border-color);
 
-  --shadow-color: rgba(black, 0.5);
+  --shadow-color: #{rgba(black, 0.5)};
   --base-box-shadow: 0 2px 7px var(--shadow-color);
 
-  --toolbar-background-color: darken($gray-900, 3%);
+  --toolbar-background-color: #{darken($gray-900, 3%)};
   --toolbar-border-color: var(--box-border-color);
   --toolbar-text-color: var(--text-color);
   --toolbar-text-secondary-color: var(--text-secondary-color);
@@ -146,20 +146,20 @@ body.theme-dark {
   --toolbar-button-border-color: var(--box-border-color);
   --toolbar-button-secondary-color: var(--toolbar-text-secondary-color);
 
-  --toolbar-button-hover-color: $white;
-  --toolbar-button-hover-background-color: $gray-800;
+  --toolbar-button-hover-color: #{$white};
+  --toolbar-button-hover-background-color: #{$gray-800};
   --toolbar-button-hover-border-color: var(--toolbar-button-border-color);
 
-  --toolbar-button-focus-background-color: $gray-800;
+  --toolbar-button-focus-background-color: #{$gray-800};
 
   --toolbar-button-active-color: var(--text-color);
   --toolbar-button-active-background-color: var(--background-color);
   --toolbar-button-active-border-color: var(--box-border-color);
 
-  --toolbar-button-progress-color: $gray-800;
-  --toolbar-button-focus-progress-color: $gray-700;
-  --toolbar-button-hover-progress-color: $gray-700;
-  --toolbar-dropdown-open-progress-color: $gray-200;
+  --toolbar-button-progress-color: #{$gray-800};
+  --toolbar-button-focus-progress-color: #{$gray-700};
+  --toolbar-button-hover-progress-color: #{$gray-700};
+  --toolbar-dropdown-open-progress-color: #{$gray-200};
 
   /**
     * App menu bar colors (Windows/Linux only)
@@ -168,11 +168,11 @@ body.theme-dark {
   --app-menu-button-hover-color: var(--toolbar-button-hover-color);
   --app-menu-button-hover-background-color: var(--toolbar-button-hover-background-color);
   --app-menu-button-active-color: var(--text-color);
-  --app-menu-button-active-background-color: $gray-800;
+  --app-menu-button-active-background-color: #{$gray-800};
   --app-menu-pane-color: var(--text-color);
   --app-menu-pane-secondary-color: var(--text-secondary-color);
-  --app-menu-pane-background-color: $gray-800;
-  --app-menu-divider-color: $gray-600;
+  --app-menu-pane-background-color: #{$gray-800};
+  --app-menu-divider-color: #{$gray-600};
 
   /**
    * Background color for badges inside of toolbar buttons.
@@ -180,16 +180,16 @@ body.theme-dark {
    * push/pull button and the PR badge in the branch drop
    * down button.
    */
-  --toolbar-badge-background-color: $gray-700;
-  --toolbar-badge-active-background-color: $gray-700;
+  --toolbar-badge-background-color: #{$gray-700};
+  --toolbar-badge-active-background-color: #{$gray-700};
 
-  --tab-bar-active-color: $blue;
+  --tab-bar-active-color: #{$blue};
   --tab-bar-background-color: var(--box-background-color);
-  --tab-bar-hover-background-color: $gray-800;
+  --tab-bar-hover-background-color: #{$gray-800};
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);
-  --tab-bar-count-background-color: $gray-700;
+  --tab-bar-count-background-color: #{$gray-700};
 
   /**
     * Badge colors when used inside of list items.
@@ -197,12 +197,12 @@ body.theme-dark {
     * of the repository list.
     */
   --list-item-badge-color: var(--text-color);
-  --list-item-badge-background-color: $gray-600;
-  --list-item-selected-badge-color: $white;
-  --list-item-selected-badge-background-color: $gray-500;
-  --list-item-selected-active-badge-color: $gray-900;
-  --list-item-selected-active-badge-background-color: $white;
-  --list-item-hover-background-color: $gray-800;
+  --list-item-badge-background-color: #{$gray-600};
+  --list-item-selected-badge-color: #{$white};
+  --list-item-selected-badge-background-color: #{$gray-500};
+  --list-item-selected-active-badge-color: #{$gray-900};
+  --list-item-selected-active-badge-background-color: #{$white};
+  --list-item-hover-background-color: #{$gray-800};
 
   /**
    * Toast notifications are shown temporarily for things like the zoom
@@ -210,112 +210,112 @@ body.theme-dark {
    * window mode.
    */
   --toast-notification-color: var(--text-color);
-  --toast-notification-background-color: rgba(black, 0.8);
+  --toast-notification-background-color: #{rgba(black, 0.8)};
 
   /** The highlight color used for focus rings and focus box shadows */
-  --focus-color: $blue;
+  --focus-color: #{$blue};
 
   /**
    * Variables for form elements
    */
-  --text-field-focus-shadow-color: rgba($blue, 0.25);
+  --text-field-focus-shadow-color: #{rgba($blue, 0.25)};
 
   /**
    * Blankslate actions, see `BlankslateAction` component.
    */
-  --primary-blankslate-action-background: $blue-900;
-  --primary-blankslate-action-border-color: $blue-700;
+  --primary-blankslate-action-background: #{$blue-900};
+  --primary-blankslate-action-border-color: #{$blue-700};
 
   /**
    * Diff view
    */
 
   --diff-text-color: var(--text-color);
-  --diff-border-color: $gray-800;
-  --diff-gutter-color: $gray-800;
-  --diff-gutter-background-color: darken($gray-900, 3%);
+  --diff-border-color: #{$gray-800};
+  --diff-gutter-color: #{$gray-800};
+  --diff-gutter-background-color: #{darken($gray-900, 3%)};
 
   --diff-line-number-color: var(--text-secondary-color);
   --diff-line-number-column-width: 50px;
 
-  --diff-selected-background-color: $blue-700;
-  --diff-selected-border-color: $blue-600;
-  --diff-selected-gutter-color: $blue-600;
+  --diff-selected-background-color: #{$blue-700};
+  --diff-selected-border-color: #{$blue-600};
+  --diff-selected-gutter-color: #{$blue-600};
   --diff-selected-text-color: var(--text-color);
 
-  --diff-add-background-color: darken($green-900, 3%);
-  --diff-add-border-color: darken($green-900, 2%);
-  --diff-add-gutter-color: darken($green-900, 2%);
-  --diff-add-gutter-background-color: darken($green-900, 8%);
-  --diff-add-inner-background-color: $green-600;
+  --diff-add-background-color: #{darken($green-900, 3%)};
+  --diff-add-border-color: #{darken($green-900, 2%)};
+  --diff-add-gutter-color: #{darken($green-900, 2%)};
+  --diff-add-gutter-background-color: #{darken($green-900, 8%)};
+  --diff-add-inner-background-color: #{$green-600};
   --diff-add-text-color: var(--diff-text-color);
 
-  --diff-delete-background-color: darken($red-900, 15%);
-  --diff-delete-border-color: darken($red-900, 10%);
-  --diff-delete-gutter-color: darken($red-900, 10%);
-  --diff-delete-gutter-background-color: darken($red-900, 20%);
-  --diff-delete-inner-background-color: $red-700;
-  --diff-delete-text-color: $red-100;
+  --diff-delete-background-color: #{darken($red-900, 15%)};
+  --diff-delete-border-color: #{darken($red-900, 10%)};
+  --diff-delete-gutter-color: #{darken($red-900, 10%)};
+  --diff-delete-gutter-background-color: #{darken($red-900, 20%)};
+  --diff-delete-inner-background-color: #{$red-700};
+  --diff-delete-text-color: #{$red-100};
 
-  --diff-hunk-background-color: darken($gray-900, 3%);
-  --diff-hunk-border-color: lighten($gray-900, 3%);
-  --diff-hunk-gutter-color: lighten($gray-900, 3%);
-  --diff-hunk-gutter-background-color: darken($gray-900, 6%);
+  --diff-hunk-background-color: #{darken($gray-900, 3%)};
+  --diff-hunk-border-color: #{lighten($gray-900, 3%)};
+  --diff-hunk-gutter-color: #{lighten($gray-900, 3%)};
+  --diff-hunk-gutter-background-color: #{darken($gray-900, 6%)};
   --diff-hunk-text-color: var(--text-secondary-color);
 
-  --diff-hover-background-color: $blue-500;
-  --diff-hover-border-color: $blue-400;
-  --diff-hover-gutter-color: $blue-400;
+  --diff-hover-background-color: #{$blue-500};
+  --diff-hover-border-color: #{$blue-400};
+  --diff-hover-gutter-color: #{$blue-400};
   --diff-hover-text-color: var(--diff-text-color);
 
-  --diff-add-hover-background-color: $green-900;
-  --diff-add-hover-border-color: $green-700;
-  --diff-add-hover-gutter-color: $green-700;
+  --diff-add-hover-background-color: #{$green-900};
+  --diff-add-hover-border-color: #{$green-700};
+  --diff-add-hover-gutter-color: #{$green-700};
   --diff-add-hover-text-color: var(--text-color);
 
-  --diff-delete-hover-background-color: $red-800;
-  --diff-delete-hover-border-color: $red-700;
-  --diff-delete-hover-gutter-color: $red-700;
+  --diff-delete-hover-background-color: #{$red-800};
+  --diff-delete-hover-border-color: #{$red-700};
+  --diff-delete-hover-gutter-color: #{$red-700};
   --diff-delete-hover-text-color: var(--text-color);
 
   // Syntax highlighting text colors
-  --syntax-variable-color: $purple-300;
-  --syntax-alt-variable-color: $blue-300;
-  --syntax-keyword-color: $red-300;
-  --syntax-atom-color: $blue-300;
-  --syntax-string-color: $orange-300;
-  --syntax-qualifier-color: $purple-300;
-  --syntax-type-color: $red-300;
-  --syntax-comment-color: $gray-400;
-  --syntax-tag-color: $green-400;
-  --syntax-attribute-color: $purple-300;
-  --syntax-link-color: $blue-300;
-  --syntax-header-color: $red-300;
+  --syntax-variable-color: #{$purple-300};
+  --syntax-alt-variable-color: #{$blue-300};
+  --syntax-keyword-color: #{$red-300};
+  --syntax-atom-color: #{$blue-300};
+  --syntax-string-color: #{$orange-300};
+  --syntax-qualifier-color: #{$purple-300};
+  --syntax-type-color: #{$red-300};
+  --syntax-comment-color: #{$gray-400};
+  --syntax-tag-color: #{$green-400};
+  --syntax-attribute-color: #{$purple-300};
+  --syntax-link-color: #{$blue-300};
+  --syntax-header-color: #{$red-300};
 
   // Colors for form errors
-  --error-color: $red;
-  --form-error-background: darken($red-900, 3%);
-  --form-error-border-color: $red-900;
+  --error-color: #{$red};
+  --form-error-background: #{darken($red-900, 3%)};
+  --form-error-border-color: #{$red-900};
   --form-error-text-color: var(--text-color);
 
   /** Overlay is used as a background for both modals and foldouts */
   --overlay-background-color: rgba(0, 0, 0, 0.5);
 
   /** Dialog */
-  --dialog-warning-color: $yellow-600;
-  --dialog-error-color: $red-600;
+  --dialog-warning-color: #{$yellow-600};
+  --dialog-error-color: #{$red-600};
 
   /** Inline paths and code */
-  --path-segment-background: $gray-700;
+  --path-segment-background: #{$gray-700};
 
   .blankslate-image {
     filter: #{'invert()'} grayscale(1) brightness(8) contrast(0.6);
   }
 
   /** Diverging notification banner colors */
-  --notification-banner-background: $gray-800;
-  --notification-banner-border-color: $gray-700;
-  --notification-ref-background: $gray-700;
+  --notification-banner-background: #{$gray-800};
+  --notification-banner-border-color: #{$gray-700};
+  --notification-ref-background: #{$gray-700};
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -91,7 +91,7 @@
         width: 100%;
         bottom: 0px;
         height: 5px;
-        background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.1) 100%);
+        background: linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 0.1) 100%);
         border-bottom: var(--base-border);
       }
     }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "klaw-sync": "^3.0.0",
     "legal-eagle": "0.16.0",
     "mini-css-extract-plugin": "^0.4.0",
-    "node-sass": "^4.7.2",
+    "node-sass": "^4.11.0",
     "octicons": "^8.2.0",
     "parallel-webpack": "^2.3.0",
     "prettier": "1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,11 +1172,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-  integrity sha1-104bh+ev/A24qttwIfP+SBAasjQ=
-
 assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
@@ -1307,17 +1302,12 @@ aws-sdk@^2.23.0:
     xml2js "0.4.17"
     xmlbuilder "4.2.1"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-  integrity sha1-FDQt0428yU0OW4fXY81jYSwOeU8=
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
   integrity sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=
@@ -1882,13 +1872,6 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  integrity sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=
-  dependencies:
-    hoek "2.x.x"
-
 boom@4.x.x:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
@@ -2266,11 +2249,6 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
   integrity sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=
-
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-  integrity sha1-cVuW6phBWTzDMGeSP17GDr2k99c=
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2894,13 +2872,6 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  integrity sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=
-  dependencies:
-    boom "2.x.x"
 
 cryptiles@3.x.x:
   version "3.1.2"
@@ -4131,7 +4102,7 @@ extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
   integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
@@ -4437,15 +4408,6 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  integrity sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
 form-data@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
@@ -4664,18 +4626,6 @@ gaze@^1.0.0, gaze@~1.1.2:
   integrity sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=
   dependencies:
     globule "^1.0.0"
-
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-  integrity sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
-  dependencies:
-    is-property "^1.0.0"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -4898,16 +4848,6 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
-  integrity sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=
-  dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    is-my-json-valid "^2.12.4"
-    pinkie-promise "^2.0.0"
-
 har-validator@~5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
@@ -5032,16 +4972,6 @@ hasha@^2.2.0:
     is-stream "^1.0.1"
     pinkie-promise "^2.0.0"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  integrity sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -5065,11 +4995,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-  integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
 hoek@4.x.x:
   version "4.2.0"
@@ -5168,15 +5093,6 @@ http-errors@1.6.2, http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  integrity sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -5588,16 +5504,6 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
-is-my-json-valid@^2.12.4:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz#3da98914a70a22f0a8563ef1511a246c6fc55471"
-  integrity sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -5684,11 +5590,6 @@ is-promise@~1, is-promise@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-1.0.1.tgz#31573761c057e33c2e91aab9e96da08cefbe76e5"
   integrity sha1-MVc3YcBX4zwukaq56W2gjO++duU=
-
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -6522,11 +6423,6 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -7088,7 +6984,7 @@ mime-db@~1.36.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
   integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
-mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   integrity sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
@@ -7281,10 +7177,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.3.2:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
-  integrity sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=
+nan@^2.10.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
+  integrity sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==
 
 nan@^2.9.2:
   version "2.10.0"
@@ -7361,20 +7257,19 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-gyp@^3.3.1:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
-  integrity sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=
+node-gyp@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
+  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
   dependencies:
     fstream "^1.0.0"
     glob "^7.0.3"
     graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
     mkdirp "^0.5.0"
     nopt "2 || 3"
     npmlog "0 || 1 || 2 || 3 || 4"
     osenv "0"
-    request "2"
+    request "^2.87.0"
     rimraf "2"
     semver "~5.3.0"
     tar "^2.0.0"
@@ -7465,10 +7360,10 @@ node-pre-gyp@^0.9.0:
     semver "^5.3.0"
     tar "^4"
 
-node-sass@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.7.2.tgz#9366778ba1469eb01438a9e8592f4262bcb6794e"
-  integrity sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==
+node-sass@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
+  integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -7482,10 +7377,10 @@ node-sass@^4.7.2:
     lodash.mergewith "^4.6.0"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.3.2"
-    node-gyp "^3.3.1"
+    nan "^2.10.0"
+    node-gyp "^3.8.0"
     npmlog "^4.0.0"
-    request "~2.79.0"
+    request "^2.88.0"
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
@@ -7622,7 +7517,7 @@ nwsapi@^2.0.7:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.8.tgz#e3603579b7e162b3dbedae4fb24e46f771d8fa24"
   integrity sha512-7RZ+qbFGiVc6v14Y8DSZjPN1wZPOaMbiiP4tzf5eNuyOITAeOIA3cMhjuKUypVIqBgCSg1KaSyAv8Ocq/0ZJ1A==
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
   integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
@@ -8652,11 +8547,6 @@ qs@6.5.1, qs@~6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@~6.3.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
-  integrity sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
-
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -9086,7 +8976,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2, request@^2.45.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
+request@^2.45.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   integrity sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==
@@ -9114,7 +9004,7 @@ request@2, request@^2.45.0, request@^2.72.0, request@^2.79.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.83.0, request@^2.87.0:
+request@^2.83.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -9139,32 +9029,6 @@ request@^2.83.0, request@^2.87.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
-
-request@~2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  integrity sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -9667,13 +9531,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^2.0.0"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  integrity sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=
-  dependencies:
-    hoek "2.x.x"
-
 sntp@2.x.x:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
@@ -10020,7 +9877,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
   integrity sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=
@@ -10389,7 +10246,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   integrity sha1-C2GKVWW23qkL80JdBNVe3EdadWE=
@@ -10540,11 +10397,6 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
-
-tunnel-agent@~0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
-  integrity sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -10872,7 +10724,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@3.1.0, uuid@^3.0.0, uuid@^3.1.0:
+uuid@3.1.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
   integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==


### PR DESCRIPTION
## Overview

I believe this is the last native module that blocks upgrading us the Node used to build and test Desktop to Node 10 aka #5876. If you want more context the original PR #5644 is worth a read (lolcry).

## Description

Armed with the regression test in #6647, this PR is split up into two parts:

 - bump the module
 - find all the places where SassScript values bleed through into the bundled scripts

The thing I haven't really got a solution for here is the development time tooling to catch issues while working on styles.

Currently it's this sort of flow:

 - `yarn build:dev && yarn start`
 - "Oh, something doesn't look right"
 - Inspect Element in the Chrome Dev Tools
 - "Where's the colour gone?"
 - "Oh, right. \*That\* thing!"
 - Make the fix

cc @desktop/design for any bright ideas

 - ~~[ ] ponder improvements to dev-time tooling to catch things~~ punting this for now, it's an annoying problem and I don't have good hooks short of writing my own linting tools 👢 
 - [x] manually diff the CSS bundles before/after to sanity check
 - [x] test update styles on Windows (light theme)
 - [x] test update styles on Windows (dark theme)
 - [x] test update styles on macOS (light theme)
 - [x] test update styles on macOS (dark theme)
 - [x] test update styles on Linux (light theme)
 - [x] test update styles on Linux (dark theme)

## Release notes

Notes: no-notes
