### PR TITLE
Add git function to get branch checkouts from reflog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
             # when lock file changes, use increasingly general patterns to restore cache
             - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
             - yarn-packages-v1-{{ .Branch }}-
+      - run: git clean -xdf node_modules/electron
       - run:
           name: Install dependencies
           command: yarn install --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
             # when lock file changes, use increasingly general patterns to restore cache
             - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
             - yarn-packages-v1-{{ .Branch }}-
-      - run: git clean -xdf node_modules/electron
       - run:
           name: Install dependencies
           command: yarn install --force

--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -64,6 +64,9 @@ export async function getRecentBranches(
   return [...names]
 }
 
+/**
+ * Gets the distinct list of branches that have been checked out after a specific date
+ */
 export async function getCheckoutsAfterDate(
   repository: Repository,
   afterDate: Date

--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -66,9 +66,11 @@ export async function getRecentBranches(
 
 /**
  * Gets the distinct list of branches that have been checked out after a specific date
+ * Returns a map keyed on branch names
  *
  * @param repository the repository who's reflog you want to check
  * @param afterDate the minimum date a checkout has to occur
+ * @returns map of branch name -> checkout date
  */
 export async function getCheckoutsAfterDate(
   repository: Repository,

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -143,7 +143,7 @@ export class BranchPruner {
 
       if (
         localBranch !== undefined &&
-        recentlyCheckedOutBranches.has(localBranch.name)
+        !recentlyCheckedOutBranches.has(localBranch.name)
       ) {
         branchesReadyForPruning.push(localBranch)
       }

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -2,7 +2,11 @@ import { Repository } from '../../../models/repository'
 import { RepositoriesStore } from '../repositories-store'
 import { Branch, BranchType } from '../../../models/branch'
 import { GitStoreCache } from '../git-store-cache'
-import { getMergedBranches, deleteBranch } from '../../git'
+import {
+  getMergedBranches,
+  deleteBranch,
+  getCheckoutsAfterDate,
+} from '../../git'
 import { fatalError } from '../../fatal-error'
 import { RepositoryStateCache } from '../repository-state-cache'
 import * as moment from 'moment'
@@ -117,6 +121,15 @@ export class BranchPruner {
       x => x.type === BranchType.Local
     )
 
+    // Get all branches checked out within the past 2 weeks
+    const twoWeeksAgo = moment()
+      .subtract(2, 'weeks')
+      .toDate()
+    const recentlyCheckedOutBranches = await getCheckoutsAfterDate(
+      this.repository,
+      twoWeeksAgo
+    )
+
     // Create array of branches that can be pruned
     const candidateBranches = mergedBranches.filter(
       b => !ReservedBranches.includes(b)
@@ -128,7 +141,10 @@ export class BranchPruner {
           localBranch.remote !== null && localBranch.name === branch
       )
 
-      if (localBranch !== undefined) {
+      if (
+        localBranch !== undefined &&
+        recentlyCheckedOutBranches.has(localBranch.name)
+      ) {
         branchesReadyForPruning.push(localBranch)
       }
     }

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -8,7 +8,7 @@ import {
   getCheckoutsAfterDate,
 } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
-import moment = require('moment')
+import * as moment from 'moment'
 
 async function createAndCheckout(
   repository: Repository,

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -5,8 +5,10 @@ import {
   createBranch,
   checkoutBranch,
   renameBranch,
+  getCheckoutsAfterDate,
 } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
+import moment = require('moment')
 
 async function createAndCheckout(
   repository: Repository,
@@ -65,6 +67,35 @@ describe('git/reflog', () => {
       expect(branches).toHaveLength(2)
       expect(branches).toContain('branch-4')
       expect(branches).toContain('branch-3')
+    })
+  })
+
+  describe('getCheckoutsAfterDate', () => {
+    it('returns does not return the branches that were checked out before a specific date', async () => {
+      await createAndCheckout(repository!, 'branch-1')
+      await createAndCheckout(repository!, 'branch-2')
+
+      const branches = await getCheckoutsAfterDate(
+        repository!,
+        moment()
+          .add(1, 'day')
+          .toDate()
+      )
+      expect(branches.size).toBe(0)
+    })
+
+    it('returns all branches checkedout after a specific date', async () => {
+      await createBranch(repository!, 'never-checked-out')
+      await createAndCheckout(repository!, 'branch-1')
+      await createAndCheckout(repository!, 'branch-2')
+
+      const branches = await getCheckoutsAfterDate(
+        repository!,
+        moment()
+          .subtract(1, 'hour')
+          .toDate()
+      )
+      expect(branches.size).toBe(2)
     })
   })
 })

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -22,7 +22,7 @@ async function createAndCheckout(
 }
 
 describe('git/reflog', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
@@ -31,26 +31,26 @@ describe('git/reflog', () => {
 
   describe('getRecentBranches', () => {
     it('returns the recently checked out branches', async () => {
-      await createAndCheckout(repository!, 'branch-1')
-      await createAndCheckout(repository!, 'branch-2')
+      await createAndCheckout(repository, 'branch-1')
+      await createAndCheckout(repository, 'branch-2')
 
-      const branches = await getRecentBranches(repository!, 10)
+      const branches = await getRecentBranches(repository, 10)
       expect(branches).toContain('branch-1')
       expect(branches).toContain('branch-2')
     })
 
     it('works after renaming a branch', async () => {
-      await createAndCheckout(repository!, 'branch-1')
-      await createAndCheckout(repository!, 'branch-2')
+      await createAndCheckout(repository, 'branch-1')
+      await createAndCheckout(repository, 'branch-2')
 
-      const allBranches = await getBranches(repository!)
+      const allBranches = await getBranches(repository)
       const currentBranch = allBranches.find(
         branch => branch.name === 'branch-2'
       )
 
-      await renameBranch(repository!, currentBranch!, 'branch-2-test')
+      await renameBranch(repository, currentBranch!, 'branch-2-test')
 
-      const branches = await getRecentBranches(repository!, 10)
+      const branches = await getRecentBranches(repository, 10)
       expect(branches).not.toContain('master')
       expect(branches).not.toContain('branch-2')
       expect(branches).toContain('branch-1')
@@ -58,12 +58,12 @@ describe('git/reflog', () => {
     })
 
     it('returns a limited number of branches', async () => {
-      await createAndCheckout(repository!, 'branch-1')
-      await createAndCheckout(repository!, 'branch-2')
-      await createAndCheckout(repository!, 'branch-3')
-      await createAndCheckout(repository!, 'branch-4')
+      await createAndCheckout(repository, 'branch-1')
+      await createAndCheckout(repository, 'branch-2')
+      await createAndCheckout(repository, 'branch-3')
+      await createAndCheckout(repository, 'branch-4')
 
-      const branches = await getRecentBranches(repository!, 2)
+      const branches = await getRecentBranches(repository, 2)
       expect(branches).toHaveLength(2)
       expect(branches).toContain('branch-4')
       expect(branches).toContain('branch-3')

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -84,7 +84,7 @@ describe('git/reflog', () => {
       expect(branches.size).toBe(0)
     })
 
-    it('returns all branches checkedout after a specific date', async () => {
+    it('returns all branches checked out after a specific date', async () => {
       await createBranch(repository!, 'never-checked-out')
       await createAndCheckout(repository!, 'branch-1')
       await createAndCheckout(repository!, 'branch-2')


### PR DESCRIPTION
Supports PR #6544 by adding a function that can get checkouts after a certain date. This is needed specifically for the piece of #750 that states branches shall be pruned if they haven't been touched for 14 days.