### PR TITLE
port linting to use renamed TS parser

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,5 @@
 root: true
-parser: typescript-eslint-parser
+parser: '@typescript-eslint/parser'
 plugins:
   - typescript
   - babel

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -21,6 +21,12 @@ const defaultBranchNameDefaultValue = __DARWIN__
   ? 'Default Branch'
   : 'default branch'
 
+enum ZoomDirection {
+  Reset,
+  In,
+  Out,
+}
+
 export type MenuLabels = {
   editorLabel?: string
   shellLabel?: string
@@ -471,12 +477,6 @@ function emit(name: MenuEvent): ClickHandler {
       ipcMain.emit('menu-event', { name })
     }
   }
-}
-
-enum ZoomDirection {
-  Reset,
-  In,
-  Out,
 }
 
 /** The zoom steps that we support, these factors must sorted */

--- a/eslint-rules/insecure-random.js
+++ b/eslint-rules/insecure-random.js
@@ -1,5 +1,3 @@
-'use strict'
-
 // strings from https://github.com/Microsoft/tslint-microsoft-contrib/blob/b720cd9/src/insecureRandomRule.ts
 const MATH_FAIL_STRING =
   'Math.random produces insecure random numbers. ' +

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "yarn": ">= 1.9"
   },
   "dependencies": {
+    "@typescript-eslint/parser": "^1.0.0",
     "airbnb-browser-shims": "^3.0.0",
     "ajv": "^6.4.0",
     "awesome-node-loader": "^1.1.0",
@@ -113,7 +114,6 @@
     "tslint-microsoft-contrib": "^5.2.1",
     "tslint-react": "^3.6.0",
     "typescript": "^3.2.0",
-    "typescript-eslint-parser": "^20.0.0",
     "typescript-tslint-plugin": "^0.0.6",
     "webpack": "^4.8.3",
     "webpack-bundle-analyzer": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:src": "yarn tslint && yarn eslint-check && yarn eslint",
     "lint:src:fix": "yarn tslint --fix && yarn eslint --fix",
     "tslint": "tslint -p .",
-    "eslint": "eslint --cache --rulesdir ./eslint-rules \"./{script,eslint-rules,tslint-rules}/**/*.{j,t}s{,x}\" \"./app/{src,typings,test}/**/*.{j,t}s{,x}\" \"./changelog.json\"",
+    "eslint": "eslint --cache --rulesdir ./eslint-rules \"./eslint-rules/**/*.js\" \"./{script,tslint-rules}/**/*.ts{,x}\" \"./app/{src,typings,test}/**/*.{j,t}s{,x}\" \"./changelog.json\"",
     "eslint-check": "eslint --print-config .eslintrc.* | eslint-config-prettier-check",
     "publish": "ts-node -P script/tsconfig.json script/publish.ts",
     "clean-slate": "rimraf out node_modules app/node_modules coverage && yarn",


### PR DESCRIPTION
## Overview

This is the follow up to #6506 because it turns out that the TypeScript + ESLint tooling has undergone a transition to a new organization and consolidating work https://eslint.org/blog/2019/01/future-typescript-eslint

## Description

There's two new packages which are relevant to Desktop:

 - [`@typescript-eslint/parser`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser) - this enables ESLint to parse TS files and apply it's rules
 - [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin) - this is a collection of TS-specific rules that can be enabled for projects

I wanted this PR to upgrade both (replacing `typescript-eslint-parser` and `eslint-plugin-typescript`) but the latter package introduces a lot more churn (some of it new, others seem incorrect or unclear) so I'll extract those details to another issue. The second package also has a lot of rules that have come from `tslint`, so perhaps this is a chance for us to try and unify things under `eslint` (one of the areas [where the TypeScript team wants to invest in 2019](https://github.com/Microsoft/TypeScript/issues/29288)).

So this is just the minimum to get us over to the new parser and address the error you might be seeing when working locally:

```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: ~3.1.1

YOUR TYPESCRIPT VERSION: 3.2.2

Please only submit bug reports when using the officially supported version.

=============
```

I'll annotate the PR with more specific notes about the other changes.

## Release notes

Notes: no-notes
