### PR TITLE
disable the app menu bar when there are no tracked repositories

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1001,6 +1001,11 @@ export class App extends React.Component<IAppProps, IAppState> {
       return null
     }
 
+    // Don't render the menu bar when the blank slate is shown
+    if (this.state.repositories.length < 1) {
+      return null
+    }
+
     const currentFoldout = this.state.currentFoldout
 
     // AppMenuBar requires us to pass a strongly typed AppMenuFoldout state or


### PR DESCRIPTION
## Overview

Fixes #6669 

## Description

On current `development` on Windows you can hover your cursor along the top and the app menu appears.

<img width="995" src="https://user-images.githubusercontent.com/359239/51544597-ae215c80-1e36-11e9-90f3-e8c04d7ed23f.png">

With this change, we use the same check for rendering the `BlankSlate` component to skip rendering the `AppMenuBar` (you'll have to imagine me hovering the cursor).

With the dark theme enabled, it no longer renders the app bar menu, which I spotted while investigating the issue:

<img width="989"  src="https://user-images.githubusercontent.com/359239/51544839-1d974c00-1e37-11e9-898e-5298c751c53a.png">

## Release notes

Notes: ensure menu is not visible when in "Let's get started" view on Windows
