### PR TITLE
add get binary files git function

### DIFF
--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -2,7 +2,7 @@
  * get all regex captures within a body of text
  * @param text string to search
  * @param re regex to search with. must have global option and one capture
- * @returns ararys of strings captured by supplied regex
+ * @returns arrays of strings captured by supplied regex
  */
 export function getCaptures(
   text: string,

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -22,6 +22,7 @@ import {
   getWorkingDirectoryDiff,
   getWorkingDirectoryImage,
   getBlobImage,
+  getBinaryPaths,
 } from '../../../src/lib/git'
 import { getStatusOrThrow } from '../../helpers/status'
 
@@ -382,6 +383,44 @@ describe('git/diff', () => {
 
       const diff = await getTextDiff(repo, files[0])
       expect(diff.text).toBe(`@@ -0,0 +1 @@\n+${testString}`)
+    })
+  })
+
+  describe('getBinaryPaths', () => {
+    describe('in empty repo', () => {
+      let repo: Repository
+      beforeEach(async () => {
+        repo = await setupEmptyRepository()
+      })
+      it('throws since HEAD doesnt exist', () => {
+        expect(getBinaryPaths(repo)).rejects.toThrow()
+      })
+    })
+    describe('in repo with text only files', () => {
+      let repo: Repository
+      beforeEach(async () => {
+        const testRepoPath = await setupFixtureRepository('repo-with-changes')
+        repo = new Repository(testRepoPath, -1, null, false)
+      })
+      it('returns an empty array', () => {
+        expect(getBinaryPaths(repo)).resolves.toHaveLength(0)
+      })
+    })
+    describe('in repo with image changes', () => {
+      let repo: Repository
+      beforeEach(async () => {
+        const testRepoPath = await setupFixtureRepository(
+          'repo-with-image-changes'
+        )
+        repo = new Repository(testRepoPath, -1, null, false)
+      })
+      it('returns all changed image files', () => {
+        expect(getBinaryPaths(repo)).resolves.toEqual([
+          'modified-image.jpg',
+          'new-animated-image.gif',
+          'new-image.png',
+        ])
+      })
     })
   })
 })


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

supports #6693 

## Description

- adds a utility function to get the currently modified binary files in a given repository
- the thinking here is that we'll be able to cross reference this with the output of status to help determine which files can have conflict markers and which ones can't
