### PR TITLE
fix manual conflict detection

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -456,6 +456,8 @@ export async function getWorkingDirectoryImage(
  * list the modified binary files' paths in the given repository
  * @param repository to run git operation in
  * @param ref ref (sha, branch, etc) to compare the working index against (is `HEAD` by default)
+ *
+ * if you're mid-merge pass `MERGE_HEAD` to ref to get a diff of `HEAD` vs `MERGE_HEAD`
  */
 export async function getBinaryPaths(
   repository: Repository,

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -455,13 +455,14 @@ export async function getWorkingDirectoryImage(
 /**
  * list the modified binary files' paths in the given repository
  * @param repository to run git operation in
- * @param ref ref (sha, branch, etc) to compare the working index against (is `HEAD` by default)
+ * @param ref ref (sha, branch, etc) to compare the working index against
  *
- * if you're mid-merge pass `MERGE_HEAD` to ref to get a diff of `HEAD` vs `MERGE_HEAD`
+ * if you're mid-merge pass `'MERGE_HEAD'` to ref to get a diff of `HEAD` vs `MERGE_HEAD`,
+ * otherwise you should probably pass `'HEAD'` to get a diff of the working tree vs `HEAD`
  */
 export async function getBinaryPaths(
   repository: Repository,
-  ref: string = 'HEAD'
+  ref: string
 ): Promise<ReadonlyArray<string>> {
   const { output } = await spawnAndComplete(
     ['diff', '--numstat', '-z', ref],

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -202,6 +202,7 @@ export async function getStatus(
         conflictCountsByPath: await getFilesWithConflictMarkers(
           repository.path
         ),
+        // this will use the diff between `HEAD` and `MERGE_HEAD` to find binary files
         binaryFilepaths: await getBinaryPaths(repository, 'MERGE_HEAD'),
       }
     : {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -71,7 +71,7 @@ interface IStatusHeadersData {
 
 type ConflictFilesDetails = {
   conflictCountsByPath: ReadonlyMap<string, number>
-  binaryFilepaths: ReadonlyArray<string>
+  binaryFilePaths: ReadonlyArray<string>
 }
 
 function parseConflictedState(
@@ -81,7 +81,7 @@ function parseConflictedState(
 ): ConflictedFileStatus {
   switch (entry.action) {
     case UnmergedEntrySummary.BothAdded: {
-      const isBinary = conflictDetails.binaryFilepaths.includes(path)
+      const isBinary = conflictDetails.binaryFilePaths.includes(path)
       if (!isBinary) {
         return {
           kind: AppFileStatusKind.Conflicted,
@@ -94,7 +94,7 @@ function parseConflictedState(
       }
     }
     case UnmergedEntrySummary.BothModified: {
-      const isBinary = conflictDetails.binaryFilepaths.includes(path)
+      const isBinary = conflictDetails.binaryFilePaths.includes(path)
       if (!isBinary) {
         return {
           kind: AppFileStatusKind.Conflicted,
@@ -203,11 +203,11 @@ export async function getStatus(
           repository.path
         ),
         // this will use the diff between `HEAD` and `MERGE_HEAD` to find binary files
-        binaryFilepaths: await getBinaryPaths(repository, 'MERGE_HEAD'),
+        binaryFilePaths: await getBinaryPaths(repository, 'MERGE_HEAD'),
       }
     : {
         conflictCountsByPath: new Map<string, number>(),
-        binaryFilepaths: [],
+        binaryFilePaths: [],
       }
 
   // Map of files keyed on their paths.

--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -3,7 +3,6 @@ import {
   AppFileStatus,
   ConflictedFileStatus,
   WorkingDirectoryStatus,
-  isManualConflict,
   isConflictWithMarkers,
 } from '../models/status'
 import { assertNever } from './fatal-error'
@@ -64,11 +63,11 @@ export function hasConflictedFiles(
  * or conflict markers
  */
 export function hasUnresolvedConflicts(status: ConflictedFileStatus) {
-  if (isManualConflict(status)) {
-    // binary file doesn't contain markers
-    return true
+  if (isConflictWithMarkers(status)) {
+    // text file will have conflict markers removed
+    return status.conflictMarkerCount > 0
   }
 
-  // text file will have conflict markers removed
-  return status.conflictMarkerCount > 0
+  // binary file doesn't contain markers
+  return true
 }

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -157,6 +157,16 @@ type TextConflictEntry = {
  */
 type ManualConflictDetails =
   | {
+      readonly action: UnmergedEntrySummary.BothAdded
+      readonly us: GitStatusEntry.Added
+      readonly them: GitStatusEntry.Added
+    }
+  | {
+      readonly action: UnmergedEntrySummary.BothModified
+      readonly us: GitStatusEntry.UpdatedButUnmerged
+      readonly them: GitStatusEntry.UpdatedButUnmerged
+    }
+  | {
       readonly action: UnmergedEntrySummary.AddedByUs
       readonly us: GitStatusEntry.Added
       readonly them: GitStatusEntry.UpdatedButUnmerged

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -402,8 +402,8 @@ describe('git/diff', () => {
         const testRepoPath = await setupFixtureRepository('repo-with-changes')
         repo = new Repository(testRepoPath, -1, null, false)
       })
-      it('returns an empty array', () => {
-        expect(getBinaryPaths(repo, 'HEAD')).resolves.toHaveLength(0)
+      it('returns an empty array', async () => {
+        expect(await getBinaryPaths(repo, 'HEAD')).toHaveLength(0)
       })
     })
     describe('in repo with image changes', () => {
@@ -414,8 +414,8 @@ describe('git/diff', () => {
         )
         repo = new Repository(testRepoPath, -1, null, false)
       })
-      it('returns all changed image files', () => {
-        expect(getBinaryPaths(repo, 'HEAD')).resolves.toEqual([
+      it('returns all changed image files', async () => {
+        expect(await getBinaryPaths(repo, 'HEAD')).toEqual([
           'modified-image.jpg',
           'new-animated-image.gif',
           'new-image.png',
@@ -432,8 +432,8 @@ describe('git/diff', () => {
         await GitProcess.exec(['checkout', 'make-a-change'], repo.path)
         await GitProcess.exec(['merge', 'master'], repo.path)
       })
-      it('returns all conflicted image files', () => {
-        expect(getBinaryPaths(repo, 'MERGE_HEAD')).resolves.toEqual([
+      it('returns all conflicted image files', async () => {
+        expect(await getBinaryPaths(repo, 'MERGE_HEAD')).toEqual([
           'my-cool-image.png',
         ])
       })

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -429,11 +429,12 @@ describe('git/diff', () => {
           'detect-conflict-in-binary-file'
         )
         repo = new Repository(testRepoPath, -1, null, false)
+        await GitProcess.exec(['checkout', 'make-a-change'], repo.path)
+        await GitProcess.exec(['merge', 'master'], repo.path)
       })
       it('returns all conflicted image files', () => {
         expect(getBinaryPaths(repo, 'MERGE_HEAD')).resolves.toEqual([
           'my-cool-image.png',
-          ,
         ])
       })
     })

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -393,7 +393,7 @@ describe('git/diff', () => {
         repo = await setupEmptyRepository()
       })
       it('throws since HEAD doesnt exist', () => {
-        expect(getBinaryPaths(repo)).rejects.toThrow()
+        expect(getBinaryPaths(repo, 'HEAD')).rejects.toThrow()
       })
     })
     describe('in repo with text only files', () => {
@@ -403,7 +403,7 @@ describe('git/diff', () => {
         repo = new Repository(testRepoPath, -1, null, false)
       })
       it('returns an empty array', () => {
-        expect(getBinaryPaths(repo)).resolves.toHaveLength(0)
+        expect(getBinaryPaths(repo, 'HEAD')).resolves.toHaveLength(0)
       })
     })
     describe('in repo with image changes', () => {
@@ -415,7 +415,7 @@ describe('git/diff', () => {
         repo = new Repository(testRepoPath, -1, null, false)
       })
       it('returns all changed image files', () => {
-        expect(getBinaryPaths(repo)).resolves.toEqual([
+        expect(getBinaryPaths(repo, 'HEAD')).resolves.toEqual([
           'modified-image.jpg',
           'new-animated-image.gif',
           'new-image.png',

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -422,5 +422,20 @@ describe('git/diff', () => {
         ])
       })
     })
+    describe('in repo with merge conflicts on image files', () => {
+      let repo: Repository
+      beforeEach(async () => {
+        const testRepoPath = await setupFixtureRepository(
+          'detect-conflict-in-binary-file'
+        )
+        repo = new Repository(testRepoPath, -1, null, false)
+      })
+      it('returns all conflicted image files', () => {
+        expect(getBinaryPaths(repo, 'MERGE_HEAD')).resolves.toEqual([
+          'my-cool-image.png',
+          ,
+        ])
+      })
+    })
   })
 })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -15,9 +15,11 @@ import {
   AppFileStatusKind,
   UnmergedEntrySummary,
   GitStatusEntry,
+  isManualConflict,
 } from '../../../src/models/status'
 import * as temp from 'temp'
 import { getStatus } from '../../../src/lib/git'
+import { isConflictedFile } from '../../../src/lib/status'
 
 const _temp = temp.track()
 const mkdir = _temp.mkdir
@@ -146,6 +148,9 @@ describe('git/status', () => {
 
         const file = files[0]
         expect(file.status.kind).toBe(AppFileStatusKind.Conflicted)
+        expect(
+          isConflictedFile(file.status) && isManualConflict(file.status)
+        ).toBe(true)
       })
 
       it('parses conflicted image file on merge after removing', async () => {
@@ -162,6 +167,9 @@ describe('git/status', () => {
 
         const file = files[0]
         expect(file.status.kind).toBe(AppFileStatusKind.Conflicted)
+        expect(
+          isConflictedFile(file.status) && isManualConflict(file.status)
+        ).toBe(true)
       })
     })
 


### PR DESCRIPTION
~~🌵 🌵 **blocked by #6697** 🌵 🌵~~ 

## Overview

fixes #6693 

### Behavior _after_ this PR

1. <img width="528" alt="screen shot 2019-01-24 at 12 21 02 pm" src="https://user-images.githubusercontent.com/964912/51706246-aeeef580-1fd2-11e9-9abe-09a49a48d746.png">

2. `git checkout --theirs imm.png`

3. <img width="540" alt="screen shot 2019-01-24 at 12 21 23 pm" src="https://user-images.githubusercontent.com/964912/51706250-b1514f80-1fd2-11e9-9a8e-913e8cdf2c2c.png">


## Description

- tightens up tests around binary merge conflicts
- uses whether a file is considered binary by git to decide if it can have conflict markers

## Release notes

Notes: [Fixed] Fix manual conflict detection for binary files
