### PR TITLE
Wireup Lua and Fortran Syntax highlighting

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -240,6 +240,19 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.vb': 'text/x-vb',
     },
   },
+  {
+    install: () => import('codemirror/mode/fortran/fortran'),
+    mappings: {
+      '.f': 'text/x-fortran',
+      '.f90': 'text/x-fortran',
+    },
+  },
+  {
+    install: () => import('codemirror/mode/lua/lua'),
+    mappings: {
+      '.lua': 'text/x-lua',
+    },
+  },
 ]
 
 /**

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, JavaServer Pages, PowerShell, Docker, Visual Basic
+JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, JavaServer Pages, PowerShell, Docker, Visual Basic, Fortran, Lua
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
## Overview

**Closes #6700**
Highlighter-tests pull is [here](https://github.com/desktop/highlighter-tests/pull/32)

## Description

Wires up Lua and Fortran Syntax highlighting.

## Release notes

Adds Syntax-Highlighting Support for Fortran and Lua.

