### PR TITLE
1.6.2 beta 1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.2-beta0",
+  "version": "1.6.2-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -12,7 +12,7 @@
       "[Improved] Add link to all release notes in Release Notes dialog - #6443. Thanks @koralcem!",
       "[Improved] Arrow for renamed/copied changes when viewing commit - #6519. Thanks @koralcem!",
       "[Improved] Menu state updating to address race condition - #6643",
-      "[Improved] \"Ignore File\" context menu label - #6689. Thanks @PaulViola!"
+      "[Improved] Updated verbiage when clicking on changed files to make it more explicit what will occur when you ignore the file(s) - #6689. Thanks @PaulViola!"
     ],
     "1.6.2-beta0": [
       "[Fixed] Don't show \"No local changes\" view when switching between changed files"

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.6.2-beta1": [
-      "[Added] Automatic switching between Dark Mode and Light on macOS - #5037. Thanks @say25!",
+      "[Added] Automatic switching between Dark and Light modes on macOS - #5037. Thanks @say25!",
       "[Added] Lua and Fortran syntax highlighting - #6700. Thanks @SimpleBinary!",
       "[Fixed] Abbreviated commits are not long enough for large repositories - #6662. Thanks @say25!",
       "[Fixed] App menu bar visible on hover on Windows when in \"Let’s get started\" mode - #6669",

--- a/changelog.json
+++ b/changelog.json
@@ -7,6 +7,8 @@
       "[Fixed] App menu bar visible on hover on Windows when in \"Let’s get started\" mode - #6669",
       "[Fixed] Remember scroll positions in History and Changes lists - #5177 #5059. Thanks @Daniel-McCarthy!",
       "[Fixed] Inconsistent \"Reveal in …\" labels for context menus - #6466. Thanks @say25!",
+      "[Fixed] Prevent concurrent fetches between user and status indicator checks - #6121 #5438 #5328",
+      "[Fixed] Merge conflict conflict did not ask user to resolve some binary files - #6693",
       "[Improved] Add link to all release notes in Release Notes dialog - #6443. Thanks @koralcem!",
       "[Improved] Arrow for renamed/copied changes when viewing commit - #6519. Thanks @koralcem!",
       "[Improved] Menu state updating to address race condition - #6643",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,17 @@
 {
   "releases": {
+    "1.6.2-beta1": [
+      "[Added] Automatic switching between Dark Mode and Light on macOS - #5037. Thanks @say25!",
+      "[Added] Lua and Fortran syntax highlighting - #6700. Thanks @SimpleBinary!",
+      "[Fixed] Abbreviated commits are not long enough for large repositories - #6662. Thanks @say25!",
+      "[Fixed] App menu bar visible on hover on Windows when in \"Let’s get started\" mode - #6669",
+      "[Fixed] Remember scroll positions in History and Changes lists - #5177 #5059. Thanks @Daniel-McCarthy!",
+      "[Fixed] Inconsistent \"Reveal in …\" labels for context menus - #6466. Thanks @say25!",
+      "[Improved] Add link to all release notes in Release Notes dialog - #6443. Thanks @koralcem!",
+      "[Improved] Arrow for renamed/copied changes when viewing commit - #6519. Thanks @koralcem!",
+      "[Improved] Menu state updating to address race condition - #6643",
+      "[Improved] \"Ignore File\" context menu label - #6689. Thanks @PaulViola!"
+    ],
     "1.6.2-beta0": [
       "[Fixed] Don't show \"No local changes\" view when switching between changed files"
     ],


### PR DESCRIPTION
## Overview

We'll be distracted next week by catching up at a team offsite, so I want to start the 1.6.2 beta process as early as possible. I might rebase this on `development` if there's anything else that people would like to get in for the beta.

~~It's getting late on Friday so might ship this beta tomorrow before jumping on a ✈️. We'll see.~~

**Planning to publish this beta Monday ~~morning~~ afternoon PST**

## Release notes

Notes: no-notes
