### PR TITLE
add Git tests for our current pull behaviour

### DIFF
--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -94,7 +94,7 @@ export async function setupConflictedRepo(): Promise<Repository> {
 
   const firstCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: Buffer.from('') }],
+    entries: [{ path: 'foo', value: '' }],
   }
 
   await makeCommit(repo, firstCommit)
@@ -105,7 +105,7 @@ export async function setupConflictedRepo(): Promise<Repository> {
 
   const secondCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: Buffer.from('b1') }],
+    entries: [{ path: 'foo', value: 'b1' }],
   }
 
   await makeCommit(repo, secondCommit)
@@ -114,7 +114,7 @@ export async function setupConflictedRepo(): Promise<Repository> {
 
   const thirdCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: Buffer.from('b2') }],
+    entries: [{ path: 'foo', value: 'b2' }],
   }
   await makeCommit(repo, thirdCommit)
 

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -93,7 +93,6 @@ export async function setupConflictedRepo(): Promise<Repository> {
   const repo = await setupEmptyRepository()
 
   const firstCommit = {
-    commitMessage: 'Commit',
     entries: [{ path: 'foo', contents: '' }],
   }
 
@@ -104,7 +103,6 @@ export async function setupConflictedRepo(): Promise<Repository> {
   await GitProcess.exec(['branch', 'other-branch'], repo.path)
 
   const secondCommit = {
-    commitMessage: 'Commit',
     entries: [{ path: 'foo', contents: 'b1' }],
   }
 
@@ -113,7 +111,6 @@ export async function setupConflictedRepo(): Promise<Repository> {
   await switchTo(repo, 'other-branch')
 
   const thirdCommit = {
-    commitMessage: 'Commit',
     entries: [{ path: 'foo', contents: 'b2' }],
   }
   await makeCommit(repo, thirdCommit)
@@ -146,7 +143,6 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   ]
 
   const firstCommit = {
-    commitMessage: 'Commit',
     entries: [{ path: 'foo', contents: 'b0' }, { path: 'bar', contents: 'b0' }],
   }
 
@@ -157,7 +153,6 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   await GitProcess.exec(['branch', 'other-branch'], repo.path)
 
   const secondCommit = {
-    commitMessage: 'Commit',
     entries: [
       { path: 'foo', contents: 'b1' },
       { path: 'bar', contents: null },
@@ -171,7 +166,6 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   await switchTo(repo, 'other-branch')
 
   const thirdCommit = {
-    commitMessage: 'Commit',
     entries: [
       { path: 'foo', contents: 'b2' },
       { path: 'bar', contents: 'b2' },

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -94,7 +94,7 @@ export async function setupConflictedRepo(): Promise<Repository> {
 
   const firstCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: '' }],
+    entries: [{ path: 'foo', contents: '' }],
   }
 
   await makeCommit(repo, firstCommit)
@@ -105,7 +105,7 @@ export async function setupConflictedRepo(): Promise<Repository> {
 
   const secondCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: 'b1' }],
+    entries: [{ path: 'foo', contents: 'b1' }],
   }
 
   await makeCommit(repo, secondCommit)
@@ -114,7 +114,7 @@ export async function setupConflictedRepo(): Promise<Repository> {
 
   const thirdCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: 'b2' }],
+    entries: [{ path: 'foo', contents: 'b2' }],
   }
   await makeCommit(repo, thirdCommit)
 
@@ -147,7 +147,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
 
   const firstCommit = {
     commitMessage: 'Commit',
-    entries: [{ path: 'foo', value: 'b0' }, { path: 'bar', value: 'b0' }],
+    entries: [{ path: 'foo', contents: 'b0' }, { path: 'bar', contents: 'b0' }],
   }
 
   await makeCommit(repo, firstCommit)
@@ -159,10 +159,10 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   const secondCommit = {
     commitMessage: 'Commit',
     entries: [
-      { path: 'foo', value: 'b1' },
-      { path: 'bar', value: null },
-      { path: 'baz', value: 'b1' },
-      { path: 'cat', value: 'b1' },
+      { path: 'foo', contents: 'b1' },
+      { path: 'bar', contents: null },
+      { path: 'baz', contents: 'b1' },
+      { path: 'cat', contents: 'b1' },
     ],
   }
 
@@ -173,10 +173,10 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   const thirdCommit = {
     commitMessage: 'Commit',
     entries: [
-      { path: 'foo', value: 'b2' },
-      { path: 'bar', value: 'b2' },
-      { path: 'baz', value: 'b2' },
-      { path: 'cat', value: 'b2' },
+      { path: 'foo', contents: 'b2' },
+      { path: 'bar', contents: 'b2' },
+      { path: 'baz', contents: 'b2' },
+      { path: 'cat', contents: 'b2' },
     ],
   }
 

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -3,6 +3,8 @@
 import * as Path from 'path'
 import * as FSE from 'fs-extra'
 
+import { mkdirSync } from './temp'
+
 const klawSync = require('klaw-sync')
 
 import { Repository } from '../../src/models/repository'
@@ -11,12 +13,6 @@ import { GitProcess } from 'dugite'
 type KlawEntry = {
   path: string
 }
-
-import * as temp from 'temp'
-const _temp = temp.track()
-
-export const mkdirSync = _temp.mkdirSync
-export const openSync = _temp.openSync
 
 /**
  * Set up the named fixture repository to be used in a test.
@@ -32,7 +28,7 @@ export async function setupFixtureRepository(
     'fixtures',
     repositoryName
   )
-  const testRepoPath = _temp.mkdirSync('desktop-git-test-')
+  const testRepoPath = mkdirSync('desktop-git-test-')
   await FSE.copy(testRepoFixturePath, testRepoPath)
 
   await FSE.rename(
@@ -66,7 +62,7 @@ export async function setupFixtureRepository(
  * @returns the new local repository
  */
 export async function setupEmptyRepository(): Promise<Repository> {
-  const repoPath = _temp.mkdirSync('desktop-empty-repo-')
+  const repoPath = mkdirSync('desktop-empty-repo-')
   await GitProcess.exec(['init'], repoPath)
 
   return new Repository(repoPath, -1, null, false)
@@ -78,7 +74,7 @@ export async function setupEmptyRepository(): Promise<Repository> {
  * interactions.
  */
 export function setupEmptyDirectory(): Repository {
-  const repoPath = _temp.mkdirSync('no-repository-here')
+  const repoPath = mkdirSync('no-repository-here')
   return new Repository(repoPath, -1, null, false)
 }
 

--- a/app/test/helpers/repository-builder-pull-test.ts
+++ b/app/test/helpers/repository-builder-pull-test.ts
@@ -1,0 +1,74 @@
+import { Repository } from '../../src/models/repository'
+import { setupEmptyRepository } from './repositories'
+import { makeCommit, switchTo } from './repository-scaffolding'
+
+/**
+ * Creates a test repository with two commits on `master`, and then
+ * two commits on `branchName` to be used as the branch for testing pull
+ * behaviour
+
+ * @param branchName name to use for new branch
+ */
+export async function createRepository(
+  branchName: string
+): Promise<Repository> {
+  const repository = await setupEmptyRepository()
+
+  // make two commits on `master` to setup the README
+
+  const firstCommit = {
+    commitMessage: 'First!',
+    entries: [
+      {
+        path: 'README.md',
+        value: Buffer.from('# HELLO WORLD! \n'),
+      },
+    ],
+  }
+
+  await makeCommit(repository, firstCommit)
+
+  const secondCommit = {
+    commitMessage: 'Second!',
+    entries: [
+      {
+        path: 'THING.md',
+        value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\n'),
+      },
+      {
+        path: 'OTHER.md',
+        value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\n'),
+      },
+    ],
+  }
+
+  await makeCommit(repository, secondCommit)
+
+  await switchTo(repository, branchName)
+
+  const firstCommitToBranch = {
+    commitMessage: 'Added a new file',
+    entries: [
+      {
+        path: 'CONTRIBUTING.md',
+        value: Buffer.from(''),
+      },
+    ],
+  }
+
+  await makeCommit(repository, firstCommitToBranch)
+
+  const secondCommitToBranch = {
+    commitMessage: 'Updated README',
+    entries: [
+      {
+        path: 'README.md',
+        value: Buffer.from('things go here'),
+      },
+    ],
+  }
+
+  await makeCommit(repository, secondCommitToBranch)
+
+  return repository
+}

--- a/app/test/helpers/repository-builder-pull-test.ts
+++ b/app/test/helpers/repository-builder-pull-test.ts
@@ -6,7 +6,7 @@ import { makeCommit, switchTo } from './repository-scaffolding'
  * Creates a test repository with two commits on `master`, and then
  * two commits on `branchName` to be used as the branch for testing pull
  * behaviour
-
+ *
  * @param branchName name to use for new branch
  */
 export async function createRepository(

--- a/app/test/helpers/repository-builder-pull-test.ts
+++ b/app/test/helpers/repository-builder-pull-test.ts
@@ -21,7 +21,7 @@ export async function createRepository(
     entries: [
       {
         path: 'README.md',
-        value: Buffer.from('# HELLO WORLD! \n'),
+        contents: '# HELLO WORLD! \n',
       },
     ],
   }
@@ -33,11 +33,11 @@ export async function createRepository(
     entries: [
       {
         path: 'THING.md',
-        value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\n'),
+        contents: '# HELLO WORLD! \nTHINGS GO HERE\n',
       },
       {
         path: 'OTHER.md',
-        value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\n'),
+        contents: '# HELLO WORLD! \nTHINGS GO HERE\n',
       },
     ],
   }
@@ -51,7 +51,7 @@ export async function createRepository(
     entries: [
       {
         path: 'CONTRIBUTING.md',
-        value: Buffer.from(''),
+        contents: '',
       },
     ],
   }
@@ -63,7 +63,7 @@ export async function createRepository(
     entries: [
       {
         path: 'README.md',
-        value: Buffer.from('things go here'),
+        contents: 'things go here',
       },
     ],
   }

--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -6,8 +6,14 @@ import { Repository } from '../../src/models/repository'
 import { mkdirSync } from './temp'
 
 type TreeEntry = {
+  /** The relative path of the file in the repository */
   readonly path: string
-  readonly value: Buffer
+  /**
+   * The contents associated with the current path.
+   *
+   * Use `null` to remove the file from the working directory before committing
+   */
+  readonly value: Buffer | string | null
 }
 
 type Tree = {
@@ -40,7 +46,11 @@ export async function cloneRepository(
 export async function makeCommit(repository: Repository, tree: Tree) {
   for (const entry of tree.entries) {
     const fullPath = Path.join(repository.path, entry.path)
-    await FSE.writeFile(fullPath, entry.value)
+    if (entry.value === null) {
+      await GitProcess.exec(['rm', entry.path], repository.path)
+    } else {
+      await FSE.writeFile(fullPath, entry.value)
+    }
   }
 
   await GitProcess.exec(['add', '.'], repository.path)

--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -55,12 +55,11 @@ export async function makeCommit(repository: Repository, tree: Tree) {
       await GitProcess.exec(['rm', entry.path], repository.path)
     } else {
       await FSE.writeFile(fullPath, entry.contents)
+      await GitProcess.exec(['add', entry.path], repository.path)
     }
   }
 
   const message = tree.commitMessage || 'commit'
-
-  await GitProcess.exec(['add', '.'], repository.path)
   await GitProcess.exec(['commit', '-m', message], repository.path)
 }
 

--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -13,7 +13,7 @@ type TreeEntry = {
    *
    * Use `null` to remove the file from the working directory before committing
    */
-  readonly value: Buffer | string | null
+  readonly contents: Buffer | string | null
 }
 
 type Tree = {
@@ -46,10 +46,10 @@ export async function cloneRepository(
 export async function makeCommit(repository: Repository, tree: Tree) {
   for (const entry of tree.entries) {
     const fullPath = Path.join(repository.path, entry.path)
-    if (entry.value === null) {
+    if (entry.contents === null) {
       await GitProcess.exec(['rm', entry.path], repository.path)
     } else {
-      await FSE.writeFile(fullPath, entry.value)
+      await FSE.writeFile(fullPath, entry.contents)
     }
   }
 

--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -17,8 +17,13 @@ type TreeEntry = {
 }
 
 type Tree = {
-  readonly commitMessage: string
   readonly entries: ReadonlyArray<TreeEntry>
+  /**
+   * Optional commit message to pass to Git.
+   *
+   * If undefined, `'commit'` will be used.
+   */
+  readonly commitMessage?: string
 }
 
 /**
@@ -53,8 +58,10 @@ export async function makeCommit(repository: Repository, tree: Tree) {
     }
   }
 
+  const message = tree.commitMessage || 'commit'
+
   await GitProcess.exec(['add', '.'], repository.path)
-  await GitProcess.exec(['commit', '-m', tree.commitMessage], repository.path)
+  await GitProcess.exec(['commit', '-m', message], repository.path)
 }
 
 export async function switchTo(repository: Repository, branch: string) {

--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -1,0 +1,63 @@
+import { GitProcess } from 'dugite'
+import * as FSE from 'fs-extra'
+import * as Path from 'path'
+
+import { Repository } from '../../src/models/repository'
+import { mkdirSync } from './temp'
+
+type TreeEntry = {
+  readonly path: string
+  readonly value: Buffer
+}
+
+type Tree = {
+  readonly commitMessage: string
+  readonly entries: ReadonlyArray<TreeEntry>
+}
+
+/**
+ * Clone a local Git repository to a new temporary directory, so that
+ * push/pull/fetch operations can be tested without requiring the network.
+ */
+export async function cloneRepository(
+  repository: Repository
+): Promise<Repository> {
+  const newDirectory = mkdirSync('desktop-git-clone-')
+
+  await GitProcess.exec(
+    ['clone', repository.path, '--', newDirectory],
+    __dirname
+  )
+
+  return new Repository(newDirectory, -2, null, false)
+}
+
+/**
+ * Make a commit tot he repository by creating the specified files in the
+ * working directory, staging all changes, and then committing with the
+ * specified message.
+ */
+export async function makeCommit(repository: Repository, tree: Tree) {
+  for (const entry of tree.entries) {
+    const fullPath = Path.join(repository.path, entry.path)
+    await FSE.writeFile(fullPath, entry.value)
+  }
+
+  await GitProcess.exec(['add', '.'], repository.path)
+  await GitProcess.exec(['commit', '-m', tree.commitMessage], repository.path)
+}
+
+export async function switchTo(repository: Repository, branch: string) {
+  const result = await GitProcess.exec(
+    ['rev-parse', '--verify', branch],
+    repository.path
+  )
+
+  if (result.exitCode === 128) {
+    // ref does not exists, checkout and create the branch
+    await GitProcess.exec(['checkout', '-b', branch], repository.path)
+  } else {
+    // just switch to the branch
+    await GitProcess.exec(['checkout', branch], repository.path)
+  }
+}

--- a/app/test/helpers/temp.ts
+++ b/app/test/helpers/temp.ts
@@ -1,7 +1,18 @@
 /* eslint-disable no-sync */
 
+/** Module for creating and managing temporary directories and files, using the
+ * `temp` Node module
+ */
 import * as temp from 'temp'
 const _temp = temp.track()
 
+/**
+ * Open a new temporary directory, specifying the prefix/suffix options the
+ * directory should use
+ */
 export const mkdirSync = _temp.mkdirSync
+/**
+ * Open a new temporary file, specifying the prefix/suffix options the file
+ * should use
+ */
 export const openSync = _temp.openSync

--- a/app/test/helpers/temp.ts
+++ b/app/test/helpers/temp.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-sync */
+
+import * as temp from 'temp'
+const _temp = temp.track()
+
+export const mkdirSync = _temp.mkdirSync
+export const openSync = _temp.openSync

--- a/app/test/helpers/tip.ts
+++ b/app/test/helpers/tip.ts
@@ -1,0 +1,15 @@
+import { getCommit } from '../../src/lib/git'
+import { Commit } from '../../src/models/commit'
+import { Repository } from '../../src/models/repository'
+
+export async function getTipOrError(repository: Repository): Promise<Commit> {
+  const commit = await getCommit(repository, 'HEAD')
+
+  if (commit === null) {
+    throw new Error(
+      'Unable to find commit for HEAD - is this an unborn repository?'
+    )
+  }
+
+  return commit
+}

--- a/app/test/helpers/tip.ts
+++ b/app/test/helpers/tip.ts
@@ -7,7 +7,7 @@ export async function getTipOrError(repository: Repository): Promise<Commit> {
 
   if (commit === null) {
     throw new Error(
-      'Unable to find commit for HEAD - is this an unborn repository?'
+      'Unable to find commit for HEAD - check that you are not working with an unborn repository'
     )
   }
 
@@ -22,7 +22,7 @@ export async function getRefOrError(
 
   if (commit === null) {
     throw new Error(
-      'Unable to find commit for HEAD - is this an unborn repository?'
+      `Unable to find commit for ${ref} - check that this exists in the repository`
     )
   }
 

--- a/app/test/helpers/tip.ts
+++ b/app/test/helpers/tip.ts
@@ -13,3 +13,18 @@ export async function getTipOrError(repository: Repository): Promise<Commit> {
 
   return commit
 }
+
+export async function getRefOrError(
+  repository: Repository,
+  ref: string
+): Promise<Commit> {
+  const commit = await getCommit(repository, ref)
+
+  if (commit === null) {
+    throw new Error(
+      'Unable to find commit for HEAD - is this an unborn repository?'
+    )
+  }
+
+  return commit
+}

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -8,7 +8,9 @@ import {
   getGlobalConfigValue,
   setGlobalConfigValue,
 } from '../../../src/lib/git'
-import { setupFixtureRepository, mkdirSync } from '../../helpers/repositories'
+
+import { mkdirSync } from '../../helpers/temp'
+import { setupFixtureRepository } from '../../helpers/repositories'
 
 describe('git/config', () => {
   let repository: Repository | null = null

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -33,7 +33,7 @@ describe('git/pull', () => {
         entries: [
           {
             path: 'README.md',
-            value: Buffer.from('# HELLO WORLD! \n WORDS GO HERE! \nLOL'),
+            contents: '# HELLO WORLD! \n WORDS GO HERE! \nLOL',
           },
         ],
       }
@@ -45,7 +45,7 @@ describe('git/pull', () => {
         entries: [
           {
             path: 'CONTRIBUTING.md',
-            value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+            contents: '# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS',
           },
         ],
       }

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -1,0 +1,144 @@
+import {
+  fetch,
+  pull,
+  getAheadBehind,
+  revSymmetricDifference,
+} from '../../../../src/lib/git'
+import { Commit } from '../../../../src/models/commit'
+import { Repository } from '../../../../src/models/repository'
+import { createRepository } from '../../../helpers/repository-builder-pull-test'
+import {
+  cloneRepository,
+  makeCommit,
+} from '../../../helpers/repository-scaffolding'
+import { getTipOrError, getRefOrError } from '../../../helpers/tip'
+import { GitProcess } from 'dugite'
+
+const featureBranch = 'this-is-a-feature'
+const origin = 'origin'
+const remoteBranch = `${origin}/${featureBranch}`
+
+describe('git/pull', () => {
+  describe('ahead and behind of tracking branch', () => {
+    let repository: Repository
+
+    beforeEach(async () => {
+      const remoteRepository = await createRepository(featureBranch)
+      repository = await cloneRepository(remoteRepository)
+
+      // make a commits to both remote and local so histories diverge
+
+      const changesForRemoteRepository = {
+        commitMessage: 'Changed a file in the remote repository',
+        entries: [
+          {
+            path: 'README.md',
+            value: Buffer.from('# HELLO WORLD! \n WORDS GO HERE! \nLOL'),
+          },
+        ],
+      }
+
+      await makeCommit(remoteRepository, changesForRemoteRepository)
+
+      const changesForLocalRepository = {
+        commitMessage: 'Added a new file to the local repository',
+        entries: [
+          {
+            path: 'CONTRIBUTING.md',
+            value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+          },
+        ],
+      }
+
+      await makeCommit(repository, changesForLocalRepository)
+      await fetch(repository, null, origin)
+    })
+
+    describe('by default', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('creates a merge commit', async () => {
+        const newTip = await getTipOrError(repository)
+
+        expect(newTip.sha).not.toBe(previousTip.sha)
+        expect(newTip.parentSHAs).toHaveLength(2)
+      })
+
+      it('is different from remote branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).not.toBe(newTip.sha)
+      })
+
+      it('is ahead of tracking branch', async () => {
+        const range = revSymmetricDifference(
+          featureBranch,
+          `${origin}/${featureBranch}`
+        )
+
+        const aheadBehind = await getAheadBehind(repository, range)
+        expect(aheadBehind).toEqual({
+          ahead: 2,
+          behind: 0,
+        })
+      })
+    })
+
+    describe('with pull.ff=false set in config', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.ff', 'false'],
+          repository.path
+        )
+
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('creates a merge commit', async () => {
+        expect(newTip.sha).not.toBe(previousTip.sha)
+        expect(newTip.parentSHAs).toHaveLength(2)
+      })
+
+      it('is ahead of tracking branch', async () => {
+        const range = revSymmetricDifference(
+          featureBranch,
+          `${origin}/${featureBranch}`
+        )
+
+        const aheadBehind = await getAheadBehind(repository, range)
+        expect(aheadBehind).toEqual({
+          ahead: 2,
+          behind: 0,
+        })
+      })
+    })
+
+    describe('with pull.ff=only set in config', () => {
+      beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.ff', 'only'],
+          repository.path
+        )
+      })
+
+      it(`throws an error as the user blocks merge commits on pull`, async () => {
+        expect(pull(repository, null, origin)).rejects.toThrow()
+      })
+    })
+  })
+})

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -136,7 +136,7 @@ describe('git/pull', () => {
         )
       })
 
-      it(`throws an error as the user blocks merge commits on pull`, async () => {
+      it(`throws an error as the user blocks merge commits on pull`, () => {
         expect(pull(repository, null, origin)).rejects.toThrow()
       })
     })

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -1,0 +1,152 @@
+import {
+  fetch,
+  pull,
+  getAheadBehind,
+  revSymmetricDifference,
+} from '../../../../src/lib/git'
+import { Commit } from '../../../../src/models/commit'
+import { Repository } from '../../../../src/models/repository'
+import { createRepository } from '../../../helpers/repository-builder-pull-test'
+import {
+  cloneRepository,
+  makeCommit,
+} from '../../../helpers/repository-scaffolding'
+import { getTipOrError, getRefOrError } from '../../../helpers/tip'
+import { GitProcess } from 'dugite'
+
+const featureBranch = 'this-is-a-feature'
+const origin = 'origin'
+const remoteBranch = `${origin}/${featureBranch}`
+
+describe('git/pull', () => {
+  describe('only ahead of tracking branch', () => {
+    let repository: Repository
+
+    beforeEach(async () => {
+      const remoteRepository = await createRepository(featureBranch)
+      repository = await cloneRepository(remoteRepository)
+
+      // add a commit to the local branch so that it is now "ahead"
+
+      const changesForLocalRepository = {
+        commitMessage: 'Added a new file to the local repository',
+        entries: [
+          {
+            path: 'CONTRIBUTING.md',
+            value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+          },
+        ],
+      }
+
+      await makeCommit(repository, changesForLocalRepository)
+      await fetch(repository, null, origin)
+    })
+
+    describe('by default', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('does not create new commit', async () => {
+        expect(newTip.sha).toBe(previousTip.sha)
+      })
+
+      it('is different to tracking branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).not.toBe(newTip.sha)
+      })
+
+      it('remains ahead of tracking branch', async () => {
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
+
+        const aheadBehind = await getAheadBehind(repository, range)
+
+        expect(aheadBehind).toEqual({
+          ahead: 1,
+          behind: 0,
+        })
+      })
+    })
+
+    describe('with pull.ff=false set in config', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.ff', 'false'],
+          repository.path
+        )
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('does not create new commit', async () => {
+        expect(newTip.sha).toBe(previousTip.sha)
+      })
+
+      it('is different to tracking branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).not.toBe(newTip.sha)
+      })
+
+      it('is ahead of tracking branch', async () => {
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
+
+        const aheadBehind = await getAheadBehind(repository, range)
+        expect(aheadBehind).toEqual({
+          ahead: 1,
+          behind: 0,
+        })
+      })
+    })
+
+    describe('with pull.ff=only set in config', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.ff', 'only'],
+          repository.path
+        )
+
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('does not create new commit', async () => {
+        expect(newTip.sha).toBe(previousTip.sha)
+      })
+
+      it('is different from tracking branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).not.toBe(newTip.sha)
+      })
+
+      it('is ahead of tracking branch', async () => {
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
+
+        const aheadBehind = await getAheadBehind(repository, range)
+
+        expect(aheadBehind).toEqual({
+          ahead: 1,
+          behind: 0,
+        })
+      })
+    })
+  })
+})

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -58,7 +58,7 @@ describe('git/pull', () => {
         expect(newTip.sha).toBe(previousTip.sha)
       })
 
-      it('is different to tracking branch', async () => {
+      it('is different from tracking branch', async () => {
         const remoteCommit = await getRefOrError(repository, remoteBranch)
         expect(remoteCommit.sha).not.toBe(newTip.sha)
       })

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -33,7 +33,7 @@ describe('git/pull', () => {
         entries: [
           {
             path: 'CONTRIBUTING.md',
-            value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+            contents: '# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS',
           },
         ],
       }

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -1,0 +1,170 @@
+import {
+  fetch,
+  pull,
+  getAheadBehind,
+  revSymmetricDifference,
+} from '../../../../src/lib/git'
+import { Commit } from '../../../../src/models/commit'
+import { Repository } from '../../../../src/models/repository'
+import { createRepository } from '../../../helpers/repository-builder-pull-test'
+import {
+  cloneRepository,
+  makeCommit,
+} from '../../../helpers/repository-scaffolding'
+import { getTipOrError, getRefOrError } from '../../../helpers/tip'
+import { GitProcess } from 'dugite'
+
+const featureBranch = 'this-is-a-feature'
+const origin = 'origin'
+const remoteBranch = `${origin}/${featureBranch}`
+
+describe('git/pull', () => {
+  describe('only behind tracking branch', () => {
+    let repository: Repository
+
+    beforeEach(async () => {
+      const remoteRepository = await createRepository(featureBranch)
+      repository = await cloneRepository(remoteRepository)
+
+      // make commits to remote is ahead of local repository
+
+      const firstCommit = {
+        commitMessage: 'Changed a file in the remote repository',
+        entries: [
+          {
+            path: 'README.md',
+            value: Buffer.from('# HELLO WORLD! \n WORDS GO HERE! \nLOL'),
+          },
+        ],
+      }
+
+      const secondCommit = {
+        commitMessage: 'Added a new file to the remote repository',
+        entries: [
+          {
+            path: 'CONTRIBUTING.md',
+            value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+          },
+        ],
+      }
+
+      await makeCommit(remoteRepository, firstCommit)
+      await makeCommit(remoteRepository, secondCommit)
+
+      await fetch(repository, null, origin)
+    })
+
+    describe('by default', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('moves local repository to remote commit', async () => {
+        const newTip = await getTipOrError(repository)
+
+        expect(newTip.sha).not.toBe(previousTip.sha)
+        expect(newTip.parentSHAs).toHaveLength(1)
+      })
+
+      it('is same as remote branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).toBe(newTip.sha)
+      })
+
+      it('is not behind tracking branch', async () => {
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
+
+        const aheadBehind = await getAheadBehind(repository, range)
+        expect(aheadBehind).toEqual({
+          ahead: 0,
+          behind: 0,
+        })
+      })
+    })
+
+    describe('with pull.ff=false set in config', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.ff', 'false'],
+          repository.path
+        )
+
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('creates a merge commit', async () => {
+        expect(newTip.sha).not.toBe(previousTip.sha)
+        expect(newTip.parentSHAs).toHaveLength(2)
+      })
+
+      it('is different from remote branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).not.toBe(newTip.sha)
+      })
+
+      it('is now ahead of tracking branch', async () => {
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
+
+        const aheadBehind = await getAheadBehind(repository, range)
+        expect(aheadBehind).toEqual({
+          ahead: 1,
+          behind: 0,
+        })
+      })
+    })
+
+    describe('with pull.ff=only set in config', () => {
+      let previousTip: Commit
+      let newTip: Commit
+
+      beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.ff', 'only'],
+          repository.path
+        )
+
+        previousTip = await getTipOrError(repository)
+
+        await pull(repository, null, origin)
+
+        newTip = await getTipOrError(repository)
+      })
+
+      it('does not create a merge commit', async () => {
+        const newTip = await getTipOrError(repository)
+
+        expect(newTip.sha).not.toBe(previousTip.sha)
+        expect(newTip.parentSHAs).toHaveLength(1)
+      })
+
+      it('is same as remote branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).toBe(newTip.sha)
+      })
+
+      it('is not behind tracking branch', async () => {
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
+
+        const aheadBehind = await getAheadBehind(repository, range)
+        expect(aheadBehind).toEqual({
+          ahead: 0,
+          behind: 0,
+        })
+      })
+    })
+  })
+})

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -33,7 +33,7 @@ describe('git/pull', () => {
         entries: [
           {
             path: 'README.md',
-            value: Buffer.from('# HELLO WORLD! \n WORDS GO HERE! \nLOL'),
+            contents: '# HELLO WORLD! \n WORDS GO HERE! \nLOL',
           },
         ],
       }
@@ -43,7 +43,7 @@ describe('git/pull', () => {
         entries: [
           {
             path: 'CONTRIBUTING.md',
-            value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+            contents: '# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS',
           },
         ],
       }

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -11,10 +11,10 @@ import {
 import { git } from '../../../src/lib/git/core'
 import {
   setupFixtureRepository,
-  mkdirSync,
   setupEmptyRepository,
 } from '../../helpers/repositories'
 import { GitProcess } from 'dugite'
+import { mkdirSync } from '../../helpers/temp'
 
 describe('git/rev-parse', () => {
   let repository: Repository | null = null

--- a/app/test/unit/validated-repository-path-test.ts
+++ b/app/test/unit/validated-repository-path-test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-sync */
 
-import { setupFixtureRepository, openSync } from '../helpers/repositories'
+import { setupFixtureRepository } from '../helpers/repositories'
+import { openSync } from '../helpers/temp'
 import { validatedRepositoryPath } from '../../src/lib/stores/helpers/validated-repository-path'
 
 describe('validatedRepositoryPath', () => {

--- a/docs/technical/crafting-git-tests.md
+++ b/docs/technical/crafting-git-tests.md
@@ -96,7 +96,7 @@ describe('ahead and behind of tracking branch', () => {
       entries: [
         {
           path: 'README.md',
-          value: Buffer.from('# HELLO WORLD! \n WORDS GO HERE! \nLOL'),
+          contents: '# HELLO WORLD! \n WORDS GO HERE! \nLOL',
         },
       ],
     }
@@ -108,7 +108,7 @@ describe('ahead and behind of tracking branch', () => {
       entries: [
         {
           path: 'CONTRIBUTING.md',
-          value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+          contents: '# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS',
         },
       ],
     }

--- a/docs/technical/crafting-git-tests.md
+++ b/docs/technical/crafting-git-tests.md
@@ -1,0 +1,180 @@
+# Crafting Git Tests
+
+This document outlines the options available for creating tests around Git
+repositories and data.
+
+## Repository Fixtures
+
+The `app/test/fixtures` directory is a special folder on disk that can be used
+to capture snapshots of a Git repository for testing. This is ideal for
+situations where:
+
+ - capturing the whole repository state (including working directory and
+   config), such as a regression test
+ - the manual work to create the repository from scratch is not worth performing
+   on every test run
+
+There are some downsides to this approach:
+
+ - the entire repository is committed within the Desktop repository, so large
+   repositories are not suitable to be imported with this approach
+ - there is automated tooling for importing a repository currently
+ - updating a repository if a test case changes is not supported - you'll need
+   to do the import again with the new state
+
+### Importing a Git repository
+
+The manual steps to add a repository fixture for testing are:
+
+ - inside the Git repository you want to import, rename all `.git` directories
+   to `_git`
+ - create a new folder inside `app/test/fixtures` named in a way that relates to
+   the tests being performed on it. The placeholder `{your-new-folder}`
+   in subsequent steps to represent whatever name you have chosen here.
+ - copy the repository contents into `app/test/fixtures/{your-new-folder}`
+ - cleanup any `app/test/fixtures/{your-new-folder}/_git/hooks/*.sample` files
+   as these are not needed for testing (and will simplify the diff a bit)
+
+Once you have done that, in your test you need to use `setupFixtureRepository`
+with the first parameter being the name of your test fixture folder.
+
+This will return a temporary path to the repository, which is cleaned up after
+the test run is completed.
+
+Here's an example of a test using `setupFixtureRepository`:
+
+```ts
+import {
+  setupFixtureRepository,
+} from '../../helpers/repositories'
+
+// ...
+
+it('returns detached for arbitrary checkout', async () => {
+  const path = await setupFixtureRepository('{your-new-folder}')
+  const repository = new Repository(path, -1, null, false)
+
+  // act
+  // assert
+})
+```
+
+## Repository Scaffolding
+
+The newer approach that we are experimenting with is to provide scaffolding APIs
+to declaratively get the repository into a state for testing. This approach is
+ideal for situations when:
+
+ - a baseline repository can differ slightly between tests, and it's easier to
+   programatically apply the changes than create multiple test fixtures
+ - the workflows being developed may change over time, and the tests themselves
+   should be flexible (and be easy to identify how they evolve)
+
+Three patterns have been implemented to support workflows we are currently
+developing:
+
+ - `cloneRepository` - make a copy of a test repository so that
+    `push`/`pull`/`fetch` can be emulated and tested without using the network
+ - `makeCommit` - express the changes to the working directory that should be committed
+ - `switchTo` - a quick way to checkout (and create if needed) a branch in the
+   repository
+
+This is an example test for `pull` behaviour which uses this scaffolding:
+
+```ts
+describe('ahead and behind of tracking branch', () => {
+  let repository: Repository
+
+  beforeEach(async () => {
+    const remoteRepository = await createRepository(featureBranch)
+    repository = await cloneRepository(remoteRepository)
+
+    // make a commits to both remote and local so histories diverge
+
+    const changesForRemoteRepository = {
+      commitMessage: 'Changed a file in the remote repository',
+      entries: [
+        {
+          path: 'README.md',
+          value: Buffer.from('# HELLO WORLD! \n WORDS GO HERE! \nLOL'),
+        },
+      ],
+    }
+
+    await makeCommit(remoteRepository, changesForRemoteRepository)
+
+    const changesForLocalRepository = {
+      commitMessage: 'Added a new file to the local repository',
+      entries: [
+        {
+          path: 'CONTRIBUTING.md',
+          value: Buffer.from('# HELLO WORLD! \nTHINGS GO HERE\nYES, THINGS'),
+        },
+      ],
+    }
+
+    await makeCommit(repository, changesForLocalRepository)
+    await fetch(repository, null, origin)
+  })
+
+  describe('by default', () => {
+    let previousTip: Commit
+    let newTip: Commit
+
+    beforeEach(async () => {
+      previousTip = await getTipOrError(repository)
+
+      await pull(repository, null, origin)
+
+      newTip = await getTipOrError(repository)
+    })
+
+    it('creates a merge commit', async () => {
+      const newTip = await getTipOrError(repository)
+
+      expect(newTip.sha).not.toBe(previousTip.sha)
+      expect(newTip.parentSHAs).toHaveLength(2)
+    })
+  })
+})
+```
+
+## Additional Git operations
+
+Once you have a `Repository` initialized in a test, if you need to run
+additional Git commands on the repository it is recommended to use
+`GitProcess.exec` from `dugite`. We recommend this approach over reusing the Git
+APIs created for Desktop in `app/src/lib/git` for a few reasons:
+
+ - the Git command line has lots of detailed documentation and options, which we
+   can use without needing to add this behaviour to Desktop's Git APIs
+ - test setup should not be coupled to application behaviour, in case that
+   application behaviour can change in the future
+ - by making the Git test setup explicit, we can focus on what Git operation is
+   being tested
+
+This is an example of how we use `GitProcess.exec` in our tests:
+
+```ts
+it('returns remotes sorted alphabetically', async () => {
+  const repository = await setupEmptyRepository()
+
+  // adding these remotes out-of-order to test how they are then retrieved
+  const url = 'https://github.com/desktop/not-found.git'
+
+  await GitProcess.exec(['remote', 'add', 'X', url], repository.path)
+  await GitProcess.exec(['remote', 'add', 'A', url], repository.path)
+  await GitProcess.exec(['remote', 'add', 'L', url], repository.path)
+  await GitProcess.exec(['remote', 'add', 'T', url], repository.path)
+  await GitProcess.exec(['remote', 'add', 'D', url], repository.path)
+
+  const result = await getRemotes(repository)
+  expect(result).toHaveLength(5)
+
+  expect(result[0].name).toEqual('A')
+  expect(result[1].name).toEqual('D')
+  expect(result[2].name).toEqual('L')
+  expect(result[3].name).toEqual('T')
+  expect(result[4].name).toEqual('X')
+})
+```


### PR DESCRIPTION
## Overview

This PR adds some scaffolding and tests for the `pull` Git operation, to provide some coverage before I dive in with rebasing (which will need similar scaffolding).

[**Crafting Git Tests docs**](https://github.com/desktop/desktop/blob/add-some-tests-for-pull/docs/technical/crafting-git-tests.md)

## Description

This PR came from the need to be able to programatically build up repositories to help with testing, instead of unpacking from an archive.

Why go down this path?

 - Archives of repositories are great for capturing regressions, but are essentially a black box of Git state
 - Updating archives over time is a pain (and also really hard to diff).
 - Building up the repository programatically in a test means we can adapt tests as our requirements and understanding of flows change.

An example of this process is the `app/test/helpers/repository-builder-pull-test.ts` function, which is responsible for setting up a repository that we use in the `pull` tests.

I've kept the scaffolding simple for now, but some examples of functions:

 - `makeCommit` - pass in a collection of files which are written to disk, staged and committed
 - `switchTo` - a quick way to ensure you're on the right branch (creates the branch if not found)

The rest of the changes were about testing how our `pull` implementation responds in these scenarios (with different configuration set):

 - ahead only (local commits not on remote)
 - behind only (remote commits not on current branch)
 - ahead and behind (commits both on remote and local that need to be reconciled)

TODO: 

 - [x] review merge conflict tests and see if they are a good candidate for the current API
 - [x] write some docs for scaffolding Git repository tests
 - [x] refine the API so it's good enough for a v1 ship

## Release notes

Notes: no-notes
