### PR TITLE
Wire up Syntax Highlighting for Crystal and Julia

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -253,6 +253,18 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.lua': 'text/x-lua',
     },
   },
+  {
+    install: () => import('codemirror/mode/crystal/crystal'),
+    mappings: {
+      '.cr': 'text/x-crystal',
+    },
+  },
+  {
+    install: () => import('codemirror/mode/julia/julia'),
+    mappings: {
+      '.jl': 'text/x-julia',
+    },
+  },
 ]
 
 /**

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, JavaServer Pages, PowerShell, Docker, Visual Basic, Fortran, Lua
+JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, JavaServer Pages, PowerShell, Docker, Visual Basic, Fortran, Lua, Crystal, Julia
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
## Wire up Syntax Highlighting for Crystal and Julia

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #6710**

## Description
- Wire up syntax highlighting for Crystal and Julia in `/app/src/highlighter/index.ts`
- Add Crystal and Julia to the list of languages in `/docs/technical/syntax-highlighting.md`

## Release notes
Add syntax highlighting support for Crystal and Julia

Notes:
Here is the [pull request](https://github.com/desktop/highlighter-tests/pull/33) that adds test files for Crystal and Julia to [desktop/highlighter-tests](https://github.com/desktop/highlighter-tests).