### PR TITLE
Remove Large File Size Warning feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -37,11 +37,6 @@ export function enableRecurseSubmodulesFlag(): boolean {
   return enableBetaFeatures()
 }
 
-/** Should the app check and warn the user about committing large files? */
-export function enableFileSizeWarningCheck(): boolean {
-  return true
-}
-
 /** Should the app set protocol.version=2 for any fetch/push/pull/clone operation? */
 export function enableGitProtocolVersionTwo(): boolean {
   return enableBetaFeatures()

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -23,7 +23,6 @@ import { CSSTransitionGroup } from 'react-transition-group'
 import { openFile } from '../lib/open-file'
 import { Account } from '../../models/account'
 import { PopupType } from '../../models/popup'
-import { enableFileSizeWarningCheck } from '../../lib/feature-flag'
 import { filesNotTrackedByLFS } from '../../lib/git/lfs'
 import { getLargeFilePaths } from '../../lib/large-files'
 import { isConflictedFile, hasUnresolvedConflicts } from '../../lib/status'
@@ -123,27 +122,25 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   private onCreateCommit = async (
     context: ICommitContext
   ): Promise<boolean> => {
-    if (enableFileSizeWarningCheck()) {
-      const overSizedFiles = await getLargeFilePaths(
-        this.props.repository,
-        this.props.changes.workingDirectory,
-        100
-      )
-      const filesIgnoredByLFS = await filesNotTrackedByLFS(
-        this.props.repository,
-        overSizedFiles
-      )
+    const overSizedFiles = await getLargeFilePaths(
+      this.props.repository,
+      this.props.changes.workingDirectory,
+      100
+    )
+    const filesIgnoredByLFS = await filesNotTrackedByLFS(
+      this.props.repository,
+      overSizedFiles
+    )
 
-      if (filesIgnoredByLFS.length !== 0) {
-        this.props.dispatcher.showPopup({
-          type: PopupType.OversizedFiles,
-          oversizedFiles: filesIgnoredByLFS,
-          context: context,
-          repository: this.props.repository,
-        })
+    if (filesIgnoredByLFS.length !== 0) {
+      this.props.dispatcher.showPopup({
+        type: PopupType.OversizedFiles,
+        oversizedFiles: filesIgnoredByLFS,
+        context: context,
+        repository: this.props.repository,
+      })
 
-        return false
-      }
+      return false
     }
 
     // are any conflicted files left?


### PR DESCRIPTION
This PR removes the feature flag for warning users when committing files larger than 100MB. It has been enabled for all users since we released 1.6 and seems to be working wonderfully. 🎉 🚀 @Daniel-McCarthy!

Closes #6718 

No release notes needed.
