### PR TITLE
show an actionable dialog when files would be overwritten

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.82.0",
+    "dugite": "1.83.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.80.0",
+    "dugite": "1.82.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -264,6 +264,10 @@ function getDescriptionForError(error: DugiteError): string {
       return 'A lock file already exists in the repository, which blocks this operation from completing.'
     case DugiteError.NoMergeToAbort:
       return 'There is no merge in progress, so there is nothing to abort.'
+    case DugiteError.NoExistingRemoteBranch:
+      return 'The remote branch does not exist.'
+    case DugiteError.LocalChangesOverwritten:
+      return 'Some of your changes would be overwritten.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2219,10 +2219,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     await this.withAuthenticatingUser(repository, (repository, account) =>
-      gitStore.performFailableOperation(() =>
-        checkoutBranch(repository, account, foundBranch, progress => {
-          this.updateCheckoutProgress(repository, progress)
-        })
+      gitStore.performFailableOperation(
+        () =>
+          checkoutBranch(repository, account, foundBranch, progress => {
+            this.updateCheckoutProgress(repository, progress)
+          }),
+        {
+          repository,
+          retryAction: {
+            type: RetryActionType.Checkout,
+            repository,
+            branch,
+          },
+        }
       )
     )
 

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -156,7 +156,7 @@ export type Popup =
     }
   | {
       type: PopupType.LocalChangesOverwritten
-      /** repository user is committing in */
+      /** repository user is checking out in */
       repository: Repository
       retryAction: RetryAction
       overwrittenFiles: ReadonlyArray<string>

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -42,6 +42,7 @@ export enum PopupType {
   OversizedFiles,
   UsageReportingChanges,
   CommitConflictsWarning,
+  LocalChangesOverwritten,
 }
 
 export type Popup =
@@ -152,4 +153,11 @@ export type Popup =
       repository: Repository
       /** information for completing the commit */
       context: ICommitContext
+    }
+  | {
+      type: PopupType.LocalChangesOverwritten
+      /** repository user is committing in */
+      repository: Repository
+      retryAction: RetryAction
+      overwrittenFiles: ReadonlyArray<string>
     }

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -1,5 +1,6 @@
 import { Repository } from './repository'
 import { CloneOptions } from './clone-options'
+import { Branch } from './branch'
 
 /** The types of actions that can be retried. */
 export enum RetryActionType {
@@ -7,6 +8,7 @@ export enum RetryActionType {
   Pull,
   Fetch,
   Clone,
+  Checkout,
 }
 
 /** The retriable actions and their associated data. */
@@ -19,4 +21,9 @@ export type RetryAction =
       url: string
       path: string
       options: CloneOptions
+    }
+  | {
+      type: RetryActionType.Checkout
+      repository: Repository
+      branch: Branch | string
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -95,6 +95,7 @@ import { PopupType, Popup } from '../models/popup'
 import { SuccessfulMerge, MergeConflictsBanner } from './banners'
 import { OversizedFiles } from './changes/oversized-files-warning'
 import { UsageStatsChange } from './usage-stats-change'
+import { LocalChangesOverwrittenWarning } from './local-changes-overwritten'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1512,6 +1513,26 @@ export class App extends React.Component<IAppProps, IAppState> {
             files={popup.files}
             repository={popup.repository}
             context={popup.context}
+            onDismissed={this.onPopupDismissed}
+          />
+        )
+      case PopupType.LocalChangesOverwritten:
+        const { selectedState } = this.state
+        if (
+          selectedState === null ||
+          selectedState.type !== SelectionType.Repository
+        ) {
+          return null
+        }
+
+        const { workingDirectory } = selectedState.state.changesState
+        return (
+          <LocalChangesOverwrittenWarning
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            retryAction={popup.retryAction}
+            overwrittenFiles={popup.overwrittenFiles}
+            workingDirectory={workingDirectory}
             onDismissed={this.onPopupDismissed}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1144,6 +1144,10 @@ export class Dispatcher {
         await this.clone(retryAction.url, retryAction.path, retryAction.options)
         break
 
+      case RetryActionType.Checkout:
+        await this.checkoutBranch(retryAction.repository, retryAction.branch)
+        break
+
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)
     }

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -359,3 +359,67 @@ export async function upstreamAlreadyExistsHandler(
 
   return null
 }
+
+/**
+ * Handler for when we attempt to checkout a branch and there are some files that would
+ * be overwritten.
+ */
+export async function localChangesOverwrittenHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (!dugiteError) {
+    return error
+  }
+
+  if (dugiteError !== DugiteError.LocalChangesOverwritten) {
+    return error
+  }
+
+  const { repository, retryAction } = e.metadata
+  if (repository == null) {
+    return error
+  }
+
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+
+  if (!retryAction) {
+    log.error(`No retry action provided for a git checkout error.`, e)
+    return error
+  }
+
+  // find the overwritten files from the error
+  const overwrittenFiles = []
+
+  const pathRegex = /^\t(.*)/gm
+  const { stderr } = gitError.result
+
+  let match = pathRegex.exec(stderr)
+
+  while (match) {
+    overwrittenFiles.push(match[1])
+    match = pathRegex.exec(stderr)
+  }
+
+  dispatcher.showPopup({
+    type: PopupType.LocalChangesOverwritten,
+    repository,
+    retryAction,
+    overwrittenFiles,
+  })
+
+  return null
+}

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -19,6 +19,7 @@ import {
   backgroundTaskHandler,
   pushNeedsPullHandler,
   upstreamAlreadyExistsHandler,
+  localChangesOverwrittenHandler,
 } from './dispatcher'
 import {
   AppStore,
@@ -156,6 +157,7 @@ dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)
+dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
 
 document.body.classList.add(`platform-${process.platform}`)
 

--- a/app/src/ui/local-changes-overwritten/index.ts
+++ b/app/src/ui/local-changes-overwritten/index.ts
@@ -1,0 +1,3 @@
+export {
+  LocalChangesOverwrittenWarning,
+} from './local-changes-overwritten-warning'

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-warning.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-warning.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Monospaced } from '../lib/monospaced'
+import { PathText } from '../lib/path-text'
+import { Dispatcher } from '../../ui/dispatcher'
+import { Repository } from '../../models/repository'
+import { RetryAction } from '../../models/retry-actions'
+import { WorkingDirectoryStatus } from '../../models/status'
+
+interface ILocalChangesOverwrittenWarningProps {
+  readonly overwrittenFiles: ReadonlyArray<string>
+  readonly onDismissed: () => void
+  readonly dispatcher: Dispatcher
+  readonly retryAction: RetryAction
+  readonly repository: Repository
+  readonly workingDirectory: WorkingDirectoryStatus
+}
+
+/** A dialog to display a list of files that are too large to commit. */
+export class LocalChangesOverwrittenWarning extends React.Component<
+  ILocalChangesOverwrittenWarningProps
+> {
+  private closeButton: Button | null = null
+
+  public constructor(props: ILocalChangesOverwrittenWarningProps) {
+    super(props)
+  }
+
+  private onCloseButtonRef = (button: Button | null) => {
+    this.closeButton = button
+  }
+
+  public componentDidMount() {
+    // Since focus is given to the Git LFS link by default, we will instead set focus onto the cancel button.
+    if (this.closeButton != null) {
+      this.closeButton.focus()
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="overwritten-files"
+        title={'Files Overwritten'}
+        onDismissed={this.props.onDismissed}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            The following files would be overwritten when checking out the
+            branch.
+          </p>
+          {this.renderFileList()}
+          <p className="recommendation">
+            We recommend you manually commit these files or discard them.
+          </p>
+        </DialogContent>
+
+        <DialogFooter>
+          <ButtonGroup destructive={true}>
+            <Button type="submit" ref={this.onCloseButtonRef}>
+              Cancel
+            </Button>
+            <Button onClick={this.discardChangesAndRetry}>
+              Discard Changes And Checkout
+            </Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderFileList() {
+    return (
+      <div className="files-list">
+        {this.props.overwrittenFiles.map(fileName => (
+          <ul key={fileName}>
+            <Monospaced>
+              <PathText path={fileName} />
+            </Monospaced>
+          </ul>
+        ))}
+      </div>
+    )
+  }
+
+  private discardChangesAndRetry = async () => {
+    this.props.dispatcher.closePopup()
+
+    const { overwrittenFiles } = this.props
+
+    await this.props.dispatcher.discardChanges(
+      this.props.repository,
+      this.props.workingDirectory.files.filter(
+        f => overwrittenFiles.indexOf(f.path) !== -1
+      )
+    )
+
+    this.props.dispatcher.performRetry(this.props.retryAction)
+  }
+}

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-warning.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-warning.tsx
@@ -18,7 +18,7 @@ interface ILocalChangesOverwrittenWarningProps {
   readonly workingDirectory: WorkingDirectoryStatus
 }
 
-/** A dialog to display a list of files that are too large to commit. */
+/** A dialog to display a list of files that would be overwritten by a checkout. */
 export class LocalChangesOverwrittenWarning extends React.Component<
   ILocalChangesOverwrittenWarningProps
 > {
@@ -33,7 +33,7 @@ export class LocalChangesOverwrittenWarning extends React.Component<
   }
 
   public componentDidMount() {
-    // Since focus is given to the Git LFS link by default, we will instead set focus onto the cancel button.
+    // Since focus is given to the overwritten files by default, we will instead set focus onto the cancel button.
     if (this.closeButton != null) {
       this.closeButton.focus()
     }
@@ -43,7 +43,7 @@ export class LocalChangesOverwrittenWarning extends React.Component<
     return (
       <Dialog
         id="overwritten-files"
-        title={'Files Overwritten'}
+        title={__DARWIN__ ? 'Files Overwritten' : 'Files overwritten'}
         onDismissed={this.props.onDismissed}
         type="warning"
       >
@@ -64,7 +64,9 @@ export class LocalChangesOverwrittenWarning extends React.Component<
               Cancel
             </Button>
             <Button onClick={this.discardChangesAndRetry}>
-              Discard Changes And Checkout
+              {__DARWIN__
+                ? 'Discard Changes And Checkout'
+                : 'Discard changes and checkout'}
             </Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -404,10 +404,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.82.0:
-  version "1.82.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.82.0.tgz#fb4e0e94630c05d0df9e9190f6163ebe8a773aad"
-  integrity sha512-/mfn8DEvlVRTHmoWKZcscwE9aTBxTo6z13WU2F+9ZT7cfc/kBHVnsag0bdqQkFmYv24bjEVaNqQ+DkyMbqVxrw==
+dugite@1.83.0:
+  version "1.83.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.83.0.tgz#06f04f8a0521bb347e20ad913a42fb6e1b405c60"
+  integrity sha512-e+QWkpU78RwM4y+Z+6wjE3A8BE+EF0zebg+pQ56Q+cQNGleEuv3Dl0u7obQ/xJgWqr2s3HoFDGpaq1RkSwPCdg==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -404,14 +404,14 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.80.0:
-  version "1.80.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.80.0.tgz#69987fd54d8afd8d56b2e0f4fe43f2db1b49d800"
-  integrity sha512-ELavYXdThykKFffPG0w4NdfWYr5FfwKOP4lmLpnripbuJOE8DTTvgEJigG4dC2Vkpe5lavWX2Oia9qQoEyMzeQ==
+dugite@1.82.0:
+  version "1.82.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.82.0.tgz#fb4e0e94630c05d0df9e9190f6163ebe8a773aad"
+  integrity sha512-/mfn8DEvlVRTHmoWKZcscwE9aTBxTo6z13WU2F+9ZT7cfc/kBHVnsag0bdqQkFmYv24bjEVaNqQ+DkyMbqVxrw==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"
-    progress "^2.0.0"
+    progress "^2.0.3"
     request "^2.88.0"
     rimraf "^2.5.4"
     tar "^4.4.7"
@@ -1183,10 +1183,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-  integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise@^7.1.1:
   version "7.3.1"


### PR DESCRIPTION
## Description

Shows an actionable dialog when files would be overwritten during a checkout. The action of the dialog is "Discard Changes and Checkout". I was also thinking about having a "Stash" action but there is no notion of stash in Desktop yet.


![2019-02-19 11 15 06](https://user-images.githubusercontent.com/1715082/53033876-afdf3f80-3437-11e9-80b3-7cf20c9134aa.gif)

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
- Show an actionable dialog when files would be overwritten during a checkout