### PR TITLE
Use standard link styling on conflicts dialog

### DIFF
--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -189,7 +189,7 @@ export class MergeConflictsDialog extends React.Component<
 
   private renderShellLink(openThisRepositoryInShell: () => void): JSX.Element {
     return (
-      <div className="cli-link">
+      <div>
         <LinkButton onClick={openThisRepositoryInShell}>
           Open in command line,
         </LinkButton>{' '}

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -106,16 +106,6 @@ dialog#merge-conflicts-list {
     }
   }
 
-  .cli-link {
-    a {
-      color: $blue;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-
   .arrow-menu {
     .octicon {
       width: 10px;


### PR DESCRIPTION
This removes some (seemingly?) unnecessary styling on the link in the conflict resolution dialog that made the link style not pass color contrast in dark mode.

|Before|After|
|---|---|
|![screen shot 2019-01-30 at 10 50 23 am](https://user-images.githubusercontent.com/10404068/52151312-88126e00-2627-11e9-85fa-399b616f1db4.png)|<img width="185" alt="screen shot 2019-01-31 at 2 59 22 pm" src="https://user-images.githubusercontent.com/10404068/52151313-88126e00-2627-11e9-8d34-6685df974087.png">|
