### PR TITLE
fix pointy corners with border-radius

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -98,7 +98,6 @@
 
     textarea {
       border: none;
-      border-radius: 0;
       color: currentColor;
       font-size: var(--font-size);
       font-family: var(--font-family-sans-serif);

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -115,6 +115,7 @@
     .action-bar {
       padding: var(--spacing-half);
       background: var(--box-background-color);
+      border-radius: var(--border-radius);
 
       // We're not faking being a textbox any more
       cursor: default;


### PR DESCRIPTION
## Overview
Addresses pointy corners on commit message issue

**Closes #6635**

## Description
Restores textarea border-radius to inherited value.

I was unable to verify whether this affects `autocompletion-popup user` and `autocompletion-popup issue` problems resulting from an earlier attempted fix, mentioned in #6459, as I couldn't replicate the autocompletion behavior in Github Desktop 1.6.1 or in the dev build.

## Release notes
Notes: no-notes