### PR TITLE
address tslint deprecated warnings because they never go away in a new VSCode install

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -120,6 +120,7 @@ function packageApp() {
     )
   }
 
+  /* tslint:disable:deprecation */
   const toPackageArch = (targetArch: string | undefined): packager.arch => {
     if (targetArch === undefined) {
       return 'x64'
@@ -134,6 +135,7 @@ function packageApp() {
     )
   }
 
+  /* tslint:disable:deprecation */
   const options: packager.Options & IPackageAdditionalOptions = {
     name: getExecutableName(),
     platform: toPackagePlatform(process.platform),

--- a/tslint-rules/buttonGroupOrderRule.ts
+++ b/tslint-rules/buttonGroupOrderRule.ts
@@ -68,7 +68,7 @@ class ButtonGroupOrderWalker extends Lint.RuleWalker {
 
       const message = `${error} ${explanation}`
 
-      this.addFailure(this.createFailure(start, width, message))
+      this.addFailureAt(start, width, message)
     }
 
     // If we've emitted any errors we'll bail here rather than try to emit
@@ -113,7 +113,7 @@ class ButtonGroupOrderWalker extends Lint.RuleWalker {
 
       const message = `${error} ${explanation}`
 
-      this.addFailure(this.createFailure(start, width, message))
+      this.addFailureAt(start, width, message)
     }
   }
 }

--- a/tslint-rules/reactNoUnboundDispatcherPropsRule.ts
+++ b/tslint-rules/reactNoUnboundDispatcherPropsRule.ts
@@ -88,7 +88,7 @@ class ReactNoUnboundDispatcherPropsWalker extends Lint.RuleWalker {
 
         const message = `${error} ${explanation}`
 
-        this.addFailure(this.createFailure(start, width, message))
+        this.addFailureAt(start, width, message)
       }
     })
   }

--- a/tslint-rules/reactProperLifecycleMethodsRule.ts
+++ b/tslint-rules/reactProperLifecycleMethodsRule.ts
@@ -77,7 +77,7 @@ class ReactProperLifecycleMethodsWalker extends Lint.RuleWalker {
       const methodName = node.name.getText()
       const message = `${methodName} should not accept any parameters.`
 
-      this.addFailure(this.createFailure(start, width, message))
+      this.addFailureAt(start, width, message)
     }
   }
 
@@ -92,9 +92,7 @@ class ReactProperLifecycleMethodsWalker extends Lint.RuleWalker {
 
     if (parameterName !== expectedParameter.name) {
       const message = `parameter should be named ${expectedParameter.name}.`
-      this.addFailure(
-        this.createFailure(parameterStart, parameterWidth, message)
-      )
+      this.addFailureAt(parameterStart, parameterWidth, message)
       return false
     }
 
@@ -102,9 +100,7 @@ class ReactProperLifecycleMethodsWalker extends Lint.RuleWalker {
 
     if (parameterTypeName !== expectedParameter.type) {
       const message = `parameter should be of type ${expectedParameter.type}.`
-      this.addFailure(
-        this.createFailure(parameterStart, parameterWidth, message)
-      )
+      this.addFailureAt(parameterStart, parameterWidth, message)
       return false
     }
 
@@ -125,9 +121,7 @@ class ReactProperLifecycleMethodsWalker extends Lint.RuleWalker {
         const parameterWidth = parameter.getWidth()
         const message = `unknown parameter ${parameterName}`
 
-        this.addFailure(
-          this.createFailure(parameterStart, parameterWidth, message)
-        )
+        this.addFailureAt(parameterStart, parameterWidth, message)
         return false
       }
 
@@ -149,9 +143,7 @@ class ReactProperLifecycleMethodsWalker extends Lint.RuleWalker {
         const parameterWidth = parameter.getWidth()
         const message = `remove unused void parameter ${parameterName}.`
 
-        this.addFailure(
-          this.createFailure(parameterStart, parameterWidth, message)
-        )
+        this.addFailureAt(parameterStart, parameterWidth, message)
         return false
       } else {
         break
@@ -196,7 +188,7 @@ class ReactProperLifecycleMethodsWalker extends Lint.RuleWalker {
       'Method names starting with component or shouldComponent ' +
       'are prohibited since they can be confused with React lifecycle methods.'
 
-    this.addFailure(this.createFailure(start, width, message))
+    this.addFailureAt(start, width, message)
   }
 }
 export class Rule extends Lint.Rules.AbstractRule {

--- a/tslint-rules/reactReadonlyPropsAndStateRule.ts
+++ b/tslint-rules/reactReadonlyPropsAndStateRule.ts
@@ -40,7 +40,7 @@ class ReactReadonlyPropsAndStateWalker extends Lint.RuleWalker {
         const width = propertySignature.getWidth()
         const error = `Property and state signatures should be read-only`
 
-        this.addFailure(this.createFailure(start, width, error))
+        this.addFailureAt(start, width, error)
       }
     })
   }


### PR DESCRIPTION
## Overview

Getting my new VSCode installation setup, and after installing the recommended extensions I start to see `tslint` warnings. Cool and helpful. The downside to this is that they don't go away, so I constantly need to workaround this list whenever I'm looking at warnings/errors:

<img width="797" src="https://user-images.githubusercontent.com/359239/52229237-d3788680-288a-11e9-9fdc-376bc505fae6.png">

I'm not sure why CI doesn't catch these, but the changes were specific and unimportant enough that I just went in and addressed them. I'll revisit this area when I'm next looking at how we can simplify/unify the `eslint`/`tslint` tooling we have.

## Release notes

Notes: no-notes
