### PR TITLE
finish migration to using @typescript-eslint packages

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -33,8 +33,8 @@ rules:
     - functions: false
       variables: false
       typedefs: false
-  ## blocked by https://github.com/nzakas/eslint-plugin-typescript/pull/23
-  # typescript/member-ordering: error
+  # this rule now works but generates a lot of issues with the codebase
+  # '@typescript-eslint/member-ordering': error
 
   '@typescript-eslint/type-annotation-spacing': error
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,7 @@
 root: true
 parser: '@typescript-eslint/parser'
 plugins:
-  - typescript
+  - '@typescript-eslint'
   - babel
   - react
   - json
@@ -20,23 +20,23 @@ rules:
   # PLUGINS #
   ###########
   # TYPESCRIPT
-  typescript/interface-name-prefix:
+  '@typescript-eslint/interface-name-prefix':
     - error
     - always
-  typescript/no-angle-bracket-type-assertion: error
-  typescript/explicit-member-accessibility: error
-  typescript/no-unused-vars: error
-  typescript/no-use-before-define:
+  '@typescript-eslint/no-angle-bracket-type-assertion': error
+  '@typescript-eslint/explicit-member-accessibility': error
+  '@typescript-eslint/no-unused-vars':
+    - error
+    - args: 'none'
+  '@typescript-eslint/no-use-before-define':
     - error
     - functions: false
       variables: false
       typedefs: false
   ## blocked by https://github.com/nzakas/eslint-plugin-typescript/pull/23
   # typescript/member-ordering: error
-  ##
-  ## blocked by https://github.com/nzakas/eslint-plugin-typescript/issues/41
-  # typescript/type-annotation-spacing: error
-  ##
+
+  '@typescript-eslint/type-annotation-spacing': error
 
   # Babel
   babel/no-invalid-this: error
@@ -48,6 +48,8 @@ rules:
   react/jsx-key: error
   react/jsx-no-bind: error
   react/no-string-refs: error
+  react/jsx-uses-vars: error
+  react/jsx-uses-react: error
 
   ###########
   # BUILTIN #

--- a/app/src/highlighter/globals.d.ts
+++ b/app/src/highlighter/globals.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable typescript/interface-name-prefix */
+/* eslint-disable @typescript-eslint/interface-name-prefix */
 
 declare namespace CodeMirror {
   interface EditorConfiguration {

--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable typescript/interface-name-prefix */
+/* eslint-disable @typescript-eslint/interface-name-prefix */
 /** Is the app running in dev mode? */
 declare const __DEV__: boolean
 

--- a/app/src/lib/parse-app-url.ts
+++ b/app/src/lib/parse-app-url.ts
@@ -41,7 +41,7 @@ export type URLActionType =
   | IOpenRepositoryFromPathAction
   | IUnknownAction
 
-// eslint-disable-next-line typescript/interface-name-prefix
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 interface ParsedUrlQueryWithUndefined {
   // `undefined` is added here to ensure we handle the missing querystring key
   // See https://github.com/Microsoft/TypeScript/issues/13778 for discussion about

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -1,7 +1,7 @@
 const queue: (config: QueueConfig) => Queue = require('queue')
 import { revSymmetricDifference } from '../../../lib/git'
 
-// eslint-disable-next-line typescript/interface-name-prefix
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 interface QueueConfig {
   // Max number of jobs the queue should process concurrently, defaults to Infinity.
   readonly concurrency: number
@@ -10,7 +10,7 @@ interface QueueConfig {
   readonly autostart: boolean
 }
 
-// eslint-disable-next-line typescript/interface-name-prefix
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 interface Queue extends NodeJS.EventEmitter {
   readonly length: number
 

--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -205,7 +205,7 @@ function orderByPosition(x: ActualTextMarker, y: ActualTextMarker) {
 
 // The types for CodeMirror.TextMarker is all wrong, this is what it
 // actually looks like
-// eslint-disable-next-line typescript/interface-name-prefix
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 interface ActualTextMarker extends CodeMirror.TextMarkerOptions {
   /** Remove the mark. */
   clear(): void

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "yarn": ">= 1.9"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^1.0.0",
+    "@typescript-eslint/eslint-plugin": "1.4.2",
+    "@typescript-eslint/parser": "1.4.2",
     "airbnb-browser-shims": "^3.0.0",
     "ajv": "^6.4.0",
     "awesome-node-loader": "^1.1.0",
@@ -76,7 +77,6 @@
     "eslint-plugin-json": "^1.2.1",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "eslint-plugin-typescript": "^0.12.0",
     "express": "^4.15.0",
     "fake-indexeddb": "^2.0.4",
     "file-loader": "^2.0.0",

--- a/script/globals.d.ts
+++ b/script/globals.d.ts
@@ -7,7 +7,7 @@ type Package = {
 }
 
 declare namespace NodeJS {
-  // eslint-disable-next-line typescript/interface-name-prefix
+  // eslint-disable-next-line @typescript-eslint/interface-name-prefix
   interface Process extends EventEmitter {
     on(event: 'unhandledRejection', listener: (error: Error) => void): this
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,19 +529,29 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/parser@^1.0.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.1.1.tgz#a979c5dc543ae4ae9b44df9def70e2a5892e7185"
-  integrity sha512-P6v+iYkI+ywp6MaFyAJ6NqU5W6fiAvMXWjCV63xTJbkQdtAngdjSCajlEEweqJqL4RNsgFCHBe5HbYyT6TmW4g==
+"@typescript-eslint/eslint-plugin@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.2.tgz#370bc32022d1cc884a5dcf62624ef2024182769d"
+  integrity sha512-6WInypy/cK4rM1dirKbD5p7iFW28DbSRKT/+PGn+DYzBWEvHq5KnZAqQ5cX25JBc0qMkFxJNxNfBbFXJyyzVcw==
   dependencies:
-    "@typescript-eslint/typescript-estree" "1.1.1"
+    "@typescript-eslint/parser" "1.4.2"
+    "@typescript-eslint/typescript-estree" "1.4.2"
+    requireindex "^1.2.0"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/parser@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.4.2.tgz#acfdee2019958a41d308d768e53ded975ef90ce8"
+  integrity sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.4.2"
     eslint-scope "^4.0.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.1.1.tgz#d5cccc227d2c8948799d127b6cc51ccb5378bf51"
-  integrity sha512-rERZSjNWb4WC425daCUktfh+0fFLy4WWlnu9bESdJv5l+t0ww0yUprRUbgzehag/dGd56Me+3uyXGV2O12qxrQ==
+"@typescript-eslint/typescript-estree@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz#b16bc36c9a4748a7fca92cba4c2d73c5325c8a85"
+  integrity sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
@@ -3685,13 +3695,6 @@ eslint-plugin-react@^7.11.1:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.2"
-
-eslint-plugin-typescript@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.12.0.tgz#e23d58cb27fe28e89fc641a1f20e8d862cb99aef"
-  integrity sha512-2+DNE8nTvdNkhem/FBJXLPSeMDOZL68vHHNfTbM+PBc5iAuwBe8xLSQubwKxABqSZDwUHg+mwGmv5c2NlImi0Q==
-  dependencies:
-    requireindex "~1.1.0"
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
@@ -8616,10 +8619,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
-  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -9934,6 +9937,13 @@ tsutils@^2.27.2:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
   integrity sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.7.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.8.0.tgz#7a3dbadc88e465596440622b65c04edc8e187ae5"
+  integrity sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
## Overview

This is the second part of #6684 and completes the transition to using the new `@typescript-eslint` packages. 

 - [x] investigate linting errors
 - [x] rewrite history to make it easier to follow

## Release notes

Notes: no-notes
