### PR TITLE
ensure list elements in MergeConflicts dialog are keyed

### DIFF
--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -200,7 +200,7 @@ export class MergeConflictsDialog extends React.Component<
 
   private renderResolvedFile(path: string): JSX.Element {
     return (
-      <li className="unmerged-file-status-resolved">
+      <li key={path} className="unmerged-file-status-resolved">
         <Octicon symbol={OcticonSymbol.fileCode} className="file-octicon" />
         <div className="column-left">
           <PathText path={path} availableWidth={200} />


### PR DESCRIPTION
## Overview

Some tech debt I picked up while working on #6698.

## Description

React expects elements which are rendered in a list to have a unique `key` prop so that adds and removes can be optimized. The [docs](https://reactjs.org/docs/lists-and-keys.html) talk more about the reasons why this is important.

The other `<li>` node inside `MergeConflictsDialog` is setup this way:

https://github.com/desktop/desktop/blob/6400fd767654d62a23c79f01bbdb67214c16c0bc/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx#L277-L280

## Release notes

Notes: performance optimization inside Merge Conflicts dialog for resolved conflicted files
