### PR TITLE
Split repository publication settings into two types

### DIFF
--- a/app/src/models/publish-settings.ts
+++ b/app/src/models/publish-settings.ts
@@ -1,0 +1,37 @@
+import { IAPIUser } from '../lib/api'
+
+export type RepositoryPublicationSettings =
+  | IEnterprisePublicationSettings
+  | IDotcomPublicationSettings
+
+export interface IEnterprisePublicationSettings {
+  readonly kind: 'ghe'
+
+  /** The name to use when publishing the repository. */
+  readonly name: string
+
+  /** The repository's description. */
+  readonly description: string
+
+  /** Should the repository be private? */
+  readonly private: boolean
+}
+
+export interface IDotcomPublicationSettings {
+  readonly kind: 'dotcom'
+
+  /** The name to use when publishing the repository. */
+  readonly name: string
+
+  /** The repository's description. */
+  readonly description: string
+
+  /** Should the repository be private? */
+  readonly private: boolean
+
+  /**
+   * The org to which this repository belongs. If null, the repository should be
+   * published as a personal repository.
+   */
+  readonly org: IAPIUser | null
+}

--- a/app/src/models/publish-settings.ts
+++ b/app/src/models/publish-settings.ts
@@ -4,8 +4,13 @@ export type RepositoryPublicationSettings =
   | IEnterprisePublicationSettings
   | IDotcomPublicationSettings
 
+export enum PublishSettingsType {
+  'enterprise',
+  'dotcom',
+}
+
 export interface IEnterprisePublicationSettings {
-  readonly kind: 'ghe'
+  readonly kind: PublishSettingsType.enterprise
 
   /** The name to use when publishing the repository. */
   readonly name: string
@@ -18,7 +23,7 @@ export interface IEnterprisePublicationSettings {
 }
 
 export interface IDotcomPublicationSettings {
-  readonly kind: 'dotcom'
+  readonly kind: PublishSettingsType.dotcom
 
   /** The name to use when publishing the repository. */
   readonly name: string

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -10,7 +10,7 @@ import { caseInsensitiveCompare } from '../../lib/compare'
 import { sanitizedRepositoryName } from '../add-repository/sanitized-repository-name'
 import { Octicon, OcticonSymbol } from '../octicons'
 
-export interface GHEPublicationSettings {
+export interface IGHEPublicationSettings {
   readonly kind: 'ghe'
 
   /** The name to use when publishing the repository. */
@@ -23,7 +23,7 @@ export interface GHEPublicationSettings {
   readonly private: boolean
 }
 
-export interface DotcomPublicationSettings {
+export interface IDotcomPublicationSettings {
   readonly kind: 'dotcom'
 
   /** The name to use when publishing the repository. */
@@ -43,8 +43,8 @@ export interface DotcomPublicationSettings {
 }
 
 export type RepositoryPublicationSettings =
-  | GHEPublicationSettings
-  | DotcomPublicationSettings
+  | IGHEPublicationSettings
+  | IDotcomPublicationSettings
 
 interface IPublishRepositoryProps {
   /** The user to use for publishing. */
@@ -126,7 +126,7 @@ export class PublishRepository extends React.Component<
 
     const value = event.currentTarget.value
     const index = parseInt(value, 10)
-    let newSettings: DotcomPublicationSettings
+    let newSettings: IDotcomPublicationSettings
     if (index < 0 || isNaN(index)) {
       newSettings = { ...settings, org: null }
     } else {

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -12,6 +12,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import {
   RepositoryPublicationSettings,
   IDotcomPublicationSettings,
+  PublishSettingsType,
 } from '../../models/publish-settings'
 
 interface IPublishRepositoryProps {
@@ -88,7 +89,7 @@ export class PublishRepository extends React.Component<
 
   private onOrgChange = (event: React.FormEvent<HTMLSelectElement>) => {
     const { settings } = this.props
-    if (settings.kind !== 'dotcom') {
+    if (settings.kind !== PublishSettingsType.dotcom) {
       return
     }
 
@@ -119,7 +120,9 @@ export class PublishRepository extends React.Component<
 
     let selectedIndex = -1
     const selectedOrg =
-      this.props.settings.kind === 'dotcom' ? this.props.settings.org : null
+      this.props.settings.kind === PublishSettingsType.dotcom
+        ? this.props.settings.org
+        : null
     for (const [index, org] of this.state.orgs.entries()) {
       if (selectedOrg && selectedOrg.id === org.id) {
         selectedIndex = index

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -150,7 +150,8 @@ export class PublishRepository extends React.Component<
     )
 
     let selectedIndex = -1
-    const selectedOrg = this.props.settings.org
+    const selectedOrg =
+      this.props.settings.kind === 'dotcom' ? this.props.settings.org : null
     for (const [index, org] of this.state.orgs.entries()) {
       if (selectedOrg && selectedOrg.id === org.id) {
         selectedIndex = index

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -10,18 +10,22 @@ import { caseInsensitiveCompare } from '../../lib/compare'
 import { sanitizedRepositoryName } from '../add-repository/sanitized-repository-name'
 import { Octicon, OcticonSymbol } from '../octicons'
 
-interface IPublishRepositoryProps {
-  /** The user to use for publishing. */
-  readonly account: Account
+export interface GHEPublicationSettings {
+  readonly kind: 'ghe'
 
-  /** The settings to use when publishing the repository. */
-  readonly settings: IPublishRepositorySettings
+  /** The name to use when publishing the repository. */
+  readonly name: string
 
-  /** The function called when any of the publish settings are changed. */
-  readonly onSettingsChanged: (settings: IPublishRepositorySettings) => void
+  /** The repository's description. */
+  readonly description: string
+
+  /** Should the repository be private? */
+  readonly private: boolean
 }
 
-export interface IPublishRepositorySettings {
+export interface DotcomPublicationSettings {
+  readonly kind: 'dotcom'
+
   /** The name to use when publishing the repository. */
   readonly name: string
 
@@ -36,6 +40,21 @@ export interface IPublishRepositorySettings {
    * published as a personal repository.
    */
   readonly org: IAPIUser | null
+}
+
+export type RepositoryPublicationSettings =
+  | GHEPublicationSettings
+  | DotcomPublicationSettings
+
+interface IPublishRepositoryProps {
+  /** The user to use for publishing. */
+  readonly account: Account
+
+  /** The settings to use when publishing the repository. */
+  readonly settings: RepositoryPublicationSettings
+
+  /** The function called when any of the publish settings are changed. */
+  readonly onSettingsChanged: (settings: RepositoryPublicationSettings) => void
 }
 
 interface IPublishRepositoryState {

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -95,8 +95,8 @@ export class PublishRepository extends React.Component<
     this.setState({ orgs })
   }
 
-  private updateSettings<K extends keyof IPublishRepositorySettings>(
-    subset: Pick<IPublishRepositorySettings, K>
+  private updateSettings<K extends keyof RepositoryPublicationSettings>(
+    subset: Pick<RepositoryPublicationSettings, K>
   ) {
     const existingSettings = this.props.settings
     const newSettings = merge(existingSettings, subset)

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -119,14 +119,22 @@ export class PublishRepository extends React.Component<
   }
 
   private onOrgChange = (event: React.FormEvent<HTMLSelectElement>) => {
+    const { settings } = this.props
+    if (settings.kind !== 'dotcom') {
+      return
+    }
+
     const value = event.currentTarget.value
     const index = parseInt(value, 10)
+    let newSettings: DotcomPublicationSettings
     if (index < 0 || isNaN(index)) {
-      this.updateSettings({ org: null })
+      newSettings = { ...settings, org: null }
     } else {
       const org = this.state.orgs[index]
-      this.updateSettings({ org })
+      newSettings = { ...settings, org }
     }
+
+    this.props.onSettingsChanged(newSettings)
   }
 
   private renderOrgs(): JSX.Element | null {

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -9,42 +9,10 @@ import { merge } from '../../lib/merge'
 import { caseInsensitiveCompare } from '../../lib/compare'
 import { sanitizedRepositoryName } from '../add-repository/sanitized-repository-name'
 import { Octicon, OcticonSymbol } from '../octicons'
-
-export interface IGHEPublicationSettings {
-  readonly kind: 'ghe'
-
-  /** The name to use when publishing the repository. */
-  readonly name: string
-
-  /** The repository's description. */
-  readonly description: string
-
-  /** Should the repository be private? */
-  readonly private: boolean
-}
-
-export interface IDotcomPublicationSettings {
-  readonly kind: 'dotcom'
-
-  /** The name to use when publishing the repository. */
-  readonly name: string
-
-  /** The repository's description. */
-  readonly description: string
-
-  /** Should the repository be private? */
-  readonly private: boolean
-
-  /**
-   * The org to which this repository belongs. If null, the repository should be
-   * published as a personal repository.
-   */
-  readonly org: IAPIUser | null
-}
-
-export type RepositoryPublicationSettings =
-  | IGHEPublicationSettings
-  | IDotcomPublicationSettings
+import {
+  RepositoryPublicationSettings,
+  IDotcomPublicationSettings,
+} from '../../models/publish-settings'
 
 interface IPublishRepositoryProps {
   /** The user to use for publishing. */

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -332,7 +332,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       }
       this.setTabState({ ...gheTabState })
     } else {
-      const dotcomTabState: IDotcomTabState = {
+      const dotcomTabState = {
         ...this.state.dotcomTabState,
         settings: settings,
       }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react'
-import {
-  PublishRepository,
-  IDotcomPublicationSettings,
-  IGHEPublicationSettings,
-  RepositoryPublicationSettings,
-} from './publish-repository'
+import { PublishRepository } from './publish-repository'
 import { Dispatcher } from '../dispatcher'
 import { Account } from '../../models/account'
 import { Repository } from '../../models/repository'
@@ -16,6 +11,11 @@ import { getDotComAPIEndpoint } from '../../lib/api'
 import { assertNever, fatalError } from '../../lib/fatal-error'
 import { CallToAction } from '../lib/call-to-action'
 import { getGitDescription } from '../../lib/git'
+import {
+  IDotcomPublicationSettings,
+  IEnterprisePublicationSettings,
+  RepositoryPublicationSettings,
+} from '../../models/publish-settings'
 
 enum PublishTab {
   DotCom = 0,
@@ -42,7 +42,7 @@ interface IGheTabState {
   readonly kind: 'ghe'
 
   /** The settings for publishing the repository. */
-  readonly settings: IGHEPublicationSettings
+  readonly settings: IEnterprisePublicationSettings
 
   /**
    * An error which, if present, is presented to the

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -118,7 +118,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     this.state = {
       currentTab: startingTab,
       dotcomTabState: { ...dotcomTabState },
-      enterpriseTabState: { ...gheTabState },
+      enterpriseTabState,
       publishing: false,
     }
   }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -82,14 +82,14 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     const startingTabState = {
       publishSettings: { ...publishSettings },
-      error: null
+      error: null,
     }
 
     this.state = {
       currentTab: startingTab,
       dotComTabState: { ...startingTabState },
       enterpriseTabState: { ...startingTabState },
-      publishing: false
+      publishing: false,
     }
   }
 
@@ -270,16 +270,18 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   }
 
   private getCurrentTabState = () =>
-      this.state.currentTab === PublishTab.DotCom ? this.state.dotComTabState : this.state.enterpriseTabState
+    this.state.currentTab === PublishTab.DotCom
+      ? this.state.dotComTabState
+      : this.state.enterpriseTabState
 
   private setTabState = (tabState: IPublishTabState) => {
     if (this.state.currentTab === PublishTab.DotCom) {
       this.setState({
-        dotComTabState: { ...tabState }
+        dotComTabState: { ...tabState },
       })
     } else {
       this.setState({
-        enterpriseTabState: { ...tabState }
+        enterpriseTabState: { ...tabState },
       })
     }
   }
@@ -287,14 +289,14 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   private setCurrentTabSettings = (settings: IPublishRepositorySettings) => {
     this.setTabState({
       ...this.getCurrentTabState(),
-      publishSettings: { ...settings }
+      publishSettings: { ...settings },
     })
   }
 
   private setCurrentTabError = (error: Error | null) => {
     this.setTabState({
       ...this.getCurrentTabState(),
-      error: error
+      error: error,
     })
   }
 }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -69,12 +69,8 @@ interface IPublishProps {
 interface IPublishState {
   /** The currently selected tab. */
   readonly currentTab: PublishTab
-
-  /** The state of dotCom tab. */
   readonly dotcomTabState: IDotcomTabState
-
-  /** The state of enterprise tab. */
-  readonly gheTabState: IEnterpriseTabState
+  readonly enterpriseTabState: IEnterpriseTabState
 
   /** Is the repository currently being published? */
   readonly publishing: boolean
@@ -122,7 +118,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     this.state = {
       currentTab: startingTab,
       dotcomTabState: { ...dotcomTabState },
-      gheTabState: { ...gheTabState },
+      enterpriseTabState: { ...gheTabState },
       publishing: false,
     }
   }
@@ -196,7 +192,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       tabState = {
         kind: 'enterprise',
         settings: settings,
-        error: this.state.gheTabState.error,
+        error: this.state.enterpriseTabState.error,
       }
     } else {
       tabState = {
@@ -322,29 +318,29 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   private getCurrentTabState = () =>
     this.state.currentTab === PublishTab.DotCom
       ? this.state.dotcomTabState
-      : this.state.gheTabState
+      : this.state.enterpriseTabState
 
   private setTabState = (state: TabState) => {
     if (state.kind === 'enterprise') {
-      this.setState({ gheTabState: { ...state } })
+      this.setState({ enterpriseTabState: state })
     } else {
-      this.setState({ dotcomTabState: { ...state } })
+      this.setState({ dotcomTabState: state })
     }
   }
 
   private setCurrentTabSettings = (settings: RepositoryPublicationSettings) => {
     if (settings.kind === PublishSettingsType.enterprise) {
       const enterpriseTabState = {
-        ...this.state.gheTabState,
+        ...this.state.enterpriseTabState,
         settings: settings,
       }
-      this.setTabState({ ...enterpriseTabState })
+      this.setTabState(enterpriseTabState)
     } else {
       const dotcomTabState = {
         ...this.state.dotcomTabState,
         settings: settings,
       }
-      this.setTabState({ ...dotcomTabState })
+      this.setTabState(dotcomTabState)
     }
   }
 

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -249,8 +249,6 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   private onTabClicked = (index: PublishTab) => {
     const isTabChanging = index !== this.state.currentTab
     if (isTabChanging) {
-      // Clear the selected org since dot com and Enterprise will have a different
-      // set of orgs.
       const settings = { ...this.state.publishSettings }
       this.setState({ currentTab: index, publishSettings: settings })
       // Swap the current stored error from the active tab with the error from

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -20,17 +20,11 @@ enum PublishTab {
   Enterprise,
 }
 
-interface IPublishProps {
-  readonly dispatcher: Dispatcher
 
-  /** The repository being published. */
-  readonly repository: Repository
 
-  /** The signed in accounts. */
-  readonly accounts: ReadonlyArray<Account>
+  /** The settings for publishing the repository. */
+  readonly settings: DotcomPublicationSettings
 
-  /** The function to call when the dialog should be dismissed. */
-  readonly onDismissed: () => void
 }
 
 interface IPublishTabState {
@@ -43,6 +37,19 @@ interface IPublishTabState {
    * related to the current step.
    */
   readonly error: Error | null
+}
+
+interface IPublishProps {
+  readonly dispatcher: Dispatcher
+
+  /** The repository being published. */
+  readonly repository: Repository
+
+  /** The signed in accounts. */
+  readonly accounts: ReadonlyArray<Account>
+
+  /** The function to call when the dialog should be dismissed. */
+  readonly onDismissed: () => void
 }
 
 interface IPublishState {

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -91,22 +91,28 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       startingTab = PublishTab.Enterprise
     }
 
-    const publishSettings = {
+    const GHEPublicationSettings = {
       name: props.repository.name,
       description: '',
       private: true,
-      org: null,
     }
 
-    const startingTabState = {
-      publishSettings: { ...publishSettings },
+    const dotcomTabState: DotcomTabState = {
+      kind: 'dotcom',
+      settings: { ...GHEPublicationSettings, kind: 'dotcom', org: null },
+      error: null,
+    }
+
+    const gheTabState: GheTabState = {
+      kind: 'ghe',
+      settings: { ...GHEPublicationSettings, kind: 'ghe' },
       error: null,
     }
 
     this.state = {
       currentTab: startingTab,
-      dotComTabState: { ...startingTabState },
-      enterpriseTabState: { ...startingTabState },
+      dotcomTabState: { ...dotcomTabState },
+      gheTabState: { ...gheTabState },
       publishing: false,
     }
   }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -106,7 +106,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       error: null,
     }
 
-    const gheTabState: IEnterpriseTabState = {
+    const enterpriseTabState: IEnterpriseTabState = {
       kind: 'enterprise',
       settings: {
         ...publicationSettings,

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -128,7 +128,6 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     try {
       const description = await getGitDescription(this.props.repository.path)
-      console.log(description)
       const settings = {
         ...currentTabState.publishSettings,
         description,

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -20,16 +20,27 @@ enum PublishTab {
   Enterprise,
 }
 
+type TabState = DotcomTabState | GheTabState
 
+interface DotcomTabState {
+  readonly kind: 'dotcom'
 
   /** The settings for publishing the repository. */
   readonly settings: DotcomPublicationSettings
 
+  /**
+   * An error which, if present, is presented to the
+   * user in close proximity to the actions or input fields
+   * related to the current step.
+   */
+  readonly error: Error | null
 }
 
-interface IPublishTabState {
+interface GheTabState {
+  readonly kind: 'ghe'
+
   /** The settings for publishing the repository. */
-  readonly publishSettings: IPublishRepositorySettings
+  readonly settings: GHEPublicationSettings
 
   /**
    * An error which, if present, is presented to the

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -68,10 +68,10 @@ interface IPublishState {
   readonly currentTab: PublishTab
 
   /** The state of dotCom tab. */
-  readonly dotComTabState: IPublishTabState
+  readonly dotcomTabState: DotcomTabState
 
   /** The state of enterprise tab. */
-  readonly enterpriseTabState: IPublishTabState
+  readonly gheTabState: GheTabState
 
   /** Is the repository currently being published? */
   readonly publishing: boolean

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -251,7 +251,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     if (isTabChanging) {
       // Clear the selected org since dot com and Enterprise will have a different
       // set of orgs.
-      const settings = { ...this.state.publishSettings, org: null }
+      const settings = { ...this.state.publishSettings }
       this.setState({ currentTab: index, publishSettings: settings })
       // Swap the current stored error from the active tab with the error from
       // the inactive tab. So that each tab saves and displays their own error.

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -15,6 +15,7 @@ import {
   IDotcomPublicationSettings,
   IEnterprisePublicationSettings,
   RepositoryPublicationSettings,
+  PublishSettingsType,
 } from '../../models/publish-settings'
 
 enum PublishTab {
@@ -39,7 +40,7 @@ interface IDotcomTabState {
 }
 
 interface EnterpriseTabState {
-  readonly kind: 'ghe'
+  readonly kind: 'enterprise'
 
   /** The settings for publishing the repository. */
   readonly settings: IEnterprisePublicationSettings
@@ -101,13 +102,20 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     const dotcomTabState: IDotcomTabState = {
       kind: 'dotcom',
-      settings: { ...publicationSettings, kind: 'dotcom', org: null },
+      settings: {
+        ...publicationSettings,
+        kind: PublishSettingsType.dotcom,
+        org: null,
+      },
       error: null,
     }
 
     const gheTabState: EnterpriseTabState = {
-      kind: 'ghe',
-      settings: { ...publicationSettings, kind: 'ghe' },
+      kind: 'enterprise',
+      settings: {
+        ...publicationSettings,
+        kind: PublishSettingsType.enterprise,
+      },
       error: null,
     }
 
@@ -184,9 +192,9 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
   private onSettingsChanged = (settings: RepositoryPublicationSettings) => {
     let tabState: TabState
-    if (settings.kind === 'ghe') {
+    if (settings.kind === PublishSettingsType.enterprise) {
       tabState = {
-        kind: 'ghe',
+        kind: 'enterprise',
         settings: settings,
         error: this.state.gheTabState.error,
       }
@@ -317,7 +325,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       : this.state.gheTabState
 
   private setTabState = (state: TabState) => {
-    if (state.kind === 'ghe') {
+    if (state.kind === 'enterprise') {
       this.setState({ gheTabState: { ...state } })
     } else {
       this.setState({ dotcomTabState: { ...state } })
@@ -325,12 +333,12 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
   }
 
   private setCurrentTabSettings = (settings: RepositoryPublicationSettings) => {
-    if (settings.kind === 'ghe') {
-      const gheTabState = {
+    if (settings.kind === PublishSettingsType.enterprise) {
+      const enterpriseTabState = {
         ...this.state.gheTabState,
         settings: settings,
       }
-      this.setTabState({ ...gheTabState })
+      this.setTabState({ ...enterpriseTabState })
     } else {
       const dotcomTabState = {
         ...this.state.dotcomTabState,

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -93,7 +93,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       startingTab = PublishTab.Enterprise
     }
 
-    const GHEPublicationSettings = {
+    const publicationSettings = {
       name: props.repository.name,
       description: '',
       private: true,
@@ -101,13 +101,13 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     const dotcomTabState: IDotcomTabState = {
       kind: 'dotcom',
-      settings: { ...GHEPublicationSettings, kind: 'dotcom', org: null },
+      settings: { ...publicationSettings, kind: 'dotcom', org: null },
       error: null,
     }
 
     const gheTabState: EnterpriseTabState = {
       kind: 'ghe',
-      settings: { ...GHEPublicationSettings, kind: 'ghe' },
+      settings: { ...publicationSettings, kind: 'ghe' },
       error: null,
     }
 

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -22,7 +22,7 @@ enum PublishTab {
   Enterprise,
 }
 
-type TabState = IDotcomTabState | IGheTabState
+type TabState = IDotcomTabState | EnterpriseTabState
 
 interface IDotcomTabState {
   readonly kind: 'dotcom'
@@ -38,7 +38,7 @@ interface IDotcomTabState {
   readonly error: Error | null
 }
 
-interface IGheTabState {
+interface EnterpriseTabState {
   readonly kind: 'ghe'
 
   /** The settings for publishing the repository. */
@@ -73,7 +73,7 @@ interface IPublishState {
   readonly dotcomTabState: IDotcomTabState
 
   /** The state of enterprise tab. */
-  readonly gheTabState: IGheTabState
+  readonly gheTabState: EnterpriseTabState
 
   /** Is the repository currently being published? */
   readonly publishing: boolean
@@ -105,7 +105,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       error: null,
     }
 
-    const gheTabState: IGheTabState = {
+    const gheTabState: EnterpriseTabState = {
       kind: 'ghe',
       settings: { ...GHEPublicationSettings, kind: 'ghe' },
       error: null,

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -23,7 +23,7 @@ enum PublishTab {
   Enterprise,
 }
 
-type TabState = IDotcomTabState | EnterpriseTabState
+type TabState = IDotcomTabState | IEnterpriseTabState
 
 interface IDotcomTabState {
   readonly kind: 'dotcom'
@@ -39,7 +39,7 @@ interface IDotcomTabState {
   readonly error: Error | null
 }
 
-interface EnterpriseTabState {
+interface IEnterpriseTabState {
   readonly kind: 'enterprise'
 
   /** The settings for publishing the repository. */
@@ -74,7 +74,7 @@ interface IPublishState {
   readonly dotcomTabState: IDotcomTabState
 
   /** The state of enterprise tab. */
-  readonly gheTabState: EnterpriseTabState
+  readonly gheTabState: IEnterpriseTabState
 
   /** Is the repository currently being published? */
   readonly publishing: boolean
@@ -110,7 +110,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       error: null,
     }
 
-    const gheTabState: EnterpriseTabState = {
+    const gheTabState: IEnterpriseTabState = {
       kind: 'enterprise',
       settings: {
         ...publicationSettings,

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -117,7 +117,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
 
     this.state = {
       currentTab: startingTab,
-      dotcomTabState: { ...dotcomTabState },
+      dotcomTabState,
       enterpriseTabState,
       publishing: false,
     }

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import {
   PublishRepository,
-  DotcomPublicationSettings,
-  GHEPublicationSettings,
+  IDotcomPublicationSettings,
+  IGHEPublicationSettings,
   RepositoryPublicationSettings,
 } from './publish-repository'
 import { Dispatcher } from '../dispatcher'
@@ -22,13 +22,13 @@ enum PublishTab {
   Enterprise,
 }
 
-type TabState = DotcomTabState | GheTabState
+type TabState = IDotcomTabState | IGheTabState
 
-interface DotcomTabState {
+interface IDotcomTabState {
   readonly kind: 'dotcom'
 
   /** The settings for publishing the repository. */
-  readonly settings: DotcomPublicationSettings
+  readonly settings: IDotcomPublicationSettings
 
   /**
    * An error which, if present, is presented to the
@@ -38,11 +38,11 @@ interface DotcomTabState {
   readonly error: Error | null
 }
 
-interface GheTabState {
+interface IGheTabState {
   readonly kind: 'ghe'
 
   /** The settings for publishing the repository. */
-  readonly settings: GHEPublicationSettings
+  readonly settings: IGHEPublicationSettings
 
   /**
    * An error which, if present, is presented to the
@@ -70,10 +70,10 @@ interface IPublishState {
   readonly currentTab: PublishTab
 
   /** The state of dotCom tab. */
-  readonly dotcomTabState: DotcomTabState
+  readonly dotcomTabState: IDotcomTabState
 
   /** The state of enterprise tab. */
-  readonly gheTabState: GheTabState
+  readonly gheTabState: IGheTabState
 
   /** Is the repository currently being published? */
   readonly publishing: boolean
@@ -99,13 +99,13 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       private: true,
     }
 
-    const dotcomTabState: DotcomTabState = {
+    const dotcomTabState: IDotcomTabState = {
       kind: 'dotcom',
       settings: { ...GHEPublicationSettings, kind: 'dotcom', org: null },
       error: null,
     }
 
-    const gheTabState: GheTabState = {
+    const gheTabState: IGheTabState = {
       kind: 'ghe',
       settings: { ...GHEPublicationSettings, kind: 'ghe' },
       error: null,
@@ -332,7 +332,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       }
       this.setTabState({ ...gheTabState })
     } else {
-      const dotcomTabState: DotcomTabState = {
+      const dotcomTabState: IDotcomTabState = {
         ...this.state.dotcomTabState,
         settings: settings,
       }


### PR DESCRIPTION
Fixes #6546
Related to #6636.

This PR includes a refactor to better support #6636 with types. I've split the publication settings into two distinct types, `DotcomPublicationSettings` and `GhePublicationSettings`. This was done because we were previously sharing state between the two tabs which meant changes made in one tab would not persist once another tab was selected. 

---
**From original PR**
![](https://d1wuojemv4s7aw.cloudfront.net/items/001m0s3y2F0I1j3b320t/Screen%20Recording%202019-01-15%20at%2006.21%20PM.gif)

cc @brendonbarreto 

## Release notes

Notes: [Fixed] Publish settings remembered when switching between publish targets
