### PR TITLE
Enable Git v2 protocol for production build

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -44,7 +44,7 @@ export function enableFileSizeWarningCheck(): boolean {
 
 /** Should the app set protocol.version=2 for any fetch/push/pull/clone operation? */
 export function enableGitProtocolVersionTwo(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 export function enableReadmeOverwriteWarning(): boolean {


### PR DESCRIPTION
Fixes: #6780

## Description

Replace `enableBetaFeatures()` with `true` to enable Git v2 protocol for production build.

## Release notes

- Enable Git v2 protocol for production build