### PR TITLE
add tracing to launch tests and emit details when test run fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,11 @@ jobs:
             yarn test:setup
             yarn test
       - run:
+          name: Test Review
+          command: |
+            yarn test:review
+          when: on_fail
+      - run:
           name: Report to codecov
           command: yarn test:report
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ addons:
 branches:
   only:
     - development
+    # investigating Travis integration test failures
+    - more-tabs-more-state
     - /^__release-.*/
 
 language: node_js

--- a/app/jest.integration.config.js
+++ b/app/jest.integration.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   testMatch: ['**/integration/**/*-test.ts{,x}'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  setupTestFrameworkScriptFile: '<rootDir>/test/setup-test-framework.ts',
+  setupFiles: ['<rootDir>/test/setup-integration-tests.ts'],
   reporters: [
     'default',
     [

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -5,6 +5,8 @@
 import { Application } from 'spectron'
 import * as path from 'path'
 
+import { getLogsDirectory } from '../helpers/logs'
+
 describe('App', function(this: any) {
   let app: Application
 
@@ -24,9 +26,16 @@ describe('App', function(this: any) {
 
     const root = path.resolve(__dirname, '..', '..', '..')
 
+    const logsDir = getLogsDirectory()
+
+    console.log(`Running Spectron and logging to ${logsDir}`)
+
     app = new Application({
       path: appPath,
       args: [path.join(root, 'out')],
+      chromeDriverLogPath: path.join(logsDir, 'chrome-driver.log'),
+      // TODO: this is a directory and will contain multiple files
+      webdriverLogPath: path.join(logsDir, 'web-driver'),
     })
     return app.start()
   })

--- a/app/test/setup-integration-tests.ts
+++ b/app/test/setup-integration-tests.ts
@@ -1,0 +1,3 @@
+import { setupLogsDirectory } from './helpers/logs'
+
+setupLogsDirectory()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ cache:
 branches:
   only:
     - development
+    # investigating integration test failures
+    - more-tabs-more-state
     - /^__release-.*/
 
 skip_tags: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,16 +21,22 @@ jobs:
       - script: |
           yarn test:setup && yarn test
         name: Test
+      - script: |
+          yarn test:review
+        displayName: Test Review
+        condition: failed()
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:
           testResultsFiles: '**junit*.xml'
           testRunTitle: $(Agent.OS) Test Results
+        condition: always()
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
+        condition: always()
 
   - job: Linux
     pool:
@@ -56,16 +62,22 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           yarn test:setup && yarn test
         name: Test
+      - script: |
+          yarn test:review
+        displayName: Test Review
+        condition: failed()
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:
           testResultsFiles: '**junit*.xml'
           testRunTitle: $(Agent.OS) Test Results
+        condition: always()
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
+        condition: always()
 
   - job: macOS
     pool:
@@ -83,16 +95,22 @@ jobs:
       - script: |
           yarn test:setup && yarn test
         name: Test
+      - script: |
+          yarn test:review
+        displayName: Test Review
+        condition: failed()
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:
           testResultsFiles: '**junit*.xml'
           testRunTitle: $(Agent.OS) Test Results
+        condition: always()
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
+        condition: always()
 
   - job: Lint
     pool:

--- a/script/test-review.ts
+++ b/script/test-review.ts
@@ -1,22 +1,14 @@
 /* eslint-disable no-sync */
 
 import * as fs from 'fs'
-import { getLogFiles } from './review-logs'
+import { getLogFiles } from '../app/test/helpers/logs'
 
-function reviewLogs() {
-  getLogFiles().forEach(file => {
+console.log(`Reviewing test failures`)
+
+getLogFiles().then(files =>
+  files.forEach(file => {
     console.log(`opening ${file}:`)
     const text = fs.readFileSync(file, 'utf-8')
     console.log(text)
   })
-}
-
-if (process.platform === 'darwin') {
-  reviewLogs()
-}
-
-if (process.platform === 'win32') {
-  if (process.env.APPVEYOR_TEST_RESULT !== '0') {
-    reviewLogs()
-  }
-}
+)

--- a/script/test-setup.ts
+++ b/script/test-setup.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs'
 import * as cp from 'child_process'
-import { getLogFiles } from './review-logs'
+import { getLogFiles } from '../app/test/helpers/logs'
 import { getProductName } from '../app/package-info'
 import { getDistPath } from './dist-info'
 import { isCircleCI, isRunningOnFork } from './build-platforms'
@@ -22,7 +22,9 @@ const output = cp.execSync('git config -l --show-origin', { encoding: 'utf-8' })
 console.log(`Git config:\n${output}\n\n`)
 
 // delete existing log files
-getLogFiles().forEach(file => {
-  console.log(`deleting ${file}`)
-  fs.unlinkSync(file)
-})
+getLogFiles().then(files =>
+  files.forEach(file => {
+    console.log(`deleting ${file}`)
+    fs.unlinkSync(file)
+  })
+)


### PR DESCRIPTION
## Overview

Adding diagnostics to our Spectron tests to be able to diagnose what #6776 is doing on Travis that's causing it to be unable to launch.

## Description

This leverages an old CI hook which reads out any log files that might exist in a known location if a CI failure occurs. I'm not sure it even still works for the original purpose, but this will help nicely for our Spectron tests where the internals can dump out logs to a known location to help us diagnose things where we can't SSH and run the tests directly.

If this approach works, we can revisit cleaning this area up to reflect what's actually valuable to us as part of diagnosing integration test failures better.

 - [ ] see the failure
 - [ ] become one with the failure
 - [ ] destroy the failure
 - [ ] rebase the commit history to clean up all the rambling

## Release notes

Notes: no-notes
