### PR TITLE
Pull request metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -143,11 +143,8 @@ export interface IDailyMeasures {
   /** The number of times the user committed a conflicted merge outside the merge conflicts dialog */
   readonly unguidedConflictedMergeCompletionCount: number
 
-  /** The number of times the user is taken to the create pull request page on dotcom from the branch menu */
-  readonly createPullRequestFromMenuCount: number
-
-  /** The number of times the user is taken to the create pull request page on dotcom from the suggested next steps flow */
-  readonly createPullRequestFromSuggestedNextStepCount: number
+  /** The number of times the user is taken to the create pull request page on dotcom */
+  readonly createPullRequestCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -61,6 +61,7 @@ export interface IDailyMeasures {
 
   /** The numbers of times a repo with indicators is clicked on repo list view */
   readonly repoWithIndicatorClicked: number
+
   /** The numbers of times a repo without indicators is clicked on repo list view */
   readonly repoWithoutIndicatorClicked: number
 
@@ -141,6 +142,12 @@ export interface IDailyMeasures {
 
   /** The number of times the user committed a conflicted merge outside the merge conflicts dialog */
   readonly unguidedConflictedMergeCompletionCount: number
+
+  /** The number of times the user is taken to the create pull request page on dotcom from the branch menu */
+  readonly createPullRequestFromMenuCount: number
+
+  /** The number of times the user is taken to the create pull request page on dotcom from the suggested next steps flow */
+  readonly createPullRequestFromSuggestedNextStepCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -80,8 +80,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   mergeConflictsDialogReopenedCount: 0,
   guidedConflictedMergeCompletionCount: 0,
   unguidedConflictedMergeCompletionCount: 0,
-  createPullRequestFromMenuCount: 0,
-  createPullRequestFromSuggestedNextStepCount: 0,
+  createPullRequestCount: 0,
 }
 
 interface IOnboardingStats {
@@ -822,23 +821,11 @@ export class StatsStore implements IStatsStore {
   }
 
   /**
-   * Increments the `createPullRequestFromMenuCount` metric
+   * Increments the `createPullRequestCount` metric
    */
-  public async recordCreatePullRequestFromMenuCount(): Promise<void> {
+  public async recordCreatePullRequest(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      createPullRequestFromMenuCount: m.createPullRequestFromMenuCount + 1,
-    }))
-  }
-
-  /**
-   * Increments the `createPullRequestFromSuggestedNextStepCount` metric
-   */
-  public async recordCreatePullRequestFromSuggestedNextStepCount(): Promise<
-    void
-  > {
-    return this.updateDailyMeasures(m => ({
-      createPullRequestFromSuggestedNextStepCount:
-        m.createPullRequestFromSuggestedNextStepCount + 1,
+      createPullRequestCount: m.createPullRequestCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -821,6 +821,27 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /**
+   * Increments the `createPullRequestFromMenuCount` metric
+   */
+  public async recordCreatePullRequestFromMenuCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      createPullRequestFromMenuCount: m.createPullRequestFromMenuCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `createPullRequestFromSuggestedNextStepCount` metric
+   */
+  public async recordCreatePullRequestFromSuggestedNextStepCount(): Promise<
+    void
+  > {
+    return this.updateDailyMeasures(m => ({
+      createPullRequestFromSuggestedNextStepCount:
+        m.createPullRequestFromSuggestedNextStepCount + 1,
+    }))
+  }
+
   public recordWelcomeWizardInitiated() {
     setNumber(WelcomeWizardInitiatedAtKey, Date.now())
     localStorage.removeItem(WelcomeWizardCompletedAtKey)

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -80,6 +80,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   mergeConflictsDialogReopenedCount: 0,
   guidedConflictedMergeCompletionCount: 0,
   unguidedConflictedMergeCompletionCount: 0,
+  createPullRequestFromMenuCount: 0,
+  createPullRequestFromSuggestedNextStepCount: 0,
 }
 
 interface IOnboardingStats {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1832,6 +1832,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (currentPullRequest == null) {
       dispatcher.createPullRequest(state.repository)
+      dispatcher.recordCreatePullRequestFromMenu()
     } else {
       dispatcher.showPullRequest(state.repository)
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1832,7 +1832,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (currentPullRequest == null) {
       dispatcher.createPullRequest(state.repository)
-      dispatcher.recordCreatePullRequestFromMenu()
+      dispatcher.recordCreatePullRequest()
     } else {
       dispatcher.showPullRequest(state.repository)
     }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -264,7 +264,6 @@ export class BranchesContainer extends React.Component<
   private onCreatePullRequest = () => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     this.props.dispatcher.createPullRequest(this.props.repository)
-    this.props.dispatcher.recordCreatePullRequestFromSuggestedNextStep()
   }
 
   private onPullRequestClicked = (pullRequest: PullRequest) => {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -264,6 +264,7 @@ export class BranchesContainer extends React.Component<
   private onCreatePullRequest = () => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     this.props.dispatcher.createPullRequest(this.props.repository)
+    this.props.dispatcher.recordCreatePullRequestFromSuggestedNextStep()
   }
 
   private onPullRequestClicked = (pullRequest: PullRequest) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1422,7 +1422,7 @@ export class Dispatcher {
   }
 
   /**
-   * Increments the `CreatePullRequestCount` metric
+   * Increments the `createPullRequestCount` metric
    */
   public recordCreatePullRequest() {
     return this.statsStore.recordCreatePullRequest()

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1425,14 +1425,7 @@ export class Dispatcher {
    * Increments the `CreatePullRequestFromMenuCount` metric
    */
   public recordCreatePullRequestFromMenu() {
-    return this.statsStore.recordCreatePullRequestFromMenuCount()
-  }
-
-  /**
-   * Increments the `CreatePullRequestFromSuggestedNextStepCount` metric
-   */
-  public recordCreatePullRequestFromSuggestedNextStep() {
-    return this.statsStore.recordCreatePullRequestFromSuggestedNextStepCount()
+    return this.statsStore.recordCreatePullRequest()
   }
 
   public recordWelcomeWizardInitiated() {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1421,6 +1421,20 @@ export class Dispatcher {
     return this.statsStore.recordDivergingBranchBannerInitatedMerge()
   }
 
+  /**
+   * Increments the `CreatePullRequestFromMenuCount` metric
+   */
+  public recordCreatePullRequestFromMenu() {
+    return this.statsStore.recordCreatePullRequestFromMenuCount()
+  }
+
+  /**
+   * Increments the `CreatePullRequestFromSuggestedNextStepCount` metric
+   */
+  public recordCreatePullRequestFromSuggestedNextStep() {
+    return this.statsStore.recordCreatePullRequestFromSuggestedNextStepCount()
+  }
+
   public recordWelcomeWizardInitiated() {
     return this.statsStore.recordWelcomeWizardInitiated()
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1422,9 +1422,9 @@ export class Dispatcher {
   }
 
   /**
-   * Increments the `CreatePullRequestFromMenuCount` metric
+   * Increments the `CreatePullRequestCount` metric
    */
-  public recordCreatePullRequestFromMenu() {
+  public recordCreatePullRequest() {
     return this.statsStore.recordCreatePullRequest()
   }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         displayName: 'Publish Test Results'
         inputs:
           testResultsFiles: '**junit*.xml'
-          testRunTitle: TestRun ${{ parameters.name }} $(node_version)
+          testRunTitle: $(Agent.OS) Test Results
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
@@ -60,7 +60,7 @@ jobs:
         displayName: 'Publish Test Results'
         inputs:
           testResultsFiles: '**junit*.xml'
-          testRunTitle: TestRun ${{ parameters.name }} $(node_version)
+          testRunTitle: $(Agent.OS) Test Results
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
@@ -87,7 +87,7 @@ jobs:
         displayName: 'Publish Test Results'
         inputs:
           testResultsFiles: '**junit*.xml'
-          testRunTitle: TestRun ${{ parameters.name }} $(node_version)
+          testRunTitle: $(Agent.OS) Test Results
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
@@ -113,3 +113,6 @@ jobs:
       - script: |
           yarn lint
         name: Lint
+      - script: |
+          yarn check-modified
+        displayName: 'Check for modified files'

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -30,9 +30,11 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | Metric | Description | Justification |
 |:--|:--|:--|
 | `active*` | Flag indicating whether the app has been interacted with during the current reporting window. | To identify users who are actively using Desktop versus those who have it open but never interact with it. |
+| `anyConflictsLeftOnMergeConflictsDialogDismissalCount` | The number of times there were any merge conflicts present when the Merge Conflicts Dialog is dismissed. | To understand whether people dismiss the dialog after resolving conflicts for one last check or just want to back out of the guided flow entirely. |
 | `branchComparisons` | The number of times a branch is compared to an arbitrary branch. | To understand usage patterns around the compare branches feature. |
 | `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
 | `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
+| `createPullRequestCount` | The number of times the user is taken to the create pull request page on GitHub.com. | To understand how people are creating pull requests via Desktop. |
 | `defaultBranchComparisons` | The number of times a branch is compared to the default branch. | To understand usage patterns around the compare branches feature. |
 | `divergingBranchBannerDismissal` | The number of times the user dismisses the diverged branch notification. | To understand usage patterns around the notification of diverging from the default branch feature. |
 | `divergingBranchBannerDisplayed` | The number of times the diverged branch notification is displayed. | To understand usage patterns around the notification of diverging from the default branch feature. |
@@ -41,11 +43,14 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `divergingBranchBannerInitiatedCompare` | The number of times the user compares from the diverged branch notification compare CTA button. | To understand usage patterns around the notification of diverging from the default branch feature. |
 | `dotcomCommits` | The number of time the user made a commit to a repo hosted on Github.com. | To understand the total percentage of commits made to GitHub repos compared to GitHub Enterprise and other remotes to help prioritize our work and focus areas |
 | `enterpriseCommits` | The number of times the user made a commit to a repo hosted on a GitHub Enterprise instance. | To understand the total percentage of commits made to GitHub Enterprise repos to help prioritize our work associated with enterprise use of GitHub Desktop compared to GitHub |
+| `guidedConflictedMergeCompletionCount` | The number of times a conflicted merge is completed from the Merge Conflicts Dialog. | To understand how many times people prefer to finish the merge in the guided flow after resolving conflicts. |
 | `loadTime` | The time (in milliseconds) it takes from when loading begins to loading end. | To make sure new versions of Desktop are not regressing on performance. |
 | `mainReadyTime` | The time (in milliseconds) it takes from when our main process code is first loaded until the app `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
 | `mergeAbortedAfterConflictsCount` | The number of times the user aborts a merge after a merge conflict. | To understand the frequency of merges that are never completed after attempting to merge and hitting a merge conflict |
 | `mergeConflictFromExplicitMergeCount` | The number of times a `git merge` initiated by Desktop resulted in a merge conflict for the user. | To understand how often people encounter a merge conflict in Desktop. |
 | `mergeConflictFromPullCount` | The number of times a `git pull` initiated by Desktop resulted in a merge conflict for the user. | To understand how often people encounter a merge conflict in Desktop. |
+| `mergeConflictsDialogDismissalCount` | The number of times the Merge Conflicts Dialog is dismissed. | To understand how frequently people prefer a different merge conflicts flow than the guided one. |
+| `mergeConflictsDialogReopenedCount` | The number of times the Merge Conflicts Dialog is reopened from the Merge Conflicts Banner. | To understand whether people find value in both the guided and unguided merge conflicts flow. |
 | `mergedWithCleanMergeHintCount` | The number of times the user has merged after seeing the 'no conflicts' merge hint. | To understand how many "clean" merges there are |
 | `mergedWithConflictWarningHintCount` | The number of times the user has merged after seeing the 'you have XX conflicted files' warning. | To understand how frequently people are merging even though they know there will be conflicts |
 | `mergedWithLoadingHintCount` | The number of times the user merged before seeing the result of the merge hint. | To understand how many people are merging before learning whether there will be conflicts or not |
@@ -59,9 +64,5 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `repoWithIndicatorClicked` | The numbers of times a repo with indicators is clicked on repo list view. | To understand usage patterns around the repository indicators feature. |
 | `repoWithoutIndicatorClicked` | The numbers of times a repo without indicators is clicked on repo list view.  | To understand usage patterns around the repository indicators feature. |
 | `unattributedCommits` | The number of commits that will go unattributed to GitHub users. | To understand how frequently commits in GitHub Desktop are unattributed and how highly we should prioritize design for those instances |
-| `updateFromDefaultBranchMenuCount` | The number of times the `Branch -> Update From Default Branch` menu item is used. | To understand usage patterns around the compare branches feature. |
-| `mergeConflictsDialogDismissalCount` | The number of times the Merge Conflicts Dialog is dismissed. | To understand how frequently people prefer a different merge conflicts flow than the guided one. |
-| `anyConflictsLeftOnMergeConflictsDialogDismissalCount` | The number of times there were any merge conflicts present when the Merge Conflicts Dialog is dismissed. | To understand whether people dismiss the dialog after resolving conflicts for one last check or just want to back out of the guided flow entirely. |
-| `mergeConflictsDialogReopenedCount` | The number of times the Merge Conflicts Dialog is reopened from the Merge Conflicts Banner. | To understand whether people find value in both the guided and unguided merge conflicts flow. |
-| `guidedConflictedMergeCompletionCount` | The number of times a conflicted merge is completed from the Merge Conflicts Dialog. | To understand how many times people prefer to finish the merge in the guided flow after resolving conflicts. |
 | `unguidedConflictedMergeCompletionCount` | The number of times a conflicted merge is completed from the diff/changes view. | To understand how many times people prefer to finish the merge in the changes/diff view after resolving conflicts. |
+| `updateFromDefaultBranchMenuCount` | The number of times the `Branch -> Update From Default Branch` menu item is used. | To understand usage patterns around the compare branches feature. |


### PR DESCRIPTION
Fixes #6772

Adds new metric to capture the number of times a user is taken to the create PR page on GitHub.com from Desktop.

We initially attempted to differentiate between the different pathways to get to this action, but because @niik's implementation of the suggested next step "Create PR" action looks to be to just hijack the menu item action, the easiest path forward here was just to have one that encompasses the three different ways to trigger it (suggested next step, keyboard shortcut, branch menu item).

---
- [x] Open issue in analytics
- [x] Update central
- [x] Update marketing site
- [x] Update `metrics.md` doc - https://github.com/desktop/desktop/pull/6791/commits/a94f799d626a86e0b53ef937d855bee3e43a9344
