### PR TITLE
Fix hitbox for RMB in 'Changes' Panel

### DIFF
--- a/app/styles/ui/_file-list.scss
+++ b/app/styles/ui/_file-list.scss
@@ -7,7 +7,6 @@
   height: 100%;
 
   .list-item {
-    padding: 0 var(--spacing);
     border-bottom: var(--base-border);
   }
 
@@ -29,6 +28,8 @@
 
     // See https://css-tricks.com/flexbox-truncated-text/
     min-width: 0;
+    height: 100%;
+    padding: 0 var(--spacing);
 
     .checkbox-component {
       flex-shrink: 0;


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #6296 : Hitbox for RMB clicks is smaller than hitbox for LMB clicks in 'Changes' panel.**

## Description

- Not all mouse button clicks are created equal.
- In the 'Changes' panel on the left, when you perform a right mouse button click, you have to be more precise and closer to the text content in the div than when you perform a left mouse button click.
- Fix has been made to increase height and switch location of padding to allow for the right mouse button click to have similar click area than the left mouse button click.

**BEFORE**

![screen shot 2019-02-07 at 10 27 47 am](https://user-images.githubusercontent.com/29465981/52430579-a8c54280-2ac3-11e9-8209-c319770320de.png)

**AFTER**

![screen shot 2019-02-07 at 10 28 16 am](https://user-images.githubusercontent.com/29465981/52430590-b2e74100-2ac3-11e9-8a39-e7335276a8b7.png)

## Release notes

Notes: [Fixed] Hitbox for items in \"Changes\" list are now the same size for primary and secondary mouse clicks.