### PR TITLE
Stops node_modules from being cached during CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             - vendor/bundle
             - .eslintcache
             - ~/.electron
-            - ~/Library/Caches/Yarn/v1
+            - ~/Library/Caches/Yarn/v4
       - run:
           name: Linting
           command: yarn lint && yarn validate-changelog && yarn check-modified

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
             - .eslintcache
             - ~/.electron
             - ~/Library/Caches/Yarn/v1
-            - ./node_modules
       - run:
           name: Linting
           command: yarn lint && yarn validate-changelog && yarn check-modified

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ cache:
   yarn: true
   timeout: 600
   directories:
-    - node_modules
     - $HOME/.electron
     - .eslintcache
     - $HOME/.cache/electron-builder

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
 
 cache:
   - .eslintcache
-  - node_modules
   - '%USERPROFILE%\.electron'
   - '%LOCALAPPDATA%\Yarn'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 cache:
   - .eslintcache
   - '%USERPROFILE%\.electron'
-  - '%LOCALAPPDATA%\Yarn'
+   - '%LOCALAPPDATA%\Yarn\Cache\v4'
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 cache:
   - .eslintcache
   - '%USERPROFILE%\.electron'
-   - '%LOCALAPPDATA%\Yarn\Cache\v4'
+  - '%LOCALAPPDATA%\Yarn\Cache\v4'
 
 branches:
   only:


### PR DESCRIPTION
Addressing the recent build issues we've been having due to cache invalidation.

**Previous build times (range)**
* Azure: 12-14 mins
* Appveyor: 13-16 mins
* Travis: 10-12 mins
* Cicle: 12-14 mins

☝️ is given as ranges because I couldn't figure out how to export build history in order to do give better descriptive stats. Also all these times are from the past week.

**After this change**
* Azure: 11m44s
* Appveyor: 17m30s
* Travis: 11m41s
* Cicle: 12m34s

Since these times are within the ranges I saw in our build history for successful builds, removing the cache doesn't seem to have made a significant impact.