### PR TITLE
improvements to integration test execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,11 @@ jobs:
             yarn test:setup
             yarn test
       - run:
+          name: Review Test Failures
+          command: |
+            yarn test:review
+          when: on_fail
+      - run:
           name: Report to codecov
           command: yarn test:report
           when: always

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -3,8 +3,10 @@
 /// <reference path="../../../node_modules/@types/node/index.d.ts" />
 
 import { Application } from 'spectron'
-import { pathExists } from 'fs-extra'
+import { pathExists, mkdirp } from 'fs-extra'
+import * as Path from 'path'
 import { getEntryPointForApp } from '../../../script/dist-info'
+import { getLogsDirectory } from '../../../script/review-logs'
 
 describe('App', function(this: any) {
   let app: Application
@@ -19,8 +21,16 @@ describe('App', function(this: any) {
       )
     }
 
+    const logsDir = getLogsDirectory()
+
+    await mkdirp(logsDir)
+
+    console.log(`Running Spectron and logging to ${logsDir}`)
+
     app = new Application({
       path: appPath,
+      chromeDriverLogPath: Path.join(logsDir, 'chrome-driver.log'),
+      webdriverLogPath: Path.join(logsDir, 'web-driver'),
     })
     await app.start()
   })

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -33,10 +33,14 @@ describe('App', function(this: any) {
     expect(count).toBe(1)
 
     const window = app.browserWindow
-    expect(window.isVisible()).resolves.toBe(true)
-    expect(window.isMinimized()).resolves.toBe(false)
+    const isVisible = await window.isVisible()
+    expect(isVisible).toBe(true)
 
-    expect(window.isMinimized()).resolves.toBe(false)
+    const isMinimized = await window.isMinimized()
+    expect(isMinimized).toBe(false)
+
+    const isMaximized = await window.isMaximized()
+    expect(isMaximized).toBe(false)
 
     const bounds = await window.getBounds()
 

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -11,8 +11,6 @@ describe('App', function(this: any) {
   beforeEach(async () => {
     const appPath = getEntryPointForApp()
 
-    console.log(`launching app '${appPath}'`)
-
     app = new Application({
       path: appPath,
     })

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -8,7 +8,7 @@ import { getEntryPointForApp } from '../../../script/dist-info'
 describe('App', function(this: any) {
   let app: Application
 
-  beforeEach(() => {
+  beforeEach(async () => {
     const appPath = getEntryPointForApp()
 
     console.log(`launching app '${appPath}'`)
@@ -16,14 +16,13 @@ describe('App', function(this: any) {
     app = new Application({
       path: appPath,
     })
-    return app.start()
+    await app.start()
   })
 
-  afterEach(function() {
+  afterEach(async () => {
     if (app && app.isRunning()) {
-      return app.stop()
+      await app.stop()
     }
-    return Promise.resolve()
   })
 
   it('opens a window on launch', async () => {

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -4,29 +4,37 @@
 
 import { Application } from 'spectron'
 import * as path from 'path'
+import { getDistPath, getExecutableName } from '../../../script/dist-info'
 
 describe('App', function(this: any) {
   let app: Application
 
   beforeEach(function() {
-    let appPath = path.join(
-      __dirname,
-      '..',
-      '..',
-      '..',
-      'node_modules',
-      '.bin',
-      'electron'
-    )
+    const distPath = getDistPath()
+    const programName = getExecutableName()
+
+    let appPath: string
+
     if (process.platform === 'win32') {
-      appPath += '.cmd'
+      appPath = path.join(distPath, `${programName}.exe`)
+    } else if (process.platform === 'darwin') {
+      appPath = path.join(
+        distPath,
+        `${programName}.app`,
+        'Contents',
+        'macOS',
+        programName
+      )
+    } else if (process.platform === 'linux') {
+      appPath = path.join(distPath, `desktop`)
+    } else {
+      throw new Error(`Unsupported platform: ${process.platform}`)
     }
 
-    const root = path.resolve(__dirname, '..', '..', '..')
+    console.log(`launching app '${appPath}'`)
 
     app = new Application({
       path: appPath,
-      args: [path.join(root, 'out')],
     })
     return app.start()
   })

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -3,33 +3,13 @@
 /// <reference path="../../../node_modules/@types/node/index.d.ts" />
 
 import { Application } from 'spectron'
-import * as path from 'path'
-import { getDistPath, getExecutableName } from '../../../script/dist-info'
+import { getEntryPointForApp } from '../../../script/dist-info'
 
 describe('App', function(this: any) {
   let app: Application
 
-  beforeEach(function() {
-    const distPath = getDistPath()
-    const programName = getExecutableName()
-
-    let appPath: string
-
-    if (process.platform === 'win32') {
-      appPath = path.join(distPath, `${programName}.exe`)
-    } else if (process.platform === 'darwin') {
-      appPath = path.join(
-        distPath,
-        `${programName}.app`,
-        'Contents',
-        'macOS',
-        programName
-      )
-    } else if (process.platform === 'linux') {
-      appPath = path.join(distPath, `desktop`)
-    } else {
-      throw new Error(`Unsupported platform: ${process.platform}`)
-    }
+  beforeEach(() => {
+    const appPath = getEntryPointForApp()
 
     console.log(`launching app '${appPath}'`)
 

--- a/app/test/integration/launch-test.ts
+++ b/app/test/integration/launch-test.ts
@@ -3,6 +3,7 @@
 /// <reference path="../../../node_modules/@types/node/index.d.ts" />
 
 import { Application } from 'spectron'
+import { pathExists } from 'fs-extra'
 import { getEntryPointForApp } from '../../../script/dist-info'
 
 describe('App', function(this: any) {
@@ -10,6 +11,13 @@ describe('App', function(this: any) {
 
   beforeEach(async () => {
     const appPath = getEntryPointForApp()
+
+    const exists = await pathExists(appPath)
+    if (!exists) {
+      throw new Error(
+        `Application expected at ${appPath} was not found on disk. Ensure you have built the app for production mode before running the integration tests.`
+      )
+    }
 
     app = new Application({
       path: appPath,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,10 @@ jobs:
       - script: |
           yarn test:setup && yarn test
         name: Test
+      - script: |
+          yarn test:review
+        displayName: 'Review Test Failures'
+        condition: failed()
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:
@@ -58,6 +62,10 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           yarn test:setup && yarn test
         name: Test
+      - script: |
+          yarn test:review
+        displayName: 'Review Test Failures'
+        condition: failed()
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:
@@ -87,6 +95,10 @@ jobs:
       - script: |
           yarn test:setup && yarn test
         name: Test
+      - script: |
+          yarn test:review
+        displayName: 'Review Test Failures'
+        condition: failed()
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -32,6 +32,27 @@ export function getExecutableName() {
   }
 }
 
+export function getEntryPointForApp() {
+  const distPath = getDistPath()
+  const programName = getExecutableName()
+
+  if (process.platform === 'win32') {
+    return Path.join(distPath, `${programName}.exe`)
+  } else if (process.platform === 'darwin') {
+    return Path.join(
+      distPath,
+      `${programName}.app`,
+      'Contents',
+      'macOS',
+      programName
+    )
+  } else if (process.platform === 'linux') {
+    return Path.join(distPath, `desktop`)
+  } else {
+    throw new Error(`Unsupported platform: ${process.platform}`)
+  }
+}
+
 export function getOSXZipName() {
   return `${productName}.zip`
 }

--- a/script/review-logs.ts
+++ b/script/review-logs.ts
@@ -6,6 +6,13 @@ import * as os from 'os'
 import { getProductName } from '../app/package-info'
 import { getExecutableName } from './dist-info'
 
+// TODO: we have types for this
+const klawSync = require('klaw-sync')
+
+type KlawEntry = {
+  path: string
+}
+
 function getUserDataPath() {
   if (process.platform === 'win32') {
     if (process.env.APPDATA) {
@@ -33,14 +40,17 @@ function getUserDataPath() {
   }
 }
 
+export function getLogsDirectory() {
+  return path.join(getUserDataPath(), 'logs')
+}
+
 export function getLogFiles(): ReadonlyArray<string> {
-  const directory = path.join(getUserDataPath(), 'logs')
+  const directory = getLogsDirectory()
   if (!fs.existsSync(directory)) {
     return []
   }
 
-  const fileNames = fs.readdirSync(directory)
-  return fileNames
-    .filter(fileName => fileName.endsWith('.log'))
-    .map(fileName => path.join(directory, fileName))
+  const entries: ReadonlyArray<KlawEntry> = klawSync(directory, { nodir: true })
+
+  return entries.map(l => l.path).filter(item => path.extname(item) === '.log')
 }


### PR DESCRIPTION
## Overview

As part of #6793 I've found a bunch of ways to improve the integration tests run. It doesn't quite solve the issues we've seen (#6802 is related) but this should help with identifying any future issues.

## Description

- [x] change launch test to use packaged app
- [x] improve `beforeEach` and `afterEach` so `jest` will exit cleanly when the `spectron` test fails, meaning tests are no longer held up until some sort of timeout occurs
- [x] remove usage of `.resolves` inside test because we can't seem to rely on these working
- [x] restore `yarn test:review` for CircleCI to see more information about failing integration tests internals
- [x] add `yarn test:review` to Pipelines config to see more information about failing integration tests internals
- [x] rebase on top of #6802 
- [ ] use the current set of tools to understand why CircleCI is failing

## Release notes

Notes: no-notes
