### PR TITLE
publish test/coverage results even if the tests report errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
       - run:
           name: Report to codecov
           command: yarn test:report
+          when: always
       - run:
           name: Teardown
           command:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,11 @@ install:
 
 script:
   - yarn lint && yarn validate-changelog && yarn check-modified && yarn
-    build:prod && yarn test:setup && yarn test && yarn test:report
+    build:prod && yarn test:setup && yarn test
+
+after_success:
+  - yarn test:report
 
 after_failure:
+  - yarn test:report
   - yarn test:review

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,6 @@ test_script:
   - ./script/test-appveyor.bat
 
 on_success:
-  - yarn test:report
   - yarn run publish
 
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,10 +38,11 @@ build_script:
 test_script:
   - yarn test:setup
   - ./script/test-appveyor.bat
-  - yarn test:report
 
 on_success:
+  - yarn test:report
   - yarn run publish
 
 on_finish:
   - yarn test:review
+  - yarn test:report

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,11 +26,13 @@ jobs:
         inputs:
           testResultsFiles: '**junit*.xml'
           testRunTitle: $(Agent.OS) Test Results
+        condition: always()
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
+        condition: always()
 
   - job: Linux
     pool:
@@ -61,11 +63,13 @@ jobs:
         inputs:
           testResultsFiles: '**junit*.xml'
           testRunTitle: $(Agent.OS) Test Results
+        condition: always()
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
+        condition: always()
 
   - job: macOS
     pool:
@@ -88,11 +92,13 @@ jobs:
         inputs:
           testResultsFiles: '**junit*.xml'
           testRunTitle: $(Agent.OS) Test Results
+        condition: always()
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage results'
         inputs:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '**/app/coverage/cobertura-coverage.xml'
+        condition: always()
 
   - job: Lint
     pool:


### PR DESCRIPTION
## Overview

This PR ensures that our CI platforms always do a `yarn test:report` to publish any test results to CodeCov. Azure Pipelines has it's own way to publish test results, but the principle is the same.

For example, [this CircleCI build](https://circleci.com/gh/desktop/desktop/7806) will "Report to CodeCov" when the tests pass.

<img width="567" src="https://user-images.githubusercontent.com/359239/52534954-a6aaf000-2d1e-11e9-9e10-582edfa78e95.png">

But [this CircleCI build](https://circleci.com/gh/desktop/desktop/7817) from #6803 returns exit code `1` inside `yarn test` and it will instead skip "Report to CodeCov" and instead check for details about the test failure (added as part of that PR) before cleaning up:

<img width="750" src="https://user-images.githubusercontent.com/359239/52534964-bcb8b080-2d1e-11e9-88c8-3aeb01085a96.png">

The goal here is to ensure we upload test and code coverage results whether or not the build succeeds. If we're only uploading test results when they pass, we'll only ever be at 100% tests passing and lack insight into what tests are failing over time.

## Release notes

Notes: no-notes
