### PR TITLE
mark repository found only if its a git repo

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1943,13 +1943,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    let foundRepository = await pathExists(repository.path)
+    const foundRepository =
+      (await pathExists(repository.path)) &&
+      (await isGitRepository(repository.path))
 
     if (foundRepository) {
-      foundRepository = await isGitRepository(repository.path)
+      this._updateRepositoryMissing(repository, false)
     }
-
-    return this._updateRepositoryMissing(repository, foundRepository)
+    return repository
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */


### PR DESCRIPTION
closes #6823 

![autorecover with no flicker](https://user-images.githubusercontent.com/964912/52587138-3c618080-2dee-11e9-8e3b-eef8fe97629b.gif)

N.B.
(double negatives are confusing, too)