### PR TITLE
unrelated changes in merge conflict commit

### DIFF
--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -50,6 +50,7 @@ export async function createCommit(
 /**
  * Creates a commit to finish an in-progress merge
  * assumes that all conflicts have already been resolved
+ * *Warning:* Does _not_ clear staged files before it commits!
  *
  * @param repository repository to execute merge in
  * @param files files to commit
@@ -59,12 +60,7 @@ export async function createMergeCommit(
   files: ReadonlyArray<WorkingDirectoryFileChange>,
   manualResolutions: ReadonlyMap<string, ManualConflictResolution> = new Map()
 ): Promise<string | undefined> {
-  // Clear the staging area, our diffs reflect the difference between the
-  // working directory and the last commit (if any) so our commits should
-  // do the same thing.
   try {
-    await unstageAll(repository)
-
     // apply manual conflict resolutions
     for (const [path, resolution] of manualResolutions) {
       const file = files.find(f => f.path === path)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3232,13 +3232,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return await gitStore.performFailableOperation(() => abortMerge(repository))
   }
 
-  /** This shouldn't be called directly. See `Dispatcher`. */
+  /** This shouldn't be called directly. See `Dispatcher`.
+   *  This method only used in the Merge Conflicts dialog flow,
+   *  not committing a conflicted merge via the "Changes" pane.
+   */
   public async _finishConflictedMerge(
     repository: Repository,
     workingDirectory: WorkingDirectoryStatus,
     manualResolutions: Map<string, ManualConflictResolutionKind>
   ): Promise<string | undefined> {
-    // filter out untracked files so we don't commit them
+    /**
+     *  The assumption made here is that all other files that were part of this merge
+     *  have already been staged by git automatically (or manually by the user via CLI).
+     *  When the user executes a merge and there are conflicts,
+     *  git stages all files that are part of the merge that _don't_ have conflicts
+     *  This means that we only need to stage the conflicted files
+     *  (whether they are manual or markered) to get all changes related to
+     *  this merge staged. This also means that any uncommitted changes in the index
+     *  that were in place before the merge was started will _not_ be included, unless
+     *  the user stages them manually via CLI.
+     *
+     *  Its also worth noting this method only used in the Merge Conflicts dialog flow, not committing a conflicted merge via the "Changes" pane.
+     *
+     *  *TLDR we only stage conflicts here because git will have already staged the rest of the changes related to this merge.*
+     */
     const conflictedFiles = workingDirectory.files.filter(f => {
       return f.status.kind === AppFileStatusKind.Conflicted
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3239,12 +3239,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     manualResolutions: Map<string, ManualConflictResolutionKind>
   ): Promise<string | undefined> {
     // filter out untracked files so we don't commit them
-    const trackedFiles = workingDirectory.files.filter(f => {
-      return f.status.kind !== AppFileStatusKind.Untracked
+    const conflictedFiles = workingDirectory.files.filter(f => {
+      return f.status.kind === AppFileStatusKind.Conflicted
     })
     const gitStore = this.gitStoreCache.get(repository)
     return await gitStore.performFailableOperation(() =>
-      createMergeCommit(repository, trackedFiles, manualResolutions)
+      createMergeCommit(repository, conflictedFiles, manualResolutions)
     )
   }
 

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -131,7 +131,9 @@ export async function setupConflictedRepo(): Promise<Repository> {
  *
  * The conflicted file will be 'foo'. There will also be uncommitted changes unrelated to the merge in 'perlin'.
  */
-export async function setupConflictedRepoWithDirt(): Promise<Repository> {
+export async function setupConflictedRepoWithUnrelatedCommittedChange(): Promise<
+  Repository
+> {
   const repo = await setupEmptyRepository()
 
   const firstCommit = {

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -22,7 +22,7 @@ import {
 import {
   setupEmptyRepository,
   setupConflictedRepoWithMultipleFiles,
-  setupConflictedRepoWithDirt,
+  setupConflictedRepoWithUnrelatedCommittedChange,
 } from '../helpers/repositories'
 import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
 
@@ -215,7 +215,7 @@ describe('AppStore', () => {
 
       beforeEach(async () => {
         appStore = await createAppStore()
-        repo = await setupConflictedRepoWithDirt()
+        repo = await setupConflictedRepoWithUnrelatedCommittedChange()
         await appStore._selectRepository(repo)
         status = await getStatusOrThrow(repo)
       })

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -22,6 +22,7 @@ import {
 import {
   setupEmptyRepository,
   setupConflictedRepoWithMultipleFiles,
+  setupConflictedRepoWithDirt,
 } from '../helpers/repositories'
 import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
 
@@ -173,38 +174,63 @@ describe('AppStore', () => {
     })
   })
   describe('_finishConflictedMerge', () => {
-    let appStore: AppStore, repo: Repository, status: IStatusResult
+    describe('with tracked and untracked files', () => {
+      let appStore: AppStore, repo: Repository, status: IStatusResult
 
-    beforeEach(async () => {
-      appStore = await createAppStore()
-      repo = await setupConflictedRepoWithMultipleFiles()
-      await appStore._selectRepository(repo)
-      status = await getStatusOrThrow(repo)
+      beforeEach(async () => {
+        appStore = await createAppStore()
+        repo = await setupConflictedRepoWithMultipleFiles()
+        await appStore._selectRepository(repo)
+        status = await getStatusOrThrow(repo)
+      })
+
+      it('commits tracked files', async () => {
+        await appStore._finishConflictedMerge(
+          repo,
+          status.workingDirectory,
+          new Map<string, ManualConflictResolutionKind>()
+        )
+        const newStatus = await getStatusOrThrow(repo)
+        const trackedFiles = newStatus.workingDirectory.files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        expect(trackedFiles).toHaveLength(0)
+      })
+      it('leaves untracked files untracked', async () => {
+        await appStore._finishConflictedMerge(
+          repo,
+          status.workingDirectory,
+          new Map<string, ManualConflictResolutionKind>()
+        )
+        const newStatus = await getStatusOrThrow(repo)
+        const untrackedfiles = newStatus.workingDirectory.files.filter(
+          f => f.status.kind === AppFileStatusKind.Untracked
+        )
+        expect(untrackedfiles).toHaveLength(1)
+      })
     })
 
-    it('commits tracked files', async () => {
-      await appStore._finishConflictedMerge(
-        repo,
-        status.workingDirectory,
-        new Map<string, ManualConflictResolutionKind>()
-      )
-      const newStatus = await getStatusOrThrow(repo)
-      const trackedFiles = newStatus.workingDirectory.files.filter(
-        f => f.status.kind !== AppFileStatusKind.Untracked
-      )
-      expect(trackedFiles).toHaveLength(0)
-    })
-    it('leaves untracked files untracked', async () => {
-      await appStore._finishConflictedMerge(
-        repo,
-        status.workingDirectory,
-        new Map<string, ManualConflictResolutionKind>()
-      )
-      const newStatus = await getStatusOrThrow(repo)
-      const untrackedfiles = newStatus.workingDirectory.files.filter(
-        f => f.status.kind === AppFileStatusKind.Untracked
-      )
-      expect(untrackedfiles).toHaveLength(1)
+    describe('with unrelated changes that are uncommitted', () => {
+      let appStore: AppStore, repo: Repository, status: IStatusResult
+
+      beforeEach(async () => {
+        appStore = await createAppStore()
+        repo = await setupConflictedRepoWithDirt()
+        await appStore._selectRepository(repo)
+        status = await getStatusOrThrow(repo)
+      })
+      it("doesn't commit unrelated changes", async () => {
+        await appStore._finishConflictedMerge(
+          repo,
+          status.workingDirectory,
+          new Map<string, ManualConflictResolutionKind>()
+        )
+        const newStatus = await getStatusOrThrow(repo)
+        const modifiedFiles = newStatus.workingDirectory.files.filter(
+          f => f.status.kind === AppFileStatusKind.Modified
+        )
+        expect(modifiedFiles).toHaveLength(1)
+      })
     })
   })
 })


### PR DESCRIPTION
## Overview

closes #6349 

## Description

- `createMergeCommit` and doesn't unstage anything prior to committing
- `_finishConflictedMerge` only manually stages files that are conflicted

Taken together, this means that we only commit files that git deems part of a conflicted merge (git automatically stages unconflicted files during a conflicted merge) as well as files that the user resolves (or stages manually). This means the user can wreak a little havoc on their merge commit for a conflicted merge, but only via the terminal, and only in very direct ways.

_NB_ — this diff is even smaller if you hide whitespace changes!

## Release notes

Notes: [Improved] Merge conflict resolution committing only commits changes relevant to the merge
