### PR TITLE
[rebase] extract functions so they can be shared

### DIFF
--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -5,9 +5,13 @@ import {
   WorkingDirectoryStatus,
   isConflictWithMarkers,
   GitStatusEntry,
+  isConflictedFileStatus,
 } from '../models/status'
 import { assertNever } from './fatal-error'
-import { ManualConflictResolution } from '../models/manual-conflict-resolution'
+import {
+  ManualConflictResolution,
+  ManualConflictResolutionKind,
+} from '../models/manual-conflict-resolution'
 
 /**
  * Convert a given `AppFileStatusKind` value to a human-readable string to be
@@ -124,4 +128,33 @@ export function getLabelForManualResolutionOption(
     default:
       return assertNever(entry, 'Unknown status entry to format')
   }
+}
+
+/** Filter working directory changes for conflicted or resolved files  */
+export function getUnmergedFiles(status: WorkingDirectoryStatus) {
+  return status.files.filter(f => isConflictedFile(f.status))
+}
+
+/** Filter working directory changes for resolved files  */
+export function getResolvedFiles(
+  status: WorkingDirectoryStatus,
+  manualResolutions: Map<string, ManualConflictResolutionKind>
+) {
+  return status.files.filter(
+    f =>
+      isConflictedFileStatus(f.status) &&
+      !hasUnresolvedConflicts(f.status, manualResolutions.get(f.path))
+  )
+}
+
+/** Filter working directory changes for conflicted files  */
+export function getConflictedFiles(
+  status: WorkingDirectoryStatus,
+  manualResolutions: Map<string, ManualConflictResolutionKind>
+) {
+  return status.files.filter(
+    f =>
+      isConflictedFileStatus(f.status) &&
+      hasUnresolvedConflicts(f.status, manualResolutions.get(f.path))
+  )
 }

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -9,18 +9,19 @@ import { Repository } from '../../models/repository'
 import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
-  isConflictedFileStatus,
 } from '../../models/status'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { DialogHeader } from '../dialog/header'
 import { LinkButton } from '../lib/link-button'
-import { isConflictedFile, hasUnresolvedConflicts } from '../../lib/status'
+import {
+  isConflictedFile,
+  getResolvedFiles,
+  getConflictedFiles,
+  getUnmergedFiles,
+} from '../../lib/status'
 import { DefaultCommitMessage } from '../../models/commit-message'
 import { renderUnmergedFile } from './unmerged-file'
-import {
-  ManualConflictResolution,
-  ManualConflictResolutionKind,
-} from '../../models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 
 interface IMergeConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -34,35 +35,6 @@ interface IMergeConflictsDialogProps {
   /* `undefined` when we didn't know the branch at the beginning of this flow */
   readonly theirBranch?: string
   readonly manualResolutions: Map<string, ManualConflictResolution>
-}
-
-/** Filter working directory changes for conflicted or resolved files  */
-function getUnmergedFiles(status: WorkingDirectoryStatus) {
-  return status.files.filter(f => isConflictedFile(f.status))
-}
-
-/** Filter working directory changes for resolved files  */
-function getResolvedFiles(
-  status: WorkingDirectoryStatus,
-  manualResolutions: Map<string, ManualConflictResolutionKind>
-) {
-  return status.files.filter(
-    f =>
-      isConflictedFileStatus(f.status) &&
-      !hasUnresolvedConflicts(f.status, manualResolutions.get(f.path))
-  )
-}
-
-/** Filter working directory changes for conflicted files  */
-function getConflictedFiles(
-  status: WorkingDirectoryStatus,
-  manualResolutions: Map<string, ManualConflictResolutionKind>
-) {
-  return status.files.filter(
-    f =>
-      isConflictedFileStatus(f.status) &&
-      hasUnresolvedConflicts(f.status, manualResolutions.get(f.path))
-  )
 }
 
 const submitButtonString = 'Commit merge'


### PR DESCRIPTION
## Overview

A small refactoring to extract these conflict-related functions into a module they can be used in the rebase flow.

These functions are helpful to identify what conflicts work needs to be done, and we have a module for grouping these functions together. I believe I'll need the same rules for the rebase flow, based on my initial prototype and testing, and this felt like a good bit of tidy-up while I was in there.

## Release notes

Notes: no-notes
