### PR TITLE
[rebase] add state changes to support detecting rebase conflicts

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -264,6 +264,15 @@ export interface IConflictState {
   readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 
+/**
+ * Stores information about conflicts when handling a rebase
+ */
+export type RebaseConflictState = {
+  readonly currentTip: string
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+  // TODO: what other state do we need to capture here?
+}
+
 export interface IRepositoryState {
   readonly commitSelection: ICommitSelection
   readonly changesState: IChangesState

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -265,6 +265,7 @@ export type MergeConflictState = {
   readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 
+/** Guard function for checking conflicts are from a merge  */
 export function isMergeConflictState(
   conflictStatus: ConflictState
 ): conflictStatus is MergeConflictState {
@@ -282,12 +283,20 @@ export type RebaseConflictState = {
   readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 
+/** Guard function for checking conflicts are from a rebase  */
 export function isRebaseConflictState(
   conflictStatus: ConflictState
 ): conflictStatus is RebaseConflictState {
   return conflictStatus.kind === 'rebase'
 }
 
+/**
+ * Conflicts can occur during a rebase or a merge.
+ *
+ * Callers should inspect the `kind` field to determine the kind of conflict
+ * that is occurring, as this will then provide additional information specific
+ * to the conflict, to help with resolving the issue.
+ */
 export type ConflictState = MergeConflictState | RebaseConflictState
 
 export interface IRepositoryState {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -265,6 +265,14 @@ export type MergeConflictState = {
   readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 
+// TODO: where should this live?
+
+export function isMergeConflictState(
+  conflictStatus: ConflictState
+): conflictStatus is MergeConflictState {
+  return conflictStatus.kind === 'merge'
+}
+
 /**
  * Stores information about conflicts when handling a rebase
  */
@@ -275,8 +283,15 @@ export type RebaseConflictState = {
   // TODO: what other state do we need to capture here?
 }
 
-// TODO: this could also be RebaseConflictsState
-export type ConflictState = MergeConflictState
+// TODO: where should this live?
+
+export function isRebaseConflictState(
+  conflictStatus: ConflictState
+): conflictStatus is RebaseConflictState {
+  return conflictStatus.kind === 'rebase'
+}
+
+export type ConflictState = MergeConflictState | RebaseConflictState
 
 export interface IRepositoryState {
   readonly commitSelection: ICommitSelection

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -265,8 +265,6 @@ export type MergeConflictState = {
   readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 
-// TODO: where should this live?
-
 export function isMergeConflictState(
   conflictStatus: ConflictState
 ): conflictStatus is MergeConflictState {
@@ -282,8 +280,6 @@ export type RebaseConflictState = {
   readonly manualResolutions: Map<string, ManualConflictResolution>
   // TODO: what other state do we need to capture here?
 }
-
-// TODO: where should this live?
 
 export function isRebaseConflictState(
   conflictStatus: ConflictState

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -258,7 +258,8 @@ export enum RepositorySectionTab {
 /**
  * Stores information about a merge conflict when it occurs
  */
-export interface IConflictState {
+export type MergeConflictState = {
+  readonly kind: 'merge'
   readonly currentBranch: string
   readonly currentTip: string
   readonly manualResolutions: Map<string, ManualConflictResolution>
@@ -268,10 +269,14 @@ export interface IConflictState {
  * Stores information about conflicts when handling a rebase
  */
 export type RebaseConflictState = {
+  readonly kind: 'rebase'
   readonly currentTip: string
   readonly manualResolutions: Map<string, ManualConflictResolution>
   // TODO: what other state do we need to capture here?
 }
+
+// TODO: this could also be RebaseConflictsState
+export type ConflictState = MergeConflictState
 
 export interface IRepositoryState {
   readonly commitSelection: ICommitSelection
@@ -438,7 +443,7 @@ export interface IChangesState {
    *
    * The absence of a value means there is no merge conflict
    */
-  readonly conflictState: IConflictState | null
+  readonly conflictState: ConflictState | null
 }
 
 /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -277,8 +277,9 @@ export function isMergeConflictState(
 export type RebaseConflictState = {
   readonly kind: 'rebase'
   readonly currentTip: string
+  readonly targetBranch: string
+  readonly originalBranchTip: string
   readonly manualResolutions: Map<string, ManualConflictResolution>
-  // TODO: what other state do we need to capture here?
 }
 
 export function isRebaseConflictState(

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -272,7 +272,7 @@ export function isMergeConflictState(
 }
 
 /**
- * Stores information about conflicts when handling a rebase
+ * Stores information about a rebase conflict when it occurs
  */
 export type RebaseConflictState = {
   readonly kind: 'rebase'
@@ -451,9 +451,9 @@ export interface IChangesState {
   readonly coAuthors: ReadonlyArray<IAuthor>
 
   /**
-   * Stores information about a merge conflict when it occurs
+   * Stores information about conflicts in the working directory
    *
-   * The absence of a value means there is no merge conflict
+   * The absence of a value means there is no merge or rebase conflict underway
    */
   readonly conflictState: ConflictState | null
 }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -23,6 +23,14 @@ function isRebaseHeadSet(repository: Repository) {
   return FSE.pathExists(path)
 }
 
+/**
+ * Detect and build up the context about the rebase being performed on a
+ * repository. This information is required to help Desktop display information
+ * to the user about the current action as well as the options available.
+ *
+ * Returns `null` if no rebase is detected, or if the expected information
+ * cannot be found in the repository.
+ */
 export async function getRebaseContext(
   repository: Repository
 ): Promise<RebaseContext | null> {

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -50,9 +50,7 @@ export async function getRebaseContext(
     )
 
     originalBranchTip = originalBranchTip.trim()
-  } catch {}
 
-  try {
     targetBranch = await FSE.readFile(
       Path.join(repository.path, '.git', 'rebase-apply', 'head-name'),
       'utf8'

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -363,17 +363,17 @@ async function getRebaseConflictDetails(repository: Repository) {
  *
  * @param repository to get details from
  * @param mergeHeadFound whether a merge conflict has been detected
- * @param rebaseHeadFound whether a rebase conflict has been detected
+ * @param rebaseContext details about the current rebase operation (if found)
  */
 async function getConflictDetails(
   repository: Repository,
   mergeHeadFound: boolean,
-  rebaseHeadFound: RebaseContext | null
+  rebaseContext: RebaseContext | null
 ): Promise<ConflictFilesDetails> {
   try {
     if (mergeHeadFound) {
       return await getMergeConflictDetails(repository)
-    } else if (rebaseHeadFound !== null) {
+    } else if (rebaseContext !== null) {
       return await getRebaseConflictDetails(repository)
     }
   } catch (error) {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -331,11 +331,8 @@ function parseStatusHeader(results: IStatusHeadersData, header: IStatusHeader) {
  */
 async function getConflictDetails(
   repository: Repository,
-  mergeHeadFound?: boolean
+  mergeHeadFound: boolean
 ): Promise<ConflictFilesDetails> {
-  if (mergeHeadFound === undefined) {
-    mergeHeadFound = await isMergeHeadSet(repository)
-  }
   // if we have any conflicted files reported by status, let
   try {
     if (mergeHeadFound) {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -26,6 +26,7 @@ import { fatalError } from '../../lib/fatal-error'
 import { isMergeHeadSet } from './merge'
 import { getBinaryPaths } from './diff'
 import { isRebaseHeadSet } from './rebase'
+import { enableNewRebaseFlow } from '../feature-flag'
 
 /**
  * V8 has a limit on the size of string it can create (~256MB), and unless we want to
@@ -194,9 +195,16 @@ export async function getStatus(
   const headers = parsed.filter(isStatusHeader)
   const entries = parsed.filter(isStatusEntry)
 
+  let conflictDetails: ConflictFilesDetails
+
   const mergeHeadFound = await isMergeHeadSet(repository)
   const rebaseHeadFound = await isRebaseHeadSet(repository)
-  const conflictDetails = await getConflictDetails(repository, mergeHeadFound)
+
+  if (enableNewRebaseFlow()) {
+    conflictDetails = await getConflictDetails(repository, mergeHeadFound)
+  } else {
+    conflictDetails = await getConflictDetails(repository, mergeHeadFound)
+  }
 
   // Map of files keyed on their paths.
   const files = entries.reduce(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -94,6 +94,7 @@ import {
   SuccessfulMergeBannerState,
   MergeConflictsBannerState,
   MergeConflictState,
+  isMergeConflictState,
 } from '../app-state'
 import { IGitHubUser } from '../databases/github-user-database'
 import {
@@ -1709,7 +1710,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const repoState = this.repositoryStateCache.get(repository)
     const { conflictState } = repoState.changesState
-    if (conflictState === null || conflictState.kind !== 'merge') {
+    if (conflictState === null || !isMergeConflictState(conflictState)) {
       return
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -134,6 +134,8 @@ import {
   createMergeCommit,
   getBranchesPointedAt,
   isGitRepository,
+  abortRebase,
+  continueRebase,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -3225,6 +3227,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     return this._refreshRepository(repository)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _abortRebase(repository: Repository): Promise<void> {
+    const gitStore = this.gitStoreCache.get(repository)
+    return await gitStore.performFailableOperation(() =>
+      abortRebase(repository)
+    )
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _continueRebase(
+    repository: Repository,
+    workingDirectory: WorkingDirectoryStatus
+  ) {
+    const gitStore = this.gitStoreCache.get(repository)
+
+    const trackedFiles = workingDirectory.files.filter(f => {
+      return f.status.kind !== AppFileStatusKind.Untracked
+    })
+
+    return await gitStore.performFailableOperation(() =>
+      continueRebase(repository, trackedFiles)
+    )
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -3,7 +3,7 @@ import {
   WorkingDirectoryFileChange,
 } from '../../../models/status'
 import { IStatusResult } from '../../git'
-import { IChangesState, IConflictState } from '../../app-state'
+import { IChangesState, ConflictState } from '../../app-state'
 import { DiffSelectionType, IDiff } from '../../../models/diff'
 import { caseInsensitiveCompare } from '../../compare'
 import { IStatsStore } from '../../stats/stats-store'
@@ -96,7 +96,7 @@ export function updateChangedFiles(
 function getConflictState(
   status: IStatusResult,
   manualResolutions: Map<string, ManualConflictResolution>
-): IConflictState | null {
+): ConflictState | null {
   if (!status.mergeHeadFound) {
     return null
   }
@@ -107,6 +107,7 @@ function getConflictState(
   }
 
   return {
+    kind: 'merge',
     currentBranch,
     currentTip,
     manualResolutions,
@@ -117,7 +118,7 @@ export function updateConflictState(
   state: IChangesState,
   status: IStatusResult,
   statsStore: IStatsStore
-): IConflictState | null {
+): ConflictState | null {
   const prevConflictState = state.conflictState
 
   const manualResolutions = prevConflictState

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -207,9 +207,10 @@ export function updateConflictState(
 ): ConflictState | null {
   const prevConflictState = state.conflictState
 
-  const manualResolutions = prevConflictState
-    ? prevConflictState.manualResolutions
-    : new Map<string, ManualConflictResolution>()
+  const manualResolutions =
+    prevConflictState !== null
+      ? prevConflictState.manualResolutions
+      : new Map<string, ManualConflictResolution>()
 
   const newConflictState = getConflictState(status, manualResolutions)
 

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -180,6 +180,19 @@ function performEffectsForRebaseStateChange(
   statsStore: IStatsStore
 ) {
   // TODO: run side-effects for rebase conflicts state changes
+
+  // what does a successful rebase look like?
+  // - the state changed from "in a rebase" to "no rebase"
+  // - the commit ID of branch they were trying to rebase is the same as it was before
+
+  // what does an aborted rebase look like?
+  // - the state changed from "in a rebase" to "no rebase"
+  // - the commit ID of branch they were trying to rebase is now different
+
+  // - we'd need to know the target branch they are rebasing
+  // - we'd need to know the commit ID at the start of the rebase
+  // - we'd need to know the commit ID when the rebase was done
+
   return
 }
 

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -117,19 +117,20 @@ function getConflictState(
     }
   }
 
-  if (status.rebaseHeadFound) {
+  if (status.rebaseContext !== null) {
     const { currentTip } = status
     if (currentTip == null) {
       return null
     }
 
+    const { targetBranch, originalBranchTip } = status.rebaseContext
+
     return {
       kind: 'rebase',
       currentTip,
       manualResolutions,
-      // TODO: how to get these from state?
-      targetBranch: '???',
-      originalBranchTip: '???',
+      targetBranch,
+      originalBranchTip,
     }
   }
 

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -127,6 +127,9 @@ function getConflictState(
       kind: 'rebase',
       currentTip,
       manualResolutions,
+      // TODO: how to get these from state?
+      targetBranch: '???',
+      originalBranchTip: '???',
     }
   }
 

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -1,0 +1,4 @@
+export type RebaseContext = {
+  readonly targetBranch: string
+  readonly originalBranchTip: string
+}

--- a/app/src/models/tip.ts
+++ b/app/src/models/tip.ts
@@ -1,10 +1,10 @@
 import { Branch } from './branch'
 
 export enum TipState {
-  Unknown,
-  Unborn,
-  Detached,
-  Valid,
+  Unknown = 'Unknown',
+  Unborn = 'Unborn',
+  Detached = 'Detached',
+  Valid = 'Valid',
 }
 
 export interface IUnknownRepository {

--- a/app/test/unit/stores/updates/changes-state-helper.ts
+++ b/app/test/unit/stores/updates/changes-state-helper.ts
@@ -26,7 +26,7 @@ export function createStatus<K extends keyof IStatusResult>(
   const baseStatus: IStatusResult = {
     exists: true,
     mergeHeadFound: false,
-    rebaseHeadFound: false,
+    rebaseContext: null,
     workingDirectory: WorkingDirectoryStatus.fromFiles([]),
   }
 

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -153,4 +153,61 @@ describe('updateConflictState', () => {
       expect(statsStore.recordMergeSuccessAfterConflicts).toHaveBeenCalled()
     })
   })
+
+  describe('rebase conflicts', () => {
+    it('returns null when no REBASE_HEAD file found', () => {
+      const prevState = createState({
+        conflictState: {
+          kind: 'rebase',
+          currentTip: 'old-sha',
+          manualResolutions,
+        },
+      })
+      const status = createStatus({ rebaseHeadFound: false })
+      const conflictState = updateConflictState(prevState, status, statsStore)
+      expect(conflictState).toBeNull()
+    })
+
+    it('returns a value when status has REBASE_HEAD set', () => {
+      const prevState = createState({
+        conflictState: null,
+      })
+      const status = createStatus({
+        rebaseHeadFound: true,
+        currentBranch: 'master',
+        currentTip: 'first-sha',
+      })
+
+      const conflictState = updateConflictState(prevState, status, statsStore)
+
+      expect(conflictState).toEqual({
+        kind: 'rebase',
+        currentTip: 'first-sha',
+        manualResolutions: new Map<string, ManualConflictResolution>(),
+      })
+    })
+
+    it('preserves manual resolutions when a rebase is detected', () => {
+      const prevState = createState({
+        conflictState: {
+          kind: 'rebase',
+          currentTip: 'old-sha',
+          manualResolutions,
+        },
+      })
+      const status = createStatus({
+        rebaseHeadFound: true,
+        currentBranch: 'master',
+        currentTip: 'first-sha',
+      })
+
+      const conflictState = updateConflictState(prevState, status, statsStore)
+
+      expect(conflictState).toEqual({
+        kind: 'rebase',
+        currentTip: 'first-sha',
+        manualResolutions,
+      })
+    })
+  })
 })

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -165,7 +165,7 @@ describe('updateConflictState', () => {
           originalBranchTip: 'some-other-sha',
         },
       })
-      const status = createStatus({ rebaseHeadFound: false })
+      const status = createStatus({ rebaseContext: null })
       const conflictState = updateConflictState(prevState, status, statsStore)
       expect(conflictState).toBeNull()
     })
@@ -175,7 +175,10 @@ describe('updateConflictState', () => {
         conflictState: null,
       })
       const status = createStatus({
-        rebaseHeadFound: true,
+        rebaseContext: {
+          targetBranch: 'my-feature-branch',
+          originalBranchTip: 'some-other-sha',
+        },
         currentBranch: 'master',
         currentTip: 'first-sha',
       })
@@ -186,6 +189,8 @@ describe('updateConflictState', () => {
         kind: 'rebase',
         currentTip: 'first-sha',
         manualResolutions: new Map<string, ManualConflictResolution>(),
+        targetBranch: 'my-feature-branch',
+        originalBranchTip: 'some-other-sha',
       })
     })
 
@@ -200,7 +205,10 @@ describe('updateConflictState', () => {
         },
       })
       const status = createStatus({
-        rebaseHeadFound: true,
+        rebaseContext: {
+          targetBranch: 'my-feature-branch',
+          originalBranchTip: 'some-other-sha',
+        },
         currentBranch: 'master',
         currentTip: 'first-sha',
       })
@@ -211,6 +219,8 @@ describe('updateConflictState', () => {
         kind: 'rebase',
         currentTip: 'first-sha',
         manualResolutions,
+        targetBranch: 'my-feature-branch',
+        originalBranchTip: 'some-other-sha',
       })
     })
   })

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -17,6 +17,7 @@ describe('updateConflictState', () => {
   it('returns null when no MERGE_HEAD file found', () => {
     const prevState = createState({
       conflictState: {
+        kind: 'merge',
         currentBranch: 'old-branch',
         currentTip: 'old-sha',
         manualResolutions,
@@ -30,6 +31,7 @@ describe('updateConflictState', () => {
   it('preserves manual resolutions between updates in the same merge', () => {
     const prevState = createState({
       conflictState: {
+        kind: 'merge',
         currentBranch: 'old-branch',
         currentTip: 'old-sha',
         manualResolutions,
@@ -44,6 +46,7 @@ describe('updateConflictState', () => {
     const conflictState = updateConflictState(prevState, status, statsStore)
 
     expect(conflictState).toEqual({
+      kind: 'merge',
       currentBranch: 'master',
       currentTip: 'first-sha',
       manualResolutions,
@@ -53,6 +56,7 @@ describe('updateConflictState', () => {
   it('returns null when MERGE_HEAD set but not branch or tip defined', () => {
     const prevState = createState({
       conflictState: {
+        kind: 'merge',
         currentBranch: 'old-branch',
         currentTip: 'old-sha',
         manualResolutions,
@@ -81,6 +85,7 @@ describe('updateConflictState', () => {
     const conflictState = updateConflictState(prevState, status, statsStore)
 
     expect(conflictState).toEqual({
+      kind: 'merge',
       currentBranch: 'master',
       currentTip: 'first-sha',
       manualResolutions: new Map<string, ManualConflictResolution>(),
@@ -90,6 +95,7 @@ describe('updateConflictState', () => {
   it('increments abort counter when branch has changed', () => {
     const prevState = createState({
       conflictState: {
+        kind: 'merge',
         currentBranch: 'old-branch',
         currentTip: 'old-sha',
         manualResolutions: new Map<string, ManualConflictResolution>(),
@@ -109,6 +115,7 @@ describe('updateConflictState', () => {
   it('increments abort counter when conflict resolved and tip has not changed', () => {
     const prevState = createState({
       conflictState: {
+        kind: 'merge',
         currentBranch: 'master',
         currentTip: 'old-sha',
         manualResolutions: new Map<string, ManualConflictResolution>(),
@@ -128,6 +135,7 @@ describe('updateConflictState', () => {
   it('increments success counter when conflict resolved and tip has changed', () => {
     const prevState = createState({
       conflictState: {
+        kind: 'merge',
         currentBranch: 'master',
         currentTip: 'old-sha',
         manualResolutions: new Map<string, ManualConflictResolution>(),

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -161,6 +161,8 @@ describe('updateConflictState', () => {
           kind: 'rebase',
           currentTip: 'old-sha',
           manualResolutions,
+          targetBranch: 'my-feature-branch',
+          originalBranchTip: 'some-other-sha',
         },
       })
       const status = createStatus({ rebaseHeadFound: false })
@@ -193,6 +195,8 @@ describe('updateConflictState', () => {
           kind: 'rebase',
           currentTip: 'old-sha',
           manualResolutions,
+          targetBranch: 'my-feature-branch',
+          originalBranchTip: 'some-other-sha',
         },
       })
       const status = createStatus({


### PR DESCRIPTION
## Overview

Introduce changes to the application internals to support detecting a rebase is underway, as well as what conflicts exists, so that these can be surfaced to the user.

## Description

With the overlap between merge conflicts and rebase conflicts, I eventually settled on this model for the conflicts state that the app maintains:

```ts
export type MergeConflictState = {
  readonly kind: 'merge'
  readonly currentBranch: string
  readonly currentTip: string
  readonly manualResolutions: Map<string, ManualConflictResolution>
}

export type RebaseConflictState = {
  readonly kind: 'rebase'
  readonly currentTip: string
  readonly manualResolutions: Map<string, ManualConflictResolution>
  // TODO: what other state do we need to capture here?
}

export type ConflictState = MergeConflictState | RebaseConflictState
```

We were previously using an interface for `IConflictState` but as we don't implement the interface I took the chance to drop the `I` prefix and come up with some better names.

My thinking on this is that you can be in one of these states with your Git repository, but never multiple states:

 - no conflicts
 - conflicts introduced by a `git merge`
 - conflicts introduced by a `git rebase`
 - (possibly) conflicts introduced by a `git stash pop`
 - (possibly) conflicts introduced by a `git cherry-pick`

The flow-on effects from this:

 - `getStatus` (which transforms our raw `git status` into an app-specific model) now looks for rebase conflict details when the feature flag is enabled
 -  `AppStore._loadStatus` (which determines whether it needs to show the merge conflicts dialog) is now aware of rebase conflicts (there's no dialog to show currently, but I've added the relevant plumbing)
 - `getConflictState` inside `changes-state.ts` (which handles state changes and performs side-effects like updating the `AppStore`)  is now aware of rebase conflicts (but doesn't perform and side-effects, see #6550 for those details)

TODO:

 - [x] write some tests for rebase conflict detection inside `getStatus`
 - [x] write some tests for rebase state transitions inside `getConflictsState`, using an example event from #6550 for reference
 - [x] figure out where the type guards should live (`app-state.ts` should be plain objects wherever possible)
 - [x] rebase and retarget PR once #6830 has been merged
 - [x] test existing merge conflicts behaviour is unaffected
 - [x] review impacted code and en sure important features are documented

## Release notes

Notes: no-notes
