### PR TITLE
Allow octicon to take and render alt text

### DIFF
--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -20,6 +20,11 @@ interface IOcticonProps {
    * An optional string to use as a tooltip for the icon
    */
   readonly title?: string
+
+  /**
+   * An optional string to provide accessible descriptive text
+   */
+  readonly description?: string
 }
 
 /**
@@ -68,6 +73,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
     const shortClassName = this.props.className
     const className = classNames('octicon', shortClassName)
     const title = this.props.title
+    const description = this.props.description
 
     return (
       <svg
@@ -77,7 +83,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
         viewBox={viewBox}
       >
         <title id="octiconTitle">{title}</title>
-        <desc id="octiconDescription">{shortClassName}</desc>
+        <desc id="octiconDescription">{description}</desc>
         <path d={symbol.d}>{this.renderTitle()}</path>
       </svg>
     )

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -66,6 +66,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
     const symbol = this.props.symbol
     const viewBox = `0 0 ${symbol.w} ${symbol.h}`
     const className = classNames('octicon', this.props.className)
+    const title = this.props.title
 
     return (
       <svg
@@ -74,6 +75,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
         version="1.1"
         viewBox={viewBox}
       >
+        <title>{title}</title>
         <path d={symbol.d}>{this.renderTitle()}</path>
       </svg>
     )

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -72,12 +72,13 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
     return (
       <svg
         aria-hidden="true"
+        aria-labelledby="octiconTitle octiconDescription"
         className={className}
         version="1.1"
         viewBox={viewBox}
       >
-        <title>{title}</title>
-        <desc>{shortClassName}</desc>
+        <title id="octiconTitle">{title}</title>
+        <desc id="octiconDescription">{shortClassName}</desc>
         <path d={symbol.d}>{this.renderTitle()}</path>
       </svg>
     )

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -65,7 +65,8 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
   public render() {
     const symbol = this.props.symbol
     const viewBox = `0 0 ${symbol.w} ${symbol.h}`
-    const className = classNames('octicon', this.props.className)
+    const shortClassName = this.props.className
+    const className = classNames('octicon', shortClassName)
     const title = this.props.title
 
     return (
@@ -76,6 +77,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
         viewBox={viewBox}
       >
         <title>{title}</title>
+        <desc>{shortClassName}</desc>
         <path d={symbol.d}>{this.renderTitle()}</path>
       </svg>
     )

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -71,7 +71,6 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
 
     return (
       <svg
-        aria-hidden="true"
         aria-labelledby="octiconTitle octiconDescription"
         className={className}
         version="1.1"


### PR DESCRIPTION
## Overview

**Closes #6495**

## Description

This PR allows the Octicon to take in a `title` prop and incorporate it into the SVG that is rendered in an accessible way.

The `title` prop already exists and is incorporated in the SVG's `path` for the purpose of tool-tips. We may be able to remove that implementation. Currently a value for title is never supplied to Octicons in the github desktop codebase. With these changes--making `<title>` the first child element of `<svg>`--the title will function like an image `alt` attribute. In case assistive technologies do not pick up on that there is an `aria-labelledby` attribute replacing `aria-hidden`, as we now want screenreaders to see the element.

In addition, as values for title are not currently being supplied, this PR also displays the supplied `className` as the SVG `<desc>` tag. The hope was to take advantage of some of the information currently being supplied to Octicons (`dropdownArrow`, `no-newline`), even though not many get descriptive classNames currently.  

## Release notes

Notes:
