### PR TITLE
1.6.3 beta 1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.2",
+  "version": "1.6.3-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.6.3-beta1": [
-      "[Fixed] Context menu option is hard to click in Changes list - #6296. Thanks @JQuinnie!",
+      "[Fixed] Context menu option is hard to trigger in Changes list - #6296. Thanks @JQuinnie!",
       "[Improved] Enable Git protocol v2 for fetch/push/pull operations - #6142",
       "[Improved] Upgrade to Electron v3"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,7 @@
 {
   "releases": {
     "1.6.3-beta1": [
+      "[New] Branches that have been merged and deleted on GitHub.com will now be pruned after two weeks - #750",
       "[Fixed] Context menu doesn't open when right clicking on the edges of files in Changes list - #6296. Thanks @JQuinnie!",
       "[Improved] Enable Git protocol v2 for fetch/push/pull operations - #6142",
       "[Improved] Upgrade to Electron v3"

--- a/changelog.json
+++ b/changelog.json
@@ -4,7 +4,7 @@
       "[New] Branches that have been merged and deleted on GitHub.com will now be pruned after two weeks - #750",
       "[Fixed] Context menu doesn't open when right clicking on the edges of files in Changes list - #6296. Thanks @JQuinnie!",
       "[Improved] Enable Git protocol v2 for fetch/push/pull operations - #6142",
-      "[Improved] Upgrade to Electron v3"
+      "[Improved] Upgrade to Electron v3 - #6391"
     ],
     "1.6.2": [
       "[Added] Allow users to also resolve manual conflicts when resolving merge conflicts - #6062",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "1.6.3-beta1": [
+      "[Fixed] Context menu option is hard to click in Changes list - #6296. Thanks @JQuinnie!",
+      "[Improved] Enable Git protocol v2 for fetch/push/pull operations - #6142",
+      "[Improved] Upgrade to Electron v3"
+    ],
     "1.6.2": [
       "[Added] Allow users to also resolve manual conflicts when resolving merge conflicts - #6062",
       "[Added] Automatic switching between Dark and Light modes on macOS - #5037. Thanks @say25!",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.6.3-beta1": [
-      "[Fixed] Context menu option is hard to trigger in Changes list - #6296. Thanks @JQuinnie!",
+      "[Fixed] Context menu doesn't open when right clicking on the edges of files in Changes list - #6296. Thanks @JQuinnie!",
       "[Improved] Enable Git protocol v2 for fetch/push/pull operations - #6142",
       "[Improved] Upgrade to Electron v3"
     ],


### PR DESCRIPTION
## Overview

This is a very early beta after `1.6.2` to ensure our Electron 3 transition is as smooth as possible, so any testing of the beta channel would be greatly appreciated.

Aiming to publish this [9am PST Friday](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20190215T09&p1=224).

 - [x] release notes are approved
 - [x] rebase on top of `development` Friday morning PST to ensure latest work goes out
 - [x] publish the beta

## Release notes

Notes: no-notes
