### PR TITLE
Filter out currently checkout branch from being pruned

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -205,12 +205,21 @@ export async function getMergedBranches(
 
   // Remove the trailing newline
   lines.splice(-1, 1)
+  const mergedBranches = new Array<IMergedBranch>()
 
-  return lines
-    .map(l => {
-      const [sha, canonicalRef] = l.split('\0')
-      // TODO: double check that SHA and canonicalRef is valid
-      return <IMergedBranch>{ sha, canonicalRef }
-    })
-    .filter(mb => mb.canonicalRef !== canonicalBranchRef)
+  for (const line of lines) {
+    const [sha, canonicalRef] = line.split('\0')
+
+    if (sha === undefined || canonicalRef === undefined) {
+      continue
+    }
+
+    if (canonicalRef !== canonicalBranchRef) {
+      continue
+    }
+
+    mergedBranches.push({ sha, canonicalRef })
+  }
+
+  return mergedBranches
 }

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -188,20 +188,17 @@ export async function getMergedBranches(
   repository: Repository,
   branchName: string
 ): Promise<ReadonlyArray<IMergedBranch>> {
-  const delimiter = '1F'
-  const delimiterString = String.fromCharCode(parseInt(delimiter, 16))
   const canonicalBranchRef = formatAsLocalRef(branchName)
 
-  const format = [
-    '%(objectname)', // SHA
-    '%(refname)',
-    `%${delimiter}`, // indicate end-of-line as %(body) may contain newlines
-  ].join('%00')
-
-  const args = ['branch', `--format=${format}`, '--merged', branchName]
+  const args = [
+    'branch',
+    `--format=%(objectname)%00%(refname)`,
+    '--merged',
+    branchName,
+  ]
 
   const { stdout } = await git(args, repository.path, 'mergedBranches')
-  const lines = stdout.split(delimiterString)
+  const lines = stdout.split('\n')
 
   // Remove the trailing newline
   lines.splice(-1, 1)

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -167,7 +167,7 @@ export async function getMergedBranches(
   repository: Repository,
   branchName: string
 ): Promise<ReadonlyArray<string>> {
-  const args = ['branch', '--format=%(refname:short)', '--merged', branchName]
+  const args = ['branch', '--format=%(refname)', '--merged', branchName]
 
   const { stdout } = await git(args, repository.path, 'mergedBranches')
 

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -198,12 +198,7 @@ export async function getMergedBranches(
     `%${delimiter}`, // indicate end-of-line as %(body) may contain newlines
   ].join('%00')
 
-  const args = [
-    'branch',
-    '--format=%(objectname)%(refname)',
-    '--merged',
-    branchName,
-  ]
+  const args = ['branch', `--format=${format}`, '--merged', branchName]
 
   const { stdout } = await git(args, repository.path, 'mergedBranches')
   const lines = stdout.split(delimiterString)

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -59,6 +59,18 @@ export async function renameBranch(
 }
 
 /**
+ * Delete the branch locally, see `deleteBranch` if you're looking to delete the
+ * branch from the remote as well.
+ */
+export async function deleteLocalBranch(
+  repository: Repository,
+  branchName: string
+): Promise<true> {
+  await git(['branch', '-D', branchName], repository.path, 'deleteLocalBranch')
+  return true
+}
+
+/**
  * Delete the branch. If the branch has a remote branch and `includeRemote` is true, it too will be
  * deleted. Silently deletes local branch if remote one is already deleted.
  */
@@ -69,11 +81,7 @@ export async function deleteBranch(
   includeRemote: boolean
 ): Promise<true> {
   if (branch.type === BranchType.Local) {
-    await git(
-      ['branch', '-D', branch.name],
-      repository.path,
-      'deleteLocalBranch'
-    )
+    await deleteLocalBranch(repository, branch.name)
   }
 
   const remote = branch.remote

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -214,7 +214,9 @@ export async function getMergedBranches(
       continue
     }
 
-    if (canonicalRef !== canonicalBranchRef) {
+    // Don't include the branch we're using to compare against
+    // in the list of branches merged into that branch.
+    if (canonicalRef === canonicalBranchRef) {
       continue
     }
 

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -4,6 +4,7 @@ import { Repository } from '../../models/repository'
 import { Branch, BranchType } from '../../models/branch'
 import { IGitAccount } from '../../models/git-account'
 import { envForAuthentication } from './authentication'
+import { formatAsLocalRef } from './refs'
 
 export interface IMergedBranch {
   /**
@@ -189,10 +190,7 @@ export async function getMergedBranches(
 ): Promise<ReadonlyArray<IMergedBranch>> {
   const delimiter = '1F'
   const delimiterString = String.fromCharCode(parseInt(delimiter, 16))
-
-  const canonicalBranchRef = branchName.startsWith('refs/heads/')
-    ? branchName
-    : `refs/heads/${branchName}`
+  const canonicalBranchRef = formatAsLocalRef(branchName)
 
   const format = [
     '%(objectname)', // SHA

--- a/app/src/lib/git/refs.ts
+++ b/app/src/lib/git/refs.ts
@@ -16,10 +16,12 @@ export function formatAsLocalRef(name: string): string {
     // In some cases, Git will report this name explicitly to distingush from
     // a remote ref with the same name - this ensures we format it correctly.
     return `refs/${name}`
-  } else {
+  } else if (!name.startsWith('refs/heads/')) {
     // By default Git will drop the heads prefix unless absolutely necessary
     // - include this to ensure the ref is fully qualified.
     return `refs/heads/${name}`
+  } else {
+    return name
   }
 }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -129,11 +129,6 @@ export class BranchPruner {
       return
     }
 
-    // Get all branches that exist on remote
-    const localBranches = branchesState.allBranches.filter(
-      x => x.type === BranchType.Local
-    )
-
     // Get all branches checked out within the past 2 weeks
     const twoWeeksAgo = moment()
       .subtract(2, 'weeks')
@@ -147,20 +142,10 @@ export class BranchPruner {
     const candidateBranches = mergedBranches.filter(
       mb => !ReservedRefs.includes(mb.canonicalRef)
     )
-    const branchesReadyForPruning = new Array<Branch>()
-    for (const branch of candidateBranches) {
-      const localBranch = localBranches.find(
-        localBranch =>
-          localBranch.remote !== null && localBranch.name === branch
-      )
 
-      if (
-        localBranch !== undefined &&
-        !recentlyCheckedOutBranches.has(localBranch.name)
-      ) {
-        branchesReadyForPruning.push(localBranch)
-      }
-    }
+    const branchesReadyForPruning = candidateBranches.filter(
+      mb => !recentlyCheckedOutCanonicalRefs.has(mb.canonicalRef)
+    )
 
     log.info(
       `Pruning ${branchesReadyForPruning.length} refs from '${

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -17,16 +17,16 @@ import { TipState } from '../../../models/tip'
 
 /** Check if a repo needs to be pruned at least every 4 hours */
 const BackgroundPruneMinimumInterval = 1000 * 60 * 60 * 4
-const ReservedBranches = [
-  'master',
-  'gh-pages',
+const ReservedRefs = [
   'HEAD',
-  'develop',
-  'dev',
-  'development',
-  'trunk',
-  'devel',
-  'release',
+  'refs/heads/master',
+  'refs/heads/gh-pages',
+  'refs/heads/develop',
+  'refs/heads/dev',
+  'refs/heads/development',
+  'refs/heads/trunk',
+  'refs/heads/devel',
+  'refs/heads/release',
 ]
 
 export class BranchPruner {
@@ -145,7 +145,7 @@ export class BranchPruner {
 
     // Create array of branches that can be pruned
     const candidateBranches = mergedBranches.filter(
-      b => !ReservedBranches.includes(b)
+      mb => !ReservedRefs.includes(mb.canonicalRef)
     )
     const branchesReadyForPruning = new Array<Branch>()
     for (const branch of candidateBranches) {

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -170,9 +170,13 @@ export class BranchPruner {
 
     const gitStore = this.gitStoreCache.get(this.repository)
     for (const branch of branchesReadyForPruning) {
-      await gitStore.performFailableOperation(() =>
-        deleteBranch(this.repository, branch!, null, false)
+      const isDeleted = await gitStore.performFailableOperation(() =>
+        deleteBranch(this.repository, branch, null, false)
       )
+
+      if (isDeleted) {
+        log.info(`Deleted ${branch.name} - ${branch.tip.sha}`)
+      }
     }
 
     await this.repositoriesStore.updateLastPruneDate(

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -80,9 +80,11 @@ export class BranchPruner {
     const currentBranchCanonicalRef = await getSymbolicRef(repository, 'HEAD')
 
     // remove the current branch
-    return mergedBranches.filter(
-      mb => mb.canonicalRef !== currentBranchCanonicalRef
-    )
+    return currentBranchCanonicalRef === null
+      ? mergedBranches
+      : mergedBranches.filter(
+          mb => mb.canonicalRef !== currentBranchCanonicalRef
+        )
   }
 
   private async pruneLocalBranches(): Promise<void> {

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -67,14 +67,14 @@ export class BranchPruner {
   private async findBranchesMergedIntoDefaultBranch(
     repository: Repository,
     defaultBranch: Branch
-  ): Promise<ReadonlyArray<IMergedBranch> | null> {
+  ): Promise<ReadonlyArray<IMergedBranch>> {
     const gitStore = this.gitStoreCache.get(repository)
     const mergedBranches = await gitStore.performFailableOperation(() =>
       getMergedBranches(repository, defaultBranch.name)
     )
 
     if (mergedBranches === undefined) {
-      return null
+      return []
     }
 
     const currentBranchCanonicalRef = await getSymbolicRef(repository, 'HEAD')
@@ -123,7 +123,7 @@ export class BranchPruner {
       defaultBranch
     )
 
-    if (mergedBranches === null) {
+    if (mergedBranches.length === 0) {
       log.info('No branches to prune.')
       return
     }

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -13,7 +13,6 @@ import {
 import { fatalError } from '../../fatal-error'
 import { RepositoryStateCache } from '../repository-state-cache'
 import * as moment from 'moment'
-import { TipState } from '../../../models/tip'
 
 /** Check if a repo needs to be pruned at least every 4 hours */
 const BackgroundPruneMinimumInterval = 1000 * 60 * 60 * 4

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -136,6 +136,9 @@ export class BranchPruner {
       this.repository,
       twoWeeksAgo
     )
+    const recentlyCheckedOutCanonicalRefs = new Set(
+      [...recentlyCheckedOutBranches.keys()].map(formatAsLocalRef)
+    )
 
     // Create array of branches that can be pruned
     const candidateBranches = mergedBranches.filter(

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -6,6 +6,9 @@ import {
   getMergedBranches,
   deleteBranch,
   getCheckoutsAfterDate,
+  getSymbolicRef,
+  IMergedBranch,
+  formatAsLocalRef,
 } from '../../git'
 import { fatalError } from '../../fatal-error'
 import { RepositoryStateCache } from '../repository-state-cache'

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -150,11 +150,11 @@ export class BranchPruner {
     )
 
     log.info(
-      `Pruning ${branchesReadyForPruning.length} refs from '${
-        this.repository.name
-      }' using '${defaultBranch.name} (${
-        defaultBranch.tip.sha
-      })' as base branch`
+      `Pruning ${
+        branchesReadyForPruning.length
+      } branches that have been merged into the default branch, ${
+        defaultBranch.name
+      } (${defaultBranch.tip.sha}), from '${this.repository.name}`
     )
 
     const gitStore = this.gitStoreCache.get(this.repository)

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -172,7 +172,7 @@ export class BranchPruner {
       )
 
       if (isDeleted) {
-        log.info(`Deleted ${branch.name} - ${branch.tip.sha}`)
+        log.info(`Pruned branch ${branchName} (was ${branch.sha})`)
       }
     }
 


### PR DESCRIPTION
The branch pruner isn't filtering out the current branch and can fail when a ref name is ambiguous. 

![image](https://user-images.githubusercontent.com/1715082/52877545-eb1ffc80-311f-11e9-9dd6-71aea693a84d.png)

```sh
info: [ui] Pruning 121 refs from 'desktop' using 'development (3c7514545e4a6f40926344e9a67c2ccf08a5bf65)' as base branch
```

```sh
debug: [ui] Executing deleteLocalBranch: git branch -D bugfix/unrelated-changes-in-merge-conflict-commit
error: [ui] `git branch -D bugfix/unrelated-changes-in-merge-conflict-commit` exited with an unexpected code: 1.
error: Cannot delete branch 'bugfix/unrelated-changes-in-merge-conflict-commit' checked out at '/Users/markus/GitHub/desktop'
```

```sh
debug: [ui] Executing deleteLocalBranch: git branch -D heads/release-1.0.13
error: [ui] `git branch -D heads/release-1.0.13` exited with an unexpected code: 1.
error: branch 'heads/release-1.0.13' not found.
```

**Todo**
- [x] Filter out the current branch
- [x] Return canonical ref names e.g. `refs/heads/dev` vs `dev`
- [x] Update pruner to compare canonical ref names
- [ ] ~Update existing test~
- [ ] ~Add a unit test to ensure current branch doesn't get pruned~ @iAmWillShepherd and @niik have manually tested this