### PR TITLE
remove old folder path from codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,7 +17,6 @@ coverage:
         base: pr
         paths:
           - 'app/src/lib/stores'
-          - 'app/src/lib/dispatcher'
           - 'app/src/lib/databases'
       models:
         target: auto


### PR DESCRIPTION
since #6695, our codecov config has been pointing to a nonexistent directory and causing codecov statuses to error out.

this removes that path from the config. (those files are now included in the ui-components glob for codecov status, so we're still tracking their coverage!)

codecov PR statuses should return after this is merged