### PR TITLE
Electron 3.1.3 => 3.1.4

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 3.1.3
+target = 3.1.4
 arch = x64

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "3.1.3",
+    "electron": "3.1.4",
     "electron-builder": "20.28.4",
     "electron-packager": "^12.0.0",
     "electron-winstaller": "2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,10 +3607,10 @@ electron-winstaller@2.5.2:
     lodash.template "^4.2.2"
     temp "^0.8.3"
 
-electron@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.3.tgz#848fa0fc62d131978cde15ec04ce195a08dc4155"
-  integrity sha512-Y1TbV5py2O0br0JVYh+ew1cW4cIOOgRNRMzwTwWuZNMZ9fK/XLlqsbZr1GpYHdiN2yIU1koO+g4Cw8VuW86NXQ==
+electron@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.4.tgz#5bc6e22887bff1b7fcdd1be2b09329b626738a03"
+  integrity sha512-YJEvfq45K7MmhLXY4mpGLG/cH5BU/1NUOcNMRzLxs3wVS/fKY2ZkJrOTncxhi1VOC1EJOQslcSdupitrW/FSig==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"


### PR DESCRIPTION
## Overview

**Closes #{issue number}**

## Description

- Bump to [Electron 3.1.4](https://github.com/electron/electron/releases/tag/v3.1.4)

## Release notes

Notes: No Notes
