### PR TITLE
unify banner state in application to pay down some tech debt

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -34,6 +34,7 @@ import { ComparisonCache } from './comparison-cache'
 import { ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
+import { Banner } from '../models/banner'
 
 export enum SelectionType {
   Repository,
@@ -99,6 +100,7 @@ export interface IAppState {
   readonly focusCommitMessage: boolean
   readonly currentPopup: Popup | null
   readonly currentFoldout: Foldout | null
+  readonly currentBanner: Banner | null
 
   /**
    * A list of currently open menus with their selected items
@@ -153,12 +155,6 @@ export interface IAppState {
 
   /** Whether we should show the update banner */
   readonly isUpdateAvailableBannerVisible: boolean
-
-  /** Whether we should show the merge success banner */
-  readonly successfulMergeBannerState: SuccessfulMergeBannerState
-
-  /** Whether we should show the merge success banner */
-  readonly mergeConflictsBannerState: MergeConflictsBannerState
 
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnRepositoryRemoval: boolean
@@ -601,23 +597,3 @@ export interface ICompareToBranch {
  * An action to send to the application store to update the compare state
  */
 export type CompareAction = IViewHistory | ICompareToBranch
-
-/** State for displaying the sucessful merge banner
- * `null` to remove banner
- */
-export type SuccessfulMergeBannerState = {
-  /** name of the branch that was merged into */
-  ourBranch: string
-  /** name of the branch we merged into `ourBranch` */
-  theirBranch?: string
-} | null
-
-/** State for displaying the merge conflicts banner
- *  `null` to remove banner
- */
-export type MergeConflictsBannerState = {
-  /** name of the branch that is being merged into */
-  readonly ourBranch: string
-  /** popup to be shown from the banner */
-  readonly popup: Popup
-} | null

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -1,0 +1,22 @@
+import { Popup } from './popup'
+
+export enum BannerType {
+  SuccessfulMerge = 'SuccessfulMerge',
+  MergeConflictsFound = 'MergeConflictsFound',
+}
+
+export type Banner =
+  | {
+      readonly type: BannerType.SuccessfulMerge
+      /** name of the branch that was merged into */
+      readonly ourBranch: string
+      /** name of the branch we merged into `ourBranch` */
+      readonly theirBranch?: string
+    }
+  | {
+      readonly type: BannerType.MergeConflictsFound
+      /** name of the branch that is being merged into */
+      readonly ourBranch: string
+      /** popup to be shown from the banner */
+      readonly popup: Popup
+    }

--- a/app/src/ui/banners/index.ts
+++ b/app/src/ui/banners/index.ts
@@ -1,4 +1,3 @@
 export { Banner } from './banner'
-export { SuccessfulMerge } from './successful-merge'
-export { MergeConflictsBanner } from './merge-conflicts-banner'
 export { UpdateAvailable } from './update-available'
+export { renderBanner } from './render-banner'

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+
+import { assertNever } from '../../lib/fatal-error'
+
+import { Banner, BannerType } from '../../models/banner'
+
+import { Dispatcher } from '../dispatcher'
+import { MergeConflictsBanner } from './merge-conflicts-banner'
+
+import { SuccessfulMerge } from './successful-merge'
+
+export function renderBanner(
+  banner: Banner | null,
+  dispatcher: Dispatcher,
+  onDismissed: () => void
+): JSX.Element | null {
+  if (!banner) {
+    return null
+  }
+
+  switch (banner.type) {
+    case BannerType.SuccessfulMerge:
+      return (
+        <SuccessfulMerge
+          ourBranch={banner.ourBranch}
+          theirBranch={banner.theirBranch}
+          onDismissed={onDismissed}
+          key={'successful-merge'}
+        />
+      )
+    case BannerType.MergeConflictsFound:
+      return (
+        <MergeConflictsBanner
+          dispatcher={dispatcher}
+          ourBranch={banner.ourBranch}
+          popup={banner.popup}
+          onDismissed={onDismissed}
+          key={'merge-conflicts'}
+        />
+      )
+
+    default:
+      return assertNever(banner, `Unknown popup type: ${banner}`)
+  }
+}

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -10,14 +10,10 @@ import { MergeConflictsBanner } from './merge-conflicts-banner'
 import { SuccessfulMerge } from './successful-merge'
 
 export function renderBanner(
-  banner: Banner | null,
+  banner: Banner,
   dispatcher: Dispatcher,
   onDismissed: () => void
-): JSX.Element | null {
-  if (!banner) {
-    return null
-  }
-
+): JSX.Element {
   switch (banner.type) {
     case BannerType.SuccessfulMerge:
       return (

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -151,7 +151,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     )
 
     if (conflictedFilesLeft.length === 0) {
-      this.props.dispatcher.clearMergeConflictsBanner()
+      this.props.dispatcher.clearBanner()
       this.props.dispatcher.recordUnguidedConflictedMergeCompletion()
     }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -9,10 +9,8 @@ import {
   Foldout,
   FoldoutType,
   ICompareFormUpdate,
-  MergeConflictsBannerState,
   MergeResultStatus,
   RepositorySectionTab,
-  SuccessfulMergeBannerState,
 } from '../../lib/app-state'
 import { ExternalEditor } from '../../lib/editors'
 import { assertNever, fatalError } from '../../lib/fatal-error'
@@ -69,6 +67,7 @@ import { TipState } from '../../models/tip'
 import { ApplicationTheme } from '../lib/application-theme'
 import { installCLI } from '../lib/install-cli'
 import { executeMenuItem } from '../main-process-proxy'
+import { Banner } from '../../models/banner'
 
 /**
  * An error handler function.
@@ -486,24 +485,17 @@ export class Dispatcher {
   }
 
   /**
-   * Set the successful merge banner's state
+   * Set the banner state for the application
    */
-  public setSuccessfulMergeBannerState(state: SuccessfulMergeBannerState) {
-    return this.appStore._setSuccessfulMergeBannerState(state)
+  public setBanner(state: Banner) {
+    return this.appStore._setBanner(state)
   }
 
   /**
-   * Set the successful merge banner's state
+   * Clear the current banner from the application (if set)
    */
-  public setMergeConflictsBannerState(state: MergeConflictsBannerState) {
-    return this.appStore._setMergeConflictsBannerState(state)
-  }
-
-  /**
-   * Clear (close) the successful merge banner
-   */
-  public clearMergeConflictsBanner() {
-    return this.appStore._setMergeConflictsBannerState(null)
+  public clearBanner() {
+    return this.appStore._clearBanner()
   }
 
   /**
@@ -645,7 +637,7 @@ export class Dispatcher {
   public async finishConflictedMerge(
     repository: Repository,
     workingDirectory: WorkingDirectoryStatus,
-    successfulMergeBannerState: SuccessfulMergeBannerState
+    successfulMergeBanner: Banner
   ) {
     // get manual resolutions in case there are manual conflicts
     const repositoryState = this.repositoryStateManager.get(repository)
@@ -663,7 +655,7 @@ export class Dispatcher {
       conflictState.manualResolutions
     )
     if (result !== undefined) {
-      this.appStore._setSuccessfulMergeBannerState(successfulMergeBannerState)
+      this.setBanner(successfulMergeBanner)
     }
   }
 

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -40,7 +40,7 @@ export class CommitConflictsWarning extends React.Component<
       this.props.repository,
       this.props.context
     )
-    this.props.dispatcher.clearMergeConflictsBanner()
+    this.props.dispatcher.clearBanner()
     this.props.dispatcher.setCommitMessage(
       this.props.repository,
       DefaultCommitMessage

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -22,6 +22,7 @@ import {
 import { DefaultCommitMessage } from '../../models/commit-message'
 import { renderUnmergedFile } from './unmerged-file'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
+import { BannerType } from '../../models/banner'
 
 interface IMergeConflictsDialogProps {
   readonly dispatcher: Dispatcher
@@ -59,6 +60,7 @@ export class MergeConflictsDialog extends React.Component<
       this.props.repository,
       this.props.workingDirectory,
       {
+        type: BannerType.SuccessfulMerge,
         ourBranch: this.props.ourBranch,
         theirBranch: this.props.theirBranch,
       }
@@ -100,7 +102,8 @@ export class MergeConflictsDialog extends React.Component<
 
   private onDismissed = async () => {
     this.props.onDismissed()
-    this.props.dispatcher.setMergeConflictsBannerState({
+    this.props.dispatcher.setBanner({
+      type: BannerType.MergeConflictsFound,
       ourBranch: this.props.ourBranch,
       popup: {
         type: PopupType.MergeConflicts,


### PR DESCRIPTION
## Overview

This PR demonstrates how a unified banner API might work in the application. I need to implement some banners as part of the rebase flow in #6698, so I wanted to open this cleanup PR early and get feedback.

Shout out to @outofambit for brain dumping her thoughts earlier today to help me get started.

## Description

This work came from our learnings about managing popups, with a slight improvement that I don't think we've done elsewhere.

First, we defined a unified `Banner` type to represent all the possible states of a banner:

https://github.com/desktop/desktop/blob/0eea8253dc44554cd6b649332e08b97192665d02/app/src/models/banner.ts#L1-L22

Then, we defined a single `currentBanner` state inside `app-state`, replacing `successfulMergeBannerState` and `mergeConflictsBannerState`.

Lastly, `AppStore` and `Dispatcher` now define a single `setBanner`/`clearBanner` functions to manage this state, rather than two pairs of functions to update each state.

This PR differs from our current `Popup` infrastructure by moving the render function out to it's own module, rather than inlining it inside `App`:

https://github.com/desktop/desktop/blob/0eea8253dc44554cd6b649332e08b97192665d02/app/src/ui/app.tsx#L1888-L1896

This means `App` doesn't need to be aware of the components it can render as banners (fewer imports, better separation of concerns), and we can use `assertNever` to ensure `renderBanner` handles all of the states it should:

https://github.com/desktop/desktop/blob/0eea8253dc44554cd6b649332e08b97192665d02/app/src/ui/banners/render-banner.tsx#L12-L41

You might note that the `UpdateAvailable` banner is technically a banner, but for the sake of this PR I'm not touching that logic or it's representation. I think it could live in there at some point, but I haven't thought about it.

## Release notes

Notes: no-notes
