### PR TITLE
display "pull with rebase" if user has set this in config

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -427,6 +427,16 @@ export interface IBranchesState {
 
   /** The pull request associated with the current branch. */
   readonly currentPullRequest: PullRequest | null
+
+  /**
+   * Is the current branch configured to rebase on pull?
+   *
+   * This can be configured in one of two ways by the user:
+   *
+   *  - `git config branch.[name].rebase true` (local)
+   *  - `git config pull.rebase true` (local or global)
+   */
+  readonly pullWithRebase?: boolean
 }
 
 export interface ICommitSelection {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -431,9 +431,8 @@ export interface IBranchesState {
   /**
    * Is the current branch configured to rebase on pull?
    *
-   * This can be configured in one of two ways by the user:
+   * This is equivalent to this config value in Git:
    *
-   *  - `git config branch.[name].rebase true` (local)
    *  - `git config pull.rebase true` (local or global)
    */
   readonly pullWithRebase?: boolean

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -431,9 +431,10 @@ export interface IBranchesState {
   /**
    * Is the current branch configured to rebase on pull?
    *
-   * This is equivalent to this config value in Git:
+   * This is the value returned from git config (local or global) for `git config pull.rebase`
    *
-   *  - `git config pull.rebase true` (local or global)
+   * If this value is not found in config, this will be `undefined` to indicate
+   * that the default Git behaviour will occur.
    */
   readonly pullWithRebase?: boolean
 }

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -157,6 +157,12 @@ export interface IDailyMeasures {
 
   /** The number of times a successful rebase is detected */
   readonly rebaseSuccessAfterConflictsCount: number
+
+  /** The number of times a user performed a pull with `pull.rebase` in config set to `true` */
+  readonly pullWithRebaseCount: number
+
+  /** The number of times a user has pulled with `pull.rebase` unset or set to `false` */
+  readonly pullWithDefaultSettingCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -85,6 +85,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseConflictsDialogReopenedCount: 0,
   rebaseAbortedAfterConflictsCount: 0,
   rebaseSuccessAfterConflictsCount: 0,
+  pullWithRebaseCount: 0,
+  pullWithDefaultSettingCount: 0,
 }
 
 interface IOnboardingStats {
@@ -863,6 +865,14 @@ export class StatsStore implements IStatsStore {
       rebaseAbortedAfterConflictsCount: m.rebaseAbortedAfterConflictsCount + 1,
     }))
   }
+  /**
+   * Increments the `pullWithRebaseCount` metric
+   */
+  public recordPullWithRebaseEnabled() {
+    return this.updateDailyMeasures(m => ({
+      pullWithRebaseCount: m.pullWithRebaseCount + 1,
+    }))
+  }
 
   /**
    * Increments the `rebaseSuccessAfterConflictsCount` metric
@@ -870,6 +880,15 @@ export class StatsStore implements IStatsStore {
   public async recordRebaseSuccessAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       rebaseSuccessAfterConflictsCount: m.rebaseSuccessAfterConflictsCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `pullWithDefaultSettingCount` metric
+   */
+  public recordPullWithDefaultSetting() {
+    return this.updateDailyMeasures(m => ({
+      pullWithDefaultSettingCount: m.pullWithDefaultSettingCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2864,6 +2864,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
             type: RetryActionType.Pull,
             repository,
           }
+
+          if (gitStore.pullWithRebase) {
+            this.statsStore.recordPullWithRebaseEnabled()
+          } else {
+            this.statsStore.recordPullWithDefaultSetting()
+          }
+
           await gitStore.performFailableOperation(
             () =>
               pullRepo(repository, account, remote.name, progress => {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -550,6 +550,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       defaultBranch: gitStore.defaultBranch,
       allBranches: gitStore.allBranches,
       recentBranches: gitStore.recentBranches,
+      pullWithRebase: gitStore.pullWithRebase,
     }))
 
     this.repositoryStateCache.updateChangesState(repository, () => ({

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -335,6 +335,8 @@ export class GitStore extends BaseStore {
       this.pullWithRebase = false
     } else {
       log.warn(`Unexpected value found for pull.rebase in config: '${result}'`)
+      // ensure any previous value is purged from app state
+      this.pullWithRebase = undefined
     }
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -62,7 +62,7 @@ import {
   revRange,
   revSymmetricDifference,
   getSymbolicRef,
-  getGlobalConfigValue,
+  getConfigValue,
 } from '../git'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import { UpstreamAlreadyExistsError } from './upstream-already-exists-error'
@@ -325,7 +325,7 @@ export class GitStore extends BaseStore {
   }
 
   private async checkPullWithRebase() {
-    const result = await getGlobalConfigValue('pull.rebase')
+    const result = await getConfigValue(this.repository, 'pull.rebase')
 
     if (result === null || result === '') {
       this.pullWithRebase = undefined

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -334,9 +334,7 @@ export class GitStore extends BaseStore {
     } else if (result === 'false') {
       this.pullWithRebase = false
     } else {
-      log.warn(
-        `Unexpected value found for pull.rebase in global config: ${result}`
-      )
+      log.warn(`Unexpected value found for pull.rebase in config: '${result}'`)
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1841,7 +1841,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     const tipState = state.branchesState.tip.kind
 
     // TODO: where shall we pull this from?
-    const pullWithRebaseValue = true
+    const { pullWithRebase } = state.branchesState
 
     return (
       <PushPullButton
@@ -1853,7 +1853,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         networkActionInProgress={state.isPushPullFetchInProgress}
         progress={progress}
         tipState={tipState}
-        pullWithRebase={pullWithRebaseValue}
+        pullWithRebase={pullWithRebase}
       />
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1840,6 +1840,9 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const tipState = state.branchesState.tip.kind
 
+    // TODO: where shall we pull this from?
+    const pullWithRebaseValue = true
+
     return (
       <PushPullButton
         dispatcher={this.props.dispatcher}
@@ -1850,6 +1853,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         networkActionInProgress={state.isPushPullFetchInProgress}
         progress={progress}
         tipState={tipState}
+        pullWithRebase={pullWithRebaseValue}
       />
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1839,8 +1839,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     const progress = state.pushPullFetchProgress
 
     const tipState = state.branchesState.tip.kind
-
-    // TODO: where shall we pull this from?
     const { pullWithRebase } = state.branchesState
 
     return (

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -40,6 +40,25 @@ interface IPushPullButtonProps {
    * Used for setting the enabled/disabled and the description text.
    */
   readonly tipState: TipState
+
+  /** Has the user configured pull.rebase to anything? */
+  readonly pullWithRebase?: boolean
+}
+
+function getActionLabel(
+  { ahead, behind }: IAheadBehind,
+  remoteName: string,
+  pullWithRebase?: boolean
+) {
+  if (behind > 0) {
+    return pullWithRebase
+      ? `Pull ${remoteName} with rebase`
+      : `Pull ${remoteName}`
+  }
+  if (ahead > 0) {
+    return `Push ${remoteName}`
+  }
+  return `Fetch ${remoteName}`
 }
 
 /**
@@ -131,18 +150,11 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
       return 'Publish branch'
     }
 
-    const { ahead, behind } = this.props.aheadBehind
-    const actionName = (function() {
-      if (behind > 0) {
-        return 'Pull'
-      }
-      if (ahead > 0) {
-        return 'Push'
-      }
-      return 'Fetch'
-    })()
-
-    return `${actionName} ${this.props.remoteName}`
+    return getActionLabel(
+      this.props.aheadBehind,
+      this.props.remoteName,
+      this.props.pullWithRebase
+    )
   }
 
   private getIcon(): OcticonSymbol {

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -8,6 +8,7 @@ import { IAheadBehind } from '../../models/branch'
 import { TipState } from '../../models/tip'
 import { RelativeTime } from '../relative-time'
 import { FetchType } from '../../models/fetch'
+import { enableNewRebaseFlow } from '../../lib/feature-flag'
 
 interface IPushPullButtonProps {
   /**
@@ -51,7 +52,7 @@ function getActionLabel(
   pullWithRebase?: boolean
 ) {
   if (behind > 0) {
-    return pullWithRebase
+    return pullWithRebase && enableNewRebaseFlow()
       ? `Pull ${remoteName} with rebase`
       : `Pull ${remoteName}`
   }


### PR DESCRIPTION
## Overview

**Closes #6553**
**Closes #3422**

Also adds `pullWithDefaultSettingCount` and `pullWithRebaseCount` metrics from #6550 

## Description

<img width="258" src="https://user-images.githubusercontent.com/359239/53111920-6d3f6500-3514-11e9-8cf3-566dc9700007.png">

## Release notes

Notes: Pull operation in UI indicates whether user has pull.rebase configured
