### PR TITLE
use fullname of github repos for filtering in repo list

### DIFF
--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -1,4 +1,8 @@
-import { Repository, ILocalRepositoryState } from '../../models/repository'
+import {
+  Repository,
+  ILocalRepositoryState,
+  nameOf,
+} from '../../models/repository'
 import { CloningRepository } from '../../models/cloning-repository'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { caseInsensitiveCompare } from '../../lib/compare'
@@ -70,8 +74,10 @@ export function groupRepositories(
       const nameCount = names.get(r.name) || 0
       const { aheadBehind, changedFilesCount } =
         localRepositoryStateLookup.get(r.id) || fallbackValue
+      const repositoryText =
+        r instanceof Repository ? [r.name, nameOf(r)] : [r.name]
       return {
-        text: [r.name],
+        text: repositoryText,
         id: r.id.toString(),
         repository: r,
         needsDisambiguation: nameCount > 1,


### PR DESCRIPTION
## Overview

small step in addressing #6460 

![filtering repository list by repository owner](https://user-images.githubusercontent.com/964912/53119287-fdc17980-3503-11e9-8c30-e278adf07888.gif)

## Description

- adds fullname (`${ownerName}/${repoName}`) of github repos to be filtered on in the repository sidebar

## Release notes

Notes: [Improved] Repository list filtering now searches GitHub owner name
