### PR TITLE
favour object spread where changes state is read inside Sidebar

### DIFF
--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -122,9 +122,11 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   private onCreateCommit = async (
     context: ICommitContext
   ): Promise<boolean> => {
+    const { workingDirectory } = this.props.changes
+
     const overSizedFiles = await getLargeFilePaths(
       this.props.repository,
-      this.props.changes.workingDirectory,
+      workingDirectory,
       100
     )
     const filesIgnoredByLFS = await filesNotTrackedByLFS(
@@ -144,7 +146,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
 
     // are any conflicted files left?
-    const conflictedFilesLeft = this.props.changes.workingDirectory.files.filter(
+    const conflictedFilesLeft = workingDirectory.files.filter(
       f =>
         isConflictedFile(f.status) &&
         f.selection.getSelectionType() === DiffSelectionType.None
@@ -156,7 +158,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
 
     // which of the files selected for committing are conflicted (with markers)?
-    const conflictedFilesSelected = this.props.changes.workingDirectory.files.filter(
+    const conflictedFilesSelected = workingDirectory.files.filter(
       f =>
         isConflictedFile(f.status) &&
         hasUnresolvedConflicts(f.status) &&
@@ -326,8 +328,13 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   }
 
   public render() {
-    const changesState = this.props.changes
-    const selectedFileIDs = changesState.selectedFileIDs
+    const {
+      selectedFileIDs,
+      workingDirectory,
+      commitMessage,
+      showCoAuthoredBy,
+      coAuthors,
+    } = this.props.changes
 
     // TODO: I think user will expect the avatar to match that which
     // they have configured in GitHub.com as well as GHE so when we add
@@ -344,7 +351,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         <ChangesList
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
-          workingDirectory={changesState.workingDirectory}
+          workingDirectory={workingDirectory}
           selectedFileIDs={selectedFileIDs}
           onFileSelectionChanged={this.onFileSelectionChanged}
           onCreateCommit={this.onCreateCommit}
@@ -360,14 +367,14 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           commitAuthor={this.props.commitAuthor}
           branch={this.props.branch}
           gitHubUser={user}
-          commitMessage={this.props.changes.commitMessage}
+          commitMessage={commitMessage}
           focusCommitMessage={this.props.focusCommitMessage}
           autocompletionProviders={this.autocompletionProviders!}
           availableWidth={this.props.availableWidth}
           onIgnore={this.onIgnore}
           isCommitting={this.props.isCommitting}
-          showCoAuthoredBy={this.props.changes.showCoAuthoredBy}
-          coAuthors={this.props.changes.coAuthors}
+          showCoAuthoredBy={showCoAuthoredBy}
+          coAuthors={coAuthors}
           externalEditorLabel={this.props.externalEditorLabel}
           onOpenInExternalEditor={this.props.onOpenInExternalEditor}
           onChangesListScrolled={this.props.onChangesListScrolled}


### PR DESCRIPTION
## Overview

Some cleanup in advance of #6890

## Description

`Sidebar` is a complex component, and it has a few places where it looks at values on `this.props.changes`, as a side effect of how the code has evolved. This commit helps to group the prop usages again to make this easier to follow where changes state is being used.

## Release notes

Notes: no-notes
