### PR TITLE
Fixed left-padding for :emoji:/@user/#issue autocomplete forms.

### DIFF
--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -89,6 +89,7 @@
   flex-grow: 1;
   height: 100%;
   min-width: 0;
+  padding: 0 var(--spacing);
 
   /* Used to highlight substring matches in autocompletion texts */
   mark {


### PR DESCRIPTION
## Overview

**Closes #6895**

## Description

Added padding-left to scss class "autocompletion-item" in desktop/app/styles/ui/_autocompletion.scss. Autocomplete rows now appear with appropriate padding between the icon and the left side of the form.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
