### PR TITLE
show a "continue rebase" button when conflicts are outstanding

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -434,8 +434,6 @@ export class ChangesList extends React.Component<
           repository={this.props.repository}
           rebaseConflictState={this.props.rebaseConflictState}
           workingDirectory={this.props.workingDirectory}
-          // TODO
-          canCommit={true}
           isCommitting={this.props.isCommitting}
         />
       ) : (

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -35,6 +35,7 @@ import { basename } from 'path'
 import { ICommitContext } from '../../models/commit'
 import { RebaseConflictState } from '../../lib/app-state'
 import { ContinueRebase } from './continue-rebase'
+import { enableNewRebaseFlow } from '../../lib/feature-flag'
 
 const RowHeight = 29
 
@@ -428,7 +429,7 @@ export class ChangesList extends React.Component<
     const singleFileCommit = filesSelected.length === 1
 
     const commitMessageElement =
-      this.props.rebaseConflictState !== null ? (
+      this.props.rebaseConflictState !== null && enableNewRebaseFlow() ? (
         <ContinueRebase
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -416,20 +416,9 @@ export class ChangesList extends React.Component<
     this.props.onChangesListScrolled(scrollTop)
   }
 
-  public render() {
-    const fileList = this.props.workingDirectory.files
-    const fileCount = fileList.length
-    const filesPlural = fileCount === 1 ? 'file' : 'files'
-    const filesDescription = `${fileCount} changed ${filesPlural}`
-    const anyFilesSelected =
-      fileCount > 0 && this.includeAllValue !== CheckboxValue.Off
-    const filesSelected = this.props.workingDirectory.files.filter(
-      f => f.selection.getSelectionType() !== DiffSelectionType.None
-    )
-    const singleFileCommit = filesSelected.length === 1
-
-    const commitMessageElement =
-      this.props.rebaseConflictState !== null && enableNewRebaseFlow() ? (
+  private renderCommitMessageForm = (): JSX.Element => {
+    if (this.props.rebaseConflictState !== null && enableNewRebaseFlow()) {
+      return (
         <ContinueRebase
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
@@ -437,29 +426,47 @@ export class ChangesList extends React.Component<
           workingDirectory={this.props.workingDirectory}
           isCommitting={this.props.isCommitting}
         />
-      ) : (
-        <CommitMessage
-          onCreateCommit={this.props.onCreateCommit}
-          branch={this.props.branch}
-          gitHubUser={this.props.gitHubUser}
-          commitAuthor={this.props.commitAuthor}
-          anyFilesSelected={anyFilesSelected}
-          repository={this.props.repository}
-          dispatcher={this.props.dispatcher}
-          commitMessage={this.props.commitMessage}
-          focusCommitMessage={this.props.focusCommitMessage}
-          autocompletionProviders={this.props.autocompletionProviders}
-          isCommitting={this.props.isCommitting}
-          showCoAuthoredBy={this.props.showCoAuthoredBy}
-          coAuthors={this.props.coAuthors}
-          placeholder={this.getPlaceholderMessage(
-            filesSelected,
-            singleFileCommit
-          )}
-          singleFileCommit={singleFileCommit}
-          key={this.props.repository.id}
-        />
       )
+    }
+
+    const fileCount = this.props.workingDirectory.files.length
+
+    const anyFilesSelected =
+      fileCount > 0 && this.includeAllValue !== CheckboxValue.Off
+    const filesSelected = this.props.workingDirectory.files.filter(
+      f => f.selection.getSelectionType() !== DiffSelectionType.None
+    )
+    const singleFileCommit = filesSelected.length === 1
+
+    return (
+      <CommitMessage
+        onCreateCommit={this.props.onCreateCommit}
+        branch={this.props.branch}
+        gitHubUser={this.props.gitHubUser}
+        commitAuthor={this.props.commitAuthor}
+        anyFilesSelected={anyFilesSelected}
+        repository={this.props.repository}
+        dispatcher={this.props.dispatcher}
+        commitMessage={this.props.commitMessage}
+        focusCommitMessage={this.props.focusCommitMessage}
+        autocompletionProviders={this.props.autocompletionProviders}
+        isCommitting={this.props.isCommitting}
+        showCoAuthoredBy={this.props.showCoAuthoredBy}
+        coAuthors={this.props.coAuthors}
+        placeholder={this.getPlaceholderMessage(
+          filesSelected,
+          singleFileCommit
+        )}
+        singleFileCommit={singleFileCommit}
+        key={this.props.repository.id}
+      />
+    )
+  }
+
+  public render() {
+    const fileCount = this.props.workingDirectory.files.length
+    const filesPlural = fileCount === 1 ? 'file' : 'files'
+    const filesDescription = `${fileCount} changed ${filesPlural}`
 
     return (
       <div className="changes-list-container file-list">
@@ -485,7 +492,7 @@ export class ChangesList extends React.Component<
           onScroll={this.onScroll}
           setScrollTop={this.props.changesListScrollTop}
         />
-        {commitMessageElement}
+        {this.renderCommitMessageForm()}
       </div>
     )
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -33,6 +33,8 @@ import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
 import { basename } from 'path'
 import { ICommitContext } from '../../models/commit'
+import { RebaseConflictState } from '../../lib/app-state'
+import { ContinueRebase } from './continue-rebase'
 
 const RowHeight = 29
 
@@ -41,6 +43,7 @@ const GitIgnoreFileName = '.gitignore'
 interface IChangesListProps {
   readonly repository: Repository
   readonly workingDirectory: WorkingDirectoryStatus
+  readonly rebaseConflictState: RebaseConflictState | null
   readonly selectedFileIDs: string[]
   readonly onFileSelectionChanged: (rows: ReadonlyArray<number>) => void
   readonly onIncludeChanged: (path: string, include: boolean) => void
@@ -424,6 +427,41 @@ export class ChangesList extends React.Component<
     )
     const singleFileCommit = filesSelected.length === 1
 
+    const commitMessageElement =
+      this.props.rebaseConflictState !== null ? (
+        <ContinueRebase
+          dispatcher={this.props.dispatcher}
+          repository={this.props.repository}
+          rebaseConflictState={this.props.rebaseConflictState}
+          workingDirectory={this.props.workingDirectory}
+          // TODO
+          canCommit={true}
+          isCommitting={this.props.isCommitting}
+        />
+      ) : (
+        <CommitMessage
+          onCreateCommit={this.props.onCreateCommit}
+          branch={this.props.branch}
+          gitHubUser={this.props.gitHubUser}
+          commitAuthor={this.props.commitAuthor}
+          anyFilesSelected={anyFilesSelected}
+          repository={this.props.repository}
+          dispatcher={this.props.dispatcher}
+          commitMessage={this.props.commitMessage}
+          focusCommitMessage={this.props.focusCommitMessage}
+          autocompletionProviders={this.props.autocompletionProviders}
+          isCommitting={this.props.isCommitting}
+          showCoAuthoredBy={this.props.showCoAuthoredBy}
+          coAuthors={this.props.coAuthors}
+          placeholder={this.getPlaceholderMessage(
+            filesSelected,
+            singleFileCommit
+          )}
+          singleFileCommit={singleFileCommit}
+          key={this.props.repository.id}
+        />
+      )
+
     return (
       <div className="changes-list-container file-list">
         <div className="header" onContextMenu={this.onContextMenu}>
@@ -448,28 +486,7 @@ export class ChangesList extends React.Component<
           onScroll={this.onScroll}
           setScrollTop={this.props.changesListScrollTop}
         />
-
-        <CommitMessage
-          onCreateCommit={this.props.onCreateCommit}
-          branch={this.props.branch}
-          gitHubUser={this.props.gitHubUser}
-          commitAuthor={this.props.commitAuthor}
-          anyFilesSelected={anyFilesSelected}
-          repository={this.props.repository}
-          dispatcher={this.props.dispatcher}
-          commitMessage={this.props.commitMessage}
-          focusCommitMessage={this.props.focusCommitMessage}
-          autocompletionProviders={this.props.autocompletionProviders}
-          isCommitting={this.props.isCommitting}
-          showCoAuthoredBy={this.props.showCoAuthoredBy}
-          coAuthors={this.props.coAuthors}
-          placeholder={this.getPlaceholderMessage(
-            filesSelected,
-            singleFileCommit
-          )}
-          singleFileCommit={singleFileCommit}
-          key={this.props.repository.id}
-        />
+        {commitMessageElement}
       </div>
     )
   }

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -5,13 +5,13 @@ import { RebaseConflictState } from '../../lib/app-state'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { WorkingDirectoryStatus } from '../../models/status'
+import { getConflictedFiles } from '../../lib/status'
 
 interface IContinueRebaseProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly workingDirectory: WorkingDirectoryStatus
   readonly rebaseConflictState: RebaseConflictState
-  readonly canCommit: boolean
   readonly isCommitting: boolean
 }
 
@@ -21,54 +21,48 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
   }
 
   private async continueRebase() {
-    if (!this.canCommit()) {
-      return
-    }
-
     this.props.dispatcher.continueRebase(
       this.props.repository,
       this.props.workingDirectory
     )
   }
 
-  private canCommit(): boolean {
-    return this.props.canCommit
-  }
-
-  private onKeyDown = (event: React.KeyboardEvent<Element>) => {
-    if (event.defaultPrevented) {
-      return
-    }
-
-    const isShortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
-    if (isShortcutKey && event.key === 'Enter' && this.canCommit()) {
-      this.continueRebase()
-      event.preventDefault()
-    }
-  }
-
   public render() {
-    const { targetBranch } = this.props.rebaseConflictState
+    const { targetBranch, manualResolutions } = this.props.rebaseConflictState
 
-    const buttonEnabled = this.canCommit() && !this.props.isCommitting
+    let canCommit = true
+
+    let tooltip = 'Continue rebase'
+
+    if (this.props.rebaseConflictState) {
+      const conflictedFilesCount = getConflictedFiles(
+        this.props.workingDirectory,
+        manualResolutions
+      ).length
+
+      if (conflictedFilesCount > 0) {
+        tooltip = 'Resolve all conflicts before continuing'
+        canCommit = false
+      }
+    }
+
+    const buttonEnabled = canCommit && !this.props.isCommitting
 
     const loading = this.props.isCommitting ? <Loading /> : undefined
 
+    // TODO: change this ID and restyle things betterer
+
     return (
-      <div
-        id="commit-message"
-        role="group"
-        aria-label="Continue rebase"
-        onKeyDown={this.onKeyDown}
-      >
+      <div id="commit-message" role="group">
         <Button
           type="submit"
           className="commit-button"
           onClick={this.onSubmit}
           disabled={!buttonEnabled}
+          tooltip={tooltip}
         >
           {loading}
-          <span title={`Rebase ${targetBranch}`}>
+          <span>
             {loading ? 'Rebasing' : 'Rebase'} <strong>{targetBranch}</strong>
           </span>
         </Button>

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -57,7 +57,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
           tooltip={tooltip}
         >
           {loading}
-          <span>{loading ? 'Rebasing' : 'Continue rebase'}</span>
+          <span>{loading !== undefined ? 'Rebasing' : 'Continue rebase'}</span>
         </Button>
       </div>
     )

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -21,7 +21,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
   }
 
   private async continueRebase() {
-    this.props.dispatcher.continueRebase(
+    await this.props.dispatcher.continueRebase(
       this.props.repository,
       this.props.workingDirectory
     )

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+import { Button } from '../lib/button'
+import { Loading } from '../lib/loading'
+import { RebaseConflictState } from '../../lib/app-state'
+import { Dispatcher } from '../dispatcher'
+import { Repository } from '../../models/repository'
+import { WorkingDirectoryStatus } from '../../models/status'
+
+interface IContinueRebaseProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly rebaseConflictState: RebaseConflictState
+  readonly canCommit: boolean
+  readonly isCommitting: boolean
+}
+
+export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
+  private onSubmit = () => {
+    this.continueRebase()
+  }
+
+  private async continueRebase() {
+    if (!this.canCommit()) {
+      return
+    }
+
+    this.props.dispatcher.continueRebase(
+      this.props.repository,
+      this.props.workingDirectory
+    )
+  }
+
+  private canCommit(): boolean {
+    return this.props.canCommit
+  }
+
+  private onKeyDown = (event: React.KeyboardEvent<Element>) => {
+    if (event.defaultPrevented) {
+      return
+    }
+
+    const isShortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
+    if (isShortcutKey && event.key === 'Enter' && this.canCommit()) {
+      this.continueRebase()
+      event.preventDefault()
+    }
+  }
+
+  public render() {
+    const { targetBranch } = this.props.rebaseConflictState
+
+    const buttonEnabled = this.canCommit() && !this.props.isCommitting
+
+    const loading = this.props.isCommitting ? <Loading /> : undefined
+
+    return (
+      <div
+        id="commit-message"
+        role="group"
+        aria-label="Continue rebase"
+        onKeyDown={this.onKeyDown}
+      >
+        <Button
+          type="submit"
+          className="commit-button"
+          onClick={this.onSubmit}
+          disabled={!buttonEnabled}
+        >
+          {loading}
+          <span title={`Rebase ${targetBranch}`}>
+            {loading ? 'Rebasing' : 'Rebase'} <strong>{targetBranch}</strong>
+          </span>
+        </Button>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -28,7 +28,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
   }
 
   public render() {
-    const { targetBranch, manualResolutions } = this.props.rebaseConflictState
+    const { manualResolutions } = this.props.rebaseConflictState
 
     let canCommit = true
 
@@ -60,9 +60,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
           tooltip={tooltip}
         >
           {loading}
-          <span>
-            {loading ? 'Rebasing' : 'Rebase'} <strong>{targetBranch}</strong>
-          </span>
+          <span>{loading ? 'Rebasing' : 'Continue rebase'}</span>
         </Button>
       </div>
     )

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -50,10 +50,8 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
 
     const loading = this.props.isCommitting ? <Loading /> : undefined
 
-    // TODO: change this ID and restyle things betterer
-
     return (
-      <div id="commit-message" role="group">
+      <div id="continue-rebase" role="group">
         <Button
           type="submit"
           className="commit-button"

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -31,19 +31,16 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
     const { manualResolutions } = this.props.rebaseConflictState
 
     let canCommit = true
-
     let tooltip = 'Continue rebase'
 
-    if (this.props.rebaseConflictState) {
-      const conflictedFilesCount = getConflictedFiles(
-        this.props.workingDirectory,
-        manualResolutions
-      ).length
+    const conflictedFilesCount = getConflictedFiles(
+      this.props.workingDirectory,
+      manualResolutions
+    ).length
 
-      if (conflictedFilesCount > 0) {
-        tooltip = 'Resolve all conflicts before continuing'
-        canCommit = false
-      }
+    if (conflictedFilesCount > 0) {
+      tooltip = 'Resolve all conflicts before continuing'
+      canCommit = false
     }
 
     const buttonEnabled = canCommit && !this.props.isCommitting

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -3,7 +3,11 @@ import * as React from 'react'
 
 import { ChangesList } from './changes-list'
 import { DiffSelectionType } from '../../models/diff'
-import { IChangesState } from '../../lib/app-state'
+import {
+  IChangesState,
+  RebaseConflictState,
+  isRebaseConflictState,
+} from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { IGitHubUser } from '../../lib/databases'
@@ -334,6 +338,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       commitMessage,
       showCoAuthoredBy,
       coAuthors,
+      conflictState,
     } = this.props.changes
 
     // TODO: I think user will expect the avatar to match that which
@@ -346,12 +351,23 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       user = this.props.gitHubUsers.get(email.toLowerCase()) || null
     }
 
+    let rebaseConflictState: RebaseConflictState | null = null
+    if (conflictState !== null) {
+      rebaseConflictState = isRebaseConflictState(conflictState)
+        ? conflictState
+        : null
+    }
+
+    const undoCommitComponent =
+      rebaseConflictState === null ? this.renderMostRecentLocalCommit() : null
+
     return (
       <div id="changes-sidebar-contents">
         <ChangesList
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
           workingDirectory={workingDirectory}
+          rebaseConflictState={rebaseConflictState}
           selectedFileIDs={selectedFileIDs}
           onFileSelectionChanged={this.onFileSelectionChanged}
           onCreateCommit={this.onCreateCommit}
@@ -380,7 +396,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onChangesListScrolled={this.props.onChangesListScrolled}
           changesListScrollTop={this.props.changesListScrollTop}
         />
-        {this.renderMostRecentLocalCommit()}
+        {undoCommitComponent}
       </div>
     )
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -30,6 +30,7 @@ import { PopupType } from '../../models/popup'
 import { filesNotTrackedByLFS } from '../../lib/git/lfs'
 import { getLargeFilePaths } from '../../lib/large-files'
 import { isConflictedFile, hasUnresolvedConflicts } from '../../lib/status'
+import { enableNewRebaseFlow } from '../../lib/feature-flag'
 
 /**
  * The timeout for the animation of the enter/leave animation for Undo.
@@ -331,6 +332,16 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     )
   }
 
+  private renderUndoCommit = (
+    rebaseConflictState: RebaseConflictState | null
+  ): JSX.Element | null => {
+    if (rebaseConflictState !== null && enableNewRebaseFlow()) {
+      return null
+    }
+
+    return this.renderMostRecentLocalCommit()
+  }
+
   public render() {
     const {
       selectedFileIDs,
@@ -357,9 +368,6 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         ? conflictState
         : null
     }
-
-    const undoCommitComponent =
-      rebaseConflictState === null ? this.renderMostRecentLocalCommit() : null
 
     return (
       <div id="changes-sidebar-contents">
@@ -396,7 +404,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onChangesListScrolled={this.props.onChangesListScrolled}
           changesListScrollTop={this.props.changesListScrollTop}
         />
-        {undoCommitComponent}
+        {this.renderUndoCommit(rebaseConflictState)}
       </div>
     )
   }

--- a/app/src/ui/rebase/rebase-conflicts-dialog.tsx
+++ b/app/src/ui/rebase/rebase-conflicts-dialog.tsx
@@ -60,11 +60,6 @@ export class RebaseConflictsDialog extends React.Component<
     )
 
     if (result === ContinueRebaseResult.CompletedWithoutError) {
-      this.props.dispatcher.setBanner({
-        type: BannerType.SuccessfulRebase,
-        targetBranch: this.props.targetBranch,
-        baseBranch: this.props.baseBranch,
-      })
       this.props.onDismissed()
     }
   }

--- a/app/styles/ui/_changes.scss
+++ b/app/styles/ui/_changes.scss
@@ -1,4 +1,5 @@
 @import 'changes/commit-message';
+@import 'changes/continue-rebase';
 @import 'changes/changes-list';
 @import 'changes/sidebar';
 @import 'changes/undo-commit';

--- a/app/styles/ui/changes/_continue-rebase.scss
+++ b/app/styles/ui/changes/_continue-rebase.scss
@@ -1,0 +1,36 @@
+@import '../../mixins';
+
+#continue-rebase {
+  border-top: 1px solid var(--box-border-color);
+  flex-direction: column;
+  flex-shrink: 0;
+  margin-top: auto;
+
+  display: flex;
+  background-color: var(--box-alt-background-color);
+  padding: var(--spacing);
+
+  .commit-button {
+    max-width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .octicon {
+      flex-shrink: 0;
+      flex-grow: 0;
+      margin-right: var(--spacing-half);
+    }
+
+    /* Due to some weirdo bug in Chrome that affects Windows
+     * and possible other platforms we can't change the opacity
+     * for disabled buttons if the button also has a
+     * overflow: hidden property set. The workaround is to put
+     * the contents of the button in a block element and put
+     * ellipsis on that instead. See commit 67fad24ed
+     */
+    > span {
+      @include ellipsis;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

**Closes #6890**

## Description

This swaps out the default commit message for a simple "Continue rebase" button to prevent the user from creating commits as usual outside of the "Rebase conflicts" dialog.

The current view in #6698 when you dismiss the "Rebase conflicts" dialog:

<img width="983" src="https://user-images.githubusercontent.com/359239/53177991-6887b900-35c7-11e9-81af-153020766a52.png">

While there are outstanding conflicts to resolve:

<img width="981"  src="https://user-images.githubusercontent.com/359239/53187961-a8a46700-35da-11e9-8472-088a8eae8d80.png">

When those are resolved:

<img width="979" src="https://user-images.githubusercontent.com/359239/53187946-9c200e80-35da-11e9-8719-15f3d7e29a51.png">

This also hides the "Undo Commit" dialog (which will appear when any rebased commit hasn't been published). 

TODO:

 - [x] review changes to sidebar code to see if it can be better organized
 - [x] confirm `Continue rebase` [does exactly what it says on the tin](https://en.wikipedia.org/wiki/Does_exactly_what_it_says_on_the_tin)

## Release notes

Notes: no-notes
