### PR TITLE
propagate information to rebase conflicts dialog when pull fails

### DIFF
--- a/app/src/lib/error-with-metadata.ts
+++ b/app/src/lib/error-with-metadata.ts
@@ -1,7 +1,7 @@
 import { Repository } from '../models/repository'
 import { CloningRepository } from '../models/cloning-repository'
 import { RetryAction } from '../models/retry-actions'
-import { IGitErrorContext } from './git-error-context'
+import { GitErrorContext } from './git-error-context'
 
 export interface IErrorMetadata {
   /** Was the action which caused this error part of a background task? */
@@ -14,7 +14,7 @@ export interface IErrorMetadata {
   readonly retryAction?: RetryAction
 
   /** Additional context that specific actions can provide fields for */
-  readonly gitContext?: IGitErrorContext
+  readonly gitContext?: GitErrorContext
 }
 
 /** An error which contains additional metadata. */

--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -1,13 +1,11 @@
-import { Tip } from '../models/tip'
-
-export type MergeConflictsErrorContext = {
+type MergeOrPullConflictsErrorContext = {
   /** The Git operation that triggered the conflicted state */
   readonly kind: 'merge' | 'pull'
-  /** The tip of the repository at the time of the merge operation */
-  readonly tip?: Tip
-  /** The branch currently being merged into the current branch, "their" in Git terminology */
+  /** The branch being merged into the current branch, "theirs" in Git terminology */
   readonly theirBranch: string
+  /** The branch associated with the current tip of the repository, "ours" in Git terminology */
+  readonly currentBranch: string
 }
 
 /** A custom shape of data for actions to provide to help with error handling */
-export type IGitErrorContext = MergeConflictsErrorContext
+export type GitErrorContext = MergeOrPullConflictsErrorContext

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -178,7 +178,7 @@ import { validatedRepositoryPath } from './helpers/validated-repository-path'
 import { RepositoryStateCache } from './repository-state-cache'
 import { readEmoji } from '../read-emoji'
 import { GitStoreCache } from './git-store-cache'
-import { MergeConflictsErrorContext } from '../git-error-context'
+import { GitErrorContext } from '../git-error-context'
 import { setNumber, setBoolean, getBoolean, getNumber } from '../local-storage'
 import { ExternalEditorError } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -2819,7 +2819,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       if (tip.kind === TipState.Valid) {
         let mergeBase: string | null = null
-        let gitContext: MergeConflictsErrorContext | undefined = undefined
+        let gitContext: GitErrorContext | undefined = undefined
 
         if (tip.branch.upstream !== null) {
           mergeBase = await getMergeBase(
@@ -2830,8 +2830,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
           gitContext = {
             kind: 'pull',
-            tip,
             theirBranch: tip.branch.upstream,
+            currentBranch: tip.branch.name,
           }
         }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1110,10 +1110,20 @@ export class GitStore extends BaseStore {
 
   /** Merge the named branch into the current branch. */
   public merge(branch: string): Promise<boolean | undefined> {
+    if (this.tip.kind !== TipState.Valid) {
+      throw new Error(
+        `unable to merge as tip state is '${
+          this.tip.kind
+        }' and the application expects the repository to be on a branch currently`
+      )
+    }
+
+    const currentBranch = this.tip.branch.name
+
     return this.performFailableOperation(() => merge(this.repository, branch), {
       gitContext: {
         kind: 'merge',
-        tip: this.tip,
+        currentBranch,
         theirBranch: branch,
       },
     })

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -13,7 +13,6 @@ import { UpstreamAlreadyExistsError } from '../../lib/stores/upstream-already-ex
 
 import { PopupType } from '../../models/popup'
 import { Repository } from '../../models/repository'
-import { TipState } from '../../models/tip'
 
 /** An error which also has a code property. */
 interface IErrorWithCode extends Error {
@@ -295,15 +294,12 @@ export async function mergeConflictHandler(
       break
   }
 
-  const { tip, theirBranch } = gitContext
-  if (tip == null || tip.kind !== TipState.Valid) {
-    return error
-  }
+  const { currentBranch, theirBranch } = gitContext
 
   dispatcher.showPopup({
     type: PopupType.MergeConflicts,
     repository,
-    ourBranch: tip.branch.name,
+    ourBranch: currentBranch,
     theirBranch,
   })
 
@@ -462,18 +458,18 @@ export async function rebaseConflictsHandler(
     return error
   }
 
-  // TODO: metrics
-  // TODO: any other context?
+  // TODO: metrics - https://github.com/desktop/desktop/issues/6550
 
-  // TODO: where can I get this from in the event of a pull failing from a rebase?
-  const baseBranch = '???'
-  const targetBranch = '???'
+  if (gitContext == null) {
+    return error
+  }
+
+  const { currentBranch } = gitContext
 
   dispatcher.showPopup({
     type: PopupType.RebaseConflicts,
     repository,
-    targetBranch,
-    baseBranch,
+    targetBranch: currentBranch,
   })
 
   return null

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -460,10 +460,6 @@ export async function rebaseConflictsHandler(
 
   // TODO: metrics - https://github.com/desktop/desktop/issues/6550
 
-  if (gitContext == null) {
-    return error
-  }
-
   const { currentBranch } = gitContext
 
   dispatcher.showPopup({


### PR DESCRIPTION
## Overview

**Closes #6892**

## Description

This PR reviews the data that we provide to the error handlers when a pull fails, so we can either show the merge conflicts or rebase conflicts flow. The biggest change here is that we were passing in the `tip` (which might not be on a branch). I've replaced this with more explicit properties:

 - `currentBranch` is the one that the user is performing the `git pull` or `git merge` on
 - `theirBranch` is the other branch involved with the operation

For a merge, it should be the "other" branch. For a rebase, it should be the tracking branch.

I can't come up with a case where the user should be able to `git pull` or `git merge` from a detached HEAD or unknown tip, so I think we should just report an error if we're in an unexpected state, rather than attempt the operation.

 - [x] testing with `git pull --rebase` to trigger conflicts

## Release notes

Notes:
