### PR TITLE
chore: Upgrade moment to 2.24.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "fuzzaldrin-plus": "^0.6.0",
     "keytar": "^4.3.0",
     "memoize-one": "^4.0.3",
-    "moment": "^2.17.1",
+    "moment": "^2.24.0",
     "mri": "^1.1.0",
     "primer-support": "^4.0.0",
     "queue": "^4.4.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1031,10 +1031,10 @@ mocha@^3.5.0:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-moment@^2.17.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
-  integrity sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 mri@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #6921**

## Description

- Upgrades moment from 2.17.1 to 2.24.0 for fix vulnerability.


## Verification

* the history view - each commit shows a relative time in the description up until some limit, then it switches to the absolute time

![2019-02-22 18 22 15](https://user-images.githubusercontent.com/24681191/53256065-b556b700-36cf-11e9-8ea6-9b0c7c9bd39c.png)


* the fetch button shows the relative time

![2019-02-22 18 23 06](https://user-images.githubusercontent.com/24681191/53256045-aa9c2200-36cf-11e9-8940-166a8aa0ed80.png)

* the branches list shows the time of the last commit to each branch

![2019-02-22 18 23 31](https://user-images.githubusercontent.com/24681191/53256005-922c0780-36cf-11e9-96fe-fceb89ab5b2d.png)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
