### PR TITLE
group and filter repositories by owner

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -67,3 +67,11 @@ export function enableNoChangesCreatePRBlankslateAction(): boolean {
 export function enableNewRebaseFlow(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/**
+ *  Enables a new UI for the repository picker that supports
+ *  grouping and filtering (GitHub) repositories by owner/organization.
+ */
+export function enableGroupRepositoriesByOwner(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -1,4 +1,8 @@
-import { Repository, ILocalRepositoryState } from '../../models/repository'
+import {
+  Repository,
+  ILocalRepositoryState,
+  nameOf,
+} from '../../models/repository'
 import { CloningRepository } from '../../models/cloning-repository'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { caseInsensitiveCompare } from '../../lib/compare'
@@ -70,8 +74,10 @@ export function groupRepositories(
       const nameCount = names.get(r.name) || 0
       const { aheadBehind, changedFilesCount } =
         localRepositoryStateLookup.get(r.id) || fallbackValue
+      const repositoryText =
+        r instanceof Repository ? [r.name, nameOf(r)] : [r.name]
       return {
-        text: [r.name],
+        text: repositoryText,
         id: r.id.toString(),
         repository: r,
         needsDisambiguation: nameCount > 1,

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -93,7 +93,8 @@ export function groupRepositories(
           text: repositoryText,
           id: r.id.toString(),
           repository: r,
-          needsDisambiguation: false,
+          needsDisambiguation:
+            nameCount > 1 && identifier === KnownRepositoryGroup.enterprise,
           aheadBehind,
           changedFilesCount,
         }

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -45,7 +45,7 @@ export function groupRepositories(
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
 ): ReadonlyArray<IFilterListGroup<IRepositoryListItem>> {
   const grouped = new Map<RepositoryGroupIdentifier, Repositoryish[]>()
-  const gitHubOwners: Array<string> = []
+  const gitHubOwners = new Set<string>()
   for (const repository of repositories) {
     const gitHubRepository =
       repository instanceof Repository ? repository.gitHubRepository : null
@@ -54,7 +54,7 @@ export function groupRepositories(
       if (gitHubRepository.endpoint === getDotComAPIEndpoint()) {
         if (enableGroupRepositoriesByOwner()) {
           group = gitHubRepository.owner.login
-          gitHubOwners.push(group)
+          gitHubOwners.add(group)
         } else {
           group = 'GitHub.com'
         }
@@ -121,15 +121,9 @@ export function groupRepositories(
 
   // NB: This ordering reflects the order in the repositories sidebar.
   if (enableGroupRepositoriesByOwner()) {
-    const owners = gitHubOwners.reduce((acc, val) => {
-      if (!acc.includes(val)) {
-        acc.push(val)
-      }
-      return acc
-    }, new Array<string>())
-    owners.sort(caseInsensitiveCompare).forEach(o => {
-      addGroup(o)
-    })
+    const owners = [...gitHubOwners.values()]
+    owners.sort(caseInsensitiveCompare)
+    owners.forEach(addGroup)
   } else {
     addGroup('GitHub.com')
   }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -144,9 +144,9 @@ export class RepositoriesList extends React.Component<
   }
 
   private getGroupLabel(identifier: RepositoryGroupIdentifier) {
-    if (identifier === KnownRepositoryGroup.enterprise) {
+    if (identifier === KnownRepositoryGroup.Enterprise) {
       return 'Enterprise'
-    } else if (identifier === KnownRepositoryGroup.other) {
+    } else if (identifier === KnownRepositoryGroup.NonGitHub) {
       return 'Other'
     } else {
       return identifier

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -6,10 +6,10 @@ import {
   IRepositoryListItem,
   Repositoryish,
   RepositoryGroupIdentifier,
+  KnownRepositoryGroup,
 } from './group-repositories'
 import { FilterList, IFilterListGroup } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
-import { assertNever } from '../../lib/fatal-error'
 import { ILocalRepositoryState } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
@@ -144,14 +144,12 @@ export class RepositoriesList extends React.Component<
   }
 
   private getGroupLabel(identifier: RepositoryGroupIdentifier) {
-    if (identifier === 'github') {
-      return 'GitHub.com'
-    } else if (identifier === 'enterprise') {
+    if (identifier === KnownRepositoryGroup.enterprise) {
       return 'Enterprise'
-    } else if (identifier === 'other') {
+    } else if (identifier === KnownRepositoryGroup.other) {
       return 'Other'
     } else {
-      return assertNever(identifier, `Unknown identifier: ${identifier}`)
+      return identifier
     }
   }
 

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -1,4 +1,7 @@
-import { groupRepositories } from '../../src/ui/repositories-list/group-repositories'
+import {
+  groupRepositories,
+  KnownRepositoryGroup,
+} from '../../src/ui/repositories-list/group-repositories'
 import { Repository, ILocalRepositoryState } from '../../src/models/repository'
 import { GitHubRepository } from '../../src/models/github-repository'
 import { Owner } from '../../src/models/owner'
@@ -13,7 +16,7 @@ describe('repository list grouping', () => {
       2,
       new GitHubRepository(
         'my-repo2',
-        new Owner('', getDotComAPIEndpoint(), null),
+        new Owner('me', getDotComAPIEndpoint(), null),
         1
       ),
       false
@@ -28,23 +31,23 @@ describe('repository list grouping', () => {
 
   const cache = new Map<number, ILocalRepositoryState>()
 
-  it('groups repositories by GitHub/Enterprise/Other', () => {
+  it('groups repositories by owners/Enterprise/Other', () => {
     const grouped = groupRepositories(repositories, cache)
     expect(grouped).toHaveLength(3)
 
-    expect(grouped[0].identifier).toBe('github')
+    expect(grouped[0].identifier).toBe('me')
     expect(grouped[0].items).toHaveLength(1)
 
     let item = grouped[0].items[0]
     expect(item.repository.path).toBe('repo2')
 
-    expect(grouped[1].identifier).toBe('enterprise')
+    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.enterprise)
     expect(grouped[1].items).toHaveLength(1)
 
     item = grouped[1].items[0]
     expect(item.repository.path).toBe('repo3')
 
-    expect(grouped[2].identifier).toBe('other')
+    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.other)
     expect(grouped[2].items).toHaveLength(1)
 
     item = grouped[2].items[0]
@@ -56,14 +59,22 @@ describe('repository list grouping', () => {
     const repoB = new Repository(
       'b',
       2,
-      new GitHubRepository('b', new Owner('', getDotComAPIEndpoint(), null), 1),
+      new GitHubRepository(
+        'b',
+        new Owner('me', getDotComAPIEndpoint(), null),
+        1
+      ),
       false
     )
     const repoC = new Repository('c', 2, null, false)
     const repoD = new Repository(
       'd',
       2,
-      new GitHubRepository('d', new Owner('', getDotComAPIEndpoint(), null), 1),
+      new GitHubRepository(
+        'd',
+        new Owner('me', getDotComAPIEndpoint(), null),
+        1
+      ),
       false
     )
     const repoZ = new Repository('z', 3, null, false)
@@ -74,14 +85,14 @@ describe('repository list grouping', () => {
     )
     expect(grouped).toHaveLength(2)
 
-    expect(grouped[0].identifier).toBe('github')
+    expect(grouped[0].identifier).toBe('me')
     expect(grouped[0].items).toHaveLength(2)
 
     let items = grouped[0].items
     expect(items[0].repository.path).toBe('b')
     expect(items[1].repository.path).toBe('d')
 
-    expect(grouped[1].identifier).toBe('other')
+    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.other)
     expect(grouped[1].items).toHaveLength(3)
 
     items = grouped[1].items
@@ -90,7 +101,7 @@ describe('repository list grouping', () => {
     expect(items[2].repository.path).toBe('z')
   })
 
-  it('marks repositories for disambiguation if they have the same name', () => {
+  it('only disambiguates Enterprise repositories', () => {
     const repoA = new Repository(
       'repo',
       1,
@@ -102,16 +113,6 @@ describe('repository list grouping', () => {
       false
     )
     const repoB = new Repository(
-      'cool-repo',
-      2,
-      new GitHubRepository(
-        'cool-repo',
-        new Owner('user2', getDotComAPIEndpoint(), null),
-        2
-      ),
-      false
-    )
-    const repoC = new Repository(
       'repo',
       2,
       new GitHubRepository(
@@ -121,21 +122,49 @@ describe('repository list grouping', () => {
       ),
       false
     )
+    const repoC = new Repository(
+      'enterprise-repo',
+      3,
+      new GitHubRepository(
+        'enterprise-repo',
+        new Owner('business', '', null),
+        1
+      ),
+      false
+    )
+    const repoD = new Repository(
+      'enterprise-repo',
+      3,
+      new GitHubRepository(
+        'enterprise-repo',
+        new Owner('silliness', '', null),
+        1
+      ),
+      false
+    )
 
-    const grouped = groupRepositories([repoA, repoB, repoC], cache)
-    expect(grouped).toHaveLength(1)
+    const grouped = groupRepositories([repoA, repoB, repoC, repoD], cache)
+    expect(grouped).toHaveLength(3)
 
-    expect(grouped[0].identifier).toBe('github')
-    expect(grouped[0].items).toHaveLength(3)
+    expect(grouped[0].identifier).toBe('user1')
+    expect(grouped[0].items).toHaveLength(1)
 
-    const items = grouped[0].items
-    expect(items[0].text[0]).toBe('cool-repo')
-    expect(items[0].needsDisambiguation).toBe(false)
+    expect(grouped[1].identifier).toBe('user2')
+    expect(grouped[1].items).toHaveLength(1)
 
-    expect(items[1].text[0]).toBe('repo')
-    expect(items[1].needsDisambiguation).toBe(true)
+    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.enterprise)
+    expect(grouped[2].items).toHaveLength(2)
 
-    expect(items[2].text[0]).toBe('repo')
-    expect(items[2].needsDisambiguation).toBe(true)
+    expect(grouped[0].items[0].text[0]).toBe('repo')
+    expect(grouped[0].items[0].needsDisambiguation).toBe(false)
+
+    expect(grouped[1].items[0].text[0]).toBe('repo')
+    expect(grouped[1].items[0].needsDisambiguation).toBe(false)
+
+    expect(grouped[2].items[0].text[0]).toBe('enterprise-repo')
+    expect(grouped[2].items[0].needsDisambiguation).toBe(true)
+
+    expect(grouped[2].items[1].text[0]).toBe('enterprise-repo')
+    expect(grouped[2].items[1].needsDisambiguation).toBe(true)
   })
 })

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -41,13 +41,13 @@ describe('repository list grouping', () => {
     let item = grouped[0].items[0]
     expect(item.repository.path).toBe('repo2')
 
-    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.enterprise)
+    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.Enterprise)
     expect(grouped[1].items).toHaveLength(1)
 
     item = grouped[1].items[0]
     expect(item.repository.path).toBe('repo3')
 
-    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.other)
+    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.NonGitHub)
     expect(grouped[2].items).toHaveLength(1)
 
     item = grouped[2].items[0]
@@ -92,7 +92,7 @@ describe('repository list grouping', () => {
     expect(items[0].repository.path).toBe('b')
     expect(items[1].repository.path).toBe('d')
 
-    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.other)
+    expect(grouped[1].identifier).toBe(KnownRepositoryGroup.NonGitHub)
     expect(grouped[1].items).toHaveLength(3)
 
     items = grouped[1].items
@@ -152,7 +152,7 @@ describe('repository list grouping', () => {
     expect(grouped[1].identifier).toBe('user2')
     expect(grouped[1].items).toHaveLength(1)
 
-    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.enterprise)
+    expect(grouped[2].identifier).toBe(KnownRepositoryGroup.Enterprise)
     expect(grouped[2].items).toHaveLength(2)
 
     expect(grouped[0].items[0].text[0]).toBe('repo')


### PR DESCRIPTION
## Overview

partly addresses #6460
reboot of #6896

![filter by owner with grouping by owner](https://user-images.githubusercontent.com/964912/53270526-cf2cd580-36a0-11e9-8990-72012044567b.gif)


## Description

- group and display github.com repositories by organization
- filter text field searches the owner field
- feature flagged for beta currently

## Release notes

Notes: [Improved] Group and filter GitHub repositories by owner name
