### PR TITLE
:heavy_plus_sign: Add NoExistingRemoteBranch Popup

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -44,6 +44,7 @@ export enum PopupType {
   CommitConflictsWarning,
   PushNeedsPull,
   LocalChangesOverwritten,
+  NoExistingRemoteBranch,
 }
 
 export type Popup =
@@ -165,4 +166,10 @@ export type Popup =
       repository: Repository
       retryAction: RetryAction
       overwrittenFiles: ReadonlyArray<string>
+    }
+  | {
+      type: PopupType.NoExistingRemoteBranch
+      /** repository user is checking out in */
+      repository: Repository
+      branchName: string
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -94,6 +94,7 @@ import { OversizedFiles } from './changes/oversized-files-warning'
 import { UsageStatsChange } from './usage-stats-change'
 import { PushNeedsPullWarning } from './push-needs-pull'
 import { LocalChangesOverwrittenWarning } from './local-changes-overwritten'
+import { NoExistingRemoteBranchWarning } from './no-existing-remote-branch'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1534,6 +1535,15 @@ export class App extends React.Component<IAppProps, IAppState> {
             retryAction={popup.retryAction}
             overwrittenFiles={popup.overwrittenFiles}
             workingDirectory={workingDirectory}
+            onDismissed={this.onPopupDismissed}
+          />
+        )
+      case PopupType.NoExistingRemoteBranch:
+        return (
+          <NoExistingRemoteBranchWarning
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            branchName={popup.branchName}
             onDismissed={this.onPopupDismissed}
           />
         )

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -20,6 +20,7 @@ import {
   pushNeedsPullHandler,
   upstreamAlreadyExistsHandler,
   localChangesOverwrittenHandler,
+  noExistingRemoteBranchHandler,
 } from './dispatcher'
 import {
   AppStore,
@@ -158,6 +159,7 @@ dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)
 dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
+dispatcher.registerErrorHandler(noExistingRemoteBranchHandler)
 
 document.body.classList.add(`platform-${process.platform}`)
 

--- a/app/src/ui/no-existing-remote-branch/index.ts
+++ b/app/src/ui/no-existing-remote-branch/index.ts
@@ -1,0 +1,3 @@
+export {
+  NoExistingRemoteBranchWarning,
+} from './no-existing-remote-branch-warning'

--- a/app/src/ui/no-existing-remote-branch/no-existing-remote-branch-warning.tsx
+++ b/app/src/ui/no-existing-remote-branch/no-existing-remote-branch-warning.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dispatcher } from '../../ui/dispatcher'
+import { Repository } from '../../models/repository'
+import { Ref } from '../lib/ref'
+
+interface INoExistingRemoteBranchWarningProps {
+  readonly onDismissed: () => void
+  readonly dispatcher: Dispatcher
+  readonly branchName: string
+  readonly repository: Repository
+}
+
+/** A dialog to display a list of files that would be overwritten by a checkout. */
+export class NoExistingRemoteBranchWarning extends React.Component<
+  INoExistingRemoteBranchWarningProps
+> {
+  private closeButton: Button | null = null
+
+  public constructor(props: INoExistingRemoteBranchWarningProps) {
+    super(props)
+  }
+
+  private onCloseButtonRef = (button: Button | null) => {
+    this.closeButton = button
+  }
+
+  public componentDidMount() {
+    // Since focus is given to the overwritten files by default, we will instead set focus onto the cancel button.
+    if (this.closeButton != null) {
+      this.closeButton.focus()
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="no-existing-remote-branch"
+        title={
+          __DARWIN__ ? 'No Existing Remote Branch' : 'No existing remote branch'
+        }
+        onDismissed={this.props.onDismissed}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            The branch <Ref>{this.props.branchName}</Ref> doesn't not exist on
+            remote.
+          </p>
+        </DialogContent>
+
+        <DialogFooter>
+          <ButtonGroup destructive={true}>
+            <Button type="submit" ref={this.onCloseButtonRef}>
+              Cancel
+            </Button>
+            <Button onClick={this.publishBranch}>
+              {__DARWIN__ ? 'Publish Branch' : 'Publish branch'}
+            </Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private publishBranch = async () => {
+    this.props.dispatcher.closePopup()
+
+    await this.props.dispatcher.push(this.props.repository)
+  }
+}


### PR DESCRIPTION
## Overview

🌵 🌵 🌵 Blocked by https://github.com/desktop/dugite/pull/301 🌵 🌵 🌵

**Closes #1325**

## Description

- Adds a better error message when pull occurs on non-existent upstream branch

![image](https://user-images.githubusercontent.com/7467062/53324921-af1b3300-38a7-11e9-9ca2-ee49acf08764.png)

## Release notes

Notes: Added a better error message when pull occurs on non-existent upstream branch
