### PR TITLE
teach branch switcher about rebase conflicts

### DIFF
--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -4,7 +4,7 @@ import { OcticonSymbol } from '../octicons'
 import { Repository } from '../../models/repository'
 import { TipState } from '../../models/tip'
 import { ToolbarDropdown, DropdownState } from './dropdown'
-import { IRepositoryState } from '../../lib/app-state'
+import { IRepositoryState, isRebaseConflictState } from '../../lib/app-state'
 import { BranchesContainer, PullRequestBadge } from '../branches'
 import { assertNever } from '../../lib/fatal-error'
 import { BranchesTab } from '../../models/branches-tab'
@@ -83,8 +83,9 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
 
   public render() {
     const { repositoryState } = this.props
-    const { branchesState, checkoutProgress } = repositoryState
+    const { branchesState, checkoutProgress, changesState } = repositoryState
     const { tip } = branchesState
+    const { conflictState } = changesState
 
     const tipKind = tip.kind
 
@@ -132,6 +133,11 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       progressValue = checkoutProgress.value
       icon = OcticonSymbol.sync
       iconClassName = 'spin'
+      canOpen = false
+    } else if (conflictState !== null && isRebaseConflictState(conflictState)) {
+      title = conflictState.targetBranch
+      description = 'Rebasing branch'
+      icon = OcticonSymbol.gitBranch
       canOpen = false
     }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -82,10 +82,10 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
   }
 
   public render() {
-    const repositoryState = this.props.repositoryState
-    const branchesState = repositoryState.branchesState
+    const { repositoryState } = this.props
+    const { branchesState, checkoutProgress } = repositoryState
+    const { tip } = branchesState
 
-    const tip = branchesState.tip
     const tipKind = tip.kind
 
     let icon = OcticonSymbol.gitBranch
@@ -118,7 +118,6 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       return assertNever(tip, `Unknown tip state: ${tipKind}`)
     }
 
-    const checkoutProgress = repositoryState.checkoutProgress
     let progressValue: number | undefined = undefined
 
     if (checkoutProgress) {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -95,6 +95,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     let title: string
     let description = __DARWIN__ ? 'Current Branch' : 'Current branch'
     let canOpen = true
+    let disabled = false
     let tooltip: string
 
     if (this.props.currentPullRequest) {
@@ -144,6 +145,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       description = 'Rebasing branch'
       icon = OcticonSymbol.gitBranch
       canOpen = false
+      disabled = true
     }
 
     const isOpen = this.props.isOpen
@@ -160,6 +162,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         onDropdownStateChanged={this.onDropDownStateChanged}
         dropdownContentRenderer={this.renderBranchFoldout}
         dropdownState={currentState}
+        disabled={disabled}
         showDisclosureArrow={canOpen}
         progressValue={progressValue}
       >

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -9,6 +9,7 @@ import { BranchesContainer, PullRequestBadge } from '../branches'
 import { assertNever } from '../../lib/fatal-error'
 import { BranchesTab } from '../../models/branches-tab'
 import { PullRequest } from '../../models/pull-request'
+import { enableNewRebaseFlow } from '../../lib/feature-flag'
 
 interface IBranchDropdownProps {
   readonly dispatcher: Dispatcher
@@ -134,7 +135,11 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       icon = OcticonSymbol.sync
       iconClassName = 'spin'
       canOpen = false
-    } else if (conflictState !== null && isRebaseConflictState(conflictState)) {
+    } else if (
+      conflictState !== null &&
+      isRebaseConflictState(conflictState) &&
+      enableNewRebaseFlow()
+    ) {
       title = conflictState.targetBranch
       description = 'Rebasing branch'
       icon = OcticonSymbol.gitBranch


### PR DESCRIPTION
## Overview

**Closes #6891**

## Description

I went with the simpler change rather than incorporating "rebase progress" which we don't currently surface in application state.

<img width="974" src="https://user-images.githubusercontent.com/359239/53443752-c0b52580-39e2-11e9-92d1-488b06223ad1.png">

## Release notes

Notes: branch switcher now indicates when a rebase is in progress
