### PR TITLE
log and drop found user when in an invalid state for caching

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.3-beta2",
+  "version": "1.6.3-test1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -241,30 +241,29 @@ export class GitHubUserStore extends BaseStore {
   private async findUserWithAPI(
     account: Account,
     repository: GitHubRepository,
-    sha: string | null,
+    sha: string,
     email: string
   ): Promise<IGitHubUser | null> {
     const api = API.fromAccount(account)
-    if (sha) {
-      const apiCommit = await api.fetchCommit(
-        repository.owner.login,
-        repository.name,
-        sha
-      )
-      if (apiCommit && apiCommit.author) {
-        const avatarURL = getAvatarWithEnterpriseFallback(
-          apiCommit.author.avatar_url,
-          email,
-          account.endpoint
-        )
 
-        return {
-          email,
-          avatarURL,
-          login: apiCommit.author.login,
-          endpoint: account.endpoint,
-          name: apiCommit.author.name || apiCommit.author.login,
-        }
+    const apiCommit = await api.fetchCommit(
+      repository.owner.login,
+      repository.name,
+      sha
+    )
+    if (apiCommit && apiCommit.author) {
+      const avatarURL = getAvatarWithEnterpriseFallback(
+        apiCommit.author.avatar_url,
+        email,
+        account.endpoint
+      )
+
+      return {
+        email,
+        avatarURL,
+        login: apiCommit.author.login,
+        endpoint: account.endpoint,
+        name: apiCommit.author.name || apiCommit.author.login,
       }
     }
 

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -177,7 +177,7 @@ export class GitHubUserStore extends BaseStore {
   public async _loadAndCacheUser(
     accounts: ReadonlyArray<Account>,
     repository: Repository,
-    sha: string | null,
+    sha: string,
     email: string
   ) {
     const endpoint = repository.gitHubRepository

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.6.3-test1": [
+      "[Improved] handling of cached users to avoid invalid state - #6940"
+    ],
     "1.6.3-beta2": [
       "[Fixed] Text selection in wrapped diff lines now allows selection of individual lines - #1551",
       "[Fixed] Resizing the diff area preserves text selection range - #2677",


### PR DESCRIPTION
## Overview

Adding some resiliency and tracing to `GitHubUserStore._loadAndCacheUser` because I don't entirely trust what it's trying to cache.

**Related to #6313 but I don't quite follow how it would result in a disabled app menu**

## Description

Keep in mind the original issue that the app is calling this function and one of these fields is `undefined`:

https://github.com/desktop/desktop/blob/c00061fb2c3613ce9e085b62a11e89f37dfcaf89/app/src/lib/stores/github-user-store.ts#L512-L518

The stack trace from #6313 mentions these three functions (albeit minified to strip the function names): `GitHubUserStore._loadAndCacheUser` -> `GitHubUserStore.cacheUser` -> `userWithLowerCase`.

And `cacheUser` is invoked only when it finds a valid object for `gitUser`:

https://github.com/desktop/desktop/blob/c00061fb2c3613ce9e085b62a11e89f37dfcaf89/app/src/lib/stores/github-user-store.ts#L233-L238

So what is `_loadAndCacheUser` doing that might be risky?

 - retrieve a cached user based on the received email address
 - if nothing found, use the GitHub API to find the author - using the given commit and email address

My working theory here is that one of these operations is returning a user with an empty `login`, which is triggering the action. The app can work fine without finding an user here, so this PR changes the behaviour of this area to:

  - emit a clear error message when it encounters a `gitUser` that's an invalid state, with details to help us isolate the issue if it gets reported
 - when the app encounters this invalid `gitUser`, it clears the variable so the app doesn't try and cache it

Armed with more details about this issue from someone who has encountered #6313, we can make this area more reliable once we know what piece of data we're missing...


## Release notes

Notes: 
