### PR TITLE
make loadAndCacheUser more resilient to bad input

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -362,6 +362,10 @@ export class API {
   public async searchForUserWithEmail(
     email: string
   ): Promise<IAPIIdentity | null> {
+    if (email.length === 0) {
+      return null
+    }
+
     try {
       const params = { q: `${email} in:email type:user` }
       const url = urlWithQueryString('search/users', params)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -59,7 +59,7 @@ export interface IAPIRepository {
  */
 export interface IAPICommit {
   readonly sha: string
-  readonly author: IAPIUser | null
+  readonly author: IAPIIdentity | {} | null
 }
 
 /**

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -25,6 +25,8 @@ if (!ClientID || !ClientID.length || !ClientSecret || !ClientSecret.length) {
   )
 }
 
+type GitHubAccountType = 'User' | 'Organization'
+
 /** The OAuth scopes we need. */
 const Scopes = ['repo', 'user']
 
@@ -61,9 +63,38 @@ export interface IAPICommit {
 }
 
 /**
- * Information about a user as returned by the GitHub API.
+ * Entity returned by the `/user/orgs` endpoint.
+ *
+ * Because this is specific to one endpoint it omits the `type` member from
+ * `IAPIIdentity` that callers might expect.
  */
-export interface IAPIUser {
+export interface IAPIOrganization {
+  readonly id: number
+  readonly url: string
+  readonly login: string
+  readonly avatar_url: string
+}
+
+/**
+ * Minimum subset of an identity returned by the GitHub API
+ */
+export interface IAPIIdentity {
+  readonly id: number
+  readonly url: string
+  readonly login: string
+  readonly avatar_url: string
+  readonly type: GitHubAccountType
+}
+
+/**
+ * Complete identity details returned in some situations by the GitHub API.
+ *
+ * If you are not sure what is returned as part of an API response, you should
+ * use `IAPIIdentity` as that contains the known subset of an identity and does
+ * not cover scenarios where privacy settings of a user control what information
+ * is returned.
+ */
+interface IAPIFullIdentity {
   readonly id: number
   readonly url: string
   readonly login: string
@@ -80,7 +111,7 @@ export interface IAPIUser {
    * specified a public email address in their profile.
    */
   readonly email: string | null
-  readonly type: 'User' | 'Organization'
+  readonly type: GitHubAccountType
 }
 
 /** The users we get from the mentionables endpoint. */

--- a/app/src/lib/gravatar.ts
+++ b/app/src/lib/gravatar.ts
@@ -35,7 +35,11 @@ export function getAvatarWithEnterpriseFallback(
   email: string | null,
   endpoint: string
 ): string {
-  if (endpoint === getDotComAPIEndpoint() || email === null) {
+  if (
+    endpoint === getDotComAPIEndpoint() ||
+    email === null ||
+    email.length === 0
+  ) {
     return avatar_url
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -73,7 +73,7 @@ import {
   getAccountForEndpoint,
   getDotComAPIEndpoint,
   getEnterpriseAPIURL,
-  IAPIUser,
+  IAPIOrganization,
 } from '../api'
 import { shell } from '../app-shell'
 import {
@@ -2969,7 +2969,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     description: string,
     private_: boolean,
     account: Account,
-    org: IAPIUser | null
+    org: IAPIOrganization | null
   ): Promise<Repository> {
     const api = API.fromAccount(account)
     const apiRepository = await api.createRepository(

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -17,6 +17,17 @@ import { fatalError } from '../fatal-error'
 import { compare } from '../compare'
 import { BaseStore } from './base-store'
 
+function isValidAuthor(
+  author: IAPIIdentity | {} | null
+): author is IAPIIdentity {
+  return (
+    author !== null &&
+    typeof author === 'object' &&
+    'avatar_url' in author &&
+    'login' in author
+  )
+}
+
 /**
  * The store for GitHub users. This is used to match commit authors to GitHub
  * users and avatars.
@@ -256,19 +267,23 @@ export class GitHubUserStore extends BaseStore {
         repository.name,
         sha
       )
-      if (apiCommit && apiCommit.author) {
-        const avatarURL = getAvatarWithEnterpriseFallback(
-          apiCommit.author.avatar_url,
-          email,
-          account.endpoint
-        )
 
-        return {
-          email,
-          avatarURL,
-          login: apiCommit.author.login,
-          endpoint: account.endpoint,
-          name: apiCommit.author.name || apiCommit.author.login,
+      if (apiCommit) {
+        const { author } = apiCommit
+        if (isValidAuthor(author)) {
+          const avatarURL = getAvatarWithEnterpriseFallback(
+            author.avatar_url,
+            email,
+            account.endpoint
+          )
+
+          return {
+            email,
+            avatarURL,
+            login: author.login,
+            endpoint: account.endpoint,
+            name: author.login,
+          }
         }
       }
     }

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -193,7 +193,7 @@ export class GitHubUserStore extends BaseStore {
   public async _loadAndCacheUser(
     accounts: ReadonlyArray<Account>,
     repository: Repository,
-    sha: string | null,
+    sha: string,
     email: string
   ) {
     const endpoint = repository.gitHubRepository
@@ -257,33 +257,32 @@ export class GitHubUserStore extends BaseStore {
   private async findUserWithAPI(
     account: Account,
     repository: GitHubRepository,
-    sha: string | null,
+    sha: string,
     email: string
   ): Promise<IGitHubUser | null> {
     const api = API.fromAccount(account)
-    if (sha) {
-      const apiCommit = await api.fetchCommit(
-        repository.owner.login,
-        repository.name,
-        sha
-      )
 
-      if (apiCommit) {
-        const { author } = apiCommit
-        if (isValidAuthor(author)) {
-          const avatarURL = getAvatarWithEnterpriseFallback(
-            author.avatar_url,
-            email,
-            account.endpoint
-          )
+    const apiCommit = await api.fetchCommit(
+      repository.owner.login,
+      repository.name,
+      sha
+    )
 
-          return {
-            email,
-            avatarURL,
-            login: author.login,
-            endpoint: account.endpoint,
-            name: author.login,
-          }
+    if (apiCommit) {
+      const { author } = apiCommit
+      if (isValidAuthor(author)) {
+        const avatarURL = getAvatarWithEnterpriseFallback(
+          author.avatar_url,
+          email,
+          account.endpoint
+        )
+
+        return {
+          email,
+          avatarURL,
+          login: author.login,
+          endpoint: account.endpoint,
+          name: author.login,
         }
       }
     }

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -1,7 +1,12 @@
 import { Repository } from '../../models/repository'
 import { Account } from '../../models/account'
 import { GitHubRepository } from '../../models/github-repository'
-import { API, getAccountForEndpoint, getDotComAPIEndpoint } from '../api'
+import {
+  API,
+  getAccountForEndpoint,
+  getDotComAPIEndpoint,
+  IAPIIdentity,
+} from '../api'
 import {
   GitHubUserDatabase,
   IGitHubUser,
@@ -280,7 +285,7 @@ export class GitHubUserStore extends BaseStore {
         login: matchingUser.login,
         avatarURL,
         endpoint: account.endpoint,
-        name: matchingUser.name || matchingUser.login,
+        name: matchingUser.login,
       }
     }
 

--- a/app/src/models/publish-settings.ts
+++ b/app/src/models/publish-settings.ts
@@ -1,4 +1,4 @@
-import { IAPIUser } from '../lib/api'
+import { IAPIOrganization } from '../lib/api'
 
 export type RepositoryPublicationSettings =
   | IEnterprisePublicationSettings
@@ -38,5 +38,5 @@ export interface IDotcomPublicationSettings {
    * The org to which this repository belongs. If null, the repository should be
    * published as a personal repository.
    */
-  readonly org: IAPIUser | null
+  readonly org: IAPIOrganization | null
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2,7 +2,7 @@ import { remote } from 'electron'
 import { Disposable } from 'event-kit'
 import * as Path from 'path'
 
-import { IAPIUser } from '../../lib/api'
+import { IAPIOrganization } from '../../lib/api'
 import { shell } from '../../lib/app-shell'
 import {
   CompareAction,
@@ -349,7 +349,7 @@ export class Dispatcher {
     description: string,
     private_: boolean,
     account: Account,
-    org: IAPIUser | null
+    org: IAPIOrganization | null
   ): Promise<Repository> {
     return this.appStore._publishRepository(
       repository,

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Account } from '../../models/account'
-import { API, IAPIUser } from '../../lib/api'
+import { API, IAPIOrganization } from '../../lib/api'
 import { TextBox } from '../lib/text-box'
 import { Select } from '../lib/select'
 import { DialogContent } from '../dialog'
@@ -27,7 +27,7 @@ interface IPublishRepositoryProps {
 }
 
 interface IPublishRepositoryState {
-  readonly orgs: ReadonlyArray<IAPIUser>
+  readonly orgs: ReadonlyArray<IAPIOrganization>
 }
 
 /** The Publish Repository component. */
@@ -59,7 +59,8 @@ export class PublishRepository extends React.Component<
 
   private async fetchOrgs(account: Account) {
     const api = API.fromAccount(account)
-    const orgs = (await api.fetchOrgs()) as Array<IAPIUser>
+    const apiOrgs = await api.fetchOrgs()
+    const orgs = [...apiOrgs]
     orgs.sort((a, b) => caseInsensitiveCompare(a.login, b.login))
     this.setState({ orgs })
   }

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -210,8 +210,6 @@ async function initializeTestRepo(
         url: '',
         login: '',
         avatar_url: '',
-        name: null,
-        email: null,
         type: 'User',
       },
       private: false,

--- a/app/test/unit/repositories-clone-grouping-test.ts
+++ b/app/test/unit/repositories-clone-grouping-test.ts
@@ -2,7 +2,7 @@ import {
   groupRepositories,
   YourRepositoriesIdentifier,
 } from '../../src/ui/clone-repository/group-repositories'
-import { IAPIRepository, IAPIUser } from '../../src/lib/api'
+import { IAPIRepository, IAPIIdentity } from '../../src/lib/api'
 
 const users = {
   shiftkey: {
@@ -12,7 +12,7 @@ const users = {
     avatar_url: '',
     name: 'Brendan Forster',
     type: 'User',
-  } as IAPIUser,
+  } as IAPIIdentity,
   desktop: {
     id: 2,
     url: '',
@@ -20,7 +20,7 @@ const users = {
     avatar_url: '',
     name: 'Desktop',
     type: 'Organization',
-  } as IAPIUser,
+  } as IAPIIdentity,
   octokit: {
     id: 3,
     url: '',
@@ -28,7 +28,7 @@ const users = {
     avatar_url: '',
     name: 'Octokit',
     type: 'Organization',
-  } as IAPIUser,
+  } as IAPIIdentity,
 }
 
 describe('clone repository grouping', () => {

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -43,8 +43,6 @@ describe('RepositoriesStore', () => {
         url: 'https://github.com/my-user',
         login: 'my-user',
         avatar_url: 'https://github.com/my-user.png',
-        email: 'my-user@users.noreply.github.com',
-        name: 'My User',
         type: 'User',
       },
       private: true,


### PR DESCRIPTION
## Overview

**Related to #6313**

## Description

This PR addresses a few things I uncovered during the investigation for #6313. I couldn't reproduce the "menus disabled" behaviour but I could trigger everything else.

Here's what I found:

 1. the GitHub API would return an empty object for the `author` for some commits, instead of `null`

This was fixed in 2484ff6 to add a runtime check that the object found is the expected shape and contents.

 2. our use of `IAPIUser` to represent a unified account does not reflect what was returned by the API. I uncovered three different shapes of data,


`IAPIUser` has been deprecated in favour of these three shapes in 8847ef6:

   - `IAPIFullIdentity` - this is the same shape as `IAPIUser` but is only used in two places - `/user` ( the details about the current user) and `/users/{user}` to find details about a GitHub account
   - `IAPIIdentity` - this is the subset of account information that is used in most places of the API - commits, pull requests, etc. No `name` or `email` is provided in this payload, irrespective of the privacy settings defined by the user. I didn't notice any strange issues downstream as a result of this change, but this is something to be mindful of while I'm doing more testing.
   - `IAPIOrganization` - the array of objects returned by `/user/orgs` is similar to `IAPIIdentity`, but for some reason omitted the `type` value (because only organizations are returned by this endpoint?). 

 3. this problem commit had it's email address set to `""` in Git

We have a few places where we look for a `null` email and bail out, so I also added checks for `""` in 9d0a484  to save API calls when searching for a user.

## Release notes

Notes: `[Fixed] caching GitHub users does not handle edge case where email is empty string`
