### PR TITLE
update TextDiff update logic

### DIFF
--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -52,6 +52,12 @@ interface ICodeMirrorHostProps {
   readonly onSwapDoc?: (cm: Editor, oldDoc: Doc) => void
 
   /**
+   * Called after the document has been swapped, meaning that consumers of this
+   * event have access to the updated viewport (as opposed to onSwapDoc)
+   */
+  readonly onAfterSwapDoc?: (cm: Editor, oldDoc: Doc, newDoc: Doc) => void
+
+  /**
    * Called when content has been copied. The default behavior may be prevented
    * by calling `preventDefault` on the event.
    */
@@ -164,7 +170,13 @@ export class CodeMirrorHost extends React.Component<ICodeMirrorHostProps, {}> {
 
   public componentDidUpdate(prevProps: ICodeMirrorHostProps) {
     if (this.codeMirror && this.props.value !== prevProps.value) {
+      const oldDoc = this.codeMirror.getDoc()
       CodeMirrorHost.updateDoc(this.codeMirror, this.props.value)
+      const newDoc = this.codeMirror.getDoc()
+
+      if (this.props.onAfterSwapDoc) {
+        this.props.onAfterSwapDoc(this.codeMirror, oldDoc, newDoc)
+      }
     }
   }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -705,14 +705,13 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
     if (canSelect(this.props.file)) {
       if (
         !canSelect(prevProps.file) ||
-        this.props.file.selection !== prevProps.file.selection
+        this.props.file.selection !== prevProps.file.selection ||
+        this.props.text === prevProps.text
       ) {
         // If the text has changed the gutters will be recreated
         // regardless but if it hasn't then we'll need to update
         // the viewport.
-        if (this.props.text === prevProps.text) {
-          this.updateViewport()
-        }
+        this.updateViewport()
       }
     }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -702,12 +702,14 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
       return
     }
 
-    if (canSelect(this.props.file)) {
-      if (
-        !canSelect(prevProps.file) ||
-        this.props.file.selection !== prevProps.file.selection ||
-        this.props.text === prevProps.text
-      ) {
+    const { file } = this.props
+    const { file: prevFile } = prevProps
+    if (canSelect(file)) {
+      if (!canSelect(prevFile)) {
+        this.updateViewport()
+      } else if (file.selection !== prevFile.selection) {
+        this.updateViewport()
+      } else if (this.props.text === prevProps.text) {
         // If the text has changed the gutters will be recreated
         // regardless but if it hasn't then we'll need to update
         // the viewport.

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -722,13 +722,14 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
     if (canSelect(this.props.file)) {
       if (
         !canSelect(prevProps.file) ||
-        this.props.file.selection !== prevProps.file.selection ||
-        this.props.text === prevProps.text
+        this.props.file.selection !== prevProps.file.selection
       ) {
         // If the text has changed the gutters will be recreated
         // regardless but if it hasn't then we'll need to update
         // the viewport.
-        this.updateViewport()
+        if (this.props.text === prevProps.text) {
+          this.updateViewport()
+        }
       }
     }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -479,6 +479,23 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
     this.markIntraLineChanges(cm.getDoc(), this.props.hunks)
   }
 
+  /**
+   * When we swap in a new document that happens to have the exact same number
+   * of lines as the previous document and where neither of those document
+   * needs scrolling (i.e the document doesn't extend beyond the visible area
+   * of the editor) we techincally never update the viewport as far as CodeMirror
+   * is concerned, meaning that we don't get a chance to update our gutters.
+   *
+   * By subscribing to the event that happens immediately after the document
+   * swap has been completed we can check for this relatively rare condition
+   * and explicitly update the viewport (and thereby the gutters).
+   */
+  private onAfterSwapDoc = (cm: Editor, oldDoc: Doc, newDoc: Doc) => {
+    if (oldDoc.lineCount() === newDoc.lineCount()) {
+      this.updateViewport()
+    }
+  }
+
   private onViewportChange = (cm: Editor, from: number, to: number) => {
     const doc = cm.getDoc()
     const batchedOps = new Array<Function>()
@@ -753,6 +770,7 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
         options={defaultEditorOptions}
         isSelectionEnabled={this.isSelectionEnabled}
         onSwapDoc={this.onSwapDoc}
+        onAfterSwapDoc={this.onAfterSwapDoc}
         onViewportChange={this.onViewportChange}
         ref={this.getAndStoreCodeMirrorInstance}
         onCopy={this.onCopy}

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -719,14 +719,12 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
       return
     }
 
-    const { file } = this.props
-    const { file: prevFile } = prevProps
-    if (canSelect(file)) {
-      if (!canSelect(prevFile)) {
-        this.updateViewport()
-      } else if (file.selection !== prevFile.selection) {
-        this.updateViewport()
-      } else if (this.props.text === prevProps.text) {
+    if (canSelect(this.props.file)) {
+      if (
+        !canSelect(prevProps.file) ||
+        this.props.file.selection !== prevProps.file.selection ||
+        this.props.text === prevProps.text
+      ) {
         // If the text has changed the gutters will be recreated
         // regardless but if it hasn't then we'll need to update
         // the viewport.


### PR DESCRIPTION
## Overview

Closes #6938 

The primary change in this PR is to call `updateViewport()` at the precisely right time in the codemirror update cycle, and then only when we are in the specific case of a diff that has changed, but hasn't changed in number of lines.

## Description

- added a hook for after a `swapDoc` event (basically whenever we change the text in the diff viewer)
- utilize hook to check for the case mentioned above and update the viewport so we don't lose our gutter
