### PR TITLE
encode file path to each emoji when reading from cache

### DIFF
--- a/app/src/lib/read-emoji.ts
+++ b/app/src/lib/read-emoji.ts
@@ -1,5 +1,6 @@
 import * as Fs from 'fs'
 import * as Path from 'path'
+import { encodePathAsUrl } from './path'
 
 /**
  * Type representing the contents of the gemoji json database
@@ -28,7 +29,7 @@ interface IGemojiDefinition {
 }
 
 function getEmojiImageUrlFromRelativePath(relativePath: string): string {
-  return `file://${Path.join(__dirname, 'emoji', relativePath)}`
+  return encodePathAsUrl(__dirname, 'emoji', relativePath)
 }
 
 /**


### PR DESCRIPTION
## Overview

**Closes #6909**

## Description

This is the same fix as outlined in #3109, which we applied to the SVGs rendered in the app at the time to address the exact same problem.

I dusted off my old VM with the problem account that I used in #3109 and verified the change works there

### `release-1.6.2`

<img width="301" alt="screen shot 2019-02-26 at 2 02 11 pm" src="https://user-images.githubusercontent.com/359239/53435554-74141f00-39cf-11e9-913e-06aa9d4499d8.png">

### This PR

<img width="309" alt="screen shot 2019-02-26 at 2 02 45 pm" src="https://user-images.githubusercontent.com/359239/53435555-74acb580-39cf-11e9-823b-e52d6028daa7.png">

## Release notes

Notes: `[Fixed] emoji in autocomplete does not render for Windows users with special characters in account name`
