### PR TITLE
the last set of rebase metrics for this release

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -273,10 +273,26 @@ export function isMergeConflictState(
  */
 export type RebaseConflictState = {
   readonly kind: 'rebase'
+  /**
+   * This is the commit ID of the HEAD of the in-flight rebase
+   */
   readonly currentTip: string
+  /**
+   * The branch chosen by the user to be rebased
+   */
   readonly targetBranch: string
+  /**
+   * The commit ID of the target branch before the rebase was initiated
+   */
   readonly originalBranchTip: string
+  /**
+   * The commit ID of the base branch onto which the history will be applied
+   */
   readonly baseBranchTip: string
+  /**
+   * Manual resolutions chosen by the user for conflicted files to be applied
+   * before continuing the rebase.
+   */
   readonly manualResolutions: Map<string, ManualConflictResolution>
 }
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -151,6 +151,12 @@ export interface IDailyMeasures {
 
   /** The number of times the rebase conflicts dialog is reopened */
   readonly rebaseConflictsDialogReopenedCount: number
+
+  /** The number of times an aborted rebase is detected */
+  readonly rebaseAbortedAfterConflictsCount: number
+
+  /** The number of times a successful rebase is detected */
+  readonly rebaseSuccessAfterConflictsCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -83,6 +83,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   createPullRequestCount: 0,
   rebaseConflictsDialogDismissalCount: 0,
   rebaseConflictsDialogReopenedCount: 0,
+  rebaseAbortedAfterConflictsCount: 0,
+  rebaseSuccessAfterConflictsCount: 0,
 }
 
 interface IOnboardingStats {
@@ -257,6 +259,8 @@ type DailyStats = ICalculatedStats &
 export interface IStatsStore {
   recordMergeAbortedAfterConflicts: () => void
   recordMergeSuccessAfterConflicts: () => void
+  recordRebaseAbortedAfterConflicts: () => void
+  recordRebaseSuccessAfterConflicts: () => void
 }
 
 /** The store for the app's stats. */
@@ -848,6 +852,24 @@ export class StatsStore implements IStatsStore {
     return this.updateDailyMeasures(m => ({
       rebaseConflictsDialogReopenedCount:
         m.rebaseConflictsDialogReopenedCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `rebaseAbortedAfterConflictsCount` metric
+   */
+  public async recordRebaseAbortedAfterConflicts(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      rebaseAbortedAfterConflictsCount: m.rebaseAbortedAfterConflictsCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `rebaseSuccessAfterConflictsCount` metric
+   */
+  public async recordRebaseSuccessAfterConflicts(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      rebaseSuccessAfterConflictsCount: m.rebaseSuccessAfterConflictsCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -188,19 +188,42 @@ function performEffectsForRebaseStateChange(
   status: IStatusResult,
   statsStore: IStatsStore
 ) {
-  // TODO: run side-effects for rebase conflicts state changes
+  const previousBranchName =
+    prevConflictState != null ? prevConflictState.targetBranch : null
+  const currentBranchName =
+    newConflictState != null ? newConflictState.targetBranch : null
 
-  // what does a successful rebase look like?
-  // - the state changed from "in a rebase" to "no rebase"
-  // - the commit ID of branch they were trying to rebase is the same as it was before
+  const branchNameChanged =
+    previousBranchName != null &&
+    currentBranchName != null &&
+    previousBranchName !== currentBranchName
 
-  // what does an aborted rebase look like?
-  // - the state changed from "in a rebase" to "no rebase"
-  // - the commit ID of branch they were trying to rebase is now different
+  // The branch name has changed while remaining conflicted -> the rebase must have been aborted
+  if (branchNameChanged) {
+    statsStore.recordRebaseAbortedAfterConflicts()
+    return
+  }
 
-  // - we'd need to know the target branch they are rebasing
-  // - we'd need to know the commit ID at the start of the rebase
-  // - we'd need to know the commit ID when the rebase was done
+  const { currentTip, currentBranch } = status
+
+  // if the repository is no longer conflicted, what do we think happened?
+  if (
+    prevConflictState != null &&
+    newConflictState == null &&
+    currentTip != null &&
+    currentBranch != null
+  ) {
+    const previousTip = prevConflictState.originalBranchTip
+
+    if (
+      previousTip !== currentTip &&
+      currentBranch === prevConflictState.targetBranch
+    ) {
+      statsStore.recordRebaseSuccessAfterConflicts()
+    } else {
+      statsStore.recordRebaseAbortedAfterConflicts()
+    }
+  }
 
   return
 }

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -231,5 +231,74 @@ describe('updateConflictState', () => {
         originalBranchTip: 'some-other-sha',
       })
     })
+
+    it('increments abort counter when conflict remains but branch has changed', () => {
+      const prevState = createState({
+        conflictState: {
+          kind: 'rebase',
+          currentTip: 'current-sha',
+          manualResolutions,
+          targetBranch: 'my-feature-branch',
+          baseBranchTip: 'another-sha',
+          originalBranchTip: 'old-sha',
+        },
+      })
+      const status = createStatus({
+        rebaseContext: {
+          targetBranch: 'a-different-feature-branch',
+          originalBranchTip: 'some-old-sha',
+          baseBranchTip: 'an-even-older-sha',
+        },
+        currentTip: 'current-sha',
+      })
+
+      updateConflictState(prevState, status, statsStore)
+
+      expect(statsStore.recordRebaseAbortedAfterConflicts).toHaveBeenCalled()
+    })
+
+    it('increments abort counter when conflict resolved but tip has not changed', () => {
+      const prevState = createState({
+        conflictState: {
+          kind: 'rebase',
+          currentTip: 'current-sha',
+          manualResolutions,
+          targetBranch: 'my-feature-branch',
+          baseBranchTip: 'another-sha',
+          originalBranchTip: 'old-sha',
+        },
+      })
+      const status = createStatus({
+        rebaseContext: null,
+        currentBranch: 'my-feature-branch',
+        currentTip: 'old-sha',
+      })
+
+      updateConflictState(prevState, status, statsStore)
+
+      expect(statsStore.recordRebaseAbortedAfterConflicts).toHaveBeenCalled()
+    })
+
+    it('increments success counter when conflict resolved and tip has changed', () => {
+      const prevState = createState({
+        conflictState: {
+          kind: 'rebase',
+          currentTip: 'current-sha',
+          manualResolutions,
+          targetBranch: 'my-feature-branch',
+          baseBranchTip: 'even-older-sha',
+          originalBranchTip: 'old-sha',
+        },
+      })
+      const status = createStatus({
+        rebaseContext: null,
+        currentBranch: 'my-feature-branch',
+        currentTip: 'new-sha',
+      })
+
+      updateConflictState(prevState, status, statsStore)
+
+      expect(statsStore.recordRebaseSuccessAfterConflicts).toHaveBeenCalled()
+    })
   })
 })

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -9,6 +9,8 @@ describe('updateConflictState', () => {
   const statsStore = {
     recordMergeAbortedAfterConflicts: jest.fn(),
     recordMergeSuccessAfterConflicts: jest.fn(),
+    recordRebaseAbortedAfterConflicts: jest.fn(),
+    recordRebaseSuccessAfterConflicts: jest.fn(),
   }
   const manualResolutions = new Map<string, ManualConflictResolution>([
     ['foo', ManualConflictResolutionKind.theirs],


### PR DESCRIPTION
## Overview

**Related to #6550**

## Description

This PR implements the remaining metrics for `1.6.3`:

> 2. Number of times a user encounters a conflict while pull rebasing.
>  2a. Number of times a pull rebase is completed successfully after a conflict.
>   2b. Number of times a pull rebase is aborted after a conflict.

The other metrics are in #6893.

I'm going to follow up with PRs for the documentation once both of these PRs are merged, because there's also backend changes to land to consume these metrics.

## Release notes

Notes: no-notes
