### PR TITLE
[rebase] menu item and dialog to start rebase operation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.83.0",
+    "dugite": "1.85.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -84,3 +84,8 @@ export function enableGroupRepositoriesByOwner(): boolean {
 export function enableLocalChangesWarningHandler(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should the app show the "rebase current branch" dialog? */
+export function enableRebaseDialog(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -268,6 +268,8 @@ function getDescriptionForError(error: DugiteError): string {
       return 'The remote branch does not exist.'
     case DugiteError.LocalChangesOverwritten:
       return 'Some of your changes would be overwritten.'
+    case DugiteError.UnresolvedConflicts:
+      return 'There are unresolved conflicts in the working directory.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -114,10 +114,26 @@ export async function abortRebase(repository: Repository) {
   await git(['rebase', '--abort'], repository.path, 'abortRebase')
 }
 
+/** The app-specific results from attempting to rebase a repository */
 export enum RebaseResult {
+  /**
+   * Git completed the rebase without reporting any errors, and the caller can
+   * signal success to the user.
+   */
   CompletedWithoutError = 'CompletedWithoutError',
+  /**
+   * The rebase encountered conflicts while attempting to rebase, and these
+   * need to be resolved by the user before the rebase can continue.
+   */
   ConflictsEncountered = 'ConflictsEncountered',
+  /**
+   * The rebase was not able to continue as tracked files were not staged in
+   * the index.
+   */
   OutstandingFilesNotStaged = 'OutstandingFilesNotStaged',
+  /**
+   * The rebase was aborted and the caller should do any additional cleanup.
+   */
   Aborted = 'Aborted',
 }
 

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -132,7 +132,9 @@ export enum RebaseResult {
    */
   OutstandingFilesNotStaged = 'OutstandingFilesNotStaged',
   /**
-   * The rebase was aborted and the caller should do any additional cleanup.
+   * The rebase was not attempted because it could not check the status of the
+   * repository. The caller needs to confirm the repository is in a usable
+   * state.
    */
   Aborted = 'Aborted',
 }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -181,10 +181,10 @@ export async function continueRebase(
 
   if (trackedFiles.length === 0) {
     const rebaseHead = Path.join(repository.path, '.git', 'REBASE_HEAD')
-    const rebaseCurrentCommit = await FSE.readFile(rebaseHead)
+    const rebaseCurrentCommit = await FSE.readFile(rebaseHead, 'utf8')
 
     log.warn(
-      `[rebase] no tracked changes to commit for ${rebaseCurrentCommit}, continuing rebase but skipping this commit`
+      `[rebase] no tracked changes to commit for ${rebaseCurrentCommit.trim()}, continuing rebase but skipping this commit`
     )
 
     const result = await git(

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -91,19 +91,23 @@ export async function getRebaseContext(
  * and it will probably have a different commit history.
  *
  * @param baseBranch the ref to start the rebase from
- * @param featureBranch the ref to rebase onto `baseBranch`
+ * @param targetBranch the ref to rebase onto `baseBranch`
  */
 export async function rebase(
   repository: Repository,
   baseBranch: string,
-  featureBranch: string
-) {
-  return await git(
-    ['rebase', baseBranch, featureBranch],
+  targetBranch: string
+): Promise<ContinueRebaseResult> {
+  const result = await git(
+    ['rebase', baseBranch, targetBranch],
     repository.path,
     'rebase',
+    // TODO: what about using successExitCodes here?
+    // successExitCodes: new Set([0, 1, 128]),
     { expectedErrors: new Set([GitError.RebaseConflicts]) }
   )
+
+  return parseRebaseResult(result)
 }
 
 /** Abandon the current rebase operation */

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -104,6 +104,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'update-branch',
   'compare-to-branch',
   'merge-branch',
+  'rebase-branch',
   'view-repository-on-github',
   'compare-on-github',
   'open-in-shell',
@@ -233,6 +234,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       onNonDefaultBranch && hasDefaultBranch && !onDetachedHead
     )
     menuStateBuilder.setEnabled('merge-branch', onBranch)
+    menuStateBuilder.setEnabled('rebase-branch', onBranch)
     menuStateBuilder.setEnabled(
       'compare-on-github',
       isHostedOnGitHub && hasPublishedBranch
@@ -287,6 +289,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     menuStateBuilder.disable('delete-branch')
     menuStateBuilder.disable('update-branch')
     menuStateBuilder.disable('merge-branch')
+    menuStateBuilder.disable('rebase-branch')
 
     menuStateBuilder.disable('push')
     menuStateBuilder.disable('pull')

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -163,6 +163,9 @@ export interface IDailyMeasures {
 
   /** The number of times a user has pulled with `pull.rebase` unset or set to `false` */
   readonly pullWithDefaultSettingCount: number
+
+  /** The number of times the user opens the "Rebase current branch" menu item */
+  readonly rebaseCurrentBranchMenuCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -87,6 +87,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseSuccessAfterConflictsCount: 0,
   pullWithRebaseCount: 0,
   pullWithDefaultSettingCount: 0,
+  rebaseCurrentBranchMenuCount: 0,
 }
 
 interface IOnboardingStats {
@@ -613,6 +614,12 @@ export class StatsStore implements IStatsStore {
   public recordMenuInitiatedMerge(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeIntoCurrentBranchMenuCount: m.mergeIntoCurrentBranchMenuCount + 1,
+    }))
+  }
+
+  public recordMenuInitiatedRebase(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      rebaseCurrentBranchMenuCount: m.rebaseCurrentBranchMenuCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -137,6 +137,7 @@ import {
   isGitRepository,
   abortRebase,
   continueRebase,
+  rebase,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -3349,6 +3350,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     return this._refreshRepository(repository)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _rebase(
+    repository: Repository,
+    baseBranch: string,
+    targetBranch: string
+  ) {
+    const gitStore = this.gitStoreCache.get(repository)
+    return await gitStore.performFailableOperation(() =>
+      rebase(repository, baseBranch, targetBranch)
+    )
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -338,10 +338,9 @@ export function buildDefaultMenu({
       {
         label: __DARWIN__
           ? 'Rebase Current Branch…'
-          : '&Rebase current branch…',
+          : 'R&ebase current branch…',
         id: 'rebase-branch',
-        // TODO: confirm shortcut
-        accelerator: 'CmdOrCtrl+Shift+R',
+        accelerator: 'CmdOrCtrl+Shift+E',
         click: emit('rebase-branch'),
         visible: enableRebaseDialog(),
       },

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -7,6 +7,7 @@ import { ensureDir } from 'fs-extra'
 
 import { log } from '../log'
 import { openDirectorySafe } from '../shell'
+import { enableRebaseDialog } from '../../lib/feature-flag'
 
 const defaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
@@ -333,6 +334,16 @@ export function buildDefaultMenu({
         id: 'merge-branch',
         accelerator: 'CmdOrCtrl+Shift+M',
         click: emit('merge-branch'),
+      },
+      {
+        label: __DARWIN__
+          ? 'Rebase Current Branch…'
+          : '&Rebase current branch…',
+        id: 'rebase-branch',
+        // TODO: confirm shortcut
+        accelerator: 'CmdOrCtrl+Shift+R',
+        click: emit('rebase-branch'),
+        visible: enableRebaseDialog(),
       },
       separator,
       {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -16,6 +16,7 @@ export type MenuEvent =
   | 'update-branch'
   | 'compare-to-branch'
   | 'merge-branch'
+  | 'rebase-branch'
   | 'show-repository-settings'
   | 'open-in-shell'
   | 'compare-on-github'

--- a/app/src/main-process/menu/menu-ids.ts
+++ b/app/src/main-process/menu/menu-ids.ts
@@ -4,6 +4,7 @@ export type MenuIDs =
   | 'preferences'
   | 'update-branch'
   | 'merge-branch'
+  | 'rebase-branch'
   | 'view-repository-on-github'
   | 'compare-on-github'
   | 'open-in-shell'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -45,6 +45,7 @@ export enum PopupType {
   PushNeedsPull,
   LocalChangesOverwritten,
   RebaseConflicts,
+  RebaseBranch,
 }
 
 export type Popup =
@@ -172,4 +173,9 @@ export type Popup =
       repository: Repository
       baseBranch?: string
       targetBranch: string
+    }
+  | {
+      type: PopupType.RebaseBranch
+      repository: Repository
+      branch?: Branch
     }

--- a/app/src/ui/banners/successful-rebase.tsx
+++ b/app/src/ui/banners/successful-rebase.tsx
@@ -16,7 +16,7 @@ export function SuccessfulRebase({
       <span>
         {'Successfully rebased '}
         <strong>{targetBranch}</strong>
-        {' on '}
+        {' onto '}
         <strong>{baseBranch}</strong>
       </span>
     ) : (

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -31,7 +31,7 @@ interface IDialogProps {
    * By omitting this consumers may use their own custom DialogHeader
    * for when the default component doesn't cut it.
    */
-  readonly title?: string
+  readonly title?: string | JSX.Element
 
   /**
    * Whether or not the dialog should be dismissable. A dismissable dialog
@@ -187,8 +187,12 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     }
 
     if (this.props.title) {
+      // createUniqueId handles static strings fine, so in the case of receiving
+      // a JSX element for the title we can just pass in a fixed value rather
+      // than trying to generate a string from an arbitrary element
+      const id = typeof this.props.title === 'string' ? this.props.title : '???'
       this.setState({
-        titleId: createUniqueId(`Dialog_${this.props.id}_${this.props.title}`),
+        titleId: createUniqueId(`Dialog_${this.props.id}_${id}`),
       })
     }
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -19,7 +19,7 @@ import {
   setGenericPassword,
   setGenericUsername,
 } from '../../lib/generic-git-auth'
-import { isGitRepository, ContinueRebaseResult } from '../../lib/git'
+import { isGitRepository, RebaseResult } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
   rejectOAuthRequest,
@@ -658,7 +658,7 @@ export class Dispatcher {
     const { conflictState } = stateBefore.changesState
 
     if (
-      result === ContinueRebaseResult.CompletedWithoutError &&
+      result === RebaseResult.CompletedWithoutError &&
       conflictState !== null &&
       isRebaseConflictState(conflictState)
     ) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -623,6 +623,52 @@ export class Dispatcher {
     return this.appStore._mergeBranch(repository, branch, mergeStatus)
   }
 
+  /** Starts a rebase for the given base and target branch */
+  public async rebase(
+    repository: Repository,
+    baseBranch: string,
+    targetBranch: string
+  ) {
+    const stateBefore = this.repositoryStateManager.get(repository)
+
+    const beforeSha = getTipSha(stateBefore.branchesState.tip)
+
+    log.info(`[rebase] starting rebase for ${beforeSha}`)
+
+    // TODO: this can happen very quickly for a trivial rebase or an OS with
+    // fast I/O - are we able to artificially slow this down so it completes at
+    // least after X ms?
+
+    const result = await this.appStore._rebase(
+      repository,
+      baseBranch,
+      targetBranch
+    )
+
+    await this.appStore._loadStatus(repository)
+
+    const stateAfter = this.repositoryStateManager.get(repository)
+    const { tip } = stateAfter.branchesState
+    const afterSha = getTipSha(tip)
+
+    log.info(
+      `[continueRebase] completed rebase - got ${result} and on tip ${afterSha} - kind ${
+        tip.kind
+      }`
+    )
+
+    if (result === RebaseResult.CompletedWithoutError) {
+      this.closePopup()
+      this.setBanner({
+        type: BannerType.SuccessfulRebase,
+        targetBranch: targetBranch,
+        baseBranch: baseBranch,
+      })
+    }
+
+    return result
+  }
+
   /** aborts the current rebase and refreshes the repository's status */
   public async abortRebase(repository: Repository) {
     await this.appStore._abortRebase(repository)
@@ -1391,6 +1437,13 @@ export class Dispatcher {
    */
   public recordMenuInitiatedMerge() {
     return this.statsStore.recordMenuInitiatedMerge()
+  }
+
+  /**
+   * Increments the `rebaseIntoCurrentBranchMenuCount` metric
+   */
+  public recordMenuInitiatedRebase() {
+    return this.statsStore.recordMenuInitiatedRebase()
   }
 
   /**

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -12,7 +12,6 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
 import { IMatches } from '../../lib/fuzzy-find'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
-import { DialogHeader } from '../dialog/header'
 
 interface IRebaseBranchDialogProps {
   readonly dispatcher: Dispatcher
@@ -122,16 +121,12 @@ export class RebaseBranchDialog extends React.Component<
         onSubmit={this.startRebase}
         loading={loading}
         disabled={disabled}
+        title={
+          <>
+            Rebase <strong>{truncatedCurrentBranchName}</strong> onto…
+          </>
+        }
       >
-        <DialogHeader
-          title={
-            <div className="rebase-dialog-header">
-              Rebase <strong>{truncatedCurrentBranchName}</strong> onto…
-            </div>
-          }
-          dismissable={true}
-          onDismissed={this.props.onDismissed}
-        />
         <DialogContent>
           <BranchList
             allBranches={this.props.allBranches}

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -13,7 +13,6 @@ import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
 import { IMatches } from '../../lib/fuzzy-find'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { DialogHeader } from '../dialog/header'
-import { Loading } from '../lib/loading'
 
 interface IRebaseBranchDialogProps {
   readonly dispatcher: Dispatcher

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -145,7 +145,7 @@ export class RebaseBranchDialog extends React.Component<
               Rebase <strong>
                 {currentBranch ? currentBranch.name : ''}
               </strong>{' '}
-              on <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
+              onto <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -99,7 +99,8 @@ export class RebaseBranchDialog extends React.Component<
       currentBranch === null ||
       currentBranch.name === selectedBranch.name
 
-    const disabled = selectedBranchIsNotCurrentBranch
+    const loading = this.state.isRebasing
+    const disabled = selectedBranchIsNotCurrentBranch || loading
 
     // the amount of characters to allow before we truncate was chosen arbitrarily
     const currentBranchName = truncateWithEllipsis(
@@ -107,13 +108,13 @@ export class RebaseBranchDialog extends React.Component<
       40
     )
 
-    const loading = this.state.isRebasing ? <Loading /> : null
-
     return (
       <Dialog
         id="rebase"
         onDismissed={this.props.onDismissed}
         onSubmit={this.startRebase}
+        loading={loading}
+        disabled={disabled}
       >
         <DialogHeader
           title={
@@ -140,11 +141,8 @@ export class RebaseBranchDialog extends React.Component<
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>
-            <Button type="submit" disabled={disabled}>
-              {loading}
-              Rebase <strong>
-                {currentBranch ? currentBranch.name : ''}
-              </strong>{' '}
+            <Button type="submit">
+              Rebase <strong>{currentBranch ? currentBranch.name : ''}</strong>{' '}
               onto <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react'
+
+import { Dispatcher } from '../dispatcher'
+
+import { Branch } from '../../models/branch'
+import { Repository } from '../../models/repository'
+
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
+import { IMatches } from '../../lib/fuzzy-find'
+import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
+import { DialogHeader } from '../dialog/header'
+import { Loading } from '../lib/loading'
+
+interface IRebaseBranchDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+
+  /**
+   * See IBranchesState.defaultBranch
+   */
+  readonly defaultBranch: Branch | null
+
+  /**
+   * The currently checked out branch
+   */
+  readonly currentBranch: Branch
+
+  /**
+   * See IBranchesState.allBranches
+   */
+  readonly allBranches: ReadonlyArray<Branch>
+
+  /**
+   * See IBranchesState.recentBranches
+   */
+  readonly recentBranches: ReadonlyArray<Branch>
+
+  /**
+   * The branch to select when the rebase dialog is opened
+   */
+  readonly initialBranch?: Branch
+
+  /**
+   * A function that's called when the dialog is dismissed by the user in the
+   * ways described in the Dialog component's dismissable prop.
+   */
+  readonly onDismissed: () => void
+}
+
+interface IRebaseBranchDialogState {
+  /** The currently selected branch. */
+  readonly selectedBranch: Branch | null
+
+  /** The filter text to use in the branch selector */
+  readonly filterText: string
+
+  readonly isRebasing: boolean
+}
+
+/** A component for initating a rebase of the current branch. */
+export class RebaseBranchDialog extends React.Component<
+  IRebaseBranchDialogProps,
+  IRebaseBranchDialogState
+> {
+  public constructor(props: IRebaseBranchDialogProps) {
+    super(props)
+
+    const selectedBranch = this.resolveSelectedBranch()
+
+    this.state = {
+      selectedBranch,
+      filterText: '',
+      isRebasing: false,
+    }
+  }
+
+  private onFilterTextChanged = (filterText: string) => {
+    this.setState({ filterText })
+  }
+
+  private onSelectionChanged = (selectedBranch: Branch | null) => {
+    this.setState({ selectedBranch })
+  }
+
+  private renderBranch = (item: IBranchListItem, matches: IMatches) => {
+    return renderDefaultBranch(item, matches, this.props.currentBranch)
+  }
+
+  public render() {
+    const selectedBranch = this.state.selectedBranch
+    const currentBranch = this.props.currentBranch
+
+    const selectedBranchIsNotCurrentBranch =
+      selectedBranch === null ||
+      currentBranch === null ||
+      currentBranch.name === selectedBranch.name
+
+    const disabled = selectedBranchIsNotCurrentBranch
+
+    // the amount of characters to allow before we truncate was chosen arbitrarily
+    const currentBranchName = truncateWithEllipsis(
+      this.props.currentBranch.name,
+      40
+    )
+
+    const loading = this.state.isRebasing ? <Loading /> : null
+
+    return (
+      <Dialog
+        id="rebase"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.startRebase}
+      >
+        <DialogHeader
+          title={
+            <div className="rebase-dialog-header">
+              Rebase <strong>{currentBranchName}</strong> onto…
+            </div>
+          }
+          dismissable={true}
+          onDismissed={this.props.onDismissed}
+        />
+        <DialogContent>
+          <BranchList
+            allBranches={this.props.allBranches}
+            currentBranch={currentBranch}
+            defaultBranch={this.props.defaultBranch}
+            recentBranches={this.props.recentBranches}
+            filterText={this.state.filterText}
+            onFilterTextChanged={this.onFilterTextChanged}
+            selectedBranch={selectedBranch}
+            onSelectionChanged={this.onSelectionChanged}
+            canCreateNewBranch={false}
+            renderBranch={this.renderBranch}
+          />
+        </DialogContent>
+        <DialogFooter>
+          <ButtonGroup>
+            <Button type="submit" disabled={disabled}>
+              {loading}
+              Rebase <strong>
+                {currentBranch ? currentBranch.name : ''}
+              </strong>{' '}
+              on <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
+            </Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private startRebase = async () => {
+    const branch = this.state.selectedBranch
+    if (!branch) {
+      return
+    }
+
+    this.setState({ isRebasing: true })
+
+    await this.props.dispatcher.rebase(
+      this.props.repository,
+      branch.name,
+      this.props.currentBranch.name
+    )
+
+    this.setState({ isRebasing: false })
+  }
+
+  /**
+   * Returns the branch to use as the selected branch
+   *
+   * The initial branch is used if passed
+   * otherwise, the default branch will be used iff it's
+   * not the currently checked out branch
+   */
+  private resolveSelectedBranch() {
+    const { currentBranch, defaultBranch, initialBranch } = this.props
+
+    if (initialBranch !== undefined) {
+      return initialBranch
+    }
+
+    return currentBranch === defaultBranch ? null : defaultBranch
+  }
+}

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -91,8 +91,8 @@ export class RebaseBranchDialog extends React.Component<
   }
 
   public render() {
-    const selectedBranch = this.state.selectedBranch
-    const currentBranch = this.props.currentBranch
+    const { selectedBranch } = this.state
+    const { currentBranch } = this.props
 
     const selectedBranchIsNotCurrentBranch =
       selectedBranch === null ||
@@ -102,9 +102,11 @@ export class RebaseBranchDialog extends React.Component<
     const loading = this.state.isRebasing
     const disabled = selectedBranchIsNotCurrentBranch || loading
 
+    const currentBranchName = currentBranch.name
+
     // the amount of characters to allow before we truncate was chosen arbitrarily
-    const currentBranchName = truncateWithEllipsis(
-      this.props.currentBranch.name,
+    const truncatedCurrentBranchName = truncateWithEllipsis(
+      currentBranchName,
       40
     )
 
@@ -119,7 +121,7 @@ export class RebaseBranchDialog extends React.Component<
         <DialogHeader
           title={
             <div className="rebase-dialog-header">
-              Rebase <strong>{currentBranchName}</strong> onto…
+              Rebase <strong>{truncatedCurrentBranchName}</strong> onto…
             </div>
           }
           dismissable={true}
@@ -142,8 +144,8 @@ export class RebaseBranchDialog extends React.Component<
         <DialogFooter>
           <ButtonGroup>
             <Button type="submit">
-              Rebase <strong>{currentBranch ? currentBranch.name : ''}</strong>{' '}
-              onto <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
+              Rebase <strong>{currentBranchName}</strong> onto{' '}
+              <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
             </Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -121,6 +121,7 @@ export class RebaseBranchDialog extends React.Component<
         onSubmit={this.startRebase}
         loading={loading}
         disabled={disabled}
+        dismissable={true}
         title={
           <>
             Rebase <strong>{truncatedCurrentBranchName}</strong> onto…

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -68,7 +68,13 @@ export class RebaseBranchDialog extends React.Component<
   public constructor(props: IRebaseBranchDialogProps) {
     super(props)
 
-    const selectedBranch = this.resolveSelectedBranch()
+    const { initialBranch, currentBranch, defaultBranch } = props
+
+    const selectedBranch = resolveSelectedBranch(
+      currentBranch,
+      defaultBranch,
+      initialBranch
+    )
 
     this.state = {
       selectedBranch,
@@ -168,21 +174,25 @@ export class RebaseBranchDialog extends React.Component<
 
     this.setState({ isRebasing: false })
   }
+}
 
-  /**
-   * Returns the branch to use as the selected branch
-   *
-   * The initial branch is used if passed
-   * otherwise, the default branch will be used if it's
-   * not the currently checked out branch
-   */
-  private resolveSelectedBranch() {
-    const { currentBranch, defaultBranch, initialBranch } = this.props
-
-    if (initialBranch !== undefined) {
-      return initialBranch
-    }
-
-    return currentBranch === defaultBranch ? null : defaultBranch
+/**
+ * Returns the branch to use as the selected branch in the dialog.
+ *
+ * The initial branch is used if defined, otherwise the default branch will be
+ * compared to the current branch.
+ *
+ * If the current branch is the default branch, `null` is returned. Otherwise
+ * the default branch is used.
+ */
+function resolveSelectedBranch(
+  currentBranch: Branch,
+  defaultBranch: Branch | null,
+  initialBranch: Branch | undefined
+) {
+  if (initialBranch !== undefined) {
+    return initialBranch
   }
+
+  return currentBranch === defaultBranch ? null : defaultBranch
 }

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -174,7 +174,7 @@ export class RebaseBranchDialog extends React.Component<
    * Returns the branch to use as the selected branch
    *
    * The initial branch is used if passed
-   * otherwise, the default branch will be used iff it's
+   * otherwise, the default branch will be used if it's
    * not the currently checked out branch
    */
   private resolveSelectedBranch() {

--- a/app/src/ui/rebase/rebase-conflicts-dialog.tsx
+++ b/app/src/ui/rebase/rebase-conflicts-dialog.tsx
@@ -9,7 +9,7 @@ import { ConflictedFilesList } from './conflict-files-list'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
-import { ContinueRebaseResult } from '../../lib/git'
+import { RebaseResult } from '../../lib/git'
 import { BannerType } from '../../models/banner'
 import { PopupType } from '../../models/popup'
 
@@ -59,7 +59,7 @@ export class RebaseConflictsDialog extends React.Component<
       this.props.workingDirectory
     )
 
-    if (result === ContinueRebaseResult.CompletedWithoutError) {
+    if (result === RebaseResult.CompletedWithoutError) {
       this.props.onDismissed()
     }
   }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -2,6 +2,7 @@
 @import 'dialogs/merge';
 @import 'dialogs/merge-conflicts';
 @import 'dialogs/rebase';
+@import 'dialogs/rebase-conflicts';
 @import 'dialogs/abort-merge';
 @import 'dialogs/push-needs-pull';
 @import 'dialogs/publish-repository';

--- a/app/styles/ui/dialogs/_rebase-conflicts.scss
+++ b/app/styles/ui/dialogs/_rebase-conflicts.scss
@@ -81,16 +81,16 @@ dialog#rebase-conflicts-list {
     }
 
     .unmerged-file-status-resolved .file-conflicts-status {
-      color: $green;
+      color: var(--color-new);
     }
 
     .unmerged-file-status-conflicts {
       .file-conflicts-status {
-        color: $orange;
+        color: var(--color-conflicted);
       }
 
       .command-line-hint {
-        color: $gray;
+        color: var(--text-secondary-color);
       }
     }
   }
@@ -119,6 +119,7 @@ dialog#rebase-conflicts-list {
   .arrow-menu {
     .octicon {
       width: 10px;
+      height: 14px;
     }
   }
 }

--- a/app/styles/ui/dialogs/_rebase-conflicts.scss
+++ b/app/styles/ui/dialogs/_rebase-conflicts.scss
@@ -106,16 +106,6 @@ dialog#rebase-conflicts-list {
     }
   }
 
-  .cli-link {
-    a {
-      color: $blue;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-
   .arrow-menu {
     .octicon {
       width: 10px;

--- a/app/styles/ui/dialogs/_rebase-conflicts.scss
+++ b/app/styles/ui/dialogs/_rebase-conflicts.scss
@@ -1,0 +1,124 @@
+@import '../../mixins';
+
+dialog#rebase-conflicts-list {
+  width: 500px;
+
+  .summary {
+    margin-bottom: 20px;
+  }
+
+  .dialog-header h1 {
+    font-weight: var(--font-weight-light);
+  }
+
+  .dialog-content {
+    padding-bottom: var(--spacing);
+  }
+
+  .green-circle {
+    background-color: var(--color-new);
+    color: var(--background-color);
+    border-radius: 50%;
+    height: 22px;
+    width: 22px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    max-height: 285px;
+    overflow-y: auto;
+
+    li {
+      margin-bottom: var(--spacing-double);
+      padding-left: 0;
+    }
+
+    li:last-of-type {
+      margin-bottom: calc(var(--spacing) * 2);
+    }
+
+    li.unmerged-file-status-resolved,
+    li.unmerged-file-status-conflicts {
+      display: flex;
+      flex-flow: row nowrap;
+
+      .file-octicon {
+        margin-right: var(--spacing);
+      }
+
+      .column-left {
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: start;
+        max-width: 50%;
+        padding-right: var(--spacing);
+
+        .path-text-component {
+          text-overflow: ellipsis;
+          max-width: 100%;
+        }
+      }
+
+      .action-buttons {
+        margin-left: auto;
+        flex-shrink: 0;
+        flex: 0 1 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .green-circle:last-child {
+        margin-left: auto;
+        margin-top: var(--spacing);
+        flex-shrink: 0;
+        flex: 0 1 auto;
+      }
+    }
+
+    .unmerged-file-status-resolved .file-conflicts-status {
+      color: $green;
+    }
+
+    .unmerged-file-status-conflicts {
+      .file-conflicts-status {
+        color: $orange;
+      }
+
+      .command-line-hint {
+        color: $gray;
+      }
+    }
+  }
+
+  .all-conflicts-resolved {
+    display: flex;
+    flex-flow: row nowrap;
+    padding: var(--spacing) 0 var(--spacing-double);
+
+    .message {
+      padding-left: var(--spacing);
+      padding-top: var(--spacing-third);
+    }
+  }
+
+  .cli-link {
+    a {
+      color: $blue;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .arrow-menu {
+    .octicon {
+      width: 10px;
+    }
+  }
+}

--- a/app/styles/ui/dialogs/_rebase.scss
+++ b/app/styles/ui/dialogs/_rebase.scss
@@ -12,6 +12,10 @@ dialog#rebase {
   // make it extremely hard to do so.
   .dialog-header {
     border-bottom: none;
+
+    h1 {
+      font-weight: var(--font-weight-light);
+    }
   }
 
   .dialog-content {
@@ -43,9 +47,5 @@ dialog#rebase {
       width: 100%;
       padding: var(--spacing-half);
     }
-  }
-
-  .rebase-dialog-header {
-    font-weight: var(--font-weight-light);
   }
 }

--- a/app/styles/ui/dialogs/_rebase.scss
+++ b/app/styles/ui/dialogs/_rebase.scss
@@ -1,124 +1,51 @@
 @import '../../mixins';
 
-dialog#rebase-conflicts-list {
-  width: 500px;
+dialog#rebase {
+  width: 450px;
 
-  .summary {
-    margin-bottom: 20px;
+  .branches-list {
+    height: 300px;
   }
 
-  .dialog-header h1 {
-    font-weight: var(--font-weight-light);
+  // We're faking it so that the filter text box appears to reside
+  // withing the header even though our current component structure
+  // make it extremely hard to do so.
+  .dialog-header {
+    border-bottom: none;
   }
 
   .dialog-content {
-    padding-bottom: var(--spacing);
-  }
-
-  .green-circle {
-    background-color: var(--color-new);
-    color: var(--background-color);
-    border-radius: 50%;
-    height: 22px;
-    width: 22px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  ul {
-    list-style: none;
     padding: 0;
-    max-height: 285px;
-    overflow-y: auto;
 
-    li {
-      margin-bottom: var(--spacing-double);
-      padding-left: 0;
-    }
+    .filter-field-row {
+      margin: 0;
+      border-bottom: var(--base-border);
 
-    li:last-of-type {
-      margin-bottom: calc(var(--spacing) * 2);
-    }
-
-    li.unmerged-file-status-resolved,
-    li.unmerged-file-status-conflicts {
-      display: flex;
-      flex-flow: row nowrap;
-
-      .file-octicon {
-        margin-right: var(--spacing);
-      }
-
-      .column-left {
-        display: flex;
-        flex-flow: column nowrap;
-        align-items: start;
-        max-width: 50%;
-        padding-right: var(--spacing);
-
-        .path-text-component {
-          text-overflow: ellipsis;
-          max-width: 100%;
-        }
-      }
-
-      .action-buttons {
-        margin-left: auto;
-        flex-shrink: 0;
-        flex: 0 1 auto;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .green-circle:last-child {
-        margin-left: auto;
-        margin-top: var(--spacing);
-        flex-shrink: 0;
-        flex: 0 1 auto;
+      .filter-list-filter-field {
+        padding: 0 var(--spacing-double);
+        padding-bottom: var(--spacing);
       }
     }
 
-    .unmerged-file-status-resolved .file-conflicts-status {
-      color: $green;
-    }
+    .list-item {
+      padding: 0 var(--spacing-double);
 
-    .unmerged-file-status-conflicts {
-      .file-conflicts-status {
-        color: $orange;
-      }
-
-      .command-line-hint {
-        color: $gray;
+      .filter-list-group-header,
+      .branches-list-item {
+        padding: 0;
       }
     }
   }
 
-  .all-conflicts-resolved {
-    display: flex;
-    flex-flow: row nowrap;
-    padding: var(--spacing) 0 var(--spacing-double);
-
-    .message {
-      padding-left: var(--spacing);
-      padding-top: var(--spacing-third);
+  .dialog-footer {
+    button[type='submit'] {
+      height: auto;
+      width: 100%;
+      padding: var(--spacing-half);
     }
   }
 
-  .cli-link {
-    a {
-      color: $blue;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-  }
-
-  .arrow-menu {
-    .octicon {
-      width: 10px;
-    }
+  .rebase-dialog-header {
+    font-weight: var(--font-weight-light);
   }
 }

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -7,7 +7,7 @@ import {
   abortRebase,
   continueRebase,
   rebase,
-  ContinueRebaseResult,
+  RebaseResult,
 } from '../../../../src/lib/git/rebase'
 import { Commit } from '../../../../src/models/commit'
 import { AppFileStatusKind } from '../../../../src/models/status'
@@ -20,7 +20,7 @@ const featureBranch = 'this-is-a-feature'
 
 describe('git/rebase', () => {
   describe('detect conflicts', () => {
-    let result: ContinueRebaseResult
+    let result: RebaseResult
     let originalBranchTip: string
     let baseBranchTip: string
     let status: IStatusResult
@@ -40,7 +40,7 @@ describe('git/rebase', () => {
     })
 
     it('returns a value indicating conflicts were encountered', async () => {
-      expect(result).toBe(ContinueRebaseResult.ConflictsEncountered)
+      expect(result).toBe(RebaseResult.ConflictsEncountered)
     })
 
     it('status detects REBASE_HEAD', async () => {
@@ -91,7 +91,7 @@ describe('git/rebase', () => {
   })
 
   describe('attempt to continue without resolving conflicts', () => {
-    let result: ContinueRebaseResult
+    let result: RebaseResult
     let originalBranchTip: string
     let baseBranchTip: string
     let status: IStatusResult
@@ -116,7 +116,7 @@ describe('git/rebase', () => {
     })
 
     it('indicates that the rebase was not complete', async () => {
-      expect(result).toBe(ContinueRebaseResult.OutstandingFilesNotStaged)
+      expect(result).toBe(RebaseResult.OutstandingFilesNotStaged)
     })
 
     it('REBASE_HEAD is still found', async () => {
@@ -138,7 +138,7 @@ describe('git/rebase', () => {
 
   describe('continue after resolving conflicts', () => {
     let beforeRebaseTip: Commit
-    let result: ContinueRebaseResult
+    let result: RebaseResult
     let status: IStatusResult
 
     beforeEach(async () => {
@@ -183,7 +183,7 @@ describe('git/rebase', () => {
     })
 
     it('returns success', () => {
-      expect(result).toBe(ContinueRebaseResult.CompletedWithoutError)
+      expect(result).toBe(RebaseResult.CompletedWithoutError)
     })
 
     it('REBASE_HEAD is no longer found', () => {

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -1,4 +1,4 @@
-import { IGitResult, GitProcess } from 'dugite'
+import { GitProcess } from 'dugite'
 import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
@@ -20,7 +20,7 @@ const featureBranch = 'this-is-a-feature'
 
 describe('git/rebase', () => {
   describe('detect conflicts', () => {
-    let result: IGitResult
+    let result: ContinueRebaseResult
     let originalBranchTip: string
     let baseBranchTip: string
     let status: IStatusResult
@@ -39,8 +39,8 @@ describe('git/rebase', () => {
       status = await getStatusOrThrow(repository)
     })
 
-    it('returns a non-zero exit code', async () => {
-      expect(result.exitCode).toBeGreaterThan(0)
+    it('returns a value indicating conflicts were encountered', async () => {
+      expect(result).toBe(ContinueRebaseResult.ConflictsEncountered)
     })
 
     it('status detects REBASE_HEAD', async () => {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -404,10 +404,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.83.0:
-  version "1.83.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.83.0.tgz#06f04f8a0521bb347e20ad913a42fb6e1b405c60"
-  integrity sha512-e+QWkpU78RwM4y+Z+6wjE3A8BE+EF0zebg+pQ56Q+cQNGleEuv3Dl0u7obQ/xJgWqr2s3HoFDGpaq1RkSwPCdg==
+dugite@1.85.0:
+  version "1.85.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.85.0.tgz#05cff1f0d4952cf32d1d6a30f4f380811e4583f5"
+  integrity sha512-33YIKzzuSIoB8cRDrIPozvvIJiPs4+XQJGcb9g48O99Q0GkPb1ipy3YjknJTTU0TwTB+NyGjA6m1jBRoR3XvuQ==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
## Overview

**Closes #6551**
**Closes #7012**
**Closes #6961**

## Description

This is the first part of enabling the user to rebase their current branch from within the app in a guided fashion, and I've omitted much of the background computation from #6959 and #6960 so that I can have something baked to help with testing.

<img width="735" alt="screen shot 2019-02-27 at 12 33 30 pm" src="https://user-images.githubusercontent.com/359239/53506842-2b22a000-3a8d-11e9-8f3c-a5d3f1c77039.png">

<img width="501" alt="screen shot 2019-02-27 at 12 33 37 pm" src="https://user-images.githubusercontent.com/359239/53506844-2b22a000-3a8d-11e9-9694-d983d5fd5007.png">

<img width="513" alt="screen shot 2019-02-27 at 12 33 48 pm" src="https://user-images.githubusercontent.com/359239/53506845-2bbb3680-3a8d-11e9-8068-854ffef3d176.png">

The menu item is enabled only for development currently.

Testing: 

 - [x] can start a rebase, and dialog closes because no conflicts with success banner shown
 - [x] can start a rebase, and dialog switches to show conflicts if encountered
 - [x] can start a rebase, can address conflicts, and continue rebase until success banner shown
 - [x] address `TODO` comments

## Release notes

Notes:
