### PR TITLE
Copy commit message props to state using componentWillReceiveProps

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -21,7 +21,6 @@ import { showContextualMenu } from '../main-process-proxy'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { IAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
-import { shallowEquals } from '../../lib/equality'
 import { ICommitContext } from '../../models/commit'
 
 const addAuthorIcon = new OcticonSymbol(
@@ -122,6 +121,20 @@ export class CommitMessage extends React.Component<
     this.props.dispatcher.setCommitMessage(this.props.repository, this.state)
   }
 
+  public componentWillReceiveProps(nextProps: ICommitMessageProps) {
+    const { commitMessage } = nextProps
+    if (!commitMessage) {
+      return
+    }
+
+    if (commitMessage !== this.props.commitMessage) {
+      this.setState({
+        summary: commitMessage.summary,
+        description: commitMessage.description,
+      })
+    }
+  }
+
   public componentDidUpdate(prevProps: ICommitMessageProps) {
     if (
       this.props.autocompletionProviders !== prevProps.autocompletionProviders
@@ -135,17 +148,6 @@ export class CommitMessage extends React.Component<
 
     if (this.props.focusCommitMessage) {
       this.focusSummary()
-    }
-
-    if (!shallowEquals(prevProps.commitMessage, this.props.commitMessage)) {
-      if (this.props.commitMessage) {
-        this.setState({
-          summary: this.props.commitMessage.summary,
-          description: this.props.commitMessage.description,
-        })
-      } else {
-        this.setState({ summary: '', description: null })
-      }
     }
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -121,13 +121,22 @@ export class CommitMessage extends React.Component<
     this.props.dispatcher.setCommitMessage(this.props.repository, this.state)
   }
 
+  /**
+   * Special case for the summary/description being reset (empty) after a commit
+   * and the commit state changing thereafter, needing a sync with incoming props.
+   * We prefer the current UI state values if the user updated them manually.
+   *
+   * NOTE: although using the lifecycle method is generally an anti-pattern, we
+   * (and the React docs) believe it to be the right answer for this situation, see:
+   * https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops
+   */
   public componentWillReceiveProps(nextProps: ICommitMessageProps) {
     const { commitMessage } = nextProps
-    if (!commitMessage) {
+    if (!commitMessage || commitMessage === this.props.commitMessage) {
       return
     }
 
-    if (commitMessage !== this.props.commitMessage) {
+    if (this.state.summary === '' && !this.state.description) {
       this.setState({
         summary: commitMessage.summary,
         description: commitMessage.description,


### PR DESCRIPTION
## Overview

This fixes the issue where commit message summary and description UI is lost when committing/undoing commits.  The change alters how the summary and description are mirrored in the component's internal `state` from `props` using  `componentWillReceiveProps()`.

Closes #6390

## Description

I've written about this at length in a [walkthrough write-up](https://github.com/humphd/desktop/tree/good-first-experience-issue-6390#walkthrough-fixing-a-bug-in-github-desktop) if more detail is required.

The bug is caused by sync issues between `state` and `props` that were exacerbated by a switch to using `!shallowEquals()` instead of `!==`, which eliminated calls to `setState()` in cases where the `props` objects were different in reference only: after a commit is made, the internal state gets wiped, and when the repo's state changes, the values from `props` need to get copied back again.

I don't work with React very much, so it's possible there is a better way to accomplish what I've done here.  However, my reading pointed to this approach, so I've opted to open a pull request in the hope of moving this bug forward.

## Release notes

Fixes problem with commit message summary and description being lost after undoing a commit.
