### PR TITLE
review unit tests and make config setup more explicit

### DIFF
--- a/app/test/helpers/local-config.ts
+++ b/app/test/helpers/local-config.ts
@@ -1,0 +1,11 @@
+import { Repository } from '../../src/models/repository'
+import { GitProcess } from 'dugite'
+
+export async function setupLocalConfig(
+  repository: Repository,
+  localConfig: Iterable<[string, string]>
+) {
+  for (const [key, value] of localConfig) {
+    await GitProcess.exec(['config', key, value], repository.path)
+  }
+}

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -348,6 +348,7 @@ describe('git/diff', () => {
         repo.path
       )
 
+      // change config on-the-fly to trigger the line endings change warning
       await GitProcess.exec(['config', 'core.autocrlf', 'true'], repo.path)
       lineEnding = '\n\n'
 

--- a/app/test/unit/git/gitignore-test.ts
+++ b/app/test/unit/git/gitignore-test.ts
@@ -68,7 +68,7 @@ describe('gitignore', () => {
         ['core.autocrlf', 'input'],
       ])
 
-      const path = repo.path
+      const { path } = repo
 
       await saveGitIgnore(repo, 'node_modules')
       await GitProcess.exec(['add', '.gitignore'], path)
@@ -134,9 +134,10 @@ describe('gitignore', () => {
   describe('appendIgnoreRule', () => {
     it('appends one rule', async () => {
       const repo = await setupEmptyRepository()
-      const path = repo.path
 
       await setupLocalConfig(repo, [['core.autocrlf', 'true']])
+
+      const { path } = repo
 
       const ignoreFile = `${path}/.gitignore`
       await FSE.writeFile(ignoreFile, 'node_modules\n')
@@ -154,7 +155,7 @@ describe('gitignore', () => {
 
       await setupLocalConfig(repo, [['core.autocrlf', 'true']])
 
-      const path = repo.path
+      const { path } = repo
 
       const ignoreFile = `${path}/.gitignore`
       await FSE.writeFile(ignoreFile, 'node_modules\n')

--- a/app/test/unit/git/gitignore-test.ts
+++ b/app/test/unit/git/gitignore-test.ts
@@ -9,6 +9,7 @@ import {
   readGitIgnoreAtRoot,
   appendIgnoreRule,
 } from '../../../src/lib/git'
+import { setupLocalConfig } from '../../helpers/local-config'
 
 describe('gitignore', () => {
   describe('readGitIgnoreAtRoot', () => {
@@ -37,16 +38,12 @@ describe('gitignore', () => {
     it('when autocrlf=true and safecrlf=true, appends CRLF to file', async () => {
       const repo = await setupEmptyRepository()
 
-      await GitProcess.exec(
-        ['config', '--local', 'core.autocrlf', 'true'],
-        repo.path
-      )
-      await GitProcess.exec(
-        ['config', '--local', 'core.safecrlf', 'true'],
-        repo.path
-      )
+      await setupLocalConfig(repo, [
+        ['core.autocrlf', 'true'],
+        ['core.safecrlf', 'true'],
+      ])
 
-      const path = repo.path
+      const { path } = repo
 
       await saveGitIgnore(repo, 'node_modules')
       await GitProcess.exec(['add', '.gitignore'], path)
@@ -64,14 +61,12 @@ describe('gitignore', () => {
     it('when autocrlf=input, appends LF to file', async () => {
       const repo = await setupEmptyRepository()
 
-      // ensure this repository only ever sticks to LF
-      await GitProcess.exec(['config', '--local', 'core.eol', 'lf'], repo.path)
-
-      // do not do any conversion of line endings when committing
-      await GitProcess.exec(
-        ['config', '--local', 'core.autocrlf', 'input'],
-        repo.path
-      )
+      setupLocalConfig(repo, [
+        // ensure this repository only ever sticks to LF
+        ['core.eol', 'lf'],
+        // do not do any conversion of line endings when committing
+        ['core.autocrlf', 'input'],
+      ])
 
       const path = repo.path
 
@@ -141,10 +136,7 @@ describe('gitignore', () => {
       const repo = await setupEmptyRepository()
       const path = repo.path
 
-      await GitProcess.exec(
-        ['config', '--local', 'core.autocrlf', 'true'],
-        path
-      )
+      await setupLocalConfig(repo, [['core.autocrlf', 'true']])
 
       const ignoreFile = `${path}/.gitignore`
       await FSE.writeFile(ignoreFile, 'node_modules\n')
@@ -159,12 +151,10 @@ describe('gitignore', () => {
 
     it('appends multiple rules', async () => {
       const repo = await setupEmptyRepository()
-      const path = repo.path
 
-      await GitProcess.exec(
-        ['config', '--local', 'core.autocrlf', 'true'],
-        path
-      )
+      await setupLocalConfig(repo, [['core.autocrlf', 'true']])
+
+      const path = repo.path
 
       const ignoreFile = `${path}/.gitignore`
       await FSE.writeFile(ignoreFile, 'node_modules\n')

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -3,6 +3,7 @@ import { getChangedFiles, getCommits } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import { AppFileStatusKind } from '../../../src/models/status'
 import { GitProcess } from 'dugite'
+import { setupLocalConfig } from '../../helpers/local-config'
 
 describe('git/log', () => {
   let repository: Repository | null = null
@@ -34,11 +35,10 @@ describe('git/log', () => {
       const path = await setupFixtureRepository('just-doing-some-signing')
       const repository = new Repository(path, 1, null, false)
 
-      // ensure the test repository is configured to detect copies
-      await GitProcess.exec(
-        ['config', 'log.showSignature', 'true'],
-        repository.path
-      )
+      // ensure the default config is to try and show signatures
+      // this should be overriden by the `getCommits` function as it may not
+      // have a valid GPG agent configured
+      await setupLocalConfig(repository, [['log.showSignature', 'true']])
 
       const commits = await getCommits(repository, 'HEAD', 100)
 
@@ -91,10 +91,7 @@ describe('git/log', () => {
       repository = new Repository(testRepoPath, -1, null, false)
 
       // ensure the test repository is configured to detect copies
-      await GitProcess.exec(
-        ['config', 'diff.renames', 'copies'],
-        repository.path
-      )
+      await setupLocalConfig(repository, [['diff.renames', 'copies']])
 
       const files = await getChangedFiles(repository, 'a500bf415')
       expect(files).toHaveLength(2)

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -2,7 +2,6 @@ import { Repository } from '../../../src/models/repository'
 import { getChangedFiles, getCommits } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import { AppFileStatusKind } from '../../../src/models/status'
-import { GitProcess } from 'dugite'
 import { setupLocalConfig } from '../../helpers/local-config'
 
 describe('git/log', () => {

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/tip'
 import { GitProcess } from 'dugite'
+import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'
 const origin = 'origin'
@@ -59,14 +60,10 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.rebase', 'false'],
-          repository.path
-        )
-        await GitProcess.exec(
-          ['config', '--local', 'pull.ff', 'false'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [
+          ['pull.rebase', 'false'],
+          ['pull.ff', 'false'],
+        ])
 
         previousTip = await getTipOrError(repository)
 
@@ -104,10 +101,7 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.rebase', 'false'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [['pull.rebase', 'false']])
 
         previousTip = await getTipOrError(repository)
 
@@ -140,10 +134,7 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.rebase', 'true'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [['pull.rebase', 'true']])
 
         previousTip = await getTipOrError(repository)
 
@@ -173,14 +164,10 @@ describe('git/pull', () => {
 
     describe('with pull.rebase=false and pull.ff=only set in config', () => {
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.rebase', 'false'],
-          repository.path
-        )
-        await GitProcess.exec(
-          ['config', '--local', 'pull.ff', 'only'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [
+          ['pull.rebase', 'false'],
+          ['pull.ff', 'only'],
+        ])
       })
 
       it(`throws an error as the user blocks merge commits on pull`, () => {

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -12,7 +12,6 @@ import {
   makeCommit,
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/tip'
-import { GitProcess } from 'dugite'
 import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -92,11 +92,15 @@ describe('git/pull', () => {
       })
     })
 
-    describe('with pull.ff=false set in config', () => {
+    describe('with pull.rebase=false and pull.ff=false set in config', () => {
       let previousTip: Commit
       let newTip: Commit
 
       beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.rebase', 'false'],
+          repository.path
+        )
         await GitProcess.exec(
           ['config', '--local', 'pull.ff', 'false'],
           repository.path
@@ -112,6 +116,11 @@ describe('git/pull', () => {
       it('creates a merge commit', async () => {
         expect(newTip.sha).not.toBe(previousTip.sha)
         expect(newTip.parentSHAs).toHaveLength(2)
+      })
+
+      it('is different from remote branch', async () => {
+        const remoteCommit = await getRefOrError(repository, remoteBranch)
+        expect(remoteCommit.sha).not.toBe(newTip.sha)
       })
 
       it('is ahead of tracking branch', async () => {
@@ -200,8 +209,12 @@ describe('git/pull', () => {
       })
     })
 
-    describe('with pull.ff=only set in config', () => {
+    describe('with pull.rebase=false and pull.ff=only set in config', () => {
       beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.rebase', 'false'],
+          repository.path
+        )
         await GitProcess.exec(
           ['config', '--local', 'pull.ff', 'only'],
           repository.path

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -54,44 +54,6 @@ describe('git/pull', () => {
       await fetch(repository, null, origin)
     })
 
-    describe('by default', () => {
-      let previousTip: Commit
-      let newTip: Commit
-
-      beforeEach(async () => {
-        previousTip = await getTipOrError(repository)
-
-        await pull(repository, null, origin)
-
-        newTip = await getTipOrError(repository)
-      })
-
-      it('creates a merge commit', async () => {
-        const newTip = await getTipOrError(repository)
-
-        expect(newTip.sha).not.toBe(previousTip.sha)
-        expect(newTip.parentSHAs).toHaveLength(2)
-      })
-
-      it('is different from remote branch', async () => {
-        const remoteCommit = await getRefOrError(repository, remoteBranch)
-        expect(remoteCommit.sha).not.toBe(newTip.sha)
-      })
-
-      it('is ahead of tracking branch', async () => {
-        const range = revSymmetricDifference(
-          featureBranch,
-          `${origin}/${featureBranch}`
-        )
-
-        const aheadBehind = await getAheadBehind(repository, range)
-        expect(aheadBehind).toEqual({
-          ahead: 2,
-          behind: 0,
-        })
-      })
-    })
-
     describe('with pull.rebase=false and pull.ff=false set in config', () => {
       let previousTip: Commit
       let newTip: Commit

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -12,7 +12,6 @@ import {
   makeCommit,
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/tip'
-import { GitProcess } from 'dugite'
 import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/tip'
 import { GitProcess } from 'dugite'
+import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'
 const origin = 'origin'
@@ -80,10 +81,8 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.ff', 'false'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [['pull.ff', 'false']])
+
         previousTip = await getTipOrError(repository)
 
         await pull(repository, null, origin)
@@ -116,10 +115,7 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.ff', 'only'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [['pull.ff', 'only']])
 
         previousTip = await getTipOrError(repository)
 

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -89,11 +89,15 @@ describe('git/pull', () => {
       })
     })
 
-    describe('with pull.ff=false set in config', () => {
+    describe('with pull.rebase=false and pull.ff=false set in config', () => {
       let previousTip: Commit
       let newTip: Commit
 
       beforeEach(async () => {
+        await GitProcess.exec(
+          ['config', '--local', 'pull.rebase', 'false'],
+          repository.path
+        )
         await GitProcess.exec(
           ['config', '--local', 'pull.ff', 'false'],
           repository.path

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -12,7 +12,7 @@ import {
   makeCommit,
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/tip'
-import { GitProcess } from 'dugite'
+import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'
 const origin = 'origin'
@@ -59,14 +59,10 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.rebase', 'false'],
-          repository.path
-        )
-        await GitProcess.exec(
-          ['config', '--local', 'pull.ff', 'false'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [
+          ['pull.rebase', 'false'],
+          ['pull.ff', 'false'],
+        ])
 
         previousTip = await getTipOrError(repository)
 
@@ -101,10 +97,7 @@ describe('git/pull', () => {
       let newTip: Commit
 
       beforeEach(async () => {
-        await GitProcess.exec(
-          ['config', '--local', 'pull.ff', 'only'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [['pull.ff', 'only']])
 
         previousTip = await getTipOrError(repository)
 

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -54,41 +54,6 @@ describe('git/pull', () => {
       await fetch(repository, null, origin)
     })
 
-    describe('by default', () => {
-      let previousTip: Commit
-      let newTip: Commit
-
-      beforeEach(async () => {
-        previousTip = await getTipOrError(repository)
-
-        await pull(repository, null, origin)
-
-        newTip = await getTipOrError(repository)
-      })
-
-      it('moves local repository to remote commit', async () => {
-        const newTip = await getTipOrError(repository)
-
-        expect(newTip.sha).not.toBe(previousTip.sha)
-        expect(newTip.parentSHAs).toHaveLength(1)
-      })
-
-      it('is same as remote branch', async () => {
-        const remoteCommit = await getRefOrError(repository, remoteBranch)
-        expect(remoteCommit.sha).toBe(newTip.sha)
-      })
-
-      it('is not behind tracking branch', async () => {
-        const range = revSymmetricDifference(featureBranch, remoteBranch)
-
-        const aheadBehind = await getAheadBehind(repository, range)
-        expect(aheadBehind).toEqual({
-          ahead: 0,
-          behind: 0,
-        })
-      })
-    })
-
     describe('with pull.rebase=false and pull.ff=false set in config', () => {
       let previousTip: Commit
       let newTip: Commit

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -20,6 +20,7 @@ import {
 import * as temp from 'temp'
 import { getStatus } from '../../../src/lib/git'
 import { isConflictedFile } from '../../../src/lib/status'
+import { setupLocalConfig } from '../../helpers/local-config'
 
 const _temp = temp.track()
 const mkdir = _temp.mkdir
@@ -229,10 +230,7 @@ describe('git/status', () => {
         // Git 2.18 now uses a new config value to handle detecting copies, so
         // users who have this enabled will see this. For reference, Desktop does
         // not enable this by default.
-        await GitProcess.exec(
-          ['config', '--local', 'status.renames', 'copies'],
-          repository.path
-        )
+        await setupLocalConfig(repository, [['status.renames', 'copies']])
 
         await GitProcess.exec(['add', '.'], repository.path)
 


### PR DESCRIPTION
## Overview

**Closes #6924**

## Description

```shellsession
$ git config --global pull.rebase
true
$ yarn test:unit
yarn run v1.13.0
$ cross-env ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron ./node_modules/jest/bin/jest --detectOpenHandles --silent --config ./app/jest.unit.config.js
...

Test Suites: 85 passed, 85 total
Tests:       3 skipped, 724 passed, 727 total
Snapshots:   0 total
Time:        14.635s
✨  Done in 15.57s.
```

And the opposite:

```shellsession
$ git config --global pull.rebase
false
$ yarn test:unit                                                                                                                                            
yarn run v1.13.0
$ cross-env ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron ./node_modules/jest/bin/jest --detectOpenHandles --silent --config ./app/jest.unit.config.js
...

Test Suites: 85 passed, 85 total
Tests:       3 skipped, 724 passed, 727 total
Snapshots:   0 total
Time:        14.865s
✨  Done in 15.64s.
```

## Release notes

Notes: no-notes
