### PR TITLE
[rebase] enable `--force-with-lease` after rebasing

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -440,6 +440,9 @@ export interface IBranchesState {
    * that the default Git behaviour will occur.
    */
   readonly pullWithRebase?: boolean
+
+  /** Tracking branches that have been rebased within Desktop */
+  readonly rebasedBranches: ReadonlyMap<string, string>
 }
 
 export interface ICommitSelection {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -162,6 +162,9 @@ export interface IAppState {
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnDiscardChanges: boolean
 
+  /** Should the app prompt the user to confirm a force push? */
+  readonly askForConfirmationOnForcePush: boolean
+
   /** The external editor to use when opening repositories */
   readonly selectedExternalEditor?: ExternalEditor
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -58,7 +58,7 @@ export async function push(
 
   if (!remoteBranch) {
     args.push('--set-upstream')
-  } else if (options && options.forceWithLease) {
+  } else if (options !== undefined && options.forceWithLease) {
     args.push('--force-with-lease')
   }
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -10,6 +10,10 @@ import { IGitAccount } from '../../models/git-account'
 import { PushProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication, AuthenticationErrors } from './authentication'
 
+export type PushOptions = {
+  readonly forceWithLease: boolean
+}
+
 /**
  * Push from the remote to the branch, optionally setting the upstream.
  *
@@ -38,6 +42,7 @@ export async function push(
   remote: string,
   localBranch: string,
   remoteBranch: string | null,
+  options?: PushOptions,
   progressCallback?: (progress: IPushProgress) => void
 ): Promise<void> {
   const networkArguments = await gitNetworkArguments(repository, account)
@@ -51,6 +56,8 @@ export async function push(
 
   if (!remoteBranch) {
     args.push('--set-upstream')
+  } else if (options && options.forceWithLease) {
+    args.push('--force-with-lease')
   }
 
   let opts: IGitExecutionOptions = {

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -1,3 +1,5 @@
+import { GitError as DugiteError } from 'dugite'
+
 import {
   git,
   IGitExecutionOptions,
@@ -60,9 +62,12 @@ export async function push(
     args.push('--force-with-lease')
   }
 
+  const expectedErrors = new Set<DugiteError>(AuthenticationErrors)
+  expectedErrors.add(DugiteError.ProtectedBranchForcePush)
+
   let opts: IGitExecutionOptions = {
     env: envForAuthentication(account),
-    expectedErrors: AuthenticationErrors,
+    expectedErrors,
   }
 
   if (progressCallback) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -213,8 +213,10 @@ const commitSummaryWidthConfigKey: string = 'commit-summary-width'
 
 const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
+const askForConfirmationOnForcePushDefault = true
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
+const confirmForcePushKey: string = 'confirmForcePush'
 
 const externalEditorKey: string = 'externalEditor'
 
@@ -290,6 +292,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private confirmRepoRemoval: boolean = confirmRepoRemovalDefault
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
+  private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
 
   private selectedExternalEditor?: ExternalEditor
@@ -533,6 +536,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       currentBanner: this.currentBanner,
       askForConfirmationOnRepositoryRemoval: this.confirmRepoRemoval,
       askForConfirmationOnDiscardChanges: this.confirmDiscardChanges,
+      askForConfirmationOnForcePush: this.askForConfirmationOnForcePush,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
       selectedShell: this.selectedShell,
@@ -1455,6 +1459,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.confirmDiscardChanges = getBoolean(
       confirmDiscardChangesKey,
       confirmDiscardChangesDefault
+    )
+
+    this.askForConfirmationOnForcePush = getBoolean(
+      confirmForcePushKey,
+      askForConfirmationOnForcePushDefault
     )
 
     const externalEditorValue = await this.getSelectedExternalEditor()
@@ -3524,6 +3533,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setBoolean(confirmDiscardChangesKey, value)
     this.emitUpdate()
 
+    return Promise.resolve()
+  }
+
+  public _setConfirmForcePushSetting(value: boolean): Promise<void> {
+    this.askForConfirmationOnForcePush = value
+    setBoolean(confirmForcePushKey, value)
+    this.emitUpdate()
     return Promise.resolve()
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -138,6 +138,7 @@ import {
   abortRebase,
   continueRebase,
   rebase,
+  PushOptions,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -2586,15 +2587,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  public async _push(repository: Repository): Promise<void> {
+  public async _push(
+    repository: Repository,
+    options?: PushOptions
+  ): Promise<void> {
     return this.withAuthenticatingUser(repository, (repository, account) => {
-      return this.performPush(repository, account)
+      return this.performPush(repository, account, options)
     })
   }
 
   private async performPush(
     repository: Repository,
-    account: IGitAccount | null
+    account: IGitAccount | null,
+    options?: PushOptions
   ): Promise<void> {
     const state = this.repositoryStateCache.get(repository)
     const { remote } = state
@@ -2663,6 +2668,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
               remoteName,
               branch.name,
               branch.upstreamWithoutRemote,
+              options,
               progress => {
                 this.updatePushPullFetchProgress(repository, {
                   ...progress,
@@ -3368,7 +3374,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _abortRebase(repository: Repository): Promise<void> {
+  public async _abortRebase(repository: Repository) {
     const gitStore = this.gitStoreCache.get(repository)
     return await gitStore.performFailableOperation(() =>
       abortRebase(repository)

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -127,6 +127,7 @@ function getInitialRepositoryState(): IRepositoryState {
       openPullRequests: new Array<PullRequest>(),
       currentPullRequest: null,
       isLoadingPullRequests: false,
+      rebasedBranches: new Map<string, string>(),
     },
     compareState: {
       isDivergingBranchBannerVisible: false,

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -46,6 +46,7 @@ export enum PopupType {
   LocalChangesOverwritten,
   RebaseConflicts,
   RebaseBranch,
+  ConfirmForcePush,
 }
 
 export type Popup =
@@ -178,4 +179,9 @@ export type Popup =
       type: PopupType.RebaseBranch
       repository: Repository
       branch?: Branch
+    }
+  | {
+      type: PopupType.ConfirmForcePush
+      repository: Repository
+      upstreamBranch: string
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1175,6 +1175,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
+            confirmForcePush={this.state.askForConfirmationOnForcePush}
             selectedExternalEditor={this.state.selectedExternalEditor}
             optOutOfUsageTracking={this.props.appStore.getStatsOptOut()}
             enterpriseAccount={this.getEnterpriseAccount()}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1903,13 +1903,18 @@ export class App extends React.Component<IAppProps, IAppState> {
     const rebaseInProgress =
       conflictState !== null && conflictState.kind === 'rebase'
 
-    const { tip } = state.branchesState
+    const { pullWithRebase, tip, rebasedBranches } = state.branchesState
 
     if (tip.kind === TipState.Valid && tip.branch.remote !== null) {
       remoteName = tip.branch.remote
     }
-
-    const { pullWithRebase } = state.branchesState
+    let branchWasRebased = false
+    if (tip.kind === TipState.Valid) {
+      const localBranchName = tip.branch.nameWithoutRemote
+      const { sha } = tip.branch.tip
+      const foundEntry = rebasedBranches.get(localBranchName)
+      branchWasRebased = foundEntry === sha
+    }
 
     return (
       <PushPullButton
@@ -1923,6 +1928,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         tipState={tip.kind}
         pullWithRebase={pullWithRebase}
         rebaseInProgress={rebaseInProgress}
+        branchWasRebased={branchWasRebased}
       />
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -96,6 +96,7 @@ import { PushNeedsPullWarning } from './push-needs-pull'
 import { LocalChangesOverwrittenWarning } from './local-changes-overwritten'
 import { RebaseConflictsDialog } from './rebase'
 import { RebaseBranchDialog } from './rebase/rebase-branch-dialog'
+import { ConfirmForcePush } from './rebase/confirm-force-push'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1616,6 +1617,19 @@ export class App extends React.Component<IAppProps, IAppState> {
             openFileInExternalEditor={this.openFileInExternalEditor}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openInShell}
+          />
+        )
+      }
+      case PopupType.ConfirmForcePush: {
+        const { askForConfirmationOnForcePush } = this.state
+
+        return (
+          <ConfirmForcePush
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+            upstreamBranch={popup.upstreamBranch}
+            askForConfirmationOnForcePush={askForConfirmationOnForcePush}
+            onDismissed={this.onPopupDismissed}
           />
         )
       }

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -16,11 +16,7 @@ interface IContinueRebaseProps {
 }
 
 export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
-  private onSubmit = () => {
-    this.continueRebase()
-  }
-
-  private async continueRebase() {
+  private onSubmit = async () => {
     await this.props.dispatcher.continueRebase(
       this.props.repository,
       this.props.workingDirectory

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -322,7 +322,7 @@ export class Dispatcher {
 
   /** Push the current branch. */
   public push(repository: Repository, options?: PushOptions): Promise<void> {
-    if (options && options.forceWithLease) {
+    if (options !== undefined && options.forceWithLease) {
       this.dropCurrentBranchFromForcePushList(repository)
     }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1420,6 +1420,10 @@ export class Dispatcher {
     )
   }
 
+  public setConfirmForcePushSetting(value: boolean) {
+    return this.appStore._setConfirmForcePushSetting(value)
+  }
+
   /**
    * Updates the application state to indicate a conflict is in-progress
    * as a result of a pull and increments the relevant metric.

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -19,7 +19,7 @@ import {
   setGenericPassword,
   setGenericUsername,
 } from '../../lib/generic-git-auth'
-import { isGitRepository, RebaseResult } from '../../lib/git'
+import { isGitRepository, RebaseResult, PushOptions } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
   rejectOAuthRequest,
@@ -321,8 +321,12 @@ export class Dispatcher {
   }
 
   /** Push the current branch. */
-  public push(repository: Repository): Promise<void> {
-    return this.appStore._push(repository)
+  public push(repository: Repository, options?: PushOptions): Promise<void> {
+    if (options && options.forceWithLease) {
+      this.dropCurrentBranchFromForcePushList(repository)
+    }
+
+    return this.appStore._push(repository, options)
   }
 
   /** Pull the current branch. */

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -15,6 +15,7 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmForcePush: boolean
   readonly availableEditors: ReadonlyArray<ExternalEditor>
   readonly selectedExternalEditor?: ExternalEditor
   readonly availableShells: ReadonlyArray<Shell>
@@ -22,6 +23,7 @@ interface IAdvancedPreferencesProps {
   readonly onOptOutofReportingchanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
   readonly onConfirmRepositoryRemovalChanged: (checked: boolean) => void
+  readonly onConfirmForcePushChanged: (checked: boolean) => void
   readonly onSelectedEditorChanged: (editor: ExternalEditor) => void
   readonly onSelectedShellChanged: (shell: Shell) => void
 
@@ -36,6 +38,7 @@ interface IAdvancedPreferencesState {
   readonly selectedShell: Shell
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmForcePush: boolean
 }
 
 export class Advanced extends React.Component<
@@ -49,6 +52,7 @@ export class Advanced extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      confirmForcePush: this.props.confirmForcePush,
       selectedExternalEditor: this.props.selectedExternalEditor,
       selectedShell: this.props.selectedShell,
     }
@@ -99,6 +103,15 @@ export class Advanced extends React.Component<
 
     this.setState({ confirmDiscardChanges: value })
     this.props.onConfirmDiscardChangesChanged(value)
+  }
+
+  private onConfirmForcePushChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ confirmForcePush: value })
+    this.props.onConfirmForcePushChanged(value)
   }
 
   private onConfirmRepositoryRemovalChanged = (
@@ -258,6 +271,15 @@ export class Advanced extends React.Component<
                 : CheckboxValue.Off
             }
             onChange={this.onConfirmDiscardChangesChanged}
+          />
+        </Row>
+        <Row>
+          <Checkbox
+            label="Show confirmation dialog before force pushing"
+            value={
+              this.state.confirmForcePush ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onConfirmForcePushChanged}
           />
         </Row>
       </DialogContent>

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -33,6 +33,7 @@ interface IPreferencesProps {
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmForcePush: boolean
   readonly selectedExternalEditor?: ExternalEditor
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
@@ -47,6 +48,7 @@ interface IPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmForcePush: boolean
   readonly automaticallySwitchTheme: boolean
   readonly availableEditors: ReadonlyArray<ExternalEditor>
   readonly selectedExternalEditor?: ExternalEditor
@@ -72,6 +74,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
+      confirmForcePush: false,
       automaticallySwitchTheme: false,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -119,6 +122,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      confirmForcePush: this.props.confirmForcePush,
       availableShells,
       availableEditors,
       mergeTool,
@@ -227,6 +231,7 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             confirmRepositoryRemoval={this.state.confirmRepositoryRemoval}
             confirmDiscardChanges={this.state.confirmDiscardChanges}
+            confirmForcePush={this.state.confirmForcePush}
             availableEditors={this.state.availableEditors}
             selectedExternalEditor={this.state.selectedExternalEditor}
             onOptOutofReportingchanged={this.onOptOutofReportingChanged}
@@ -234,6 +239,7 @@ export class Preferences extends React.Component<
               this.onConfirmRepositoryRemovalChanged
             }
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
+            onConfirmForcePushChanged={this.onConfirmForcePushChanged}
             onSelectedEditorChanged={this.onSelectedEditorChanged}
             availableShells={this.state.availableShells}
             selectedShell={this.state.selectedShell}
@@ -259,6 +265,10 @@ export class Preferences extends React.Component<
 
   private onConfirmDiscardChangesChanged = (value: boolean) => {
     this.setState({ confirmDiscardChanges: value })
+  }
+
+  private onConfirmForcePushChanged = (value: boolean) => {
+    this.setState({ confirmForcePush: value })
   }
 
   private onCommitterNameChanged = (committerName: string) => {
@@ -334,6 +344,10 @@ export class Preferences extends React.Component<
     )
     await this.props.dispatcher.setConfirmRepoRemovalSetting(
       this.state.confirmRepositoryRemoval
+    )
+
+    await this.props.dispatcher.setConfirmForcePushSetting(
+      this.state.confirmForcePush
     )
 
     if (this.state.selectedExternalEditor) {

--- a/app/src/ui/rebase/confirm-force-push.tsx
+++ b/app/src/ui/rebase/confirm-force-push.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import { Dispatcher } from '../dispatcher'
+import { ButtonGroup } from '../lib/button-group'
+import { DialogFooter, DialogContent, Dialog } from '../dialog'
+import { Button } from '../lib/button'
+import { Repository } from '../../models/repository'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+
+interface IConfirmForcePushProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly upstreamBranch: string
+  readonly askForConfirmationOnForcePush: boolean
+  readonly onDismissed: () => void
+}
+
+interface IConfirmForcePushState {
+  readonly isLoading: boolean
+  readonly askForConfirmationOnForcePush: boolean
+}
+
+export class ConfirmForcePush extends React.Component<
+  IConfirmForcePushProps,
+  IConfirmForcePushState
+> {
+  public constructor(props: IConfirmForcePushProps) {
+    super(props)
+
+    this.state = {
+      isLoading: false,
+      askForConfirmationOnForcePush: props.askForConfirmationOnForcePush,
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        title="Are you sure you want to force push?"
+        dismissable={!this.state.isLoading}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onForcePush}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            A force push will rewrite history on{' '}
+            <strong>{this.props.upstreamBranch}</strong>. Any collaborators
+            working on this branch will need to reset their own local branch to
+            match the history of the remote.
+          </p>
+          <div>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.askForConfirmationOnForcePush
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onAskForConfirmationOnForcePushChanged}
+            />
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <ButtonGroup>
+            <Button type="submit">I'm sure</Button>
+            <Button onClick={this.props.onDismissed}>Cancel</Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onAskForConfirmationOnForcePushChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ askForConfirmationOnForcePush: value })
+  }
+
+  private onForcePush = async () => {
+    this.props.dispatcher.setConfirmForcePushSetting(
+      this.state.askForConfirmationOnForcePush
+    )
+    this.props.onDismissed()
+
+    await this.props.dispatcher.performForcePush(this.props.repository)
+  }
+}

--- a/app/src/ui/rebase/rebase-branch-dialog.tsx
+++ b/app/src/ui/rebase/rebase-branch-dialog.tsx
@@ -160,6 +160,8 @@ export class RebaseBranchDialog extends React.Component<
       return
     }
 
+    // TODO: transition to a rebase progress dialog
+
     this.setState({ isRebasing: true })
 
     await this.props.dispatcher.rebase(
@@ -169,6 +171,8 @@ export class RebaseBranchDialog extends React.Component<
     )
 
     this.setState({ isRebasing: false })
+
+    this.props.onDismissed()
   }
 }
 

--- a/app/src/ui/rebase/rebase-conflicts-dialog.tsx
+++ b/app/src/ui/rebase/rebase-conflicts-dialog.tsx
@@ -15,7 +15,6 @@ import {
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
-import { RebaseResult } from '../../lib/git'
 import { BannerType } from '../../models/banner'
 import { PopupType } from '../../models/popup'
 import {
@@ -66,14 +65,10 @@ export class RebaseConflictsDialog extends React.Component<
   }
 
   private onSubmit = async () => {
-    const result = await this.props.dispatcher.continueRebase(
+    await this.props.dispatcher.continueRebase(
       this.props.repository,
       this.props.workingDirectory
     )
-
-    if (result === RebaseResult.CompletedWithoutError) {
-      this.props.onDismissed()
-    }
   }
 
   private renderHeaderTitle(targetBranch: string, baseBranch?: string) {

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -52,6 +52,16 @@ interface IPushPullButtonProps {
   readonly branchWasRebased: boolean
 }
 
+/**
+ * This represents the "double arrow" icon used to show a force-push, and is a
+ * less complicated icon than the generated Octicon from the `octicons` package.
+ */
+const forcePushIcon = new OcticonSymbol(
+  10,
+  16,
+  'M3 11H0l5-6 5 6H7v4H3v-4zM5 1l5 6H8.33L5 3 1.662 7H0l5-6z'
+)
+
 function getActionLabel(
   aheadBehind: IAheadBehind,
   remoteName: string,
@@ -193,7 +203,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
     }
 
     if (this.props.branchWasRebased) {
-      return OcticonSymbol.repoForcePush
+      return forcePushIcon
     }
 
     if (behind > 0) {


### PR DESCRIPTION
## Overview

**Closes #6913**

![](https://user-images.githubusercontent.com/359239/54045376-d7f4cf80-41a7-11e9-944a-fd6e31c64544.gif)

## Description

This PR touches a few areas to enable `--force-with-lease` after a rebased is completed in the app:

 - when a rebase is complete, add the updated branch to a list of valid branches that can be force pushed later
 - updated the push/pull button to show when the current branch can be force pushed
 - a new dialog to confirm the force push, controlled by a new preference
 - `push` now has the ability to set `--force-with-lease`
 - do the thing (right up until branch protections block me from doing it)

TODO: 

 - [x] no-op rebase should not enable force push (check that tip has changed from original commit ID)
 - [x] icon for "force push" is a plain Octicon - swap out for custom icon
 - [x] a bunch more testing
 - [x] rebase once #6961 is reviewed and merged
 - [x] cleanup commit history

## Release notes

Notes: `[Improved] users are able to force push branches that were rebased within Desktop`
