### PR TITLE
provide a better description when rebase in progress

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1838,6 +1838,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     const remoteName = state.remote ? state.remote.name : null
     const progress = state.pushPullFetchProgress
 
+    const { conflictState } = state.changesState
+
+    const rebaseInProgress =
+      conflictState !== null && conflictState.kind === 'rebase'
+
     const tipState = state.branchesState.tip.kind
     const { pullWithRebase } = state.branchesState
 
@@ -1852,6 +1857,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         progress={progress}
         tipState={tipState}
         pullWithRebase={pullWithRebase}
+        rebaseInProgress={rebaseInProgress}
       />
     )
   }

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -44,6 +44,9 @@ interface IPushPullButtonProps {
 
   /** Has the user configured pull.rebase to anything? */
   readonly pullWithRebase?: boolean
+
+  /** Is the detached HEAD state related to a rebase or not? */
+  readonly rebaseInProgress: boolean
 }
 
 function getActionLabel(
@@ -189,7 +192,9 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
     }
 
     if (tipState === TipState.Detached) {
-      return 'Cannot publish detached HEAD'
+      return this.props.rebaseInProgress
+        ? 'Rebase in progress'
+        : 'Cannot publish detached HEAD'
     }
 
     if (tipState === TipState.Unborn) {


### PR DESCRIPTION
## Overview

**Closes #6980**

## Description

This tweaks the push/pull button to avoid mentioning `detached HEAD` when a rebase is in progress:

<img width="979" alt="screen shot 2019-03-01 at 7 44 12 am" src="https://user-images.githubusercontent.com/359239/53636249-e9613900-3bf5-11e9-90b7-322d6117996c.png">

## Release notes

Notes: no-notes
