### PR TITLE
ensure push goes to the right remote

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2619,7 +2619,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (tip.kind === TipState.Valid) {
         const { branch } = tip
 
-        const pushTitle = `Pushing to ${remote.name}`
+        const remoteName = branch.remote || remote.name
+
+        const pushTitle = `Pushing to ${remoteName}`
 
         // Emit an initial progress even before our push begins
         // since we're doing some work to get remotes up front.
@@ -2627,7 +2629,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           kind: 'push',
           title: pushTitle,
           value: 0,
-          remote: remote.name,
+          remote: remoteName,
           branch: branch.name,
         })
 
@@ -2656,7 +2658,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             await pushRepo(
               repository,
               account,
-              remote.name,
+              remoteName,
               branch.name,
               branch.upstreamWithoutRemote,
               progress => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1835,7 +1835,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return <RevertProgress progress={revertProgress} />
     }
 
-    const remoteName = state.remote ? state.remote.name : null
+    let remoteName = state.remote ? state.remote.name : null
     const progress = state.pushPullFetchProgress
 
     const { conflictState } = state.changesState
@@ -1843,7 +1843,12 @@ export class App extends React.Component<IAppProps, IAppState> {
     const rebaseInProgress =
       conflictState !== null && conflictState.kind === 'rebase'
 
-    const tipState = state.branchesState.tip.kind
+    const { tip } = state.branchesState
+
+    if (tip.kind === TipState.Valid && tip.branch.remote !== null) {
+      remoteName = tip.branch.remote
+    }
+
     const { pullWithRebase } = state.branchesState
 
     return (
@@ -1855,7 +1860,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         lastFetched={state.lastFetched}
         networkActionInProgress={state.isPushPullFetchInProgress}
         progress={progress}
-        tipState={tipState}
+        tipState={tip.kind}
         pullWithRebase={pullWithRebase}
         rebaseInProgress={rebaseInProgress}
       />


### PR DESCRIPTION
## Overview

This is an annoying bug I uncovered while testing #6981, and I think it was significant enough to extract and review before landing more rebase work.

## The Bug

As part of testing #6981 I would sometimes see the force push complete, and sometimes I'd see it remain in the ahead/behind state despite no errors being reported by the `push`.

I have these two remotes configured, and the branch I am working on is tracking `upstream`:

```
$ git remote -v
origin	https://github.com/shiftkey/desktop (fetch)
origin	https://github.com/shiftkey/desktop (push)
upstream	https://github.com/desktop/desktop.git (fetch)
upstream	https://github.com/desktop/desktop.git (push)
```

Puzzled by it sometimes working, I eventually added this code inside `performPush` as a sanity check:

```diff
diff --git a/app/src/lib/stores/app-store.ts b/app/src/lib/stores/app-store.ts
index 82afe85b7..4de1895af 100644
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2619,6 +2619,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (tip.kind === TipState.Valid) {
         const { branch } = tip
 
+        if (branch.remote !== null && branch.remote !== remote.name) {
+          debugger
+        }
+
         const pushTitle = `Pushing to ${remote.name}`
 
         // Emit an initial progress even before our push begins
```

And after setting up to force push (note the `upstream` mention here):

<img width="256"  src="https://user-images.githubusercontent.com/359239/53656307-4b876180-3c29-11e9-9107-0a59e1eecf44.png">

I was eventually able to trip this check:

<img width="564" alt="screen shot 2019-03-01 at 1 41 54 pm" src="https://user-images.githubusercontent.com/359239/53656308-4b876180-3c29-11e9-972b-aa83523c1515.png">

What is the button showing at this point?

<img width="253" alt="screen shot 2019-03-01 at 1 42 00 pm" src="https://user-images.githubusercontent.com/359239/53656309-4c1ff800-3c29-11e9-9144-420adfbec145.png">

Oh, oh no. I peeked at the state of the local variables and I seem to have stumbled upon a state where the "current" remote is `origin` rather than `upstream`:

<img width="428" alt="screen shot 2019-03-01 at 1 42 47 pm" src="https://user-images.githubusercontent.com/359239/53656311-4c1ff800-3c29-11e9-9e33-09159431cc1a.png">

What does this mean? Well, it means `origin` is passed into as an argument to `git push`

<img width="371" alt="screen shot 2019-03-01 at 1 43 11 pm" src="https://user-images.githubusercontent.com/359239/53656312-4c1ff800-3c29-11e9-9f55-b2bc78aa3c44.png">

And the branch is pushed to the wrong remote 😱 

## The Fix

I've broken this PR down into the three places that need to be fixed here to address this race condition:

 - [x] 026122b  - show the tracking branch remote, if set, before the default remote
 - [x] ba3ee4b - use the tracking branch remote on push, if set
 - ~~[ ] `????????` - nail down race condition that causes `loadRemotes` to not have the right remote~~

https://github.com/desktop/desktop/blob/ba3ee4bba9ca9cbd89d1a899c3f6c38658e76a53/app/src/lib/stores/git-store.ts#L977-L980

## Release notes

Notes: `[Fixed] race condition causes branch to be published to wrong remote`
