### PR TITLE
clarify type signature for findDefaultRemote

### DIFF
--- a/app/src/lib/stores/helpers/find-default-remote.ts
+++ b/app/src/lib/stores/helpers/find-default-remote.ts
@@ -9,6 +9,8 @@ import { IRemote } from '../../../models/remote'
  *
  * @param remotes A list of remotes for a given repository
  */
-export function findDefaultRemote(remotes: ReadonlyArray<IRemote>) {
+export function findDefaultRemote(
+  remotes: ReadonlyArray<IRemote>
+): IRemote | null {
   return remotes.find(x => x.name === 'origin') || remotes[0] || null
 }

--- a/app/test/unit/git/remote-test.ts
+++ b/app/test/unit/git/remote-test.ts
@@ -63,6 +63,11 @@ describe('git/remote', () => {
   })
 
   describe('findDefaultRemote', () => {
+    it('returns null for empty array', async () => {
+      const result = await findDefaultRemote([])
+      expect(result).toBeNull()
+    })
+
     it('returns origin when multiple remotes found', async () => {
       const testRepoPath = await setupFixtureRepository(
         'repo-with-multiple-remotes'


### PR DESCRIPTION
## Overview

While looking at the root cause of #6986 I noticed this little bit of dubious type inference:

<img width="558" src="https://user-images.githubusercontent.com/359239/53659667-84780400-3c32-11e9-8662-72eed2395312.png">

## Description

This is a limitation of many fine programming languages which lack runtime bounds checks on arrays. In this case, JavaScript assumes that the indexer on an array will return a value, but it will return `undefined` for values outside the array.

<img width="193" src="https://user-images.githubusercontent.com/359239/53659814-ce60ea00-3c32-11e9-890a-bff5bbd0633e.png">

The TypeScript declarations for [`ReadonlyArray`](https://github.com/Microsoft/TypeScript/blob/master/src/lib/es5.d.ts#L1066) follow this lead:

```
interface ReadonlyArray<T> {
    // other members
    readonly [n: number]: T;
}
```

There's a discussion about the behaviour and the team's rationale here: https://github.com/Microsoft/TypeScript/issues/13778

This PR does simplest thing to clarify the signature for this function:

1. confirm the behaviour is correct with a test for an empty array
2. make the signature explicit that `null` needs to be handled

I also could have unrolled this code to not rely on coalescing `undefined` and explicitly check the length of the array, which would make it more readable and restore the type inference, but it didn't feel worth the time.

## Release notes

Notes: no-notes
