### PR TITLE
disable push menu item when on detached HEAD

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -240,7 +240,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     )
     menuStateBuilder.setEnabled(
       'push',
-      !branchIsUnborn && !networkActionInProgress
+      !branchIsUnborn && !onDetachedHead && !networkActionInProgress
     )
     menuStateBuilder.setEnabled(
       'pull',


### PR DESCRIPTION
## Overview

Addresses this bit of feedback from #6984:

> the `Push` menu item is still active in the Repo menu, which triggers a console error:
  `Uncaught (in promise) Error: The current repository is in a detached HEAD state`

## Description

`1.6.3-beta3`:

<img width="901" src="https://user-images.githubusercontent.com/359239/53666025-5fd85800-3c43-11e9-946d-f95f403d74b4.png">

This PR:

<img width="804" src="https://user-images.githubusercontent.com/359239/53666197-daa17300-3c43-11e9-88dd-5c62da887617.png">

## Release notes

Notes: no-notes
