### PR TITLE
disable new branch for detached head

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -248,7 +248,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     )
     menuStateBuilder.setEnabled(
       'create-branch',
-      !tipStateIsUnknown && !branchIsUnborn
+      !tipStateIsUnknown && !branchIsUnborn && !onDetachedHead
     )
 
     menuStateBuilder.setEnabled('compare-to-branch', !onDetachedHead)


### PR DESCRIPTION
if rebase in progress, then `New Branch` menu option should be disabled as well to avoid confusion and error: 

`git -c credential.helper= -c protocol.version=2 checkout --progress cccc --recurse-submodules --` exited with an unexpected code: 1. 2-simple-rebase-conflict/LICENSE.md: needs merge, error: you need to resolve your current index first`

![image](https://user-images.githubusercontent.com/14828183/53673807-de29ff80-3c2d-11e9-8a8d-1c12c55577b7.png)

related to https://github.com/desktop/desktop/pull/6992 and https://github.com/desktop/desktop/pull/6984

Feel free to close or edit if needed. 