### PR TITLE
disable create branch menu item when dealing with rebase conflicts

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -253,7 +253,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     )
     menuStateBuilder.setEnabled(
       'create-branch',
-      !tipStateIsUnknown && !branchIsUnborn
+      !tipStateIsUnknown && !branchIsUnborn && !rebaseInProgress
     )
 
     menuStateBuilder.setEnabled('compare-to-branch', !onDetachedHead)

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -153,6 +153,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let networkActionInProgress = false
   let tipStateIsUnknown = false
   let branchIsUnborn = false
+  let rebaseInProgress = false
 
   if (selectedState && selectedState.type === SelectionType.Repository) {
     repositorySelected = true
@@ -184,6 +185,10 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     }
 
     networkActionInProgress = selectedState.state.isPushPullFetchInProgress
+
+    const { conflictState } = selectedState.state.changesState
+
+    rebaseInProgress = conflictState !== null && conflictState.kind === 'rebase'
   }
 
   // These are IDs for menu items that are entirely _and only_


### PR DESCRIPTION
## Overview

**A more targeted fix for #6994**

## Description

When you are in the middle of a rebase, Desktop should not let the user create a new branch as this is a potential source of confusion.

This wasn't blocked previously because the "detached HEAD" scenario is a way for users to create a new branch based on an arbitrary commit in the repository history.

#### Current `development` branch

<img width="699" src="https://user-images.githubusercontent.com/359239/53735638-e36d9100-3e5d-11e9-83df-86de6bffa2c5.png">

#### This PR

<img width="760" src="https://user-images.githubusercontent.com/359239/53735652-eb2d3580-3e5d-11e9-9669-70db1c599d65.png">

## Release notes

Notes: no-notes
