### PR TITLE
add more tests to clarify rebase behaviour

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3381,13 +3381,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     workingDirectory: WorkingDirectoryStatus
   ) {
     const gitStore = this.gitStoreCache.get(repository)
-
-    const trackedFiles = workingDirectory.files.filter(f => {
-      return f.status.kind !== AppFileStatusKind.Untracked
-    })
-
     return await gitStore.performFailableOperation(() =>
-      continueRebase(repository, trackedFiles)
+      continueRebase(repository, workingDirectory.files)
     )
   }
 

--- a/app/test/helpers/repository-builder-rebase-test.ts
+++ b/app/test/helpers/repository-builder-rebase-test.ts
@@ -40,6 +40,10 @@ export async function createRepository(
         path: 'OTHER.md',
         contents: '# HELLO WORLD! \nTHINGS GO HERE\n',
       },
+      {
+        path: 'THIRD.md',
+        contents: 'nothing goes here',
+      },
     ],
   }
 

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -209,7 +209,7 @@ describe('git/rebase', () => {
   describe('continue with additional changes unrelated to conflicted files', () => {
     let beforeRebaseTip: Commit
     let filesInRebasedCommit: ReadonlyArray<CommittedFileChange>
-    let result: ContinueRebaseResult
+    let result: RebaseResult
     let status: IStatusResult
 
     beforeEach(async () => {
@@ -257,7 +257,7 @@ describe('git/rebase', () => {
     })
 
     it('returns success', () => {
-      expect(result).toBe(ContinueRebaseResult.CompletedWithoutError)
+      expect(result).toBe(RebaseResult.CompletedWithoutError)
     })
 
     it('keeps untracked working directory file out of rebase', () => {
@@ -276,6 +276,47 @@ describe('git/rebase', () => {
 
     it('branch is now a different ref', () => {
       expect(status.currentTip).not.toBe(beforeRebaseTip.sha)
+    })
+  })
+
+  describe('continue with tracked change omitted from list', () => {
+    let result: RebaseResult
+
+    beforeEach(async () => {
+      const repository = await createRepository(baseBranch, featureBranch)
+
+      await rebase(repository, baseBranch, featureBranch)
+
+      // resolve conflicts by writing files to disk
+      await FSE.writeFile(
+        Path.join(repository.path, 'THING.md'),
+        '# HELLO WORLD! \nTHINGS GO HERE\nFEATURE BRANCH UNDERWAY\n'
+      )
+
+      await FSE.writeFile(
+        Path.join(repository.path, 'OTHER.md'),
+        '# HELLO WORLD! \nTHINGS GO HERE\nALSO FEATURE BRANCH UNDERWAY\n'
+      )
+
+      // change unrelated tracked while rebasing changes
+      await FSE.writeFile(
+        Path.join(repository.path, 'THIRD.md'),
+        'this change should be included in the latest commit'
+      )
+
+      const afterRebase = await getStatusOrThrow(repository)
+
+      const { files } = afterRebase.workingDirectory
+
+      // omit the last change should cause Git to error because it requires
+      // all tracked changes to be staged as a prerequisite for rebasing
+      const onlyConflictedFiles = files.filter(f => f.path !== 'THIRD.md')
+
+      result = await continueRebase(repository, onlyConflictedFiles)
+    })
+
+    it('returns error code indicating that required files were missing', () => {
+      expect(result).toBe(RebaseResult.OutstandingFilesNotStaged)
     })
   })
 })

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -2,7 +2,7 @@ import { GitProcess } from 'dugite'
 import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
-import { IStatusResult } from '../../../../src/lib/git'
+import { IStatusResult, getChangedFiles } from '../../../../src/lib/git'
 import {
   abortRebase,
   continueRebase,
@@ -10,7 +10,10 @@ import {
   RebaseResult,
 } from '../../../../src/lib/git/rebase'
 import { Commit } from '../../../../src/models/commit'
-import { AppFileStatusKind } from '../../../../src/models/status'
+import {
+  AppFileStatusKind,
+  CommittedFileChange,
+} from '../../../../src/models/status'
 import { createRepository } from '../../../helpers/repository-builder-rebase-test'
 import { getStatusOrThrow } from '../../../helpers/status'
 import { getRefOrError } from '../../../helpers/tip'
@@ -192,6 +195,79 @@ describe('git/rebase', () => {
 
     it('no longer has working directory changes', () => {
       expect(status.workingDirectory.files).toHaveLength(0)
+    })
+
+    it('returns to the feature branch', () => {
+      expect(status.currentBranch).toBe(featureBranch)
+    })
+
+    it('branch is now a different ref', () => {
+      expect(status.currentTip).not.toBe(beforeRebaseTip.sha)
+    })
+  })
+
+  describe('continue with additional changes unrelated to conflicted files', () => {
+    let beforeRebaseTip: Commit
+    let filesInRebasedCommit: ReadonlyArray<CommittedFileChange>
+    let result: ContinueRebaseResult
+    let status: IStatusResult
+
+    beforeEach(async () => {
+      const repository = await createRepository(baseBranch, featureBranch)
+
+      beforeRebaseTip = await getRefOrError(repository, featureBranch)
+
+      await rebase(repository, baseBranch, featureBranch)
+
+      // resolve conflicts by writing files to disk
+      await FSE.writeFile(
+        Path.join(repository.path, 'THING.md'),
+        '# HELLO WORLD! \nTHINGS GO HERE\nFEATURE BRANCH UNDERWAY\n'
+      )
+
+      await FSE.writeFile(
+        Path.join(repository.path, 'OTHER.md'),
+        '# HELLO WORLD! \nTHINGS GO HERE\nALSO FEATURE BRANCH UNDERWAY\n'
+      )
+
+      // change unrelated tracked while rebasing changes
+      await FSE.writeFile(
+        Path.join(repository.path, 'THIRD.md'),
+        'this change should be included in the latest commit'
+      )
+
+      // add untracked file before continuing rebase
+      await FSE.writeFile(
+        Path.join(repository.path, 'UNTRACKED-FILE.md'),
+        'this file should remain in the working directory'
+      )
+
+      const afterRebase = await getStatusOrThrow(repository)
+
+      const { files } = afterRebase.workingDirectory
+
+      result = await continueRebase(repository, files)
+
+      status = await getStatusOrThrow(repository)
+
+      filesInRebasedCommit = await getChangedFiles(
+        repository,
+        status.currentTip!
+      )
+    })
+
+    it('returns success', () => {
+      expect(result).toBe(ContinueRebaseResult.CompletedWithoutError)
+    })
+
+    it('keeps untracked working directory file out of rebase', () => {
+      expect(status.workingDirectory.files).toHaveLength(1)
+    })
+
+    it('has modified but unconflicted file in commit contents', () => {
+      expect(
+        filesInRebasedCommit.find(f => f.path === 'THIRD.md')
+      ).not.toBeUndefined()
     })
 
     it('returns to the feature branch', () => {


### PR DESCRIPTION
## Overview

Following on from this comment https://github.com/desktop/desktop/pull/6984#issuecomment-468873887 I added two tests to confirm the behaviour from Git matches what I outlined in https://github.com/desktop/desktop/pull/6984#issuecomment-469259254

## Description

These were the two tests that were added:

```
  git/rebase
    continue with additional changes unrelated to conflicted files
```

This tests resolves two conflicts and also:

 - adds an untracked file to the working directory
 - modifies a tracked file which is unrelated to any conflicted files

When `continueRebase` runs, it includes the tracked file in the rebased commit, and leaves the untracked file in the working directory.

```
  git/rebase
    continue with tracked change omitted from list
```

This tests resolves two conflicts and makes an additional change:

 - a tracked file is modified separate to any conflicted files
 - excludes this change from the `files` array passed into `continueRebase`

When `continueRebase` runs, it errors to indicate that there are unstaged changes that prevent it from continuing the rebase. 

The only functional change related to this PR is pushing the tracked changes filter into `continueRebase`, which is already present with `1.6.3` but means I can avoid all the hassles of configuring `AppStore` to test.

```ts
  const trackedFiles = files.filter(f => {
    return f.status.kind !== AppFileStatusKind.Untracked
  })
```

## Release notes

Notes: no-notes
