### PR TITLE
put "local changes overwritten" dialog behind feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -75,3 +75,12 @@ export function enablePullWithRebase(): boolean {
 export function enableGroupRepositoriesByOwner(): boolean {
   return enableBetaFeatures()
 }
+
+/**
+ * As there is some lack of clarity about this feature with how it overlaps
+ * with planned support for stashing changes, this warning dialog is behind
+ * a feature flag for the moment.
+ */
+export function enableLocalChangesWarningHandler(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -82,5 +82,5 @@ export function enableGroupRepositoriesByOwner(): boolean {
  * a feature flag for the moment.
  */
 export function enableLocalChangesWarningHandler(): boolean {
-  return enableBetaFeatures()
+  return enableDevelopmentFeatures()
 }

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -54,7 +54,10 @@ import {
 import { UiActivityMonitor } from './lib/ui-activity-monitor'
 import { RepositoryStateCache } from '../lib/stores/repository-state-cache'
 import { ApiRepositoriesStore } from '../lib/stores/api-repositories-store'
-import { enablePullWithRebase } from '../lib/feature-flag'
+import {
+  enablePullWithRebase,
+  enableLocalChangesWarningHandler,
+} from '../lib/feature-flag'
 
 if (__DEV__) {
   installDevGlobals()
@@ -159,7 +162,9 @@ dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)
-dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
+if (enableLocalChangesWarningHandler()) {
+  dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
+}
 if (enablePullWithRebase()) {
   dispatcher.registerErrorHandler(rebaseConflictsHandler)
 }


### PR DESCRIPTION
## Overview

This PR puts the work contributed in #6755 behind a feature flag so that it won't go out as part of the 1.6.3 release today.

## Description

Why are we unshipping #6755? 

 - #6755 was opened without a corresponding issue. This might seem minor, but we require an issue to give us an opportunity to discuss problems with workflows in sufficient detail, to ensure we land on the right solution. We should have identified this earlier, and that's on the maintainers to better communicate this requirement and ensure the right discussions happen.
 - The changes in #6755 overlap with our potential plans to support stashing changes within the app. You can see the latest designs for this workflow in https://github.com/desktop/desktop/issues/6107#issuecomment-467197085.

It feels inappropriate for us to ship this workflow change in Desktop if we're going to be changing this workflow significantly in the near term, so this PR will feature-flag the error handler (that shows the new dialog) to avoid it being displayed for `beta` or `production` users while we evaluate the designs for stashing support.

## Release notes

Notes: no-notes
