### PR TITLE
only trigger conflicts flow for the selected repository

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1616,7 +1616,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       conflictState: updateConflictState(state, status, this.statsStore),
     }))
 
-    this._triggerConflictsFlow(repository)
+    if (this.selectedRepository === repository) {
+      this._triggerConflictsFlow(repository)
+    }
 
     this.emitUpdate()
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -203,11 +203,6 @@ export class Dispatcher {
     return this.appStore._selectRepository(repository)
   }
 
-  /** Load the working directory status. */
-  public loadStatus(repository: Repository): Promise<boolean> {
-    return this.appStore._loadStatus(repository)
-  }
-
   /** Change the selected section in the repository. */
   public changeRepositorySection(
     repository: Repository,


### PR DESCRIPTION
## Overview

**Related to #6313**

## Description

See reproduction steps in https://github.com/desktop/desktop/issues/6313#issuecomment-470162214

I focused on this area because @cheshire137 mentioned that it seemed to occur when dealing with merge conflicts, which was how I stumbled upon the fix below.

I thought this might have been affected by #6141 (first released in `1.6.2-beta1`) which introduces the code path: 

> - `AppStore.withPushPullFetch` runs
> - ... which calls `AppStore._refreshRepository`
> - ... which calls `AppStore.loadStatus`
> - ... which calls `AppStore._triggerConflictsFlow`

But the original issue was reported against `1.5.1-beta0` so I'm not sure this is completely resolved.

I also pushed c2e7276a4 as some cleanup because I couldn't find any callers for that API.

## Release notes

Notes: no-notes
