### PR TITLE
improve error handling inside fetchAll

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -484,6 +484,15 @@ export class API {
         return []
       }
 
+      if (response.status >= 500 && response.status < 599) {
+        log.warn(
+          `fetchAll: '${path}' returned a server error code '${
+            response.status
+          }'`
+        )
+        return []
+      }
+
       const items = await parsedResponse<ReadonlyArray<T>>(response)
       if (items) {
         buf.push(...items)

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -475,12 +475,18 @@ export class API {
 
     do {
       const response = await this.request('GET', nextPath)
-      if (response.status === HttpStatusCode.NotFound) {
-        log.warn(`fetchAll: '${path}' returned a 404`)
-        return []
-      }
+
       if (response.status === HttpStatusCode.NotModified) {
         log.warn(`fetchAll: '${path}' returned a 304`)
+        return []
+      }
+
+      if (response.status >= 400 && response.status < 499) {
+        log.warn(
+          `fetchAll: '${path}' returned a client error code '${
+            response.status
+          }'`
+        )
         return []
       }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -478,7 +478,7 @@ export class API {
 
       if (response.status === HttpStatusCode.NotModified) {
         log.warn(`fetchAll: '${path}' returned a 304`)
-        return []
+        return buf
       }
 
       if (response.status >= 400 && response.status < 499) {
@@ -487,7 +487,7 @@ export class API {
             response.status
           }'`
         )
-        return []
+        return buf
       }
 
       if (response.status >= 500 && response.status < 599) {
@@ -496,7 +496,7 @@ export class API {
             response.status
           }'`
         )
-        return []
+        return buf
       }
 
       const items = await parsedResponse<ReadonlyArray<T>>(response)


### PR DESCRIPTION
## Overview

**Closes #7019**

## Description

This changes how `fetchAll` works in three ways:

 - makes it aware of `5xx` HTTP error codes, logs a helpful message and returns
 - handles all `4xx` HTTP error codes, not just `404`
 - if an error is encountered, return the current pages of deserialized results (not an empty array)

The original error was occurring when fetching page `19` out of an unknown amount, and for the sake of showing _something_ I think this API should return whatever it has currently retrieved before the error occurred.

## Release notes

Notes: `[Improved]
