### PR TITLE
Explicit refresh of PR list and avoid skeleton loading screen when we have PRs to show

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -176,7 +176,12 @@ export class BranchesContainer extends React.Component<
 
   private renderPullRequests() {
     if (this.props.isLoadingPullRequests) {
-      return <PullRequestsLoading key="prs-loading" />
+      return (
+        <PullRequestsLoading
+          key="prs-loading"
+          renderPostFilter={this.renderPullRequestPostFilter}
+        />
+      )
     }
 
     const pullRequests = this.props.pullRequests
@@ -200,7 +205,27 @@ export class BranchesContainer extends React.Component<
         onFilterTextChanged={this.onPullRequestFilterTextChanged}
         onItemClick={this.onPullRequestClicked}
         onDismiss={this.onDismiss}
+        renderPostFilter={this.renderPullRequestPostFilter}
       />
+    )
+  }
+
+  private onRefreshPullRequests = () => {
+    this.props.dispatcher.refreshPullRequests(this.props.repository)
+  }
+
+  private renderPullRequestPostFilter = () => {
+    return (
+      <Button
+        disabled={this.props.isLoadingPullRequests}
+        onClick={this.onRefreshPullRequests}
+        tooltip="Refresh the list of pull requests"
+      >
+        <Octicon
+          symbol={OcticonSymbol.sync}
+          className={this.props.isLoadingPullRequests ? 'spin' : undefined}
+        />
+      </Button>
     )
   }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -175,7 +175,10 @@ export class BranchesContainer extends React.Component<
   }
 
   private renderPullRequests() {
-    if (this.props.isLoadingPullRequests) {
+    if (
+      this.props.isLoadingPullRequests &&
+      this.props.pullRequests.length === 0
+    ) {
       return (
         <PullRequestsLoading
           key="prs-loading"

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -50,6 +50,9 @@ interface IPullRequestListProps {
   /** Called when the user opts to create a pull request */
   readonly onCreatePullRequest: () => void
 
+  /** Called to render content after the filter. */
+  readonly renderPostFilter?: () => JSX.Element | null
+
   /** Callback fired when user selects a new pull request */
   readonly onSelectionChanged?: (
     pullRequest: PullRequest | null,
@@ -133,6 +136,7 @@ export class PullRequestList extends React.Component<
         onSelectionChanged={this.onSelectionChanged}
         onFilterKeyDown={this.props.onFilterKeyDown}
         renderNoItems={this.renderNoItems}
+        renderPostFilter={this.props.renderPostFilter}
       />
     )
   }

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -24,24 +24,25 @@ const prLoadingItemProps: IPullRequestListItemProps = {
   },
 }
 
+const items: Array<IFilterListItem> = []
+
+for (let i = 0; i < FacadeCount; i++) {
+  items.push({
+    text: [''],
+    id: i.toString(),
+  })
+}
+
+const groups = [
+  {
+    identifier: '',
+    items: items,
+  },
+]
+
 /** The placeholder for when pull requests are still loading. */
 export class PullRequestsLoading extends React.Component<{}, {}> {
   public render() {
-    const items: Array<IFilterListItem> = []
-    for (let i = 0; i < FacadeCount; i++) {
-      items.push({
-        text: [''],
-        id: i.toString(),
-      })
-    }
-
-    const groups = [
-      {
-        identifier: '',
-        items,
-      },
-    ]
-
     return (
       <FilterList<IFilterListItem>
         className="pull-request-list"

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -41,7 +41,7 @@ const groups = [
 ]
 
 /** The placeholder for when pull requests are still loading. */
-export class PullRequestsLoading extends React.Component<{}, {}> {
+export class PullRequestsLoading extends React.PureComponent<
   public render() {
     return (
       <FilterList<IFilterListItem>

--- a/app/src/ui/branches/pull-requests-loading.tsx
+++ b/app/src/ui/branches/pull-requests-loading.tsx
@@ -40,8 +40,16 @@ const groups = [
   },
 ]
 
+interface IPullRequestLoadingProps {
+  /** Called to render content after the filter. */
+  readonly renderPostFilter?: () => JSX.Element | null
+}
+
 /** The placeholder for when pull requests are still loading. */
 export class PullRequestsLoading extends React.PureComponent<
+  IPullRequestLoadingProps,
+  {}
+> {
   public render() {
     return (
       <FilterList<IFilterListItem>
@@ -52,6 +60,7 @@ export class PullRequestsLoading extends React.PureComponent<
         renderItem={this.renderItem}
         invalidationProps={groups}
         disabled={true}
+        renderPostFilter={this.props.renderPostFilter}
       />
     )
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1547,4 +1547,11 @@ export class Dispatcher {
   public recordRebaseConflictsDialogReopened() {
     this.statsStore.recordRebaseConflictsDialogReopened()
   }
+
+  /**
+   * Refresh the list of open pull requests for the given repository.
+   */
+  public refreshPullRequests(repository: Repository): Promise<void> {
+    return this.appStore._refreshPullRequests(repository)
+  }
 }

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -78,10 +78,10 @@
   height: 100%;
   width: 100%;
 
-  .filter-list-filter-field {
+  &.filter-list .filter-field-row {
     // The rows have built-in margin to their content so
     // we only need half a spacer here
-    padding-bottom: var(--spacing-half);
+    margin-bottom: var(--spacing-half);
   }
 
   .list-item.selected:focus {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

References: #6982 

## Description

This is the first in a series of PRs to address how the app retrieves, stores, and presents pull requests. This change adds an explicit refresh button for the PR list in a similar manner to what we have for repositories in the clone dialog. Prior to this change the only way to explicitly refresh the list of pull requests was by clicking on the fetch button in the toolbar which was undiscoverable and to make matters worse the fetch button is unavailable when on an unpublished branch making it impossible to refresh the list on-demand.

This PR also alters the behavior of the PR list such that we no longer replace the list with a skeleton loading view whenever the PR list is loading. The skeleton loading view made it impossible to check out a PR while we were refreshing. Instead we now only show that view when we're doing the initial load (or when the previous load didn't return any PRs) or in other words we only show it when we don't already have any PRs to show in the list.

Here's a before and after comparison.

### Before

![pre-loading](https://user-images.githubusercontent.com/634063/53966074-b980cc80-40f2-11e9-8d9e-334bd17d0379.gif)

### After

![post-loading](https://user-images.githubusercontent.com/634063/53966085-bf76ad80-40f2-11e9-839b-6e4f2416daa5.gif)

The keen observer will note that it takes a very long time to refresh the list of PRs. This is due to the fact that we're fetching the latest PR status (i.e. CI status) for each PR before we return the new list. This is something I'm planning on decoupling in another PR very soon. 

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: