### PR TITLE
feat: Add visual feedback on Remove and Discard changes dialogs

### DIFF
--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -84,7 +84,9 @@ export class DiscardChanges extends React.Component<
 
         <DialogFooter>
           <ButtonGroup destructive={true}>
-            <Button type="submit">Cancel</Button>
+            <Button disabled={this.state.isDiscardingChanges} type="submit">
+              Cancel
+            </Button>
             <Button
               onClick={this.discard}
               disabled={this.state.isDiscardingChanges}

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -60,6 +60,7 @@ export class DiscardChanges extends React.Component<
 
   public render() {
     const discardingAllChanges = this.props.discardingAllChanges
+    const isDiscardingChanges = this.state.isDiscardingChanges
 
     return (
       <Dialog
@@ -70,7 +71,8 @@ export class DiscardChanges extends React.Component<
             : toPlatformCase('Confirm Discard Changes')
         }
         onDismissed={this.props.onDismissed}
-        loading={this.state.isDiscardingChanges}
+        dismissable={isDiscardingChanges ? false : true}
+        loading={isDiscardingChanges}
         type="warning"
       >
         <DialogContent>
@@ -84,13 +86,10 @@ export class DiscardChanges extends React.Component<
 
         <DialogFooter>
           <ButtonGroup destructive={true}>
-            <Button disabled={this.state.isDiscardingChanges} type="submit">
+            <Button disabled={isDiscardingChanges} type="submit">
               Cancel
             </Button>
-            <Button
-              onClick={this.discard}
-              disabled={this.state.isDiscardingChanges}
-            >
+            <Button onClick={this.discard} disabled={isDiscardingChanges}>
               {discardingAllChanges
                 ? toPlatformCase('Discard All Changes')
                 : toPlatformCase('Discard Changes')}

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -70,6 +70,7 @@ export class DiscardChanges extends React.Component<
             : toPlatformCase('Confirm Discard Changes')
         }
         onDismissed={this.props.onDismissed}
+        loading={this.state.isDiscardingChanges}
         type="warning"
       >
         <DialogContent>
@@ -84,7 +85,10 @@ export class DiscardChanges extends React.Component<
         <DialogFooter>
           <ButtonGroup destructive={true}>
             <Button type="submit">Cancel</Button>
-            <Button onClick={this.discard}>
+            <Button
+              onClick={this.discard}
+              disabled={this.state.isDiscardingChanges}
+            >
               {discardingAllChanges
                 ? toPlatformCase('Discard All Changes')
                 : toPlatformCase('Discard Changes')}

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -55,13 +55,16 @@ export class ConfirmRemoveRepository extends React.Component<
   }
 
   public render() {
+    const isRemovingRepository = this.state.isRemovingRepository
+
     return (
       <Dialog
         id="confirm-remove-repository"
         key="remove-repository-confirmation"
         type="warning"
         title={__DARWIN__ ? 'Remove Repository' : 'Remove repository'}
-        loading={this.state.isRemovingRepository}
+        dismissable={isRemovingRepository ? false : true}
+        loading={isRemovingRepository}
         onDismissed={this.cancel}
         onSubmit={this.cancel}
       >
@@ -91,13 +94,10 @@ export class ConfirmRemoveRepository extends React.Component<
         </DialogContent>
         <DialogFooter>
           <ButtonGroup destructive={true}>
-            <Button disabled={this.state.isRemovingRepository} type="submit">
+            <Button disabled={isRemovingRepository} type="submit">
               Cancel
             </Button>
-            <Button
-              onClick={this.onConfirmed}
-              disabled={this.state.isRemovingRepository}
-            >
+            <Button onClick={this.onConfirmed} disabled={isRemovingRepository}>
               Remove
             </Button>
           </ButtonGroup>

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -23,6 +23,7 @@ interface IConfirmRemoveRepositoryProps {
 
 interface IConfirmRemoveRepositoryState {
   readonly deleteRepoFromDisk: boolean
+  readonly isRemovingRepository: boolean
 }
 
 export class ConfirmRemoveRepository extends React.Component<
@@ -34,6 +35,7 @@ export class ConfirmRemoveRepository extends React.Component<
 
     this.state = {
       deleteRepoFromDisk: false,
+      isRemovingRepository: false,
     }
   }
 
@@ -42,6 +44,8 @@ export class ConfirmRemoveRepository extends React.Component<
   }
 
   private onConfirmed = () => {
+    this.setState({ isRemovingRepository: true })
+
     this.props.onConfirmation(
       this.props.repository,
       this.state.deleteRepoFromDisk
@@ -57,6 +61,7 @@ export class ConfirmRemoveRepository extends React.Component<
         key="remove-repository-confirmation"
         type="warning"
         title={__DARWIN__ ? 'Remove Repository' : 'Remove repository'}
+        loading={this.state.isRemovingRepository}
         onDismissed={this.cancel}
         onSubmit={this.cancel}
       >
@@ -87,7 +92,12 @@ export class ConfirmRemoveRepository extends React.Component<
         <DialogFooter>
           <ButtonGroup destructive={true}>
             <Button type="submit">Cancel</Button>
-            <Button onClick={this.onConfirmed}>Remove</Button>
+            <Button
+              onClick={this.onConfirmed}
+              disabled={this.state.isRemovingRepository}
+            >
+              Remove
+            </Button>
           </ButtonGroup>
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -91,7 +91,9 @@ export class ConfirmRemoveRepository extends React.Component<
         </DialogContent>
         <DialogFooter>
           <ButtonGroup destructive={true}>
-            <Button type="submit">Cancel</Button>
+            <Button disabled={this.state.isRemovingRepository} type="submit">
+              Cancel
+            </Button>
             <Button
               onClick={this.onConfirmed}
               disabled={this.state.isRemovingRepository}


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #7015**

## Description

- Added spinners and disables button when "Remove Repository" and "Discard changes" dialogs have a action.

Discarding: 
![discarding](https://user-images.githubusercontent.com/24681191/53982065-9cf98a00-411c-11e9-93bb-565dc13fd293.gif)

Removing:
![removing repo](https://user-images.githubusercontent.com/24681191/53982087-ac78d300-411c-11e9-9e16-c81f49b29a86.gif)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: `[Improved?] "Remove" and "Discard changes" dialogs show visual effects on action`
