### PR TITLE
Add function to apply an arbitrary stash entry

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -1,3 +1,6 @@
+import { git } from './core'
+import { Repository } from '../../models/repository'
+
 export interface IStashEntry {
   /** The name of the branch at the time the entry was created. */
   readonly branchName: string
@@ -13,4 +16,16 @@ export interface IStashEntry {
  * `git log -g refs/stash --pretty="%nentry: %gd%nsubject: %gs%nhash: %H%n"`
  * in a repo with some stash entries.
  */
-export async function applyStashEntry(stashSha: string): Promise<void> {}
+export async function applyStashEntry(
+  repository: Repository,
+  stashSha: string
+): Promise<void> {
+  const result = await git(
+    ['stash', 'apply', `${stashSha}`],
+    repository.path,
+    'applyStashEntry',
+    {
+      successExitCodes: new Set([0, 1, 128]),
+    }
+  )
+}

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -5,3 +5,12 @@ export interface IStashEntry {
   /** The SHA of the commit object created as a result of stashing. */
   readonly stashSha: string
 }
+
+/**
+ * Applies the stash entry identified by matching `stashSha` to its commit hash.
+ *
+ * To see the commit hash of stash entry, run
+ * `git log -g refs/stash --pretty="%nentry: %gd%nsubject: %gs%nhash: %H%n"`
+ * in a repo with some stash entries.
+ */
+export async function applyStashEntry(stashSha: string): Promise<void> {}


### PR DESCRIPTION
See tracking issue - #6987

Desktop has to handle the stash entries list being changed externally, so we can't depend on 
* `git stash pop` - it's not guaranteed our entry will be at the top of the stack
*  the entry's name (e.g. `sha@{0}`) - the stash entry they point to can change
Using the the commit hash of the stash entry appears to be the best way to **uniquely id** an entry.

This PR adds a function that can apply an arbitrary stash entry using its commit hash.