### PR TITLE
test and refactor current push/pull button behaviour

### DIFF
--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react'
-import { ToolbarButton, ToolbarButtonStyle } from './button'
+
 import { Progress } from '../../models/progress'
-import { Dispatcher } from '../dispatcher'
-import { Octicon, OcticonSymbol } from '../octicons'
 import { Repository } from '../../models/repository'
 import { IAheadBehind } from '../../models/branch'
 import { TipState } from '../../models/tip'
-import { RelativeTime } from '../relative-time'
 import { FetchType } from '../../models/fetch'
+
 import { enablePullWithRebase } from '../../lib/feature-flag'
+
+import { Dispatcher } from '../dispatcher'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { RelativeTime } from '../relative-time'
+
+import { ToolbarButton, ToolbarButtonStyle } from './button'
 
 interface IPushPullButtonProps {
   /**
@@ -52,6 +56,189 @@ interface IPushPullButtonProps {
   readonly branchWasRebased: boolean
 }
 
+function renderAheadBehind(aheadBehind: IAheadBehind) {
+  const { ahead, behind } = aheadBehind
+  if (ahead === 0 && behind === 0) {
+    return null
+  }
+
+  const content = new Array<JSX.Element>()
+  if (ahead > 0) {
+    content.push(
+      <span key="ahead">
+        {ahead}
+        <Octicon symbol={OcticonSymbol.arrowSmallUp} />
+      </span>
+    )
+  }
+
+  if (behind > 0) {
+    content.push(
+      <span key="behind">
+        {behind}
+        <Octicon symbol={OcticonSymbol.arrowSmallDown} />
+      </span>
+    )
+  }
+
+  return <div className="ahead-behind">{content}</div>
+}
+
+function renderLastFetched(lastFetched: Date | null): JSX.Element | string {
+  if (lastFetched) {
+    return (
+      <span>
+        Last fetched <RelativeTime date={lastFetched} />
+      </span>
+    )
+  } else {
+    return 'Never fetched'
+  }
+}
+
+/** The common props for all button states */
+const defaultProps = {
+  className: 'push-pull-button',
+  style: ToolbarButtonStyle.Subtitle,
+}
+
+function progressButton(progress: Progress, networkActionInProgress: boolean) {
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title={progress.title}
+      description={progress.description || 'Hang on…'}
+      progressValue={progress.value}
+      icon={OcticonSymbol.sync}
+      iconClassName={networkActionInProgress ? 'spin' : ''}
+      tooltip={progress.description}
+      disabled={true}
+    />
+  )
+}
+
+function publishRepositoryButton(onClick: () => void) {
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title="Publish repository"
+      description="Publish this repository to GitHub"
+      className="push-pull-button"
+      icon={OcticonSymbol.cloudUpload}
+      style={ToolbarButtonStyle.Subtitle}
+      onClick={onClick}
+    />
+  )
+}
+
+function unbornRepositoryButton() {
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title="Publish branch"
+      description="Cannot publish unborn HEAD"
+      icon={OcticonSymbol.cloudUpload}
+      disabled={true}
+    />
+  )
+}
+
+function detachedHeadButton(rebaseInProgress: boolean) {
+  const description = rebaseInProgress
+    ? 'Rebase in progress'
+    : 'Cannot publish detached HEAD'
+
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title="Publish branch"
+      description={description}
+      icon={OcticonSymbol.cloudUpload}
+      disabled={true}
+    />
+  )
+}
+
+function publishBranchButton(isGitHub: boolean, onClick: () => void) {
+  const description = isGitHub
+    ? 'Publish this branch to GitHub'
+    : 'Publish this branch to the remote'
+
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title="Publish branch"
+      description={description}
+      icon={OcticonSymbol.cloudUpload}
+      onClick={onClick}
+    />
+  )
+}
+
+function fetchButton(
+  remoteName: string,
+  aheadBehind: IAheadBehind,
+  lastFetched: Date | null,
+  onClick: () => void
+) {
+  const title = `Fetch ${remoteName}`
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title={title}
+      description={renderLastFetched(lastFetched)}
+      icon={OcticonSymbol.sync}
+      onClick={onClick}
+    >
+      {renderAheadBehind(aheadBehind)}
+    </ToolbarButton>
+  )
+}
+
+function pullButton(
+  remoteName: string,
+  aheadBehind: IAheadBehind,
+  lastFetched: Date | null,
+  pullWithRebase: boolean,
+  onClick: () => void
+) {
+  const title =
+    pullWithRebase && enablePullWithRebase()
+      ? `Pull ${remoteName} with rebase`
+      : `Pull ${remoteName}`
+
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title={title}
+      description={renderLastFetched(lastFetched)}
+      icon={OcticonSymbol.arrowDown}
+      onClick={onClick}
+    >
+      {renderAheadBehind(aheadBehind)}
+    </ToolbarButton>
+  )
+}
+
+function pushButton(
+  remoteName: string,
+  aheadBehind: IAheadBehind,
+  lastFetched: Date | null,
+  onClick: () => void
+) {
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title={`Push ${remoteName}`}
+      description={renderLastFetched(lastFetched)}
+      icon={OcticonSymbol.arrowUp}
+      onClick={onClick}
+    >
+      {renderAheadBehind(aheadBehind)}
+    </ToolbarButton>
+  )
+}
+
 /**
  * This represents the "double arrow" icon used to show a force-push, and is a
  * less complicated icon than the generated Octicon from the `octicons` package.
@@ -62,30 +249,23 @@ const forcePushIcon = new OcticonSymbol(
   'M3 11H0l5-6 5 6H7v4H3v-4zM5 1l5 6H8.33L5 3 1.662 7H0l5-6z'
 )
 
-function getActionLabel(
-  aheadBehind: IAheadBehind,
+function forcePushButton(
   remoteName: string,
-  branchWasRebased: boolean,
-  pullWithRebase?: boolean
+  aheadBehind: IAheadBehind,
+  lastFetched: Date | null,
+  onClick: () => void
 ) {
-  if (isBranchRebased(branchWasRebased, aheadBehind)) {
-    return `Force push ${remoteName}`
-  }
-
-  const { ahead, behind } = aheadBehind
-  if (behind > 0) {
-    return pullWithRebase && enablePullWithRebase()
-      ? `Pull ${remoteName} with rebase`
-      : `Pull ${remoteName}`
-  }
-  if (ahead > 0) {
-    return `Push ${remoteName}`
-  }
-  return `Fetch ${remoteName}`
-}
-
-function isBranchRebased(branchWasRebased: boolean, aheadBehind: IAheadBehind) {
-  return branchWasRebased && aheadBehind.behind > 0 && aheadBehind.ahead > 0
+  return (
+    <ToolbarButton
+      {...defaultProps}
+      title={`Force push ${remoteName}`}
+      description={renderLastFetched(lastFetched)}
+      icon={forcePushIcon}
+      onClick={onClick}
+    >
+      {renderAheadBehind(aheadBehind)}
+    </ToolbarButton>
+  )
 }
 
 /**
@@ -93,180 +273,85 @@ function isBranchRebased(branchWasRebased: boolean, aheadBehind: IAheadBehind) {
  * repository.
  */
 export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
+  private push = () => {
+    this.props.dispatcher.push(this.props.repository)
+  }
+
+  private forcePushWithLease = () => {
+    this.props.dispatcher.confirmOrForcePush(this.props.repository)
+  }
+
+  private pull = () => {
+    this.props.dispatcher.pull(this.props.repository)
+  }
+
+  private fetch = () => {
+    this.props.dispatcher.fetch(
+      this.props.repository,
+      FetchType.UserInitiatedTask
+    )
+  }
+
   public render() {
-    const progress = this.props.progress
+    const {
+      progress,
+      networkActionInProgress,
+      aheadBehind,
+      remoteName,
+      repository,
+      tipState,
+      rebaseInProgress,
+      lastFetched,
+      pullWithRebase,
+      branchWasRebased,
+    } = this.props
 
-    const title = progress ? progress.title : this.getTitle()
-
-    const description = progress
-      ? progress.description || 'Hang on…'
-      : this.getDescription(this.props.tipState)
-
-    const progressValue = progress ? progress.value : undefined
-
-    const networkActive =
-      this.props.networkActionInProgress || !!this.props.progress
-
-    // if we have a remote associated with this repository, we should enable this branch
-    // when the tip is valid (no detached HEAD, no unborn repository)
-    //
-    // otherwise we consider the repository unpublished, and they should be able to
-    // open the publish dialog - we'll handle publishing the current branch afterwards
-    // if it exists
-    const validState = this.props.remoteName
-      ? this.props.tipState === TipState.Valid
-      : true
-
-    const disabled = !validState || networkActive
-
-    return (
-      <ToolbarButton
-        title={title}
-        description={description}
-        progressValue={progressValue}
-        className="push-pull-button"
-        icon={this.getIcon()}
-        iconClassName={this.props.networkActionInProgress ? 'spin' : ''}
-        style={ToolbarButtonStyle.Subtitle}
-        onClick={this.performAction}
-        tooltip={progress ? progress.description : undefined}
-        disabled={disabled}
-      >
-        {this.renderAheadBehind()}
-      </ToolbarButton>
-    )
-  }
-
-  private renderAheadBehind() {
-    if (!this.props.aheadBehind || this.props.progress) {
-      return null
+    if (progress !== null) {
+      return progressButton(progress, networkActionInProgress)
     }
 
-    const { ahead, behind } = this.props.aheadBehind
-    if (ahead === 0 && behind === 0) {
-      return null
-    }
-
-    const content: JSX.Element[] = []
-    if (ahead > 0) {
-      content.push(
-        <span key="ahead">
-          {ahead}
-          <Octicon symbol={OcticonSymbol.arrowSmallUp} />
-        </span>
-      )
-    }
-
-    if (behind > 0) {
-      content.push(
-        <span key="behind">
-          {behind}
-          <Octicon symbol={OcticonSymbol.arrowSmallDown} />
-        </span>
-      )
-    }
-
-    return <div className="ahead-behind">{content}</div>
-  }
-
-  private getTitle(): string {
-    if (!this.props.remoteName) {
-      return 'Publish repository'
-    }
-    if (!this.props.aheadBehind) {
-      return 'Publish branch'
-    }
-
-    return getActionLabel(
-      this.props.aheadBehind,
-      this.props.remoteName,
-      this.props.branchWasRebased,
-      this.props.pullWithRebase
-    )
-  }
-
-  private getIcon(): OcticonSymbol {
-    if (this.props.networkActionInProgress) {
-      return OcticonSymbol.sync
-    }
-
-    if (!this.props.remoteName) {
-      return OcticonSymbol.cloudUpload
-    }
-    if (!this.props.aheadBehind) {
-      return OcticonSymbol.cloudUpload
-    }
-
-    const { ahead, behind } = this.props.aheadBehind
-    if (this.props.networkActionInProgress) {
-      return OcticonSymbol.sync
-    }
-
-    if (this.props.branchWasRebased) {
-      return forcePushIcon
-    }
-
-    if (behind > 0) {
-      return OcticonSymbol.arrowDown
-    }
-    if (ahead > 0) {
-      return OcticonSymbol.arrowUp
-    }
-    return OcticonSymbol.sync
-  }
-
-  private getDescription(tipState: TipState): JSX.Element | string {
-    if (!this.props.remoteName) {
-      return 'Publish this repository to GitHub'
-    }
-
-    if (tipState === TipState.Detached) {
-      return this.props.rebaseInProgress
-        ? 'Rebase in progress'
-        : 'Cannot publish detached HEAD'
+    if (remoteName === null) {
+      return publishRepositoryButton(this.push)
     }
 
     if (tipState === TipState.Unborn) {
-      return 'Cannot publish unborn HEAD'
+      return unbornRepositoryButton()
     }
 
-    if (!this.props.aheadBehind) {
-      const isGitHub = !!this.props.repository.gitHubRepository
-      return isGitHub
-        ? 'Publish this branch to GitHub'
-        : 'Publish this branch to the remote'
+    if (tipState === TipState.Detached) {
+      return detachedHeadButton(rebaseInProgress)
     }
 
-    const lastFetched = this.props.lastFetched
-    if (lastFetched) {
-      return (
-        <span>
-          Last fetched <RelativeTime date={lastFetched} />
-        </span>
-      )
-    } else {
-      return 'Never fetched'
-    }
-  }
-
-  private performAction = () => {
-    const { repository, dispatcher, aheadBehind, branchWasRebased } = this.props
-
-    if (!aheadBehind) {
-      dispatcher.push(repository)
-      return
+    if (aheadBehind === null) {
+      const isGitHubRepository = repository.gitHubRepository !== null
+      return publishBranchButton(isGitHubRepository, this.push)
     }
 
     const { ahead, behind } = aheadBehind
 
-    if (isBranchRebased(branchWasRebased, aheadBehind)) {
-      dispatcher.confirmOrForcePush(repository)
-    } else if (behind > 0) {
-      dispatcher.pull(repository)
-    } else if (ahead > 0) {
-      dispatcher.push(repository)
-    } else {
-      dispatcher.fetch(repository, FetchType.UserInitiatedTask)
+    if (ahead === 0 && behind === 0) {
+      return fetchButton(remoteName, aheadBehind, lastFetched, this.fetch)
     }
+
+    if (branchWasRebased && behind > 0 && ahead > 0) {
+      return forcePushButton(
+        remoteName,
+        aheadBehind,
+        lastFetched,
+        this.forcePushWithLease
+      )
+    }
+
+    if (behind > 0) {
+      return pullButton(
+        remoteName,
+        aheadBehind,
+        lastFetched,
+        pullWithRebase || false,
+        this.pull
+      )
+    }
+
+    return pushButton(remoteName, aheadBehind, lastFetched, this.push)
   }
 }


### PR DESCRIPTION
## Overview

**Closes #6985**

## Description

- [x] add component testing to `yarn test` step
- [x] setup test suite for `PushPullButton` to cover majority of output cases
- [x] rewrite `PushPullButton.render` to be more maintainable
- [x] rebase changes on top of #6981 once merged
- [x] add more tests to cover force push scenario
- [x] extract component tests out of this branch
- [x] write up some notes about the experience of doing this component testing

## Notes

Diff details aside, the size of the component in the production bundle increased 18% (from 3048 characters to 3615 characters, so still less than 4KB) for the component, which is mostly because we no longer have a central `React.createElement` inside `render()`.

You can see the human-readable before-vs-after (with whitespace and indenting) output in this gist: https://gist.github.com/shiftkey/a3b4ddb7c7e3537e28127279cd5969c7

## Release notes

Notes: no-notes
