### PR TITLE
feat: add context menu for highlighted text in diff view

### DIFF
--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -60,6 +60,11 @@ interface ICodeMirrorHostProps {
   readonly onAfterSwapDoc?: (cm: Editor, oldDoc: Doc, newDoc: Doc) => void
 
   /**
+   * Called when user want to open context menu.
+   */
+  readonly onContextMenu?: (cm: Editor, event: Event) => void
+
+  /**
    * Called when content has been copied. The default behavior may be prevented
    * by calling `preventDefault` on the event.
    */
@@ -158,6 +163,7 @@ export class CodeMirrorHost extends React.Component<ICodeMirrorHostProps, {}> {
     this.codeMirror.on('viewportChange', this.onViewportChange)
     this.codeMirror.on('beforeSelectionChange', this.beforeSelectionChanged)
     this.codeMirror.on('copy', this.onCopy)
+    this.codeMirror.on('contextmenu', this.onContextMenu)
     this.codeMirror.on('swapDoc', this.onSwapDoc as any)
 
     CodeMirrorHost.updateDoc(this.codeMirror, this.props.value)
@@ -167,6 +173,12 @@ export class CodeMirrorHost extends React.Component<ICodeMirrorHostProps, {}> {
   private onSwapDoc = (cm: Editor, oldDoc: Doc) => {
     if (this.props.onSwapDoc) {
       this.props.onSwapDoc(cm, oldDoc)
+    }
+  }
+
+  private onContextMenu = (instance: Editor, event: Event) => {
+    if (this.props.onContextMenu) {
+      this.props.onContextMenu(instance, event)
     }
   }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -36,6 +36,7 @@ import { structuralEquals } from '../../lib/equality'
 import { assertNever } from '../../lib/fatal-error'
 import { clamp } from '../../lib/clamp'
 import { uuid } from '../../lib/uuid'
+import { showContextualMenu } from '../main-process-proxy'
 
 /** The longest line for which we'd try to calculate a line diff. */
 const MaxIntraLineDiffStringLength = 4096
@@ -469,6 +470,27 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
     this.codeMirror = cmh === null ? null : cmh.getEditor()
   }
 
+  private onContextMenu = (instance: CodeMirror.Editor, event: Event) => {
+    const selectionRanges = instance.getDoc().listSelections()
+    const isTextSelected = selectionRanges != null
+
+    const action = () => {
+      if (this.onCopy !== null) {
+        this.onCopy(instance, event)
+      }
+    }
+
+    const items = [
+      {
+        label: 'Copy',
+        action,
+        enabled: this.onCopy && isTextSelected,
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
   private onCopy = (editor: Editor, event: Event) => {
     event.preventDefault()
 
@@ -867,6 +889,7 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
         onAfterSwapDoc={this.onAfterSwapDoc}
         onViewportChange={this.onViewportChange}
         ref={this.getAndStoreCodeMirrorInstance}
+        onContextMenu={this.onContextMenu}
         onCopy={this.onCopy}
       />
     )


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #5100**

## Description

- Added context menu for selected text in the diff with copy action.

![copy-work-please](https://user-images.githubusercontent.com/24681191/54087228-74aa9f00-4359-11e9-84e0-556ca3d44f9e.gif)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: `[Improved?] Context menu for selected text in diff view`
