### PR TITLE
Prevent feedback loop toggling repository missing flag

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2053,7 +2053,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const foundRepository =
       (await pathExists(repository.path)) &&
-      (await isGitRepository(repository.path))
+      (await isGitRepository(repository.path)) &&
+      (await this._loadStatus(repository))
 
     if (foundRepository) {
       return await this._updateRepositoryMissing(repository, false)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2056,7 +2056,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       (await isGitRepository(repository.path))
 
     if (foundRepository) {
-      this._updateRepositoryMissing(repository, false)
+      return await this._updateRepositoryMissing(repository, false)
     }
     return repository
   }


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

References: https://github.com/desktop/desktop/issues/7038 but we suspect the actual problem is with the bumped version of Git and this is merely a side effect of `git status` failing.

## Description

The flickering feedback loop happens because when `git status` fails in `refreshRepository` we update the missing flag which causes the repositories store to emit an update. That gets caught by the `repositoriesStore.onDidUpdate` callback in appStore which calls `updateRepositorySelectionAfterRepositoriesChanged` which concludes that the selection has changed as its mechanism for determining that is by comparing the `repository#hash` property for the previously selected repository and the new instance (all fine thus far) which then causes it to call `selectRepository` which calls `recoverMissingRepository`.

`recoverMissingRepository` checks to see whether the path exists, and whether it can run `git rev-parse --show-cdup` inside of that repository directory. If it can, it flips the missing flag and calls refresh. Refresh also checks for the path to exist and calls `rev-parse` but after it's done that it calls `git status` and if *that fails* it flips the missing flag back to missing.

Heres a high level overview of the loop.

1. We refresh the repository and check that the repository path exists and run `git rev-parse --show-cdup`
2. We try to run `git status` which fails causing us to set the repository missing flag
3. The “auto recover mechanism” kicks in and tries to determine whether the repository exists or not by checking if the path exists and running `rev-parse --show-cdup`; concludes that it does exist and resets the missing flag
4. Back to 1

This "fixes" the problem by making sure that `recoverMissingRepository` also requires that `git status` succeeds. It's not an ideal solution but it plugs the hole.

### Reproduction techniques

The core of the issue is that the repository *must* exist and `git status` *must fail*. To reproduce this if you're a dev you can just short-circuit `getStatus` to always return null. Or you can sabotage an existing repository in such a way that `rev-parse` succeeds but `git status` fails. I did this by removing a submodule from my clone of the GitHub extension for Visual Studio.

```sh
Markuss-MacBook-Pro:visualstudio markus$ git status
fatal: not a git repository: script/../.git/modules/script
```

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: