### PR TITLE
Enterprise users should be able to publish to an organization

### DIFF
--- a/app/src/models/publish-settings.ts
+++ b/app/src/models/publish-settings.ts
@@ -20,6 +20,12 @@ export interface IEnterprisePublicationSettings {
 
   /** Should the repository be private? */
   readonly private: boolean
+
+  /**
+   * The org to which this repository belongs. If null, the repository should be
+   * published as a personal repository.
+   */
+  readonly org: IAPIUser | null
 }
 
 export interface IDotcomPublicationSettings {

--- a/app/src/models/publish-settings.ts
+++ b/app/src/models/publish-settings.ts
@@ -25,7 +25,7 @@ export interface IEnterprisePublicationSettings {
    * The org to which this repository belongs. If null, the repository should be
    * published as a personal repository.
    */
-  readonly org: IAPIUser | null
+  readonly org: IAPIOrganization | null
 }
 
 export interface IDotcomPublicationSettings {

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -9,11 +9,7 @@ import { merge } from '../../lib/merge'
 import { caseInsensitiveCompare } from '../../lib/compare'
 import { sanitizedRepositoryName } from '../add-repository/sanitized-repository-name'
 import { Octicon, OcticonSymbol } from '../octicons'
-import {
-  RepositoryPublicationSettings,
-  IDotcomPublicationSettings,
-  PublishSettingsType,
-} from '../../models/publish-settings'
+import { RepositoryPublicationSettings } from '../../models/publish-settings'
 
 interface IPublishRepositoryProps {
   /** The user to use for publishing. */
@@ -90,13 +86,10 @@ export class PublishRepository extends React.Component<
 
   private onOrgChange = (event: React.FormEvent<HTMLSelectElement>) => {
     const { settings } = this.props
-    if (settings.kind !== PublishSettingsType.dotcom) {
-      return
-    }
 
     const value = event.currentTarget.value
     const index = parseInt(value, 10)
-    let newSettings: IDotcomPublicationSettings
+    let newSettings: RepositoryPublicationSettings
     if (index < 0 || isNaN(index)) {
       newSettings = { ...settings, org: null }
     } else {
@@ -120,10 +113,8 @@ export class PublishRepository extends React.Component<
     )
 
     let selectedIndex = -1
-    const selectedOrg =
-      this.props.settings.kind === PublishSettingsType.dotcom
-        ? this.props.settings.org
-        : null
+
+    const selectedOrg = this.props.settings.org
     for (const [index, org] of this.state.orgs.entries()) {
       if (selectedOrg && selectedOrg.id === org.id) {
         selectedIndex = index

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -111,6 +111,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
       settings: {
         ...publicationSettings,
         kind: PublishSettingsType.enterprise,
+        org: null,
       },
       error: null,
     }


### PR DESCRIPTION
## Overview

**Closes #7052**

## Description

Publish repository shows the available organization for both GitHub and GitHub Enterprise accounts, but there were some subtle changes in #6776 that were also introduced:

 - `renderOrgs` did not render the selected organization if you were on a GitHub Enterprise account - 6eb0a58799d14f0e1d025c67fbccf979c72f1100
 - `onOrgChange` was skipped for an Enterprise account e0d85ddf90d557447514f64d50da06d32ccd95c3

I'm not sure where this requirement came from, but it means that Enterprise users aren't able to publish to an organization of their choosing from in the app. There's a workaround in https://github.com/desktop/desktop/issues/7052#issuecomment-472059849 but if we feel this is urgent enough we should co-ordinate a hotfix update later in the week.

If we agree with that approach, the first two commits should be cherry-picked on top of the release branch - 4eb56e4eb is a cleanup because of #6945.

## Release notes

Notes: `[Fixed] Publish Repository does not let you choose an organization on your Enterprise account`
