### PR TITLE
back out of dugite upgrade

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.85.0",
+    "dugite": "1.80.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -264,12 +264,6 @@ function getDescriptionForError(error: DugiteError): string {
       return 'A lock file already exists in the repository, which blocks this operation from completing.'
     case DugiteError.NoMergeToAbort:
       return 'There is no merge in progress, so there is nothing to abort.'
-    case DugiteError.NoExistingRemoteBranch:
-      return 'The remote branch does not exist.'
-    case DugiteError.LocalChangesOverwritten:
-      return 'Some of your changes would be overwritten.'
-    case DugiteError.UnresolvedConflicts:
-      return 'There are unresolved conflicts in the working directory.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -139,16 +139,22 @@ export enum RebaseResult {
   Aborted = 'Aborted',
 }
 
+// TODO: restore `expectedErrors` matching code
+
+const rebaseEncounteredConflictsRe = /Resolve all conflicts manually, mark them as resolved/
+
+const filesNotMergedRe = /You must edit all merge conflicts and then\nmark them as resolved/
+
 function parseRebaseResult(result: IGitResult): RebaseResult {
   if (result.exitCode === 0) {
     return RebaseResult.CompletedWithoutError
   }
 
-  if (result.gitError === GitError.RebaseConflicts) {
+  if (rebaseEncounteredConflictsRe.test(result.stdout)) {
     return RebaseResult.ConflictsEncountered
   }
 
-  if (result.gitError === GitError.UnresolvedConflicts) {
+  if (filesNotMergedRe.test(result.stdout)) {
     return RebaseResult.OutstandingFilesNotStaged
   }
 
@@ -214,10 +220,8 @@ export async function continueRebase(
       repository.path,
       'continueRebaseSkipCurrentCommit',
       {
-        expectedErrors: new Set([
-          GitError.RebaseConflicts,
-          GitError.UnresolvedConflicts,
-        ]),
+        // TODO: restore `expectedErrors` lookup code
+        successExitCodes: new Set([0, 1, 128]),
       }
     )
 
@@ -229,10 +233,8 @@ export async function continueRebase(
     repository.path,
     'continueRebase',
     {
-      expectedErrors: new Set([
-        GitError.RebaseConflicts,
-        GitError.UnresolvedConflicts,
-      ]),
+      // TODO: restore `expectedErrors` lookup code
+      successExitCodes: new Set([0, 1, 128]),
     }
   )
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -402,14 +402,14 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.85.0:
-  version "1.85.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.85.0.tgz#05cff1f0d4952cf32d1d6a30f4f380811e4583f5"
-  integrity sha512-33YIKzzuSIoB8cRDrIPozvvIJiPs4+XQJGcb9g48O99Q0GkPb1ipy3YjknJTTU0TwTB+NyGjA6m1jBRoR3XvuQ==
+dugite@1.80.0:
+  version "1.80.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.80.0.tgz#69987fd54d8afd8d56b2e0f4fe43f2db1b49d800"
+  integrity sha512-ELavYXdThykKFffPG0w4NdfWYr5FfwKOP4lmLpnripbuJOE8DTTvgEJigG4dC2Vkpe5lavWX2Oia9qQoEyMzeQ==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"
-    progress "^2.0.3"
+    progress "^2.0.0"
     request "^2.88.0"
     rimraf "^2.5.4"
     tar "^4.4.7"
@@ -1186,7 +1186,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-progress@^2.0.3:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==


### PR DESCRIPTION
## Overview

We rolled back to an old version of `dugite` in #7063 but `development` currently has a later version which supports new error codes. While we figure out how to balance upgrading Git with supporting building features for Desktop (more details on this soon) I wanted to ensure we're on a known good version of `dugite` rather than testing with a known problem version of Git.

## Release notes

Notes: no-notes
