### PR TITLE
bugfix: always pass in the configured org

### DIFF
--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -289,8 +289,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
     }
 
     const settings = currentTabState.settings
-    const org =
-      currentTabState.kind === 'dotcom' ? currentTabState.settings.org : null
+    const { org } = currentTabState.settings
 
     try {
       await this.props.dispatcher.publishRepository(


### PR DESCRIPTION
## Overview

This PR ensures the chosen organization is used when publishing using the GitHub API.

Related to #7082 and #7052


## Release notes

Notes: no-notes
