### PR TITLE
propagate progress when performing a rebase

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -15,8 +15,7 @@ import { stageManualConflictResolution } from './stage'
 import { stageFiles } from './update-index'
 
 import { getStatus } from './status'
-import { RebaseContext } from '../../models/rebase'
-import { IRebaseProgress } from '../../models/progress'
+import { RebaseContext, RebaseProgressOptions } from '../../models/rebase'
 import { IGitProgress, IGitOutput, IGitProgressParser } from '../progress'
 import { merge } from '../merge'
 
@@ -137,18 +136,6 @@ function createStdoutProgressProcessCallback(
       progressCallback(parser.parse(line))
     })
   }
-}
-
-/**
- * Options to pass in to rebase progress reporting
- */
-export type RebaseProgressOptions = {
-  /** The number of commits already rebased as part of the operation */
-  start: number
-  /** The number of commits to be rebased as part of the operation */
-  total: number
-  /** The callback to fire when rebase progress is reported */
-  progressCallback: (progress: IRebaseProgress) => void
 }
 
 /**

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -104,7 +104,9 @@ class GitRebaseParser {
 
   public parse(line: string): IRebaseProgress | null {
     const match = rebaseApplyingRe.exec(line)
-    if (match == null || match.length != 2) {
+    if (match == null || match.length !== 2) {
+      // Git will sometimes emit other output (for example, when it tries to
+      // resolve conflicts) and this does not match the expected output
       return null
     }
 

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -138,6 +138,32 @@ function createStdoutProgressProcessCallback(
   }
 }
 
+function configureOptionsForRebase(
+  options: IGitExecutionOptions,
+  progress?: RebaseProgressOptions
+) {
+  if (!progress) {
+    return options
+  }
+
+  const { start, total, progressCallback } = progress
+
+  return merge(options, {
+    processCallback: createStdoutProgressProcessCallback(
+      new GitRebaseParser(start, total),
+      progress => {
+        const message =
+          progress.kind === 'progress' ? progress.details.text : progress.text
+
+        progressCallback({
+          message,
+          percent: progress.percent,
+        })
+      }
+    ),
+  })
+}
+
 /**
  * A stub function to use for initiating rebase in the app.
  *

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -87,6 +87,7 @@ export async function getRebaseContext(
   return null
 }
 
+/** Regex for identifying when rebase applied each commit onto the base branch */
 const rebaseApplyingRe = /^Applying: (.*)/
 
 /**

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -117,7 +117,9 @@ class GitRebaseParser {
 
     return {
       kind: 'rebase',
-      title: `Rebasing ${this.currentCommitCount} of ${this.totalCommitCount}`,
+      title: `Rebasing ${this.currentCommitCount} of ${
+        this.totalCommitCount
+      } commits`,
       value,
       commitSummary,
     }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -105,7 +105,7 @@ class GitRebaseParser {
 
   public parse(line: string): IRebaseProgress | null {
     const match = rebaseApplyingRe.exec(line)
-    if (match == null || match.length !== 2) {
+    if (match === null || match.length !== 2) {
       // Git will sometimes emit other output (for example, when it tries to
       // resolve conflicts) and this does not match the expected output
       return null
@@ -118,7 +118,7 @@ class GitRebaseParser {
 
     return {
       kind: 'rebase',
-      title: `Rebasing ${this.currentCommitCount} of ${
+      title: `Rebasing commit ${this.currentCommitCount} of ${
         this.totalCommitCount
       } commits`,
       value,
@@ -131,7 +131,7 @@ function configureOptionsForRebase(
   options: IGitExecutionOptions,
   progress?: RebaseProgressOptions
 ) {
-  if (!progress) {
+  if (progress === undefined) {
     return options
   }
 

--- a/app/src/lib/progress/from-process.ts
+++ b/app/src/lib/progress/from-process.ts
@@ -3,7 +3,7 @@ import * as Fs from 'fs'
 import * as Path from 'path'
 import * as byline from 'byline'
 
-import { IGitProgress, IGitOutput, IGitProgressParser } from './git'
+import { GitProgressParser, IGitProgress, IGitOutput } from './git'
 import { IGitExecutionOptions } from '../git/core'
 import { merge } from '../merge'
 import { GitLFSProgressParser, createLFSProgressFile } from './lfs'
@@ -18,7 +18,7 @@ import { tailByLine } from '../file-system'
  */
 export async function executionOptionsWithProgress(
   options: IGitExecutionOptions,
-  parser: IGitProgressParser,
+  parser: GitProgressParser,
   progressCallback: (progress: IGitProgress | IGitOutput) => void
 ): Promise<IGitExecutionOptions> {
   let lfsProgressPath = null
@@ -49,7 +49,7 @@ export async function executionOptionsWithProgress(
  * process and parsing its contents using the provided parser.
  */
 function createProgressProcessCallback(
-  parser: IGitProgressParser,
+  parser: GitProgressParser,
   lfsProgressPath: string | null,
   progressCallback: (progress: IGitProgress | IGitOutput) => void
 ): (process: ChildProcess) => void {

--- a/app/src/lib/progress/from-process.ts
+++ b/app/src/lib/progress/from-process.ts
@@ -3,7 +3,7 @@ import * as Fs from 'fs'
 import * as Path from 'path'
 import * as byline from 'byline'
 
-import { GitProgressParser, IGitProgress, IGitOutput } from './git'
+import { IGitProgress, IGitOutput, IGitProgressParser } from './git'
 import { IGitExecutionOptions } from '../git/core'
 import { merge } from '../merge'
 import { GitLFSProgressParser, createLFSProgressFile } from './lfs'
@@ -18,7 +18,7 @@ import { tailByLine } from '../file-system'
  */
 export async function executionOptionsWithProgress(
   options: IGitExecutionOptions,
-  parser: GitProgressParser,
+  parser: IGitProgressParser,
   progressCallback: (progress: IGitProgress | IGitOutput) => void
 ): Promise<IGitExecutionOptions> {
   let lfsProgressPath = null
@@ -49,7 +49,7 @@ export async function executionOptionsWithProgress(
  * process and parsing its contents using the provided parser.
  */
 function createProgressProcessCallback(
-  parser: GitProgressParser,
+  parser: IGitProgressParser,
   lfsProgressPath: string | null,
   progressCallback: (progress: IGitProgress | IGitOutput) => void
 ): (process: ChildProcess) => void {

--- a/app/src/lib/progress/git.ts
+++ b/app/src/lib/progress/git.ts
@@ -138,18 +138,6 @@ export interface IGitProgressInfo {
 }
 
 /**
- * Base interface for parsing progess reported from Git
- */
-export interface IGitProgressParser {
-  /**
-   * Parse the given line of output from Git, returns either an IGitProgress
-   * instance if the line could successfully be parsed as a Git progress
-   * event or a IGitOutput instance if the line couldn't be parsed.
-   */
-  parse: (line: string) => IGitProgress | IGitOutput
-}
-
-/**
  * A utility class for interpreting progress output from `git`
  * and turning that into a percentage value estimating the overall progress
  * of the an operation. An operation could be something like `git fetch`
@@ -159,7 +147,7 @@ export interface IGitProgressParser {
  * A parser cannot be reused, it's mean to parse a single stderr stream
  * for Git.
  */
-export class GitProgressParser implements IGitProgressParser {
+export class GitProgressParser {
   private readonly steps: ReadonlyArray<IProgressStep>
 
   /* The provided steps should always occur in order but some
@@ -197,6 +185,11 @@ export class GitProgressParser implements IGitProgressParser {
     }))
   }
 
+  /**
+   * Parse the given line of output from Git, returns either an `IGitProgress`
+   * instance if the line could successfully be parsed as a Git progress
+   * event or a `IGitOutput` instance if the line couldn't be parsed.
+   */
   public parse(line: string): IGitProgress | IGitOutput {
     const progress = parse(line)
 

--- a/app/src/lib/progress/git.ts
+++ b/app/src/lib/progress/git.ts
@@ -188,7 +188,9 @@ export class GitProgressParser {
   /**
    * Parse the given line of output from Git, returns either an `IGitProgress`
    * instance if the line could successfully be parsed as a Git progress
-   * event or a `IGitOutput` instance if the line couldn't be parsed.
+   * event whose title was registered with this parser or an `IGitOutput`
+   * instance if the line couldn't be parsed or if the title wasn't
+   * registered with the parser.
    */
   public parse(line: string): IGitProgress | IGitOutput {
     const progress = parse(line)

--- a/app/src/lib/progress/git.ts
+++ b/app/src/lib/progress/git.ts
@@ -138,6 +138,20 @@ export interface IGitProgressInfo {
 }
 
 /**
+ * Base interface for parsing progess reported from Git
+ */
+export interface IGitProgressParser {
+  /**
+   * Parse the given line of output from Git, returns either an IGitProgress
+   * instance if the line could successfully be parsed as a Git progress
+   * event whose title was registered with this parser or an IGitOutput
+   * instance if the line couldn't be parsed or if the title wasn't
+   * registered with the parser.
+   */
+  parse: (line: string) => IGitProgress | IGitOutput
+}
+
+/**
  * A utility class for interpreting progress output from `git`
  * and turning that into a percentage value estimating the overall progress
  * of the an operation. An operation could be something like `git fetch`
@@ -147,7 +161,7 @@ export interface IGitProgressInfo {
  * A parser cannot be reused, it's mean to parse a single stderr stream
  * for Git.
  */
-export class GitProgressParser {
+export class GitProgressParser implements IGitProgressParser {
   private readonly steps: ReadonlyArray<IProgressStep>
 
   /* The provided steps should always occur in order but some
@@ -185,13 +199,6 @@ export class GitProgressParser {
     }))
   }
 
-  /**
-   * Parse the given line of output from Git, returns either an IGitProgress
-   * instance if the line could successfully be parsed as a Git progress
-   * event whose title was registered with this parser or an IGitOutput
-   * instance if the line couldn't be parsed or if the title wasn't
-   * registered with the parser.
-   */
   public parse(line: string): IGitProgress | IGitOutput {
     const progress = parse(line)
 

--- a/app/src/lib/progress/git.ts
+++ b/app/src/lib/progress/git.ts
@@ -144,9 +144,7 @@ export interface IGitProgressParser {
   /**
    * Parse the given line of output from Git, returns either an IGitProgress
    * instance if the line could successfully be parsed as a Git progress
-   * event whose title was registered with this parser or an IGitOutput
-   * instance if the line couldn't be parsed or if the title wasn't
-   * registered with the parser.
+   * event or a IGitOutput instance if the line couldn't be parsed.
    */
   parse: (line: string) => IGitProgress | IGitOutput
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3395,11 +3395,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _continueRebase(
     repository: Repository,
-    workingDirectory: WorkingDirectoryStatus
+    workingDirectory: WorkingDirectoryStatus,
+    manualResolutions: ReadonlyMap<string, ManualConflictResolution>
   ) {
     const gitStore = this.gitStoreCache.get(repository)
     return await gitStore.performFailableOperation(() =>
-      continueRebase(repository, workingDirectory.files)
+      continueRebase(repository, workingDirectory.files, manualResolutions)
     )
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -139,7 +139,6 @@ import {
   continueRebase,
   rebase,
   PushOptions,
-  RebaseProgressOptions,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -196,6 +195,7 @@ import {
 import { BranchPruner } from './helpers/branch-pruner'
 import { enableBranchPruning, enablePullWithRebase } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
+import { RebaseProgressOptions } from '../../models/rebase'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -139,6 +139,7 @@ import {
   continueRebase,
   rebase,
   PushOptions,
+  RebaseProgressOptions,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -3374,11 +3375,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _rebase(
     repository: Repository,
     baseBranch: string,
-    targetBranch: string
+    targetBranch: string,
+    progress?: RebaseProgressOptions
   ) {
     const gitStore = this.gitStoreCache.get(repository)
     return await gitStore.performFailableOperation(() =>
-      rebase(repository, baseBranch, targetBranch)
+      rebase(repository, baseBranch, targetBranch, progress)
     )
   }
 

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -100,9 +100,10 @@ export interface IRevertProgress extends IProgress {
 }
 
 /** An object describing the progress of a rebase operation */
-export interface IRebaseProgress {
-  readonly message: string
-  readonly percent: number
+export interface IRebaseProgress extends IProgress {
+  readonly kind: 'rebase'
+  /** The summary of the commit applied to the base branch */
+  readonly commitSummary: string
 }
 
 export type Progress =
@@ -112,3 +113,4 @@ export type Progress =
   | IPullProgress
   | IPushProgress
   | IRevertProgress
+  | IRebaseProgress

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -99,6 +99,12 @@ export interface IRevertProgress extends IProgress {
   kind: 'revert'
 }
 
+/** An object describing the progress of a rebase operation */
+export interface IRebaseProgress {
+  readonly message: string
+  readonly percent: number
+}
+
 export type Progress =
   | IGenericProgress
   | ICheckoutProgress

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -1,5 +1,19 @@
+import { IRebaseProgress } from './progress'
+
 export type RebaseContext = {
   readonly targetBranch: string
   readonly baseBranchTip: string
   readonly originalBranchTip: string
+}
+
+/**
+ * Options to pass in to rebase progress reporting
+ */
+export type RebaseProgressOptions = {
+  /** The number of commits already rebased as part of the operation */
+  start: number
+  /** The number of commits to be rebased as part of the operation */
+  total: number
+  /** The callback to fire when rebase progress is reported */
+  progressCallback: (progress: IRebaseProgress) => void
 }

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -17,9 +17,12 @@ interface IContinueRebaseProps {
 
 export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
   private onSubmit = async () => {
+    const { manualResolutions } = this.props.rebaseConflictState
+
     await this.props.dispatcher.continueRebase(
       this.props.repository,
-      this.props.workingDirectory
+      this.props.workingDirectory,
+      manualResolutions
     )
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -19,12 +19,7 @@ import {
   setGenericPassword,
   setGenericUsername,
 } from '../../lib/generic-git-auth'
-import {
-  isGitRepository,
-  RebaseResult,
-  PushOptions,
-  RebaseProgressOptions,
-} from '../../lib/git'
+import { isGitRepository, RebaseResult, PushOptions } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
   rejectOAuthRequest,
@@ -70,6 +65,7 @@ import {
   WorkingDirectoryStatus,
 } from '../../models/status'
 import { TipState, IValidBranch } from '../../models/tip'
+import { RebaseProgressOptions } from '../../models/rebase'
 import { Banner, BannerType } from '../../models/banner'
 
 import { ApplicationTheme } from '../lib/application-theme'

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -19,7 +19,12 @@ import {
   setGenericPassword,
   setGenericUsername,
 } from '../../lib/generic-git-auth'
-import { isGitRepository, RebaseResult, PushOptions } from '../../lib/git'
+import {
+  isGitRepository,
+  RebaseResult,
+  PushOptions,
+  RebaseProgressOptions,
+} from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
   rejectOAuthRequest,
@@ -676,7 +681,8 @@ export class Dispatcher {
   public async rebase(
     repository: Repository,
     baseBranch: string,
-    targetBranch: string
+    targetBranch: string,
+    progress?: RebaseProgressOptions
   ) {
     const stateBefore = this.repositoryStateManager.get(repository)
 
@@ -691,7 +697,8 @@ export class Dispatcher {
     const result = await this.appStore._rebase(
       repository,
       baseBranch,
-      targetBranch
+      targetBranch,
+      progress
     )
 
     await this.appStore._loadStatus(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -730,7 +730,8 @@ export class Dispatcher {
 
   public async continueRebase(
     repository: Repository,
-    workingDirectory: WorkingDirectoryStatus
+    workingDirectory: WorkingDirectoryStatus,
+    manualResolutions: ReadonlyMap<string, ManualConflictResolution>
   ) {
     const stateBefore = this.repositoryStateManager.get(repository)
 
@@ -740,7 +741,8 @@ export class Dispatcher {
 
     const result = await this.appStore._continueRebase(
       repository,
-      workingDirectory
+      workingDirectory,
+      manualResolutions
     )
     await this.appStore._loadStatus(repository)
 

--- a/app/src/ui/rebase/rebase-conflicts-dialog.tsx
+++ b/app/src/ui/rebase/rebase-conflicts-dialog.tsx
@@ -66,7 +66,8 @@ export class RebaseConflictsDialog extends React.Component<
   private onSubmit = async () => {
     await this.props.dispatcher.continueRebase(
       this.props.repository,
-      this.props.workingDirectory
+      this.props.workingDirectory,
+      this.props.manualResolutions
     )
   }
 


### PR DESCRIPTION
## Overview

**Plumbing and internals related to #6962**

## Description

This PR adds the relevant Git plumbing to support propagating progress. This is living inside `rebase.ts` rather than `app/src/lib/progress` for a couple of reasons:

 - rebase progress is emitted by `stdout`, whereas typical Git progress is emitted by `stderr` (that's why i have a standalone `createStdoutProgressProcessCallback`)
 - rebase progress can start from 0% (when starting the rebase) or from some percent less than 100% (when continuing the rebase) - this is what I need to figure out next, but this PR adds support for the progress parser to know where it started from

**For the moment there's no callers that use this, but I have an upcoming PR next that builds upon this to implement #6962.**

There were also some related changes that I introduced that overlapped with these changes:

 - define a `IGitProgressParser` interface - my rebase parser doesn't need `steps`, `stepIndex` and `lastPercent`  that were part of `GitProgressParser`, and I believe those should be internal to the parser anyway 60fe84686737d3782d9bd69de1ee0ae0e755f1da
 - I updated some callers to `continueRebase` to ensure they were passing through the correct `manualResolutions` map 46a5ce85b769110d0db938625166ce7a3eb2314c

## Release notes

Notes: no-notes
