### PR TITLE
FRR and issue triage updates

### DIFF
--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -11,6 +11,7 @@ Each rotation is a week long. While first responder your primary duties are:
 
 1. Triage issues.
     * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
+    * At mention @desktop/support and add `support` label if the issue feels applicable to only the user reporting it, and isn't something more broadly relevant.
     * Ensure issues are labeled accurately.
     * Review issues labeled [`reviewer-needs-to-reproduce`](https://github.com/desktop/desktop/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Areviewer-needs-to-reproduce) and close any that have gone 2 weeks with no new activity after the last question by a reviewer.
     * Review issues labeled [`more-information-needed`](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and close any that have gone 7 days without an issue template being filled out. Otherwise, the `no-response` bot will close it after 2 weeks.

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -17,7 +17,6 @@ Each rotation is a week long. While first responder your primary duties are:
     * Review issues labeled [`more-information-needed`](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and close any that have gone 7 days without an issue template being filled out. Otherwise, the `no-response` bot will close it after 2 weeks.
     * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
 1. Check community pull requests and label ones that are `ready-for-review`.
-1. Review community pull requests.
 
 Once those things are done, you should feel free to spend your time scratching your own itches on the project. Really wanna refactor that one monstrous component? Go for it! Wanna fix that one bug that drives you nuts? Do it! Wanna upgrade all of our dependencies? You're an awesome masochist!
 

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -12,8 +12,8 @@ Each rotation is a week long. While first responder your primary duties are:
 1. Triage issues.
     * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
     * Ensure issues are labeled accurately.
-    * Review issues labelled [`reviewer-needs-to-reproduce`](https://github.com/desktop/desktop/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Areviewer-needs-to-reproduce) and close any that have gone 2 weeks with no new activity after the last question by a reviewer.
-    * Review issues labelled [`more-information-needed`](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and close any that have gone 7 days without an issue template being filled out. Otherwise, the `no-response` bot will close it after 2 weeks.
+    * Review issues labeled [`reviewer-needs-to-reproduce`](https://github.com/desktop/desktop/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Areviewer-needs-to-reproduce) and close any that have gone 2 weeks with no new activity after the last question by a reviewer.
+    * Review issues labeled [`more-information-needed`](https://github.com/desktop/desktop/issues?q=is%3Aopen+is%3Aissue+label%3Amore-information-needed+sort%3Aupdated-asc) and close any that have gone 7 days without an issue template being filled out. Otherwise, the `no-response` bot will close it after 2 weeks.
     * See [issue-triage.md](issue-triage.md) for more information on our issue triage process.
 1. Check community pull requests and label ones that are `ready-for-review`.
 1. Review community pull requests.

--- a/docs/process/first-responder.md
+++ b/docs/process/first-responder.md
@@ -10,7 +10,8 @@ We have a first responder rotation. The goals of the rotation are:
 Each rotation is a week long. While first responder your primary duties are:
 
 1. Triage issues.
-    * Troubleshoot or follow up on troubleshooting started by the previous first responder. The current first responder should always bear responsibility for pushing troubleshooting forward, unless another team member has explicitly taken ownership.
+    * The current first responder is not responsible for following up on issues still open from previous first responders. However, they should highlight to the team the issues that have been left unanswered for at least 5 days
+    from previous responders to increase visibility and potentially point out which are highest priority.
     * At mention @desktop/support and add `support` label if the issue feels applicable to only the user reporting it, and isn't something more broadly relevant.
     * Ensure issues are labeled accurately.
     * Review issues labeled [`reviewer-needs-to-reproduce`](https://github.com/desktop/desktop/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+sort%3Aupdated-asc+label%3Areviewer-needs-to-reproduce) and close any that have gone 2 weeks with no new activity after the last question by a reviewer.

--- a/docs/process/issue-triage.md
+++ b/docs/process/issue-triage.md
@@ -153,22 +153,6 @@ work should proceed:
 
 e.g. GitHub Desktop should support worktrees as a first class feature.
 
-### Future Proposals
-
-The Desktop team has a [roadmap](roadmap.md) defined for the next few releases,
-so that you can see what our future plans look like. Some enhancements suggested
-by the community will be for things that are interesting but are also well
-beyond the current plans of the team.
-
-We will apply the `future-proposal` label to these issues, so that they can be
-searched for when it comes time to plan for the future. However, to keep
-our issue tracker focused on tasks currently on the roadmap we will close these
-future proposals to avoid information overload.
-
-You can view [the list](https://github.com/desktop/desktop/issues?q=is%3Aissue+label%3Afuture-proposal)
-of these `future-proposal` tasks, and continue to add your thoughts and feedback
-there.
-
 ## Out-of-scope
 
 We anticipate ideas or suggestions that don't align with how we see the

--- a/docs/process/issue-triage.md
+++ b/docs/process/issue-triage.md
@@ -84,6 +84,8 @@ issues from time to time that isn't and won't be covered here.
    close with a request to fill out the template.
 1. Label the issue as a `bug` if the issue is a regression or behaviour that
    needs to be fixed.
+1. Label the issue with `support` if the issue is specific to one person's
+   configuration and isn't more broadly relevant to other users.
 1. If the issue has already been fixed, add a comment linking to the original
    issue and close the issue.
 1. If anything is unclear but the template is adequately filled out, post what
@@ -103,6 +105,11 @@ If a reviewer cannot understand or reproduce the issue with the information prov
 Although we use a bot, the first responder should also do a manual sweep of issues that are open and labeled `more-information-needed` at least once a week.
 * If a `more-information-needed` issue is stale for more than 14 days after the last comment by a reviewer, the issue will be automatically closed by the no-response bot.
 * If the original poster did not fill out the issue template and has not responded to our request within 7 days, close the issue with the following message `I'm closing the issue due to inactivity but I'm happy to re-open if you can provide more details.`
+
+## Support
+
+If an issue reported feels specific to one user's setup and a solution will likely not be relevant to other users of Desktop, the reviewer should add the label `support`
+and @-mention @desktop/support so they're able to work with the user to figure out what's causing the problem.
 
 ## Needs Reproduction
 


### PR DESCRIPTION
Closes #5486

This PR will update the first responder and issue triage docs to be slightly more reflective of current state, if not perfectly aspirational just yet. 

1. Removes reviewing PRs from explicit expectation of the first responder. It's certainly something they can do, but not all first responders do PR review ordinarily. 
2. Properly document the role of @desktop/support. 
3. Remove `future proposal` from issue triage labels because we're not actively using it anymore and trying to remove the existing ones.
4. Clarify that first responders should not be responsible for following up on every previous issue, but rather that they should highlight things that have gone without a response.

Note: There's probably more that could be done to improve the first responder doc in particular, as I'm not sure it's actually reflective of what we're doing. But I wanted to take baby steps.