### PR TITLE
Add notes about ask-pass errors to known-issues.md

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -157,3 +157,28 @@ file:"C:\ProgramData/Git/config" http.sslcainfo=[some value here]
 [http]
 sslCAInfo = [some value here]
 ```
+
+### Ask-Pass-Trampoline.bat errors - [#2623](https://github.com/desktop/desktop/issues/2623), [#4124](https://github.com/desktop/desktop/issues/4124), [#6882](https://github.com/desktop/desktop/issues/6882), [#6789](https://github.com/desktop/desktop/issues/6879)
+
+An example of the error message:
+
+```
+The system cannot find the path specified.
+error: unable to read askpass response from 'C:\Users\User\AppData\Local\GitHubDesktop\app-1.6.2\resources\app\static\ask-pass-trampoline.bat'
+fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+```
+
+Known causes and workarounds:
+
+-  Modifying the `AutoRun` registry entry. To check if this entry has been modified open `Regedit.exe` and navigate to `HKEY_CURRENT_USER\Software\Microsoft\Command Processor\autorun` to see if there is anything set (sometimes applications will also modify this). See [#6789](https://github.com/desktop/desktop/issues/6879#issuecomment-471042891) and [2623](https://github.com/desktop/desktop/issues/2623#issuecomment-334305916) for examples of this.
+
+- Special characters in your Windows username like a `&` or `-` can cause this error to be thrown. See [#7064](https://github.com/desktop/desktop/issues/7064) for an example of this. Try installing GitHub Desktop in a new user account to verify if this is the case.
+
+- Antivirus software can sometimes prevent GitHub Desktop from installing correctly. If you are running antivirus software that could be causing this try temporarily disabling it and reinstalling GitHub Desktop.
+
+- If none of these potential causes are present on your machine, try performing a fresh installation of GitHub Desktop to see if that gets things working again. Here are the steps you can take to do that:
+
+  1. Close GitHub Desktop
+  2. Delete the `%AppData%\GitHub Desktop\` directory
+  3. Delete the `%LocalAppData%\GitHubDesktop\` directory
+  3. Reinstall GitHub Desktop from http://desktop.github.com

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -158,7 +158,7 @@ file:"C:\ProgramData/Git/config" http.sslcainfo=[some value here]
 sslCAInfo = [some value here]
 ```
 
-### Ask-Pass-Trampoline.bat errors - [#2623](https://github.com/desktop/desktop/issues/2623), [#4124](https://github.com/desktop/desktop/issues/4124), [#6882](https://github.com/desktop/desktop/issues/6882), [#6789](https://github.com/desktop/desktop/issues/6879)
+### `ask-pass-trampoline.bat` errors - [#2623](https://github.com/desktop/desktop/issues/2623), [#4124](https://github.com/desktop/desktop/issues/4124), [#6882](https://github.com/desktop/desktop/issues/6882), [#6789](https://github.com/desktop/desktop/issues/6879)
 
 An example of the error message:
 
@@ -170,7 +170,7 @@ fatal: could not read Username for 'https://github.com': terminal prompts disabl
 
 Known causes and workarounds:
 
--  Modifying the `AutoRun` registry entry. To check if this entry has been modified open `Regedit.exe` and navigate to `HKEY_CURRENT_USER\Software\Microsoft\Command Processor\autorun` to see if there is anything set (sometimes applications will also modify this). See [#6789](https://github.com/desktop/desktop/issues/6879#issuecomment-471042891) and [2623](https://github.com/desktop/desktop/issues/2623#issuecomment-334305916) for examples of this.
+-  Modifying the `AutoRun` registry entry. To check if this entry has been modified open `Regedit.exe` and navigate to `HKEY_CURRENT_USER\Software\Microsoft\Command Processor\autorun` to see if there is anything set (sometimes applications will also modify this). See [#6789](https://github.com/desktop/desktop/issues/6879#issuecomment-471042891) and [#2623](https://github.com/desktop/desktop/issues/2623#issuecomment-334305916) for examples of this.
 
 - Special characters in your Windows username like a `&` or `-` can cause this error to be thrown. See [#7064](https://github.com/desktop/desktop/issues/7064) for an example of this. Try installing GitHub Desktop in a new user account to verify if this is the case.
 
@@ -181,4 +181,4 @@ Known causes and workarounds:
   1. Close GitHub Desktop
   2. Delete the `%AppData%\GitHub Desktop\` directory
   3. Delete the `%LocalAppData%\GitHubDesktop\` directory
-  3. Reinstall GitHub Desktop from http://desktop.github.com
+  4. Reinstall GitHub Desktop from [desktop.github.com](https://desktop.github.com)


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

A number of users have been running into the `ask-pass-trampoline.bat` error, and since we have a list of at least a few known causes, I thought it would be good to add this information to our `known-issues.md` file under the `Windows` section. This gives us a source to reference to users who can then look through the various known causes and see if it applies to their situation.

## Description

I've covered a few cases and workarounds users can try:
- Checking if the `Autorun` registry entry has been modified by the user or another application
- Special characters in their Windows username
- Disabling antivirus to ensure it isn't messing with the installation process
- Performing a fresh installation by removing the `GitHubDesktop` directories and reinstalling

If there are any other cases or workarounds across the variety of issues we've seen that I've missed, let me know. 

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:

n/a