### PR TITLE
Don't crash when failing to create log file

### DIFF
--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -49,7 +49,7 @@ function initializeWinston(path: string): winston.LogMethod {
   // disk being full). If logging fails that's not a big deal
   // so we'll just suppress any error, besides, the console
   // logger will likely still work.
-  fileLogger.on('error', _ => {})
+  fileLogger.on('error', () => {})
 
   const consoleLogger = new winston.transports.Console({
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'error',

--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -43,6 +43,14 @@ function initializeWinston(path: string): winston.LogMethod {
     maxFiles: MaxLogFiles,
   })
 
+  // The file logger handles errors when it can't write to an
+  // existing file but emits an error when attempting to create
+  // a file and failing (for example due to permissions or the
+  // disk being full). If logging fails that's not a big deal
+  // so we'll just suppress any error, besides, the console
+  // logger will likely still work.
+  fileLogger.on('error', _ => {})
+
   const consoleLogger = new winston.transports.Console({
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'error',
   })


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

I encountered this issue when testing some PR related functionality inside of a very conservatively sized virtual machine. Our `FileLogger` which is responsible for writing our log messages to disk (as well as rotating the files and cleaning up old log files) normally handles errors when trying to write to a log file when the disk is full but it emits (effectively throws) an unhandled exception when it fails to _create_ the log file in the first place. The reason for this could be that the user doesn't have sufficient permissions to write to the log file directory (unlikely but theoretically possible) or, more likely, due to the disk being completely full and unable to accommodate even an empty file.

In this scenario the application will crash on startup and immediately show the crash reporter dialog to the user.

## Description

Failing to create the log file (for whatever reason) is not a critical condition in the app and as such we shouldn't crash the application because of it. This PR changes the behavior to ignore any errors thrown by the FileLogger.

Now, while this ought to fix one of our biggest sources of crashes (wild, right?) in the app that obviously doesn't mean that the app will work flawlessly in an environment that doesn't have enough space to create a single file. It's even possible we'll start seeing crashes from elsewhere in the app as a result of removing this particular source of crashes but even if that's the case, the statement I made above still holds, we should never crash simply because we're unable to write to the log file.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
