### PR TITLE
tell tslint inside VSCode to ignore definition files when linting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,6 @@
   "prettier.singleQuote": true,
   "prettier.trailingComma": "es5",
   "editor.formatOnSave": true,
-  "prettier.ignorePath": ".prettierignore"
+  "prettier.ignorePath": ".prettierignore",
+  "tslint.ignoreDefinitionFiles": true
 }


### PR DESCRIPTION
## Overview

A little tooling quirk that has been driving me up the wall for weeks - `tslint` inside VSCode deciding to lint definition files that we don't manage, distracting from actual things that I need to look at:

<img width="1155" src="https://user-images.githubusercontent.com/359239/54441033-9c638380-471a-11e9-89ff-d31271b491b8.png">

## Description

To reproduce:

- use a recent version of VSCode (macOS `1.32.3` here)
- find an imports that will go to a definition file, like `import * as React from 'react'`
- on the `'react'` part of the import,  use `Go to Definition` to navigate to the definition file

<img width="491" src="https://user-images.githubusercontent.com/359239/54440940-6e7e3f00-471a-11e9-87ac-aca552b3f128.png">

In previous builds of VSCode it would keep these warnings around until you restarted the app, so it looks like they've been fixing related issues to this, but I still need this switch to make it easier to dive into declaration files when understanding third party code and how it's getting used in Desktop.

## Release notes

Notes: no-notes
