### PR TITLE
Enable darwinDarkModeSupport when packaging for macOS 

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -170,6 +170,7 @@ function packageApp() {
     // macOS
     appBundleId: getBundleID(),
     appCategoryType: 'public.app-category.developer-tools',
+    darwinDarkModeSupport: true,
     osxSign: true,
     protocols: [
       {


### PR DESCRIPTION
## Overview

**Closes #7118**

## Description

- Use the `darwinDarkModeSupport` option from `electron-packager` 

## Release notes

Notes:  [Fixed] The window frame and the top bar in full-screen mode do not adjust to the dark mode on macOS.