### PR TITLE
Check OS Dark Mode On Start Up

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -196,6 +196,7 @@ import { BranchPruner } from './helpers/branch-pruner'
 import { enableBranchPruning, enablePullWithRebase } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import { RebaseProgressOptions } from '../../models/rebase'
+import { isDarkModeEnabled } from '../../ui/lib/dark-theme'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -1483,8 +1484,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ? imageDiffTypeDefault
         : parseInt(imageDiffTypeValue)
 
-    this.selectedTheme = getPersistedTheme()
     this.automaticallySwitchTheme = getAutoSwitchPersistedTheme()
+
+    if (this.automaticallySwitchTheme) {
+      this.selectedTheme = isDarkModeEnabled()
+        ? ApplicationTheme.Dark
+        : ApplicationTheme.Light
+      setPersistedTheme(this.selectedTheme)
+    } else {
+      this.selectedTheme = getPersistedTheme()
+    }
 
     themeChangeMonitor.onThemeChanged(theme => {
       if (this.automaticallySwitchTheme) {


### PR DESCRIPTION
## Overview

**Closes #7116**

## Description

- If OS Theme Switches with Desktop closed, respected current theme on open

## Release notes

Notes:  [Fixed] If OS Theme switches with Desktop closed, respect current theme on next open