### PR TITLE
Fix mistaken classification of all crashes as being related to launch

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -45,6 +45,12 @@ let onDidLoadFns: Array<OnDidLoadFn> | null = []
 function handleUncaughtException(error: Error) {
   preventQuit = true
 
+  // If we haven't got a window we'll assume it's because
+  // we've just launched and haven't created it yet.
+  // It could also be because we're encountering an unhandled
+  // exception on shutdown but that's less likely and since
+  // this only affects the presentation of the crash dialog
+  // it's a safe assumption to make.
   const isLaunchError = mainWindow === null
 
   if (mainWindow) {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -45,12 +45,13 @@ let onDidLoadFns: Array<OnDidLoadFn> | null = []
 function handleUncaughtException(error: Error) {
   preventQuit = true
 
+  const isLaunchError = mainWindow === null
+
   if (mainWindow) {
     mainWindow.destroy()
     mainWindow = null
   }
 
-  const isLaunchError = !mainWindow
   showUncaughtException(isLaunchError, error)
 }
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

Spotted this while addressing a crash related to our use of CodeMirror. When the main process detects a crash it attempts to determine whether that crash was the result of a failure while launching the process or if it occurred post launch.

In 79a85a3 we were shuffling some code around and in the proccess we inadvertently moved the check for whether the main window exists to after we've destroyed it and cleaned up the handle.

The end result being that we always assume that a crash is the result of a launch problem.

## Description

### Before

All crashes are classified as being launch-related

<img width="712" alt="image" src="https://user-images.githubusercontent.com/634063/54693747-6f9eda00-4b27-11e9-8f40-3e6614d2cd97.png">

### After

<img width="668" alt="image" src="https://user-images.githubusercontent.com/634063/54693725-631a8180-4b27-11e9-8277-6733e6450eef.png">


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes