### PR TITLE
tidy up merge status model and introduce rebase status model

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -13,7 +13,7 @@ import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { BranchesTab } from '../models/branches-tab'
 import { PullRequest } from '../models/pull-request'
 import { IAuthor } from '../models/author'
-import { MergeResultKind } from '../models/merge'
+import { MergeResult } from '../models/merge'
 import { ICommitMessage } from '../models/commit-message'
 import {
   IRevertProgress,
@@ -554,7 +554,7 @@ export interface ICompareState {
   readonly formState: IDisplayHistory | ICompareBranch
 
   /** The result of merging the compare branch into the current branch, if a branch selected */
-  readonly mergeStatus: MergeResultStatus | null
+  readonly mergeStatus: MergeResult | null
 
   /** Whether the branch list should be expanded or hidden */
   readonly showBranchList: boolean
@@ -609,17 +609,6 @@ export interface ICompareFormUpdate {
   /** Thew new state of the branches list */
   readonly showBranchList: boolean
 }
-
-export type MergeResultStatus =
-  | {
-      kind: MergeResultKind.Loading
-    }
-  | {
-      kind: MergeResultKind.Conflicts
-      conflictedFiles: number
-    }
-  | { kind: MergeResultKind.Clean }
-  | { kind: MergeResultKind.Invalid }
 
 export interface IViewHistory {
   readonly kind: HistoryTabMode.History

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -5,7 +5,8 @@ import { git } from './core'
 import { GitError } from 'dugite'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
-import { MergeResult, MergeResultKind } from '../../models/merge'
+import { MergeResult } from '../../models/merge'
+import { ComputedActionKind } from '../../models/action'
 import { parseMergeResult } from '../merge-tree-parser'
 import { spawnAndComplete } from './spawn'
 
@@ -77,11 +78,11 @@ export async function mergeTree(
   const mergeBase = await getMergeBase(repository, ours.tip.sha, theirs.tip.sha)
 
   if (mergeBase === null) {
-    return { kind: MergeResultKind.Invalid }
+    return { kind: ComputedActionKind.Invalid }
   }
 
   if (mergeBase === ours.tip.sha || mergeBase === theirs.tip.sha) {
-    return { kind: MergeResultKind.Clean, entries: [] }
+    return { kind: ComputedActionKind.Clean, entries: [] }
   }
 
   const result = await spawnAndComplete(
@@ -94,7 +95,7 @@ export async function mergeTree(
 
   if (output.length === 0) {
     // the merge commit will be empty - this is fine!
-    return { kind: MergeResultKind.Clean, entries: [] }
+    return { kind: ComputedActionKind.Clean, entries: [] }
   }
 
   return parseMergeResult(output)

--- a/app/src/lib/merge-tree-parser.ts
+++ b/app/src/lib/merge-tree-parser.ts
@@ -1,4 +1,5 @@
-import { IMergeEntry, MergeResult, MergeResultKind } from '../models/merge'
+import { IMergeEntry, MergeResult } from '../models/merge'
+import { ComputedActionKind } from '../models/action'
 
 interface IBlobSource {
   readonly type: string
@@ -193,10 +194,10 @@ export function parseMergeResult(text: string): MergeResult {
 
   if (entriesWithConflicts.length > 0) {
     return {
-      kind: MergeResultKind.Conflicts,
+      kind: ComputedActionKind.Conflicts,
       conflictedFiles: entriesWithConflicts.length,
     }
   } else {
-    return { kind: MergeResultKind.Clean, entries }
+    return { kind: ComputedActionKind.Clean, entries }
   }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -89,7 +89,6 @@ import {
   PossibleSelections,
   RepositorySectionTab,
   SelectionType,
-  MergeResultStatus,
   ComparisonMode,
   MergeConflictState,
   isMergeConflictState,
@@ -172,7 +171,7 @@ import { hasShownWelcomeFlow, markWelcomeFlowComplete } from '../welcome'
 import { getWindowState, WindowState } from '../window-state'
 import { TypedBaseStore } from './base-store'
 import { AheadBehindUpdater } from './helpers/ahead-behind-updater'
-import { MergeResultKind } from '../../models/merge'
+import { MergeResult } from '../../models/merge'
 import { promiseWithMinimumTimeout } from '../promise'
 import { BackgroundFetcher } from './helpers/background-fetcher'
 import { inferComparisonBranch } from './helpers/infer-comparison-branch'
@@ -198,6 +197,7 @@ import { enableBranchPruning, enablePullWithRebase } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import { RebaseProgressOptions } from '../../models/rebase'
 import { isDarkModeEnabled } from '../../ui/lib/dark-theme'
+import { ComputedActionKind } from '../../models/action'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -884,8 +884,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.currentAheadBehindUpdater.insert(from, to, aheadBehind)
     }
 
-    const loadingMerge: MergeResultStatus = {
-      kind: MergeResultKind.Loading,
+    const loadingMerge: MergeResult = {
+      kind: ComputedActionKind.Loading,
     }
 
     this.repositoryStateCache.updateCompareState(repository, () => ({
@@ -3353,16 +3353,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _mergeBranch(
     repository: Repository,
     branch: string,
-    mergeStatus: MergeResultStatus | null
+    mergeStatus: MergeResult | null
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 
     if (mergeStatus !== null) {
-      if (mergeStatus.kind === MergeResultKind.Clean) {
+      if (mergeStatus.kind === ComputedActionKind.Clean) {
         this.statsStore.recordMergeHintSuccessAndUserProceeded()
-      } else if (mergeStatus.kind === MergeResultKind.Conflicts) {
+      } else if (mergeStatus.kind === ComputedActionKind.Conflicts) {
         this.statsStore.recordUserProceededAfterConflictWarning()
-      } else if (mergeStatus.kind === MergeResultKind.Loading) {
+      } else if (mergeStatus.kind === ComputedActionKind.Loading) {
         this.statsStore.recordUserProceededWhileLoading()
       }
     }

--- a/app/src/models/action.ts
+++ b/app/src/models/action.ts
@@ -9,6 +9,6 @@ export enum ComputedActionKind {
   Invalid = 'invalid',
   /** The action should complete without any additional work required by the user */
   Clean = 'clean',
-  /** The action requires additional work by the user to complete succesfully */
+  /** The action requires additional work by the user to complete successfully */
   Conflicts = 'conflicts',
 }

--- a/app/src/models/action.ts
+++ b/app/src/models/action.ts
@@ -1,0 +1,14 @@
+/**
+ * A state representing the app computing whether a planned action will require
+ * further work by the user to complete.
+ */
+export enum ComputedActionKind {
+  /** The action is being computed in the background */
+  Loading = 'loading',
+  /** The action cannot be completed, for reasons the app should explain */
+  Invalid = 'invalid',
+  /** The action should complete without any additional work required by the user */
+  Clean = 'clean',
+  /** The action requires additional work by the user to complete succesfully */
+  Conflicts = 'conflicts',
+}

--- a/app/src/models/merge.ts
+++ b/app/src/models/merge.ts
@@ -1,9 +1,4 @@
-export enum MergeResultKind {
-  Loading = 'loading',
-  Invalid = 'invalid',
-  Clean = 'clean',
-  Conflicts = 'conflicts',
-}
+import { ComputedActionKind } from './action'
 
 interface IBlobResult {
   readonly mode: string
@@ -22,17 +17,25 @@ export interface IMergeEntry {
 }
 
 export interface IMergeSuccess {
-  readonly kind: MergeResultKind.Clean
+  readonly kind: ComputedActionKind.Clean
   readonly entries: ReadonlyArray<IMergeEntry>
 }
 
-export interface IMergeError {
-  readonly kind: MergeResultKind.Conflicts
+export type IMergeError = {
+  readonly kind: ComputedActionKind.Conflicts
   readonly conflictedFiles: number
 }
 
-export interface IMergeUnsupported {
-  readonly kind: MergeResultKind.Invalid
+export type IMergeUnsupported = {
+  readonly kind: ComputedActionKind.Invalid
 }
 
-export type MergeResult = IMergeSuccess | IMergeError | IMergeUnsupported
+export type IMergeLoading = {
+  readonly kind: ComputedActionKind.Loading
+}
+
+export type MergeResult =
+  | IMergeSuccess
+  | IMergeError
+  | IMergeUnsupported
+  | IMergeLoading

--- a/app/src/models/merge.ts
+++ b/app/src/models/merge.ts
@@ -16,7 +16,7 @@ export interface IMergeEntry {
   readonly hasConflicts?: boolean
 }
 
-export interface MergeSuccess {
+export type MergeSuccess = {
   readonly kind: ComputedActionKind.Clean
   readonly entries: ReadonlyArray<IMergeEntry>
 }

--- a/app/src/models/merge.ts
+++ b/app/src/models/merge.ts
@@ -16,26 +16,26 @@ export interface IMergeEntry {
   readonly hasConflicts?: boolean
 }
 
-export interface IMergeSuccess {
+export interface MergeSuccess {
   readonly kind: ComputedActionKind.Clean
   readonly entries: ReadonlyArray<IMergeEntry>
 }
 
-export type IMergeError = {
+export type MergeError = {
   readonly kind: ComputedActionKind.Conflicts
   readonly conflictedFiles: number
 }
 
-export type IMergeUnsupported = {
+export type MergeUnsupported = {
   readonly kind: ComputedActionKind.Invalid
 }
 
-export type IMergeLoading = {
+export type MergeLoading = {
   readonly kind: ComputedActionKind.Loading
 }
 
 export type MergeResult =
-  | IMergeSuccess
-  | IMergeError
-  | IMergeUnsupported
-  | IMergeLoading
+  | MergeSuccess
+  | MergeError
+  | MergeUnsupported
+  | MergeLoading

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -1,4 +1,6 @@
 import { IRebaseProgress } from './progress'
+import { ComputedActionKind } from './action'
+import { Commit } from './commit'
 
 export type RebaseContext = {
   readonly targetBranch: string
@@ -17,3 +19,27 @@ export type RebaseProgressOptions = {
   /** The callback to fire when rebase progress is reported */
   progressCallback: (progress: IRebaseProgress) => void
 }
+
+export type RebaseSuccess = {
+  readonly kind: ComputedActionKind.Clean
+  readonly commits: ReadonlyArray<Commit>
+}
+
+export type RebaseConflicts = {
+  readonly kind: ComputedActionKind.Conflicts
+  readonly conflictedFiles: number
+}
+
+export type RebaseUnsupported = {
+  readonly kind: ComputedActionKind.Invalid
+}
+
+export type RebaseLoading = {
+  readonly kind: ComputedActionKind.Loading
+}
+
+export type RebasePreviewResult =
+  | RebaseSuccess
+  | RebaseConflicts
+  | RebaseUnsupported
+  | RebaseLoading

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -27,7 +27,6 @@ export type RebaseSuccess = {
 
 export type RebaseConflicts = {
   readonly kind: ComputedActionKind.Conflicts
-  readonly conflictedFiles: number
 }
 
 export type RebaseUnsupported = {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -9,7 +9,6 @@ import {
   Foldout,
   FoldoutType,
   ICompareFormUpdate,
-  MergeResultStatus,
   RepositorySectionTab,
   isRebaseConflictState,
 } from '../../lib/app-state'
@@ -71,6 +70,7 @@ import { Banner, BannerType } from '../../models/banner'
 import { ApplicationTheme } from '../lib/application-theme'
 import { installCLI } from '../lib/install-cli'
 import { executeMenuItem } from '../main-process-proxy'
+import { MergeResult } from '../../models/merge'
 
 /**
  * An error handler function.
@@ -623,7 +623,7 @@ export class Dispatcher {
   public mergeBranch(
     repository: Repository,
     branch: string,
-    mergeStatus: MergeResultStatus | null
+    mergeStatus: MergeResult | null
   ): Promise<void> {
     return this.appStore._mergeBranch(repository, branch, mergeStatus)
   }

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react'
 
-import { MergeResultStatus, HistoryTabMode } from '../../lib/app-state'
+import { HistoryTabMode } from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { MergeStatusHeader } from './merge-status-header'
-import { MergeResultKind } from '../../models/merge'
+import { MergeResult } from '../../models/merge'
+import { ComputedActionKind } from '../../models/action'
 
 interface IMergeCallToActionWithConflictsProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
-  readonly mergeStatus: MergeResultStatus | null
+  readonly mergeStatus: MergeResult | null
   readonly currentBranch: Branch
   readonly comparisonBranch: Branch
   readonly commitsBehind: number
@@ -31,7 +32,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
 
     const cannotMergeBranch =
       this.props.mergeStatus != null &&
-      this.props.mergeStatus.kind === MergeResultKind.Invalid
+      this.props.mergeStatus.kind === ComputedActionKind.Invalid
 
     const disabled = commitsBehind <= 0 || cannotMergeBranch
 
@@ -66,27 +67,27 @@ export class MergeCallToActionWithConflicts extends React.Component<
   private renderMergeDetails(
     currentBranch: Branch,
     comparisonBranch: Branch,
-    mergeStatus: MergeResultStatus | null,
+    mergeStatus: MergeResult | null,
     behindCount: number
   ) {
     if (mergeStatus === null) {
       return null
     }
 
-    if (mergeStatus.kind === MergeResultKind.Loading) {
+    if (mergeStatus.kind === ComputedActionKind.Loading) {
       return this.renderLoadingMergeMessage()
     }
-    if (mergeStatus.kind === MergeResultKind.Clean) {
+    if (mergeStatus.kind === ComputedActionKind.Clean) {
       return this.renderCleanMergeMessage(
         currentBranch,
         comparisonBranch,
         behindCount
       )
     }
-    if (mergeStatus.kind === MergeResultKind.Invalid) {
+    if (mergeStatus.kind === ComputedActionKind.Invalid) {
       return this.renderInvalidMergeMessage()
     }
-    if (mergeStatus.kind === MergeResultKind.Conflicts) {
+    if (mergeStatus.kind === ComputedActionKind.Conflicts) {
       return this.renderConflictedMergeMessage(
         currentBranch,
         comparisonBranch,

--- a/app/src/ui/history/merge-status-header.tsx
+++ b/app/src/ui/history/merge-status-header.tsx
@@ -2,15 +2,15 @@ import * as React from 'react'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { assertNever } from '../../lib/fatal-error'
 import * as classNames from 'classnames'
-import { MergeResultStatus } from '../../lib/app-state'
-import { MergeResultKind } from '../../models/merge'
+import { MergeResult } from '../../models/merge'
+import { ComputedActionKind } from '../../models/action'
 
 interface IMergeStatusIconProps {
   /** The classname for the underlying element. */
   readonly className?: string
 
   /** The status to display. */
-  readonly status: MergeResultStatus | null
+  readonly status: MergeResult | null
 }
 
 /** The little CI status indicator. */
@@ -41,15 +41,15 @@ export class MergeStatusHeader extends React.Component<
   }
 }
 
-function getSymbolForState(status: MergeResultKind): OcticonSymbol {
+function getSymbolForState(status: ComputedActionKind): OcticonSymbol {
   switch (status) {
-    case MergeResultKind.Loading:
+    case ComputedActionKind.Loading:
       return OcticonSymbol.primitiveDot
-    case MergeResultKind.Conflicts:
+    case ComputedActionKind.Conflicts:
       return OcticonSymbol.alert
-    case MergeResultKind.Invalid:
+    case ComputedActionKind.Invalid:
       return OcticonSymbol.x
-    case MergeResultKind.Clean:
+    case ComputedActionKind.Clean:
       return OcticonSymbol.check
   }
 

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -13,8 +13,8 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
 import { revSymmetricDifference } from '../../lib/git'
 import { IMatches } from '../../lib/fuzzy-find'
-import { MergeResultStatus } from '../../lib/app-state'
-import { MergeResultKind } from '../../models/merge'
+import { MergeResult } from '../../models/merge'
+import { ComputedActionKind } from '../../models/action'
 import { MergeStatusHeader } from '../history/merge-status-header'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
@@ -61,7 +61,7 @@ interface IMergeState {
   readonly selectedBranch: Branch | null
 
   /** The merge result of comparing the selected branch to the current branch */
-  readonly mergeStatus: MergeResultStatus | null
+  readonly mergeStatus: MergeResult | null
 
   /**
    * The number of commits that would be brought in by the merge.
@@ -141,20 +141,20 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
   }
 
   private renderMergeStatusMessage(
-    mergeStatus: MergeResultStatus,
+    mergeStatus: MergeResult,
     branch: Branch,
     currentBranch: Branch,
     commitCount: number
   ): JSX.Element {
-    if (mergeStatus.kind === MergeResultKind.Loading) {
+    if (mergeStatus.kind === ComputedActionKind.Loading) {
       return this.renderLoadingMergeMessage()
     }
 
-    if (mergeStatus.kind === MergeResultKind.Clean) {
+    if (mergeStatus.kind === ComputedActionKind.Clean) {
       return this.renderCleanMergeMessage(branch, currentBranch, commitCount)
     }
 
-    if (mergeStatus.kind === MergeResultKind.Invalid) {
+    if (mergeStatus.kind === ComputedActionKind.Invalid) {
       return this.renderInvalidMergeMessage()
     }
 
@@ -244,7 +244,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
 
     const cannotMergeBranch =
       this.state.mergeStatus != null &&
-      this.state.mergeStatus.kind === MergeResultKind.Invalid
+      this.state.mergeStatus.kind === ComputedActionKind.Invalid
 
     const disabled = invalidBranchState || cannotMergeBranch
 
@@ -296,7 +296,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
   }
 
   private async updateMergeStatus(branch: Branch) {
-    this.setState({ mergeStatus: { kind: MergeResultKind.Loading } })
+    this.setState({ mergeStatus: { kind: ComputedActionKind.Loading } })
 
     const { currentBranch } = this.props
 

--- a/app/test/unit/git/parse-merge-result-test.ts
+++ b/app/test/unit/git/parse-merge-result-test.ts
@@ -1,13 +1,11 @@
 import * as Path from 'path'
 import * as FSE from 'fs-extra'
-import { parseMergeResult } from '../../../src/lib/merge-tree-parser'
-import {
-  IMergeSuccess,
-  IMergeError,
-  MergeResultKind,
-} from '../../../src/models/merge'
-
 import * as glob from 'glob'
+
+import { parseMergeResult } from '../../../src/lib/merge-tree-parser'
+
+import { IMergeSuccess, IMergeError } from '../../../src/models/merge'
+import { ComputedActionKind } from '../../../src/models/action'
 
 const filenameRegex = /merge\-(.*)\-into\-(.*).txt/
 
@@ -45,7 +43,7 @@ describe('parseMergeResult', () => {
     const input = await FSE.readFile(filePath, { encoding: 'utf8' })
 
     const result = parseMergeResult(input)
-    expect(result.kind).toBe(MergeResultKind.Clean)
+    expect(result.kind).toBe(ComputedActionKind.Clean)
 
     const mergeResult = result as IMergeSuccess
     expect(mergeResult.entries).toHaveLength(21)
@@ -63,7 +61,7 @@ describe('parseMergeResult', () => {
     const input = await FSE.readFile(filePath, { encoding: 'utf8' })
 
     const result = parseMergeResult(input)
-    expect(result.kind).toBe(MergeResultKind.Conflicts)
+    expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
     const mergeResult = result as IMergeError
     expect(mergeResult.conflictedFiles).toBe(1)
@@ -79,7 +77,7 @@ describe('parseMergeResult', () => {
         const input = await FSE.readFile(f, { encoding: 'utf8' })
 
         const result = parseMergeResult(input)
-        expect(result.kind).toBe(MergeResultKind.Conflicts)
+        expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
         const mergeResult = result as IMergeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
@@ -97,7 +95,7 @@ describe('parseMergeResult', () => {
         const input = await FSE.readFile(f, { encoding: 'utf8' })
 
         const result = parseMergeResult(input)
-        expect(result.kind).toBe(MergeResultKind.Conflicts)
+        expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
         const mergeResult = result as IMergeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
@@ -115,7 +113,7 @@ describe('parseMergeResult', () => {
         const input = await FSE.readFile(f, { encoding: 'utf8' })
 
         const result = parseMergeResult(input)
-        expect(result.kind).toBe(MergeResultKind.Conflicts)
+        expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
         const mergeResult = result as IMergeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)

--- a/app/test/unit/git/parse-merge-result-test.ts
+++ b/app/test/unit/git/parse-merge-result-test.ts
@@ -4,7 +4,7 @@ import * as glob from 'glob'
 
 import { parseMergeResult } from '../../../src/lib/merge-tree-parser'
 
-import { IMergeSuccess, IMergeError } from '../../../src/models/merge'
+import { MergeSuccess, MergeError } from '../../../src/models/merge'
 import { ComputedActionKind } from '../../../src/models/action'
 
 const filenameRegex = /merge\-(.*)\-into\-(.*).txt/
@@ -45,7 +45,7 @@ describe('parseMergeResult', () => {
     const result = parseMergeResult(input)
     expect(result.kind).toBe(ComputedActionKind.Clean)
 
-    const mergeResult = result as IMergeSuccess
+    const mergeResult = result as MergeSuccess
     expect(mergeResult.entries).toHaveLength(21)
     mergeResult.entries.forEach(e => {
       expect(e.diff).not.toBe('')
@@ -63,7 +63,7 @@ describe('parseMergeResult', () => {
     const result = parseMergeResult(input)
     expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
-    const mergeResult = result as IMergeError
+    const mergeResult = result as MergeError
     expect(mergeResult.conflictedFiles).toBe(1)
   })
 
@@ -79,7 +79,7 @@ describe('parseMergeResult', () => {
         const result = parseMergeResult(input)
         expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
-        const mergeResult = result as IMergeError
+        const mergeResult = result as MergeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
       })
     }
@@ -97,7 +97,7 @@ describe('parseMergeResult', () => {
         const result = parseMergeResult(input)
         expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
-        const mergeResult = result as IMergeError
+        const mergeResult = result as MergeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
       })
     }
@@ -115,7 +115,7 @@ describe('parseMergeResult', () => {
         const result = parseMergeResult(input)
         expect(result.kind).toBe(ComputedActionKind.Conflicts)
 
-        const mergeResult = result as IMergeError
+        const mergeResult = result as MergeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
       })
     }


### PR DESCRIPTION
## Overview

Groundwork to complete #6960 and #6959

## Description

This PR addresses two pieces of tech debt that I noticed while refreshing my memory on how we computed the "merge status" when comparing branches (either in the History sidebar or in the Merge Branch dialog).

 - We have a `MergeResultKind` which looks very similar to what I need for the rebase status
    - this has been renamed to `ComputedActionKind` and now lives in it's own module
 - We had two very similar models - `MergeResultStatus` in app state and `MergeResult` in the models folder
    - these have been unified under `MergeResult` so that we have a common model for this "merge status"

I also added in the `RebasePreviewResult` status which will be used in subsequent PRs to represent the "success"/"conflicts" rebase preview state at the start of the rebase flow.

## Release notes

Notes: no-notes
