### PR TITLE
Add GitLab and Bitbucket authentication docs

### DIFF
--- a/docs/integrations/bitbucket.md
+++ b/docs/integrations/bitbucket.md
@@ -10,7 +10,7 @@ To authenticate against Bitbucket repositories you will need to create a persona
 
 3. Under **App passwords** click **Create app password**
 
-![](https://user-images.githubusercontent.com/721500/54835003-a98eee00-4c97-11e9-809f-1b409aa4c5f9.png)
+![](https://user-images.githubusercontent.com/721500/54835632-ead3cd80-4c98-11e9-94fb-f94945581fe7.png)
 
 4. Under the **Details** section in **Add app password** enter a label for your password
 
@@ -18,7 +18,7 @@ To authenticate against Bitbucket repositories you will need to create a persona
 
 6. Click **Create** to create a new token, and then copy the token to your clipboard.
 
-![](https://user-images.githubusercontent.com/721500/54835019-b14e9280-4c97-11e9-98e2-bf308e6a42f9.png)
+![](https://user-images.githubusercontent.com/721500/54835624-e8717380-4c98-11e9-89b8-37d286cf99b6.png)
 
 ## Cloning your Bitbucket repository in GitHub Desktop
 

--- a/docs/integrations/bitbucket.md
+++ b/docs/integrations/bitbucket.md
@@ -1,0 +1,33 @@
+# Authenticating to Bitbucket with GitHub Desktop
+
+## Creating a Personal Access Token in Bitbucket
+
+To authenticate against Bitbucket repositories you will need to create a personal access token.
+
+1. Go to your Bitbucket account and select **Bitbucket settings** in the user profile dropdown.
+
+2. Select **App passwords**
+
+3. Under **App passwords** click **Create app password**
+
+![](https://user-images.githubusercontent.com/721500/54833905-603d9f00-4c95-11e9-8cd7-62a294542022.png)
+
+4. Under the **Details** section in **Add app password** enter a label for your password
+
+5. Under **Permissions** select `read` and `write` in the **Repositories** section to ensure that GitHub Desktop has the correct read/write access to your GitLab repositories.
+
+6. Click **Create** to create a new token, and then copy the token to your clipboard.
+
+![](https://user-images.githubusercontent.com/721500/54833912-63d12600-4c95-11e9-805c-6208aaccad20.png)
+
+## Cloning your Bitbucket repository in GitHub Desktop
+
+ 1. Open GitHub Desktop and go to **File** > **Clone Repository** > **URL**. Enter the Git URL of your Bitbucket repository. Make sure you enter the correct URL, which should have the following structure:
+
+      `https://bitbucket.com/<username>/<repository>`
+
+ 2. You will receive an `Authentication Failed` error. Enter your Bitbucket username and paste in the token you just copied to your clipboard as your password. Click **Save and Retry** to successfully clone the repository to your local machine in GitHub Desktop.
+
+![](https://user-images.githubusercontent.com/721500/54832263-36cf4400-4c92-11e9-8937-6617a0a564b5.png)
+
+   - **Note:** Your Bitbucket credentials will be securely stored on your local machine so you will not need to repeat this process when cloning another repository from Bitbucket.

--- a/docs/integrations/bitbucket.md
+++ b/docs/integrations/bitbucket.md
@@ -10,7 +10,7 @@ To authenticate against Bitbucket repositories you will need to create a persona
 
 3. Under **App passwords** click **Create app password**
 
-![](https://user-images.githubusercontent.com/721500/54833905-603d9f00-4c95-11e9-8cd7-62a294542022.png)
+![](https://user-images.githubusercontent.com/721500/54835003-a98eee00-4c97-11e9-809f-1b409aa4c5f9.png)
 
 4. Under the **Details** section in **Add app password** enter a label for your password
 
@@ -18,7 +18,7 @@ To authenticate against Bitbucket repositories you will need to create a persona
 
 6. Click **Create** to create a new token, and then copy the token to your clipboard.
 
-![](https://user-images.githubusercontent.com/721500/54833912-63d12600-4c95-11e9-805c-6208aaccad20.png)
+![](https://user-images.githubusercontent.com/721500/54835019-b14e9280-4c97-11e9-98e2-bf308e6a42f9.png)
 
 ## Cloning your Bitbucket repository in GitHub Desktop
 
@@ -28,6 +28,6 @@ To authenticate against Bitbucket repositories you will need to create a persona
 
  2. You will receive an `Authentication Failed` error. Enter your Bitbucket username and paste in the token you just copied to your clipboard as your password. Click **Save and Retry** to successfully clone the repository to your local machine in GitHub Desktop.
 
-![](https://user-images.githubusercontent.com/721500/54832263-36cf4400-4c92-11e9-8937-6617a0a564b5.png)
+![](https://user-images.githubusercontent.com/721500/54835296-33d75200-4c98-11e9-9c6f-71bbfdd26336.png)
 
    - **Note:** Your Bitbucket credentials will be securely stored on your local machine so you will not need to repeat this process when cloning another repository from Bitbucket.

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -8,7 +8,7 @@ To authenticate against GitLab repositories you will need to create a personal a
 
 ![](https://user-images.githubusercontent.com/721500/54834720-1f468a00-4c97-11e9-9a0f-4c92224064d0.png)
 
-2. Select ** Access tokens**
+2. Select **Access tokens**
 
 3. Under **Add a personal access token** choose a name and set an expiration date for your token.
 

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -6,7 +6,7 @@ To authenticate against GitLab repositories you will need to create a personal a
 
 1. Go to your GitLab account and select **Settings** in the user profile dropdown.
 
-![](https://user-images.githubusercontent.com/721500/54831873-8d884e00-4c91-11e9-9087-57af715d8321.png)
+![](https://user-images.githubusercontent.com/721500/54834720-1f468a00-4c97-11e9-9a0f-4c92224064d0.png)
 
 2. Select ** Access tokens**
 
@@ -26,6 +26,6 @@ To authenticate against GitLab repositories you will need to create a personal a
 
  2. You will receive an `Authentication Failed` error. Enter your GitLab username and paste in the token you just copied to your clipboard as your password. Click **Save and Retry** to successfully clone the repository to your local machine in GitHub Desktop.
 
-![](https://user-images.githubusercontent.com/721500/54832263-36cf4400-4c92-11e9-8937-6617a0a564b5.png)
+![](https://user-images.githubusercontent.com/721500/54835396-5f5a3c80-4c98-11e9-9306-df234f8f7abc.png)
 
    - **Note:** Your GitLab credentials will be securely stored on your local machine so you will not need to repeat this process when cloning another repository from GitLab.

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -1,6 +1,6 @@
 # Authenticating to GitLab with GitHub Desktop
 
-## Creating a Personal Access Token in Azure DevOps
+## Creating a Personal Access Token in GitLab
 
 To authenticate against GitLab repositories you will need to create a personal access token.
 
@@ -14,7 +14,7 @@ To authenticate against GitLab repositories you will need to create a personal a
 
 4. For **Scopes** select `api` to ensure that GitHub Desktop has the correct read/write access to your GitLab repositories.
 
-5. Click **Create personal access token** to create a new token, and then copy your token to the clipboard.
+5. Click **Create personal access token** to create a new token, and then copy the token to your clipboard.
 
 ![](https://user-images.githubusercontent.com/721500/54831880-8feaa800-4c91-11e9-801b-40ed2af869a0.png)
 

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -1,0 +1,31 @@
+# Authenticating to GitLab with GitHub Desktop
+
+## Creating a Personal Access Token in Azure DevOps
+
+To authenticate against GitLab repositories you will need to create a personal access token.
+
+1. Go to your GitLab account and select **Settings** in the user profile dropdown.
+
+![](https://user-images.githubusercontent.com/721500/54831873-8d884e00-4c91-11e9-9087-57af715d8321.png)
+
+2. Select ** Access tokens**
+
+3. Under **Add a personal access token** choose a name and set an expiration date for your token.
+
+4. For **Scopes** select `api` to ensure that GitHub Desktop has the correct read/write access to your GitLab repositories.
+
+5. Click **Create personal access token** to create a new token, and then copy your token to the clipboard.
+
+![](https://user-images.githubusercontent.com/721500/54831880-8feaa800-4c91-11e9-801b-40ed2af869a0.png)
+
+## Cloning your GitLab repository in GitHub Desktop
+
+ 1. Open GitHub Desktop and go to **File** > **Clone Repository** > **URL**. Enter the Git URL of your GitLab repository. Make sure you enter the correct URL, which should have the following structure:
+
+      `https://gitlab.com/<username>/<repository>`
+
+ 2. You will receive an `Authentication Failed` error. Enter your GitLab username and paste in the token you just copied to your clipboard as your password. Click **Save and Retry** to successfully clone the repository to your local machine in GitHub Desktop.
+
+![](https://user-images.githubusercontent.com/721500/54832263-36cf4400-4c92-11e9-8937-6617a0a564b5.png)
+
+   - **Note:** Your GitLab credentials will be securely stored on your local machine so you will not need to repeat this process when cloning another repository from GitLab.


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #5103**

## Description

This PR creates two new documents that provide the steps needed to authenticate to repositories that are hosted on GitLab and Bitbucket. I followed the basic template of the Azure DevOps doc and modified the steps and screenshots to align with each respective platform.

## Release notes

n/a
<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

