### PR TITLE
at build time, ensure licenses include trailing newline

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -365,12 +365,18 @@ function generateLicenseMetadata(outRoot: string) {
     const fullPath = path.join(licensesDir, file)
     const contents = fs.readFileSync(fullPath, 'utf8')
     const result = frontMatter<IChooseALicense>(contents)
+
+    const licenseText = result.body.trim()
+    // ensure that any license file created in the app does not trigger the
+    // "no newline at end of file" warning when viewing diffs
+    const licenseTextWithNewLine = `${licenseText}\n`
+
     const license: ILicense = {
       name: result.attributes.nickname || result.attributes.title,
       featured: result.attributes.featured || false,
       hidden:
         result.attributes.hidden === undefined || result.attributes.hidden,
-      body: result.body.trim(),
+      body: licenseTextWithNewLine,
     }
 
     if (!license.hidden) {


### PR DESCRIPTION
## Overview

This is an alternative fix to #6999, and it differs to #7072 because there's a solution that can be applied when the app is built rather than adding a runtime check, but it requires some extra context to explain why this works.

**Closes #6999**

## Description

The list of licenses available in Desktop are stored in `static/available-licenses.json` and these are generated when you run `yarn build:dev` or `yarn build:prod`.

https://github.com/desktop/desktop/blob/0c24836b13d31559f577a3e9cadc0194f7d6bba5/script/build.ts#L380-L382

The source for these files is reading the available licenses from `choosealicense.com` (linked via submodule) and building up the JSON payload like this:

https://github.com/desktop/desktop/blob/0c24836b13d31559f577a3e9cadc0194f7d6bba5/script/build.ts#L367-L373

The bug itself occurs because we `result.body.trim()` any trailing newline characters. This PR puts back a trailing `\n`, avoiding the need for us to do a runtime check for the newline.

## Release notes

Notes: `[Fixed] "Add New Repository" licenses did not contain trailing newline`
