### PR TITLE
Open In Xcode

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -95,9 +95,15 @@ export async function getAvailableShells(): Promise<
 
 export function launch(
   foundShell: IFoundShell<Shell>,
-  path: string
+  path: string,
+  arg: string,
+  openXcode: boolean
 ): ChildProcess {
   const bundleID = getBundleID(foundShell.shell)
-  const commandArgs = ['-b', bundleID, path]
+  var commandArgs = [arg, bundleID, path]
+  //If opening XCode, set the bundleID field to Xcode
+  if (openXcode) {
+    commandArgs = [arg, 'Xcode', path]
+  }
   return spawn('open', commandArgs)
 }

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -100,10 +100,10 @@ export function launch(
   openXcode: boolean
 ): ChildProcess {
   const bundleID = getBundleID(foundShell.shell)
-  var commandArgs = [arg, bundleID, path]
   //If opening XCode, set the bundleID field to Xcode
   if (openXcode) {
-    commandArgs = [arg, 'Xcode', path]
+    return spawn('open', [arg, 'Xcode', path])
+  } else {
+    return spawn('open', [arg, bundleID, path])
   }
-  return spawn('open', commandArgs)
 }

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -87,12 +87,12 @@ export async function launchXcode(
       }'.  Please open ${label} and select an available shell.`
     )
   }
+  let cp: ChildProcess | null = null
   if (__DARWIN__) {
     cp = Darwin.launch(shell as IFoundShell<Darwin.Shell>, path, '-a', true)
   } else {
     throw new ShellError('Could not run on Non-Darwin sysyems.')
   }
-  let cp: ChildProcess | null = null
   if (cp != null) {
     addErrorTracing(shell.shell, cp, onError)
     return Promise.resolve()

--- a/app/src/lib/shells/shared.ts
+++ b/app/src/lib/shells/shared.ts
@@ -77,41 +77,33 @@ export async function launchXcode(
   shell: FoundShell,
   path: string,
   onError: (error: Error) => void
-  ): Promise<void> {
-    // We have to manually cast the wider `Shell` type into the platform-specific
-    // type. This is less than ideal, but maybe the best we can do without
-    // platform-specific build targets.
-    const exists = await pathExists(shell.path)
-    if (!exists) {
-      const label = __DARWIN__ ? 'Preferences' : 'Options'
-      throw new ShellError(
-        `Could not find executable for '${shell.shell}' at path '${
-          shell.path
-        }'.  Please open ${label} and select an available shell.`
-      )
-    }
-
-    if (!__DARWIN__) {
-      throw new ShellError("Xcode not installed.")
-    }
-
-    let cp: ChildProcess | null = null
-
-    if (__DARWIN__) {
-      cp = Darwin.launch(shell as IFoundShell<Darwin.Shell>, path, '-a', true)
-    }
-
-    if (cp != null) {
-      addErrorTracing(shell.shell, cp, onError)
-      return Promise.resolve()
-    } else {
-      return Promise.reject(
-        `Platform not currently supported for launching shells: ${
-          process.platform
-        }`
-      )
-    }
+): Promise<void> {
+  const exists = await pathExists(shell.path)
+  if (!exists) {
+    const label = __DARWIN__ ? 'Preferences' : 'Options'
+    throw new ShellError(
+      `Could not find executable for '${shell.shell}' at path '${
+        shell.path
+      }'.  Please open ${label} and select an available shell.`
+    )
   }
+  if (__DARWIN__) {
+    cp = Darwin.launch(shell as IFoundShell<Darwin.Shell>, path, '-a', true)
+  } else {
+    throw new ShellError('Could not run on Non-Darwin sysyems.')
+  }
+  let cp: ChildProcess | null = null
+  if (cp != null) {
+    addErrorTracing(shell.shell, cp, onError)
+    return Promise.resolve()
+  } else {
+    return Promise.reject(
+      `Platform not currently supported for launching shells: ${
+        process.platform
+      }`
+    )
+  }
+}
 
 /** Launch the given shell at the path. */
 export async function launchShell(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -158,6 +158,7 @@ import {
   Default as DefaultShell,
   findShellOrDefault,
   launchShell,
+  launchXcode,
   parse as parseShell,
   Shell,
 } from '../shells'
@@ -3460,6 +3461,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     try {
       const match = await findShellOrDefault(this.selectedShell)
       await launchShell(match, path, error => this._pushError(error))
+    } catch (error) {
+      this.emitError(error)
+    }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _openXcode(path: string) {
+    this.statsStore.recordOpenShell()
+
+    try {
+      const match = await findShellOrDefault(this.selectedShell)
+      await launchXcode(match, path, error => this._pushError(error))
     } catch (error) {
       this.emitError(error)
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1787,6 +1787,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         }
         onRemoveRepository={this.removeRepository}
         onOpenInShell={this.openInShell}
+        onOpenInXcode={this.openInXcode}
         onShowRepository={this.showRepository}
         onOpenInExternalEditor={this.openInExternalEditor}
         externalEditorLabel={externalEditorLabel}
@@ -1802,6 +1803,14 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.props.dispatcher.openShell(repository.path)
+  }
+
+  private openInXcode = (repository: Repository | CloningRepository) => {
+    if (!(repository instanceof Repository)) {
+      return
+    }
+
+    this.props.dispatcher.openXcode(repository.path)
   }
 
   private openFileInExternalEditor = (fullPath: string) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -869,9 +869,7 @@ export class Dispatcher {
    * The option to open in Xcode will only render on UI if
    * Xcode is installed.
    */
-  public async openXcode(
-    path: string
-  ): Promise<void> {
+  public async openXcode(path: string): Promise<void> {
     this.appStore._openXcode(path)
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -865,6 +865,17 @@ export class Dispatcher {
   }
 
   /**
+   * Opens a Xcode window in the current path
+   * The option to open in Xcode will only render on UI if
+   * Xcode is installed.
+   */
+  public async openXcode(
+    path: string
+  ): Promise<void> {
+    this.appStore._openXcode(path)
+  }
+
+  /**
    * Opens a path in the external editor selected by the user.
    */
   public async openInExternalEditor(fullPath: string): Promise<void> {

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -13,6 +13,10 @@ export const RevealInFileManagerLabel = __DARWIN__
   ? 'Show in Explorer'
   : 'Show in your File Manager'
 
+export const OpenInXcodeLabel = __DARWIN__
+  ? 'Open with Xcode'
+  : 'Open with xcode'
+
 export const TrashNameLabel = __DARWIN__ ? 'Trash' : 'Recycle Bin'
 
 export const OpenWithDefaultProgramLabel = __DARWIN__

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -47,6 +47,9 @@ interface IRepositoriesListProps {
   /** Called when the repository should be shown in the shell. */
   readonly onOpenInShell: (repository: Repositoryish) => void
 
+  /** Called when the repository project should be shown in Xcode. */
+  readonly onOpenInXcode: (repository: Repositoryish) => void
+
   /** Called when the repository should be opened in an external editor */
   readonly onOpenInExternalEditor: (repository: Repositoryish) => void
 
@@ -133,6 +136,7 @@ export class RepositoriesList extends React.Component<
         onRemoveRepository={this.props.onRemoveRepository}
         onShowRepository={this.props.onShowRepository}
         onOpenInShell={this.props.onOpenInShell}
+        onOpenInXcode={this.props.onOpenInXcode}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         externalEditorLabel={this.props.externalEditorLabel}
         shellLabel={this.props.shellLabel}

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -8,6 +8,7 @@ import { HighlightText } from '../lib/highlight-text'
 import { IMatches } from '../../lib/fuzzy-find'
 import { IAheadBehind } from '../../models/branch'
 import { RevealInFileManagerLabel } from '../lib/context-menu'
+import { OpenInXcodeLabel } from '../lib/context-menu'
 
 const defaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
@@ -27,6 +28,9 @@ interface IRepositoryListItemProps {
 
   /** Called when the repository should be shown in the shell. */
   readonly onOpenInShell: (repository: Repositoryish) => void
+
+  /** Called when the repository project should be shown in Xcode. */
+  readonly onOpenInXcode: (repository: Repositoryish) => void
 
   /** Called when the repository should be opened in an external editor */
   readonly onOpenInExternalEditor: (repository: Repositoryish) => void
@@ -158,6 +162,11 @@ export class RepositoryListItem extends React.Component<
         enabled: !missing,
       },
       {
+        label: OpenInXcodeLabel,
+        action: this.openInXcode,
+        enabled: !missing && __DARWIN__,
+      },
+      {
         label: RevealInFileManagerLabel,
         action: this.showRepository,
         enabled: !missing,
@@ -188,6 +197,10 @@ export class RepositoryListItem extends React.Component<
 
   private openInShell = () => {
     this.props.onOpenInShell(this.props.repository)
+  }
+
+  private openInXcode = () => {
+    this.props.onOpenInXcode(this.props.repository)
   }
 
   private openInExternalEditor = () => {


### PR DESCRIPTION
## Overview

Addressing issue #4825 to allow open in Xcode for the current repository using a command line `open -a Xcode .`

## Description

- Added the menu item for open in Xcode, which will only be enabled when running on Mac OS Darwin system.
- Added the function to trigger Xcode on the repository directory by using a command line

## Release notes

[New] Open the repository Xcode project in Xcode on Mac OS.

Notes:

The Xcode will display the error message "Could not open file (/path)" if opened on a folder that doesn't contain any Xcode project files. Will think about the solutions for this issue and continue PR.