### PR TITLE
Tweaks to onboarding language

### DIFF
--- a/app/src/ui/blank-slate/blank-slate.tsx
+++ b/app/src/ui/blank-slate/blank-slate.tsx
@@ -325,7 +325,7 @@ export class BlankSlateView extends React.Component<
               <Octicon symbol={OcticonSymbol.plus} />
               <div>
                 {__DARWIN__
-                  ? 'Create a New Repository on Your Hard Drive…'
+                  ? 'Create a New Repository on your Hard Drive…'
                   : 'Create a New Repository on your hard drive…'}
               </div>
             </Button>
@@ -335,7 +335,7 @@ export class BlankSlateView extends React.Component<
               <Octicon symbol={OcticonSymbol.fileDirectory} />
               <div>
                 {__DARWIN__
-                  ? 'Add an Existing Repository from Your Hard Drive…'
+                  ? 'Add an Existing Repository from your Hard Drive…'
                   : 'Add an Existing Repository from your hard drive…'}
               </div>
             </Button>

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -280,7 +280,7 @@ export class NoChanges extends React.Component<
 
     const description = (
       <>
-        Select your editor in {' '}
+        Select your editor in{' '}
         <LinkButton onClick={this.openPreferences}>
           {__DARWIN__ ? 'Preferences' : 'Options'}
         </LinkButton>

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -280,7 +280,7 @@ export class NoChanges extends React.Component<
 
     const description = (
       <>
-        Select your editor{' '}
+        Select your editor in {' '}
         <LinkButton onClick={this.openPreferences}>
           {__DARWIN__ ? 'Preferences' : 'Options'}
         </LinkButton>

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -235,7 +235,7 @@ export class NoChanges extends React.Component<
 
     return this.renderMenuBackedAction(
       'open-working-directory',
-      `View the files in your repository in ${fileManager}`
+      `View the files of your repository in ${fileManager}`
     )
   }
 
@@ -280,9 +280,9 @@ export class NoChanges extends React.Component<
 
     const description = (
       <>
-        Configure which editor you wish to use in{' '}
+        Select your editor{' '}
         <LinkButton onClick={this.openPreferences}>
-          {__DARWIN__ ? 'preferences' : 'options'}
+          {__DARWIN__ ? 'Preferences' : 'Options'}
         </LinkButton>
       </>
     )


### PR DESCRIPTION
Closes #6638

Updated the current language semantics as suggested in #6638 

Examples:

<img width="624" alt="Screen Shot 2019-03-25 at 10 42 35 AM" src="https://user-images.githubusercontent.com/14828183/54952739-c707c600-4eea-11e9-9754-8687880ce6b6.png">
<img width="601" alt="Screen Shot 2019-03-25 at 10 42 45 AM" src="https://user-images.githubusercontent.com/14828183/54952741-c707c600-4eea-11e9-8c65-db070045421e.png">
