### PR TITLE
Highlight current repo in "recent" group (and not elsewhere)

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -64,6 +64,11 @@ export interface IAppState {
   readonly repositories: ReadonlyArray<Repository | CloningRepository>
 
   /**
+   * List of IDs of the most recently opened repositories (most recent first)
+   */
+  readonly recentRepositories: ReadonlyArray<number>
+
+  /**
    * A cache of the latest repository state values, keyed by the repository id
    */
   readonly localRepositoryStateLookup: Map<number, ILocalRepositoryState>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1191,10 +1191,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (previousRepositoryId !== null) {
       recentRepositories.splice(0, 0, currentRepositoryId, previousRepositoryId)
     }
-    if (recentRepositories.length > RecentRepositoriesLength) {
-      recentRepositories.pop()
-    }
-    this.recentlyOpenedRepositories = recentRepositories
+    this.recentlyOpenedRepositories = recentRepositories.slice(
+      0,
+      RecentRepositoriesLength
+    )
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1162,7 +1162,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       ? previouslySelectedRepository.id
       : null
     if (enableGroupRepositoriesByOwner()) {
-      this._updateRecentRepositories(previousRepositoryId, repository.id)
+      this.updateRecentRepositories(previousRepositoryId, repository.id)
     }
 
     // if repository might be marked missing, try checking if it has been restored
@@ -1182,11 +1182,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   // update the stored list of recently opened repositories
-  private _updateRecentRepositories(
+  private updateRecentRepositories(
     previousRepositoryId: number | null,
     currentRepositoryId: number
   ) {
-    const recentRepositories = this._getRecentRepositories().filter(
+    const recentRepositories = this.getRecentRepositories().filter(
       el => el !== currentRepositoryId && el !== previousRepositoryId
     )
     if (previousRepositoryId !== null) {
@@ -1205,7 +1205,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   // get the stored list of recently opened repositories
-  private _getRecentRepositories() {
+  private getRecentRepositories() {
     const storedIds = localStorage.getItem(RecentRepositoriesKey)
     let storedRepositories: Array<number> = []
     if (storedIds) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1186,7 +1186,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     previousRepositoryId: number | null,
     currentRepositoryId: number
   ) {
-    const recentRepositories = this.getRecentRepositories().filter(
+    const recentRepositories = this.getStoredRecentRepositories().filter(
       el => el !== currentRepositoryId && el !== previousRepositoryId
     )
     if (previousRepositoryId !== null) {
@@ -1205,7 +1205,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   // get the stored list of recently opened repositories
-  private getRecentRepositories() {
+  private getStoredRecentRepositories() {
     const storedIds = localStorage.getItem(RecentRepositoriesKey)
     let storedRepositories: Array<number> = []
     if (storedIds) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -244,6 +244,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private accounts: ReadonlyArray<Account> = new Array<Account>()
   private repositories: ReadonlyArray<Repository> = new Array<Repository>()
+  private recentRepositories: ReadonlyArray<number> = new Array<number>()
 
   private selectedRepository: Repository | CloningRepository | null = null
 
@@ -523,6 +524,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return {
       accounts: this.accounts,
       repositories,
+      recentRepositories: this.recentRepositories,
       localRepositoryStateLookup: this.localRepositoryStateLookup,
       windowState: this.windowState,
       windowZoomFactor: this.windowZoomFactor,
@@ -1184,20 +1186,26 @@ export class AppStore extends TypedBaseStore<IAppState> {
     previousRepositoryId: number | null,
     currentRepositoryId: number
   ) {
-    const recentRepositories = this.getRecentRepositories().filter(
+    const recentRepositories = this._getRecentRepositories().filter(
       el => el !== currentRepositoryId && el !== previousRepositoryId
     )
     if (previousRepositoryId !== null) {
       recentRepositories.unshift(previousRepositoryId)
     }
-    const toBeStored = recentRepositories
-      .slice(0, RecentRepositoriesLength)
-      .join(RecentRepositoriesDelimiter)
-    localStorage.setItem(RecentRepositoriesKey, toBeStored)
+    const slicedRecentRepositories = recentRepositories.slice(
+      0,
+      RecentRepositoriesLength
+    )
+    localStorage.setItem(
+      RecentRepositoriesKey,
+      slicedRecentRepositories.join(RecentRepositoriesDelimiter)
+    )
+    this.recentRepositories = slicedRecentRepositories
+    this.emitUpdate()
   }
 
   // get the stored list of recently opened repositories
-  public getRecentRepositories() {
+  private _getRecentRepositories() {
     const storedIds = localStorage.getItem(RecentRepositoriesKey)
     let storedRepositories: Array<number> = []
     if (storedIds) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -193,7 +193,11 @@ import {
   ManualConflictResolutionKind,
 } from '../../models/manual-conflict-resolution'
 import { BranchPruner } from './helpers/branch-pruner'
-import { enableBranchPruning, enablePullWithRebase } from '../feature-flag'
+import {
+  enableBranchPruning,
+  enablePullWithRebase,
+  enableGroupRepositoriesByOwner,
+} from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import { RebaseProgressOptions } from '../../models/rebase'
 
@@ -1156,7 +1160,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const previousRepositoryId = previouslySelectedRepository
       ? previouslySelectedRepository.id
       : null
-    this._updateRecentRepositories(previousRepositoryId, repository.id)
+    if (enableGroupRepositoriesByOwner()) {
+      this._updateRecentRepositories(previousRepositoryId, repository.id)
+    }
 
     // if repository might be marked missing, try checking if it has been restored
     const refreshedRepository = await this.recoverMissingRepository(repository)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -211,6 +211,10 @@ const FastForwardBranchesThreshold = 20
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
 const RecentRepositoriesKey = 'recently-selected-repositories'
+/**
+ *  maximum number of repositories shown in the "Recent" repositories group
+ *  in the repository switcher dropdown
+ */
 export const RecentRepositoriesLength = 5
 const RecentRepositoriesDelimiter = ','
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -211,7 +211,7 @@ const FastForwardBranchesThreshold = 20
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
 const RecentRepositoriesKey = 'recently-selected-repositories'
-const RecentRepositoriesLength = 5
+export const RecentRepositoriesLength = 5
 const RecentRepositoriesDelimiter = ','
 
 const defaultSidebarWidth: number = 250

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1208,7 +1208,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  // get the stored list of recently opened repositories
   private getStoredRecentRepositories() {
     const storedIds = localStorage.getItem(RecentRepositoriesKey)
     let storedRepositories: Array<number> = []

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -215,7 +215,7 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  *  maximum number of repositories shown in the "Recent" repositories group
  *  in the repository switcher dropdown
  */
-export const RecentRepositoriesLength = 5
+const RecentRepositoriesLength = 5
 const RecentRepositoriesDelimiter = ','
 
 const defaultSidebarWidth: number = 250

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1196,6 +1196,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (previousRepositoryId !== null) {
       recentRepositories.unshift(previousRepositoryId)
     }
+    recentRepositories.unshift(currentRepositoryId)
     const slicedRecentRepositories = recentRepositories.slice(
       0,
       RecentRepositoriesLength

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1781,7 +1781,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         selectedRepository={selectedRepository}
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
-        recentRepositories={this.props.appStore.getRecentRepositories()}
+        recentRepositories={this.state.recentRepositories}
         localRepositoryStateLookup={this.state.localRepositoryStateLookup}
         askForConfirmationOnRemoveRepository={
           this.state.askForConfirmationOnRepositoryRemoval

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1781,6 +1781,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         selectedRepository={selectedRepository}
         onSelectionChanged={this.onSelectionChanged}
         repositories={this.state.repositories}
+        recentRepositories={this.props.appStore.getRecentRepositories()}
         localRepositoryStateLookup={this.state.localRepositoryStateLookup}
         askForConfirmationOnRemoveRepository={
           this.state.askForConfirmationOnRepositoryRemoval

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -145,13 +145,6 @@ export function makeRecentRepositoriesGroup(
   repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
 ): IFilterListGroup<IRepositoryListItem> {
-  if (repositories === null) {
-    return {
-      identifier: '',
-      items: [],
-    }
-  }
-
   const names = new Map<string, number>()
   for (const id of recentRepositories) {
     const repository = repositories.find(r => r.id === id)

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -146,13 +146,19 @@ export function makeRecentRepositoriesGroup(
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
 ): IFilterListGroup<IRepositoryListItem> {
   if (repositories === null) {
-    return { identifier: '', items: [] }
+    return {
+      identifier: '',
+      items: [],
+    }
   }
 
   const names = new Map<string, number>()
-  for (const repository of repositories) {
-    const existingCount = names.get(repository.name) || 0
-    names.set(repository.name, existingCount + 1)
+  for (const id of recentRepositories) {
+    const repository = repositories.find(r => r.id === id)
+    if (repository !== undefined) {
+      const existingCount = names.get(repository.name) || 0
+      names.set(repository.name, existingCount + 1)
+    }
   }
 
   const items = recentRepositories

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -154,29 +154,30 @@ export function makeRecentRepositoriesGroup(
     }
   }
 
-  const items = recentRepositories
-    .map(id => {
-      const repository = repositories.find(r => r.id === id)
-      if (repository === undefined) {
-        return null
-      }
-      const { aheadBehind, changedFilesCount } =
-        localRepositoryStateLookup.get(id) || fallbackValue
-      const repositoryText: ReadonlyArray<string> =
-        repository instanceof Repository
-          ? [repository.name, nameOf(repository)]
-          : [repository.name]
-      const nameCount = names.get(repository.name) || 0
-      return {
-        text: repositoryText,
-        id: id.toString(),
-        repository,
-        needsDisambiguation: nameCount > 1,
-        aheadBehind,
-        changedFilesCount,
-      }
+  const items = new Array<IRepositoryListItem>()
+
+  for (const id of recentRepositories) {
+    const repository = repositories.find(r => r.id === id)
+    if (repository === undefined) {
+      continue
+    }
+
+    const { aheadBehind, changedFilesCount } =
+      localRepositoryStateLookup.get(id) || fallbackValue
+    const repositoryText =
+      repository instanceof Repository
+        ? [repository.name, nameOf(repository)]
+        : [repository.name]
+    const nameCount = names.get(repository.name) || 0
+    items.push({
+      text: repositoryText,
+      id: id.toString(),
+      repository,
+      needsDisambiguation: nameCount > 1,
+      aheadBehind,
+      changedFilesCount,
     })
-    .filter(el => el !== null) as ReadonlyArray<IRepositoryListItem>
+  }
 
   return {
     identifier: 'Recent',

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -142,7 +142,7 @@ export function groupRepositories(
  */
 export function makeRecentRepositoriesGroup(
   recentRepositories: ReadonlyArray<number>,
-  repositories: ReadonlyArray<Repositoryish> | null,
+  repositories: ReadonlyArray<Repositoryish>,
   localRepositoryStateLookup: ReadonlyMap<number, ILocalRepositoryState>
 ): IFilterListGroup<IRepositoryListItem> {
   if (repositories === null) {

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -134,7 +134,7 @@ export function groupRepositories(
 }
 
 /**
- * creates the group `Recent` of repositories recently opened for use with `FilterList` component
+ * Creates the group `Recent` of repositories recently opened for use with `FilterList` component
  *
  * @param recentRepositories list of recent repositories' ids
  * @param repositories full list of repositories (we use this to get data about the `recentRepositories`)

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -21,6 +21,7 @@ import { PopupType } from '../../models/popup'
 import { encodePathAsUrl } from '../../lib/path'
 import memoizeOne from 'memoize-one'
 import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
+import { RecentRepositoriesLength } from '../../lib/stores'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -187,16 +188,18 @@ export class RepositoriesList extends React.Component<
       this.props.selectedRepository
     )
 
-    const groups = enableGroupRepositoriesByOwner()
-      ? [
-          makeRecentRepositoriesGroup(
-            this.props.recentRepositories,
-            this.props.repositories,
-            this.props.localRepositoryStateLookup
-          ),
-          ...baseGroups,
-        ]
-      : baseGroups
+    const groups =
+      enableGroupRepositoriesByOwner() &&
+      this.props.repositories.length > RecentRepositoriesLength + 2
+        ? [
+            makeRecentRepositoriesGroup(
+              this.props.recentRepositories,
+              this.props.repositories,
+              this.props.localRepositoryStateLookup
+            ),
+            ...baseGroups,
+          ]
+        : baseGroups
 
     return (
       <div className="repository-list">

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -21,9 +21,10 @@ import { PopupType } from '../../models/popup'
 import { encodePathAsUrl } from '../../lib/path'
 import memoizeOne from 'memoize-one'
 import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
-import { RecentRepositoriesLength } from '../../lib/stores'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
+
+const recentRepositoriesThreshold = 7
 
 interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
@@ -190,7 +191,7 @@ export class RepositoriesList extends React.Component<
 
     const groups =
       enableGroupRepositoriesByOwner() &&
-      this.props.repositories.length > RecentRepositoriesLength + 2
+      this.props.repositories.length > recentRepositoriesThreshold
         ? [
             makeRecentRepositoriesGroup(
               this.props.recentRepositories,

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -184,11 +184,6 @@ export class RepositoriesList extends React.Component<
       this.props.localRepositoryStateLookup
     )
 
-    const selectedItem = this.getSelectedListItem(
-      baseGroups,
-      this.props.selectedRepository
-    )
-
     const groups =
       enableGroupRepositoriesByOwner() &&
       this.props.repositories.length > recentRepositoriesThreshold
@@ -201,6 +196,11 @@ export class RepositoriesList extends React.Component<
             ...baseGroups,
           ]
         : baseGroups
+
+    const selectedItem = this.getSelectedListItem(
+      groups,
+      this.props.selectedRepository
+    )
 
     return (
       <div className="repository-list">

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -23,6 +23,7 @@ import { IMenuItem } from '../../lib/menu-item'
 import { PopupType } from '../../models/popup'
 import { encodePathAsUrl } from '../../lib/path'
 import memoizeOne from 'memoize-one'
+import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -232,14 +233,16 @@ export class RepositoriesList extends React.Component<
       this.props.selectedRepository
     )
 
-    const groups = [
-      this.getRecentRepositoriesGroup(
-        this.props.recentRepositories,
-        this.props.repositories,
-        this.props.localRepositoryStateLookup
-      ),
-      ...baseGroups,
-    ]
+    const groups = enableGroupRepositoriesByOwner()
+      ? [
+          this.getRecentRepositoriesGroup(
+            this.props.recentRepositories,
+            this.props.repositories,
+            this.props.localRepositoryStateLookup
+          ),
+          ...baseGroups,
+        ]
+      : baseGroups
 
     return (
       <div className="repository-list">


### PR DESCRIPTION
(built off of #7130)

i've been thinking about this and got inspired by https://github.com/desktop/desktop/pull/7130#pullrequestreview-217857237 with a potential solution.

<img width="268" alt="Screen Shot 2019-03-25 at 2 44 57 PM" src="https://user-images.githubusercontent.com/964912/54956625-ac931400-4f0d-11e9-97c3-16f5181fde9e.png">

in my playing with it, i think it's less confusing, but i'd love others' feedback!

(also, i think its points to a suggestion @billygriffin made earlier: that we differentiate the "Recent" group visually from the other groups somehow)