### PR TITLE
preview the number of commits that will be rebased

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -234,7 +234,7 @@ class GitRebaseParser {
       return null
     }
 
-    const commitSummary = match[1]
+    const currentCommitSummary = match[1]
     this.rebasedCommitCount++
 
     const progress = this.rebasedCommitCount / this.totalCommitCount
@@ -248,7 +248,7 @@ class GitRebaseParser {
       value,
       rebasedCommitCount: this.rebasedCommitCount,
       totalCommitCount: this.totalCommitCount,
-      commitSummary,
+      currentCommitSummary,
     }
   }
 }

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -10,7 +10,11 @@ import { clamp } from './clamp'
 import { Repository } from '../models/repository'
 import { getCurrentProgress } from './git'
 
-export const initializeNewRebaseFlow = (state: IRepositoryState) => {
+/**
+ * Setup the rebase flow state when the user neeeds to select a branch as the
+ * base for the operation.
+ */
+export function initializeNewRebaseFlow(state: IRepositoryState) {
   const {
     defaultBranch,
     allBranches,
@@ -38,10 +42,19 @@ export const initializeNewRebaseFlow = (state: IRepositoryState) => {
   return initialState
 }
 
-export const initializeRebaseFlowForConflictedRepository = async (
+/**
+ * Setup the rebase flow when rebase conflicts are detected in the repository.
+ *
+ * This indicates a rebase is in progress, and the application needs to guide
+ * the user to resolve conflicts and complete the rebae.
+ *
+ * @param repository the repository dealing with conflicts
+ * @param conflictState current set of conflicts
+ */
+export async function initializeRebaseFlowForConflictedRepository(
   repository: Repository,
   conflictState: RebaseConflictState
-): Promise<ShowConflictsStep> => {
+): Promise<ShowConflictsStep> {
   const { targetBranch, baseBranch } = conflictState
 
   const previousProgress = await getCurrentProgress(repository)

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -7,6 +7,8 @@ import {
 import { Branch } from '../models/branch'
 import { TipState } from '../models/tip'
 import { clamp } from './clamp'
+import { Repository } from '../models/repository'
+import { getCurrentProgress } from './git'
 
 export const initializeNewRebaseFlow = (state: IRepositoryState) => {
   const {
@@ -36,15 +38,19 @@ export const initializeNewRebaseFlow = (state: IRepositoryState) => {
   return initialState
 }
 
-export const initializeRebaseFlowForConflictedRepository = (
+export const initializeRebaseFlowForConflictedRepository = async (
+  repository: Repository,
   conflictState: RebaseConflictState
-) => {
+): Promise<ShowConflictsStep> => {
   const { targetBranch, baseBranch } = conflictState
+
+  const previousProgress = await getCurrentProgress(repository)
 
   const initialState: ShowConflictsStep = {
     kind: RebaseStep.ShowConflicts,
     targetBranch,
     baseBranch,
+    previousProgress,
   }
 
   return initialState

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1749,7 +1749,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const initialState = initializeRebaseFlowForConflictedRepository(
+    const initialState = await initializeRebaseFlowForConflictedRepository(
+      repository,
       conflictState
     )
 

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -34,5 +34,5 @@ export type Banner =
       /** name of the branch that was used to rebase */
       readonly targetBranch: string
       /** callback to run when user clicks on link in banner text */
-      readonly onOpenDialog: () => void
+      readonly onOpenDialog: () => Promise<void>
     }

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -34,5 +34,5 @@ export type Banner =
       /** name of the branch that was used to rebase */
       readonly targetBranch: string
       /** callback to run when user clicks on link in banner text */
-      readonly onOpenDialog: () => Promise<void>
+      readonly onOpenDialog: () => void
     }

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -103,7 +103,7 @@ export interface IRevertProgress extends IProgress {
 export interface IRebaseProgress extends IProgress {
   readonly kind: 'rebase'
   /** The summary of the commit applied to the base branch */
-  readonly commitSummary: string
+  readonly currentCommitSummary: string
   /** The number of commits currently rebased onto the base branch */
   readonly rebasedCommitCount: number
   /** The toal number of commits to rebase on top of the current branch */

--- a/app/src/models/rebase-flow-state.ts
+++ b/app/src/models/rebase-flow-state.ts
@@ -1,4 +1,5 @@
 import { Branch } from './branch'
+import { RebaseProgressSummary } from './rebase'
 
 /** Union type representing the possible states of the rebase flow */
 export type RebaseFlowState =
@@ -88,6 +89,11 @@ export type ShowConflictsStep = {
   readonly kind: RebaseStep.ShowConflicts
   readonly targetBranch: string
   readonly baseBranch?: string
+  /**
+   * Optional context to provide if rebase dialog was dismissed, as previous
+   * state should be used here when resuming the rebase.
+   */
+  readonly previousProgress: RebaseProgressSummary | null
 }
 
 /** Shape of data to track when user hides conflicts dialog */

--- a/app/src/models/rebase-flow-state.ts
+++ b/app/src/models/rebase-flow-state.ts
@@ -81,7 +81,7 @@ export type ShowProgressStep = {
    * want to defer the rebase action until after _something_ is shown to the
    * user.
    */
-  readonly rebaseAction?: () => Promise<void>
+  readonly rebaseAction: (() => Promise<void>) | null
 }
 
 /** Shape of data to show conflicts that need to be resolved by the user */

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -49,7 +49,7 @@ export type RebaseProgressSummary = {
   /** Track the current number of commits rebased across dialogs and states */
   readonly rebasedCommitCount: number
   /** The commit summary associated with the current commit (if known) */
-  readonly commitSummary?: string
+  readonly currentCommitSummary?: string
   /** The list of known commits that will be rebased onto the base branch */
   readonly commits: ReadonlyArray<CommitOneLine>
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1568,7 +1568,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         )
       }
       case PopupType.RebaseFlow: {
-        const { selectedState } = this.state
+        const { selectedState, emoji } = this.state
 
         if (
           selectedState === null ||
@@ -1601,6 +1601,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
             onShowRebaseConflictsBanner={this.onShowRebaseConflictsBanner}
+            emoji={emoji}
           />
         )
       }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1629,7 +1629,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setBanner({
       type: BannerType.RebaseConflictsFound,
       targetBranch,
-      onOpenDialog: () => {
+      onOpenDialog: async () => {
         const { changesState } = this.props.repositoryStateManager.get(
           repository
         )
@@ -1641,7 +1641,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           )
           return
         }
-        const initialState = initializeRebaseFlowForConflictedRepository(
+        const initialState = await initializeRebaseFlowForConflictedRepository(
+          repository,
           conflictState
         )
 

--- a/app/src/ui/banners/rebase-conflicts-banner.tsx
+++ b/app/src/ui/banners/rebase-conflicts-banner.tsx
@@ -9,7 +9,7 @@ interface IRebaseConflictsBannerProps {
   /** branch the user is rebasing into */
   readonly targetBranch: string
   /** callback to fire when the dialog should be reopened */
-  readonly onOpenDialog: () => Promise<void>
+  readonly onOpenDialog: () => void
   /** callback to fire to dismiss the banner */
   readonly onDismissed: () => void
 }
@@ -20,7 +20,7 @@ export class RebaseConflictsBanner extends React.Component<
 > {
   private openDialog = async () => {
     this.props.onDismissed()
-    await this.props.onOpenDialog()
+    this.props.onOpenDialog()
     this.props.dispatcher.recordRebaseConflictsDialogReopened()
   }
 

--- a/app/src/ui/banners/rebase-conflicts-banner.tsx
+++ b/app/src/ui/banners/rebase-conflicts-banner.tsx
@@ -9,7 +9,7 @@ interface IRebaseConflictsBannerProps {
   /** branch the user is rebasing into */
   readonly targetBranch: string
   /** callback to fire when the dialog should be reopened */
-  readonly onOpenDialog: () => void
+  readonly onOpenDialog: () => Promise<void>
   /** callback to fire to dismiss the banner */
   readonly onDismissed: () => void
 }
@@ -18,9 +18,9 @@ export class RebaseConflictsBanner extends React.Component<
   IRebaseConflictsBannerProps,
   {}
 > {
-  private openDialog = () => {
+  private openDialog = async () => {
     this.props.onDismissed()
-    this.props.onOpenDialog()
+    await this.props.onOpenDialog()
     this.props.dispatcher.recordRebaseConflictsDialogReopened()
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -322,9 +322,11 @@ export class Dispatcher {
       conflictState: updatedConflictState,
     }))
 
-    const initialState = initializeRebaseFlowForConflictedRepository(
+    const initialState = await initializeRebaseFlowForConflictedRepository(
+      repository,
       updatedConflictState
     )
+
     this.showPopup({
       type: PopupType.RebaseFlow,
       repository,

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -5,7 +5,7 @@ import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
-import { MergeStatusHeader } from './merge-status-header'
+import { ActionStatusIcon } from '../lib/action-status-icon'
 import { MergeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
 
@@ -52,7 +52,10 @@ export class MergeCallToActionWithConflicts extends React.Component<
   private renderMergeStatus() {
     return (
       <div className="merge-status-component">
-        <MergeStatusHeader status={this.props.mergeStatus} />
+        <ActionStatusIcon
+          status={this.props.mergeStatus}
+          classNamePrefix="merge-status"
+        />
 
         {this.renderMergeDetails(
           this.props.currentBranch,

--- a/app/src/ui/lib/action-status-icon.tsx
+++ b/app/src/ui/lib/action-status-icon.tsx
@@ -1,40 +1,42 @@
 import * as React from 'react'
-import { Octicon, OcticonSymbol } from '../octicons'
-import { assertNever } from '../../lib/fatal-error'
 import * as classNames from 'classnames'
-import { MergeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
+import { assertNever } from '../../lib/fatal-error'
 
-interface IMergeStatusIconProps {
+import { Octicon, OcticonSymbol } from '../octicons'
+
+interface IActionStatusIconProps {
+  /** The status to display to the user */
+  readonly status: { kind: ComputedAction } | null
+
+  /** A required class name prefix for the Octicon component */
+  readonly classNamePrefix: string
+
   /** The classname for the underlying element. */
   readonly className?: string
-
-  /** The status to display. */
-  readonly status: MergeResult | null
 }
 
-/** The little CI status indicator. */
-export class MergeStatusHeader extends React.Component<
-  IMergeStatusIconProps,
-  {}
-> {
+/** An indicator to display representing the result of a computed action */
+export class ActionStatusIcon extends React.Component<IActionStatusIconProps> {
   public render() {
-    const { status } = this.props
+    const { status, classNamePrefix } = this.props
     if (status === null) {
       return null
     }
 
-    const state = status.kind
+    const { kind } = status
+
+    const className = `${classNamePrefix}-icon-container`
 
     return (
-      <div className="merge-status-icon-container">
+      <div className={className}>
         <Octicon
           className={classNames(
-            'merge-status',
-            `merge-status-${state}`,
+            classNamePrefix,
+            `${classNamePrefix}-${kind}`,
             this.props.className
           )}
-          symbol={getSymbolForState(state)}
+          symbol={getSymbolForState(kind)}
         />
       </div>
     )

--- a/app/src/ui/lib/action-status-icon.tsx
+++ b/app/src/ui/lib/action-status-icon.tsx
@@ -16,7 +16,7 @@ interface IActionStatusIconProps {
   readonly className?: string
 }
 
-/** 
+/**
  * A component used to render a visual indication of a `ComputedAction` state.
  *
  * In essence this is a small wrapper around an `Octicon` which determines which

--- a/app/src/ui/lib/action-status-icon.tsx
+++ b/app/src/ui/lib/action-status-icon.tsx
@@ -16,7 +16,15 @@ interface IActionStatusIconProps {
   readonly className?: string
 }
 
-/** An indicator to display representing the result of a computed action */
+/** 
+ * A component used to render a visual indication of a `ComputedAction` state.
+ *
+ * In essence this is a small wrapper around an `Octicon` which determines which
+ * icon to use based on the `ComputedAction`. A computed action is essentially
+ * the current state of a merge or a rebase operation and this component is used
+ * in the header of merge or rebase conflict dialogs to augment the textual
+ * representation of the current merge or rebase progress.
+ */
 export class ActionStatusIcon extends React.Component<IActionStatusIconProps> {
   public render() {
     const { status, classNamePrefix } = this.props

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -15,7 +15,7 @@ import { revSymmetricDifference } from '../../lib/git'
 import { IMatches } from '../../lib/fuzzy-find'
 import { MergeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
-import { MergeStatusHeader } from '../history/merge-status-header'
+import { ActionStatusIcon } from '../lib/action-status-icon'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 
@@ -126,7 +126,10 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
 
     return (
       <div className="merge-status-component">
-        <MergeStatusHeader status={this.state.mergeStatus} />
+        <ActionStatusIcon
+          status={this.state.mergeStatus}
+          classNamePrefix="merge-status"
+        />
         <p className="merge-info">
           {this.renderMergeStatusMessage(
             mergeStatus,

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -118,14 +118,20 @@ export class ChooseBranchDialog extends React.Component<
 
   public render() {
     const { selectedBranch } = this.state
-    const { currentBranch } = this.props
+    const { currentBranch, rebasePreviewStatus } = this.props
 
     const selectedBranchIsNotCurrentBranch =
       selectedBranch === null ||
       currentBranch === null ||
       currentBranch.name === selectedBranch.name
 
-    const disabled = selectedBranchIsNotCurrentBranch
+    const noCommitsToRebase =
+      rebasePreviewStatus !== null &&
+      rebasePreviewStatus.kind === ComputedAction.Clean
+        ? rebasePreviewStatus.commits.length === 0
+        : true
+
+    const disabled = selectedBranchIsNotCurrentBranch || noCommitsToRebase
 
     const currentBranchName = currentBranch.name
 
@@ -165,7 +171,7 @@ export class ChooseBranchDialog extends React.Component<
         <DialogFooter>
           {this.renderRebaseStatus()}
           <ButtonGroup>
-            <Button type="submit">
+            <Button type="submit" disabled={disabled}>
               Rebase <strong>{currentBranchName}</strong> onto{' '}
               <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
             </Button>
@@ -243,7 +249,12 @@ export class ChooseBranchDialog extends React.Component<
     commitsToRebase: number
   ) {
     if (commitsToRebase <= 0) {
-      return null
+      return (
+        <React.Fragment>
+          This branch is up to date with{` `}
+          <strong>{currentBranch.name}</strong>
+        </React.Fragment>
+      )
     }
 
     const pluralized = commitsToRebase === 1 ? 'commit' : 'commits'

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -11,6 +11,7 @@ import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 
 import { Button } from '../lib/button'
 import { ButtonGroup } from '../lib/button-group'
+import { ActionStatusIcon } from '../lib/action-status-icon'
 
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
@@ -162,6 +163,7 @@ export class ChooseBranchDialog extends React.Component<
           />
         </DialogContent>
         <DialogFooter>
+          {this.renderRebaseStatus()}
           <ButtonGroup>
             <Button type="submit">
               Rebase <strong>{currentBranchName}</strong> onto{' '}
@@ -170,6 +172,90 @@ export class ChooseBranchDialog extends React.Component<
           </ButtonGroup>
         </DialogFooter>
       </Dialog>
+    )
+  }
+
+  private renderRebaseStatus = () => {
+    const { currentBranch, rebasePreviewStatus } = this.props
+    const { selectedBranch } = this.state
+
+    if (rebasePreviewStatus === null) {
+      return null
+    }
+
+    if (selectedBranch === null) {
+      return null
+    }
+
+    if (currentBranch.name === selectedBranch.name) {
+      return null
+    }
+
+    return (
+      <div className="rebase-status-component">
+        <ActionStatusIcon
+          status={this.props.rebasePreviewStatus}
+          classNamePrefix="rebase-status"
+        />
+        <p className="rebase-message">
+          {this.renderRebaseDetails(
+            currentBranch,
+            selectedBranch,
+            rebasePreviewStatus
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  private renderRebaseDetails(
+    currentBranch: Branch,
+    baseBranch: Branch,
+    rebaseStatus: RebasePreview
+  ): JSX.Element | null {
+    if (rebaseStatus.kind === ComputedAction.Loading) {
+      return this.renderLoadingRebaseMessage()
+    }
+    if (rebaseStatus.kind === ComputedAction.Clean) {
+      return this.renderCleanRebaseMessage(
+        currentBranch,
+        baseBranch,
+        rebaseStatus.commits.length
+      )
+    }
+
+    // TODO: other scenarios to display some context about
+
+    return null
+  }
+
+  private renderLoadingRebaseMessage() {
+    return (
+      <React.Fragment>
+        Checking for ability to rebase automatically...
+      </React.Fragment>
+    )
+  }
+
+  private renderCleanRebaseMessage(
+    currentBranch: Branch,
+    baseBranch: Branch,
+    commitsToRebase: number
+  ) {
+    if (commitsToRebase <= 0) {
+      return null
+    }
+
+    const pluralized = commitsToRebase === 1 ? 'commit' : 'commits'
+    return (
+      <React.Fragment>
+        This will rebase
+        <strong>{` ${commitsToRebase} ${pluralized}`}</strong>
+        {` from `}
+        <strong>{currentBranch.name}</strong>
+        {` onto `}
+        <strong>{baseBranch.name}</strong>
+      </React.Fragment>
     )
   }
 

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -250,23 +250,23 @@ export class ChooseBranchDialog extends React.Component<
   ) {
     if (commitsToRebase <= 0) {
       return (
-        <React.Fragment>
+        <>
           This branch is up to date with{` `}
           <strong>{currentBranch.name}</strong>
-        </React.Fragment>
+        </>
       )
     }
 
     const pluralized = commitsToRebase === 1 ? 'commit' : 'commits'
     return (
-      <React.Fragment>
+      <>
         This will rebase
         <strong>{` ${commitsToRebase} ${pluralized}`}</strong>
         {` from `}
         <strong>{currentBranch.name}</strong>
         {` onto `}
         <strong>{baseBranch.name}</strong>
-      </React.Fragment>
+      </>
     )
   }
 

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -236,11 +236,7 @@ export class ChooseBranchDialog extends React.Component<
   }
 
   private renderLoadingRebaseMessage() {
-    return (
-      <React.Fragment>
-        Checking for ability to rebase automatically...
-      </React.Fragment>
-    )
+    return <>Checking for ability to rebase automatically...</>
   }
 
   private renderCleanRebaseMessage(

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -3,6 +3,8 @@ import * as React from 'react'
 import { timeout } from '../../lib/promise'
 import { formatRebaseValue } from '../../lib/rebase'
 
+import { RichText } from '../lib/rich-text'
+
 import { Dialog, DialogContent } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { RebaseProgressSummary } from '../../models/rebase'
@@ -10,6 +12,9 @@ import { RebaseProgressSummary } from '../../models/rebase'
 interface IRebaseProgressDialogProps {
   /** Progress information about the current rebase */
   readonly progress: RebaseProgressSummary
+
+  readonly emoji: Map<string, string>
+
   /**
    * An optional action to run when the component is mounted
    *
@@ -61,7 +66,12 @@ export class RebaseProgressDialog extends React.Component<
                 <div className="message">
                   Commit {rebasedCommitCount} of {commits.length}
                 </div>
-                <div className="detail">{currentCommitSummary}</div>
+                <div className="detail">
+                  <RichText
+                    emoji={this.props.emoji}
+                    text={currentCommitSummary || ''}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -38,7 +38,7 @@ export class RebaseProgressDialog extends React.Component<
       rebasedCommitCount,
       commits,
       value,
-      commitSummary,
+      currentCommitSummary,
     } = this.props.progress
     const progressValue = formatRebaseValue(value)
     return (
@@ -61,7 +61,7 @@ export class RebaseProgressDialog extends React.Component<
                 <div className="message">
                   Commit {rebasedCommitCount} of {commits.length}
                 </div>
-                <div className="detail">{commitSummary}</div>
+                <div className="detail">{currentCommitSummary}</div>
               </div>
             </div>
           </div>

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -20,7 +20,7 @@ interface IRebaseProgressDialogProps {
    *
    * This should typically be the rebase action to perform.
    */
-  readonly rebaseAction?: () => Promise<void>
+  readonly rebaseAction: (() => Promise<void>) | null
 }
 
 export class RebaseProgressDialog extends React.Component<

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -264,6 +264,8 @@ export class RebaseFlow extends React.Component<
   }
 
   private updateProgress = (progress: IRebaseProgress) => {
+    const { rebasedCommitCount, value, commitSummary } = progress
+
     // this ensures the progress bar fills to 100%, while `componentDidUpdate`
     // detects and handles the state transition after a period of time to ensure
     // the UI shows _something_ before closing the dialog
@@ -271,7 +273,9 @@ export class RebaseFlow extends React.Component<
       const { commits } = prevState.progress
       return {
         progress: {
-          ...progress,
+          rebasedCommitCount,
+          value,
+          currentCommitSummary: commitSummary,
           commits,
         },
       }
@@ -287,12 +291,21 @@ export class RebaseFlow extends React.Component<
     // detects and handles the state transition after a period of time to ensure
     // the UI shows _something_ before closing the dialog
     this.setState(prevState => {
+      let currentCommitSummary: string | undefined = undefined
+
+      const { rebaseStatus } = prevState
+
+      if (rebaseStatus !== null && rebaseStatus.kind === ComputedAction.Clean) {
+        const { commits } = rebaseStatus
+        currentCommitSummary = commits[commits.length - 1].summary
+      }
+
       const { commits } = prevState.progress
-      const rebasedCommitCount = commits.length
       return {
         progress: {
           value: 1,
-          rebasedCommitCount,
+          currentCommitSummary,
+          rebasedCommitCount: commits.length,
           commits,
         },
       }
@@ -385,6 +398,9 @@ export class RebaseFlow extends React.Component<
       const newProgressValue = newCount / commits.length
       const value = formatRebaseValue(newProgressValue)
 
+      const currentCommitSummary =
+        newCount <= commits.length ? commits[newCount - 1].summary : undefined
+
       return {
         step: {
           kind: RebaseStep.ShowProgress,
@@ -394,6 +410,7 @@ export class RebaseFlow extends React.Component<
           value,
           rebasedCommitCount: newCount,
           commits,
+          currentCommitSummary,
         },
       }
     })

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -300,7 +300,10 @@ export class RebaseFlow extends React.Component<
 
       if (rebaseStatus !== null && rebaseStatus.kind === ComputedAction.Clean) {
         const { commits } = rebaseStatus
-        currentCommitSummary = commits[commits.length - 1].summary
+        if (commits.length > 0) {
+          const last = commits.length - 1
+          currentCommitSummary = commits[last].summary
+        }
       }
 
       const { commits } = prevState.progress

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -70,24 +70,20 @@ interface IRebaseFlowProps {
 }
 
 interface IRebaseFlowState {
-  /** The current step in the rebase flow */
+  /**
+   * The current step in the rebase flow, containing application-specific
+   * state needed for the UI components.
+   */
   readonly step: RebaseFlowState
 
-  /**
-   * Tracking the tip of the repository when conflicts were last resolved to
-   * ensure the flow returns to displaying conflicts only when the rebase
-   * proceeds, and not as a side-effect of other prop changes.
-   */
-  readonly lastResolvedConflictsTip: string | null
-
-  /** Progress information about the current rebase */
+  /** Git progress information about the current rebase */
   readonly progress: RebaseProgressSummary
 
   /**
    * A preview of the rebase, using the selected base branch to test whether the
-   * current branch may be cleanly applied.
+   * current branch will be cleanly applied.
    */
-  readonly rebaseStatus: RebasePreview | null
+  readonly rebasePreview: RebasePreview | null
 
   /**
    * Track whether the user has done work to resolve conflicts as part of this
@@ -95,6 +91,13 @@ interface IRebaseFlowState {
    * abort the rebase and lose that work.
    */
   readonly userHasResolvedConflicts: boolean
+
+  /**
+   * Tracking the tip of the repository when conflicts were last resolved to
+   * ensure the flow returns to displaying conflicts only when the rebase
+   * proceeds, and not as a side-effect of other prop changes.
+   */
+  readonly lastResolvedConflictsTip: string | null
 }
 
 /** A component for initiating and performing a rebase of the current branch. */
@@ -116,7 +119,7 @@ export class RebaseFlow extends React.Component<
         commits: [],
       },
       userHasResolvedConflicts: false,
-      rebaseStatus: null,
+      rebasePreview: null,
     }
 
     const { step } = this.state
@@ -211,7 +214,7 @@ export class RebaseFlow extends React.Component<
 
     this.setState(
       () => ({
-        rebaseStatus: {
+        rebasePreview: {
           kind: ComputedAction.Loading,
         },
       }),
@@ -233,7 +236,7 @@ export class RebaseFlow extends React.Component<
         //       conflicts to come
 
         this.setState(() => ({
-          rebaseStatus: {
+          rebasePreview: {
             kind: ComputedAction.Clean,
             commits,
           },
@@ -293,7 +296,7 @@ export class RebaseFlow extends React.Component<
     this.setState(prevState => {
       let currentCommitSummary: string | undefined = undefined
 
-      const { rebaseStatus } = prevState
+      const { rebasePreview: rebaseStatus } = prevState
 
       if (rebaseStatus !== null && rebaseStatus.kind === ComputedAction.Clean) {
         const { commits } = rebaseStatus
@@ -490,7 +493,7 @@ export class RebaseFlow extends React.Component<
             onDismissed={onFlowEnded}
             onStartRebase={this.onStartRebase}
             onBranchChanged={this.testRebaseOperation}
-            rebasePreviewStatus={this.state.rebaseStatus}
+            rebasePreviewStatus={this.state.rebasePreview}
           />
         )
       }

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -9,9 +9,12 @@ import { RebaseConflictState } from '../../lib/app-state'
 
 import { Repository } from '../../models/repository'
 import { RebaseStep, RebaseFlowState } from '../../models/rebase-flow-state'
-import { RebaseProgressSummary } from '../../models/rebase'
+import { RebaseProgressSummary, RebasePreview } from '../../models/rebase'
 import { IRebaseProgress } from '../../models/progress'
 import { WorkingDirectoryStatus } from '../../models/status'
+import { CommitOneLine } from '../../models/commit'
+import { Branch } from '../../models/branch'
+import { ComputedAction } from '../../models/computed-action'
 
 import { Dispatcher } from '../dispatcher'
 
@@ -19,7 +22,6 @@ import { ChooseBranchDialog } from './choose-branch'
 import { ShowConflictedFilesDialog } from './show-conflicted-files-dialog'
 import { RebaseProgressDialog } from './progress-dialog'
 import { ConfirmAbortDialog } from './confirm-abort-dialog'
-import { CommitOneLine } from '../../models/commit'
 
 interface IRebaseFlowProps {
   /**
@@ -82,6 +84,12 @@ interface IRebaseFlowState {
   readonly progress: RebaseProgressSummary
 
   /**
+   * A preview of the rebase, using the selected base branch to test whether the
+   * current branch may be cleanly applied.
+   */
+  readonly rebaseStatus: RebasePreview | null
+
+  /**
    * Track whether the user has done work to resolve conflicts as part of this
    * rebase, as the component should confirm with the user that they wish to
    * abort the rebase and lose that work.
@@ -108,6 +116,7 @@ export class RebaseFlow extends React.Component<
         commits: [],
       },
       userHasResolvedConflicts: false,
+      rebaseStatus: null,
     }
 
     const { step } = this.state
@@ -193,6 +202,46 @@ export class RebaseFlow extends React.Component<
     }
   }
 
+  private testRebaseOperation = (baseBranch: Branch) => {
+    const { step } = this.state
+    if (step.kind !== RebaseStep.ChooseBranch) {
+      log.warn(`[RebaseFlow] testRebaseOperation invoked but on the wrong step`)
+      return
+    }
+
+    this.setState(
+      () => ({
+        rebaseStatus: {
+          kind: ComputedAction.Loading,
+        },
+      }),
+      async () => {
+        const commits = await getCommitsInRange(
+          this.props.repository,
+          baseBranch.tip.sha,
+          step.currentBranch.tip.sha
+        )
+
+        // TODO: in what situations might this not be possible to compute
+
+        // TODO: check if this is a fast-forward (i.e. the selected branch is
+        //       a direct descendant of the base branch) because this is a
+        //       trivial rebase
+
+        // TODO: generate the patches associated with these commits and see if
+        //       they will apply to the base branch - if it fails, there will be
+        //       conflicts to come
+
+        this.setState(() => ({
+          rebaseStatus: {
+            kind: ComputedAction.Clean,
+            commits,
+          },
+        }))
+      }
+    )
+  }
+
   private moveToShowConflictedFileState = () => {
     const { workingDirectory, conflictState } = this.props
 
@@ -253,11 +302,13 @@ export class RebaseFlow extends React.Component<
   private onStartRebase = async (
     baseBranch: string,
     targetBranch: string,
-    totalCommitCount: number
+    commits: ReadonlyArray<CommitOneLine>
   ) => {
     if (this.state.step.kind !== RebaseStep.ChooseBranch) {
       throw new Error(`Invalid step to start rebase: ${this.state.step.kind}`)
     }
+
+    const totalCommitCount = commits.length
 
     const startRebaseAction = async () => {
       const result = await this.props.dispatcher.rebase(
@@ -276,38 +327,26 @@ export class RebaseFlow extends React.Component<
       }
     }
 
-    // TODO:
-    // clean this up in https://github.com/desktop/desktop/pull/7167 as
-    // the commits will be checked in the ChooseBranch step and passed into
-    // here to start the rebase
-    let commits: ReadonlyArray<CommitOneLine> = []
+    this.setState(() => {
+      const currentCommitSummary =
+        commits.length > 0 ? commits[0].summary : undefined
 
-    try {
-      commits = await getCommitsInRange(
-        this.props.repository,
-        baseBranch,
-        targetBranch
-      )
-    } catch (err) {
-      log.warn(
-        `Unexpected error while getting commits that will be part of the rebase`,
-        err
-      )
-    }
+      const rebasedCommitCount = 1
+      const newProgressValue = rebasedCommitCount / commits.length
 
-    this.setState(() => ({
-      step: {
-        kind: RebaseStep.ShowProgress,
-        rebaseAction: startRebaseAction,
-      },
-      progress: {
-        value: 0,
-        rebasedCommitCount: 1,
-        totalCommitCount,
-
-        commits,
-      },
-    }))
+      return {
+        step: {
+          kind: RebaseStep.ShowProgress,
+          rebaseAction: startRebaseAction,
+        },
+        progress: {
+          commits,
+          value: formatRebaseValue(newProgressValue),
+          rebasedCommitCount,
+          currentCommitSummary,
+        },
+      }
+    })
   }
 
   private onContinueRebase = async () => {
@@ -433,6 +472,8 @@ export class RebaseFlow extends React.Component<
             initialBranch={initialBranch}
             onDismissed={onFlowEnded}
             onStartRebase={this.onStartRebase}
+            onBranchChanged={this.testRebaseOperation}
+            rebasePreviewStatus={this.state.rebaseStatus}
           />
         )
       }

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -30,6 +30,7 @@ interface IRebaseFlowProps {
 
   readonly repository: Repository
   readonly dispatcher: Dispatcher
+  readonly emoji: Map<string, string>
 
   /** The current state of the working directory */
   readonly workingDirectory: WorkingDirectoryStatus
@@ -439,6 +440,7 @@ export class RebaseFlow extends React.Component<
         return (
           <RebaseProgressDialog
             progress={this.state.progress}
+            emoji={this.props.emoji}
             rebaseAction={step.rebaseAction}
           />
         )

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -108,6 +108,18 @@ export class RebaseFlow extends React.Component<
       },
       userHasResolvedConflicts: false,
     }
+
+    const { step } = this.state
+
+    if (
+      step.kind === RebaseStep.ShowConflicts &&
+      step.previousProgress !== null
+    ) {
+      this.state = {
+        ...this.state,
+        progress: step.previousProgress,
+      }
+    }
   }
 
   public componentWillUnmount() {
@@ -132,6 +144,7 @@ export class RebaseFlow extends React.Component<
             targetBranch,
             workingDirectory,
             manualResolutions,
+            previousProgress: null,
           },
         })
       } else if (this.state.progress.value >= 1) {
@@ -195,6 +208,7 @@ export class RebaseFlow extends React.Component<
         targetBranch,
         workingDirectory,
         manualResolutions,
+        previousProgress: null,
       },
     })
   }

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -264,7 +264,7 @@ export class RebaseFlow extends React.Component<
   }
 
   private updateProgress = (progress: IRebaseProgress) => {
-    const { rebasedCommitCount, value, commitSummary } = progress
+    const { rebasedCommitCount, value, currentCommitSummary } = progress
 
     // this ensures the progress bar fills to 100%, while `componentDidUpdate`
     // detects and handles the state transition after a period of time to ensure
@@ -275,7 +275,7 @@ export class RebaseFlow extends React.Component<
         progress: {
           rebasedCommitCount,
           value,
-          currentCommitSummary: commitSummary,
+          currentCommitSummary,
           commits,
         },
       }

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -68,4 +68,5 @@
 @import 'ui/fancy-text-box';
 @import 'ui/notification-banner';
 @import 'ui/merge-status';
+@import 'ui/rebase-status';
 @import 'ui/cloneable-repository-filter-list';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -411,6 +411,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   /** rebase progress bar */
   --dialog-rebase-progress-background: #{$green};
 
+  /** merge/rebase status indicators */
   --status-pending-color: #{$yellow-700};
   --status-error-color: #{$red-500};
   --status-success-color: #{$green-500};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -410,6 +410,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   /** rebase progress bar */
   --dialog-rebase-progress-background: #{$green};
+
+  --status-pending-color: #{$yellow-700};
+  --status-error-color: #{$red-500};
+  --status-success-color: #{$green-500};
 }
 
 ::backdrop {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -316,6 +316,11 @@ body.theme-dark {
   --notification-banner-background: #{$gray-800};
   --notification-banner-border-color: #{$gray-700};
   --notification-ref-background: #{$gray-700};
+
+  /** merge/rebase status indicators */
+  --status-pending-color: #{$yellow-700};
+  --status-error-color: #{$red-500};
+  --status-success-color: #{$green-500};
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/rebase-status.scss
+++ b/app/styles/ui/rebase-status.scss
@@ -15,7 +15,7 @@
   }
 
   .rebase-status-loading {
-    color: $yellow-700;
+    color: var(--status-pending-color);
   }
 
   .rebase-status-conflicts {
@@ -23,11 +23,11 @@
   }
 
   .rebase-status-invalid {
-    color: $red-500;
+    color: var(--status-error-color);
   }
 
   .rebase-status-clean {
-    color: $green-500;
+    color: var(--status-success-color);
   }
 
   .rebase-message,

--- a/app/styles/ui/rebase-status.scss
+++ b/app/styles/ui/rebase-status.scss
@@ -1,0 +1,68 @@
+.rebase-status-component {
+  .rebase-status-icon-container {
+    height: 20px;
+    position: relative;
+    text-align: center;
+
+    .rebase-status {
+      background: var(--background-color);
+      border-width: 0 var(--spacing-half);
+      border: solid transparent;
+      box-sizing: content-box;
+      position: relative;
+      z-index: 1;
+    }
+  }
+
+  .rebase-status-loading {
+    color: $yellow-700;
+  }
+
+  .rebase-status-conflicts {
+    color: var(--color-conflicted);
+  }
+
+  .rebase-status-invalid {
+    color: $red-500;
+  }
+
+  .rebase-status-clean {
+    color: $green-500;
+  }
+
+  .rebase-message,
+  .rebase-info {
+    margin-bottom: 0;
+    text-align: center;
+    color: var(--text-secondary-color);
+
+    strong {
+      color: var(--text-color);
+    }
+  }
+
+  .rebase-message {
+    padding-bottom: var(--spacing);
+  }
+}
+
+dialog#rebase {
+  .rebase-info {
+    margin-top: var(--spacing-half);
+    margin-bottom: var(--spacing);
+  }
+
+  .rebase-status-component {
+    margin-top: 0;
+  }
+
+  .rebase-status-icon-container {
+    &:after {
+      border-bottom: 0;
+    }
+  }
+
+  .dialog-footer {
+    padding-top: var(--spacing);
+  }
+}


### PR DESCRIPTION
## Overview

**Closes #6959**

## Description

Similar to the Merge Branch flow, the Rebase Flow now shows the number of commits that will be moved as part of the operation:

<img width="984" src="https://user-images.githubusercontent.com/359239/55102915-35dd4e80-50a6-11e9-973e-d5b9e1108817.png">

#6960 is tracking detecting conflicts at this stage, so for now this PR is focused on just the happy path and it's testing.

 - [x] use the component in the "Choose Branch" stage to show the status of the rebase
 - [x] pass information from APIs added in #7175 into the rebase flow state, so that commit messages can be shown without relying on the underling Git operation
 - [x] tidy up CSS to reduce excessive whitespace
 - [x] tidy up history to make changes easier to follow
 - [x] rebase on top of #7175 once merged, and tidy up history
 - [x] show "up to date" message when rebase does not contain any commits to rebase

Some additional polish related to this area while I'm in here testing:

 - [x] extract `MergeStatusHeader` into a generalized UI component `ActionStatusIcon` (lots of internals are hard-coded to `merge-status`
 - [x] render Emoji in the progress view if the commit message contains any `:emoji:`

## Release notes

Notes: no-notes
