### PR TITLE
Catch exceptions thrown by parsedResponse

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -317,7 +317,8 @@ export class API {
   public async fetchAccount(): Promise<IAPIFullIdentity> {
     try {
       const response = await this.request('GET', 'user')
-      return await parsedResponse<IAPIFullIdentity>(response)
+      const result = await parsedResponse<IAPIFullIdentity>(response)
+      return result
     } catch (e) {
       log.warn(`fetchAccount: failed with endpoint ${this.endpoint}`, e)
       throw e

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -317,8 +317,7 @@ export class API {
   public async fetchAccount(): Promise<IAPIFullIdentity> {
     try {
       const response = await this.request('GET', 'user')
-      const result = await parsedResponse<IAPIFullIdentity>(response)
-      return result
+      return await parsedResponse<IAPIFullIdentity>(response)
     } catch (e) {
       log.warn(`fetchAccount: failed with endpoint ${this.endpoint}`, e)
       throw e
@@ -351,7 +350,7 @@ export class API {
         log.warn(`fetchCommit: '${path}' returned a 404`)
         return null
       }
-      return parsedResponse<IAPICommit>(response)
+      return await parsedResponse<IAPICommit>(response)
     } catch (e) {
       log.warn(`fetchCommit: returned an error '${owner}/${name}@${sha}'`, e)
       return null
@@ -390,7 +389,7 @@ export class API {
   /** Fetch all the orgs to which the user belongs. */
   public async fetchOrgs(): Promise<ReadonlyArray<IAPIOrganization>> {
     try {
-      return this.fetchAll<IAPIOrganization>('user/orgs')
+      return await this.fetchAll<IAPIOrganization>('user/orgs')
     } catch (e) {
       log.warn(`fetchOrgs: failed with endpoint ${this.endpoint}`, e)
       return []


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

@tierninho [Spotted an error in his console](https://github.com/desktop/desktop/pull/7163/#issuecomment-476922906) which caught my eye while testing #7163.

![image](https://user-images.githubusercontent.com/14828183/55042483-bbdd9480-4fd5-11e9-9b8f-ec2979d3060d.png)

## Description

Our API class conventionally catches API errors, suppresses them, logs an error in the console, and returns null. At first glance the method from which @tierninho's error was thrown was following that pattern.

https://github.com/desktop/desktop/blob/6206729db9212815a14fe761637be28a036c01d2/app/src/lib/api.ts#L347-L358

As such I was confused when I saw that the error in @tierninho's console wasn't the result of our logging but was actually an uncaught promise error. Looking more carefully at the code I saw that we weren't awaiting the results of `parsedResponse`, we were merely returning the promise which is perfectly legal to do in TypeScript (i.e. it won't get wrapped in another promise like it would in, say, c#). The problem with it though is that it makes bypasses the try/catch. I spotted a few other places with the same oversight and decided it was worth addressing.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes.