### PR TITLE
add escape hatch notes at start of rebase attempt

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -723,7 +723,7 @@ export class Dispatcher {
 
     log.info(`[rebase] starting rebase for ${targetBranch} at ${beforeSha}`)
     log.info(
-      `[rebase] to restore the previous state if this rebase is unsatisfactory:`
+      `[rebase] to restore the previous state if this completed rebase is unsatisfactory:`
     )
     log.info(`[rebase] - git checkout ${targetBranch}`)
     log.info(`[rebase] - git reset ${beforeSha} --hard`)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -721,7 +721,12 @@ export class Dispatcher {
 
     const beforeSha = getTipSha(stateBefore.branchesState.tip)
 
-    log.info(`[rebase] starting rebase for ${beforeSha}`)
+    log.info(`[rebase] starting rebase for ${targetBranch} at ${beforeSha}`)
+    log.info(
+      `[rebase] to restore the previous state if this rebase is unsatisfactory:`
+    )
+    log.info(`[rebase] - git checkout ${targetBranch}`)
+    log.info(`[rebase] - git reset ${beforeSha} --hard`)
 
     const result = await this.appStore._rebase(
       repository,


### PR DESCRIPTION
## Overview

In a discussion last week with @billygriffin and @nerdneha about the rebase feature we touched on a number of things, but one thing we wanted to get into the rebase MVP slated for this week is a support-friendly way to help users who aren't happy with their rebase get back to a happy place.

## Description

This PR improves the logging at the start of a rebase in case a user reaches out to @desktop/support to ask for help when a rebase has gone awry.

In this case, we embed in the logs the context required to restore the branch to the state before the rebase. We're thinking of other ways to help users get back to their previous state, but this bit of work here will help us with the rebase MVP without needing to change the UI/UX of what will ship.

## Release notes

Notes: no-notes
