### PR TITLE
refresh repository state after rebase completed

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -66,7 +66,7 @@ import {
 } from '../../models/status'
 import { TipState, IValidBranch } from '../../models/tip'
 import { RebaseProgressOptions } from '../../models/rebase'
-import { Banner, BannerType } from '../../models/banner'
+import { Banner } from '../../models/banner'
 
 import { ApplicationTheme } from '../lib/application-theme'
 import { installCLI } from '../lib/install-cli'
@@ -747,12 +747,6 @@ export class Dispatcher {
         this.addRebasedBranchToForcePushList(repository, tip, beforeSha)
       }
 
-      this.setBanner({
-        type: BannerType.SuccessfulRebase,
-        targetBranch: targetBranch,
-        baseBranch: baseBranch,
-      })
-
       await this.refreshRepository(repository)
     }
 
@@ -795,22 +789,17 @@ export class Dispatcher {
 
     const { conflictState } = stateBefore.changesState
 
-    if (result === RebaseResult.CompletedWithoutError) {
-      this.closePopup()
-
-      if (conflictState !== null && isRebaseConflictState(conflictState)) {
-        this.setBanner({
-          type: BannerType.SuccessfulRebase,
-          targetBranch: conflictState.targetBranch,
-        })
-
-        if (tip.kind === TipState.Valid) {
-          this.addRebasedBranchToForcePushList(
-            repository,
-            tip,
-            conflictState.originalBranchTip
-          )
-        }
+    if (
+      result === RebaseResult.CompletedWithoutError &&
+      conflictState !== null &&
+      isRebaseConflictState(conflictState)
+    ) {
+      if (tip.kind === TipState.Valid) {
+        this.addRebasedBranchToForcePushList(
+          repository,
+          tip,
+          conflictState.originalBranchTip
+        )
       }
 
       await this.refreshRepository(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -752,6 +752,8 @@ export class Dispatcher {
         targetBranch: targetBranch,
         baseBranch: baseBranch,
       })
+
+      await this.refreshRepository(repository)
     }
 
     return result
@@ -810,6 +812,8 @@ export class Dispatcher {
           )
         }
       }
+
+      await this.refreshRepository(repository)
     }
 
     return result

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -92,6 +92,8 @@ export class RebaseFlow extends React.Component<
   IRebaseFlowProps,
   IRebaseFlowState
 > {
+  private ignoreUpdateEvents = false
+
   public constructor(props: IRebaseFlowProps) {
     super(props)
 
@@ -105,6 +107,10 @@ export class RebaseFlow extends React.Component<
       },
       userHasResolvedConflicts: false,
     }
+  }
+
+  public componentWillUnmount() {
+    this.ignoreUpdateEvents = true
   }
 
   public async componentDidUpdate() {
@@ -131,6 +137,10 @@ export class RebaseFlow extends React.Component<
         // waiting before the CSS animation to give the progress UI a chance to
         // show it reaches 100%
         await timeout(1000)
+
+        if (this.ignoreUpdateEvents) {
+          return
+        }
 
         this.setState(
           {
@@ -195,6 +205,10 @@ export class RebaseFlow extends React.Component<
   }
 
   private moveToCompletedState = () => {
+    if (this.ignoreUpdateEvents) {
+      return
+    }
+
     // this ensures the progress bar fills to 100%, while `componentDidUpdate`
     // detects and handles the state transition after a period of time to ensure
     // the UI shows _something_ before closing the dialog


### PR DESCRIPTION
## Overview

**Closes #7031**

## Description

This PR addresses the original bug by refreshing the repository after the rebase has completed (previously we'd only `loadStatus` to update the conflicted files). This ensures the history and the selected commit now reflect the rebased history.

The second commit in this branch cleans up some state changes the dispatcher no longer needs to do since #7117 was merged and `RebaseFlow` is now responsible for the transitions.

The last commit in this branch is the fix for a different variant of the `setState` warning identified in https://github.com/desktop/desktop/pull/7117#issuecomment-477676352 which occurs when the component is unmounted but still getting `componentDidUpdate` messages. I plan to revisit this post-MVP to see if we can reduce our dependency on `componentDidUpdate` to help with state transitions.

## Release notes

Notes: no-notes
