### PR TITLE
enable rule to warn about Buffer constructor usage

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -70,6 +70,7 @@ rules:
   strict:
     - error
     - global
+  no-buffer-constructor: error
 
   ###########
   # SPECIAL #

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -45,7 +45,7 @@ async function getOldFileContent(
     file.status.kind === AppFileStatusKind.New ||
     file.status.kind === AppFileStatusKind.Untracked
   ) {
-    return new Buffer(0)
+    return Buffer.alloc(0)
   }
 
   let commitish
@@ -75,7 +75,7 @@ async function getNewFileContent(
   file: ChangedFile
 ): Promise<Buffer> {
   if (file.status.kind === AppFileStatusKind.Deleted) {
-    return new Buffer(0)
+    return Buffer.alloc(0)
   }
 
   if (file instanceof WorkingDirectoryFileChange) {
@@ -103,20 +103,20 @@ export async function getFileContents(
 ): Promise<IFileContents> {
   const oldContentsPromise = lineFilters.oldLineFilter.length
     ? getOldFileContent(repo, file)
-    : Promise.resolve(new Buffer(0))
+    : Promise.resolve(Buffer.alloc(0))
 
   const newContentsPromise = lineFilters.newLineFilter.length
     ? getNewFileContent(repo, file)
-    : Promise.resolve(new Buffer(0))
+    : Promise.resolve(Buffer.alloc(0))
 
   const [oldContents, newContents] = await Promise.all([
     oldContentsPromise.catch(e => {
       log.error('Could not load old contents for syntax highlighting', e)
-      return new Buffer(0)
+      return Buffer.alloc(0)
     }),
     newContentsPromise.catch(e => {
       log.error('Could not load new contents for syntax highlighting', e)
-      return new Buffer(0)
+      return Buffer.alloc(0)
     }),
   ])
 


### PR DESCRIPTION
## Overview

As part of testing the rebase flow I kept noticing this warning from within the Dev Tools:

>(node:63731) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

<img width="1621" alt="Screen Shot 2019-04-01 at 2 26 55 PM" src="https://user-images.githubusercontent.com/359239/55347039-3ac94600-548a-11e9-8bd3-74c1992a037b.png">

This was a warning from our upgrade to Electron 3 (that now uses Node 10) about some API changes in Node core.

## Description

Some of the [`Buffer` constructor APIs](https://nodejs.org/docs/latest-v10.x/api/buffer.html) have been deprecated since Node 10.0 and will likely be removed at a later date:

<img width="544" src="https://user-images.githubusercontent.com/359239/55346852-d1493780-5489-11e9-89d2-70b31ebca2db.png">

The reasons why have been outlined in https://github.com/nodejs/node/issues/4660 and a more in-depth writeup in https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md.

It's not something that is keeping me awake at night currently, but seeing it on every launch while I test locally in dev tools has annoyed me enough to address it.

I've enabled the [`no-buffer-constructor`](https://eslint.org/docs/rules/no-buffer-constructor) eslint to find anywhere we use this API in the codebase, and I plan to clean these up the violations by swapping them to the recommend APIs.

## Release notes

Notes: no-notes
