### PR TITLE
bail out of rendering a remote action in the NoChanges view after a rebase

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -292,7 +292,12 @@ export class NoChanges extends React.Component<
 
   private renderRemoteAction() {
     const { remote, aheadBehind, branchesState } = this.props.repositoryState
-    const { tip, defaultBranch, currentPullRequest } = branchesState
+    const {
+      tip,
+      defaultBranch,
+      currentPullRequest,
+      rebasedBranches,
+    } = branchesState
 
     if (tip.kind !== TipState.Valid) {
       return null
@@ -305,6 +310,18 @@ export class NoChanges extends React.Component<
     // Branch not published
     if (aheadBehind === null) {
       return this.renderPublishBranchAction(tip)
+    }
+
+    const localBranchName = tip.branch.nameWithoutRemote
+    const { sha } = tip.branch.tip
+    const foundEntry = rebasedBranches.get(localBranchName)
+    const branchWasRebased = foundEntry === sha
+
+    if (branchWasRebased) {
+      // do not render an action currently after the rebase has completed, as
+      // the default behaviour is currently to pull in changes from the tracking
+      // branch which will could potentially lead to a more confusing history
+      return null
     }
 
     if (aheadBehind.behind > 0) {


### PR DESCRIPTION
## Overview

**Closes #6990**

## Description

In #6990 we decided to hide the remote action if the branch had been rebased, to avoid encouraging the user to pull in the remote commits again and messing up their rebased branch.

We have plans post `1.7.0` to iterate on this area and see if we can provide more helpful context after the rebase is completed, but for now we want to keep things simple.

## Release notes

Notes: no-notes
