### PR TITLE
lift state out of rebase flow components to live in repository state

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -35,7 +35,7 @@ import { ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
-import { RebaseProgressSummary, RebasePreview } from '../models/rebase'
+import { GitRebaseProgress, RebasePreview } from '../models/rebase'
 import { RebaseFlowState } from '../models/rebase-flow-state'
 
 export enum SelectionType {
@@ -481,7 +481,7 @@ export interface IRebaseState {
   /**
    * The underlying Git information associated with the current rebase
    */
-  readonly progress: RebaseProgressSummary
+  readonly progress: GitRebaseProgress
 
   /**
    * Whether the user has done work to resolve any conflicts as part of this

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -36,6 +36,7 @@ import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
 import { RebaseProgressSummary } from '../models/rebase'
+import { RebaseFlowState } from '../models/rebase-flow-state'
 
 export enum SelectionType {
   Repository,
@@ -459,6 +460,7 @@ export interface IBranchesState {
 }
 
 export interface IRebaseState {
+  readonly step: RebaseFlowState | null
   readonly progress: RebaseProgressSummary
 }
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -35,6 +35,7 @@ import { ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
+import { RebaseProgressSummary } from '../models/rebase'
 
 export enum SelectionType {
   Repository,
@@ -341,6 +342,8 @@ export interface IRepositoryState {
 
   readonly branchesState: IBranchesState
 
+  readonly rebaseState: IRebaseState
+
   /**
    * Mapping from lowercased email addresses to the associated GitHub user. Note
    * that an email address may not have an associated GitHub user, or the user
@@ -453,6 +456,10 @@ export interface IBranchesState {
 
   /** Tracking branches that have been rebased within Desktop */
   readonly rebasedBranches: ReadonlyMap<string, string>
+}
+
+export interface IRebaseState {
+  readonly progress: RebaseProgressSummary
 }
 
 export interface ICommitSelection {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -459,19 +459,25 @@ export interface IBranchesState {
   readonly rebasedBranches: ReadonlyMap<string, string>
 }
 
+/** State associated with a rebase being performed on a repository */
 export interface IRebaseState {
+  /** The current step of the flow the user should see */
   readonly step: RebaseFlowState | null
-  readonly progress: RebaseProgressSummary
+
   /**
-   * A preview of the rebase, using the selected base branch to test whether the
-   * current branch will be cleanly applied.
+   * A preview of the rebase, tested before performing the rebase itself, using
+   * the selected base branch to test whether the current branch will be cleanly
+   * applied.
    */
   readonly preview: RebasePreview | null
 
+  /** The underlying Git information associated with the current rebase */
+  readonly progress: RebaseProgressSummary
+
   /**
-   * Track whether the user has done work to resolve conflicts as part of this
-   * rebase, as the component should confirm with the user that they wish to
-   * abort the rebase and lose that work.
+   * Whether the user has done work to resolve any conflicts as part of this
+   * rebase, as the rebase flow should confirm the user wishes to abort the
+   * rebase and lose that work.
    */
   readonly userHasResolvedConflicts: boolean
 }

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -36,7 +36,7 @@ import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
 import { GitRebaseProgress, RebasePreview } from '../models/rebase'
-import { RebaseFlowState } from '../models/rebase-flow-state'
+import { RebaseFlowStep } from '../models/rebase-flow-step'
 
 export enum SelectionType {
   Repository,
@@ -466,7 +466,7 @@ export interface IRebaseState {
    *
    * `null` indicates that there is no rebase underway.
    */
-  readonly step: RebaseFlowState | null
+  readonly step: RebaseFlowStep | null
 
   /**
    * A preview of the rebase, tested before performing the rebase itself, using

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -461,17 +461,26 @@ export interface IBranchesState {
 
 /** State associated with a rebase being performed on a repository */
 export interface IRebaseState {
-  /** The current step of the flow the user should see */
+  /**
+   * The current step of the flow the user should see.
+   *
+   * `null` indicates that there is no rebase underway.
+   */
   readonly step: RebaseFlowState | null
 
   /**
    * A preview of the rebase, tested before performing the rebase itself, using
    * the selected base branch to test whether the current branch will be cleanly
    * applied.
+   *
+   * This will be set to `null` when no base branch has been selected to
+   * initiate the rebase.
    */
   readonly preview: RebasePreview | null
 
-  /** The underlying Git information associated with the current rebase */
+  /**
+   * The underlying Git information associated with the current rebase
+   */
   readonly progress: RebaseProgressSummary
 
   /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -35,7 +35,7 @@ import { ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
-import { RebaseProgressSummary } from '../models/rebase'
+import { RebaseProgressSummary, RebasePreview } from '../models/rebase'
 import { RebaseFlowState } from '../models/rebase-flow-state'
 
 export enum SelectionType {
@@ -462,6 +462,11 @@ export interface IBranchesState {
 export interface IRebaseState {
   readonly step: RebaseFlowState | null
   readonly progress: RebaseProgressSummary
+  /**
+   * A preview of the rebase, using the selected base branch to test whether the
+   * current branch will be cleanly applied.
+   */
+  readonly preview: RebasePreview | null
 }
 
 export interface ICommitSelection {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -4,7 +4,7 @@ import { IDiff, ImageDiffType } from '../models/diff'
 import { Repository, ILocalRepositoryState } from '../models/repository'
 import { Branch, IAheadBehind } from '../models/branch'
 import { Tip } from '../models/tip'
-import { Commit } from '../models/commit'
+import { Commit, CommitOneLine } from '../models/commit'
 import { CommittedFileChange, WorkingDirectoryStatus } from '../models/status'
 import { CloningRepository } from '../models/cloning-repository'
 import { IMenu } from '../models/app-menu'
@@ -480,8 +480,19 @@ export interface IRebaseState {
 
   /**
    * The underlying Git information associated with the current rebase
+   *
+   * This will be set to `null` when no base branch has been selected to
+   * initiate the rebase.
    */
-  readonly progress: GitRebaseProgress
+  readonly progress: GitRebaseProgress | null
+
+  /**
+   * The known range of commits that will be applied to the repository
+   *
+   * This will be set to `null` when no base branch has been selected to
+   * initiate the rebase.
+   */
+  readonly commits: ReadonlyArray<CommitOneLine> | null
 
   /**
    * Whether the user has done work to resolve any conflicts as part of this

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -467,6 +467,13 @@ export interface IRebaseState {
    * current branch will be cleanly applied.
    */
   readonly preview: RebasePreview | null
+
+  /**
+   * Track whether the user has done work to resolve conflicts as part of this
+   * rebase, as the component should confirm with the user that they wish to
+   * abort the rebase and lose that work.
+   */
+  readonly userHasResolvedConflicts: boolean
 }
 
 export interface ICommitSelection {

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -191,11 +191,24 @@ export async function getRebaseSnapshot(
       return null
     }
 
+    // this number starts from 1, but our array of commits starts from 0
+    const nextCommitIndex = next - 1
+
+    const hasValidCommit =
+      commits.length > 0 &&
+      nextCommitIndex >= 0 &&
+      nextCommitIndex <= commits.length
+
+    const currentCommitSummary = hasValidCommit
+      ? commits[nextCommitIndex].summary
+      : null
+
     return {
       progress: {
         value,
         rebasedCommitCount: next,
         totalCommitCount: last,
+        currentCommitSummary,
       },
       commits,
     }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -8,7 +8,7 @@ import { Repository } from '../../models/repository'
 import {
   RebaseContext,
   RebaseProgressOptions,
-  RebaseProgressSummary,
+  GitRebaseProgress,
 } from '../../models/rebase'
 import { IRebaseProgress } from '../../models/progress'
 import {
@@ -106,7 +106,7 @@ export async function getRebaseContext(
  */
 export async function getCurrentProgress(
   repository: Repository
-): Promise<RebaseProgressSummary | null> {
+): Promise<GitRebaseProgress | null> {
   const rebaseHead = await isRebaseHeadSet(repository)
   if (!rebaseHead) {
     return null

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -248,6 +248,11 @@ class GitRebaseParser {
     const progress = this.rebasedCommitCount / this.totalCommitCount
     const value = formatRebaseValue(progress)
 
+    // TODO: dig into why we sometimes get an extra progress event reported
+    if (this.rebasedCommitCount > this.totalCommitCount) {
+      this.rebasedCommitCount = this.totalCommitCount
+    }
+
     return {
       kind: 'rebase',
       title: `Rebasing commit ${this.rebasedCommitCount} of ${

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -297,11 +297,11 @@ export async function rebase(
   targetBranch: string,
   progressCallback?: (progress: IRebaseProgress) => void
 ): Promise<RebaseResult> {
-  const baseOptions = {
+  const baseOptions: IGitExecutionOptions = {
     expectedErrors: new Set([GitError.RebaseConflicts]),
   }
 
-  let options: IGitExecutionOptions
+  let options = baseOptions
 
   if (progressCallback !== undefined) {
     const commits = await getCommitsInRange(
@@ -317,8 +317,6 @@ export async function rebase(
       totalCommitCount,
       progressCallback,
     })
-  } else {
-    options = baseOptions
   }
 
   const result = await git(
@@ -434,14 +432,14 @@ export async function continueRebase(
     f => f.status.kind !== AppFileStatusKind.Untracked
   )
 
-  const baseOptions = {
+  const baseOptions: IGitExecutionOptions = {
     expectedErrors: new Set([
       GitError.RebaseConflicts,
       GitError.UnresolvedConflicts,
     ]),
   }
 
-  let options: IGitExecutionOptions
+  let options = baseOptions
 
   if (progressCallback !== undefined) {
     const progress = await getCurrentProgress(repository)
@@ -461,8 +459,6 @@ export async function continueRebase(
       totalCommitCount,
       progressCallback,
     })
-  } else {
-    options = baseOptions
   }
 
   if (trackedFilesAfter.length === 0) {

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -6,7 +6,7 @@ import * as byline from 'byline'
 
 import { Repository } from '../../models/repository'
 import {
-  RebaseContext,
+  RebaseInternalState,
   RebaseProgressOptions,
   GitRebaseProgress,
 } from '../../models/rebase'
@@ -37,16 +37,16 @@ function isRebaseHeadSet(repository: Repository) {
 }
 
 /**
- * Detect and build up the context about the rebase being performed on a
- * repository. This information is required to help Desktop display information
- * to the user about the current action as well as the options available.
+ * Get the internal state about the rebase being performed on a repository. This
+ * information is required to help Desktop display information to the user
+ * about the current action as well as the options available.
  *
  * Returns `null` if no rebase is detected, or if the expected information
  * cannot be found in the repository.
  */
-export async function getRebaseContext(
+export async function getRebaseInternalState(
   repository: Repository
-): Promise<RebaseContext | null> {
+): Promise<RebaseInternalState | null> {
   const isRebase = await isRebaseHeadSet(repository)
 
   if (!isRebase) {
@@ -96,14 +96,15 @@ export async function getRebaseContext(
 }
 
 /**
- * Inspect the `.git/rebase-apply` folder and convert the current context into
- * a progress summary that can be passed into the rebase flow to hydrate the
- * component state.
+ * Inspect the `.git/rebase-apply` folder and convert the current rebase state
+ * into data that can be provided to the rebase flow to update the application
+ * state.
  *
  * This is required when Desktop is not responsible for initiating the rebase:
  *
  *   - when a rebase outside Desktop encounters conflicts
  *   - when a `git pull --rebase` was run and encounters conflicts
+ *
  */
 export async function getRebaseSnapshot(
   repository: Repository

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -16,6 +16,7 @@ import {
   AppFileStatusKind,
 } from '../../models/status'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
+import { CommitOneLine } from '../../models/commit'
 
 import { merge } from '../merge'
 import { formatRebaseValue } from '../rebase'
@@ -25,7 +26,6 @@ import { stageManualConflictResolution } from './stage'
 import { stageFiles } from './update-index'
 import { getStatus } from './status'
 import { getCommitsInRange } from './rev-list'
-import { CommitOneLine } from '../../models/commit'
 
 /**
  * Check the `.git/REBASE_HEAD` file exists in a repository to confirm

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -239,7 +239,7 @@ export async function getStatus(
     branchAheadBehind,
     exists: true,
     mergeHeadFound,
-    rebaseInternalState: rebaseInternalState,
+    rebaseInternalState,
     workingDirectory,
   }
 }
@@ -373,7 +373,9 @@ async function getConflictDetails(
   try {
     if (mergeHeadFound) {
       return await getMergeConflictDetails(repository)
-    } else if (rebaseInternalState !== null) {
+    }
+    
+    if (rebaseInternalState !== null) {
       return await getRebaseConflictDetails(repository)
     }
   } catch (error) {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -25,9 +25,9 @@ import { IAheadBehind } from '../../models/branch'
 import { fatalError } from '../../lib/fatal-error'
 import { isMergeHeadSet } from './merge'
 import { getBinaryPaths } from './diff'
-import { getRebaseContext } from './rebase'
+import { getRebaseInternalState } from './rebase'
 import { enablePullWithRebase } from '../feature-flag'
-import { RebaseContext } from '../../models/rebase'
+import { RebaseInternalState } from '../../models/rebase'
 
 /**
  * V8 has a limit on the size of string it can create (~256MB), and unless we want to
@@ -60,7 +60,7 @@ export interface IStatusResult {
   readonly mergeHeadFound: boolean
 
   /** details about the rebase operation, if found */
-  readonly rebaseContext: RebaseContext | null
+  readonly rebaseContext: RebaseInternalState | null
 
   /** the absolute path to the repository's working directory */
   readonly workingDirectory: WorkingDirectoryStatus
@@ -199,7 +199,7 @@ export async function getStatus(
   let conflictDetails: ConflictFilesDetails
 
   const mergeHeadFound = await isMergeHeadSet(repository)
-  const rebaseContext = await getRebaseContext(repository)
+  const rebaseContext = await getRebaseInternalState(repository)
 
   if (enablePullWithRebase()) {
     conflictDetails = await getConflictDetails(
@@ -368,7 +368,7 @@ async function getRebaseConflictDetails(repository: Repository) {
 async function getConflictDetails(
   repository: Repository,
   mergeHeadFound: boolean,
-  rebaseContext: RebaseContext | null
+  rebaseContext: RebaseInternalState | null
 ): Promise<ConflictFilesDetails> {
   try {
     if (mergeHeadFound) {

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -374,7 +374,7 @@ async function getConflictDetails(
     if (mergeHeadFound) {
       return await getMergeConflictDetails(repository)
     }
-    
+
     if (rebaseInternalState !== null) {
       return await getRebaseConflictDetails(repository)
     }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -60,7 +60,7 @@ export interface IStatusResult {
   readonly mergeHeadFound: boolean
 
   /** details about the rebase operation, if found */
-  readonly rebaseContext: RebaseInternalState | null
+  readonly rebaseInternalState: RebaseInternalState | null
 
   /** the absolute path to the repository's working directory */
   readonly workingDirectory: WorkingDirectoryStatus
@@ -199,13 +199,13 @@ export async function getStatus(
   let conflictDetails: ConflictFilesDetails
 
   const mergeHeadFound = await isMergeHeadSet(repository)
-  const rebaseContext = await getRebaseInternalState(repository)
+  const rebaseInternalState = await getRebaseInternalState(repository)
 
   if (enablePullWithRebase()) {
     conflictDetails = await getConflictDetails(
       repository,
       mergeHeadFound,
-      rebaseContext
+      rebaseInternalState
     )
   } else {
     conflictDetails = await getConflictDetails(repository, mergeHeadFound, null)
@@ -239,7 +239,7 @@ export async function getStatus(
     branchAheadBehind,
     exists: true,
     mergeHeadFound,
-    rebaseContext,
+    rebaseInternalState: rebaseInternalState,
     workingDirectory,
   }
 }
@@ -363,17 +363,17 @@ async function getRebaseConflictDetails(repository: Repository) {
  *
  * @param repository to get details from
  * @param mergeHeadFound whether a merge conflict has been detected
- * @param rebaseContext details about the current rebase operation (if found)
+ * @param rebaseInternalState details about the current rebase operation (if found)
  */
 async function getConflictDetails(
   repository: Repository,
   mergeHeadFound: boolean,
-  rebaseContext: RebaseInternalState | null
+  rebaseInternalState: RebaseInternalState | null
 ): Promise<ConflictFilesDetails> {
   try {
     if (mergeHeadFound) {
       return await getMergeConflictDetails(repository)
-    } else if (rebaseContext !== null) {
+    } else if (rebaseInternalState !== null) {
       return await getRebaseConflictDetails(repository)
     }
   } catch (error) {

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -52,14 +52,10 @@ export function initializeNewRebaseFlow(state: IRepositoryState) {
 export function initializeRebaseFlowForConflictedRepository(
   conflictState: RebaseConflictState
 ): ShowConflictsStep {
-  const { targetBranch, baseBranch } = conflictState
-
   const initialState: ShowConflictsStep = {
     kind: RebaseStep.ShowConflicts,
-    targetBranch,
-    baseBranch,
+    conflictState,
   }
-
   return initialState
 }
 

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -3,7 +3,7 @@ import {
   ChooseBranchesStep,
   RebaseStep,
   ShowConflictsStep,
-} from '../models/rebase-flow-state'
+} from '../models/rebase-flow-step'
 import { Branch } from '../models/branch'
 import { TipState } from '../models/tip'
 import { clamp } from './clamp'

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -7,8 +7,6 @@ import {
 import { Branch } from '../models/branch'
 import { TipState } from '../models/tip'
 import { clamp } from './clamp'
-import { Repository } from '../models/repository'
-import { getCurrentProgress } from './git'
 
 /**
  * Setup the rebase flow state when the user neeeds to select a branch as the
@@ -51,19 +49,15 @@ export function initializeNewRebaseFlow(state: IRepositoryState) {
  * @param repository the repository dealing with conflicts
  * @param conflictState current set of conflicts
  */
-export async function initializeRebaseFlowForConflictedRepository(
-  repository: Repository,
+export function initializeRebaseFlowForConflictedRepository(
   conflictState: RebaseConflictState
-): Promise<ShowConflictsStep> {
+): ShowConflictsStep {
   const { targetBranch, baseBranch } = conflictState
-
-  const previousProgress = await getCurrentProgress(repository)
 
   const initialState: ShowConflictsStep = {
     kind: RebaseStep.ShowConflicts,
     targetBranch,
     baseBranch,
-    previousProgress,
   }
 
   return initialState

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -46,7 +46,6 @@ export function initializeNewRebaseFlow(state: IRepositoryState) {
  * This indicates a rebase is in progress, and the application needs to guide
  * the user to resolve conflicts and complete the rebae.
  *
- * @param repository the repository dealing with conflicts
  * @param conflictState current set of conflicts
  */
 export function initializeRebaseFlowForConflictedRepository(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -207,12 +207,7 @@ import {
 import { Banner, BannerType } from '../../models/banner'
 import { isDarkModeEnabled } from '../../ui/lib/dark-theme'
 import { ComputedAction } from '../../models/computed-action'
-import {
-  RebaseFlowStep,
-  RebaseStep,
-  ShowConflictsStep,
-  ConfirmAbortStep,
-} from '../../models/rebase-flow-step'
+import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 import { RebasePreview } from '../../models/rebase'
 
 /**
@@ -1740,22 +1735,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     if (step.kind === RebaseStep.ShowConflicts) {
-      const updatedStep: ShowConflictsStep = {
-        kind: RebaseStep.ShowConflicts,
-        conflictState,
-      }
-
       this.repositoryStateCache.updateRebaseState(repository, () => ({
-        step: updatedStep,
+        step: { ...step, conflictState },
       }))
     } else if (step.kind === RebaseStep.ConfirmAbort) {
-      const updatedStep: ConfirmAbortStep = {
-        kind: RebaseStep.ConfirmAbort,
-        conflictState,
-      }
-
       this.repositoryStateCache.updateRebaseState(repository, () => ({
-        step: updatedStep,
+        step: { ...step, conflictState },
       }))
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3426,6 +3426,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._refreshRepository(repository)
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public _setRebaseProgressFromState = async (repository: Repository) => {
     const snapshot = await getRebaseSnapshot(repository)
     if (snapshot === null) {
@@ -3455,6 +3456,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public _initializeRebaseProgress(
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
@@ -3477,6 +3479,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public _setConflictsResolved(repository: Repository) {
     // an update is not emitted here because there is no need
     // to trigger a re-render at this point
@@ -3503,6 +3506,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public _endRebaseFlow(repository: Repository) {
     this.repositoryStateCache.updateRebaseState(repository, () => ({
       step: null,
@@ -3515,6 +3519,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _previewRebase(
     repository: Repository,
     baseBranch: Branch,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3469,6 +3469,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  public _setConflictsResolved(repository: Repository) {
+    this.repositoryStateCache.updateRebaseState(repository, () => ({
+      userHasResolvedConflicts: true,
+    }))
+
+    // an update is not emitted here because there is no need
+    // to trigger a re-render at this point
+  }
+
   public _setRebaseFlow(repository: Repository, step: RebaseFlowState) {
     log.warn(
       `[AppStore._setRebaseFlow] setting step to ${JSON.stringify(step)}`
@@ -3492,6 +3501,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
           rebasedCommitCount: 0,
           commits: [],
         },
+        preview: null,
+        userHasResolvedConflicts: false,
       }
     })
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3427,7 +3427,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public _setRebaseProgressFromState = async (repository: Repository) => {
+  public async _setRebaseProgressFromState(repository: Repository) {
     const snapshot = await getRebaseSnapshot(repository)
     if (snapshot === null) {
       return

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1767,10 +1767,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       conflictState
     )
 
+    this._setRebaseFlow(repository, initialState)
+
     this._showPopup({
       type: PopupType.RebaseFlow,
       repository,
-      initialState,
     })
   }
 
@@ -3444,10 +3445,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         : undefined
 
       const newProgressValue = rebasedCommitCount / commits.length
-
-      log.warn(
-        `[_setRebaseProgress] setting commit summary to ${currentCommitSummary}`
-      )
 
       return {
         progress: {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3519,6 +3519,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     if (step.kind === RebaseStep.ShowProgress && step.rebaseAction !== null) {
+      // this timeout is intended to defer the action from running immediately
+      // after the progress UI is shown, to better show that rebase is
+      // progressing rather than suddenly appearing and disappearing again
       await timeout(500)
       await step.rebaseAction()
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -207,7 +207,7 @@ import {
 import { Banner, BannerType } from '../../models/banner'
 import { isDarkModeEnabled } from '../../ui/lib/dark-theme'
 import { ComputedAction } from '../../models/computed-action'
-import { RebaseFlowState, RebaseStep } from '../../models/rebase-flow-state'
+import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 import { RebasePreview } from '../../models/rebase'
 
 /**
@@ -3480,7 +3480,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public async _setRebaseFlow(
     repository: Repository,
-    step: RebaseFlowState
+    step: RebaseFlowStep
   ): Promise<void> {
     log.warn(
       `[AppStore._setRebaseFlow] setting step to ${JSON.stringify(step)}`

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1758,11 +1758,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await this._setRebaseProgressFromState(repository)
 
-    const initialState = initializeRebaseFlowForConflictedRepository(
-      conflictState
-    )
+    const step = initializeRebaseFlowForConflictedRepository(conflictState)
 
-    this._setRebaseFlow(repository, initialState)
+    this.repositoryStateCache.updateRebaseState(repository, () => ({
+      step,
+    }))
 
     this._showPopup({
       type: PopupType.RebaseFlow,
@@ -3486,7 +3486,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }))
   }
 
-  public async _setRebaseFlow(
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _setRebaseFlowStep(
     repository: Repository,
     step: RebaseFlowStep
   ): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3434,23 +3434,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const { progress, commits } = snapshot
-    const { rebasedCommitCount } = progress
-
-    const hasValidCommit =
-      commits.length > 0 &&
-      rebasedCommitCount >= 0 &&
-      rebasedCommitCount <= commits.length
-
-    const currentCommitSummary = hasValidCommit
-      ? commits[rebasedCommitCount].summary
-      : undefined
 
     this.repositoryStateCache.updateRebaseState(repository, () => {
       return {
-        progress: {
-          ...progress,
-          currentCommitSummary,
-        },
+        progress,
         commits,
       }
     })
@@ -3463,7 +3450,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ) {
     this.repositoryStateCache.updateRebaseState(repository, () => {
       const hasCommits = commits.length > 0
-      const firstCommitSummary = hasCommits ? commits[0].summary : undefined
+      const firstCommitSummary = hasCommits ? commits[0].summary : null
 
       return {
         progress: {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3590,7 +3590,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       log.warn(
         `[AppStore._rebase] setting progress for ${
           progress.rebasedCommitCount
-        } out of ${commits.length}`
+        } out of ${progress.totalCommitCount} with messsage: '${
+          progress.currentCommitSummary
+        }'`
       )
 
       this.repositoryStateCache.updateRebaseState(repository, () => ({
@@ -3629,8 +3631,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       log.warn(
         `[AppStore._continueRebase] setting progress for ${
           progress.rebasedCommitCount
-        } out of ${progress.totalCommitCount}`
+        } out of ${progress.totalCommitCount} with messsage: '${
+          progress.currentCommitSummary
+        }'`
       )
+
       this.repositoryStateCache.updateRebaseState(repository, () => ({
         progress,
       }))

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -16,6 +16,7 @@ import {
   IRepositoryState,
   RepositorySectionTab,
   ICommitSelection,
+  IRebaseState,
 } from '../app-state'
 import { ComparisonCache } from '../comparison-cache'
 import { IGitHubUser } from '../databases'
@@ -97,6 +98,17 @@ export class RepositoryStateCache {
       return { branchesState: newState }
     })
   }
+
+  public updateRebaseState<K extends keyof IRebaseState>(
+    repository: Repository,
+    fn: (branchesState: IRebaseState) => Pick<IRebaseState, K>
+  ) {
+    this.update(repository, state => {
+      const { rebaseState } = state
+      const newState = merge(rebaseState, fn(rebaseState))
+      return { rebaseState: newState }
+    })
+  }
 }
 
 function getInitialRepositoryState(): IRepositoryState {
@@ -146,6 +158,7 @@ function getInitialRepositoryState(): IRepositoryState {
       inferredComparisonBranch: { branch: null, aheadBehind: null },
     },
     rebaseState: {
+      step: null,
       progress: {
         value: 0,
         rebasedCommitCount: 0,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -164,6 +164,7 @@ function getInitialRepositoryState(): IRepositoryState {
         rebasedCommitCount: 0,
         commits: [],
       },
+      preview: null,
     },
     commitAuthor: null,
     gitHubUsers: new Map<string, IGitHubUser>(),

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -159,12 +159,9 @@ function getInitialRepositoryState(): IRepositoryState {
     },
     rebaseState: {
       step: null,
-      progress: {
-        value: 0,
-        rebasedCommitCount: 0,
-        commits: [],
-      },
+      progress: null,
       preview: null,
+      commits: null,
       userHasResolvedConflicts: false,
     },
     commitAuthor: null,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -165,6 +165,7 @@ function getInitialRepositoryState(): IRepositoryState {
         commits: [],
       },
       preview: null,
+      userHasResolvedConflicts: false,
     },
     commitAuthor: null,
     gitHubUsers: new Map<string, IGitHubUser>(),

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -145,6 +145,13 @@ function getInitialRepositoryState(): IRepositoryState {
       defaultBranch: null,
       inferredComparisonBranch: { branch: null, aheadBehind: null },
     },
+    rebaseState: {
+      progress: {
+        value: 0,
+        rebasedCommitCount: 0,
+        commits: [],
+      },
+    },
     commitAuthor: null,
     gitHubUsers: new Map<string, IGitHubUser>(),
     commitLookup: new Map<string, Commit>(),

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -117,7 +117,7 @@ function getConflictState(
     }
   }
 
-  if (status.rebaseContext !== null) {
+  if (status.rebaseInternalState !== null) {
     const { currentTip } = status
     if (currentTip == null) {
       return null
@@ -127,7 +127,7 @@ function getConflictState(
       targetBranch,
       originalBranchTip,
       baseBranchTip,
-    } = status.rebaseContext
+    } = status.rebaseInternalState
 
     return {
       kind: 'rebase',

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -7,7 +7,6 @@ import { RetryAction } from './retry-actions'
 import { WorkingDirectoryFileChange } from './status'
 import { PreferencesTab } from './preferences'
 import { ICommitContext } from './commit'
-import { RebaseFlowState } from './rebase-flow-state'
 
 export enum PopupType {
   RenameBranch = 1,
@@ -177,5 +176,4 @@ export type Popup =
   | {
       type: PopupType.RebaseFlow
       repository: Repository
-      initialState: RebaseFlowState
     }

--- a/app/src/models/rebase-flow-state.ts
+++ b/app/src/models/rebase-flow-state.ts
@@ -1,4 +1,5 @@
 import { Branch } from './branch'
+import { RebaseConflictState } from '../lib/app-state'
 
 /** Union type representing the possible states of the rebase flow */
 export type RebaseFlowState =
@@ -86,8 +87,7 @@ export type ShowProgressStep = {
 /** Shape of data to show conflicts that need to be resolved by the user */
 export type ShowConflictsStep = {
   readonly kind: RebaseStep.ShowConflicts
-  readonly targetBranch: string
-  readonly baseBranch?: string
+  readonly conflictState: RebaseConflictState
 }
 
 /** Shape of data to track when user hides conflicts dialog */

--- a/app/src/models/rebase-flow-state.ts
+++ b/app/src/models/rebase-flow-state.ts
@@ -89,10 +89,8 @@ export type ShowConflictsStep = {
   readonly kind: RebaseStep.ShowConflicts
   readonly targetBranch: string
   readonly baseBranch?: string
-  /**
-   * Optional context to provide if rebase dialog was dismissed, as previous
-   * state should be used here when resuming the rebase.
-   */
+
+  /** @deprecated PUSH THIS INTO APP STATE */
   readonly previousProgress: RebaseProgressSummary | null
 }
 

--- a/app/src/models/rebase-flow-state.ts
+++ b/app/src/models/rebase-flow-state.ts
@@ -1,5 +1,4 @@
 import { Branch } from './branch'
-import { RebaseProgressSummary } from './rebase'
 
 /** Union type representing the possible states of the rebase flow */
 export type RebaseFlowState =
@@ -89,9 +88,6 @@ export type ShowConflictsStep = {
   readonly kind: RebaseStep.ShowConflicts
   readonly targetBranch: string
   readonly baseBranch?: string
-
-  /** @deprecated PUSH THIS INTO APP STATE */
-  readonly previousProgress: RebaseProgressSummary | null
 }
 
 /** Shape of data to track when user hides conflicts dialog */

--- a/app/src/models/rebase-flow-step.ts
+++ b/app/src/models/rebase-flow-step.ts
@@ -1,5 +1,6 @@
 import { Branch } from './branch'
 import { RebaseConflictState } from '../lib/app-state'
+import { RebaseResult } from '../lib/git'
 
 /** Union type representing the possible states of the rebase flow */
 export type RebaseFlowStep =
@@ -81,7 +82,7 @@ export type ShowProgressStep = {
    * want to defer the rebase action until after _something_ is shown to the
    * user.
    */
-  readonly rebaseAction: (() => Promise<void>) | null
+  readonly rebaseAction: (() => Promise<RebaseResult>) | null
 }
 
 /** Shape of data to show conflicts that need to be resolved by the user */

--- a/app/src/models/rebase-flow-step.ts
+++ b/app/src/models/rebase-flow-step.ts
@@ -2,7 +2,7 @@ import { Branch } from './branch'
 import { RebaseConflictState } from '../lib/app-state'
 
 /** Union type representing the possible states of the rebase flow */
-export type RebaseFlowState =
+export type RebaseFlowStep =
   | ChooseBranchesStep
   | ShowProgressStep
   | ShowConflictsStep

--- a/app/src/models/rebase-flow-step.ts
+++ b/app/src/models/rebase-flow-step.ts
@@ -1,6 +1,5 @@
 import { Branch } from './branch'
 import { RebaseConflictState } from '../lib/app-state'
-import { RebaseResult } from '../lib/git'
 
 /** Union type representing the possible states of the rebase flow */
 export type RebaseFlowStep =
@@ -82,7 +81,7 @@ export type ShowProgressStep = {
    * want to defer the rebase action until after _something_ is shown to the
    * user.
    */
-  readonly rebaseAction: (() => Promise<RebaseResult>) | null
+  readonly rebaseAction: (() => Promise<void>) | null
 }
 
 /** Shape of data to show conflicts that need to be resolved by the user */

--- a/app/src/models/rebase-flow-step.ts
+++ b/app/src/models/rebase-flow-step.ts
@@ -98,8 +98,7 @@ export type HideConflictsStep = {
 /** Shape of data to use when confirming user should abort rebase */
 export type ConfirmAbortStep = {
   readonly kind: RebaseStep.ConfirmAbort
-  readonly targetBranch: string
-  readonly baseBranch?: string
+  readonly conflictState: RebaseConflictState
 }
 
 /** Shape of data to track when rebase has completed successfully */

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -43,7 +43,7 @@ export type RebasePreview =
   | RebaseNotSupported
   | RebaseLoading
 
-/** Represents a snapshot of a Git rebase operation as shown to the user */
+/** Represents the progress of a Git rebase operation to be shown to the user */
 export type GitRebaseProgress = {
   /** A numeric value between 0 and 1 representing the percent completed */
   readonly value: number
@@ -51,6 +51,14 @@ export type GitRebaseProgress = {
   readonly rebasedCommitCount: number
   /** The commit summary associated with the current commit (if found) */
   readonly currentCommitSummary?: string
-  /** The list of known commits that will be rebased onto the base branch */
+  /** The count of known commits that will be rebased onto the base branch */
+  readonly totalCommitCount: number
+}
+
+/** Represents a snapshot of the rebase state from the Git repository  */
+export type GitRebaseSnapshot = {
+  /** The sequence of commits that are used in the rebase */
   readonly commits: ReadonlyArray<CommitOneLine>
+  /** The progress of the operation */
+  readonly progress: GitRebaseProgress
 }

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -63,7 +63,7 @@ export type GitRebaseProgress = {
   /** The current number of commits rebased as part of this operation */
   readonly rebasedCommitCount: number
   /** The commit summary associated with the current commit (if found) */
-  readonly currentCommitSummary?: string
+  readonly currentCommitSummary: string | null
   /** The count of known commits that will be rebased onto the base branch */
   readonly totalCommitCount: number
 }

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -43,7 +43,7 @@ export type RebasePreview =
   | RebaseNotSupported
   | RebaseLoading
 
-export type RebaseProgressSummary = {
+export type GitRebaseProgress = {
   /** A numeric value between 0 and 1 representing the rebase progress */
   readonly value: number
   /** Track the current number of commits rebased across dialogs and states */

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -2,9 +2,22 @@ import { IRebaseProgress } from './progress'
 import { ComputedAction } from './computed-action'
 import { CommitOneLine } from './commit'
 
-export type RebaseContext = {
+/**
+ * Rebase internal state used to track how and where the rebase is applied to
+ * the repository.
+ */
+export type RebaseInternalState = {
+  /** The branch containing commits that should be rebased */
   readonly targetBranch: string
+  /**
+   * The commit ID of the base branch, to be used as a starting point for
+   * the rebase.
+   */
   readonly baseBranchTip: string
+  /**
+   * The commit ID of the target branch at the start of the rebase, which points
+   * to the original commit history.
+   */
   readonly originalBranchTip: string
 }
 

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -43,12 +43,13 @@ export type RebasePreview =
   | RebaseNotSupported
   | RebaseLoading
 
+/** Represents a snapshot of a Git rebase operation as shown to the user */
 export type GitRebaseProgress = {
-  /** A numeric value between 0 and 1 representing the rebase progress */
+  /** A numeric value between 0 and 1 representing the percent completed */
   readonly value: number
-  /** Track the current number of commits rebased across dialogs and states */
+  /** The current number of commits rebased as part of this operation */
   readonly rebasedCommitCount: number
-  /** The commit summary associated with the current commit (if known) */
+  /** The commit summary associated with the current commit (if found) */
   readonly currentCommitSummary?: string
   /** The list of known commits that will be rebased onto the base branch */
   readonly commits: ReadonlyArray<CommitOneLine>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -100,6 +100,7 @@ import {
   initializeRebaseFlowForConflictedRepository,
 } from '../lib/rebase'
 import { BannerType } from '../models/banner'
+import { getCurrentProgress } from '../lib/git'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1644,8 +1645,17 @@ export class App extends React.Component<IAppProps, IAppState> {
           )
           return
         }
-        const initialState = await initializeRebaseFlowForConflictedRepository(
-          repository,
+
+        const progress = await getCurrentProgress(repository)
+        if (progress !== null) {
+          this.props.dispatcher.setRebaseProgress(
+            repository,
+            progress.rebasedCommitCount,
+            progress.commits
+          )
+        }
+
+        const initialState = initializeRebaseFlowForConflictedRepository(
           conflictState
         )
 
@@ -1658,8 +1668,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
   }
 
-  private onRebaseFlowEnded = () => {
+  private onRebaseFlowEnded = (repository: Repository) => {
     this.props.dispatcher.closePopup()
+    this.props.dispatcher.endRebaseFlow(repository)
   }
 
   private onUsageReportingDismissed = (optOut: boolean) => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1578,13 +1578,18 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
-        const { initialState } = popup
-
         const { changesState, rebaseState } = selectedState.state
         const { workingDirectory, conflictState } = changesState
-        const { progress } = rebaseState
+        const { progress, step } = rebaseState
 
         if (conflictState !== null && conflictState.kind === 'merge') {
+          log.warn(
+            '[App] invalid state encountered - rebase flow should not be used when merge conflicts found'
+          )
+          return null
+        }
+
+        if (step === null) {
           log.warn(
             '[App] invalid state encountered - rebase flow should not be used when merge conflicts found'
           )
@@ -1597,10 +1602,10 @@ export class App extends React.Component<IAppProps, IAppState> {
             openFileInExternalEditor={this.openFileInExternalEditor}
             dispatcher={this.props.dispatcher}
             onFlowEnded={this.onRebaseFlowEnded}
-            initialState={initialState}
             workingDirectory={workingDirectory}
             conflictState={conflictState}
             progress={progress}
+            step={step}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
             onShowRebaseConflictsBanner={this.onShowRebaseConflictsBanner}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -947,7 +947,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const initialState = initializeNewRebaseFlow(repositoryState)
 
-    this.props.dispatcher.setRebaseFlow(repository, initialState)
+    this.props.dispatcher.setRebaseFlowStep(repository, initialState)
 
     this.props.dispatcher.showPopup({
       type: PopupType.RebaseFlow,
@@ -1664,7 +1664,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           conflictState
         )
 
-        this.props.dispatcher.setRebaseFlow(repository, initialState)
+        this.props.dispatcher.setRebaseFlowStep(repository, initialState)
 
         this.props.dispatcher.showPopup({
           type: PopupType.RebaseFlow,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -948,10 +948,11 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const initialState = initializeNewRebaseFlow(repositoryState)
 
+    this.props.dispatcher.setRebaseFlow(repository, initialState)
+
     this.props.dispatcher.showPopup({
       type: PopupType.RebaseFlow,
       repository,
-      initialState,
     })
   }
 
@@ -1664,10 +1665,11 @@ export class App extends React.Component<IAppProps, IAppState> {
           conflictState
         )
 
+        this.props.dispatcher.setRebaseFlow(repository, initialState)
+
         this.props.dispatcher.showPopup({
           type: PopupType.RebaseFlow,
           repository,
-          initialState,
         })
       },
     })

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1579,8 +1579,9 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const { initialState } = popup
 
-        const { changesState } = selectedState.state
+        const { changesState, rebaseState } = selectedState.state
         const { workingDirectory, conflictState } = changesState
+        const { progress } = rebaseState
 
         if (conflictState !== null && conflictState.kind === 'merge') {
           log.warn(
@@ -1598,6 +1599,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             initialState={initialState}
             workingDirectory={workingDirectory}
             conflictState={conflictState}
+            progress={progress}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
             onShowRebaseConflictsBanner={this.onShowRebaseConflictsBanner}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1597,7 +1597,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         if (step === null) {
           log.warn(
-            '[App] invalid state encountered - rebase flow should not be used when merge conflicts found'
+            '[App] invalid state encountered - rebase flow should not be active when step is null'
           )
           return null
         }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1581,7 +1581,12 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const { changesState, rebaseState } = selectedState.state
         const { workingDirectory, conflictState } = changesState
-        const { progress, step, preview } = rebaseState
+        const {
+          progress,
+          step,
+          preview,
+          userHasResolvedConflicts,
+        } = rebaseState
 
         if (conflictState !== null && conflictState.kind === 'merge') {
           log.warn(
@@ -1608,6 +1613,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             progress={progress}
             step={step}
             preview={preview}
+            userHasResolvedConflicts={userHasResolvedConflicts}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
             onShowRebaseConflictsBanner={this.onShowRebaseConflictsBanner}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -100,7 +100,6 @@ import {
   initializeRebaseFlowForConflictedRepository,
 } from '../lib/rebase'
 import { BannerType } from '../models/banner'
-import { getRebaseSnapshot } from '../lib/git'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1659,15 +1658,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           return
         }
 
-        const snapshot = await getRebaseSnapshot(repository)
-        if (snapshot !== null) {
-          const { commits, progress } = snapshot
-          this.props.dispatcher.setRebaseProgress(
-            repository,
-            progress.rebasedCommitCount,
-            commits
-          )
-        }
+        await this.props.dispatcher.setRebaseProgressFromState(repository)
 
         const initialState = initializeRebaseFlowForConflictedRepository(
           conflictState

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1581,7 +1581,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const { changesState, rebaseState } = selectedState.state
         const { workingDirectory, conflictState } = changesState
-        const { progress, step } = rebaseState
+        const { progress, step, preview } = rebaseState
 
         if (conflictState !== null && conflictState.kind === 'merge') {
           log.warn(
@@ -1607,6 +1607,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             conflictState={conflictState}
             progress={progress}
             step={step}
+            preview={preview}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
             onShowRebaseConflictsBanner={this.onShowRebaseConflictsBanner}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -100,7 +100,7 @@ import {
   initializeRebaseFlowForConflictedRepository,
 } from '../lib/rebase'
 import { BannerType } from '../models/banner'
-import { getCurrentProgress } from '../lib/git'
+import { getRebaseSnapshot } from '../lib/git'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1659,12 +1659,13 @@ export class App extends React.Component<IAppProps, IAppState> {
           return
         }
 
-        const progress = await getCurrentProgress(repository)
-        if (progress !== null) {
+        const snapshot = await getRebaseSnapshot(repository)
+        if (snapshot !== null) {
+          const { commits, progress } = snapshot
           this.props.dispatcher.setRebaseProgress(
             repository,
             progress.rebasedCommitCount,
-            progress.commits
+            commits
           )
         }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -945,9 +945,9 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const repositoryState = this.props.repositoryStateManager.get(repository)
 
-    const initialState = initializeNewRebaseFlow(repositoryState)
+    const initialStep = initializeNewRebaseFlow(repositoryState)
 
-    this.props.dispatcher.setRebaseFlowStep(repository, initialState)
+    this.props.dispatcher.setRebaseFlowStep(repository, initialStep)
 
     this.props.dispatcher.showPopup({
       type: PopupType.RebaseFlow,
@@ -1660,11 +1660,11 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         await this.props.dispatcher.setRebaseProgressFromState(repository)
 
-        const initialState = initializeRebaseFlowForConflictedRepository(
+        const initialStep = initializeRebaseFlowForConflictedRepository(
           conflictState
         )
 
-        this.props.dispatcher.setRebaseFlowStep(repository, initialState)
+        this.props.dispatcher.setRebaseFlowStep(repository, initialStep)
 
         this.props.dispatcher.showPopup({
           type: PopupType.RebaseFlow,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1608,7 +1608,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             onFlowEnded={this.onRebaseFlowEnded}
             workingDirectory={workingDirectory}
-            conflictState={conflictState}
             progress={progress}
             step={step}
             preview={preview}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -49,7 +49,7 @@ import { Branch } from '../../models/branch'
 import { BranchesTab } from '../../models/branches-tab'
 import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloningRepository } from '../../models/cloning-repository'
-import { Commit, ICommitContext } from '../../models/commit'
+import { Commit, ICommitContext, CommitOneLine } from '../../models/commit'
 import { ICommitMessage } from '../../models/commit-message'
 import { DiffSelection, ImageDiffType } from '../../models/diff'
 import { FetchType } from '../../models/fetch'
@@ -65,7 +65,6 @@ import {
   WorkingDirectoryStatus,
 } from '../../models/status'
 import { TipState, IValidBranch } from '../../models/tip'
-import { RebaseProgressOptions } from '../../models/rebase'
 import { Banner } from '../../models/banner'
 
 import { ApplicationTheme } from '../lib/application-theme'
@@ -717,7 +716,7 @@ export class Dispatcher {
     repository: Repository,
     baseBranch: string,
     targetBranch: string,
-    progress?: RebaseProgressOptions
+    commits: ReadonlyArray<CommitOneLine>
   ): Promise<RebaseResult> {
     const stateBefore = this.repositoryStateManager.get(repository)
 
@@ -734,7 +733,7 @@ export class Dispatcher {
       repository,
       baseBranch,
       targetBranch,
-      progress
+      commits
     )
 
     await this.appStore._loadStatus(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -711,6 +711,18 @@ export class Dispatcher {
     }))
   }
 
+  public setRebaseProgress(
+    repository: Repository,
+    rebasedCommitCount: number,
+    commits: ReadonlyArray<CommitOneLine>
+  ) {
+    return this.appStore._setRebaseProgress(
+      repository,
+      rebasedCommitCount,
+      commits
+    )
+  }
+
   /** Starts a rebase for the given base and target branch */
   public async rebase(
     repository: Repository,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -81,7 +81,7 @@ import {
   StatusCallBack,
 } from '../../lib/stores/commit-status-store'
 import { MergeResult } from '../../models/merge'
-import { RebaseFlowState, RebaseStep } from '../../models/rebase-flow-state'
+import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 
 /**
  * An error handler function.
@@ -749,7 +749,7 @@ export class Dispatcher {
 
   public setRebaseFlow(
     repository: Repository,
-    step: RebaseFlowState
+    step: RebaseFlowStep
   ): Promise<void> {
     return this.appStore._setRebaseFlow(repository, step)
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -80,6 +80,7 @@ import {
   StatusCallBack,
 } from '../../lib/stores/commit-status-store'
 import { MergeResult } from '../../models/merge'
+import { RebaseFlowState } from '../../models/rebase-flow-state'
 
 /**
  * An error handler function.
@@ -730,6 +731,10 @@ export class Dispatcher {
     commits: ReadonlyArray<CommitOneLine>
   ) {
     this.appStore._setRebaseProgress(repository, rebasedCommitCount, commits)
+  }
+
+  public setRebaseFlow(repository: Repository, step: RebaseFlowState) {
+    this.appStore._setRebaseFlow(repository, step)
   }
 
   public endRebaseFlow(repository: Repository) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -724,10 +724,21 @@ export class Dispatcher {
     }))
   }
 
+  /**
+   * Update the rebase state to indicate the user has resolved conflicts in the
+   * current repository.
+   */
   public setConflictsResolved(repository: Repository) {
     return this.appStore._setConflictsResolved(repository)
   }
 
+  /**
+   * Initialize the progress in application state based on the known commits
+   * that will be applied in the rebase.
+   *
+   * @param commits the list of commits that exist on the target branch which do
+   *                not exist on the base branch
+   */
   public initializeRebaseProgress(
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
@@ -735,10 +746,17 @@ export class Dispatcher {
     return this.appStore._initializeRebaseProgress(repository, commits)
   }
 
+  /**
+   * Update the rebase progress in application state by querying the Git
+   * repository state.
+   */
   public setRebaseProgressFromState(repository: Repository) {
     return this.appStore._setRebaseProgressFromState(repository)
   }
 
+  /**
+   * Move the rebase flow to a new state.
+   */
   public setRebaseFlowStep(
     repository: Repository,
     step: RebaseFlowStep

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -20,12 +20,7 @@ import {
   setGenericPassword,
   setGenericUsername,
 } from '../../lib/generic-git-auth'
-import {
-  isGitRepository,
-  RebaseResult,
-  PushOptions,
-  getRebaseSnapshot,
-} from '../../lib/git'
+import { isGitRepository, RebaseResult, PushOptions } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
   rejectOAuthRequest,
@@ -337,11 +332,7 @@ export class Dispatcher {
       conflictState: updatedConflictState,
     }))
 
-    const snapshot = await getRebaseSnapshot(repository)
-    if (snapshot !== null) {
-      const { progress, commits } = snapshot
-      this.setRebaseProgress(repository, progress.rebasedCommitCount, commits)
-    }
+    await this.setRebaseProgressFromState(repository)
 
     const initialState = initializeRebaseFlowForConflictedRepository(
       updatedConflictState
@@ -737,12 +728,15 @@ export class Dispatcher {
     this.appStore._setConflictsResolved(repository)
   }
 
-  public setRebaseProgress(
+  public initializeRebaseProgress(
     repository: Repository,
-    rebasedCommitCount: number,
     commits: ReadonlyArray<CommitOneLine>
   ) {
-    this.appStore._setRebaseProgress(repository, rebasedCommitCount, commits)
+    this.appStore._initializeRebaseProgress(repository, commits)
+  }
+
+  public setRebaseProgressFromState(repository: Repository) {
+    return this.appStore._setRebaseProgressFromState(repository)
   }
 
   public setRebaseFlow(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -24,7 +24,7 @@ import {
   isGitRepository,
   RebaseResult,
   PushOptions,
-  getCurrentProgress,
+  getRebaseSnapshot,
 } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
 import {
@@ -337,13 +337,10 @@ export class Dispatcher {
       conflictState: updatedConflictState,
     }))
 
-    const progress = await getCurrentProgress(repository)
-    if (progress !== null) {
-      this.setRebaseProgress(
-        repository,
-        progress.rebasedCommitCount,
-        progress.commits
-      )
+    const snapshot = await getRebaseSnapshot(repository)
+    if (snapshot !== null) {
+      const { progress, commits } = snapshot
+      this.setRebaseProgress(repository, progress.rebasedCommitCount, commits)
     }
 
     const initialState = initializeRebaseFlowForConflictedRepository(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -754,8 +754,7 @@ export class Dispatcher {
   public async rebase(
     repository: Repository,
     baseBranch: string,
-    targetBranch: string,
-    commits: ReadonlyArray<CommitOneLine>
+    targetBranch: string
   ): Promise<RebaseResult> {
     const stateBefore = this.repositoryStateManager.get(repository)
 
@@ -771,8 +770,7 @@ export class Dispatcher {
     const result = await this.appStore._rebase(
       repository,
       baseBranch,
-      targetBranch,
-      commits
+      targetBranch
     )
 
     await this.appStore._loadStatus(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -747,8 +747,11 @@ export class Dispatcher {
     this.appStore._setRebaseProgress(repository, rebasedCommitCount, commits)
   }
 
-  public setRebaseFlow(repository: Repository, step: RebaseFlowState) {
-    this.appStore._setRebaseFlow(repository, step)
+  public setRebaseFlow(
+    repository: Repository,
+    step: RebaseFlowState
+  ): Promise<void> {
+    return this.appStore._setRebaseFlow(repository, step)
   }
 
   public endRebaseFlow(repository: Repository) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -734,6 +734,10 @@ export class Dispatcher {
     }))
   }
 
+  public setConflictsResolved(repository: Repository) {
+    this.appStore._setConflictsResolved(repository)
+  }
+
   public setRebaseProgress(
     repository: Repository,
     rebasedCommitCount: number,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -305,6 +305,14 @@ export class Dispatcher {
     return this.appStore._closeFoldout(foldout)
   }
 
+  public previewRebase(
+    repository: Repository,
+    baseBranch: Branch,
+    targetBranch: Branch
+  ) {
+    return this.appStore._previewRebase(repository, baseBranch, targetBranch)
+  }
+
   public async launchRebaseFlow({
     repository,
     targetBranch,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -302,6 +302,9 @@ export class Dispatcher {
     return this.appStore._closeFoldout(foldout)
   }
 
+  /**
+   * Compute a preview of the planned rebase action
+   */
   public previewRebase(
     repository: Repository,
     baseBranch: Branch,
@@ -331,11 +334,11 @@ export class Dispatcher {
 
     await this.setRebaseProgressFromState(repository)
 
-    const initialState = initializeRebaseFlowForConflictedRepository(
+    const initialStep = initializeRebaseFlowForConflictedRepository(
       updatedConflictState
     )
 
-    this.setRebaseFlowStep(repository, initialState)
+    this.setRebaseFlowStep(repository, initialStep)
 
     this.showPopup({
       type: PopupType.RebaseFlow,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -310,13 +310,10 @@ export class Dispatcher {
     return this.appStore._previewRebase(repository, baseBranch, targetBranch)
   }
 
-  public async launchRebaseFlow({
-    repository,
-    targetBranch,
-  }: {
-    repository: Repository
-    targetBranch: string
-  }) {
+  /**
+   * Initialize and launch the rebase flow for a conflicted repository
+   */
+  public async launchRebaseFlow(repository: Repository, targetBranch: string) {
     await this.appStore._loadStatus(repository)
 
     const repositoryState = this.repositoryStateManager.get(repository)
@@ -338,7 +335,7 @@ export class Dispatcher {
       updatedConflictState
     )
 
-    this.setRebaseFlow(repository, initialState)
+    this.setRebaseFlowStep(repository, initialState)
 
     this.showPopup({
       type: PopupType.RebaseFlow,
@@ -725,27 +722,28 @@ export class Dispatcher {
   }
 
   public setConflictsResolved(repository: Repository) {
-    this.appStore._setConflictsResolved(repository)
+    return this.appStore._setConflictsResolved(repository)
   }
 
   public initializeRebaseProgress(
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ) {
-    this.appStore._initializeRebaseProgress(repository, commits)
+    return this.appStore._initializeRebaseProgress(repository, commits)
   }
 
   public setRebaseProgressFromState(repository: Repository) {
     return this.appStore._setRebaseProgressFromState(repository)
   }
 
-  public setRebaseFlow(
+  public setRebaseFlowStep(
     repository: Repository,
     step: RebaseFlowStep
   ): Promise<void> {
-    return this.appStore._setRebaseFlow(repository, step)
+    return this.appStore._setRebaseFlowStep(repository, step)
   }
 
+  /** End the rebase flow and cleanup any related app state */
   public endRebaseFlow(repository: Repository) {
     return this.appStore._endRebaseFlow(repository)
   }
@@ -917,7 +915,7 @@ export class Dispatcher {
     repository: Repository,
     conflictState: RebaseConflictState
   ) => {
-    this.setRebaseFlow(repository, {
+    this.setRebaseFlowStep(repository, {
       kind: RebaseStep.ShowConflicts,
       conflictState,
     })

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -340,10 +340,11 @@ export class Dispatcher {
       updatedConflictState
     )
 
+    this.setRebaseFlow(repository, initialState)
+
     this.showPopup({
       type: PopupType.RebaseFlow,
       repository,
-      initialState,
     })
   }
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -396,10 +396,7 @@ export async function rebaseConflictsHandler(
 
   const { currentBranch } = gitContext
 
-  dispatcher.launchRebaseFlow({
-    repository,
-    targetBranch: currentBranch,
-  })
+  dispatcher.launchRebaseFlow(repository, currentBranch)
 
   return null
 }

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -15,8 +15,11 @@ import { ActionStatusIcon } from '../lib/action-status-icon'
 
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
+import { Dispatcher } from '../dispatcher'
 
 interface IChooseBranchDialogProps {
+  readonly dispatcher: Dispatcher
+
   readonly repository: Repository
 
   /**
@@ -56,8 +59,6 @@ interface IChooseBranchDialogProps {
    */
   readonly onDismissed: () => void
 
-  readonly onBranchChanged: (branch: Branch) => void
-
   /** Callback to signal to start the rebase */
   readonly onStartRebase: (
     baseBranch: string,
@@ -91,7 +92,7 @@ export class ChooseBranchDialog extends React.Component<
     )
 
     if (selectedBranch !== null) {
-      this.props.onBranchChanged(selectedBranch)
+      this.onBranchChanged(selectedBranch)
     }
 
     this.state = {
@@ -104,11 +105,21 @@ export class ChooseBranchDialog extends React.Component<
     this.setState({ filterText })
   }
 
+  private onBranchChanged = (selectedBranch: Branch) => {
+    const { currentBranch } = this.props
+
+    this.props.dispatcher.previewRebase(
+      this.props.repository,
+      selectedBranch,
+      currentBranch
+    )
+  }
+
   private onSelectionChanged = (selectedBranch: Branch | null) => {
     this.setState({ selectedBranch })
 
     if (selectedBranch !== null) {
-      this.props.onBranchChanged(selectedBranch)
+      this.onBranchChanged(selectedBranch)
     }
   }
 

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -133,6 +133,12 @@ export class ChooseBranchDialog extends React.Component<
 
     const disabled = selectedBranchIsNotCurrentBranch || noCommitsToRebase
 
+    const tooltip = selectedBranchIsNotCurrentBranch
+      ? 'You are not able to rebase this branch onto itself'
+      : noCommitsToRebase
+      ? 'There are no commits on the current branch to rebase'
+      : undefined
+
     const currentBranchName = currentBranch.name
 
     // the amount of characters to allow before we truncate was chosen arbitrarily
@@ -146,7 +152,6 @@ export class ChooseBranchDialog extends React.Component<
         id="rebase"
         onDismissed={this.props.onDismissed}
         onSubmit={this.startRebase}
-        disabled={disabled}
         dismissable={true}
         title={
           <>
@@ -171,7 +176,7 @@ export class ChooseBranchDialog extends React.Component<
         <DialogFooter>
           {this.renderRebaseStatus()}
           <ButtonGroup>
-            <Button type="submit" disabled={disabled}>
+            <Button type="submit" disabled={disabled} tooltip={tooltip}>
               Rebase <strong>{currentBranchName}</strong> onto{' '}
               <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
             </Button>

--- a/app/src/ui/rebase/confirm-abort-dialog.tsx
+++ b/app/src/ui/rebase/confirm-abort-dialog.tsx
@@ -14,7 +14,7 @@ const abortButtonString = 'Abort rebase'
 interface IConfirmAbortDialogProps {
   readonly step: ConfirmAbortStep
 
-  readonly onReturnToConflicts: () => void
+  readonly onReturnToConflicts: (step: ConfirmAbortStep) => void
   readonly onConfirmAbort: () => Promise<void>
 }
 
@@ -49,7 +49,7 @@ export class ConfirmAbortDialog extends React.Component<
    *  Dismisses the modal and shows the rebase conflicts modal
    */
   private onCancel = async () => {
-    await this.props.onReturnToConflicts()
+    await this.props.onReturnToConflicts(this.props.step)
   }
 
   private renderTextContent(targetBranch: string, baseBranch?: string) {

--- a/app/src/ui/rebase/confirm-abort-dialog.tsx
+++ b/app/src/ui/rebase/confirm-abort-dialog.tsx
@@ -77,8 +77,8 @@ export class ConfirmAbortDialog extends React.Component<
       <div className="column-left">
         {firstParagraph}
         <p>
-          Aborting this merge will take you back to the pre-merge state and the
-          conflicts you've already resolved will still be present.
+          Aborting this rebase will take you back to the original branch state
+          and and the conflicts you have already resolved will be discarded.
         </p>
       </div>
     )

--- a/app/src/ui/rebase/confirm-abort-dialog.tsx
+++ b/app/src/ui/rebase/confirm-abort-dialog.tsx
@@ -5,14 +5,14 @@ import { Button } from '../lib/button'
 
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OcticonSymbol, Octicon } from '../octicons'
+import { ConfirmAbortStep } from '../../models/rebase-flow-step'
 
 const titleString = 'Confirm abort rebase'
 const cancelButtonString = 'Cancel'
 const abortButtonString = 'Abort rebase'
 
 interface IConfirmAbortDialogProps {
-  readonly baseBranch?: string
-  readonly targetBranch: string
+  readonly step: ConfirmAbortStep
 
   readonly onReturnToConflicts: () => void
   readonly onConfirmAbort: () => Promise<void>
@@ -85,6 +85,8 @@ export class ConfirmAbortDialog extends React.Component<
   }
 
   public render() {
+    const { targetBranch, baseBranch } = this.props.step.conflictState
+
     return (
       <Dialog
         id="abort-merge-warning"
@@ -96,10 +98,7 @@ export class ConfirmAbortDialog extends React.Component<
       >
         <DialogContent className="content-wrapper">
           <Octicon symbol={OcticonSymbol.alert} />
-          {this.renderTextContent(
-            this.props.targetBranch,
-            this.props.baseBranch
-          )}
+          {this.renderTextContent(targetBranch, baseBranch)}
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { timeout } from '../../lib/promise'
 import { formatRebaseValue } from '../../lib/rebase'
 
 import { RichText } from '../lib/rich-text'
@@ -14,13 +13,6 @@ interface IRebaseProgressDialogProps {
   readonly progress: RebaseProgressSummary
 
   readonly emoji: Map<string, string>
-
-  /**
-   * An optional action to run when the component is mounted
-   *
-   * This should typically be the rebase action to perform.
-   */
-  readonly rebaseAction: (() => Promise<void>) | null
 }
 
 export class RebaseProgressDialog extends React.Component<
@@ -28,14 +20,6 @@ export class RebaseProgressDialog extends React.Component<
 > {
   private onDismissed = () => {
     // this dialog is undismissable, but I need to handle the event
-  }
-
-  /** After a delay, run the assigned action to start/continue the rebase */
-  public async componentDidMount() {
-    if (this.props.rebaseAction) {
-      await timeout(500)
-      await this.props.rebaseAction()
-    }
   }
 
   public render() {

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -25,7 +25,7 @@ export class RebaseProgressDialog extends React.Component<
   public render() {
     const {
       rebasedCommitCount,
-      commits,
+      totalCommitCount,
       value,
       currentCommitSummary,
     } = this.props.progress
@@ -52,7 +52,7 @@ export class RebaseProgressDialog extends React.Component<
               </div>
               <div className="summary">
                 <div className="message">
-                  Commit {count} of {commits.length}
+                  Commit {count} of {totalCommitCount}
                 </div>
                 <div className="detail">
                   <RichText

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -6,11 +6,11 @@ import { RichText } from '../lib/rich-text'
 
 import { Dialog, DialogContent } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
-import { RebaseProgressSummary } from '../../models/rebase'
+import { GitRebaseProgress } from '../../models/rebase'
 
 interface IRebaseProgressDialogProps {
   /** Progress information about the current rebase */
-  readonly progress: RebaseProgressSummary
+  readonly progress: GitRebaseProgress
 
   readonly emoji: Map<string, string>
 }

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -30,8 +30,8 @@ export class RebaseProgressDialog extends React.Component<
       currentCommitSummary,
     } = this.props.progress
 
-    // ensure progress always starts from 0
-    const count = rebasedCommitCount === 0 ? 1 : rebasedCommitCount
+    // ensure progress always starts from 1
+    const count = rebasedCommitCount <= 1 ? 1 : rebasedCommitCount
 
     const progressValue = formatRebaseValue(value)
     return (

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -45,6 +45,10 @@ export class RebaseProgressDialog extends React.Component<
       value,
       currentCommitSummary,
     } = this.props.progress
+
+    // ensure progress always starts from 0
+    const count = rebasedCommitCount === 0 ? 1 : rebasedCommitCount
+
     const progressValue = formatRebaseValue(value)
     return (
       <Dialog
@@ -64,7 +68,7 @@ export class RebaseProgressDialog extends React.Component<
               </div>
               <div className="summary">
                 <div className="message">
-                  Commit {rebasedCommitCount} of {commits.length}
+                  Commit {count} of {commits.length}
                 </div>
                 <div className="detail">
                   <RichText

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -138,7 +138,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
   private onContinueRebase = async () => {
     if (this.props.step.kind !== RebaseStep.ShowConflicts) {
       throw new Error(
-        `Invalid step to continue rebase rebase: ${this.props.step.kind}`
+        `Invalid step to continue rebase: ${this.props.step.kind}`
       )
     }
 

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -7,9 +7,9 @@ import { RebaseConflictState } from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import {
   RebaseStep,
-  RebaseFlowState,
+  RebaseFlowStep,
   ShowConflictsStep,
-} from '../../models/rebase-flow-state'
+} from '../../models/rebase-flow-step'
 import { GitRebaseProgress, RebasePreview } from '../../models/rebase'
 import { WorkingDirectoryStatus } from '../../models/status'
 import { CommitOneLine } from '../../models/commit'
@@ -43,7 +43,7 @@ interface IRebaseFlowProps {
    * The current step in the rebase flow, containing application-specific
    * state needed for the UI components.
    */
-  readonly step: RebaseFlowState
+  readonly step: RebaseFlowStep
 
   /**
    * A preview of the rebase, using the selected base branch to test whether the

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -59,7 +59,7 @@ interface IRebaseFlowProps {
    * Callback to fire to signal to the application that the rebase flow has
    * either ended in success or has been aborted and the flow can be closed.
    */
-  readonly onFlowEnded: () => void
+  readonly onFlowEnded: (repository: Repository) => void
 
   /**
    * Callbacks for the conflict selection components to let the user jump out
@@ -156,7 +156,7 @@ export class RebaseFlow extends React.Component<
               kind: RebaseStep.Completed,
             },
           },
-          () => this.props.onFlowEnded()
+          () => this.props.onFlowEnded(this.props.repository)
         )
       }
     }
@@ -394,7 +394,11 @@ export class RebaseFlow extends React.Component<
 
   private onAbortRebase = async () => {
     await this.props.dispatcher.abortRebase(this.props.repository)
-    this.props.onFlowEnded()
+    this.onFlowEnded()
+  }
+
+  private onFlowEnded = () => {
+    this.props.onFlowEnded(this.props.repository)
   }
 
   public render() {
@@ -402,7 +406,7 @@ export class RebaseFlow extends React.Component<
 
     switch (step.kind) {
       case RebaseStep.ChooseBranch: {
-        const { repository, onFlowEnded } = this.props
+        const { repository } = this.props
         const {
           allBranches,
           defaultBranch,
@@ -419,7 +423,7 @@ export class RebaseFlow extends React.Component<
             recentBranches={recentBranches}
             currentBranch={currentBranch}
             initialBranch={initialBranch}
-            onDismissed={onFlowEnded}
+            onDismissed={this.onFlowEnded}
             onStartRebase={this.onStartRebase}
             onBranchChanged={this.testRebaseOperation}
             rebasePreviewStatus={this.state.rebasePreview}
@@ -437,7 +441,6 @@ export class RebaseFlow extends React.Component<
       case RebaseStep.ShowConflicts: {
         const {
           repository,
-          onFlowEnded,
           resolvedExternalEditor,
           openFileInExternalEditor,
           openRepositoryInShell,
@@ -453,7 +456,7 @@ export class RebaseFlow extends React.Component<
           log.error(
             '[RebaseFlow] ending rebase flow as user has likely made changes to the repository from the command line'
           )
-          this.props.onFlowEnded()
+          this.onFlowEnded()
           return null
         }
 
@@ -464,7 +467,7 @@ export class RebaseFlow extends React.Component<
           <ShowConflictedFilesDialog
             key="view-conflicts"
             repository={repository}
-            onDismissed={onFlowEnded}
+            onDismissed={this.onFlowEnded}
             onContinueRebase={this.onContinueRebase}
             dispatcher={dispatcher}
             showRebaseConflictsBanner={this.showRebaseConflictsBanner}

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -131,7 +131,10 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       throw new Error(`Invalid step to start rebase: ${this.props.step.kind}`)
     }
 
-    this.props.dispatcher.setRebaseProgress(this.props.repository, 0, commits)
+    this.props.dispatcher.initializeRebaseProgress(
+      this.props.repository,
+      commits
+    )
 
     const startRebaseAction = () => {
       return this.props.dispatcher.rebase(

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -112,10 +112,6 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
     targetBranch: string,
     commits: ReadonlyArray<CommitOneLine>
   ) => {
-    if (this.props.step.kind !== RebaseStep.ChooseBranch) {
-      throw new Error(`Invalid step to start rebase: ${this.props.step.kind}`)
-    }
-
     this.props.dispatcher.initializeRebaseProgress(
       this.props.repository,
       commits

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -160,14 +160,14 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
 
   private onConfirmAbortRebase = (step: ShowConflictsStep) => {
     const { workingDirectory, userHasResolvedConflicts } = this.props
-    const { manualResolutions, targetBranch, baseBranch } = step.conflictState
+    const { conflictState } = step
+    const { manualResolutions } = conflictState
 
     if (userHasResolvedConflicts) {
       // a previous commit was resolved by the user
       this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
         kind: RebaseStep.ConfirmAbort,
-        targetBranch,
-        baseBranch,
+        conflictState,
       })
       return
     }
@@ -181,8 +181,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
     if (resolvedConflicts.length > 0) {
       this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
         kind: RebaseStep.ConfirmAbort,
-        targetBranch,
-        baseBranch,
+        conflictState,
       })
     } else {
       this.onAbortRebase()
@@ -246,20 +245,8 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
           openRepositoryInShell,
           dispatcher,
           workingDirectory,
-          conflictState,
           userHasResolvedConflicts,
         } = this.props
-
-        if (conflictState === null) {
-          log.error(
-            '[RebaseFlow] unable to find conflicts for this repository despite being in conflicted state'
-          )
-          log.error(
-            '[RebaseFlow] ending rebase flow as user has likely made changes to the repository from the command line'
-          )
-          this.onFlowEnded()
-          return null
-        }
 
         return (
           <ShowConflictedFilesDialog
@@ -268,7 +255,6 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
             dispatcher={dispatcher}
             step={step}
             showRebaseConflictsBanner={this.showRebaseConflictsBanner}
-            conflictState={conflictState}
             workingDirectory={workingDirectory}
             userHasResolvedConflicts={userHasResolvedConflicts}
             resolvedExternalEditor={resolvedExternalEditor}
@@ -282,13 +268,11 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       }
 
       case RebaseStep.ConfirmAbort:
-        const { targetBranch, baseBranch } = step
         return (
           <ConfirmAbortDialog
+            step={step}
             onConfirmAbort={this.onAbortRebase}
             onReturnToConflicts={this.moveToShowConflictedFileState}
-            targetBranch={targetBranch}
-            baseBranch={baseBranch}
           />
         )
       case RebaseStep.HideConflicts:

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -96,8 +96,6 @@ export class RebaseFlow extends React.Component<
   IRebaseFlowProps,
   IRebaseFlowState
 > {
-  private ignoreUpdateEvents = false
-
   public constructor(props: IRebaseFlowProps) {
     super(props)
 
@@ -106,10 +104,6 @@ export class RebaseFlow extends React.Component<
       userHasResolvedConflicts: false,
       rebasePreview: null,
     }
-  }
-
-  public componentWillUnmount() {
-    this.ignoreUpdateEvents = true
   }
 
   public async componentDidUpdate() {
@@ -196,10 +190,6 @@ export class RebaseFlow extends React.Component<
   }
 
   private moveToCompletedState = () => {
-    if (this.ignoreUpdateEvents) {
-      return
-    }
-
     // this ensures the progress bar fills to 100%, while `componentDidUpdate`
     // detects and handles the state transition after a period of time to ensure
     // the UI shows _something_ before closing the dialog

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -135,17 +135,8 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
     })
   }
 
-  private onContinueRebase = async () => {
-    if (this.props.step.kind !== RebaseStep.ShowConflicts) {
-      throw new Error(
-        `Invalid step to continue rebase: ${this.props.step.kind}`
-      )
-    }
-
-    const { conflictState } = this.props
-    if (conflictState === null) {
-      throw new Error(`No conflicted files found, unable to continue rebase`)
-    }
+  private onContinueRebase = async (step: ShowConflictsStep) => {
+    const { conflictState } = step
 
     const continueRebaseAction = () => {
       return this.props.dispatcher.continueRebase(

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 
 import { assertNever } from '../../lib/fatal-error'
-import { RebaseConflictState } from '../../lib/app-state'
 
 import { Repository } from '../../models/repository'
 import {
   RebaseStep,
   RebaseFlowStep,
   ShowConflictsStep,
+  ConfirmAbortStep,
 } from '../../models/rebase-flow-step'
 import { GitRebaseProgress, RebasePreview } from '../../models/rebase'
 import { WorkingDirectoryStatus } from '../../models/status'
@@ -28,14 +28,6 @@ interface IRebaseFlowProps {
 
   /** The current state of the working directory */
   readonly workingDirectory: WorkingDirectoryStatus
-
-  /**
-   * Snapshot of conflicts in the current repository
-   *
-   * Will be `null` while the rebase is in progress but has not encountered
-   * conflicts.
-   */
-  readonly conflictState: RebaseConflictState | null
 
   /**
    * The current step in the rebase flow, containing application-specific
@@ -93,14 +85,8 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
     }
   }
 
-  private moveToShowConflictedFileState = () => {
-    const { conflictState } = this.props
-
-    if (conflictState === null) {
-      log.error('[RebaseFlow] unable to detect conflicts for this repository')
-      return
-    }
-
+  private moveToShowConflictedFileState = (step: ConfirmAbortStep) => {
+    const { conflictState } = step
     this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
       kind: RebaseStep.ShowConflicts,
       conflictState,

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -116,7 +116,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       return
     }
 
-    this.props.dispatcher.setRebaseFlow(this.props.repository, {
+    this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
       kind: RebaseStep.ShowConflicts,
       conflictState,
     })
@@ -144,7 +144,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       )
     }
 
-    this.props.dispatcher.setRebaseFlow(this.props.repository, {
+    this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
       kind: RebaseStep.ShowProgress,
       rebaseAction: startRebaseAction,
     })
@@ -170,14 +170,14 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       )
     }
 
-    this.props.dispatcher.setRebaseFlow(this.props.repository, {
+    this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
       kind: RebaseStep.ShowProgress,
       rebaseAction: continueRebaseAction,
     })
   }
 
   private showRebaseConflictsBanner = (step: ShowConflictsStep) => {
-    this.props.dispatcher.setRebaseFlow(this.props.repository, {
+    this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
       kind: RebaseStep.HideConflicts,
     })
 
@@ -192,7 +192,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
 
     if (userHasResolvedConflicts) {
       // a previous commit was resolved by the user
-      this.props.dispatcher.setRebaseFlow(this.props.repository, {
+      this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
         kind: RebaseStep.ConfirmAbort,
         targetBranch,
         baseBranch,
@@ -207,7 +207,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
     )
 
     if (resolvedConflicts.length > 0) {
-      this.props.dispatcher.setRebaseFlow(this.props.repository, {
+      this.props.dispatcher.setRebaseFlowStep(this.props.repository, {
         kind: RebaseStep.ConfirmAbort,
         targetBranch,
         baseBranch,

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -10,7 +10,7 @@ import {
   RebaseFlowState,
   ShowConflictsStep,
 } from '../../models/rebase-flow-state'
-import { RebaseProgressSummary, RebasePreview } from '../../models/rebase'
+import { GitRebaseProgress, RebasePreview } from '../../models/rebase'
 import { WorkingDirectoryStatus } from '../../models/status'
 import { CommitOneLine } from '../../models/commit'
 import { Branch } from '../../models/branch'
@@ -52,7 +52,7 @@ interface IRebaseFlowProps {
   readonly preview: RebasePreview | null
 
   /** Git progress information about the current rebase */
-  readonly progress: RebaseProgressSummary
+  readonly progress: GitRebaseProgress
 
   /**
    * Track whether the user has done work to resolve conflicts as part of this

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -140,8 +140,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       return this.props.dispatcher.rebase(
         this.props.repository,
         baseBranch,
-        targetBranch,
-        commits
+        targetBranch
       )
     }
 

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -285,7 +285,6 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
           <RebaseProgressDialog
             progress={this.props.progress}
             emoji={this.props.emoji}
-            rebaseAction={step.rebaseAction}
           />
         )
       case RebaseStep.ShowConflicts: {

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -12,7 +12,6 @@ import {
 import { GitRebaseProgress, RebasePreview } from '../../models/rebase'
 import { WorkingDirectoryStatus } from '../../models/status'
 import { CommitOneLine } from '../../models/commit'
-import { Branch } from '../../models/branch'
 
 import { Dispatcher } from '../dispatcher'
 
@@ -92,20 +91,6 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
     this.state = {
       userHasResolvedConflicts: false,
     }
-  }
-
-  private testRebaseOperation = (baseBranch: Branch) => {
-    const { step } = this.props
-    if (step.kind !== RebaseStep.ChooseBranch) {
-      log.warn(`[RebaseFlow] testRebaseOperation invoked but on the wrong step`)
-      return
-    }
-
-    this.props.dispatcher.previewRebase(
-      this.props.repository,
-      baseBranch,
-      step.currentBranch
-    )
   }
 
   private moveToShowConflictedFileState = () => {
@@ -231,7 +216,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
 
     switch (step.kind) {
       case RebaseStep.ChooseBranch: {
-        const { repository } = this.props
+        const { repository, dispatcher } = this.props
         const {
           allBranches,
           defaultBranch,
@@ -243,6 +228,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
           <ChooseBranchDialog
             key="choose-branch"
             repository={repository}
+            dispatcher={dispatcher}
             allBranches={allBranches}
             defaultBranch={defaultBranch}
             recentBranches={recentBranches}
@@ -250,7 +236,6 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
             initialBranch={initialBranch}
             onDismissed={this.onFlowEnded}
             onStartRebase={this.onStartRebase}
-            onBranchChanged={this.testRebaseOperation}
             rebasePreviewStatus={this.props.preview}
           />
         )

--- a/app/src/ui/rebase/show-conflicted-files-dialog.tsx
+++ b/app/src/ui/rebase/show-conflicted-files-dialog.tsx
@@ -24,7 +24,6 @@ import { renderUnmergedFile } from '../lib/conflicts/unmerged-file'
 
 import { DialogContent, Dialog, DialogFooter } from '../dialog'
 import { Dispatcher } from '../dispatcher'
-import { RebaseConflictState } from '../../lib/app-state'
 import { ShowConflictsStep } from '../../models/rebase-flow-step'
 
 interface IShowConflictedFilesDialogProps {
@@ -34,7 +33,6 @@ interface IShowConflictedFilesDialogProps {
   readonly step: ShowConflictsStep
 
   readonly userHasResolvedConflicts: boolean
-  readonly conflictState: RebaseConflictState
   readonly workingDirectory: WorkingDirectoryStatus
 
   readonly onDismissed: () => void
@@ -68,12 +66,8 @@ export class ShowConflictedFilesDialog extends React.Component<
   }
 
   public componentWillUnmount() {
-    const {
-      workingDirectory,
-      conflictState,
-      userHasResolvedConflicts,
-    } = this.props
-
+    const { workingDirectory, step, userHasResolvedConflicts } = this.props
+    const { conflictState } = step
     const { manualResolutions } = conflictState
 
     // skip this work once we know conflicts have been resolved
@@ -137,7 +131,7 @@ export class ShowConflictedFilesDialog extends React.Component<
       manualResolutions,
       targetBranch,
       baseBranch,
-    } = this.props.conflictState
+    } = this.props.step.conflictState
 
     return (
       <ul className="unmerged-file-statuses">
@@ -178,8 +172,8 @@ export class ShowConflictedFilesDialog extends React.Component<
   }
 
   public render() {
-    const { workingDirectory, conflictState } = this.props
-    const { manualResolutions, targetBranch, baseBranch } = conflictState
+    const { workingDirectory, step } = this.props
+    const { manualResolutions, targetBranch, baseBranch } = step.conflictState
 
     const unmergedFiles = getUnmergedFiles(workingDirectory)
     const conflictedFilesCount = getConflictedFiles(

--- a/app/src/ui/rebase/show-conflicted-files-dialog.tsx
+++ b/app/src/ui/rebase/show-conflicted-files-dialog.tsx
@@ -28,14 +28,18 @@ import { Dispatcher } from '../dispatcher'
 interface IShowConflictedFilesDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
+
+  readonly userHasResolvedConflicts: boolean
   readonly targetBranch: string
   readonly baseBranch?: string
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+
   readonly onDismissed: () => void
   readonly onContinueRebase: () => void
   readonly onAbortRebase: () => Promise<void>
   readonly showRebaseConflictsBanner: () => void
-  readonly workingDirectory: WorkingDirectoryStatus
-  readonly manualResolutions: Map<string, ManualConflictResolution>
+
   readonly openFileInExternalEditor: (path: string) => void
   readonly resolvedExternalEditor: string | null
   readonly openRepositoryInShell: (repository: Repository) => void

--- a/app/src/ui/rebase/show-conflicted-files-dialog.tsx
+++ b/app/src/ui/rebase/show-conflicted-files-dialog.tsx
@@ -38,7 +38,7 @@ interface IShowConflictedFilesDialogProps {
   readonly workingDirectory: WorkingDirectoryStatus
 
   readonly onDismissed: () => void
-  readonly onContinueRebase: () => void
+  readonly onContinueRebase: (step: ShowConflictsStep) => void
   readonly onAbortRebase: (step: ShowConflictsStep) => void
   readonly showRebaseConflictsBanner: (step: ShowConflictsStep) => void
 
@@ -105,7 +105,7 @@ export class ShowConflictedFilesDialog extends React.Component<
   }
 
   private onSubmit = async () => {
-    this.props.onContinueRebase()
+    this.props.onContinueRebase(this.props.step)
   }
 
   private renderHeaderTitle(targetBranch: string, baseBranch?: string) {

--- a/app/src/ui/rebase/show-conflicted-files-dialog.tsx
+++ b/app/src/ui/rebase/show-conflicted-files-dialog.tsx
@@ -25,10 +25,13 @@ import { renderUnmergedFile } from '../lib/conflicts/unmerged-file'
 import { DialogContent, Dialog, DialogFooter } from '../dialog'
 import { Dispatcher } from '../dispatcher'
 import { RebaseConflictState } from '../../lib/app-state'
+import { ShowConflictsStep } from '../../models/rebase-flow-state'
 
 interface IShowConflictedFilesDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
+
+  readonly step: ShowConflictsStep
 
   readonly userHasResolvedConflicts: boolean
   readonly conflictState: RebaseConflictState
@@ -36,8 +39,8 @@ interface IShowConflictedFilesDialogProps {
 
   readonly onDismissed: () => void
   readonly onContinueRebase: () => void
-  readonly onAbortRebase: (conflictState: RebaseConflictState) => void
-  readonly showRebaseConflictsBanner: () => void
+  readonly onAbortRebase: (step: ShowConflictsStep) => void
+  readonly showRebaseConflictsBanner: (step: ShowConflictsStep) => void
 
   readonly openFileInExternalEditor: (path: string) => void
   readonly resolvedExternalEditor: string | null
@@ -91,14 +94,14 @@ export class ShowConflictedFilesDialog extends React.Component<
   private onCancel = async () => {
     this.setState({ isAborting: true })
 
-    this.props.onAbortRebase(this.props.conflictState)
+    this.props.onAbortRebase(this.props.step)
 
     this.setState({ isAborting: false })
   }
 
   private onDismissed = () => {
     this.props.onDismissed()
-    this.props.showRebaseConflictsBanner()
+    this.props.showRebaseConflictsBanner(this.props.step)
   }
 
   private onSubmit = async () => {

--- a/app/src/ui/rebase/show-conflicted-files-dialog.tsx
+++ b/app/src/ui/rebase/show-conflicted-files-dialog.tsx
@@ -25,7 +25,7 @@ import { renderUnmergedFile } from '../lib/conflicts/unmerged-file'
 import { DialogContent, Dialog, DialogFooter } from '../dialog'
 import { Dispatcher } from '../dispatcher'
 import { RebaseConflictState } from '../../lib/app-state'
-import { ShowConflictsStep } from '../../models/rebase-flow-state'
+import { ShowConflictsStep } from '../../models/rebase-flow-step'
 
 interface IShowConflictedFilesDialogProps {
   readonly dispatcher: Dispatcher

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -26,7 +26,7 @@ export function createStatus<K extends keyof IStatusResult>(
   const baseStatus: IStatusResult = {
     exists: true,
     mergeHeadFound: false,
-    rebaseContext: null,
+    rebaseInternalState: null,
     workingDirectory: WorkingDirectoryStatus.fromFiles([]),
   }
 

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -47,7 +47,7 @@ describe('git/rebase', () => {
     })
 
     it('status detects REBASE_HEAD', async () => {
-      expect(status.rebaseContext).toEqual({
+      expect(status.rebaseInternalState).toEqual({
         originalBranchTip,
         baseBranchTip,
         targetBranch: 'this-is-a-feature',
@@ -81,7 +81,7 @@ describe('git/rebase', () => {
     })
 
     it('REBASE_HEAD is no longer found', async () => {
-      expect(status.rebaseContext).toBeNull()
+      expect(status.rebaseInternalState).toBeNull()
     })
 
     it('no longer has working directory changes', async () => {
@@ -123,7 +123,7 @@ describe('git/rebase', () => {
     })
 
     it('REBASE_HEAD is still found', async () => {
-      expect(status.rebaseContext).toEqual({
+      expect(status.rebaseInternalState).toEqual({
         originalBranchTip,
         baseBranchTip,
         targetBranch: 'this-is-a-feature',
@@ -190,7 +190,7 @@ describe('git/rebase', () => {
     })
 
     it('REBASE_HEAD is no longer found', () => {
-      expect(status.rebaseContext).toBeNull()
+      expect(status.rebaseInternalState).toBeNull()
     })
 
     it('no longer has working directory changes', () => {

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -50,6 +50,8 @@ describe('git/rebase', () => {
       expect(s.commits[0].summary).toEqual('Feature Branch!')
 
       expect(s.progress.rebasedCommitCount).toEqual(1)
+      expect(s.progress.totalCommitCount).toEqual(1)
+      expect(s.progress.currentCommitSummary).toEqual('Feature Branch!')
       expect(s.progress.value).toEqual(1)
     })
 
@@ -84,6 +86,10 @@ describe('git/rebase', () => {
       expect(s.commits[0].summary).toEqual('Feature Branch First Commit!')
 
       expect(s.progress.rebasedCommitCount).toEqual(1)
+      expect(s.progress.totalCommitCount).toEqual(10)
+      expect(s.progress.currentCommitSummary).toEqual(
+        'Feature Branch First Commit!'
+      )
       expect(s.progress.value).toEqual(0.1)
     })
 

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -45,12 +45,12 @@ describe('git/rebase', () => {
 
     it('status detects REBASE_HEAD', () => {
       expect(snapshot).not.toEqual(null)
-      const p = snapshot!
-      expect(p.commits.length).toEqual(1)
-      expect(p.commits[0].summary).toEqual('Feature Branch!')
+      const s = snapshot!
+      expect(s.commits.length).toEqual(1)
+      expect(s.commits[0].summary).toEqual('Feature Branch!')
 
-      expect(p.progress.rebasedCommitCount).toEqual(1)
-      expect(p.progress.value).toEqual(1)
+      expect(s.progress.rebasedCommitCount).toEqual(1)
+      expect(s.progress.value).toEqual(1)
     })
 
     it('is a detached HEAD state', () => {
@@ -79,12 +79,12 @@ describe('git/rebase', () => {
 
     it('status detects REBASE_HEAD', () => {
       expect(snapshot).not.toEqual(null)
-      const p = snapshot!
-      expect(p.commits.length).toEqual(10)
-      expect(p.commits[0].summary).toEqual('Feature Branch First Commit!')
+      const s = snapshot!
+      expect(s.commits.length).toEqual(10)
+      expect(s.commits[0].summary).toEqual('Feature Branch First Commit!')
 
-      expect(p.progress.rebasedCommitCount).toEqual(1)
-      expect(p.progress.value).toEqual(0.1)
+      expect(s.progress.rebasedCommitCount).toEqual(1)
+      expect(s.progress.value).toEqual(0.1)
     })
 
     it('is a detached HEAD state', () => {

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -2,12 +2,12 @@ import { IStatusResult } from '../../../../src/lib/git'
 import {
   rebase,
   RebaseResult,
-  getCurrentProgress,
-} from '../../../../src/lib/git/rebase'
+  getRebaseSnapshot,
+} from '../../../../src/lib/git'
 import { createRepository as createShortRebaseTest } from '../../../helpers/repository-builder-rebase-test'
 import { createRepository as createLongRebaseTest } from '../../../helpers/repository-builder-long-rebase-test'
 import { getStatusOrThrow } from '../../../helpers/status'
-import { GitRebaseProgress } from '../../../../src/models/rebase'
+import { GitRebaseSnapshot } from '../../../../src/models/rebase'
 import { setupEmptyDirectory } from '../../../helpers/repositories'
 
 const baseBranch = 'base-branch'
@@ -18,7 +18,7 @@ describe('git/rebase', () => {
     it('returns null for rebase progress', async () => {
       const repository = await setupEmptyDirectory()
 
-      const progress = await getCurrentProgress(repository)
+      const progress = await getRebaseSnapshot(repository)
 
       expect(progress).toEqual(null)
     })
@@ -26,7 +26,7 @@ describe('git/rebase', () => {
 
   describe('can parse progress', () => {
     let result: RebaseResult
-    let progress: GitRebaseProgress | null
+    let snapshot: GitRebaseSnapshot | null
     let status: IStatusResult
 
     beforeEach(async () => {
@@ -34,7 +34,7 @@ describe('git/rebase', () => {
 
       result = await rebase(repository, baseBranch, featureBranch)
 
-      progress = await getCurrentProgress(repository)
+      snapshot = await getRebaseSnapshot(repository)
 
       status = await getStatusOrThrow(repository)
     })
@@ -44,13 +44,13 @@ describe('git/rebase', () => {
     })
 
     it('status detects REBASE_HEAD', () => {
-      expect(progress).not.toEqual(null)
-      const p = progress!
+      expect(snapshot).not.toEqual(null)
+      const p = snapshot!
       expect(p.commits.length).toEqual(1)
       expect(p.commits[0].summary).toEqual('Feature Branch!')
 
-      expect(p.rebasedCommitCount).toEqual(1)
-      expect(p.value).toEqual(1)
+      expect(p.progress.rebasedCommitCount).toEqual(1)
+      expect(p.progress.value).toEqual(1)
     })
 
     it('is a detached HEAD state', () => {
@@ -60,7 +60,7 @@ describe('git/rebase', () => {
 
   describe('can parse progress for long rebase', () => {
     let result: RebaseResult
-    let progress: GitRebaseProgress | null
+    let snapshot: GitRebaseSnapshot | null
     let status: IStatusResult
 
     beforeEach(async () => {
@@ -68,7 +68,7 @@ describe('git/rebase', () => {
 
       result = await rebase(repository, baseBranch, featureBranch)
 
-      progress = await getCurrentProgress(repository)
+      snapshot = await getRebaseSnapshot(repository)
 
       status = await getStatusOrThrow(repository)
     })
@@ -78,13 +78,13 @@ describe('git/rebase', () => {
     })
 
     it('status detects REBASE_HEAD', () => {
-      expect(progress).not.toEqual(null)
-      const p = progress!
+      expect(snapshot).not.toEqual(null)
+      const p = snapshot!
       expect(p.commits.length).toEqual(10)
       expect(p.commits[0].summary).toEqual('Feature Branch First Commit!')
 
-      expect(p.rebasedCommitCount).toEqual(1)
-      expect(p.value).toEqual(0.1)
+      expect(p.progress.rebasedCommitCount).toEqual(1)
+      expect(p.progress.value).toEqual(0.1)
     })
 
     it('is a detached HEAD state', () => {

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -7,7 +7,7 @@ import {
 import { createRepository as createShortRebaseTest } from '../../../helpers/repository-builder-rebase-test'
 import { createRepository as createLongRebaseTest } from '../../../helpers/repository-builder-long-rebase-test'
 import { getStatusOrThrow } from '../../../helpers/status'
-import { RebaseProgressSummary } from '../../../../src/models/rebase'
+import { GitRebaseProgress } from '../../../../src/models/rebase'
 import { setupEmptyDirectory } from '../../../helpers/repositories'
 
 const baseBranch = 'base-branch'
@@ -26,7 +26,7 @@ describe('git/rebase', () => {
 
   describe('can parse progress', () => {
     let result: RebaseResult
-    let progress: RebaseProgressSummary | null
+    let progress: GitRebaseProgress | null
     let status: IStatusResult
 
     beforeEach(async () => {
@@ -60,7 +60,7 @@ describe('git/rebase', () => {
 
   describe('can parse progress for long rebase', () => {
     let result: RebaseResult
-    let progress: RebaseProgressSummary | null
+    let progress: GitRebaseProgress | null
     let status: IStatusResult
 
     beforeEach(async () => {

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -171,7 +171,7 @@ describe('updateConflictState', () => {
           originalBranchTip: 'some-other-sha',
         },
       })
-      const status = createStatus({ rebaseContext: null })
+      const status = createStatus({ rebaseInternalState: null })
       const conflictState = updateConflictState(prevState, status, statsStore)
       expect(conflictState).toBeNull()
     })
@@ -181,7 +181,7 @@ describe('updateConflictState', () => {
         conflictState: null,
       })
       const status = createStatus({
-        rebaseContext: {
+        rebaseInternalState: {
           targetBranch: 'my-feature-branch',
           baseBranchTip: 'another-sha',
           originalBranchTip: 'some-other-sha',
@@ -214,7 +214,7 @@ describe('updateConflictState', () => {
         },
       })
       const status = createStatus({
-        rebaseContext: {
+        rebaseInternalState: {
           targetBranch: 'my-feature-branch',
           baseBranchTip: 'another-sha',
           originalBranchTip: 'some-other-sha',
@@ -247,7 +247,7 @@ describe('updateConflictState', () => {
         },
       })
       const status = createStatus({
-        rebaseContext: {
+        rebaseInternalState: {
           targetBranch: 'a-different-feature-branch',
           originalBranchTip: 'some-old-sha',
           baseBranchTip: 'an-even-older-sha',
@@ -272,7 +272,7 @@ describe('updateConflictState', () => {
         },
       })
       const status = createStatus({
-        rebaseContext: null,
+        rebaseInternalState: null,
         currentBranch: 'my-feature-branch',
         currentTip: 'old-sha',
       })
@@ -294,7 +294,7 @@ describe('updateConflictState', () => {
         },
       })
       const status = createStatus({
-        rebaseContext: null,
+        rebaseInternalState: null,
         currentBranch: 'my-feature-branch',
         currentTip: 'new-sha',
       })


### PR DESCRIPTION
## Overview

This PR helps to clean up a bunch of component state and uses `Dispatcher` and `AppStore` to drive the rebase flow. This helps to tighten up some of the transitions between states in the rebase flow, and does away with most of the `shouldComponentUpdate` work that was handling the transitions while I was getting the flow working.

I've also included the fix for #7139 because it got sufficiently annoying while testing to have the filter box disabled while trying to find a branch (the filter would end up choosing the current branch, which would disable the form, and I'd have to manually find and choose the branch)

<img width="485" src="https://user-images.githubusercontent.com/359239/55497692-4a769500-5618-11e9-8845-26a9537c104e.png">

I also noticed that the second paragraph in the Abort Rebase dialog could be better.

Previously, you'd see this:

<img width="477" src="https://user-images.githubusercontent.com/359239/55497724-5c583800-5618-11e9-9c4f-bc4952caca4a.png">

With this PR, it's now this:

<img width="473" src="https://user-images.githubusercontent.com/359239/55497725-5c583800-5618-11e9-94bc-a4810842c4aa.png">

Fixes #7139 

## Description

These things are moved into `IRepositoryState.rebaseState`, which required moving more functionality into `Dispatcher` and `AppStore`

  - [x]  `step: RebaseFlowState` - the state of the flow to show to the user
  - [x] `progress: RebaseProgressSummary` - the state of the Git repository which shows through as progress
  - [x] `rebasePreview: RebasePreview | null`  - the result of the user choosing the rebase
  - [x] `userHasResolvedConflicts: boolean` - whether the rebase

Other tidy up related to these changes:

 - [x] cleanup tracing log messages
 - [x] review names of things and see if things can be clarified
 - [x] docs on all the things
 - [x] review state changes and see if there's anything that could be better organized
 - [x] review `RebaseFlow` and see if there's any other cleanup possible
 - [x] ensure teardown of rebase flow clear relevant app state 
 - [x] ensure transitions in and out of progress are smooth (not suddenly disappearing)
 - ~~[ ] find double-counting rebase progress case (e.g. `9 out of 8 commits rebased`)~~ punting this for now, counting is hard

## Release notes

Notes:
