### PR TITLE
azure pipelines builds all PRs and only development branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,10 @@ variables:
   PYTHON: 'python2.7'
 
 trigger:
-  - development
+  batch: true
+  branches:
+    include:
+      - development
 
 pr:
   autoCancel: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,10 @@ variables:
   PYTHON: 'python2.7'
 
 trigger:
-  pr:
-    autoCancel: false
-  branches:
-    include:
-      - development
+  - development
+
+pr:
+  autoCancel: false
 
 jobs:
   - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ trigger:
   - development
 
 pr:
-  autoCancel: false
+  autoCancel: true
 
 jobs:
   - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,13 @@
 variables:
   PYTHON: 'python2.7'
 
+trigger:
+  pr:
+    autoCancel: false
+  branches:
+    include:
+      - development
+
 jobs:
   - job: Windows
     pool:


### PR DESCRIPTION
This explicitly configures our azure pipelines CI to build
* all PRs
* all pushes to `development`.

Extras:
* previous in-progress builds for a PR are cancelled when new commits are pushed
* branch builds for `development` are batched (which I think means if you push multiple commits at once, it only builds the _latest_ commit)

This _should_ eliminate duplicate builds for PR branches (and i've verified that as much as i can without merging this).