### PR TITLE
warn before rebase if operation requires a force push

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -26,6 +26,7 @@ import { stageManualConflictResolution } from './stage'
 import { stageFiles } from './update-index'
 import { getStatus } from './status'
 import { getCommitsInRange } from './rev-list'
+import { Branch } from '../../models/branch'
 
 /**
  * Check the `.git/REBASE_HEAD` file exists in a repository to confirm
@@ -319,8 +320,8 @@ function configureOptionsForRebase(
  */
 export async function rebase(
   repository: Repository,
-  baseBranch: string,
-  targetBranch: string,
+  baseBranch: Branch,
+  targetBranch: Branch,
   progressCallback?: (progress: IRebaseProgress) => void
 ): Promise<RebaseResult> {
   const baseOptions: IGitExecutionOptions = {
@@ -332,8 +333,8 @@ export async function rebase(
   if (progressCallback !== undefined) {
     const commits = await getCommitsInRange(
       repository,
-      baseBranch,
-      targetBranch
+      baseBranch.tip.sha,
+      targetBranch.tip.sha
     )
 
     const totalCommitCount = commits.length
@@ -346,7 +347,7 @@ export async function rebase(
   }
 
   const result = await git(
-    ['rebase', baseBranch, targetBranch],
+    ['rebase', baseBranch.name, targetBranch.name],
     repository.path,
     'rebase',
     options

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -93,6 +93,8 @@ import {
   MergeConflictState,
   isMergeConflictState,
   RebaseConflictState,
+  IRebaseState,
+  IRepositoryState,
 } from '../app-state'
 import { IGitHubUser } from '../databases/github-user-database'
 import {
@@ -1747,11 +1749,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async _triggerConflictsFlow(repository: Repository) {
     if (enablePullWithRebase()) {
-      const repoState = this.repositoryStateCache.get(repository)
-      const { conflictState } = repoState.changesState
+      const state = this.repositoryStateCache.get(repository)
+      const { conflictState } = state.changesState
 
       if (conflictState === null) {
-        this.clearConflictsFlowVisuals()
+        this.clearConflictsFlowVisuals(state)
         return
       }
 
@@ -1770,7 +1772,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /**
    * Cleanup any related UI related to conflicts if still in use.
    */
-  private clearConflictsFlowVisuals() {
+  private clearConflictsFlowVisuals(state: IRepositoryState) {
+    if (userIsStartingRebaseFlow(this.currentPopup, state.rebaseState)) {
+      return
+    }
+
     this._closePopup(PopupType.MergeConflicts)
     this._closePopup(PopupType.AbortMerge)
     this._clearBanner(BannerType.MergeConflictsFound)
@@ -4704,4 +4710,36 @@ function getBehindOrDefault(aheadBehind: IAheadBehind | null): number {
   }
 
   return aheadBehind.behind
+}
+
+/**
+ * Check if the user is in a rebase flow step that doesn't depend on conflicted
+ * state, as the app should not attempt to clean up any popups or banners while
+ * this is occurring.
+ */
+function userIsStartingRebaseFlow(
+  currentPopup: Popup | null,
+  state: IRebaseState
+) {
+  if (currentPopup === null) {
+    return false
+  }
+
+  if (currentPopup.type !== PopupType.RebaseFlow) {
+    return false
+  }
+
+  if (state.step === null) {
+    return false
+  }
+
+  if (
+    state.step.kind === RebaseStep.ChooseBranch ||
+    state.step.kind === RebaseStep.WarnForcePush ||
+    state.step.kind === RebaseStep.ShowProgress
+  ) {
+    return true
+  }
+
+  return false
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3602,8 +3602,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _rebase(
     repository: Repository,
-    baseBranch: string,
-    targetBranch: string
+    baseBranch: Branch,
+    targetBranch: Branch
   ): Promise<RebaseResult> {
     const progressCallback = (progress: IRebaseProgress) => {
       this.repositoryStateCache.updateRebaseState(repository, () => ({

--- a/app/src/models/rebase-flow-step.ts
+++ b/app/src/models/rebase-flow-step.ts
@@ -83,8 +83,8 @@ export type ChooseBranchesStep = {
 
 export type WarnForcePushStep = {
   readonly kind: RebaseStep.WarnForcePush
-  readonly baseBranch: string
-  readonly targetBranch: string
+  readonly baseBranch: Branch
+  readonly targetBranch: Branch
   readonly commits: ReadonlyArray<CommitOneLine>
 }
 

--- a/app/src/models/rebase-flow-step.ts
+++ b/app/src/models/rebase-flow-step.ts
@@ -1,9 +1,11 @@
 import { Branch } from './branch'
 import { RebaseConflictState } from '../lib/app-state'
+import { CommitOneLine } from './commit'
 
 /** Union type representing the possible states of the rebase flow */
 export type RebaseFlowStep =
   | ChooseBranchesStep
+  | WarnForcePushStep
   | ShowProgressStep
   | ShowConflictsStep
   | HideConflictsStep
@@ -20,6 +22,15 @@ export const enum RebaseStep {
    * conflicts.
    */
   ChooseBranch = 'ChooseBranch',
+  /**
+   * The initial state of a rebase - the user choosing the start point.
+   *
+   * This is not encountered if the user tries to 'pull with rebase' and
+   * encounters conflicts, because the rebase happens as part of the pull
+   * operation and the only remaining work for the user is to resolve any
+   * conflicts.
+   */
+  WarnForcePush = 'WarnForcePush',
   /**
    * After the user chooses which branch to use as the base branch for the
    * rebase, the progress view is shown indicating how the rebase work is
@@ -68,6 +79,13 @@ export type ChooseBranchesStep = {
   readonly allBranches: ReadonlyArray<Branch>
   readonly recentBranches: ReadonlyArray<Branch>
   readonly initialBranch?: Branch
+}
+
+export type WarnForcePushStep = {
+  readonly kind: RebaseStep.WarnForcePush
+  readonly baseBranch: string
+  readonly targetBranch: string
+  readonly commits: ReadonlyArray<CommitOneLine>
 }
 
 /** Shape of data to show progress of the current rebase */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1612,6 +1612,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             step={step}
             preview={preview}
             userHasResolvedConflicts={userHasResolvedConflicts}
+            askForConfirmationOnForcePush={
+              this.state.askForConfirmationOnForcePush
+            }
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
             onShowRebaseConflictsBanner={this.onShowRebaseConflictsBanner}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -356,7 +356,7 @@ export class Dispatcher {
     this.initializeRebaseProgress(repository, commits)
 
     const startRebaseAction = () => {
-      return this.rebase(repository, baseBranch.name, targetBranch.name)
+      return this.rebase(repository, baseBranch, targetBranch)
     }
 
     this.setRebaseFlowStep(repository, {
@@ -826,8 +826,8 @@ export class Dispatcher {
   /** Starts a rebase for the given base and target branch */
   public async rebase(
     repository: Repository,
-    baseBranch: string,
-    targetBranch: string
+    baseBranch: Branch,
+    targetBranch: Branch
   ): Promise<void> {
     const stateBefore = this.repositoryStateManager.get(repository)
 
@@ -889,8 +889,8 @@ export class Dispatcher {
         repository,
         {
           type: BannerType.SuccessfulRebase,
-          targetBranch: targetBranch,
-          baseBranch: baseBranch,
+          targetBranch: targetBranch.name,
+          baseBranch: baseBranch.name,
         },
         tip,
         beforeSha

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -332,11 +332,10 @@ export class Dispatcher {
   ): Promise<void> {
     const { askForConfirmationOnForcePush } = this.appStore.getState()
 
-    if (
-      !askForConfirmationOnForcePush ||
-      options === undefined ||
-      options.continueWithForcePush === false
-    ) {
+    const hasOverridenForcePushCheck =
+      options !== undefined && options.continueWithForcePush
+
+    if (askForConfirmationOnForcePush && !hasOverridenForcePushCheck) {
       // if the branch is tracking a remote branch
       if (targetBranch.upstream !== null) {
         // and the remote branch has commits that don't exist on the base branch

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -324,7 +324,7 @@ export class Dispatcher {
     targetBranch: Branch,
     commits: ReadonlyArray<CommitOneLine>,
     options?: { continueWithForcePush: boolean }
-  ) {
+  ): Promise<void> {
     if (options === undefined || options.continueWithForcePush === false) {
       // TODO:
       //

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -325,27 +325,32 @@ export class Dispatcher {
     commits: ReadonlyArray<CommitOneLine>,
     options?: { continueWithForcePush: boolean }
   ): Promise<void> {
-    if (options === undefined || options.continueWithForcePush === false) {
-      // TODO:
-      //
-      // if the target branch is tracking a remote branch
-      //
-      // AND
-      //
-      // the remote branch contains commits that will be rewritten as part of
-      // this rebase
-      //
-      // THEN
-      //
-      // the app should move to the "Warn Force Push" step first
+    const { askForConfirmationOnForcePush } = this.appStore.getState()
 
-      this.setRebaseFlowStep(repository, {
-        kind: RebaseStep.WarnForcePush,
-        baseBranch,
-        targetBranch,
-        commits,
-      })
-      return
+    if (
+      !askForConfirmationOnForcePush ||
+      options === undefined ||
+      options.continueWithForcePush === false
+    ) {
+      // if the branch is tracking a remote branch
+      if (targetBranch.upstream !== null) {
+        // TODO:
+        //
+        // if the remote branch contains commits that will be rewritten as part of
+        // this rebase
+        //
+        // THEN
+        //
+        // the app should move to the "Warn Force Push" step first
+
+        this.setRebaseFlowStep(repository, {
+          kind: RebaseStep.WarnForcePush,
+          baseBranch,
+          targetBranch,
+          commits,
+        })
+        return
+      }
     }
 
     this.initializeRebaseProgress(repository, commits)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -317,6 +317,38 @@ export class Dispatcher {
     return this.appStore._previewRebase(repository, baseBranch, targetBranch)
   }
 
+  /** Initialize and start the rebase operation */
+  public async startRebase(
+    repository: Repository,
+    baseBranch: string,
+    targetBranch: string,
+    commits: ReadonlyArray<CommitOneLine>
+  ) {
+    // TODO:
+    //
+    // if the target branch is tracking a remote branch
+    //
+    // AND
+    //
+    // the remote branch contains commits that will be rewritten as part of
+    // this rebase
+    //
+    // THEN
+    //
+    // the app should move to the "Warn Force Push" step first
+
+    this.initializeRebaseProgress(repository, commits)
+
+    const startRebaseAction = () => {
+      return this.rebase(repository, baseBranch, targetBranch)
+    }
+
+    this.setRebaseFlowStep(repository, {
+      kind: RebaseStep.ShowProgress,
+      rebaseAction: startRebaseAction,
+    })
+  }
+
   /**
    * Initialize and launch the rebase flow for a conflicted repository
    */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -320,27 +320,38 @@ export class Dispatcher {
   /** Initialize and start the rebase operation */
   public async startRebase(
     repository: Repository,
-    baseBranch: string,
-    targetBranch: string,
-    commits: ReadonlyArray<CommitOneLine>
+    baseBranch: Branch,
+    targetBranch: Branch,
+    commits: ReadonlyArray<CommitOneLine>,
+    options?: { continueWithForcePush: boolean }
   ) {
-    // TODO:
-    //
-    // if the target branch is tracking a remote branch
-    //
-    // AND
-    //
-    // the remote branch contains commits that will be rewritten as part of
-    // this rebase
-    //
-    // THEN
-    //
-    // the app should move to the "Warn Force Push" step first
+    if (options === undefined || options.continueWithForcePush === false) {
+      // TODO:
+      //
+      // if the target branch is tracking a remote branch
+      //
+      // AND
+      //
+      // the remote branch contains commits that will be rewritten as part of
+      // this rebase
+      //
+      // THEN
+      //
+      // the app should move to the "Warn Force Push" step first
+
+      this.setRebaseFlowStep(repository, {
+        kind: RebaseStep.WarnForcePush,
+        baseBranch,
+        targetBranch,
+        commits,
+      })
+      return
+    }
 
     this.initializeRebaseProgress(repository, commits)
 
     const startRebaseAction = () => {
-      return this.rebase(repository, baseBranch, targetBranch)
+      return this.rebase(repository, baseBranch.name, targetBranch.name)
     }
 
     this.setRebaseFlowStep(repository, {

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -4,7 +4,6 @@ import { Branch } from '../../models/branch'
 import { Repository } from '../../models/repository'
 import { RebasePreview } from '../../models/rebase'
 import { ComputedAction } from '../../models/computed-action'
-import { CommitOneLine } from '../../models/commit'
 
 import { IMatches } from '../../lib/fuzzy-find'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
@@ -58,13 +57,6 @@ interface IChooseBranchDialogProps {
    * ways described in the Dialog component's dismissable prop.
    */
   readonly onDismissed: () => void
-
-  /** Callback to signal to start the rebase */
-  readonly onStartRebase: (
-    baseBranch: string,
-    targetBranch: string,
-    commits: ReadonlyArray<CommitOneLine>
-  ) => void
 }
 
 interface IChooseBranchDialogState {
@@ -297,7 +289,8 @@ export class ChooseBranchDialog extends React.Component<
       return
     }
 
-    this.props.onStartRebase(
+    this.props.dispatcher.startRebase(
+      this.props.repository,
       branch.name,
       this.props.currentBranch.name,
       rebasePreviewStatus.commits

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -291,8 +291,8 @@ export class ChooseBranchDialog extends React.Component<
 
     this.props.dispatcher.startRebase(
       this.props.repository,
-      branch.name,
-      this.props.currentBranch.name,
+      branch,
+      this.props.currentBranch,
       rebasePreviewStatus.commits
     )
   }

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -51,6 +51,8 @@ interface IRebaseFlowProps {
    */
   readonly userHasResolvedConflicts: boolean
 
+  readonly askForConfirmationOnForcePush: boolean
+
   /**
    * Callback to hide the rebase flow and show a banner about the current state
    * of conflicts, because this component will be unmounted by the runtime.
@@ -237,15 +239,18 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
           />
         )
       case RebaseStep.WarnForcePush:
-        const { repository, dispatcher } = this.props
+        const {
+          repository,
+          dispatcher,
+          askForConfirmationOnForcePush,
+        } = this.props
 
         return (
           <WarnForcePushDialog
             step={step}
             dispatcher={dispatcher}
             repository={repository}
-            // TODO: should we plumb the preference into here?
-            askForConfirmationOnForcePush={true}
+            askForConfirmationOnForcePush={askForConfirmationOnForcePush}
             onDismissed={this.onFlowEnded}
           />
         )

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -70,7 +70,7 @@ export class WarnForcePushDialog extends React.Component<
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>
-            <Button type="submit">Continue rebase</Button>
+            <Button type="submit">Begin rebase</Button>
             <Button onClick={this.props.onDismissed}>Cancel</Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -51,8 +51,10 @@ export class WarnForcePushDialog extends React.Component<
             onto <strong>{baseBranch.name}</strong>?
           </p>
           <p>
-            This rebase will rewrite the history on the remote branch and
-            require a force push to complete the rebase flow.
+            In order to push this branch to your remote branch, you will need to
+            force push the branch after the rebase is complete. That will alter
+            the history on the remote and potentially cause problems for others
+            collaborating on this branch.
           </p>
           <div>
             <Checkbox

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -41,7 +41,7 @@ export class WarnForcePushDialog extends React.Component<
       <Dialog
         title="This rebase will require a force push"
         onDismissed={this.props.onDismissed}
-        onSubmit={this.onContinueRebase}
+        onSubmit={this.onBeginRebase}
         disableClickDismissalAlways={true}
         type="warning"
       >
@@ -86,7 +86,7 @@ export class WarnForcePushDialog extends React.Component<
     this.setState({ askForConfirmationOnForcePush: value })
   }
 
-  private onContinueRebase = async () => {
+  private onBeginRebase = async () => {
     this.props.dispatcher.setConfirmForcePushSetting(
       this.state.askForConfirmationOnForcePush
     )

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -9,6 +9,7 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 
 import { Dispatcher } from '../dispatcher'
 import { DialogFooter, DialogContent, Dialog } from '../dialog'
+import { Ref } from '../lib/ref'
 
 interface IWarnForcePushProps {
   readonly dispatcher: Dispatcher
@@ -37,9 +38,13 @@ export class WarnForcePushDialog extends React.Component<
   public render() {
     const { baseBranch, targetBranch } = this.props.step
 
+    const title = __DARWIN__
+      ? 'Rebase Will Require Force Push'
+      : 'Rebase will require force push'
+
     return (
       <Dialog
-        title="This rebase will require a force push"
+        title={title}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onBeginRebase}
         disableClickDismissalAlways={true}
@@ -47,8 +52,8 @@ export class WarnForcePushDialog extends React.Component<
       >
         <DialogContent>
           <p>
-            Are you sure you want to rebase <strong>{targetBranch.name}</strong>{' '}
-            onto <strong>{baseBranch.name}</strong>?
+            Are you sure you want to rebase <Ref>{targetBranch.name}</Ref> onto{' '}
+            <Ref>{baseBranch.name}</Ref>?
           </p>
           <p>
             At the end of the rebase flow, GitHub Desktop will enable you to

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -51,10 +51,10 @@ export class WarnForcePushDialog extends React.Component<
             onto <strong>{baseBranch.name}</strong>?
           </p>
           <p>
-            In order to push this branch to your remote branch, you will need to
-            force push the branch after the rebase is complete. That will alter
-            the history on the remote and potentially cause problems for others
-            collaborating on this branch.
+            At the end of the rebase flow, you will need to force push the
+            branch to update the upstream branch. That will alter the history on
+            the remote and potentially cause problems for others collaborating
+            on this branch.
           </p>
           <div>
             <Checkbox

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -42,6 +42,7 @@ export class WarnForcePushDialog extends React.Component<
         title="This rebase will require a force push"
         onDismissed={this.props.onDismissed}
         onSubmit={this.onContinueRebase}
+        disableClickDismissalAlways={true}
         type="warning"
       >
         <DialogContent>

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -95,7 +95,8 @@ export class WarnForcePushDialog extends React.Component<
       this.props.repository,
       baseBranch,
       targetBranch,
-      commits
+      commits,
+      { continueWithForcePush: true }
     )
   }
 }

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+import { WarnForcePushStep } from '../../models/rebase-flow-step'
+
+import { Button } from '../lib/button'
+import { ButtonGroup } from '../lib/button-group'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+
+import { Dispatcher } from '../dispatcher'
+import { DialogFooter, DialogContent, Dialog } from '../dialog'
+
+interface IWarnForcePushProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly step: WarnForcePushStep
+  readonly askForConfirmationOnForcePush: boolean
+  readonly onDismissed: () => void
+}
+
+interface IWarnForcePushState {
+  readonly askForConfirmationOnForcePush: boolean
+}
+
+export class WarnForcePushDialog extends React.Component<
+  IWarnForcePushProps,
+  IWarnForcePushState
+> {
+  public constructor(props: IWarnForcePushProps) {
+    super(props)
+
+    this.state = {
+      askForConfirmationOnForcePush: props.askForConfirmationOnForcePush,
+    }
+  }
+
+  public render() {
+    const { baseBranch, targetBranch } = this.props.step
+
+    return (
+      <Dialog
+        title="This rebase will require a force push"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onContinueRebase}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            Are you sure you want to rebase <strong>{targetBranch}</strong> onto{' '}
+            <strong>{baseBranch}</strong>?
+          </p>
+          <p>
+            This rebase will rewrite history and require a force push to update
+            the remote branch.
+          </p>
+          <div>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.askForConfirmationOnForcePush
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onAskForConfirmationOnForcePushChanged}
+            />
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <ButtonGroup>
+            <Button type="submit">Continue rebase</Button>
+            <Button onClick={this.props.onDismissed}>Cancel</Button>
+          </ButtonGroup>
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onAskForConfirmationOnForcePushChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ askForConfirmationOnForcePush: value })
+  }
+
+  private onContinueRebase = async () => {
+    this.props.dispatcher.setConfirmForcePushSetting(
+      this.state.askForConfirmationOnForcePush
+    )
+    this.props.onDismissed()
+
+    const { baseBranch, targetBranch, commits } = this.props.step
+
+    await this.props.dispatcher.startRebase(
+      this.props.repository,
+      baseBranch,
+      targetBranch,
+      commits
+    )
+  }
+}

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -46,8 +46,8 @@ export class WarnForcePushDialog extends React.Component<
       >
         <DialogContent>
           <p>
-            Are you sure you want to rebase <strong>{targetBranch}</strong> onto{' '}
-            <strong>{baseBranch}</strong>?
+            Are you sure you want to rebase <strong>{targetBranch.name}</strong>{' '}
+            onto <strong>{baseBranch.name}</strong>?
           </p>
           <p>
             This rebase will rewrite history and require a force push to update
@@ -87,7 +87,6 @@ export class WarnForcePushDialog extends React.Component<
     this.props.dispatcher.setConfirmForcePushSetting(
       this.state.askForConfirmationOnForcePush
     )
-    this.props.onDismissed()
 
     const { baseBranch, targetBranch, commits } = this.props.step
 

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -51,10 +51,10 @@ export class WarnForcePushDialog extends React.Component<
             onto <strong>{baseBranch.name}</strong>?
           </p>
           <p>
-            At the end of the rebase flow, you will need to force push the
-            branch to update the upstream branch. That will alter the history on
-            the remote and potentially cause problems for others collaborating
-            on this branch.
+            At the end of the rebase flow, GitHub Desktop will enable you to
+            force push the branch to update the upstream branch. Force pushing
+            will alter the history on the remote and potentially cause problems
+            for others collaborating on this branch.
           </p>
           <div>
             <Checkbox

--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -50,8 +50,8 @@ export class WarnForcePushDialog extends React.Component<
             onto <strong>{baseBranch.name}</strong>?
           </p>
           <p>
-            This rebase will rewrite history and require a force push to update
-            the remote branch.
+            This rebase will rewrite the history on the remote branch and
+            require a force push to complete the rebase flow.
           </p>
           <div>
             <Checkbox

--- a/app/test/helpers/git.ts
+++ b/app/test/helpers/git.ts
@@ -3,6 +3,11 @@ import { Commit } from '../../src/models/commit'
 import { Repository } from '../../src/models/repository'
 import { Branch } from '../../src/models/branch'
 
+/**
+ * Get the tip commit of the current repository
+ *
+ * Throws an error if the repository is unborn, to indicate an invalid state.
+ */
 export async function getTipOrError(repository: Repository): Promise<Commit> {
   const commit = await getCommit(repository, 'HEAD')
 
@@ -15,6 +20,11 @@ export async function getTipOrError(repository: Repository): Promise<Commit> {
   return commit
 }
 
+/**
+ * Get the commit associated with a provided ref (could also be a commit ID or a branch name).
+ *
+ * Throws an error if the commit cannot be found in the repository.
+ */
 export async function getRefOrError(
   repository: Repository,
   ref: string
@@ -30,6 +40,12 @@ export async function getRefOrError(
   return commit
 }
 
+/**
+ * Get the branch object associated with a local branch name.
+ *
+ * Throws an error if it cannot find the expected `refs/heads/{name}` ref in the
+ * repository.
+ */
 export async function getBranchOrError(
   repository: Repository,
   name: string

--- a/app/test/helpers/tip.ts
+++ b/app/test/helpers/tip.ts
@@ -1,6 +1,7 @@
-import { getCommit } from '../../src/lib/git'
+import { getCommit, getBranches } from '../../src/lib/git'
 import { Commit } from '../../src/models/commit'
 import { Repository } from '../../src/models/repository'
+import { Branch } from '../../src/models/branch'
 
 export async function getTipOrError(repository: Repository): Promise<Commit> {
   const commit = await getCommit(repository, 'HEAD')
@@ -27,4 +28,20 @@ export async function getRefOrError(
   }
 
   return commit
+}
+
+export async function getBranchOrError(
+  repository: Repository,
+  name: string
+): Promise<Branch> {
+  const ref = `refs/heads/${name}`
+  const branches = await getBranches(repository, ref)
+
+  if (branches.length === 0) {
+    throw new Error(
+      `Unable to find branch matching ${ref} - check that this exists in the repository`
+    )
+  }
+
+  return branches[0]
 }

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -11,7 +11,7 @@ import {
   cloneRepository,
   makeCommit,
 } from '../../../helpers/repository-scaffolding'
-import { getTipOrError, getRefOrError } from '../../../helpers/tip'
+import { getTipOrError, getRefOrError } from '../../../helpers/git'
 import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -11,7 +11,7 @@ import {
   cloneRepository,
   makeCommit,
 } from '../../../helpers/repository-scaffolding'
-import { getTipOrError, getRefOrError } from '../../../helpers/tip'
+import { getTipOrError, getRefOrError } from '../../../helpers/git'
 import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -11,7 +11,7 @@ import {
   cloneRepository,
   makeCommit,
 } from '../../../helpers/repository-scaffolding'
-import { getTipOrError, getRefOrError } from '../../../helpers/tip'
+import { getTipOrError, getRefOrError } from '../../../helpers/git'
 import { setupLocalConfig } from '../../../helpers/local-config'
 
 const featureBranch = 'this-is-a-feature'

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -16,10 +16,11 @@ import {
 } from '../../../../src/models/status'
 import { createRepository } from '../../../helpers/repository-builder-rebase-test'
 import { getStatusOrThrow } from '../../../helpers/status'
-import { getRefOrError } from '../../../helpers/tip'
+import { getRefOrError, getBranchOrError } from '../../../helpers/tip'
+import { Branch } from '../../../../src/models/branch'
 
-const baseBranch = 'base-branch'
-const featureBranch = 'this-is-a-feature'
+const baseBranchName = 'base-branch'
+const featureBranchName = 'this-is-a-feature'
 
 describe('git/rebase', () => {
   describe('detect conflicts', () => {
@@ -29,13 +30,19 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createRepository(baseBranch, featureBranch)
+      const repository = await createRepository(
+        baseBranchName,
+        featureBranchName
+      )
 
-      const featureTip = await getRefOrError(repository, featureBranch)
-      originalBranchTip = featureTip.sha
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+      originalBranchTip = featureBranch.tip.sha
 
-      const baseTip = await getRefOrError(repository, baseBranch)
-      baseBranchTip = baseTip.sha
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
+      baseBranchTip = baseBranch.tip.sha
 
       result = await rebase(repository, baseBranch, featureBranch)
 
@@ -71,7 +78,17 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createRepository(baseBranch, featureBranch)
+      const repository = await createRepository(
+        baseBranchName,
+        featureBranchName
+      )
+
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
 
       await rebase(repository, baseBranch, featureBranch)
 
@@ -89,7 +106,7 @@ describe('git/rebase', () => {
     })
 
     it('returns to the feature branch', async () => {
-      expect(status.currentBranch).toBe(featureBranch)
+      expect(status.currentBranch).toBe(featureBranchName)
     })
   })
 
@@ -100,13 +117,19 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createRepository(baseBranch, featureBranch)
+      const repository = await createRepository(
+        baseBranchName,
+        featureBranchName
+      )
 
-      const featureTip = await getRefOrError(repository, featureBranch)
-      originalBranchTip = featureTip.sha
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+      originalBranchTip = featureBranch.tip.sha
 
-      const baseTip = await getRefOrError(repository, baseBranch)
-      baseBranchTip = baseTip.sha
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
+      baseBranchTip = baseBranch.tip.sha
 
       await rebase(repository, baseBranch, featureBranch)
 
@@ -145,9 +168,18 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createRepository(baseBranch, featureBranch)
+      const repository = await createRepository(
+        baseBranchName,
+        featureBranchName
+      )
 
-      beforeRebaseTip = await getRefOrError(repository, featureBranch)
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+      beforeRebaseTip = featureBranch.tip
+
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
 
       await rebase(repository, baseBranch, featureBranch)
 
@@ -198,7 +230,7 @@ describe('git/rebase', () => {
     })
 
     it('returns to the feature branch', () => {
-      expect(status.currentBranch).toBe(featureBranch)
+      expect(status.currentBranch).toBe(featureBranchName)
     })
 
     it('branch is now a different ref', () => {
@@ -213,9 +245,18 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createRepository(baseBranch, featureBranch)
+      const repository = await createRepository(
+        baseBranchName,
+        featureBranchName
+      )
 
-      beforeRebaseTip = await getRefOrError(repository, featureBranch)
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+      beforeRebaseTip = featureBranch.tip
+
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
 
       await rebase(repository, baseBranch, featureBranch)
 
@@ -271,7 +312,7 @@ describe('git/rebase', () => {
     })
 
     it('returns to the feature branch', () => {
-      expect(status.currentBranch).toBe(featureBranch)
+      expect(status.currentBranch).toBe(featureBranchName)
     })
 
     it('branch is now a different ref', () => {
@@ -283,7 +324,17 @@ describe('git/rebase', () => {
     let result: RebaseResult
 
     beforeEach(async () => {
-      const repository = await createRepository(baseBranch, featureBranch)
+      const repository = await createRepository(
+        baseBranchName,
+        featureBranchName
+      )
+
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
 
       await rebase(repository, baseBranch, featureBranch)
 

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -16,8 +16,7 @@ import {
 } from '../../../../src/models/status'
 import { createRepository } from '../../../helpers/repository-builder-rebase-test'
 import { getStatusOrThrow } from '../../../helpers/status'
-import { getRefOrError, getBranchOrError } from '../../../helpers/tip'
-import { Branch } from '../../../../src/models/branch'
+import { getBranchOrError } from '../../../helpers/git'
 
 const baseBranchName = 'base-branch'
 const featureBranchName = 'this-is-a-feature'

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -9,9 +9,10 @@ import { createRepository as createLongRebaseTest } from '../../../helpers/repos
 import { getStatusOrThrow } from '../../../helpers/status'
 import { GitRebaseSnapshot } from '../../../../src/models/rebase'
 import { setupEmptyDirectory } from '../../../helpers/repositories'
+import { getBranchOrError } from '../../../helpers/git'
 
-const baseBranch = 'base-branch'
-const featureBranch = 'this-is-a-feature'
+const baseBranchName = 'base-branch'
+const featureBranchName = 'this-is-a-feature'
 
 describe('git/rebase', () => {
   describe('skips a normal repository', () => {
@@ -30,7 +31,17 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createShortRebaseTest(baseBranch, featureBranch)
+      const repository = await createShortRebaseTest(
+        baseBranchName,
+        featureBranchName
+      )
+
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
 
       result = await rebase(repository, baseBranch, featureBranch)
 
@@ -66,7 +77,17 @@ describe('git/rebase', () => {
     let status: IStatusResult
 
     beforeEach(async () => {
-      const repository = await createLongRebaseTest(baseBranch, featureBranch)
+      const repository = await createLongRebaseTest(
+        baseBranchName,
+        featureBranchName
+      )
+
+      const featureBranch = await getBranchOrError(
+        repository,
+        featureBranchName
+      )
+
+      const baseBranch = await getBranchOrError(repository, baseBranchName)
 
       result = await rebase(repository, baseBranch, featureBranch)
 

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -12,7 +12,7 @@ import {
   IStashEntry,
   applyStashEntry,
 } from '../../../src/lib/git/stash'
-import { getTipOrError } from '../../helpers/tip'
+import { getTipOrError } from '../../helpers/git'
 import { getStatusOrThrow } from '../../helpers/status'
 import { AppFileStatusKind } from '../../../src/models/status'
 


### PR DESCRIPTION
## Overview

**Closes #6963**

<img width="650" src="https://user-images.githubusercontent.com/359239/55970997-a2338280-5c4e-11e9-83da-fd8b94b86360.png">

## Description

- [x] wireup UI to show when rebase
- [x] plug in user preference to warn about force push
- [x] implement logic to if remote branch has commits that will be rebased
- [x] use `Branch` shape rather than `string` as this contains the relevant tracking branch
- [x] update tests to use `Branch` rather than `string`

## Release notes

Notes: no-notes
