### PR TITLE
[Stashing] Update desktop stash marker

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -23,9 +23,9 @@ const stashEntryRe = /^([0-9a-f]{40})@(.+)$/
  * RegEx for determining if a stash entry is created by Desktop
  *
  * This is done by looking for a magic string with the following
- * format: `!!GitHub_Desktop<branch@commit>`
+ * format: `!!GitHub_Desktop<branch>`
  */
-const desktopStashEntryMessageRe = /!!GitHub_Desktop<(.+)@([0-9|a-z|A-Z]{40})>$/
+const desktopStashEntryMessageRe = /!!GitHub_Desktop<(.+)>$/
 
 /**
  * Get the list of stash entries created by Desktop in the current repository
@@ -106,8 +106,8 @@ export async function getLastDesktopStashEntryForBranch(
 }
 
 /** Creates a stash entry message that idicates the entry was created by Desktop */
-export function createDesktopStashMessage(branchName: string, tipSha: string) {
-  return `${DesktopStashEntryMarker}<${branchName}@${tipSha}>`
+export function createDesktopStashMessage(branchName: string) {
+  return `${DesktopStashEntryMarker}<${branchName}>`
 }
 
 /**
@@ -117,10 +117,9 @@ export function createDesktopStashMessage(branchName: string, tipSha: string) {
  */
 export async function createDesktopStashEntry(
   repository: Repository,
-  branchName: string,
-  tipSha: string
+  branchName: string
 ) {
-  const message = createDesktopStashMessage(branchName, tipSha)
+  const message = createDesktopStashMessage(branchName)
   await git(
     ['stash', 'push', '--include-untracked', '-m', message],
     repository.path,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4714,7 +4714,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    await createDesktopStashEntry(repository, branchName, tip.branch.tip.sha)
+    await createDesktopStashEntry(repository, branchName)
   }
 
   public async _popStash(repository: Repository, branch: Branch) {

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -12,7 +12,6 @@ import {
   IStashEntry,
   popStashEntry,
 } from '../../../src/lib/git/stash'
-import { getTipOrError } from '../../helpers/tip'
 import { getStatusOrThrow } from '../../helpers/status'
 import { AppFileStatusKind } from '../../../src/models/status'
 
@@ -70,8 +69,12 @@ describe('git/stash', () => {
     it('creates a stash entry when repo is not unborn or in any kind of conflict or rebase state', async () => {
       await FSE.appendFile(readme, 'just testing stuff')
 
-      const tipCommit = await getTipOrError(repository)
-      await createDesktopStashEntry(repository, 'master', tipCommit.sha)
+      await createDesktopStashEntry(repository, 'master')
+
+      const entries = await getDesktopStashEntries(repository)
+
+      expect(entries).toHaveLength(1)
+      expect(entries[0].branchName).toBe('master')
     })
 
     it('stashes untracked files and removes them from the working directory', async () => {
@@ -84,8 +87,7 @@ describe('git/stash', () => {
       expect(files).toHaveLength(1)
       expect(files[0].status.kind).toBe(AppFileStatusKind.Untracked)
 
-      const tip = await getTipOrError(repository)
-      await createDesktopStashEntry(repository, 'master', tip.sha)
+      await createDesktopStashEntry(repository, 'master')
 
       status = await getStatusOrThrow(repository)
       files = status.workingDirectory.files
@@ -139,13 +141,10 @@ describe('git/stash', () => {
   describe('createDesktopStashMessage', () => {
     it('creates message that matches Desktop stash entry format', () => {
       const branchName = 'master'
-      const tipSha = 'bc45b3b97993eed2c3d7872a0b766b3e29a12e4b'
 
-      const message = createDesktopStashMessage(branchName, tipSha)
+      const message = createDesktopStashMessage(branchName)
 
-      expect(message).toBe(
-        '!!GitHub_Desktop<master@bc45b3b97993eed2c3d7872a0b766b3e29a12e4b>'
-      )
+      expect(message).toBe('!!GitHub_Desktop<master>')
     })
   })
 
@@ -259,14 +258,8 @@ async function stash(
   branchName: string,
   message: string | null
 ): Promise<void> {
-  const tip = await getTipOrError(repository)
   const result = await GitProcess.exec(
-    [
-      'stash',
-      'push',
-      '-m',
-      message || createDesktopStashMessage(branchName, tip.sha),
-    ],
+    ['stash', 'push', '-m', message || createDesktopStashMessage(branchName)],
     repository.path
   )
 


### PR DESCRIPTION
Removes the tip SHA component from the Desktop stash marker. I initially thought having this info would be useful, but viewing the stash commit would show that same information, so I've yanked it to simplify the code a bit.