### PR TITLE
Only render pr bubble if there are PRs

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -95,16 +95,19 @@ export class BranchesContainer extends React.Component<
     )
   }
 
+  private renderOpenPullRequestsBubble() {
+    const { pullRequests } = this.props
+
+    if (pullRequests.length > 0) {
+      return <span className="count">{pullRequests.length}</span>
+    }
+
+    return null
+  }
+
   private renderTabBar() {
     if (!this.props.repository.gitHubRepository) {
       return null
-    }
-
-    let countElement = null
-    if (this.props.pullRequests) {
-      countElement = (
-        <span className="count">{this.props.pullRequests.length}</span>
-      )
     }
 
     return (
@@ -115,8 +118,7 @@ export class BranchesContainer extends React.Component<
         <span>Branches</span>
         <span className="pull-request-tab">
           {__DARWIN__ ? 'Pull Requests' : 'Pull requests'}
-
-          {countElement}
+          {this.renderOpenPullRequestsBubble()}
         </span>
       </TabBar>
     )


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This is part of the larger PR work that I'm doing and is extracted here in an attempt to reduce the size of what's going to be a fairly large PR for the bigger story.


## Description

This removes the count bubble in the PR tab inside of the branches foldout when there are no PRs

<img width="184" alt="image" src="https://user-images.githubusercontent.com/634063/55943467-ef135b00-5c46-11e9-80cc-49fb6f0a7620.png">

This is now consistent with the behavior of the count bubble in the changes tab which only shows when there are changes.

<img width="119" alt="image" src="https://user-images.githubusercontent.com/634063/55943407-d99e3100-5c46-11e9-85f5-f238b78e9991.png">

<img width="123" alt="image" src="https://user-images.githubusercontent.com/634063/55943425-e02ca880-5c46-11e9-84aa-47a031a85e65.png">


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes