### PR TITLE
[WIP] bump dugite to latest beta package

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.87.0",
+    "dugite": "1.88.0-beta.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -382,10 +382,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.87.0:
-  version "1.87.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.87.0.tgz#ba42c25401420a92c6c8f0c71823ac54124b4b65"
-  integrity sha512-+aW2Ql3yw1AEO8Z8nVbjOAEzsinMJMmAg4uf5lzTewFUAHd0danuMPXMP9uMuGuUYN/LQtt4kR2XLuWoD8wRSQ==
+dugite@1.88.0-beta.0:
+  version "1.88.0-beta.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.88.0-beta.0.tgz#7bc9ec4f4bb8fd6ffc862f71e50caf96315e5cb8"
+  integrity sha512-EzHuwalHFxGu49HwTGql2id2Vf9+skwRqMybF53MkQqaV61khtk/hmbHdkPVP5/Cwp+paBTkIqeQHHt02a6OVA==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
## Overview

Investigating how much the use of builtin commands that landed in Git 2.20 helps with the rebase unit tests.

## Description

@niik pointed out this morning the significant difference when running the rebase tests that use `Git `v2.19.1`) on each OS:

```
[Windows] PASS app/test/unit/git/rebase/detect-conflict-test.ts (50.26s)
[macOS  ] PASS app/test/unit/git/rebase/detect-conflict-test.ts (17.742s)
[Linux  ] PASS app/test/unit/git/rebase/detect-conflict-test.ts (13.458s)
```

I'm opening this draft PR to see how things change when run against Git `v2.21.0` (latest stable).

## Release notes

Notes:  no-notes
