### PR TITLE
Handle text diff component unmount in the middle of syntax highlighting

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -223,14 +223,14 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
     const propsSnapshot = this.props
 
     const lineFilters = getLineFilters(hunks)
+    const tsOpt = this.codeMirror.getOption('tabSize')
+    const tabSize = typeof tsOpt === 'number' ? tsOpt : 4
+
     const contents = await getFileContents(repository, file, lineFilters)
 
     if (!highlightParametersEqual(this.props, propsSnapshot)) {
       return
     }
-
-    const tsOpt = this.codeMirror.getOption('tabSize')
-    const tabSize = typeof tsOpt === 'number' ? tsOpt : 4
 
     const tokens = await highlightContents(contents, tabSize, lineFilters)
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -245,7 +245,9 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
       newTokens: tokens.newTokens,
     }
 
-    this.codeMirror.setOption('mode', spec)
+    if (this.codeMirror) {
+      this.codeMirror.setOption('mode', spec)
+    }
   }
 
   /**

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -211,11 +211,11 @@ export class TextDiff extends React.Component<ITextDiffProps, {}> {
   private hunkHighlightRange: ISelection | null = null
 
   private async initDiffSyntaxMode() {
-    const { file, hunks, repository } = this.props
-
     if (!this.codeMirror) {
       return
     }
+
+    const { file, hunks, repository } = this.props
 
     // Store the current props to that we can see if anything
     // changes from underneath us as we're making asynchronous


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

@tierninho [spotted an error](https://github.com/desktop/desktop/pull/7210#issuecomment-482394496) while testing stashing

![image](https://user-images.githubusercontent.com/634063/56017088-85568800-5cfe-11e9-885f-630c87ca160a.png)

Closes #6970


## Description

This error was not related to stashing at all but deserves to be addressed in this release. The syntax highlighting process consists of two big blocks of asynchronous work, first the loading of the full contents of the file in question and second the syntax highlighting web worker doing the actual tokenization.

At any time while these asynchronous actions runs it's possible for the text diff component to become unmounted which would cause the code mirror instance to be reset to null. Unfortunately TypeScript doesn't help us here and the type narrowing on `this.codemirror` done earlier in the function gives us a false sense of security that it'll remain non-null (see https://github.com/Microsoft/TypeScript/issues/16228). I for one would love to see even stricter checks for this but it is what it is.

This PR shuffles things arounds and adds additional type guards to ensure we don't try to use the codemirror instance after we've been unmounted.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes