### PR TITLE
[Stashing] Only load stash files when necessary

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -992,11 +992,7 @@ export class GitStore extends BaseStore {
         // If we've already loaded the files for this stash there's
         // no point in us doing it again. We know the contents haven't
         // changed since the SHA is the same.
-        if (
-          existing !== undefined &&
-          existing.stashSha === entry.stashSha &&
-          existing.files.kind === StashedChangesLoadStates.Loaded
-        ) {
+        if (existing !== undefined && existing.stashSha === entry.stashSha) {
           map.set(entry.branchName, {
             ...entry,
             files: existing.files,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1020,16 +1020,30 @@ export class GitStore extends BaseStore {
       return
     }
 
-    this._stashEntries.set(stashEntry.branchName, {
-      ...stashEntry,
+    let existingEntry = this._stashEntries.get(stashEntry.branchName)
+
+    if (existingEntry === undefined) {
+      return
+    }
+
+    const { branchName } = existingEntry
+
+    this._stashEntries.set(branchName, {
+      ...existingEntry,
       files: { kind: StashedChangesLoadStates.Loading },
     })
     this.emitUpdate()
 
-    const files = await getChangedFiles(this.repository, stashEntry.stashSha)
+    const files = await getChangedFiles(this.repository, existingEntry.stashSha)
+
+    existingEntry = this._stashEntries.get(branchName)
+
+    if (existingEntry === undefined) {
+      return
+    }
 
     this._stashEntries.set(stashEntry.branchName, {
-      ...stashEntry,
+      ...existingEntry,
       files: {
         kind: StashedChangesLoadStates.Loaded,
         files,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -987,7 +987,23 @@ export class GitStore extends BaseStore {
       // we only want the first entry we find for each branch,
       // so we skip all subsequent ones
       if (!map.has(entry.branchName)) {
-        map.set(entry.branchName, entry)
+        const existing = this._stashEntries.get(entry.branchName)
+
+        // If we've already loaded the files for this stash there's
+        // no point in us doing it again. We know the contents haven't
+        // changed since the SHA is the same.
+        if (
+          existing !== undefined &&
+          existing.stashSha === entry.stashSha &&
+          existing.files.kind === StashedChangesLoadStates.Loaded
+        ) {
+          map.set(entry.branchName, {
+            ...entry,
+            files: existing.files,
+          })
+        } else {
+          map.set(entry.branchName, entry)
+        }
       }
     }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1020,6 +1020,10 @@ export class GitStore extends BaseStore {
    * Updates the latest stash entry with a list of files that it changes
    */
   public async loadStashedFiles(stashEntry: IStashEntry) {
+    if (stashEntry.files.kind !== StashedChangesLoadStates.NotLoaded) {
+      return
+    }
+
     this._stashEntries.set(stashEntry.branchName, {
       ...stashEntry,
       files: { kind: StashedChangesLoadStates.Loading },

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1020,6 +1020,12 @@ export class GitStore extends BaseStore {
    * Updates the latest stash entry with a list of files that it changes
    */
   public async loadStashedFiles(stashEntry: IStashEntry) {
+    this._stashEntries.set(stashEntry.branchName, {
+      ...stashEntry,
+      files: { kind: StashedChangesLoadStates.Loading },
+    })
+    this.emitUpdate()
+
     const files = await getChangedFiles(this.repository, stashEntry.stashSha)
 
     this._stashEntries.set(stashEntry.branchName, {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -993,10 +993,7 @@ export class GitStore extends BaseStore {
         // no point in us doing it again. We know the contents haven't
         // changed since the SHA is the same.
         if (existing !== undefined && existing.stashSha === entry.stashSha) {
-          map.set(entry.branchName, {
-            ...entry,
-            files: existing.files,
-          })
+          map.set(entry.branchName, { ...entry, files: existing.files })
         } else {
           map.set(entry.branchName, entry)
         }


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This addresses [one piece of feedback](https://github.com/desktop/desktop/pull/7210#discussion_r274882369) that I had in #7210

> This is a dangerous pattern, we should not be calling the dispatcher from render methods. The Repository component could get re-rendered any number of times before the `loadStashedFiles` method is is able to complete and emit an update, causing us to shell out to Git for each render.
>
> I think we can find a much better pattern for this by letting the appStore take care of loading stashed files when the right conditions exists for doing so but in the meantime I'm going to open a PR to ensure we're never loading stashed files more than once for any stash entry.

## Description

This PR does a few things. It removes flickering in the stashed changes view by persisting loaded files for a given stash entry. Prior to this the list of stashed files would get cleared on each refresh (i.e. window focus) but due to the nature of stashes we can be certain that as long as the commit SHA is still the same the list of files will be as well.

Second, this PR now set the `Loading` state when commencing loading files for a stash. This lets us ensure that only one git process is launched per stash entry.

Finally, this takes into account the asynchronous nature of `loadStashedFiles` and accounts for the fact that the stash entry passed to the method may be stale. It's possible that we've reloaded the list of stashes but not yet emitted an update.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes