### PR TITLE
[Stashing] Git stash method, delimiter parsing, and don't swallow errors

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -91,11 +91,8 @@ export async function createDesktopStashEntry(
   branchName: string
 ) {
   const message = createDesktopStashMessage(branchName)
-  await git(
-    ['stash', 'push', '--include-untracked', '-m', message],
-    repository.path,
-    'createStashEntry'
-  )
+  const args = ['stash', 'push', '--include-untracked', '-m', message]
+  await git(args, repository.path, 'createStashEntry')
 }
 
 async function getStashEntryMatchingSha(repository: Repository, sha: string) {
@@ -144,10 +141,5 @@ export async function popStashEntry(
 
 function extractBranchFromMessage(message: string): string | null {
   const match = desktopStashEntryMessageRe.exec(message)
-  if (match === null) {
-    return null
-  }
-
-  const branchName = match[1]
-  return branchName.length > 0 ? branchName : null
+  return match === null || match[1].length === 0 ? null : match[1]
 }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -112,23 +112,12 @@ export async function dropDesktopStashEntry(
   repository: Repository,
   stashSha: string
 ) {
-  // get the latest name for the stash entry since it may have changed
-  const stashEntries = await getDesktopStashEntries(repository)
+  const entryToDelete = await getStashEntryMatchingSha(repository, stashSha)
 
-  if (stashEntries.length === 0) {
-    return
+  if (entryToDelete !== null) {
+    const args = ['stash', 'drop', entryToDelete.name]
+    await git(args, repository.path, 'dropStashEntry')
   }
-
-  const entryToDelete = stashEntries.find(e => e.stashSha === stashSha)
-  if (entryToDelete === undefined) {
-    return
-  }
-
-  await git(
-    ['stash', 'drop', entryToDelete.name],
-    repository.path,
-    'dropStashEntry'
-  )
 }
 
 /**

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -1,6 +1,5 @@
 import { git } from '.'
 import { Repository } from '../../models/repository'
-import { GitError, IGitResult } from './core'
 import { GitError as DugiteError } from 'dugite'
 import {
   IStashEntry,

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -6,9 +6,6 @@ import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 
 export const DesktopStashEntryMarker = '!!GitHub_Desktop'
 
-/** RegEx for parsing out the stash SHA and message */
-const stashEntryRe = /^([0-9a-f]{40})@(.+)$/
-
 /**
  * RegEx for determining if a stash entry is created by Desktop
  *

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -146,20 +146,14 @@ export async function popStashEntry(
     return
   }
 
-  try {
-    await git(
-      ['stash', 'pop', `${stashToPop.name}`],
-      repository.path,
-      'popStashEntry',
-      {
-        expectedErrors,
-      }
-    )
-  } catch (err) {
-    if (err instanceof GitError) {
-      log.error(err.message)
+  await git(
+    ['stash', 'pop', `${stashToPop.name}`],
+    repository.path,
+    'popStashEntry',
+    {
+      expectedErrors,
     }
-  }
+  )
 }
 
 function extractBranchFromMessage(message: string): string | null {

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -98,6 +98,11 @@ export async function createDesktopStashEntry(
   )
 }
 
+async function getStashEntryMatchingSha(repository: Repository, sha: string) {
+  const stashEntries = await getDesktopStashEntries(repository)
+  return stashEntries.find(e => e.stashSha === sha) || null
+}
+
 /**
  * Removes the given stash entry if it exists
  *

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -134,26 +134,12 @@ export async function popStashEntry(
   // ignoring these git errors for now, this will change when we start
   // implementing the stash conflict flow
   const expectedErrors = new Set<DugiteError>([DugiteError.MergeConflicts])
-  // get the latest name for the stash entry since it may have changed
-  const stashEntries = await getDesktopStashEntries(repository)
+  const stashToPop = await getStashEntryMatchingSha(repository, stashSha)
 
-  if (stashEntries.length === 0) {
-    return
+  if (stashToPop !== null) {
+    const args = ['stash', 'pop', `${stashToPop.name}`]
+    await git(args, repository.path, 'popStashEntry', { expectedErrors })
   }
-
-  const stashToPop = stashEntries.find(e => e.stashSha === stashSha)
-  if (stashToPop === undefined) {
-    return
-  }
-
-  await git(
-    ['stash', 'pop', `${stashToPop.name}`],
-    repository.path,
-    'popStashEntry',
-    {
-      expectedErrors,
-    }
-  )
 }
 
 function extractBranchFromMessage(message: string): string | null {

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -2,7 +2,11 @@ import { git } from '.'
 import { Repository } from '../../models/repository'
 import { GitError, IGitResult } from './core'
 import { GitError as DugiteError } from 'dugite'
-import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
+import {
+  IStashEntry,
+  StashedChangesLoadStates,
+  StashedFileChanges,
+} from '../../models/stash-entry'
 
 export const DesktopStashEntryMarker = '!!GitHub_Desktop'
 

--- a/app/src/models/stash-entry.ts
+++ b/app/src/models/stash-entry.ts
@@ -21,7 +21,7 @@ export enum StashedChangesLoadStates {
   Loaded = 'Loaded',
 }
 
-type StashedFileChanges =
+export type StashedFileChanges =
   | {
       kind:
         | StashedChangesLoadStates.NotLoaded

--- a/app/src/models/stash-entry.ts
+++ b/app/src/models/stash-entry.ts
@@ -23,11 +23,11 @@ export enum StashedChangesLoadStates {
 
 export type StashedFileChanges =
   | {
-      kind:
+      readonly kind:
         | StashedChangesLoadStates.NotLoaded
         | StashedChangesLoadStates.Loading
     }
   | {
-      kind: StashedChangesLoadStates.Loaded
-      files: ReadonlyArray<CommittedFileChange>
+      readonly kind: StashedChangesLoadStates.Loaded
+      readonly files: ReadonlyArray<CommittedFileChange>
     }


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This addresses [some feedback I gave in](https://github.com/desktop/desktop/pull/7210#discussion_r274887038) #7210. 

## Description

Instead of parsing `stderr` looking for a string we're now simply counting 128 among the successful exit codes. This simplifies the logic and lets all other errors flow freely past this method. Furthermore this PR implements the same parsing logic that we use elsewhere for log-related output. As a side-effect of this I have now included the stash reference name in the output from git log. Conceptually we want to rely on Git behaviors wherever possible and in doing so we're also able to clean up our logic for inferring these stash names.

Lastly I've introduced a `getStashEntryMatchinSha` method which lets us remove some duplicated logic.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
