### PR TITLE
[Stashing] Address button order of stash diff viewer for Windows

### DIFF
--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -1,5 +1,3 @@
-/* tslint:disable:button-group-order */
-
 import * as React from 'react'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { FileList } from '../history/file-list'
@@ -119,10 +117,10 @@ const Header: React.SFC<{
     <div className="header">
       <h3>Stashed changes</h3>
       <ButtonGroup>
-        <Button onClick={onClearClick}>Clear</Button>
         <Button onClick={onSubmitClick} type="submit">
           Restore
         </Button>
+        <Button onClick={onClearClick}>Clear</Button>
       </ButtonGroup>
     </div>
   )

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -116,7 +116,7 @@ const Header: React.SFC<{
   return (
     <div className="header">
       <h3>Stashed changes</h3>
-      <ButtonGroup>
+      <ButtonGroup destructive={true}>
         <Button onClick={onSubmitClick} type="submit">
           Restore
         </Button>


### PR DESCRIPTION
Fixes #7273

**macOS**
![macOS](https://user-images.githubusercontent.com/1715082/56158960-2193bf80-5f89-11e9-8804-9386408bd4b9.png)

**Windows (before)**
![Windows-Before](https://user-images.githubusercontent.com/1715082/56158974-29536400-5f89-11e9-8ba5-504b74374090.png)

**Windows (after)**
![Windows-After](https://user-images.githubusercontent.com/1715082/56159005-3cfeca80-5f89-11e9-8b0d-59e64e997b2d.png)

☝️ is the same as before...
