### PR TITLE
conflicts - add space between button label and octicon

### DIFF
--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -75,6 +75,8 @@ dialog#rebase-conflicts-list {
         .resolve-arrow-menu {
           .octicon {
             margin-left: var(--spacing-half);
+            width: 10px;
+            height: 14px;
           }
         }
       }

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -71,6 +71,12 @@ dialog#rebase-conflicts-list {
         display: flex;
         align-items: center;
         justify-content: center;
+
+        .resolve-arrow-menu {
+          .octicon {
+            margin-left: var(--spacing-half);
+          }
+        }
       }
 
       .green-circle:last-child {


### PR DESCRIPTION
## Overview

Closes out this bit of feedback from #7218:

> * The `resolve` carrot is warped. Shouldn't it look like the Open in Editor one?
> 
> <img alt="Screen Shot 2019-04-04 at 7 55 42 AM" width="106" src="https://user-images.githubusercontent.com/14828183/55580088-78f67d80-56b5-11e9-901d-346743ba359c.png">
> 
> <img alt="Screen Shot 2019-04-04 at 8 39 53 AM" width="114" src="https://user-images.githubusercontent.com/14828183/55580091-798f1400-56b5-11e9-840f-bf7cc953a17c.png">

## Description

I ended up just focusing on the spacing between the two elements because the "Open in Editor" flow has two buttons (the left button launching the editor, the second button displaying a context menu) and that didn't feel consistent here (because I only have a context menu to show).

Current `development` branch - resolving merge and rebase conflict where manual options are required:

<img width="527" src="https://user-images.githubusercontent.com/359239/56163826-b60c1b00-5fa5-11e9-8647-3d64d26cf5de.png">
<img width="519" src="https://user-images.githubusercontent.com/359239/56163827-b60c1b00-5fa5-11e9-95c0-27d2a57f8cff.png">

After this PR:

<img width="535" src="https://user-images.githubusercontent.com/359239/56163837-bc9a9280-5fa5-11e9-8ad3-79f025148f19.png">
<img width="582" src="https://user-images.githubusercontent.com/359239/56163838-bc9a9280-5fa5-11e9-90a5-e1650b0b6aa6.png">

## Release notes

Notes: `[Improved] button style for manual conflict resolution options`
