### PR TITLE
make FileList support generic FileChange in props

### DIFF
--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -49,6 +49,9 @@ interface IFileListProps {
   readonly repository: Repository
 }
 
+/**
+ * Display a list of changed files as part of a commit or stash
+ */
 export class FileList extends React.Component<IFileListProps> {
   private onSelectedRowChanged = (row: number) => {
     const file = this.props.files[row]

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -21,10 +21,10 @@ import { showContextualMenu } from '../main-process-proxy'
 import { clipboard } from 'electron'
 import { mapStatus } from '../../lib/status'
 
-interface IFileListProps {
-  readonly files: ReadonlyArray<FileChange>
-  readonly selectedFile: FileChange | null
-  readonly onSelectedFileChanged: (file: FileChange) => void
+interface IFileListProps<T extends FileChange> {
+  readonly files: ReadonlyArray<T>
+  readonly selectedFile: T | null
+  readonly onSelectedFileChanged: (file: T) => void
   readonly availableWidth: number
 
   /**
@@ -49,7 +49,9 @@ interface IFileListProps {
   readonly repository: Repository
 }
 
-export class FileList extends React.Component<IFileListProps, {}> {
+export class FileList<T extends FileChange> extends React.Component<
+  IFileListProps<T>
+> {
   private onSelectedRowChanged = (row: number) => {
     const file = this.props.files[row]
     this.props.onSelectedFileChanged(file)

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -3,7 +3,7 @@ import * as Path from 'path'
 import { pathExists } from 'fs-extra'
 import { revealInFileManager } from '../../lib/app-shell'
 
-import { FileChange } from '../../models/status'
+import { FileChange, CommittedFileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
 
 import { PathLabel } from '../lib/path-label'
@@ -21,10 +21,10 @@ import { showContextualMenu } from '../main-process-proxy'
 import { clipboard } from 'electron'
 import { mapStatus } from '../../lib/status'
 
-interface IFileListProps<T extends FileChange> {
-  readonly files: ReadonlyArray<T>
-  readonly selectedFile: T | null
-  readonly onSelectedFileChanged: (file: T) => void
+interface IFileListProps {
+  readonly files: ReadonlyArray<CommittedFileChange>
+  readonly selectedFile: CommittedFileChange | null
+  readonly onSelectedFileChanged: (file: CommittedFileChange) => void
   readonly availableWidth: number
 
   /**
@@ -49,9 +49,7 @@ interface IFileListProps<T extends FileChange> {
   readonly repository: Repository
 }
 
-export class FileList<T extends FileChange> extends React.Component<
-  IFileListProps<T>
-> {
+export class FileList extends React.Component<IFileListProps> {
   private onSelectedRowChanged = (row: number) => {
     const file = this.props.files[row]
     this.props.onSelectedFileChanged(file)

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -3,7 +3,7 @@ import * as Path from 'path'
 import { pathExists } from 'fs-extra'
 import { revealInFileManager } from '../../lib/app-shell'
 
-import { FileChange, CommittedFileChange } from '../../models/status'
+import { CommittedFileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
 
 import { PathLabel } from '../lib/path-label'
@@ -89,7 +89,7 @@ export class FileList extends React.Component<IFileListProps> {
     )
   }
 
-  private rowForFile(file: FileChange | null): number {
+  private rowForFile(file: CommittedFileChange | null): number {
     return file ? this.props.files.findIndex(f => f.path === file.path) : -1
   }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -161,7 +161,7 @@ export class SelectedCommit extends React.Component<
     const availableWidth = this.props.commitSummaryWidth - 1
 
     return (
-      <FileList<CommittedFileChange>
+      <FileList
         files={files}
         onSelectedFileChanged={this.onFileSelected}
         selectedFile={this.props.selectedFile}

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -5,7 +5,7 @@ import { CommitSummary } from './commit-summary'
 import { Diff } from '../diff'
 import { FileList } from './file-list'
 import { Repository } from '../../models/repository'
-import { CommittedFileChange, FileChange } from '../../models/status'
+import { CommittedFileChange } from '../../models/status'
 import { Commit } from '../../models/commit'
 import { Dispatcher } from '../dispatcher'
 import { encodePathAsUrl } from '../../lib/path'
@@ -58,11 +58,8 @@ export class SelectedCommit extends React.Component<
     }
   }
 
-  private onFileSelected = (file: FileChange) => {
-    this.props.dispatcher.changeFileSelection(
-      this.props.repository,
-      file as CommittedFileChange
-    )
+  private onFileSelected = (file: CommittedFileChange) => {
+    this.props.dispatcher.changeFileSelection(this.props.repository, file)
   }
 
   private onHistoryRef = (ref: HTMLDivElement | null) => {
@@ -164,7 +161,7 @@ export class SelectedCommit extends React.Component<
     const availableWidth = this.props.commitSummaryWidth - 1
 
     return (
-      <FileList
+      <FileList<CommittedFileChange>
         files={files}
         onSelectedFileChanged={this.onFileSelected}
         selectedFile={this.props.selectedFile}

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -87,7 +87,7 @@ export class StashDiffViewer extends React.PureComponent<
             onResize={this.onResize}
             onReset={this.onReset}
           >
-            <FileList<CommittedFileChange>
+            <FileList
               files={files}
               onSelectedFileChanged={this.onSelectedFileChanged}
               selectedFile={this.props.selectedStashedFile}

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { FileList } from '../history/file-list'
 import { Dispatcher } from '../dispatcher'
-import { FileChange, CommittedFileChange } from '../../models/status'
+import { CommittedFileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
 import { openFile } from '../lib/open-file'
 import { join } from 'path'
@@ -41,10 +41,10 @@ interface IStashDiffViewerProps {
 export class StashDiffViewer extends React.PureComponent<
   IStashDiffViewerProps
 > {
-  private onSelectedFileChanged = (file: FileChange) =>
+  private onSelectedFileChanged = (file: CommittedFileChange) =>
     this.props.dispatcher.changeStashedFileSelection(
       this.props.repository,
-      file as CommittedFileChange
+      file
     )
 
   private onOpenItem = (path: string) =>
@@ -59,7 +59,7 @@ export class StashDiffViewer extends React.PureComponent<
     const files =
       this.props.stashEntry.files.kind === StashedChangesLoadStates.Loaded
         ? this.props.stashEntry.files.files
-        : new Array<FileChange>()
+        : new Array<CommittedFileChange>()
 
     const diffComponent =
       this.props.selectedStashedFile && this.props.stashedFileDiff ? (
@@ -86,7 +86,7 @@ export class StashDiffViewer extends React.PureComponent<
             onResize={this.onResize}
             onReset={this.onReset}
           >
-            <FileList
+            <FileList<CommittedFileChange>
               files={files}
               onSelectedFileChanged={this.onSelectedFileChanged}
               selectedFile={this.props.selectedStashedFile}

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -62,7 +62,8 @@ export class StashDiffViewer extends React.PureComponent<
         : new Array<CommittedFileChange>()
 
     const diffComponent =
-      this.props.selectedStashedFile && this.props.stashedFileDiff ? (
+      this.props.selectedStashedFile !== null &&
+      this.props.stashedFileDiff !== null ? (
         <Diff
           repository={this.props.repository}
           readOnly={true}


### PR DESCRIPTION
## Overview

**Closes #7296**

Opening this up early because I've found that #7290 also touches this component, and will requires a more complex workaround as we don't have a good way of "disabling" the context menu currently.

## Description

- make `FileList` generic so that consumers can control what shape of data is used in the list
- update usages so that no `CommittedFileChange` checks are necessary
- tidy up additional truthy checks for `!== null`

## Release notes

Notes: no-notes
