### PR TITLE
[Stashing] Update stash state after dropping entry

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4787,6 +4787,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
+    this._changeStashedFileSelection(repository, null)
+
     await this._refreshRepository(repository)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4786,6 +4786,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         previousStash.branchName
       }`
     )
+
+    await this._refreshRepository(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4877,7 +4877,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _changeStashedFileSelection(
     repository: Repository,
-    file: CommittedFileChange
+    file: CommittedFileChange | null
   ): Promise<void> {
     if (!enableStashing()) {
       return
@@ -4887,6 +4887,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedStashedFileDiff: null,
     }))
     this.emitUpdate()
+
+    if (file === null) {
+      return
+    }
 
     const diff = await getCommitDiff(repository, file, file.commitish)
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2026,7 +2026,7 @@ export class Dispatcher {
    */
   public changeStashedFileSelection(
     repository: Repository,
-    file: CommittedFileChange
+    file: CommittedFileChange | null
   ): Promise<void> {
     return this.appStore._changeStashedFileSelection(repository, file)
   }


### PR DESCRIPTION
Fixes #7280

The issue turned out to be two fold:
1. We weren't updating our cache of Desktop stash entries, `GitStore.stashEntries`
1. We weren't updating `ChangesState` when an entry was dropped
 
![2019-04-15 17 37 50](https://user-images.githubusercontent.com/1715082/56169892-4564fe80-5fa5-11e9-9ae3-b37ef50a1eaf.gif)
