### PR TITLE
disable context menu when viewing files in diff

### DIFF
--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -13,7 +13,7 @@ interface IFileListProps {
   readonly selectedFile: CommittedFileChange | null
   readonly onSelectedFileChanged: (file: CommittedFileChange) => void
   readonly availableWidth: number
-  readonly onContextMenu?: () => void
+  readonly onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void
 }
 
 /**
@@ -40,7 +40,7 @@ export class FileList extends React.Component<IFileListProps> {
       statusWidth
 
     return (
-      <div className="file" onContextMenu={this.onContextMenu}>
+      <div className="file" onContextMenu={this.props.onContextMenu}>
         <PathLabel
           path={file.path}
           status={file.status}
@@ -72,13 +72,5 @@ export class FileList extends React.Component<IFileListProps> {
         />
       </div>
     )
-  }
-
-  private onContextMenu = async (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault()
-
-    if (this.props.onContextMenu) {
-      this.props.onContextMenu()
-    }
   }
 }

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -1,24 +1,11 @@
 import * as React from 'react'
-import * as Path from 'path'
-import { pathExists } from 'fs-extra'
-import { revealInFileManager } from '../../lib/app-shell'
 
 import { CommittedFileChange } from '../../models/status'
-import { Repository } from '../../models/repository'
 
 import { PathLabel } from '../lib/path-label'
-import {
-  isSafeFileExtension,
-  CopyFilePathLabel,
-  DefaultEditorLabel,
-  RevealInFileManagerLabel,
-  OpenWithDefaultProgramLabel,
-} from '../lib/context-menu'
 import { List } from '../lib/list'
 
 import { Octicon, iconForStatus } from '../octicons'
-import { showContextualMenu } from '../main-process-proxy'
-import { clipboard } from 'electron'
 import { mapStatus } from '../../lib/status'
 
 interface IFileListProps {
@@ -26,27 +13,7 @@ interface IFileListProps {
   readonly selectedFile: CommittedFileChange | null
   readonly onSelectedFileChanged: (file: CommittedFileChange) => void
   readonly availableWidth: number
-
-  /**
-   * Called to open a file with its default application
-   * @param path The path of the file relative to the root of the repository
-   */
-  readonly onOpenItem: (path: string) => void
-
-  /** The name of the currently selected external editor */
-  readonly externalEditorLabel?: string
-
-  /**
-   * Called to open a file using the user's configured applications
-   * @param path The path of the file relative to the root of the repository
-   */
-  readonly onOpenInExternalEditor: (path: string) => void
-
-  /**
-   * Repository that we use to get the base path and build
-   * full path for the file in commit to check for file existence
-   */
-  readonly repository: Repository
+  readonly onContextMenu?: () => void
 }
 
 /**
@@ -110,53 +77,8 @@ export class FileList extends React.Component<IFileListProps> {
   private onContextMenu = async (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
 
-    if (this.props.selectedFile == null) {
-      return
+    if (this.props.onContextMenu) {
+      this.props.onContextMenu()
     }
-
-    const filePath = this.props.selectedFile.path
-    const fullPath = Path.join(this.props.repository.path, filePath)
-    const fileExistsOnDisk = await pathExists(fullPath)
-    if (!fileExistsOnDisk) {
-      showContextualMenu([
-        {
-          label: __DARWIN__
-            ? 'File Does Not Exist on Disk'
-            : 'File does not exist on disk',
-          enabled: false,
-        },
-      ])
-      return
-    }
-
-    const extension = Path.extname(filePath)
-
-    const isSafeExtension = isSafeFileExtension(extension)
-    const openInExternalEditor = this.props.externalEditorLabel
-      ? `Open in ${this.props.externalEditorLabel}`
-      : DefaultEditorLabel
-
-    const items = [
-      {
-        label: CopyFilePathLabel,
-        action: () => clipboard.writeText(fullPath),
-      },
-      {
-        label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(this.props.repository, filePath),
-        enabled: fileExistsOnDisk,
-      },
-      {
-        label: openInExternalEditor,
-        action: () => this.props.onOpenInExternalEditor(fullPath),
-        enabled: isSafeExtension && fileExistsOnDisk,
-      },
-      {
-        label: OpenWithDefaultProgramLabel,
-        action: () => this.props.onOpenItem(filePath),
-        enabled: isSafeExtension && fileExistsOnDisk,
-      },
-    ]
-    showContextualMenu(items)
   }
 }

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -1,19 +1,34 @@
 import * as React from 'react'
+import { clipboard } from 'electron'
+import { pathExists } from 'fs-extra'
 import * as Path from 'path'
 
-import { CommitSummary } from './commit-summary'
-import { Diff } from '../diff'
-import { FileList } from './file-list'
 import { Repository } from '../../models/repository'
 import { CommittedFileChange } from '../../models/status'
 import { Commit } from '../../models/commit'
-import { Dispatcher } from '../dispatcher'
-import { encodePathAsUrl } from '../../lib/path'
-import { ThrottledScheduler } from '../lib/throttled-scheduler'
-import { IGitHubUser } from '../../lib/databases'
-import { Resizable } from '../resizable'
-import { openFile } from '../lib/open-file'
 import { IDiff, ImageDiffType } from '../../models/diff'
+
+import { encodePathAsUrl } from '../../lib/path'
+import { IGitHubUser } from '../../lib/databases'
+import { revealInFileManager } from '../../lib/app-shell'
+
+import { openFile } from '../lib/open-file'
+import {
+  isSafeFileExtension,
+  CopyFilePathLabel,
+  DefaultEditorLabel,
+  RevealInFileManagerLabel,
+  OpenWithDefaultProgramLabel,
+} from '../lib/context-menu'
+import { ThrottledScheduler } from '../lib/throttled-scheduler'
+
+import { Diff } from '../diff'
+import { Dispatcher } from '../dispatcher'
+import { Resizable } from '../resizable'
+import { showContextualMenu } from '../main-process-proxy'
+
+import { CommitSummary } from './commit-summary'
+import { FileList } from './file-list'
 
 interface ISelectedCommitProps {
   readonly repository: Repository
@@ -166,10 +181,7 @@ export class SelectedCommit extends React.Component<
         onSelectedFileChanged={this.onFileSelected}
         selectedFile={this.props.selectedFile}
         availableWidth={availableWidth}
-        onOpenItem={this.onOpenItem}
-        externalEditorLabel={this.props.externalEditorLabel}
-        onOpenInExternalEditor={this.props.onOpenInExternalEditor}
-        repository={this.props.repository}
+        onContextMenu={this.onContextMenu}
       />
     )
   }
@@ -207,6 +219,57 @@ export class SelectedCommit extends React.Component<
         </div>
       </div>
     )
+  }
+
+  private onContextMenu = async () => {
+    if (this.props.selectedFile == null) {
+      return
+    }
+
+    const filePath = this.props.selectedFile.path
+    const fullPath = Path.join(this.props.repository.path, filePath)
+    const fileExistsOnDisk = await pathExists(fullPath)
+    if (!fileExistsOnDisk) {
+      showContextualMenu([
+        {
+          label: __DARWIN__
+            ? 'File Does Not Exist on Disk'
+            : 'File does not exist on disk',
+          enabled: false,
+        },
+      ])
+      return
+    }
+
+    const extension = Path.extname(filePath)
+
+    const isSafeExtension = isSafeFileExtension(extension)
+    const openInExternalEditor = this.props.externalEditorLabel
+      ? `Open in ${this.props.externalEditorLabel}`
+      : DefaultEditorLabel
+
+    const items = [
+      {
+        label: CopyFilePathLabel,
+        action: () => clipboard.writeText(fullPath),
+      },
+      {
+        label: RevealInFileManagerLabel,
+        action: () => revealInFileManager(this.props.repository, filePath),
+        enabled: fileExistsOnDisk,
+      },
+      {
+        label: openInExternalEditor,
+        action: () => this.props.onOpenInExternalEditor(fullPath),
+        enabled: isSafeExtension && fileExistsOnDisk,
+      },
+      {
+        label: OpenWithDefaultProgramLabel,
+        action: () => this.onOpenItem(filePath),
+        enabled: isSafeExtension && fileExistsOnDisk,
+      },
+    ]
+    showContextualMenu(items)
   }
 }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -221,7 +221,9 @@ export class SelectedCommit extends React.Component<
     )
   }
 
-  private onContextMenu = async () => {
+  private onContextMenu = async (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault()
+
     if (this.props.selectedFile == null) {
       return
     }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -287,8 +287,6 @@ export class RepositoryView extends React.Component<
           }
           imageDiffType={this.props.imageDiffType}
           fileListWidth={this.props.stashedFilesWidth}
-          externalEditorLabel={this.props.externalEditorLabel}
-          onOpenInExternalEditor={this.props.onOpenInExternalEditor}
           repository={this.props.repository}
           dispatcher={this.props.dispatcher}
         />

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -6,8 +6,6 @@ import { FileList } from '../history/file-list'
 import { Dispatcher } from '../dispatcher'
 import { CommittedFileChange } from '../../models/status'
 import { Repository } from '../../models/repository'
-import { openFile } from '../lib/open-file'
-import { join } from 'path'
 import { Diff } from '../diff'
 import { IDiff, ImageDiffType } from '../../models/diff'
 import { Resizable } from '../resizable'
@@ -27,8 +25,6 @@ interface IStashDiffViewerProps {
 
   /** width to use for the files list pane */
   readonly fileListWidth: number
-  readonly externalEditorLabel?: string
-  readonly onOpenInExternalEditor: (path: string) => void
   readonly repository: Repository
   readonly dispatcher: Dispatcher
 }
@@ -46,9 +42,6 @@ export class StashDiffViewer extends React.PureComponent<
       this.props.repository,
       file
     )
-
-  private onOpenItem = (path: string) =>
-    openFile(join(this.props.repository.path, path), this.props.dispatcher)
 
   private onResize = (width: number) =>
     this.props.dispatcher.setStashedFilesWidth(width)
@@ -92,10 +85,6 @@ export class StashDiffViewer extends React.PureComponent<
               onSelectedFileChanged={this.onSelectedFileChanged}
               selectedFile={this.props.selectedStashedFile}
               availableWidth={this.props.fileListWidth}
-              onOpenItem={this.onOpenItem}
-              externalEditorLabel={this.props.externalEditorLabel}
-              onOpenInExternalEditor={this.props.onOpenInExternalEditor}
-              repository={this.props.repository}
             />
           </Resizable>
           {diffComponent}


### PR DESCRIPTION
## Overview

**Related to #7290**

## Description

This PR refactors the `onContextMenu` callback inside `FileList` in favour of a callback, so that the components can control the behaviour:

 - `FileList` now omits several unnecessary props because `onContextMenu` no longer lives in there
 - `SelectedCommit` now contains the existing behaviour
 - `StashDiffViewer ` cleans up the props which are no longer needed

## Release notes

Notes: no-notes
