### PR TITLE
[Stashing] A select selection

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -522,17 +522,29 @@ export interface ICommitSelection {
   /** The diff of the currently-selected file */
   readonly diff: IDiff | null
 }
-
-export interface IChangesState {
-  readonly workingDirectory: WorkingDirectoryStatus
+export type ChangesWorkingDirectorySelection = {
+  readonly kind: 'workingDirectory'
 
   /**
    * The ID of the selected files. The files themselves can be looked up in
    * `workingDirectory`.
    */
   readonly selectedFileIDs: string[]
-
   readonly diff: IDiff | null
+}
+
+export type ChangesStashSelection = {
+  readonly kind: 'stash'
+
+  /** Currently selected file in the stash diff viewer UI (aka the file we want to show the diff for) */
+  readonly selectedStashedFile: CommittedFileChange | null
+
+  /** Currently selected file's diff */
+  readonly selectedStashedFileDiff: IDiff | null
+}
+
+export interface IChangesState {
+  readonly workingDirectory: WorkingDirectoryStatus
 
   /** The commit message for a work-in-progress commit in the changes view. */
   readonly commitMessage: ICommitMessage
@@ -559,14 +571,10 @@ export interface IChangesState {
    */
   readonly conflictState: ConflictState | null
 
-  /** Whether or not to show the UI for a stash entry. */
-  readonly shouldShowStashedChanges: boolean
-
-  /** Currently selected file in the stash diff viewer UI (aka the file we want to show the diff for) */
-  readonly selectedStashedFile: CommittedFileChange | null
-
-  /** Currently selected file's diff */
-  readonly selectedStashedFileDiff: IDiff | null
+  readonly selection:
+    | ChangesWorkingDirectorySelection
+    | ChangesStashSelection
+    | null
 }
 
 /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -584,6 +584,12 @@ export interface IChangesState {
    */
   readonly stashEntry: IStashEntry | null
 
+  /**
+   * The current selection state in the Changes view. Can be either
+   * working directory or a stash. In the case of a working directory
+   * selection multiple files may be selected. See `ChangesSelection`
+   * for more information about the differences between the two.
+   */
   readonly selection: ChangesSelection
 }
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -522,6 +522,12 @@ export interface ICommitSelection {
   /** The diff of the currently-selected file */
   readonly diff: IDiff | null
 }
+
+export enum ChangesSelectionKind {
+  WorkingDirectory,
+  Stash,
+}
+
 export type ChangesWorkingDirectorySelection = {
   readonly kind: 'workingDirectory'
 
@@ -534,7 +540,7 @@ export type ChangesWorkingDirectorySelection = {
 }
 
 export type ChangesStashSelection = {
-  readonly kind: 'stash'
+  readonly kind: ChangesSelectionKind.Stash
 
   /** Currently selected file in the stash diff viewer UI (aka the file we want to show the diff for) */
   readonly selectedStashedFile: CommittedFileChange | null
@@ -581,7 +587,7 @@ export interface IChangesState {
    */
   readonly stashEntry: IStashEntry | null
 
-  readonly selection: ChangesSelection | null
+  readonly selection: ChangesSelection
 }
 
 /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -575,6 +575,12 @@ export interface IChangesState {
    */
   readonly conflictState: ConflictState | null
 
+  /**
+   * The latest GitHub Desktop stash entry for the current branch, or null
+   * if no stash exists for the current branch.
+   */
+  readonly stashEntry: IStashEntry | null
+
   readonly selection: ChangesSelection | null
 }
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -530,7 +530,7 @@ export type ChangesWorkingDirectorySelection = {
 
   /**
    * The ID of the selected files. The files themselves can be looked up in
-   * `workingDirectory`.
+   * the `workingDirectory` property in IChangesState.
    */
   readonly selectedFileIDs: string[]
   readonly diff: IDiff | null

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -529,7 +529,7 @@ export enum ChangesSelectionKind {
 }
 
 export type ChangesWorkingDirectorySelection = {
-  readonly kind: 'workingDirectory'
+  readonly kind: ChangesSelectionKind.WorkingDirectory
 
   /**
    * The ID of the selected files. The files themselves can be looked up in

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -371,9 +371,6 @@ export interface IRepositoryState {
   /** The state of the current branch in relation to its upstream. */
   readonly aheadBehind: IAheadBehind | null
 
-  /** A map keyed on the canonical ref name of stash entries created by Desktop. */
-  readonly stashEntries: ReadonlyMap<string, IStashEntry>
-
   /** Is a push/pull/fetch in progress? */
   readonly isPushPullFetchInProgress: boolean
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -543,6 +543,10 @@ export type ChangesStashSelection = {
   readonly selectedStashedFileDiff: IDiff | null
 }
 
+export type ChangesSelection =
+  | ChangesWorkingDirectorySelection
+  | ChangesStashSelection
+
 export interface IChangesState {
   readonly workingDirectory: WorkingDirectoryStatus
 
@@ -571,10 +575,7 @@ export interface IChangesState {
    */
   readonly conflictState: ConflictState | null
 
-  readonly selection:
-    | ChangesWorkingDirectorySelection
-    | ChangesStashSelection
-    | null
+  readonly selection: ChangesSelection | null
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1959,7 +1959,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  /** This shouldn't be called directly. See `Dispatcher`. */
+  /**
+   * Changes the selection in the changes view to the working directory and
+   * optionally selects a particular file from the working directory.
+   *
+   *  @param files An array of files to select when showing the working directory.
+   *               If undefined this method will preserve the previously selected
+   *               files or pick the first changed file if no selection exists.
+   *
+   * Note: This shouldn't be called directly. See `Dispatcher`.
+   */
   public async _selectWorkingDirectoryFiles(
     repository: Repository,
     files?: ReadonlyArray<WorkingDirectoryFileChange>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -601,12 +601,26 @@ export class AppStore extends TypedBaseStore<IAppState> {
       pullWithRebase: gitStore.pullWithRebase,
     }))
 
-    this.repositoryStateCache.updateChangesState(repository, () => ({
-      commitMessage: gitStore.commitMessage,
-      showCoAuthoredBy: gitStore.showCoAuthoredBy,
-      coAuthors: gitStore.coAuthors,
-      stashEntry: gitStore.currentBranchStashEntry,
-    }))
+    this.repositoryStateCache.updateChangesState(repository, state => {
+      const stashEntry = gitStore.currentBranchStashEntry
+
+      // If we're showing a stash now and the stash entry doesn't exist
+      // any more we need to switch back over to the working directory.
+      // If not, we'll just keep the selection that we've got.
+      const selection =
+        state.selection.kind === ChangesSelectionKind.Stash &&
+        stashEntry === null
+          ? selectWorkingDirectoryFiles(state)
+          : { selection: state.selection }
+
+      return {
+        commitMessage: gitStore.commitMessage,
+        showCoAuthoredBy: gitStore.showCoAuthoredBy,
+        coAuthors: gitStore.coAuthors,
+        stashEntry,
+        ...selection,
+      }
+    })
 
     this.repositoryStateCache.update(repository, () => ({
       commitLookup: gitStore.commitLookup,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2095,7 +2095,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  /** This shouldn't be called directly. See `Dispatcher`. */
+  /**
+   * Changes the selection in the changes view to the stash entry view and
+   * optionally selects a particular file from the current stash entry.
+   *
+   *  @param file  A file to select when showing the stash entry.
+   *               If undefined this method will preserve the previously selected
+   *               file or pick the first changed file if no selection exists.
+   *
+   * Note: This shouldn't be called directly. See `Dispatcher`.
+   */
   public async _selectStashedFile(
     repository: Repository,
     file?: CommittedFileChange | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -95,6 +95,7 @@ import {
   RebaseConflictState,
   IRebaseState,
   IRepositoryState,
+  ChangesSelectionKind,
 } from '../app-state'
 import { IGitHubUser } from '../databases/github-user-database'
 import {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4957,7 +4957,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this.gitStoreCache.get(repository).loadStashEntries()
+    await this._refreshRepository(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -4975,7 +4975,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this.gitStoreCache.get(repository).loadStashEntries()
+    await this._refreshRepository(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -604,6 +604,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitMessage: gitStore.commitMessage,
       showCoAuthoredBy: gitStore.showCoAuthoredBy,
       coAuthors: gitStore.coAuthors,
+      stashEntry: gitStore.currentBranchStashEntry,
     }))
 
     this.repositoryStateCache.update(repository, () => ({
@@ -612,7 +613,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       aheadBehind: gitStore.aheadBehind,
       remote: gitStore.currentRemote,
       lastFetched: gitStore.lastFetched,
-      stashEntries: gitStore.stashEntries,
     }))
 
     this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2105,7 +2105,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
           selectedStashedFile = null
         }
       } else {
-        selectedStashedFile = file
+        const { stashEntry } = state
+        if (
+          file !== null &&
+          stashEntry !== null &&
+          stashEntry.files.kind === StashedChangesLoadStates.Loaded
+        ) {
+          const files = stashEntry.files.files
+
+          // Look up the selected file in the stash entry, it's possible that
+          // the stash entry or file list has changed since the consumer called
+          // us. The workingdirectory selection handles this by using IDs rather
+          // than references.
+          selectedStashedFile = files.find(x => x.id === file.id) || null
+        } else {
+          selectedStashedFile = null
+        }
       }
 
       return {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2125,7 +2125,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       return {
         selection: {
-          kind: <ChangesSelectionKind.Stash>ChangesSelectionKind.Stash,
+          kind: ChangesSelectionKind.Stash as ChangesSelectionKind.Stash,
           selectedStashedFile,
           selectedStashedFileDiff: null,
         },
@@ -2164,7 +2164,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (file === null) {
       this.repositoryStateCache.updateChangesState(repository, () => ({
         selection: {
-          kind: <ChangesSelectionKind.Stash>ChangesSelectionKind.Stash,
+          kind: ChangesSelectionKind.Stash as ChangesSelectionKind.Stash,
           selectedStashedFile: null,
           selectedStashedFileDiff: null,
         },
@@ -2189,7 +2189,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoryStateCache.updateChangesState(repository, () => ({
       selection: {
-        kind: <ChangesSelectionKind.Stash>ChangesSelectionKind.Stash,
+        kind: ChangesSelectionKind.Stash as ChangesSelectionKind.Stash,
         selectedStashedFile: file,
         selectedStashedFileDiff: diff,
       },

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -96,6 +96,7 @@ import {
   IRebaseState,
   IRepositoryState,
   ChangesSelectionKind,
+  ChangesWorkingDirectorySelection,
 } from '../app-state'
 import { IGitHubUser } from '../databases/github-user-database'
 import {
@@ -2085,11 +2086,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
     const workingDirectory = WorkingDirectoryStatus.fromFiles(updatedFiles)
 
+    const selection: ChangesWorkingDirectorySelection = {
+      ...changesState.selection,
+      diff,
+    }
+
     this.repositoryStateCache.updateChangesState(repository, () => ({
-      selection: {
-        ...changesState.selection,
-        diff,
-      },
+      selection,
       workingDirectory,
     }))
     this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -196,6 +196,7 @@ import { ApiRepositoriesStore } from './api-repositories-store'
 import {
   updateChangedFiles,
   updateConflictState,
+  selectWorkingDirectoryFiles,
 } from './updates/changes-state'
 import {
   ManualConflictResolution,
@@ -1949,29 +1950,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     files?: ReadonlyArray<WorkingDirectoryFileChange>
   ): Promise<void> {
-    this.repositoryStateCache.updateChangesState(repository, state => {
-      let selectedFileIDs: Array<string>
-
-      if (files === undefined) {
-        if (state.workingDirectory.files.length > 0) {
-          selectedFileIDs = [state.workingDirectory.files[0].id]
-        } else {
-          selectedFileIDs = new Array<string>()
-        }
-      } else {
-        selectedFileIDs = files.map(x => x.id)
-      }
-
-      return {
-        selection: {
-          kind: <ChangesSelectionKind.WorkingDirectory>(
-            ChangesSelectionKind.WorkingDirectory
-          ),
-          selectedFileIDs,
-          diff: null,
-        },
-      }
-    })
+    this.repositoryStateCache.updateChangesState(repository, state =>
+      selectWorkingDirectoryFiles(state, files)
+    )
 
     this.emitUpdate()
     this.updateChangesWorkingDirectoryDiff(repository)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2118,7 +2118,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
           state.stashEntry.files.kind === StashedChangesLoadStates.Loaded &&
           state.stashEntry.files.files.length > 0
         ) {
-          selectedStashedFile = state.stashEntry.files.files[0]
+          const files = state.stashEntry.files.files
+          const { selection } = state
+
+          // Try to preserve the selection
+          if (
+            selection.kind === ChangesSelectionKind.Stash &&
+            selection.selectedStashedFile !== null
+          ) {
+            const currentlySelected = selection.selectedStashedFile
+
+            selectedStashedFile =
+              currentlySelected !== null
+                ? files.find(x => x.id === currentlySelected.id) || files[0]
+                : null
+          } else {
+            selectedStashedFile = files[0]
+          }
         } else {
           selectedStashedFile = null
         }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2159,7 +2159,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           selectedStashedFileDiff: null,
         },
       }))
-
+      this.emitUpdate()
       return
     }
 
@@ -2184,6 +2184,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         selectedStashedFileDiff: diff,
       },
     }))
+    this.emitUpdate()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1961,7 +1961,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /**
    * Changes the selection in the changes view to the working directory and
-   * optionally selects a particular file from the working directory.
+   * optionally selects one or more files from the working directory.
    *
    *  @param files An array of files to select when showing the working directory.
    *               If undefined this method will preserve the previously selected

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4946,6 +4946,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         previousStash.branchName
       }`
     )
+
+    await this.gitStoreCache.get(repository).loadStashEntries()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -4963,7 +4965,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this._refreshRepository(repository)
+    await this.gitStoreCache.get(repository).loadStashEntries()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -4984,7 +4986,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this._refreshRepository(repository)
+    await this.gitStoreCache.get(repository).loadStashEntries()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4988,18 +4988,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _loadStashedFiles(
-    repository: Repository,
-    stashEntry: IStashEntry
-  ) {
-    if (!enableStashing()) {
-      return
-    }
-    const gitStore = this.gitStoreCache.get(repository)
-    await gitStore.loadStashedFiles(stashEntry)
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
   public _setStashedFilesWidth(width: number): Promise<void> {
     this.stashedFilesWidth = width
     setNumber(stashedFilesWidthConfigKey, width)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1002,7 +1002,7 @@ export class GitStore extends BaseStore {
     this._stashEntries = map
     this.emitUpdate()
 
-    this.loadStashedFilesForCurrentStashEntry()
+    this.loadFilesForCurrentStashEntry()
   }
 
   /**
@@ -1018,7 +1018,7 @@ export class GitStore extends BaseStore {
   /**
    * Updates the latest stash entry with a list of files that it changes
    */
-  private async loadStashedFilesForCurrentStashEntry() {
+  private async loadFilesForCurrentStashEntry() {
     if (!enableStashing()) {
       return
     }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1002,10 +1002,16 @@ export class GitStore extends BaseStore {
     }
 
     this._stashEntries = map
-    this._currentBranchStashEntry =
+
+    const currentStashEntry =
       this._tip && this._tip.kind === TipState.Valid
         ? map.get(this._tip.branch.name) || null
         : null
+
+    if (currentStashEntry) {
+      await this.loadStashedFiles(currentStashEntry)
+      this._currentBranchStashEntry = currentStashEntry
+    }
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -132,6 +132,8 @@ export class GitStore extends BaseStore {
 
   private _stashEntries = new Map<string, IStashEntry>()
 
+  private _currentBranchStashEntry: IStashEntry | null = null
+
   public constructor(repository: Repository, shell: IAppShell) {
     super()
 
@@ -1000,12 +1002,20 @@ export class GitStore extends BaseStore {
     }
 
     this._stashEntries = map
+    this._currentBranchStashEntry =
+      this._tip && this._tip.kind === TipState.Valid
+        ? map.get(this._tip.branch.name) || null
+        : null
+
     this.emitUpdate()
   }
 
-  /** A map key on the canonical ref name of GitHub Desktop created stash entries for the repository */
-  public get stashEntries() {
-    return this._stashEntries
+  /**
+   * A GitHub Desktop created stash entries for the current branch or
+   * null if no entry exists
+   */
+  public get currentBranchStashEntry() {
+    return this._currentBranchStashEntry
   }
 
   /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1021,7 +1021,7 @@ export class GitStore extends BaseStore {
   /**
    * Updates the latest stash entry with a list of files that it changes
    */
-  public async loadStashedFiles(stashEntry: IStashEntry) {
+  private async loadStashedFiles(stashEntry: IStashEntry) {
     if (!enableStashing()) {
       return
     }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -23,7 +23,6 @@ import { ComparisonCache } from '../comparison-cache'
 import { IGitHubUser } from '../databases'
 import { merge } from '../merge'
 import { DefaultCommitMessage } from '../../models/commit-message'
-import { IStashEntry } from '../../models/stash-entry'
 
 export class RepositoryStateCache {
   private readonly repositoryState = new Map<string, IRepositoryState>()
@@ -184,6 +183,5 @@ function getInitialRepositoryState(): IRepositoryState {
     revertProgress: null,
     branchFilterText: '',
     pullRequestFilterText: '',
-    stashEntries: new Map<string, IStashEntry>(),
   }
 }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -17,6 +17,7 @@ import {
   RepositorySectionTab,
   ICommitSelection,
   IRebaseState,
+  ChangesSelectionKind,
 } from '../app-state'
 import { ComparisonCache } from '../comparison-cache'
 import { IGitHubUser } from '../databases'
@@ -124,15 +125,16 @@ function getInitialRepositoryState(): IRepositoryState {
       workingDirectory: WorkingDirectoryStatus.fromFiles(
         new Array<WorkingDirectoryFileChange>()
       ),
-      selectedFileIDs: [],
-      diff: null,
+      selection: {
+        kind: ChangesSelectionKind.WorkingDirectory,
+        selectedFileIDs: [],
+        diff: null,
+      },
       commitMessage: DefaultCommitMessage,
       coAuthors: [],
       showCoAuthoredBy: false,
       conflictState: null,
-      shouldShowStashedChanges: false,
-      selectedStashedFile: null,
-      selectedStashedFileDiff: null,
+      stashEntry: null,
     },
     selectedSection: RepositorySectionTab.Changes,
     branchesState: {

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -295,3 +295,47 @@ export function updateConflictState(
 
   return newConflictState
 }
+
+/**
+ * Generate the partial state needed to update ChangesState selection property
+ * when a user or external constraints require us to do so.
+ *
+ * @param state The current changes state
+ * @param files An array of files to select when showing the working directory.
+ *              If undefined this method will preserve the previously selected
+ *              files or pick the first changed file if no selection exists.
+ */
+export function selectWorkingDirectoryFiles(
+  state: IChangesState,
+  files?: ReadonlyArray<WorkingDirectoryFileChange>
+): Pick<IChangesState, 'selection'> {
+  let selectedFileIDs: Array<string>
+
+  if (files === undefined) {
+    if (state.selection.kind === ChangesSelectionKind.WorkingDirectory) {
+      // No files provided, just a desire to make sure selection is
+      // working directory. If it already is there's nothing for us to do.
+      return { selection: state.selection }
+    } else if (state.workingDirectory.files.length > 0) {
+      // No files provided and the current selection is stash, pick the
+      // first file we've got.
+      selectedFileIDs = [state.workingDirectory.files[0].id]
+    } else {
+      // Not much to do here. No files provided, nothing in the
+      // working directory.
+      selectedFileIDs = new Array<string>()
+    }
+  } else {
+    selectedFileIDs = files.map(x => x.id)
+  }
+
+  return {
+    selection: {
+      kind: <ChangesSelectionKind.WorkingDirectory>(
+        ChangesSelectionKind.WorkingDirectory
+      ),
+      selectedFileIDs,
+      diff: null,
+    },
+  }
+}

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -10,11 +10,14 @@ import {
   isMergeConflictState,
   isRebaseConflictState,
   RebaseConflictState,
+  ChangesSelection,
+  ChangesSelectionKind,
 } from '../../app-state'
-import { DiffSelectionType, IDiff } from '../../../models/diff'
+import { DiffSelectionType } from '../../../models/diff'
 import { caseInsensitiveCompare } from '../../compare'
 import { IStatsStore } from '../../stats/stats-store'
 import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
+import { assertNever } from '../../fatal-error'
 
 /**
  * Internal shape of the return value from this response because the compiler
@@ -23,8 +26,7 @@ import { ManualConflictResolution } from '../../../models/manual-conflict-resolu
  */
 type ChangedFilesResult = {
   readonly workingDirectory: WorkingDirectoryStatus
-  readonly selectedFileIDs: string[]
-  readonly diff: IDiff | null
+  readonly selection: ChangesSelection
 }
 
 export function updateChangedFiles(
@@ -62,19 +64,6 @@ export function updateChangedFiles(
   // lookups using .find on the mergedFiles array.
   const mergedFileIds = new Set(mergedFiles.map(x => x.id))
 
-  // The previously selected files might not be available in the working
-  // directory any more due to having been committed or discarded so we'll
-  // do a pass over and filter out any selected files that aren't available.
-  let selectedFileIDs = state.selectedFileIDs.filter(id =>
-    mergedFileIds.has(id)
-  )
-
-  // Select the first file if we don't have anything selected and we
-  // have something to select.
-  if (selectedFileIDs.length === 0 && mergedFiles.length > 0) {
-    selectedFileIDs = [mergedFiles[0].id]
-  }
-
   // The file selection could have changed if the previously selected files
   // are no longer selectable (they were discarded or committed) but if they
   // were not changed we can reuse the diff. Note, however that we only render
@@ -83,17 +72,46 @@ export function updateChangedFiles(
   // diff we had, if not we'll clear it.
   const workingDirectory = WorkingDirectoryStatus.fromFiles(mergedFiles)
 
-  const diff =
-    selectedFileIDs.length === 1 &&
-    state.selectedFileIDs.length === 1 &&
-    state.selectedFileIDs[0] === selectedFileIDs[0]
-      ? state.diff
-      : null
+  const selectionKind = state.selection.kind
+  if (state.selection.kind === ChangesSelectionKind.WorkingDirectory) {
+    // The previously selected files might not be available in the working
+    // directory any more due to having been committed or discarded so we'll
+    // do a pass over and filter out any selected files that aren't available.
+    let selectedFileIDs = state.selection.selectedFileIDs.filter(id =>
+      mergedFileIds.has(id)
+    )
 
-  return {
-    workingDirectory,
-    selectedFileIDs,
-    diff,
+    // Select the first file if we don't have anything selected and we
+    // have something to select.
+    if (selectedFileIDs.length === 0 && mergedFiles.length > 0) {
+      selectedFileIDs = [mergedFiles[0].id]
+    }
+
+    const diff =
+      selectedFileIDs.length === 1 &&
+      state.selection.selectedFileIDs.length === 1 &&
+      state.selection.selectedFileIDs[0] === selectedFileIDs[0]
+        ? state.selection.diff
+        : null
+
+    return {
+      workingDirectory,
+      selection: {
+        kind: ChangesSelectionKind.WorkingDirectory,
+        selectedFileIDs,
+        diff,
+      },
+    }
+  } else if (state.selection.kind === ChangesSelectionKind.Stash) {
+    return {
+      workingDirectory,
+      selection: state.selection,
+    }
+  } else {
+    return assertNever(
+      state.selection,
+      `Unknown selection kind ${selectionKind}`
+    )
   }
 }
 

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -331,9 +331,7 @@ export function selectWorkingDirectoryFiles(
 
   return {
     selection: {
-      kind: <ChangesSelectionKind.WorkingDirectory>(
-        ChangesSelectionKind.WorkingDirectory
-      ),
+      kind: ChangesSelectionKind.WorkingDirectory as ChangesSelectionKind.WorkingDirectory,
       selectedFileIDs,
       diff: null,
     },

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1641,7 +1641,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         const { repository, branchToCheckout } = popup
         const {
           branchesState,
-          stashEntries,
+          changesState,
         } = this.props.repositoryStateManager.get(repository)
         const { tip } = branchesState
 
@@ -1650,7 +1650,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         }
 
         const currentBranch = tip.branch
-        const hasAssociatedStash = stashEntries.has(currentBranch.name)
+        const hasAssociatedStash = changesState.stashEntry !== null
 
         return (
           <StashAndSwitchBranch

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -485,9 +485,9 @@ export class ChangesList extends React.Component<
 
   private onStashEntryClicked = () => {
     if (this.props.isShowingStashEntry) {
-      this.props.dispatcher.hideStashEntry(this.props.repository)
+      this.props.dispatcher.selectWorkingDirectoryFiles(this.props.repository)
     } else {
-      this.props.dispatcher.showStashEntry(this.props.repository)
+      this.props.dispatcher.selectStashedFile(this.props.repository)
     }
   }
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   IChangesState,
   RebaseConflictState,
   isRebaseConflictState,
+  ChangesSelectionKind,
 } from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
@@ -192,7 +193,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
 
   private onFileSelectionChanged = (rows: ReadonlyArray<number>) => {
     const files = rows.map(i => this.props.changes.workingDirectory.files[i])
-    this.props.dispatcher.changeChangesSelection(this.props.repository, files)
+    this.props.dispatcher.selectWorkingDirectoryFiles(
+      this.props.repository,
+      files
+    )
   }
 
   private onIncludeChanged = (path: string, include: boolean) => {
@@ -348,12 +352,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
 
   public render() {
     const {
-      selectedFileIDs,
       workingDirectory,
       commitMessage,
       showCoAuthoredBy,
       coAuthors,
       conflictState,
+      selection,
     } = this.props.changes
 
     // TODO: I think user will expect the avatar to match that which
@@ -372,6 +376,13 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
         ? conflictState
         : null
     }
+
+    const selectedFileIDs =
+      selection.kind === ChangesSelectionKind.WorkingDirectory
+        ? selection.selectedFileIDs
+        : []
+
+    const isShowingStashEntry = selection.kind === ChangesSelectionKind.Stash
 
     return (
       <div id="changes-sidebar-contents">
@@ -408,7 +419,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onChangesListScrolled={this.props.onChangesListScrolled}
           changesListScrollTop={this.props.changesListScrollTop}
           stashEntry={this.props.stashEntry}
-          isShowingStashEntry={this.props.changes.shouldShowStashedChanges}
+          isShowingStashEntry={isShowingStashEntry}
         />
         {this.renderUndoCommit(rebaseConflictState)}
       </div>

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -32,7 +32,6 @@ import { filesNotTrackedByLFS } from '../../lib/git/lfs'
 import { getLargeFilePaths } from '../../lib/large-files'
 import { isConflictedFile, hasUnresolvedConflicts } from '../../lib/status'
 import { enablePullWithRebase } from '../../lib/feature-flag'
-import { IStashEntry } from '../../models/stash-entry'
 
 /**
  * The timeout for the animation of the enter/leave animation for Undo.
@@ -70,9 +69,6 @@ interface IChangesSidebarProps {
   readonly onOpenInExternalEditor: (fullPath: string) => void
   readonly onChangesListScrolled: (scrollTop: number) => void
   readonly changesListScrollTop: number
-
-  /** The Desktop-created stash entry for the current branch or null if no entry exists */
-  readonly stashEntry: IStashEntry | null
 }
 
 export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
@@ -418,7 +414,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onOpenInExternalEditor={this.props.onOpenInExternalEditor}
           onChangesListScrolled={this.props.onChangesListScrolled}
           changesListScrollTop={this.props.changesListScrollTop}
-          stashEntry={this.props.stashEntry}
+          stashEntry={this.props.changes.stashEntry}
           isShowingStashEntry={isShowingStashEntry}
         />
         {this.renderUndoCommit(rebaseConflictState)}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -229,7 +229,7 @@ export class Dispatcher {
 
   /**
    * Changes the selection in the changes view to the working directory and
-   * optionally selects a particular file from the working directory.
+   * optionally selects one or more files from the working directory.
    *
    *  @param files An array of files to select when showing the working directory.
    *               If undefined this method will preserve the previously selected

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -227,7 +227,14 @@ export class Dispatcher {
     return this.appStore._changeRepositorySection(repository, section)
   }
 
-  /** Change the currently selected file in Changes. */
+  /**
+   * Changes the selection in the changes view to the working directory and
+   * optionally selects a particular file from the working directory.
+   *
+   *  @param files An array of files to select when showing the working directory.
+   *               If undefined this method will preserve the previously selected
+   *               files or pick the first changed file if no selection exists.
+   */
   public selectWorkingDirectoryFiles(
     repository: Repository,
     selectedFiles?: WorkingDirectoryFileChange[]

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2011,11 +2011,6 @@ export class Dispatcher {
     return this.appStore._popStashEntry(repository, stashEntry)
   }
 
-  /** Loads the list of changed files for the latest stash on this branch   */
-  public loadStashedFiles(repository: Repository, stashEntry: IStashEntry) {
-    return this.appStore._loadStashedFiles(repository, stashEntry)
-  }
-
   /**
    * Set the width of the commit summary column in the
    * history view to the given value.

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -242,6 +242,14 @@ export class Dispatcher {
     return this.appStore._selectWorkingDirectoryFiles(repository, selectedFiles)
   }
 
+  /**
+   * Changes the selection in the changes view to the stash entry view and
+   * optionally selects a particular file from the current stash entry.
+   *
+   *  @param file  A file to select when showing the stash entry.
+   *               If undefined this method will preserve the previously selected
+   *               file or pick the first changed file if no selection exists.
+   */
   public selectStashedFile(
     repository: Repository,
     file?: CommittedFileChange | null

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -228,11 +228,18 @@ export class Dispatcher {
   }
 
   /** Change the currently selected file in Changes. */
-  public changeChangesSelection(
+  public selectWorkingDirectoryFiles(
     repository: Repository,
-    selectedFiles: WorkingDirectoryFileChange[]
+    selectedFiles?: WorkingDirectoryFileChange[]
   ): Promise<void> {
-    return this.appStore._changeChangesSelection(repository, selectedFiles)
+    return this.appStore._selectWorkingDirectoryFiles(repository, selectedFiles)
+  }
+
+  public selectStashedFile(
+    repository: Repository,
+    file?: CommittedFileChange | null
+  ): Promise<void> {
+    return this.appStore._selectStashedFile(repository, file)
   }
 
   /**
@@ -2004,37 +2011,9 @@ export class Dispatcher {
     return this.appStore._popStashEntry(repository, stashEntry)
   }
 
-  /**
-   * Show the UI for stashed changes
-   */
-  public showStashEntry(repository: Repository) {
-    return this.appStore._showStashEntry(repository)
-  }
-
-  /**
-   * Hide the UI for stashed changes
-   */
-  public hideStashEntry(repository: Repository) {
-    return this.appStore._hideStashEntry(repository)
-  }
-
   /** Loads the list of changed files for the latest stash on this branch   */
   public loadStashedFiles(repository: Repository, stashEntry: IStashEntry) {
     return this.appStore._loadStashedFiles(repository, stashEntry)
-  }
-
-  /**
-   * Change the selected changed file in the stash diff viewer.
-   *
-   * @param repository The currently active repository instance
-   *
-   * @param file
-   */
-  public changeStashedFileSelection(
-    repository: Repository,
-    file: CommittedFileChange
-  ): Promise<void> {
-    return this.appStore._changeStashedFileSelection(repository, file)
   }
 
   /**

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -23,7 +23,6 @@ import { FocusContainer } from './lib/focus-container'
 import { OcticonSymbol, Octicon } from './octicons'
 import { ImageDiffType } from '../models/diff'
 import { IMenu } from '../models/app-menu'
-import { enableStashing } from '../lib/feature-flag'
 import { StashDiffViewer } from './stashing'
 import { StashedChangesLoadStates } from '../models/stash-entry'
 
@@ -146,7 +145,6 @@ export class RepositoryView extends React.Component<
 
     // -1 Because of right hand side border
     const availableWidth = this.props.sidebarWidth - 1
-    const stashEntry = this.currentStashForBranch()
 
     return (
       <ChangesSidebar
@@ -172,7 +170,6 @@ export class RepositoryView extends React.Component<
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onChangesListScrolled={this.onChangesListScrolled}
         changesListScrollTop={this.state.changesListScrollTop}
-        stashEntry={stashEntry}
       />
     )
   }
@@ -251,28 +248,6 @@ export class RepositoryView extends React.Component<
     }
   }
 
-  private currentStashForBranch() {
-    if (!enableStashing()) {
-      return null
-    }
-
-    const { branchesState, stashEntries } = this.props.state
-    const tip = branchesState.tip
-    if (tip.kind !== TipState.Valid) {
-      return null
-    }
-
-    // Using the short form ref name because the branch model does not keep track
-    // of the canonical ref name. Todo: update model to use the canonical ref name.
-    const branch = tip.branch
-    const stashEntry = stashEntries.get(branch.name)
-    if (stashEntry === undefined) {
-      return null
-    }
-
-    return stashEntry
-  }
-
   private renderStashedChangesContent(): JSX.Element | null {
     const { changesState } = this.props.state
     const { selection, stashEntry } = changesState
@@ -295,10 +270,8 @@ export class RepositoryView extends React.Component<
           dispatcher={this.props.dispatcher}
         />
       )
-    } else if (this.props.state.branchesState.tip.kind === TipState.Valid) {
-      this.props.dispatcher.loadStashedFiles(this.props.repository, stashEntry)
-      return null
     }
+
     return null
   }
 

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -42,10 +42,7 @@ export class StashDiffViewer extends React.PureComponent<
   IStashDiffViewerProps
 > {
   private onSelectedFileChanged = (file: CommittedFileChange) =>
-    this.props.dispatcher.changeStashedFileSelection(
-      this.props.repository,
-      file
-    )
+    this.props.dispatcher.selectStashedFile(this.props.repository, file)
 
   private onOpenItem = (path: string) =>
     openFile(join(this.props.repository.path, path), this.props.dispatcher)

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -42,7 +42,7 @@ export class StashDiffViewer extends React.PureComponent<
   IStashDiffViewerProps
 > {
   private onSelectedFileChanged = (file: FileChange) =>
-    this.props.dispatcher.changeStashedFileSelection(
+    this.props.dispatcher.selectStashedFile(
       this.props.repository,
       file as CommittedFileChange
     )

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -1,4 +1,4 @@
-import { IChangesState } from '../../src/lib/app-state'
+import { IChangesState, ChangesSelectionKind } from '../../src/lib/app-state'
 import { WorkingDirectoryStatus } from '../../src/models/status'
 import { merge } from '../../src/lib/merge'
 import { IStatusResult } from '../../src/lib/git'
@@ -9,15 +9,16 @@ export function createState<K extends keyof IChangesState>(
 ): IChangesState {
   const baseChangesState: IChangesState = {
     workingDirectory: WorkingDirectoryStatus.fromFiles([]),
-    selectedFileIDs: [],
-    diff: null,
+    selection: {
+      kind: ChangesSelectionKind.WorkingDirectory,
+      selectedFileIDs: [],
+      diff: null,
+    },
     commitMessage: DefaultCommitMessage,
     showCoAuthoredBy: false,
     coAuthors: [],
     conflictState: null,
-    shouldShowStashedChanges: false,
-    selectedStashedFile: null,
-    selectedStashedFileDiff: null,
+    stashEntry: null,
   }
 
   return merge(baseChangesState, pick)

--- a/app/test/unit/stores/updates/update-changed-files-test.ts
+++ b/app/test/unit/stores/updates/update-changed-files-test.ts
@@ -8,11 +8,13 @@ import {
   DiffSelection,
   DiffSelectionType,
   DiffType,
+  IBinaryDiff,
 } from '../../../../src/models/diff'
 import {
   createState,
   createStatus,
 } from '../../../helpers/changes-state-helper'
+import { ChangesSelectionKind } from '../../../../src/lib/app-state'
 
 const allSelected = DiffSelection.fromInitialSelection(DiffSelectionType.All)
 const noneSelected = DiffSelection.fromInitialSelection(DiffSelectionType.None)
@@ -31,7 +33,7 @@ const files = [
 ]
 
 describe('updateChangedFiles', () => {
-  describe('workingDirectory', () => {
+  describe(ChangesSelectionKind.WorkingDirectory, () => {
     let partiallySelectedFile: WorkingDirectoryFileChange
     let oldWorkingDirectory: WorkingDirectoryStatus
 
@@ -118,39 +120,62 @@ describe('updateChangedFiles', () => {
       const status = createStatus({
         workingDirectory: WorkingDirectoryStatus.fromFiles(files),
       })
-      const { selectedFileIDs } = updateChangedFiles(prevState, status, false)
+      const { selection } = updateChangedFiles(prevState, status, false)
 
-      expect(selectedFileIDs).toHaveLength(1)
-      // NOTE: `updateChangedFiles` sorts the paths and `app/package.json` will
-      // appear in list before `README.md`
-      expect(selectedFileIDs[0]).toBe(files[1].id)
+      expect(selection.kind).toBe(ChangesSelectionKind.WorkingDirectory)
+
+      if (selection.kind === ChangesSelectionKind.WorkingDirectory) {
+        const { selectedFileIDs } = selection
+        expect(selectedFileIDs).toHaveLength(1)
+        // NOTE: `updateChangedFiles` sorts the paths and `app/package.json` will
+        // appear in list before `README.md`
+        expect(selectedFileIDs[0]).toBe(files[1].id)
+      }
     })
 
     it('remembers previous selection if file is found in status', () => {
       const firstFile = files[0].id
       const prevState = createState({
-        selectedFileIDs: [firstFile],
+        selection: {
+          kind: ChangesSelectionKind.WorkingDirectory,
+          selectedFileIDs: [firstFile],
+          diff: null,
+        },
       })
 
       const status = createStatus({
         workingDirectory: WorkingDirectoryStatus.fromFiles(files),
       })
-      const { selectedFileIDs } = updateChangedFiles(prevState, status, false)
+      const { selection } = updateChangedFiles(prevState, status, false)
 
-      expect(selectedFileIDs).toHaveLength(1)
-      expect(selectedFileIDs[0]).toBe(firstFile)
+      expect(selection.kind).toBe(ChangesSelectionKind.WorkingDirectory)
+
+      if (selection.kind === ChangesSelectionKind.WorkingDirectory) {
+        const { selectedFileIDs } = selection
+        expect(selectedFileIDs).toHaveLength(1)
+        expect(selectedFileIDs[0]).toBe(firstFile)
+      }
     })
 
     it('clears selection if no files found in status', () => {
       const firstFile = files[0].id
       const prevState = createState({
-        selectedFileIDs: [firstFile],
+        selection: {
+          kind: ChangesSelectionKind.WorkingDirectory,
+          selectedFileIDs: [firstFile],
+          diff: null,
+        },
       })
 
       const status = createStatus({})
-      const { selectedFileIDs } = updateChangedFiles(prevState, status, false)
+      const { selection } = updateChangedFiles(prevState, status, false)
 
-      expect(selectedFileIDs).toHaveLength(0)
+      expect(selection.kind).toBe(ChangesSelectionKind.WorkingDirectory)
+
+      if (selection.kind === ChangesSelectionKind.WorkingDirectory) {
+        const { selectedFileIDs } = selection
+        expect(selectedFileIDs).toHaveLength(0)
+      }
     })
   })
 
@@ -160,15 +185,22 @@ describe('updateChangedFiles', () => {
 
       const prevState = createState({
         workingDirectory: workingDirectory,
-        // an unknown file was set as selected last time
-        selectedFileIDs: ['id-from-file-not-in-status'],
-        diff: { kind: DiffType.Binary },
+        selection: {
+          kind: ChangesSelectionKind.WorkingDirectory,
+          // an unknown file was set as selected last time
+          selectedFileIDs: ['id-from-file-not-in-status'],
+          diff: { kind: DiffType.Binary },
+        },
       })
 
       const status = createStatus({ workingDirectory })
-      const { diff } = updateChangedFiles(prevState, status, false)
+      const { selection } = updateChangedFiles(prevState, status, false)
 
-      expect(diff).toBeNull()
+      expect(selection.kind).toBe(ChangesSelectionKind.WorkingDirectory)
+
+      if (selection.kind === ChangesSelectionKind.WorkingDirectory) {
+        expect(selection.diff).toBeNull()
+      }
     })
 
     it('returns same diff if selected file from previous state is found', () => {
@@ -176,19 +208,26 @@ describe('updateChangedFiles', () => {
 
       // first file was selected the last time we updated state
       const selectedFileIDs = [files[0].id]
+      const diff: IBinaryDiff = { kind: DiffType.Binary }
 
       const prevState = createState({
         workingDirectory,
-        selectedFileIDs,
-        diff: { kind: DiffType.Binary },
+        selection: {
+          kind: ChangesSelectionKind.WorkingDirectory,
+          selectedFileIDs,
+          diff,
+        },
       })
 
       // same working directory is provided as last time
       const status = createStatus({ workingDirectory })
 
-      const { diff } = updateChangedFiles(prevState, status, false)
+      const { selection } = updateChangedFiles(prevState, status, false)
+      expect(selection.kind).toBe(ChangesSelectionKind.WorkingDirectory)
 
-      expect(diff).toBe(prevState.diff)
+      if (selection.kind === ChangesSelectionKind.WorkingDirectory) {
+        expect(selection.diff).toBe(diff)
+      }
     })
   })
 })

--- a/app/test/unit/stores/updates/update-changed-files-test.ts
+++ b/app/test/unit/stores/updates/update-changed-files-test.ts
@@ -33,7 +33,7 @@ const files = [
 ]
 
 describe('updateChangedFiles', () => {
-  describe(ChangesSelectionKind.WorkingDirectory, () => {
+  describe('workingDirectory', () => {
     let partiallySelectedFile: WorkingDirectoryFileChange
     let oldWorkingDirectory: WorkingDirectoryStatus
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This PR updates our model to match the constraints of the user interface. In particular this makes sure that since it should only be possible to select either a changed file in the working directory or a stash entry.

**Closes #7281** - Focus gets reset from stashed file change list to changes list when app regains focus
**Closes #7280** - Overwriting stashes show old diff state
**Closes #7270** - Move the responsibility of loading stash files from the component to the AppStore
**Closes #7312** - Selection is not reset when stash entry disappears

## Description

After reading #7264 I came to the conclusion that the way we deal with state surrounding stashes is working against us. I had a similar comment in the initial review of the stashing PR though that was focused more on the performance implications.

> This is a dangerous pattern, we should not be calling the dispatcher from render methods. The Repository component could get re-rendered any number of times before the loadStashedFiles method is is able to complete and emit an update, causing us to shell out to Git for each render.
>
>  I think we can find a much better pattern for this by letting the appStore take care of loading stashed files when the right conditions exists for doing so but in the meantime I'm going to open a PR to ensure we're never loading stashed files more than once for any stash entry.

Prior to this PR we differentiated between whether the user was looking at a stash or not by one flag in changes state called `shouldShowStashedChanges`. This flag was toggled when the user selected or deselected the stash entry in the sidebar. Next to this flag we kept the state of the currently selected stashed file (if any) alongside the currently selected file (or files) in the working directory.

In doing so we've created a scenario where it's perfectly legal from the perspective of the model to have selected a file in the working directory and a file in a stash entry at the same time and we therefore put the responsibility of ensuring that never happened on the UI. Such an approach is prone to errors and confusing to deal with as a developer.

With this PR we're restructuring our models to more closely reflect the reality of the UI, i.e. one may select a file in the working directory, or a file in a stash, but never both.

Additionally this moves us away from having all stash entries for all branches available in the UI layer and instead let the stores take care of figuring out whether the _current_ branch has an associated stash entry or not.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes