### PR TITLE
[Stashing] Changed the button title from Clear to Discard

### DIFF
--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -119,7 +119,7 @@ const Header: React.SFC<{
     <div className="header">
       <h3>Stashed changes</h3>
       <ButtonGroup>
-        <Button onClick={onClearClick}>Clear</Button>
+        <Button onClick={onClearClick}>Discard</Button>
         <Button onClick={onSubmitClick} type="submit">
           Restore
         </Button>


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #7304**

## Description
This PR changes the button title in stash diff UI from `Clear` to `Discard`.

### Screenshot
![ToDiscard](https://user-images.githubusercontent.com/11808736/56226488-4c2b6880-60ae-11e9-9e09-b2e12043b30c.jpg)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
