### PR TITLE
show untracked files in stash

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -175,7 +175,7 @@ export async function getStashedFiles(
 
   const trackedFiles = parseChangedFiles(trackedResult.stdout, committish)
 
-  const untrackedArgs = [...baseArgs, NullTreeSHA, `${committish}^3`, '--']
+  const untrackedArgs = [...baseArgs, `${NullTreeSHA}..${committish}^3`, '--']
   const untrackedResult = await git(
     untrackedArgs,
     repository.path,

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -160,22 +160,22 @@ const NullTreeSHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
  */
 export async function getStashedFiles(
   repository: Repository,
-  committish: string
+  stashSha: string
 ): Promise<ReadonlyArray<CommittedFileChange>> {
   // opt-in for rename detection (-M) and copies detection (-C)
   // this is equivalent to the user configuring 'diff.renames' to 'copies'
   // NOTE: order here matters - doing -M before -C means copies aren't detected
   const baseArgs = ['diff', '-C', '-M', '--name-status', '-z']
-  const trackedArgs = [...baseArgs, `${committish}^..${committish}`, '--']
+  const trackedArgs = [...baseArgs, `${stashSha}^..${stashSha}`, '--']
   const trackedResult = await git(
     trackedArgs,
     repository.path,
     'getStashedFiles (tracked)'
   )
 
-  const trackedFiles = parseChangedFiles(trackedResult.stdout, committish)
+  const trackedFiles = parseChangedFiles(trackedResult.stdout, stashSha)
 
-  const untrackedArgs = [...baseArgs, `${NullTreeSHA}..${committish}^3`, '--']
+  const untrackedArgs = [...baseArgs, `${NullTreeSHA}..${stashSha}^3`, '--']
   const untrackedResult = await git(
     untrackedArgs,
     repository.path,
@@ -193,7 +193,7 @@ export async function getStashedFiles(
   if (untrackedResult.exitCode === 0 && untrackedResult.stdout.length > 0) {
     const untrackedFiles = parseChangedFiles(
       untrackedResult.stdout,
-      `${committish}^3`
+      `${stashSha}^3`
     )
 
     // we want untracked changes to override potential

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -148,8 +148,6 @@ function extractBranchFromMessage(message: string): string | null {
 /**
  * Get the files that were changed in the given stash commit.
  *
- * Runs `git diff` twice, once for tracked changes in the stash
- * and once for untracked changes in the stash.
  * This is different than `getChangedFiles` because stashes
  * have _3 parents(!!!)_
  */

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -185,12 +185,18 @@ export async function getStashedFiles(
     }
   )
 
-  const untrackedFiles = parseChangedFiles(
-    untrackedResult.stdout,
-    `${committish}^3`
-  )
+  // if that command is successful and has output, we'll parse it
+  // and merge it with the other output
+  if (untrackedResult.exitCode === 0 && untrackedResult.stdout.length > 0) {
+    const untrackedFiles = parseChangedFiles(
+      untrackedResult.stdout,
+      `${committish}^3`
+    )
 
-  // order is important here, since we want untracked changes to
-  // override potential (and uncommon) collisions with tracked changes
-  return [...trackedFiles, ...untrackedFiles]
+    // order is important here, since we want untracked changes to
+    // override potential (and uncommon) collisions with tracked changes
+    return [...trackedFiles, ...untrackedFiles]
+  }
+
+  return trackedFiles
 }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -144,7 +144,10 @@ function extractBranchFromMessage(message: string): string | null {
   return match === null || match[1].length === 0 ? null : match[1]
 }
 
-/** The SHA for the empty tree. */
+/**
+ * The SHA for the [empty tree](https://stackoverflow.com/questions/9765453/is-gits-semi-secret-empty-tree-object-reliable-and-why-is-there-not-a-symbolic).
+ *
+ */
 const NullTreeSHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 /**

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -144,7 +144,7 @@ function extractBranchFromMessage(message: string): string | null {
   return match === null || match[1].length === 0 ? null : match[1]
 }
 
-/** The SHA for the null tree. */
+/** The SHA for the empty tree. */
 const NullTreeSHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 /**

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -196,9 +196,15 @@ export async function getStashedFiles(
       `${committish}^3`
     )
 
-    // order is important here, since we want untracked changes to
-    // override potential (and uncommon) collisions with tracked changes
-    return [...trackedFiles, ...untrackedFiles]
+    // we want untracked changes to override potential
+    // collisions with tracked changes
+    const allFiles = Array.from(untrackedFiles)
+    for (const trackedFile of trackedFiles) {
+      if (!untrackedFiles.some(f => f.path === trackedFile.path)) {
+        allFiles.push(trackedFile)
+      }
+    }
+    return allFiles
   }
 
   return trackedFiles

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -166,7 +166,7 @@ export async function getStashedFiles(
   // this is equivalent to the user configuring 'diff.renames' to 'copies'
   // NOTE: order here matters - doing -M before -C means copies aren't detected
   const baseArgs = ['diff', '-C', '-M', '--name-status', '-z']
-  const trackedArgs = [...baseArgs, committish, `${committish}^`, '--']
+  const trackedArgs = [...baseArgs, `${committish}^..${committish}`, '--']
   const trackedResult = await git(
     trackedArgs,
     repository.path,

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -166,7 +166,8 @@ export async function getStashedFiles(
   return [...files.values()].sort((x, y) => compare(x.path, y.path))
 }
 
-/**Same thing as `getChangedFiles` but with extra handling for 128 exit code
+/**
+ * Same thing as `getChangedFiles` but with extra handling for 128 exit code
  * (which happens if the commit's parent is not valid)
  *
  * **TODO:** merge this with `getChangedFiles` in `log.ts`


### PR DESCRIPTION
## Overview

closes #7287 

Let's please review this ASAP so we can ship it to beta. 👩‍🎤 

![gif](https://user-images.githubusercontent.com/964912/56230529-54918e00-6031-11e9-8ed3-3d1345ed5f87.gif)

## Description

We now run `git diff` twice to get a list of files for a stash:
- once for tracked files (which we were doing before)
- again for untracked files (which is new)

This is because git stashes store untracked files separately from tracked files (read: in two different commits).

## Discussion

There are some minor opportunities to refactor this function, but I'm not sure they are that worthwhile, and may even make the code harder to read. There's potentially a more core git function we could derive but that would take more reflection from me to isolate.

I also want to add test coverage for this function, and will file a follow up issue for that.