### PR TITLE
Dismiss popup when new branch creation is completed

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2701,7 +2701,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    return await this._checkoutBranch(repository, branch)
+    const repo = await this._checkoutBranch(repository, branch)
+    this._closePopup()
+    return repo
   }
 
   private updateCheckoutProgress(


### PR DESCRIPTION
Fixes regression that caused the _New Branch_ dialog to not be dismissed when there were no changes present in working directory.

**After**
![2019-04-17 11 54 57](https://user-images.githubusercontent.com/1715082/56306329-c3411b00-6107-11e9-8840-684f86ebe27d.gif)

