### PR TITLE
cleanup rebase if unable to start the operation

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -937,6 +937,11 @@ export class Dispatcher {
         tip,
         beforeSha
       )
+    } else if (result === RebaseResult.Error) {
+      // we were unable to successfully start the rebase, and an error should
+      // be shown through the default error handling infrastructure, so we can
+      // just abandon the rebase for now
+      this.endRebaseFlow(repository)
     }
   }
 


### PR DESCRIPTION
## Overview

**Closes #7223**

## Description

If you don't have `rebase.autostash=true` in your Git config, a rebase cannot be started if you have uncommitted changes in your repository. This was displayed to the user by our error handling infrastucture.

<img width="1285" src="https://user-images.githubusercontent.com/359239/56316321-60b04500-6130-11e9-8015-f26879e5b7a0.png">

The part that was missing about this was that we didn't abandon the rebase flow - which meant the progress dialog would be shown after this despite there not being anything to do.

This is now addressed.

## Release notes

Notes: no-notes
