### PR TITLE
check if the target branch has already been rebased 

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3917,20 +3917,31 @@ export class AppStore extends TypedBaseStore<IAppState> {
       targetBranch.tip.sha
     )
 
-    // TODO: in what situations might this not be possible to compute
+    // TODO: in what situations might this not be possible to compute?
 
-    // TODO: check if this is a fast-forward (i.e. the selected branch is
-    //       a direct descendant of the base branch) because this is a
-    //       trivial rebase
+    const base = await getMergeBase(
+      repository,
+      baseBranch.tip.sha,
+      targetBranch.tip.sha
+    )
+
+    if (base === baseBranch.tip.sha) {
+      // the target branch is a direct descendant of the base branch
+      // which means the target branch is already up to date
+      preview = {
+        kind: ComputedAction.Clean,
+        commits: [],
+      }
+    } else {
+      preview = {
+        kind: ComputedAction.Clean,
+        commits,
+      }
+    }
 
     // TODO: generate the patches associated with these commits and see if
     //       they will apply to the base branch - if it fails, there will be
     //       conflicts to come
-
-    preview = {
-      kind: ComputedAction.Clean,
-      commits,
-    }
 
     this.repositoryStateCache.updateRebaseState(repository, () => ({
       preview,


### PR DESCRIPTION
## Overview

**Related to #7341**

## Description

This PR addresses a scenario I had in mind when previewing the rebase: "what if there's no work to do?"

To test this out, I check for the merge base between the target branch and the base branch. If the merge base is the same as the base branch, this means the target branch is directly accessible from the base branch - so the rebase is a no-op.

The latest beta shows this message in the footer:

<img width="463"  src="https://user-images.githubusercontent.com/359239/56360194-4622ae00-61ba-11e9-9b2a-f5e989335394.png">

With this PR, it now shows this (and prevents the rebase from proceeding):

<img width="468" src="https://user-images.githubusercontent.com/359239/56360195-46bb4480-61ba-11e9-8ecf-d567d500afe6.png">

I'm not 💯% sold on the words yet, but I mostly wanted to open this up to confirm it's the same scenario from #7341 that would avoid the confusion about an unnecessary rebase...

## Release notes

Notes: no-notes
