### PR TITLE
keep the branch name in memory while the rebase is in progress

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1823,13 +1823,20 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (step.kind === RebaseStep.ShowConflicts) {
+    if (
+      step.kind === RebaseStep.ShowConflicts ||
+      step.kind === RebaseStep.ConfirmAbort
+    ) {
+      // merge in new conflicts with known branches so they are not forgotten
+      const { baseBranch, targetBranch } = step.conflictState
+      const newConflictsState = {
+        ...conflictState,
+        baseBranch,
+        targetBranch,
+      }
+
       this.repositoryStateCache.updateRebaseState(repository, () => ({
-        step: { ...step, conflictState },
-      }))
-    } else if (step.kind === RebaseStep.ConfirmAbort) {
-      this.repositoryStateCache.updateRebaseState(repository, () => ({
-        step: { ...step, conflictState },
+        step: { ...step, conflictState: newConflictsState },
       }))
     }
   }

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -17,12 +17,12 @@ interface IContinueRebaseProps {
 
 export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
   private onSubmit = async () => {
-    const { manualResolutions } = this.props.rebaseConflictState
+    const { rebaseConflictState } = this.props
 
     await this.props.dispatcher.continueRebase(
       this.props.repository,
       this.props.workingDirectory,
-      manualResolutions
+      rebaseConflictState
     )
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -10,7 +10,6 @@ import {
   FoldoutType,
   ICompareFormUpdate,
   RepositorySectionTab,
-  isRebaseConflictState,
   isMergeConflictState,
   RebaseConflictState,
 } from '../../lib/app-state'
@@ -953,19 +952,15 @@ export class Dispatcher {
   public async continueRebase(
     repository: Repository,
     workingDirectory: WorkingDirectoryStatus,
-    manualResolutions: ReadonlyMap<string, ManualConflictResolution>
+    conflictsState: RebaseConflictState
   ): Promise<void> {
     const stateBefore = this.repositoryStateManager.get(repository)
-    const { conflictState } = stateBefore.changesState
-
-    if (conflictState === null || !isRebaseConflictState(conflictState)) {
-      log.warn(
-        `[continueRebase] no conflicts found, likely an invalid rebase state`
-      )
-      return
-    }
-
-    const { targetBranch, baseBranch, originalBranchTip } = conflictState
+    const {
+      targetBranch,
+      baseBranch,
+      originalBranchTip,
+      manualResolutions,
+    } = conflictsState
 
     const beforeSha = getTipSha(stateBefore.branchesState.tip)
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -915,7 +915,13 @@ export class Dispatcher {
         return
       }
 
-      this.switchToConflicts(repository, conflictState)
+      const conflictsWithBranches: RebaseConflictState = {
+        ...conflictState,
+        baseBranch: baseBranch.name,
+        targetBranch: targetBranch.name,
+      }
+
+      this.switchToConflicts(repository, conflictsWithBranches)
     } else if (result === RebaseResult.CompletedWithoutError) {
       if (tip.kind !== TipState.Valid) {
         log.warn(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1007,7 +1007,14 @@ export class Dispatcher {
         return
       }
 
-      this.switchToConflicts(repository, conflictState)
+      // ensure branches are persisted when transitioning back to conflicts
+      const conflictsWithBranches: RebaseConflictState = {
+        ...conflictState,
+        baseBranch,
+        targetBranch,
+      }
+
+      this.switchToConflicts(repository, conflictsWithBranches)
     } else if (result === RebaseResult.CompletedWithoutError) {
       if (tip.kind !== TipState.Valid) {
         log.warn(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -874,11 +874,13 @@ export class Dispatcher {
 
     const beforeSha = getTipSha(stateBefore.branchesState.tip)
 
-    log.info(`[rebase] starting rebase for ${targetBranch} at ${beforeSha}`)
+    log.info(
+      `[rebase] starting rebase for ${targetBranch.name} at ${beforeSha}`
+    )
     log.info(
       `[rebase] to restore the previous state if this completed rebase is unsatisfactory:`
     )
-    log.info(`[rebase] - git checkout ${targetBranch}`)
+    log.info(`[rebase] - git checkout ${targetBranch.name}`)
     log.info(`[rebase] - git reset ${beforeSha} --hard`)
 
     const result = await this.appStore._rebase(
@@ -925,7 +927,7 @@ export class Dispatcher {
     } else if (result === RebaseResult.CompletedWithoutError) {
       if (tip.kind !== TipState.Valid) {
         log.warn(
-          `[continueRebase] tip after completing rebase is ${
+          `[rebase] tip after completing rebase is ${
             tip.kind
           } but this should be a valid tip if the rebase completed without error`
         )

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -102,7 +102,7 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
       return this.props.dispatcher.continueRebase(
         this.props.repository,
         this.props.workingDirectory,
-        conflictState.manualResolutions
+        conflictState
       )
     }
 


### PR DESCRIPTION
## Overview

**Closes #7220**

## Description

This PR addresses the work required to "remember" the branches involved with the rebase as the user works through the back-and-forth of resolving conflicts.

As the flow needs to update itself as the conflicts are resolved, but the base branch chosen at the start needs to be remember, we need to:

 - add those to the initial conflicts state - fae973c
 - merge those in with new conflicts reported by the app - 8320cfb

The other two commits in this PR:

 - I was able to simplify some of the work by providing the known valid state - 940b55f6829f7bfa6e26da9d0722d691c6116141
 - Tidied up some tracing messages - d1e2ce3f082482d425604eb9a65b67f847c87922

## Release notes

Notes: no-notes
