### PR TITLE
lock file state when in rebase conflicts

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react'
 
-import { AppFileStatus } from '../../models/status'
 import { PathLabel } from '../lib/path-label'
 import { Octicon, iconForStatus } from '../octicons'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { mapStatus } from '../../lib/status'
+import { WorkingDirectoryFileChange } from '../../models/status'
 
 interface IChangedFileProps {
-  readonly id: string
-  readonly path: string
-  readonly status: AppFileStatus
+  readonly file: WorkingDirectoryFileChange
   readonly include: boolean | null
   readonly availableWidth: number
   readonly disableSelection: boolean
@@ -17,9 +15,7 @@ interface IChangedFileProps {
 
   /** Callback called when user right-clicks on an item */
   readonly onContextMenu: (
-    id: string,
-    path: string,
-    status: AppFileStatus,
+    file: WorkingDirectoryFileChange,
     event: React.MouseEvent<HTMLDivElement>
   ) => void
 }
@@ -28,7 +24,7 @@ interface IChangedFileProps {
 export class ChangedFile extends React.Component<IChangedFileProps, {}> {
   private handleCheckboxChange = (event: React.FormEvent<HTMLInputElement>) => {
     const include = event.currentTarget.checked
-    this.props.onIncludeChanged(this.props.path, include)
+    this.props.onIncludeChanged(this.props.file.path, include)
   }
 
   private get checkboxValue(): CheckboxValue {
@@ -42,7 +38,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
   }
 
   public render() {
-    const status = this.props.status
+    const { status, path } = this.props.file
     const fileStatus = mapStatus(status)
 
     const listItemPadding = 10 * 2
@@ -70,8 +66,8 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
         />
 
         <PathLabel
-          path={this.props.path}
-          status={this.props.status}
+          path={path}
+          status={status}
           availableWidth={availablePathWidth}
         />
 
@@ -85,11 +81,6 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
   }
 
   private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    this.props.onContextMenu(
-      this.props.id,
-      this.props.path,
-      this.props.status,
-      event
-    )
+    this.props.onContextMenu(this.props.file, event)
   }
 }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -321,6 +321,36 @@ export class ChangesList extends React.Component<
     }
   }
 
+  private getRevealInFileManagerMenuItem = (
+    file: WorkingDirectoryFileChange
+  ): IMenuItem => {
+    return {
+      label: RevealInFileManagerLabel,
+      action: () => revealInFileManager(this.props.repository, file.path),
+      enabled: file.status.kind !== AppFileStatusKind.Deleted,
+    }
+  }
+
+  private getOpenInExternalEditorMenuItem = (
+    file: WorkingDirectoryFileChange,
+    enabled: boolean
+  ): IMenuItem => {
+    const { externalEditorLabel, repository } = this.props
+
+    const openInExternalEditor = externalEditorLabel
+      ? `Open in ${externalEditorLabel}`
+      : DefaultEditorLabel
+
+    return {
+      label: openInExternalEditor,
+      action: () => {
+        const fullPath = Path.join(repository.path, file.path)
+        this.props.onOpenInExternalEditor(fullPath)
+      },
+      enabled,
+    }
+  }
+
   private getDefaultContextMenu(
     file: WorkingDirectoryFileChange
   ): ReadonlyArray<IMenuItem> {
@@ -329,16 +359,7 @@ export class ChangesList extends React.Component<
     const extension = Path.extname(path)
     const isSafeExtension = isSafeFileExtension(extension)
 
-    const {
-      workingDirectory,
-      externalEditorLabel,
-      selectedFileIDs,
-      repository,
-    } = this.props
-
-    const openInExternalEditor = externalEditorLabel
-      ? `Open in ${externalEditorLabel}`
-      : DefaultEditorLabel
+    const { workingDirectory, selectedFileIDs } = this.props
 
     const selectedFiles = new Array<WorkingDirectoryFileChange>()
     const paths = new Array<string>()
@@ -420,19 +441,8 @@ export class ChangesList extends React.Component<
     items.push(
       { type: 'separator' },
       this.getCopyPathMenuItem(file),
-      {
-        label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(repository, path),
-        enabled: status.kind !== AppFileStatusKind.Deleted,
-      },
-      {
-        label: openInExternalEditor,
-        action: () => {
-          const fullPath = Path.join(repository.path, path)
-          this.props.onOpenInExternalEditor(fullPath)
-        },
-        enabled,
-      },
+      this.getRevealInFileManagerMenuItem(file),
+      this.getOpenInExternalEditorMenuItem(file, enabled),
       {
         label: OpenWithDefaultProgramLabel,
         action: () => this.props.onOpenItem(path),
@@ -451,12 +461,6 @@ export class ChangesList extends React.Component<
     const extension = Path.extname(path)
     const isSafeExtension = isSafeFileExtension(extension)
 
-    const { externalEditorLabel, repository } = this.props
-
-    const openInExternalEditor = externalEditorLabel
-      ? `Open in ${externalEditorLabel}`
-      : DefaultEditorLabel
-
     const items = new Array<IMenuItem>()
 
     if (file.status.kind === AppFileStatusKind.Untracked) {
@@ -474,19 +478,8 @@ export class ChangesList extends React.Component<
 
     items.push(
       this.getCopyPathMenuItem(file),
-      {
-        label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(repository, path),
-        enabled: status.kind !== AppFileStatusKind.Deleted,
-      },
-      {
-        label: openInExternalEditor,
-        action: () => {
-          const fullPath = Path.join(repository.path, path)
-          this.props.onOpenInExternalEditor(fullPath)
-        },
-        enabled,
-      },
+      this.getRevealInFileManagerMenuItem(file),
+      this.getOpenInExternalEditorMenuItem(file, enabled),
       {
         label: OpenWithDefaultProgramLabel,
         action: () => this.props.onOpenItem(path),

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -186,7 +186,15 @@ export class ChangesList extends React.Component<
   }
 
   private renderRow = (row: number): JSX.Element => {
-    const file = this.props.workingDirectory.files[row]
+    const {
+      workingDirectory,
+      rebaseConflictState,
+      isCommitting,
+      onIncludeChanged,
+      availableWidth,
+    } = this.props
+
+    const file = workingDirectory.files[row]
     const selection = file.selection.getSelectionType()
 
     const includeAll =
@@ -197,12 +205,11 @@ export class ChangesList extends React.Component<
         : null
 
     const include =
-      this.props.rebaseConflictState !== null
+      rebaseConflictState !== null
         ? file.status.kind !== AppFileStatusKind.Untracked
         : includeAll
 
-    const disableSelection =
-      this.props.isCommitting || this.props.rebaseConflictState !== null
+    const disableSelection = isCommitting || rebaseConflictState !== null
 
     return (
       <ChangedFile
@@ -212,8 +219,8 @@ export class ChangesList extends React.Component<
         include={include}
         key={file.id}
         onContextMenu={this.onItemContextMenu}
-        onIncludeChanged={this.props.onIncludeChanged}
-        availableWidth={this.props.availableWidth}
+        onIncludeChanged={onIncludeChanged}
+        availableWidth={availableWidth}
         disableSelection={disableSelection}
       />
     )

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -62,12 +62,27 @@ function getIncludeAllValue(
   rebaseConflictState: RebaseConflictState | null
 ) {
   if (rebaseConflictState !== null) {
-    // there should be changes to rebase if conflicts are detected
-    return workingDirectory.files.some(
+    if (workingDirectory.files.length === 0) {
+      // the current commit will be skipped in the rebase
+      return CheckboxValue.Off
+    }
+
+    // untracked files will be skipped by the rebase, so we need to ensure that
+    // the "Include All" checkbox matches this state
+    const onlyUntrackedFilesFound = workingDirectory.files.every(
       f => f.status.kind === AppFileStatusKind.Untracked
     )
-      ? CheckboxValue.Mixed
-      : CheckboxValue.On
+
+    if (onlyUntrackedFilesFound) {
+      return CheckboxValue.Off
+    }
+
+    const onlyTrackedFilesFound = workingDirectory.files.every(
+      f => f.status.kind !== AppFileStatusKind.Untracked
+    )
+
+    // show "Mixed" if we have a mixture of tracked and untracked changes
+    return onlyTrackedFilesFound ? CheckboxValue.On : CheckboxValue.Mixed
   }
 
   const { includeAll } = workingDirectory

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -319,17 +319,24 @@ export class ChangesList extends React.Component<
 
     const extension = Path.extname(path)
     const isSafeExtension = isSafeFileExtension(extension)
-    const openInExternalEditor = this.props.externalEditorLabel
-      ? `Open in ${this.props.externalEditorLabel}`
+
+    const {
+      workingDirectory,
+      externalEditorLabel,
+      selectedFileIDs,
+      repository,
+    } = this.props
+
+    const openInExternalEditor = externalEditorLabel
+      ? `Open in ${externalEditorLabel}`
       : DefaultEditorLabel
 
-    const wd = this.props.workingDirectory
     const selectedFiles = new Array<WorkingDirectoryFileChange>()
     const paths = new Array<string>()
     const extensions = new Set<string>()
 
     const addItemToArray = (fileID: string) => {
-      const newFile = wd.findFileWithID(fileID)
+      const newFile = workingDirectory.findFileWithID(fileID)
       if (newFile) {
         selectedFiles.push(newFile)
         paths.push(newFile.path)
@@ -341,10 +348,10 @@ export class ChangesList extends React.Component<
       }
     }
 
-    if (this.props.selectedFileIDs.includes(id)) {
+    if (selectedFileIDs.includes(id)) {
       // user has selected a file inside an existing selection
       // -> context menu entries should be applied to all selected files
-      this.props.selectedFileIDs.forEach(addItemToArray)
+      selectedFileIDs.forEach(addItemToArray)
     } else {
       // this is outside their previous selection
       // -> context menu entries should be applied to just this file
@@ -404,19 +411,19 @@ export class ChangesList extends React.Component<
       {
         label: CopyFilePathLabel,
         action: () => {
-          const fullPath = Path.join(this.props.repository.path, path)
+          const fullPath = Path.join(repository.path, path)
           clipboard.writeText(fullPath)
         },
       },
       {
         label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(this.props.repository, path),
+        action: () => revealInFileManager(repository, path),
         enabled: status.kind !== AppFileStatusKind.Deleted,
       },
       {
         label: openInExternalEditor,
         action: () => {
-          const fullPath = Path.join(this.props.repository.path, path)
+          const fullPath = Path.join(repository.path, path)
           this.props.onOpenInExternalEditor(fullPath)
         },
         enabled: isSafeExtension && status.kind !== AppFileStatusKind.Deleted,

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -474,6 +474,10 @@ export class ChangesList extends React.Component<
     } = this.props
 
     if (rebaseConflictState !== null && enablePullWithRebase()) {
+      const hasUntrackedChanges = workingDirectory.files.some(
+        f => f.status.kind === AppFileStatusKind.Untracked
+      )
+
       return (
         <ContinueRebase
           dispatcher={dispatcher}
@@ -481,6 +485,7 @@ export class ChangesList extends React.Component<
           rebaseConflictState={rebaseConflictState}
           workingDirectory={workingDirectory}
           isCommitting={isCommitting}
+          hasUntrackedChanges={hasUntrackedChanges}
         />
       )
     }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -309,6 +309,18 @@ export class ChangesList extends React.Component<
     showContextualMenu(items)
   }
 
+  private getCopyPathMenuItem = (
+    file: WorkingDirectoryFileChange
+  ): IMenuItem => {
+    return {
+      label: CopyFilePathLabel,
+      action: () => {
+        const fullPath = Path.join(this.props.repository.path, file.path)
+        clipboard.writeText(fullPath)
+      },
+    }
+  }
+
   private getDefaultContextMenu(
     file: WorkingDirectoryFileChange
   ): ReadonlyArray<IMenuItem> {
@@ -407,13 +419,7 @@ export class ChangesList extends React.Component<
 
     items.push(
       { type: 'separator' },
-      {
-        label: CopyFilePathLabel,
-        action: () => {
-          const fullPath = Path.join(repository.path, path)
-          clipboard.writeText(fullPath)
-        },
-      },
+      this.getCopyPathMenuItem(file),
       {
         label: RevealInFileManagerLabel,
         action: () => revealInFileManager(repository, path),
@@ -467,13 +473,7 @@ export class ChangesList extends React.Component<
     const enabled = isSafeExtension && status.kind !== AppFileStatusKind.Deleted
 
     items.push(
-      {
-        label: CopyFilePathLabel,
-        action: () => {
-          const fullPath = Path.join(repository.path, path)
-          clipboard.writeText(fullPath)
-        },
-      },
+      this.getCopyPathMenuItem(file),
       {
         label: RevealInFileManagerLabel,
         action: () => revealInFileManager(repository, path),

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -485,6 +485,8 @@ export class ChangesList extends React.Component<
         enabled: isSafeExtension && status.kind !== AppFileStatusKind.Deleted,
       }
     )
+
+    showContextualMenu(items)
   }
 
   private onItemContextMenu = (

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -6,7 +6,6 @@ import { Dispatcher } from '../dispatcher'
 import { IMenuItem } from '../../lib/menu-item'
 import { revealInFileManager } from '../../lib/app-shell'
 import {
-  AppFileStatus,
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
   AppFileStatusKind,
@@ -237,9 +236,7 @@ export class ChangesList extends React.Component<
 
     return (
       <ChangedFile
-        id={file.id}
-        path={file.path}
-        status={file.status}
+        file={file}
         include={include}
         key={file.id}
         onContextMenu={this.onItemContextMenu}
@@ -313,12 +310,12 @@ export class ChangesList extends React.Component<
   }
 
   private onItemContextMenu = (
-    id: string,
-    path: string,
-    status: AppFileStatus,
+    file: WorkingDirectoryFileChange,
     event: React.MouseEvent<HTMLDivElement>
   ) => {
     event.preventDefault()
+
+    const { id, path, status } = file
 
     const extension = Path.extname(path)
     const isSafeExtension = isSafeFileExtension(extension)

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -196,17 +196,25 @@ export class ChangesList extends React.Component<
         ? false
         : null
 
+    const include =
+      this.props.rebaseConflictState !== null
+        ? file.status.kind !== AppFileStatusKind.Untracked
+        : includeAll
+
+    const disableSelection =
+      this.props.isCommitting || this.props.rebaseConflictState !== null
+
     return (
       <ChangedFile
         id={file.id}
         path={file.path}
         status={file.status}
-        include={includeAll}
+        include={include}
         key={file.id}
         onContextMenu={this.onItemContextMenu}
         onIncludeChanged={this.props.onIncludeChanged}
         availableWidth={this.props.availableWidth}
-        disableSelection={this.props.isCommitting}
+        disableSelection={disableSelection}
       />
     )
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -309,6 +309,22 @@ export class ChangesList extends React.Component<
     showContextualMenu(items)
   }
 
+  private getDiscardChangesMenuItem = (
+    paths: ReadonlyArray<string>
+  ): IMenuItem => {
+    return {
+      label: this.getDiscardChangesMenuItemLabel(paths),
+      action: () => this.onDiscardChanges(paths),
+    }
+  }
+
+  private getDiscardAllChangesMenuItem = (): IMenuItem => {
+    return {
+      label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
+      action: () => this.onDiscardAllChanges(),
+    }
+  }
+
   private getCopyPathMenuItem = (
     file: WorkingDirectoryFileChange
   ): IMenuItem => {
@@ -389,14 +405,8 @@ export class ChangesList extends React.Component<
     }
 
     const items: IMenuItem[] = [
-      {
-        label: this.getDiscardChangesMenuItemLabel(paths),
-        action: () => this.onDiscardChanges(paths),
-      },
-      {
-        label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
-        action: () => this.onDiscardAllChanges(),
-      },
+      this.getDiscardChangesMenuItem(paths),
+      this.getDiscardAllChangesMenuItem(),
       { type: 'separator' },
     ]
     if (paths.length === 1) {
@@ -464,14 +474,9 @@ export class ChangesList extends React.Component<
     const items = new Array<IMenuItem>()
 
     if (file.status.kind === AppFileStatusKind.Untracked) {
-      const paths = [file.path]
-      items.push(
-        {
-          label: this.getDiscardChangesMenuItemLabel(paths),
-          action: () => this.onDiscardChanges(paths),
-        },
-        { type: 'separator' }
-      )
+      items.push(this.getDiscardChangesMenuItem([file.path]), {
+        type: 'separator',
+      })
     }
 
     const enabled = isSafeExtension && status.kind !== AppFileStatusKind.Deleted

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -57,6 +57,7 @@ const StashIcon = new OcticonSymbol(
 
 const GitIgnoreFileName = '.gitignore'
 
+/** Compute the 'Include All' checkbox value from the repository state */
 function getIncludeAllValue(
   workingDirectory: WorkingDirectoryStatus,
   rebaseConflictState: RebaseConflictState | null

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -57,6 +57,17 @@ const StashIcon = new OcticonSymbol(
 
 const GitIgnoreFileName = '.gitignore'
 
+function getIncludeAllValue(workingDirectory: WorkingDirectoryStatus) {
+  const { includeAll } = workingDirectory
+  if (includeAll === true) {
+    return CheckboxValue.On
+  } else if (includeAll === false) {
+    return CheckboxValue.Off
+  } else {
+    return CheckboxValue.Mixed
+  }
+}
+
 interface IChangesListProps {
   readonly repository: Repository
   readonly workingDirectory: WorkingDirectoryStatus
@@ -224,17 +235,6 @@ export class ChangesList extends React.Component<
         disableSelection={disableSelection}
       />
     )
-  }
-
-  private get includeAllValue(): CheckboxValue {
-    const includeAll = this.props.workingDirectory.includeAll
-    if (includeAll === true) {
-      return CheckboxValue.On
-    } else if (includeAll === false) {
-      return CheckboxValue.Off
-    } else {
-      return CheckboxValue.Mixed
-    }
   }
 
   private onDiscardAllChanges = () => {
@@ -467,7 +467,8 @@ export class ChangesList extends React.Component<
     const fileCount = this.props.workingDirectory.files.length
 
     const anyFilesSelected =
-      fileCount > 0 && this.includeAllValue !== CheckboxValue.Off
+      fileCount > 0 &&
+      getIncludeAllValue(this.props.workingDirectory) !== CheckboxValue.Off
     const filesSelected = this.props.workingDirectory.files.filter(
       f => f.selection.getSelectionType() !== DiffSelectionType.None
     )
@@ -540,13 +541,14 @@ export class ChangesList extends React.Component<
     const fileCount = this.props.workingDirectory.files.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
     const filesDescription = `${fileCount} changed ${filesPlural}`
+    const includeAllValue = getIncludeAllValue(this.props.workingDirectory)
 
     return (
       <div className="changes-list-container file-list">
         <div className="header" onContextMenu={this.onContextMenu}>
           <Checkbox
             label={filesDescription}
-            value={this.includeAllValue}
+            value={includeAllValue}
             onChange={this.onIncludeAllChanged}
             disabled={fileCount === 0 || this.props.isCommitting}
           />

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -309,7 +309,9 @@ export class ChangesList extends React.Component<
     showContextualMenu(items)
   }
 
-  private getDefaultContextMenu(file: WorkingDirectoryFileChange) {
+  private getDefaultContextMenu(
+    file: WorkingDirectoryFileChange
+  ): ReadonlyArray<IMenuItem> {
     const { id, path, status } = file
 
     const extension = Path.extname(path)
@@ -433,7 +435,9 @@ export class ChangesList extends React.Component<
     return items
   }
 
-  private getRebaseContextMenu(file: WorkingDirectoryFileChange) {
+  private getRebaseContextMenu(
+    file: WorkingDirectoryFileChange
+  ): ReadonlyArray<IMenuItem> {
     const { path, status } = file
 
     const extension = Path.extname(path)

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -403,6 +403,8 @@ export class ChangesList extends React.Component<
         })
       })
 
+    const enabled = isSafeExtension && status.kind !== AppFileStatusKind.Deleted
+
     items.push(
       { type: 'separator' },
       {
@@ -423,12 +425,12 @@ export class ChangesList extends React.Component<
           const fullPath = Path.join(repository.path, path)
           this.props.onOpenInExternalEditor(fullPath)
         },
-        enabled: isSafeExtension && status.kind !== AppFileStatusKind.Deleted,
+        enabled,
       },
       {
         label: OpenWithDefaultProgramLabel,
         action: () => this.props.onOpenItem(path),
-        enabled: isSafeExtension && status.kind !== AppFileStatusKind.Deleted,
+        enabled,
       }
     )
 
@@ -462,6 +464,8 @@ export class ChangesList extends React.Component<
       )
     }
 
+    const enabled = isSafeExtension && status.kind !== AppFileStatusKind.Deleted
+
     items.push(
       {
         label: CopyFilePathLabel,
@@ -481,12 +485,12 @@ export class ChangesList extends React.Component<
           const fullPath = Path.join(repository.path, path)
           this.props.onOpenInExternalEditor(fullPath)
         },
-        enabled: isSafeExtension && status.kind !== AppFileStatusKind.Deleted,
+        enabled,
       },
       {
         label: OpenWithDefaultProgramLabel,
         action: () => this.props.onOpenItem(path),
-        enabled: isSafeExtension && status.kind !== AppFileStatusKind.Deleted,
+        enabled,
       }
     )
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -309,7 +309,7 @@ export class ChangesList extends React.Component<
     showContextualMenu(items)
   }
 
-  private showDefaultContextMenu(file: WorkingDirectoryFileChange) {
+  private getDefaultContextMenu(file: WorkingDirectoryFileChange) {
     const { id, path, status } = file
 
     const extension = Path.extname(path)
@@ -430,10 +430,10 @@ export class ChangesList extends React.Component<
       }
     )
 
-    showContextualMenu(items)
+    return items
   }
 
-  private showRebaseContextMenu(file: WorkingDirectoryFileChange) {
+  private getRebaseContextMenu(file: WorkingDirectoryFileChange) {
     const { path, status } = file
 
     const extension = Path.extname(path)
@@ -486,7 +486,7 @@ export class ChangesList extends React.Component<
       }
     )
 
-    showContextualMenu(items)
+    return items
   }
 
   private onItemContextMenu = (
@@ -495,11 +495,12 @@ export class ChangesList extends React.Component<
   ) => {
     event.preventDefault()
 
-    if (this.props.rebaseConflictState === null) {
-      this.showDefaultContextMenu(file)
-    } else {
-      this.showRebaseContextMenu(file)
-    }
+    const items =
+      this.props.rebaseConflictState === null
+        ? this.getDefaultContextMenu(file)
+        : this.getRebaseContextMenu(file)
+
+    showContextualMenu(items)
   }
 
   private getPlaceholderMessage(

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -465,27 +465,37 @@ export class ChangesList extends React.Component<
   }
 
   private renderCommitMessageForm = (): JSX.Element => {
-    if (this.props.rebaseConflictState !== null && enablePullWithRebase()) {
+    const {
+      rebaseConflictState,
+      workingDirectory,
+      repository,
+      dispatcher,
+      isCommitting,
+    } = this.props
+
+    if (rebaseConflictState !== null && enablePullWithRebase()) {
       return (
         <ContinueRebase
-          dispatcher={this.props.dispatcher}
-          repository={this.props.repository}
-          rebaseConflictState={this.props.rebaseConflictState}
-          workingDirectory={this.props.workingDirectory}
-          isCommitting={this.props.isCommitting}
+          dispatcher={dispatcher}
+          repository={repository}
+          rebaseConflictState={rebaseConflictState}
+          workingDirectory={workingDirectory}
+          isCommitting={isCommitting}
         />
       )
     }
 
-    const fileCount = this.props.workingDirectory.files.length
+    const fileCount = workingDirectory.files.length
+
+    const includeAllValue = getIncludeAllValue(
+      workingDirectory,
+      rebaseConflictState
+    )
 
     const anyFilesSelected =
-      fileCount > 0 &&
-      getIncludeAllValue(
-        this.props.workingDirectory,
-        this.props.rebaseConflictState
-      ) !== CheckboxValue.Off
-    const filesSelected = this.props.workingDirectory.files.filter(
+      fileCount > 0 && includeAllValue !== CheckboxValue.Off
+
+    const filesSelected = workingDirectory.files.filter(
       f => f.selection.getSelectionType() !== DiffSelectionType.None
     )
     const singleFileCommit = filesSelected.length === 1
@@ -497,12 +507,12 @@ export class ChangesList extends React.Component<
         gitHubUser={this.props.gitHubUser}
         commitAuthor={this.props.commitAuthor}
         anyFilesSelected={anyFilesSelected}
-        repository={this.props.repository}
-        dispatcher={this.props.dispatcher}
+        repository={repository}
+        dispatcher={dispatcher}
         commitMessage={this.props.commitMessage}
         focusCommitMessage={this.props.focusCommitMessage}
         autocompletionProviders={this.props.autocompletionProviders}
-        isCommitting={this.props.isCommitting}
+        isCommitting={isCommitting}
         showCoAuthoredBy={this.props.showCoAuthoredBy}
         coAuthors={this.props.coAuthors}
         placeholder={this.getPlaceholderMessage(
@@ -510,7 +520,7 @@ export class ChangesList extends React.Component<
           singleFileCommit
         )}
         singleFileCommit={singleFileCommit}
-        key={this.props.repository.id}
+        key={repository.id}
       />
     )
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -298,6 +298,11 @@ export class ChangesList extends React.Component<
   private onContextMenu = (event: React.MouseEvent<any>) => {
     event.preventDefault()
 
+    // need to preserve the working directory state while dealing with conflicts
+    if (this.props.rebaseConflictState !== null) {
+      return
+    }
+
     const items: IMenuItem[] = [
       {
         label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -49,7 +49,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
 
     const warnAboutUncommittedFiles = this.props.hasUntrackedChanges ? (
       <div className="warning-uncommitted-files">
-        Uncommitted files will be excluded
+        Untracked files will be excluded
       </div>
     ) : (
       undefined

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -13,6 +13,7 @@ interface IContinueRebaseProps {
   readonly workingDirectory: WorkingDirectoryStatus
   readonly rebaseConflictState: RebaseConflictState
   readonly isCommitting: boolean
+  readonly hasUntrackedChanges: boolean
 }
 
 export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
@@ -46,8 +47,16 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
 
     const loading = this.props.isCommitting ? <Loading /> : undefined
 
+    const warnAboutUncommittedFiles = this.props.hasUntrackedChanges ? (
+      <div className="warning-uncommitted-files">
+        Uncommitted files will be ignored
+      </div>
+    ) : (
+      undefined
+    )
+
     return (
-      <div id="continue-rebase" role="group">
+      <div id="continue-rebase">
         <Button
           type="submit"
           className="commit-button"
@@ -58,6 +67,8 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
           {loading}
           <span>{loading !== undefined ? 'Rebasing' : 'Continue rebase'}</span>
         </Button>
+
+        {warnAboutUncommittedFiles}
       </div>
     )
   }

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -47,8 +47,8 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
 
     const loading = this.props.isCommitting ? <Loading /> : undefined
 
-    const warnAboutUncommittedFiles = this.props.hasUntrackedChanges ? (
-      <div className="warning-uncommitted-files">
+    const warnAboutUntrackedFiles = this.props.hasUntrackedChanges ? (
+      <div className="warning-untracked-files">
         Untracked files will be excluded
       </div>
     ) : (
@@ -68,7 +68,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
           <span>{loading !== undefined ? 'Rebasing' : 'Continue rebase'}</span>
         </Button>
 
-        {warnAboutUncommittedFiles}
+        {warnAboutUntrackedFiles}
       </div>
     )
   }

--- a/app/src/ui/changes/continue-rebase.tsx
+++ b/app/src/ui/changes/continue-rebase.tsx
@@ -49,7 +49,7 @@ export class ContinueRebase extends React.Component<IContinueRebaseProps, {}> {
 
     const warnAboutUncommittedFiles = this.props.hasUntrackedChanges ? (
       <div className="warning-uncommitted-files">
-        Uncommitted files will be ignored
+        Uncommitted files will be excluded
       </div>
     ) : (
       undefined

--- a/app/styles/ui/changes/_continue-rebase.scss
+++ b/app/styles/ui/changes/_continue-rebase.scss
@@ -10,6 +10,11 @@
   background-color: var(--box-alt-background-color);
   padding: var(--spacing);
 
+  .warning-uncommitted-files {
+    padding: var(--spacing-half);
+    text-align: center;
+  }
+
   .commit-button {
     max-width: 100%;
     display: flex;

--- a/app/styles/ui/changes/_continue-rebase.scss
+++ b/app/styles/ui/changes/_continue-rebase.scss
@@ -10,7 +10,7 @@
   background-color: var(--box-alt-background-color);
   padding: var(--spacing);
 
-  .warning-uncommitted-files {
+  .warning-untracked-files {
     padding-top: var(--spacing-half);
     text-align: center;
   }

--- a/app/styles/ui/changes/_continue-rebase.scss
+++ b/app/styles/ui/changes/_continue-rebase.scss
@@ -11,7 +11,7 @@
   padding: var(--spacing);
 
   .warning-uncommitted-files {
-    padding: var(--spacing-half);
+    padding-top: var(--spacing-half);
     text-align: center;
   }
 


### PR DESCRIPTION
## Overview

**Closes #7006**

## Description

This PR updates the `ChangesList` component to lock down the checkboxes when rebase conflicts are detected.

Currently you can change all the checkboxes in the list, but these choices are ignored because the rebase flow needs to stage all tracked files (untracked files are ignored by `git` when rebasing) to continue correctly:

<img width="651" src="https://user-images.githubusercontent.com/359239/56504235-44c0f080-64ee-11e9-825d-ffd186e30e9a.png">

With this PR, we now:

 - disable all checkboxes while you are dealing with rebase conflicts
 - lock the checkbox state to include tracked files, and exclude untracked files

<img width="654"  src="https://user-images.githubusercontent.com/359239/56504249-50141c00-64ee-11e9-82a6-17fca3c5319d.png">

This is how the underlying `git rebase` works by default, and Desktop needs to follow this convention when staging files before continuing the rebase.

TODO: 
 - [x] lock down checkbox state
 - [x] warn when untracked files exist
 - [x] show a subset of the context menu options when in the middle of a rebase

## Release notes

Notes: `[Improved] Changes list state better reflects rebase flow when handling conflicts` 
