### PR TITLE
rebase flow - update copy when choosing branch

### DIFF
--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -158,7 +158,7 @@ export class ChooseBranchDialog extends React.Component<
         dismissable={true}
         title={
           <>
-            Rebase <strong>{truncatedCurrentBranchName}</strong> onto…
+            Rebase <strong>{truncatedCurrentBranchName}</strong>…
           </>
         }
       >
@@ -180,8 +180,7 @@ export class ChooseBranchDialog extends React.Component<
           {this.renderRebaseStatus()}
           <ButtonGroup>
             <Button type="submit" disabled={disabled} tooltip={tooltip}>
-              Rebase <strong>{currentBranchName}</strong> onto{' '}
-              <strong>{selectedBranch ? selectedBranch.name : ''}</strong>
+              Rebase <strong>{currentBranchName}</strong>
             </Button>
           </ButtonGroup>
         </DialogFooter>
@@ -264,11 +263,9 @@ export class ChooseBranchDialog extends React.Component<
     const pluralized = commitsToRebase === 1 ? 'commit' : 'commits'
     return (
       <>
-        This will rebase
+        This will apply
         <strong>{` ${commitsToRebase} ${pluralized}`}</strong>
-        {` from `}
-        <strong>{currentBranch.name}</strong>
-        {` onto `}
+        {` on top of `}
         <strong>{baseBranch.name}</strong>
       </>
     )

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -180,7 +180,7 @@ export class ChooseBranchDialog extends React.Component<
           {this.renderRebaseStatus()}
           <ButtonGroup>
             <Button type="submit" disabled={disabled} tooltip={tooltip}>
-              Rebase <strong>{currentBranchName}</strong>
+              Start rebase
             </Button>
           </ButtonGroup>
         </DialogFooter>
@@ -263,7 +263,8 @@ export class ChooseBranchDialog extends React.Component<
     const pluralized = commitsToRebase === 1 ? 'commit' : 'commits'
     return (
       <>
-        This will apply
+        This will update <strong>{currentBranch.name}</strong>
+        {` by applying `}
         <strong>{` ${commitsToRebase} ${pluralized}`}</strong>
         {` on top of `}
         <strong>{baseBranch.name}</strong>

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -264,7 +264,7 @@ export class ChooseBranchDialog extends React.Component<
     return (
       <>
         This will update <strong>{currentBranch.name}</strong>
-        {` by applying `}
+        {` by applying its `}
         <strong>{` ${commitsToRebase} ${pluralized}`}</strong>
         {` on top of `}
         <strong>{baseBranch.name}</strong>


### PR DESCRIPTION
## Overview

This PR is an attempt to simplify the words shown when choosing the base branch to use in the rebase. The main thread of feedback we got at the time was a nervousness about the base branch (the one you are choosing) being modified or updated, and I wanted to eliminate this confusion.

## Description

This is the current view you'll see after choosing a branch:

<img width="505"  src="https://user-images.githubusercontent.com/359239/56662472-6cdd5a80-667a-11e9-840e-a8693ccba6a5.png">

After plenty of thought, I settled on trying to strip back the words to reduce the confusion:

<img width="480" src="https://user-images.githubusercontent.com/359239/56689006-771a4b80-66b0-11e9-84d4-5aa39469496d.png">

The key goals I settled on:

 - be less wordy - focus on what will happen
 - remove the suggestions that the base branch is affected by this - "onto" -> "on top of", or omitted
 - reduce the mentions of the base branch where possible - emphasize the current branch

I'd love your thoughts on how this changes the information about starting the rebase.

cc @feministy @zeke as you raised feedback in this vein - I'd love to hear if this feels better.

## Release notes

Notes: no-notes
