### PR TITLE
fix stash diff viewer button order (for mac)

### DIFF
--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -139,14 +139,14 @@ const Header: React.SFC<{
   return (
     <div className="header">
       <h3>Stashed changes</h3>
-      <ButtonGroup destructive={false}>
       <div className="row">
-        <Button onClick={onRestoreClick} type="submit">
-          Restore
-        </Button>
-        <Button onClick={onDiscardClick}>Discard</Button>
-      </ButtonGroup>
-      <div className="explanatory-text">{restoreMessage}</div>
+        <ButtonGroup destructive={false}>
+          <Button onClick={onRestoreClick} type="submit">
+            Restore
+          </Button>
+          <Button onClick={onDiscardClick}>Discard</Button>
+        </ButtonGroup>
+        <div className="explanatory-text">{restoreMessage}</div>
       </div>
     </div>
   )

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -140,12 +140,14 @@ const Header: React.SFC<{
     <div className="header">
       <h3>Stashed changes</h3>
       <ButtonGroup destructive={false}>
+      <div className="row">
         <Button onClick={onRestoreClick} type="submit">
           Restore
         </Button>
         <Button onClick={onDiscardClick}>Discard</Button>
       </ButtonGroup>
       <div className="explanatory-text">{restoreMessage}</div>
+      </div>
     </div>
   )
 }

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -131,15 +131,14 @@ const Header: React.SFC<{
     </>
   )
 
+  // we pass `false` to `ButtonGroup` below because it assumes
+  // the "submit" button performs the destructive action.
+  // In this case the destructive action is performed by the
+  // non-submit button so we _lie_ to the props to get
+  // the correct button ordering
   return (
     <div className="header">
       <h3>Stashed changes</h3>
-      {/*
-      this is false because ButtonGroup assumes the submit button
-      performs the destructive action. In this case the destructive
-      action is performed by the non-submit button so we lie to the
-      props to get the correct button ordering
-       */}
       <ButtonGroup destructive={false}>
         <Button onClick={onRestoreClick} type="submit">
           Restore

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -109,11 +109,13 @@ const Header: React.SFC<{
   dispatcher: Dispatcher
   isWorkingTreeClean: boolean
 }> = props => {
+  const { dispatcher, repository, stashEntry, isWorkingTreeClean } = props
+
   const onDiscardClick = () => {
-    props.dispatcher.dropStash(props.repository, props.stashEntry)
+    dispatcher.dropStash(repository, stashEntry)
   }
   const onRestoreClick = () => {
-    props.dispatcher.popStash(props.repository, props.stashEntry)
+    dispatcher.popStash(repository, stashEntry)
   }
 
   const restoreMessage = isWorkingTreeClean ? (
@@ -144,6 +146,7 @@ const Header: React.SFC<{
         </Button>
         <Button onClick={onDiscardClick}>Discard</Button>
       </ButtonGroup>
+      <div className="explanatory-text">{restoreMessage}</div>
     </div>
   )
 }

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -94,20 +94,26 @@ const Header: React.SFC<{
   repository: Repository
   dispatcher: Dispatcher
 }> = props => {
-  const onClearClick = () => {
+  const onDiscardClick = () => {
     props.dispatcher.dropStash(props.repository, props.stashEntry)
   }
-  const onSubmitClick = () => {
+  const onRestoreClick = () => {
     props.dispatcher.popStash(props.repository, props.stashEntry)
   }
   return (
     <div className="header">
       <h3>Stashed changes</h3>
-      <ButtonGroup destructive={true}>
-        <Button onClick={onSubmitClick} type="submit">
+      {/*
+      this is false because ButtonGroup assumes the submit button
+      performs the destructive action. In this case the destructive
+      action is performed by the non-submit button so we lie to the
+      props to get the correct button ordering
+       */}
+      <ButtonGroup destructive={false}>
+        <Button onClick={onRestoreClick} type="submit">
           Restore
         </Button>
-        <Button onClick={onClearClick}>Discard</Button>
+        <Button onClick={onDiscardClick}>Discard</Button>
       </ButtonGroup>
     </div>
   )


### PR DESCRIPTION
fixes #7273

Windows (i spoofed windows in code locally):
<img width="1212" alt="Screen Shot 2019-04-24 at 2 10 34 PM" src="https://user-images.githubusercontent.com/964912/56694213-09aff000-669b-11e9-9fc9-a78dcb19c202.png">

Mac:
<img width="1212" alt="Screen Shot 2019-04-24 at 2 09 28 PM" src="https://user-images.githubusercontent.com/964912/56694210-06b4ff80-669b-11e9-99de-3b51e9cd8d4b.png">
