### PR TITLE
Update verbiage for leaving changes on current branch vs bringing them to new branch

### DIFF
--- a/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
+++ b/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
@@ -97,20 +97,20 @@ export class StashAndSwitchBranch extends React.Component<
     const { branchToCheckout } = this.props
     const items = [
       {
-        title: `Yes, stash my changes on ${this.props.currentBranch.name}`,
-        description: 'Stash your in-progress work and return to it later',
+        title: `Leave my changes on ${this.props.currentBranch.name}`,
+        description: 'Your in-progress work will be stashed on this branch for you to return to later',
       },
       {
-        title: `No, bring my changes to ${branchToCheckout.name}`,
+        title: `Bring my changes to ${branchToCheckout.name}`,
         description:
-          'Your in-progress work will automatically follow you to the new branch',
+          'Your in-progress work will follow you to the new branch',
       },
     ]
 
     return (
       <Row>
         <VerticalSegmentedControl
-          label="Do you want to stash your changes?"
+          label="You have changes on this branch. What would you like to do with them?"
           items={items}
           selectedIndex={this.state.selectedStashAction}
           onSelectionChanged={this.onSelectionChanged}

--- a/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
+++ b/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
@@ -98,12 +98,12 @@ export class StashAndSwitchBranch extends React.Component<
     const items = [
       {
         title: `Leave my changes on ${this.props.currentBranch.name}`,
-        description: 'Your in-progress work will be stashed on this branch for you to return to later',
+        description:
+          'Your in-progress work will be stashed on this branch for you to return to later',
       },
       {
         title: `Bring my changes to ${branchToCheckout.name}`,
-        description:
-          'Your in-progress work will follow you to the new branch',
+        description: 'Your in-progress work will follow you to the new branch',
       },
     ]
 

--- a/app/styles/ui/_vertical-segmented-control.scss
+++ b/app/styles/ui/_vertical-segmented-control.scss
@@ -9,7 +9,7 @@ fieldset.vertical-segmented-control {
 
   legend {
     margin-bottom: var(--spacing-third);
-    padding: 0;
+    padding: 0 0 5px 0;
     @include ellipsis;
   }
 


### PR DESCRIPTION
## Overview

Based on some user feedback and discussion in Slack, proposing a few changes to the dialog that pops up when switching branches that allows you to either stash your changes or bring them with you to the new branch.

The goals:

1. Remove explicit "Would you like to stash?" and "Yes/No" because that can convey different things to different people depending on their workflow.
2. Use similar language pattern for explanatory text in each box to help with consistency. 
3. Add a bit of separation between the question of what you'd like to do with the changes and your options. Note: This bleeds through to other similar dialogs (like creating a new branch), but I tested them and they all actually benefit from the small additional vertical spacing I think.

Before:

<img width="465" alt="Screen Shot 2019-04-24 at 12 07 07 PM" src="https://user-images.githubusercontent.com/5091167/56690365-82fb1300-669a-11e9-926c-6838c8ddc4e8.png">


After:

<img width="462" alt="Screen Shot 2019-04-24 at 2 08 20 PM" src="https://user-images.githubusercontent.com/5091167/56690354-7b3b6e80-669a-11e9-9e88-13bc8f63a200.png">


## Release notes

No notes