### PR TITLE
set an upper bound on our supported Node for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 8.11 <12.0.0",
+    "node": ">= 8.11 < 12.0.0",
     "yarn": ">= 1.9"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 8.11",
+    "node": ">= 8.11 <12.0.0",
     "yarn": ">= 1.9"
   },
   "dependencies": {


### PR DESCRIPTION
## Overview

Node 12 is out, but our version of `node-sass` is not compatible with it, which impacts building the project.

## Description

Until https://github.com/sass/node-sass/pull/2633 lands and a new release is available that we can upgrade the project to, this change will prevent the user from building the project.

This will prevent bug reports where the tooling is not in a supported state, but also give us an indicator of how many contributors are already on Node 12.

## Release notes

Notes: no-notes
