### PR TITLE
Fix: Cannot use `esc` key to close Repository list and Branch list

### DIFF
--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -137,7 +137,7 @@ interface IToolbarDropdownState {
 export class ToolbarDropdown extends React.Component<
   IToolbarDropdownProps,
   IToolbarDropdownState
-  > {
+> {
   private innerButton: ToolbarButton | null = null
 
   public constructor(props: IToolbarDropdownProps) {

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -279,7 +279,7 @@ export class ToolbarDropdown extends React.Component<
         <div
           className="foldout"
           style={this.getFoldoutStyle()}
-          tabIndex={0}
+          tabIndex={-1}
           onKeyDown={this.onFoldoutKeyDown}
         >
           {this.props.dropdownContentRenderer()}

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -137,7 +137,7 @@ interface IToolbarDropdownState {
 export class ToolbarDropdown extends React.Component<
   IToolbarDropdownProps,
   IToolbarDropdownState
-> {
+  > {
   private innerButton: ToolbarButton | null = null
 
   public constructor(props: IToolbarDropdownProps) {
@@ -279,6 +279,7 @@ export class ToolbarDropdown extends React.Component<
         <div
           className="foldout"
           style={this.getFoldoutStyle()}
+          tabIndex={0}
           onKeyDown={this.onFoldoutKeyDown}
         >
           {this.props.dropdownContentRenderer()}


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #7177**

## Description

This PR fixes to close Repository list and Branch list using Escape key.
The reason of this bug is that `onKeyDown` in `<div>` on React is not working.
We can focus to this `<div>` by `tabIndex={0}`.
I referred to [this answer of stackoverflow](https://stackoverflow.com/a/44434971).

## Screenshot

### Currently

![BeforeFixToCloseDropdown](https://user-images.githubusercontent.com/11808736/56765296-af6d7700-67e1-11e9-9994-d1521f011abb.gif)

### After fixing

![FixToCloseDropdown](https://user-images.githubusercontent.com/11808736/56765348-c744fb00-67e1-11e9-8b01-fd0c163ddee1.gif)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
