### PR TITLE
smoother transitions when previewing rebase

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -35,7 +35,7 @@ import { ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
-import { GitRebaseProgress, RebasePreview } from '../models/rebase'
+import { GitRebaseProgress } from '../models/rebase'
 import { RebaseFlowStep } from '../models/rebase-flow-step'
 import { IStashEntry } from '../models/stash-entry'
 
@@ -471,16 +471,6 @@ export interface IRebaseState {
    * `null` indicates that there is no rebase underway.
    */
   readonly step: RebaseFlowStep | null
-
-  /**
-   * A preview of the rebase, tested before performing the rebase itself, using
-   * the selected base branch to test whether the current branch will be cleanly
-   * applied.
-   *
-   * This will be set to `null` when no base branch has been selected to
-   * initiate the rebase.
-   */
-  readonly preview: RebasePreview | null
 
   /**
    * The underlying Git information associated with the current rebase

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -144,7 +144,6 @@ import {
   PushOptions,
   RebaseResult,
   getRebaseSnapshot,
-  getCommitsInRange,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -223,7 +222,6 @@ import {
 import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-strategy'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
-import { RebasePreview } from '../../models/rebase'
 import { MenuLabels } from '../../main-process/menu'
 import { arrayEquals } from '../equality'
 
@@ -3926,61 +3924,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commits: null,
       preview: null,
       userHasResolvedConflicts: false,
-    }))
-
-    this.emitUpdate()
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _previewRebase(
-    repository: Repository,
-    baseBranch: Branch,
-    targetBranch: Branch
-  ) {
-    let preview: RebasePreview = {
-      kind: ComputedAction.Loading,
-    }
-
-    this.repositoryStateCache.updateRebaseState(repository, () => ({
-      preview,
-    }))
-
-    this.emitUpdate()
-
-    const commits = await getCommitsInRange(
-      repository,
-      baseBranch.tip.sha,
-      targetBranch.tip.sha
-    )
-
-    // TODO: in what situations might this not be possible to compute?
-
-    const base = await getMergeBase(
-      repository,
-      baseBranch.tip.sha,
-      targetBranch.tip.sha
-    )
-
-    if (base === baseBranch.tip.sha) {
-      // the target branch is a direct descendant of the base branch
-      // which means the target branch is already up to date
-      preview = {
-        kind: ComputedAction.Clean,
-        commits: [],
-      }
-    } else {
-      preview = {
-        kind: ComputedAction.Clean,
-        commits,
-      }
-    }
-
-    // TODO: generate the patches associated with these commits and see if
-    //       they will apply to the base branch - if it fails, there will be
-    //       conflicts to come
-
-    this.repositoryStateCache.updateRebaseState(repository, () => ({
-      preview,
     }))
 
     this.emitUpdate()

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -165,7 +165,6 @@ function getInitialRepositoryState(): IRepositoryState {
     rebaseState: {
       step: null,
       progress: null,
-      preview: null,
       commits: null,
       userHasResolvedConflicts: false,
     },

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1612,12 +1612,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const { changesState, rebaseState } = selectedState.state
         const { workingDirectory, conflictState } = changesState
-        const {
-          progress,
-          step,
-          preview,
-          userHasResolvedConflicts,
-        } = rebaseState
+        const { progress, step, userHasResolvedConflicts } = rebaseState
 
         if (conflictState !== null && conflictState.kind === 'merge') {
           log.warn(
@@ -1642,7 +1637,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             workingDirectory={workingDirectory}
             progress={progress}
             step={step}
-            preview={preview}
             userHasResolvedConflicts={userHasResolvedConflicts}
             askForConfirmationOnForcePush={
               this.state.askForConfirmationOnForcePush

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -334,17 +334,6 @@ export class Dispatcher {
     return this.appStore._closeFoldout(foldout)
   }
 
-  /**
-   * Compute a preview of the planned rebase action
-   */
-  public previewRebase(
-    repository: Repository,
-    baseBranch: Branch,
-    targetBranch: Branch
-  ) {
-    return this.appStore._previewRebase(repository, baseBranch, targetBranch)
-  }
-
   /** Initialize and start the rebase operation */
   public async startRebase(
     repository: Repository,

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -143,23 +143,18 @@ export class ChooseBranchDialog extends React.Component<
       return
     }
 
-    if (base === baseBranch.tip.sha) {
-      // the target branch is a direct descendant of the base branch
-      // which means the target branch is already up to date
-      this.setState({
-        rebasePreview: {
-          kind: ComputedAction.Clean,
-          commits: [],
-        },
-      })
-    } else {
-      this.setState({
-        rebasePreview: {
-          kind: ComputedAction.Clean,
-          commits,
-        },
-      })
-    }
+    // the target branch is a direct descendant of the base branch
+    // which means the target branch is already up to date and the commits
+    // do not need to be applied
+    const isDirectDescendant = base === baseBranch.tip.sha
+    const commitsOrIgnore = isDirectDescendant ? [] : commits
+
+    this.setState({
+      rebasePreview: {
+        kind: ComputedAction.Clean,
+        commits: commitsOrIgnore,
+      },
+    })
 
     // TODO: generate the patches associated with these commits and see if
     //       they will apply to the base branch - if it fails, there will be

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -120,7 +120,7 @@ export class ChooseBranchDialog extends React.Component<
 
     const { commits, base } = await promiseWithMinimumTimeout(async () => {
       const commits = await getCommitsInRange(
-        this.props.repository,
+        repository,
         baseBranch.tip.sha,
         targetBranch.tip.sha
       )

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -74,6 +74,8 @@ export class ChooseBranchDialog extends React.Component<
   IChooseBranchDialogProps,
   IChooseBranchDialogState
 > {
+  private computingRebaseForBranch: string | null = null
+
   public constructor(props: IChooseBranchDialogProps) {
     super(props)
 
@@ -107,6 +109,8 @@ export class ChooseBranchDialog extends React.Component<
   }
 
   private async updateRebaseStatus(baseBranch: Branch, targetBranch: Branch) {
+    this.computingRebaseForBranch = baseBranch.name
+
     const { repository } = this.props
     this.setState({
       rebasePreview: {
@@ -131,6 +135,13 @@ export class ChooseBranchDialog extends React.Component<
 
       return { commits, base }
     }, 500)
+
+    // if the branch being track has changed since we started this work, abandon
+    // any further state updates (this function is re-entrant if the user is
+    // using the keyboard to quickly switch branches)
+    if (this.computingRebaseForBranch !== baseBranch.name) {
+      return
+    }
 
     if (base === baseBranch.tip.sha) {
       // the target branch is a direct descendant of the base branch

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -9,7 +9,7 @@ import {
   ShowConflictsStep,
   ConfirmAbortStep,
 } from '../../models/rebase-flow-step'
-import { GitRebaseProgress, RebasePreview } from '../../models/rebase'
+import { GitRebaseProgress } from '../../models/rebase'
 import { WorkingDirectoryStatus } from '../../models/status'
 
 import { Dispatcher } from '../dispatcher'
@@ -34,12 +34,6 @@ interface IRebaseFlowProps {
    * state needed for the UI components.
    */
   readonly step: RebaseFlowStep
-
-  /**
-   * A preview of the rebase, using the selected base branch to test whether the
-   * current branch will be cleanly applied.
-   */
-  readonly preview: RebasePreview | null
 
   /** Git progress information about the current rebase */
   readonly progress: GitRebaseProgress | null
@@ -185,7 +179,6 @@ export class RebaseFlow extends React.Component<IRebaseFlowProps> {
             currentBranch={currentBranch}
             initialBranch={initialBranch}
             onDismissed={this.onFlowEnded}
-            rebasePreviewStatus={this.props.preview}
           />
         )
       }


### PR DESCRIPTION
## Overview

This change came from some feedback from @tierninho about how you could cause a noticeable flicker when you initiate a rebase, but use the keyboard to navigate the branch list.

## Description

To clean things up, I did three things based on what we learned from doing this for the Merge Branch flow:

 - changed the `ChooseBranch` component to use local state for computing this rebase status, rather than invoking the `Dispatcher`, which then invoked the `AppStore`, which then updated app state and triggered re-rendering - 68d07b6

 - introduced `promiseWithMinimumTimeout` and set a lower bound of 500ms (same value we use in Merge Branch) to ensure it spends an appropriate amount of time in the "loading" state before continuing - 4147206

 - as this method is re-entrant and can take time while `await`-ing, I added a guard check after computing the rebase preview to bail out of the branch had changed since we started on this - 87c52e1

I'm not a huge fan of that third commit, and I'll think about ways for us to better model this pattern because I'm sure we do similar things elsewhere and have different headaches to deal with. Without the third commit you can cursor quickly past a bunch of branches, and then you'll see it update multiple times as the code "catches up" to the input events.

## Release notes

Notes: no-notes
