### PR TITLE
tidy up tests to avoid needing to exclaim ourselves

### DIFF
--- a/app/test/unit/accounts-store-test.ts
+++ b/app/test/unit/accounts-store-test.ts
@@ -3,7 +3,8 @@ import { AccountsStore } from '../../src/lib/stores'
 import { InMemoryStore, AsyncInMemoryStore } from '../helpers/stores'
 
 describe('AccountsStore', () => {
-  let accountsStore: AccountsStore | null = null
+  let accountsStore: AccountsStore
+
   beforeEach(() => {
     accountsStore = new AccountsStore(
       new InMemoryStore(),
@@ -14,11 +15,11 @@ describe('AccountsStore', () => {
   describe('adding a new user', () => {
     it('contains the added user', async () => {
       const newAccountLogin = 'joan'
-      await accountsStore!.addAccount(
+      await accountsStore.addAccount(
         new Account(newAccountLogin, '', 'deadbeef', [], '', 1, '')
       )
 
-      const users = await accountsStore!.getAll()
+      const users = await accountsStore.getAll()
       expect(users[0].login).toBe(newAccountLogin)
     })
   })

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -130,21 +130,21 @@ describe('AppStore', () => {
       }
     }
 
-    let repo: Repository | null = null
+    let repository: Repository
     let firstCommit: Commit | null = null
 
     beforeEach(async () => {
-      repo = await setupEmptyRepository()
+      repository = await setupEmptyRepository()
 
       const file = 'README.md'
-      const filePath = Path.join(repo.path, file)
+      const filePath = Path.join(repository.path, file)
 
       await FSE.writeFile(filePath, 'SOME WORDS GO HERE\n')
 
-      await GitProcess.exec(['add', file], repo.path)
-      await GitProcess.exec(['commit', '-m', 'added file'], repo.path)
+      await GitProcess.exec(['add', file], repository.path)
+      await GitProcess.exec(['commit', '-m', 'added file'], repository.path)
 
-      firstCommit = await getCommit(repo, 'master')
+      firstCommit = await getCommit(repository, 'master')
       expect(firstCommit).not.toBeNull()
       expect(firstCommit!.parentSHAs).toHaveLength(0)
     })
@@ -159,8 +159,6 @@ describe('AppStore', () => {
     // I've opened https://github.com/desktop/desktop/issues/5543
     // to ensure this isn't forgotten.
     it.skip('clears the undo commit dialog', async () => {
-      const repository = repo!
-
       const { appStore } = await createAppStore()
 
       // select the repository and show the changes view

--- a/app/test/unit/app-test.tsx
+++ b/app/test/unit/app-test.tsx
@@ -30,12 +30,12 @@ import { ApiRepositoriesStore } from '../../src/lib/stores/api-repositories-stor
 import { CommitStatusStore } from '../../src/lib/stores/commit-status-store'
 
 describe('App', () => {
-  let appStore: AppStore | null = null
-  let dispatcher: Dispatcher | null = null
-  let statsStore: StatsStore | null = null
-  let repositoryStateManager: RepositoryStateCache | null = null
-  let githubUserStore: GitHubUserStore | null = null
-  let issuesStore: IssuesStore | null = null
+  let appStore: AppStore
+  let dispatcher: Dispatcher
+  let statsStore: StatsStore
+  let repositoryStateManager: RepositoryStateCache
+  let githubUserStore: GitHubUserStore
+  let issuesStore: IssuesStore
 
   beforeEach(async () => {
     const db = new TestGitHubUserDatabase()
@@ -66,7 +66,7 @@ describe('App', () => {
     issuesStore = new IssuesStore(issuesDb)
 
     repositoryStateManager = new RepositoryStateCache(repo =>
-      githubUserStore!.getUsersForRepository(repo)
+      githubUserStore.getUsersForRepository(repo)
     )
 
     const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
@@ -96,11 +96,11 @@ describe('App', () => {
   it('renders', async () => {
     const app = TestUtils.renderIntoDocument(
       <App
-        dispatcher={dispatcher!}
-        appStore={appStore!}
-        repositoryStateManager={repositoryStateManager!}
-        issuesStore={issuesStore!}
-        gitHubUserStore={githubUserStore!}
+        dispatcher={dispatcher}
+        appStore={appStore}
+        repositoryStateManager={repositoryStateManager}
+        issuesStore={issuesStore}
+        gitHubUserStore={githubUserStore}
         startTime={0}
       />
     ) as React.Component<any, any>

--- a/app/test/unit/git-store-cache-test.ts
+++ b/app/test/unit/git-store-cache-test.ts
@@ -3,19 +3,17 @@ import { GitStoreCache } from '../../src/lib/stores/git-store-cache'
 import { shell } from '../helpers/test-app-shell'
 
 describe('GitStoreCache', () => {
-  let r: Repository | null = null
+  let repository: Repository
 
   const onGitStoreUpdated = () => {}
   const onDidLoadNewCommits = () => {}
   const onDidError = () => {}
 
   beforeEach(() => {
-    r = new Repository('/something/path', 1, null, false)
+    repository = new Repository('/something/path', 1, null, false)
   })
 
   it('returns same instance of GitStore', () => {
-    const repository = r!
-
     const cache = new GitStoreCache(
       shell,
       onGitStoreUpdated,
@@ -30,8 +28,6 @@ describe('GitStoreCache', () => {
   })
 
   it('returns different instance of GitStore after removing', () => {
-    const repository = r!
-
     const cache = new GitStoreCache(
       shell,
       onGitStoreUpdated,

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -96,41 +96,41 @@ describe('GitStore', () => {
   })
 
   describe('undo first commit', () => {
-    let repo: Repository | null = null
+    let repository: Repository
     let firstCommit: Commit | null = null
 
     const commitMessage = 'added file'
 
     beforeEach(async () => {
-      repo = await setupEmptyRepository()
+      repository = await setupEmptyRepository()
 
       const file = 'README.md'
-      const filePath = Path.join(repo.path, file)
+      const filePath = Path.join(repository.path, file)
 
       await FSE.writeFile(filePath, 'SOME WORDS GO HERE\n')
 
-      await GitProcess.exec(['add', file], repo.path)
-      await GitProcess.exec(['commit', '-m', commitMessage], repo.path)
+      await GitProcess.exec(['add', file], repository.path)
+      await GitProcess.exec(['commit', '-m', commitMessage], repository.path)
 
-      firstCommit = await getCommit(repo!, 'master')
+      firstCommit = await getCommit(repository, 'master')
       expect(firstCommit).not.toBeNull()
       expect(firstCommit!.parentSHAs).toHaveLength(0)
     })
 
     it('reports the repository is unborn', async () => {
-      const gitStore = new GitStore(repo!, shell)
+      const gitStore = new GitStore(repository, shell)
 
       await gitStore.loadStatus()
       expect(gitStore.tip.kind).toEqual(TipState.Valid)
 
       await gitStore.undoCommit(firstCommit!)
 
-      const after = await getStatusOrThrow(repo!)
+      const after = await getStatusOrThrow(repository)
       expect(after.currentTip).toBeUndefined()
     })
 
     it('pre-fills the commit message', async () => {
-      const gitStore = new GitStore(repo!, shell)
+      const gitStore = new GitStore(repository, shell)
 
       await gitStore.undoCommit(firstCommit!)
 
@@ -140,7 +140,7 @@ describe('GitStore', () => {
     })
 
     it('clears the undo commit dialog', async () => {
-      const gitStore = new GitStore(repo!, shell)
+      const gitStore = new GitStore(repository, shell)
 
       await gitStore.loadStatus()
 
@@ -160,7 +160,7 @@ describe('GitStore', () => {
     })
 
     it('has no staged files', async () => {
-      const gitStore = new GitStore(repo!, shell)
+      const gitStore = new GitStore(repository, shell)
 
       await gitStore.loadStatus()
 
@@ -181,7 +181,7 @@ describe('GitStore', () => {
           '-z',
           '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
         ],
-        repo!.path
+        repository.path
       )
       expect(result.stdout.length).toEqual(0)
     })

--- a/app/test/unit/git/config-test.ts
+++ b/app/test/unit/git/config-test.ts
@@ -13,7 +13,7 @@ import { mkdirSync } from '../../helpers/temp'
 import { setupFixtureRepository } from '../../helpers/repositories'
 
 describe('git/config', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
@@ -22,15 +22,12 @@ describe('git/config', () => {
 
   describe('config', () => {
     it('looks up config values', async () => {
-      const bare = await getConfigValue(repository!, 'core.bare')
+      const bare = await getConfigValue(repository, 'core.bare')
       expect(bare).toBe('false')
     })
 
     it('returns null for undefined values', async () => {
-      const value = await getConfigValue(
-        repository!,
-        'core.the-meaning-of-life'
-      )
+      const value = await getConfigValue(repository, 'core.the-meaning-of-life')
       expect(value).toBeNull()
     })
   })

--- a/app/test/unit/git/core-test.ts
+++ b/app/test/unit/git/core-test.ts
@@ -5,7 +5,7 @@ import { git } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 
 describe('git/core', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
@@ -18,7 +18,7 @@ describe('git/core', () => {
 
       let threw = false
       try {
-        const result = await git(args, repository!.path, 'test', {
+        const result = await git(args, repository.path, 'test', {
           expectedErrors: new Set([GitError.BadRevision]),
         })
         expect(result.gitError).toBe(GitError.BadRevision)
@@ -34,7 +34,7 @@ describe('git/core', () => {
 
       let threw = false
       try {
-        await git(args, repository!.path, 'test', {
+        await git(args, repository.path, 'test', {
           expectedErrors: new Set([GitError.SSHKeyAuditUnverified]),
         })
       } catch (e) {
@@ -51,7 +51,7 @@ describe('git/core', () => {
 
       let threw = false
       try {
-        const result = await git(args, repository!.path, 'test', {
+        const result = await git(args, repository.path, 'test', {
           successExitCodes: new Set([128]),
         })
         expect(result.exitCode).toBe(128)
@@ -67,7 +67,7 @@ describe('git/core', () => {
 
       let threw = false
       try {
-        await git(args, repository!.path, 'test', {
+        await git(args, repository.path, 'test', {
           successExitCodes: new Set([2]),
         })
       } catch (e) {

--- a/app/test/unit/git/diff-test.ts
+++ b/app/test/unit/git/diff-test.ts
@@ -38,7 +38,7 @@ async function getTextDiff(
 }
 
 describe('git/diff', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('repo-with-image-changes')
@@ -55,7 +55,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.New },
         diffSelection
       )
-      const current = await getWorkingDirectoryImage(repository!, file)
+      const current = await getWorkingDirectoryImage(repository, file)
 
       expect(current.mediaType).toBe('image/png')
       expect(current.contents).toMatch(/A2HkbLsBYSgAAAABJRU5ErkJggg==$/)
@@ -70,7 +70,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.Modified },
         diffSelection
       )
-      const current = await getWorkingDirectoryImage(repository!, file)
+      const current = await getWorkingDirectoryImage(repository, file)
       expect(current.mediaType).toBe('image/jpg')
       expect(current.contents).toMatch(/gdTTb6MClWJ3BU8T8PTtXoB88kFL\/9k=$/)
     })
@@ -86,7 +86,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.Modified },
         diffSelection
       )
-      const current = await getBlobImage(repository!, file.path, 'HEAD')
+      const current = await getBlobImage(repository, file.path, 'HEAD')
 
       expect(current.mediaType).toBe('image/jpg')
       expect(current.contents).toMatch(
@@ -103,7 +103,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.Deleted },
         diffSelection
       )
-      const previous = await getBlobImage(repository!, file.path, 'HEAD')
+      const previous = await getBlobImage(repository, file.path, 'HEAD')
 
       expect(previous.mediaType).toBe('image/gif')
       expect(previous.contents).toMatch(
@@ -122,7 +122,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.Modified },
         diffSelection
       )
-      const diff = await getWorkingDirectoryDiff(repository!, file)
+      const diff = await getWorkingDirectoryDiff(repository, file)
 
       expect(diff.kind === DiffType.Image)
 
@@ -143,7 +143,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.New },
         diffSelection
       )
-      const diff = await getTextDiff(repository!, file)
+      const diff = await getTextDiff(repository, file)
 
       expect(diff.hunks.length).toBeGreaterThan(0)
     })
@@ -164,7 +164,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.New },
         diffSelection
       )
-      const diff = await getTextDiff(repository!, file)
+      const diff = await getTextDiff(repository, file)
 
       const hunk = diff.hunks[0]
 
@@ -189,7 +189,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.Modified },
         diffSelection
       )
-      const diff = await getTextDiff(repository!, file)
+      const diff = await getTextDiff(repository, file)
 
       const first = diff.hunks[0]
       expect(first.lines[0].text).toContain('@@ -4,10 +4,6 @@')
@@ -217,7 +217,7 @@ describe('git/diff', () => {
         { kind: AppFileStatusKind.Modified },
         diffSelection
       )
-      const diff = await getTextDiff(repository!, file)
+      const diff = await getTextDiff(repository, file)
 
       const first = diff.hunks[0]
       expect(first.lines[0].text).toContain('@@ -2,7 +2,7 @@ ')

--- a/app/test/unit/git/for-each-ref-test.ts
+++ b/app/test/unit/git/for-each-ref-test.ts
@@ -8,7 +8,7 @@ import { getBranches } from '../../../src/lib/git/for-each-ref'
 import { BranchType } from '../../../src/models/branch'
 
 describe('git/for-each-ref', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('repo-with-many-refs')
@@ -17,7 +17,7 @@ describe('git/for-each-ref', () => {
 
   describe('getBranches', () => {
     it('fetches branches using for-each-ref', async () => {
-      const branches = (await getBranches(repository!)).filter(
+      const branches = (await getBranches(repository)).filter(
         b => b.type === BranchType.Local
       )
 

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -5,7 +5,7 @@ import { AppFileStatusKind } from '../../../src/models/status'
 import { setupLocalConfig } from '../../helpers/local-config'
 
 describe('git/log', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
@@ -14,7 +14,7 @@ describe('git/log', () => {
 
   describe('getCommits', () => {
     it('loads history', async () => {
-      const commits = await getCommits(repository!, 'HEAD', 100)
+      const commits = await getCommits(repository, 'HEAD', 100)
       expect(commits).toHaveLength(5)
 
       const firstCommit = commits[commits.length - 1]
@@ -50,7 +50,7 @@ describe('git/log', () => {
   describe('getChangedFiles', () => {
     it('loads the files changed in the commit', async () => {
       const files = await getChangedFiles(
-        repository!,
+        repository,
         '7cd6640e5b6ca8dbfd0b33d0281ebe702127079c'
       )
       expect(files).toHaveLength(1)
@@ -109,7 +109,7 @@ describe('git/log', () => {
     })
 
     it('handles commit when HEAD exists on disk', async () => {
-      const files = await getChangedFiles(repository!, 'HEAD')
+      const files = await getChangedFiles(repository, 'HEAD')
       expect(files).toHaveLength(1)
       expect(files[0].path).toBe('README.md')
       expect(files[0].status.kind).toBe(AppFileStatusKind.Modified)

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -72,11 +72,11 @@ describe('git/reflog', () => {
 
   describe('getCheckoutsAfterDate', () => {
     it('returns does not return the branches that were checked out before a specific date', async () => {
-      await createAndCheckout(repository!, 'branch-1')
-      await createAndCheckout(repository!, 'branch-2')
+      await createAndCheckout(repository, 'branch-1')
+      await createAndCheckout(repository, 'branch-2')
 
       const branches = await getCheckoutsAfterDate(
-        repository!,
+        repository,
         moment()
           .add(1, 'day')
           .toDate()
@@ -85,12 +85,12 @@ describe('git/reflog', () => {
     })
 
     it('returns all branches checked out after a specific date', async () => {
-      await createBranch(repository!, 'never-checked-out', null)
-      await createAndCheckout(repository!, 'branch-1')
-      await createAndCheckout(repository!, 'branch-2')
+      await createBranch(repository, 'never-checked-out', null)
+      await createAndCheckout(repository, 'branch-1')
+      await createAndCheckout(repository, 'branch-2')
 
       const branches = await getCheckoutsAfterDate(
-        repository!,
+        repository,
         moment()
           .subtract(1, 'hour')
           .toDate()

--- a/app/test/unit/git/reset-test.ts
+++ b/app/test/unit/git/reset-test.ts
@@ -9,7 +9,7 @@ import { GitProcess } from 'dugite'
 import * as FSE from 'fs-extra'
 
 describe('git/reset', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
@@ -18,22 +18,22 @@ describe('git/reset', () => {
 
   describe('reset', () => {
     it('can hard reset a repository', async () => {
-      const repoPath = repository!.path
+      const repoPath = repository.path
       const fileName = 'README.md'
       const filePath = path.join(repoPath, fileName)
 
       await FSE.writeFile(filePath, 'Hi world\n')
 
-      await reset(repository!, GitResetMode.Hard, 'HEAD')
+      await reset(repository, GitResetMode.Hard, 'HEAD')
 
-      const status = await getStatusOrThrow(repository!)
+      const status = await getStatusOrThrow(repository)
       expect(status.workingDirectory.files).toHaveLength(0)
     })
   })
 
   describe('resetPaths', () => {
     it.skip('resets discarded staged file', async () => {
-      const repoPath = repository!.path
+      const repoPath = repository.path
       const fileName = 'README.md'
       const filePath = path.join(repoPath, fileName)
 
@@ -44,7 +44,7 @@ describe('git/reset', () => {
       GitProcess.exec(['add', fileName], repoPath)
       await FSE.unlink(filePath)
 
-      await resetPaths(repository!, GitResetMode.Mixed, 'HEAD', [filePath])
+      await resetPaths(repository, GitResetMode.Mixed, 'HEAD', [filePath])
 
       // then checkout the version from the index to restore it
       await GitProcess.exec(
@@ -52,7 +52,7 @@ describe('git/reset', () => {
         repoPath
       )
 
-      const status = await getStatusOrThrow(repository!)
+      const status = await getStatusOrThrow(repository)
       expect(status.workingDirectory.files).toHaveLength(0)
     })
   })

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -17,7 +17,7 @@ import { GitProcess } from 'dugite'
 import { mkdirSync } from '../../helpers/temp'
 
 describe('git/rev-parse', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
@@ -26,12 +26,12 @@ describe('git/rev-parse', () => {
 
   describe('isGitRepository', () => {
     it('should return true for a repository', async () => {
-      const result = await isGitRepository(repository!.path)
+      const result = await isGitRepository(repository.path)
       expect(result).toBe(true)
     })
 
     it('should return false for a directory', async () => {
-      const result = await isGitRepository(path.dirname(repository!.path))
+      const result = await isGitRepository(path.dirname(repository.path))
       expect(result).toBe(false)
     })
   })
@@ -72,14 +72,14 @@ describe('git/rev-parse', () => {
 
   describe('getTopLevelWorkingDirectory', () => {
     it('should return an absolute path when run inside a working directory', async () => {
-      const result = await getTopLevelWorkingDirectory(repository!.path)
-      expect(result).toBe(repository!.path)
+      const result = await getTopLevelWorkingDirectory(repository.path)
+      expect(result).toBe(repository.path)
 
-      const subdirPath = path.join(repository!.path, 'subdir')
+      const subdirPath = path.join(repository.path, 'subdir')
       await FSE.mkdir(subdirPath)
 
-      const subDirResult = await getTopLevelWorkingDirectory(repository!.path)
-      expect(subDirResult).toBe(repository!.path)
+      const subDirResult = await getTopLevelWorkingDirectory(repository.path)
+      expect(subDirResult).toBe(repository.path)
     })
 
     it('should return null when not run inside a working directory', async () => {
@@ -88,7 +88,7 @@ describe('git/rev-parse', () => {
     })
 
     it('should resolve top level directory run inside the .git folder', async () => {
-      const p = path.join(repository!.path, '.git')
+      const p = path.join(repository.path, '.git')
       const result = await getTopLevelWorkingDirectory(p)
       expect(result).toBe(p)
     })

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -27,7 +27,7 @@ const mkdir = _temp.mkdir
 
 describe('git/status', () => {
   describe('getStatus', () => {
-    let repository: Repository | null = null
+    let repository: Repository
 
     describe('with conflicted repo', () => {
       let filePath: string
@@ -38,7 +38,7 @@ describe('git/status', () => {
       })
 
       it('parses conflicted files with markers', async () => {
-        const status = await getStatusOrThrow(repository!)
+        const status = await getStatusOrThrow(repository)
         const files = status.workingDirectory.files
         expect(files).toHaveLength(5)
         const conflictedFiles = files.filter(
@@ -84,7 +84,7 @@ describe('git/status', () => {
       })
 
       it('parses conflicted files without markers', async () => {
-        const status = await getStatusOrThrow(repository!)
+        const status = await getStatusOrThrow(repository)
         const files = status.workingDirectory.files
         expect(files).toHaveLength(5)
         expect(
@@ -139,7 +139,7 @@ describe('git/status', () => {
 
       it('parses resolved files', async () => {
         await FSE.writeFile(filePath, 'b1b2')
-        const status = await getStatusOrThrow(repository!)
+        const status = await getStatusOrThrow(repository)
         const files = status.workingDirectory.files
 
         expect(files).toHaveLength(5)
@@ -173,7 +173,7 @@ describe('git/status', () => {
       })
 
       it('parses conflicted image file on merge', async () => {
-        const repo = repository!
+        const repo = repository
 
         await GitProcess.exec(['merge', 'master'], repo.path)
 
@@ -189,7 +189,7 @@ describe('git/status', () => {
       })
 
       it('parses conflicted image file on merge after removing', async () => {
-        const repo = repository!
+        const repo = repository
 
         await GitProcess.exec(['rm', 'my-cool-image.png'], repo.path)
         await GitProcess.exec(['commit', '-am', 'removed the image'], repo.path)
@@ -216,11 +216,11 @@ describe('git/status', () => {
 
       it('parses changed files', async () => {
         await FSE.writeFile(
-          path.join(repository!.path, 'README.md'),
+          path.join(repository.path, 'README.md'),
           'Hi world\n'
         )
 
-        const status = await getStatusOrThrow(repository!)
+        const status = await getStatusOrThrow(repository)
         const files = status.workingDirectory.files
         expect(files).toHaveLength(1)
 
@@ -230,7 +230,7 @@ describe('git/status', () => {
       })
 
       it('returns an empty array when there are no changes', async () => {
-        const status = await getStatusOrThrow(repository!)
+        const status = await getStatusOrThrow(repository)
         const files = status.workingDirectory.files
         expect(files).toHaveLength(0)
       })
@@ -285,7 +285,7 @@ describe('git/status', () => {
 
       it.skip('Handles at least 10k untracked files without failing', async () => {
         const numFiles = 10000
-        const basePath = repository!.path
+        const basePath = repository.path
 
         await mkdir(basePath)
 
@@ -298,7 +298,7 @@ describe('git/status', () => {
         }
         await Promise.all(promises)
 
-        const status = await getStatusOrThrow(repository!)
+        const status = await getStatusOrThrow(repository)
         const files = status.workingDirectory.files
         expect(files).toHaveLength(numFiles)
       }, 25000) // needs a little extra time on CI

--- a/app/test/unit/patch-formatter-test.ts
+++ b/app/test/unit/patch-formatter-test.ts
@@ -31,7 +31,7 @@ async function parseDiff(diff: string): Promise<ITextDiff> {
 }
 
 describe('patch formatting', () => {
-  let repository: Repository | null = null
+  let repository: Repository
 
   describe('formatPatchesForModifiedFile', () => {
     beforeEach(async () => {
@@ -51,7 +51,7 @@ describe('patch formatting', () => {
         unselectedFile
       )
 
-      const diff = await getWorkingDirectoryDiff(repository!, file)
+      const diff = await getWorkingDirectoryDiff(repository, file)
 
       expect(diff.kind === DiffType.Text)
 
@@ -90,7 +90,7 @@ describe('patch formatting', () => {
         unselectedFile
       )
 
-      const diff = await getWorkingDirectoryDiff(repository!, file)
+      const diff = await getWorkingDirectoryDiff(repository, file)
 
       expect(diff.kind === DiffType.Text)
 
@@ -130,7 +130,7 @@ describe('patch formatting', () => {
         unselectedFile
       )
 
-      const diff = await getWorkingDirectoryDiff(repository!, file)
+      const diff = await getWorkingDirectoryDiff(repository, file)
 
       expect(diff.kind === DiffType.Text)
 
@@ -159,7 +159,7 @@ describe('patch formatting', () => {
 
     it(`creates the right patch when an addition is selected but preceding deletions aren't`, async () => {
       const modifiedFile = 'modified-file.md'
-      await FSE.writeFile(Path.join(repository!.path, modifiedFile), 'line 1\n')
+      await FSE.writeFile(Path.join(repository.path, modifiedFile), 'line 1\n')
 
       const unselectedFile = DiffSelection.fromInitialSelection(
         DiffSelectionType.None
@@ -170,7 +170,7 @@ describe('patch formatting', () => {
         unselectedFile
       )
 
-      const diff = await getWorkingDirectoryDiff(repository!, file)
+      const diff = await getWorkingDirectoryDiff(repository, file)
 
       expect(diff.kind === DiffType.Text)
 

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -3,7 +3,7 @@ import { TestRepositoriesDatabase } from '../helpers/databases'
 import { IAPIRepository } from '../../src/lib/api'
 
 describe('RepositoriesStore', () => {
-  let repositoriesStore: RepositoriesStore | null = null
+  let repositoriesStore: RepositoriesStore
 
   beforeEach(async () => {
     const db = new TestRepositoriesDatabase()
@@ -15,19 +15,19 @@ describe('RepositoriesStore', () => {
   describe('adding a new repository', () => {
     it('contains the added repository', async () => {
       const repoPath = '/some/cool/path'
-      await repositoriesStore!.addRepository(repoPath)
+      await repositoriesStore.addRepository(repoPath)
 
-      const repositories = await repositoriesStore!.getAll()
+      const repositories = await repositoriesStore.getAll()
       expect(repositories[0].path).toBe(repoPath)
     })
   })
 
   describe('getting all repositories', () => {
     it('returns multiple repositories', async () => {
-      await repositoriesStore!.addRepository('/some/cool/path')
-      await repositoriesStore!.addRepository('/some/other/path')
+      await repositoriesStore.addRepository('/some/cool/path')
+      await repositoriesStore.addRepository('/some/other/path')
 
-      const repositories = await repositoriesStore!.getAll()
+      const repositories = await repositoriesStore.getAll()
       expect(repositories).toHaveLength(2)
     })
   })

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -53,19 +53,17 @@ function createSamplePullRequest(gitHubRepository: GitHubRepository) {
 }
 
 describe('RepositoryStateCache', () => {
-  let r: Repository | null = null
+  let repository: Repository
   const defaultGetUsersFunc = (repo: Repository) =>
     new Map<string, IGitHubUser>()
 
   beforeEach(() => {
-    r = new Repository('/something/path', 1, null, false)
+    repository = new Repository('/something/path', 1, null, false)
   })
 
   it('can update branches state for a repository', () => {
     const gitHubRepository = createSampleGitHubRepository()
     const firstPullRequest = createSamplePullRequest(gitHubRepository)
-
-    const repository = r!
 
     const cache = new RepositoryStateCache(defaultGetUsersFunc)
 
@@ -91,7 +89,6 @@ describe('RepositoryStateCache', () => {
     ]
 
     const summary = 'Hello world!'
-    const repository = r!
 
     const cache = new RepositoryStateCache(defaultGetUsersFunc)
 
@@ -115,7 +112,6 @@ describe('RepositoryStateCache', () => {
 
   it('can update compare state for a repository', () => {
     const filterText = 'my-cool-branch'
-    const repository = r!
 
     const cache = new RepositoryStateCache(defaultGetUsersFunc)
 

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -42,8 +42,7 @@ describe('Tokenizer', () => {
     const htmlURL = `${host}/${login}/${name}`
     const cloneURL = `${host}/${login}/${name}.git`
 
-    let gitHubRepository: GitHubRepository | null = null
-    gitHubRepository = {
+    const gitHubRepository: GitHubRepository = {
       dbID: 1,
       name,
       owner: {


### PR DESCRIPTION
## Overview

I can't recall the PR where this was first discussed, but on Friday I was looking over some Git tests thinking about some optimizations we could make and realized there was a chance to cleanup some of our test setup.

## Description

A while ago we were talking about how our tests are sometimes fighting with the typechecker because of how we setup the objects used in the test:

```
let repo: Repository | null = null
...
repo = await setupEmptyRepository()
...
const after = await getStatusOrThrow(repo!)
```

We don't need to explicitly assign `null` when initializing these variables (we would if this was inside a class because of the `--strictPropertyInitialization` compiler flag that landed in [TypeScript 2.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html)), and if we omit the `| null = null` part here we then avoid the need to tell the typechecker that we expect a value to exist here (using `!`).

I feel this is a safe change because the use of `!` is a compile-time check, and running the tests would verify they are correct no matter which approach we use here - so why not keep things simple?

I also tidied up some places where we'd use `repo` or `r` as an alias and then `const repository = repo!` to workaround this issue.

## Release notes

Notes: no-notes
