### PR TITLE
get last stored value for stash pane width at launch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1572,6 +1572,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitSummaryWidthConfigKey,
       defaultCommitSummaryWidth
     )
+    this.stashedFilesWidth = getNumber(
+      stashedFilesWidthConfigKey,
+      defaultStashedFilesWidth
+    )
 
     this.confirmRepoRemoval = getBoolean(
       confirmRepoRemovalKey,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -327,9 +327,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   private appIsFocused: boolean = false
 
-  private sidebarWidth: number = defaultSidebarWidth
-  private commitSummaryWidth: number = defaultCommitSummaryWidth
-  private stashedFilesWidth: number = defaultStashedFilesWidth
+  private sidebarWidth: number = getNumber(
+    sidebarWidthConfigKey,
+    defaultSidebarWidth
+  )
+  private commitSummaryWidth: number = getNumber(
+    commitSummaryWidthConfigKey,
+    defaultCommitSummaryWidth
+  )
+  private stashedFilesWidth: number = getNumber(
+    stashedFilesWidthConfigKey,
+    defaultStashedFilesWidth
+  )
   private windowState: WindowState
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -327,18 +327,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   private appIsFocused: boolean = false
 
-  private sidebarWidth: number = getNumber(
-    sidebarWidthConfigKey,
-    defaultSidebarWidth
-  )
-  private commitSummaryWidth: number = getNumber(
-    commitSummaryWidthConfigKey,
-    defaultCommitSummaryWidth
-  )
-  private stashedFilesWidth: number = getNumber(
-    stashedFilesWidthConfigKey,
-    defaultStashedFilesWidth
-  )
+  private sidebarWidth: number = defaultSidebarWidth
+  private commitSummaryWidth: number = defaultCommitSummaryWidth
+  private stashedFilesWidth: number = defaultStashedFilesWidth
   private windowState: WindowState
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false


### PR DESCRIPTION
## Overview

closes #7416 

## Release notes

Notes: [Fixed] Stash files list retains width between app restarts
