### PR TITLE
Manually drop successful stash pop with conflicts

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -172,8 +172,8 @@ export async function popStashEntry(
     // report an exit code of `1` and are not dropped after being applied.
     // so, we check for this case and drop them manually
     if (result.exitCode === 1) {
-      // because we use --quiet flag, we don't get output successful
-      // stash pops that have conflicts
+      // because we use --quiet flag, we don't get output for
+      // successful stash pops that have conflicts
       if (result.stderr.length > 0 || result.stdout.length > 0) {
         throw new GitError(result, args)
       }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -172,9 +172,8 @@ export async function popStashEntry(
     // report an exit code of `1` and are not dropped after being applied.
     // so, we check for this case and drop them manually
     if (result.exitCode === 1) {
-      // because we use --quiet flag, we don't get output for
-      // successful stash pops that have conflicts
-      if (result.stderr.length > 0 || result.stdout.length > 0) {
+      if (result.stderr.length > 0) {
+        // rethrow, because anything in stderr should prevent the stash from being popped
         throw new GitError(result, args)
       }
 

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -158,11 +158,34 @@ export async function popStashEntry(
   // ignoring these git errors for now, this will change when we start
   // implementing the stash conflict flow
   const expectedErrors = new Set<DugiteError>([DugiteError.MergeConflicts])
+  const successExitCodes = new Set<number>([0, 1])
   const stashToPop = await getStashEntryMatchingSha(repository, stashSha)
 
   if (stashToPop !== null) {
-    const args = ['stash', 'pop', `${stashToPop.name}`]
-    await git(args, repository.path, 'popStashEntry', { expectedErrors })
+    const args = ['stash', 'pop', '--quiet', `${stashToPop.name}`]
+    const result = await git(args, repository.path, 'popStashEntry', {
+      expectedErrors,
+      successExitCodes,
+    })
+
+    // popping a stashes that create conflicts in the working directory
+    // report an exit code of `1` and are not dropped after being applied.
+    // so, we check for this case and drop them manually
+    if (result.exitCode === 1) {
+      // because we use --quiet flag, we don't get output successful
+      // stash pops that have conflicts
+      if (result.stderr.length > 0 || result.stdout.length > 0) {
+        throw new GitError(result, args)
+      }
+
+      log.info(
+        `[popStashEntry] a stash was popped successfully but exit code ${
+          result.exitCode
+        } reported.`
+      )
+      // bye bye
+      await dropDesktopStashEntry(repository, stashSha)
+    }
   }
 }
 

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -288,7 +288,7 @@ describe('git/stash', () => {
         await FSE.writeFile(readme, Math.random()) // eslint-disable-line insecure-random
 
         const entryToApply = entries[0]
-        expect(
+        await expect(
           popStashEntry(repository, entryToApply.stashSha)
         ).rejects.toThrowError()
       })


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

Closes #7383 

## Description

- adds `--quiet` option to `stash pop`
- adds `1` as a success exit code for `stash pop` and manually inspects for output
- manually drops stash when its popped but not dropped by git
- updates and adds more test coverage for `stash pop`