### PR TITLE
Adjust the changelog indentation for 1.7.0 beta 2

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -43,14 +43,14 @@
       "[Improved] \"Add\" button in repository list should always be visible - #6646"
     ],
     "1.7.0-beta2": [
-        "[New] Rebase your current branch onto another branch using a guided flow - #5953",
-        "[Fixed] Horizontal scroll bar appears unnecessarily when switching branches - #7212",
-        "[Fixed] License templates do not end with newline character - #6999",
-        "[Fixed] Merge/Rebase conflicts banners do not clear when aborting the operation outside Desktop - #7046",
-        "[Fixed] Missing tooltips for change indicators in the sidebar - #7174",
-        "[Fixed] Icon accessibility labels fail when multiple icons are visible at the same time - #7174",
-        "[Improved] Pull requests load faster and PR build status updates automatically - #7163"
-      ],
+      "[New] Rebase your current branch onto another branch using a guided flow - #5953",
+      "[Fixed] Horizontal scroll bar appears unnecessarily when switching branches - #7212",
+      "[Fixed] License templates do not end with newline character - #6999",
+      "[Fixed] Merge/Rebase conflicts banners do not clear when aborting the operation outside Desktop - #7046",
+      "[Fixed] Missing tooltips for change indicators in the sidebar - #7174",
+      "[Fixed] Icon accessibility labels fail when multiple icons are visible at the same time - #7174",
+      "[Improved] Pull requests load faster and PR build status updates automatically - #7163"
+    ],
     "1.7.0-beta1": [
       "[New] Recently opened repositories appear at the top of the repository list - #7132",
       "[Fixed] Error when selecting diff text while diff is updating - #7131",


### PR DESCRIPTION
Just a very minimal enhancement here. 

As I was just reading through the upcoming changelog, I noticed the indentation for 1.7.0 beta 2 was not matching the code style. This PR simply fixes that.


