### PR TITLE
 cleanup remotes sequentially to avoid lockfile issue

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -187,10 +187,9 @@ export class PullRequestStore extends TypedBaseStore<GitHubRepository> {
     repository: Repository,
     remotes: ReadonlyArray<IRemote>
   ) {
-    const promises: Array<Promise<void>> = []
-
-    remotes.forEach(r => promises.push(removeRemote(repository, r.name)))
-    await Promise.all(promises)
+    for (const remote of remotes) {
+      await removeRemote(repository, remote.name)
+    }
   }
 
   private updateActiveFetchCount(


### PR DESCRIPTION
## Overview

Found this bug while investigating some performance issues, and wanted to review/land this independent of that work as it's a really specific fix

## Description

The repro to this step is to add a lot of remotes from forks that are no longer used, using the `github-desktop-` prefix. After running `fetchAndCachePullRequests` (every 10mins or manually), the app also runs `pruneForkedRemotes` to find any remotes that are no longer associated with forks.

With the current implementation, it creates a bunch of promises (spawning Git processes to work concurrently) and then waits for them to complete.

The problem here is that Git appears to also need to update `.git/packed-refs`, and concurrent Git operations to update this file can trigger an error (like what happens with the index). [More details about packed refs can be found here](https://git-scm.com/docs/git-pack-refs).

This is obviously an extreme case, but we can be better here and run this work sequentially cleaning them up.

Here's a bunch of logs showing the problem:

<img width="826"  src="https://user-images.githubusercontent.com/359239/57146389-947ba380-6d9b-11e9-80e2-a37fefb845c9.png">
<img width="841" src="https://user-images.githubusercontent.com/359239/57146390-947ba380-6d9b-11e9-940a-6ee1d7b4f322.png">
<img width="825" src="https://user-images.githubusercontent.com/359239/57146391-947ba380-6d9b-11e9-952c-5ca0a033d750.png">
<img width="845" src="https://user-images.githubusercontent.com/359239/57146392-95143a00-6d9b-11e9-9620-c2105e21a69e.png">
<img width="830" src="https://user-images.githubusercontent.com/359239/57146393-95143a00-6d9b-11e9-97e7-7fea120b5938.png">








## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
