### PR TITLE
Reimplement baseline stashing metrics on top of last prod release

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.5-beta1",
+  "version": "1.6.5-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.82.0",
+    "dugite": "1.87.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.80.0",
+    "dugite": "1.82.0",
     "electron-window-state": "^4.0.2",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.4",
+  "version": "1.6.5-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "1.6.5-beta2",
+  "version": "1.6.5",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -28,6 +28,9 @@ export interface IDatabaseRepository {
   readonly gitHubRepositoryID: number | null
   readonly path: string
   readonly missing: boolean
+
+  /** The last time the stash entries were checked for the repository */
+  readonly lastStashCheckDate: number | null
 }
 
 /** The repositories database. */

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -267,7 +267,7 @@ function getDescriptionForError(error: DugiteError): string {
     case DugiteError.NoExistingRemoteBranch:
       return 'The remote branch does not exist.'
     case DugiteError.LocalChangesOverwritten:
-      return 'Unable to switch branches as there are working directory changes that would be overwritten. Please commit or stash your changes.'
+      return 'Unable to switch branches as there are working directory changes which would be overwritten. Please commit or stash your changes.'
     case DugiteError.UnresolvedConflicts:
       return 'There are unresolved conflicts in the working directory.'
     default:

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -267,7 +267,7 @@ function getDescriptionForError(error: DugiteError): string {
     case DugiteError.NoExistingRemoteBranch:
       return 'The remote branch does not exist.'
     case DugiteError.LocalChangesOverwritten:
-      return 'Some of your changes would be overwritten.'
+      return 'Unable to switch branches as there are working directory changes that would be overwritten. Please commit or stash your changes.'
     case DugiteError.UnresolvedConflicts:
       return 'There are unresolved conflicts in the working directory.'
     default:

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -268,6 +268,8 @@ function getDescriptionForError(error: DugiteError): string {
       return 'The remote branch does not exist.'
     case DugiteError.LocalChangesOverwritten:
       return 'Some of your changes would be overwritten.'
+    case DugiteError.UnresolvedConflicts:
+      return 'There are unresolved conflicts in the working directory.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -264,6 +264,10 @@ function getDescriptionForError(error: DugiteError): string {
       return 'A lock file already exists in the repository, which blocks this operation from completing.'
     case DugiteError.NoMergeToAbort:
       return 'There is no merge in progress, so there is nothing to abort.'
+    case DugiteError.NoExistingRemoteBranch:
+      return 'The remote branch does not exist.'
+    case DugiteError.LocalChangesOverwritten:
+      return 'Some of your changes would be overwritten.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -1,6 +1,17 @@
 import { Repository } from '../../models/repository'
 import { git } from '.'
 
+/**
+ * RegEx for determining if a stash entry is created by Desktop
+ *
+ * This is done by looking for a magic string with the following
+ * format: `!!GitHub_Desktop<branch>`
+ */
+const desktopStashEntryMessageRe = /!!GitHub_Desktop<(.+)>$/
+
+/**
+ * Gets the number of stash entries for the given repository
+ */
 export async function getStashSize(repository: Repository): Promise<number> {
   const delimiter = '1F'
   const format = ['%gd', '%H', '%gs'].join(`%x${delimiter}`)
@@ -20,7 +31,10 @@ export async function getStashSize(repository: Repository): Promise<number> {
     return 0
   }
 
-  const stashEntries = result.stdout.split('\0').filter(s => s !== '')
+  const stashEntries = result.stdout
+    .split('\0')
+    .filter(s => s !== '')
+    .filter(s => !desktopStashEntryMessageRe.test(s))
 
   return stashEntries.length
 }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -1,0 +1,26 @@
+import { Repository } from '../../models/repository'
+import { git } from '.'
+
+export async function getStashSize(repository: Repository): Promise<number> {
+  const delimiter = '1F'
+  const format = ['%gd', '%H', '%gs'].join(`%x${delimiter}`)
+
+  const result = await git(
+    ['log', '-g', '-z', `--pretty=${format}`, 'refs/stash'],
+    repository.path,
+    'getStashSize',
+    {
+      successExitCodes: new Set([0, 128]),
+    }
+  )
+
+  // There's no refs/stashes reflog in the repository or it's not
+  // even a repository. In either case we don't care
+  if (result.exitCode === 128) {
+    return 0
+  }
+
+  const stashEntries = result.stdout.split('\0').filter(s => s !== '')
+
+  return stashEntries.length
+}

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -163,6 +163,12 @@ export interface IDailyMeasures {
 
   /** The number of times a user has pulled with `pull.rebase` unset or set to `false` */
   readonly pullWithDefaultSettingCount: number
+
+  /**
+   * The number of times the user is presented with the error
+   * message "Some of your changes would be overwritten"
+   */
+  readonly errorWhenSwitchingBranchesWithUncommmittedChanges: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -168,7 +168,7 @@ export interface IDailyMeasures {
    * The number of stash entries created outside of Desktop
    * in a given 24 hour day
    */
-  readonly stashesCreatedOutsideDesktop: number
+  readonly stashEntriesCreatedOutsideDesktop: number
 
   /**
    * The number of times the user is presented with the error

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -165,6 +165,12 @@ export interface IDailyMeasures {
   readonly pullWithDefaultSettingCount: number
 
   /**
+   * The number of stash entries created outside of Desktop
+   * in a given 24 hour day
+   */
+  readonly stashesCreatedOutsideDesktop: number
+
+  /**
    * The number of times the user is presented with the error
    * message "Some of your changes would be overwritten"
    */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -87,6 +87,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseSuccessAfterConflictsCount: 0,
   pullWithRebaseCount: 0,
   pullWithDefaultSettingCount: 0,
+  stashesCreatedOutsideDesktop: 0,
   errorWhenSwitchingBranchesWithUncommmittedChanges: 0,
 }
 
@@ -933,6 +934,15 @@ export class StatsStore implements IStatsStore {
   public async recordMergeAbortedAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeAbortedAfterConflictsCount: m.mergeAbortedAfterConflictsCount + 1,
+    }))
+  }
+
+  /** Record the number of stash entries created outside of Desktop for the day */
+  public async addStashesCreatedOutsideDesktop(
+    stashCount: number
+  ): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      stashesCreatedOutsideDesktop: m.stashesCreatedOutsideDesktop + stashCount,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -87,7 +87,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseSuccessAfterConflictsCount: 0,
   pullWithRebaseCount: 0,
   pullWithDefaultSettingCount: 0,
-  stashesCreatedOutsideDesktop: 0,
+  stashEntriesCreatedOutsideDesktop: 0,
   errorWhenSwitchingBranchesWithUncommmittedChanges: 0,
 }
 
@@ -938,11 +938,12 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record the number of stash entries created outside of Desktop for the day */
-  public async addStashesCreatedOutsideDesktop(
+  public async addStashEntriesCreatedOutsideDesktop(
     stashCount: number
   ): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      stashesCreatedOutsideDesktop: m.stashesCreatedOutsideDesktop + stashCount,
+      stashEntriesCreatedOutsideDesktop:
+        m.stashEntriesCreatedOutsideDesktop + stashCount,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -87,6 +87,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseSuccessAfterConflictsCount: 0,
   pullWithRebaseCount: 0,
   pullWithDefaultSettingCount: 0,
+  errorWhenSwitchingBranchesWithUncommmittedChanges: 0,
 }
 
 interface IOnboardingStats {
@@ -932,6 +933,19 @@ export class StatsStore implements IStatsStore {
   public async recordMergeAbortedAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeAbortedAfterConflictsCount: m.mergeAbortedAfterConflictsCount + 1,
+    }))
+  }
+
+  /**
+   * Record the number of times the user experiences the error
+   * "Some of your changes would be overwritten" when switching branches
+   */
+  public async recordErrorWhenSwitchingBranchesWithUncommmittedChanges(): Promise<
+    void
+  > {
+    return this.updateDailyMeasures(m => ({
+      errorWhenSwitchingBranchesWithUncommmittedChanges:
+        m.errorWhenSwitchingBranchesWithUncommmittedChanges + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3589,6 +3589,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (lastStashEntryCheck == null || threshold.isAfter(lastStashEntryCheck)) {
       // `lastStashEntryCheck` being equal to null means we've never checked for
       // the given repo
+      const stashSize = await getStashSize(repository)
+      this.statsStore.addStashesCreatedOutsideDesktop(stashSize)
 
       await this.repositoriesStore.updateLastStashCheckDate(repository)
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1141,6 +1141,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return Promise.resolve(null)
     }
 
+    this.updateStashEntryCountMetric(repository)
     setNumber(LastSelectedRepositoryIDKey, repository.id)
 
     // if repository might be marked missing, try checking if it has been restored
@@ -2392,8 +2393,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         }
       )
     )
-
-    this.updateStashEntryCountMetric(repository)
 
     try {
       this.updateCheckoutProgress(repository, {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3588,10 +3588,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (lastStashEntryCheck == null || threshold.isAfter(lastStashEntryCheck)) {
       // `lastStashEntryCheck` being equal to null means we've never checked for
       // the given repo
-      const stashSize = await getStashSize(repository)
-      this.statsStore.addStashEntriesCreatedOutsideDesktop(stashSize)
 
-      await this.repositoriesStore.updateLastStashCheckDate(repository)
+      try {
+        const stashSize = await getStashSize(repository)
+        this.statsStore.addStashEntriesCreatedOutsideDesktop(stashSize)
+      } finally {
+        await this.repositoriesStore.updateLastStashCheckDate(repository)
+      }
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3589,7 +3589,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // `lastStashEntryCheck` being equal to null means we've never checked for
       // the given repo
       const stashSize = await getStashSize(repository)
-      this.statsStore.addStashesCreatedOutsideDesktop(stashSize)
+      this.statsStore.addStashEntriesCreatedOutsideDesktop(stashSize)
 
       await this.repositoriesStore.updateLastStashCheckDate(repository)
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -193,6 +193,8 @@ import {
 import { BranchPruner } from './helpers/branch-pruner'
 import { enableBranchPruning, enablePullWithRebase } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
+import moment = require('moment')
+import { getStashSize } from '../git/stash'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -2391,6 +2393,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
     )
 
+    this.updateStashEntryCountMetric(repository)
+
     try {
       this.updateCheckoutProgress(repository, {
         kind,
@@ -3574,6 +3578,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       this.emitUpdate()
+    }
+  }
+  private async updateStashEntryCountMetric(repository: Repository) {
+    const lastStashEntryCheck = await this.repositoriesStore.getLastStashCheckDate(
+      repository
+    )
+    const dateNow = moment()
+    const threshold = dateNow.subtract(24, 'hours')
+    if (lastStashEntryCheck == null || threshold.isAfter(lastStashEntryCheck)) {
+      // `lastStashEntryCheck` being equal to null means we've never checked for
+      // the given repo
+
+      await this.repositoriesStore.updateLastStashCheckDate(repository)
     }
   }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -147,6 +147,7 @@ export class RepositoriesStore extends BaseStore {
             path,
             gitHubRepositoryID: null,
             missing: false,
+            lastStashCheckDate: null,
           })
         }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -179,14 +179,16 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    const gitHubRepositoryID = repository.gitHubRepository
-      ? repository.gitHubRepository.dbID
-      : null
+    const oldRecord = await this.db.repositories.get(repoID)
+    if (oldRecord === undefined) {
+      return fatalError(
+        `\`updateRepositoryMissing\` - unable to find repo with ID ${repoID} in database.`
+      )
+    }
+
     await this.db.repositories.put({
-      id: repository.id,
-      path: repository.path,
+      ...oldRecord,
       missing,
-      gitHubRepositoryID,
     })
 
     this.emitUpdate()
@@ -211,14 +213,16 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    const gitHubRepositoryID = repository.gitHubRepository
-      ? repository.gitHubRepository.dbID
-      : null
+    const oldRecord = await this.db.repositories.get(repoID)
+    if (oldRecord === undefined) {
+      return fatalError(
+        `\`updateRepositoryPath\` - unable to find repo with ID ${repoID} in database.`
+      )
+    }
+
     await this.db.repositories.put({
-      id: repository.id,
-      missing: false,
-      path: path,
-      gitHubRepositoryID,
+      ...oldRecord,
+      path,
     })
 
     this.emitUpdate()

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -235,6 +235,57 @@ export class RepositoriesStore extends BaseStore {
     )
   }
 
+  /**
+   * Sets the last time the repository was checked for stash entries
+   *
+   * @param repository The repository in which to update the last stash check date for
+   * @param date The date and time in which the last stash check took place; defaults to
+   * the current time
+   */
+  public async updateLastStashCheckDate(
+    repository: Repository,
+    date: number = Date.now()
+  ): Promise<void> {
+    const repoID = repository.id
+    if (repoID === 0) {
+      return fatalError(
+        '`updateLastStashCheckDate` can only update the last stash check date for a repository which has been added to the database.'
+      )
+    }
+
+    await this.db.repositories.update(repoID, {
+      lastStashCheckDate: date,
+    })
+
+    this.emitUpdate()
+  }
+
+  /**
+   * Gets the last time the repository was checked for stash entries
+   *
+   * @param repository The repository in which to update the last stash check date for
+   */
+  public async getLastStashCheckDate(
+    repository: Repository
+  ): Promise<number | null> {
+    const repoID = repository.id
+    if (!repoID) {
+      return fatalError(
+        '`getLastStashCheckDate` - can only retrieve the last stash check date for a repositories that have been stored in the database.'
+      )
+    }
+
+    const record = await this.db.repositories.get(repoID)
+
+    if (record === undefined) {
+      return fatalError(
+        `'getLastStashCheckDate' - unable to find repository with ID: ${repoID}`
+      )
+    }
+
+    return record!.lastStashCheckDate
+  }
+
   private async putOwner(endpoint: string, login: string): Promise<Owner> {
     login = login.toLowerCase()
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -179,16 +179,19 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
+    const gitHubRepositoryID = repository.gitHubRepository
+      ? repository.gitHubRepository.dbID
+      : null
     const oldRecord = await this.db.repositories.get(repoID)
-    if (oldRecord === undefined) {
-      return fatalError(
-        `\`updateRepositoryMissing\` - unable to find repo with ID ${repoID} in database.`
-      )
-    }
+    const lastStashCheckDate =
+      oldRecord !== undefined ? oldRecord.lastStashCheckDate : null
 
     await this.db.repositories.put({
-      ...oldRecord,
+      id: repository.id,
+      path: repository.path,
       missing,
+      gitHubRepositoryID,
+      lastStashCheckDate,
     })
 
     this.emitUpdate()
@@ -213,16 +216,19 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
+    const gitHubRepositoryID = repository.gitHubRepository
+      ? repository.gitHubRepository.dbID
+      : null
     const oldRecord = await this.db.repositories.get(repoID)
-    if (oldRecord === undefined) {
-      return fatalError(
-        `\`updateRepositoryPath\` - unable to find repo with ID ${repoID} in database.`
-      )
-    }
+    const lastStashCheckDate =
+      oldRecord !== undefined ? oldRecord.lastStashCheckDate : null
 
     await this.db.repositories.put({
-      ...oldRecord,
+      id: repository.id,
+      missing: false,
       path,
+      gitHubRepositoryID,
+      lastStashCheckDate,
     })
 
     this.emitUpdate()

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1547,4 +1547,9 @@ export class Dispatcher {
   public recordRebaseConflictsDialogReopened() {
     this.statsStore.recordRebaseConflictsDialogReopened()
   }
+
+  /** Increments the `errorWhenSwitchingBranchesWithUncommmittedChanges` metric */
+  public recordErrorWhenSwitchingBranchesWithUncommmittedChanges() {
+    return this.statsStore.recordErrorWhenSwitchingBranchesWithUncommmittedChanges()
+  }
 }

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -442,4 +442,8 @@ export async function localChangesOverwrittenHandler(
   if (!(repository instanceof Repository)) {
     return error
   }
+
+  dispatcher.recordErrorWhenSwitchingBranchesWithUncommmittedChanges()
+
+  return error
 }

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -406,3 +406,40 @@ export async function rebaseConflictsHandler(
 
   return null
 }
+
+/**
+ * Handler for when we attempt to checkout a branch and there are some files that would
+ * be overwritten.
+ */
+export async function localChangesOverwrittenHandler(
+  error: Error,
+  dispatcher: Dispatcher
+): Promise<Error | null> {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (!dugiteError) {
+    return error
+  }
+
+  if (dugiteError !== DugiteError.LocalChangesOverwritten) {
+    return error
+  }
+
+  const { repository } = e.metadata
+  if (repository == null) {
+    return error
+  }
+
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+}

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -20,6 +20,7 @@ import {
   pushNeedsPullHandler,
   upstreamAlreadyExistsHandler,
   rebaseConflictsHandler,
+  localChangesOverwrittenHandler,
 } from './dispatcher'
 import {
   AppStore,
@@ -158,6 +159,7 @@ dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)
+dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
 
 if (enablePullWithRebase()) {
   dispatcher.registerErrorHandler(rebaseConflictsHandler)

--- a/app/src/ui/publish-repository/publish-repository.tsx
+++ b/app/src/ui/publish-repository/publish-repository.tsx
@@ -9,11 +9,7 @@ import { merge } from '../../lib/merge'
 import { caseInsensitiveCompare } from '../../lib/compare'
 import { sanitizedRepositoryName } from '../add-repository/sanitized-repository-name'
 import { Octicon, OcticonSymbol } from '../octicons'
-import {
-  RepositoryPublicationSettings,
-  IDotcomPublicationSettings,
-  PublishSettingsType,
-} from '../../models/publish-settings'
+import { RepositoryPublicationSettings } from '../../models/publish-settings'
 
 interface IPublishRepositoryProps {
   /** The user to use for publishing. */
@@ -89,13 +85,10 @@ export class PublishRepository extends React.Component<
 
   private onOrgChange = (event: React.FormEvent<HTMLSelectElement>) => {
     const { settings } = this.props
-    if (settings.kind !== PublishSettingsType.dotcom) {
-      return
-    }
 
     const value = event.currentTarget.value
     const index = parseInt(value, 10)
-    let newSettings: IDotcomPublicationSettings
+    let newSettings: RepositoryPublicationSettings
     if (index < 0 || isNaN(index)) {
       newSettings = { ...settings, org: null }
     } else {
@@ -119,10 +112,8 @@ export class PublishRepository extends React.Component<
     )
 
     let selectedIndex = -1
-    const selectedOrg =
-      this.props.settings.kind === PublishSettingsType.dotcom
-        ? this.props.settings.org
-        : null
+
+    const selectedOrg = this.props.settings.org
     for (const [index, org] of this.state.orgs.entries()) {
       if (selectedOrg && selectedOrg.id === org.id) {
         selectedIndex = index

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -404,10 +404,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.82.0:
-  version "1.82.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.82.0.tgz#fb4e0e94630c05d0df9e9190f6163ebe8a773aad"
-  integrity sha512-/mfn8DEvlVRTHmoWKZcscwE9aTBxTo6z13WU2F+9ZT7cfc/kBHVnsag0bdqQkFmYv24bjEVaNqQ+DkyMbqVxrw==
+dugite@1.87.0:
+  version "1.87.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.87.0.tgz#ba42c25401420a92c6c8f0c71823ac54124b4b65"
+  integrity sha512-+aW2Ql3yw1AEO8Z8nVbjOAEzsinMJMmAg4uf5lzTewFUAHd0danuMPXMP9uMuGuUYN/LQtt4kR2XLuWoD8wRSQ==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -404,14 +404,14 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.80.0:
-  version "1.80.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.80.0.tgz#69987fd54d8afd8d56b2e0f4fe43f2db1b49d800"
-  integrity sha512-ELavYXdThykKFffPG0w4NdfWYr5FfwKOP4lmLpnripbuJOE8DTTvgEJigG4dC2Vkpe5lavWX2Oia9qQoEyMzeQ==
+dugite@1.82.0:
+  version "1.82.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.82.0.tgz#fb4e0e94630c05d0df9e9190f6163ebe8a773aad"
+  integrity sha512-/mfn8DEvlVRTHmoWKZcscwE9aTBxTo6z13WU2F+9ZT7cfc/kBHVnsag0bdqQkFmYv24bjEVaNqQ+DkyMbqVxrw==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"
-    progress "^2.0.0"
+    progress "^2.0.3"
     request "^2.88.0"
     rimraf "^2.5.4"
     tar "^4.4.7"
@@ -1183,7 +1183,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-progress@^2.0.0:
+progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.6.5-beta2": [
+      "[Fixed] Publish Repository does not let you choose an organization on your Enterprise account - #7052"
+    ],
     "1.6.5-beta1": [
       "[Fixed] Publish Repository does not let you choose an organization on your Enterprise account - #7052"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.6.5": [
+      "[Fixed] Publish Repository does not let you publish to an organization on your Enterprise account - #7052"
+    ],
     "1.6.5-beta2": [
       "[Fixed] Publish Repository does not let you choose an organization on your Enterprise account - #7052"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "1.6.5-beta1": [
-      "[Fixed] Publish Repository does not let you choose an organization on your Enterprise account"
+      "[Fixed] Publish Repository does not let you choose an organization on your Enterprise account - #7052"
     ],
     "1.6.4": [
       "[Fixed] Embedded Git not working for core.longpath usage in some environments - #7028",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "1.6.5-beta1": [
+      "[Fixed] Publish Repository does not let you choose an organization on your Enterprise account"
+    ],
     "1.6.4": [
       "[Fixed] Embedded Git not working for core.longpath usage in some environments - #7028",
       "[Fixed] \"Recover missing repository\" can get stuck in a loop - #7038"


### PR DESCRIPTION
Get's metrics in place so we have a baseline for future metrics that will be added to address https://github.com/desktop/desktop/issues/7246.

This PR adds two new metrics:
* `stashEntriesCreatedOutsideDesktop` - the number of stash entries we know about for the day. 
* `errorWhenSwitchingBranchesWithUncommmittedChanges` - incremented when the user experiences an error trying to check out a new branch with uncommitted changes

The `stashEntriesCreatedOutsideDesktop` metric is a bit lazy because its value depends on which repositories a user opens during the day. So if you have 100 stashed in your-favorite-repo, but you never open that repo, those stash entries are not counted towards this metric. I chose this approach to limit the amount of background work we do. I'm open to changing the behaviour of this function if needed.

**Review checklist**
- [x] Review https://github.com/github/central/pull/432
- [x] Review https://github.com/github/desktop.github.com/pull/131

**Testing** - https://github.com/desktop/desktop/pull/7438#issuecomment-488133619.

Related PR:  #7438