### PR TITLE
update repository state selectively during stashing

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5059,10 +5059,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await Promise.all([
-      this._loadStatus(repository, true),
-      gitStore.loadStashEntries(),
-    ])
+    await this._refreshRepository(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2843,7 +2843,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         uncommittedChangesStrategy ===
         UncommittedChangesStrategy.moveToNewBranch
       ) {
-        await this._createStash(repository, foundBranch.name, false)
+        await createDesktopStashEntry(repository, foundBranch.name)
         shouldPopStash = true
       }
     }
@@ -2872,7 +2872,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       )
 
       if (stash !== null) {
-        await this._popStashEntry(repository, stash)
+        await gitStore.performFailableOperation(() => {
+          return popStashEntry(repository, stash.stashSha)
+        })
       } else {
         log.info(
           `[AppStore._checkoutBranch] no stash found that matches ${

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5049,7 +5049,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this._refreshRepository(repository)
+    await Promise.all([
+      this._loadStatus(repository, true),
+      this.gitStoreCache.get(repository).loadStashEntries(),
+    ])
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -5067,7 +5070,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this._refreshRepository(repository)
+    await Promise.all([
+      this._loadStatus(repository, true),
+      this.gitStoreCache.get(repository).loadStashEntries(),
+    ])
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5074,7 +5074,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await Promise.all([
       this._loadStatus(repository, true),
-      this.gitStoreCache.get(repository).loadStashEntries(),
+      gitStore.loadStashEntries(),
     ])
   }
 
@@ -5096,7 +5096,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this.gitStoreCache.get(repository).loadStashEntries()
+    await gitStore.loadStashEntries()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */


### PR DESCRIPTION
## Overview

related to #7464 , specifically 

> Overlapping getStatus calls introduce a bottleneck

which is a regression introduced by the implementation of stashing wrappers in app-store

## Description

- only update the parts of the repository state we need to after popping or pushing a stash
- don't update repository state at all if pushing/popping around checking out a branch

## To do
- [x] avoid `getStatus` calls when leaving changes on a branch

## Measurements

Using @shiftkey's `trace-all-the-things` branch, I made the follow measurements on my macbook pro:

### Scenario:
bring a single file change from `master` to `100768/pr-review-double-comment` via switching branches (requires a stash, checkout, and pop) on `github/github`

### Overall time
**Before:** 18s
**After:** 14s

(dev build of current production: 9s)

### Number of git commands that took more than .1s 
**Before:** 20
**After:** 10

(dev build of current production: 6)