### PR TITLE
Improve error message when publishing repo to an organization

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -444,7 +444,7 @@ export class API {
           throw new Error(
             `Unable to create repository for organization '${
               org.login
-            }'. Verify it exists and that you have permission to create a repository there.`
+            }'. Verify that it exists, that it's a paid organization, and that you have permission to create a repository there.`
           )
         }
         throw e


### PR DESCRIPTION
Paid organizations can't have private repos, so our error message can help people be aware of that.

## Overview

**Related to #2165**

When closing https://github.com/desktop/desktop/issues/2165, we found that free orgs still don't have the ability to contain private repositories. Therefore, this PR updates our error message when publishing a repo to an organization to indicate that that is one of the things that might be wrong when someone is attempting to publish.

## Release notes

No notes
