### PR TITLE
avoid invoking status when updating indicator for current repository

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2487,7 +2487,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const status = await this._loadStatus(repository)
     if (!status) {
       await this._updateRepositoryMissing(repository, true)
-      this.updateRepositoryIndicator(repository, null)
+      this.updateSidebarIndicator(repository, null)
       return
     }
 
@@ -2521,13 +2521,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.updateMenuItemLabels(latestState)
 
     this._initializeCompare(repository)
-    this.updateRepositoryIndicator(repository, status)
+    this.updateSidebarIndicator(repository, status)
   }
 
   /**
    * Update the repository sidebar indicator for the repository
    */
-  private async updateRepositoryIndicator(
+  private async updateSidebarIndicator(
     repository: Repository,
     status: IStatusResult | null
   ): Promise<void> {
@@ -2552,7 +2552,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /**
    * Refresh sidebar indicators for the set of repositories tracked in the app.
    */
-  public async refreshAllIndicators() {
+  public async refreshAllSidebarIndicators() {
     const startTime = performance && performance.now ? performance.now() : null
 
     // keep a reference to the current set of repositories to avoid the array

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2549,20 +2549,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  public refreshAllIndicators() {
-    return this.refreshIndicatorsForRepositories(this.repositories)
-  }
-
   /**
-   * Refresh in-memory indicators for a set of repositories
-   *
-   * @param repositories the set of repositories to update
-   * @param tryBackgroundFetch whether the action should also try and fetch new changes from the remote
+   * Refresh sidebar indicators for the set of repositories tracked in the app.
    */
-  private async refreshIndicatorsForRepositories(
-    repositories: ReadonlyArray<Repository>
-  ): Promise<void> {
+  public async refreshAllIndicators() {
     const startTime = performance && performance.now ? performance.now() : null
+
+    // keep a reference to the current set of repositories to avoid the array
+    // changing while this is running
+    const repositories = new Array<Repository>(...this.repositories)
 
     for (const repo of repositories) {
       await this.refreshIndicatorForRepository(repo)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2550,7 +2550,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public refreshAllIndicators() {
-    return this.refreshIndicatorsForRepositories(this.repositories, true)
+    return this.refreshIndicatorsForRepositories(this.repositories)
   }
 
   /**
@@ -2560,13 +2560,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * @param tryBackgroundFetch whether the action should also try and fetch new changes from the remote
    */
   private async refreshIndicatorsForRepositories(
-    repositories: ReadonlyArray<Repository>,
-    tryBackgroundFetch: boolean
+    repositories: ReadonlyArray<Repository>
   ): Promise<void> {
     const startTime = performance && performance.now ? performance.now() : null
 
     for (const repo of repositories) {
-      await this.refreshIndicatorForRepository(repo, tryBackgroundFetch)
+      await this.refreshIndicatorForRepository(repo)
     }
 
     if (startTime && repositories.length > 1) {
@@ -2588,10 +2587,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * @param repository the repository to check and update
    * @param tryBackgroundFetch whether the action should also try and fetch new changes from the remote
    */
-  private async refreshIndicatorForRepository(
-    repository: Repository,
-    tryBackgroundFetch: boolean
-  ) {
+  private async refreshIndicatorForRepository(repository: Repository) {
     const lookup = this.localRepositoryStateLookup
 
     if (repository.missing) {
@@ -2612,16 +2608,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (tryBackgroundFetch) {
-      const lastPush = await inferLastPushForRepository(
-        this.accounts,
-        gitStore,
-        repository
-      )
+    const lastPush = await inferLastPushForRepository(
+      this.accounts,
+      gitStore,
+      repository
+    )
 
-      if (this.shouldBackgroundFetch(repository, lastPush)) {
-        await this._fetch(repository, FetchType.BackgroundTask)
-      }
+    if (this.shouldBackgroundFetch(repository, lastPush)) {
+      await this._fetch(repository, FetchType.BackgroundTask)
     }
 
     lookup.set(repository.id, {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2456,7 +2456,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const foundRepository =
       (await pathExists(repository.path)) &&
       (await isGitRepository(repository.path)) &&
-      (await this._loadStatus(repository))
+      (await this._loadStatus(repository)) !== null
 
     if (foundRepository) {
       return await this._updateRepositoryMissing(repository, false)
@@ -2485,9 +2485,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // is in a bad state - let's mark it as missing here and give up on the
     // further work
     const status = await this._loadStatus(repository)
-    if (!status) {
+    this.updateSidebarIndicator(repository, status)
+
+    if (status === null) {
       await this._updateRepositoryMissing(repository, true)
-      this.updateSidebarIndicator(repository, null)
       return
     }
 
@@ -2521,7 +2522,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.updateMenuItemLabels(latestState)
 
     this._initializeCompare(repository)
-    this.updateSidebarIndicator(repository, status)
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2577,10 +2577,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
-   * Refresh in-memory indicators for a repository
-   *
-   * @param repository the repository to check and update
-   * @param tryBackgroundFetch whether the action should also try and fetch new changes from the remote
+   * Refresh indicator in repository list for a specific repository
    */
   private async refreshIndicatorForRepository(repository: Repository) {
     const lookup = this.localRepositoryStateLookup

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -190,10 +190,10 @@ export class App extends React.Component<IAppProps, IAppState> {
       const initialTimeout = window.setTimeout(async () => {
         window.clearTimeout(initialTimeout)
 
-        await this.props.appStore.refreshAllIndicators()
+        await this.props.appStore.refreshAllSidebarIndicators()
 
         this.updateIntervalHandle = window.setInterval(() => {
-          this.props.appStore.refreshAllIndicators()
+          this.props.appStore.refreshAllSidebarIndicators()
         }, UpdateRepositoryIndicatorInterval)
       }, InitialRepositoryIndicatorTimeout)
     })


### PR DESCRIPTION
## Overview

Related to #7464 

## Description

Whenever `AppStore._refreshRepository` runs (updating the current repository), it also runs `AppStore.refreshIndicatorsForRepositories` at the end.

Internally this does two expensive things:

 - run `AppStore._loadStatus()` to see whether there are working directory changes
 - run `AppStore.fetch()` to background fetch and detect the ahead/behind of the current branch

This feels rather wasteful to do for the active repository, and we already have a `AppStore._loadStatus()` result from earlier in `AppStore._refreshRepository` that has sufficient information for this UI (are there working changes?).

Given this function opts out of fetching while refreshing, and we have a relatively recent `getStatus` result, this PR introduces a more explicit `AppStore.updateSidebarIndicator` that is now used in `refreshRepository`, and leaves the existing behaviour in `AppStore.refreshAllSidebarIndicators` to be run when the background refresh happens.

This PR eliminates three Git operations that run on every refresh (a `git status` and two `git diff`).

On a `desktop/desktop` repository with a clean working directory:

**Before**

<img width="774" src="https://user-images.githubusercontent.com/359239/57316202-a2973000-70cb-11e9-9538-a4fefbf0fd77.png">

**After**

<img width="779"  src="https://user-images.githubusercontent.com/359239/57316392-12a5b600-70cc-11e9-9d0b-8f84f5c73c9d.png">

On a `nodejs/node` repository with 33k files removed in the working directory:

**Before**

<img width="780" src="https://user-images.githubusercontent.com/359239/57316188-99a65e80-70cb-11e9-89e1-2f1835a6d784.png">

**After**

<img width="776"  src="https://user-images.githubusercontent.com/359239/57315920-fb19fd80-70ca-11e9-8421-a545c6e470d2.png">

## Release notes

Notes: no-notes
