### PR TITLE
use the index state to detect whether there are conflicted files present

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -27,6 +27,7 @@ import { stageFiles } from './update-index'
 import { getStatus } from './status'
 import { getCommitsInRange } from './rev-list'
 import { Branch } from '../../models/branch'
+import { enablePullWithRebase } from '../feature-flag'
 
 /**
  * Check the `.git/REBASE_HEAD` file exists in a repository to confirm
@@ -48,6 +49,10 @@ function isRebaseHeadSet(repository: Repository) {
 export async function getRebaseInternalState(
   repository: Repository
 ): Promise<RebaseInternalState | null> {
+  if (!enablePullWithRebase()) {
+    return null
+  }
+
   const isRebase = await isRebaseHeadSet(repository)
 
   if (!isRebase) {

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -1,5 +1,4 @@
 import { GitError as DugiteError } from 'dugite'
-import { git } from '.'
 
 import { Repository } from '../../models/repository'
 import {
@@ -9,7 +8,7 @@ import {
 } from '../../models/stash-entry'
 import { CommittedFileChange } from '../../models/status'
 
-import { GitError } from './core'
+import { git, GitError } from './core'
 import { parseChangedFiles } from './log'
 
 export const DesktopStashEntryMarker = '!!GitHub_Desktop'

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -212,9 +212,7 @@ export async function getStatus(
       conflictedFilesInIndex,
       rebaseInternalState
     )
-    // a little optimization so we don't run `getWorkingDirectoryConflictDetails`
-    // when there are no files to even detect conflicts in
-  } else if (entries.length > 0) {
+  } else {
     conflictDetails = await getConflictDetails(
       repository,
       mergeHeadFound,

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -26,7 +26,6 @@ import { fatalError } from '../../lib/fatal-error'
 import { isMergeHeadSet } from './merge'
 import { getBinaryPaths } from './diff'
 import { getRebaseInternalState } from './rebase'
-import { enablePullWithRebase } from '../feature-flag'
 import { RebaseInternalState } from '../../models/rebase'
 
 /**
@@ -196,30 +195,16 @@ export async function getStatus(
   const headers = parsed.filter(isStatusHeader)
   const entries = parsed.filter(isStatusEntry)
 
-  let conflictDetails: ConflictFilesDetails = {
-    conflictCountsByPath: new Map<string, number>(),
-    binaryFilePaths: new Array<string>(),
-  }
-
   const mergeHeadFound = await isMergeHeadSet(repository)
   const conflictedFilesInIndex = entries.some(e => e.statusCode === 'UU')
   const rebaseInternalState = await getRebaseInternalState(repository)
 
-  if (enablePullWithRebase()) {
-    conflictDetails = await getConflictDetails(
-      repository,
-      mergeHeadFound,
-      conflictedFilesInIndex,
-      rebaseInternalState
-    )
-  } else {
-    conflictDetails = await getConflictDetails(
-      repository,
-      mergeHeadFound,
-      conflictedFilesInIndex,
-      null
-    )
-  }
+  const conflictDetails = await getConflictDetails(
+    repository,
+    mergeHeadFound,
+    conflictedFilesInIndex,
+    rebaseInternalState
+  )
 
   // Map of files keyed on their paths.
   const files = entries.reduce(

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -149,6 +149,10 @@ function convertToAppStatus(
   return fatalError(`Unknown file status ${status}`)
 }
 
+// List of known conflicted index entries for a file, extracted from mapStatus
+// inside `app/src/lib/status-parser.ts` for convenience
+const conflictStatusCodes = ['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']
+
 /**
  *  Retrieve the status for a given repository,
  *  and fail gracefully if the location is not a Git repository
@@ -196,7 +200,9 @@ export async function getStatus(
   const entries = parsed.filter(isStatusEntry)
 
   const mergeHeadFound = await isMergeHeadSet(repository)
-  const conflictedFilesInIndex = entries.some(e => e.statusCode === 'UU')
+  const conflictedFilesInIndex = entries.some(
+    e => conflictStatusCodes.indexOf(e.statusCode) > -1
+  )
   const rebaseInternalState = await getRebaseInternalState(repository)
 
   const conflictDetails = await getConflictDetails(

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -251,7 +251,8 @@ describe('git/stash', () => {
     })
 
     describe('when there are (resolvable) conflicts', () => {
-      it('restores changes and drops stash', async () => {
+      let entryToApply: IStashEntry
+      beforeEach(async () => {
         await generateTestStashEntry(repository, 'master', true)
         const entries = await getDesktopStashEntries(repository)
         expect(entries.length).toBe(1)
@@ -263,19 +264,32 @@ describe('git/stash', () => {
           repository.path
         )
 
-        let status = await getStatusOrThrow(repository)
-        let files = status.workingDirectory.files
+        const status = await getStatusOrThrow(repository)
+        const files = status.workingDirectory.files
         expect(files).toHaveLength(0)
 
-        const entryToApply = entries[0]
+        entryToApply = entries[0]
         await popStashEntry(repository, entryToApply.stashSha)
+      })
 
-        status = await getStatusOrThrow(repository)
-        files = status.workingDirectory.files
+      it('restores changes and drops stash', async () => {
+        const status = await getStatusOrThrow(repository)
+        const files = status.workingDirectory.files
         expect(files).toHaveLength(1)
 
         const entriesAfter = await getDesktopStashEntries(repository)
         expect(entriesAfter).not.toContain(entryToApply)
+      })
+
+      it('detects conflicted file', async () => {
+        const status = await getStatusOrThrow(repository)
+        const files = status.workingDirectory.files
+        expect(files).toHaveLength(1)
+
+        const conflictedFiles = files.filter(
+          f => f.status.kind === AppFileStatusKind.Conflicted
+        )
+        expect(conflictedFiles).toHaveLength(1)
       })
     })
     describe('when there are unresolvable conflicts', () => {

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -251,8 +251,7 @@ describe('git/stash', () => {
     })
 
     describe('when there are (resolvable) conflicts', () => {
-      let entryToApply: IStashEntry
-      beforeEach(async () => {
+      it('restores changes and drops stash', async () => {
         await generateTestStashEntry(repository, 'master', true)
         const entries = await getDesktopStashEntries(repository)
         expect(entries.length).toBe(1)
@@ -264,32 +263,19 @@ describe('git/stash', () => {
           repository.path
         )
 
-        const status = await getStatusOrThrow(repository)
-        const files = status.workingDirectory.files
+        let status = await getStatusOrThrow(repository)
+        let files = status.workingDirectory.files
         expect(files).toHaveLength(0)
 
-        entryToApply = entries[0]
+        const entryToApply = entries[0]
         await popStashEntry(repository, entryToApply.stashSha)
-      })
 
-      it('restores changes and drops stash', async () => {
-        const status = await getStatusOrThrow(repository)
-        const files = status.workingDirectory.files
+        status = await getStatusOrThrow(repository)
+        files = status.workingDirectory.files
         expect(files).toHaveLength(1)
 
         const entriesAfter = await getDesktopStashEntries(repository)
         expect(entriesAfter).not.toContain(entryToApply)
-      })
-
-      it('detects conflicted file', async () => {
-        const status = await getStatusOrThrow(repository)
-        const files = status.workingDirectory.files
-        expect(files).toHaveLength(1)
-
-        const conflictedFiles = files.filter(
-          f => f.status.kind === AppFileStatusKind.Conflicted
-        )
-        expect(conflictedFiles).toHaveLength(1)
       })
     })
     describe('when there are unresolvable conflicts', () => {


### PR DESCRIPTION
## Overview

Related to #7464 

## Description

This PR tunes a code path inside `getStatus` that was introduced as part of the new stash flow in #7380. The original implementation was a naive "do we have changes?" check and it turns out that `git diff` is rather expensive when dealing with a large number of working directory changes.

Here's a profile of a refresh in the `nodejs/node` repository when all of the files are marked for deletion (I've highlighted the overall timing):

<img width="941" src="https://user-images.githubusercontent.com/359239/57327210-b9964c00-70e4-11e9-9275-924f0ec696d6.png">

You'll note that `getFilesWithConflictMarkers` and `getBinaryPaths` take a combined 4.7 seconds, or about 85% of the overall 5.5 seconds it takes to refresh. 

You can also see these fire again outside the scope of the refresh, but I've opened #7475 because I think that work is unnecessary:

<img width="528" src="https://user-images.githubusercontent.com/359239/57327547-9d46df00-70e5-11e9-8c65-0b084bda385a.png">

The fix I settled on was to look at the index for unmerged files _if we cannot detect a merge or rebase in progress_. If we do not detect any unmerged files in the index, I believe we can skip doing any `git diff` invocations and save time.

## Release notes

Notes: `[Improved] checks for stashing conflicts only when the right state found in index`
