### PR TITLE
tweak the output when in development mode for helpful performance context

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -741,8 +741,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     initialAction?: CompareAction
   ) {
-    log.debug('[AppStore] initializing compare state')
-
     const state = this.repositoryStateCache.get(repository)
 
     const { branchesState, compareState } = state

--- a/app/src/ui/lib/git-perf.ts
+++ b/app/src/ui/lib/git-perf.ts
@@ -18,7 +18,6 @@ export async function measure<T>(
 ): Promise<T> {
   const id = ++markID
 
-  log.debug(`Executing ${cmd}`)
   const startTime = performance && performance.now ? performance.now() : null
 
   markBegin(id, cmd)
@@ -27,7 +26,7 @@ export async function measure<T>(
   } finally {
     if (startTime) {
       const rawTime = performance.now() - startTime
-      if (rawTime > 1000) {
+      if (__DEV__ || rawTime > 1000) {
         const timeInSeconds = (rawTime / 1000).toFixed(3)
         log.info(`Executing ${cmd} (took ${timeInSeconds}s)`)
       }


### PR DESCRIPTION
## Overview

Some cleanup I would like to land as a result of investigating #7464 

## Description

Two little changes:

 - 655c69cdec5bedb8ed59e32a73ddd7b724c070e9 always shows the Git operations when `__DEV__` is enabled, in production we only log slow Git operations as usual
 - ef487442b9d31ece3beb3f3cc3e686e4ab286c62 this debug message is just noise when `__DEV__` is enabled

## Release notes

Notes: no-notes
