### PR TITLE
Upgrade from Xcode 9.3.0 to 9.3.1 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/desktop/desktop
   macos:
-    xcode: '9.3.0'
+    xcode: '9.3.1'
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

CircleCI will soon deprecate Xcode 9.3.0. More details [here](https://discuss.circleci.com/t/removing-support-for-xcode-versions-9-0-0-9-3-0-and-9-4-0/30084).

Moving the project from 9.3.0 to 9.3.1 should have no impact on the CircleCI jobs, and it will help avoid problems due to Xcode 9.3.0 image deprecation. Plus it will help the project to hit fewer Xcode bugs.

