### PR TITLE
Upgrade from Xcode 9.3.0 to 9.3.1 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/desktop/desktop
   macos:
-    xcode: '9.3.0'
+    xcode: '9.3.1'
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

Backport of #7479 in advance of cutting a release after the image has been pulled.

## Release notes

Notes: no-notes
