### PR TITLE
Don't persist branch and PR filters

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -404,12 +404,6 @@ export interface IRepositoryState {
    * null if no such operation is in flight.
    */
   readonly revertProgress: IRevertProgress | null
-
-  /** The current branch filter text. */
-  readonly branchFilterText: string
-
-  /** The current pull request filter text. */
-  readonly pullRequestFilterText: string
 }
 
 export interface IBranchesState {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1130,28 +1130,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _setBranchFilterText(
-    repository: Repository,
-    text: string
-  ): Promise<void> {
-    this.repositoryStateCache.update(repository, () => ({
-      branchFilterText: text,
-    }))
-    this.emitUpdate()
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _setPullRequestFilterText(
-    repository: Repository,
-    text: string
-  ): Promise<void> {
-    this.repositoryStateCache.update(repository, () => ({
-      pullRequestFilterText: text,
-    }))
-    this.emitUpdate()
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _changeFileSelection(
     repository: Repository,
     file: CommittedFileChange

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -180,7 +180,5 @@ function getInitialRepositoryState(): IRepositoryState {
     checkoutProgress: null,
     pushPullFetchProgress: null,
     revertProgress: null,
-    branchFilterText: '',
-    pullRequestFilterText: '',
   }
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -31,8 +31,6 @@ interface IBranchesContainerProps {
   readonly currentBranch: Branch | null
   readonly recentBranches: ReadonlyArray<Branch>
   readonly pullRequests: ReadonlyArray<PullRequest>
-  readonly branchFilterText: string
-  readonly pullRequestFilterText: string
 
   /** The pull request associated with the current branch. */
   readonly currentPullRequest: PullRequest | null
@@ -59,8 +57,8 @@ export class BranchesContainer extends React.Component<
     this.state = {
       selectedBranch: props.currentBranch,
       selectedPullRequest: props.currentPullRequest,
-      branchFilterText: props.branchFilterText,
-      pullRequestFilterText: props.pullRequestFilterText,
+      branchFilterText: '',
+      pullRequestFilterText: '',
     }
   }
 
@@ -286,16 +284,5 @@ export class BranchesContainer extends React.Component<
     )
 
     this.onPullRequestSelectionChanged(pullRequest)
-  }
-
-  public componentWillUnmount() {
-    this.props.dispatcher.setBranchFilterText(
-      this.props.repository,
-      this.state.branchFilterText
-    )
-    this.props.dispatcher.setPullRequestFilterText(
-      this.props.repository,
-      this.state.pullRequestFilterText
-    )
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -195,22 +195,6 @@ export class Dispatcher {
     return this.appStore._setRepositoryFilterText(text)
   }
 
-  /** Set the branch filter text. */
-  public setBranchFilterText(
-    repository: Repository,
-    text: string
-  ): Promise<void> {
-    return this.appStore._setBranchFilterText(repository, text)
-  }
-
-  /** Set the branch filter text. */
-  public setPullRequestFilterText(
-    repository: Repository,
-    text: string
-  ): Promise<void> {
-    return this.appStore._setPullRequestFilterText(repository, text)
-  }
-
   /** Select the repository. */
   public selectRepository(
     repository: Repository | CloningRepository

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -67,8 +67,6 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         pullRequests={this.props.pullRequests}
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
-        branchFilterText={repositoryState.branchFilterText}
-        pullRequestFilterText={repositoryState.pullRequestFilterText}
       />
     )
   }


### PR DESCRIPTION
Closes #7437 

In #6002 (issue) and #6088 (PR) we persisted the branch and PR filters when users open and close the branch and PR dropdowns. We've seen feedback from users and experienced the confusion ourselves, and this reverts that change. I'm particularly appreciative to @Daniel-McCarthy for their efforts in doing this work in the first place, and I apologize that I didn't foresee the potential unintended consequences from a product perspective.

Filtering branches:
<img width="369" alt="Screen Shot 2019-05-08 at 1 25 13 PM" src="https://user-images.githubusercontent.com/5091167/57403028-eb1b2000-7195-11e9-943a-0736001d15e1.png">

After closing and reopening:
<img width="364" alt="Screen Shot 2019-05-08 at 1 25 24 PM" src="https://user-images.githubusercontent.com/5091167/57403032-eeaea700-7195-11e9-8c53-8269045c7020.png">

## Release notes

Notes:

`Don't persist branch and pull request filters after switching branches`
