### PR TITLE
also build PRs targeting release branch pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
 branches:
   only:
     - development
+    - releases/*
     - /^__release-.*/
 
 language: node_js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ cache:
 branches:
   only:
     - development
+    - releases/*
     - /^__release-.*/
 
 skip_tags: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ trigger:
   branches:
     include:
       - development
+      - releases/*
 
 pr:
   autoCancel: true

--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -124,6 +124,8 @@ Create a new branch to represent the work that will be released to users:
  - for `production` releases, branch from the latest beta tag
     - to find this tag: `git tag | grep 'beta' | sort -r | head -n 1`
 
+When naming the branch, ensure you use the `releases/[version]` pattern to ensure all CI platforms are aware of the branch and will build any PRs that target the branch.
+
 If you are creating a new beta release, the `yarn draft-release beta` command will help you find the new release entries for the changelog.
 
 If you are create a new `production` release, you should just combine and sort the previous `beta` changelog entries.


### PR DESCRIPTION
## Overview

I opened #7481 to target the upcoming release branch `releases/1.6.6` but only two of the builds fired:

<img width="556" src="https://user-images.githubusercontent.com/359239/57377392-b482dc80-7178-11e9-87fd-6aef12b3a704.png">

To avoid any further confusion, I propose we add this `releases/*` pattern to our list of branches. I added a comment to the `docs/process/releasing-updates.md` document to mention this.

## Release notes

Notes: no-notes
