### PR TITLE
Adds some cache to improve baseline metrics performance

### DIFF
--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -299,7 +299,7 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    lastCheckDate = record!.lastStashCheckDate
+    lastCheckDate = record.lastStashCheckDate
     if (lastCheckDate !== null) {
       this.lastStashCheckCache.set(repoID, lastCheckDate)
     }


### PR DESCRIPTION
@shiftkey shared some performance numbers he collected on his machine for IndexedDB queries

> lastStashEntryCheck takes ~150ms (with some outliers in the 400ms+ range) on my Windows test machine. not sure how that makes me feel.

It didn't make me feel great, so we discussed possible solutions which resulted in this PR.

Look at them gains!
![Screen Shot 2019-05-08 at 3 50 11 PM](https://user-images.githubusercontent.com/1715082/57408921-8f0fc600-71ac-11e9-8df7-ff5af9e78333.png)

cc @shiftkey  @billygriffin @outofambit 