### PR TITLE
cherry pick enabling all ci services for release branches into 1.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
 branches:
   only:
     - development
+    - releases/*
     - /^__release-.*/
 
 language: node_js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ cache:
 branches:
   only:
     - development
+    - releases/*
     - /^__release-.*/
 
 skip_tags: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,16 @@
 variables:
   PYTHON: 'python2.7'
 
+trigger:
+  batch: true
+  branches:
+    include:
+      - development
+      - releases/*
+
+pr:
+  autoCancel: true
+
 jobs:
   - job: Windows
     pool:


### PR DESCRIPTION
cherry picks the critical part of #7482 for the `1.6.6` release branch so we can use it in other branches targeting it (via merge or rebase)