### PR TITLE
appveyor and travis only take regex for branch filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 branches:
   only:
     - development
-    - releases/*
+    - /releases\/.+/
     - /^__release-.*/
 
 language: node_js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ cache:
 branches:
   only:
     - development
-    - releases/*
+    - /releases\/.+/
     - /^__release-.*/
 
 skip_tags: true


### PR DESCRIPTION
followup for #7482 to use regex instead of wildcards for appveyor and travis

(i've already cherry picked this commit into `releases/1.6.6` to test)