### PR TITLE
added a test helper to generate strings for test data

### DIFF
--- a/app/test/helpers/random-data.ts
+++ b/app/test/helpers/random-data.ts
@@ -1,0 +1,12 @@
+import { randomBytes } from 'crypto'
+
+/**
+ * Generate a pseudo-random sequence of hexadecimal values for use in testing.
+ *
+ * Source: https://blog.abelotech.com/posts/generate-random-values-nodejs-javascript/
+ */
+export function generateString(length: number = 32) {
+  return randomBytes(Math.ceil(length / 2))
+    .toString('hex') // convert to hexadecimal format
+    .slice(0, length) // return required number of characters
+}

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -17,6 +17,7 @@ import {
   IStashEntry,
   StashedChangesLoadStates,
 } from '../../../src/models/stash-entry'
+import { generateString } from '../../helpers/random-data'
 
 describe('git/stash', () => {
   describe('getStash', () => {
@@ -262,7 +263,7 @@ describe('git/stash', () => {
         expect(desktopEntries.length).toBe(1)
 
         const readme = path.join(repository.path, 'README.md')
-        await FSE.appendFile(readme, Math.random()) // eslint-disable-line insecure-random
+        await FSE.appendFile(readme, generateString())
         await GitProcess.exec(
           ['commit', '-am', 'later commit'],
           repository.path
@@ -292,7 +293,7 @@ describe('git/stash', () => {
         expect(desktopEntries.length).toBe(1)
 
         const readme = path.join(repository.path, 'README.md')
-        await FSE.writeFile(readme, Math.random()) // eslint-disable-line insecure-random
+        await FSE.writeFile(readme, generateString())
 
         const entryToApply = desktopEntries[0]
         await expect(
@@ -332,6 +333,6 @@ async function generateTestStashEntry(
 ): Promise<void> {
   const message = simulateDesktopEntry ? null : 'Should get filtered'
   const readme = path.join(repository.path, 'README.md')
-  await FSE.appendFile(readme, Math.random()) // eslint-disable-line insecure-random
+  await FSE.appendFile(readme, generateString())
   await stash(repository, branchName, message)
 }

--- a/app/test/unit/git/status-test.ts
+++ b/app/test/unit/git/status-test.ts
@@ -21,6 +21,7 @@ import * as temp from 'temp'
 import { getStatus } from '../../../src/lib/git'
 import { isConflictedFile } from '../../../src/lib/status'
 import { setupLocalConfig } from '../../helpers/local-config'
+import { generateString } from '../../helpers/random-data'
 
 const _temp = temp.track()
 const mkdir = _temp.mkdir
@@ -114,11 +115,11 @@ describe('git/status', () => {
         )
 
         // write a change to the readme into the stash
-        await FSE.appendFile(readme, Math.random()) // eslint-disable-line insecure-random
+        await FSE.appendFile(readme, generateString())
         await GitProcess.exec(['stash'], repository.path)
 
         // write a different change to the README and commit it
-        await FSE.appendFile(readme, Math.random()) // eslint-disable-line insecure-random
+        await FSE.appendFile(readme, generateString())
         await GitProcess.exec(
           ['commit', '-am', 'later commit'],
           repository.path


### PR DESCRIPTION
## Overview

I found myself touching tests related to stashing in #7476 and disliked our use of `Math.random()` inside the tests. This PR suggests a better API to represent this case.

## Description

Why did I dislike the use of `Math.random()`? A couple of things come to mind:

 - the tests write some random data into a file to represent a change - using an API that returns a random number between 0 and 1 feels like a source of confusion
 - we have [a rule about using insecure random numbers](https://github.com/desktop/desktop/blob/development/eslint-rules/insecure-random.js) to prevent mis-use, and everywhere we use this in tests we have to suppress this warning (and continue to for any new tests like this)

I decided instead to provide a helper function to address this underlying need from these tests:

> give me some random data that I can use as a string

This also means we can stop using `Math.random()` in our tests. 

## Release notes

Notes: no-notes
