### PR TITLE
add timing API to understand how long important actions take

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -21,6 +21,7 @@ import { PullRequestList } from './pull-request-list'
 import { IBranchListItem } from './group-branches'
 import { renderDefaultBranch } from './branch-renderer'
 import { IMatches } from '../../lib/fuzzy-find'
+import { startTimer } from '../lib/timing'
 
 interface IBranchesContainerProps {
   readonly dispatcher: Dispatcher
@@ -236,7 +237,14 @@ export class BranchesContainer extends React.Component<
     const currentBranch = this.props.currentBranch
 
     if (currentBranch == null || currentBranch.name !== branch.name) {
-      this.props.dispatcher.checkoutBranch(this.props.repository, branch)
+      const timer = startTimer(
+        'checkout branch from list',
+        this.props.repository
+      )
+
+      this.props.dispatcher
+        .checkoutBranch(this.props.repository, branch)
+        .then(() => timer.done())
     }
   }
 
@@ -278,10 +286,13 @@ export class BranchesContainer extends React.Component<
 
   private onPullRequestClicked = (pullRequest: PullRequest) => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
-    this.props.dispatcher.checkoutPullRequest(
-      this.props.repository,
-      pullRequest
+    const timer = startTimer(
+      'checkout pull request from list',
+      this.props.repository
     )
+    this.props.dispatcher
+      .checkoutPullRequest(this.props.repository, pullRequest)
+      .then(() => timer.done())
 
     this.onPullRequestSelectionChanged(pullRequest)
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -22,6 +22,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { IAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
 import { ICommitContext } from '../../models/commit'
+import { startTimer } from '../lib/timing'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -217,7 +218,9 @@ export class CommitMessage extends React.Component<
       trailers,
     }
 
+    const timer = startTimer('create commit', this.props.repository)
     const commitCreated = await this.props.onCreateCommit(commitContext)
+    timer.done()
 
     if (commitCreated) {
       this.clearCommitMessage()

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -24,6 +24,7 @@ import {
   renderBranchNameExistsOnRemoteWarning,
 } from '../lib/branch-name-warnings'
 import { getStartPoint } from '../../lib/create-branch'
+import { startTimer } from '../lib/timing'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -292,11 +293,13 @@ export class CreateBranch extends React.Component<
 
     if (name.length > 0) {
       this.setState({ isCreatingBranch: true })
+      const timer = startTimer('create branch', this.props.repository)
       await this.props.dispatcher.createBranch(
         this.props.repository,
         name,
         startPoint
       )
+      timer.done()
     }
   }
 }

--- a/app/src/ui/lib/timing.ts
+++ b/app/src/ui/lib/timing.ts
@@ -1,0 +1,44 @@
+import { Repository, nameOf } from '../../models/repository'
+
+function onCompleted(startTime: number, messagePrefix: string): () => void {
+  return () => {
+    const rawTime = performance.now() - startTime
+    const timeInSeconds = (rawTime / 1000).toFixed(3)
+    const message = `[Timing] ${messagePrefix} took ${timeInSeconds}s`
+    log.info(message)
+  }
+}
+
+/**
+ * Obtain a timer to measure a unit of work being performed on behalf of the
+ * user.
+ *
+ * The caller will signal completion by invoking the `done` callback which
+ * will compute the time taken and emit a helpful message into the logs.
+ *
+ * This will help users provide feedback about workflows that are noticeably
+ * slow for them, and allow engineers to correlate which Git operations might
+ * also be involved in this.
+ *
+ * **Only use this to measure actions performed by the user, as we want to avoid
+ * adding noise to the log output by adding unimportant timing information.**
+ *
+ */
+export function startTimer(action: string, repository: Repository) {
+  const startTime = performance && performance.now ? performance.now() : null
+
+  if (startTime === null) {
+    log.warn(
+      `[Timing] invoked but performance.now not found - are you using this outside the renderer?`
+    )
+    return {
+      done: () => {},
+    }
+  }
+
+  const messagePrefix = `Action '${action}' for '${nameOf(repository)}'`
+
+  return {
+    done: onCompleted(startTime, messagePrefix),
+  }
+}

--- a/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
+++ b/app/src/ui/stash-changes/stash-and-switch-branch-dialog.tsx
@@ -13,11 +13,13 @@ import {
 } from '../../models/uncommitted-changes-strategy'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { PopupType } from '../../models/popup'
+import { startTimer } from '../lib/timing'
 
 enum StashAction {
   StashOnCurrentBranch,
   MoveToNewBranch,
 }
+
 interface ISwitchBranchProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
@@ -151,6 +153,7 @@ export class StashAndSwitchBranch extends React.Component<
 
     this.setState({ isStashingChanges: true })
 
+    const timer = startTimer('stash and checkout', repository)
     try {
       if (selectedStashAction === StashAction.StashOnCurrentBranch) {
         await dispatcher.checkoutBranch(
@@ -166,6 +169,7 @@ export class StashAndSwitchBranch extends React.Component<
         })
       }
     } finally {
+      timer.done()
       this.setState({ isStashingChanges: false }, () => {
         this.props.onDismissed()
       })


### PR DESCRIPTION
## Overview

Related to #7464 and #7477, this PR adds some infrastructure to help us understand how long things take for the user, to give us an idea of where to spend our time with performance improvements.

## Description

Here's an actual piece of feedback from one of our beta testers:

> *2. create a branch from your current branch and bring changes with you*
> 
>  - prod: 3 seconds
>  - beta: 8 seconds

I want to avoid making users get this stuff manually, for a few reasons:

 - making them re-run scenarios _after_ noticing a problem isn't fun
 - manually gather timings is a complicated task with a production app
 - unless the user remembers to provide more information about their setup (which OS, and even which repository can make a huge difference), more back and forth here with the maintainers is needed to get a bigger picture

We have a place for things like this - the logs. So why not put them there, and the user can just upload the log and we gain these extra insights for free?

After my learnings from #7464 I settled on a simple API and some recommendations about _when_ we should use it.

```ts
const timer = startTimer('stash and checkout', repository)
await this.stashAndCheckout()
timer.done()
```

The inputs to `startTimer` are:

 - a human-friendly name representing the action being performed - this appears in the logs later
 - the repository currently in use - because of how repositories can vary in shape and size, I think this is important to know up front to give a sense of the type of performance issue to investigate

So, when and where do I recommend using this?

 - Apply to operations that are performed by the user _and then block, waiting on them to complete_. These areas are functions where users will notice regressions, and it'd be great to know the impact when things have changed enough to receive feedback. I included some examples in this PR:
   - `checkout branch from list`
   - `stash and checkout`
   - `create branch`
   - `create commit`
 - Apply this to important operations and workflows - we don't want to overload the logs with noise, but we want to know early if a beta release significant affects workflows existing workflows (and by how much)
  - Measure as close to the user interaction as possible - ideally the UI components should invoke an action and wait on the result. If you're measuring something deep inside a data store, I recommend a different approach.
  - Measure actions that are stable - we want to track performance over time, so choose actions where the underlying implementation is unlikely to change radically between updates.

## Release notes

Notes: no-notes
