### PR TITLE
Absolute url mangling

### DIFF
--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -89,6 +89,12 @@ export function getAbsoluteUrl(endpoint: string, path: string): string {
     relativePath = relativePath.substr(7)
   }
 
+  // Our API endpoints are a bit sloppy in that they don't typically
+  // include the trailing slash (i.e. we use https://api.github.com for
+  // dotcom and https://ghe.enterprise.local/api/v3 for Enterprise when
+  // both of those should really include the trailing slash since that's
+  // the qualified base). We'll work around our past since here by ensuring
+  // that the endpoint ends with a trailing slash.
   const base = endpoint.endsWith('/') ? endpoint : `${endpoint}/`
 
   return new URL(relativePath, base).toString()

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -1,4 +1,5 @@
 import * as appProxy from '../ui/lib/app-proxy'
+import { URL } from 'url'
 
 /** The HTTP methods available. */
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'HEAD'
@@ -87,7 +88,10 @@ export function getAbsoluteUrl(endpoint: string, path: string): string {
   if (relativePath.startsWith('api/v3/')) {
     relativePath = relativePath.substr(7)
   }
-  return encodeURI(`${endpoint}/${relativePath}`)
+
+  const base = endpoint.endsWith('/') ? endpoint : `${endpoint}/`
+
+  return new URL(relativePath, base).toString()
 }
 
 /**

--- a/app/test/unit/http-test.ts
+++ b/app/test/unit/http-test.ts
@@ -2,6 +2,17 @@ import { getAbsoluteUrl } from '../../src/lib/http'
 import { getDotComAPIEndpoint } from '../../src/lib/api'
 
 describe('getAbsoluteUrl', () => {
+  it("doesn't mangle encoded query parameters", () => {
+    const dotcomEndpoint = getDotComAPIEndpoint()
+    const result = getAbsoluteUrl(
+      dotcomEndpoint,
+      '/issues?since=2019-05-10T16%3A00%3A00Z'
+    )
+    expect(result).toBe(
+      'https://api.github.com/issues?since=2019-05-10T16%3A00%3A00Z'
+    )
+  })
+
   describe('dotcom endpoint', () => {
     const dotcomEndpoint = getDotComAPIEndpoint()
 

--- a/app/test/unit/http-test.ts
+++ b/app/test/unit/http-test.ts
@@ -3,9 +3,8 @@ import { getDotComAPIEndpoint } from '../../src/lib/api'
 
 describe('getAbsoluteUrl', () => {
   it("doesn't mangle encoded query parameters", () => {
-    const dotcomEndpoint = getDotComAPIEndpoint()
     const result = getAbsoluteUrl(
-      dotcomEndpoint,
+      getDotComAPIEndpoint(),
       '/issues?since=2019-05-10T16%3A00%3A00Z'
     )
     expect(result).toBe(

--- a/app/test/unit/http-test.ts
+++ b/app/test/unit/http-test.ts
@@ -2,16 +2,6 @@ import { getAbsoluteUrl } from '../../src/lib/http'
 import { getDotComAPIEndpoint } from '../../src/lib/api'
 
 describe('getAbsoluteUrl', () => {
-  it("doesn't mangle encoded query parameters", () => {
-    const result = getAbsoluteUrl(
-      getDotComAPIEndpoint(),
-      '/issues?since=2019-05-10T16%3A00%3A00Z'
-    )
-    expect(result).toBe(
-      'https://api.github.com/issues?since=2019-05-10T16%3A00%3A00Z'
-    )
-  })
-
   describe('dotcom endpoint', () => {
     const dotcomEndpoint = getDotComAPIEndpoint()
 
@@ -23,6 +13,16 @@ describe('getAbsoluteUrl', () => {
     it('handles missing leading slash', () => {
       const result = getAbsoluteUrl(dotcomEndpoint, 'user/repos')
       expect(result).toBe('https://api.github.com/user/repos')
+    })
+
+    it("doesn't mangle encoded query parameters", () => {
+      const result = getAbsoluteUrl(
+        getDotComAPIEndpoint(),
+        '/issues?since=2019-05-10T16%3A00%3A00Z'
+      )
+      expect(result).toBe(
+        'https://api.github.com/issues?since=2019-05-10T16%3A00%3A00Z'
+      )
     })
   })
 
@@ -45,6 +45,16 @@ describe('getAbsoluteUrl', () => {
         '/api/v3/user/repos?page=2'
       )
       expect(result).toBe(`${enterpriseEndpoint}/user/repos?page=2`)
+    })
+
+    it("doesn't mangle encoded query parameters", () => {
+      const result = getAbsoluteUrl(
+        enterpriseEndpoint,
+        '/issues?since=2019-05-10T16%3A00%3A00Z'
+      )
+      expect(result).toBe(
+        `${enterpriseEndpoint}/issues?since=2019-05-10T16%3A00%3A00Z`
+      )
     })
   })
 })


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

I spotted this while looking at requests using the `since` query parameter (such as the `/issues` API). I noticed that even though we were continually fetching issues we were always getting more than one result back (what I'd have expected is for the first fetch to get a bunch of issues and then the following request, using the conditional `since` parameter updated based on the previous response, would get far less).

Looking more carefully at the requests we were sending I noticed that the `since` parameter had been escaped twice.

```
https://api.github.com/repos/github/central/issues?state=all&since=2019-02-27T22%253A54%253A11Z&per_page=100
```

See the `%253A`? That's supposed to be just `%3A` (url encoded `:`).

Digging into this a bit further it turns out that when we initially implemented querying for issues using the `since` parameter in #548 we didn't do any post-processing of the URL (back then we were still using octokit.js). Later on, in #1814 I implemented hypermedia support such that we could traverse paginated API responses based on the `Link` tags. In doing so I modified the logic in our `request` method such that it could [accept both relative and absolute URIs](https://github.com/desktop/desktop/commit/a000bf8944d931a29ba8e078844ee1ebc68b8ea0). After that it was discovered that this particular approach caused problems with Enterprise URLs so the logic was altered yet again to a [simpler string concatenation](https://github.com/desktop/desktop/commit/9b4f40b94733c0bc2defbb2d652051682824b2b8):

```ts
const relativePath = path[0] === '/' ? path.substr(1) : path
const url = encodeURI(`${endpoint}/${relativePath}`)
```

At this point we had (partially) broken the `since` parameter for issues. I say partially because it turns out that the ruby date/time parser is pretty forgiving so when parsing our mangled timestamps it would still parse the date.

```rb
irb(main):005:0> require('time')
=> true
irb(main):006:0> Time.parse('2019-02-27T22%3A54%3A11Z')
=> 2019-02-27 00:00:00 +0100
```

This led to us always asking for issues changes since midnight rather than issues changes since the last time we fetched.

All of these problems could have been avoided if we had paid a little bit closer attention super early on and opted to always use trailing slashes for our API endpoint addresses but that ship has sailed and I don't feel comfortable changing that now so we'll do yet another workaround but this time with a specific test that should help prevent regressions in the future.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes