### PR TITLE
Added Accelerator and Access key for Exit

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -95,7 +95,10 @@ export function buildDefaultMenu({
         { role: 'hideothers' },
         { role: 'unhide' },
         separator,
-        { role: 'quit' },
+        {
+          role: 'quit',
+          accelerator: 'CmdOrCtrl+Shift+Q',
+        },
       ],
     })
   }
@@ -137,7 +140,10 @@ export function buildDefaultMenu({
         click: emit('show-preferences'),
       },
       separator,
-      { role: 'quit' }
+      {
+        role: 'quit',
+        accelerator: 'CmdOrCtrl+Shift+Q',
+      }
     )
   }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -95,10 +95,7 @@ export function buildDefaultMenu({
         { role: 'hideothers' },
         { role: 'unhide' },
         separator,
-        {
-          role: 'quit',
-          accelerator: 'CmdOrCtrl+Shift+Q',
-        },
+        { role: 'quit' },
       ],
     })
   }
@@ -142,7 +139,8 @@ export function buildDefaultMenu({
       separator,
       {
         role: 'quit',
-        accelerator: 'CmdOrCtrl+Shift+Q',
+        label: 'E&xit',
+        accelerator: 'Alt+F4',
       }
     )
   }


### PR DESCRIPTION
Added Alt+F4 as a shortcut for quit in the default menu and added access key Alt+F+X for it

## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #6507**

## Description

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: [Improved] Keyboard shortcut now shown next to Exit menu item on Windows
