### PR TITLE
Shiftkey/perf/explore memoizing refresh

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,6 +39,7 @@
     "moment": "^2.24.0",
     "mri": "^1.1.0",
     "p-limit": "^2.2.0",
+    "p-memoize": "^3.1.0",
     "primer-support": "^4.0.0",
     "queue": "^4.4.2",
     "quick-lru": "^3.0.0",

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -224,6 +224,7 @@ import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
+import * as pMemoize from 'p-memoize'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -359,6 +360,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.Light
   private automaticallySwitchTheme = false
+
+  private readonly memoizedRefresh = pMemoize(
+    (repository: Repository) => this.refreshRepositoryInternal(repository),
+    { maxAge: 1000 }
+  )
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -1290,7 +1296,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     previouslySelectedRepository: Repository | CloningRepository | null
   ): Promise<Repository | null> {
-    this._refreshRepository(repository)
+    this.memoizedRefresh(repository)
 
     const gitHubRepository = repository.gitHubRepository
 
@@ -1372,7 +1378,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.gitStoreCache,
         this.repositoriesStore,
         this.repositoryStateCache,
-        repository => this._refreshRepository(repository)
+        repository => this.memoizedRefresh(repository)
       )
       this.currentBranchPruner = pruner
       this.currentBranchPruner.start()
@@ -2357,7 +2363,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         }
       }
 
-      await this._refreshRepository(repository)
+      await this.memoizedRefresh(repository)
       await this.refreshChangesSection(repository, {
         includingStatus: true,
         clearPartialState: true,
@@ -2438,10 +2444,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const updatedRepository = await this.recoverMissingRepository(repository)
       if (!updatedRepository.missing) {
         // repository has been restored, attempt to refresh it now.
-        return this._refreshRepository(updatedRepository)
+        return this.memoizedRefresh(updatedRepository)
       }
     } else {
-      return this._refreshRepository(repository)
+      return this.memoizedRefresh(repository)
     }
   }
 
@@ -2463,8 +2469,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
+  public async refreshRepository(
+    repository: Repository
+  ) {
+    return this.memoizedRefresh(repository)
+  }
+
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _refreshRepository(repository: Repository): Promise<void> {
+  public async refreshRepositoryInternal(
+    repository: Repository
+  ): Promise<void> {
+    const startTime = performance && performance.now ? performance.now() : null
+    log.warn(`[REFRESH] starting for ${nameOf(repository)}`)
+
     if (repository.missing) {
       return
     }
@@ -2520,6 +2537,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this._initializeCompare(repository)
     this.refreshIndicatorsForRepositories([repository], false)
+
+    if (startTime) {
+      const rawTime = performance.now() - startTime
+      const timeInSeconds = (rawTime / 1000).toFixed(3)
+      log.warn(
+        `[REFRESH] ending for ${nameOf(repository)} at ${timeInSeconds}s`
+      )
+    } else {
+      log.warn(`[REFRESH] ending for ${nameOf(repository)} without timings`)
+    }
   }
 
   public refreshAllIndicators() {
@@ -2895,7 +2922,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         targetBranch: foundBranch.name,
       })
 
-      await this._refreshRepository(repository)
+      await this.memoizedRefresh(repository)
     } finally {
       this.updateCheckoutProgress(repository, null)
       this._initializeCompare(repository, {
@@ -3034,7 +3061,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       renameBranch(repository, branch, newName)
     )
 
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -3062,7 +3089,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         deleteBranch(r, branch, account, includeRemote)
       )
 
-      return this._refreshRepository(r)
+      return this.memoizedRefresh(r)
     })
   }
 
@@ -3193,7 +3220,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
               value: refreshStartProgress,
             })
 
-            await this._refreshRepository(repository)
+            await this.memoizedRefresh(repository)
 
             this.updatePushPullFetchProgress(repository, {
               kind: 'generic',
@@ -3385,7 +3412,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             await gitStore.reconcileHistory(mergeBase)
           }
 
-          await this._refreshRepository(repository)
+          await this.memoizedRefresh(repository)
 
           this.updatePushPullFetchProgress(repository, {
             kind: 'generic',
@@ -3560,7 +3587,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
     await gitStore.discardChanges(files)
 
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   public async _undoCommit(
@@ -3577,7 +3604,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.clearSelectedCommit(repository)
     }
 
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   /**
@@ -3599,7 +3626,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const gitStore = this.gitStoreCache.get(repository)
         await gitStore.fetchRefspec(account, refspec)
 
-        return this._refreshRepository(repository)
+        return this.memoizedRefresh(repository)
       }
     )
   }
@@ -3683,7 +3710,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           value: fetchWeight,
         })
 
-        await this._refreshRepository(repository)
+        await this.memoizedRefresh(repository)
 
         this.updatePushPullFetchProgress(repository, {
           kind: 'generic',
@@ -3833,7 +3860,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
     }
 
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -4070,7 +4097,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     text: string
   ): Promise<void> {
     await saveGitIgnore(repository, text)
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   /** Has the user opted out of stats reporting? */
@@ -4218,7 +4245,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     pattern: string | string[]
   ): Promise<void> {
     await appendIgnoreRule(repository, pattern)
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   public _resetSignInState(): Promise<void> {
@@ -4519,7 +4546,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
 
       this.updateRevertProgress(repo, null)
-      await this._refreshRepository(repository)
+      await this.memoizedRefresh(repository)
     })
   }
 
@@ -4796,7 +4823,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
     await gitStore.updateExistingUpstreamRemote()
 
-    return this._refreshRepository(repository)
+    return this.memoizedRefresh(repository)
   }
 
   private getIgnoreExistingUpstreamRemoteKey(repository: Repository): string {
@@ -5059,7 +5086,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }`
     )
 
-    await this._refreshRepository(repository)
+    await this.memoizedRefresh(repository)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1464,7 +1464,7 @@ export class Dispatcher {
 
     // ensure a fresh clone repository has it's in-memory state
     // up-to-date before performing the "Clone in Desktop" steps
-    await this.appStore._refreshRepository(repository)
+    await this.appStore.refreshRepository(repository)
 
     const state = this.repositoryStateManager.get(repository)
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1464,7 +1464,10 @@ export class Dispatcher {
 
     // ensure a fresh clone repository has it's in-memory state
     // up-to-date before performing the "Clone in Desktop" steps
-    await this.appStore.refreshRepository(repository)
+    await this.appStore.refreshRepository(
+      repository,
+      'handleCloneInDesktopOptions'
+    )
 
     const state = this.repositoryStateManager.get(repository)
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -829,10 +829,26 @@ lru-cache@^4.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
 mem@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/mem/-/mem-0.1.1.tgz#24df988c3102b03c074c1b296239c5b2e6647825"
   integrity sha1-JN+YjDECsDwHTBspYjnFsuZkeCU=
+
+mem@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
 
 memoize-one@^4.0.3:
   version "4.0.3"
@@ -862,6 +878,11 @@ mime-types@~2.1.19:
   integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
   dependencies:
     mime-db "~1.36.0"
+
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 mimic-response@^1.0.0:
   version "1.0.1"
@@ -1025,12 +1046,30 @@ os-tmpdir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
+
 p-limit@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
   dependencies:
     p-try "^2.0.0"
+
+p-memoize@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-memoize/-/p-memoize-3.1.0.tgz#ac7587983c9e530139f969ca7b41ef40e93659aa"
+  integrity sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==
+  dependencies:
+    mem "^4.3.0"
+    mimic-fn "^2.1.0"
 
 p-try@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #{issue number}**

## Description

-

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
