### PR TITLE
retrieve and cache protected branch information per-repository

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -226,6 +226,11 @@ export interface IAPIRefStatus {
   readonly statuses: ReadonlyArray<IAPIRefStatusItem>
 }
 
+export interface IAPIBranch {
+  readonly name: string
+  readonly protected: boolean
+}
+
 interface IAPIPullRequestRef {
   readonly ref: string
   readonly sha: string
@@ -694,6 +699,15 @@ export class API {
     const path = `repos/${owner}/${name}/commits/${ref}/status`
     const response = await this.request('GET', path)
     return await parsedResponse<IAPIRefStatus>(response)
+  }
+
+  public async fetchProtectedBranches(
+    owner: string,
+    name: string
+  ): Promise<ReadonlyArray<IAPIBranch>> {
+    const path = `repos/${owner}/${name}/branches?protected=true`
+    const response = await this.request('GET', path)
+    return await parsedResponse<IAPIBranch[]>(response)
   }
 
   /**

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -226,8 +226,20 @@ export interface IAPIRefStatus {
   readonly statuses: ReadonlyArray<IAPIRefStatusItem>
 }
 
+/** Branch information returned by the GitHub API */
 export interface IAPIBranch {
+  /**
+   * The name of the branch stored on the remote.
+   *
+   * NOTE: this is NOT a fully-qualified ref (i.e. `refs/heads/master`)
+   */
   readonly name: string
+  /**
+   * Branch protection settings:
+   *
+   *  - `true` indicates that the branch is protected in some way
+   *  - `false` indicates no branch protection set
+   */
   readonly protected: boolean
 }
 

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -23,6 +23,12 @@ export interface IDatabaseGitHubRepository {
   readonly lastPruneDate: number | null
 }
 
+export interface IDatabaseGitHubBranch {
+  readonly repoId: number
+  readonly name: string
+  readonly protected: boolean
+}
+
 export interface IDatabaseRepository {
   readonly id?: number | null
   readonly gitHubRepositoryID: number | null
@@ -40,6 +46,9 @@ export class RepositoriesDatabase extends BaseDatabase {
 
   /** The GitHub repositories table. */
   public gitHubRepositories!: Dexie.Table<IDatabaseGitHubRepository, number>
+
+  /** The branch lookup table for GitHub repositories table. */
+  public githubBranches!: Dexie.Table<IDatabaseGitHubBranch, number>
 
   /** The GitHub repository owners table. */
   public owners!: Dexie.Table<IDatabaseOwner, number>
@@ -76,6 +85,10 @@ export class RepositoriesDatabase extends BaseDatabase {
 
     this.conditionalVersion(5, {
       gitHubRepositories: '++id, name, &[ownerID+name], cloneURL',
+    })
+
+    this.conditionalVersion(6, {
+      githubBranches: '[repoId+name], repoId',
     })
   }
 }

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -87,7 +87,7 @@ export class RepositoriesDatabase extends BaseDatabase {
     })
 
     this.conditionalVersion(6, {
-      protectedBranches: '[repoId+name]',
+      protectedBranches: '[repoId+name], repoId',
     })
   }
 }

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -23,10 +23,9 @@ export interface IDatabaseGitHubRepository {
   readonly lastPruneDate: number | null
 }
 
-export interface IDatabaseGitHubBranch {
+export interface IDatabaseProtectedBranch {
   readonly repoId: number
   readonly name: string
-  readonly protected: boolean
 }
 
 export interface IDatabaseRepository {
@@ -48,7 +47,7 @@ export class RepositoriesDatabase extends BaseDatabase {
   public gitHubRepositories!: Dexie.Table<IDatabaseGitHubRepository, number>
 
   /** The branch lookup table for GitHub repositories table. */
-  public githubBranches!: Dexie.Table<IDatabaseGitHubBranch, number>
+  public protectedBranches!: Dexie.Table<IDatabaseProtectedBranch, number>
 
   /** The GitHub repository owners table. */
   public owners!: Dexie.Table<IDatabaseOwner, number>
@@ -88,7 +87,7 @@ export class RepositoriesDatabase extends BaseDatabase {
     })
 
     this.conditionalVersion(6, {
-      githubBranches: '[repoId+name], repoId',
+      protectedBranches: '[repoId+name]',
     })
   }
 }

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -23,8 +23,14 @@ export interface IDatabaseGitHubRepository {
   readonly lastPruneDate: number | null
 }
 
+/** A record to track the protected branch information for a GitHub repository */
 export interface IDatabaseProtectedBranch {
   readonly repoId: number
+  /**
+   * The branch name associated with the branch protection settings
+   *
+   * NOTE: this is NOT a fully-qualified ref (i.e. `refs/heads/master`)
+   */
   readonly name: string
 }
 

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -48,7 +48,7 @@ export interface IDatabaseRepository {
  * Branches are keyed on the ID of the GitHubRepository that they belong to
  * and the short name of the branch.
  */
-export type BranchKey = [number, string]
+type BranchKey = [number, string]
 
 /** The repositories database. */
 export class RepositoriesDatabase extends BaseDatabase {

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -44,6 +44,12 @@ export interface IDatabaseRepository {
   readonly lastStashCheckDate: number | null
 }
 
+/**
+ * Branches are keyed on the ID of the GitHubRepository that they belong to
+ * and the short name of the branch.
+ */
+export type BranchKey = [number, string]
+
 /** The repositories database. */
 export class RepositoriesDatabase extends BaseDatabase {
   /** The local repositories table. */
@@ -53,10 +59,7 @@ export class RepositoriesDatabase extends BaseDatabase {
   public gitHubRepositories!: Dexie.Table<IDatabaseGitHubRepository, number>
 
   /** A table containing the names of protected branches per repository. */
-  public protectedBranches!: Dexie.Table<
-    IDatabaseProtectedBranch,
-    [number, string]
-  >
+  public protectedBranches!: Dexie.Table<IDatabaseProtectedBranch, BranchKey>
 
   /** The GitHub repository owners table. */
   public owners!: Dexie.Table<IDatabaseOwner, number>

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -53,7 +53,10 @@ export class RepositoriesDatabase extends BaseDatabase {
   public gitHubRepositories!: Dexie.Table<IDatabaseGitHubRepository, number>
 
   /** A table containing the names of protected branches per repository. */
-  public protectedBranches!: Dexie.Table<IDatabaseProtectedBranch, number>
+  public protectedBranches!: Dexie.Table<
+    IDatabaseProtectedBranch,
+    [number, string]
+  >
 
   /** The GitHub repository owners table. */
   public owners!: Dexie.Table<IDatabaseOwner, number>

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -46,7 +46,7 @@ export class RepositoriesDatabase extends BaseDatabase {
   /** The GitHub repositories table. */
   public gitHubRepositories!: Dexie.Table<IDatabaseGitHubRepository, number>
 
-  /** The branch lookup table for GitHub repositories table. */
+  /** A table containing the names of protected branches per repository. */
   public protectedBranches!: Dexie.Table<IDatabaseProtectedBranch, number>
 
   /** The GitHub repository owners table. */

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -85,3 +85,11 @@ export function enableRebaseDialog(): boolean {
 export function enableStashing(): boolean {
   return enableBetaFeatures()
 }
+
+/**
+ * Should the app warn the user when they are committing that they are using a
+ * protected branch?
+ */
+export function enableBranchProtectionWarning(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2374,18 +2374,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
           }
         }
 
-        if (gitStore.tip.kind === TipState.Valid) {
+        if (
+          gitStore.tip.kind === TipState.Valid &&
+          gitStore.currentRemote !== null
+        ) {
           // look up if the tracked branch matches a protected remote branch
-          const { upstreamWithoutRemote } = gitStore.tip.branch
+          const { upstream } = gitStore.tip.branch
 
-          if (upstreamWithoutRemote !== null) {
-            const protectedBranches = await this.repositoriesStore.getProtectedBranches(
+          if (upstream !== null) {
+            const remoteName = gitStore.currentRemote.name
+
+            const protectedBranchNames = await this.repositoriesStore.getProtectedBranches(
               repository.gitHubRepository
             )
 
-            if (protectedBranches.indexOf(upstreamWithoutRemote) >= 0) {
+            // convert these branches to a canonical reference to avoid the need
+            // to rely on the logic in `upstreamWithoutRemote`
+            const protectedBranches = protectedBranchNames.map(
+              b => `${remoteName}/${b}`
+            )
+
+            if (protectedBranches.indexOf(upstream) >= 0) {
               log.debug(
-                `[_commitIncludedChanges] the branch '${upstreamWithoutRemote}' is protected by the GitHub API`
+                `[_commitIncludedChanges] the upstream ref '${upstream}' is protected by the GitHub API`
               )
             }
           }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2379,24 +2379,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
           gitStore.currentRemote !== null
         ) {
           // look up if the tracked branch matches a protected remote branch
-          const { upstream } = gitStore.tip.branch
+          const { upstreamWithoutRemote } = gitStore.tip.branch
 
-          if (upstream !== null) {
-            const remoteName = gitStore.currentRemote.name
-
-            const protectedBranchNames = await this.repositoriesStore.getProtectedBranches(
-              repository.gitHubRepository
+          if (upstreamWithoutRemote !== null) {
+            const isProtected = await this.repositoriesStore.isBranchProtected(
+              repository.gitHubRepository,
+              upstreamWithoutRemote
             )
 
-            // convert these branches to a canonical reference to avoid the need
-            // to rely on the logic in `upstreamWithoutRemote`
-            const protectedBranches = protectedBranchNames.map(
-              b => `${remoteName}/${b}`
-            )
-
-            if (protectedBranches.indexOf(upstream) >= 0) {
+            if (isProtected) {
               log.debug(
-                `[_commitIncludedChanges] the upstream ref '${upstream}' is protected by the GitHub API`
+                `[_commitIncludedChanges] the upstream ref '${upstreamWithoutRemote}' is protected by the GitHub API`
               )
             }
           }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2373,6 +2373,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
             }
           }
         }
+
+        if (gitStore.tip.kind === TipState.Valid) {
+          // look up if the tracked branch matches a protected remote branch
+          const { upstreamWithoutRemote } = gitStore.tip.branch
+
+          if (upstreamWithoutRemote !== null) {
+            const protectedBranches = await this.repositoriesStore.getProtectedBranches(
+              repository.gitHubRepository
+            )
+
+            if (protectedBranches.indexOf(upstreamWithoutRemote) >= 0) {
+              log.debug(
+                `[_commitIncludedChanges] the branch '${upstreamWithoutRemote}' is protected by the GitHub API`
+              )
+            }
+          }
+        }
       }
 
       await this._refreshRepository(repository)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2998,11 +2998,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
+    const { owner, name } = matchedGitHubRepository
+
     const api = API.fromAccount(account)
-    const apiRepo = await api.fetchRepository(
-      matchedGitHubRepository.owner,
-      matchedGitHubRepository.name
-    )
+    const apiRepo = await api.fetchRepository(owner, name)
 
     if (!apiRepo) {
       // This is the same as above. If the request fails, we wanna preserve the
@@ -3019,11 +3018,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
+    const branches = await api.fetchProtectedBranches(owner, name)
+
     const endpoint = matchedGitHubRepository.endpoint
     return this.repositoriesStore.updateGitHubRepository(
       repository,
       endpoint,
-      apiRepo
+      apiRepo,
+      branches
     )
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -78,6 +78,7 @@ import {
   getAccountForEndpoint,
   getDotComAPIEndpoint,
   IAPIOrganization,
+  IAPIBranch,
 } from '../api'
 import { shell } from '../app-shell'
 import {
@@ -214,6 +215,7 @@ import {
   enablePullWithRebase,
   enableGroupRepositoriesByOwner,
   enableStashing,
+  enableBranchProtectionWarning,
 } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import * as moment from 'moment'
@@ -2375,6 +2377,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         }
 
         if (
+          enableBranchProtectionWarning() &&
           gitStore.tip.kind === TipState.Valid &&
           gitStore.currentRemote !== null
         ) {
@@ -3039,7 +3042,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    const branches = await api.fetchProtectedBranches(owner, name)
+    const branches = enableBranchProtectionWarning()
+      ? await api.fetchProtectedBranches(owner, name)
+      : new Array<IAPIBranch>()
 
     const endpoint = matchedGitHubRepository.endpoint
     return this.repositoriesStore.updateGitHubRepository(

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -416,6 +416,12 @@ export class RepositoriesStore extends BaseStore {
           name: b.name,
         }))
 
+        for (const item of items) {
+          // update cached values to avoid database lookup
+          const key = getKey(repoId, item.name)
+          this.branchProtectionCache.set(key, true)
+        }
+
         await this.db.protectedBranches.bulkAdd(items)
 
         return updatedGitHubRepo
@@ -515,7 +521,7 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    const key = `${gitHubRepository.dbID}-${branchName}`
+    const key = getKey(gitHubRepository.dbID, branchName)
 
     const existing = this.branchProtectionCache.get(key)
     if (existing !== undefined) {
@@ -533,4 +539,9 @@ export class RepositoriesStore extends BaseStore {
 
     return value
   }
+}
+
+/** Compute the key for the branch protection cache */
+function getKey(dbID: number, branchName: string) {
+  return `${dbID}-${branchName}`
 }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -402,14 +402,16 @@ export class RepositoriesStore extends BaseStore {
           gitHubRepositoryID: updatedGitHubRepo.dbID,
         })
 
+        const repoId = updatedGitHubRepo.dbID!
+
         await this.db.githubBranches
           .where('repoId')
-          .equals(updatedGitHubRepo.dbID!)
+          .equals(repoId)
           .delete()
 
         const items = branches.map<IDatabaseGitHubBranch>(b => ({
           ...b,
-          repoId: updatedGitHubRepo.dbID!,
+          repoId,
         }))
 
         await this.db.githubBranches.bulkAdd(items)

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -500,4 +500,21 @@ export class RepositoriesStore extends BaseStore {
 
     return record!.lastPruneDate
   }
+
+  public async getProtectedBranches(
+    gitHubRepository: GitHubRepository
+  ): Promise<ReadonlyArray<string>> {
+    if (gitHubRepository.dbID === null) {
+      return fatalError(
+        'unable to get protected branches, GitHub repository has a null dbID'
+      )
+    }
+
+    const results = await this.db.githubBranches
+      .where('repoId')
+      .equals(gitHubRepository.dbID)
+      .toArray()
+
+    return results.map(r => r.name)
+  }
 }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -18,6 +18,8 @@ export class RepositoriesStore extends BaseStore {
   // Key-repo ID, Value-date
   private lastStashCheckCache = new Map<number, number>()
 
+  private branchProtectionCache = new Map<string, boolean>()
+
   public constructor(db: RepositoriesDatabase) {
     super()
 
@@ -513,13 +515,22 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
+    const key = `${gitHubRepository.dbID}-${branchName}`
+
+    const existing = this.branchProtectionCache.get(key)
+    if (existing !== undefined) {
+      return existing
+    }
+
     const result = await this.db.protectedBranches
       .where('[repoId+name]')
       .equals([gitHubRepository.dbID, branchName])
       .first()
 
-    // TODO: caching?
+    const value = !!result
 
-    return !!result
+    this.branchProtectionCache.set(key, value)
+
+    return value
   }
 }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -548,10 +548,10 @@ export class RepositoriesStore extends BaseStore {
       return existing
     }
 
-    const result = await this.db.protectedBranches.get({
-      repoId: gitHubRepository.dbID,
-      name: branchName,
-    })
+    const result = await this.db.protectedBranches.get([
+      gitHubRepository.dbID,
+      branchName,
+    ])
 
     const value = result !== undefined
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -548,12 +548,12 @@ export class RepositoriesStore extends BaseStore {
       return existing
     }
 
-    const result = await this.db.protectedBranches
-      .where('[repoId+name]')
-      .equals([gitHubRepository.dbID, branchName])
-      .first()
+    const result = await this.db.protectedBranches.get({
+      repoId: gitHubRepository.dbID,
+      name: branchName,
+    })
 
-    const value = !!result
+    const value = result !== undefined
 
     this.branchProtectionCache.set(key, value)
 

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -222,7 +222,8 @@ async function initializeTestRepo(
     repository = await repositoriesStore.updateGitHubRepository(
       repository,
       '',
-      ghAPIResult
+      ghAPIResult,
+      []
     )
   }
   await primeCaches(repository, repositoriesStateCache)

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -60,7 +60,8 @@ describe('RepositoriesStore', () => {
       await repositoriesStore!.updateGitHubRepository(
         addedRepo,
         'https://api.github.com',
-        gitHubRepo
+        gitHubRepo,
+        []
       )
 
       const repositories = await repositoriesStore!.getAll()
@@ -79,7 +80,8 @@ describe('RepositoriesStore', () => {
       const updatedFirstRepo = await repositoriesStore!.updateGitHubRepository(
         firstRepo,
         'https://api.github.com',
-        gitHubRepo
+        gitHubRepo,
+        []
       )
 
       const secondRepo = await repositoriesStore!.addRepository(
@@ -88,7 +90,8 @@ describe('RepositoriesStore', () => {
       const updatedSecondRepo = await repositoriesStore!.updateGitHubRepository(
         secondRepo,
         'https://api.github.com',
-        gitHubRepo
+        gitHubRepo,
+        []
       )
 
       expect(updatedFirstRepo.gitHubRepository!.dbID).toBe(


### PR DESCRIPTION
## Overview

**First part of #7091**

## Description

This PR lands the work required to retrieve the protected branch and store it in IndexedDB. I'd love some feedback about the table changes made (cc @niik @iAmWillShepherd) to ensure they make sense.

I also wired up a simple check to see if the tracking branch being committed to (they don't need to match up, so I'm deferring to Git rather than trusting the user is following conventions) is found in the list of cached protected branches.

If we're fine with the changes and landing them for 1.7, I'll follow up with subsequent PRs to refine the checks and record metrics to complete #7091.

## Release notes

Notes: no-notes
