### PR TITLE
Apply first-click dismissal prevention on macOS as well

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -12,7 +12,7 @@ const dismissGracePeriodMs = 250
 
 /**
  * The time (in milliseconds) that we should wait after focusing before we
- * re-enable click dismissal. Note that this is only used on Windows.
+ * re-enable click dismissal.
  */
 const DisableClickDismissalDelay = 500
 

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -216,16 +216,18 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     // On Windows and Linux, a click which focuses the window will also get
     // passed down into the DOM. But we don't want to dismiss the dialog based
     // on that click. See https://github.com/desktop/desktop/issues/2486.
-    if (__WIN32__ || __LINUX__) {
-      this.clearClickDismissalTimer()
+    // macOS normally automatically disables "click-through" behavior but
+    // we've intentionally turned that off so we need to apply the same
+    // behavior regardless of platform.
+    // See https://github.com/desktop/desktop/pull/3843.
+    this.clearClickDismissalTimer()
 
-      this.disableClickDismissal = true
+    this.disableClickDismissal = true
 
-      this.disableClickDismissalTimeoutId = window.setTimeout(() => {
-        this.disableClickDismissal = false
-        this.disableClickDismissalTimeoutId = null
-      }, DisableClickDismissalDelay)
-    }
+    this.disableClickDismissalTimeoutId = window.setTimeout(() => {
+      this.disableClickDismissal = false
+      this.disableClickDismissalTimeoutId = null
+    }, DisableClickDismissalDelay)
   }
 
   private clearClickDismissalTimer() {


### PR DESCRIPTION
## Overview

**Closes #7526**

## Description

In https://github.com/desktop/desktop/pull/2488 we implemented a workaround for Windows such that when clicking on the dialog backdrop when it's not focused wouldn't dismiss the dialog. We never implemented a workaround for macOS because at the time we still relied on the native support on macOS where the default behavior is to ignore the first click on an application. Later on, in https://github.com/desktop/desktop/pull/3843 we decided to disable that behavior but we never applied the corresponding workaround for macOS.

This PR removes the condition that caused the workaround to only work on Windows.

(Reviewing this is easier if you turn off whitespace changes)

## Release notes

Notes: [Fixed] Clicking outside of a dialog window when the application isn't focused no longer dismisses the dialog (macOS)