### PR TITLE
Ensure `updateStashEntryCountMetric` is updated during a long session of Desktop

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1141,7 +1141,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return Promise.resolve(null)
     }
 
-    this.updateStashEntryCountMetric(repository)
     setNumber(LastSelectedRepositoryIDKey, repository.id)
 
     // if repository might be marked missing, try checking if it has been restored
@@ -2113,6 +2112,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       refreshSectionPromise,
     ])
 
+    // this promise is fire-and-forget, so kno need to await it
+    this.updateStashEntryCountMetric(repository)
     this._updateCurrentPullRequest(repository)
     this.updateMenuItemLabels(repository)
     this._initializeCompare(repository)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2112,7 +2112,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       refreshSectionPromise,
     ])
 
-    // this promise is fire-and-forget, so kno need to await it
+    // this promise is fire-and-forget, so no need to await it
     this.updateStashEntryCountMetric(repository)
     this._updateCurrentPullRequest(repository)
     this.updateMenuItemLabels(repository)


### PR DESCRIPTION
Addresses feedback left in #7470 ([comment](https://github.com/desktop/desktop/pull/7470/files#r283814821)) by moving where we do the stash size check.

cc @niik @billygriffin 