### PR TITLE
fixing tests for 1.6.6 branch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4242,7 +4242,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       try {
         const stashSize = await getStashSize(repository)
-        this.statsStore.addStashEntriesCreatedOutsideDesktop(stashSize)
+        await this.statsStore.addStashEntriesCreatedOutsideDesktop(stashSize)
       } finally {
         await this.repositoriesStore.updateLastStashCheckDate(repository)
       }

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -185,11 +185,7 @@ describe('AppStore', () => {
       let repo: Repository
 
       beforeEach(async () => {
-        const { path } = await setupConflictedRepoWithMultipleFiles()
-        const repositories = await appStore._addRepositories([path])
-        repo = repositories[0]
-
-        await appStore._selectRepository(repo)
+        repo = await setupConflictedRepoWithMultipleFiles()
       })
 
       it('commits tracked files', async () => {

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -182,14 +182,15 @@ describe('AppStore', () => {
     })
 
     describe('with tracked and untracked files', () => {
-      let repo: Repository
+      let repo: Repository, status: IStatusResult
 
       beforeEach(async () => {
         repo = await setupConflictedRepoWithMultipleFiles()
+        repo = (await appStore._addRepositories([repo.path]))[0]
+        status = await getStatusOrThrow(repo)
       })
 
       it('commits tracked files', async () => {
-        const status = await getStatusOrThrow(repo)
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
@@ -202,7 +203,6 @@ describe('AppStore', () => {
         expect(trackedFiles).toHaveLength(0)
       })
       it('leaves untracked files untracked', async () => {
-        const status = await getStatusOrThrow(repo)
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
@@ -220,11 +220,8 @@ describe('AppStore', () => {
       let repo: Repository, status: IStatusResult
 
       beforeEach(async () => {
-        const { path } = await setupConflictedRepoWithUnrelatedCommittedChange()
-        const repositories = await appStore._addRepositories([path])
-        repo = repositories[0]
-
-        await appStore._selectRepository(repo)
+        repo = await setupConflictedRepoWithUnrelatedCommittedChange()
+        repo = (await appStore._addRepositories([repo.path]))[0]
         status = await getStatusOrThrow(repo)
       })
       it("doesn't commit unrelated changes", async () => {

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -182,7 +182,7 @@ describe('AppStore', () => {
     })
 
     describe('with tracked and untracked files', () => {
-      let repo: Repository, status: IStatusResult
+      let repo: Repository
 
       beforeEach(async () => {
         const { path } = await setupConflictedRepoWithMultipleFiles()
@@ -190,10 +190,10 @@ describe('AppStore', () => {
         repo = repositories[0]
 
         await appStore._selectRepository(repo)
-        status = await getStatusOrThrow(repo)
       })
 
       it('commits tracked files', async () => {
+        const status = await getStatusOrThrow(repo)
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
@@ -206,6 +206,7 @@ describe('AppStore', () => {
         expect(trackedFiles).toHaveLength(0)
       })
       it('leaves untracked files untracked', async () => {
+        const status = await getStatusOrThrow(repo)
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -182,15 +182,11 @@ describe('AppStore', () => {
     })
 
     describe('with tracked and untracked files', () => {
-      let repo: Repository, status: IStatusResult
-
-      beforeEach(async () => {
-        repo = await setupConflictedRepoWithMultipleFiles()
-        repo = (await appStore._addRepositories([repo.path]))[0]
-        status = await getStatusOrThrow(repo)
-      })
-
       it('commits tracked files', async () => {
+        let repo = await setupConflictedRepoWithMultipleFiles()
+        repo = (await appStore._addRepositories([repo.path]))[0]
+        const status = await getStatusOrThrow(repo)
+
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
@@ -203,6 +199,9 @@ describe('AppStore', () => {
         expect(trackedFiles).toHaveLength(0)
       })
       it('leaves untracked files untracked', async () => {
+        let repo = await setupConflictedRepoWithMultipleFiles()
+        repo = (await appStore._addRepositories([repo.path]))[0]
+        const status = await getStatusOrThrow(repo)
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,9 +6,12 @@ trigger:
   branches:
     include:
       - development
+      - releases/*
 
 pr:
   autoCancel: true
+  branches:
+    include: '*'
 
 jobs:
   - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ trigger:
   branches:
     include:
       - development
-      - releases/*
 
 pr:
   autoCancel: true


### PR DESCRIPTION
resolved some shared state issues in the jest tests by moving setup from a `beforeEach` to each individual test. its not pretty, but it works and i don't think its worth spending more time on this.