### PR TITLE
run azure for all prs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:
   autoCancel: true
   branches:
     include:
-    - '*'
+      - '*'
 
 jobs:
   - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,9 @@ trigger:
 
 pr:
   autoCancel: true
+  branches:
+    include:
+    - '*'
 
 jobs:
   - job: Windows


### PR DESCRIPTION
explicitly adds all branches to the `pr` trigger for azure. this should cause _all_ prs to trigger the azure pipelines instead of just ones that merge into `development` or a `releases/*` branch.