### PR TITLE
better setup to land these cursed tests

### DIFF
--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -47,7 +47,7 @@ import { ManualConflictResolutionKind } from '../../src/models/manual-conflict-r
 jest.mock('../../src/lib/window-state')
 
 describe('AppStore', () => {
-  async function createAppStore(): Promise<AppStore> {
+  async function createAppStore() {
     const db = new TestGitHubUserDatabase()
     await db.reset()
 
@@ -79,7 +79,7 @@ describe('AppStore', () => {
 
     const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
 
-    return new AppStore(
+    const appStore = new AppStore(
       githubUserStore,
       new CloningRepositoriesStore(),
       new IssuesStore(issuesDb),
@@ -91,10 +91,12 @@ describe('AppStore', () => {
       repositoryStateManager,
       apiRepositoriesStore
     )
+
+    return { appStore, repositoriesStore }
   }
 
   it('can select a repository', async () => {
-    const appStore = await createAppStore()
+    const { appStore, repositoriesStore } = await createAppStore()
 
     const { path } = await setupEmptyRepository()
     const repositories = await appStore._addRepositories([path])
@@ -157,7 +159,7 @@ describe('AppStore', () => {
     it.skip('clears the undo commit dialog', async () => {
       const repository = repo!
 
-      const appStore = await createAppStore()
+      const { appStore } = await createAppStore()
 
       // select the repository and show the changes view
       await appStore._selectRepository(repository)
@@ -178,7 +180,8 @@ describe('AppStore', () => {
   describe('_finishConflictedMerge', () => {
     let appStore: AppStore
     beforeEach(async () => {
-      appStore = await createAppStore()
+      const result = await createAppStore()
+      appStore = result.appStore
     })
 
     describe('with tracked and untracked files', () => {

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -102,6 +102,8 @@ describe('AppStore', () => {
     const repositories = await appStore._addRepositories([path])
     const repo = repositories[0]
 
+    await repositoriesStore.updateLastStashCheckDate(repo)
+
     await appStore._selectRepository(repo)
 
     const state = appStore.getState()
@@ -179,15 +181,21 @@ describe('AppStore', () => {
   })
   describe('_finishConflictedMerge', () => {
     let appStore: AppStore
+    let repositoriesStore: RepositoriesStore
+
     beforeEach(async () => {
       const result = await createAppStore()
       appStore = result.appStore
+      repositoriesStore = result.repositoriesStore
     })
 
     describe('with tracked and untracked files', () => {
       it('commits tracked files', async () => {
         let repo = await setupConflictedRepoWithMultipleFiles()
         repo = (await appStore._addRepositories([repo.path]))[0]
+
+        await repositoriesStore.updateLastStashCheckDate(repo)
+
         const status = await getStatusOrThrow(repo)
 
         await appStore._finishConflictedMerge(
@@ -204,6 +212,9 @@ describe('AppStore', () => {
       it('leaves untracked files untracked', async () => {
         let repo = await setupConflictedRepoWithMultipleFiles()
         repo = (await appStore._addRepositories([repo.path]))[0]
+
+        await repositoriesStore.updateLastStashCheckDate(repo)
+
         const status = await getStatusOrThrow(repo)
         await appStore._finishConflictedMerge(
           repo,
@@ -224,6 +235,7 @@ describe('AppStore', () => {
       beforeEach(async () => {
         repo = await setupConflictedRepoWithUnrelatedCommittedChange()
         repo = (await appStore._addRepositories([repo.path]))[0]
+        await repositoriesStore.updateLastStashCheckDate(repo)
         status = await getStatusOrThrow(repo)
       })
       it("doesn't commit unrelated changes", async () => {


### PR DESCRIPTION
## Overview

**Alternative proposal to #7558 to get the tests passing against 1.6.6.**

## Description

This (should) avoid running the new code by setting the relevant `lastStashDate` flag in the repositories store database and in-memory cache.

## Release notes

Notes: no-notes
