### PR TITLE
disable flaky tests in 1.6.6 release branch

### DIFF
--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -179,7 +179,12 @@ describe('AppStore', () => {
       expect(state.localCommitSHAs).toHaveLength(0)
     })
   })
-  describe('_finishConflictedMerge', () => {
+
+  // skipping these tests because its not worth the time it would take
+  // to make them reliable. the underlying problem is that this scenario
+  // triggers an asynchronous call to the stats db that sometimes doesn't
+  // finish before the test is over (which then errors out)
+  describe.skip('_finishConflictedMerge', () => {
     let appStore: AppStore
     let repositoriesStore: RepositoriesStore
 


### PR DESCRIPTION
## Context

We've been dealing with intermittent test failures in #7537. A good amount of time has been spent trying to isolate and fix this, but we're still not out of the woods.

## The Problem

The `_finishConflictedMerge` tests trigger `appStore._refreshRepository`, which makes an asynchronous, but un-`await`-ed call to the stats store and database. Sometimes this results in an attempt to access the database after the test has ended, which throws an error and (rightfully) fails the test.

## Summary

To be clear, this isn't a bug in appStore's behavior, but it is evidence of a difficult-to-test architecture that requires more scaffolding/mocking/rigging in our tests for them to be reliable. This PR disables the tests in question so they can be revisited at some point in the future. (tracked over in #7563)

_____

### Even More Context

(#7558 looked into forcing these calls to complete before the test finished, but affects the behavior of the appStore in those situations, which could affect the performance of the app. and #7561 attempted to fix this by manually calling the stats store before the test to prevent it from getting triggered in the test cases.)