### PR TITLE
wrapping up the current rebase epic

### DIFF
--- a/docs/process/labels.md
+++ b/docs/process/labels.md
@@ -71,7 +71,6 @@ these labels do not become overused and add noise to the issue tracker.
 
 |                              | Label name     |  Description |
 | ---------------------------- | -------------- |  ----------- |
-| [:mag_right:][epic:rebase]   | `epic:rebase`  | Supporting rebase flows in the app |
 | [:mag_right:][epic:stashing] | `epic:stashing`| Supporting stashing uncommitted changes in the app |
 
 ### Specialized areas


### PR DESCRIPTION
## Overview

As we're happy with the rebase flow that will ship with 1.7, we can tidy up some things.

## Description

- [x] unassign labels from open issues
- [x] drop label from list in documentation
- [x] close [project board](https://github.com/desktop/desktop/projects/20)

## Release notes

Notes: no-notes
