### PR TITLE
Dial down on the explicit fetching of pull requests

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3723,7 +3723,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.updatePushPullFetchProgress(repository, null)
 
         if (fetchType === FetchType.UserInitiatedTask) {
-          this._refreshPullRequests(repository)
           if (repository.gitHubRepository != null) {
             this._refreshIssues(repository.gitHubRepository)
           }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1435,13 +1435,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private startPullRequestUpdater(repository: Repository) {
     if (this.currentPullRequestUpdater) {
-      fatalError(
-        `A pull request updater is already active and cannot start updating on ${nameOf(
-          repository
-        )}`
-      )
-
-      return
+      this.stopPullRequestUpdater()
     }
 
     // We don't want to run the pull request updater when the app is in

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1337,7 +1337,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.pullRequestStore.getAll(gitHubRepository).then(prs => {
         this.onPullRequestChanged(gitHubRepository, prs)
       })
-      this._refreshPullRequests(repository)
     }
 
     // The selected repository could have changed while we were refreshing.


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This PR contains some cleanup work after #7501.

## Description

Three changes in this PR.

First, don't crash with a fatal error if attempting to start PR updater when it's already running. #7501 increased the complexities of when the PR updater is started and stopped by introducing stop/start when the app is blurred/focused. It's difficult to envision all scenarios and timing here and it's possible (though not verified) that an edge case may exist where we would attempt to start the PR updater while it's already running. As such I've taken the safe route here of simply stopping the current PR updater if one exists before launching it again.

The last two changes revolve around when to explicitly refresh PRs. Previously we would refresh PRs when the user explicitly initiated a fetch and when the repository was selected. That's no longer necessary since the PR updater will take care of updating as well as maintaining a good balance between frequency of updates and staying in sync with the server. If we keep these refresh callsites around there's a risk that we'll be running PR updates more frequently than what's prudent.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes