### PR TITLE
record metrics for protected branch scenarios due for 1.7

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -91,5 +91,5 @@ export function enableStashing(): boolean {
  * protected branch?
  */
 export function enableBranchProtectionWarning(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -140,6 +140,9 @@ export interface IDailyMeasures {
   /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */
   readonly commitsToProtectedBranch: number
 
+  /** A flag indicating the user made a commit to a repository with branch protections enabled */
+  readonly commitWithBranchProtectionsEnabled: boolean
+
   /** The number of times the user dismissed the merge conflicts dialog */
   readonly mergeConflictsDialogDismissalCount: number
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -137,6 +137,9 @@ export interface IDailyMeasures {
   /** The number of time the user made a commit to a repo hosted on Github.com */
   readonly dotcomCommits: number
 
+  /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */
+  readonly commitMadeToProtectedBranch: number
+
   /** The number of times the user dismissed the merge conflicts dialog */
   readonly mergeConflictsDialogDismissalCount: number
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -140,8 +140,8 @@ export interface IDailyMeasures {
   /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */
   readonly commitsToProtectedBranch: number
 
-  /** A flag indicating the user made a commit to a repository with branch protections enabled */
-  readonly commitWithBranchProtectionsEnabled: boolean
+  /** The number of times the user made a commit to a repository with branch protections enabled */
+  readonly commitsToRepositoryWithBranchProtections: number
 
   /** The number of times the user dismissed the merge conflicts dialog */
   readonly mergeConflictsDialogDismissalCount: number

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -138,7 +138,7 @@ export interface IDailyMeasures {
   readonly dotcomCommits: number
 
   /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */
-  readonly commitsMadeToProtectedBranch: number
+  readonly commitsToProtectedBranch: number
 
   /** The number of times the user dismissed the merge conflicts dialog */
   readonly mergeConflictsDialogDismissalCount: number

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -138,7 +138,7 @@ export interface IDailyMeasures {
   readonly dotcomCommits: number
 
   /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */
-  readonly commitMadeToProtectedBranch: number
+  readonly commitsMadeToProtectedBranch: number
 
   /** The number of times the user dismissed the merge conflicts dialog */
   readonly mergeConflictsDialogDismissalCount: number

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -134,7 +134,7 @@ export interface IDailyMeasures {
    */
   readonly enterpriseCommits: number
 
-  /** The number of time the user made a commit to a repo hosted on Github.com */
+  /** The number of times the user made a commit to a repo hosted on Github.com */
   readonly dotcomCommits: number
 
   /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -100,7 +100,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   suggestedStepPublishRepository: 0,
   suggestedStepPublishBranch: 0,
   suggestedStepCreatePullRequest: 0,
-  commitMadeToProtectedBranch: 0,
+  commitsMadeToProtectedBranch: 0,
 }
 
 interface IOnboardingStats {
@@ -686,7 +686,7 @@ export class StatsStore implements IStatsStore {
   /** Record that the user made a commit to a protected GitHub or GitHub Enterprise repository */
   public recordCommitMadeToProtectedBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      commitMadeToProtectedBranch: m.commitMadeToProtectedBranch + 1,
+      commitsMadeToProtectedBranch: m.commitsMadeToProtectedBranch + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -691,6 +691,12 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  public recordCommitWithBranchProtectionsEnabled(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      commitWithBranchProtectionsEnabled: true,
+    }))
+  }
+
   /** Set whether the user has opted out of stats reporting. */
   public async setOptOut(
     optOut: boolean,

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -101,7 +101,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   suggestedStepPublishBranch: 0,
   suggestedStepCreatePullRequest: 0,
   commitsToProtectedBranch: 0,
-  commitWithBranchProtectionsEnabled: false,
+  commitsToRepositoryWithBranchProtections: 0,
 }
 
 interface IOnboardingStats {
@@ -692,9 +692,10 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record the user made a commit to repository which has branch protections enabled */
-  public recordCommitWithBranchProtectionsEnabled(): Promise<void> {
+  public recordCommitToRepositoryWithBranchProtections(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      commitWithBranchProtectionsEnabled: true,
+      commitsToRepositoryWithBranchProtections:
+        m.commitsToRepositoryWithBranchProtections + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -100,7 +100,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   suggestedStepPublishRepository: 0,
   suggestedStepPublishBranch: 0,
   suggestedStepCreatePullRequest: 0,
-  commitsMadeToProtectedBranch: 0,
+  commitsToProtectedBranch: 0,
 }
 
 interface IOnboardingStats {
@@ -684,9 +684,9 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record that the user made a commit to a protected GitHub or GitHub Enterprise repository */
-  public recordCommitMadeToProtectedBranch(): Promise<void> {
+  public recordCommitToProtectedBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      commitsMadeToProtectedBranch: m.commitsMadeToProtectedBranch + 1,
+      commitsToProtectedBranch: m.commitsToProtectedBranch + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -684,13 +684,14 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  /** Record that the user made a commit to a protected GitHub or GitHub Enterprise repository */
+  /** Record the user made a commit to a protected GitHub or GitHub Enterprise repository */
   public recordCommitToProtectedBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       commitsToProtectedBranch: m.commitsToProtectedBranch + 1,
     }))
   }
 
+  /** Record the user made a commit to repository which has branch protections enabled */
   public recordCommitWithBranchProtectionsEnabled(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       commitWithBranchProtectionsEnabled: true,

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -683,6 +683,13 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /** Record that the user made a commit to a protected GitHub or GitHub Enterprise repository */
+  public recordCommitMadeToProtectedBranch(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      commitMadeToProtectedBranch: m.commitMadeToProtectedBranch + 1,
+    }))
+  }
+
   /** Set whether the user has opted out of stats reporting. */
   public async setOptOut(
     optOut: boolean,

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -101,6 +101,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   suggestedStepPublishBranch: 0,
   suggestedStepCreatePullRequest: 0,
   commitsToProtectedBranch: 0,
+  commitWithBranchProtectionsEnabled: false,
 }
 
 interface IOnboardingStats {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -100,6 +100,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   suggestedStepPublishRepository: 0,
   suggestedStepPublishBranch: 0,
   suggestedStepCreatePullRequest: 0,
+  commitMadeToProtectedBranch: 0,
 }
 
 interface IOnboardingStats {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2383,14 +2383,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
           if (upstreamWithoutRemote !== null) {
             const {
-              branchProtectionCount,
+              branchProtectionsFound,
               isProtected,
             } = await this.repositoriesStore.getBranchProtectionContext(
               repository.gitHubRepository,
               upstreamWithoutRemote
             )
 
-            if (branchProtectionCount > 0) {
+            if (branchProtectionsFound) {
               this.statsStore.recordCommitWithBranchProtectionsEnabled()
             }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -163,6 +163,7 @@ import {
   IMatchedGitHubRepository,
   matchGitHubRepository,
   repositoryMatchesRemote,
+  urlMatchesCloneURL,
 } from '../repository-matching'
 import {
   initializeRebaseFlowForConflictedRepository,
@@ -2381,7 +2382,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
           // look up if the tracked branch matches a protected remote branch
           const { upstreamWithoutRemote } = gitStore.tip.branch
 
-          if (upstreamWithoutRemote !== null) {
+          // ensure the remote associated with this branch is the one we
+          // are checking the branch protections against
+          const remoteURL = gitStore.currentRemote.url
+
+          if (
+            upstreamWithoutRemote !== null &&
+            urlMatchesCloneURL(remoteURL, repository.gitHubRepository)
+          ) {
             const {
               branchProtectionsFound,
               isProtected,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2388,9 +2388,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             )
 
             if (isProtected) {
-              log.debug(
-                `[_commitIncludedChanges] the upstream ref '${upstreamWithoutRemote}' is protected by the GitHub API`
-              )
+              this.statsStore.recordCommitMadeToProtectedBranch()
             }
           }
         }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2399,7 +2399,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             )
 
             if (branchProtectionsFound) {
-              this.statsStore.recordCommitWithBranchProtectionsEnabled()
+              this.statsStore.recordCommitToRepositoryWithBranchProtections()
             }
 
             if (isRemoteBranchProtected) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2382,10 +2382,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
           const { upstreamWithoutRemote } = gitStore.tip.branch
 
           if (upstreamWithoutRemote !== null) {
-            const isProtected = await this.repositoriesStore.isBranchProtected(
+            const {
+              branchProtectionCount,
+              isProtected,
+            } = await this.repositoriesStore.getBranchProtectionContext(
               repository.gitHubRepository,
               upstreamWithoutRemote
             )
+
+            if (branchProtectionCount > 0) {
+              this.statsStore.recordCommitWithBranchProtectionsEnabled()
+            }
 
             if (isProtected) {
               this.statsStore.recordCommitToProtectedBranch()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2388,7 +2388,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             )
 
             if (isProtected) {
-              this.statsStore.recordCommitMadeToProtectedBranch()
+              this.statsStore.recordCommitToProtectedBranch()
             }
           }
         }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2392,7 +2392,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           ) {
             const {
               branchProtectionsFound,
-              isProtected,
+              isRemoteBranchProtected,
             } = await this.repositoriesStore.getBranchProtectionContext(
               repository.gitHubRepository,
               upstreamWithoutRemote
@@ -2402,7 +2402,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
               this.statsStore.recordCommitWithBranchProtectionsEnabled()
             }
 
-            if (isProtected) {
+            if (isRemoteBranchProtected) {
               this.statsStore.recordCommitToProtectedBranch()
             }
           }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2392,7 +2392,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
           // name because 99.99% (citation needed) of users like to keep their
           // naming patterns consistent between local and remote repositories
 
-          const branchName = findBranchName(gitStore.tip)
+          const branchName = findBranchName(
+            gitStore.tip,
+            gitStore.currentRemote,
+            repository.gitHubRepository
+          )
 
           if (branchName !== null) {
             const isRemoteBranchProtected = await this.repositoriesStore.isBranchProtectedOnRemote(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -237,7 +237,7 @@ import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
-import { findBranchName } from './helpers/find-branch-name'
+import { findRemoteBranchName } from './helpers/find-branch-name'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -2375,9 +2375,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         }
 
         if (enableBranchProtectionWarning()) {
-          // first, see if there are any branch protections enabled for this
-          // repository (or the upstream if working in a fork)
-
           const branchProtectionsFound = await this.repositoriesStore.hasBranchProtectionsConfigured(
             repository.gitHubRepository
           )
@@ -2386,13 +2383,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             this.statsStore.recordCommitToRepositoryWithBranchProtections()
           }
 
-          // second, check the current branch to determine whether branch
-          // protections are enabled - we can use the remote branch name if
-          // tracking information is set, or fall back to using the local branch
-          // name because 99.99% (citation needed) of users like to keep their
-          // naming patterns consistent between local and remote repositories
-
-          const branchName = findBranchName(
+          const branchName = findRemoteBranchName(
             gitStore.tip,
             gitStore.currentRemote,
             repository.gitHubRepository

--- a/app/src/lib/stores/helpers/find-branch-name.ts
+++ b/app/src/lib/stores/helpers/find-branch-name.ts
@@ -1,0 +1,20 @@
+import { Tip, TipState } from '../../../models/tip'
+
+/**
+ * Function to determine which branch name to use when looking for branch
+ * protection information.
+ *
+ * Currently ignores any remote-specific information, in favour of just looking
+ * at the tracking branch name (if set).
+ */
+export function findBranchName(tip: Tip): string | null {
+  if (tip.kind !== TipState.Valid) {
+    return null
+  }
+
+  if (tip.branch.upstreamWithoutRemote !== null) {
+    return tip.branch.upstreamWithoutRemote
+  }
+
+  return tip.branch.nameWithoutRemote
+}

--- a/app/src/lib/stores/helpers/find-branch-name.ts
+++ b/app/src/lib/stores/helpers/find-branch-name.ts
@@ -12,7 +12,7 @@ import { urlMatchesCloneURL } from '../../repository-matching'
  * branch name as that's a reasonable approximation for what would happen if the
  * user tries to push the new branch.
  */
-export function findBranchName(
+export function findRemoteBranchName(
   tip: Tip,
   remote: IRemote | null,
   gitHubRepository: GitHubRepository

--- a/app/src/lib/stores/helpers/find-branch-name.ts
+++ b/app/src/lib/stores/helpers/find-branch-name.ts
@@ -1,18 +1,31 @@
 import { Tip, TipState } from '../../../models/tip'
+import { IRemote } from '../../../models/remote'
+import { GitHubRepository } from '../../../models/github-repository'
+import { urlMatchesCloneURL } from '../../repository-matching'
 
 /**
  * Function to determine which branch name to use when looking for branch
  * protection information.
  *
- * Currently ignores any remote-specific information, in favour of just looking
- * at the tracking branch name (if set).
+ * If the remote branch matches the current `githubRepository` associated with
+ * the repostiory, this will be used. Otherwise we will fall back to using the
+ * branch name as that's a reasonable approximation for what would happen if the
+ * user tries to push the new branch.
  */
-export function findBranchName(tip: Tip): string | null {
+export function findBranchName(
+  tip: Tip,
+  remote: IRemote | null,
+  gitHubRepository: GitHubRepository
+): string | null {
   if (tip.kind !== TipState.Valid) {
     return null
   }
 
-  if (tip.branch.upstreamWithoutRemote !== null) {
+  if (
+    tip.branch.upstreamWithoutRemote !== null &&
+    remote !== null &&
+    urlMatchesCloneURL(remote.url, gitHubRepository)
+  ) {
     return tip.branch.upstreamWithoutRemote
   }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -557,6 +557,10 @@ export class RepositoriesStore extends BaseStore {
     return record!.lastPruneDate
   }
 
+  /**
+   * Inspect the cache or database to find out information about the branch
+   * protection configuration for the current repository and branch.
+   */
   public async getBranchProtectionContext(
     gitHubRepository: GitHubRepository,
     branchName: string

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -557,21 +557,18 @@ export class RepositoriesStore extends BaseStore {
         'unable to get protected branches, GitHub repository has a null dbID'
       )
     }
+
+    const repoID = gitHubRepository.dbID
+
     const cachedBranchProtectionFound = this.branchProtectionFoundCache.get(
-      gitHubRepository.dbID
+      repoID
     )
 
     if (cachedBranchProtectionFound === undefined) {
-      return this.loadAndCacheBranchProtection(
-        gitHubRepository.dbID,
-        branchName
-      )
+      return this.loadAndCacheBranchProtection(repoID, branchName)
     } else {
       // fall back to the current behaviour for now
-      const isProtected = await this.isBranchProtected(
-        gitHubRepository,
-        branchName
-      )
+      const isProtected = await this.isBranchProtected(repoID, branchName)
 
       return {
         branchProtectionsFound: cachedBranchProtectionFound,
@@ -610,26 +607,17 @@ export class RepositoriesStore extends BaseStore {
   }
 
   private async isBranchProtected(
-    gitHubRepository: GitHubRepository,
+    repoID: number,
     branchName: string
   ): Promise<boolean> {
-    if (gitHubRepository.dbID === null) {
-      return fatalError(
-        'unable to get protected branches, GitHub repository has a null dbID'
-      )
-    }
-
-    const key = getKey(gitHubRepository.dbID, branchName)
+    const key = getKey(repoID, branchName)
 
     const existing = this.branchProtectionCache.get(key)
     if (existing !== undefined) {
       return existing
     }
 
-    const result = await this.db.protectedBranches.get([
-      gitHubRepository.dbID,
-      branchName,
-    ])
+    const result = await this.db.protectedBranches.get([repoID, branchName])
 
     const value = result !== undefined
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -12,8 +12,14 @@ import { IAPIRepository, IAPIBranch } from '../api'
 import { BaseStore } from './base-store'
 import { enableBranchProtectionWarning } from '../feature-flag'
 
+/**
+ * Branch protection information associated with a given GitHub or GitHub
+ * Enterprise repository.
+ */
 type BranchProtectionContext = {
+  /** Does the repository have any branch protections enabled? */
   readonly branchProtectionsFound: boolean
+  /** Is the current branch marked as protected on the remote repository? */
   readonly isProtected: boolean
 }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -594,11 +594,15 @@ export class RepositoriesStore extends BaseStore {
     }
   }
 
+  /**
+   * Load the branch protection information for a repository from the database
+   * and cache the results in memory
+   */
   private async loadAndCacheBranchProtection(
     repoID: number,
     branchName: string
   ) {
-    //  hit the database to find any protected branches
+    // query the database to find any protected branches
     const branches = await this.db.protectedBranches
       .where('repoId')
       .equals(repoID)
@@ -607,13 +611,12 @@ export class RepositoriesStore extends BaseStore {
     const branchProtectionsFound = branches.length > 0
 
     // fill the retrieved records into the per-branch cache
-
     for (const branch of branches) {
       const key = getKey(repoID, branch.name)
       this.protectionEnabledForBranchCache.set(key, true)
     }
 
-    // find the current branch in the cache, or false if not found
+    // find the current branch in the cache, or return `false` if not found
     const key = getKey(repoID, branchName)
     const isProtected = this.protectionEnabledForBranchCache.get(key) || false
 
@@ -623,6 +626,7 @@ export class RepositoriesStore extends BaseStore {
     }
   }
 
+  /** Check for the branch protection of a given branch on the remote */
   private async isBranchProtected(
     repoID: number,
     branchName: string

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -579,7 +579,7 @@ export class RepositoriesStore extends BaseStore {
 
     if (branchProtectionsFound === undefined) {
       return this.loadAndCacheBranchProtection(repoID, branchName)
-    } else if (branchProtectionsFound) {
+    } else if (branchProtectionsFound === true) {
       // as we know branch protections are enabled for the repository, check
       // this specific branch either in the cache or the database
       const isRemoteBranchProtected = await this.isBranchProtected(

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -451,14 +451,17 @@ export class RepositoriesStore extends BaseStore {
             this.protectionEnabledForBranchCache.set(key, true)
           }
 
-          this.branchProtectionSettingsFoundCache.set(repoId, true)
-
           await this.db.protectedBranches
             .where('repoId')
             .equals(repoId)
             .delete()
 
-          await this.db.protectedBranches.bulkAdd(branchRecords)
+          const protectionsFound = branchRecords.length > 0
+          this.branchProtectionSettingsFoundCache.set(repoId, protectionsFound)
+
+          if (branchRecords.length > 0) {
+            await this.db.protectedBranches.bulkAdd(branchRecords)
+          }
         }
 
         return updatedGitHubRepo

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -20,7 +20,7 @@ type BranchProtectionContext = {
   /** Does the repository have any branch protections enabled? */
   readonly branchProtectionsFound: boolean
   /** Is the current branch marked as protected on the remote repository? */
-  readonly isProtected: boolean
+  readonly isRemoteBranchProtected: boolean
 }
 
 /** The store for local repositories. */
@@ -578,11 +578,14 @@ export class RepositoriesStore extends BaseStore {
     } else if (branchProtectionsFound) {
       // as we know branch protections are enabled for the repository, check
       // this specific branch either in the cache or the database
-      const isProtected = await this.isBranchProtected(repoID, branchName)
+      const isRemoteBranchProtected = await this.isBranchProtected(
+        repoID,
+        branchName
+      )
 
       return {
         branchProtectionsFound,
-        isProtected,
+        isRemoteBranchProtected,
       }
     }
 
@@ -590,7 +593,7 @@ export class RepositoriesStore extends BaseStore {
     // current branch cannot be protected
     return {
       branchProtectionsFound,
-      isProtected: false,
+      isRemoteBranchProtected: false,
     }
   }
 
@@ -618,11 +621,12 @@ export class RepositoriesStore extends BaseStore {
 
     // find the current branch in the cache, or return `false` if not found
     const key = getKey(repoID, branchName)
-    const isProtected = this.protectionEnabledForBranchCache.get(key) || false
+    const isRemoteBranchProtected =
+      this.protectionEnabledForBranchCache.get(key) || false
 
     return {
       branchProtectionsFound,
-      isProtected,
+      isRemoteBranchProtected,
     }
   }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -563,20 +563,28 @@ export class RepositoriesStore extends BaseStore {
 
     const repoID = gitHubRepository.dbID
 
-    const cachedBranchProtectionFound = this.branchProtectionSettingsFoundCache.get(
+    const branchProtectionsFound = this.branchProtectionSettingsFoundCache.get(
       repoID
     )
 
-    if (cachedBranchProtectionFound === undefined) {
+    if (branchProtectionsFound === undefined) {
       return this.loadAndCacheBranchProtection(repoID, branchName)
-    } else {
-      // fall back to the current behaviour for now
+    } else if (branchProtectionsFound) {
+      // as we know branch protections are enabled for the repository, check
+      // this specific branch either in the cache or the database
       const isProtected = await this.isBranchProtected(repoID, branchName)
 
       return {
-        branchProtectionsFound: cachedBranchProtectionFound,
+        branchProtectionsFound,
         isProtected,
       }
+    }
+
+    // we have no branch protections enabled for this repository, therefore the
+    // current branch cannot be protected
+    return {
+      branchProtectionsFound,
+      isProtected: false,
     }
   }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -616,6 +616,7 @@ export class RepositoriesStore extends BaseStore {
       .toArray()
 
     const branchProtectionsFound = branches.length > 0
+    this.branchProtectionSettingsFoundCache.set(repoID, branchProtectionsFound)
 
     // fill the retrieved records into the per-branch cache
     for (const branch of branches) {

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -622,9 +622,6 @@ export class RepositoriesStore extends BaseStore {
   /**
    * Check if the given branch for the repository is protected through the
    * GitHub API.
-   *
-   * Will also check the parent repository if is defined and the fork repository
-   * does not have this branch protected.
    */
   public async isBranchProtectedOnRemote(
     gitHubRepository: GitHubRepository,
@@ -637,21 +634,7 @@ export class RepositoriesStore extends BaseStore {
     }
 
     const { dbID } = gitHubRepository
-    const isProtected = await this.isBranchProtected(dbID, branchName)
-
-    if (isProtected) {
-      return true
-    }
-
-    if (
-      gitHubRepository.parent !== null &&
-      gitHubRepository.parent.dbID !== null
-    ) {
-      const parentID = gitHubRepository.parent.dbID
-      return await this.isBranchProtected(parentID, branchName)
-    }
-
-    return false
+    return await this.isBranchProtected(dbID, branchName)
   }
 }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -619,10 +619,12 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    const repoID = gitHubRepository.dbID
-    const found = await this.findOrCacheBranchProtections(repoID)
+    const { dbID } = gitHubRepository
+    const isBranchProtectionsFound = await this.findOrCacheBranchProtections(
+      dbID
+    )
 
-    if (found) {
+    if (isBranchProtectionsFound) {
       return true
     }
 
@@ -654,10 +656,10 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    const repoID = gitHubRepository.dbID
-    const found = await this.isBranchProtected(repoID, branchName)
+    const { dbID } = gitHubRepository
+    const isProtected = await this.isBranchProtected(dbID, branchName)
 
-    if (found) {
+    if (isProtected) {
       return true
     }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -611,15 +611,18 @@ export class RepositoriesStore extends BaseStore {
     const { dbID } = gitHubRepository
     const key = getKey(dbID, branchName)
 
-    const existing = this.protectionEnabledForBranchCache.get(key)
-    if (existing === true) {
-      return existing
+    const cachedProtectionValue = this.protectionEnabledForBranchCache.get(key)
+    if (cachedProtectionValue === true) {
+      return cachedProtectionValue
     }
 
-    const result = await this.db.protectedBranches.get([dbID, branchName])
+    const databaseValue = await this.db.protectedBranches.get([
+      dbID,
+      branchName,
+    ])
 
     // if no row found, this means no protection is found for the branch
-    const value = result !== undefined
+    const value = databaseValue !== undefined
 
     this.protectionEnabledForBranchCache.set(key, value)
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -602,8 +602,11 @@ export class RepositoriesStore extends BaseStore {
   }
 
   /**
-   * Check if any branch protection settings are enabled for the current
-   * repository or parent repository, using the GitHub API configuration.
+   * Check if any branch protection settings are enabled for the repository
+   * through the GitHub API.
+   *
+   * Will also check the parent repository if is defined and the fork repository
+   * does not have this branch protected.
    */
   public async hasBranchProtectionsConfigured(
     gitHubRepository: GitHubRepository
@@ -633,7 +636,13 @@ export class RepositoriesStore extends BaseStore {
     return false
   }
 
-  /** Check for the branch protection of a given branch on the remote */
+  /**
+   * Check if the given branch for the repository is protected through the
+   * GitHub API.
+   *
+   * Will also check the parent repository if is defined and the fork repository
+   * does not have this branch protected.
+   */
   public async isBranchProtectedOnRemote(
     gitHubRepository: GitHubRepository,
     branchName: string

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -606,9 +606,6 @@ export class RepositoriesStore extends BaseStore {
   /**
    * Check if any branch protection settings are enabled for the repository
    * through the GitHub API.
-   *
-   * Will also check the parent repository if is defined and the fork repository
-   * does not have this branch protected.
    */
   public async hasBranchProtectionsConfigured(
     gitHubRepository: GitHubRepository
@@ -619,24 +616,7 @@ export class RepositoriesStore extends BaseStore {
       )
     }
 
-    const { dbID } = gitHubRepository
-    const isBranchProtectionsFound = await this.findOrCacheBranchProtections(
-      dbID
-    )
-
-    if (isBranchProtectionsFound) {
-      return true
-    }
-
-    if (
-      gitHubRepository.parent !== null &&
-      gitHubRepository.parent.dbID !== null
-    ) {
-      const parentID = gitHubRepository.parent.dbID
-      return await this.findOrCacheBranchProtections(parentID)
-    }
-
-    return false
+    return await this.findOrCacheBranchProtections(gitHubRepository.dbID)
   }
 
   /**

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -34,6 +34,7 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `branchComparisons` | The number of times a branch is compared to an arbitrary branch. | To understand usage patterns around the compare branches feature. |
 | `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
 | `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
+| `commitsMadeToProtectedBranch` | The number of commits made to a protected branch. | To understand whether the app could guide users depending on the repository configuration. |
 | `createPullRequestCount` | The number of times the user is taken to the create pull request page on GitHub.com. | To understand how people are creating pull requests via Desktop. |
 | `defaultBranchComparisons` | The number of times a branch is compared to the default branch. | To understand usage patterns around the compare branches feature. |
 | `divergingBranchBannerDismissal` | The number of times the user dismisses the diverged branch notification. | To understand usage patterns around the notification of diverging from the default branch feature. |

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -34,7 +34,7 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `branchComparisons` | The number of times a branch is compared to an arbitrary branch. | To understand usage patterns around the compare branches feature. |
 | `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
 | `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
-| `commitsMadeToProtectedBranch` | The number of commits made to a protected branch. | To understand whether the app could guide users depending on the repository configuration. |
+| `commitsToProtectedBranch` | Flag indicating the user committed to a repository with protected branches set. | To understand whether the app could guide users depending on the repository configuration. |
 | `createPullRequestCount` | The number of times the user is taken to the create pull request page on GitHub.com. | To understand how people are creating pull requests via Desktop. |
 | `defaultBranchComparisons` | The number of times a branch is compared to the default branch. | To understand usage patterns around the compare branches feature. |
 | `divergingBranchBannerDismissal` | The number of times the user dismisses the diverged branch notification. | To understand usage patterns around the notification of diverging from the default branch feature. |

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -35,6 +35,7 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
 | `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
 | `commitsToProtectedBranch` | Flag indicating the user committed to a repository with protected branches set. | To understand whether the app could guide users depending on the repository configuration. |
+| `commitWithBranchProtectionsEnabled` | The number of commits made to a protected branch. | To understand whether the app could guide users depending on the repository configuration. |
 | `createPullRequestCount` | The number of times the user is taken to the create pull request page on GitHub.com. | To understand how people are creating pull requests via Desktop. |
 | `defaultBranchComparisons` | The number of times a branch is compared to the default branch. | To understand usage patterns around the compare branches feature. |
 | `divergingBranchBannerDismissal` | The number of times the user dismisses the diverged branch notification. | To understand usage patterns around the notification of diverging from the default branch feature. |

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -34,8 +34,8 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `branchComparisons` | The number of times a branch is compared to an arbitrary branch. | To understand usage patterns around the compare branches feature. |
 | `coAuthoredCommits` | The number of commits created with one or more co-authors. | To understand usage patterns of commits made in Desktop. |
 | `commits` | The number of commits made. | To understand usage patterns of commits made in Desktop. |
-| `commitsToProtectedBranch` | Flag indicating the user committed to a repository with protected branches set. | To understand whether the app could guide users depending on the repository configuration. |
-| `commitWithBranchProtectionsEnabled` | The number of commits made to a protected branch. | To understand whether the app could guide users depending on the repository configuration. |
+| `commitsToProtectedBranch` | The number of commits made to a protected branch. | To understand whether the app could guide users depending on the repository configuration. |
+| `commitsToRepositoryWithBranchProtections` | The number of commits made to a repository which has branch protections enabled. | To understand whether the app could guide users depending on the repository configuration. |
 | `createPullRequestCount` | The number of times the user is taken to the create pull request page on GitHub.com. | To understand how people are creating pull requests via Desktop. |
 | `defaultBranchComparisons` | The number of times a branch is compared to the default branch. | To understand usage patterns around the compare branches feature. |
 | `divergingBranchBannerDismissal` | The number of times the user dismisses the diverged branch notification. | To understand usage patterns around the notification of diverging from the default branch feature. |


### PR DESCRIPTION
## Overview

**Second PR to address #7091**

## Description

- [x] add `commitsToProtectedBranch` and `commitWithBranchProtectionsEnabled` to help understand how protected branches are encountered in the wild
- [x] update metrics docs with this information
- [x] address gaps with `RepositoriesStore` not being aware of "branch protection is enabled" scenario
- [x] wire up metrics when committing
- [x] tune caching so that at worst only one DB call occurs when `RepositoriesStore.getBranchProtectionContext` runs
- [x] rebase on top of `development` once #7529 has been merged
- [x] open Central PR to consume and pass through these metrics - https://github.com/github/central/pull/434
- [x] open marketing site PR to document these metrics - https://github.com/github/desktop.github.com/pull/132

I believe this is feature-complete now, and will go out with the next beta. I'll follow up with a PR to enable it for production based on how further testing on beta looks.

## Release notes

Notes: no-notes
