### PR TITLE
explanation for text file with manual conflict diff

### DIFF
--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -70,7 +70,7 @@ export type ManualConflict = {
 /** Union of potential conflict scenarios the application should handle */
 export type ConflictedFileStatus = ConflictsWithMarkers | ManualConflict
 
-/** Custom typeguard to differentiate ConflictsWithMarkers from other Conflict types */
+/** Custom typeguard to differentiate Conflict files from other types */
 export function isConflictedFileStatus(
   appFileStatus: AppFileStatus
 ): appFileStatus is ConflictedFileStatus {

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -194,7 +194,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
       ) {
         return (
           <div className="panel empty">
-            The file is in conflict and must be resolved via command line.
+            The file is in conflict and must be resolved via the command line.
           </div>
         )
       }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -10,6 +10,8 @@ import {
   CommittedFileChange,
   WorkingDirectoryFileChange,
   AppFileStatusKind,
+  isManualConflict,
+  isConflictedFileStatus,
 } from '../../models/status'
 import {
   DiffSelection,
@@ -182,6 +184,17 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
         return (
           <div className="panel renamed">
             The file was renamed but not changed
+          </div>
+        )
+      }
+
+      if (
+        isConflictedFileStatus(this.props.file.status) &&
+        isManualConflict(this.props.file.status)
+      ) {
+        return (
+          <div className="panel empty">
+            The file is in conflict and must be resolved via command line.
           </div>
         )
       }


### PR DESCRIPTION
## Overview

In testing stashing, we found that our diff ui did not handle text files with manual conflicts well. This pull request adds logic to our `Diff` component to show a helpful message in that case (instead of the fallback no content changes found message).

### Before
<img width="1013" alt="Screen Shot 2019-05-22 at 5 30 40 PM" src="https://user-images.githubusercontent.com/964912/58217365-5812d780-7cb7-11e9-8716-cd3c00279d06.png">

### After
<img width="978" alt="Screen Shot 2019-05-22 at 4 12 38 PM" src="https://user-images.githubusercontent.com/964912/58217258-d7ec7200-7cb6-11e9-8b40-516191268bbe.png">

This is meant to be an iteration that we can revisit over time as we spend more time developing the conflict handling UI for stashing.

### Reproduction Giph

![bring-deleted-file-conflict](https://user-images.githubusercontent.com/964912/58217223-a5db1000-7cb6-11e9-8de9-bf137cfd41a2.gif)

It's absolutely possible to get into this state by getting into a conflicted merge and closing the merge conflicts dialog and selecting similarly conflicted files.

## Release notes

Notes: Show explanation for manually conflicted text files in diff viewer