### PR TITLE
add check that remote ref does not exist when pruning

### DIFF
--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -69,10 +69,10 @@ export async function getRecentBranches(
  * Returns a map keyed on branch names
  *
  * @param repository the repository who's reflog you want to check
- * @param afterDate the minimum date a checkout has to occur
+ * @param afterDate filters checkouts so that only those occuring on or after this date are returned
  * @returns map of branch name -> checkout date
  */
-export async function getCheckoutsAfterDate(
+export async function getBranchCheckouts(
   repository: Repository,
   afterDate: Date
 ): Promise<Map<string, Date>> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5139,6 +5139,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return Promise.resolve()
   }
+
+  public async _forceBranchPruning() {
+    if (this.currentBranchPruner === null) {
+      return
+    }
+
+    await this.currentBranchPruner.prune()
+  }
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5145,7 +5145,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    await this.currentBranchPruner.prune()
+    await this.currentBranchPruner.testPrune()
   }
 }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -179,20 +179,11 @@ export class BranchPruner {
       .subtract(2, 'weeks')
       .toDate()
 
-    const recentlyCheckedOutBranches = await getBranchCheckouts(
-      this.repository,
-      twoWeeksAgo
-    )
-
-    const recentlyCheckedOutCanonicalRefs = new Set(
-      [...recentlyCheckedOutBranches.keys()].map(formatAsLocalRef)
-    )
-
     const branchRefPrefix = `refs/heads/`
 
     const branchesReadyForPruning = await this.filterBranches(
       mergedBranches,
-      recentlyCheckedOutCanonicalRefs
+      twoWeeksAgo
     )
 
     log.info(
@@ -243,12 +234,20 @@ export class BranchPruner {
 
   private async filterBranches(
     mergedBranches: ReadonlyArray<IMergedBranch>,
-    recentlyCheckedOutCanonicalRefs: Set<string>
+    afterDate: Date
   ): Promise<ReadonlyArray<IMergedBranch>> {
     const { branchesState } = this.repositoriesStateCache.get(this.repository)
     const { allBranches } = branchesState
 
-    // Create array of branches that can be pruned
+    const recentlyCheckedOutBranches = await getBranchCheckouts(
+      this.repository,
+      afterDate
+    )
+
+    const recentlyCheckedOutCanonicalRefs = new Set(
+      [...recentlyCheckedOutBranches.keys()].map(formatAsLocalRef)
+    )
+
     const candidateBranches = mergedBranches.filter(
       mb => !ReservedRefs.includes(mb.canonicalRef)
     )

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -107,7 +107,11 @@ export class BranchPruner {
 
     // Using type coelescing behavior to deal with Dexie returning `undefined`
     // for records that haven't been updated with the new field yet
-    if (lastPruneDate != null && threshold.isBefore(lastPruneDate)) {
+    if (
+      !__DEV__ &&
+      lastPruneDate != null &&
+      threshold.isBefore(lastPruneDate)
+    ) {
       log.info(
         `[Branch Pruner] last prune took place ${moment(lastPruneDate).from(
           dateNow

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -161,6 +161,12 @@ export class BranchPruner {
 
     const branchesReadyForPruning = candidateBranches.filter(mb => {
       if (recentlyCheckedOutCanonicalRefs.has(mb.canonicalRef)) {
+        // branch was recently checked out, exclude it from pruning
+        return false
+      }
+
+      if (!mb.canonicalRef.startsWith(branchRefPrefix)) {
+        // branch does not match the expected conventions, exclude it
         return false
       }
 
@@ -209,10 +215,6 @@ export class BranchPruner {
     const gitStore = this.gitStoreCache.get(this.repository)
 
     for (const branch of branchesReadyForPruning) {
-      if (!branch.canonicalRef.startsWith(branchRefPrefix)) {
-        continue
-      }
-
       const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
 
       // don't delete branches when in development mode to help with testing

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -247,20 +247,25 @@ export class BranchPruner {
       } (${defaultBranch.tip.sha}), from '${this.repository.name}`
     )
 
-    const gitStore = this.gitStoreCache.get(this.repository)
-
-    for (const branch of branchesReadyForPruning) {
-      const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
-
-      // only perform the delete when the right flag is set when calling this function
-      if (!options.deleteBranch) {
+    if (!options.deleteBranch) {
+      log.info(
+        `[Branch Pruner] Branch pruning will not delete any branches because options.deleteBranch is false.`
+      )
+      for (const branch of branchesReadyForPruning) {
+        const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
         log.info(
           `[Branch Pruner] ${branchName} (was ${
             branch.sha
           }) has been marked for pruning.`
         )
-        continue
       }
+      return
+    }
+
+    const gitStore = this.gitStoreCache.get(this.repository)
+
+    for (const branch of branchesReadyForPruning) {
+      const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
 
       const isDeleted = await gitStore.performFailableOperation(() =>
         deleteLocalBranch(this.repository, branchName)

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -171,31 +171,31 @@ export class BranchPruner {
       )
 
       if (localBranch === undefined) {
-        // if we can't find this ref in repository state, should we preserve it?
-        debugger
+        // unable to find the local branch in repository state, this feels
+        // sufficient concerning to indicate we shouldn't try and delete this
+        // reference
         return false
       }
 
       if (localBranch.upstream === null) {
-        // no upstream ref is known for this branch, which means we can clean it
-        // up fine
-        debugger
+        // no remote ref is being tracked for this branch, which means it
+        // most likely wasn't pushed to the remote, so we can include this
+        // in our prune list
         return true
       }
 
-      const remoteBranch = allBranches.find(
+      const remoteRef = allBranches.find(
         b => b.type === BranchType.Remote && b.name === localBranch.upstream
       )
 
-      if (remoteBranch !== null) {
-        // upstream ref still exists on the remote, so we should not prune it
-        debugger
-        return false
+      if (remoteRef === undefined) {
+        // the remote ref cannot be found for this branch, which is a good
+        // indicator it was deleted from the repository and can be cleaned up
+        // here too
+        return true
       }
 
-      debugger
-
-      return true
+      return false
     })
 
     log.info(

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -64,8 +64,8 @@ export class BranchPruner {
     this.timer = null
   }
 
-  public async prune(): Promise<void> {
-    return this.pruneLocalBranches()
+  public async testPrune(): Promise<void> {
+    return this.pruneLocalBranches(false)
   }
 
   private async findBranchesMergedIntoDefaultBranch(
@@ -91,7 +91,9 @@ export class BranchPruner {
         )
   }
 
-  private async pruneLocalBranches(): Promise<void> {
+  private async pruneLocalBranches(
+    deleteBranch: boolean = true
+  ): Promise<void> {
     if (this.repository.gitHubRepository === null) {
       return
     }
@@ -217,8 +219,8 @@ export class BranchPruner {
     for (const branch of branchesReadyForPruning) {
       const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
 
-      // don't delete branches when in development mode to help with testing
-      if (__DEV__) {
+      // only perform the delete when the right flag is set when calling this function
+      if (!deleteBranch) {
         log.info(
           `[Branch Pruner] ${branchName} (was ${
             branch.sha

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -109,7 +109,7 @@ export class BranchPruner {
     // for records that haven't been updated with the new field yet
     if (lastPruneDate != null && threshold.isBefore(lastPruneDate)) {
       log.info(
-        `Last prune took place ${moment(lastPruneDate).from(
+        `[Branch Pruner] last prune took place ${moment(lastPruneDate).from(
           dateNow
         )} - skipping`
       )
@@ -130,7 +130,7 @@ export class BranchPruner {
     )
 
     if (mergedBranches.length === 0) {
-      log.info('No branches to prune.')
+      log.info('[Branch Pruner] no branches to prune.')
       return
     }
 
@@ -181,7 +181,7 @@ export class BranchPruner {
     })
 
     log.info(
-      `Pruning ${
+      `[Branch Pruner] pruning ${
         branchesReadyForPruning.length
       } branches that have been merged into the default branch, ${
         defaultBranch.name
@@ -213,7 +213,9 @@ export class BranchPruner {
       )
 
       if (isDeleted) {
-        log.info(`Pruned branch ${branchName} (was ${branch.sha})`)
+        log.info(
+          `[Branch Pruner] branch ${branchName} (${branch.sha}) was pruned`
+        )
       }
     }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -29,6 +29,8 @@ const ReservedRefs = [
   'refs/heads/release',
 ]
 
+const BranchRefPrefix = `refs/heads/`
+
 /**
  * Behavior flags for the branch prune execution, to aid with testing and
  * verifying locally.
@@ -179,8 +181,6 @@ export class BranchPruner {
       .subtract(2, 'weeks')
       .toDate()
 
-    const branchRefPrefix = `refs/heads/`
-
     const branchesReadyForPruning = await this.filterBranches(
       mergedBranches,
       twoWeeksAgo
@@ -199,7 +199,7 @@ export class BranchPruner {
         `[Branch Pruner] Branch pruning will not delete any branches because options.deleteBranch is false.`
       )
       for (const branch of branchesReadyForPruning) {
-        const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
+        const branchName = branch.canonicalRef.substr(BranchRefPrefix.length)
         log.info(
           `[Branch Pruner] ${branchName} (was ${
             branch.sha
@@ -212,7 +212,7 @@ export class BranchPruner {
     const gitStore = this.gitStoreCache.get(this.repository)
 
     for (const branch of branchesReadyForPruning) {
-      const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
+      const branchName = branch.canonicalRef.substr(BranchRefPrefix.length)
 
       const isDeleted = await gitStore.performFailableOperation(() =>
         deleteLocalBranch(this.repository, branchName)
@@ -252,8 +252,6 @@ export class BranchPruner {
       mb => !ReservedRefs.includes(mb.canonicalRef)
     )
 
-    const branchRefPrefix = `refs/heads/`
-
     const branchesReadyForPruning = new Array<IMergedBranch>()
 
     for (const mb of candidateBranches) {
@@ -262,12 +260,12 @@ export class BranchPruner {
         continue
       }
 
-      if (!mb.canonicalRef.startsWith(branchRefPrefix)) {
+      if (!mb.canonicalRef.startsWith(BranchRefPrefix)) {
         // branch does not match the expected conventions, exclude it
         continue
       }
 
-      const branchName = mb.canonicalRef.substr(branchRefPrefix.length)
+      const branchName = mb.canonicalRef.substr(BranchRefPrefix.length)
 
       const localBranch = allBranches.find(
         b => b.type === BranchType.Local && b.name === branchName

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -134,10 +134,12 @@ export class BranchPruner {
     const twoWeeksAgo = moment()
       .subtract(2, 'weeks')
       .toDate()
+
     const recentlyCheckedOutBranches = await getCheckoutsAfterDate(
       this.repository,
       twoWeeksAgo
     )
+
     const recentlyCheckedOutCanonicalRefs = new Set(
       [...recentlyCheckedOutBranches.keys()].map(formatAsLocalRef)
     )
@@ -150,6 +152,10 @@ export class BranchPruner {
     const branchesReadyForPruning = candidateBranches.filter(
       mb => !recentlyCheckedOutCanonicalRefs.has(mb.canonicalRef)
     )
+
+    // TODO: find the local branch in repository state
+    // TODO: find if it is tracking a remote ref
+    // TODO: if that remote ref exists, exclude local branch from list
 
     log.info(
       `Pruning ${

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -240,9 +240,6 @@ export class BranchPruner {
       )
 
       if (remoteBranch.length === 0) {
-        // the remote ref cannot be found for this branch, which is a good
-        // indicator it was deleted from the repository and can be cleaned up
-        // here too
         return true
       }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -232,6 +232,21 @@ export class BranchPruner {
     this.onPruneCompleted(this.repository)
   }
 
+  /**
+   * Filter merged branches to avoid pruning important branches
+   *
+   * This function excludes branches that have been merged into the default
+   * branch, but satisfy some other condition that indicates they are still
+   * active:
+   *
+   *  - were checked out after `afterDate`
+   *  - match an entry in the reserved list of branch names found in `ReservedRefs`
+   *  - a ref that doesn't match the `refs/heads/{name}` format
+   *  - cannot be found in application state
+   *  - are tracking a remote ref that has not been deleted
+   *
+   * @param afterDate exclude branches that have beeen checked out since this date
+   */
   private async filterBranches(
     mergedBranches: ReadonlyArray<IMergedBranch>,
     afterDate: Date

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -497,6 +497,10 @@ export function buildDefaultMenu({
             click: emit('show-release-notes-popup'),
           },
         ],
+      },
+      {
+        label: 'Prune branches',
+        click: emit('force-prune-branches'),
       }
     )
   }

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -34,3 +34,4 @@ export type MenuEvent =
   | 'show-release-notes-popup'
   | 'show-stashed-changes'
   | 'hide-stashed-changes'
+  | 'force-prune-branches'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -370,6 +370,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.showStashedChanges()
       case 'hide-stashed-changes':
         return this.hideStashedChanges()
+      case 'force-prune-branches':
+        return this.forcePruneBranches()
     }
 
     return assertNever(name, `Unknown menu event name: ${name}`)
@@ -428,6 +430,14 @@ export class App extends React.Component<IAppProps, IAppState> {
         },
       })
     }
+  }
+
+  private forcePruneBranches() {
+    if (!__DEV__) {
+      return
+    }
+
+    this.props.appStore._forceBranchPruning()
   }
 
   /**

--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -97,3 +97,17 @@ export async function switchTo(repository: Repository, branch: string) {
     await GitProcess.exec(['checkout', branch], repository.path)
   }
 }
+
+export async function cloneLocalRepository(
+  repository: Repository
+): Promise<Repository> {
+  const repoPath = mkdirSync('blank-folder')
+  const args = ['clone', '--', repository.path, repoPath]
+  const result = await GitProcess.exec(args, repository.path)
+
+  if (result.exitCode === 128) {
+    throw new Error(JSON.stringify(result))
+  } else {
+    return new Repository(repoPath, -1, null, true)
+  }
+}

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -83,12 +83,9 @@ describe('BranchPruner', () => {
     await branchPruner.start()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
-    const expectedBranchesAfterPruning = [
-      'not-deleted-branch-1',
-      'deleted-branch-1',
-    ]
+    const expectedPrunedBranches = ['not-deleted-branch-1', 'deleted-branch-1']
 
-    for (const branch of expectedBranchesAfterPruning) {
+    for (const branch of expectedPrunedBranches) {
       expect(branchesAfterPruning).not.toContain(branch)
     }
   })

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -83,11 +83,8 @@ describe('BranchPruner', () => {
     await branchPruner.start()
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
-    const expectedPrunedBranches = ['not-deleted-branch-1', 'deleted-branch-1']
-
-    for (const branch of expectedPrunedBranches) {
-      expect(branchesAfterPruning).not.toContain(branch)
-    }
+    expect(branchesAfterPruning).not.toContain('deleted-branch-1')
+    expect(branchesAfterPruning).toContain('not-deleted-branch-1')
   })
 
   it('does not prune if the last prune date is less than 24 hours ago', async () => {

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -5,7 +5,7 @@ import {
   createBranch,
   checkoutBranch,
   renameBranch,
-  getCheckoutsAfterDate,
+  getBranchCheckouts,
 } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import * as moment from 'moment'
@@ -75,7 +75,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository!, 'branch-1')
       await createAndCheckout(repository!, 'branch-2')
 
-      const branches = await getCheckoutsAfterDate(
+      const branches = await getBranchCheckouts(
         repository!,
         moment()
           .add(1, 'day')
@@ -89,7 +89,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository!, 'branch-1')
       await createAndCheckout(repository!, 'branch-2')
 
-      const branches = await getCheckoutsAfterDate(
+      const branches = await getBranchCheckouts(
         repository!,
         moment()
           .subtract(1, 'hour')


### PR DESCRIPTION
## Overview

**Closes #7604**

This fix wasn't as trivial as I'd hoped it would be, but I'll walk you through the changes and how we ended up here.

 - [ ] gather feedback on proposed changes
 - [ ] tidy up commit history to make changes easier to follow
 - [ ] more testing of corner cases

## Description

The intended fix was described like this:

> The fix would involve either using `git ls-remote` to get a list of all refs on the remote or using state that Desktop already has.

As we want to avoid the network call associated with `ls-remote`, and the branches for pruning should be stale for at least two weeks, the application state should be safe enough to rely on here.

### Problem 1 - Where are my branches?

Being able to enumerate application state to find  the remote branch didn't work, because of how we merge together local and remote branches. I added tests to `GitStore` to confirm this behaviour in d66a271e2. I didn't want to change how `GitStore.mergeRemoteAndLocalBranches` works just to address this bug, so I fell back to invoking `getBranches` to look for this specific ref. I think this is fine for what we're trying to do here - we filter out plenty of conditions before we get to this point, so this should only run for a subset of the merged branches.

### Problem 2 - Now it's async

With that working, a different problem appeared - `Array.filter` (where all the checks are being performed) doesn't support `async/await`. I needed to change that to a `for` loop to build up the results. This now lives in `BranchPruner.filterBranch` and I've tried to preserve the flow of the previous rules as much as possible to avoid further confusion.

### Problem 3 - Testing Things

The feedback loop on testing this on `development` is not really available, and #6916 had some logic to make this easier to test in dev mode. I borrowed from that and tried to keep this as simple as possible, but I eventually came to the realization that this needs runtime flags to control the behaviour of the branch pruner, and ended up with the creatively-named `PruneRuntimeOptions` type to represent this:

```ts
/**
 * Behavior flags for the branch prune execution, to aid with testing and
 * verifying locally.
 */
type PruneRuntimeOptions = {
  /**
   * By default the branch pruner will only run every 24 hours
   *
   * Set this flag to `false` to ignore this check.
   */
  readonly enforcePruneThreshold: boolean
  /**
   * By default the branch pruner will also delete the branches it believes can
   * be pruned safely.
   *
   * Set this to `false` to keep these in your repository.
   */
  readonly deleteBranch: boolean
}
```

This is a bit more explicit than what we originally had in  #6916, but I hope this makes the overall component easier to follow. Here's the default options:

```ts
const DefaultPruneOptions: PruneRuntimeOptions = {
  enforcePruneThreshold: true,
  deleteBranch: true,
}
```

And here's what the test when running this in development mode does:

```ts
  public async testPrune(): Promise<void> {
    return this.pruneLocalBranches({
      enforcePruneThreshold: false,
      deleteBranch: false,
    })
  }
```

I resisted the urge to put these into one "flag" because while they feel similar, they represent two very distinct decisions (run the branch pruner checks, versus deleting the valid refs) and being able to switch one or the other off for testing feels like something worth supporting.

### Good news!

By going through the process of implementing this flow, I found a test was now impacted. Fearing I'd regressed something, I looked into it and found this scenario was now being handled correctly:

```ts
    const expectedBranchesAfterPruning = [
      'not-deleted-branch-1',
      'deleted-branch-1',
    ]

    for (const branch of expectedBranchesAfterPruning) {
      expect(branchesAfterPruning).not.toContain(branch)
    }
```

I remember talking with @iAmWillShepherd about this at some stage, but `not-deleted-branch-1` was an example of a merged branch with a valid remote ref, so now we correctly handle this in the branch pruner, which was Precisely The Bug™ :tada:

This test is now updated to reflect this change.

```ts
    expect(branchesAfterPruning).not.toContain('deleted-branch-1')
    expect(branchesAfterPruning).toContain('not-deleted-branch-1')
```

## Release notes

Notes: no-notes
