### PR TITLE
Rearrange Repository List's Indicators

### DIFF
--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -161,8 +161,11 @@ export class RepositoriesList extends React.Component<
   private renderGroupHeader = (id: string) => {
     const identifier = id as RepositoryGroupIdentifier
     const label = this.getGroupLabel(identifier)
+    const className = enableGroupRepositoriesByOwner()
+      ? 'filter-list-group-header group-repositories-by-owner'
+      : 'filter-list-group-header'
     return (
-      <div key={identifier} className="filter-list-group-header">
+      <div key={identifier} className={className}>
         {label}
       </div>
     )

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -8,6 +8,7 @@ import { HighlightText } from '../lib/highlight-text'
 import { IMatches } from '../../lib/fuzzy-find'
 import { IAheadBehind } from '../../models/branch'
 import { RevealInFileManagerLabel } from '../lib/context-menu'
+import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
 
 const defaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
@@ -99,8 +100,12 @@ export class RepositoryListItem extends React.Component<
       prefix = `${gitHubRepo.owner.login}/`
     }
 
+    const className = enableGroupRepositoriesByOwner()
+      ? 'repository-list-item group-repositories-by-owner'
+      : 'repository-list-item'
+
     return (
-      <div onContextMenu={this.onContextMenu} className="repository-list-item">
+      <div onContextMenu={this.onContextMenu} className={className}>
         <div
           className="change-indicator-wrapper"
           title={

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -108,9 +108,9 @@ export class RepositoryListItem extends React.Component<
         </div>
 
         {repository instanceof Repository &&
-          renderRepoIndicator({
+          renderRepoIndicators({
             aheadBehind: this.props.aheadBehind,
-            hasChanges,
+            hasChanges: enableGroupRepositoriesByOwner() && hasChanges,
           })}
       </div>
     )
@@ -183,7 +183,7 @@ export class RepositoryListItem extends React.Component<
   }
 }
 
-const renderRepoIndicator: React.SFC<{
+const renderRepoIndicators: React.SFC<{
   aheadBehind: IAheadBehind | null
   hasChanges: boolean
 }> = props => {
@@ -217,15 +217,15 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
 }
 
 const renderChangesIndicator = () => {
+  const classNames = enableGroupRepositoriesByOwner()
+    ? 'change-indicator-wrapper group-repositories-by-owner'
+    : 'change-indicator-wrapper'
   return (
     <div
-      className="change-indicator-wrapper"
+      className={classNames}
       title="There are uncommitted changes in this repository"
     >
-      <Octicon
-        className="change-indicator"
-        symbol={OcticonSymbol.primitiveDot}
-      />
+      <Octicon symbol={OcticonSymbol.primitiveDot} />
     </div>
   )
 }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -62,35 +62,7 @@ export class RepositoryListItem extends React.Component<
     const gitHubRepo =
       repository instanceof Repository ? repository.gitHubRepository : null
     const hasChanges = this.props.changedFilesCount > 0
-    const renderAheadBehindIndicator = () => {
-      if (
-        !(repository instanceof Repository) ||
-        this.props.aheadBehind === null
-      ) {
-        return null
-      }
-      const { ahead, behind } = this.props.aheadBehind
-      if (ahead === 0 && behind === 0) {
-        return null
-      }
-      const commitGrammar = (commitNum: number) =>
-        `${commitNum} commit${commitNum > 1 ? 's' : ''}` // english is hard
-      const aheadBehindTooltip =
-        'The currently checked out branch is' +
-        (behind ? ` ${commitGrammar(behind)} behind ` : '') +
-        (behind && ahead ? 'and' : '') +
-        (ahead ? ` ${commitGrammar(ahead)} ahead of ` : '') +
-        'its tracked branch.'
 
-      return (
-        <div className="ahead-behind" title={aheadBehindTooltip}>
-          {ahead > 0 ? <Octicon symbol={OcticonSymbol.arrowSmallUp} /> : null}
-          {behind > 0 ? (
-            <Octicon symbol={OcticonSymbol.arrowSmallDown} />
-          ) : null}
-        </div>
-      )
-    }
     const repoTooltip = gitHubRepo
       ? gitHubRepo.fullName + '\n' + gitHubRepo.htmlURL + '\n' + path
       : path
@@ -106,20 +78,27 @@ export class RepositoryListItem extends React.Component<
 
     return (
       <div onContextMenu={this.onContextMenu} className={className}>
-        <div
-          className="change-indicator-wrapper"
-          title={
-            hasChanges ? 'There are uncommitted changes in this repository' : ''
-          }
-        >
-          {hasChanges ? (
-            <Octicon
-              className="change-indicator"
-              symbol={OcticonSymbol.primitiveDot}
-            />
-          ) : null}
-        </div>
-        <Octicon symbol={iconForRepository(repository)} />
+        {!enableGroupRepositoriesByOwner() && (
+          <div
+            className="change-indicator-wrapper"
+            title={
+              hasChanges
+                ? 'There are uncommitted changes in this repository'
+                : ''
+            }
+          >
+            {hasChanges ? (
+              <Octicon
+                className="change-indicator"
+                symbol={OcticonSymbol.primitiveDot}
+              />
+            ) : null}
+          </div>
+        )}
+        <Octicon
+          className="icon-for-repository"
+          symbol={iconForRepository(repository)}
+        />
         <div className="name" title={repoTooltip}>
           {prefix ? <span className="prefix">{prefix}</span> : null}
           <HighlightText
@@ -128,7 +107,11 @@ export class RepositoryListItem extends React.Component<
           />
         </div>
 
-        {renderAheadBehindIndicator()}
+        {repository instanceof Repository &&
+          renderRepoIndicator({
+            aheadBehind: this.props.aheadBehind,
+            hasChanges,
+          })}
       </div>
     )
   }
@@ -199,3 +182,53 @@ export class RepositoryListItem extends React.Component<
     this.props.onOpenInExternalEditor(this.props.repository)
   }
 }
+
+const renderRepoIndicator: React.SFC<{
+  aheadBehind: IAheadBehind | null
+  hasChanges: boolean
+}> = props => {
+  return (
+    <div className="repo-indicators">
+      {props.aheadBehind && renderAheadBehindIndicator(props.aheadBehind)}
+      {props.hasChanges && renderChangesIndicator()}
+    </div>
+  )
+}
+
+const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
+  const { ahead, behind } = aheadBehind
+  if (ahead === 0 && behind === 0) {
+    return null
+  }
+
+  const aheadBehindTooltip =
+    'The currently checked out branch is' +
+    (behind ? ` ${commitGrammar(behind)} behind ` : '') +
+    (behind && ahead ? 'and' : '') +
+    (ahead ? ` ${commitGrammar(ahead)} ahead of ` : '') +
+    'its tracked branch.'
+
+  return (
+    <div className="ahead-behind" title={aheadBehindTooltip}>
+      {ahead > 0 && <Octicon symbol={OcticonSymbol.arrowSmallUp} />}
+      {behind > 0 && <Octicon symbol={OcticonSymbol.arrowSmallDown} />}
+    </div>
+  )
+}
+
+const renderChangesIndicator = () => {
+  return (
+    <div
+      className="change-indicator-wrapper"
+      title="There are uncommitted changes in this repository"
+    >
+      <Octicon
+        className="change-indicator"
+        symbol={OcticonSymbol.primitiveDot}
+      />
+    </div>
+  )
+}
+
+const commitGrammar = (commitNum: number) =>
+  `${commitNum} commit${commitNum > 1 ? 's' : ''}` // english is hard

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -34,6 +34,10 @@
     // name and truncate accordingly
     width: 100%;
 
+    &:not(.group-repositories-by-owner) {
+      padding-left: 0;
+    }
+
     .icon-for-repository {
       // Some room between the icon and repository name
       margin-right: var(--spacing-half);
@@ -69,17 +73,21 @@
       align-items: center;
     }
 
-    .change-indicator {
-      color: var(--tab-bar-active-color);
-      width: auto;
-    }
-
     .change-indicator-wrapper {
       display: flex;
       min-width: 12px;
-      margin-left: var(--spacing-half);
       justify-content: center;
       align-items: center;
+      margin-left: var(--spacing-half);
+
+      .octicon {
+        color: var(--tab-bar-active-color);
+        width: auto;
+      }
+
+      &:not(.group-repositories-by-owner) {
+        margin-right: var(--spacing-half);
+      }
     }
 
     .ahead-behind {

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -34,7 +34,7 @@
     // name and truncate accordingly
     width: 100%;
 
-    .octicon {
+    .icon-for-repository {
       // Some room between the icon and repository name
       margin-right: var(--spacing-half);
 
@@ -62,15 +62,24 @@
       }
     }
 
+    .repo-indicators {
+      margin-left: auto;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+    }
+
     .change-indicator {
       color: var(--tab-bar-active-color);
-      margin-right: 0;
       width: auto;
     }
 
     .change-indicator-wrapper {
       display: flex;
       min-width: 12px;
+      margin-left: var(--spacing-half);
+      justify-content: center;
+      align-items: center;
     }
 
     .ahead-behind {
@@ -98,10 +107,6 @@
         width: 12px;
       }
     }
-  }
-
-  .repository-list-item.group-repositories-by-owner {
-    padding: 0 var(--spacing) 0 0;
   }
 
   .filter-list-group-header.group-repositories-by-owner {

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -100,6 +100,14 @@
     }
   }
 
+  .repository-list-item.group-repositories-by-owner {
+    padding: 0 var(--spacing) 0 0;
+  }
+
+  .filter-list-group-header.group-repositories-by-owner {
+    padding-top: var(--spacing);
+  }
+
   .new-repository-button {
     flex-shrink: 0;
 


### PR DESCRIPTION
## Overview

closes #7133 

<img width="287" alt="Screen Shot 2019-05-24 at 11 23 17 AM" src="https://user-images.githubusercontent.com/964912/58348810-83f89f00-7e16-11e9-8972-cde10a44414b.png">

<img width="311" alt="Screen Shot 2019-05-24 at 11 23 54 AM" src="https://user-images.githubusercontent.com/964912/58348814-865af900-7e16-11e9-84ae-dce2b4a82f11.png">

<img width="293" alt="Screen Shot 2019-05-24 at 11 41 45 AM" src="https://user-images.githubusercontent.com/964912/58349735-f7031500-7e18-11e9-9479-813a28eaf80b.png">

## Description

- small bit of refactoring this the repository indicators rendering logic
- add new styles/structure and feature flag

## Release notes

Notes: [Improved] Rearrange repository indicators to help with readability
