### PR TITLE
improve the dev-time experience of testing branch pruning

### DIFF
--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -69,10 +69,10 @@ export async function getRecentBranches(
  * Returns a map keyed on branch names
  *
  * @param repository the repository who's reflog you want to check
- * @param afterDate the minimum date a checkout has to occur
+ * @param afterDate filters checkouts so that only those occuring on or after this date are returned
  * @returns map of branch name -> checkout date
  */
-export async function getCheckoutsAfterDate(
+export async function getBranchCheckouts(
   repository: Repository,
   afterDate: Date
 ): Promise<Map<string, Date>> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5228,6 +5228,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     return Promise.resolve()
   }
+
+  public async _testPruneBranches() {
+    if (this.currentBranchPruner === null) {
+      return
+    }
+
+    await this.currentBranchPruner.testPrune()
+  }
 }
 
 /**

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -210,9 +210,9 @@ export class BranchPruner {
         continue
       }
 
-      if (options.deleteBranch) {
-        const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
+      const branchName = branch.canonicalRef.substr(branchRefPrefix.length)
 
+      if (options.deleteBranch) {
         const isDeleted = await gitStore.performFailableOperation(() =>
           deleteLocalBranch(this.repository, branchName)
         )
@@ -220,6 +220,8 @@ export class BranchPruner {
         if (isDeleted) {
           log.info(`Pruned branch ${branchName} (was ${branch.sha})`)
         }
+      } else {
+        log.info(`Branch '${branchName}' marked for deletion`)
       }
     }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -148,7 +148,7 @@ export class BranchPruner {
       threshold.isBefore(lastPruneDate)
     ) {
       log.info(
-        `Last prune took place ${moment(lastPruneDate).from(
+        `[BranchPruner] Last prune took place ${moment(lastPruneDate).from(
           dateNow
         )} - skipping`
       )
@@ -169,7 +169,7 @@ export class BranchPruner {
     )
 
     if (mergedBranches.length === 0) {
-      log.info('No branches to prune.')
+      log.info('[BranchPruner] No branches to prune.')
       return
     }
 
@@ -195,7 +195,7 @@ export class BranchPruner {
     )
 
     log.info(
-      `Pruning ${
+      `[BranchPruner] Pruning ${
         branchesReadyForPruning.length
       } branches that have been merged into the default branch, ${
         defaultBranch.name
@@ -218,10 +218,12 @@ export class BranchPruner {
         )
 
         if (isDeleted) {
-          log.info(`Pruned branch ${branchName} (was ${branch.sha})`)
+          log.info(
+            `[BranchPruner] Pruned branch ${branchName} (was ${branch.sha})`
+          )
         }
       } else {
-        log.info(`Branch '${branchName}' marked for deletion`)
+        log.info(`[BranchPruner] Branch '${branchName}' marked for deletion`)
       }
     }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -497,6 +497,10 @@ export function buildDefaultMenu({
             click: emit('show-release-notes-popup'),
           },
         ],
+      },
+      {
+        label: 'Prune branches',
+        click: emit('test-prune-branches'),
       }
     )
   }

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -34,3 +34,4 @@ export type MenuEvent =
   | 'show-release-notes-popup'
   | 'show-stashed-changes'
   | 'hide-stashed-changes'
+  | 'test-prune-branches'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -365,6 +365,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.showStashedChanges()
       case 'hide-stashed-changes':
         return this.hideStashedChanges()
+      case 'test-prune-branches':
+        return this.testPruneBranches()
     }
 
     return assertNever(name, `Unknown menu event name: ${name}`)
@@ -423,6 +425,14 @@ export class App extends React.Component<IAppProps, IAppState> {
         },
       })
     }
+  }
+
+  private testPruneBranches() {
+    if (!__DEV__) {
+      return
+    }
+
+    this.props.appStore._testPruneBranches()
   }
 
   /**

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -5,7 +5,7 @@ import {
   createBranch,
   checkoutBranch,
   renameBranch,
-  getCheckoutsAfterDate,
+  getBranchCheckouts,
 } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import * as moment from 'moment'
@@ -75,7 +75,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository, 'branch-1')
       await createAndCheckout(repository, 'branch-2')
 
-      const branches = await getCheckoutsAfterDate(
+      const branches = await getBranchCheckouts(
         repository,
         moment()
           .add(1, 'day')
@@ -89,7 +89,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository, 'branch-1')
       await createAndCheckout(repository, 'branch-2')
 
-      const branches = await getCheckoutsAfterDate(
+      const branches = await getBranchCheckouts(
         repository,
         moment()
           .subtract(1, 'hour')


### PR DESCRIPTION
## Overview

**Related to #7604 and #6916**

**Supersedes #6916**

## Description

This PR implements two runtime flags to `BranchPruner.pruneLocalBranches` to control how it behaves:

 - `enforcePruneThreshold` - whether to check and respect the prune threshold tracked in IndexedDB for the repository
 - `deleteBranch` - whether to actually remove the branch from the local repository

These are both set to `true` by default, but this PR also adds a menu item (visible when `__DEV__` is set) to be able to test the branch pruning logic against a live application.

## Release notes

Notes: no-notes
