### PR TITLE
Suggested changes metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -220,7 +220,11 @@ export interface IDailyMeasures {
 
   /**
    * The number of times the user has used the Create PR suggestion
-   * in the suggested next steps view
+   * in the suggested next steps view. Note that this number is a
+   * subset of `createPullRequestCount`. I.e. if the Create PR suggestion
+   * is invoked both `suggestedStepCreatePR` and `createPullRequestCount`
+   * will increment whereas if a PR is created from the menu or from
+   * a keyboard shortcut only `createPullRequestCount` will increment.
    */
   readonly suggestedStepCreatePR: number
 }

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -192,37 +192,37 @@ export interface IDailyMeasures {
    * The number of times the user has opened their external editor from the
    * suggested next steps view
    */
-  suggestedStepOpenInExternalEditor: number
+  readonly suggestedStepOpenInExternalEditor: number
 
   /**
    * The number of times the user has opened their repository in Finder/Explorer
    * from the suggested next steps view
    */
-  suggestedStepOpenWorkingDirectory: number
+  readonly suggestedStepOpenWorkingDirectory: number
 
   /**
    * The number of times the user has opened their repository on GitHub from the
    * suggested next steps view
    */
-  suggestedStepViewOnGitHub: number
+  readonly suggestedStepViewOnGitHub: number
 
   /**
    * The number of times the user has used the publish repository action from the
    * suggested next steps view
    */
-  suggestedStepPublishRepository: number
+  readonly suggestedStepPublishRepository: number
 
   /**
    * The number of times the user has used the publish branch action branch from
    * the suggested next steps view
    */
-  suggestedStepPublishBranch: number
+  readonly suggestedStepPublishBranch: number
 
   /**
    * The number of times the user has used the Create PR suggestion
    * in the suggested next steps view
    */
-  suggestedStepCreatePR: number
+  readonly suggestedStepCreatePR: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -187,11 +187,41 @@ export interface IDailyMeasures {
 
   /** The number of times the user opens the "Rebase current branch" menu item */
   readonly rebaseCurrentBranchMenuCount: number
+
+  /**
+   * The number of times the user has opened their external editor from the
+   * suggested next steps view
+   */
   suggestedStepOpenInExternalEditor: number
+
+  /**
+   * The number of times the user has opened their repository in Finder/Explorer
+   * from the suggested next steps view
+   */
   suggestedStepOpenWorkingDirectory: number
+
+  /**
+   * The number of times the user has opened their repository on GitHub from the
+   * suggested next steps view
+   */
   suggestedStepViewOnGitHub: number
+
+  /**
+   * The number of times the user has used the publish repository action from the
+   * suggested next steps view
+   */
   suggestedStepPublishRepository: number
+
+  /**
+   * The number of times the user has used the publish branch action branch from
+   * the suggested next steps view
+   */
   suggestedStepPublishBranch: number
+
+  /**
+   * The number of times the user has used the Create PR suggestion
+   * in the suggested next steps view
+   */
   suggestedStepCreatePR: number
 }
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -187,6 +187,12 @@ export interface IDailyMeasures {
 
   /** The number of times the user opens the "Rebase current branch" menu item */
   readonly rebaseCurrentBranchMenuCount: number
+  suggestedStepOpenInExternalEditor: number
+  suggestedStepOpenWorkingDirectory: number
+  suggestedStepViewOnGitHub: number
+  suggestedStepPublishRepository: number
+  suggestedStepPublishBranch: number
+  suggestedStepCreatePR: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -226,7 +226,7 @@ export interface IDailyMeasures {
    * will increment whereas if a PR is created from the menu or from
    * a keyboard shortcut only `createPullRequestCount` will increment.
    */
-  readonly suggestedStepCreatePR: number
+  readonly suggestedStepCreatePullRequest: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1016,7 +1016,7 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has opened their external editor
    * from the suggested next steps view
    */
-  public async recordSuggestedStepOpenInExternalEditor(): Promise<void> {
+  public recordSuggestedStepOpenInExternalEditor(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepOpenInExternalEditor:
         m.suggestedStepOpenInExternalEditor + 1,
@@ -1025,7 +1025,7 @@ export class StatsStore implements IStatsStore {
 
   /**
    * Increment the number of times the user has opened their repository in
-   * Finder/Explorerfrom the suggested next steps view
+   * Finder/Explorer from the suggested next steps view
    */
   public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
     return this.updateDailyMeasures(m => ({

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -99,7 +99,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   suggestedStepViewOnGitHub: 0,
   suggestedStepPublishRepository: 0,
   suggestedStepPublishBranch: 0,
-  suggestedStepCreatePR: 0,
+  suggestedStepCreatePullRequest: 0,
 }
 
 interface IOnboardingStats {
@@ -1068,9 +1068,9 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has used the Create PR suggestion
    * in the suggested next steps view.
    */
-  public recordSuggestedStepCreatePR(): Promise<void> {
+  public recordSuggestedStepCreatePullRequest(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      suggestedStepCreatePR: m.suggestedStepCreatePR + 1,
+      suggestedStepCreatePullRequest: m.suggestedStepCreatePullRequest + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1012,6 +1012,44 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  public async recordSuggestedStepOpenInExternalEditor(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      suggestedStepOpenInExternalEditor:
+        m.suggestedStepOpenInExternalEditor + 1,
+    }))
+  }
+
+  public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      suggestedStepOpenWorkingDirectory:
+        m.suggestedStepOpenWorkingDirectory + 1,
+    }))
+  }
+
+  public async recordSuggestedStepViewOnGitHub(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      suggestedStepViewOnGitHub: m.suggestedStepViewOnGitHub + 1,
+    }))
+  }
+
+  public async recordSuggestedStepPublishRepository(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      suggestedStepPublishRepository: m.suggestedStepPublishRepository + 1,
+    }))
+  }
+
+  public async recordSuggestedStepPublishBranch(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      suggestedStepPublishBranch: m.suggestedStepPublishBranch + 1,
+    }))
+  }
+
+  public async recordSuggestedStepCreatePR(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      suggestedStepCreatePR: m.suggestedStepCreatePR + 1,
+    }))
+  }
+
   private onUiActivity = async () => {
     this.disableUiActivityMonitoring()
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1027,7 +1027,7 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has opened their repository in
    * Finder/Explorer from the suggested next steps view
    */
-  public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
+  public recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepOpenWorkingDirectory:
         m.suggestedStepOpenWorkingDirectory + 1,
@@ -1038,7 +1038,7 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has opened their repository on
    * GitHub from the suggested next steps view
    */
-  public async recordSuggestedStepViewOnGitHub(): Promise<void> {
+  public recordSuggestedStepViewOnGitHub(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepViewOnGitHub: m.suggestedStepViewOnGitHub + 1,
     }))
@@ -1048,7 +1048,7 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has used the publish repository
    * action from the suggested next steps view
    */
-  public async recordSuggestedStepPublishRepository(): Promise<void> {
+  public recordSuggestedStepPublishRepository(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepPublishRepository: m.suggestedStepPublishRepository + 1,
     }))
@@ -1058,7 +1058,7 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has used the publish branch
    * action branch from the suggested next steps view
    */
-  public async recordSuggestedStepPublishBranch(): Promise<void> {
+  public recordSuggestedStepPublishBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepPublishBranch: m.suggestedStepPublishBranch + 1,
     }))
@@ -1068,7 +1068,7 @@ export class StatsStore implements IStatsStore {
    * Increment the number of times the user has used the Create PR suggestion
    * in the suggested next steps view.
    */
-  public async recordSuggestedStepCreatePR(): Promise<void> {
+  public recordSuggestedStepCreatePR(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepCreatePR: m.suggestedStepCreatePR + 1,
     }))

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1012,6 +1012,10 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /**
+   * Increment the number of times the user has opened their external editor
+   * from the suggested next steps view
+   */
   public async recordSuggestedStepOpenInExternalEditor(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepOpenInExternalEditor:
@@ -1019,6 +1023,10 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /**
+   * Increment the number of times the user has opened their repository in
+   * Finder/Explorerfrom the suggested next steps view
+   */
   public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepOpenWorkingDirectory:
@@ -1026,24 +1034,40 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /**
+   * Increment the number of times the user has opened their repository on
+   * GitHub from the suggested next steps view
+   */
   public async recordSuggestedStepViewOnGitHub(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepViewOnGitHub: m.suggestedStepViewOnGitHub + 1,
     }))
   }
 
+  /**
+   * Increment the number of times the user has used the publish repository
+   * action from the suggested next steps view
+   */
   public async recordSuggestedStepPublishRepository(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepPublishRepository: m.suggestedStepPublishRepository + 1,
     }))
   }
 
+  /**
+   * Increment the number of times the user has used the publish branch
+   * action branch from the suggested next steps view
+   */
   public async recordSuggestedStepPublishBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepPublishBranch: m.suggestedStepPublishBranch + 1,
     }))
   }
 
+  /**
+   * Increment the number of times the user has used the Create PR suggestion
+   * in the suggested next steps view.
+   */
   public async recordSuggestedStepCreatePR(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       suggestedStepCreatePR: m.suggestedStepCreatePR + 1,

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -94,6 +94,12 @@ const DefaultDailyMeasures: IDailyMeasures = {
   stashEntriesCreatedOutsideDesktop: 0,
   errorWhenSwitchingBranchesWithUncommmittedChanges: 0,
   rebaseCurrentBranchMenuCount: 0,
+  suggestedStepOpenInExternalEditor: 0,
+  suggestedStepOpenWorkingDirectory: 0,
+  suggestedStepViewOnGitHub: 0,
+  suggestedStepPublishRepository: 0,
+  suggestedStepPublishBranch: 0,
+  suggestedStepCreatePR: 0,
 }
 
 interface IOnboardingStats {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -324,21 +324,17 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.props.dispatcher.showPopup({ type: PopupType.Preferences })
       case 'open-working-directory':
         return this.openCurrentRepositoryWorkingDirectory()
-      case 'update-branch': {
+      case 'update-branch':
         this.props.dispatcher.recordMenuInitiatedUpdate()
         return this.updateBranch()
-      }
-      case 'compare-to-branch': {
+      case 'compare-to-branch':
         return this.showHistory(true)
-      }
-      case 'merge-branch': {
+      case 'merge-branch':
         this.props.dispatcher.recordMenuInitiatedMerge()
         return this.mergeBranch()
-      }
-      case 'rebase-branch': {
+      case 'rebase-branch':
         this.props.dispatcher.recordMenuInitiatedRebase()
         return this.showRebaseDialog()
-      }
       case 'show-repository-settings':
         return this.showRepositorySettings()
       case 'view-repository-on-github':
@@ -355,9 +351,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.boomtown()
       case 'go-to-commit-message':
         return this.goToCommitMessage()
-      case 'open-pull-request': {
+      case 'open-pull-request':
         return this.openPullRequest()
-      }
       case 'install-cli':
         return this.props.dispatcher.installCLI()
       case 'open-external-editor':

--- a/app/src/ui/changes/blankslate-action.tsx
+++ b/app/src/ui/changes/blankslate-action.tsx
@@ -31,7 +31,7 @@ interface IBlankSlateActionProps {
    * A callback which is invoked when the user clicks
    * or activates the action using their keyboard.
    */
-  readonly onClick: () => void
+  readonly onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
 
   /**
    * The type of action, currently supported actions are

--- a/app/src/ui/changes/menu-backed-blankslate-action.tsx
+++ b/app/src/ui/changes/menu-backed-blankslate-action.tsx
@@ -49,6 +49,16 @@ interface IMenuBackedBlankSlateActionProps {
    * clickable.
    */
   readonly disabled?: boolean
+
+  /**
+   * A callback which is invoked when the user clicks
+   * or activates the action using their keyboard.
+   *
+   * In order to suppress the menu backed action from being invoked
+   * consumers of this event will need to suppress the default behavior
+   * by calling `e.preventDefault`.
+   */
+  readonly onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 /**
@@ -82,6 +92,12 @@ export class MenuBackedBlankslateAction extends React.Component<
   }
 
   private onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    executeMenuItemById(this.props.menuItemId)
+    if (this.props.onClick !== undefined) {
+      this.props.onClick(e)
+    }
+
+    if (!e.defaultPrevented) {
+      executeMenuItemById(this.props.menuItemId)
+    }
   }
 }

--- a/app/src/ui/changes/menu-backed-blankslate-action.tsx
+++ b/app/src/ui/changes/menu-backed-blankslate-action.tsx
@@ -81,7 +81,7 @@ export class MenuBackedBlankslateAction extends React.Component<
     )
   }
 
-  private onClick = () => {
+  private onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     executeMenuItemById(this.props.menuItemId)
   }
 }

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -307,8 +307,16 @@ export class NoChanges extends React.Component<
       </>
     )
 
-    return this.renderMenuBackedAction(itemId, title, description)
+    return this.renderMenuBackedAction(
+      itemId,
+      title,
+      description,
+      this.onOpenInExternalEditorClicked
+    )
   }
+
+  private onOpenInExternalEditorClicked = () =>
+    this.props.dispatcher.recordSuggestedStepOpenInExternalEditor()
 
   private renderRemoteAction() {
     const { remote, aheadBehind, branchesState } = this.props.repositoryState

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -641,9 +641,13 @@ export class NoChanges extends React.Component<
         discoverabilityContent={this.renderDiscoverabilityElements(menuItem)}
         type="primary"
         disabled={!menuItem.enabled}
+        onClick={this.onCreatePullRequestClicked}
       />
     )
   }
+
+  private onCreatePullRequestClicked = () =>
+    this.props.dispatcher.recordSuggestedStepCreatePR()
 
   private renderActions() {
     return (

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -214,7 +214,8 @@ export class NoChanges extends React.Component<
   private renderMenuBackedAction(
     itemId: MenuIDs,
     title: string,
-    description?: string | JSX.Element
+    description?: string | JSX.Element,
+    onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   ) {
     const menuItem = this.getMenuItemInfo(itemId)
 
@@ -231,6 +232,7 @@ export class NoChanges extends React.Component<
         menuItemId={itemId}
         buttonText={formatMenuItemLabel(menuItem.label)}
         disabled={!menuItem.enabled}
+        onClick={onClick}
       />
     )
   }

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -21,6 +21,7 @@ import { IAheadBehind } from '../../models/branch'
 import { IRemote } from '../../models/remote'
 import { isCurrentBranchForcePush } from '../../lib/rebase'
 import { StashedChangesLoadStates } from '../../models/stash-entry'
+import { Dispatcher } from '../dispatcher'
 
 function formatMenuItemLabel(text: string) {
   if (__WIN32__ || __LINUX__) {
@@ -38,6 +39,8 @@ function formatParentMenuLabel(menuItem: IMenuItemInfo) {
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 
 interface INoChangesProps {
+  readonly dispatcher: Dispatcher
+
   /**
    * The currently selected repository
    */

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -245,9 +245,14 @@ export class NoChanges extends React.Component<
 
     return this.renderMenuBackedAction(
       'open-working-directory',
-      `View the files of your repository in ${fileManager}`
+      `View the files of your repository in ${fileManager}`,
+      undefined,
+      this.onShowInFileManagerClicked
     )
   }
+
+  private onShowInFileManagerClicked = () =>
+    this.props.dispatcher.recordSuggestedStepOpenWorkingDirectory()
 
   private renderViewOnGitHub() {
     const isGitHub = this.props.repository.gitHubRepository !== null

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -263,9 +263,14 @@ export class NoChanges extends React.Component<
 
     return this.renderMenuBackedAction(
       'view-repository-on-github',
-      `Open the repository page on GitHub in your browser`
+      `Open the repository page on GitHub in your browser`,
+      undefined,
+      this.onViewOnGitHubClicked
     )
   }
+
+  private onViewOnGitHubClicked = () =>
+    this.props.dispatcher.recordSuggestedStepViewOnGitHub()
 
   private openPreferences = () => {
     executeMenuItemById('preferences')

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -452,9 +452,13 @@ export class NoChanges extends React.Component<
         menuItemId={itemId}
         type="primary"
         disabled={!menuItem.enabled}
+        onClick={this.onPublishRepositoryClicked}
       />
     )
   }
+
+  private onPublishRepositoryClicked = () =>
+    this.props.dispatcher.recordSuggestedStepPublishRepository()
 
   private renderPublishBranchAction(tip: IValidBranch) {
     // This is a bit confusing, there's no dedicated

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -501,9 +501,13 @@ export class NoChanges extends React.Component<
         buttonText="Publish branch"
         type="primary"
         disabled={!menuItem.enabled}
+        onClick={this.onPublishBranchClicked}
       />
     )
   }
+
+  private onPublishBranchClicked = () =>
+    this.props.dispatcher.recordSuggestedStepPublishBranch()
 
   private renderPullBranchAction(
     tip: IValidBranch,

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -647,7 +647,7 @@ export class NoChanges extends React.Component<
   }
 
   private onCreatePullRequestClicked = () =>
-    this.props.dispatcher.recordSuggestedStepCreatePR()
+    this.props.dispatcher.recordSuggestedStepCreatePullRequest()
 
   private renderActions() {
     return (

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2030,4 +2030,28 @@ export class Dispatcher {
   public hideStashedChanges(repository: Repository) {
     return this.appStore._hideStashedChanges(repository)
   }
+
+  public async recordSuggestedStepOpenInExternalEditor(): Promise<void> {
+    this.statsStore.recordSuggestedStepOpenInExternalEditor()
+  }
+
+  public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
+    this.statsStore.recordSuggestedStepOpenWorkingDirectory()
+  }
+
+  public async recordSuggestedStepViewOnGitHub(): Promise<void> {
+    this.statsStore.recordSuggestedStepViewOnGitHub()
+  }
+
+  public async recordSuggestedStepPublishRepository(): Promise<void> {
+    this.statsStore.recordSuggestedStepPublishRepository()
+  }
+
+  public async recordSuggestedStepPublishBranch(): Promise<void> {
+    this.statsStore.recordSuggestedStepPublishBranch()
+  }
+
+  public async recordSuggestedStepCreatePR(): Promise<void> {
+    this.statsStore.recordSuggestedStepCreatePR()
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2035,48 +2035,48 @@ export class Dispatcher {
    * Increment the number of times the user has opened their external editor
    * from the suggested next steps view
    */
-  public async recordSuggestedStepOpenInExternalEditor(): Promise<void> {
-    this.statsStore.recordSuggestedStepOpenInExternalEditor()
+  public recordSuggestedStepOpenInExternalEditor(): Promise<void> {
+    return this.statsStore.recordSuggestedStepOpenInExternalEditor()
   }
 
   /**
    * Increment the number of times the user has opened their repository in
    * Finder/Explorerfrom the suggested next steps view
    */
-  public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
-    this.statsStore.recordSuggestedStepOpenWorkingDirectory()
+  public recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
+    return this.statsStore.recordSuggestedStepOpenWorkingDirectory()
   }
 
   /**
    * Increment the number of times the user has opened their repository on
    * GitHub from the suggested next steps view
    */
-  public async recordSuggestedStepViewOnGitHub(): Promise<void> {
-    this.statsStore.recordSuggestedStepViewOnGitHub()
+  public recordSuggestedStepViewOnGitHub(): Promise<void> {
+    return this.statsStore.recordSuggestedStepViewOnGitHub()
   }
 
   /**
    * Increment the number of times the user has used the publish repository
    * action from the suggested next steps view
    */
-  public async recordSuggestedStepPublishRepository(): Promise<void> {
-    this.statsStore.recordSuggestedStepPublishRepository()
+  public recordSuggestedStepPublishRepository(): Promise<void> {
+    return this.statsStore.recordSuggestedStepPublishRepository()
   }
 
   /**
    * Increment the number of times the user has used the publish branch
    * action branch from the suggested next steps view
    */
-  public async recordSuggestedStepPublishBranch(): Promise<void> {
-    this.statsStore.recordSuggestedStepPublishBranch()
+  public recordSuggestedStepPublishBranch(): Promise<void> {
+    return this.statsStore.recordSuggestedStepPublishBranch()
   }
 
   /**
    * Increment the number of times the user has used the Create PR suggestion
    * in the suggested next steps view.
    */
-  public async recordSuggestedStepCreatePR(): Promise<void> {
-    this.statsStore.recordSuggestedStepCreatePR()
+  public recordSuggestedStepCreatePR(): Promise<void> {
+    return this.statsStore.recordSuggestedStepCreatePR()
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2031,26 +2031,50 @@ export class Dispatcher {
     return this.appStore._hideStashedChanges(repository)
   }
 
+  /**
+   * Increment the number of times the user has opened their external editor
+   * from the suggested next steps view
+   */
   public async recordSuggestedStepOpenInExternalEditor(): Promise<void> {
     this.statsStore.recordSuggestedStepOpenInExternalEditor()
   }
 
+  /**
+   * Increment the number of times the user has opened their repository in
+   * Finder/Explorerfrom the suggested next steps view
+   */
   public async recordSuggestedStepOpenWorkingDirectory(): Promise<void> {
     this.statsStore.recordSuggestedStepOpenWorkingDirectory()
   }
 
+  /**
+   * Increment the number of times the user has opened their repository on
+   * GitHub from the suggested next steps view
+   */
   public async recordSuggestedStepViewOnGitHub(): Promise<void> {
     this.statsStore.recordSuggestedStepViewOnGitHub()
   }
 
+  /**
+   * Increment the number of times the user has used the publish repository
+   * action from the suggested next steps view
+   */
   public async recordSuggestedStepPublishRepository(): Promise<void> {
     this.statsStore.recordSuggestedStepPublishRepository()
   }
 
+  /**
+   * Increment the number of times the user has used the publish branch
+   * action branch from the suggested next steps view
+   */
   public async recordSuggestedStepPublishBranch(): Promise<void> {
     this.statsStore.recordSuggestedStepPublishBranch()
   }
 
+  /**
+   * Increment the number of times the user has used the Create PR suggestion
+   * in the suggested next steps view.
+   */
   public async recordSuggestedStepCreatePR(): Promise<void> {
     this.statsStore.recordSuggestedStepCreatePR()
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2075,8 +2075,8 @@ export class Dispatcher {
    * Increment the number of times the user has used the Create PR suggestion
    * in the suggested next steps view.
    */
-  public recordSuggestedStepCreatePR(): Promise<void> {
-    return this.statsStore.recordSuggestedStepCreatePR()
+  public recordSuggestedStepCreatePullRequest(): Promise<void> {
+    return this.statsStore.recordSuggestedStepCreatePullRequest()
   }
 
   /**

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -139,12 +139,12 @@ export class Button extends React.Component<IButtonProps, {}> {
   }
 
   private onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (this.props.type !== 'submit') {
-      event.preventDefault()
-    }
-
     if (this.props.onClick) {
       this.props.onClick(event)
+    }
+
+    if (this.props.type !== 'submit') {
+      event.preventDefault()
     }
   }
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -301,6 +301,7 @@ export class RepositoryView extends React.Component<
             isExternalEditorAvailable={
               this.props.externalEditorLabel !== undefined
             }
+            dispatcher={this.props.dispatcher}
           />
         )
       } else {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Addresses (but does not yet fully close): #6714**

This PR implements the critical piece of #6714, namely the `suggestedStepCreatePR` metric which will allow us to differentiate between how often users use the create pull request suggested next step vs how often they use the menu (the latter already exists in production as `createPullRequestCount`).

Additionally this will give us metrics to evaluate the relative use, and effectiveness, of the various suggested next steps.

I'm tentatively putting this into 1.7.0 since this would be nice to have but if we run up on the deadline this is not a critical piece.

## Description

The entirety of metrics added are as follows

### suggestedStepOpenInExternalEditor

The number of times the user has opened their external editor from the suggested next steps view

### suggestedStepOpenWorkingDirectory

The number of times the user has opened their repository in Finder/Explorer from the suggested next steps view

### suggestedStepViewOnGitHub

The number of times the user has opened their repository on GitHub from the suggested next steps view

### suggestedStepPublishRepository

The number of times the user has used the publish repository action from the suggested next steps view

### suggestedStepPublishBranch

The number of times the user has used the publish branch action branch from the suggested next steps view

### suggestedStepCreatePR

The number of times the user has used the Create PR suggestion in the suggested next steps view. Note that this number is a subset of `createPullRequestCount`. I.e. if the Create PR suggestion is invoked both `suggestedStepCreatePR` and `createPullRequestCount` will increment whereas if a PR is created from the menu or from a keyboard shortcut only `createPullRequestCount` will increment.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes