### PR TITLE
Discard all shortcut

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -9,10 +9,8 @@ import { log } from '../log'
 import { openDirectorySafe } from '../shell'
 import { enableRebaseDialog, enableStashing } from '../../lib/feature-flag'
 import { MenuLabelsEvent } from '../../models/menu-labels'
+import { DefaultEditorLabel } from '../../ui/lib/context-menu'
 
-const defaultEditorLabel = __DARWIN__
-  ? 'Open in External Editor'
-  : 'Open in external editor'
 const defaultShellLabel = __DARWIN__
   ? 'Open in Terminal'
   : 'Open in Command Prompt'
@@ -57,7 +55,7 @@ export function buildDefaultMenu({
 
   const editorLabel =
     selectedExternalEditor === null
-      ? defaultEditorLabel
+      ? DefaultEditorLabel
       : `Open in ${selectedExternalEditor}`
 
   const template = new Array<Electron.MenuItemConstructorOptions>()

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -351,6 +351,7 @@ export function buildDefaultMenu({
       {
         label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
         id: 'discard-all-changes',
+        accelerator: 'CmdOrCtrl+Shift+Delete',
         click: emit('discard-all-changes'),
       },
       separator,

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -284,7 +284,7 @@ export function buildDefaultMenu({
       {
         label: removeRepoLabel,
         id: 'remove-repository',
-        accelerator: 'CmdOrCtrl+Delete',
+        accelerator: 'CmdOrCtrl+Backspace',
         click: emit('remove-repository'),
       },
       separator,
@@ -351,7 +351,7 @@ export function buildDefaultMenu({
       {
         label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
         id: 'discard-all-changes',
-        accelerator: 'CmdOrCtrl+Shift+Delete',
+        accelerator: 'CmdOrCtrl+Shift+Backspace',
         click: emit('discard-all-changes'),
       },
       separator,

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -7,12 +7,11 @@ import { IMenuItem } from '../../lib/menu-item'
 import { HighlightText } from '../lib/highlight-text'
 import { IMatches } from '../../lib/fuzzy-find'
 import { IAheadBehind } from '../../models/branch'
-import { RevealInFileManagerLabel } from '../lib/context-menu'
+import {
+  RevealInFileManagerLabel,
+  DefaultEditorLabel,
+} from '../lib/context-menu'
 import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
-
-const defaultEditorLabel = __DARWIN__
-  ? 'Open in External Editor'
-  : 'Open in external editor'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -137,7 +136,7 @@ export class RepositoryListItem extends React.Component<
     const missing = repository instanceof Repository && repository.missing
     const openInExternalEditor = this.props.externalEditorLabel
       ? `Open in ${this.props.externalEditorLabel}`
-      : defaultEditorLabel
+      : DefaultEditorLabel
 
     const items: ReadonlyArray<IMenuItem> = [
       {


### PR DESCRIPTION
## Overview

**Closes #7588**

## Description

- Adds menu item shortcut to "Discard all Changes" (Cmd/Ctrl+Shift+Delete)
- Removes some extra const string declarations

## Release notes

Notes: Adds menu item shortcut to "Discard all Changes" 