### PR TITLE
extract internal type from getStashes API

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -34,7 +34,7 @@ type StashResult = {
 
 /**
  * Get the list of stash entries created by Desktop in the current repository
- * using the default ordering of refs (wich is LIFO ordering),
+ * using the default ordering of refs (which is LIFO ordering),
  * as well as the total amount of stash entries.
  */
 export async function getStashes(repository: Repository): Promise<StashResult> {

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -27,7 +27,7 @@ type StashResult = {
 
   /**
    * The total amount of stash entries,
-   * i.e. stash entries created by desktop and outside of desktop
+   * i.e. stash entries created both by Desktop and outside of Desktop
    */
   readonly stashEntryCount: number
 }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -21,14 +21,7 @@ export const DesktopStashEntryMarker = '!!GitHub_Desktop'
  */
 const desktopStashEntryMessageRe = /!!GitHub_Desktop<(.+)>$/
 
-/**
- * Get the list of stash entries created by Desktop in the current repository
- * using the default ordering of refs (wich is LIFO ordering),
- * as well as the total amount of stash entries.
- */
-export async function getStashes(
-  repository: Repository
-): Promise<{
+type StashResult = {
   /** The stash entries created by Desktop */
   readonly desktopEntries: ReadonlyArray<IStashEntry>
 
@@ -37,7 +30,14 @@ export async function getStashes(
    * i.e. stash entries created by desktop and outside of desktop
    */
   readonly stashEntryCount: number
-}> {
+}
+
+/**
+ * Get the list of stash entries created by Desktop in the current repository
+ * using the default ordering of refs (wich is LIFO ordering),
+ * as well as the total amount of stash entries.
+ */
+export async function getStashes(repository: Repository): Promise<StashResult> {
   const delimiter = '1F'
   const delimiterString = String.fromCharCode(parseInt(delimiter, 16))
   const format = ['%gd', '%H', '%gs'].join(`%x${delimiter}`)


### PR DESCRIPTION
## Overview

**Cleanup related to https://github.com/desktop/desktop/pull/7438#discussion_r288555459**

## Description

We should try and avoid inline type declarations for code we control, even if we don't find ourselves needing to export it.

In this case we also had inline code comments, which felt like an indicator this could be exported in the future.

## Release notes

Notes: no-notes
