### PR TITLE
Add description to Arguments in writeDefaultReadme 

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -232,7 +232,11 @@ export class CreateRepository extends React.Component<
 
     if (this.state.createWithReadme) {
       try {
-        await writeDefaultReadme(fullPath, this.state.name)
+        await writeDefaultReadme(
+          fullPath,
+          this.state.name,
+          this.state.description
+        )
       } catch (e) {
         log.error(`createRepository: unable to write README at ${fullPath}`, e)
         this.props.dispatcher.postError(e)

--- a/app/src/ui/add-repository/write-default-readme.ts
+++ b/app/src/ui/add-repository/write-default-readme.ts
@@ -3,8 +3,10 @@ import * as Path from 'path'
 
 const DefaultReadmeName = 'README.md'
 
-function defaultReadmeContents(name: string): string {
-  return `# ${name}\n`
+function defaultReadmeContents(name: string, description?: string): string {
+  return description !== undefined
+    ? `# ${name}\n ${description}\n`
+    : `# ${name}\n`
 }
 
 /**
@@ -12,9 +14,10 @@ function defaultReadmeContents(name: string): string {
  */
 export async function writeDefaultReadme(
   path: string,
-  name: string
+  name: string,
+  description?: string
 ): Promise<void> {
   const fullPath = Path.join(path, DefaultReadmeName)
-  const contents = defaultReadmeContents(name)
+  const contents = defaultReadmeContents(name, description)
   await writeFile(fullPath, contents)
 }

--- a/app/test/unit/write-default-readme-test.ts
+++ b/app/test/unit/write-default-readme-test.ts
@@ -1,0 +1,35 @@
+import * as FSE from 'fs-extra'
+import * as path from 'path'
+import { mkdirSync } from '../helpers/temp'
+
+import { writeDefaultReadme } from '../../src/ui/add-repository/write-default-readme'
+
+describe('repository setup', () => {
+  describe('writeDefaultReadme', () => {
+    let directory: string
+    let file: string
+
+    beforeEach(() => {
+      directory = mkdirSync('new-readme')
+      file = path.join(directory, 'README.md')
+    })
+
+    it('writes a default README without a description', async () => {
+      await writeDefaultReadme(directory, 'some-repository')
+
+      const text = await FSE.readFile(file, 'utf8')
+      expect(text).toBe('# some-repository\n')
+    })
+
+    it('writes a README with description when provided', async () => {
+      await writeDefaultReadme(
+        directory,
+        'some-repository',
+        'description goes here'
+      )
+
+      const text = await FSE.readFile(file, 'utf8')
+      expect(text).toBe('# some-repository\n description goes here\n')
+    })
+  })
+})


### PR DESCRIPTION
## Overview

**Closes #7571**

## Description

README.md does not include the description when created by GitHub Desktop

Solution: Include description in the list of arguments, the writeDefaultReadme.
Left description argument as an optional argument in the writeDefaultReadme Component 


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: none