### PR TITLE
[WIP] Fix wrapping in history list

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -526,7 +526,7 @@ export class List extends React.Component<IListProps, IListState> {
 
     const newRow = findNextSelectableRow(
       this.props.rowCount,
-      { direction, row: lastSelection },
+      { direction, row: lastSelection, wrap: false },
       this.canSelectRow
     )
 


### PR DESCRIPTION
Don't wrap the history list.

This PR is WIP.

Need to adjust the code so that we only disable wrapping for history? (unless we want to disable it for all lists, I personally wouldn't mind.

Fixes #7679