### PR TITLE
[Hotfix] Pull request update crash for non-db GitHubRepositories

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -9,7 +9,7 @@ import {
 import { GitHubRepository } from '../../models/github-repository'
 import { Account } from '../../models/account'
 import { API, IAPIPullRequest, MaxResultsError } from '../api'
-import { fatalError, forceUnwrap } from '../fatal-error'
+import { fatalError } from '../fatal-error'
 import { RepositoriesStore } from './repositories-store'
 import { PullRequest, PullRequestRef } from '../../models/pull-request'
 import { structuralEquals } from '../equality'
@@ -69,7 +69,16 @@ export class PullRequestStore {
 
   /** Loads all pull requests against the given repository. */
   public refreshPullRequests(repo: GitHubRepository, account: Account) {
-    const dbId = forceUnwrap("Can't refresh PRs, no dbId", repo.dbID)
+    const dbId = repo.dbID
+
+    if (dbId === null) {
+      // This can happen when the `repositoryWithRefreshedGitHubRepository`
+      // method in AppStore fails to retrieve API information about the current
+      // repository either due to the user being signed out or the API failing
+      // to provide a response. There's nothing for us to do when that happens
+      // so instead of crashing we'll bail here.
+      return Promise.resolve()
+    }
 
     const currentOp = this.currentRefreshOperations.get(dbId)
 

--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -191,8 +191,13 @@ export class PullRequestStore {
 
   /** Gets all stored pull requests for the given repository. */
   public async getAll(repository: GitHubRepository) {
-    if (repository.dbID == null) {
-      return fatalError("Can't fetch PRs for repository, no dbId")
+    if (repository.dbID === null) {
+      // This can happen when the `repositoryWithRefreshedGitHubRepository`
+      // method in AppStore fails to retrieve API information about the current
+      // repository either due to the user being signed out or the API failing
+      // to provide a response. There's nothing for us to do when that happens
+      // so instead of crashing we'll bail here.
+      return []
     }
 
     const records = await this.db.getAllPullRequestsInRepository(repository)

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,8 @@
 {
   "releases": {
-    "2.0.1": [],
+    "2.0.1": [
+      "[Fixed] Crash when attempting to update pull requests with partially updated repository information."
+    ],
     "2.0.0": [
       "[New] You can now choose to bring your changes with you to a new branch or stash them on the current branch when switching branches - #6107",
       "[New] Rebase your current branch onto another branch using a guided flow - #5953",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.0.1": [
-      "[Fixed] Crash when attempting to update pull requests with partially updated repository information."
+      "[Fixed] Crash when attempting to update pull requests with partially updated repository information. - #7688"
     ],
     "2.0.0": [
       "[New] You can now choose to bring your changes with you to a new branch or stash them on the current branch when switching branches - #6107",


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

We've seen reports of crashes where the `PullRequestStore` is called with a `GitHubRepository` that's not inserted into the database. Early investigation shows that this can happen when `AppStore.repositoryWithRefreshedGitHubRepository` fails to refresh repository information (either because the user is signed out or because the API fails to respond).

## Description

A proper solution to this will require investigating the logic in `repositoryWithRefreshedGitHubRepository` to see whether is might make sense to keep the existing repository information rather than creating a skeleton object but such a change is more risky so for now we will handle this particular case in the store.