### PR TITLE
Additional debug data in crash reports

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -65,11 +65,15 @@ function getUptimeInSeconds() {
   return (now() - launchTime) / 1000
 }
 
+function getExtraErrorContext(): Record<string, string> {
+  return {
+    uptime: getUptimeInSeconds().toFixed(3),
+  }
+}
+
 process.on('uncaughtException', (error: Error) => {
   error = withSourceMappedStack(error)
-  reportError(error, {
-    uptime: getUptimeInSeconds().toFixed(3),
-  })
+  reportError(error, getExtraErrorContext())
   handleUncaughtException(error)
 })
 
@@ -456,7 +460,7 @@ app.on('ready', () => {
       { error, extra }: { error: Error; extra: { [key: string]: string } }
     ) => {
       reportError(error, {
-        uptime: getUptimeInSeconds().toFixed(3),
+        ...getExtraErrorContext(),
         ...extra,
       })
     }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -58,10 +58,18 @@ function handleUncaughtException(error: Error) {
   showUncaughtException(isLaunchError, error)
 }
 
+/**
+ * Calculates the number of seconds the app has been running
+ */
+function getUptimeInSeconds() {
+  return (now() - launchTime) / 1000
+}
+
 process.on('uncaughtException', (error: Error) => {
   error = withSourceMappedStack(error)
-
-  reportError(error)
+  reportError(error, {
+    uptime: getUptimeInSeconds().toFixed(3),
+  })
   handleUncaughtException(error)
 })
 
@@ -447,7 +455,10 @@ app.on('ready', () => {
       event: Electron.IpcMessageEvent,
       { error, extra }: { error: Error; extra: { [key: string]: string } }
     ) => {
-      reportError(error, extra)
+      reportError(error, {
+        uptime: getUptimeInSeconds().toFixed(3),
+        ...extra,
+      })
     }
   )
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -68,6 +68,7 @@ function getUptimeInSeconds() {
 function getExtraErrorContext(): Record<string, string> {
   return {
     uptime: getUptimeInSeconds().toFixed(3),
+    time: new Date().toString(),
   }
 }
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -99,10 +99,12 @@ process.once('uncaughtException', (error: Error) => {
       `An uncaught exception was thrown. If this were a production build it would be reported to Central. Instead, maybe give it a lil lookyloo.`
     )
   } else {
-    sendErrorReport(error, {
+    const extra: Record<string, string> = {
       osVersion: getOS(),
       guid: getGUID(),
-    })
+    }
+
+    sendErrorReport(error, extra)
   }
 
   reportUncaughtException(error)

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -90,8 +90,8 @@ if (!process.env.TEST_ENV) {
 }
 
 let currentState: IAppState | null = null
-let lastPromiseRejection: string | null = null
-let lastPromiseRejectionTime: Date | null = null
+let lastUnhandledRejection: string | null = null
+let lastUnhandledRejectionTime: Date | null = null
 
 process.once('uncaughtException', (error: Error) => {
   error = withSourceMappedStack(error)
@@ -139,11 +139,11 @@ process.once('uncaughtException', (error: Error) => {
         }
 
         if (
-          lastPromiseRejection !== null &&
-          lastPromiseRejectionTime !== null
+          lastUnhandledRejection !== null &&
+          lastUnhandledRejectionTime !== null
         ) {
-          extra.lastPromiseRejection = lastPromiseRejection
-          extra.lastPromiseRejectionTime = lastPromiseRejectionTime.toString()
+          extra.lastUnhandledRejection = lastUnhandledRejection
+          extra.lastUnhandledRejectionTime = lastUnhandledRejectionTime.toString()
         }
 
         extra.repositoryCount = `${currentState.repositories.length}`
@@ -166,8 +166,8 @@ process.once('uncaughtException', (error: Error) => {
 window.addEventListener('unhandledrejection', ev => {
   if (ev.reason !== null && ev.reason !== undefined) {
     try {
-      lastPromiseRejection = `${ev.reason}`
-      lastPromiseRejectionTime = new Date()
+      lastUnhandledRejection = `${ev.reason}`
+      lastUnhandledRejectionTime = new Date()
     } catch (err) {
       /* ignore */
     }

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -120,6 +120,12 @@ process.once('uncaughtException', (error: Error) => {
 
         if (currentState.selectedState !== null) {
           extra.selectedState = `${currentState.selectedState.type}`
+
+          if (currentState.selectedState.type === SelectionType.Repository) {
+            extra.selectedRepositorySection = `${
+              currentState.selectedState.state.selectedSection
+            }`
+          }
         }
 
         if (currentState.currentFoldout !== null) {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -149,9 +149,12 @@ process.once('uncaughtException', (error: Error) => {
         extra.repositoryCount = `${currentState.repositories.length}`
         extra.windowState = currentState.windowState
         extra.accounts = `${currentState.accounts.length}`
-        extra.automaticallySwitchTheme = `${
-          currentState.automaticallySwitchTheme
-        }`
+
+        if (__DARWIN__) {
+          extra.automaticallySwitchTheme = `${
+            currentState.automaticallySwitchTheme
+          }`
+        }
       }
     } catch (err) {
       /* ignore */

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -163,6 +163,20 @@ process.once('uncaughtException', (error: Error) => {
   reportUncaughtException(error)
 })
 
+/**
+ * Chromium won't crash on an unhandled rejection (similar to how
+ * it won't crash on an unhandled error). We've taken the approach
+ * that unhandled errors should crash the app and very likely we
+ * should do the same thing for unhandled promise rejections but
+ * that's a bit too risky to do until we've established some sense
+ * of how often it happens. For now this simply stores the last
+ * rejection so that we can pass it along with the crash report
+ * if the app does crash. Note that this does not prevent the
+ * default browser behavior of logging since we're not calling
+ * `preventDefault` on the event.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event
+ */
 window.addEventListener('unhandledrejection', ev => {
   if (ev.reason !== null && ev.reason !== undefined) {
     try {

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.0.2": [
-      "[Added] Extend crash reports with more information about application state for troubleshooting."
+      "[Added] Extend crash reports with more information about application state for troubleshooting. - #7693"
     ],
     "2.0.1": [
       "[Fixed] Crash when attempting to update pull requests with partially updated repository information. - #7688"

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,8 @@
 {
   "releases": {
-    "2.0.2": [],
+    "2.0.2": [
+      "[Added] Extend crash reports with more information about application state for troubleshooting."
+    ],
     "2.0.1": [
       "[Fixed] Crash when attempting to update pull requests with partially updated repository information. - #7688"
     ],


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

We're seeing a number of crashes related to the most recent releases (2.x) and have realized we lack some key information about the state that the application is in which makes troubleshooting (and ultimately delivering a fix for affected users) slower than it needs to be.

## Description

This PR adds a number of fields to our existing crash reports which will hopefully help us troubleshoot rare crashes with no clear reproduction steps more easily.

The newly added fields are as follows

| Field | Explanation |
|-----|-----|
| time | The current time of the environment (including the time zone offset) |
| uptime | The number of seconds the application had been running when the error was encountered |
| currentBanner | The type of banner (if any) that the app was showing when the error was encountered |
| currentPopup | The type of popup (if any) that the app was showing when the error was encountered |
| selectedState | The current repository selection type, i.e. repository, missing repository, cloning repository (if any) |
| selectedRepositorySection | The selected tab in the repository view, i.e. changes or history |
| currentFoldout | The type of foldout (application drop down such as the repository list or branches list) (if any) that the app was showing when the error was encountered |
| inWelcomeFlow | Whether the app was in the welcome flow when the error was encountered |
| windowZoomFactor | The current zoom factor (if not the default zoom level) |
| activeAppError | The number of application errors currently shown in the app (if any) |
| lastUnhandledRejection | The last unhandled promise rejection seen in the app (see comments in code) |
| lastUnhandledRejectionTime | Time when the last unhandled promise rejection occurred |
| repositoryCount | The number of repositories tracked in the app at the time |
| windowState | The window state (minimized, maximized, etc) |
| accounts | The *number* of accounts currently signed in |
| automaticallySwitchTheme | Whether the app automatically switches themes based on the system configuration (macOS only) |