### PR TITLE
Fix account identity mismatch

### DIFF
--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -75,7 +75,7 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
   /**
    * Add the account to the store.
    */
-  public async addAccount(account: Account): Promise<void> {
+  public async addAccount(account: Account): Promise<Account | null> {
     await this.loadingPromise
 
     let updated = account
@@ -103,12 +103,13 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
       } else {
         this.emitError(e)
       }
-      return
+      return null
     }
 
     this.accounts = [...this.accounts, updated]
 
     this.save()
+    return updated
   }
 
   /** Refresh all accounts by fetching their latest info from the API. */

--- a/app/src/lib/stores/api-repositories-store.ts
+++ b/app/src/lib/stores/api-repositories-store.ts
@@ -171,15 +171,16 @@ export class ApiRepositoriesStore extends BaseStore {
    * the provided account has explicit permissions to access.
    */
   public async loadRepositories(account: Account) {
-    const existingRepositories = this.accountState.get(account)
+    const existingAccount = resolveAccount(account, this.accountState)
+    const existingRepositories = this.accountState.get(existingAccount)
 
     if (existingRepositories !== undefined && existingRepositories.loading) {
       return
     }
 
-    this.updateAccount(account, { loading: true })
+    this.updateAccount(existingAccount, { loading: true })
 
-    const api = API.fromAccount(account)
+    const api = API.fromAccount(existingAccount)
     const repositories = await api.fetchRepositories()
 
     if (repositories === null) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4467,7 +4467,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // a refresh of the repositories available for cloning straight away
     // in order to have the list of repositories ready for them when they
     // get to the blankslate.
-    if (this.showWelcomeFlow && storedAccount) {
+    if (this.showWelcomeFlow && storedAccount !== null) {
       this.apiRepositoriesStore.loadRepositories(storedAccount)
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4450,7 +4450,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     log.info(
       `[AppStore] adding account ${account.login} (${account.name}) to store`
     )
-    await this.accountsStore.addAccount(account)
+    const storedAccount = await this.accountsStore.addAccount(account)
     const selectedState = this.getState().selectedState
 
     if (selectedState && selectedState.type === SelectionType.Repository) {
@@ -4467,8 +4467,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // a refresh of the repositories available for cloning straight away
     // in order to have the list of repositories ready for them when they
     // get to the blankslate.
-    if (this.showWelcomeFlow) {
-      this.apiRepositoriesStore.loadRepositories(account)
+    if (this.showWelcomeFlow && storedAccount) {
+      this.apiRepositoriesStore.loadRepositories(storedAccount)
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -473,18 +473,14 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private getDotComAccount(): Account | null {
-    const state = this.props.appStore.getState()
-    const accounts = state.accounts
-    const dotComAccount = accounts.find(
+    const dotComAccount = this.state.accounts.find(
       a => a.endpoint === getDotComAPIEndpoint()
     )
     return dotComAccount || null
   }
 
   private getEnterpriseAccount(): Account | null {
-    const state = this.props.appStore.getState()
-    const accounts = state.accounts
-    const enterpriseAccount = accounts.find(
+    const enterpriseAccount = this.state.accounts.find(
       a => a.endpoint !== getDotComAPIEndpoint()
     )
     return enterpriseAccount || null

--- a/app/src/ui/blank-slate/blank-slate.tsx
+++ b/app/src/ui/blank-slate/blank-slate.tsx
@@ -142,8 +142,17 @@ export class BlankSlateView extends React.Component<
     this.ensureRepositoriesForAccount(this.getSelectedAccount())
   }
 
-  public componentDidUpdate(prevProps: IBlankSlateProps) {
-    this.ensureRepositoriesForAccount(this.getSelectedAccount())
+  public componentDidUpdate(
+    prevProps: IBlankSlateProps,
+    prevState: IBlankSlateState
+  ) {
+    if (
+      prevProps.dotComAccount !== this.props.dotComAccount ||
+      prevProps.enterpriseAccount !== this.props.enterpriseAccount ||
+      prevState.selectedTab !== this.state.selectedTab
+    ) {
+      this.ensureRepositoriesForAccount(this.getSelectedAccount())
+    }
   }
 
   private ensureRepositoriesForAccount(account: Account | null) {

--- a/app/src/ui/blank-slate/blank-slate.tsx
+++ b/app/src/ui/blank-slate/blank-slate.tsx
@@ -159,7 +159,7 @@ export class BlankSlateView extends React.Component<
     if (account !== null) {
       const accountState = this.props.apiRepositories.get(account)
 
-      if (accountState === undefined || accountState.repositories === null) {
+      if (accountState === undefined) {
         this.props.onRefreshRepositories(account)
       }
     }

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,8 @@
 {
   "releases": {
-    "2.0.3": [],
+    "2.0.3": [
+      "[Fixed] Crash when loading repositories after signing in through the welcome flow."
+    ],
     "2.0.2": [
       "[Added] Extend crash reports with more information about application state for troubleshooting. - #7693"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.0.3": [
-      "[Fixed] Crash when loading repositories after signing in through the welcome flow."
+      "[Fixed] Crash when loading repositories after signing in through the welcome flow. - #7699"
     ],
     "2.0.2": [
       "[Added] Extend crash reports with more information about application state for troubleshooting. - #7693"


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This should fix the source of our recent crashes after 2.0.

## Description

The API repositories store (the store responsible for loading and caching cloneable repositories for an account) was built on reference equality. In hindsight that was probably a bad idea but fixing that holistically is too much for tonight.

What happened was that when you sign in through the welcome wizard we get an `Account` from the sign-in process which we pass to the `AccountsStore` which creates a new `Account` instance. We would then tell the `ApiRepositoriesStore` to load the initial `Account` instance that we got, thereby creating a mismatch between the truth as IAppState saw it and how `ApiRepositoriesStore` saw it.

This was exacerbated, but not caused, by us calling `ensureRepositoriesForAccount` unconditionally from `componentDidUpdate` (relying on the ApiRepositoriesStore to prevent loading already loaded accounts)

The end result of all of this was that for each time the blank slate component got updated we would trigger another reload of all repositories for the account, exponentially driving up the number of requests to the API until eventually the app buckled under the load.

On macOS, however, there was another problem. When the app window was hidden (which can only happen on macOS by closing the window) [we would synchronously emit updates from AppStore](https://github.com/desktop/desktop/blob/c2dc85f8153f78bbca84baa012fe285909d2dae3/app/src/lib/stores/app-store.ts#L503-L509) which caused us to run into [a depth limit](https://reactjs.org/docs/error-decoder.html/?invariant=185) in react which ultimately caused the crashes on macOS.