### PR TITLE
refresh should handle when the branch API is unavailable

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -718,8 +718,16 @@ export class API {
     name: string
   ): Promise<ReadonlyArray<IAPIBranch>> {
     const path = `repos/${owner}/${name}/branches?protected=true`
-    const response = await this.request('GET', path)
-    return await parsedResponse<IAPIBranch[]>(response)
+    try {
+      const response = await this.request('GET', path)
+      return await parsedResponse<IAPIBranch[]>(response)
+    } catch (err) {
+      log.info(
+        `[fetchProtectedBranches] unable to list protected branches`,
+        err
+      )
+      return new Array<IAPIBranch>()
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview

**Closes #7713**

## Description

We uncovered in https://github.com/desktop/desktop/issues/7713#issuecomment-500560261 that there's an unhandled error when a GHE instance returns a 404 for the branches API we enabled to query for protected branches.

```
http.ts:145 GET https://adsd-app10.ss-inf.nsx1.census.gov/api/v3/repos/AuthoringSandbox/gitplay/branches?protected=true 404 (Not Found)
t.request @ http.ts:145
request @ api.ts:765
fetchProtectedBranches @ api.ts:721
repositoryWithRefreshedGitHubRepository @ app-store.ts:3119
...
```

I thought this API was pretty stable and trusted it was there for our GHE users, but that seems to be a flawed assumption. I've wrapped the API call to log a message and return an empty array if the error is encountered - this should help prevent it from impacting the overall refresh operation.

## Release notes

Notes: `[Fixed] refresh of some GitHub Enterprise repositories failing because of missing API`
