### PR TITLE
pass the current state when emitting show event from BrowserWindow

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -184,7 +184,11 @@ import {
   hasSeenUsageStatsNote,
 } from '../stats'
 import { hasShownWelcomeFlow, markWelcomeFlowComplete } from '../welcome'
-import { getWindowState, WindowState } from '../window-state'
+import {
+  getWindowState,
+  WindowState,
+  windowStateChannelName,
+} from '../window-state'
 import { TypedBaseStore } from './base-store'
 import { AheadBehindUpdater } from './helpers/ahead-behind-updater'
 import { MergeResult } from '../../models/merge'
@@ -412,7 +416,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private wireupIpcEventHandlers(window: Electron.BrowserWindow) {
     ipcRenderer.on(
-      'window-state-changed',
+      windowStateChannelName,
       (event: Electron.IpcMessageEvent, args: any[]) => {
         this.windowState = getWindowState(window)
         this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -417,8 +417,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private wireupIpcEventHandlers(window: Electron.BrowserWindow) {
     ipcRenderer.on(
       windowStateChannelName,
-      (event: Electron.IpcMessageEvent, args: any[]) => {
-        this.windowState = getWindowState(window)
+      (event: Electron.IpcMessageEvent, windowState: WindowState) => {
+        this.windowState = windowState
         this.emitUpdate()
       }
     )

--- a/app/src/lib/window-state.ts
+++ b/app/src/lib/window-state.ts
@@ -45,7 +45,12 @@ export function registerWindowStateChangedEvents(
   window.on('unmaximize', () => sendWindowStateEvent(window, 'normal'))
   window.on('restore', () => sendWindowStateEvent(window, 'normal'))
   window.on('hide', () => sendWindowStateEvent(window, 'hidden'))
-  window.on('show', () => sendWindowStateEvent(window, 'normal'))
+  window.on('show', () => {
+    // because the app can be maximized before being closed - which will restore it
+    // maximized on the next launch - this function should inspect the current state
+    // rather than always assume it is a 'normal' launch
+    sendWindowStateEvent(window, getWindowState(window))
+  })
 }
 
 /**

--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -52,9 +52,9 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
 
   private onWindowStateChanged = (
     event: Electron.IpcMessageEvent,
-    args: any
+    windowState: WindowState
   ) => {
-    this.setState({ windowState: args as WindowState })
+    this.setState({ windowState })
   }
 
   private onMinimize = () => {


### PR DESCRIPTION
## Overview

**Closes #7750**

## Description

The root cause of this issue is that the main process subscribes to the `show` event from `BrowserWindow` (to indicate when the window is first displayed) to then emit a message to the renderer process so that the UI is in the right state. This has always emitted `normal` despite the fact that the app could have been maximized when it was previously closed.

This PR now checks what the window state is at the time and emits that to the app. And because this is related to the launch state of the app, I'll ensure this behaviour is correct across all the platforms.

 - [x] test on Windows in development mode
 - [x] test on Windows in production mode
 - [x] test on macOS in development mode
 - [x] test on macOS in production mode
 - [x] test on Linux in development mode
 - [x] test on Linux in production mode

## Release notes

Notes: Launching app on Windows after being maximized does not restore correct window state
