### PR TITLE
Add back "Discard all changes" context menu

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -259,7 +259,10 @@ export class ChangesList extends React.Component<
   }
 
   private onDiscardAllChanges = () => {
-    this.props.onDiscardChangesFromFiles(this.props.workingDirectory.files, true)
+    this.props.onDiscardChangesFromFiles(
+      this.props.workingDirectory.files,
+      true
+    )
   }
 
   private onDiscardChanges = (files: ReadonlyArray<string>) => {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -305,6 +305,25 @@ export class ChangesList extends React.Component<
     return this.props.askForConfirmationOnDiscardChanges ? `${label}…` : label
   }
 
+  private onContextMenu = (event: React.MouseEvent<any>) => {
+    event.preventDefault()
+
+    // need to preserve the working directory state while dealing with conflicts
+    if (this.props.rebaseConflictState !== null) {
+      return
+    }
+
+    const items: IMenuItem[] = [
+      {
+        label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
+        action: this.onDiscardAllChanges,
+        enabled: this.props.workingDirectory.files.length > 0,
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
   private getDiscardChangesMenuItem = (
     paths: ReadonlyArray<string>
   ): IMenuItem => {
@@ -650,7 +669,7 @@ export class ChangesList extends React.Component<
 
     return (
       <div className="changes-list-container file-list">
-        <div className="header">
+        <div className="header" onContextMenu={this.onContextMenu}>
           <Checkbox
             label={filesDescription}
             value={includeAllValue}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -258,6 +258,10 @@ export class ChangesList extends React.Component<
     )
   }
 
+  private onDiscardAllChanges = () => {
+    this.props.onDiscardChangesFromFiles(this.props.workingDirectory.files, true)
+  }
+
   private onDiscardChanges = (files: ReadonlyArray<string>) => {
     const workingDirectory = this.props.workingDirectory
 


### PR DESCRIPTION
## Overview

This reverts commit 5bcc5e0b2423b42ba34bbeac8c9073cd2061ded3 to add back the "Discard all changes" context menu when right-clicking the "x files changed" header above the changes list.

**Closes #7696**

## Description

We removed this because we got feedback that the context menu was not discoverable. We still think that's true, but we should have had a better alternative in place prior to removing this one, and that's my fault - sorry to everyone who experienced this as a regression.

We've thought about a few different options to increase discoverability, but while we're discussing it we want to ensure the experience that many people have come to expect still exists until there's a good alternative in place.

## Release notes

[Added] "Discard all changes" context menu available from Changes header
