### PR TITLE
Fix select all keyboard shortcut in lists on Windows

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -401,6 +401,8 @@ export class List extends React.Component<IListProps, IListState> {
         this.moveSelection('up', event)
       }
       event.preventDefault()
+    } else if (!__DARWIN__ && event.key === 'a' && event.ctrlKey) {
+      this.onSelectAll(event)
     }
   }
 

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -402,6 +402,11 @@ export class List extends React.Component<IListProps, IListState> {
       }
       event.preventDefault()
     } else if (!__DARWIN__ && event.key === 'a' && event.ctrlKey) {
+      // On Windows Chromium will steal the Ctrl+A shortcut before
+      // Electron gets its hands on it meaning that the Select all
+      // menu item can't be invoked by means of keyboard shortcuts
+      // on Windows. Clicking on the menu item still emits the
+      // 'select-all' custom DOM event.
       this.onSelectAll(event)
     }
   }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -312,7 +312,7 @@ export class List extends React.Component<IListProps, IListState> {
     }
   }
 
-  private onSelectAll = (event: Event) => {
+  private onSelectAll = (event: Event | React.SyntheticEvent<any>) => {
     const selectionMode = this.props.selectionMode
 
     if (selectionMode !== 'range' && selectionMode !== 'multi') {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #7759**

## Description

When a user invokes the `Select All` menu item under the `Edit` menu Desktop dispatches a custom DOM event called `select-all` which components can (currently only `List` implements this) elect to handle. #7759 pointed out that `Ctrl+A` doesn't work on Windows and it turns out that this is a [known problem](https://github.com/electron/electron/issues/3682#issuecomment-161952094) where Chromium will steal a few select keyboard shortcuts (Ctrl+A, Ctrl+Z, etc) in such a way that Electron doesn't have a chance to match them to menu item accelerators.

This PR adds a special case for Windows in lists so that we handle the DOM event for `Ctrl+A` and treat it the same way as we would the `select-all` custom DOM event.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: [Fixed] Ctrl+A keyboard shortcut didn't select all changed files on Windows.