### PR TITLE
stop caching eslint cache for now on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
   nodejs_version: '8.12'
 
 cache:
-  - .eslintcache
   - '%USERPROFILE%\.electron'
   - '%LOCALAPPDATA%\Yarn\Cache\v4'
 


### PR DESCRIPTION
## Overview

We merged #7681 yesterday and I thought we were good but there's an internal error when running ESLint on AppVeyor currently:

```
$ eslint --cache --rulesdir ./eslint-rules "./eslint-rules/**/*.js" "./{script,tslint-rules}/**/*.ts{,x}" "./app/{src,typings,test}/**/*.{j,t}s{,x}" "./changelog.json"
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.keys (C:\projects\desktop\node_modules\flat-cache\cache.js:52:19)
    at removeNotFoundFiles (C:\projects\desktop\node_modules\file-entry-cache\cache.js:18:35)
    at Object.create (C:\projects\desktop\node_modules\file-entry-cache\cache.js:31:5)
    at new LintResultCache (C:\projects\desktop\node_modules\eslint\lib\util\lint-result-cache.js:62:46)
    at new CLIEngine (C:\projects\desktop\node_modules\eslint\lib\cli-engine.js:476:37)
    at Object.execute (C:\projects\desktop\node_modules\eslint\lib\cli.js:204:28)
    at Object.<anonymous> (C:\projects\desktop\node_modules\eslint\bin\eslint.js:78:28)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It might be related to cutting a release branch today, as the first failing AppVeyor build for the moment is https://ci.appveyor.com/project/github-windows/desktop/builds/25205720, which was testing the merge commit of `releases/2.0.4` into `development` (which is totally unimportant right now).

Since then it looks like all builds testing the merge of a branch into `development` on AppVeyor are errorring, which is affecting #7766 and #7683 (and potentially others under review).

## Description

I'm going to look closely at this tomorrow after shipping the hotfix, but for now I propose just dropping the AppVeyor cache so I can unblock merging some 2.1 work into `development`.

## Release notes

Notes: no-notes
