### PR TITLE
Add key property for all dialogs to ensure transitions

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1420,16 +1420,23 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.RemoveRepository:
         return (
           <ConfirmRemoveRepository
+            key="confirm-remove-repository"
             repository={popup.repository}
             onConfirmation={this.onConfirmRepoRemoval}
             onDismissed={this.onPopupDismissed}
           />
         )
       case PopupType.TermsAndConditions:
-        return <TermsAndConditions onDismissed={this.onPopupDismissed} />
+        return (
+          <TermsAndConditions
+            key="terms-and-conditions"
+            onDismissed={this.onPopupDismissed}
+          />
+        )
       case PopupType.PushBranchCommits:
         return (
           <PushBranchCommits
+            key="push-branch-commits"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             branch={popup.branch}
@@ -1439,10 +1446,16 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       case PopupType.CLIInstalled:
-        return <CLIInstalled onDismissed={this.onPopupDismissed} />
+        return (
+          <CLIInstalled
+            key="cli-installed"
+            onDismissed={this.onPopupDismissed}
+          />
+        )
       case PopupType.GenericGitAuthentication:
         return (
           <GenericGitAuthentication
+            key="generic-git-authentication"
             hostname={popup.hostname}
             onDismiss={this.onPopupDismissed}
             onSave={this.onSaveCredentials}
@@ -1475,6 +1488,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.InitializeLFS:
         return (
           <InitializeLFS
+            key="initialize-lfs"
             repositories={popup.repositories}
             onDismissed={this.onPopupDismissed}
             onInitialize={this.initializeLFS}
@@ -1483,6 +1497,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.LFSAttributeMismatch:
         return (
           <AttributeMismatch
+            key="lsf-attribute-mismatch"
             onDismissed={this.onPopupDismissed}
             onUpdateExistingFilters={this.updateExistingLFSFilters}
           />
@@ -1490,6 +1505,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.UpstreamAlreadyExists:
         return (
           <UpstreamAlreadyExists
+            key="upstream-already-exists"
             repository={popup.repository}
             existingRemote={popup.existingRemote}
             onDismissed={this.onPopupDismissed}
@@ -1500,6 +1516,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.ReleaseNotes:
         return (
           <ReleaseNotes
+            key="release-notes"
             emoji={this.state.emoji}
             newRelease={popup.newRelease}
             onDismissed={this.onPopupDismissed}
@@ -1508,6 +1525,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.DeletePullRequest:
         return (
           <DeletePullRequest
+            key="delete-pull-request"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             branch={popup.branch}
@@ -1535,6 +1553,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         return (
           <MergeConflictsDialog
+            key="merge-conflicts-dialog"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             workingDirectory={workingDirectory}
@@ -1551,6 +1570,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.OversizedFiles:
         return (
           <OversizedFiles
+            key="oversized-files"
             oversizedFiles={popup.oversizedFiles}
             onDismissed={this.onPopupDismissed}
             dispatcher={this.props.dispatcher}
@@ -1577,6 +1597,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         return (
           <AbortMergeWarning
+            key="abort-merge-warning"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             onDismissed={this.onPopupDismissed}
@@ -1588,6 +1609,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.UsageReportingChanges:
         return (
           <UsageStatsChange
+            key="usage-stats-change"
             onOpenUsageDataUrl={this.openUsageDataUrl}
             onDismissed={this.onUsageReportingDismissed}
           />
@@ -1595,6 +1617,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.CommitConflictsWarning:
         return (
           <CommitConflictsWarning
+            key="commit-conflicts-warning"
             dispatcher={this.props.dispatcher}
             files={popup.files}
             repository={popup.repository}
@@ -1605,6 +1628,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.PushNeedsPull:
         return (
           <PushNeedsPullWarning
+            key="push-needs-pull"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             onDismissed={this.onPopupDismissed}
@@ -1640,6 +1664,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         return (
           <RebaseFlow
+            key="rebase-flow"
             repository={popup.repository}
             openFileInExternalEditor={this.openFileInExternalEditor}
             dispatcher={this.props.dispatcher}
@@ -1663,6 +1688,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         return (
           <ConfirmForcePush
+            key="confirm-force-push"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             upstreamBranch={popup.upstreamBranch}
@@ -1688,6 +1714,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         return (
           <StashAndSwitchBranch
+            key="stash-and-switch-branch"
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             currentBranch={currentBranch}
@@ -1701,6 +1728,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         const { repository, branchToCheckout: branchToCheckout } = popup
         return (
           <OverwriteStash
+            key="overwite-stash"
             dispatcher={this.props.dispatcher}
             repository={repository}
             branchToCheckout={branchToCheckout}
@@ -1713,6 +1741,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         return (
           <ConfirmDiscardStashDialog
+            key="confirm-discard-stash-dialog"
             dispatcher={this.props.dispatcher}
             repository={repository}
             stash={stash}


### PR DESCRIPTION
## Overview

While investigating a crash related to dialogs, I saw that most of our dialog components are missing a `key` property, which is needed to ensure that the component isn't created/destroyed more than once during transitions.

This PR adds `key`s to all dialog components that lack them.