### PR TITLE
drop unnecessary async modifiers from public API for StatsStore

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -732,14 +732,14 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record that user dismissed diverging branch notification */
-  public async recordDivergingBranchBannerDismissal(): Promise<void> {
+  public recordDivergingBranchBannerDismissal(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       divergingBranchBannerDismissal: m.divergingBranchBannerDismissal + 1,
     }))
   }
 
   /** Record that user initiated a merge from within the notification banner */
-  public async recordDivergingBranchBannerInitatedMerge(): Promise<void> {
+  public recordDivergingBranchBannerInitatedMerge(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       divergingBranchBannerInitatedMerge:
         m.divergingBranchBannerInitatedMerge + 1,
@@ -747,7 +747,7 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record that user initiated a compare from within the notification banner */
-  public async recordDivergingBranchBannerInitiatedCompare(): Promise<void> {
+  public recordDivergingBranchBannerInitiatedCompare(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       divergingBranchBannerInitiatedCompare:
         m.divergingBranchBannerInitiatedCompare + 1,
@@ -758,7 +758,7 @@ export class StatsStore implements IStatsStore {
    * Record that user initiated a merge after getting to compare view
    * from within notification banner
    */
-  public async recordDivergingBranchBannerInfluencedMerge(): Promise<void> {
+  public recordDivergingBranchBannerInfluencedMerge(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       divergingBranchBannerInfluencedMerge:
         m.divergingBranchBannerInfluencedMerge + 1,
@@ -766,7 +766,7 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record that the user was shown the notification banner */
-  public async recordDivergingBranchBannerDisplayed(): Promise<void> {
+  public recordDivergingBranchBannerDisplayed(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       divergingBranchBannerDisplayed: m.divergingBranchBannerDisplayed + 1,
     }))
@@ -835,21 +835,21 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
-  public async recordUserProceededWhileLoading(): Promise<void> {
+  public recordUserProceededWhileLoading(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergedWithLoadingHintCount: m.mergedWithLoadingHintCount + 1,
     }))
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
-  public async recordMergeHintSuccessAndUserProceeded(): Promise<void> {
+  public recordMergeHintSuccessAndUserProceeded(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergedWithCleanMergeHintCount: m.mergedWithCleanMergeHintCount + 1,
     }))
   }
 
   /** Record that the user saw a 'merge conflicts' warning but continued with the merge */
-  public async recordUserProceededAfterConflictWarning(): Promise<void> {
+  public recordUserProceededAfterConflictWarning(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergedWithConflictWarningHintCount:
         m.mergedWithConflictWarningHintCount + 1,
@@ -859,7 +859,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `mergeConflictsDialogDismissalCount` metric
    */
-  public async recordMergeConflictsDialogDismissal(): Promise<void> {
+  public recordMergeConflictsDialogDismissal(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeConflictsDialogDismissalCount:
         m.mergeConflictsDialogDismissalCount + 1,
@@ -869,7 +869,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `anyConflictsLeftOnMergeConflictsDialogDismissalCount` metric
    */
-  public async recordAnyConflictsLeftOnMergeConflictsDialogDismissal(): Promise<
+  public recordAnyConflictsLeftOnMergeConflictsDialogDismissal(): Promise<
     void
   > {
     return this.updateDailyMeasures(m => ({
@@ -881,7 +881,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `mergeConflictsDialogReopenedCount` metric
    */
-  public async recordMergeConflictsDialogReopened(): Promise<void> {
+  public recordMergeConflictsDialogReopened(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeConflictsDialogReopenedCount:
         m.mergeConflictsDialogReopenedCount + 1,
@@ -891,7 +891,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `guidedConflictedMergeCompletionCount` metric
    */
-  public async recordGuidedConflictedMergeCompletion(): Promise<void> {
+  public recordGuidedConflictedMergeCompletion(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       guidedConflictedMergeCompletionCount:
         m.guidedConflictedMergeCompletionCount + 1,
@@ -901,7 +901,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `unguidedConflictedMergeCompletionCount` metric
    */
-  public async recordUnguidedConflictedMergeCompletion(): Promise<void> {
+  public recordUnguidedConflictedMergeCompletion(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       unguidedConflictedMergeCompletionCount:
         m.unguidedConflictedMergeCompletionCount + 1,
@@ -911,7 +911,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `createPullRequestCount` metric
    */
-  public async recordCreatePullRequest(): Promise<void> {
+  public recordCreatePullRequest(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       createPullRequestCount: m.createPullRequestCount + 1,
     }))
@@ -920,7 +920,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `rebaseConflictsDialogDismissalCount` metric
    */
-  public async recordRebaseConflictsDialogDismissal(): Promise<void> {
+  public recordRebaseConflictsDialogDismissal(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       rebaseConflictsDialogDismissalCount:
         m.rebaseConflictsDialogDismissalCount + 1,
@@ -930,7 +930,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `rebaseConflictsDialogDismissalCount` metric
    */
-  public async recordRebaseConflictsDialogReopened(): Promise<void> {
+  public recordRebaseConflictsDialogReopened(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       rebaseConflictsDialogReopenedCount:
         m.rebaseConflictsDialogReopenedCount + 1,
@@ -940,7 +940,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `rebaseAbortedAfterConflictsCount` metric
    */
-  public async recordRebaseAbortedAfterConflicts(): Promise<void> {
+  public recordRebaseAbortedAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       rebaseAbortedAfterConflictsCount: m.rebaseAbortedAfterConflictsCount + 1,
     }))
@@ -957,7 +957,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Increments the `rebaseSuccessAfterConflictsCount` metric
    */
-  public async recordRebaseSuccessAfterConflicts(): Promise<void> {
+  public recordRebaseSuccessAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       rebaseSuccessAfterConflictsCount: m.rebaseSuccessAfterConflictsCount + 1,
     }))
@@ -1002,77 +1002,77 @@ export class StatsStore implements IStatsStore {
   }
 
   /** Record when a conflicted merge was successfully completed by the user */
-  public async recordMergeSuccessAfterConflicts(): Promise<void> {
+  public recordMergeSuccessAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeSuccessAfterConflictsCount: m.mergeSuccessAfterConflictsCount + 1,
     }))
   }
 
   /** Record when a conflicted merge was aborted by the user */
-  public async recordMergeAbortedAfterConflicts(): Promise<void> {
+  public recordMergeAbortedAfterConflicts(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       mergeAbortedAfterConflictsCount: m.mergeAbortedAfterConflictsCount + 1,
     }))
   }
 
   /** Record when the user views a stash entry after checking out a branch */
-  public async recordStashViewedAfterCheckout(): Promise<void> {
+  public recordStashViewedAfterCheckout(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       stashViewedAfterCheckoutCount: m.stashViewedAfterCheckoutCount + 1,
     }))
   }
 
   /** Record when the user **doesn't** view a stash entry after checking out a branch */
-  public async recordStashNotViewedAfterCheckout(): Promise<void> {
+  public recordStashNotViewedAfterCheckout(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       stashNotViewedAfterCheckoutCount: m.stashNotViewedAfterCheckoutCount + 1,
     }))
   }
 
   /** Record when the user elects to take changes to new branch over stashing */
-  public async recordChangesTakenToNewBranch(): Promise<void> {
+  public recordChangesTakenToNewBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       changesTakenToNewBranchCount: m.changesTakenToNewBranchCount + 1,
     }))
   }
 
   /** Record when the user elects to stash changes on the current branch */
-  public async recordStashCreatedOnCurrentBranch(): Promise<void> {
+  public recordStashCreatedOnCurrentBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       stashCreatedOnCurrentBranchCount: m.stashCreatedOnCurrentBranchCount + 1,
     }))
   }
 
   /** Record when the user discards a stash entry */
-  public async recordStashDiscard(): Promise<void> {
+  public recordStashDiscard(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       stashDiscardCount: m.stashDiscardCount + 1,
     }))
   }
 
   /** Record when the user views a stash entry */
-  public async recordStashView(): Promise<void> {
+  public recordStashView(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       stashViewCount: m.stashViewCount + 1,
     }))
   }
 
   /** Record when the user restores a stash entry */
-  public async recordStashRestore(): Promise<void> {
+  public recordStashRestore(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       stashRestoreCount: m.stashRestoreCount + 1,
     }))
   }
 
   /** Record when the user takes no action on the stash entry */
-  public async recordNoActionTakenOnStash(): Promise<void> {
+  public recordNoActionTakenOnStash(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       noActionTakenOnStashCount: m.noActionTakenOnStashCount + 1,
     }))
   }
 
   /** Record the number of stash entries created outside of Desktop for the day */
-  public async addStashEntriesCreatedOutsideDesktop(
+  public addStashEntriesCreatedOutsideDesktop(
     stashCount: number
   ): Promise<void> {
     return this.updateDailyMeasures(m => ({
@@ -1085,7 +1085,7 @@ export class StatsStore implements IStatsStore {
    * Record the number of times the user experiences the error
    * "Some of your changes would be overwritten" when switching branches
    */
-  public async recordErrorWhenSwitchingBranchesWithUncommmittedChanges(): Promise<
+  public recordErrorWhenSwitchingBranchesWithUncommmittedChanges(): Promise<
     void
   > {
     return this.updateDailyMeasures(m => ({


### PR DESCRIPTION
## Overview

**Related to #7645**

## Description

In advance of some metrics-related work for 2.1, I figured I'd use this as a chance to cleanup this area before I do some testing in there.

I almost wanted to also drop the `Promise<void>` return type annotations in here, as I think they add noise given how each API infers and inherits from calling `updateDailyMeasures`. If you think this could also be tidied up while we're in here, let me know!

## Release notes

Notes: no-notes
