### PR TITLE
add measure for rebase completion without conflicts

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -170,8 +170,11 @@ export interface IDailyMeasures {
   /** The number of times an aborted rebase is detected */
   readonly rebaseAbortedAfterConflictsCount: number
 
-  /** The number of times a successful rebase is detected */
+  /** The number of times a successful rebase after handling conflicts is detected */
   readonly rebaseSuccessAfterConflictsCount: number
+
+  /** The number of times a successful rebase without conflicts is detected */
+  readonly rebaseSuccessWithoutConflictsCount: number
 
   /** The number of times a user performed a pull with `pull.rebase` in config set to `true` */
   readonly pullWithRebaseCount: number

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -929,7 +929,7 @@ export class StatsStore implements IStatsStore {
   }
 
   /**
-   * Increments the `rebaseConflictsDialogDismissalCount` metric
+   * Increments the `rebaseConflictsDialogReopenedCount` metric
    */
   public async recordRebaseConflictsDialogReopened(): Promise<void> {
     return this.updateDailyMeasures(m => ({

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -89,6 +89,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   rebaseConflictsDialogReopenedCount: 0,
   rebaseAbortedAfterConflictsCount: 0,
   rebaseSuccessAfterConflictsCount: 0,
+  rebaseSuccessWithoutConflictsCount: 0,
   pullWithRebaseCount: 0,
   pullWithDefaultSettingCount: 0,
   stashEntriesCreatedOutsideDesktop: 0,
@@ -951,6 +952,16 @@ export class StatsStore implements IStatsStore {
   public recordPullWithRebaseEnabled() {
     return this.updateDailyMeasures(m => ({
       pullWithRebaseCount: m.pullWithRebaseCount + 1,
+    }))
+  }
+
+  /**
+   * Increments the `rebaseSuccessWithoutConflictsCount` metric
+   */
+  public recordRebaseSuccessWithoutConflicts(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      rebaseSuccessWithoutConflictsCount:
+        m.rebaseSuccessWithoutConflictsCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -233,11 +233,11 @@ function performEffectsForRebaseStateChange(
   ) {
     const previousTip = prevConflictState.originalBranchTip
 
-    if (
+    const previousTipChanged =
       previousTip !== currentTip &&
       currentBranch === prevConflictState.targetBranch
-    ) {
-      statsStore.recordRebaseSuccessAfterConflicts()
+
+    if (previousTipChanged) {
     } else {
       statsStore.recordRebaseAbortedAfterConflicts()
     }

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -237,8 +237,7 @@ function performEffectsForRebaseStateChange(
       previousTip !== currentTip &&
       currentBranch === prevConflictState.targetBranch
 
-    if (previousTipChanged) {
-    } else {
+    if (!previousTipChanged) {
       statsStore.recordRebaseAbortedAfterConflicts()
     }
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -907,6 +907,8 @@ export class Dispatcher {
         return
       }
 
+      this.statsStore.recordRebaseSuccessWithoutConflicts()
+
       await this.completeRebase(
         repository,
         {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1005,6 +1005,8 @@ export class Dispatcher {
         return
       }
 
+      this.statsStore.recordRebaseSuccessAfterConflicts()
+
       await this.completeRebase(
         repository,
         {

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -7,14 +7,19 @@ import {
   ManualConflictResolution,
   ManualConflictResolutionKind,
 } from '../../../../src/models/manual-conflict-resolution'
+import { IStatsStore } from '../../../../src/lib/stats'
 
 describe('updateConflictState', () => {
-  const statsStore = {
-    recordMergeAbortedAfterConflicts: jest.fn(),
-    recordMergeSuccessAfterConflicts: jest.fn(),
-    recordRebaseAbortedAfterConflicts: jest.fn(),
-    recordRebaseSuccessAfterConflicts: jest.fn(),
-  }
+  let statsStore: IStatsStore
+  beforeEach(() => {
+    statsStore = {
+      recordMergeAbortedAfterConflicts: jest.fn(),
+      recordMergeSuccessAfterConflicts: jest.fn(),
+      recordRebaseAbortedAfterConflicts: jest.fn(),
+      recordRebaseSuccessAfterConflicts: jest.fn(),
+    }
+  })
+
   const manualResolutions = new Map<string, ManualConflictResolution>([
     ['foo', ManualConflictResolutionKind.theirs],
   ])

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -282,7 +282,7 @@ describe('updateConflictState', () => {
       expect(statsStore.recordRebaseAbortedAfterConflicts).toHaveBeenCalled()
     })
 
-    it('increments success counter when conflict resolved and tip has changed', () => {
+    it('does not increment aborted counter when conflict resolved and tip has changed', () => {
       const prevState = createState({
         conflictState: {
           kind: 'rebase',
@@ -301,7 +301,9 @@ describe('updateConflictState', () => {
 
       updateConflictState(prevState, status, statsStore)
 
-      expect(statsStore.recordRebaseSuccessAfterConflicts).toHaveBeenCalled()
+      expect(
+        statsStore.recordRebaseAbortedAfterConflicts
+      ).not.toHaveBeenCalled()
     })
   })
 })

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -75,7 +75,7 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `rebaseConflictsDialogReopenedCount` | The number of times the rebase conflicts dialog is reopened. |To understand how users respond when they encounter rebase conflicts. |
 | `rebaseCurrentBranchMenuCount` | The number of times the `Branch -> Rebase Current Branch` menu item is used. | To understand how often users start a rebase in the app. |
 | `rebaseSuccessAfterConflictsCount` |  The number of times a successful rebase is made in the app after the user resolved conflicts. | To understand whether users are able to complete the rebase conflicts flow. |
-| `rebaseSuccessWithoutConflictsCount` | The number of times a successful rebase is made in the app without the user needing to resolve conflicts. | To understand whether users are able to complete the rebase conflicts flow. |
+| `rebaseSuccessWithoutConflictsCount` | The number of times a successful rebase is made in the app without the user needing to resolve conflicts. | To understand how frequently people are rebasing compared to merging. |
 | `rendererReadyTime` | The time (in milliseconds) it takes from when our renderer process code is first loaded until the renderer `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
 | `repoWithIndicatorClicked` | The numbers of times a repo with indicators is clicked on repo list view. | To understand usage patterns around the repository indicators feature. |
 | `repoWithoutIndicatorClicked` | The numbers of times a repo without indicators is clicked on repo list view.  | To understand usage patterns around the repository indicators feature. |

--- a/docs/process/metrics.md
+++ b/docs/process/metrics.md
@@ -74,7 +74,8 @@ These are general metrics about feature usage and specific feature behaviors. Th
 | `rebaseConflictsDialogDismissalCount` | The number of times the rebase conflicts dialog is dismissed. | To understand how users respond when they encounter rebase conflicts. |
 | `rebaseConflictsDialogReopenedCount` | The number of times the rebase conflicts dialog is reopened. |To understand how users respond when they encounter rebase conflicts. |
 | `rebaseCurrentBranchMenuCount` | The number of times the `Branch -> Rebase Current Branch` menu item is used. | To understand how often users start a rebase in the app. |
-| `rebaseSuccessAfterConflictsCount` |  The number of times a successful rebase is detected in the app. | To understand whether users are able to complete the rebase conflicts flow. |
+| `rebaseSuccessAfterConflictsCount` |  The number of times a successful rebase is made in the app after the user resolved conflicts. | To understand whether users are able to complete the rebase conflicts flow. |
+| `rebaseSuccessWithoutConflictsCount` | The number of times a successful rebase is made in the app without the user needing to resolve conflicts. | To understand whether users are able to complete the rebase conflicts flow. |
 | `rendererReadyTime` | The time (in milliseconds) it takes from when our renderer process code is first loaded until the renderer `ready` event is emitted. | To make sure new versions of Desktop are not regressing on performance. |
 | `repoWithIndicatorClicked` | The numbers of times a repo with indicators is clicked on repo list view. | To understand usage patterns around the repository indicators feature. |
 | `repoWithoutIndicatorClicked` | The numbers of times a repo without indicators is clicked on repo list view.  | To understand usage patterns around the repository indicators feature. |


### PR DESCRIPTION
## Overview

Following on from #7793, there was an additional case that we don't currently have insights into - completing a rebase without encountering conflicts. This PR adds that measure, and gives me an opportunity to review what's there.

## Description

- [x]  add `rebaseSuccessWithoutConflictsCount` measure
- [x] increment `rebaseSuccessWithoutConflictsCount` and `rebaseSuccessAfterConflictsCount` as part of rebase flow
- [x] test flows and ensure measures are working as expected
- [x] setup central PR to consume measure https://github.com/github/central/pull/439
- [x] setup marketing site PR to list measure https://github.com/github/desktop.github.com/pull/137

## Release notes

Notes: no-notes
