### PR TITLE
update vscode settings to integrate with eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,9 @@
   "prettier.trailingComma": "es5",
   "editor.formatOnSave": true,
   "prettier.ignorePath": ".prettierignore",
-  "tslint.ignoreDefinitionFiles": true
+  "tslint.ignoreDefinitionFiles": true,
+  "eslint.options": {
+    "configFile": ".eslintrc.yml",
+    "rulePaths": ["eslint-rules"]
+  }
 }


### PR DESCRIPTION
## Overview

**Related to #7655**

## Description

We weren't able to find the root cause of this initially, but I stumbled upon the error today and then sat down to poke at it and figure out the solution. I believe these keys are all that we need to include to mimic what we run in `package.json`.

cc @ADustyOldMuffin @outofambit 

## Release notes

Notes: no-notes
