### PR TITLE
migrate some TSLint rules to the equivalent for ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ plugins:
   - babel
   - react
   - json
+  - import
 
 settings:
   react:
@@ -69,6 +70,9 @@ rules:
   react/no-string-refs: error
   react/jsx-uses-vars: error
   react/jsx-uses-react: error
+
+  # Import
+  import/no-deprecated: error
 
   ###########
   # BUILTIN #

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -99,6 +99,7 @@ rules:
     - error
     - global
   no-buffer-constructor: error
+  no-unreachable: error
 
   ###########
   # SPECIAL #

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,6 +28,7 @@ rules:
     - error
     - always
   '@typescript-eslint/class-name-casing': error
+  '@typescript-eslint/no-extraneous-class': error
   '@typescript-eslint/no-angle-bracket-type-assertion': error
   '@typescript-eslint/explicit-member-accessibility': error
   '@typescript-eslint/no-unused-vars':

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,6 +27,7 @@ rules:
   '@typescript-eslint/interface-name-prefix':
     - error
     - always
+  '@typescript-eslint/class-name-casing': error
   '@typescript-eslint/no-angle-bracket-type-assertion': error
   '@typescript-eslint/explicit-member-accessibility': error
   '@typescript-eslint/no-unused-vars':

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ plugins:
   - react
   - json
   - import
+  - jsdoc
 
 settings:
   react:
@@ -73,6 +74,10 @@ rules:
 
   # Import
   import/no-deprecated: error
+
+  # JSDoc
+  jsdoc/check-syntax: error
+  jsdoc/check-alignment: error
 
   ###########
   # BUILTIN #

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,8 +39,23 @@ rules:
     - functions: false
       variables: false
       typedefs: false
-  # this rule now works but generates a lot of issues with the codebase
-  # '@typescript-eslint/member-ordering': error
+  '@typescript-eslint/member-ordering':
+    - error
+    - default:
+        # emulating variables-before-functions
+        - public-static-field
+        - protected-static-field
+        - private-static-field
+        - public-instance-field
+        - protected-instance-field
+        - private-instance-field
+        # emulating static-before-instance
+        - public-static-method
+        - protected-static-method
+        - private-static-method
+        - public-static-field
+        - protected-static-field
+        - private-static-field
 
   # Babel
   babel/no-invalid-this: error

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -93,12 +93,12 @@ const RecentBranchesLimit = 5
 
 /** The store for a repository's git data. */
 export class GitStore extends BaseStore {
-  private readonly shell: IAppShell
-
   /** The commits keyed by their SHA. */
   public readonly commitLookup = new Map<string, Commit>()
 
   public pullWithRebase?: boolean
+
+  private readonly shell: IAppShell
 
   private _history: ReadonlyArray<string> = new Array()
 

--- a/app/test/helpers/test-activity-monitor.ts
+++ b/app/test/helpers/test-activity-monitor.ts
@@ -5,8 +5,9 @@ import {
 import { Emitter, Disposable } from 'event-kit'
 
 export class TestActivityMonitor implements IUiActivityMonitor {
-  private readonly emitter = new Emitter()
   public subscriptionCount = 0
+
+  private readonly emitter = new Emitter()
 
   public onActivity(handler: (kind: UiActivityKind) => void) {
     this.subscriptionCount++

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-json": "^1.4.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.17.3",
+    "eslint-plugin-jsdoc": "^7.2.3",
     "eslint-plugin-json": "^1.4.0",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "ts-jest": "^23.1.4",
     "ts-node": "^7.0.0",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.14.0",
     "tslint-microsoft-contrib": "^5.2.1",
     "tslint-react": "^3.6.0",
     "typescript": "^3.4.3",

--- a/tslint.json
+++ b/tslint.json
@@ -28,17 +28,6 @@
     ],
     // not ported from tslint-microsoft-contrib
     "react-this-binding-issue": true,
-    // this is covered by Prettier and should not need to be checked here too
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      }
-    ],
     // recommendations: `camelcase`, `no-underscore-dangle`, `id-blacklist`, and/or `id-match` from core
     "variable-name": [true, "ban-keywords"]
   }

--- a/tslint.json
+++ b/tslint.json
@@ -8,8 +8,6 @@
   "rules": {
     // local TSLint rule that should be ported
     "button-group-order": true,
-    // JSDoc rules deprecated in core ESLint and the recommended plugin is `eslint-plugin-jsdoc`
-    "jsdoc-format": true,
     // not ported
     "promise-must-complete": true,
     // local TSLint rule that should be ported

--- a/tslint.json
+++ b/tslint.json
@@ -10,12 +10,6 @@
     "button-group-order": true,
     // JSDoc rules deprecated in core ESLint and the recommended plugin is `eslint-plugin-jsdoc`
     "jsdoc-format": true,
-    // ported to `@typescript-eslint/member-ordering`
-    "member-ordering": [
-      true,
-      "static-before-instance",
-      "variables-before-functions"
-    ],
     // not ported
     "promise-must-complete": true,
     // local TSLint rule that should be ported

--- a/tslint.json
+++ b/tslint.json
@@ -6,19 +6,29 @@
     "tslint-rules/"
   ],
   "rules": {
+    // local TSLint rule that should be ported
     "button-group-order": true,
+    // ported to @typescript-eslint/class-name-casing
     "class-name": true,
+    // JSDoc rules deprecated in core ESLint and the recommended plugin is `eslint-plugin-jsdoc`
     "jsdoc-format": true,
+    // ported to `@typescript-eslint/member-ordering`
     "member-ordering": [
       true,
       "static-before-instance",
       "variables-before-functions"
     ],
+    // this has been ported to `typescript-eslint/no-extraneous-class
     "no-unnecessary-class": true,
+    // not ported
     "promise-must-complete": true,
+    // local TSLint rule that should be ported
     "react-no-unbound-dispatcher-props": true,
+    // local TSLint rule that should be ported
     "react-proper-lifecycle-methods": true,
+    // local TSLint rule that should be ported
     "react-readonly-props-and-state": true,
+    // local TSLint rule that should be ported
     "react-unused-props-and-state": [
       true,
       {
@@ -26,7 +36,9 @@
         "state-interface-regex": "State$"
       }
     ],
+    // not ported from tslint-microsoft-contrib
     "react-this-binding-issue": true,
+    // this is covered by Prettier and should not need to be checked here too
     "typedef-whitespace": [
       true,
       {
@@ -37,7 +49,9 @@
         "variable-declaration": "nospace"
       }
     ],
+    // recommendations: `camelcase`, `no-underscore-dangle`, `id-blacklist`, and/or `id-match` from core
     "variable-name": [true, "ban-keywords"],
+    // recommendation: `import/no-deprecated` from `eslint-plugin-import`
     "deprecation": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,4 @@
 {
-  "extends": ["tslint-config-prettier"],
   "rulesDirectory": [
     "node_modules/tslint-react/rules",
     "node_modules/tslint-microsoft-contrib/",

--- a/tslint.json
+++ b/tslint.json
@@ -16,8 +16,6 @@
       "static-before-instance",
       "variables-before-functions"
     ],
-    // this has been ported to `typescript-eslint/no-extraneous-class
-    "no-unnecessary-class": true,
     // not ported
     "promise-must-complete": true,
     // local TSLint rule that should be ported

--- a/tslint.json
+++ b/tslint.json
@@ -1,13 +1,16 @@
 {
   "rulesDirectory": [
+    // what default rules should we be using that can be moved over to ESLint?
     "node_modules/tslint-react/rules",
+    // we have one more rule that we'd love to be able to port over to ESLint below
     "node_modules/tslint-microsoft-contrib/",
+    // our custom rules, outlined below
     "tslint-rules/"
   ],
   "rules": {
     // local TSLint rule that should be ported
     "button-group-order": true,
-    // not ported
+    // not ported from TSLint core
     "promise-must-complete": true,
     // local TSLint rule that should be ported
     "react-no-unbound-dispatcher-props": true,
@@ -23,7 +26,7 @@
         "state-interface-regex": "State$"
       }
     ],
-    // not ported from tslint-microsoft-contrib
+    // not ported from `tslint-microsoft-contrib`
     "react-this-binding-issue": true,
     // recommendations: `camelcase`, `no-underscore-dangle`, `id-blacklist`, and/or `id-match` from core
     "variable-name": [true, "ban-keywords"]

--- a/tslint.json
+++ b/tslint.json
@@ -40,8 +40,6 @@
       }
     ],
     // recommendations: `camelcase`, `no-underscore-dangle`, `id-blacklist`, and/or `id-match` from core
-    "variable-name": [true, "ban-keywords"],
-    // recommendation: `import/no-deprecated` from `eslint-plugin-import`
-    "deprecation": true
+    "variable-name": [true, "ban-keywords"]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,8 +8,6 @@
   "rules": {
     // local TSLint rule that should be ported
     "button-group-order": true,
-    // ported to @typescript-eslint/class-name-casing
-    "class-name": true,
     // JSDoc rules deprecated in core ESLint and the recommended plugin is `eslint-plugin-jsdoc`
     "jsdoc-format": true,
     // ported to `@typescript-eslint/member-ordering`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2475,6 +2475,11 @@ commander@~2.13.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
   integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
 
+comment-parser@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.5.4.tgz#089840b9cccacad2b769b231ed43081d501b9487"
+  integrity sha512-0h7W6Y1Kb6zKQMJqdX41C5qf9ITCVIsD2qP2RaqDF3GFkXFrmuAuv5zUOuo19YzyC9scjBNpqzuaRQ2Sy5pxMQ==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -3579,6 +3584,15 @@ eslint-plugin-import@^2.17.3:
     minimatch "^3.0.4"
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
+
+eslint-plugin-jsdoc@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-7.2.3.tgz#04d21890cdadf33290f865b27f2f901f1321aa42"
+  integrity sha512-233HUc5ftIlmswaNmck++gkoW2iubcDDbM4KCzTHaawJFODuTNriDmZyKm8+7GgNnnwlkrE0mmD4TCzrdMTnsA==
+  dependencies:
+    comment-parser "^0.5.4"
+    jsdoctypeparser "3.1.0"
+    lodash "^4.17.11"
 
 eslint-plugin-json@^1.4.0:
   version "1.4.0"
@@ -5952,6 +5966,11 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsdoctypeparser@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-3.1.0.tgz#2f65f75165c4d9c632bb4fda13ed36b78321a43b"
+  integrity sha512-JNbkKpDFqbYjg+IU3FNo7qjX7Opy7CwjHywT32zgAcz/d4lX6Umn5jOHVETUdnNNgGrMk0nEx1gvP0F4M0hzlQ==
 
 jsdom@^11.5.1:
   version "11.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9591,11 +9591,6 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint-config-prettier@^1.14.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
-  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-
 tslint-microsoft-contrib@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,6 +2563,11 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
@@ -3086,6 +3091,14 @@ dmg-builder@5.3.1:
     parse-color "^1.0.0"
     sanitize-filename "^1.6.1"
 
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -3527,12 +3540,45 @@ eslint-config-prettier@^4.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-import-resolver-node@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  integrity sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^2.0.0"
+
 eslint-plugin-babel@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz#2e7f251ccc249326da760c1a4c948a91c32d0023"
   integrity sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==
   dependencies:
     eslint-rule-composer "^0.3.0"
+
+eslint-plugin-import@^2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz#00548b4434c18faebaba04b24ae6198f280de189"
+  integrity sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==
+  dependencies:
+    array-includes "^3.0.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.2"
+    eslint-module-utils "^2.4.0"
+    has "^1.0.3"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    read-pkg-up "^2.0.0"
+    resolve "^1.11.0"
 
 eslint-plugin-json@^1.4.0:
   version "1.4.0"
@@ -8338,7 +8384,7 @@ resolve@^1.1.6, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.10.1:
+resolve@^1.10.1, resolve@^1.11.0, resolve@^1.5.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==


### PR DESCRIPTION
## Overview

🌵🌵🌵 **builds upon #7806, please review that first** 🌵🌵🌵 

**Closes #7643**

## Description

This PR reduces our usage of TSLint rules, replacing a bunch of work with the equivalent ESLint integrations.

I started from [this roadmap for migrating TSLint rules](https://github.com/typescript-eslint/typescript-eslint/blob/c4df4ff72d1b6cdad2b968f08233efbc01372976/packages/eslint-plugin/ROADMAP.md) and annotated the `tslint.json` config to indicate where things now live (not everything has been ported).

Then I worked through porting some of the low-hanging fruit one-by-one, verifying the change didn't raise false positives. There's still a few rules left to go - most of which were being looked at in #6912 because they required manual porting. 

This was also a chance to look at two other popular plugins that could help us in the future:

 - `eslint-plugin-import` - I think this will be handy for #7627 
 - `eslint-plugin-jsdoc` - we use JSDoc a lot, and this has a lot of very opinionated rules for ensuring these are consistent

## Release notes

Notes: no-notes
