### PR TITLE
Shiftkey/cleanup/open dialog using ipc

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -1,6 +1,6 @@
 import '../lib/logging/main/install'
 
-import { app, Menu, ipcMain, BrowserWindow, shell } from 'electron'
+import { app, Menu, ipcMain, BrowserWindow, shell, dialog } from 'electron'
 import * as Fs from 'fs'
 
 import { MenuLabelsEvent } from '../models/menu-labels'
@@ -25,6 +25,7 @@ import { now } from './now'
 import { showUncaughtException } from './show-uncaught-exception'
 import { IMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
+import { OpenDialogPreferences } from '../models/electron'
 
 enableSourceMaps()
 
@@ -464,6 +465,25 @@ app.on('ready', () => {
 
       const result = shell.openExternal(path)
       event.sender.send('open-external-result', { result })
+    }
+  )
+
+  ipcMain.on(
+    'show-open-dialog',
+    (
+      event: Electron.IpcMessageEvent,
+      { properties }: { properties: Array<OpenDialogPreferences> }
+    ) => {
+      const browserWindow = BrowserWindow.fromWebContents(event.sender)
+
+      const directories: string[] | undefined = dialog.showOpenDialog(
+        browserWindow,
+        {
+          properties,
+        }
+      )
+
+      event.sender.send('show-open-dialog-result', { directories })
     }
   )
 

--- a/app/src/models/electron.ts
+++ b/app/src/models/electron.ts
@@ -1,0 +1,10 @@
+/** Mirrored from electron's type declarations */
+export type OpenDialogPreferences =
+  | 'openFile'
+  | 'openDirectory'
+  | 'multiSelections'
+  | 'showHiddenFiles'
+  | 'createDirectory'
+  | 'promptToCreate'
+  | 'noResolveAliases'
+  | 'treatPackageAsDirectory'

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -1,4 +1,3 @@
-import { remote } from 'electron'
 import * as React from 'react'
 
 import { Dispatcher } from '../dispatcher'
@@ -11,6 +10,7 @@ import { Row } from '../lib/row'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
+import { showOpenDialog } from '../lib/show-open-dialog'
 import { PopupType } from '../../models/popup'
 import * as Path from 'path'
 
@@ -174,10 +174,9 @@ export class AddExistingRepository extends React.Component<
   }
 
   private showFilePicker = async () => {
-    const directory: string[] | null = remote.dialog.showOpenDialog({
-      properties: ['createDirectory', 'openDirectory'],
-    })
-    if (!directory) {
+    const directory = await showOpenDialog(['openDirectory', 'createDirectory'])
+
+    if (directory === undefined) {
       return
     }
 

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -1,4 +1,3 @@
-import { remote } from 'electron'
 import * as React from 'react'
 import * as Path from 'path'
 import * as FSE from 'fs-extra'
@@ -30,6 +29,7 @@ import { LinkButton } from '../lib/link-button'
 import { PopupType } from '../../models/popup'
 import { Ref } from '../lib/ref'
 import { enableReadmeOverwriteWarning } from '../../lib/feature-flag'
+import { showOpenDialog } from '../lib/show-open-dialog'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -158,9 +158,7 @@ export class CreateRepository extends React.Component<
   }
 
   private showFilePicker = async () => {
-    const directory: string[] | null = remote.dialog.showOpenDialog({
-      properties: ['createDirectory', 'openDirectory'],
-    })
+    const directory = await showOpenDialog(['createDirectory', 'openDirectory'])
 
     if (!directory) {
       return

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -1,6 +1,5 @@
 import * as Path from 'path'
 import * as React from 'react'
-import { remote } from 'electron'
 import { readdir } from 'fs-extra'
 
 import { Button } from '../lib/button'
@@ -26,6 +25,7 @@ import { CallToAction } from '../lib/call-to-action'
 import { IAccountRepositories } from '../../lib/stores/api-repositories-store'
 import { merge } from '../../lib/merge'
 import { ClickSource } from '../lib/list'
+import { showOpenDialog } from '../lib/show-open-dialog'
 
 interface ICloneRepositoryProps {
   readonly dispatcher: Dispatcher
@@ -510,9 +510,10 @@ export class CloneRepository extends React.Component<
   }
 
   private onChooseDirectory = async () => {
-    const directories = remote.dialog.showOpenDialog({
-      properties: ['createDirectory', 'openDirectory'],
-    })
+    const directories = await showOpenDialog([
+      'createDirectory',
+      'openDirectory',
+    ])
 
     if (!directories) {
       return

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -84,6 +84,7 @@ import { MergeResult } from '../../models/merge'
 import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-strategy'
 import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 import { IStashEntry } from '../../models/stash-entry'
+import { showOpenDialog } from '../lib/show-open-dialog'
 
 /**
  * An error handler function.
@@ -1295,9 +1296,7 @@ export class Dispatcher {
    * Update the location of an existing repository and clear the missing flag.
    */
   public async relocateRepository(repository: Repository): Promise<void> {
-    const directories = remote.dialog.showOpenDialog({
-      properties: ['openDirectory'],
-    })
+    const directories = await showOpenDialog(['openDirectory'])
 
     if (directories && directories.length > 0) {
       const newPath = directories[0]

--- a/app/src/ui/lib/show-open-dialog.ts
+++ b/app/src/ui/lib/show-open-dialog.ts
@@ -1,0 +1,22 @@
+import { ipcRenderer } from 'electron'
+import { OpenDialogPreferences } from '../../models/electron'
+
+/**
+ * IPC-based wrapper for Electron's showOpenDialog, which ensures this follows
+ * the recommended patterns for showing the underlying dialog
+ */
+export function showOpenDialog(preferences: Array<OpenDialogPreferences>) {
+  return new Promise<ReadonlyArray<string> | undefined>((resolve, reject) => {
+    ipcRenderer.once(
+      'show-open-dialog-result',
+      (
+        event: Electron.IpcMessageEvent,
+        { directories }: { directories: string[] | undefined }
+      ) => {
+        resolve(directories)
+      }
+    )
+
+    ipcRenderer.send('show-open-dialog', { preferences })
+  })
+}


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #{issue number}**

## Description

-

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
