### PR TITLE
introduce OnDiskRepository type to support using worktrees in Git operations

### DIFF
--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -15,8 +15,14 @@ function getBaseName(path: string): string {
   return baseName
 }
 
+/** The minimal shape required for a repository to be used in Git operations */
+export type OnDiskRepository = {
+  /** The working directory of this repository */
+  readonly path: string
+}
+
 /** A local repository. */
-export class Repository {
+export class Repository implements OnDiskRepository {
   public readonly name: string
 
   /**

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -50,6 +50,12 @@ export class Repository implements OnDiskRepository {
   }
 }
 
+/** A minimal shape representing a worktree of a Git repository */
+export type WorkTree = OnDiskRepository & {
+  /** The commit associated with the HEAD of the repository */
+  readonly head: string
+}
+
 /**
  * A snapshot for the local state for a given repository
  */


### PR DESCRIPTION
## Overview

**Related to #7445**

## Description

As part of sketching out the Git APIs I'd need to address rebase conflict detection I realised that I'd need worktrees, but they don't satisfy the `Repository` type because:

  - they aren't stored in IndexedDB 
  - they aren't directly associated with a GitHub repository

Initially I went with building out APIs that worked against the worktree abstraction, but that felt suboptimal because I'd now need to support APIs that worked both against repositories and worktrees.

While refreshing myself about #7445 I realised that all our Git APIs only need the `path` to the repository, so that's where this `OnDiskRepository` type came from. Rather than refactor them all now, I'm going to:

 - introduce this PR with the new abstraction
 - build out the required Git APIs related to #7445 using this new abstraction
 - open a tech-debt task to track updating all our other Git APIs later to clean up our existing work

This also has the benefit of making much of our repository setup where we've hard-coded values  to satisfy the `Repository` type unnecessary:

https://github.com/desktop/desktop/blob/d08b4a8ca35c0972c694e207a28b3556105a9b3e/app/test/helpers/repositories.ts#L66-L71

## Release notes

Notes: no-notes
