### PR TITLE
new feature flag for protected branches UI work

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -87,9 +87,10 @@ export function enableStashing(): boolean {
 }
 
 /**
- * Should the app warn the user when they are committing that they are using a
- * protected branch?
+ * Should the application query for branch protection information and store this
+ * to help the maintainers understand how broadly branch protections are
+ * encountered?
  */
-export function enableBranchProtectionWarning(): boolean {
+export function enableBranchProtectionChecks(): boolean {
   return true
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -94,3 +94,15 @@ export function enableStashing(): boolean {
 export function enableBranchProtectionChecks(): boolean {
   return true
 }
+
+/**
+ * Should the application warn the user when they are about to commit to a
+ * protected branch, and encourage them into a flow to move their changes to
+ * a new branch?
+ *
+ * As this builds upon existing branch protection features in the codebase, this
+ * flag is linked to to `enableBranchProtectionChecks()`.
+ */
+export function enableBranchProtectionWarningFlow(): boolean {
+  return enableBranchProtectionChecks() && enableDevelopmentFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -215,7 +215,7 @@ import {
   enablePullWithRebase,
   enableGroupRepositoriesByOwner,
   enableStashing,
-  enableBranchProtectionWarning,
+  enableBranchProtectionChecks,
 } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import * as moment from 'moment'
@@ -2384,7 +2384,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           }
         }
 
-        if (enableBranchProtectionWarning()) {
+        if (enableBranchProtectionChecks()) {
           const branchProtectionsFound = await this.repositoriesStore.hasBranchProtectionsConfigured(
             repository.gitHubRepository
           )
@@ -3112,7 +3112,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    const branches = enableBranchProtectionWarning()
+    const branches = enableBranchProtectionChecks()
       ? await api.fetchProtectedBranches(owner, name)
       : new Array<IAPIBranch>()
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -10,7 +10,7 @@ import { Repository } from '../../models/repository'
 import { fatalError } from '../fatal-error'
 import { IAPIRepository, IAPIBranch } from '../api'
 import { BaseStore } from './base-store'
-import { enableBranchProtectionWarning } from '../feature-flag'
+import { enableBranchProtectionChecks } from '../feature-flag'
 
 /** The store for local repositories. */
 export class RepositoriesStore extends BaseStore {
@@ -415,7 +415,7 @@ export class RepositoriesStore extends BaseStore {
           gitHubRepositoryID: updatedGitHubRepo.dbID,
         })
 
-        if (enableBranchProtectionWarning()) {
+        if (enableBranchProtectionChecks()) {
           const repoId = updatedGitHubRepo.dbID!
 
           // This update flow is organized into two stages:


### PR DESCRIPTION
## Overview

**Related to #7023**

## Description

As part of 2.0 we shipped the first piece of branch protection around gathering metrics about whether users are encountering this in the wild, behind `enableBranchProtectionWarning`.

As I dive into more work in #7023 I feel this isn't the best name for it, so I've broken this out into two flags:

 - `enableBranchProtectionChecks` - covering the work the current app does to cache and check for branch protections when committing
 - `enableBranchProtectionWarningFlow` - covering the next bit of work around showing a warning to the user and hopefully helping them avoid this issue

## Release notes

Notes: no-notes
