### PR TITLE
first pass at UI for warning about protected branches

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -577,6 +577,9 @@ export interface IChangesState {
    * for more information about the differences between the two.
    */
   readonly selection: ChangesSelection
+
+  /** `true` if the GitHub API reports that the branch is protected */
+  readonly currentBranchProtected: boolean
 }
 
 /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -580,6 +580,12 @@ export interface IChangesState {
 
   /** `true` if the GitHub API reports that the branch is protected */
   readonly currentBranchProtected: boolean
+
+  /**
+   * A flag to indicate the user clicked the "switch branch" link when they
+   * saw the prompt about the current branch being protected.
+   */
+  readonly userWantsToMoveChangesFromProtectedBranch: boolean
 }
 
 /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -256,10 +256,20 @@ export type AppMenuFoldout = {
   openedWithAccessKey?: boolean
 }
 
+export type BranchFoldout = {
+  type: FoldoutType.Branch
+
+  /**
+   * A flag to indicate the user clicked the "switch branch" link when they
+   * saw the prompt about the current branch being protected.
+   */
+  handleProtectedBranchWarning?: boolean
+}
+
 export type Foldout =
   | { type: FoldoutType.Repository }
-  | { type: FoldoutType.Branch }
   | { type: FoldoutType.AddMenu }
+  | BranchFoldout
   | AppMenuFoldout
 
 export enum RepositorySectionTab {
@@ -580,12 +590,6 @@ export interface IChangesState {
 
   /** `true` if the GitHub API reports that the branch is protected */
   readonly currentBranchProtected: boolean
-
-  /**
-   * A flag to indicate the user clicked the "switch branch" link when they
-   * saw the prompt about the current branch being protected.
-   */
-  readonly userWantsToMoveChangesFromProtectedBranch: boolean
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2839,8 +2839,34 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    if (
+      this.selectedRepository !== null &&
+      this.selectedRepository instanceof Repository
+    ) {
+      log.warn(
+        `[AppStore._closeFoldout] clearing flag for userWantsToMoveChangesFromProtectedBranch`
+      )
+      this.repositoryStateCache.updateChangesState(
+        this.selectedRepository,
+        () => ({
+          userWantsToMoveChangesFromProtectedBranch: false,
+        })
+      )
+    }
+
     this.currentFoldout = null
     this.emitUpdate()
+  }
+
+  public _moveChangesToAnotherBranch(repository: Repository) {
+    log.warn(
+      `[AppStore._moveChangesToAnotherBranch] setting flag for userWantsToMoveChangesFromProtectedBranch`
+    )
+    this.repositoryStateCache.updateChangesState(repository, () => ({
+      userWantsToMoveChangesFromProtectedBranch: true,
+    }))
+
+    return this._showFoldout({ type: FoldoutType.Branch })
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3220,6 +3220,37 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
   }
 
+  private async updateBranchProtections(repository: Repository) {
+    if (
+      repository.gitHubRepository === null ||
+      repository.gitHubRepository.dbID === null
+    ) {
+      return
+    }
+
+    const { owner, name } = repository.gitHubRepository
+
+    const account = getAccountForEndpoint(
+      this.accounts,
+      repository.gitHubRepository.endpoint
+    )
+
+    if (account === null) {
+      return
+    }
+
+    const api = API.fromAccount(account)
+
+    const branches = enableBranchProtectionChecks()
+      ? await api.fetchProtectedBranches(owner.login, name)
+      : new Array<IAPIBranch>()
+
+    return this.repositoriesStore.updateBranchProtections(
+      repository.gitHubRepository,
+      branches
+    )
+  }
+
   private async matchGitHubRepository(
     repository: Repository
   ): Promise<IMatchedGitHubRepository | null> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2929,7 +2929,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    const repo = await this._checkoutBranch(repository, branch)
+    const repo = await this._checkoutBranch(
+      repository,
+      branch,
+      uncommittedChangesStrategy
+    )
     this._closePopup()
     return repo
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3447,13 +3447,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
               value: refreshStartProgress,
             })
 
-            await this._refreshRepository(repository)
-
             // manually refresh branch protections after the push, to ensure
             // any new branch will immediately report as protected
-
             await this.updateBranchProtectionsFromAPI(repository)
-            await this.refreshBranchProtectionState(repository)
+
+            await this._refreshRepository(repository)
 
             this.updatePushPullFetchProgress(repository, {
               kind: 'generic',
@@ -3644,6 +3642,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
           if (mergeBase) {
             await gitStore.reconcileHistory(mergeBase)
           }
+
+          // manually refresh branch protections after the push, to ensure
+          // any new branch will immediately report as protected
+          await this.updateBranchProtectionsFromAPI(repository)
 
           await this._refreshRepository(repository)
 
@@ -3942,6 +3944,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
           title: refreshTitle,
           value: fetchWeight,
         })
+
+        // manually refresh branch protections after the push, to ensure
+        // any new branch will immediately report as protected
+        await this.updateBranchProtectionsFromAPI(repository)
 
         await this._refreshRepository(repository)
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3209,17 +3209,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    const branches = enableBranchProtectionChecks()
-      ? await api.fetchProtectedBranches(owner, name)
-      : new Array<IAPIBranch>()
-
     const endpoint = matchedGitHubRepository.endpoint
-    return this.repositoriesStore.updateGitHubRepository(
+    const updatedRepository = this.repositoriesStore.updateGitHubRepository(
       repository,
       endpoint,
-      apiRepo,
-      branches
+      apiRepo
     )
+
+    await this.updateBranchProtections(repository)
+
+    return updatedRepository
   }
 
   private async updateBranchProtections(repository: Repository) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -713,8 +713,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       lastFetched: gitStore.lastFetched,
     }))
 
-    await this.refreshBranchProtectionState(repository)
-
     // _selectWorkingDirectoryFiles and _selectStashedFile will
     // emit updates by themselves.
     if (selectWorkingDirectory) {
@@ -2599,6 +2597,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       gitStore.updateLastFetched(),
       gitStore.loadStashEntries(),
       this.refreshAuthor(repository),
+      this.refreshBranchProtectionState(repository),
       refreshSectionPromise,
     ])
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -731,6 +731,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    await this.updateBranchProtections(repository)
+
     const gitStore = this.gitStoreCache.get(repository)
 
     if (

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2869,7 +2869,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { changesState, branchesState } = this.repositoryStateCache.get(
       repository
     )
-
     const { tip } = branchesState
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
     const hasChanges = changesState.workingDirectory.files.length > 0
@@ -3149,7 +3148,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const endpoint = matchedGitHubRepository.endpoint
-    const updatedRepository = this.repositoriesStore.updateGitHubRepository(
+    const updatedRepository = await this.repositoriesStore.updateGitHubRepository(
       repository,
       endpoint,
       apiRepo

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -624,7 +624,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  private async onGitStoreUpdated(repository: Repository, gitStore: GitStore) {
+  private onGitStoreUpdated(repository: Repository, gitStore: GitStore) {
     const prevRepositoryState = this.repositoryStateCache.get(repository)
 
     this.repositoryStateCache.updateBranchesState(repository, state => {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2816,27 +2816,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (popupType !== undefined && popupType === PopupType.CreateBranch) {
-      this.clearProtectedBranchFlag()
-    }
-
     this.currentPopup = null
     this.emitUpdate()
-  }
-
-  private clearProtectedBranchFlag() {
-    if (
-      this.selectedRepository !== null &&
-      this.selectedRepository instanceof Repository
-    ) {
-      this.clearProtectedBranchFlagForRepository(this.selectedRepository)
-    }
-  }
-
-  private clearProtectedBranchFlagForRepository(repository: Repository) {
-    this.repositoryStateCache.updateChangesState(repository, () => ({
-      userWantsToMoveChangesFromProtectedBranch: false,
-    }))
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -2856,10 +2837,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _closeFoldout(
-    foldout: FoldoutType,
-    preserveProtectedBranchFlag: boolean = false
-  ): Promise<void> {
+  public async _closeFoldout(foldout: FoldoutType): Promise<void> {
     if (this.currentFoldout == null) {
       return
     }
@@ -2868,20 +2846,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (!preserveProtectedBranchFlag) {
-      this.clearProtectedBranchFlag()
-    }
-
     this.currentFoldout = null
     this.emitUpdate()
-  }
-
-  public _moveChangesToAnotherBranch(repository: Repository) {
-    this.repositoryStateCache.updateChangesState(repository, () => ({
-      userWantsToMoveChangesFromProtectedBranch: true,
-    }))
-
-    return this._showFoldout({ type: FoldoutType.Branch })
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -2903,18 +2869,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { changesState, branchesState } = this.repositoryStateCache.get(
       repository
     )
-
-    if (changesState.userWantsToMoveChangesFromProtectedBranch) {
-      // if we find this flag set as a result of the Protected Branch flow
-      // we should bypass any sort of "Switch Branch" flow to get out of the
-      // user's way
-      uncommittedChangesStrategy = {
-        kind: UncommittedChangesStrategyKind.MoveToNewBranch,
-        transientStashEntry: null,
-      }
-
-      this.clearProtectedBranchFlagForRepository(repository)
-    }
 
     const { tip } = branchesState
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
@@ -2988,18 +2942,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { changesState, branchesState } = this.repositoryStateCache.get(
       repository
     )
-
-    if (changesState.userWantsToMoveChangesFromProtectedBranch) {
-      // if we find this flag set as a result of the Protected Branch flow
-      // we should bypass any sort of "Switch Branch" flow to get out of the
-      // user's way
-      uncommittedChangesStrategy = {
-        kind: UncommittedChangesStrategyKind.MoveToNewBranch,
-        transientStashEntry: null,
-      }
-
-      this.clearProtectedBranchFlagForRepository(repository)
-    }
 
     let stashToPop: IStashEntry | null = null
     if (enableStashing()) {

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -388,8 +388,7 @@ export class RepositoriesStore extends BaseStore {
   public async updateGitHubRepository(
     repository: Repository,
     endpoint: string,
-    gitHubRepository: IAPIRepository,
-    branches: ReadonlyArray<IAPIBranch>
+    gitHubRepository: IAPIRepository
   ): Promise<Repository> {
     const repoID = repository.id
     if (!repoID) {
@@ -402,7 +401,6 @@ export class RepositoriesStore extends BaseStore {
       'rw',
       this.db.repositories,
       this.db.gitHubRepositories,
-      this.db.protectedBranches,
       this.db.owners,
       async () => {
         const localRepo = (await this.db.repositories.get(repoID))!
@@ -414,50 +412,6 @@ export class RepositoriesStore extends BaseStore {
         await this.db.repositories.update(localRepo.id!, {
           gitHubRepositoryID: updatedGitHubRepo.dbID,
         })
-
-        if (enableBranchProtectionChecks()) {
-          const repoId = updatedGitHubRepo.dbID!
-
-          // This update flow is organized into two stages:
-          //
-          // - update the in-memory cache
-          // - update the underyling database state
-          //
-          // This should ensure any stale values are not being used, and avoids
-          // the need to query the database while the results are in memory.
-
-          const prefix = getKeyPrefix(repoId)
-
-          for (const key of this.protectionEnabledForBranchCache.keys()) {
-            // invalidate any cached entries belonging to this repository
-            if (key.startsWith(prefix)) {
-              this.protectionEnabledForBranchCache.delete(key)
-            }
-          }
-
-          const branchRecords = branches.map<IDatabaseProtectedBranch>(b => ({
-            repoId,
-            name: b.name,
-          }))
-
-          // update cached values to avoid database lookup
-          for (const item of branchRecords) {
-            const key = getKey(repoId, item.name)
-            this.protectionEnabledForBranchCache.set(key, true)
-          }
-
-          await this.db.protectedBranches
-            .where('repoId')
-            .equals(repoId)
-            .delete()
-
-          const protectionsFound = branchRecords.length > 0
-          this.branchProtectionSettingsFoundCache.set(repoId, protectionsFound)
-
-          if (branchRecords.length > 0) {
-            await this.db.protectedBranches.bulkAdd(branchRecords)
-          }
-        }
 
         return updatedGitHubRepo
       }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -427,7 +427,7 @@ export class RepositoriesStore extends BaseStore {
     )
   }
 
-  /** Add or update the repository's GitHub repository. */
+  /** Add or update the branch protections associated with a GitHub repository. */
   public async updateBranchProtections(
     gitHubRepository: GitHubRepository,
     protectedBranches: ReadonlyArray<IAPIBranch>

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -134,6 +134,7 @@ function getInitialRepositoryState(): IRepositoryState {
       showCoAuthoredBy: false,
       conflictState: null,
       stashEntry: null,
+      currentBranchProtected: false,
     },
     selectedSection: RepositorySectionTab.Changes,
     branchesState: {

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -135,6 +135,7 @@ function getInitialRepositoryState(): IRepositoryState {
       conflictState: null,
       stashEntry: null,
       currentBranchProtected: false,
+      userWantsToMoveChangesFromProtectedBranch: false,
     },
     selectedSection: RepositorySectionTab.Changes,
     branchesState: {

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -135,7 +135,6 @@ function getInitialRepositoryState(): IRepositoryState {
       conflictState: null,
       stashEntry: null,
       currentBranchProtected: false,
-      userWantsToMoveChangesFromProtectedBranch: false,
     },
     selectedSection: RepositorySectionTab.Changes,
     branchesState: {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -82,6 +82,12 @@ export type Popup =
   | {
       type: PopupType.CreateBranch
       repository: Repository
+
+      /**
+       * A flag to indicate the user clicked the "switch branch" link when they
+       * saw the prompt about the current branch being protected.
+       */
+      handleProtectedBranchWarning?: boolean
       initialName?: string
     }
   | { type: PopupType.SignIn }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -88,6 +88,7 @@ export type Popup =
        * saw the prompt about the current branch being protected.
        */
       handleProtectedBranchWarning?: boolean
+
       initialName?: string
     }
   | { type: PopupType.SignIn }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1363,6 +1363,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={this.onPopupDismissed}
             dispatcher={this.props.dispatcher}
             initialName={popup.initialName || ''}
+            handleProtectedBranchWarning={
+              popup.handleProtectedBranchWarning || false
+            }
           />
         )
       }
@@ -2152,8 +2155,15 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     const currentFoldout = this.state.currentFoldout
-    const isOpen =
-      !!currentFoldout && currentFoldout.type === FoldoutType.Branch
+
+    let isOpen = false
+    let handleProtectedBranchWarning = false
+
+    if (currentFoldout !== null && currentFoldout.type === FoldoutType.Branch) {
+      isOpen = true
+      handleProtectedBranchWarning =
+        currentFoldout.handleProtectedBranchWarning || false
+    }
 
     const repository = selection.repository
     const branchesState = selection.state.branchesState
@@ -2169,6 +2179,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         pullRequests={branchesState.openPullRequests}
         currentPullRequest={branchesState.currentPullRequest}
         isLoadingPullRequests={branchesState.isLoadingPullRequests}
+        handleProtectedBranchWarning={handleProtectedBranchWarning}
       />
     )
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1363,9 +1363,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={this.onPopupDismissed}
             dispatcher={this.props.dispatcher}
             initialName={popup.initialName || ''}
-            handleProtectedBranchWarning={
-              popup.handleProtectedBranchWarning || false
-            }
+            handleProtectedBranchWarning={popup.handleProtectedBranchWarning}
           />
         )
       }
@@ -2157,12 +2155,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     const currentFoldout = this.state.currentFoldout
 
     let isOpen = false
-    let handleProtectedBranchWarning = false
+    let handleProtectedBranchWarning: boolean | undefined
 
     if (currentFoldout !== null && currentFoldout.type === FoldoutType.Branch) {
       isOpen = true
-      handleProtectedBranchWarning =
-        currentFoldout.handleProtectedBranchWarning || false
+      handleProtectedBranchWarning = currentFoldout.handleProtectedBranchWarning
     }
 
     const repository = selection.repository

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -232,7 +232,7 @@ export class BranchesContainer extends React.Component<
   }
 
   private onBranchItemClick = (branch: Branch) => {
-    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch, true)
 
     const currentBranch = this.props.currentBranch
 
@@ -257,7 +257,7 @@ export class BranchesContainer extends React.Component<
   }
 
   private onCreateBranchWithName = (name: string) => {
-    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch, true)
     this.props.dispatcher.showPopup({
       type: PopupType.CreateBranch,
       repository: this.props.repository,

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -43,7 +43,8 @@ interface IBranchesContainerProps {
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 
-  readonly handleProtectedBranchWarning: boolean
+  /** Was this component launched from the "Protected Branch" warning message? */
+  readonly handleProtectedBranchWarning?: boolean
 }
 
 interface IBranchesContainerState {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -25,6 +25,7 @@ import { startTimer } from '../lib/timing'
 import {
   UncommittedChangesStrategyKind,
   UncommittedChangesStrategy,
+  askToStash,
 } from '../../models/uncommitted-changes-strategy'
 
 interface IBranchesContainerProps {
@@ -241,26 +242,26 @@ export class BranchesContainer extends React.Component<
   private onBranchItemClick = (branch: Branch) => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
 
-    const currentBranch = this.props.currentBranch
+    const {
+      currentBranch,
+      repository,
+      handleProtectedBranchWarning,
+    } = this.props
 
     if (currentBranch == null || currentBranch.name !== branch.name) {
-      const timer = startTimer(
-        'checkout branch from list',
-        this.props.repository
-      )
+      const timer = startTimer('checkout branch from list', repository)
 
       // if the user arrived at this dialog from the Protected Branch flow
       // we should bypass the "Switch Branch" flow and get out of the user's way
-      const strategy: UncommittedChangesStrategy = this.props
-        .handleProtectedBranchWarning
+      const strategy: UncommittedChangesStrategy = handleProtectedBranchWarning
         ? {
             kind: UncommittedChangesStrategyKind.MoveToNewBranch,
             transientStashEntry: null,
           }
-        : { kind: UncommittedChangesStrategyKind.AskForConfirmation }
+        : askToStash
 
       this.props.dispatcher
-        .checkoutBranch(this.props.repository, branch, strategy)
+        .checkoutBranch(repository, branch, strategy)
         .then(() => timer.done())
     }
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -38,7 +38,6 @@ import { enablePullWithRebase, enableStashing } from '../../lib/feature-flag'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { IStashEntry } from '../../models/stash-entry'
 import * as classNames from 'classnames'
-import { ProtectedBranchWarning } from './protected-branch-warning'
 
 const RowHeight = 29
 const StashIcon = new OcticonSymbol(
@@ -582,10 +581,6 @@ export class ChangesList extends React.Component<
       )
     }
 
-    if (currentBranchProtected && this.props.branch !== null) {
-      return <ProtectedBranchWarning currentBranch={this.props.branch} />
-    }
-
     const fileCount = workingDirectory.files.length
 
     const includeAllValue = getIncludeAllValue(
@@ -622,6 +617,7 @@ export class ChangesList extends React.Component<
         )}
         singleFileCommit={singleFileCommit}
         key={repository.id}
+        currentBranchProtected={currentBranchProtected}
       />
     )
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -38,6 +38,7 @@ import { enablePullWithRebase, enableStashing } from '../../lib/feature-flag'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { IStashEntry } from '../../models/stash-entry'
 import * as classNames from 'classnames'
+import { ProtectedBranchWarning } from './protected-branch-warning'
 
 const RowHeight = 29
 const StashIcon = new OcticonSymbol(
@@ -125,6 +126,7 @@ interface IChangesListProps {
   readonly dispatcher: Dispatcher
   readonly availableWidth: number
   readonly isCommitting: boolean
+  readonly currentBranchProtected: boolean
 
   /**
    * Click event handler passed directly to the onRowClick prop of List, see
@@ -560,6 +562,7 @@ export class ChangesList extends React.Component<
       repository,
       dispatcher,
       isCommitting,
+      currentBranchProtected,
     } = this.props
 
     if (rebaseConflictState !== null && enablePullWithRebase()) {
@@ -577,6 +580,10 @@ export class ChangesList extends React.Component<
           hasUntrackedChanges={hasUntrackedChanges}
         />
       )
+    }
+
+    if (currentBranchProtected && this.props.branch !== null) {
+      return <ProtectedBranchWarning currentBranch={this.props.branch} />
     }
 
     const fileCount = workingDirectory.files.length

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -24,6 +24,7 @@ import { IMenuItem } from '../../lib/menu-item'
 import { ICommitContext } from '../../models/commit'
 import { startTimer } from '../lib/timing'
 import { ProtectedBranchWarning } from './protected-branch-warning'
+import { enableBranchProtectionWarningFlow } from '../../lib/feature-flag'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -442,6 +443,10 @@ export class CommitMessage extends React.Component<
   }
 
   private renderProtectedBranchWarning = (branch: string) => {
+    if (!enableBranchProtectionWarningFlow()) {
+      return null
+    }
+
     const { currentBranchProtected } = this.props
 
     if (!currentBranchProtected) {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -447,13 +447,15 @@ export class CommitMessage extends React.Component<
       return null
     }
 
-    const { currentBranchProtected } = this.props
+    const { currentBranchProtected, dispatcher } = this.props
 
     if (!currentBranchProtected) {
       return null
     }
 
-    return <ProtectedBranchWarning currentBranch={branch} />
+    return (
+      <ProtectedBranchWarning currentBranch={branch} dispatcher={dispatcher} />
+    )
   }
 
   public render() {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -23,6 +23,7 @@ import { IAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
 import { ICommitContext } from '../../models/commit'
 import { startTimer } from '../lib/timing'
+import { ProtectedBranchWarning } from './protected-branch-warning'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -47,6 +48,7 @@ interface ICommitMessageProps {
   readonly isCommitting: boolean
   readonly placeholder: string
   readonly singleFileCommit: boolean
+  readonly currentBranchProtected: boolean
 
   /**
    * Whether or not to show a field for adding co-authors to
@@ -439,6 +441,16 @@ export class CommitMessage extends React.Component<
     return <div className={className}>{this.renderCoAuthorToggleButton()}</div>
   }
 
+  private renderProtectedBranchWarning = (branch: string) => {
+    const { currentBranchProtected } = this.props
+
+    if (!currentBranchProtected) {
+      return null
+    }
+
+    return <ProtectedBranchWarning currentBranch={branch} />
+  }
+
   public render() {
     const branchName = this.props.branch ? this.props.branch : 'master'
 
@@ -500,6 +512,8 @@ export class CommitMessage extends React.Component<
         </FocusContainer>
 
         {this.renderCoAuthorInput()}
+
+        {this.renderProtectedBranchWarning(branchName)}
 
         <Button
           type="submit"

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -447,14 +447,18 @@ export class CommitMessage extends React.Component<
       return null
     }
 
-    const { currentBranchProtected, dispatcher } = this.props
+    const { currentBranchProtected, dispatcher, repository } = this.props
 
     if (!currentBranchProtected) {
       return null
     }
 
     return (
-      <ProtectedBranchWarning currentBranch={branch} dispatcher={dispatcher} />
+      <ProtectedBranchWarning
+        currentBranch={branch}
+        dispatcher={dispatcher}
+        repository={repository}
+      />
     )
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -447,18 +447,14 @@ export class CommitMessage extends React.Component<
       return null
     }
 
-    const { currentBranchProtected, dispatcher, repository } = this.props
+    const { currentBranchProtected, dispatcher } = this.props
 
     if (!currentBranchProtected) {
       return null
     }
 
     return (
-      <ProtectedBranchWarning
-        currentBranch={branch}
-        dispatcher={dispatcher}
-        repository={repository}
-      />
+      <ProtectedBranchWarning currentBranch={branch} dispatcher={dispatcher} />
     )
   }
 

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { Button } from '../lib/button'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
 
@@ -30,12 +29,6 @@ export class ProtectedBranchWarning extends React.Component<
           <LinkButton onClick={this.onSwitchBranch}>switch branches</LinkButton>
           ?
         </div>
-
-        <Button type="submit" className="commit-button">
-          <span>
-            Commit to <strong>{this.props.currentBranch}</strong> anyway...
-          </span>
-        </Button>
       </div>
     )
   }

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -17,9 +17,18 @@ export class ProtectedBranchWarning extends React.Component<
     this.props.dispatcher.moveChangesToAnotherBranch(this.props.repository)
   }
 
+  private ignoreContextMenu = (event: React.MouseEvent<any>) => {
+    // this prevents the context menu for the root element of CommitMessage from
+    // firing - it shows 'Add Co-Authors' or 'Remove Co-Authors' based on the
+    // form state, and for now I'm going to leave that behaviour as-is
+
+    // feel free to remove this if that behaviouris revisited
+    event.preventDefault()
+  }
+
   public render() {
     return (
-      <div id="protected-branch">
+      <div id="protected-branch" onContextMenu={this.ignoreContextMenu}>
         <div className="protected-branch-icon-container">
           <Octicon
             className="protected-branch-icon"

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
 import { Dispatcher } from '../dispatcher'
-import { FoldoutType } from '../../lib/app-state'
+import { Repository } from '../../models/repository'
 
 interface IProtectedBranchWarningProps {
   readonly dispatcher: Dispatcher
+  readonly repository: Repository
   readonly currentBranch: string
 }
 
@@ -13,7 +14,7 @@ export class ProtectedBranchWarning extends React.Component<
   IProtectedBranchWarningProps
 > {
   private onSwitchBranch = () => {
-    this.props.dispatcher.showFoldout({ type: FoldoutType.Branch })
+    this.props.dispatcher.moveChangesToAnotherBranch(this.props.repository)
   }
 
   public render() {

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Button } from '../lib/button'
 import { Octicon, OcticonSymbol } from '../octicons'
+import { LinkButton } from '../lib/link-button'
 
 interface IProtectedBranchWarningProps {
   readonly currentBranch: string
@@ -9,6 +10,10 @@ interface IProtectedBranchWarningProps {
 export class ProtectedBranchWarning extends React.Component<
   IProtectedBranchWarningProps
 > {
+  private onSwitchBranch = () => {
+    // TODO: wire up event handler to fire and move to a new branch
+  }
+
   public render() {
     return (
       <div id="protected-branch">
@@ -20,12 +25,16 @@ export class ProtectedBranchWarning extends React.Component<
         </div>
 
         <div className="warning-message">
-          You can't commit to <strong>{this.props.currentBranch}</strong>{' '}
-          because it's a protected branch.
+          <strong>{this.props.currentBranch}</strong> is a protected branch.
+          Want to{' '}
+          <LinkButton onClick={this.onSwitchBranch}>switch branches</LinkButton>
+          ?
         </div>
 
-        <Button type="submit" className="commit-button" disabled={true}>
-          <span>Switch branch...</span>
+        <Button type="submit" className="commit-button">
+          <span>
+            Commit to <strong>{this.props.currentBranch}</strong> anyway...
+          </span>
         </Button>
       </div>
     )

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { Button } from '../lib/button'
+import { Octicon, OcticonSymbol } from '../octicons'
+
+interface IProtectedBranchWarningProps {
+  readonly currentBranch: string
+}
+
+export class ProtectedBranchWarning extends React.Component<
+  IProtectedBranchWarningProps
+> {
+  public render() {
+    return (
+      <div id="protected-branch">
+        <div className="protected-branch-icon-container">
+          <Octicon
+            className="protected-branch-icon"
+            symbol={OcticonSymbol.alert}
+          />
+        </div>
+
+        <div className="warning-message">
+          You can't commit to <strong>{this.props.currentBranch}</strong>{' '}
+          because it's a protected branch.
+        </div>
+
+        <Button type="submit" className="commit-button" disabled={true}>
+          <span>Switch branch...</span>
+        </Button>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
+import { Dispatcher } from '../dispatcher'
+import { FoldoutType } from '../../lib/app-state'
 
 interface IProtectedBranchWarningProps {
+  readonly dispatcher: Dispatcher
   readonly currentBranch: string
 }
 
@@ -10,7 +13,7 @@ export class ProtectedBranchWarning extends React.Component<
   IProtectedBranchWarningProps
 > {
   private onSwitchBranch = () => {
-    // TODO: wire up event handler to fire and move to a new branch
+    this.props.dispatcher.showFoldout({ type: FoldoutType.Branch })
   }
 
   public render() {

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -2,11 +2,10 @@ import * as React from 'react'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { LinkButton } from '../lib/link-button'
 import { Dispatcher } from '../dispatcher'
-import { Repository } from '../../models/repository'
+import { FoldoutType } from '../../lib/app-state'
 
 interface IProtectedBranchWarningProps {
   readonly dispatcher: Dispatcher
-  readonly repository: Repository
   readonly currentBranch: string
 }
 
@@ -14,7 +13,10 @@ export class ProtectedBranchWarning extends React.Component<
   IProtectedBranchWarningProps
 > {
   private onSwitchBranch = () => {
-    this.props.dispatcher.moveChangesToAnotherBranch(this.props.repository)
+    this.props.dispatcher.showFoldout({
+      type: FoldoutType.Branch,
+      handleProtectedBranchWarning: true,
+    })
   }
 
   private ignoreContextMenu = (event: React.MouseEvent<any>) => {

--- a/app/src/ui/changes/protected-branch-warning.tsx
+++ b/app/src/ui/changes/protected-branch-warning.tsx
@@ -22,7 +22,7 @@ export class ProtectedBranchWarning extends React.Component<
     // firing - it shows 'Add Co-Authors' or 'Remove Co-Authors' based on the
     // form state, and for now I'm going to leave that behaviour as-is
 
-    // feel free to remove this if that behaviouris revisited
+    // feel free to remove this if that behaviour is revisited
     event.preventDefault()
   }
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -354,6 +354,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       coAuthors,
       conflictState,
       selection,
+      currentBranchProtected,
     } = this.props.changes
 
     // TODO: I think user will expect the avatar to match that which
@@ -416,7 +417,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           changesListScrollTop={this.props.changesListScrollTop}
           stashEntry={this.props.changes.stashEntry}
           isShowingStashEntry={isShowingStashEntry}
-          currentBranchProtected={true}
+          currentBranchProtected={currentBranchProtected}
         />
         {this.renderUndoCommit(rebaseConflictState)}
       </div>

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -416,6 +416,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           changesListScrollTop={this.props.changesListScrollTop}
           stashEntry={this.props.changes.stashEntry}
           isShowingStashEntry={isShowingStashEntry}
+          currentBranchProtected={true}
         />
         {this.renderUndoCommit(rebaseConflictState)}
       </div>

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -294,6 +294,9 @@ export class CreateBranch extends React.Component<
     if (name.length > 0) {
       this.setState({ isCreatingBranch: true })
       const timer = startTimer('create branch', this.props.repository)
+
+      // TODO: if the branch chosen here is protected
+
       await this.props.dispatcher.createBranch(
         this.props.repository,
         name,

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -294,9 +294,6 @@ export class CreateBranch extends React.Component<
     if (name.length > 0) {
       this.setState({ isCreatingBranch: true })
       const timer = startTimer('create branch', this.props.repository)
-
-      // TODO: if the branch chosen here is protected
-
       await this.props.dispatcher.createBranch(
         this.props.repository,
         name,

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -286,24 +286,29 @@ export class CreateBranch extends React.Component<
 
     let startPoint: string | null = null
 
+    const {
+      defaultBranch,
+      handleProtectedBranchWarning,
+      repository,
+    } = this.props
+
     if (this.state.startPoint === StartPoint.DefaultBranch) {
       // This really shouldn't happen, we take all kinds of precautions
       // to make sure the startPoint state is valid given the current props.
-      if (!this.props.defaultBranch) {
+      if (!defaultBranch) {
         this.setState({
           currentError: new Error('Could not determine the default branch'),
         })
         return
       }
 
-      startPoint = this.props.defaultBranch.name
+      startPoint = defaultBranch.name
     }
 
     if (name.length > 0) {
       // if the user arrived at this dialog from the Protected Branch flow
       // we should bypass the "Switch Branch" flow and get out of the user's way
-      const strategy: UncommittedChangesStrategy = this.props
-        .handleProtectedBranchWarning
+      const strategy: UncommittedChangesStrategy = handleProtectedBranchWarning
         ? {
             kind: UncommittedChangesStrategyKind.MoveToNewBranch,
             transientStashEntry: null,
@@ -311,9 +316,9 @@ export class CreateBranch extends React.Component<
         : askToStash
 
       this.setState({ isCreatingBranch: true })
-      const timer = startTimer('create branch', this.props.repository)
+      const timer = startTimer('create branch', repository)
       await this.props.dispatcher.createBranch(
-        this.props.repository,
+        repository,
         name,
         startPoint,
         strategy

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -39,7 +39,9 @@ interface ICreateBranchProps {
   readonly defaultBranch: Branch | null
   readonly allBranches: ReadonlyArray<Branch>
   readonly initialName: string
-  readonly handleProtectedBranchWarning: boolean
+
+  /** Was this component launched from the "Protected Branch" warning message? */
+  readonly handleProtectedBranchWarning?: boolean
 }
 
 interface ICreateBranchState {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -313,9 +313,17 @@ export class Dispatcher {
     return this.appStore._closeCurrentFoldout()
   }
 
-  /** Close the specified foldout. */
-  public closeFoldout(foldout: FoldoutType): Promise<void> {
-    return this.appStore._closeFoldout(foldout)
+  /**
+   * Close the specified foldout
+   *
+   * @param foldout the type of foldout to close
+   * @param preserveProtectedBranchFlag ensure the "Protected Branch" flow is not cleared (if set)
+   */
+  public closeFoldout(
+    foldout: FoldoutType,
+    preserveProtectedBranchFlag: boolean = false
+  ): Promise<void> {
+    return this.appStore._closeFoldout(foldout, preserveProtectedBranchFlag)
   }
 
   /** Initialize and start the rebase operation */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -402,6 +402,16 @@ export class Dispatcher {
   }
 
   /**
+   * Start the flow to move the changes to another branch
+   *
+   * This just launches the branch foldout to keep things simple, but we need to
+   * track some internal state here as well to use in future steps.
+   */
+  public moveChangesToAnotherBranch(repository: Repository) {
+    return this.appStore._moveChangesToAnotherBranch(repository)
+  }
+
+  /**
    * Create a new branch from the given starting point and check it out.
    *
    * If the startPoint argument is omitted the new branch will be created based

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -319,11 +319,8 @@ export class Dispatcher {
    * @param foldout the type of foldout to close
    * @param preserveProtectedBranchFlag ensure the "Protected Branch" flow is not cleared (if set)
    */
-  public closeFoldout(
-    foldout: FoldoutType,
-    preserveProtectedBranchFlag: boolean = false
-  ): Promise<void> {
-    return this.appStore._closeFoldout(foldout, preserveProtectedBranchFlag)
+  public closeFoldout(foldout: FoldoutType): Promise<void> {
+    return this.appStore._closeFoldout(foldout)
   }
 
   /** Initialize and start the rebase operation */
@@ -407,16 +404,6 @@ export class Dispatcher {
       type: PopupType.RebaseFlow,
       repository,
     })
-  }
-
-  /**
-   * Start the flow to move the changes to another branch
-   *
-   * This just launches the branch foldout to keep things simple, but we need to
-   * track some internal state here as well to use in future steps.
-   */
-  public moveChangesToAnotherBranch(repository: Repository) {
-    return this.appStore._moveChangesToAnotherBranch(repository)
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -313,12 +313,7 @@ export class Dispatcher {
     return this.appStore._closeCurrentFoldout()
   }
 
-  /**
-   * Close the specified foldout
-   *
-   * @param foldout the type of foldout to close
-   * @param preserveProtectedBranchFlag ensure the "Protected Branch" flow is not cleared (if set)
-   */
+  /** Close the specified foldout */
   public closeFoldout(foldout: FoldoutType): Promise<void> {
     return this.appStore._closeFoldout(foldout)
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -43,7 +43,7 @@ interface IBranchDropdownProps {
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 
-  readonly handleProtectedBranchWarning: boolean
+  readonly handleProtectedBranchWarning?: boolean
 }
 
 /**

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -43,6 +43,7 @@ interface IBranchDropdownProps {
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 
+  /** Was this component launched from the "Protected Branch" warning message? */
   readonly handleProtectedBranchWarning?: boolean
 }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -42,6 +42,8 @@ interface IBranchDropdownProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
+
+  readonly handleProtectedBranchWarning: boolean
 }
 
 /**
@@ -67,6 +69,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         pullRequests={this.props.pullRequests}
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
+        handleProtectedBranchWarning={this.props.handleProtectedBranchWarning}
       />
     )
   }

--- a/app/styles/ui/_changes.scss
+++ b/app/styles/ui/_changes.scss
@@ -7,3 +7,4 @@
 @import 'changes/no-changes';
 @import 'changes/oversized-files-warning';
 @import 'changes/blankslate-action';
+@import 'changes/protected-branch';

--- a/app/styles/ui/changes/_protected-branch.scss
+++ b/app/styles/ui/changes/_protected-branch.scss
@@ -18,6 +18,7 @@
 
     strong {
       color: var(--text-color);
+      word-wrap: break-word;
     }
   }
 

--- a/app/styles/ui/changes/_protected-branch.scss
+++ b/app/styles/ui/changes/_protected-branch.scss
@@ -9,7 +9,7 @@
 
   display: flex;
   background-color: var(--box-alt-background-color);
-  padding: var(--spacing);
+  padding-top: var(--spacing);
 
   .warning-message {
     margin-bottom: 0;

--- a/app/styles/ui/changes/_protected-branch.scss
+++ b/app/styles/ui/changes/_protected-branch.scss
@@ -1,0 +1,58 @@
+@import '../../mixins';
+
+/** A React component holding the commit message entry */
+#protected-branch {
+  border-top: 1px solid var(--box-border-color);
+  flex-direction: column;
+  flex-shrink: 0;
+  margin-top: auto;
+
+  display: flex;
+  background-color: var(--box-alt-background-color);
+  padding: var(--spacing);
+
+  .warning-message {
+    margin-bottom: 0;
+    text-align: center;
+    color: var(--text-secondary-color);
+
+    strong {
+      color: var(--text-color);
+    }
+  }
+
+  .protected-branch-icon-container {
+    height: 20px;
+    position: relative;
+    text-align: center;
+
+    .protected-branch-icon {
+      color: var(--status-pending-color);
+    }
+  }
+
+  .commit-button {
+    max-width: 100%;
+    margin-top: var(--spacing);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .octicon {
+      flex-shrink: 0;
+      flex-grow: 0;
+      margin-right: var(--spacing-half);
+    }
+
+    /* Due to some weirdo bug in Chrome that affects Windows
+     * and possible other platforms we can't change the opacity
+     * for disabled buttons if the button also has a
+     * overflow: hidden property set. The workaround is to put
+     * the contents of the button in a block element and put
+     * ellipsis on that instead. See commit 67fad24ed
+     */
+    > span {
+      @include ellipsis;
+    }
+  }
+}

--- a/app/styles/ui/changes/_protected-branch.scss
+++ b/app/styles/ui/changes/_protected-branch.scss
@@ -28,6 +28,24 @@
 
     .protected-branch-icon {
       color: var(--status-pending-color);
+
+      background: var(--box-alt-background-color);
+      border-width: 0 var(--spacing-half);
+      border: solid transparent;
+      box-sizing: content-box;
+      position: relative;
+      z-index: 1;
+    }
+
+    &:after {
+      display: block;
+      border-bottom: var(--base-border);
+      content: '';
+      position: absolute;
+      z-index: 0;
+      display: block;
+      width: 100%;
+      top: var(--spacing);
     }
   }
 

--- a/app/styles/ui/changes/_protected-branch.scss
+++ b/app/styles/ui/changes/_protected-branch.scss
@@ -48,29 +48,4 @@
       top: var(--spacing);
     }
   }
-
-  .commit-button {
-    max-width: 100%;
-    margin-top: var(--spacing);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    .octicon {
-      flex-shrink: 0;
-      flex-grow: 0;
-      margin-right: var(--spacing-half);
-    }
-
-    /* Due to some weirdo bug in Chrome that affects Windows
-     * and possible other platforms we can't change the opacity
-     * for disabled buttons if the button also has a
-     * overflow: hidden property set. The workaround is to put
-     * the contents of the button in a block element and put
-     * ellipsis on that instead. See commit 67fad24ed
-     */
-    > span {
-      @include ellipsis;
-    }
-  }
 }

--- a/app/styles/ui/changes/_protected-branch.scss
+++ b/app/styles/ui/changes/_protected-branch.scss
@@ -1,6 +1,5 @@
 @import '../../mixins';
 
-/** A React component holding the commit message entry */
 #protected-branch {
   border-top: 1px solid var(--box-border-color);
   flex-direction: column;
@@ -28,7 +27,7 @@
     text-align: center;
 
     .protected-branch-icon {
-      color: var(--status-pending-color);
+      color: var(--dialog-warning-color);
 
       background: var(--box-alt-background-color);
       border-width: 0 var(--spacing-half);

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -19,6 +19,7 @@ export function createState<K extends keyof IChangesState>(
     coAuthors: [],
     conflictState: null,
     stashEntry: null,
+    currentBranchProtected: false,
   }
 
   return merge(baseChangesState, pick)

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -20,6 +20,7 @@ export function createState<K extends keyof IChangesState>(
     conflictState: null,
     stashEntry: null,
     currentBranchProtected: false,
+    userWantsToMoveChangesFromProtectedBranch: false,
   }
 
   return merge(baseChangesState, pick)

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -20,7 +20,6 @@ export function createState<K extends keyof IChangesState>(
     conflictState: null,
     stashEntry: null,
     currentBranchProtected: false,
-    userWantsToMoveChangesFromProtectedBranch: false,
   }
 
   return merge(baseChangesState, pick)

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -222,8 +222,7 @@ async function initializeTestRepo(
     repository = await repositoriesStore.updateGitHubRepository(
       repository,
       '',
-      ghAPIResult,
-      []
+      ghAPIResult
     )
   }
   await primeCaches(repository, repositoriesStateCache)

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -60,8 +60,7 @@ describe('RepositoriesStore', () => {
       await repositoriesStore!.updateGitHubRepository(
         addedRepo,
         'https://api.github.com',
-        gitHubRepo,
-        []
+        gitHubRepo
       )
 
       const repositories = await repositoriesStore!.getAll()
@@ -80,8 +79,7 @@ describe('RepositoriesStore', () => {
       const updatedFirstRepo = await repositoriesStore!.updateGitHubRepository(
         firstRepo,
         'https://api.github.com',
-        gitHubRepo,
-        []
+        gitHubRepo
       )
 
       const secondRepo = await repositoriesStore!.addRepository(
@@ -90,8 +88,7 @@ describe('RepositoriesStore', () => {
       const updatedSecondRepo = await repositoriesStore!.updateGitHubRepository(
         secondRepo,
         'https://api.github.com',
-        gitHubRepo,
-        []
+        gitHubRepo
       )
 
       expect(updatedFirstRepo.gitHubRepository!.dbID).toBe(


### PR DESCRIPTION
## Overview

**Related to #7023**

## Description

This PR is a quick-and-dirty implementation of the flow outlined in https://github.com/desktop/desktop/issues/7023#issuecomment-487761202 to gather feedback and ponder more on the warning and the initial flow.

![](https://user-images.githubusercontent.com/359239/59714776-cd0afb80-91e8-11e9-81da-d00bd96bbe1f.gif)

We don't block committing currently, because some teams can be exempt from the branch protection enforcement. However we can't get a full picture of the branch protection details from the API - in particular from Enterprise Server instances - because teams can be private. I'm talking with the team responsible for this to see if there are other was for us to be able to check "can i push?" without exposing sensitive information.

Because of that limitation, I went with a mixture of the "Alternate option" and the proposed flow on this first attempt. You'll note from the GIF above that we:

 - provide a warning, but also a clickable link to let the user switch branches
    - this is our way to help them to a solution, which feels more complete than a warning without anything actionable
 - don't provide any more context after opening the branch switcher
    - my gut feeling after using it a bit is that we could put them straight into a "Create branch" flow to avoid confusion, but I'd love others to try this out and see how it feels

TODO:

 - [x] polish styles to match designs
 - [x] wrap on long branch names
 - [x] investigate whether we can hook into the stash options to indicate that we are always bringing our changes with us? If that's not easy, it might need some refactoring in advance of landing this PR.
 - [x] gather feedback
 - [x] improve API updating to more quickly indicate when a branch is protected
 - [x] handle context menu to prevent a menu being displayed
 - [x] rebase once #7825 has been merged
## Release notes

Notes: no-notes
