### PR TITLE
use xcode 9.4.1 image and avoid nvm for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/desktop/desktop
   macos:
-    xcode: '9.3.1'
-
-step-library:
-  - &install-node
-    run:
-      name: Install Node Version Manager
-      command: |
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
-        export NVM_DIR="$HOME/.nvm"
-        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-        nvm install v10
-        nvm alias default v10
-        echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-        echo "[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"" >> $BASH_ENV
+    xcode: '9.4.1'
 
 jobs:
   build:
@@ -29,9 +16,6 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-      - *install-node
-      - run: |
-          node -v
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache


### PR DESCRIPTION
from https://github.com/desktop/desktop/pull/7507#discussion_r294042699

i did a little extra digging and found that a minor version bump in xcode image on circleci would get us on a 10.x version of node without needing to use nvm. see https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-430/index.html

don't feel strongly about this, but thought i would put this out there