### PR TITLE
update last prune timestamp every time we look for branches to prune

### DIFF
--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -155,6 +155,12 @@ export class BranchPruner {
       return
     }
 
+    // update the last prune date first thing after we check it!
+    await this.repositoriesStore.updateLastPruneDate(
+      this.repository,
+      Date.now()
+    )
+
     // Get list of branches that have been merged
     const { branchesState } = this.repositoriesStateCache.get(this.repository)
     const { defaultBranch } = branchesState
@@ -226,11 +232,6 @@ export class BranchPruner {
         log.info(`[BranchPruner] Branch '${branchName}' marked for deletion`)
       }
     }
-
-    await this.repositoriesStore.updateLastPruneDate(
-      this.repository,
-      Date.now()
-    )
     this.onPruneCompleted(this.repository)
   }
 }


### PR DESCRIPTION
## Overview

closes #7620 

## Description

- move the update timestamp command to be the first thing we do in pruning (after we check if its time to prune)