### PR TITLE
Shiftkey/perf/cache refresh promises to prevent concurrent refreshes

### DIFF
--- a/app/src/lib/promise-cache.ts
+++ b/app/src/lib/promise-cache.ts
@@ -1,0 +1,42 @@
+export class PromiseCache<TInput, TResult> {
+  private readonly cache = new Map<string, Promise<TResult>>()
+
+  public constructor(
+    private readonly kind: string,
+    private readonly getKey: (input: TInput) => string,
+    private readonly create: (input: TInput) => Promise<TResult>
+  ) {}
+
+  public get(input: TInput): Promise<TResult> {
+    const key = this.getKey(input)
+    const existing = this.cache.get(key)
+
+    if (existing != null) {
+      log.debug(`[PromiseCache] returning cached promise for ${this.kind}`)
+      return existing
+    }
+
+    const cleanup = () => {
+      log.debug(
+        `[PromiseCache] removing completed promise for cache for ${this.kind}`
+      )
+      this.cache.delete(key)
+    }
+
+    log.debug(`[PromiseCache] creating new promise to cache for ${this.kind}`)
+
+    const wrappedPromise = this.create(input).then(
+      result => {
+        cleanup()
+        return result
+      },
+      error => {
+        cleanup()
+        return Promise.reject(error)
+      }
+    )
+
+    this.cache.set(key, wrappedPromise)
+    return wrappedPromise
+  }
+}

--- a/app/src/lib/promise-cache.ts
+++ b/app/src/lib/promise-cache.ts
@@ -1,12 +1,32 @@
 import { Emitter, Disposable } from 'event-kit'
 
+/**
+ * A generic promise cache for use where the application is running an action
+ * that can take a long time to complete. This should be used when
+ */
 export class PromiseCache<TInput, TResult> {
   private readonly cache = new Map<string, Promise<TResult>>()
   private readonly emitter = new Emitter()
 
   public constructor(
+    /**
+     * A unique identifier for the cache to help with development-time tracing
+     */
     private readonly kind: string,
+    /**
+     * A function to compute the key of the input object, which is then used to
+     * lookup a cached promise. This key should be stable and predictable to
+     * ensure only one promise is alive per input object.
+     */
     private readonly getKey: (input: TInput) => string,
+    /**
+     * The function to create the new promise, which will be wrapped and managed
+     * by the cache.
+     *
+     * Errors are not swallowed by the cache, so ensure the caller has wrapped
+     * the function being used here in its own error handling, to ensure it
+     * does not propagate into the app itself.
+     */
     private readonly create: (input: TInput) => Promise<TResult>
   ) {}
 

--- a/app/src/lib/promise-cache.ts
+++ b/app/src/lib/promise-cache.ts
@@ -18,6 +18,14 @@ export class PromiseCache<TInput, TResult> {
     this.emitter.emit('promise-created', input)
   }
 
+  public onPromiseCompleted(fn: (input: TInput) => void): Disposable {
+    return this.emitter.on('promise-completed', fn)
+  }
+
+  private promiseDidComplete(input: TInput) {
+    this.emitter.emit('promise-completed', input)
+  }
+
   public get(input: TInput): Promise<TResult> {
     const key = this.getKey(input)
     const existing = this.cache.get(key)
@@ -31,6 +39,7 @@ export class PromiseCache<TInput, TResult> {
       log.debug(
         `[PromiseCache] removing completed promise for cache for ${this.kind}`
       )
+      this.promiseDidComplete(input)
       this.cache.delete(key)
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -229,6 +229,7 @@ import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
 import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
+import { PromiseCache } from '../promise-cache'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -364,6 +365,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.Light
   private automaticallySwitchTheme = false
+
+  private readonly refreshPromisesCache = new PromiseCache<Repository, void>(
+    'refresh',
+    r => r.hash,
+    r => this.actuallyRefreshRepository(r)
+  )
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -2479,7 +2486,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
-  private async refreshRepository(repository: Repository): Promise<void> {}
+  private async refreshRepository(repository: Repository): Promise<void> {
+    return this.refreshPromisesCache.get(repository)
+  }
 
   private async actuallyRefreshRepository(
     repository: Repository

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2479,8 +2479,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
-  /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _refreshRepository(repository: Repository): Promise<void> {
+  private async refreshRepository(repository: Repository): Promise<void> {}
+
+  private async actuallyRefreshRepository(
+    repository: Repository
+  ): Promise<void> {
     if (repository.missing) {
       return
     }
@@ -2535,6 +2538,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.updateMenuItemLabels(latestState)
 
     this._initializeCompare(repository)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _refreshRepository(repository: Repository): Promise<void> {
+    return this.refreshRepository(repository)
   }
 
   /**

--- a/app/test/unit/promise-cache-test.ts
+++ b/app/test/unit/promise-cache-test.ts
@@ -1,0 +1,25 @@
+import { PromiseCache } from '../../src/lib/promise-cache'
+
+describe('PromiseCache', () => {
+  it('returns the same promise', () => {
+    // this promise never completes, to ensure it is not evacuated
+    // from the cache
+
+    const createPromise = jest.fn(
+      // tslint:disable-next-line:promise-must-complete
+      (s: string) => new Promise((resolve, reject) => {})
+    )
+
+    const cache = new PromiseCache<string, void>(
+      'test',
+      s => s,
+      s => createPromise(s)
+    )
+
+    const first = cache.get('thing')
+    const second = cache.get('thing')
+
+    expect(first).toBe(second)
+    expect(createPromise).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/test/unit/promise-cache-test.ts
+++ b/app/test/unit/promise-cache-test.ts
@@ -1,11 +1,9 @@
 import { PromiseCache } from '../../src/lib/promise-cache'
 
 describe('PromiseCache', () => {
-  it('returns the same promise', () => {
-    // this promise never completes, to ensure it is not evacuated
-    // from the cache
-
+  it('returns the same promise when the same key is provided and the promise has not expired', () => {
     const createPromise = jest.fn(
+      // ensuring this promise never completes
       // tslint:disable-next-line:promise-must-complete
       (s: string) => new Promise((resolve, reject) => {})
     )
@@ -21,5 +19,45 @@ describe('PromiseCache', () => {
 
     expect(first).toBe(second)
     expect(createPromise).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns different promise when different key used', () => {
+    const createPromise = jest.fn(
+      // ensuring this promise never completes
+      // tslint:disable-next-line:promise-must-complete
+      (s: string) => new Promise((resolve, reject) => {})
+    )
+
+    const cache = new PromiseCache<string, void>(
+      'test',
+      s => s,
+      s => createPromise(s)
+    )
+
+    const first = cache.get('thing')
+    const second = cache.get('another-thing')
+
+    expect(first).not.toBe(second)
+    expect(createPromise).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns different promise when different key used', () => {
+    const createPromise = jest.fn(
+      // ensuring this promise never completes
+      // tslint:disable-next-line:promise-must-complete
+      (s: string) => new Promise((resolve, reject) => {})
+    )
+
+    const cache = new PromiseCache<string, void>(
+      'test',
+      s => s,
+      s => createPromise(s)
+    )
+
+    const first = cache.get('thing')
+    const second = cache.get('another-thing')
+
+    expect(first).not.toBe(second)
+    expect(createPromise).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #{issue number}**

## Description

-

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
