### PR TITLE
Shiftkey/testing/what is firing a refresh in 1 6 6

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2031,23 +2031,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _refreshOrRecoverRepository(
-    repository: Repository
+    repository: Repository,
+    context: string
   ): Promise<void> {
     // if repository is missing, try checking if it has been restored
     if (repository.missing) {
       const updatedRepository = await this.recoverMissingRepository(repository)
       if (!updatedRepository.missing) {
         // repository has been restored, attempt to refresh it now.
-        return this._refreshRepositoryBy(
-          updatedRepository,
-          '_refreshOrRecoverRepository - first path'
-        )
+        return this._refreshRepositoryBy(updatedRepository, context)
       }
     } else {
-      return this._refreshRepositoryBy(
-        repository,
-        '_refreshOrRecoverRepository - second path'
-      )
+      return this._refreshRepositoryBy(repository, context)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2065,8 +2065,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public async _refreshRepositoryBy(repository: Repository, context: string) {
-    log.warn(`[refresh] started by ${context}`)
+    const message = `[refresh] started by ${context}`
+    log.warn(message)
+    console.time(message)
     await this._refreshRepository(repository)
+    console.timeEnd(message)
     log.warn(`[refresh] completed by ${context}`)
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1066,7 +1066,10 @@ export class Dispatcher {
 
     // ensure a fresh clone repository has it's in-memory state
     // up-to-date before performing the "Clone in Desktop" steps
-    await this.appStore._refreshRepository(repository)
+    await this.appStore._refreshRepositoryBy(
+      repository,
+      'Dispatcher.handleCloneInDesktopOptions'
+    )
 
     const state = this.repositoryStateManager.get(repository)
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -269,8 +269,11 @@ export class Dispatcher {
   /**
    * Refresh the repository. This would be used, e.g., when the app gains focus.
    */
-  public refreshRepository(repository: Repository): Promise<void> {
-    return this.appStore._refreshOrRecoverRepository(repository)
+  public refreshRepository(
+    repository: Repository,
+    context: string
+  ): Promise<void> {
+    return this.appStore._refreshOrRecoverRepository(repository, context)
   }
 
   /** Show the popup. This will close any current popup. */
@@ -1066,7 +1069,7 @@ export class Dispatcher {
 
     // ensure a fresh clone repository has it's in-memory state
     // up-to-date before performing the "Clone in Desktop" steps
-    await this.appStore._refreshRepositoryBy(
+    await this.refreshRepository(
       repository,
       'Dispatcher.handleCloneInDesktopOptions'
     )

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -178,7 +178,7 @@ ipcRenderer.on('focus', () => {
     selectedState &&
     !(selectedState.type === SelectionType.CloningRepository)
   ) {
-    dispatcher.refreshRepository(selectedState.repository)
+    dispatcher.refreshRepository(selectedState.repository, 'focus')
   }
 
   dispatcher.setAppFocusState(true)

--- a/app/src/ui/lib/git-perf.ts
+++ b/app/src/ui/lib/git-perf.ts
@@ -27,7 +27,7 @@ export async function measure<T>(
   } finally {
     if (startTime) {
       const rawTime = performance.now() - startTime
-      if (rawTime > 1000) {
+      if (rawTime > 100) {
         const timeInSeconds = (rawTime / 1000).toFixed(3)
         log.info(`Executing ${cmd} (took ${timeInSeconds}s)`)
       }

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -62,7 +62,7 @@ export class MissingRepository extends React.Component<
   }
 
   private checkAgain = () => {
-    this.props.dispatcher.refreshRepository(this.props.repository)
+    this.props.dispatcher.refreshRepository(this.props.repository, 'checkAgain')
   }
 
   private remove = () => {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #{issue number}**

## Description

-

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
