### PR TITLE
updated tab header to "Enterprise Server" label

### DIFF
--- a/app/src/ui/blank-slate/blank-slate.tsx
+++ b/app/src/ui/blank-slate/blank-slate.tsx
@@ -308,7 +308,7 @@ export class BlankSlateView extends React.Component<
     return (
       <TabBar selectedIndex={selectedIndex} onTabClicked={this.onTabClicked}>
         <span>GitHub.com</span>
-        <span>Enterprise</span>
+        <span>GitHub Enterprise Server</span>
       </TabBar>
     )
   }


### PR DESCRIPTION
## Overview

**Related to #7729**

## Description

Current `development` build, when looking at the "Let's get started" view:

<img width="559" src="https://user-images.githubusercontent.com/359239/59865158-be465500-935e-11e9-9ad2-f9d23500cacc.png">

This PR:

<img width="580"  src="https://user-images.githubusercontent.com/359239/59865118-a66ed100-935e-11e9-828d-45edec650eb5.png">



## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
