### PR TITLE
add loadBranches tests

### DIFF
--- a/app/test/helpers/repository-scaffolding.ts
+++ b/app/test/helpers/repository-scaffolding.ts
@@ -97,3 +97,17 @@ export async function switchTo(repository: Repository, branch: string) {
     await GitProcess.exec(['checkout', branch], repository.path)
   }
 }
+
+export async function cloneLocalRepository(
+  repository: Repository
+): Promise<Repository> {
+  const repoPath = mkdirSync('blank-folder')
+  const args = ['clone', '--', repository.path, repoPath]
+  const result = await GitProcess.exec(args, repository.path)
+
+  if (result.exitCode === 128) {
+    throw new Error(JSON.stringify(result))
+  } else {
+    return new Repository(repoPath, -1, null, true)
+  }
+}


### PR DESCRIPTION
## Overview

While working on branch pruning bugs, I noticed that we didn't extract the new unit tests for `loadBranches` from #7616 (probably because there was plenty more to focus on for 2.0).

This PR is just a cherry-pick of the commits associated with that work.

cc @shiftkey, the author of this work