### PR TITLE
add new test to cover a specific branch pruner case

### DIFF
--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -1,0 +1,41 @@
+import { setupEmptyRepository } from './repositories'
+import { makeCommit, switchTo } from './repository-scaffolding'
+import { GitProcess } from 'dugite'
+
+export async function createRepository() {
+  const repo = await setupEmptyRepository()
+
+  const firstCommit = {
+    entries: [
+      { path: 'foo', contents: '' },
+      { path: 'perlin', contents: 'perlin' },
+    ],
+  }
+
+  await makeCommit(repo, firstCommit)
+
+  await switchTo(repo, 'other-branch')
+
+  const secondCommit = {
+    entries: [{ path: 'foo', contents: 'b1' }],
+  }
+
+  await makeCommit(repo, secondCommit)
+
+  const thirdCommit = {
+    entries: [{ path: 'foo', contents: 'b2' }],
+  }
+  await makeCommit(repo, thirdCommit)
+
+  await switchTo(repo, 'master')
+
+  await GitProcess.exec(['merge', 'other-branch'], repo.path)
+
+  // clear reflog of all entries, so any branches are considered candidates for pruning
+  await GitProcess.exec(
+    ['reflog', 'expire', '--expire=now', '--expire-unreachable=now', '--all'],
+    repo.path
+  )
+
+  return repo.path
+}

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -1,6 +1,10 @@
 import { setupEmptyRepository } from './repositories'
 import { makeCommit, switchTo } from './repository-scaffolding'
 import { GitProcess } from 'dugite'
+import { RepositoriesStore, GitStore } from '../../src/lib/stores'
+import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cache'
+import { Repository } from '../../src/models/repository'
+import { IAPIRepository } from '../../src/lib/api'
 
 export async function createRepository() {
   const repo = await setupEmptyRepository()
@@ -14,7 +18,9 @@ export async function createRepository() {
 
   await makeCommit(repo, firstCommit)
 
-  await switchTo(repo, 'other-branch')
+  // creating the new branch before switching so that we have distinct changes
+  // on both branches and also to ensure a merge commit is needed
+  await GitProcess.exec(['branch', 'other-branch'], repo.path)
 
   const secondCommit = {
     entries: [{ path: 'foo', contents: 'b1' }],
@@ -22,14 +28,22 @@ export async function createRepository() {
 
   await makeCommit(repo, secondCommit)
 
+  await switchTo(repo, 'other-branch')
+
   const thirdCommit = {
-    entries: [{ path: 'foo', contents: 'b2' }],
+    entries: [{ path: 'bar', contents: 'b2' }],
   }
   await makeCommit(repo, thirdCommit)
 
+  const fourthCommit = {
+    entries: [{ path: 'baz', contents: 'very much more words' }],
+  }
+  await makeCommit(repo, fourthCommit)
+
   await switchTo(repo, 'master')
 
-  await GitProcess.exec(['merge', 'other-branch'], repo.path)
+  // ensure the merge operation always creates a merge commit
+  await GitProcess.exec(['merge', 'other-branch', '--no-ff'], repo.path)
 
   // clear reflog of all entries, so any branches are considered candidates for pruning
   await GitProcess.exec(
@@ -38,4 +52,73 @@ export async function createRepository() {
   )
 
   return repo.path
+}
+
+export async function setupRepository(
+  path: string,
+  repositoriesStore: RepositoriesStore,
+  repositoriesStateCache: RepositoryStateCache,
+  includesGhRepo: boolean,
+  defaultBranchName: string,
+  lastPruneDate?: Date
+) {
+  let repository = await repositoriesStore.addRepository(path)
+  if (includesGhRepo) {
+    const ghAPIResult: IAPIRepository = {
+      clone_url: 'string',
+      ssh_url: 'string',
+      html_url: 'string',
+      name: 'string',
+      owner: {
+        id: 0,
+        url: '',
+        login: '',
+        avatar_url: '',
+        type: 'User',
+      },
+      private: false,
+      fork: false,
+      default_branch: defaultBranchName,
+      pushed_at: 'string',
+      parent: null,
+    }
+
+    repository = await repositoriesStore.updateGitHubRepository(
+      repository,
+      '',
+      ghAPIResult,
+      []
+    )
+  }
+  await primeCaches(repository, repositoriesStateCache)
+
+  lastPruneDate &&
+    repositoriesStore.updateLastPruneDate(repository, lastPruneDate.getTime())
+  return repository
+}
+
+/**
+ * Setup state correctly without having to expose
+ * the internals of the GitStore and caches
+ */
+async function primeCaches(
+  repository: Repository,
+  repositoriesStateCache: RepositoryStateCache
+) {
+  const gitStore = new GitStore(repository, shell)
+
+  // rather than re-create the branches and stuff as objects, these calls
+  // will run the underlying Git operations and update the GitStore state
+  await gitStore.loadRemotes()
+  await gitStore.loadBranches()
+  await gitStore.loadStatus()
+
+  // once that is done, we can populate the repository state in the same way
+  // that AppStore does for the sake of this test
+  repositoriesStateCache.updateBranchesState(repository, () => ({
+    tip: gitStore.tip,
+    defaultBranch: gitStore.defaultBranch,
+    allBranches: gitStore.allBranches,
+    recentBranches: gitStore.recentBranches,
+  }))
 }

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -5,6 +5,7 @@ import { RepositoriesStore, GitStore } from '../../src/lib/stores'
 import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cache'
 import { Repository } from '../../src/models/repository'
 import { IAPIRepository } from '../../src/lib/api'
+import { shell } from './test-app-shell'
 
 export async function createRepository() {
   const repo = await setupEmptyRepository()

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -2,15 +2,17 @@ import * as moment from 'moment'
 import { BranchPruner } from '../../src/lib/stores/helpers/branch-pruner'
 import { Repository } from '../../src/models/repository'
 import { GitStoreCache } from '../../src/lib/stores/git-store-cache'
-import { RepositoriesStore, GitStore } from '../../src/lib/stores'
+import { RepositoriesStore } from '../../src/lib/stores'
 import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cache'
 import { setupFixtureRepository } from '../helpers/repositories'
 import { shell } from '../helpers/test-app-shell'
 import { TestRepositoriesDatabase } from '../helpers/databases'
 import { GitProcess } from 'dugite'
 import { IGitHubUser } from '../../src/lib/databases'
-import { IAPIRepository } from '../../src/lib/api'
-import { createRepository as createPrunedRepository } from '../helpers/repository-builder-branch-pruner'
+import {
+  createRepository as createPrunedRepository,
+  setupRepository,
+} from '../helpers/repository-builder-branch-pruner'
 
 describe('BranchPruner', () => {
   const onGitStoreUpdated = () => {}
@@ -42,12 +44,16 @@ describe('BranchPruner', () => {
   })
 
   it('does nothing on non GitHub repositories', async () => {
-    const repo = await initializeTestRepo(
+    const path = await setupFixtureRepository('branch-prune-tests')
+
+    const repo = await setupRepository(
+      path,
       repositoriesStore,
       repositoriesStateCache,
       false,
       'master'
     )
+
     const branchPruner = new BranchPruner(
       repo,
       gitStoreCache,
@@ -66,7 +72,10 @@ describe('BranchPruner', () => {
   it('prunes for GitHub repository', async () => {
     const fixedDate = moment()
     const lastPruneDate = fixedDate.subtract(1, 'day')
-    const repo = await initializeTestRepo(
+
+    const path = await setupFixtureRepository('branch-prune-tests')
+    const repo = await setupRepository(
+      path,
       repositoriesStore,
       repositoriesStateCache,
       true,
@@ -91,7 +100,9 @@ describe('BranchPruner', () => {
   it('does not prune if the last prune date is less than 24 hours ago', async () => {
     const fixedDate = moment()
     const lastPruneDate = fixedDate.subtract(4, 'hours')
-    const repo = await initializeTestRepo(
+    const path = await setupFixtureRepository('branch-prune-tests')
+    const repo = await setupRepository(
+      path,
       repositoriesStore,
       repositoriesStateCache,
       true,
@@ -116,7 +127,10 @@ describe('BranchPruner', () => {
   it('does not prune if there is no default branch', async () => {
     const fixedDate = moment()
     const lastPruneDate = fixedDate.subtract(1, 'day')
-    const repo = await initializeTestRepo(
+    const path = await setupFixtureRepository('branch-prune-tests')
+
+    const repo = await setupRepository(
+      path,
       repositoriesStore,
       repositoriesStateCache,
       true,
@@ -141,7 +155,10 @@ describe('BranchPruner', () => {
   it('does not prune reserved branches', async () => {
     const fixedDate = moment()
     const lastPruneDate = fixedDate.subtract(1, 'day')
-    const repo = await initializeTestRepo(
+
+    const path = await setupFixtureRepository('branch-prune-tests')
+    const repo = await setupRepository(
+      path,
       repositoriesStore,
       repositoriesStateCache,
       true,
@@ -181,45 +198,17 @@ describe('BranchPruner', () => {
     const fixedDate = moment()
     const lastPruneDate = fixedDate.subtract(1, 'day')
 
-    let repository = await repositoriesStore.addRepository(path)
-
-    const ghAPIResult: IAPIRepository = {
-      clone_url: 'string',
-      ssh_url: 'string',
-      html_url: 'string',
-      name: 'string',
-      owner: {
-        id: 0,
-        url: '',
-        login: '',
-        avatar_url: '',
-        type: 'User',
-      },
-      private: false,
-      fork: false,
-      default_branch: 'master',
-      pushed_at: 'string',
-      parent: null,
-    }
-
-    repository = await repositoriesStore.updateGitHubRepository(
-      repository,
-      '',
-      ghAPIResult,
-      []
+    const repo = await setupRepository(
+      path,
+      repositoriesStore,
+      repositoriesStateCache,
+      true,
+      'master',
+      lastPruneDate.toDate()
     )
 
-    await primeCaches(repository, repositoriesStateCache)
-
-    if (lastPruneDate) {
-      repositoriesStore.updateLastPruneDate(
-        repository,
-        lastPruneDate.toDate().getTime()
-      )
-    }
-
     const branchPruner = new BranchPruner(
-      repository,
+      repo,
       gitStoreCache,
       repositoriesStore,
       repositoriesStateCache,
@@ -227,7 +216,7 @@ describe('BranchPruner', () => {
     )
 
     await branchPruner.start()
-    const branchesAfterPruning = await getBranchesFromGit(repository)
+    const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesAfterPruning).toContain('master')
     expect(branchesAfterPruning).not.toContain('other-branch')
@@ -240,74 +229,4 @@ async function getBranchesFromGit(repository: Repository) {
     .split('\n')
     .filter(s => s.length > 0)
     .map(s => s.substr(2))
-}
-
-async function initializeTestRepo(
-  repositoriesStore: RepositoriesStore,
-  repositoriesStateCache: RepositoryStateCache,
-  includesGhRepo: boolean,
-  defaultBranchName: string,
-  lastPruneDate?: Date
-) {
-  const path = await setupFixtureRepository('branch-prune-tests')
-
-  let repository = await repositoriesStore.addRepository(path)
-  if (includesGhRepo) {
-    const ghAPIResult: IAPIRepository = {
-      clone_url: 'string',
-      ssh_url: 'string',
-      html_url: 'string',
-      name: 'string',
-      owner: {
-        id: 0,
-        url: '',
-        login: '',
-        avatar_url: '',
-        type: 'User',
-      },
-      private: false,
-      fork: false,
-      default_branch: defaultBranchName,
-      pushed_at: 'string',
-      parent: null,
-    }
-
-    repository = await repositoriesStore.updateGitHubRepository(
-      repository,
-      '',
-      ghAPIResult,
-      []
-    )
-  }
-  await primeCaches(repository, repositoriesStateCache)
-
-  lastPruneDate &&
-    repositoriesStore.updateLastPruneDate(repository, lastPruneDate.getTime())
-  return repository
-}
-
-/**
- * Setup state correctly without having to expose
- * the internals of the GitStore and caches
- */
-async function primeCaches(
-  repository: Repository,
-  repositoriesStateCache: RepositoryStateCache
-) {
-  const gitStore = new GitStore(repository, shell)
-
-  // rather than re-create the branches and stuff as objects, these calls
-  // will run the underlying Git operations and update the GitStore state
-  await gitStore.loadRemotes()
-  await gitStore.loadBranches()
-  await gitStore.loadStatus()
-
-  // once that is done, we can populate the repository state in the same way
-  // that AppStore does for the sake of this test
-  repositoriesStateCache.updateBranchesState(repository, () => ({
-    tip: gitStore.tip,
-    defaultBranch: gitStore.defaultBranch,
-    allBranches: gitStore.allBranches,
-    recentBranches: gitStore.recentBranches,
-  }))
 }

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -192,7 +192,7 @@ describe('BranchPruner', () => {
     }
   })
 
-  it('prunes branch that is merged and valid but lacks an upstream', async () => {
+  it('never prunes a branch that lacks an upstream', async () => {
     const path = await createPrunedRepository()
 
     const fixedDate = moment()
@@ -219,7 +219,7 @@ describe('BranchPruner', () => {
     const branchesAfterPruning = await getBranchesFromGit(repo)
 
     expect(branchesAfterPruning).toContain('master')
-    expect(branchesAfterPruning).not.toContain('other-branch')
+    expect(branchesAfterPruning).toContain('other-branch')
   })
 })
 


### PR DESCRIPTION
## Overview

**Related to #7839**

This PR adds a failing test case and tidies up the branch pruner test setup to make it a bit easier to manage.

## Description

There's a scenario that I don't believe is handled correctly by #7839. Consider this repository history, with a feature branch being merged into the default branch:


```shellsession 
$ git log --oneline --graph
*   4cee0cc (HEAD -> master) Merge branch 'other-branch'
|\
| * b6addfe (other-branch) commit
| * d061c89 commit
* | f74aff4 commit
|/
* 6d7abea commit
```

Putting aside any information related to "when `other-branch` was last used" or "when the last time the branch pruner ran", let's see what Git thinks about what can be merged:

```
$ git branch --merged master
* master
  other-branch
```

But when I run the `prunes branch that is merged and valid but lacks an upstream` test, I end up in this code path:

https://github.com/desktop/desktop/blob/7299d96340e69dc8ed815f470eb5c906eda575d1/app/src/lib/stores/helpers/branch-pruner.ts#L271-L275

Because the branch was never published, it gets filtered out of the `branchesReadyForPruning` list, and won't ever be pruned.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
