### PR TITLE
Out of order state update in create repository dialog

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -586,9 +586,9 @@ export class CreateRepository extends React.Component<
     )
   }
 
-  private onWindowFocus = async () => {
+  private onWindowFocus = () => {
     // Verify whether or not a README.md file exists at the chosen directory
     // in case one has been added or removed and the warning can be displayed.
-    await this.updateReadMeExists(this.state.path, this.state.name)
+    this.updateReadMeExists(this.state.path, this.state.name)
   }
 }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -139,10 +139,16 @@ export class CreateRepository extends React.Component<
   }
 
   private onPathChanged = async (path: string) => {
-    const isRepository = await isGitRepository(path)
-    await this.updateReadMeExists(path, this.state.name)
+    this.setState({ path, isValidPath: null })
 
-    this.setState({ isRepository, path, isValidPath: null })
+    const isRepository = await isGitRepository(path)
+
+    // Only update isRepository if the path is still the
+    // same one we were using to check whether it looked
+    // like a repository.
+    this.setState(state => (state.path === path ? { isRepository } : null))
+
+    this.updateReadMeExists(path, this.state.name)
   }
 
   private onNameChanged = (name: string) => {

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -183,7 +183,9 @@ export class CreateRepository extends React.Component<
 
     const fullPath = Path.join(path, sanitizedRepositoryName(name), 'README.md')
     const readMeExists = await FSE.pathExists(fullPath)
-    this.setState({ readMeExists })
+
+    // Only update readMeExists if the path is still the same
+    this.setState(state => (state.path === path ? { readMeExists } : null))
   }
 
   private resolveRepositoryRoot = async (): Promise<string> => {

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -146,11 +146,11 @@ export class CreateRepository extends React.Component<
   }
 
   private onNameChanged = async (name: string) => {
+    this.setState({ name })
+
     if (enableReadmeOverwriteWarning()) {
       await this.updateReadMeExists(this.state.path, name)
     }
-
-    this.setState({ name })
   }
 
   private onDescriptionChanged = (description: string) => {

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -145,11 +145,11 @@ export class CreateRepository extends React.Component<
     this.setState({ isRepository, path, isValidPath: null })
   }
 
-  private onNameChanged = async (name: string) => {
+  private onNameChanged = (name: string) => {
     this.setState({ name })
 
     if (enableReadmeOverwriteWarning()) {
-      await this.updateReadMeExists(this.state.path, name)
+      this.updateReadMeExists(this.state.path, name)
     }
   }
 

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -147,10 +147,7 @@ export class CreateRepository extends React.Component<
 
   private onNameChanged = (name: string) => {
     this.setState({ name })
-
-    if (enableReadmeOverwriteWarning()) {
-      this.updateReadMeExists(this.state.path, name)
-    }
+    this.updateReadMeExists(this.state.path, name)
   }
 
   private onDescriptionChanged = (description: string) => {
@@ -174,6 +171,10 @@ export class CreateRepository extends React.Component<
   }
 
   private async updateReadMeExists(path: string, name: string) {
+    if (!enableReadmeOverwriteWarning()) {
+      return
+    }
+
     const fullPath = Path.join(path, sanitizedRepositoryName(name), 'README.md')
     const readMeExists = await FSE.pathExists(fullPath)
     this.setState({ readMeExists })
@@ -588,8 +589,6 @@ export class CreateRepository extends React.Component<
   private onWindowFocus = async () => {
     // Verify whether or not a README.md file exists at the chosen directory
     // in case one has been added or removed and the warning can be displayed.
-    if (enableReadmeOverwriteWarning()) {
-      await this.updateReadMeExists(this.state.path, this.state.name)
-    }
+    await this.updateReadMeExists(this.state.path, this.state.name)
   }
 }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -120,6 +120,8 @@ export class CreateRepository extends React.Component<
   }
 
   public async componentDidMount() {
+    window.addEventListener('focus', this.onWindowFocus)
+
     const gitIgnoreNames = await getGitIgnoreNames()
     this.setState({ gitIgnoreNames })
 
@@ -129,9 +131,7 @@ export class CreateRepository extends React.Component<
     const isRepository = await isGitRepository(this.state.path)
     this.setState({ isRepository })
 
-    await this.updateReadMeExists(this.state.path, this.state.name)
-
-    window.addEventListener('focus', this.onWindowFocus)
+    this.updateReadMeExists(this.state.path, this.state.name)
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

#7862 describes an issue where the cursor would jump to the end of the input text field when attempting to add characters anywhere but at the end of the field. This is commonly associated with out of order state (asynchronous) updates, frequently due to awaits.

**Closes #7862**

## Description

This particular issue was caused by calling, and awaiting the results of `this.updateReadMeExists` in the `onNameChanged` event handler before updating the state to reflect the newly entered value. A quick reshuffling of these actions solved the problem but I decided to also address some lingering state update ordering concerns I had.

The changes all revolve around trying to do as much of the synchronous work as possible before awaiting asynchronous methods and ensuring that queued state updates were fully applied before validating, and updating state in asynchronous methods.

There was also some inconsistency around when the `enableReadmeOverwriteWarning` method was consulted so I moved all checks of that to the actual method doing the work.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: [Fixed] Input cursor sometimes jumped to the end of the name text box in the create repository dialog.