### PR TITLE
Text search in diffs

### DIFF
--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -19,6 +19,8 @@ if (__DARWIN__) {
   require('codemirror/addon/scroll/simplescrollbars')
 }
 
+require('codemirror/addon/search/search')
+
 interface ICodeMirrorHostProps {
   /**
    * An optional class name for the wrapper element around the

--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -19,7 +19,7 @@ if (__DARWIN__) {
   require('codemirror/addon/scroll/simplescrollbars')
 }
 
-require('codemirror/addon/search/search')
+import 'codemirror/addon/search/search'
 
 interface ICodeMirrorHostProps {
   /**

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -129,6 +129,25 @@ interface ITextDiffProps {
 
 const diffGutterName = 'diff-gutter'
 
+function showSearch(cm: Editor) {
+  cm.execCommand('findPersistent')
+  const wrapper = cm.getWrapperElement()
+
+  if (wrapper) {
+    const searchLabel = wrapper.querySelector('.CodeMirror-search-label')
+    const searchField = wrapper.querySelector('.CodeMirror-search-field')
+
+    if (
+      searchLabel instanceof HTMLElement &&
+      searchField instanceof HTMLInputElement
+    ) {
+      searchLabel.style.display = 'none'
+      searchField.placeholder = 'Search'
+      searchField.style.width = null
+    }
+  }
+}
+
 const defaultEditorOptions: IEditorConfigurationExtra = {
   lineNumbers: false,
   readOnly: true,
@@ -140,7 +159,7 @@ const defaultEditorOptions: IEditorConfigurationExtra = {
   extraKeys: {
     Tab: false,
     'Shift-Tab': false,
-    [__DARWIN__ ? 'Cmd-F' : 'Ctrl-F']: 'findPersistent',
+    [__DARWIN__ ? 'Cmd-F' : 'Ctrl-F']: showSearch,
   },
   scrollbarStyle: __DARWIN__ ? 'simple' : 'native',
   styleSelectedText: true,

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -133,18 +133,27 @@ function showSearch(cm: Editor) {
   cm.execCommand('findPersistent')
   const wrapper = cm.getWrapperElement()
 
-  if (wrapper) {
-    const searchLabel = wrapper.querySelector('.CodeMirror-search-label')
-    const searchField = wrapper.querySelector('.CodeMirror-search-field')
+  if (!wrapper) {
+    return
+  }
 
-    if (
-      searchLabel instanceof HTMLElement &&
-      searchField instanceof HTMLInputElement
-    ) {
-      searchLabel.style.display = 'none'
-      searchField.placeholder = 'Search'
-      searchField.style.width = null
-    }
+  const dialog = wrapper.querySelector('.CodeMirror-dialog')
+
+  if (!dialog) {
+    return
+  }
+
+  dialog.classList.add('CodeMirror-search-dialog')
+  const searchLabel = dialog.querySelector('.CodeMirror-search-label')
+  const searchField = dialog.querySelector('.CodeMirror-search-field')
+
+  if (
+    searchLabel instanceof HTMLElement &&
+    searchField instanceof HTMLInputElement
+  ) {
+    searchLabel.style.display = 'none'
+    searchField.placeholder = 'Search'
+    searchField.style.width = null
   }
 }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -137,7 +137,11 @@ const defaultEditorOptions: IEditorConfigurationExtra = {
   lineWrapping: true,
   mode: { name: DiffSyntaxMode.ModeName },
   // Make sure CodeMirror doesn't capture Tab (and Shift-Tab) and thus destroy tab navigation
-  extraKeys: { Tab: false, 'Shift-Tab': false },
+  extraKeys: {
+    Tab: false,
+    'Shift-Tab': false,
+    [__DARWIN__ ? 'Cmd-F' : 'Ctrl-F']: 'findPersistent',
+  },
   scrollbarStyle: __DARWIN__ ? 'simple' : 'native',
   styleSelectedText: true,
   lineSeparator: '\n',

--- a/app/styles/_vendor.scss
+++ b/app/styles/_vendor.scss
@@ -1,4 +1,5 @@
 @import '~react-virtualized/styles.css';
 @import '~codemirror/lib/codemirror.css';
+@import '~codemirror/addon/dialog/dialog.css';
 @import '~codemirror/theme/solarized.css';
 @import '~codemirror/addon/scroll/simplescrollbars.css';

--- a/app/styles/ui/_codemirror.scss
+++ b/app/styles/ui/_codemirror.scss
@@ -1,7 +1,12 @@
 // Use the platform default background color for text
 // selection when the editor has a selection _and_ is
 // focused.
-.CodeMirror-focused {
+// Unfortunately CodeMirror-focused isn't set when we
+// have a dialog open (which, at time of writing, only
+// happens when searching) so we'll apply the same styles
+// there as well.
+.CodeMirror-focused,
+.CodeMirror.dialog-opened {
   .CodeMirror-selected {
     background: Highlight;
   }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -61,6 +61,29 @@
   .diff-gutter {
     width: 125px;
   }
+
+  span.CodeMirror-search-hint {
+    display: none;
+  }
+
+  .CodeMirror-dialog.CodeMirror-dialog-top {
+    left: auto;
+    border: var(--base-border);
+    border-top: 0;
+    right: var(--spacing);
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    padding: var(--spacing-half) var(--spacing);
+    box-shadow: var(--base-box-shadow);
+  }
+
+  input.CodeMirror-search-field {
+    background: var(--box-background-color);
+    color: var(--text-color);
+    font-size: var(--font-size);
+    font-family: var(--font-family-sans-serif);
+    height: var(--text-field-height);
+    padding: 0 var(--spacing-half);
+  }
 }
 
 // The container element which holds the before and after

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -82,7 +82,8 @@
     font-size: var(--font-size);
     font-family: var(--font-family-sans-serif);
     height: var(--text-field-height);
-    padding: 0 var(--spacing-half);
+    padding: 0;
+    width: 180px;
   }
 }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -62,11 +62,7 @@
     width: 125px;
   }
 
-  span.CodeMirror-search-hint {
-    display: none;
-  }
-
-  .CodeMirror-dialog.CodeMirror-dialog-top {
+  .CodeMirror-search-dialog {
     left: auto;
     border: var(--base-border);
     border-top: 0;
@@ -74,16 +70,24 @@
     border-radius: 0 0 var(--border-radius) var(--border-radius);
     padding: var(--spacing-half) var(--spacing);
     box-shadow: var(--base-box-shadow);
-  }
 
-  input.CodeMirror-search-field {
-    background: var(--box-background-color);
-    color: var(--text-color);
-    font-size: var(--font-size);
-    font-family: var(--font-family-sans-serif);
-    height: var(--text-field-height);
-    padding: 0;
-    width: 180px;
+    .CodeMirror-search-hint {
+      display: none;
+    }
+
+    input.CodeMirror-search-field {
+      background: var(--box-background-color);
+      color: var(--text-color);
+      font-size: var(--font-size);
+      font-family: var(--font-family-sans-serif);
+      height: var(--text-field-height);
+      padding: 0;
+      width: 180px;
+    }
+
+    .buttons {
+      display: inline-block;
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #7538**

## Description

This turns on the CodeMirror search plugin in order to add text searching functionality to our diffs in Desktop.  The plugin is coupled with a little sprinkle of our own logic to make the search box look and feel like a Desktop component.

Searching is triggered by focusing on (clicking) the diff and hitting <kbd>⌘F</kbd> on macOS and <kbd>Ctrl</kbd>+<kbd>F</kbd> on Windows. Once the user had typed their query into the search field and hit <kbd>Enter</kbd> all matching locations in the document are highlighted and the first match is selected. Subsequent <kbd>Enter</kbd> presses will select the next match and <kbd>Shift</kbd>+<kbd>Enter</kbd> will select the previous match.

The search plugin also supports (though we're not going to advertise that) regular expression matchin by pre- and postfixing the expression with forward slashes (i.e `/search(Field|Label)/`).

## Demo

![Jun-25-2019 15-53-04](https://user-images.githubusercontent.com/634063/60105214-3946ab80-9763-11e9-8d05-b9e11f5d9117.gif)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: [Added] Cmd/Ctrl+F will trigger a text search while focused on a diff.