### PR TITLE
2.1.0-beta2 release

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.1.0-beta1",
+  "version": "2.1.0-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -104,5 +104,5 @@ export function enableBranchProtectionChecks(): boolean {
  * flag is linked to to `enableBranchProtectionChecks()`.
  */
 export function enableBranchProtectionWarningFlow(): boolean {
-  return enableBranchProtectionChecks() && enableDevelopmentFeatures()
+  return enableBranchProtectionChecks() && enableBetaFeatures()
 }

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,9 @@
 {
   "releases": {
+    "2.1.0-beta2": [
+      "[New] Commit form will warn user when working on a protected branch - #7826"
+    ],
     "2.1.0-beta1": [
-      "[New] Commit form will warn user when working on a protected branch - #7826",
       "[Added] Keyboard shortcut for \"Discard All Changes\" menu item - #7588. Thanks @say25!",
       "[Fixed] New repository does not write description into README - #7571. Thanks @noelledusahel!",
       "[Fixed] Disable \"Discard\" and \"Restore\" buttons while restoring stash - #7289",


### PR DESCRIPTION
## Overview

We overlooked a feature flag for the Protected Branches UX change in #7826 when we shipped the beta yesterday, so this PR is just a commit on top of the previous release - no additional work since merged into `development ` will be going out with this release. 

## Description

- [x] approval for release notes
- [x] 🚢 to beta
- [x] merge in `development`

