### PR TITLE
template updates for `bug report` and `problems to raise`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -64,8 +64,8 @@ https://github.com/desktop/desktop/blob/development/docs/contributing/timeline-p
 <!--
 Attach your log file (You can simply drag your file here to insert it) to this issue. Please make sure the generated link to your log file is **below** this comment section otherwise it will not appear when you submit your issue.
 
-macOS logs location: `~/Library/Application Support/GitHub Desktop/logs/*.desktop.production.log`
-Windows logs location: `%APPDATA%\GitHub Desktop\logs\*.desktop.production.log`
+macOS logs accessible from the Help menu or location: `~/Library/Application Support/GitHub Desktop/logs/*.desktop.production.log`
+Windows logs accessible from the Help menu or location: `%APPDATA%\GitHub Desktop\logs\*.desktop.production.log`
 
 The log files are organized by date, so see if anything was generated for today's date.
 -->

--- a/.github/ISSUE_TEMPLATE/problem-to-raise.md
+++ b/.github/ISSUE_TEMPLATE/problem-to-raise.md
@@ -4,6 +4,15 @@ about: Surface a problem that you think should be solved
 
 ---
 
+<!--
+First and foremost, we’d like to thank you for taking the time to contribute to our project. Before submitting your issue, please follow these steps:
+
+1. Familiarize yourself with our contributing guide:
+	* https://github.com/desktop/desktop/blob/development/.github/CONTRIBUTING.md#contributing-to-github-desktop
+2. Make sure your issue isn’t a duplicate of another issue
+3. If you have made it to this step, go ahead and fill out the template below
+-->
+
 **Please describe the problem you think should be solved**
 A clear and concise description of what the problem is and who else might be impacted. Screenshots are encouraged.
 


### PR DESCRIPTION
Our bug report issue templates never mention the `Help` menu for easy access to to log files. 

This will make it easier for users to attach and share.

Also, the problem template has no intro section. 