### PR TITLE
Revert "enable branch protection warning on beta"

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -109,5 +109,5 @@ export function enableWSLDetection(): boolean {
  * flag is linked to to `enableBranchProtectionChecks()`.
  */
 export function enableBranchProtectionWarningFlow(): boolean {
-  return enableBranchProtectionChecks() && enableBetaFeatures()
+  return enableBranchProtectionChecks() && enableDevelopmentFeatures()
 }


### PR DESCRIPTION
## Overview

**Related to #7023 and #7826**

## Description

After some initial feedback we've uncovered gaps in our knowledge about the exclusions for branch protection rules (where teams are allowed to push to a protected branch), as well as some other smaller cases (signed commits, rules affecting admin users), which make it feel like it's not the best time to be gathering feedback about the proposed UI changes from #7826.

For the moment I propose showing this for the development build only, until we can obtain the information we need from the GitHub API to confirm the user is not able to commit to a given protected branch.

## Release notes

Notes: no-notes
