### PR TITLE
hide the protected branch warning for Enterprise repositories

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -25,6 +25,7 @@ import { ICommitContext } from '../../models/commit'
 import { startTimer } from '../lib/timing'
 import { ProtectedBranchWarning } from './protected-branch-warning'
 import { enableBranchProtectionWarningFlow } from '../../lib/feature-flag'
+import { getDotComAPIEndpoint } from '../../lib/api'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -447,9 +448,19 @@ export class CommitMessage extends React.Component<
       return null
     }
 
-    const { currentBranchProtected, dispatcher } = this.props
+    const { currentBranchProtected, dispatcher, repository } = this.props
 
     if (!currentBranchProtected) {
+      return null
+    }
+
+    if (
+      repository.gitHubRepository === null ||
+      repository.gitHubRepository.endpoint !== getDotComAPIEndpoint()
+    ) {
+      // don't prompt for GitHub Enterprise repositories because we may not able
+      // to access the list of teams that are permitted to push to this protected
+      // branch
       return null
     }
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #{issue number}**

## Description

-

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
