### PR TITLE
Adds help URL for macOS Keychain issues

### DIFF
--- a/app/src/lib/stores/accounts-store.ts
+++ b/app/src/lib/stores/accounts-store.ts
@@ -97,7 +97,11 @@ export class AccountsStore extends TypedBaseStore<ReadonlyArray<Account>> {
       if (__DARWIN__ && isKeyChainError(e)) {
         this.emitError(
           new Error(
-            `GitHub Desktop was unable to store the account token in the keychain. Please check you have unlocked access to the 'login' keychain.`
+            `GitHub Desktop was unable to store the account token in the keychain. 
+             Please check you have unlocked access to the 'login' keychain. Further documention can be found {' '}
+             <LinkButton onClick={this.props.onShowExamples}>
+               here.`
+             </LinkButton>
           )
         )
       } else {


### PR DESCRIPTION
Following conversation with a Desktop user, we decided to add further documentation to the current error messaging. 

The current message lacks detail on how to fix the issue:
![Screen Shot 2019-07-15 at 10 12 11 AM](https://user-images.githubusercontent.com/14828183/61245794-0ef46800-a6e9-11e9-966f-9cb2680a1edf.png)

This PR adds the this link: https://github.com/desktop/desktop/blob/development/docs/known-issues.md#the-username-or-passphrase-you-entered-is-not-correct-error-after-signing-into-account---3263 to the error message.

Unsure where to add:
```
private onShowAccountsStoreExamples = () => {
    this.props.dispatcher.openInBrowser('https://github.com/desktop/desktop/blob/development/docs/known-issues.md#the-username-or-passphrase-you-entered-is-not-correct-error-after-signing-into-account---3263')
  }
```

❓ If someone can point to the file, that would be helpful. 