### PR TITLE
fix overflowing diffs in electron five (5)

### DIFF
--- a/app/styles/ui/_commit-details.scss
+++ b/app/styles/ui/_commit-details.scss
@@ -3,7 +3,7 @@
 .commit-details {
   display: flex;
   flex-direction: row;
-  flex: 1 1 auto;
+  flex: 1;
   overflow: hidden;
 
   .fill-window {

--- a/app/styles/ui/_commit-details.scss
+++ b/app/styles/ui/_commit-details.scss
@@ -3,7 +3,8 @@
 .commit-details {
   display: flex;
   flex-direction: row;
-  flex: 1;
+  flex: 1 1 auto;
+  overflow: hidden;
 
   .fill-window {
     // necessary for "no files in commit" view to

--- a/app/styles/ui/_repository.scss
+++ b/app/styles/ui/_repository.scss
@@ -6,6 +6,7 @@
   flex-direction: row;
   flex: 1;
   border-top: var(--base-border);
+  max-height: 100%;
 
   > .focus-container {
     display: flex;

--- a/app/styles/ui/_stash-diff-viewer.scss
+++ b/app/styles/ui/_stash-diff-viewer.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  max-height: 100%;
 
   .header {
     display: flex;

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex-grow: 1;
   min-width: 0;
+  max-height: 100%;
 
   .header {
     span {
@@ -64,4 +65,5 @@
   display: flex;
   flex-grow: 1;
   min-width: 0;
+  overflow: hidden;
 }

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  max-height: 100%;
 
   // Necessary so that the diff doesn't expand
   // beyond the width of the history


### PR DESCRIPTION
## Overview

closes #7967 
closes #7968 

## Description

- applied some more stringent css to keep things in bounds and scrollable

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: [Fixed] Overflowing diffs
