### PR TITLE
add new types for Git work trees

### DIFF
--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -15,21 +15,35 @@ function getBaseName(path: string): string {
   return baseName
 }
 
+/** Base type for a directory you can run git commands successfully */
+export type WorkingTree = {
+  readonly path: string
+}
+
 /** A local repository. */
 export class Repository {
   public readonly name: string
+  /** The main working tree's path
+   * (also what we commonly think of as the repository's working directory)
+   */
+  private readonly mainWorkTree: WorkingTree
 
   /**
    * @param path The working directory of this repository
    * @param missing Was the repository missing on disk last we checked?
    */
   public constructor(
-    public readonly path: string,
+    path: string,
     public readonly id: number,
     public readonly gitHubRepository: GitHubRepository | null,
     public readonly missing: boolean
   ) {
+    this.mainWorkTree = { path }
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
+  }
+
+  public get path(): string {
+    return this.mainWorkTree.path
   }
 
   /**
@@ -42,6 +56,12 @@ export class Repository {
       this.path
     }+${this.missing}+${this.name}`
   }
+}
+
+/** A worktree linked to a main working tree (aka `Repository`) */
+export type LinkedWorkTree = WorkingTree & {
+  /** The sha of the head commit in this work tree */
+  readonly head: string
 }
 
 /**

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -23,8 +23,9 @@ export type WorkingTree = {
 /** A local repository. */
 export class Repository {
   public readonly name: string
-  /** The main working tree's path
-   * (also what we commonly think of as the repository's working directory)
+  /**
+   * The main working tree (what we commonly
+   * think of as the repository's working directory)
    */
   private readonly mainWorkTree: WorkingTree
 


### PR DESCRIPTION
## Overview

supports #6960 
based on #7819

## Description

- adds base type for work trees
- incorporates work tree type into repository model (every repository has a main work tree)
- adds linked work tree type

_____

## About work trees

> A git repository can support multiple working trees, allowing you to check out more than one branch at a time. With git worktree add a new working tree is associated with the repository. This new working tree is called a "linked working tree" as opposed to the "main working tree" prepared by "git init" or "git clone". A repository has one main working tree (if it’s not a bare repository) and zero or more linked working trees.

_from https://git-scm.com/docs/git-worktree_