### PR TITLE
Fix word overflow in external editor error popup

### DIFF
--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -39,4 +39,8 @@
 
 #external-editor-error {
   width: 450px;
+
+  p {
+    word-wrap: break-word;
+  }
 }


### PR DESCRIPTION
## Overview

**Closes #7988**

## Description

Adds a style to wrap words in the editor error popup

**Before**
<img width="1072" alt="Screen Shot 2019-07-23 at 3 49 18 PM" src="https://user-images.githubusercontent.com/1715082/61746806-1e675700-ad62-11e9-8feb-69656571a797.png">

**After**
<img width="1072" alt="Screen Shot 2019-07-23 at 3 48 07 PM" src="https://user-images.githubusercontent.com/1715082/61746833-2aebaf80-ad62-11e9-9e6e-f8411a2a9773.png">


## Release notes

Fixes issue where error message could appear outside the boundary of its container

