### PR TITLE
swap request bot label to new one

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -13,7 +13,7 @@ requestInfoReplyComment: >
 
   Thanks for understanding and meeting us halfway 😀
 
-requestInfoLabelToAdd: more-information-needed
+requestInfoLabelToAdd: more-info-needed
 
 requestInfoOn:
   pullRequest: false


### PR DESCRIPTION
The proper label is now `more-info-needed` so the bot created the old label `more-information-needed` each time it was evoked. 