### PR TITLE
menu update does not invoke required Electron API to update application menu for macOS

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -396,6 +396,7 @@ app.on('ready', () => {
       }
 
       if (sendMenuChangedEvent && mainWindow) {
+        Menu.setApplicationMenu(currentMenu)
         mainWindow.sendAppMenu()
       }
     }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -367,14 +367,15 @@ app.on('ready', () => {
     ) => {
       let sendMenuChangedEvent = false
 
+      const currentMenu = Menu.getApplicationMenu()
+
+      if (currentMenu === null) {
+        log.debug(`unable to get current menu, bailing out...`)
+        return
+      }
+
       for (const item of items) {
         const { id, state } = item
-
-        const currentMenu = Menu.getApplicationMenu()
-
-        if (currentMenu === null) {
-          return
-        }
 
         const menuItem = currentMenu.getMenuItemById(id)
 


### PR DESCRIPTION
## Overview

**Related to #7991**

## Description

This adds an explicit `Menu.setApplicationMenu(menu)` call where we previously didn't had one.

This seems to have worked incidentally when the renderer emits a `'update-menu-state'` event, but I believe the upgrade to Electron 5 has changed this behaviour.

I also tweaked the flow to save calling `Menu.getApplicationMenu()` within the `for` loop, as this check would exit the update if it can't find a menu. This can be done outside the loop and save some cycles.

## Release notes

Notes: `[Fixed] menu state not updated for macOS after performing some actions`
