### PR TITLE
use checkout to resolve unmerged binary file conflicts

### DIFF
--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -54,13 +54,31 @@ export async function stageManualConflictResolution(
       )).exitCode
       break
     }
-    case GitStatusEntry.Added:
-    case GitStatusEntry.UpdatedButUnmerged: {
+    case GitStatusEntry.Added: {
       exitCode = (await git(
         ['add', file.path],
         repository.path,
         'addConflictedFile'
       )).exitCode
+      break
+    }
+    case GitStatusEntry.UpdatedButUnmerged: {
+      const choiceFlag =
+        manualResolution === ManualConflictResolutionKind.theirs
+          ? 'theirs'
+          : 'ours'
+      exitCode = (await git(
+        ['checkout', `--${choiceFlag}`, '--', file.path],
+        repository.path,
+        'checkoutConflictedFile'
+      )).exitCode
+      if (exitCode === 0) {
+        exitCode = (await git(
+          ['add', file.path],
+          repository.path,
+          'addConflictedFile'
+        )).exitCode
+      }
       break
     }
     default:

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -183,13 +183,6 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   Repository
 > {
   const repo = await setupEmptyRepository()
-  const filePaths = [
-    Path.join(repo.path, 'foo'),
-    Path.join(repo.path, 'bar'),
-    Path.join(repo.path, 'baz'),
-    Path.join(repo.path, 'cat'),
-    Path.join(repo.path, 'dog'),
-  ]
 
   const firstCommit = {
     entries: [{ path: 'foo', contents: 'b0' }, { path: 'bar', contents: 'b0' }],
@@ -225,7 +218,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
 
   await makeCommit(repo, thirdCommit)
 
-  await FSE.writeFile(filePaths[4], 'touch')
+  await FSE.writeFile(Path.join(repo.path, 'dog'), 'touch')
 
   await GitProcess.exec(['merge', 'master'], repo.path)
 

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -548,9 +548,9 @@ describe('git/commit', () => {
           trackedFiles,
           manualResolutions
         )
-        expect(await FSE.pathExists(path.join(repository.path, 'bar'))).toBe(
-          true
-        )
+        expect(
+          await FSE.pathExists(path.join(repository.path, 'bar'))
+        ).toBeTrue()
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)
@@ -568,9 +568,9 @@ describe('git/commit', () => {
           trackedFiles,
           manualResolutions
         )
-        expect(await FSE.pathExists(path.join(repository.path, 'bar'))).toBe(
-          false
-        )
+        expect(
+          await FSE.pathExists(path.join(repository.path, 'bar'))
+        ).toBeFalse()
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -555,6 +555,58 @@ describe('git/commit', () => {
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)
       })
+      it.skip('chooses their version of a file and commits', async () => {
+        const fileName = 'foo'
+        const {
+          workingDirectory: { files },
+        } = await getStatusOrThrow(repository)
+        const trackedFiles = files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        const manualResolutions = new Map([
+          [fileName, ManualConflictResolutionKind.theirs],
+        ])
+        const sha = await createMergeCommit(
+          repository,
+          trackedFiles,
+          manualResolutions
+        )
+        expect(sha).toBeString()
+        expect(sha).not.toBeEmpty()
+        expect(
+          await FSE.readFile(path.join(repository.path, fileName), 'utf8')
+        ).toInclude('b1')
+        const {
+          workingDirectory: { files: newFiles },
+        } = await getStatusOrThrow(repository)
+        expect(newFiles.some(f => f.path === fileName)).toBeFalse()
+      })
+      it.skip('chooses our version of a file and commits', async () => {
+        const fileName = 'foo'
+        const {
+          workingDirectory: { files },
+        } = await getStatusOrThrow(repository)
+        const trackedFiles = files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        const manualResolutions = new Map([
+          [fileName, ManualConflictResolutionKind.ours],
+        ])
+        const sha = await createMergeCommit(
+          repository,
+          trackedFiles,
+          manualResolutions
+        )
+        expect(sha).toBeString()
+        expect(sha).not.toBeEmpty()
+        expect(
+          await FSE.readFile(path.join(repository.path, fileName), 'utf8')
+        ).toInclude('b2')
+        const {
+          workingDirectory: { files: newFiles },
+        } = await getStatusOrThrow(repository)
+        expect(newFiles.some(f => f.path === fileName)).toBeFalse()
+      })
       it('deletes files chosen to be removed and commits', async () => {
         const status = await getStatusOrThrow(repository)
         const trackedFiles = status.workingDirectory.files.filter(

--- a/app/test/unit/git/merge-test.ts
+++ b/app/test/unit/git/merge-test.ts
@@ -21,7 +21,7 @@ describe('git/merge', () => {
         repository = new Repository(path, -1, null, false)
       })
       it('returns true', async () => {
-        expect(await merge(repository, 'dev')).toBe(true)
+        expect(await merge(repository, 'dev')).toBeTrue()
       })
     })
     describe('and is a noop', () => {
@@ -32,7 +32,7 @@ describe('git/merge', () => {
         await merge(repository, 'dev')
       })
       it('returns false', async () => {
-        expect(await merge(repository, 'dev')).toBe(false)
+        expect(await merge(repository, 'dev')).toBeFalse()
       })
     })
   })


### PR DESCRIPTION
## Overview

Closes #8059 

## Description

it looks like our prior implementation of manual conflict resolution never worked for files that were changed in both branches. this is because it would simply stage whatever state the file was in in the index (probably a weird conflicted state, or whatever was their before the merge/rebase was started).

this PR adds the step of explicitly `git checkout`-ing the desired version of the file before staging it, ensuring we choose the single version of the file the user requested in the UI.

we need to double check that this works for merging _and_ rebasing due to [this potential complication](https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt---theirs). (it might check out the opposite version in a rebasing flow, but that should be easy to address if that is the case.)

## Release notes

Notes: [Fixed] Manual conflict resolution always added the same file version
