### PR TITLE
Handle when checkout branch fails

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2988,7 +2988,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     try {
       this.updateCheckoutProgress(repository, {
-        kind: "checkout",
+        kind: 'checkout',
         title: __DARWIN__ ? 'Refreshing Repository' : 'Refreshing repository',
         value: 1,
         targetBranch: foundBranch.name,
@@ -3068,7 +3068,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           repository,
           branch.name
         )
-        await authenticatedCheckoutBranch(repository)  
+        await authenticatedCheckoutBranch(repository)
         return stash
       } else {
         return null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2963,23 +2963,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (
       uncommittedChangesStrategy.kind ===
-        UncommittedChangesStrategyKind.MoveToNewBranch &&
-      stashToPop
+      UncommittedChangesStrategyKind.MoveToNewBranch
     ) {
-      // We increment the metric after checkout succeeds to guard
-      // against double counting when an error occurs on checkout.
-      // When an error occurs, one of our error handlers will inspect
-      // it and make a call to `moveChangesToBranchAndCheckout` which will
-      // call this method again once the working directory has been cleared.
-      this.statsStore.recordChangesTakenToNewBranch()
-
       stashToPop = stashToPop || uncommittedChangesStrategy.transientStashEntry
-      if (stashToPop !== null) {
+      if (stashToPop) {
+        // We increment the metric after checkout succeeds to guard
+        // against double counting when an error occurs on checkout.
+        // When an error occurs, one of our error handlers will inspect
+        // it and make a call to `moveChangesToBranchAndCheckout` which will
+        // call this method again once the working directory has been cleared.
+        this.statsStore.recordChangesTakenToNewBranch()
         const stashSha = stashToPop.stashSha
         const gitStore = this.gitStoreCache.get(repository)
-        await gitStore.performFailableOperation(() => {
-          return popStashEntry(repository, stashSha)
-        })
+        await gitStore.performFailableOperation(() =>
+          popStashEntry(repository, stashSha)
+        )
       }
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -243,7 +243,6 @@ import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { findRemoteBranchName } from './helpers/find-branch-name'
 import { isLocalChangesWouldBeOverwrittenError } from '../../ui/dispatcher'
-import { IErrorMetadata } from '../error-with-metadata'
 
 /**
  * As fast-forwarding local branches is proportional to the number of local
@@ -3021,27 +3020,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<IStashEntry | null> {
     const gitStore = this.gitStoreCache.get(repository)
     const authenticatedCheckoutBranch = (repository: Repository) => {
-      const metadata: IErrorMetadata = {
-        repository,
-        retryAction: {
-          type: RetryActionType.Checkout,
-          repository,
-          branch: branch.name,
-        },
-        gitContext: {
-          kind: 'checkout',
-          branchToCheckout: branch.name,
-        },
-      }
-
       return this.withAuthenticatingUser(repository, (repository, account) =>
-        gitStore.performFailableOperation(
-          () =>
-            checkoutBranch(repository, account, branch, progress => {
+          checkoutBranch(
+            repository,
+            account,
+            branch,
+            progress => {
               this.updateCheckoutProgress(repository, progress)
-            }),
-          metadata
-        )
+            }
+          )
       )
     }
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -422,17 +422,7 @@ export async function localChangesOverwrittenHandler(
     return error
   }
 
-  const gitError = asGitError(e.underlyingError)
-  if (!gitError) {
-    return error
-  }
-
-  const dugiteError = gitError.result.gitError
-  if (!dugiteError) {
-    return error
-  }
-
-  if (dugiteError !== DugiteError.LocalChangesOverwritten) {
+  if (!isLocalChangesWouldBeOverwrittenError(e)) {
     return error
   }
 
@@ -461,4 +451,28 @@ export async function localChangesOverwrittenHandler(
   await dispatcher.moveChangesToBranchAndCheckout(repository, branchToCheckout)
 
   return null
+}
+
+/**
+ * Checks if the given error has a `DugiteError.LocalChangesOverwritten`
+ *
+ * @todo This might be better to have live in a different file?
+ */
+export function isLocalChangesWouldBeOverwrittenError(
+  error: ErrorWithMetadata
+): DugiteError.LocalChangesOverwritten | null {
+  const gitError = asGitError(error.underlyingError)
+  if (!gitError) {
+    return null
+  }
+
+  const dugiteError = gitError.result.gitError
+  if (!dugiteError) {
+    return null
+  }
+
+  if (dugiteError !== DugiteError.LocalChangesOverwritten) {
+    return null
+  }
+  return dugiteError
 }


### PR DESCRIPTION
## Overview

Addresses https://github.com/desktop/desktop/issues/7617

One of the concerns in the issue above was that Desktop wasn't awaiting calls to `checkoutBranch`

```ts
 const checkoutSucceeded =
  (await this.withAuthenticatingUser(repository, (repository, account) =>
    gitStore.performFailableOperation(
      () =>
        checkoutBranch(repository, account, foundBranch, progress => {
          this.updateCheckoutProgress(repository, progress)
  }),
```

It turns out it is already awaiting, because `checkoutBranch` returns a promise to `performFailableOperation` which returns a promise to `withAuthenticatingUser` which is awaited.

But there is another concern raised in the issue. When a checking out a branch fails (because of conflicts or some other evil) Desktop should stashing the changes and checkout the branch again. This was happening as a side effect in the error handlers, but now it is handled explicitly in the `AppStore._checkoutBranch` method.

Speaking of the _checkoutBranch method, it's pretty long and tricky to follow. I created this pseudo code story to help me understand what the method is trying to do:

```
Do you have changes and is “ask before stashing” set?
	**Yes**
		Show a that popup and exit before doing anything (the popup will end up calling checkoutBranch again)
	**No**
		continue	
Are you on a branch and you want to keep your changes on that current branch?
	Stash the changes for the current branch
Or do you want to move your changes to the branch you are checking out?
	Are there deleted files and there is no transientStashEntry
		Create a stash
Checkout the branch
	Was there an error (maybe a conflict or some other badness)
		Is there already a stash
			THROW ERROR
		Are there no local changes?
			THROW ERROR
		Stash the changes
		Checkout again
Is there a stash and you moving changes to a new branch?
        Apply the stash
etc...
```

Now that I understand how it works I think I'll be able to clean up the method a bit (like https://github.com/desktop/desktop/issues/7609 describes) in a follow up PR.

Closes https://github.com/desktop/desktop/issues/7617

## Description

Notes:
- Diff best viewed with `Hide whitespace changes` on.