### PR TITLE
Fast forward recent branches if FastForwardBranchesThreshold is exceeded

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3593,7 +3593,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       eligibleBranches =
         defaultBranch != null &&
         eligibleForFastForward(defaultBranch, currentBranchName)
-          ? [defaultBranch]
+          ? [defaultBranch].concat(state.branchesState.recentBranches)
           : []
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3593,7 +3593,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       eligibleBranches =
         defaultBranch != null &&
         eligibleForFastForward(defaultBranch, currentBranchName)
-          ? [defaultBranch].concat(state.branchesState.recentBranches)
+          ? [defaultBranch, ...state.branchesState.recentBranches]
           : []
     }
 


### PR DESCRIPTION
# Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

Ensure recent branches are updated during remote interactions.

**Closes #7761**

## Description

This enhancement came about from investigating #7761. When a remote interaction takes place (push, pull, fetch), `fastForwardBranches` gets called and local branches are fast-forwarded to match their corresponding remotes. If the number of branches exceeds `FastForwardBranchesThreshold` then previously we would only fast forward the default branch, presumably for performance reasons. Now that we have easy access to `recentBranches` on our Branch model, we can fast-forward recent branches as well.

This can be helpful in ensuring that when merging and rebasing, the base branch is updated with relevant remote changes. Note that Desktop periodically fetches and fast-forwards branches for users, and this can be done manually by clicking the "Fetch origin" button.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->
Ensure recent branches are updated during remote interactions.

Notes: 

Manually tested with the following steps:
1. create a branch called `branch`
1. create a branch called `twig`
1. make a commit on `twig`
1. make a commit on `branch`
1. git push so that commit shows up on remote `branch`
1. make commit on `branch` remote using GitHub UI so that the local branch is behind 
1. in Desktop ensure that `twig` is checked out
1. click "Fetch origin"
1. check out `branch` and verify that remote commit is now on local branch

Did not add tests because (1) this is a low-risk change and (2) there is no existing test that covers the functionality in fastForwardBranches. 