### PR TITLE
In the checkoutBranch method, move stash logic into new method.

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2917,7 +2917,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    let stashToPop: IStashEntry | null = this._stashIfNeeded(
+    let stashToPop: IStashEntry | null = await this._stashBasedOnUncommittedChangesStrategy(
       repository,
       foundBranch,
       uncommittedChangesStrategy
@@ -3000,7 +3000,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
-  private async _stashIfNeeded(
+  private async _stashBasedOnUncommittedChangesStrategy(
     repository: Repository,
     branch: Branch,
     uncommittedChangesStrategy: UncommittedChangesStrategy = askToStash

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2907,21 +2907,24 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository
     )
 
-    const hasChanges = changesState.workingDirectory.files.length > 0
-    if (hasChanges && uncommittedChangesStrategy.kind === askToStash.kind) {
-      this._showPopup({
-        type: PopupType.StashAndSwitchBranch,
-        branchToCheckout: foundBranch,
-        repository,
-      })
-      return repository
-    }
+    let stashToPop: IStashEntry | null = null
+    if (enableStashing()) {
+      const hasChanges = changesState.workingDirectory.files.length > 0
+      if (hasChanges && uncommittedChangesStrategy.kind === askToStash.kind) {
+        this._showPopup({
+          type: PopupType.StashAndSwitchBranch,
+          branchToCheckout: foundBranch,
+          repository,
+        })
+        return repository
+      }
 
-    const stashToPop = await this.stashBasedOnUncommittedChangesStrategy(
-      repository,
-      foundBranch,
-      uncommittedChangesStrategy
-    )
+      stashToPop = await this.stashBasedOnUncommittedChangesStrategy(
+        repository,
+        foundBranch,
+        uncommittedChangesStrategy
+      )
+    }
 
     const checkoutSucceeded =
       (await this.withAuthenticatingUser(repository, (repository, account) =>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2917,7 +2917,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return repository
     }
 
-    let stashToPop: IStashEntry | null = await this._stashBasedOnUncommittedChangesStrategy(
+    const stashToPop = await this.stashBasedOnUncommittedChangesStrategy(
       repository,
       foundBranch,
       uncommittedChangesStrategy
@@ -2958,11 +2958,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // call this method again once the working directory has been cleared.
       this.statsStore.recordChangesTakenToNewBranch()
 
-      stashToPop = stashToPop || uncommittedChangesStrategy.transientStashEntry
-      if (stashToPop !== null) {
-        const stashSha = stashToPop.stashSha
+      const stash = stashToPop || uncommittedChangesStrategy.transientStashEntry
+      if (stash) {
         await gitStore.performFailableOperation(() => {
-          return popStashEntry(repository, stashSha)
+          return popStashEntry(repository, stash.stashSha)
         })
       }
     }
@@ -3000,7 +2999,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
-  private async _stashBasedOnUncommittedChangesStrategy(
+  private async stashBasedOnUncommittedChangesStrategy(
     repository: Repository,
     branch: Branch,
     uncommittedChangesStrategy: UncommittedChangesStrategy = askToStash


### PR DESCRIPTION
## Overview

Closes https://github.com/desktop/desktop/issues/7609

## Description

This is a straight forward extraction of some code in the _checkoutBranch method . 

- I ended up with a method name that is pretty long `_stashBasedOnUncommittedChangesStrategy` so if you have a better name I'm all ears 🌽! 
- I removed the `enableStashing` because the feature is globally enabled!