### PR TITLE
Added CodeRunner to the External Editor list

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -270,7 +270,7 @@ export async function getAvailableEditors(): Promise<
   if (codeRunnerPath) {
     results.push({ editor: ExternalEditor.CodeRunner, path: codeRunnerPath })
   }
-  
+
   if (slickeditPath) {
     results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
   }

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -16,6 +16,7 @@ export enum ExternalEditor {
   Brackets = 'Brackets',
   WebStorm = 'WebStorm',
   Typora = 'Typora',
+  CodeRunner = 'CodeRunner',
   SlickEdit = 'SlickEdit',
 }
 
@@ -56,6 +57,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Typora) {
     return ExternalEditor.Typora
   }
+  if (label === ExternalEditor.CodeRunner) {
+    return ExternalEditor.CodeRunner
+  }
   if (label === ExternalEditor.SlickEdit) {
     return ExternalEditor.SlickEdit
   }
@@ -93,6 +97,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.jetbrains.WebStorm']
     case ExternalEditor.Typora:
       return ['abnerworks.Typora']
+    case ExternalEditor.CodeRunner:
+      return ['com.krill.CodeRunner']
     case ExternalEditor.SlickEdit:
       return [
         'com.slickedit.SlickEditPro2018',
@@ -140,6 +146,8 @@ function getExecutableShim(
       return Path.join(installPath, 'Contents', 'MacOS', 'WebStorm')
     case ExternalEditor.Typora:
       return Path.join(installPath, 'Contents', 'MacOS', 'Typora')
+    case ExternalEditor.CodeRunner:
+      return Path.join(installPath, 'Contents', 'MacOS', 'CodeRunner')
     case ExternalEditor.SlickEdit:
       return Path.join(installPath, 'Contents', 'MacOS', 'vs')
     default:
@@ -189,6 +197,7 @@ export async function getAvailableEditors(): Promise<
     bracketsPath,
     webStormPath,
     typoraPath,
+    codeRunnerPath,
     slickeditPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
@@ -203,6 +212,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.Brackets),
     findApplication(ExternalEditor.WebStorm),
     findApplication(ExternalEditor.Typora),
+    findApplication(ExternalEditor.CodeRunner),
     findApplication(ExternalEditor.SlickEdit),
   ])
 
@@ -257,6 +267,10 @@ export async function getAvailableEditors(): Promise<
     results.push({ editor: ExternalEditor.Typora, path: typoraPath })
   }
 
+  if (codeRunnerPath) {
+    results.push({ editor: ExternalEditor.CodeRunner, path: codeRunnerPath })
+  }
+  
   if (slickeditPath) {
     results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
   }


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #3814 )

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8091**

## Description

- I updated the External Editors list to include [CodeRunner](https://coderunnerapp.com/) as an option for GitHub Desktop.


## Release notes

- The only section I was unsure about is the function getExecutableShim() section.  I attempted to follow the instructions until I got to [Step 2: Find executable to launch](https://github.com/desktop/desktop/blob/development/docs/technical/editor-integration.md#step-2-find-executable-to-launch), which was not very helpful so I just mirrored the majority of the other applications hoping this is what is needed.

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

## Notes
- Adds CodeRunner as an External Editor option when already installed on computer
