### PR TITLE
Fix manual conflict resolution for binary files

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -347,18 +347,3 @@ export async function gitNetworkArguments(
 export function parseCommitSHA(result: IGitResult): string {
   return result.stdout.split(']')[0].split(' ')[1]
 }
-
-/**
- * Run a Git command and return whether the exit code indicated success
- *
- * This defers to the default error handling infrastructure inside if an error
- * is encountered.
- */
-export async function runGitCommand(
-  args: string[],
-  path: string,
-  name: string
-): Promise<boolean> {
-  const { exitCode } = await git(args, path, name)
-  return exitCode === 0
-}

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -347,3 +347,18 @@ export async function gitNetworkArguments(
 export function parseCommitSHA(result: IGitResult): string {
   return result.stdout.split(']')[0].split(' ')[1]
 }
+
+/**
+ * Run a Git command and return whether the exit code indicated success
+ *
+ * This defers to the default error handling infrastructure inside if an error
+ * is encountered.
+ */
+export async function runGitCommand(
+  args: string[],
+  path: string,
+  name: string
+): Promise<boolean> {
+  const { exitCode } = await git(args, path, name)
+  return exitCode === 0
+}

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -9,7 +9,7 @@ import {
   ManualConflictResolution,
   ManualConflictResolutionKind,
 } from '../../models/manual-conflict-resolution'
-import { git } from '.'
+import { runGitCommand } from '.'
 import { assertNever } from '../fatal-error'
 
 /**
@@ -80,19 +80,4 @@ export async function stageManualConflictResolution(
     default:
       return assertNever(chosen, 'unnacounted for git status entry possibility')
   }
-}
-
-/**
- * Run a Git command and return whether the exit code indicated success
- *
- * This defers to the default error handling infrastructure inside if an error
- * is encountered.
- */
-async function runGitCommand(
-  args: string[],
-  path: string,
-  name: string
-): Promise<boolean> {
-  const { exitCode } = await git(args, path, name)
-  return exitCode === 0
 }

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -57,14 +57,12 @@ export async function stageManualConflictResolution(
         manualResolution === ManualConflictResolutionKind.theirs
           ? 'theirs'
           : 'ours'
-      const checkoutCompleted = await git(
+      await git(
         ['checkout', `--${choiceFlag}`, '--', file.path],
         repository.path,
         'checkoutConflictedFile'
       )
-      if (checkoutCompleted) {
-        await git(['add', file.path], repository.path, 'addConflictedFile')
-      }
+      await git(['add', file.path], repository.path, 'addConflictedFile')
       break
     }
     default:

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -54,13 +54,31 @@ export async function stageManualConflictResolution(
       )).exitCode
       break
     }
-    case GitStatusEntry.Added:
-    case GitStatusEntry.UpdatedButUnmerged: {
+    case GitStatusEntry.Added: {
       exitCode = (await git(
         ['add', file.path],
         repository.path,
         'addConflictedFile'
       )).exitCode
+      break
+    }
+    case GitStatusEntry.UpdatedButUnmerged: {
+      const choiceFlag =
+        manualResolution === ManualConflictResolutionKind.theirs
+          ? 'theirs'
+          : 'ours'
+      exitCode = (await git(
+        ['checkout', `--${choiceFlag}`, '--', file.path],
+        repository.path,
+        'checkoutConflictedFile'
+      )).exitCode
+      if (exitCode === 0) {
+        exitCode = (await git(
+          ['add', file.path],
+          repository.path,
+          'addConflictedFile'
+        )).exitCode
+      }
       break
     }
     default:

--- a/app/test/helpers/repositories.ts
+++ b/app/test/helpers/repositories.ts
@@ -183,13 +183,6 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
   Repository
 > {
   const repo = await setupEmptyRepository()
-  const filePaths = [
-    Path.join(repo.path, 'foo'),
-    Path.join(repo.path, 'bar'),
-    Path.join(repo.path, 'baz'),
-    Path.join(repo.path, 'cat'),
-    Path.join(repo.path, 'dog'),
-  ]
 
   const firstCommit = {
     entries: [{ path: 'foo', contents: 'b0' }, { path: 'bar', contents: 'b0' }],
@@ -225,7 +218,7 @@ export async function setupConflictedRepoWithMultipleFiles(): Promise<
 
   await makeCommit(repo, thirdCommit)
 
-  await FSE.writeFile(filePaths[4], 'touch')
+  await FSE.writeFile(Path.join(repo.path, 'dog'), 'touch')
 
   await GitProcess.exec(['merge', 'master'], repo.path)
 

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -548,9 +548,9 @@ describe('git/commit', () => {
           trackedFiles,
           manualResolutions
         )
-        expect(await FSE.pathExists(path.join(repository.path, 'bar'))).toBe(
-          true
-        )
+        expect(
+          await FSE.pathExists(path.join(repository.path, 'bar'))
+        ).toBeTrue()
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)
@@ -568,9 +568,9 @@ describe('git/commit', () => {
           trackedFiles,
           manualResolutions
         )
-        expect(await FSE.pathExists(path.join(repository.path, 'bar'))).toBe(
-          false
-        )
+        expect(
+          await FSE.pathExists(path.join(repository.path, 'bar'))
+        ).toBeFalse()
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -555,6 +555,58 @@ describe('git/commit', () => {
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)
       })
+      it.skip('chooses their version of a file and commits', async () => {
+        const fileName = 'foo'
+        const {
+          workingDirectory: { files },
+        } = await getStatusOrThrow(repository)
+        const trackedFiles = files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        const manualResolutions = new Map([
+          [fileName, ManualConflictResolutionKind.theirs],
+        ])
+        const sha = await createMergeCommit(
+          repository,
+          trackedFiles,
+          manualResolutions
+        )
+        expect(sha).toBeString()
+        expect(sha).not.toBeEmpty()
+        expect(
+          await FSE.readFile(path.join(repository.path, fileName), 'utf8')
+        ).toInclude('b1')
+        const {
+          workingDirectory: { files: newFiles },
+        } = await getStatusOrThrow(repository)
+        expect(newFiles.some(f => f.path === fileName)).toBeFalse()
+      })
+      it.skip('chooses our version of a file and commits', async () => {
+        const fileName = 'foo'
+        const {
+          workingDirectory: { files },
+        } = await getStatusOrThrow(repository)
+        const trackedFiles = files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        const manualResolutions = new Map([
+          [fileName, ManualConflictResolutionKind.ours],
+        ])
+        const sha = await createMergeCommit(
+          repository,
+          trackedFiles,
+          manualResolutions
+        )
+        expect(sha).toBeString()
+        expect(sha).not.toBeEmpty()
+        expect(
+          await FSE.readFile(path.join(repository.path, fileName), 'utf8')
+        ).toInclude('b2')
+        const {
+          workingDirectory: { files: newFiles },
+        } = await getStatusOrThrow(repository)
+        expect(newFiles.some(f => f.path === fileName)).toBeFalse()
+      })
       it('deletes files chosen to be removed and commits', async () => {
         const status = await getStatusOrThrow(repository)
         const trackedFiles = status.workingDirectory.files.filter(

--- a/app/test/unit/git/merge-test.ts
+++ b/app/test/unit/git/merge-test.ts
@@ -21,7 +21,7 @@ describe('git/merge', () => {
         repository = new Repository(path, -1, null, false)
       })
       it('returns true', async () => {
-        expect(await merge(repository, 'dev')).toBe(true)
+        expect(await merge(repository, 'dev')).toBeTrue()
       })
     })
     describe('and is a noop', () => {
@@ -32,7 +32,7 @@ describe('git/merge', () => {
         await merge(repository, 'dev')
       })
       it('returns false', async () => {
-        expect(await merge(repository, 'dev')).toBe(false)
+        expect(await merge(repository, 'dev')).toBeFalse()
       })
     })
   })


### PR DESCRIPTION
## Overview

Supersedes #8060 
**Closes #8059 **
Potentially addresses #7166 (needs verification. my guess is that it doesn't, though https://github.com/desktop/desktop/issues/8059#issuecomment-517673659 indicates that it might)

## Description

In certain merge conflict cases, the file under conflict does not have merge markers. Examples include if a file has been deleted on one branch and modified on another, or if the file is a binary file and has been modified on both branches. In Desktop parlance, we call these "Manual conflicts".

For manually resolving binary files, previously if the user selected changes from the `theirs` branch (the branch being merged into the current branch) as part of the merge, they would be unpleasantly surprised to find that the change from the current branch (`ours`) were used in the merge. This was an oversight that never worked correctly (as opposed to a regression). We simply used `git add` to stage the conflicted file, which committed the working directory contents (the version of the file on the current branch). 

With this PR, we ensure that we use the correct version of binary files under conflict by checking out the proper version before staging (`git checkout --ours/theirs -- filePath`). 

Tests were added for choosing both the `theirs` and `ours` versions of conflicted binary files during a merge, which should help protect against future regressions. 

Manual testing steps for merging:

1. download [repo-binary-file.zip](https://github.com/desktop/desktop/files/3494892/repo-binary-file.zip)
1. check out `master` and verify that you're on commit `bbb019c` (or `reset --hard` to it)
1. check out `branch` and verify that you're on commit `0359ae5` (or `reset --hard` to it)
1. merge `master` into `branch`
1. click "Resolve" and choose "Use modified file from master" 
1. click "Commit merge"
1. view the `cute_rodent.jpeg` file and verify that it has rotated left by 90 degrees
1. now redo merge... `git reset --hard 0359ae5` to make it so that we're back to where we started
1. merge `master` into `branch` again
1. click "Resolve" and choose "Use modified file from branch" 
1. click "Commit merge"
1. view the `cute_rodent.jpeg` file and verify that image is now upside-down

Manual testing steps for rebasing:

1. download [repo-binary-file.zip](https://github.com/desktop/desktop/files/3494892/repo-binary-file.zip)
1. check out `master` and verify that you're on commit `bbb019c` (or `reset --hard` to it)
1. check out `branch` and verify that you're on commit `0359ae5` (or `reset --hard` to it)
1. rebase `branch` onto `master`
1. click "Resolve" and choose "Use modified file from master" 
1. click "Continue rebase"
1. view the `cute_rodent.jpeg` file and verify that it has rotated left by 90 degrees
1. now redo rebase... `git reset --hard 0359ae5`  to make it so that we're back to where we started
1. rebase `branch` onto `master` again
1. click "Resolve" and choose "Use modified file from branch" 
1. click "Continue rebase"
1. view the `cute_rodent.jpeg` file and verify that image is now upside-down

## Release notes

Notes: Fixes manual conflict resolution for binary files
