### PR TITLE
Bump dugite to 1.87.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.87.0",
+    "dugite": "1.87.1",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-uri-to-path": "0.0.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -382,10 +382,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.87.0:
-  version "1.87.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.87.0.tgz#ba42c25401420a92c6c8f0c71823ac54124b4b65"
-  integrity sha512-+aW2Ql3yw1AEO8Z8nVbjOAEzsinMJMmAg4uf5lzTewFUAHd0danuMPXMP9uMuGuUYN/LQtt4kR2XLuWoD8wRSQ==
+dugite@1.87.1:
+  version "1.87.1"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.87.1.tgz#827d21e8f0de1974815a1d04cf2423c2a455e9a6"
+  integrity sha512-nUlfkS3XMgSYCm6IMqw/0L+oNVMNVCFkBoOTYJ36A6K6DivsAYVizIBjkqzd/VD0pHIyuqt7Uew7WhnQ1g5QRA==
   dependencies:
     checksum "^0.1.1"
     mkdirp "^0.5.1"


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This bumps dugite to 1.87.1 which in turn updates Git for Windows to version 2.19.2.windows.2 (see https://github.com/desktop/dugite-native/pull/304) in order to address the [CVE-2019-1211](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-1211) security vulnerability.

## Description

The Git vulnerability affects multi-user Windows environments, see the [information published by the Visual Studio team](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-1211) for more information.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: `[Fixed] Update embedded Git on Windows to address security vulnerability`