### PR TITLE
Fix problem with 2-up image rendering

### DIFF
--- a/app/src/ui/diff/image-diffs/modified-image-diff.tsx
+++ b/app/src/ui/diff/image-diffs/modified-image-diff.tsx
@@ -168,9 +168,6 @@ export class ModifiedImageDiff extends React.Component<
         return (
           <TwoUp
             {...this.getCommonProps(maxSize)}
-            containerWidth={
-              (this.state.containerSize && this.state.containerSize.width) || 0
-            }
             previousImageSize={this.state.previousImageSize}
             currentImageSize={this.state.currentImageSize}
           />

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -5,14 +5,6 @@ import { ISize } from './sizing'
 import { formatBytes, Sign } from '../../lib/bytes'
 import * as classNames from 'classnames'
 
-/**
- * The height of the Deleted/Added labels at the top and the image dimension
- * labels.
- */
-const ControlsHeight = 60
-
-const XPadding = 20
-
 interface ITwoUpProps extends ICommonImageDiffProperties {
   readonly containerWidth: number
 
@@ -22,13 +14,6 @@ interface ITwoUpProps extends ICommonImageDiffProperties {
 
 export class TwoUp extends React.Component<ITwoUpProps, {}> {
   public render() {
-    const style: React.CSSProperties = {
-      maxWidth: Math.min(
-        (this.props.containerWidth - XPadding) / 2,
-        this.props.maxSize.width
-      ),
-      maxHeight: this.props.maxSize.height - ControlsHeight,
-    }
     const percentDiff = (previous: number, current: number) => {
       const diff = Math.round((100 * (current - previous)) / previous)
       const sign = diff > 0 ? '+' : ''
@@ -52,7 +37,6 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
             <ImageContainer
               image={this.props.previous}
               onElementLoad={this.props.onPreviousImageLoad}
-              style={style}
             />
 
             <div className="image-diff-footer">
@@ -68,7 +52,6 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
             <ImageContainer
               image={this.props.current}
               onElementLoad={this.props.onCurrentImageLoad}
-              style={style}
             />
 
             <div className="image-diff-footer">

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -6,8 +6,6 @@ import { formatBytes, Sign } from '../../lib/bytes'
 import * as classNames from 'classnames'
 
 interface ITwoUpProps extends ICommonImageDiffProperties {
-  readonly containerWidth: number
-
   readonly previousImageSize: ISize | null
   readonly currentImageSize: ISize | null
 }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -369,14 +369,16 @@
 
 .image-diff-container {
   display: flex;
-  flex: 1;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  flex-direction: column;
 
   .image-diff-two-up {
     display: flex;
-    align-items: center;
+    max-height: 100%;
+    padding: 0 var(--spacing-double);
 
     .image-diff-previous {
       margin-right: var(--spacing-half);


### PR DESCRIPTION
## Overview

Closes https://github.com/desktop/desktop/issues/7520

## Description

The "two up" image diff had some trouble. The first problem was if an image's height was 60px, a `max-height` would be set to 0. The second problem was images with a large height or width would overflow out of bounds. Both of these problems can be seen in this gif.

**Before**
![](https://d.pr/i/1BDaJW+)

**After**
![](https://d.pr/i/DXn376+)

I cleaned this up be removing the calculated maxWidth and maxHeight values and instead relying on flexbox to handle the sizing. Much like me, this fix is close to perfect but with a caveat. If you are viewing a very large image and resize the window, the images don't resize. This also was broken on development. I tried for too long to get this to work, but am being pragmatic and throwing in the towel.

## Release notes

- Fixes 2-up diff image rendering problem.
