### PR TITLE
Prevent CodeMirror search plugin from stealing registered global keyboard shortcuts

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -171,6 +171,12 @@ const defaultEditorOptions: IEditorConfigurationExtra = {
     // Steal the default key binding so that we can launch our
     // custom search UI.
     [__DARWIN__ ? 'Cmd-F' : 'Ctrl-F']: showSearch,
+    // Disable all other search-related shortcuts so that they
+    // don't interfer with global app shortcuts.
+    [__DARWIN__ ? 'Cmd-G' : 'Ctrl-G']: false, // findNext
+    [__DARWIN__ ? 'Shift-Cmd-G' : 'Shift-Ctrl-G']: false, // findPrev
+    [__DARWIN__ ? 'Cmd-Alt-F' : 'Shift-Ctrl-F']: false, // replace
+    [__DARWIN__ ? 'Shift-Cmd-Alt-F' : 'Shift-Ctrl-R']: false, // replaceAll
   },
   scrollbarStyle: __DARWIN__ ? 'simple' : 'native',
   styleSelectedText: true,

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -168,6 +168,8 @@ const defaultEditorOptions: IEditorConfigurationExtra = {
   extraKeys: {
     Tab: false,
     'Shift-Tab': false,
+    // Steal the default key binding so that we can launch our
+    // custom search UI.
     [__DARWIN__ ? 'Cmd-F' : 'Ctrl-F']: showSearch,
   },
   scrollbarStyle: __DARWIN__ ? 'simple' : 'native',

--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -708,6 +708,12 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
         'Ctrl-Space': 'autocomplete',
         'Ctrl-Enter': false,
         'Cmd-Enter': false,
+        // Disable all search-related shortcuts.
+        [__DARWIN__ ? 'Cmd-F' : 'Ctrl-F']: false, // find
+        [__DARWIN__ ? 'Cmd-G' : 'Ctrl-G']: false, // findNext
+        [__DARWIN__ ? 'Shift-Cmd-G' : 'Shift-Ctrl-G']: false, // findPrev
+        [__DARWIN__ ? 'Cmd-Alt-F' : 'Shift-Ctrl-F']: false, // replace
+        [__DARWIN__ ? 'Shift-Cmd-Alt-F' : 'Shift-Ctrl-R']: false, // replaceAll
       },
       readOnly: this.props.disabled ? 'nocursor' : false,
       hintOptions: {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8068**

## Description

When I added the search plugin back in https://github.com/desktop/desktop/pull/7866 I forgot to look for new keyboard bindings that would come into effect through the default key maps. Looking through [the default key maps](https://github.com/codemirror/CodeMirror/blob/5.44.0/src/input/keymap.js#L8-L47) and [the commands registered by the search plugin](https://github.com/codemirror/CodeMirror/blob/6454f583167a44016ee452b1787466f442bd9122/addon/search/search.js#L249-L257) I arrived at this list of keyboard shortcuts to disable.

As part of this I also found that the co-author input control (which is also based on CodeMirror) also reacted to these shortcuts and showed a (unstyled and very unusable) search bar so I took care of that as well.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: [Fixed] Some menu keyboard shortcuts didn't work while focused on a text diff.