### PR TITLE
Ignore global gitconfig for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ app/node_modules/
 *.iml
 .envrc
 junit*.xml
+*.swp

--- a/app/test/unit-test-env.ts
+++ b/app/test/unit-test-env.ts
@@ -6,6 +6,8 @@ const environmentVariables = {
   GIT_COMMITTER_EMAIL: 'joe.bloggs@somewhere.com',
   // signalling to dugite to use the bundled Git environment
   TEST_ENV: '1',
+  HOME: '',
+  USERPROFILE: '',
 }
 
 process.env = { ...process.env, ...environmentVariables }


### PR DESCRIPTION
## Overview

**Closes #8078**

## Description

We have experienced test failures when a user's local `.gitconfig` file sets things our tests don't expect. This PR forces unit tests to ignore a user's `.gitconfig` by unsetting `HOME` and `USERPROFILE` (for mac/linux and windows respectively).

While the original issue suggested punting on this kind of decision we'd like to try it in the hopes of no longer playing whack-a-mole or experiencing surprise test failures.

## Release notes

Notes: no-notes