### PR TITLE
Make Windows protocol launcher code less brittle

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -2,6 +2,7 @@ import '../lib/logging/main/install'
 
 import { app, Menu, ipcMain, BrowserWindow, shell } from 'electron'
 import * as Fs from 'fs'
+import * as URL from 'url'
 
 import { MenuLabelsEvent } from '../models/menu-labels'
 
@@ -70,6 +71,19 @@ function getExtraErrorContext(): Record<string, string> {
     uptime: getUptimeInSeconds().toFixed(3),
     time: new Date().toString(),
   }
+}
+
+const possibleProtocols = new Set(['x-github-client'])
+if (__DEV__) {
+  possibleProtocols.add('x-github-desktop-dev-auth')
+} else {
+  possibleProtocols.add('x-github-desktop-auth')
+}
+// Also support Desktop Classic's protocols.
+if (__DARWIN__) {
+  possibleProtocols.add('github-mac')
+} else if (__WIN32__) {
+  possibleProtocols.add('github-windows')
 }
 
 process.on('uncaughtException', (error: Error) => {
@@ -189,12 +203,20 @@ function handlePossibleProtocolLauncherArgs(args: ReadonlyArray<string>) {
 
   if (__WIN32__) {
     // Desktop registers it's protocol handler callback on Windows as
-    // `[executable path] --protocol-launcher "%1"`. At launch it checks
-    // for that exact scenario here before doing any processing, and only
-    // processing the first argument. If there's more than 3 args because of a
+    // `[executable path] --protocol-launcher "%1"`. Note that extra command
+    // line arguments might be added by Chromium
+    // (https://electronjs.org/docs/api/app#event-second-instance).
+    // At launch Desktop checks for that exact scenario here before doing any
+    // processing. If there's more than one matching url argument because of a
     // malformed or untrusted url then we bail out.
-    if (args.length === 3 && args[1] === '--protocol-launcher') {
-      handleAppURL(args[2])
+
+    const matchingUrls = args.filter(arg => {
+      const url = URL.parse(arg)
+      return url.protocol && possibleProtocols.has(url.protocol.slice(0, -1))
+    })
+
+    if (args[1] === '--protocol-launcher' && matchingUrls.length === 1) {
+      handleAppURL(matchingUrls[0])
     }
   } else if (args.length > 1) {
     handleAppURL(args[1])
@@ -229,20 +251,7 @@ app.on('ready', () => {
 
   readyTime = now() - launchTime
 
-  setAsDefaultProtocolClient('x-github-client')
-
-  if (__DEV__) {
-    setAsDefaultProtocolClient('x-github-desktop-dev-auth')
-  } else {
-    setAsDefaultProtocolClient('x-github-desktop-auth')
-  }
-
-  // Also support Desktop Classic's protocols.
-  if (__DARWIN__) {
-    setAsDefaultProtocolClient('github-mac')
-  } else if (__WIN32__) {
-    setAsDefaultProtocolClient('github-windows')
-  }
+  possibleProtocols.forEach(protocol => setAsDefaultProtocolClient(protocol))
 
   createWindow()
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

Fix bug breaking OAuth login flow on Windows by improving protocol launcher code to handle the fact that with the Electron 5 upgrade, Chromium now adds extra command line arguments for the `second-instance` event (see [docs](https://electronjs.org/docs/api/app#event-second-instance)).

**Closes #8154**
Fixes #8142
Fixes https://github.com/github/ce-desktop/issues/611

## Description

With the Electron 5 upgrade, Chromium now adds extra command line arguments for the [`second-instance` event](https://electronjs.org/docs/api/app#event-second-instance). This event gets emitted during our OAuth login flow. We are now seeing two additional arguments:

```
[
  executable_path,
  "--protocol-launcher",
  "--allow-file-access-from-files",                                         <---
  "--original-process-start-time=13211099044577424",    <---
  "x-github-client://oauth/..."
]
```

Previously, our protocol launcher code expected the app url passed to be the third argument. So with the Electron upgrade the OAuth broke because we were passing the wrong argument to `handleAppURL`. 

This PR introduces more robust protocol launcher code, which checks for arguments that match one of our registered protocols without relying on argument location. 

@desktop/core a couple of notes:
* I am lacking historical context on this code and made some educated guesses, so I left some comments with questions for folks who have been around longer than I have
* for the sake of expediency, please feel free to push code directly to this branch and carry forward the work (or change what I have entirely)

/cc @vilmibm 

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: Fixes bug breaking OAuth login flow on Windows due to Electron 5 upgrade
