### PR TITLE
remove codecov statuses config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,32 +3,5 @@ coverage:
   round: nearest
   # thresholds for red to green color coding
   range: '10...80'
-
-  status:
-    project:
-      lib-git:
-        target: auto
-        threshold: 5%
-        base: pr
-        paths: 'app/src/lib/git'
-      lib-app:
-        target: auto
-        threshold: 5%
-        base: pr
-        paths:
-          - 'app/src/lib/stores'
-          - 'app/src/lib/databases'
-      models:
-        target: auto
-        threshold: 5%
-        base: pr
-        paths: 'app/src/models'
-      ui-components:
-        target: auto
-        threshold: 5%
-        base: pr
-        paths: 'app/src/ui'
-    patch: no
-    changes: no
-
+  status: off
 comment: off


### PR DESCRIPTION
## Overview

disables PR statuses from codecov

## Description

- we discussed this last week as probably being more noise than signal among our CI providers in PR review
- code coverage will still be tracked, there just won't be a status reported on commits and PRs in the GitHub UI

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
