### PR TITLE
Shared feature flag and stubs for onboarding tutorial

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -105,3 +105,7 @@ export function enableBranchProtectionWarningFlow(): boolean {
 export function enableHideWhitespaceInDiffOption(): boolean {
   return enableBetaFeatures()
 }
+
+export function enableTutorial(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -106,6 +106,10 @@ export function enableHideWhitespaceInDiffOption(): boolean {
   return enableBetaFeatures()
 }
 
+/**
+ * Should we enable the onboarding tutorial. This includes the initial
+ * configuration of the tutorial repo as well as the tutorial itself.
+ */
 export function enableTutorial(): boolean {
   return enableDevelopmentFeatures()
 }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -2,6 +2,7 @@ import * as Path from 'path'
 
 import { GitHubRepository } from './github-repository'
 import { IAheadBehind } from './branch'
+import { enableTutorial } from '../lib/feature-flag'
 
 function getBaseName(path: string): string {
   const baseName = Path.basename(path)
@@ -56,6 +57,14 @@ export class Repository {
     return `${this.id}+${this.gitHubRepository && this.gitHubRepository.hash}+${
       this.path
     }+${this.missing}+${this.name}`
+  }
+
+  /**
+   * Whether or not this repository is set up as the onboarding
+   * tutorial repository.
+   */
+  public get isTutorialRepository(): boolean {
+    return enableTutorial() && this.name === 'tutorial'
   }
 }
 

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -64,7 +64,11 @@ export class Repository {
    * tutorial repository.
    */
   public get isTutorialRepository(): boolean {
-    return enableTutorial() && this.name === 'tutorial'
+    return (
+      enableTutorial() &&
+      this.name.startsWith('desktop-tutorial') &&
+      this.gitHubRepository !== null
+    )
   }
 }
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

Hey @outofambit and @kuychaco! Seeing as I'll be doing the entry point to the tutorial (https://github.com/desktop/desktop/issues/8148) and you'll be doing the actual tutorial (https://github.com/desktop/desktop/issues/8149) I figured it'd made sense for us to have some minimal common ground so that you don't have to wait for my work to actually create a repository.

## Description

This PR adds an overarching feature flag for the onboarding tutorial as well as a new property on the `Repository` model called `isTutorialRepository`. My work from here on will be to actually let the user create this repository and ensure it's published to GitHub.com/GHE.

For now though the conditions for a repository to be considered a "tutorial repository" will be that its name starts with `desktop-tutorial` (meaning y'all can use `github-tutorial-NNN` for testing) and that it's published to GitHub.com/GHE. When my work is done this property will likely be set once when creating the tutorial repo and then persisted into the database.

Does this sound like a decent start for you?

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes