### PR TITLE
Run Appveyor builds on PRs on Epic branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ branches:
     - development
     - /releases\/.+/
     - /^__release-.*/
+    - /epic\/.*/
 
 skip_tags: true
 


### PR DESCRIPTION
Appveyor previously ran tests if the PR was based on the `development` or `release/*` branches. This wasn't going to cut it for @outofambit ([slack history](https://github.slack.com/archives/C17LP0XU3/p1568219560282800)). So now appveyor will run tests if the PR is based on a branch name matching the `epic/*` pattern.