### PR TITLE
googleRevert "use panel css for changes sidebar"

### DIFF
--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -382,7 +382,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     const isShowingStashEntry = selection.kind === ChangesSelectionKind.Stash
 
     return (
-      <div className="panel">
+      <div id="changes-sidebar-contents">
         <ChangesList
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}

--- a/app/styles/ui/_changes.scss
+++ b/app/styles/ui/_changes.scss
@@ -1,6 +1,7 @@
 @import 'changes/commit-message';
 @import 'changes/continue-rebase';
 @import 'changes/changes-list';
+@import 'changes/sidebar';
 @import 'changes/undo-commit';
 @import 'changes/changes-view';
 @import 'changes/no-changes';

--- a/app/styles/ui/changes/_sidebar.scss
+++ b/app/styles/ui/changes/_sidebar.scss
@@ -1,0 +1,6 @@
+#changes-sidebar-contents {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #{issue number}**

## Description

-

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes:
