### PR TITLE
[Onboarding Tutorial] platform-specific keyboard shortcuts

### DIFF
--- a/app/src/ui/tutorial-panel/tutorial-panel.tsx
+++ b/app/src/ui/tutorial-panel/tutorial-panel.tsx
@@ -172,7 +172,7 @@ export class TutorialPanel extends React.Component<
                 </Button>
                 <kbd>⇧</kbd>
                 <kbd>⌘</kbd>
-                <kbd>R</kbd>
+                <kbd>A</kbd>
               </div>
             )}
           </TutorialStepInstructions>

--- a/app/src/ui/tutorial-panel/tutorial-panel.tsx
+++ b/app/src/ui/tutorial-panel/tutorial-panel.tsx
@@ -188,10 +188,6 @@ export class TutorialPanel extends React.Component<
               Write a message that describes the changes you made. When you’re
               done, click the commit button to finish.
             </p>
-            <div className="action">
-              <kbd>⌘</kbd>
-              <kbd>Enter</kbd>
-            </div>
           </TutorialStepInstructions>
           <TutorialStepInstructions
             summaryText="Push to GitHub"

--- a/app/src/ui/tutorial-panel/tutorial-panel.tsx
+++ b/app/src/ui/tutorial-panel/tutorial-panel.tsx
@@ -142,9 +142,19 @@ export class TutorialPanel extends React.Component<
               clicking "${__DARWIN__ ? 'New Branch' : 'New branch'}".`}
             </p>
             <div className="action">
-              <kbd>⇧</kbd>
-              <kbd>⌘</kbd>
-              <kbd>N</kbd>
+              {__DARWIN__ ? (
+                <>
+                  <kbd>⌘</kbd>
+                  <kbd>⇧</kbd>
+                  <kbd>N</kbd>
+                </>
+              ) : (
+                <>
+                  <kbd>Ctrl</kbd>
+                  <kbd>Shift</kbd>
+                  <kbd>N</kbd>
+                </>
+              )}
             </div>
           </TutorialStepInstructions>
           <TutorialStepInstructions
@@ -170,9 +180,19 @@ export class TutorialPanel extends React.Component<
                 >
                   {__DARWIN__ ? 'Open Editor' : 'Open editor'}
                 </Button>
-                <kbd>⇧</kbd>
-                <kbd>⌘</kbd>
-                <kbd>A</kbd>
+                {__DARWIN__ ? (
+                  <>
+                    <kbd>⌘</kbd>
+                    <kbd>⇧</kbd>
+                    <kbd>A</kbd>
+                  </>
+                ) : (
+                  <>
+                    <kbd>Ctrl</kbd>
+                    <kbd>Shift</kbd>
+                    <kbd>A</kbd>
+                  </>
+                )}
               </div>
             )}
           </TutorialStepInstructions>
@@ -202,8 +222,17 @@ export class TutorialPanel extends React.Component<
               commits made on your computer to a branch.
             </p>
             <div className="action">
-              <kbd>⌘</kbd>
-              <kbd>P</kbd>
+              {__DARWIN__ ? (
+                <>
+                  <kbd>⌘</kbd>
+                  <kbd>P</kbd>
+                </>
+              ) : (
+                <>
+                  <kbd>Ctrl</kbd>
+                  <kbd>P</kbd>
+                </>
+              )}
             </div>
           </TutorialStepInstructions>
           <TutorialStepInstructions
@@ -223,8 +252,17 @@ export class TutorialPanel extends React.Component<
               <Button onClick={this.openPullRequest}>
                 {__DARWIN__ ? 'Open Pull Request' : 'Open pull request'}
               </Button>
-              <kbd>⌘</kbd>
-              <kbd>R</kbd>
+              {__DARWIN__ ? (
+                <>
+                  <kbd>⌘</kbd>
+                  <kbd>R</kbd>
+                </>
+              ) : (
+                <>
+                  <kbd>Ctrl</kbd>
+                  <kbd>R</kbd>
+                </>
+              )}
             </div>
           </TutorialStepInstructions>
         </ol>


### PR DESCRIPTION
🌵 🌵 **merge this _after_ #8242** 🌵 🌵 

## Overview

stop-gap measure for #8249 

the goal here is to get the keyboard shortcuts good enough to ship to beta, then make this implementation more robust in a later PR.

<details>
<summary>screenshots</summary>

**macOS**

<img width="286" alt="Screen Shot 2019-09-19 at 3 51 31 PM" src="https://user-images.githubusercontent.com/964912/65288391-99978000-dafb-11e9-9858-b66054e5c0f9.png">

<img width="286" alt="Screen Shot 2019-09-19 at 3 51 45 PM" src="https://user-images.githubusercontent.com/964912/65288392-99978000-dafb-11e9-93c1-49a345e95c1c.png">

<img width="291" alt="Screen Shot 2019-09-19 at 3 51 51 PM" src="https://user-images.githubusercontent.com/964912/65288393-99978000-dafb-11e9-9a7a-8a5a7557b0a3.png">

<img width="283" alt="Screen Shot 2019-09-19 at 3 51 57 PM" src="https://user-images.githubusercontent.com/964912/65288394-99978000-dafb-11e9-9c3d-4aa20710a537.png">

**win32**

<img width="284" alt="Screen Shot 2019-09-19 at 4 36 54 PM" src="https://user-images.githubusercontent.com/964912/65288463-c77cc480-dafb-11e9-9efd-486c83ebddfb.png">

<img width="284" alt="Screen Shot 2019-09-19 at 4 37 01 PM" src="https://user-images.githubusercontent.com/964912/65288464-c8155b00-dafb-11e9-90ab-f1f0b930ff3a.png">

<img width="280" alt="Screen Shot 2019-09-19 at 4 37 09 PM" src="https://user-images.githubusercontent.com/964912/65288465-c8155b00-dafb-11e9-9916-dbd11fd819e7.png">

<img width="283" alt="Screen Shot 2019-09-19 at 4 37 15 PM" src="https://user-images.githubusercontent.com/964912/65288467-c8adf180-dafb-11e9-8571-e711d154d314.png">

</details>

## Description

- removes confusing keyboard shortcut for committing
- reorders mac keyboard shortcuts into standard order (<kbd>⌘</kbd><kbd>⇧</kbd><kbd>N</kbd> instead of <kbd>⇧</kbd><kbd>⌘</kbd><kbd>N</kbd>)
- adds windows keyboard shortcts

## Release notes

Notes: no-notes
