### PR TITLE
[Tutorial] Update resolved editor at launch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5203,6 +5203,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const resolvedExternalEditor = match != null ? match.editor : null
     if (this.resolvedExternalEditor !== resolvedExternalEditor) {
       this.resolvedExternalEditor = resolvedExternalEditor
+
+      // Make sure we let the tutorial assesor know that we have a new editor
+      // in case it's stuck waiting for one to be selected.
+      if (this.currentOnboardingTutorialStep === TutorialStep.PickEditor) {
+        if (this.selectedRepository instanceof Repository) {
+          this.updateCurrentTutorialStep(this.selectedRepository)
+        }
+      }
+
       this.emitUpdate()
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4334,14 +4334,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
-  public _setExternalEditor(selectedEditor: ExternalEditor): Promise<void> {
+  public async _setExternalEditor(selectedEditor: ExternalEditor) {
     this.selectedExternalEditor = selectedEditor
     localStorage.setItem(externalEditorKey, selectedEditor)
     this.emitUpdate()
 
     this.updateMenuLabelsForSelectedRepository()
 
-    return Promise.resolve()
+    // Make sure we keep the resolved (cached) editor
+    // in sync when the user changes their editor choice.
+    await this._resolveCurrentEditor()
   }
 
   public _setShell(shell: Shell): Promise<void> {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4623,13 +4623,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         apiRepository
       )
       this.tutorialAssessor.onNewTutorialRepository()
-
-      // if we don't have an editor, check for one
-      // this is so that we can mark the 1st step as done
-      // if an editor is found
-      if (this.resolvedExternalEditor === null) {
-        await this._resolveCurrentEditor()
-      }
     } else {
       const error = new Error(`${path} isn't a git repository.`)
       this.emitError(error)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -415,6 +415,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.tutorialAssessor = new OnboardingTutorialAssessor(
       this.getResolvedExternalEditor
     )
+
+    // Deferred, attempts to resolve the user's selected editor (i.e.
+    // ensures that it's actually present on the machine), needs to
+    // happen after the tutorial assessor has been initialized, see:
+    // https://github.com/desktop/desktop/pull/8242#pullrequestreview-289936574
+    this._resolveCurrentEditor().catch(e =>
+      log.error('Failed resolving current editor at startup', e)
+    )
   }
 
   /** Figure out what step of the tutorial the user needs to do next */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1797,10 +1797,6 @@ export class Dispatcher {
     return this.appStore._updateCompareForm(repository, newState)
   }
 
-  public resolveCurrentEditor() {
-    return this.appStore._resolveCurrentEditor()
-  }
-
   /**
    *  update the manual resolution method for a file
    */

--- a/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
+++ b/app/src/ui/merge-conflicts/merge-conflicts-dialog.tsx
@@ -50,10 +50,6 @@ export class MergeConflictsDialog extends React.Component<
   IMergeConflictsDialogProps,
   {}
 > {
-  public async componentDidMount() {
-    this.props.dispatcher.resolveCurrentEditor()
-  }
-
   /**
    *  commits the merge displays the repository changes tab and dismisses the modal
    */

--- a/app/src/ui/rebase/show-conflicted-files-dialog.tsx
+++ b/app/src/ui/rebase/show-conflicted-files-dialog.tsx
@@ -61,10 +61,6 @@ export class ShowConflictedFilesDialog extends React.Component<
     }
   }
 
-  public componentDidMount() {
-    this.props.dispatcher.resolveCurrentEditor()
-  }
-
   public componentWillUnmount() {
     const { workingDirectory, step, userHasResolvedConflicts } = this.props
     const { conflictState } = step


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

This is a follow up to the discussion in https://github.com/desktop/desktop/pull/8242 about whether we should be resolving the external editor during startup or not.

## Description

From https://github.com/desktop/desktop/pull/8242#pullrequestreview-289936574

> Additionally I found an unfortunate side-effect of moving to only resolving the external editor on focus which is that you might not trigger the resolve at all while going through the creation flow unless you explicitly blur and focus the app. See 👇 
>
> ![2019-09-18 16-59-18 2019-09-18 17_00_25](https://user-images.githubusercontent.com/634063/65160622-56270e00-da36-11e9-80d1-12f1141b9012.gif)
>
> We probably need to do some magic to trigger the resolve at least once initially.

From https://github.com/desktop/desktop/pull/8242#issuecomment-533342932

> I'm not sure why we don't do this during app startup if no editor is configured? For now, I've added it to AppStore._addTutorialRepository in 14175f5.

From https://github.com/desktop/desktop/pull/8242#pullrequestreview-291134338

> Yeah, me neither. I think we ought to. The fix you did works well for the first time you're going through the tutorial but not if you re-enter the tutorial later. I'm not gonna hold up this PR for that though but I'll open a PR to address that. I also noticed that it doesn't seem like the resolvedExternalEditor gets updated when the user changes their editor preference. I'll open a separate PR to address this such that we can get this merged.

---

This PR does two things, first it attempts to resolve the current editor at launch and second it notifies the tutorial assessor when a new editor has been resolved (if applicable). This in turn means that there's no longer any need for the conflicts dialogs to manually ask for a resolved editor.