### PR TITLE
Prevent triggering multiple tutorial creation flows in parallel

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1826,7 +1826,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     account: Account,
     apiRepository: IAPIRepository
   ) => {
-    this.props.dispatcher.addTutorialRepository(
+    return this.props.dispatcher.addTutorialRepository(
       path,
       account.endpoint,
       apiRepository

--- a/app/src/ui/blank-slate/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/blank-slate/create-tutorial-repository-dialog.tsx
@@ -195,6 +195,8 @@ export class CreateTutorialRepositoryDialog extends React.Component<
       this.props.onTutorialRepositoryCreated(path, account, repo)
       this.props.onDismissed()
     } catch (err) {
+      this.setState({ loading: false })
+
       if (err instanceof GitError) {
         this.props.onError(err)
       } else {
@@ -204,8 +206,6 @@ export class CreateTutorialRepositoryDialog extends React.Component<
           )
         )
       }
-    } finally {
-      this.setState({ loading: false })
     }
   }
 

--- a/app/src/ui/blank-slate/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/blank-slate/create-tutorial-repository-dialog.tsx
@@ -249,6 +249,7 @@ export class CreateTutorialRepositoryDialog extends React.Component<
         onSubmit={this.onSubmit}
         dismissable={!this.state.loading}
         loading={this.state.loading}
+        disabled={this.state.loading}
       >
         <DialogContent>
           <div>

--- a/app/src/ui/blank-slate/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/blank-slate/create-tutorial-repository-dialog.tsx
@@ -55,7 +55,7 @@ interface ICreateTutorialRepositoryDialogProps {
     path: string,
     account: Account,
     apiRepository: IAPIRepository
-  ) => void
+  ) => Promise<void>
 
   /**
    * Event triggered when the component encounters an error while
@@ -188,14 +188,14 @@ export class CreateTutorialRepositoryDialog extends React.Component<
       )
 
       await this.pushRepo(path, account, (title, value, description) => {
-        this.setProgress(title, 0.3 + value * 0.7, description)
+        this.setProgress(title, 0.3 + value * 0.6, description)
       })
 
-      this.setState({ progress: undefined })
-      this.props.onTutorialRepositoryCreated(path, account, repo)
+      this.setProgress('Finalizing tutorial repository', 0.9)
+      await this.props.onTutorialRepositoryCreated(path, account, repo)
       this.props.onDismissed()
     } catch (err) {
-      this.setState({ loading: false })
+      this.setState({ loading: false, progress: undefined })
 
       if (err instanceof GitError) {
         this.props.onError(err)


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8288**

## Description

I forgot to disable the dialog while the tutorial repository is being created which resulted in the end user being able to trigger multiple tutorial repo creation flows in parallel as well as being able to cancel a non-cancellable flow 🤦‍♂ 

This also ensures that we don't end up calling `setState` after the dialog has been unmounted.