### PR TITLE
Properly split highlighting modes on Windows

### DIFF
--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -161,13 +161,13 @@ export const highlighter = merge({}, commonConfig, {
         modes: {
           enforce: true,
           name: (mod, chunks) => {
-            const builtInMode = /node_modules\/codemirror\/mode\/(\w+)\//.exec(
+            const builtInMode = /node_modules[\\\/]codemirror[\\\/]mode[\\\/](\w+)[\\\/]/i.exec(
               mod.resource
             )
             if (builtInMode) {
               return `mode/${builtInMode[1]}`
             }
-            const external = /node_modules\/codemirror-mode-(\w+)\//.exec(
+            const external = /node_modules[\\\/]codemirror-mode-(\w+)[\\\/]/i.exec(
               mod.resource
             )
             if (external) {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

When doing the beta release yesterday I noticed this warning in the build logs

![image](https://user-images.githubusercontent.com/634063/65499358-c5c94d00-debd-11e9-8837-49874afdbe5d.png)

I was quite confused by that since that was exactly what https://github.com/desktop/desktop/pull/4764 was supposed to solve by splitting up each CodeMirror mode into its own file. Prior to finding this I was absolutely certain I had tested the webpack paths on Windows and found them to be POSIX-normalized but upon investigating this I'm now filled with doubt.

## Description

This ensures that we do our CodeMirror mode codesplitting properly regardless of platform by accepting both `/` and `\` as path separator characters. Code splitting performance measurements  can be found in #4764 and gave us a ~54% improvement in initial highlighting speed.