### PR TITLE
Support enforced web flow authentication on Dotcom

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -865,6 +865,12 @@ export enum AuthorizationResponseKind {
   PersonalAccessTokenBlocked,
   Error,
   EnterpriseTooOld,
+  /**
+   * The API has indicated that the current user belongs to
+   * one or more organizations using SAML and as a result is
+   * required to pass through the web flow for authentication.
+   */
+  SAMLWebFlowRequired,
 }
 
 export type AuthorizationResponse =
@@ -878,6 +884,7 @@ export type AuthorizationResponse =
   | { kind: AuthorizationResponseKind.UserRequiresVerification }
   | { kind: AuthorizationResponseKind.PersonalAccessTokenBlocked }
   | { kind: AuthorizationResponseKind.EnterpriseTooOld }
+  | { kind: AuthorizationResponseKind.SAMLWebFlowRequired }
 
 /**
  * Create an authorization with the given login, password, and one-time

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -866,11 +866,10 @@ export enum AuthorizationResponseKind {
   Error,
   EnterpriseTooOld,
   /**
-   * The API has indicated that the current user belongs to
-   * one or more organizations using SAML and as a result is
-   * required to pass through the web flow for authentication.
+   * The API has indicated that the user is required to go through
+   * the web authentication flow.
    */
-  SAMLWebFlowRequired,
+  WebFlowRequired,
 }
 
 export type AuthorizationResponse =
@@ -884,7 +883,7 @@ export type AuthorizationResponse =
   | { kind: AuthorizationResponseKind.UserRequiresVerification }
   | { kind: AuthorizationResponseKind.PersonalAccessTokenBlocked }
   | { kind: AuthorizationResponseKind.EnterpriseTooOld }
-  | { kind: AuthorizationResponseKind.SAMLWebFlowRequired }
+  | { kind: AuthorizationResponseKind.WebFlowRequired }
 
 /**
  * Create an authorization with the given login, password, and one-time
@@ -966,7 +965,7 @@ export async function createAuthorization(
         // Authorization API does not support providing personal access tokens
         return { kind: AuthorizationResponseKind.PersonalAccessTokenBlocked }
       } else if (response.status === 410) {
-        return { kind: AuthorizationResponseKind.SAMLWebFlowRequired }
+        return { kind: AuthorizationResponseKind.WebFlowRequired }
       } else if (response.status === 422) {
         if (apiError.errors) {
           for (const error of apiError.errors) {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -965,6 +965,12 @@ export async function createAuthorization(
       ) {
         // Authorization API does not support providing personal access tokens
         return { kind: AuthorizationResponseKind.PersonalAccessTokenBlocked }
+      } else if (
+        response.status === 403 &&
+        apiError.message ===
+          'This user belongs to one or more organizations with SAML enabled.'
+      ) {
+        return { kind: AuthorizationResponseKind.SAMLWebFlowRequired }
       } else if (response.status === 422) {
         if (apiError.errors) {
           for (const error of apiError.errors) {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -965,11 +965,7 @@ export async function createAuthorization(
       ) {
         // Authorization API does not support providing personal access tokens
         return { kind: AuthorizationResponseKind.PersonalAccessTokenBlocked }
-      } else if (
-        response.status === 403 &&
-        apiError.message ===
-          'This user belongs to one or more organizations with SAML enabled.'
-      ) {
+      } else if (response.status === 410) {
         return { kind: AuthorizationResponseKind.SAMLWebFlowRequired }
       } else if (response.status === 422) {
         if (apiError.errors) {

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -390,9 +390,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
           loading: false,
           error: new Error(EnterpriseTooOldMessage),
         })
-      } else if (
-        response.kind === AuthorizationResponseKind.SAMLWebFlowRequired
-      ) {
+      } else if (response.kind === AuthorizationResponseKind.WebFlowRequired) {
         this.setState({
           ...currentState,
           loading: false,
@@ -630,7 +628,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
         case AuthorizationResponseKind.EnterpriseTooOld:
           this.emitError(new Error(EnterpriseTooOldMessage))
           break
-        case AuthorizationResponseKind.SAMLWebFlowRequired:
+        case AuthorizationResponseKind.WebFlowRequired:
           this.setState({
             ...currentState,
             forgotPasswordUrl: this.getForgotPasswordURL(currentState.endpoint),

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -390,6 +390,15 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
           loading: false,
           error: new Error(EnterpriseTooOldMessage),
         })
+      } else if (
+        response.kind === AuthorizationResponseKind.SAMLWebFlowRequired
+      ) {
+        this.setState({
+          ...currentState,
+          loading: false,
+          supportsBasicAuth: false,
+          kind: SignInStep.Authentication,
+        })
       } else {
         return assertNever(response, `Unsupported response: ${response}`)
       }
@@ -620,6 +629,16 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
           break
         case AuthorizationResponseKind.EnterpriseTooOld:
           this.emitError(new Error(EnterpriseTooOldMessage))
+          break
+        case AuthorizationResponseKind.SAMLWebFlowRequired:
+          this.setState({
+            ...currentState,
+            forgotPasswordUrl: this.getForgotPasswordURL(currentState.endpoint),
+            loading: false,
+            supportsBasicAuth: false,
+            kind: SignInStep.Authentication,
+            error: null,
+          })
           break
         default:
           assertNever(response, `Unknown response: ${response}`)

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -173,7 +173,10 @@ export class AuthenticationForm extends React.Component<
     if (this.props.endpoint === getDotComAPIEndpoint()) {
       return (
         <>
-          <p>GitHub.com requires you to sign in with your browser.</p>
+          <p>
+            To improve the security of your account, GitHub now requires you to
+            sign in through your browser.
+          </p>
           <p>
             Your browser will redirect you back to GitHub Desktop once you've
             signed in. If your browser asks for your permission to launch GitHub

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -6,8 +6,18 @@ import { Form } from './form'
 import { Button } from './button'
 import { TextBox } from './text-box'
 import { Errors } from './errors'
+import { getDotComAPIEndpoint } from '../../lib/api'
 
 interface IAuthenticationFormProps {
+  /**
+   * The URL to the host which we're currently authenticating
+   * against. This will be either https://api.github.com when
+   * signing in against GitHub.com or a user-specified
+   * URL when signing in against a GitHub Enterprise Server
+   * instance.
+   */
+  readonly endpoint: string
+
   /** Does the server support basic auth? */
   readonly supportsBasicAuth: boolean
 
@@ -149,12 +159,7 @@ export class AuthenticationForm extends React.Component<
     return (
       <div>
         {basicAuth ? <hr className="short-rule" /> : null}
-        {basicAuth ? null : (
-          <p>
-            Your GitHub Enterprise Server instance requires you to sign in with
-            your browser.
-          </p>
-        )}
+        {basicAuth ? null : this.renderEndpointRequiresWebFlow()}
 
         <div className="sign-in-footer">
           {basicAuth ? browserSignInLink : browserSignInButton}
@@ -162,6 +167,19 @@ export class AuthenticationForm extends React.Component<
         </div>
       </div>
     )
+  }
+
+  private renderEndpointRequiresWebFlow() {
+    if (this.props.endpoint === getDotComAPIEndpoint()) {
+      return <p>Please continue the sign-in process in your browser.</p>
+    } else {
+      return (
+        <p>
+          Your GitHub Enterprise Server instance requires you to sign in with
+          your browser.
+        </p>
+      )
+    }
   }
 
   private renderError() {

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -171,7 +171,16 @@ export class AuthenticationForm extends React.Component<
 
   private renderEndpointRequiresWebFlow() {
     if (this.props.endpoint === getDotComAPIEndpoint()) {
-      return <p>Please continue the sign-in process in your browser.</p>
+      return (
+        <>
+          <p>GitHub.com requires you to sign in with your browser.</p>
+          <p>
+            Your browser will redirect you back to GitHub Desktop once you've
+            signed in. If your browser asks for your permission to launch GitHub
+            Desktop please allow it to.
+          </p>
+        </>
+      )
     } else {
       return (
         <p>

--- a/app/src/ui/lib/sign-in.tsx
+++ b/app/src/ui/lib/sign-in.tsx
@@ -63,6 +63,7 @@ export class SignIn extends React.Component<ISignInProps, {}> {
         onBrowserSignInRequested={this.onBrowserSignInRequested}
         onSubmit={this.onCredentialsEntered}
         forgotPasswordUrl={state.forgotPasswordUrl}
+        endpoint={state.endpoint}
       />
     )
   }

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -186,7 +186,12 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       if (state.endpoint === getDotComAPIEndpoint()) {
         return (
           <DialogContent>
-            <p>Please continue the sign-in process in your browser.</p>
+            <p>GitHub.com requires you to sign in with your browser.</p>
+            <p>
+              Your browser will redirect you back to GitHub Desktop once you've
+              signed in. If your browser asks for your permission to launch
+              GitHub Desktop please allow it to.
+            </p>
           </DialogContent>
         )
       } else {

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -17,6 +17,7 @@ import { ButtonGroup } from '../lib/button-group'
 import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
 
 import { getWelcomeMessage } from '../../lib/2fa'
+import { getDotComAPIEndpoint } from '../../lib/api'
 
 interface ISignInProps {
   readonly dispatcher: Dispatcher
@@ -176,14 +177,22 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
 
   private renderAuthenticationStep(state: IAuthenticationState) {
     if (!state.supportsBasicAuth) {
-      return (
-        <DialogContent>
-          <p>
-            Your GitHub Enterprise Server instance requires you to sign in with
-            your browser.
-          </p>
-        </DialogContent>
-      )
+      if (state.endpoint === getDotComAPIEndpoint()) {
+        return (
+          <DialogContent>
+            <p>Please continue the sign-in process in your browser.</p>
+          </DialogContent>
+        )
+      } else {
+        return (
+          <DialogContent>
+            <p>
+              Your GitHub Enterprise Server instance requires you to sign in
+              with your browser.
+            </p>
+          </DialogContent>
+        )
+      }
     }
 
     const disableSubmit = state.loading

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -32,6 +32,12 @@ interface ISignInState {
   readonly otpToken: string
 }
 
+const SignInWithBrowserTitle = __DARWIN__
+  ? 'Sign in Using Your Browser'
+  : 'Sign in using your browser'
+
+const DefaultTitle = 'Sign in'
+
 export class SignIn extends React.Component<ISignInProps, ISignInState> {
   public constructor(props: ISignInProps) {
     super(props)
@@ -297,10 +303,17 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       <DialogError>{state.error.message}</DialogError>
     ) : null
 
+    const title =
+      this.props.signInState &&
+      this.props.signInState.kind === SignInStep.Authentication &&
+      !this.props.signInState.supportsBasicAuth
+        ? SignInWithBrowserTitle
+        : DefaultTitle
+
     return (
       <Dialog
         id="sign-in"
-        title="Sign in"
+        title={title}
         disabled={disabled}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -186,7 +186,10 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       if (state.endpoint === getDotComAPIEndpoint()) {
         return (
           <DialogContent>
-            <p>GitHub.com requires you to sign in with your browser.</p>
+            <p>
+              To improve the security of your account, GitHub now requires you
+              to sign in through your browser.
+            </p>
             <p>
               Your browser will redirect you back to GitHub Desktop once you've
               signed in. If your browser asks for your permission to launch


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

For GitHub Enterprise Server we've long supported the ability for server admins to enforce web flow authentication over basic authentication. This PR is the first step towards supporting the same for GitHub.com users.

## Description

Send the user to the browser to complete their sign-in when security policies dictate that they're required to.
