### PR TITLE
[Onboarding tutorial] Display "Open editor" button after editor has been installed

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2373,6 +2373,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           }
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}
+          resolvedExternalEditor={state.resolvedExternalEditor}
           onOpenInExternalEditor={this.openFileInExternalEditor}
           appMenu={this.state.appMenuState[0]}
           currentTutorialStep={this.state.currentOnboardingTutorialStep}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -28,6 +28,7 @@ import { StashedChangesLoadStates } from '../models/stash-entry'
 import { TutorialPanel } from './tutorial-panel'
 import { enableTutorial } from '../lib/feature-flag'
 import { TutorialStep } from '../models/tutorial-step'
+import { ExternalEditor } from '../lib/editors'
 
 /** The widest the sidebar can be with the minimum window size. */
 const MaxSidebarWidth = 495
@@ -51,6 +52,9 @@ interface IRepositoryViewProps {
 
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
+
+  /** A cached entry representing an external editor found on the user's machine */
+  readonly resolvedExternalEditor: ExternalEditor | null
 
   /**
    * Callback to open a selected file using the configured external editor
@@ -423,7 +427,7 @@ export class RepositoryView extends React.Component<
         <TutorialPanel
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
-          externalEditorLabel={this.props.externalEditorLabel}
+          resolvedExternalEditor={this.props.resolvedExternalEditor}
           currentTutorialStep={this.props.currentTutorialStep}
         />
       )

--- a/app/src/ui/tutorial-panel/tutorial-panel.tsx
+++ b/app/src/ui/tutorial-panel/tutorial-panel.tsx
@@ -176,10 +176,7 @@ export class TutorialPanel extends React.Component<
             </p>
             {this.props.resolvedExternalEditor && (
               <div className="action">
-                <Button
-                  onClick={this.openTutorialFileInEditor}
-                  disabled={!this.props.resolvedExternalEditor}
-                >
+                <Button onClick={this.openTutorialFileInEditor}>
                   {__DARWIN__ ? 'Open Editor' : 'Open editor'}
                 </Button>
                 {__DARWIN__ ? (

--- a/app/src/ui/tutorial-panel/tutorial-panel.tsx
+++ b/app/src/ui/tutorial-panel/tutorial-panel.tsx
@@ -12,6 +12,7 @@ import {
   orderedTutorialSteps,
 } from '../../models/tutorial-step'
 import { encodePathAsUrl } from '../../lib/path'
+import { ExternalEditor } from '../../lib/editors'
 
 const TutorialPanelImage = encodePathAsUrl(
   __dirname,
@@ -25,7 +26,7 @@ interface ITutorialPanelProps {
   /** name of the configured external editor
    * (`undefined` if none is configured.)
    */
-  readonly externalEditorLabel?: string
+  readonly resolvedExternalEditor: ExternalEditor | null
   readonly currentTutorialStep: ValidTutorialStep
 }
 
@@ -173,11 +174,11 @@ export class TutorialPanel extends React.Component<
               {` `}
               file, save it, and come back.
             </p>
-            {this.props.externalEditorLabel && (
+            {this.props.resolvedExternalEditor && (
               <div className="action">
                 <Button
                   onClick={this.openTutorialFileInEditor}
-                  disabled={!this.props.externalEditorLabel}
+                  disabled={!this.props.resolvedExternalEditor}
                 >
                   {__DARWIN__ ? 'Open Editor' : 'Open editor'}
                 </Button>


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8315**

## Description

The OnboardingTutorialAssessor uses the `resolvedExternalEditor` to determine whether the first step is completed it. Prior to this PR we were using `externalEditorLabel` (ie. `selectedExternalEditor`) to determine whether or not to show the "Open editor" button. With these changes we are now using `resolvedExternalEditor`.

In theory, the `selectedExternalEditor` should be updated to match `resolvedExternalEditor` when an editor is found. #8322 is another issue stemming from these two getting out of sync. I think the ideal solution would be to simplify the code by dropping `selectedExternalEditor` because the two seem pretty redundant anyhow. However, for the sake of getting the key onboarding tutorial features out the door I've opted to start with this quick fix.

Manual testing steps:
* Decide which editor you want to test installation of. Let's say Atom for now
* Make sure there are no other editors installed, or tell Desktop to ignore them by commenting out the appropriate lines of code. For example, to ignore VS Code on Mac comment out https://github.com/desktop/desktop/blob/41703eddb4bacbf29b104ec1dfb2d96ebdc47790/app/src/lib/editors/darwin.ts#L247
* Clear local storage cache to get rid of cached editor
<img width="481" alt="GitHub_Desktop-dev_and_Comparing_development___ku-show-open-editor-button_·_desktop_desktop" src="https://user-images.githubusercontent.com/7910250/65544181-93245200-dec7-11e9-9151-c85983ab0e59.png">

* Reload Desktop-dev window
* Ensure that there are no repositories in Desktop in order to access "Let's get started" page
* Click "Create a tutorial repo"
* Note that step 1 is not marked as complete. Note that step 3 does not show an "Open editor" button.
* Install Atom.
* After focusing Desktop again, step 1 should be marked as complete
* Note that step 3 shows an "Open editor" button. Click it.
* README.md file opens in Atom

## Release notes

Notes: no-notes

/cc @outofambit @niik 