### PR TITLE
Make app's version string selectable text instead of a special link

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { clipboard } from 'electron'
 
 import { Row } from '../lib/row'
 import { Button } from '../lib/button'
@@ -68,10 +67,6 @@ export class About extends React.Component<IAboutProps, IAboutState> {
 
   private onUpdateStateChanged = (updateState: IUpdateState) => {
     this.setState({ updateState })
-  }
-
-  private onClickVersion = () => {
-    clipboard.writeText(this.props.applicationVersion)
   }
 
   public componentDidMount() {
@@ -270,14 +265,8 @@ export class About extends React.Component<IAboutProps, IAboutState> {
           </Row>
           <h2>{name}</h2>
           <p className="no-padding">
-            <LinkButton
-              title="Click to copy"
-              className="version-text"
-              onClick={this.onClickVersion}
-            >
-              {versionText}
-            </LinkButton>{' '}
-            ({releaseNotesLink})
+            <span className="selectable-text">{versionText}</span> (
+            {releaseNotesLink})
           </p>
           <p className="no-padding">
             <LinkButton onClick={this.props.onShowTermsAndConditions}>

--- a/app/styles/_globals.scss
+++ b/app/styles/_globals.scss
@@ -68,6 +68,12 @@ body {
   }
 }
 
+.selectable-text {
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: auto;
+}
+
 img {
   -webkit-user-drag: none;
   user-select: none;


### PR DESCRIPTION
## Overview

Fixes https://github.com/desktop/desktop/issues/8215
Followup to https://github.com/desktop/desktop/pull/1948

## Description

The version string in the About dialog looks like other links in the same dialog (blue, underline on hover), but is not really a hyperlink. Instead, clicking on it puts the version number to clipboard.

This change makes the version text selectable instead and relies on the user to select it and copy to clipboard manually if they so desire. On macOS, for example, the text can be triple-clicked in order to be selected in full without having to make a precise selection with a mouse (this is OS-wide behavior).

This aims to make the About dialog a little more intuitive.

### Before
![](https://user-images.githubusercontent.com/2289/64378961-be133880-cfe2-11e9-8140-f8fb6c86fc77.png)

### After
<img width="452" alt="Screen Shot 2019-09-25 at 4 13 18 PM" src="https://user-images.githubusercontent.com/887/65609140-9266eb00-dfaf-11e9-9436-77683f80597f.png">


## Release notes

Notes:
- Make the application version string in the About dialog be selectable text