### PR TITLE
Pre-fill user name and email in configure Git step in Welcome Wizard (again)

### DIFF
--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -64,6 +64,12 @@ export function getDefaultEmail(emails: ReadonlyArray<IAPIEmail>): string {
 
   return emails[0].email || ''
 }
+
+/**
+ * Returns the stealth email host name for a given endpoint. The stealth
+ * email host is hardcoded to the subdomain users.noreply under the
+ * endpoint host.
+ */
 function getStealthEmailHostForEndpoint(endpoint: string) {
   const url = URL.parse(endpoint)
   return getDotComAPIEndpoint() !== endpoint

--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -1,4 +1,6 @@
-import { IAPIEmail } from './api'
+import * as URL from 'url'
+
+import { IAPIEmail, getDotComAPIEndpoint } from './api'
 import { Account } from '../models/account'
 
 /**
@@ -26,9 +28,12 @@ export function lookupPreferredEmail(account: Account): IAPIEmail | null {
     return primary
   }
 
+  const stealthSuffix = `@${getStealthEmailHostForEndpoint(account.endpoint)}`
+
   const noReply = emails.find(e =>
-    e.email.toLowerCase().endsWith('@users.noreply.github.com')
+    e.email.toLowerCase().endsWith(stealthSuffix)
   )
+
   if (noReply) {
     return noReply
   }
@@ -58,4 +63,10 @@ export function getDefaultEmail(emails: ReadonlyArray<IAPIEmail>): string {
   }
 
   return emails[0].email || ''
+}
+function getStealthEmailHostForEndpoint(endpoint: string) {
+  const url = URL.parse(endpoint)
+  return getDotComAPIEndpoint() !== endpoint
+    ? `users.noreply.${url.hostname}`
+    : 'users.noreply.github.com'
 }

--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -1,4 +1,5 @@
 import { IAPIEmail } from './api'
+import { Account } from '../models/account'
 
 /**
  * Lookup a suitable email address to display in the application, based on the
@@ -13,9 +14,9 @@ import { IAPIEmail } from './api'
  *
  * @param emails array of email addresses associated with an account
  */
-export function lookupPreferredEmail(
-  emails: ReadonlyArray<IAPIEmail>
-): IAPIEmail | null {
+export function lookupPreferredEmail(account: Account): IAPIEmail | null {
+  const emails = account.emails
+
   if (emails.length === 0) {
     return null
   }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -84,7 +84,7 @@ export class ConfigureGitUser extends React.Component<
         }
 
         if (this.state.email.length === 0) {
-          const preferredEmail = lookupPreferredEmail(account.emails)
+          const preferredEmail = lookupPreferredEmail(account)
           if (preferredEmail) {
             this.setState({
               email: preferredEmail.email,

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -65,7 +65,7 @@ export class ConfigureGitUser extends React.Component<
       globalUserEmail,
       name: prevState.name.length === 0 ? globalUserName || '' : prevState.name,
       email:
-        prevState.email.length === 0 ? globalUserEmail || '' : prevState.name,
+        prevState.email.length === 0 ? globalUserEmail || '' : prevState.email,
     }))
   }
 

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -76,22 +76,25 @@ export class ConfigureGitUser extends React.Component<
     ) {
       if (this.props.accounts[0] !== prevProps.accounts[0]) {
         const account = this.props.accounts[0]
+        this.setDefaultValuesFromAccount(account)
+      }
+    }
+  }
 
-        if (this.state.name.length === 0) {
-          this.setState({
-            name: account.name || account.login,
-          })
-        }
+  private setDefaultValuesFromAccount(account: Account) {
+    if (this.state.name.length === 0) {
+      this.setState({
+        name: account.name || account.login,
+      })
+    }
 
-        if (this.state.email.length === 0) {
-          const preferredEmail = lookupPreferredEmail(account)
-          if (preferredEmail) {
-            this.setState({
-              email: preferredEmail.email,
-              avatarURL: this.avatarURLForEmail(preferredEmail.email),
-            })
-          }
-        }
+    if (this.state.email.length === 0) {
+      const preferredEmail = lookupPreferredEmail(account)
+      if (preferredEmail) {
+        this.setState({
+          email: preferredEmail.email,
+          avatarURL: this.avatarURLForEmail(preferredEmail.email),
+        })
       }
     }
   }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -55,6 +55,19 @@ export class ConfigureGitUser extends React.Component<
   }
 
   public async componentWillMount() {
+    const [globalUserName, globalUserEmail] = await Promise.all([
+      getGlobalConfigValue('user.name'),
+      getGlobalConfigValue('user.email'),
+    ])
+
+    this.setState(prevState => ({
+      globalUserName,
+      globalUserEmail,
+      name: prevState.name.length === 0 ? globalUserName || '' : prevState.name,
+      email:
+        prevState.email.length === 0 ? globalUserEmail || '' : prevState.name,
+    }))
+  }
 
       }
     }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -45,7 +45,13 @@ export class ConfigureGitUser extends React.Component<
   public constructor(props: IConfigureGitUserProps) {
     super(props)
 
-    this.state = { name: '', email: '', avatarURL: null }
+    this.state = {
+      globalUserName: null,
+      globalUserEmail: null,
+      name: '',
+      email: '',
+      avatarURL: null,
+    }
   }
 
   public async componentWillMount() {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -42,6 +42,9 @@ export class ConfigureGitUser extends React.Component<
   IConfigureGitUserProps,
   IConfigureGitUserState
 > {
+  private readonly globalUsernamePromise = getGlobalConfigValue('user.name')
+  private readonly globalEmailPromise = getGlobalConfigValue('user.email')
+
   public constructor(props: IConfigureGitUserProps) {
     super(props)
 
@@ -54,10 +57,10 @@ export class ConfigureGitUser extends React.Component<
     }
   }
 
-  public async componentWillMount() {
+  public async componentDidMount() {
     const [globalUserName, globalUserEmail] = await Promise.all([
-      getGlobalConfigValue('user.name'),
-      getGlobalConfigValue('user.email'),
+      this.globalUsernamePromise,
+      this.globalEmailPromise,
     ])
 
     this.setState(prevState => ({
@@ -67,9 +70,7 @@ export class ConfigureGitUser extends React.Component<
       email:
         prevState.email.length === 0 ? globalUserEmail || '' : prevState.email,
     }))
-  }
 
-  public componentDidMount() {
     if (this.props.accounts.length > 0) {
       this.setDefaultValuesFromAccount(this.props.accounts[0])
     }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -55,23 +55,9 @@ export class ConfigureGitUser extends React.Component<
   }
 
   public async componentWillMount() {
-    let name = await getGlobalConfigValue('user.name')
-    let email = await getGlobalConfigValue('user.email')
 
-    const user = this.props.accounts[0]
-    if ((!name || !name.length) && user) {
-      name = user.name && user.name.length ? user.name : user.login
-    }
-
-    if ((!email || !email.length) && user) {
-      const found = lookupPreferredEmail(user.emails)
-      if (found) {
-        email = found.email
       }
     }
-
-    const avatarURL = email ? this.avatarURLForEmail(email) : null
-    this.setState({ name: name || '', email: email || '', avatarURL })
   }
 
   private dateWithMinuteOffset(date: Date, minuteOffset: number): Date {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -69,6 +69,29 @@ export class ConfigureGitUser extends React.Component<
     }))
   }
 
+  public componentDidUpdate(prevProps: IConfigureGitUserProps) {
+    if (
+      this.props.accounts !== prevProps.accounts &&
+      this.props.accounts.length > 0
+    ) {
+      if (this.props.accounts[0] !== prevProps.accounts[0]) {
+        const account = this.props.accounts[0]
+
+        if (this.state.name.length === 0) {
+          this.setState({
+            name: account.name || account.login,
+          })
+        }
+
+        if (this.state.email.length === 0) {
+          const preferredEmail = lookupPreferredEmail(account.emails)
+          if (preferredEmail) {
+            this.setState({
+              email: preferredEmail.email,
+              avatarURL: this.avatarURLForEmail(preferredEmail.email),
+            })
+          }
+        }
       }
     }
   }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -58,22 +58,40 @@ export class ConfigureGitUser extends React.Component<
   }
 
   public async componentDidMount() {
+    // Capture the current accounts prop because we'll be
+    // doing a bunch of asynchronous stuff and we can't
+    // rely on this.props.account to tell us what that prop
+    // was at mount-time.
+    const accounts = this.props.accounts
+
     const [globalUserName, globalUserEmail] = await Promise.all([
       this.globalUsernamePromise,
       this.globalEmailPromise,
     ])
 
-    this.setState(prevState => ({
-      globalUserName,
-      globalUserEmail,
-      name: prevState.name.length === 0 ? globalUserName || '' : prevState.name,
-      email:
-        prevState.email.length === 0 ? globalUserEmail || '' : prevState.email,
-    }))
-
-    if (this.props.accounts.length > 0) {
-      this.setDefaultValuesFromAccount(this.props.accounts[0])
-    }
+    this.setState(
+      prevState => ({
+        globalUserName,
+        globalUserEmail,
+        name:
+          prevState.name.length === 0 ? globalUserName || '' : prevState.name,
+        email:
+          prevState.email.length === 0
+            ? globalUserEmail || ''
+            : prevState.email,
+      }),
+      () => {
+        // Chances are low that we actually have an account at mount-time
+        // the way things are designed now but in case the app changes around
+        // us and we do get passed an account at mount time in the future we
+        // want to make sure that not only was it passed at mount time but also
+        // that it hasn't been changed since (if it has been then
+        // componentDidUpdate would be responsible for handling it).
+        if (accounts === this.props.accounts && accounts.length > 0) {
+          this.setDefaultValuesFromAccount(accounts[0])
+        }
+      }
+    )
   }
 
   public componentDidUpdate(prevProps: IConfigureGitUserProps) {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -25,6 +25,9 @@ interface IConfigureGitUserProps {
 }
 
 interface IConfigureGitUserState {
+  readonly globalUserName: string | null
+  readonly globalUserEmail: string | null
+
   readonly name: string
   readonly email: string
   readonly avatarURL: string | null

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -190,14 +190,13 @@ export class ConfigureGitUser extends React.Component<
     if (this.props.onSave) {
       this.props.onSave()
     }
+    const { name, email, globalUserName, globalUserEmail } = this.state
 
-    const name = this.state.name
-    if (name.length) {
+    if (name.length > 0 && name !== globalUserName) {
       await setGlobalConfigValue('user.name', name)
     }
 
-    const email = this.state.email
-    if (email.length) {
+    if (email.length > 0 && email !== globalUserEmail) {
       await setGlobalConfigValue('user.email', email)
     }
   }

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -69,6 +69,12 @@ export class ConfigureGitUser extends React.Component<
     }))
   }
 
+  public componentDidMount() {
+    if (this.props.accounts.length > 0) {
+      this.setDefaultValuesFromAccount(this.props.accounts[0])
+    }
+  }
+
   public componentDidUpdate(prevProps: IConfigureGitUserProps) {
     if (
       this.props.accounts !== prevProps.accounts &&

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -187,9 +187,6 @@ export class ConfigureGitUser extends React.Component<
   }
 
   private save = async () => {
-    if (this.props.onSave) {
-      this.props.onSave()
-    }
     const { name, email, globalUserName, globalUserEmail } = this.state
 
     if (name.length > 0 && name !== globalUserName) {
@@ -198,6 +195,10 @@ export class ConfigureGitUser extends React.Component<
 
     if (email.length > 0 && email !== globalUserEmail) {
       await setGlobalConfigValue('user.email', email)
+    }
+
+    if (this.props.onSave) {
+      this.props.onSave()
     }
   }
 }

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -41,7 +41,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
   }
 
   private renderAccount(account: Account) {
-    const found = lookupPreferredEmail(account.emails)
+    const found = lookupPreferredEmail(account)
     const email = found ? found.email : ''
 
     const avatarUser: IAvatarUser = {

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -96,7 +96,7 @@ export class Preferences extends React.Component<
         }
 
         if (!committerEmail) {
-          const found = lookupPreferredEmail(account.emails)
+          const found = lookupPreferredEmail(account)
           if (found) {
             committerEmail = found.email
           }

--- a/app/test/unit/email-test.ts
+++ b/app/test/unit/email-test.ts
@@ -1,9 +1,20 @@
 import { lookupPreferredEmail } from '../../src/lib/email'
-import { IAPIEmail } from '../../src/lib/api'
+import { IAPIEmail, getDotComAPIEndpoint } from '../../src/lib/api'
+import { Account } from '../../src/models/account'
 
 describe('emails', () => {
   it('returns null for empty list', () => {
-    expect(lookupPreferredEmail([])).toBeNull()
+    const account = new Account(
+      'shiftkey',
+      getDotComAPIEndpoint(),
+      '',
+      [],
+      '',
+      -1,
+      'Caps Lock'
+    )
+
+    expect(lookupPreferredEmail(account)).toBeNull()
   })
 
   it('returns the primary if it has public visibility', () => {
@@ -28,7 +39,17 @@ describe('emails', () => {
       },
     ]
 
-    const result = lookupPreferredEmail(emails)
+    const account = new Account(
+      'shiftkey',
+      getDotComAPIEndpoint(),
+      '',
+      emails,
+      '',
+      -1,
+      'Caps Lock'
+    )
+
+    const result = lookupPreferredEmail(account)
     expect(result).not.toBeNull()
     expect(result!.email).toBe('my-primary-email@example.com')
   })
@@ -55,7 +76,17 @@ describe('emails', () => {
       },
     ]
 
-    const result = lookupPreferredEmail(emails)
+    const account = new Account(
+      'shiftkey',
+      getDotComAPIEndpoint(),
+      '',
+      emails,
+      '',
+      -1,
+      'Caps Lock'
+    )
+
+    const result = lookupPreferredEmail(account)
     expect(result).not.toBeNull()
     expect(result!.email).toBe('my-primary-email@example.com')
   })
@@ -82,7 +113,17 @@ describe('emails', () => {
       },
     ]
 
-    const result = lookupPreferredEmail(emails)
+    const account = new Account(
+      'shiftkey',
+      getDotComAPIEndpoint(),
+      '',
+      emails,
+      '',
+      -1,
+      'Caps Lock'
+    )
+
+    const result = lookupPreferredEmail(account)
     expect(result).not.toBeNull()
     expect(result!.email).toBe('shiftkey@users.noreply.github.com')
   })
@@ -103,7 +144,17 @@ describe('emails', () => {
       },
     ]
 
-    const result = lookupPreferredEmail(emails)
+    const account = new Account(
+      'shiftkey',
+      getDotComAPIEndpoint(),
+      '',
+      emails,
+      '',
+      -1,
+      'Caps Lock'
+    )
+
+    const result = lookupPreferredEmail(account)
     expect(result).not.toBeNull()
     expect(result!.email).toBe('shiftkey@example.com')
   })

--- a/app/test/unit/email-test.ts
+++ b/app/test/unit/email-test.ts
@@ -1,5 +1,9 @@
 import { lookupPreferredEmail } from '../../src/lib/email'
-import { IAPIEmail, getDotComAPIEndpoint } from '../../src/lib/api'
+import {
+  IAPIEmail,
+  getDotComAPIEndpoint,
+  getEnterpriseAPIURL,
+} from '../../src/lib/api'
 import { Account } from '../../src/models/account'
 
 describe('emails', () => {
@@ -126,6 +130,43 @@ describe('emails', () => {
     const result = lookupPreferredEmail(account)
     expect(result).not.toBeNull()
     expect(result!.email).toBe('shiftkey@users.noreply.github.com')
+  })
+
+  it('returns the noreply if there is no public address for GitHub Enterprise Server as well', () => {
+    const emails: IAPIEmail[] = [
+      {
+        email: 'shiftkey@example.com',
+        primary: false,
+        verified: true,
+        visibility: null,
+      },
+      {
+        email: 'shiftkey@users.noreply.github.example.com',
+        primary: false,
+        verified: true,
+        visibility: null,
+      },
+      {
+        email: 'my-primary-email@example.com',
+        primary: true,
+        verified: true,
+        visibility: 'private',
+      },
+    ]
+
+    const account = new Account(
+      'shiftkey',
+      getEnterpriseAPIURL('https://github.example.com'),
+      '',
+      emails,
+      '',
+      -1,
+      'Caps Lock'
+    )
+
+    const result = lookupPreferredEmail(account)
+    expect(result).not.toBeNull()
+    expect(result!.email).toBe('shiftkey@users.noreply.github.example.com')
   })
 
   it('uses first email if nothing special found', () => {


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8323**

## Description

Due to a race condition introduced sometime after we initially shipped the welcome wizard the name and email fields in the Configure Git step in the welcome wizard were no longer pre-filled with information from the user's account.

This PR handles takes care of the race condition and expands the logic for determining the most likely candidate for preferred email address to also support stealth (aka no-reply/anonymous) email addresses for GitHub Enterprise Server.

### Testing notes

What I've been doing to test this is to explicitly unset the globally configured `user.name` and `user.email` configurations. I've been using this combo command `git config --global --unset user.name && git config --global --unset user.email`.

After clearing the config I make sure to sign out of all accounts in the application (usually by deleting the `users` entry in local storage) and then delete the `has-shown-welcome-flow` local storage setting in order to force the app into the welcome wizard again.

After signing in make sure that the name and email matches what you'd expect given your user profile settings on Dotcom.

## Release notes

Notes: [Fixed] Git configuration fields in onboarding were not pre-filled from user's profile