### PR TITLE
Prevent dialogs that take text input from being easily dismissable.

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -140,6 +140,7 @@ export class AddExistingRepository extends React.Component<
         title={__DARWIN__ ? 'Add Local Repository' : 'Add local repository'}
         onSubmit={this.addRepository}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
       >
         <DialogContent>
           <Row>

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -525,6 +525,7 @@ export class CreateRepository extends React.Component<
         loading={this.state.creating}
         onSubmit={this.createRepository}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
       >
         {this.renderInvalidPathError()}
 

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -211,6 +211,7 @@ export class CloneRepository extends React.Component<
         title={__DARWIN__ ? 'Clone a Repository' : 'Clone a repository'}
         onSubmit={this.clone}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
         loading={this.state.loading}
       >
         <TabBar

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -221,6 +221,7 @@ export class CreateBranch extends React.Component<
         title={__DARWIN__ ? 'Create a Branch' : 'Create a branch'}
         onSubmit={this.createBranch}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
         loading={this.state.isCreatingBranch}
         disabled={this.state.isCreatingBranch}
       >

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -50,6 +50,7 @@ export class GenericGitAuthentication extends React.Component<
         id="generic-git-auth"
         title={__DARWIN__ ? `Authentication Failed` : `Authentication failed`}
         onDismissed={this.props.onDismiss}
+        disableClickDismissalAlways={true}
         onSubmit={this.save}
       >
         <DialogContent>

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -135,6 +135,7 @@ export class Preferences extends React.Component<
         id="preferences"
         title={__DARWIN__ ? 'Preferences' : 'Options'}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
         onSubmit={this.onSave}
       >
         {this.renderDisallowedCharactersError()}

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -132,6 +132,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
         id="publish-repository"
         title={__DARWIN__ ? 'Publish Repository' : 'Publish repository'}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
         onSubmit={this.publishRepository}
         disabled={this.state.publishing}
         loading={this.state.publishing}

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -45,6 +45,7 @@ export class RenameBranch extends React.Component<
         id="rename-branch"
         title={__DARWIN__ ? 'Rename Branch' : 'Rename branch'}
         onDismissed={this.cancel}
+        disableClickDismissalAlways={true}
         onSubmit={this.renameBranch}
       >
         <DialogContent>

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -84,6 +84,7 @@ export class RepositorySettings extends React.Component<
         id="repository-settings"
         title={__DARWIN__ ? 'Repository Settings' : 'Repository settings'}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
         onSubmit={this.onSubmit}
         disabled={this.state.disabled}
       >

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -324,6 +324,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         title={title}
         disabled={disabled}
         onDismissed={this.props.onDismissed}
+        disableClickDismissalAlways={true}
         onSubmit={this.onSubmit}
         loading={state.loading}
       >


### PR DESCRIPTION
## Overview

Fixes #8276.

## Description

Previously, most dialogs allowed the user to dismiss them by clicking outside the dialog. This is not ideal when the dialog has textual input fields because the user has the potential to lose the data they have entered in the fields if they accidentally click (or release the mouse) outside the dialog.

Now, all dialogs that have textual input fields set the `disableClickDismissalAlways` property to `true`, thus prohibiting the possibility of the dialog closing in response to an out-of-dialog click.

## Release notes

I'm not sure how the release note should be phrased: what tense, et cetera; thus, I'll leave its formulation to someone else.
