### PR TITLE
Completed editor step description

### DIFF
--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -108,27 +108,36 @@ export class TutorialPanel extends React.Component<
             skipLinkButton={<SkipLinkButton onClick={this.skipEditorInstall} />}
             onSummaryClick={this.onStepSummaryClick}
           >
-            <p className="description">
-              It doesn’t look like you have a text editor installed. We can
-              recommend{' '}
-              <LinkButton uri="https://atom.io" title="Open the Atom website">
-                Atom
-              </LinkButton>
-              {` or `}
-              <LinkButton
-                uri="https://code.visualstudio.com"
-                title="Open the VS Code website"
-              >
-                Visual Studio Code
-              </LinkButton>
-              , but feel free to use any.
-            </p>
-            {!this.isStepComplete(TutorialStep.PickEditor) && (
-              <div className="action">
-                <LinkButton onClick={this.skipEditorInstall}>
-                  I have an editor
-                </LinkButton>
-              </div>
+            {!this.isStepComplete(TutorialStep.PickEditor) ? (
+              <>
+                <p className="description">
+                  It doesn’t look like you have a text editor installed. We can
+                  recommend{' '}
+                  <LinkButton
+                    uri="https://atom.io"
+                    title="Open the Atom website"
+                  >
+                    Atom
+                  </LinkButton>
+                  {` or `}
+                  <LinkButton
+                    uri="https://code.visualstudio.com"
+                    title="Open the VS Code website"
+                  >
+                    Visual Studio Code
+                  </LinkButton>
+                  , but feel free to use any.
+                </p>
+                <div className="action">
+                  <LinkButton onClick={this.skipEditorInstall}>
+                    I have an editor
+                  </LinkButton>
+                </div>
+              </>
+            ) : (
+              <p className="description">
+                Your default editor is {this.props.resolvedExternalEditor}
+              </p>
             )}
           </TutorialStepInstructions>
           <TutorialStepInstructions

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -138,8 +138,9 @@ export class TutorialPanel extends React.Component<
               </>
             ) : (
               <p className="description">
-                Your default editor is <strong>{this.props.resolvedExternalEditor}</strong>. You
-                can change your preferred editor in{' '}
+                Your default editor is{' '}
+                <strong>{this.props.resolvedExternalEditor}</strong>. You can
+                change your preferred editor in{' '}
                 <LinkButton onClick={this.onPreferencesClick}>
                   {__DARWIN__ ? 'Preferences' : 'options'}
                 </LinkButton>

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -14,6 +14,7 @@ import {
 import { encodePathAsUrl } from '../../lib/path'
 import { ExternalEditor } from '../../lib/editors'
 import { PopupType } from '../../models/popup'
+import { PreferencesTab } from '../../models/preferences'
 
 const TutorialPanelImage = encodePathAsUrl(
   __dirname,
@@ -297,7 +298,10 @@ export class TutorialPanel extends React.Component<
   }
 
   private onPreferencesClick = () => {
-    this.props.dispatcher.showPopup({ type: PopupType.Preferences })
+    this.props.dispatcher.showPopup({
+      type: PopupType.Preferences,
+      initialSelectedTab: PreferencesTab.Advanced,
+    })
   }
 }
 

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -137,8 +137,8 @@ export class TutorialPanel extends React.Component<
               </>
             ) : (
               <p className="description">
-                Your default editor is {this.props.resolvedExternalEditor}. You
-                can select your preferred editor in{' '}
+                Your default editor is <strong>{this.props.resolvedExternalEditor}</strong>. You
+                can change your preferred editor in{' '}
                 <LinkButton onClick={this.onPreferencesClick}>
                   {__DARWIN__ ? 'Preferences' : 'options'}
                 </LinkButton>

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../models/tutorial-step'
 import { encodePathAsUrl } from '../../lib/path'
 import { ExternalEditor } from '../../lib/editors'
+import { PopupType } from '../../models/popup'
 
 const TutorialPanelImage = encodePathAsUrl(
   __dirname,
@@ -136,7 +137,11 @@ export class TutorialPanel extends React.Component<
               </>
             ) : (
               <p className="description">
-                Your default editor is {this.props.resolvedExternalEditor}
+                Your default editor is {this.props.resolvedExternalEditor}. You
+                can select your preferred editor in{' '}
+                <LinkButton onClick={this.onPreferencesClick}>
+                  {__DARWIN__ ? 'Preferences' : 'options'}
+                </LinkButton>
               </p>
             )}
           </TutorialStepInstructions>
@@ -289,6 +294,10 @@ export class TutorialPanel extends React.Component<
   /** this makes sure we only have one `TutorialListItem` open at a time */
   public onStepSummaryClick = (id: ValidTutorialStep) => {
     this.setState({ currentlyOpenSectionId: id })
+  }
+
+  private onPreferencesClick = () => {
+    this.props.dispatcher.showPopup({ type: PopupType.Preferences })
   }
 }
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8353**

## Description

This PR consists of two commits, one that does exactly what's outlined in #8353, i.e. change the contents of the editor tutorial step once completed to `Your default editor is [editor]`.

The second commit adds a second sentence explaining where to change the preferred editor and a link to open the preferences dialog. I'm heading off for the weekend now so if there's any contention about adding the second sentence please just revert that commit.

![image](https://user-images.githubusercontent.com/634063/65785094-deeb2b80-e153-11e9-97e3-007c29044150.png)


## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes