### PR TITLE
Tweak responsive styles for welcome pane

### DIFF
--- a/app/styles/ui/onboarding-tutorial/_welcome.scss
+++ b/app/styles/ui/onboarding-tutorial/_welcome.scss
@@ -17,7 +17,7 @@
     h1 {
       font-weight: var(--font-weight-light);
       font-size: var(--font-size-xxl);
-      line-height: 1.1
+      line-height: 1.1;
     }
     p {
       margin: var(--spacing-half) 0;

--- a/app/styles/ui/onboarding-tutorial/_welcome.scss
+++ b/app/styles/ui/onboarding-tutorial/_welcome.scss
@@ -17,9 +17,10 @@
     h1 {
       font-weight: var(--font-weight-light);
       font-size: var(--font-size-xxl);
+      line-height: 1.1
     }
     p {
-      margin: 0;
+      margin: var(--spacing-half) 0;
       padding: 0;
     }
   }
@@ -28,11 +29,13 @@
     justify-content: space-around;
     padding: 0;
     max-width: 600px;
+    flex-wrap: wrap;
 
     li {
       display: flex;
       flex-flow: column nowrap;
       flex: 0 1 160px;
+      padding: 0 var(--spacing-half) var(--spacing-double);
 
       img {
         align-self: center;


### PR DESCRIPTION
This fixes some styling bugs when the welcome pane gets smaller

Fixes https://github.com/desktop/desktop/issues/8352

<img width="1072" alt="Screen Shot 2019-09-27 at 1 24 43 PM" src="https://user-images.githubusercontent.com/10404068/65800038-53a97000-e12a-11e9-8d18-fa4dc7f4c6bd.png">
