### PR TITLE
[Onboarding tutorial] Retain commit summary placeholder in tutorial repo

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -530,9 +530,9 @@ export class ChangesList extends React.Component<
 
   private getPlaceholderMessage(
     files: ReadonlyArray<WorkingDirectoryFileChange>,
-    singleFileCommit: boolean
+    prepopulateCommitSummary: boolean
   ) {
-    if (!singleFileCommit) {
+    if (!prepopulateCommitSummary) {
       return 'Summary (required)'
     }
 
@@ -598,7 +598,8 @@ export class ChangesList extends React.Component<
     const filesSelected = workingDirectory.files.filter(
       f => f.selection.getSelectionType() !== DiffSelectionType.None
     )
-    const singleFileCommit = filesSelected.length === 1
+    const prepopulateCommitSummary =
+      filesSelected.length === 1 && !repository.isTutorialRepository
 
     return (
       <CommitMessage
@@ -617,9 +618,9 @@ export class ChangesList extends React.Component<
         coAuthors={this.props.coAuthors}
         placeholder={this.getPlaceholderMessage(
           filesSelected,
-          singleFileCommit
+          prepopulateCommitSummary
         )}
-        singleFileCommit={singleFileCommit}
+        prepopulateCommitSummary={prepopulateCommitSummary}
         key={repository.id}
         currentBranchProtected={currentBranchProtected}
       />

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -598,6 +598,11 @@ export class ChangesList extends React.Component<
     const filesSelected = workingDirectory.files.filter(
       f => f.selection.getSelectionType() !== DiffSelectionType.None
     )
+
+    // When a single file is selected, we use a default commit summary
+    // based on the file name and change status.
+    // However, for onboarding tutorial repositories, we don't want to do this.
+    // See https://github.com/desktop/desktop/issues/8354
     const prepopulateCommitSummary =
       filesSelected.length === 1 && !repository.isTutorialRepository
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -48,7 +48,7 @@ interface ICommitMessageProps {
   readonly autocompletionProviders: ReadonlyArray<IAutocompletionProvider<any>>
   readonly isCommitting: boolean
   readonly placeholder: string
-  readonly singleFileCommit: boolean
+  readonly prepopulateCommitSummary: boolean
   readonly currentBranchProtected: boolean
 
   /**
@@ -211,7 +211,7 @@ export class CommitMessage extends React.Component<
     const trailers = this.getCoAuthorTrailers()
 
     const summaryOrPlaceholder =
-      this.props.singleFileCommit && !this.state.summary
+      this.props.prepopulateCommitSummary && !this.state.summary
         ? this.props.placeholder
         : summary
 
@@ -233,7 +233,7 @@ export class CommitMessage extends React.Component<
   private canCommit(): boolean {
     return (
       (this.props.anyFilesSelected && this.state.summary.length > 0) ||
-      this.props.singleFileCommit
+      this.props.prepopulateCommitSummary
     )
   }
 


### PR DESCRIPTION
## Overview

TODO
- [ ] update tutorial commit step copy accordingly 

**Closes #8354**

## Description

Ordinarily, when a single file is selected, we use a default commit summary "Update README.md" and allow users to commit without supplying their own commit message.

<img width="249" alt="GitHub_Desktop" src="https://user-images.githubusercontent.com/7910250/65807174-0a651a80-e142-11e9-8c89-1249503da086.png">

However, @billygriffin uncovered during usability testing of the onboarding tutorial that people were skipping over the summary field when making a commit. 

To make it more things more clear to the user where to input their commit message, this PR makes it so that we do not add a default commit summary when in a tutorial repository. This allows us to point the user to the "summary" input box. The commit button will be disabled until the user enters a summary.

<img width="248" alt="GitHub_Desktop-dev" src="https://user-images.githubusercontent.com/7910250/65807284-75aeec80-e142-11e9-9e8c-22168a517af4.png">

## Release notes

Notes: no-notes
