### PR TITLE
[onboarding] metrics revision + addition

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -322,6 +322,13 @@ export interface IDailyMeasures {
    * Has the user completed all tutorial steps?
    */
   readonly tutorialCompleted: boolean
+
+  /**
+   * _[Onboarding tutorial]_
+   * What's the highest tutorial step completed by user?
+   * (`0` is tutorial created, first step is `1`)
+   */
+  readonly highestTutorialStepCompleted: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -121,6 +121,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tutorialBranchPushed: false,
   tutorialPrCreated: false,
   tutorialCompleted: false,
+  // this is `-1` because `0` signifies "tutorial created"
+  highestTutorialStepCompleted: -1,
 }
 
 interface IOnboardingStats {
@@ -1248,6 +1250,15 @@ export class StatsStore implements IStatsStore {
   public recordTutorialCompleted() {
     return this.updateDailyMeasures(() => ({
       tutorialCompleted: true,
+    }))
+  }
+
+  public recordHighestTutorialStepCompleted(step: number) {
+    return this.updateDailyMeasures(m => ({
+      highestTutorialStepCompleted: Math.max(
+        step,
+        m.highestTutorialStepCompleted
+      ),
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1219,30 +1219,45 @@ export class StatsStore implements IStatsStore {
 
   public recordTutorialBranchCreated() {
     return this.updateDailyMeasures(() => ({
+      tutorialEditorInstalled: true,
       tutorialBranchCreated: true,
     }))
   }
 
   public recordTutorialFileEdited() {
     return this.updateDailyMeasures(() => ({
+      tutorialEditorInstalled: true,
+      tutorialBranchCreated: true,
       tutorialFileEdited: true,
     }))
   }
 
   public recordTutorialCommitCreated() {
     return this.updateDailyMeasures(() => ({
+      tutorialEditorInstalled: true,
+      tutorialBranchCreated: true,
+      tutorialFileEdited: true,
       tutorialCommitCreated: true,
     }))
   }
 
   public recordTutorialBranchPushed() {
     return this.updateDailyMeasures(() => ({
+      tutorialEditorInstalled: true,
+      tutorialBranchCreated: true,
+      tutorialFileEdited: true,
+      tutorialCommitCreated: true,
       tutorialBranchPushed: true,
     }))
   }
 
   public recordTutorialPrCreated() {
     return this.updateDailyMeasures(() => ({
+      tutorialEditorInstalled: true,
+      tutorialBranchCreated: true,
+      tutorialFileEdited: true,
+      tutorialCommitCreated: true,
+      tutorialBranchPushed: true,
       tutorialPrCreated: true,
     }))
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -240,7 +240,11 @@ import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { findRemoteBranchName } from './helpers/find-branch-name'
 import { findBranchesForFastForward } from './helpers/find-branches-for-fast-forward'
-import { TutorialStep } from '../../models/tutorial-step'
+import {
+  TutorialStep,
+  isValidTutorialStep,
+  orderedTutorialSteps,
+} from '../../models/tutorial-step'
 import { OnboardingTutorialAssessor } from './helpers/tutorial-assessor'
 import { getUntrackedFiles } from '../status'
 
@@ -444,34 +448,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private recordTutorialStepCompleted(step: TutorialStep): void {
-    switch (step) {
-      case TutorialStep.PickEditor:
-        this.statsStore.recordTutorialRepoCreated()
-        break
-      case TutorialStep.CreateBranch:
-        this.statsStore.recordTutorialEditorInstalled()
-        break
-      case TutorialStep.EditFile:
-        this.statsStore.recordTutorialBranchCreated()
-        break
-      case TutorialStep.MakeCommit:
-        this.statsStore.recordTutorialFileEdited()
-        break
-      case TutorialStep.PushBranch:
-        this.statsStore.recordTutorialCommitCreated()
-        break
-      case TutorialStep.OpenPullRequest:
-        this.statsStore.recordTutorialBranchPushed()
-        break
-      case TutorialStep.AllDone:
-        this.statsStore.recordTutorialPrCreated()
-        this.statsStore.recordTutorialCompleted()
-        break
-      case TutorialStep.NotApplicable:
-      case TutorialStep.Paused:
-        break
-      default:
-        assertNever(step, 'Unaccounted for step type')
+    // if it's not a valid step, we don't need to record anything
+    if (!isValidTutorialStep(step)) {
+      return
+    }
+    const stepInd = orderedTutorialSteps.indexOf(step)
+    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.PickEditor)) {
+      this.statsStore.recordTutorialEditorInstalled()
+    }
+    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.CreateBranch)) {
+      this.statsStore.recordTutorialBranchCreated()
+    }
+    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.EditFile)) {
+      this.statsStore.recordTutorialFileEdited()
+    }
+    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.MakeCommit)) {
+      this.statsStore.recordTutorialCommitCreated()
+    }
+    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.PushBranch)) {
+      this.statsStore.recordTutorialBranchPushed()
+    }
+    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.OpenPullRequest)) {
+      this.statsStore.recordTutorialPrCreated()
+      this.statsStore.recordTutorialCompleted()
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -240,11 +240,7 @@ import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { findRemoteBranchName } from './helpers/find-branch-name'
 import { findBranchesForFastForward } from './helpers/find-branches-for-fast-forward'
-import {
-  TutorialStep,
-  isValidTutorialStep,
-  orderedTutorialSteps,
-} from '../../models/tutorial-step'
+import { TutorialStep, orderedTutorialSteps, isValidTutorialStep } from '../../models/tutorial-step'
 import { OnboardingTutorialAssessor } from './helpers/tutorial-assessor'
 import { getUntrackedFiles } from '../status'
 
@@ -448,32 +444,39 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private recordTutorialStepCompleted(step: TutorialStep): void {
-    // if it's not a valid step, we don't need to record anything
     if (!isValidTutorialStep(step)) {
       return
     }
 
-    const stepInd = orderedTutorialSteps.indexOf(step)
-    this.statsStore.recordHighestTutorialStepCompleted(stepInd)
+    this.statsStore.recordHighestTutorialStepCompleted(
+      orderedTutorialSteps.indexOf(step)
+    )
 
-    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.PickEditor)) {
-      this.statsStore.recordTutorialEditorInstalled()
-    }
-    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.CreateBranch)) {
-      this.statsStore.recordTutorialBranchCreated()
-    }
-    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.EditFile)) {
-      this.statsStore.recordTutorialFileEdited()
-    }
-    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.MakeCommit)) {
-      this.statsStore.recordTutorialCommitCreated()
-    }
-    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.PushBranch)) {
-      this.statsStore.recordTutorialBranchPushed()
-    }
-    if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.OpenPullRequest)) {
-      this.statsStore.recordTutorialPrCreated()
-      this.statsStore.recordTutorialCompleted()
+    switch (step) {
+      case TutorialStep.PickEditor:
+        // don't need to record anything for the first step
+        break
+      case TutorialStep.CreateBranch:
+        this.statsStore.recordTutorialEditorInstalled()
+        break
+      case TutorialStep.EditFile:
+        this.statsStore.recordTutorialBranchCreated()
+        break
+      case TutorialStep.MakeCommit:
+        this.statsStore.recordTutorialFileEdited()
+        break
+      case TutorialStep.PushBranch:
+        this.statsStore.recordTutorialCommitCreated()
+        break
+      case TutorialStep.OpenPullRequest:
+        this.statsStore.recordTutorialBranchPushed()
+        break
+      case TutorialStep.AllDone:
+        this.statsStore.recordTutorialPrCreated()
+        this.statsStore.recordTutorialCompleted()
+        break
+      default:
+        assertNever(step, 'Unaccounted for step type')
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -240,7 +240,11 @@ import { arrayEquals } from '../equality'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { findRemoteBranchName } from './helpers/find-branch-name'
 import { findBranchesForFastForward } from './helpers/find-branches-for-fast-forward'
-import { TutorialStep, orderedTutorialSteps, isValidTutorialStep } from '../../models/tutorial-step'
+import {
+  TutorialStep,
+  orderedTutorialSteps,
+  isValidTutorialStep,
+} from '../../models/tutorial-step'
 import { OnboardingTutorialAssessor } from './helpers/tutorial-assessor'
 import { getUntrackedFiles } from '../status'
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -452,7 +452,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (!isValidTutorialStep(step)) {
       return
     }
+
     const stepInd = orderedTutorialSteps.indexOf(step)
+    this.statsStore.recordHighestTutorialStepCompleted(stepInd)
+
     if (stepInd > orderedTutorialSteps.indexOf(TutorialStep.PickEditor)) {
       this.statsStore.recordTutorialEditorInstalled()
     }


### PR DESCRIPTION
## Overview

#8233 #8360

This PR revises some metrics logic in #8360 and adds an additional measure.

## Description

- https://github.com/desktop/desktop/commit/330eb741ce42feb69e45f01da4ea272ec4538261 refactors `recordTutorialStepCompleted` to ensure that the individual step booleans are marked off properly when a user completes more than a single step between runs of `updateCurrentTutorialStep`. unfortunately this implementation loses the exhaustive check of `assertNever`, but it does guarantee our metric data to be more accurate.
- https://github.com/desktop/desktop/commit/d601338b69dfb706b322b716be85e034bba2524b adds the additional measure `highestTutorialStepCompleted`, which is the index of the highest step completed. this captures essentially the same information as the `boolean`s from #8360, but will be much easier to query from the analytics side (no `AND`ing up to 6 booleans). **i'm proposing we include both.** if we change order of tutorial steps, `highestTutorialStepCompleted` will no longer provide a meaningful index to _which_ step the user last completed (for example, if step 3 becomes push branch instead of edit readme, `highestTutorialStepCompleted` == 3 would have different implications over time. so we could use the `highestTutorialStepCompleted` as a measure of attrition/retention over the tutorial, and the individual `boolean` measure to drill down for more information.

this PR is split into two commits so https://github.com/desktop/desktop/commit/d601338b69dfb706b322b716be85e034bba2524b can easily be reverted should we decide against including both kinds of metrics.

cc— @billygriffin @kuychaco @niik 

## Release notes

Notes: no-notes
