### PR TITLE
Fixed strong contrast border colors.

### DIFF
--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -6,7 +6,7 @@
 @import '~primer-support/lib/variables/color-system.scss';
 
 #desktop-app-title-bar {
-  border-bottom: 1px solid #181818!important;
+  border-bottom: 1px solid #181818 !important;
 }
 
 body.theme-dark {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -5,6 +5,10 @@
 // Primer colors, see https://github.com/primer/primer-css/blob/master/modules/primer-support/lib/variables/color-system.scss
 @import '~primer-support/lib/variables/color-system.scss';
 
+#desktop-app-title-bar {
+  border-bottom: 1px solid #181818!important;
+}
+
 body.theme-dark {
   --color-new: #{$green};
   --color-deleted: #{$red};
@@ -71,7 +75,7 @@ body.theme-dark {
   /**
    * Border color for boxes.
    */
-  --box-border-color: #141414;
+  --box-border-color: #191919;
   --box-border-accent-color: #{$blue};
 
   /**


### PR DESCRIPTION
This pull request corrects the **strong contrast** between the borders of some elements. The change is especially noticeable on the title-bar border color.

Box border color changed `#141414` -> `#191919`.
Title bar border color changed `#000000` -> `#181818`.

### Before

![image](https://user-images.githubusercontent.com/39625750/65892461-04c03c80-e3af-11e9-8053-a33562d99647.png)

### After

![image](https://user-images.githubusercontent.com/39625750/65892481-0ee23b00-e3af-11e9-8816-10028c1c5f53.png)