### PR TITLE
Fixed strong contrast titlebar buttons.

### DIFF
--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -335,3 +335,11 @@ body.theme-dark {
 .CodeMirror-cursor {
   border-left-color: currentColor;
 }
+
+.window-controls button:hover {
+  background-color: #363d45!important;
+}
+
+.window-controls button.close:hover {
+  background-color: #bc0005!important;
+}

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -337,9 +337,9 @@ body.theme-dark {
 }
 
 .window-controls button:hover {
-  background-color: #363d45!important;
+  background-color: #363d45 !important;
 }
 
 .window-controls button.close:hover {
-  background-color: #bc0005!important;
+  background-color: #bc0005 !important;
 }


### PR DESCRIPTION
I improved the color of the buttons in state `hover`, now they are **less contrasting** and **pleasing to the eyes**, see for yourself.

### Before

![image](https://user-images.githubusercontent.com/39625750/65893443-a005e180-e3b0-11e9-8b36-4bec282f2939.png)

![image](https://user-images.githubusercontent.com/39625750/65893458-a4ca9580-e3b0-11e9-89cf-792dfc7e43ab.png)

### After

![image](https://user-images.githubusercontent.com/39625750/65893481-ac8a3a00-e3b0-11e9-9bb4-158bd7474d73.png)

![image](https://user-images.githubusercontent.com/39625750/65893489-b0b65780-e3b0-11e9-9442-02c1307aa7e4.png)
