### PR TITLE
[onboarding] use number of repos to limit tutorial pausing

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -432,7 +432,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const currentStep = await this.tutorialAssessor.getCurrentStep(
       repository.isTutorialRepository,
-      this.repositoryStateCache.get(repository)
+      this.repositoryStateCache.get(repository),
+      this.repositories.length
     )
     log.info(`Current tutorial step is ${currentStep}`)
     // only emit an update if its changed

--- a/app/src/lib/stores/helpers/tutorial-assessor.ts
+++ b/app/src/lib/stores/helpers/tutorial-assessor.ts
@@ -38,11 +38,12 @@ export class OnboardingTutorialAssessor {
   /** Determines what step the user needs to complete next in the Onboarding Tutorial */
   public async getCurrentStep(
     isTutorialRepo: boolean,
-    repositoryState: IRepositoryState
+    repositoryState: IRepositoryState,
+    repoCount: number
   ): Promise<TutorialStep> {
     if (!isTutorialRepo) {
       return TutorialStep.NotApplicable
-    } else if (this.tutorialPaused) {
+    } else if (this.tutorialPaused && repoCount === 1) {
       return TutorialStep.Paused
     } else if (!(await this.isEditorInstalled())) {
       return TutorialStep.PickEditor


### PR DESCRIPTION
## Overview

closes #8341

## Description

- use the total number of repositories to determine if pausing matters in `tutorialAssessor`

## Release notes

Notes: no-notes
