### PR TITLE
Resolve the current editor after loading the selected editor

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -420,14 +420,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.tutorialAssessor = new OnboardingTutorialAssessor(
       this.getResolvedExternalEditor
     )
-
-    // Deferred, attempts to resolve the user's selected editor (i.e.
-    // ensures that it's actually present on the machine), needs to
-    // happen after the tutorial assessor has been initialized, see:
-    // https://github.com/desktop/desktop/pull/8242#pullrequestreview-289936574
-    this._resolveCurrentEditor().catch(e =>
-      log.error('Failed resolving current editor at startup', e)
-    )
   }
 
   /** Figure out what step of the tutorial the user needs to do next */
@@ -1760,6 +1752,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (externalEditorValue) {
       this.selectedExternalEditor = externalEditorValue
     }
+
+    // Deferred, attempts to resolve the user's selected editor (i.e.
+    // ensures that it's actually present on the machine), needs to
+    // happen after the tutorial assessor has been initialized, see:
+    // https://github.com/desktop/desktop/pull/8242#pullrequestreview-289936574
+    this._resolveCurrentEditor().catch(e =>
+      log.error('Failed resolving current editor at startup', e)
+    )
 
     const shellValue = localStorage.getItem(shellKey)
     this.selectedShell = shellValue ? parseShell(shellValue) : DefaultShell


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8322**

## Description

The resolved editor (`resolvedExternalEditor`) is a function of what editors are installed on the user's machine and which editor they prefer (`selectedExternalEditor`). If their preferred editor isn't available the resolved editor will be the first editor we find on the user's machine or none if we can't find any editors.

As such the resolved editor can't be determined until after the selected editor has been determined. This PR changes the order of things to ensure that the resolved editor is updated after the selected editor value has been loaded from the localStorage.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes
