### PR TITLE
Resolve harder

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5268,7 +5268,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public async _resolveCurrentEditor() {
-    const match = await findEditorOrDefault(this.selectedExternalEditor)
+    const match = await findEditorOrDefault(this.selectedExternalEditor).catch(
+      () => findEditorOrDefault()
+    )
+
     const resolvedExternalEditor = match != null ? match.editor : null
     if (this.resolvedExternalEditor !== resolvedExternalEditor) {
       this.resolvedExternalEditor = resolvedExternalEditor

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5268,6 +5268,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public async _resolveCurrentEditor() {
+    // findEditorOrDefault may, despite its name, throw when given a
+    // preferred editor argument. When given no arguments it will never
+    // throw. In this instance we really don't want it to throw but we
+    // also want to attempt to resolve the user's preferred editor so
+    // we'll try twice (which is fine from a performance perspective since
+    // the list of available editors is cached).
     const match = await findEditorOrDefault(this.selectedExternalEditor).catch(
       () => findEditorOrDefault()
     )


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8386**

**Note that this targets the release branch**

## Description

In #8386 @kuychaco found that `resolveCurrentEditor` could throw an error if the preferred editor wasn't found. The error itself wouldn't cause any issues but the behavior could cause us to incorrectly state that the user had no useable editor installed. @kuychaco then opened   https://github.com/desktop/desktop/pull/8388 with the intention to refactor and solve this error in a proper way. This PR is not that and does not supersede or replace #8388.

Instead this PR is a quick and dirty (yet safe) workaround which ensures that the `resolveCurrentEditor` doesn't throw when the preferred editor isn't installed.

I think this might be worthwhile to include in the release for two reasons

1. It fixes the edge-case reported in #8386 
2. Having `_resolveCurrentEditor` throw when it wasn't intended to feels dangerous to me. Right now the only unintended side-effect of this that I've been able to prove is that background refresh might stop working while in the tutorial which doesn't matter but there could be other unforeseen consequences.

cc @kuychaco @outofambit @billygriffin.

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: no-notes