### PR TITLE
Fix [object Object] pre-filled url text in the clone dialogue when opened from BlankSlateView

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { ipcRenderer, remote } from 'electron'
 import { CSSTransitionGroup } from 'react-transition-group'
-import * as URL from 'url'
 
 import {
   IAppState,
@@ -150,18 +149,6 @@ export const dialogTransitionLeaveTimeout = 100
  * changes. See https://github.com/desktop/desktop/issues/1398.
  */
 const ReadyDelay = 100
-
-/**
- * Check if url is valid by checking to see if it can be parsed
- */
-export function isValidUrl(url: string): boolean {
-  try {
-    URL.parse(url)
-    return true
-  } catch (e) {
-    return false
-  }
-}
 
 export class App extends React.Component<IAppProps, IAppState> {
   private loading = true
@@ -683,7 +670,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   private showCloneRepo = (cloneUrl?: string) => {
     let initialURL: string | null = null
 
-    if (cloneUrl !== undefined && isValidUrl(cloneUrl)) {
+    if (cloneUrl !== undefined) {
       this.props.dispatcher.changeCloneRepositoriesTab(
         CloneRepositoryTab.Generic
       )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { ipcRenderer, remote } from 'electron'
 import { CSSTransitionGroup } from 'react-transition-group'
+import * as URL from 'url'
 
 import {
   IAppState,
@@ -149,6 +150,18 @@ export const dialogTransitionLeaveTimeout = 100
  * changes. See https://github.com/desktop/desktop/issues/1398.
  */
 const ReadyDelay = 100
+
+/**
+ * Check if url is valid by checking to see if it can be parsed
+ */
+export function isValidUrl(url: string): boolean {
+  try {
+    URL.parse(url)
+    return true
+  } catch (e) {
+    return false
+  }
+}
 
 export class App extends React.Component<IAppProps, IAppState> {
   private loading = true
@@ -670,7 +683,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   private showCloneRepo = (cloneUrl?: string) => {
     let initialURL: string | null = null
 
-    if (cloneUrl !== undefined) {
+    if (cloneUrl !== undefined && isValidUrl(cloneUrl)) {
       this.props.dispatcher.changeCloneRepositoriesTab(
         CloneRepositoryTab.Generic
       )

--- a/app/src/ui/blank-slate/blank-slate.tsx
+++ b/app/src/ui/blank-slate/blank-slate.tsx
@@ -331,6 +331,12 @@ export class BlankSlateView extends React.Component<
     }
   }
 
+  // Note: this wrapper is necessary in order to ensure
+  // `onClone` does not get passed a click event
+  // and accidentally interpret that as a url
+  // See https://github.com/desktop/desktop/issues/8394
+  private onShowClone = () => this.props.onClone()
+
   private renderButtonGroupButton(
     symbol: OcticonSymbol,
     title: string,
@@ -387,7 +393,7 @@ export class BlankSlateView extends React.Component<
       __DARWIN__
         ? 'Clone a Repository from the Internet…'
         : 'Clone a repository from the Internet…',
-      this.props.onClone
+      this.onShowClone
     )
   }
 


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

**Closes #8394**

## Description

A regression was introduced when we introduced the onboarding tutorial and made changes in the `BlankSlateView` component. We got rid of a wrapper method that prevented a click event object from being passed along to `showCloneRepo` where it is eventually treated as a string...

https://github.com/desktop/desktop/blob/ac48f98a14f9670f6689b6f900685322e9cb45b9/app/src/ui/app.tsx#L670

This PR restores the wrapper method, ensuring that when the "Clone" button is clicked, no arguments are passed to `showCloneRepo` and `cloneUrl` is `undefined`. I've added a comment in the code to ensure that this wrapper remains in place, as otherwise it is very easy to assume it's unnecessary because all it does is call a prop method. 

### Alternative approach
Before implementing ☝️I played around with other ways to guard against this bug from a code robustness standpoint (as opposed to relying on a comment within the code). We could verify that the `cloneUrl` is valid in `showCloneRepo` (something like 2f16869). The benefit would be that this makes the `showCloneRepo` method more robust (only valid urls get through). The drawback is that it adds a bit of extra logic and computation. If we like 2f16869 we can revert ac48f98 to get back to it. 

## Release notes

Notes: Fixes weird pre-filled url text in the clone dialogue when opened from BlankSlateView
