### PR TITLE
Shorten Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,7 +33,7 @@ Add screenshots to help explain your problem, if applicable.
 
 ### Logs
 
-Attach you logs by opening the `Help` menu and selecting `Show Logs...`, if applicable.
+Attach your logs by opening the `Help` menu and selecting `Show Logs...`, if applicable.
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,68 +4,37 @@ about: Report a problem encountered while using GitHub Desktop
 
 ---
 
-<!--
-First and foremost, we’d like to thank you for taking the time to contribute to our project. Before submitting your issue, please follow these steps:
+### Describe the bug
 
-1. Familiarize yourself with our contributing guide:
-	* https://github.com/desktop/desktop/blob/development/.github/CONTRIBUTING.md#contributing-to-github-desktop
-2. Check if your issue (and sometimes workaround) is in the known-issues doc:
-	* https://github.com/desktop/desktop/blob/development/docs/known-issues.md
-3. Make sure your issue isn’t a duplicate of another issue
-4. If you have made it to this step, go ahead and fill out the template below
--->
+A clear and concise description of what the bug is.
 
-## Description
-<!--
-Provide a detailed description of the behavior you're seeing or the behavior you'd like to see **below** this comment.
--->
+### Version & OS
 
+Open 'About GitHub Desktop' menu to see the Desktop version. Also include what operating system you are using.
 
-## Version
-<!--
-Place the version of GitHub Desktop you have installed **below** this comment. This is displayed under the 'About GitHub Desktop' menu item. If you are running from source, include the commit by running `git rev-parse HEAD` from the local repository.
--->
-* GitHub Desktop:
-<!--
-Place the version of your operating system **below** this comment. The operating system you are running on may also help with reproducing the issue. If you are on macOS, launch 'About This Mac' and write down the OS version listed. If you are on Windows, open 'Command Prompt' and attach the output of this command: 'cmd /c ver'
--->
-* Operating system:
+### Steps to reproduce the behavior
 
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
-## Steps to Reproduce
-<!--
-List the steps to reproduce your issue **below** this comment
-ex,
-1. `step 1`
-2. `step 2`
-3. `and so on…`
--->
+### Expected behavior
 
-### Expected Behavior
-<!-- What you expected to happen -->
+A clear and concise description of what you expected to happen.
 
-### Actual Behavior
-<!-- What actually happens -->
+### Actual behavior
 
+A clear and concise description of what actually happened.
 
-## Additional Information
-<!--
-Place any additional information, configuration, or data that might be necessary to reproduce the issue **below** this comment.
+### Screenshots
 
-If you have screen shots or gifs that demonstrate the issue, please include them.
-
-If the issue involves a specific public repository, including the information about it will make it easier to recreate the issue.
-
-If you are dealing with a performance issue or regression, attaching a Performance profile of the task will help the developers understand the runtime behavior of the application on your machine.
-https://github.com/desktop/desktop/blob/development/docs/contributing/timeline-profile.md
--->
+Add screenshots to help explain your problem, if applicable.
 
 ### Logs
-<!--
-Attach your log file (You can simply drag your file here to insert it) to this issue. Please make sure the generated link to your log file is **below** this comment section otherwise it will not appear when you submit your issue.
 
-macOS logs accessible from the Help menu or location: `~/Library/Application Support/GitHub Desktop/logs/*.desktop.production.log`
-Windows logs accessible from the Help menu or location: `%APPDATA%\GitHub Desktop\logs\*.desktop.production.log`
+Attach you logs by opening the `Help` menu and selecting `Show Logs...`, if applicable.
 
-The log files are organized by date, so see if anything was generated for today's date.
--->
+### Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/problem-to-raise.md
+++ b/.github/ISSUE_TEMPLATE/problem-to-raise.md
@@ -4,7 +4,6 @@ about: Surface a problem that you think should be solved
 
 ---
 
-<!--
 ### Describe the feature or problem you’d like to solve
 
 A clear and concise description of what the feature or problem is.

--- a/.github/ISSUE_TEMPLATE/problem-to-raise.md
+++ b/.github/ISSUE_TEMPLATE/problem-to-raise.md
@@ -10,7 +10,7 @@ A clear and concise description of what the feature or problem is.
 
 ### Proposed solution
 
-How will it benefit Desktop and its users.
+How will it benefit Desktop and its users?
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/problem-to-raise.md
+++ b/.github/ISSUE_TEMPLATE/problem-to-raise.md
@@ -1,24 +1,18 @@
 ---
-name: "\U0001F389 Problem to raise"
+name: "\U0001F389 Submit a request or solve a problem"
 about: Surface a problem that you think should be solved
 
 ---
 
 <!--
-First and foremost, we’d like to thank you for taking the time to contribute to our project. Before submitting your issue, please follow these steps:
+### Describe the feature or problem you’d like to solve
 
-1. Familiarize yourself with our contributing guide:
-	* https://github.com/desktop/desktop/blob/development/.github/CONTRIBUTING.md#contributing-to-github-desktop
-2. Make sure your issue isn’t a duplicate of another issue
-3. If you have made it to this step, go ahead and fill out the template below
--->
+A clear and concise description of what the feature or problem is.
 
-**Please describe the problem you think should be solved**
-A clear and concise description of what the problem is and who else might be impacted. Screenshots are encouraged.
+### Proposed solution
 
-Example:
+How will it benefit Desktop and its users.
 
-> “When I run into a merge conflict, I don’t know where to go to resolve it. Anyone who works off of multiple branches will likely run into this problem at least occasionally.”
+### Additional context
 
-**[Optional] Do you have any potential solutions in mind?**
-A clear and concise description of one or more solutions you think might solve the problem. Please include any considered drawbacks or tradeoffs, and how users might use your solution(s). Screenshots or mockups are helpful here!
+Add any other context like screenshots or mockups are helpful, if applicable.

--- a/.github/ISSUE_TEMPLATE/problem-to-raise.md
+++ b/.github/ISSUE_TEMPLATE/problem-to-raise.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F389 Submit a request or solve a problem"
+name: "\U00002B50 Submit a request or solve a problem"
 about: Surface a problem that you think should be solved
 
 ---


### PR DESCRIPTION
## Overview

Revised our two issue templates to make them simpler to read and use, as they are too cumbersome.

## Changes

* removed implied content and unnecessary links
* made sections short and concise
