### PR TITLE
Don't terminate the app immediately when the main window is closed

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -89,6 +89,16 @@ if (__DARWIN__) {
   possibleProtocols.add('github-windows')
 }
 
+app.on('window-all-closed', () => {
+  // If we don't subscribe to this event and all windows are closed, the default
+  // behavior is to quit the app. We don't want that though, we control that
+  // behavior through the mainWindow onClose event such that on macOS we only
+  // hide the main window when a user attempts to close it.
+  //
+  // If we don't subscribe to this and change the default behavior we break
+  // the crash process window which is shown after the main window is closed.
+})
+
 process.on('uncaughtException', (error: Error) => {
   error = withSourceMappedStack(error)
   reportError(error, getExtraErrorContext())


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

## Description

Some time recently (likely related to one of our Electron upgrades) the logic for when to terminate the application subtly changed to immediate termination as soon as no `BrowserWindow` instances were active.

Unfortunately this meant that our crash window broke and with it likely some percentage of all crashes ended up never getting shipped to central.

The crash handling process in Desktop (for a renderer crash) looks something like this (simplified)

1. Renderer catches an uncaughtException event
2. Renderer sticks some additional data onto the event and passes it to the main process
3. The main process closes the main window
4. The main process initiates an asynchronous network request to post the error to central
5. The main process launches the crash process

In between steps three and five we'd get interrupted by the application shutting down and therefore we're likely loosing quite a bit of needles from clients.

You can verify that the crash process doesn't work by clicking on `Help -> Crash renderer process` while in development mode or by running the following line of code in the DevTools console on the production process.

```
require('electron').remote.getCurrentWebContents().send('menu-event', { name: 'boomtown' })
```

## Release notes

<!--

If this is related to a feature, bugfix or improvement, we'd love your help to
summarize these changes to assist with drafting the release notes when this pull
request is merged.

You can leave this blank if you're not sure.

If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".

Some examples of changelog entries from earlier releases:

  - Adds support for Python 3 in GitHub Desktop CLI for macOS users
  - Fixes problem with commit being reset when switching between History and Changes tabs
  - Fixes caret in co-author selector, which is hidden when dark theme is enabled
  - Improves status parsing performance when handling thousands of changed files

-->

Notes: TBD