### PR TITLE
Don't cut off link external octicon in "Open Pull Request" button

### DIFF
--- a/app/styles/ui/onboarding-tutorial/_right-panel.scss
+++ b/app/styles/ui/onboarding-tutorial/_right-panel.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-flow: column nowrap;
   flex: 1 1 350px;
-  min-width: 264px;
+  min-width: 274px;
   max-width: 350px;
   height: 100%;
   background-color: var(--background-color);


### PR DESCRIPTION
## Overview

<!--

What issue are you addressing? (for example, #1234)

If an issue doesn't exist for this pull request (PR) to address, please open one
to allow for discussion before opening this PR.

You can open a new issue at https://github.com/desktop/desktop/issues/new/choose
-->

Closes #8408 

## Description

Increase the min-width of the onboarding tutorial panel by 10px so button never gets squished enough that the link external octicon gets cut off

An alternative approach considered was to have the keyboard shortcut overflow to the next line if the panel width became too small. We opted for the current approach because it's more straight-forward and the difference in width is only 10px.

## Screenshots
### Before:
<img width="287" alt="GitHub_Desktop-dev" src="https://user-images.githubusercontent.com/7910250/66243847-f7f75d80-e6ba-11e9-8597-8d792c4cfd92.png">

### After:
<img width="284" alt="GitHub_Desktop-dev" src="https://user-images.githubusercontent.com/7910250/66243843-f29a1300-e6ba-11e9-9b04-ff0c6c6f9238.png">

## Release notes

Notes: no-notes
