### PR TITLE
Create and use keyboard shortcut react component

### DIFF
--- a/app/src/ui/keyboard-shortcut.tsx
+++ b/app/src/ui/keyboard-shortcut.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+
+import { getPlatformSpecificNameOrSymbolForModifier } from '../lib/menu-item'
+import { MenuItem } from '../models/app-menu'
+
+interface IKeyboardShortcutProps {
+  /**
+   * An array of strings (one for each key), or a `MenuItem`,
+   * from which the array of strings will be extracted.
+   */
+  readonly keyCombo: ReadonlyArray<string> | MenuItem
+}
+
+export const KeyboardShortcut: React.SFC<IKeyboardShortcutProps> = props => {
+  // TODO: clean up this type differentiation
+  const keys = Array.isArray(props.keyCombo)
+    ? (props.keyCombo as ReadonlyArray<string>)
+    : extractKeyCombo(props.keyCombo as MenuItem)
+  return (
+    <>
+      {keys.map((k, i) => (
+        <kbd key={k + i}>{k}</kbd>
+      ))}
+    </>
+  )
+}
+
+export function extractKeyCombo(item: MenuItem): ReadonlyArray<string> {
+  if (item.type === 'separator' || item.type === 'submenuItem') {
+    return []
+  }
+
+  if (item.accelerator === null) {
+    return []
+  }
+
+  return item.accelerator
+    .split('+')
+    .map(getPlatformSpecificNameOrSymbolForModifier)
+}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -316,7 +316,7 @@ export class RepositoryView extends React.Component<
     )
   }
 
-  private renderTutorialPane(): JSX.Element {
+  private renderTutorialCenterView(): JSX.Element {
     if (this.props.currentTutorialStep === TutorialStep.AllDone) {
       return (
         <TutorialDone
@@ -348,7 +348,7 @@ export class RepositoryView extends React.Component<
         enableTutorial() &&
         this.props.currentTutorialStep !== TutorialStep.NotApplicable
       ) {
-        return this.renderTutorialPane()
+        return this.renderTutorialCenterView()
       } else {
         return (
           <NoChanges


### PR DESCRIPTION
Closes #8346 

## Description

- [x] create `KeyboardShortcut` React component
- [x] use `KeyboardShortcut` in `NoChanges` component
- [ ] use `KeyboardShortcut` in `TutorialDone` component
- [ ] reorder shortcut key order on Mac
- [ ] verify styles
- [ ] fix up gross `as` typcasting in `KeyboardShortcut`

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

Notes: no-notes
