### PR TITLE
Extend arrow navigation in lists for MacOS

### DIFF
--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -224,8 +224,15 @@ export class AppMenuBarButton extends React.Component<
 
     this.props.onKeyDown(this.props.menuItem, event)
 
+    const { ctrlKey, key } = event
+
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+
     if (!this.isMenuOpen && !event.defaultPrevented) {
-      if (event.key === 'ArrowDown') {
+      if (isArrowDown) {
         this.props.onOpen(this.props.menuItem, true)
         event.preventDefault()
       }

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -375,11 +375,19 @@ export abstract class AutocompletingTextInput<
   private getMovementDirection(
     event: React.KeyboardEvent<any>
   ): SelectionDirection | null {
-    switch (event.key) {
-      case 'ArrowUp':
-        return 'up'
-      case 'ArrowDown':
-        return 'down'
+    const { ctrlKey, key } = event
+
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+    const isArrowUp =
+      key === 'ArrowUp' || (__DARWIN__ && ctrlKey && key === 'p')
+
+    if (isArrowUp) {
+      return 'up'
+    } else if (isArrowDown) {
+      return 'down'
     }
 
     return null

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -394,7 +394,14 @@ export class CompareSidebar extends React.Component<
   private onBranchFilterKeyDown = (
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
-    const key = event.key
+    const { ctrlKey, key } = event
+
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+    const isArrowUp =
+      key === 'ArrowUp' || (__DARWIN__ && ctrlKey && key === 'p')
 
     if (key === 'Enter') {
       if (this.resultCount === 0) {
@@ -422,11 +429,11 @@ export class CompareSidebar extends React.Component<
       }
     } else if (key === 'Escape') {
       this.handleEscape()
-    } else if (key === 'ArrowDown') {
+    } else if (isArrowDown) {
       if (this.branchList !== null) {
         this.branchList.selectNextItem(true, 'down')
       }
-    } else if (key === 'ArrowUp') {
+    } else if (isArrowUp) {
       if (this.branchList !== null) {
         this.branchList.selectNextItem(true, 'up')
       }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -407,9 +407,18 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     let shouldFocus = false
 
-    if (event.key === 'ArrowUp' && row === firstSelectableRow) {
+    const { ctrlKey, key } = event
+
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+    const isArrowUp =
+      key === 'ArrowUp' || (__DARWIN__ && ctrlKey && key === 'p')
+
+    if (isArrowUp && row === firstSelectableRow) {
       shouldFocus = true
-    } else if (event.key === 'ArrowDown' && row === lastSelectableRow) {
+    } else if (isArrowDown && row === lastSelectableRow) {
       shouldFocus = true
     }
 
@@ -425,7 +434,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
   private onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const list = this.list
-    const key = event.key
+    const { ctrlKey, key } = event
 
     if (!list) {
       return
@@ -441,7 +450,12 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
 
     const rowCount = this.state.rows.length
 
-    if (key === 'ArrowDown') {
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+
+    if (isArrowDown) {
       if (rowCount > 0) {
         const selectedRow = findNextSelectableRow(
           rowCount,

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -379,7 +379,16 @@ export class List extends React.Component<IListProps, IListState> {
       return
     }
 
-    if (event.key === 'ArrowDown') {
+    const { ctrlKey, key } = event
+
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+    const isArrowUp =
+      key === 'ArrowUp' || (__DARWIN__ && ctrlKey && key === 'p')
+
+    if (isArrowDown) {
       if (
         event.shiftKey &&
         this.props.selectionMode &&
@@ -390,7 +399,7 @@ export class List extends React.Component<IListProps, IListState> {
         this.moveSelection('down', event)
       }
       event.preventDefault()
-    } else if (event.key === 'ArrowUp') {
+    } else if (isArrowUp) {
       if (
         event.shiftKey &&
         this.props.selectionMode &&

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -126,12 +126,21 @@ export class VerticalSegmentedControl extends React.Component<
   }
 
   private onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
-    if (event.key === 'ArrowUp') {
+    const { ctrlKey, key } = event
+
+    // macOS also supports emacs-inspired shortcuts for moving up/down lists
+    // see https://jblevins.org/log/kbd for more information
+    const isArrowDown =
+      key === 'ArrowDown' || (__DARWIN__ && ctrlKey && key === 'n')
+    const isArrowUp =
+      key === 'ArrowUp' || (__DARWIN__ && ctrlKey && key === 'p')
+
+    if (isArrowUp) {
       if (this.props.selectedIndex > 0) {
         this.props.onSelectionChanged(this.props.selectedIndex - 1)
       }
       event.preventDefault()
-    } else if (event.key === 'ArrowDown') {
+    } else if (isArrowDown) {
       if (this.props.selectedIndex < this.props.items.length - 1) {
         this.props.onSelectionChanged(this.props.selectedIndex + 1)
       }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #7266

## Description

- Extend code in app to allow for Ctrl+N and Ctrl+P navigation in lists

### Screenshots


![ScreenRecording2019-10-04at10265](https://user-images.githubusercontent.com/22846452/66248643-4e828d00-e6f7-11e9-9270-fdc7a56cef34.gif)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
- Add the ability to navigate lists with Ctrl+N to move down and Ctrl+P to move up
