### PR TITLE
Fix exectuable path for launching vscodium on macos

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -143,7 +143,7 @@ function getExecutableShim(
         'Resources',
         'app',
         'bin',
-        'codium'
+        'code'
       )
     case ExternalEditor.MacVim:
       return Path.join(installPath, 'Contents', 'MacOS', 'MacVim')


### PR DESCRIPTION
#8000 

## Description

Fix support for launching VSCodium. It was just a typo regarding the executable.

## Release notes

Notes: no-notes
