### PR TITLE
Reverse columns on "Let's get started" screen

### DIFF
--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -250,9 +250,15 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
 
   private renderNoItems = () => {
     const { loading, repositories } = this.props
+    const endpointName =
+      this.props.account.endpoint === getDotComAPIEndpoint()
+        ? 'GitHub.com'
+        : getHTMLURL(this.props.account.endpoint)
 
     if (loading && (repositories === null || repositories.length === 0)) {
-      return <div className="no-items loading">Loading repositories…</div>
+      return (
+        <div className="no-items loading">{`Loading repositories from ${endpointName}…`}</div>
+      )
     }
 
     if (this.props.filterText.length !== 0) {
@@ -265,11 +271,6 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
         </div>
       )
     }
-
-    const endpointName =
-      this.props.account.endpoint === getDotComAPIEndpoint()
-        ? 'GitHub.com'
-        : getHTMLURL(this.props.account.endpoint)
 
     return (
       <div className="no-items empty-repository-list">

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -276,10 +276,10 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
     return (
       <div className="no-items empty-repository-list">
         <div>
-          Couldn't find any repositories for the account{' '}
+          Couldn't find any repositories for{' '}
           <Ref>{this.props.account.login}</Ref> on {endpointName}.{' '}
           <LinkButton onClick={this.refreshRepositories}>
-            Refresh the list
+            Refresh this list
           </LinkButton>{' '}
           if you've created a repository recently.
         </div>

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -176,7 +176,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
         renderNoItems={this.renderNoItems}
         renderPostFilter={this.renderPostFilter}
         onItemClick={this.props.onItemClicked ? this.onItemClick : undefined}
-        placeholderText="Filter repositories"
+        placeholderText="Filter your repositories"
       />
     )
   }
@@ -276,7 +276,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
     return (
       <div className="no-items empty-repository-list">
         <div>
-          Couldn't find any repositories for{' '}
+          Looks like there are no repositories for{' '}
           <Ref>{this.props.account.login}</Ref> on {endpointName}.{' '}
           <LinkButton onClick={this.refreshRepositories}>
             Refresh this list

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -176,6 +176,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
         renderNoItems={this.renderNoItems}
         renderPostFilter={this.renderPostFilter}
         onItemClick={this.props.onItemClicked ? this.onItemClick : undefined}
+        placeholderText="Filter repositories"
       />
     )
   }

--- a/app/src/ui/lib/filter-list.tsx
+++ b/app/src/ui/lib/filter-list.tsx
@@ -145,6 +145,9 @@ interface IFilterListProps<T extends IFilterListItem> {
    * Callback to fire when the items in the filter list are updated
    */
   readonly onFilterListResultsChanged?: (resultCount: number) => void
+
+  /** Placeholder text for text box. Default is "Filter". */
+  readonly placeholderText?: string
 }
 
 interface IFilterListState<T extends IFilterListItem> {
@@ -241,7 +244,7 @@ export class FilterList<T extends IFilterListItem> extends React.Component<
         ref={this.onTextBoxRef}
         type="search"
         autoFocus={true}
-        placeholder="Filter"
+        placeholder={this.props.placeholderText || 'Filter'}
         className="filter-list-filter-field"
         onValueChanged={this.onFilterValueChanged}
         onKeyDown={this.onKeyDown}

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -200,7 +200,7 @@ export class NoRepositoriesView extends React.Component<
     const accountState = this.props.apiRepositories.get(account)
 
     return (
-      <div className="content-pane left">
+      <div className="content-pane repository-list">
         {this.renderAccountsTabBar()}
         {this.renderAccountRepositoryList(account, accountState)}
       </div>

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -135,8 +135,8 @@ export class NoRepositoriesView extends React.Component<
         </header>
 
         <div className="content">
-          {this.renderLeftPanel()}
-          {this.renderRightPanel()}
+          {this.renderGetStartedActions()}
+          {this.renderRepositoryList()}
         </div>
 
         <img
@@ -189,7 +189,7 @@ export class NoRepositoriesView extends React.Component<
     }
   }
 
-  private renderLeftPanel() {
+  private renderRepositoryList() {
     const account = this.getSelectedAccount()
 
     if (account === null) {
@@ -202,7 +202,7 @@ export class NoRepositoriesView extends React.Component<
     return (
       <div className="content-pane left">
         {this.renderAccountsTabBar()}
-        {this.renderAccountTab(account, accountState)}
+        {this.renderAccountRepositoryList(account, accountState)}
       </div>
     )
   }
@@ -213,7 +213,7 @@ export class NoRepositoriesView extends React.Component<
       : this.state.selectedEnterpriseRepository
   }
 
-  private renderAccountTab(
+  private renderAccountRepositoryList(
     account: Account,
     accountState: IAccountRepositories | undefined
   ) {
@@ -420,7 +420,7 @@ export class NoRepositoriesView extends React.Component<
     )
   }
 
-  private renderRightPanel() {
+  private renderGetStartedActions() {
     return (
       <div className="content-pane right">
         <ul className="button-group">

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -422,7 +422,7 @@ export class NoRepositoriesView extends React.Component<
 
   private renderGetStartedActions() {
     return (
-      <div className="content-pane right">
+      <div className="content-pane">
         <ul className="button-group">
           {this.renderTutorialRepositoryButton()}
           {this.renderCloneButton()}

--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -113,7 +113,7 @@
     z-index: -1;
   }
 
-  .content-pane.left {
+  .content-pane.repository-list {
     .tab-bar {
       margin-bottom: var(--spacing);
       border: var(--base-border);


### PR DESCRIPTION
🌵🌵 **Should be merged after #8434, as this PR depends on that renaming work** 🌵 🌵 

Closes #8441

## Description

* Reverse columns on "Let's get started!" screen to reduce friction towards taking the next step.
* Took a pass at improving the filter list's text (placeholder text for text box, and loading text for list).

### Screenshots

#### Before: 

<img width="890" alt="GitHub_Desktop-dev" src="https://user-images.githubusercontent.com/7910250/66612090-7a799480-eb75-11e9-825d-f2af7913b984.png">

#### After:

<img width="890" alt="GitHub_Desktop-dev" src="https://user-images.githubusercontent.com/7910250/66619648-90498280-eb92-11e9-8250-2e2d81ae21ae.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Prominence of "Start tutorial" button on "No Repositories" view
