### PR TITLE
Support including repository owner in repository directory layout

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -9,8 +9,9 @@ import { Dispatcher } from '../dispatcher'
 import {
   getDefaultDir,
   setDefaultDir,
-  getDefaultDirLayout,
-  setDefaultDirLayout,
+  getRepositoryLayout,
+  setRepositoryLayout,
+  RepositoryLayout,
 } from '../lib/default-dir'
 import { Account } from '../../models/account'
 import {
@@ -559,7 +560,7 @@ export class CloneRepository extends React.Component<
         newPath = Path.dirname(ownerDir)
       }
     } else if (parsed) {
-      if (getDefaultDirLayout() === 'ownerName') {
+      if (getRepositoryLayout() === RepositoryLayout.OwnerName) {
         newPath = Path.join(tabState.path, parsed.owner, parsed.name)
       } else {
         newPath = Path.join(tabState.path, parsed.name)
@@ -681,9 +682,9 @@ export class CloneRepository extends React.Component<
     const basename = Path.basename(defaultDir)
     if (parsedUrl != null && basename === parsedUrl.owner) {
       defaultDir = Path.resolve(defaultDir, '..')
-      setDefaultDirLayout('ownerName')
+      setRepositoryLayout(RepositoryLayout.OwnerName)
     } else {
-      setDefaultDirLayout('name')
+      setRepositoryLayout(RepositoryLayout.Name)
     }
 
     setDefaultDir(defaultDir)

--- a/app/src/ui/lib/default-dir.ts
+++ b/app/src/ui/lib/default-dir.ts
@@ -2,6 +2,7 @@ import * as Path from 'path'
 import { getDocumentsPath } from './app-proxy'
 
 const localStorageKey = 'last-clone-location'
+const localLayoutKey = 'last-clone-location-layout'
 
 /** The path to the default directory. */
 export function getDefaultDir(): string {
@@ -13,4 +14,13 @@ export function getDefaultDir(): string {
 
 export function setDefaultDir(path: string) {
   localStorage.setItem(localStorageKey, path)
+}
+
+/** The layout of the default directory. */
+export function getDefaultDirLayout(): string {
+  return localStorage.getItem(localLayoutKey) || 'unknown'
+}
+
+export function setDefaultDirLayout(layout: string) {
+  localStorage.setItem(localLayoutKey, layout)
 }

--- a/app/src/ui/lib/default-dir.ts
+++ b/app/src/ui/lib/default-dir.ts
@@ -2,7 +2,15 @@ import * as Path from 'path'
 import { getDocumentsPath } from './app-proxy'
 
 const localStorageKey = 'last-clone-location'
-const localLayoutKey = 'last-clone-location-layout'
+const localLayoutKey = 'repository-layout'
+
+/** How to layout repositories in the repository directory. */
+export enum RepositoryLayout {
+  /** Layout repositories by name. */
+  Name = 'NAME',
+  /** Layout repositories by owner and name. */
+  OwnerName = 'OWNER_NAME',
+}
 
 /** The path to the default directory. */
 export function getDefaultDir(): string {
@@ -16,11 +24,12 @@ export function setDefaultDir(path: string) {
   localStorage.setItem(localStorageKey, path)
 }
 
-/** The layout of the default directory. */
-export function getDefaultDirLayout(): string {
-  return localStorage.getItem(localLayoutKey) || 'unknown'
+/** The preferred repository layout. */
+export function getRepositoryLayout(): RepositoryLayout {
+  return (localStorage.getItem(localLayoutKey) ||
+    RepositoryLayout.Name) as RepositoryLayout
 }
 
-export function setDefaultDirLayout(layout: string) {
+export function setRepositoryLayout(layout: RepositoryLayout) {
   localStorage.setItem(localLayoutKey, layout)
 }


### PR DESCRIPTION
Add support for using either a flat repository directory layout or a hierarchical one that includes the repository owner. The preferred layout will be saved alongside the default directory whenever a repository is cloned.

Closes #8461

## Description

- If a user clones `https://github.com/jcansdale/repo_name` into `C:\Source\GitHub\repo_name`, infer a default directory of `C:\Source\GitHub` and a flat directory layout
- If a user clones `https://github.com/jcansdale/repo_name` into `C:\Source\GitHub\jcansdale\repo_name`, infer a default directory of `C:\Source\GitHub` and a directory layout that includes the repository `owner`
- Update the `name` or `owner/name` component of the local path whenever a different repository is selected (or edited)

## Blar blar blar

More to come. This is a draft PR! 😉 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
