### PR TITLE
Onboarding sizing tweaks

### DIFF
--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -69,9 +69,9 @@
           min-width: 0;
 
           .octicon {
-            margin-right: var(--spacing);
-            height: 32px;
-            width: 32px;
+            margin: var(--spacing-half) var(--spacing) var(--spacing-half) var(--spacing-half);
+            height: 24px;
+            width: 24px;
           }
         }
       }

--- a/app/styles/ui/onboarding-tutorial/_welcome.scss
+++ b/app/styles/ui/onboarding-tutorial/_welcome.scss
@@ -12,15 +12,16 @@
     flex-flow: column nowrap;
     align-items: center;
     margin: var(--spacing-quint) 0;
+    padding-top: var(--spacing-double);
     text-align: center;
 
     h1 {
       font-weight: var(--font-weight-light);
-      font-size: var(--font-size-xxl);
+      font-size: var(--font-size-xl);
       line-height: 1.1;
     }
     p {
-      margin: var(--spacing-half) 0;
+      margin: var(--spacing-third) 0;
       padding: 0;
     }
   }


### PR DESCRIPTION
## Description

This does some small sizing tweaks. The header on the tutorial welcome screen, and the icons on the buttons on the Let's Get Started screen were both feeling a little big

-

### Screenshots


![Screen Shot 2019-10-18 at 10 22 24 AM](https://user-images.githubusercontent.com/10404068/67115163-6bf13580-f192-11e9-8c5d-1bc7f77d7187.png)



![Screen Shot 2019-10-18 at 10 28 43 AM](https://user-images.githubusercontent.com/10404068/67115164-6bf13580-f192-11e9-931e-2cd1ae3a9963.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
