### PR TITLE
Prevent crash app container overflow

### DIFF
--- a/app/src/crash/styles/crash.scss
+++ b/app/src/crash/styles/crash.scss
@@ -70,6 +70,7 @@ main {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-height: 0;
 
   .footer {
     flex: none;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I suspect this regressed during the Electron 5 upgrade but I haven't verified that. When we fixed the other crash app problem in #8405 we used the boomtown exception which didn't have a long enough stack trace to trigger this condition

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

**Before**
![Screenshot 2019-10-28 at 10 32 09](https://user-images.githubusercontent.com/634063/67677402-3c0d1380-f984-11e9-8422-68da9425d48e.png)
**After**
![Screenshot 2019-10-28 at 10 33 45](https://user-images.githubusercontent.com/634063/67677404-3ca5aa00-f984-11e9-9774-f3f12769fc1d.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes