### PR TITLE
Change text for dialog buttons

### DIFF
--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -57,7 +57,7 @@ export class DeleteBranch extends React.Component<
         <DialogFooter>
           <ButtonGroup destructive={true}>
             <Button type="submit">Cancel</Button>
-            <Button onClick={this.deleteBranch}>Delete</Button>
+            <Button onClick={this.deleteBranch}>Delete branch</Button>
           </ButtonGroup>
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -293,7 +293,7 @@ export class CreateTutorialRepositoryDialog extends React.Component<
         </DialogContent>
         <DialogFooter>
           <ButtonGroup>
-            <Button type="submit">Continue</Button>
+            <Button type="submit">Create tutorial repository</Button>
             <Button onClick={this.onCancel}>Cancel</Button>
           </ButtonGroup>
         </DialogFooter>

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -323,7 +323,7 @@ export class Preferences extends React.Component<
           <DialogFooter>
             <ButtonGroup>
               <Button type="submit" disabled={hasDisabledError}>
-                Save
+                Save preferences
               </Button>
               <Button onClick={this.props.onDismissed}>Cancel</Button>
             </ButtonGroup>

--- a/app/src/ui/remove-repository/confirm-remove-repository.tsx
+++ b/app/src/ui/remove-repository/confirm-remove-repository.tsx
@@ -98,7 +98,7 @@ export class ConfirmRemoveRepository extends React.Component<
               Cancel
             </Button>
             <Button onClick={this.onConfirmed} disabled={isRemovingRepository}>
-              Remove
+              Remove repository
             </Button>
           </ButtonGroup>
         </DialogFooter>


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #8591 

## Description

- Changes the button text for the confirm button on the remove repository + delete branch dialog screens.

### Screenshots

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: I’m on the fence... either no-notes or something along the lines of “Updated button text for removing repositories and deleting branches.”
