### PR TITLE
Audit exception messages

### DIFF
--- a/app/src/lib/diff-parser.ts
+++ b/app/src/lib/diff-parser.ts
@@ -230,7 +230,7 @@ export class DiffParser {
   private parseHunkHeader(line: string): DiffHunkHeader {
     const m = diffHeaderRe.exec(line)
     if (!m) {
-      throw new Error(`Invalid hunk header format: '${line}'`)
+      throw new Error(`Invalid hunk header format`)
     }
 
     // If endLines are missing default to 1, see diffHeaderRe docs
@@ -312,7 +312,7 @@ export class DiffParser {
         // See https://github.com/git/git/blob/21f862b498925194f8f1ebe8203b7a7df756555b/apply.c#L1725-L1732
         if (line.length < 12) {
           throw new Error(
-            `Expected no newline at end of file marker but got ${line}`
+            `Expected "no newline at end of file" marker to be at least 12 bytes long`
           )
         }
 

--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -83,14 +83,14 @@ export async function getBranches(
     const author = CommitIdentity.parseIdentity(authorIdentity)
 
     if (!author) {
-      throw new Error(`Couldn't parse author identity ${authorIdentity}`)
+      throw new Error(`Couldn't parse author identity for '${shortSha}'`)
     }
 
     const committerIdentity = pieces[6]
     const committer = CommitIdentity.parseIdentity(committerIdentity)
 
     if (!committer) {
-      throw new Error(`Couldn't parse committer identity ${committerIdentity}`)
+      throw new Error(`Couldn't parse committer identity for '${shortSha}'`)
     }
 
     const parentSHAs = pieces[7].split(' ')

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -131,13 +131,13 @@ export async function getCommits(
     const author = CommitIdentity.parseIdentity(authorIdentity)
 
     if (!author) {
-      throw new Error(`Couldn't parse author identity ${authorIdentity}`)
+      throw new Error(`Couldn't parse author identity for '${shortSha}'`)
     }
 
     const committer = CommitIdentity.parseIdentity(committerIdentity)
 
     if (!committer) {
-      throw new Error(`Couldn't parse committer identity ${committerIdentity}`)
+      throw new Error(`Couldn't parse committer identity for '${shortSha}'`)
     }
 
     return new Commit(

--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -70,7 +70,7 @@ export async function createTemporaryWorkTree(
   // intentionally vague here to cover `undefined` and `null`
   if (!workTree) {
     throw new Error(
-      `[addWorkTree] Unable to find created worktree at path ${workTreePath}`
+      `[addWorkTree] Unable to find created worktree "${directoryName}"`
     )
   }
 

--- a/app/src/lib/merge-tree-parser.ts
+++ b/app/src/lib/merge-tree-parser.ts
@@ -100,7 +100,8 @@ export function parseMergeResult(text: string): MergeResult {
   let mergeEntryHeader: string | undefined
   let currentMergeEntry: IMergeEntry | undefined
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
     const headerMatch = contextHeaderRe.exec(line)
     if (headerMatch != null) {
       mergeEntryHeader = headerMatch[1]
@@ -133,7 +134,7 @@ export function parseMergeResult(text: string): MergeResult {
 
       if (mergeEntryHeader == null) {
         log.warn(
-          `An unknown header was set while trying to parse the blob ${line}`
+          `An unknown header was set while trying to parse the blob on line ${i}`
         )
         continue
       }
@@ -160,7 +161,7 @@ export function parseMergeResult(text: string): MergeResult {
 
     if (currentMergeEntry == null) {
       throw new Error(
-        `invalid state - trying to append the diff to a merge entry that isn't defined. line: '${line}'`
+        `invalid state - trying to append the diff to a merge entry that isn't defined on line ${i}`
       )
     } else {
       const currentDiff = currentMergeEntry.diff

--- a/app/src/lib/patch-formatter.ts
+++ b/app/src/lib/patch-formatter.ts
@@ -217,9 +217,8 @@ export function formatPatch(
   // If we get into this state we should never have been called in the first
   // place. Someone gave us a faulty diff and/or faulty selection state.
   if (!patch.length) {
-    throw new Error(
-      `Could not generate a patch for file ${file.path}, patch empty`
-    )
+    log.debug(`formatPatch: empty path for ${file.path}`)
+    throw new Error(`Could not generate a patch, no changes`)
   }
 
   patch = formatPatchHeaderForFile(file) + patch

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -101,7 +101,8 @@ function parseChangedEntry(field: string): IStatusEntry {
   const match = changedEntryRe.exec(field)
 
   if (!match) {
-    throw new Error(`Failed to parse status line for changed entry: ${field}`)
+    log.debug(`parseChangedEntry parse error: ${field}`)
+    throw new Error(`Failed to parse status line for changed entry`)
   }
 
   return {
@@ -121,9 +122,8 @@ function parsedRenamedOrCopiedEntry(
   const match = renamedOrCopiedEntryRe.exec(field)
 
   if (!match) {
-    throw new Error(
-      `Failed to parse status line for renamed or copied entry: ${field}`
-    )
+    log.debug(`parsedRenamedOrCopiedEntry parse error: ${field}`)
+    throw new Error(`Failed to parse status line for renamed or copied entry`)
   }
 
   if (!oldPath) {
@@ -147,7 +147,8 @@ function parseUnmergedEntry(field: string): IStatusEntry {
   const match = unmergedEntryRe.exec(field)
 
   if (!match) {
-    throw new Error(`Failed to parse status line for unmerged entry: ${field}`)
+    log.debug(`parseUnmergedEntry parse error: ${field}`)
+    throw new Error(`Failed to parse status line for unmerged entry`)
   }
 
   return {

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -69,7 +69,7 @@ export class RepositoriesStore extends BaseStore {
     const owner = await this.db.owners.get(dbRepo.ownerID)
 
     if (owner == null) {
-      throw new Error(`Couldn't find the owner for ${dbRepo.name}`)
+      throw new Error(`Couldn't find repository owner ${dbRepo.ownerID}`)
     }
 
     let parent: GitHubRepository | null = null

--- a/app/src/lib/tailer.ts
+++ b/app/src/lib/tailer.ts
@@ -49,9 +49,7 @@ export class Tailer {
    */
   public start() {
     if (this.state) {
-      throw new Error(
-        `Cannot start an already started Tailer for "${this.path}"!`
-      )
+      throw new Error(`Tailer already running`)
     }
 
     try {

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -184,7 +184,7 @@ export class CreateTutorialRepositoryDialog extends React.Component<
 
       if (await pathExists(path)) {
         throw new Error(
-          `The path ${path} already exists. Please move it ` +
+          `The path '${path}' already exists. Please move it ` +
             'out of the way, or remove it, and then try again.'
         )
       }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This PR audits our exception messages and, where possible, attempts to remove potentially sensitive information such as file contents and repository paths that we don't need for troubleshooting.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes