### PR TITLE
add tooltip for open in editor button

### DIFF
--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -70,7 +70,6 @@ export class RepositoryListItem extends React.Component<
     if (this.props.needsDisambiguation && gitHubRepo) {
       prefix = `${gitHubRepo.owner.login}/`
     }
-    let tooltip: string
 
     const className = enableGroupRepositoriesByOwner()
       ? 'repository-list-item group-repositories-by-owner'

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -70,6 +70,7 @@ export class RepositoryListItem extends React.Component<
     if (this.props.needsDisambiguation && gitHubRepo) {
       prefix = `${gitHubRepo.owner.login}/`
     }
+    let tooltip: string
 
     const className = enableGroupRepositoriesByOwner()
       ? 'repository-list-item group-repositories-by-owner'
@@ -145,6 +146,7 @@ export class RepositoryListItem extends React.Component<
     const items: ReadonlyArray<IMenuItem> = [
       {
         label: `Open in ${this.props.shellLabel}`,
+        tooltip: `Open in ${this.props.shellLabel}`,
         action: this.openInShell,
         enabled: !missing,
       },


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #6266 

## Description

- Adds a tooltip for the “open in editor” button. As mentioned in the issue, this is useful for editors with longer names.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
