### PR TITLE
Improve verbiage for deleting branch with PR

### DIFF
--- a/app/src/ui/delete-branch/delete-pull-request-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-pull-request-dialog.tsx
@@ -29,13 +29,13 @@ export class DeletePullRequest extends React.Component<IDeleteBranchProps, {}> {
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>
-          <p>This branch has an open pull request associated with it.</p>
+          <p>This branch may have an open pull request associated with it.</p>
           <p>
             If{' '}
             <LinkButton onClick={this.openPullRequest}>
               #{this.props.pullRequest.pullRequestNumber}
             </LinkButton>{' '}
-            has been merged, you can also remove the remote branch on GitHub.
+            has been merged, you can also go to GitHub.com to delete the remote branch.
           </p>
         </DialogContent>
         <DialogFooter>


### PR DESCRIPTION
Closes #8416 

## Description

The text for the dialog is misleading when you're deleting a branch that has or previously had a pull request associated with it.

### Screenshots

Before: 
<img width="533" alt="Screen Shot 2019-11-22 at 1 39 55 PM" src="https://user-images.githubusercontent.com/5091167/69458873-9b650600-0d2d-11ea-8680-57a545147edd.png">

After:
Forthcoming


## Release notes
Notes: No notes
