### PR TITLE
Don't prompt to stash changes when switching away from protected branch

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -262,12 +262,6 @@ export type AppMenuFoldout = {
 
 export type BranchFoldout = {
   type: FoldoutType.Branch
-
-  /**
-   * A flag to indicate the user clicked the "switch branch" link when they
-   * saw the prompt about the current branch being protected.
-   */
-  handleProtectedBranchWarning?: boolean
 }
 
 export type Foldout =

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -26,7 +26,10 @@ import {
   ImageDiffType,
 } from '../../models/diff'
 import { FetchType } from '../../models/fetch'
-import { GitHubRepository } from '../../models/github-repository'
+import {
+  GitHubRepository,
+  hasWritePermission,
+} from '../../models/github-repository'
 import { Owner } from '../../models/owner'
 import { PullRequest } from '../../models/pull-request'
 import {
@@ -847,8 +850,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const owner = gitHubRepo.owner.login
         const api = API.fromAccount(account)
 
+        const hasWritePermissionForRepository =
+          gitHubRepo === null || hasWritePermission(gitHubRepo)
+
         const pushControl = await api.fetchPushControl(owner, name, branchName)
-        const currentBranchProtected = !isBranchPushable(pushControl)
+        const currentBranchProtected =
+          hasWritePermissionForRepository && !isBranchPushable(pushControl)
 
         this.repositoryStateCache.updateChangesState(repository, () => ({
           currentBranchProtected,

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -93,6 +93,8 @@ export type Popup =
        */
       handleProtectedBranchWarning?: boolean
 
+      currentBranchProtected: boolean
+
       initialName?: string
     }
   | { type: PopupType.SignIn }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -86,13 +86,6 @@ export type Popup =
   | {
       type: PopupType.CreateBranch
       repository: Repository
-
-      /**
-       * A flag to indicate the user clicked the "switch branch" link when they
-       * saw the prompt about the current branch being protected.
-       */
-      handleProtectedBranchWarning?: boolean
-
       currentBranchProtected: boolean
 
       initialName?: string

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1424,6 +1424,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case PopupType.CreateBranch: {
         const state = this.props.repositoryStateManager.get(popup.repository)
         const branchesState = state.branchesState
+        const currentBranchProtected = state.changesState.currentBranchProtected
         const repository = popup.repository
 
         if (branchesState.tip.kind === TipState.Unknown) {
@@ -1442,6 +1443,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             initialName={popup.initialName || ''}
             handleProtectedBranchWarning={popup.handleProtectedBranchWarning}
+            currentBranchProtected={currentBranchProtected}
           />
         )
       }
@@ -2262,9 +2264,13 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const repository = selection.repository
 
+    const state = this.props.repositoryStateManager.get(repository)
+    const currentBranchProtected = state.changesState.currentBranchProtected
+
     return this.props.dispatcher.showPopup({
       type: PopupType.CreateBranch,
       repository,
+      currentBranchProtected,
     })
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1442,7 +1442,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={this.onPopupDismissed}
             dispatcher={this.props.dispatcher}
             initialName={popup.initialName || ''}
-            handleProtectedBranchWarning={popup.handleProtectedBranchWarning}
             currentBranchProtected={currentBranchProtected}
           />
         )
@@ -2316,13 +2315,8 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const currentFoldout = this.state.currentFoldout
 
-    let isOpen = false
-    let handleProtectedBranchWarning: boolean | undefined
-
-    if (currentFoldout !== null && currentFoldout.type === FoldoutType.Branch) {
-      isOpen = true
-      handleProtectedBranchWarning = currentFoldout.handleProtectedBranchWarning
-    }
+    const isOpen =
+      currentFoldout !== null && currentFoldout.type === FoldoutType.Branch
 
     const repository = selection.repository
     const branchesState = selection.state.branchesState
@@ -2338,7 +2332,6 @@ export class App extends React.Component<IAppProps, IAppState> {
         pullRequests={branchesState.openPullRequests}
         currentPullRequest={branchesState.currentPullRequest}
         isLoadingPullRequests={branchesState.isLoadingPullRequests}
-        handleProtectedBranchWarning={handleProtectedBranchWarning}
         shouldNudge={
           this.state.currentOnboardingTutorialStep === TutorialStep.CreateBranch
         }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -272,13 +272,13 @@ export class BranchesContainer extends React.Component<
   }
 
   private onCreateBranchWithName = (name: string) => {
-    const { repository, handleProtectedBranchWarning } = this.props
+    const { repository, currentBranchProtected } = this.props
 
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     this.props.dispatcher.showPopup({
       type: PopupType.CreateBranch,
       repository,
-      handleProtectedBranchWarning,
+      currentBranchProtected,
       initialName: name,
     })
   }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -46,6 +46,8 @@ interface IBranchesContainerProps {
 
   /** Was this component launched from the "Protected Branch" warning message? */
   readonly handleProtectedBranchWarning?: boolean
+
+  readonly currentBranchProtected: boolean
 }
 
 interface IBranchesContainerState {
@@ -242,18 +244,13 @@ export class BranchesContainer extends React.Component<
   private onBranchItemClick = (branch: Branch) => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
 
-    const {
-      currentBranch,
-      repository,
-      handleProtectedBranchWarning,
-    } = this.props
+    const { currentBranch, repository, currentBranchProtected } = this.props
 
     if (currentBranch == null || currentBranch.name !== branch.name) {
       const timer = startTimer('checkout branch from list', repository)
 
-      // if the user arrived at this dialog from the Protected Branch flow
-      // we should bypass the "Switch Branch" flow and get out of the user's way
-      const strategy: UncommittedChangesStrategy = handleProtectedBranchWarning
+      // Never prompt to stash changes if someone is switching away from a protected branch
+      const strategy: UncommittedChangesStrategy = currentBranchProtected
         ? {
             kind: UncommittedChangesStrategyKind.MoveToNewBranch,
             transientStashEntry: null,

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -44,9 +44,6 @@ interface IBranchesContainerProps {
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 
-  /** Was this component launched from the "Protected Branch" warning message? */
-  readonly handleProtectedBranchWarning?: boolean
-
   readonly currentBranchProtected: boolean
 }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -484,7 +484,6 @@ export class CommitMessage extends React.Component<
   private onSwitchBranch = () => {
     this.props.dispatcher.showFoldout({
       type: FoldoutType.Branch,
-      handleProtectedBranchWarning: true,
     })
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -25,6 +25,8 @@ import { ICommitContext } from '../../models/commit'
 import { startTimer } from '../lib/timing'
 import { PermissionsCommitWarning } from './permissions-commit-warning'
 import { enableBranchProtectionWarningFlow } from '../../lib/feature-flag'
+import { LinkButton } from '../lib/link-button'
+import { FoldoutType } from '../../lib/app-state'
 
 const addAuthorIcon = new OcticonSymbol(
   12,
@@ -456,19 +458,34 @@ export class CommitMessage extends React.Component<
     const {
       currentBranchProtected,
       hasWritePermissionForRepository,
-      dispatcher,
       repository,
     } = this.props
 
-    return (
-      <PermissionsCommitWarning
-        currentBranch={branch}
-        repositoryName={repository.name}
-        hasWritePermissionForRepository={hasWritePermissionForRepository}
-        currentBranchProtected={currentBranchProtected}
-        dispatcher={dispatcher}
-      />
-    )
+    if (!hasWritePermissionForRepository) {
+      return (
+        <PermissionsCommitWarning>
+          You do not have permission to push to{' '}
+          <strong>{repository.name}</strong>.
+        </PermissionsCommitWarning>
+      )
+    } else if (currentBranchProtected) {
+      return (
+        <PermissionsCommitWarning>
+          <strong>{branch}</strong> is a protected branch. Want to{' '}
+          <LinkButton onClick={this.onSwitchBranch}>switch branches</LinkButton>
+          ?
+        </PermissionsCommitWarning>
+      )
+    } else {
+      return null
+    }
+  }
+
+  private onSwitchBranch = () => {
+    this.props.dispatcher.showFoldout({
+      type: FoldoutType.Branch,
+      handleProtectedBranchWarning: true,
+    })
   }
 
   public render() {

--- a/app/src/ui/changes/permissions-commit-warning.tsx
+++ b/app/src/ui/changes/permissions-commit-warning.tsx
@@ -1,97 +1,24 @@
 import * as React from 'react'
 import { Octicon, OcticonSymbol } from '../octicons'
-import { LinkButton } from '../lib/link-button'
-import { Dispatcher } from '../dispatcher'
-import { FoldoutType } from '../../lib/app-state'
 
-interface IPermissionsCommitWarningProps {
-  readonly dispatcher: Dispatcher
-  readonly currentBranch: string
-  readonly repositoryName: string
-  readonly hasWritePermissionForRepository: boolean
-  readonly currentBranchProtected: boolean
-}
-
-/** A warning for the user if they won't be able to push to a branch,
- *  either because its a *protected branch* or they don't have *write
- *  permission* for the repository.
- *
- * (If neither of those conditions are met, this component renders nothing.)
+/** A warning displayed above the commit button
  */
-export class PermissionsCommitWarning extends React.Component<
-  IPermissionsCommitWarningProps
-> {
-  private onSwitchBranch = () => {
-    this.props.dispatcher.showFoldout({
-      type: FoldoutType.Branch,
-      handleProtectedBranchWarning: true,
-    })
-  }
-
-  private ignoreContextMenu = (event: React.MouseEvent<any>) => {
-    // this prevents the context menu for the root element of CommitMessage from
-    // firing - it shows 'Add Co-Authors' or 'Remove Co-Authors' based on the
-    // form state, and for now I'm going to leave that behaviour as-is
-
-    // feel free to remove this if that behaviour is revisited
-    event.preventDefault()
-  }
-
-  public render() {
-    if (
-      this.props.hasWritePermissionForRepository &&
-      !this.props.currentBranchProtected
-    ) {
-      return null
-    }
-
-    return (
-      <div
-        id="permissions-commit-warning"
-        onContextMenu={this.ignoreContextMenu}
-      >
-        <div className="warning-icon-container">
-          <Octicon className="warning-icon" symbol={OcticonSymbol.alert} />
-        </div>
-        <div className="warning-message">{this.renderWarningMesage()}</div>
+export const PermissionsCommitWarning: React.SFC = props => {
+  return (
+    <div id="permissions-commit-warning" onContextMenu={ignoreContextMenu}>
+      <div className="warning-icon-container">
+        <Octicon className="warning-icon" symbol={OcticonSymbol.alert} />
       </div>
-    )
-  }
-
-  private renderWarningMesage() {
-    if (!this.props.hasWritePermissionForRepository) {
-      return <ReadonlyRepoMessage name={this.props.repositoryName} />
-    }
-    if (this.props.currentBranchProtected) {
-      return (
-        <ProtectedBranchMessage
-          currentBranch={this.props.currentBranch}
-          onSwitchBranch={this.onSwitchBranch}
-        />
-      )
-    }
-    return <></>
-  }
-}
-
-const ReadonlyRepoMessage: React.SFC<{
-  name: string
-}> = props => {
-  return (
-    <>
-      You do not have permission to push to <strong>{props.name}</strong>.
-    </>
+      <div className="warning-message">{props.children}</div>
+    </div>
   )
 }
 
-const ProtectedBranchMessage: React.SFC<{
-  currentBranch: string
-  onSwitchBranch: () => void
-}> = props => {
-  return (
-    <>
-      <strong>{props.currentBranch}</strong> is a protected branch. Want to{' '}
-      <LinkButton onClick={props.onSwitchBranch}>switch branches</LinkButton>?
-    </>
-  )
+const ignoreContextMenu = (event: React.MouseEvent<any>) => {
+  // this prevents the context menu for the root element of CommitMessage from
+  // firing - it shows 'Add Co-Authors' or 'Remove Co-Authors' based on the
+  // form state, and for now I'm going to leave that behaviour as-is
+
+  // feel free to remove this if that behaviour is revisited
+  event.preventDefault()
 }

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -41,6 +41,8 @@ interface ICreateBranchProps {
 
   /** Was this component launched from the "Protected Branch" warning message? */
   readonly handleProtectedBranchWarning?: boolean
+
+  readonly currentBranchProtected: boolean
 }
 
 interface ICreateBranchState {
@@ -283,11 +285,7 @@ export class CreateBranch extends React.Component<
 
     let startPoint: string | null = null
 
-    const {
-      defaultBranch,
-      handleProtectedBranchWarning,
-      repository,
-    } = this.props
+    const { defaultBranch, currentBranchProtected, repository } = this.props
 
     if (this.state.startPoint === StartPoint.DefaultBranch) {
       // This really shouldn't happen, we take all kinds of precautions
@@ -303,9 +301,8 @@ export class CreateBranch extends React.Component<
     }
 
     if (name.length > 0) {
-      // if the user arrived at this dialog from the Protected Branch flow
-      // we should bypass the "Switch Branch" flow and get out of the user's way
-      const strategy: UncommittedChangesStrategy = handleProtectedBranchWarning
+      // never prompt to stash changes if someone is switching away from a protected branch
+      const strategy: UncommittedChangesStrategy = currentBranchProtected
         ? {
             kind: UncommittedChangesStrategyKind.MoveToNewBranch,
             transientStashEntry: null,

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -38,10 +38,6 @@ interface ICreateBranchProps {
   readonly defaultBranch: Branch | null
   readonly allBranches: ReadonlyArray<Branch>
   readonly initialName: string
-
-  /** Was this component launched from the "Protected Branch" warning message? */
-  readonly handleProtectedBranchWarning?: boolean
-
   readonly currentBranchProtected: boolean
 }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -43,9 +43,6 @@ interface IBranchDropdownProps {
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 
-  /** Was this component launched from the "Protected Branch" warning message? */
-  readonly handleProtectedBranchWarning?: boolean
-
   /** Whether this component should show its onboarding tutorial nudge arrow */
   readonly shouldNudge: boolean
 }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -57,6 +57,8 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
   private renderBranchFoldout = (): JSX.Element | null => {
     const repositoryState = this.props.repositoryState
     const branchesState = repositoryState.branchesState
+    const currentBranchProtected =
+      repositoryState.changesState.currentBranchProtected
 
     const tip = repositoryState.branchesState.tip
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
@@ -73,7 +75,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         pullRequests={this.props.pullRequests}
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
-        handleProtectedBranchWarning={this.props.handleProtectedBranchWarning}
+        currentBranchProtected={currentBranchProtected}
       />
     )
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #8664

## Description

This PR makes it such that in all cases Desktop does not prompt the user to stash uncommitted changes when switching away from a protected branch. We are assuming that people will NOT want to stash changes on a protected branch that they'll never be able to push, so we go ahead and carry over the changes without asking.

All cases being:
* via the "Want to switch branches" link in the protected branch warning
* selecting another branch via the branch switcher
* creating a new branch via the branch switcher

This PR also updates `currentBranchProtected` in the AppStore to be more accurate. Previously it was a false positive if the user has no write access and therefore cannot push. Now it is only true if the user has write access to the repo and the current branch is indeed protected.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 
