### PR TITLE
Render PR badge on top of progress bar

### DIFF
--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -13,6 +13,16 @@
   flex-direction: row;
   height: var(--height);
 
+  // This is necessary for our absolutely positioned progress bar to work.
+  // We position the toolbar button container relatively so that we can
+  // position the progress bar absolutely in relation to the container.
+  // We then explicitly position all child elements of the container
+  // relatively in order for the progress bar not to position itself
+  // above all the other content.
+  //
+  // See toolbar/_button.scss
+  position: relative;
+
   align-items: center;
 
   border-radius: var(--border-radius);


### PR DESCRIPTION

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #8622

## Description

Ensure that the PR badge is rendered on top of the progress bar "background" in the branches dropdown when switching branches.

### Screenshots

#### Before
![Screen Shot 2019-11-29 at 15 02 44](https://user-images.githubusercontent.com/634063/69875974-b3550080-12be-11ea-8e55-d07d5d9efdbd.png)

#### After
![Screen Shot 2019-11-29 at 15 02 36](https://user-images.githubusercontent.com/634063/69875973-b3550080-12be-11ea-9689-195365ef95f5.png)


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] PR details obscured while switching branches.
