### PR TITLE
Render autocomplete popup on top of CodeMirror author input

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -36,12 +36,6 @@
   &.with-co-authors .description-focus-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-
-    // Hack for when co-authors field is merged
-    // with description text area.
-    &.focus-within {
-      z-index: 1;
-    }
   }
 
   .co-authors-toggle {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #4084

## Description

By having an explicit z-index on the focus container we're preventing the descendent node popup element from elevating itself on top of CodeMirror. This was all done just to not have the co-author input cover the subtle focus shadow at the bottom of the description text area and it's absolutely not worth it.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

![image](https://user-images.githubusercontent.com/634063/69972287-a552ea00-1521-11ea-84c1-c3d9e211f8dd.png)

#### After

![image](https://user-images.githubusercontent.com/634063/69972266-9cfaaf00-1521-11ea-8672-859d604226e5.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Issue, and author autocompletion in commit description are no longer obscured by co-author area.
