### PR TITLE
Don't expect all IAPIRepository instances to have permissions

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -104,6 +104,14 @@ export interface IAPIRepository {
   readonly default_branch: string
   readonly pushed_at: string
   readonly parent: IAPIRepository | null
+
+  /**
+   * The high-level permissions that the currently authenticated
+   * user enjoys for the repository. Undefined if the API call
+   * was made without an authenticated user or if the repository
+   * isn't the primarily requested one (i.e. if this is the parent
+   * repository of the requested repository)
+   */
   readonly permissions?: IAPIRepositoryPermissions
 }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -103,7 +103,7 @@ export interface IAPIRepository {
   readonly fork: boolean
   readonly default_branch: string
   readonly pushed_at: string
-  readonly parent: IAPIRepository | null
+  readonly parent?: IAPIRepository
 
   /**
    * The high-level permissions that the currently authenticated

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -111,6 +111,14 @@ export interface IAPIRepository {
    * was made without an authenticated user or if the repository
    * isn't the primarily requested one (i.e. if this is the parent
    * repository of the requested repository)
+   *
+   * The permissions hash will also be omitted when the repository
+   * information is embedded within another object such as a pull
+   * request (base.repo or head.repo).
+   *
+   * In other words, the only time when the permissions property
+   * will be present is when explicitly fetching the repository
+   * through the `/repos/user/name` endpoint or similar.
    */
   readonly permissions?: IAPIRepositoryPermissions
 }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -104,7 +104,7 @@ export interface IAPIRepository {
   readonly default_branch: string
   readonly pushed_at: string
   readonly parent: IAPIRepository | null
-  readonly permissions: IAPIRepositoryPermissions
+  readonly permissions?: IAPIRepositoryPermissions
 }
 
 /*

--- a/app/src/models/github-repository.ts
+++ b/app/src/models/github-repository.ts
@@ -1,5 +1,7 @@
 import { Owner } from './owner'
 
+export type GitHubRepositoryPermission = 'read' | 'write' | 'admin' | null
+
 /** A GitHub repository. */
 export class GitHubRepository {
   public constructor(
@@ -17,7 +19,7 @@ export class GitHubRepository {
     public readonly defaultBranch: string | null = 'master',
     public readonly cloneURL: string | null = null,
     /** The user's permissions for this github repository. `null` if unknown. */
-    public readonly permissions: 'read' | 'write' | 'admin' | null = null,
+    public readonly permissions: GitHubRepositoryPermission = null,
     public readonly parent: GitHubRepository | null = null
   ) {}
 

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -81,7 +81,6 @@ export async function setupRepository(
       fork: false,
       default_branch: defaultBranchName,
       pushed_at: 'string',
-      parent: null,
       permissions: {
         pull: true,
         push: true,

--- a/app/test/unit/repositories-clone-grouping-test.ts
+++ b/app/test/unit/repositories-clone-grouping-test.ts
@@ -43,7 +43,6 @@ describe('clone repository grouping', () => {
         private: true,
         fork: true,
         default_branch: '',
-        parent: null,
         pushed_at: '1995-12-17T03:24:00',
         permissions: {
           pull: true,
@@ -60,7 +59,6 @@ describe('clone repository grouping', () => {
         private: false,
         fork: false,
         default_branch: '',
-        parent: null,
         pushed_at: '1995-12-17T03:24:00',
         permissions: {
           pull: true,
@@ -77,7 +75,6 @@ describe('clone repository grouping', () => {
         private: true,
         fork: false,
         default_branch: '',
-        parent: null,
         pushed_at: '1995-12-17T03:24:00',
         permissions: {
           pull: true,

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -48,7 +48,6 @@ describe('RepositoriesStore', () => {
       private: true,
       fork: false,
       default_branch: 'master',
-      parent: null,
       pushed_at: '1995-12-17T03:24:00',
       permissions: {
         pull: true,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This is related to #8635, I ran into this today when I was testing something unrelated and saw an error in my console

<img width="601" alt="image" src="https://user-images.githubusercontent.com/634063/70169928-0e766100-16cc-11ea-87b2-5592e6998e5f.png">

In this instance the error broke PR fetching since when fetching pull requests we always upsert the api repository information from the PR's `base.repo` and `head.repo` properties. These embedded repository informations doesn't include the permissions hash that we rely on being present (see #8635).

In this PR we change our definition to not assume that repository information returned from the API include permissions as well as attempt to preserve pre-existing permissions stored in the database when we're updating repository information from other sources than the `/repos/user/repo` endpoint.

This also changes the definition of `IAPIRepository.parent` from being nullable to being optional. I've verified with the API commit history that we've never returned a null parent, it's either there or it's omitted. We've accidentally handled this case due to truthy falsy checks in the past but it's worth accurately representing what the API provides to avoid problems in the future.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Pull requests list failed to update
