### PR TITLE
Remove false branch protection warning when switching branches

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -818,6 +818,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  private clearBranchProtectionState(repository: Repository) {
+    console.warn('clear')
+    this.repositoryStateCache.updateChangesState(repository, () => ({
+      currentBranchProtected: false,
+    }))
+    this.emitUpdate()
+  }
+
   private async refreshBranchProtectionState(repository: Repository) {
     if (!enableBranchProtectionWarningFlow()) {
       return
@@ -856,6 +864,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const pushControl = await api.fetchPushControl(owner, name, branchName)
         const currentBranchProtected =
           hasWritePermissionForRepository && !isBranchPushable(pushControl)
+
+        console.warn('set actual value', currentBranchProtected)
 
         this.repositoryStateCache.updateChangesState(repository, () => ({
           currentBranchProtected,
@@ -3078,6 +3088,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
         )
       )) !== undefined
 
+    if (checkoutSucceeded) {
+      this.clearBranchProtectionState(repository)
+    }
+    
     if (
       enableStashing() &&
       uncommittedChangesStrategy.kind ===

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -819,7 +819,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private clearBranchProtectionState(repository: Repository) {
-    console.warn('clear')
     this.repositoryStateCache.updateChangesState(repository, () => ({
       currentBranchProtected: false,
     }))
@@ -864,8 +863,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const pushControl = await api.fetchPushControl(owner, name, branchName)
         const currentBranchProtected =
           hasWritePermissionForRepository && !isBranchPushable(pushControl)
-
-        console.warn('set actual value', currentBranchProtected)
 
         this.repositoryStateCache.updateChangesState(repository, () => ({
           currentBranchProtected,
@@ -3091,7 +3088,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (checkoutSucceeded) {
       this.clearBranchProtectionState(repository)
     }
-    
+
     if (
       enableStashing() &&
       uncommittedChangesStrategy.kind ===


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #8743

## Description

When switching branches, clear `currentBranchProtected` state so that there is no flicker of a message saying the new branch is protected. 

### Screenshots

**Before** 
(notice that branch protection warning momentarily says branch checked out is protected)
![branch-checkout-flicker](https://user-images.githubusercontent.com/7910250/70668211-d15c2280-1c27-11ea-9697-72646c3c8876.gif)

**After** 
(notice there's no flicker!)
![branch-checkout-no-flicker](https://user-images.githubusercontent.com/7910250/70668225-d91bc700-1c27-11ea-8e48-be1f94864c34.gif)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Remove false branch protection warning when switching branches