### PR TITLE
Update branch protection state for checkout outside of Desktop

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -762,7 +762,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
             state.tip.kind === TipState.Valid &&
             tip.branch.name !== state.tip.branch.name
           ) {
-            console.warn(tip.branch.name, state.tip.branch.name)
             this.refreshBranchProtectionState(repository)
           }
         }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -756,6 +756,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
             const prs = state.openPullRequests
             currentPullRequest = findAssociatedPullRequest(branch, prs, remote)
           }
+
+          if (
+            tip.kind === TipState.Valid &&
+            state.tip.kind === TipState.Valid &&
+            tip.branch.name !== state.tip.branch.name
+          ) {
+            console.warn(tip.branch.name, state.tip.branch.name)
+            this.refreshBranchProtectionState(repository)
+          }
         }
       }
 
@@ -3111,7 +3120,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
 
       await this._refreshRepository(repository)
-      await this.refreshBranchProtectionState(repository)
     } finally {
       this.updateCheckoutProgress(repository, null)
       this._initializeCompare(repository, {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #8790

## Description

Previously we updated the branch protection state in the `_checkoutBranch` method of `AppStore`, which doesn't get called when a user checks out a branch on the command line. With this PR, we update the branch protection state when the branch tip in the `repositoryStateCache` is being changed.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Update branch protection warning when branch switch occurs outside of Desktop
