### PR TITLE
Support GoLand as external editor on Mac

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -20,6 +20,7 @@ export enum ExternalEditor {
   CodeRunner = 'CodeRunner',
   SlickEdit = 'SlickEdit',
   Xcode = 'Xcode',
+  GoLand = 'GoLand',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -73,6 +74,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Xcode) {
     return ExternalEditor.Xcode
   }
+  if (label === ExternalEditor.GoLand) {
+    return ExternalEditor.GoLand
+  }
   return null
 }
 
@@ -120,6 +124,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       ]
     case ExternalEditor.Xcode:
       return ['com.apple.dt.Xcode']
+    case ExternalEditor.GoLand:
+      return ['com.jetbrains.goland']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -175,6 +181,8 @@ function getExecutableShim(
       return Path.join(installPath, 'Contents', 'MacOS', 'vs')
     case ExternalEditor.Xcode:
       return '/usr/bin/xed'
+    case ExternalEditor.GoLand:
+      return Path.join(installPath, 'Contents', 'MacOS', 'goland')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -226,6 +234,7 @@ export async function getAvailableEditors(): Promise<
     codeRunnerPath,
     slickeditPath,
     xcodePath,
+    golandPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),
@@ -243,6 +252,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.CodeRunner),
     findApplication(ExternalEditor.SlickEdit),
     findApplication(ExternalEditor.Xcode),
+    findApplication(ExternalEditor.GoLand),
   ])
 
   if (atomPath) {
@@ -310,6 +320,10 @@ export async function getAvailableEditors(): Promise<
 
   if (xcodePath) {
     results.push({ editor: ExternalEditor.Xcode, path: xcodePath })
+  }
+
+  if (golandPath) {
+    results.push({ editor: ExternalEditor.GoLand, path: golandPath })
   }
 
   return results

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -262,6 +262,7 @@ These editors are currently supported:
  - [WebStorm](https://www.jetbrains.com/webstorm/)
  - [Typora](https://typora.io/)
  - [SlickEdit](https://www.slickedit.com)
+ - [GoLand](https://www.jetbrains.com/go/)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
Closes #8802

## Description

Adding support for GoLand as external editor on Mac

### Screenshots
<img width="617" alt="Screenshot 2019-12-30 at 2 05 18 PM" src="https://user-images.githubusercontent.com/326949/71581347-6bb7d380-2b0d-11ea-8a93-29c6a7d1b0e9.png">

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Support GoLand as external editor on Mac
