### PR TITLE
Refactor RepositoriesStore to use TypedBaseStore

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -556,7 +556,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
     this.accountsStore.onDidError(error => this.emitError(error))
 
-    this.repositoriesStore.onDidUpdate((updateRepositories) => {
+    this.repositoriesStore.onDidUpdate(updateRepositories => {
       this.repositories = updateRepositories
       this.updateRepositorySelectionAfterRepositoriesChanged()
       this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -556,8 +556,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
     this.accountsStore.onDidError(error => this.emitError(error))
 
-    this.repositoriesStore.onDidUpdate(async () => {
-      this.repositories = await this.repositoriesStore.getAll()
+    this.repositoriesStore.onDidUpdate((updateRepositories) => {
+      this.repositories = updateRepositories
       this.updateRepositorySelectionAfterRepositoriesChanged()
       this.emitUpdate()
     })

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -12,11 +12,13 @@ import {
 import { Repository } from '../../models/repository'
 import { fatalError } from '../fatal-error'
 import { IAPIRepository, IAPIBranch, IAPIRepositoryPermissions } from '../api'
-import { BaseStore } from './base-store'
+import { TypedBaseStore } from './base-store'
 import { enableBranchProtectionChecks } from '../feature-flag'
 
 /** The store for local repositories. */
-export class RepositoriesStore extends BaseStore {
+export class RepositoriesStore extends TypedBaseStore<
+  ReadonlyArray<Repository>
+> {
   private db: RepositoriesDatabase
 
   // Key-repo ID, Value-date
@@ -183,7 +185,7 @@ export class RepositoriesStore extends BaseStore {
       }
     )
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
   }
 
   /**
@@ -224,7 +226,7 @@ export class RepositoriesStore extends BaseStore {
       }
     )
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
 
     return repository
   }
@@ -233,7 +235,7 @@ export class RepositoriesStore extends BaseStore {
   public async removeRepository(repoID: number): Promise<void> {
     await this.db.repositories.delete(repoID)
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
   }
 
   /** Update the repository's `missing` flag. */
@@ -250,7 +252,7 @@ export class RepositoriesStore extends BaseStore {
 
     await this.db.repositories.update(repoID, { missing })
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
 
     return new Repository(
       repository.path,
@@ -278,7 +280,7 @@ export class RepositoriesStore extends BaseStore {
       path,
     })
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
 
     return new Repository(
       path,
@@ -313,7 +315,7 @@ export class RepositoriesStore extends BaseStore {
 
     this.lastStashCheckCache.set(repoID, date)
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
   }
 
   /**
@@ -465,7 +467,7 @@ export class RepositoriesStore extends BaseStore {
       }
     )
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
 
     return new Repository(
       repository.path,
@@ -536,7 +538,7 @@ export class RepositoriesStore extends BaseStore {
       }
     })
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
   }
 
   /**
@@ -574,7 +576,7 @@ export class RepositoriesStore extends BaseStore {
       lastPruneDate: date,
     })
 
-    this.emitUpdate()
+    this.emitUpdate(await this.getAll())
   }
 
   public async getLastPruneDate(

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -315,7 +315,7 @@ export class RepositoriesStore extends TypedBaseStore<
 
     this.lastStashCheckCache.set(repoID, date)
 
-    this.emitUpdate(await this.getAll())
+    // this update doesn't affect the list (or its items) we emit from this store, so no need to `emitUpdatedRepositories`
   }
 
   /**
@@ -538,7 +538,7 @@ export class RepositoriesStore extends TypedBaseStore<
       }
     })
 
-    this.emitUpdate(await this.getAll())
+    // this update doesn't affect the list (or its items) we emit from this store, so no need to `emitUpdatedRepositories`
   }
 
   /**
@@ -576,7 +576,7 @@ export class RepositoriesStore extends TypedBaseStore<
       lastPruneDate: date,
     })
 
-    this.emitUpdate(await this.getAll())
+    // this update doesn't affect the list (or its items) we emit from this store, so no need to `emitUpdatedRepositories`
   }
 
   public async getLastPruneDate(

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -185,7 +185,7 @@ export class RepositoriesStore extends TypedBaseStore<
       }
     )
 
-    this.emitUpdate(await this.getAll())
+    this.emitUpdatedRepositories()
   }
 
   /**
@@ -226,7 +226,7 @@ export class RepositoriesStore extends TypedBaseStore<
       }
     )
 
-    this.emitUpdate(await this.getAll())
+    this.emitUpdatedRepositories()
 
     return repository
   }
@@ -235,7 +235,7 @@ export class RepositoriesStore extends TypedBaseStore<
   public async removeRepository(repoID: number): Promise<void> {
     await this.db.repositories.delete(repoID)
 
-    this.emitUpdate(await this.getAll())
+    this.emitUpdatedRepositories()
   }
 
   /** Update the repository's `missing` flag. */
@@ -252,7 +252,7 @@ export class RepositoriesStore extends TypedBaseStore<
 
     await this.db.repositories.update(repoID, { missing })
 
-    this.emitUpdate(await this.getAll())
+    this.emitUpdatedRepositories()
 
     return new Repository(
       repository.path,
@@ -280,7 +280,7 @@ export class RepositoriesStore extends TypedBaseStore<
       path,
     })
 
-    this.emitUpdate(await this.getAll())
+    this.emitUpdatedRepositories()
 
     return new Repository(
       path,
@@ -467,7 +467,7 @@ export class RepositoriesStore extends TypedBaseStore<
       }
     )
 
-    this.emitUpdate(await this.getAll())
+    this.emitUpdatedRepositories()
 
     return new Repository(
       repository.path,
@@ -660,6 +660,14 @@ export class RepositoriesStore extends TypedBaseStore<
     }
 
     return branchProtectionsFound
+  }
+
+  /**
+   * Helper method to emit updates consistently
+   * (This is the only way we emit updates from this store.)
+   */
+  private async emitUpdatedRepositories() {
+    this.emitUpdate(await this.getAll())
   }
 }
 


### PR DESCRIPTION
Refactor RepositoriesStore to emit its collection of repositories in all updates instead of deferring the `.getAll()` call to its update subscribers.

This pull request shouldn't affect current behavior, but will support future performance improvements (for #8825).
