### PR TITLE
[Fork] Propogate updates from PullRequestStore to all related repos

### DIFF
--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -52,7 +52,7 @@ export class PullRequestCoordinator {
         }
 
         // find all related repos
-        const { clones, forks } = findRepositoriesForGitHubRepository(
+        const { matches, forks } = findRepositoriesForGitHubRepository(
           ghRepo,
           this.repositories
         )
@@ -64,9 +64,9 @@ export class PullRequestCoordinator {
           )
         }
 
-        // emit updates for clones
-        for (const c of clones) {
-          fn(c, pullRequests)
+        // emit updates for matches
+        for (const match of matches) {
+          fn(match, pullRequests)
         }
       }
     )
@@ -81,11 +81,11 @@ export class PullRequestCoordinator {
   ) {
     return this.pullRequestStore.onIsLoadingPullRequests(
       (ghRepo, pullRequests) => {
-        const { clones, forks } = findRepositoriesForGitHubRepository(
+        const { matches, forks } = findRepositoriesForGitHubRepository(
           ghRepo,
           this.repositories
         )
-        for (const repo of [...clones, ...forks]) {
+        for (const repo of [...matches, ...forks]) {
           fn(repo, pullRequests)
         }
       }
@@ -183,23 +183,26 @@ export class PullRequestCoordinator {
 }
 
 /**
- * Helper for matching a GitHubRepository to its local clone
- * and fork Repositories
+ * Finds local repositories that depend on a GitHubRepository
+ *
+ * includes:
+ *   * matches: repos with the GitHub repo as its default remote
+ *   * forks: repos that are forks of the GitHub repo
  *
  * @param gitHubRepository
  * @param repositories list of repositories to search for a match
- * @returns two lists of repositories: direct clones and forks
+ * @returns two lists of repositories: matches and forks
  */
 function findRepositoriesForGitHubRepository(
   gitHubRepository: GitHubRepository,
   repositories: ReadonlyArray<RepositoryWithGitHubRepository>
 ) {
   const { dbID } = gitHubRepository
-  const clones = new Array<RepositoryWithGitHubRepository>(),
+  const matches = new Array<RepositoryWithGitHubRepository>(),
     forks = new Array<RepositoryWithGitHubRepository>()
   for (const r of repositories) {
     if (r.gitHubRepository.dbID === dbID) {
-      clones.push(r)
+      matches.push(r)
     } else if (
       r.gitHubRepository.parent !== null &&
       r.gitHubRepository.parent.dbID === dbID
@@ -208,5 +211,5 @@ function findRepositoriesForGitHubRepository(
     }
   }
 
-  return { clones, forks }
+  return { matches, forks }
 }

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -79,15 +79,28 @@ export class PullRequestCoordinator {
     )
   }
 
-  /** Loads (from remote) all pull requests for the given repository. */
+  /** Loads (from remote) all pull requests for the given repository and its upstreams. */
   public refreshPullRequests(
     repository: RepositoryWithGitHubRepository,
     account: Account
   ) {
-    return this.pullRequestStore.refreshPullRequests(
-      repository.gitHubRepository,
-      account
-    )
+    if (repository.gitHubRepository.parent !== null) {
+      return Promise.all([
+        this.pullRequestStore.refreshPullRequests(
+          repository.gitHubRepository,
+          account
+        ),
+        this.pullRequestStore.refreshPullRequests(
+          repository.gitHubRepository.parent,
+          account
+        ),
+      ])
+    } else {
+      return this.pullRequestStore.refreshPullRequests(
+        repository.gitHubRepository,
+        account
+      )
+    }
   }
 
   /** Get all Pull Requests for the given Repository that are in the PullRequestStore */

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -103,9 +103,20 @@ export class PullRequestCoordinator {
     }
   }
 
-  /** Get all Pull Requests for the given Repository that are in the PullRequestStore */
-  public getAllPullRequests(repository: RepositoryWithGitHubRepository) {
-    return this.pullRequestStore.getAll(repository.gitHubRepository)
+  /**
+   * Get all Pull Requests that are stored locally for the given Repository
+   * (Doesn't load anything from the GitHub API.)
+   */
+  public async getAllPullRequests(repository: RepositoryWithGitHubRepository) {
+    if (repository.gitHubRepository.parent !== null) {
+      const [prs, upstreamPrs] = await Promise.all([
+        this.pullRequestStore.getAll(repository.gitHubRepository),
+        this.pullRequestStore.getAll(repository.gitHubRepository.parent),
+      ])
+      return [...prs, ...upstreamPrs]
+    } else {
+      return await this.pullRequestStore.getAll(repository.gitHubRepository)
+    }
   }
 
   /** Start background Pull Request updates machinery for this Repository */

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -168,17 +168,19 @@ export class PullRequestCoordinator {
     gitHubRepository: GitHubRepository
   ): Promise<ReadonlyArray<PullRequest>> {
     const { dbID } = gitHubRepository
-    // this check should never be false, but we have to check for typescript
-    if (dbID !== null) {
-      if (!this.prCache.has(dbID)) {
-        this.prCache.set(
-          dbID,
-          await this.pullRequestStore.getAll(gitHubRepository)
-        )
-      }
-      return this.prCache.get(dbID) || []
+    // this check should never be true, but we have to check
+    // for typescript and provide a sensible fallback
+    if (dbID === null) {
+      return []
     }
-    return []
+
+    if (!this.prCache.has(dbID)) {
+      this.prCache.set(
+        dbID,
+        await this.pullRequestStore.getAll(gitHubRepository)
+      )
+    }
+    return this.prCache.get(dbID) || []
   }
 }
 

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -107,7 +107,9 @@ export class PullRequestCoordinator {
    * Get all Pull Requests that are stored locally for the given Repository
    * (Doesn't load anything from the GitHub API.)
    */
-  public async getAllPullRequests(repository: RepositoryWithGitHubRepository) {
+  public async getAllPullRequests(
+    repository: RepositoryWithGitHubRepository
+  ): Promise<ReadonlyArray<PullRequest>> {
     if (repository.gitHubRepository.parent !== null) {
       const [prs, upstreamPrs] = await Promise.all([
         this.pullRequestStore.getAll(repository.gitHubRepository),

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -93,24 +93,17 @@ export class PullRequestCoordinator {
   }
 
   /** Loads (from remote) all pull requests for the given repository and its upstreams. */
-  public refreshPullRequests(
+  public async refreshPullRequests(
     repository: RepositoryWithGitHubRepository,
     account: Account
   ) {
+    await this.pullRequestStore.refreshPullRequests(
+      repository.gitHubRepository,
+      account
+    )
     if (repository.gitHubRepository.parent !== null) {
-      return Promise.all([
-        this.pullRequestStore.refreshPullRequests(
-          repository.gitHubRepository,
-          account
-        ),
-        this.pullRequestStore.refreshPullRequests(
-          repository.gitHubRepository.parent,
-          account
-        ),
-      ])
-    } else {
-      return this.pullRequestStore.refreshPullRequests(
-        repository.gitHubRepository,
+      await this.pullRequestStore.refreshPullRequests(
+        repository.gitHubRepository.parent,
         account
       )
     }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -102,7 +102,7 @@ export class BranchesContainer extends React.Component<
   }
 
   private renderOpenPullRequestsBubble() {
-    const { pullRequests } = this.props
+    const pullRequests = this.getPullRequests()
 
     if (pullRequests.length > 0) {
       return <span className="count">{pullRequests.length}</span>
@@ -174,8 +174,6 @@ export class BranchesContainer extends React.Component<
       return null
     }
 
-    const pullRequests = this.props.pullRequests
-    const repo = this.props.repository
     const isOnDefaultBranch =
       this.props.defaultBranch &&
       this.props.currentBranch &&
@@ -184,9 +182,9 @@ export class BranchesContainer extends React.Component<
     return (
       <PullRequestList
         key="pr-list"
-        pullRequests={pullRequests}
+        pullRequests={this.getPullRequests()}
         selectedPullRequest={this.state.selectedPullRequest}
-        repositoryName={nameOf(repo)}
+        repositoryName={nameOf(this.props.repository)}
         isOnDefaultBranch={!!isOnDefaultBranch}
         onSelectionChanged={this.onPullRequestSelectionChanged}
         onCreateBranch={this.onCreateBranch}
@@ -310,5 +308,18 @@ export class BranchesContainer extends React.Component<
       .then(() => timer.done())
 
     this.onPullRequestSelectionChanged(pullRequest)
+  }
+
+  /**
+   *  Returns which Pull Requests to display
+   *  (For now, filters out any pull requests targeting upstream)
+   */
+  private getPullRequests() {
+    const { gitHubRepository } = this.props.repository
+    return gitHubRepository !== null
+      ? this.props.pullRequests.filter(
+          pr => pr.base.gitHubRepository.hash === gitHubRepository.hash
+        )
+      : this.props.pullRequests
   }
 }


### PR DESCRIPTION
supports #8549
(builds on #8825)

## Description

### Core Changes

Refactors `PullRequestCoordinator` to account for forks in pull request updates emitted to `AppStore`. This ensures that...

* Anytime we emit an update to `AppStore` for a local fork, we include pull requests for that fork, as well as its upstream.
* Anytime we get updates for a local fork or its upstream github repo, we emit an update for the fork (and the upstream of course).

...which also means...

* When we fetch pull requests for a fork, we emit a list of pull requests that includes them, as well as pull requests for its upstream github repository.
* When we fetch pull requests for an upstream, we emit a list of pull requests for that local repo, as well as an updated list of pull requests for all local forks.

### Ancillary Changes

* Added a `filter` to the pull request tab in the branch container so we don't show the expanded list of pull requests this work introduces. The PR list UI should remain unchanged.

## Testing + Screenshots

These two images show the primary test cases for this PR.

This branch has a PR opened to the upstream repository. Therefore there is a "matching PR" open and the "Open a PR" suggested action does not show.

<img width="962" alt="Screen Shot 2020-01-09 at 4 52 02 PM" src="https://user-images.githubusercontent.com/964912/72116977-d2ed3900-3300-11ea-8680-81a1e57bd439.png">

The list of PRs only includes one PR on the remote and none from upstream. It's matched a local branch to the PR.

<img width="729" alt="Screen Shot 2020-01-09 at 4 51 47 PM" src="https://user-images.githubusercontent.com/964912/72116976-d2ed3900-3300-11ea-9ee0-b8314f64f00e.png">

<details>
<summary><strong>Another verification</strong></summary>

This shows the props for the `BranchesContainer`, which is the component in which the PRs are filtered for the PR list UI. There are 7 PRs (1 for the fork, and 6 for the upstream), but only the 1 is shown in the UI. This shows we are populating the PR database properly.

<img width="973" alt="Screen Shot 2020-01-09 at 4 59 55 PM" src="https://user-images.githubusercontent.com/964912/72117175-953ce000-3301-11ea-86df-508a5eb1b942.png">
</details>