### PR TITLE
[Fork] PullRequestUpdater handles local forks

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1618,18 +1618,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (this.appIsFocused && isRepositoryWithGitHubRepository(repository)) {
       const account = getAccountForRepository(this.accounts, repository)
       if (account !== null) {
-        return this.pullRequestCoordinator.startPullRequestUpdaters(
+        return this.pullRequestCoordinator.startPullRequestUpdater(
           repository,
           account
         )
       }
     }
-    // we always want to stop the current ones, to be safe
-    this.pullRequestCoordinator.stopPullRequestUpdaters()
+    // we always want to stop the current one, to be safe
+    this.pullRequestCoordinator.stopPullRequestUpdater()
   }
 
   private stopPullRequestUpdater() {
-    this.pullRequestCoordinator.stopPullRequestUpdaters()
+    this.pullRequestCoordinator.stopPullRequestUpdater()
   }
 
   private shouldBackgroundFetch(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1618,18 +1618,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (this.appIsFocused && isRepositoryWithGitHubRepository(repository)) {
       const account = getAccountForRepository(this.accounts, repository)
       if (account !== null) {
-        return this.pullRequestCoordinator.startPullRequestUpdater(
+        return this.pullRequestCoordinator.startPullRequestUpdaters(
           repository,
           account
         )
       }
     }
-    // we always want to stop the current one, to be safe
-    this.pullRequestCoordinator.stopPullRequestUpdater()
+    // we always want to stop the current ones, to be safe
+    this.pullRequestCoordinator.stopPullRequestUpdaters()
   }
 
   private stopPullRequestUpdater() {
-    this.pullRequestCoordinator.stopPullRequestUpdater()
+    this.pullRequestCoordinator.stopPullRequestUpdaters()
   }
 
   private shouldBackgroundFetch(

--- a/app/src/lib/stores/helpers/pull-request-updater.ts
+++ b/app/src/lib/stores/helpers/pull-request-updater.ts
@@ -1,6 +1,6 @@
-import { PullRequestStore } from '../pull-request-store'
 import { Account } from '../../../models/account'
-import { GitHubRepository } from '../../../models/github-repository'
+import { RepositoryWithGitHubRepository } from '../../../models/repository'
+import { PullRequestCoordinator } from '../pull-request-coordinator'
 
 /** Check for new or updated pull requests every 30 minutes */
 const PullRequestInterval = 30 * 60 * 1000
@@ -25,9 +25,9 @@ export class PullRequestUpdater {
   private running = false
 
   public constructor(
-    private readonly repository: GitHubRepository,
+    private readonly repository: RepositoryWithGitHubRepository,
     private readonly account: Account,
-    private readonly store: PullRequestStore
+    private readonly coordinator: PullRequestCoordinator
   ) {}
 
   /** Starts the updater */
@@ -39,7 +39,7 @@ export class PullRequestUpdater {
   }
 
   private getTimeSinceLastRefresh() {
-    const lastRefreshed = this.store.getLastRefreshed(this.repository)
+    const lastRefreshed = this.coordinator.getLastRefreshed(this.repository)
     const timeSince =
       lastRefreshed === undefined ? Infinity : Date.now() - lastRefreshed
     return timeSince
@@ -62,7 +62,7 @@ export class PullRequestUpdater {
       this.scheduleTick()
     }
 
-    this.store
+    this.coordinator
       .refreshPullRequests(this.repository, this.account)
       .catch(() => {})
       .then(() => this.scheduleTick())

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -169,18 +169,16 @@ export class PullRequestCoordinator {
   public getLastRefreshed(
     repository: RepositoryWithGitHubRepository
   ): number | undefined {
-    const ghRepos = [repository.gitHubRepository]
-    if (repository.gitHubRepository.parent !== null) {
-      ghRepos.push(repository.gitHubRepository.parent)
-    }
-    const times = new Array<number>()
-    for (const ghr of ghRepos) {
-      const lastRefreshed = this.pullRequestStore.getLastRefreshed(ghr)
-      if (lastRefreshed !== undefined) {
-        times.push(lastRefreshed)
-      }
-    }
-    return times.length > 0 ? Math.min(...times) : undefined
+    const ghr = repository.gitHubRepository
+    const lastRefresh = this.pullRequestStore.getLastRefreshed(ghr)
+
+    const parentLastRefresh = ghr.parent
+      ? this.pullRequestStore.getLastRefreshed(ghr.parent)
+      : undefined
+
+    return !lastRefresh || !parentLastRefresh
+      ? lastRefresh || parentLastRefresh
+      : Math.min(lastRefresh, parentLastRefresh)
   }
 
   /**

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -156,7 +156,19 @@ export class PullRequestCoordinator {
     }
   }
 
-  public getLastRefreshed(repository: RepositoryWithGitHubRepository) {
+  /**
+   * Get the last time a repository's pull requests were fetched
+   * from the GitHub API
+   *
+   * Since `PullRequestStore` stores these timestamps by
+   * GitHubRepository, we gather the timestamps for all
+   * **related repos** and return _the least recent one._
+   *
+   * If we can't find any timestamps stored, returns `undefined`
+   */
+  public getLastRefreshed(
+    repository: RepositoryWithGitHubRepository
+  ): number | undefined {
     const ghRepos = [repository.gitHubRepository]
     if (repository.gitHubRepository.parent !== null) {
       ghRepos.push(repository.gitHubRepository.parent)
@@ -168,7 +180,7 @@ export class PullRequestCoordinator {
         times.push(lastRefreshed)
       }
     }
-    return Math.max(...times)
+    return times.length > 0 ? Math.min(...times) : undefined
   }
 
   /**

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -162,7 +162,7 @@ export class PullRequestCoordinator {
    *
    * Since `PullRequestStore` stores these timestamps by
    * GitHubRepository, we gather the timestamps for all
-   * the repository and its parent and return _oldest one._
+   * the repository and its parent and return the _oldest one._
    *
    * If we can't find any timestamps stored, returns `undefined`
    */

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -161,10 +161,11 @@ export class PullRequestCoordinator {
    * from the GitHub API
    *
    * Since `PullRequestStore` stores these timestamps by
-   * GitHubRepository, we gather the timestamps for all
-   * the repository and its parent and return the _oldest one._
+   * `GitHubRepository`, we get timestamps for this
+   * repo's `GitHubRepository` and its parent (if it has one)
+   * and return the _older one._
    *
-   * If we can't find any timestamps stored, returns `undefined`
+   * If neither timestamp is stored, returns `undefined`
    */
   public getLastRefreshed(
     repository: RepositoryWithGitHubRepository

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -156,6 +156,21 @@ export class PullRequestCoordinator {
     }
   }
 
+  public getLastRefreshed(repository: RepositoryWithGitHubRepository) {
+    const ghRepos = [repository.gitHubRepository]
+    if (repository.gitHubRepository.parent !== null) {
+      ghRepos.push(repository.gitHubRepository.parent)
+    }
+    const times = new Array<number>()
+    for (const ghr of ghRepos) {
+      const lastRefreshed = this.pullRequestStore.getLastRefreshed(ghr)
+      if (lastRefreshed !== undefined) {
+        times.push(lastRefreshed)
+      }
+    }
+    return Math.max(...times)
+  }
+
   /**
    * Get all Pull Requests that are stored locally for the given Repository
    * (Doesn't load anything new from the GitHub API.)
@@ -184,9 +199,9 @@ export class PullRequestCoordinator {
     }
 
     this.currentPullRequestUpdater = new PullRequestUpdater(
-      repository.gitHubRepository,
+      repository,
       account,
-      this.pullRequestStore
+      this
     )
     this.currentPullRequestUpdater.start()
   }

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -175,7 +175,7 @@ export class PullRequestCoordinator {
   }
 
   /**
-   * Start background Pull Request updates machinery for this Repository
+   * Start background pull request fetching machinery for this Repository
    * (Stops and removes any current pull request updaters.)
    */
   public startPullRequestUpdaters(
@@ -209,7 +209,7 @@ export class PullRequestCoordinator {
   }
 
   /**
-   * Stop background Pull Request updates machinery for this Repository
+   * Stop background background pull request fetching machinery for this Repository
    * Removes all current pull request updaters.
    * (Use `startPullRequestUpdaters` to create some new ones.)
    */

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -162,7 +162,7 @@ export class PullRequestCoordinator {
    *
    * Since `PullRequestStore` stores these timestamps by
    * GitHubRepository, we gather the timestamps for all
-   * **related repos** and return _the least recent one._
+   * the repository and its parent and return _oldest one._
    *
    * If we can't find any timestamps stored, returns `undefined`
    */


### PR DESCRIPTION
closes #8549 (🎉)

Changes pull request background updating logic in `PullRequestUpdater` to request periodic updates for both the github remote of a `Repository`, as well as its upstream (if it has one).

## Description

* `PullRequestUpdater` now calls `PullRequestCoordinator.refreshPullRequests` for a `Repository`, not a `GitHubRepository`
* `PullRequestCoordinator` helps determine last refreshed time for a `Repository` by surveying the last refreshed times of its `GitHubRepository`s and returning the least recent one
* `PullRequestUpdater` only deals in `Repository`s not `GitHubRepository`s