### PR TITLE
SAML re-authorization dialog

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -184,23 +184,38 @@ export async function git(
   throw new GitError(gitResult, args)
 }
 
-function getDescriptionForError(error: DugiteError): string {
+export function isAuthFailureError(
+  error: DugiteError
+): error is
+  | DugiteError.SSHAuthenticationFailed
+  | DugiteError.SSHPermissionDenied
+  | DugiteError.HTTPSAuthenticationFailed {
   switch (error) {
-    case DugiteError.SSHKeyAuditUnverified:
-      return 'The SSH key is unverified.'
     case DugiteError.SSHAuthenticationFailed:
     case DugiteError.SSHPermissionDenied:
     case DugiteError.HTTPSAuthenticationFailed:
-      const menuHint = __DARWIN__
-        ? 'GitHub Desktop > Preferences.'
-        : 'File > Options.'
-      return `Authentication failed. Some common reasons include:
+      return true
+  }
+  return false
+}
+
+function getDescriptionForError(error: DugiteError): string {
+  if (isAuthFailureError(error)) {
+    const menuHint = __DARWIN__
+      ? 'GitHub Desktop > Preferences.'
+      : 'File > Options.'
+    return `Authentication failed. Some common reasons include:
 
 - You are not logged in to your account: see ${menuHint}
 - You may need to log out and log back in to refresh your token.
 - You do not have permission to access this repository.
 - The repository is archived on GitHub. Check the repository settings to confirm you are still permitted to push commits.
 - If you use SSH authentication, check that your key is added to the ssh-agent and associated with your account.`
+  }
+
+  switch (error) {
+    case DugiteError.SSHKeyAuditUnverified:
+      return 'The SSH key is unverified.'
     case DugiteError.RemoteDisconnection:
       return 'The remote disconnected. Check your Internet connection and try again.'
     case DugiteError.HostDown:

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -184,6 +184,12 @@ export async function git(
   throw new GitError(gitResult, args)
 }
 
+/**
+ * Determine whether the provided `error` is an authentication failure
+ * as per our definition. Note that this is not an exhaustive list of
+ * authentication failures, only a collection of errors that we treat
+ * equally in terms of error message and presentation to the user.
+ */
 export function isAuthFailureError(
   error: DugiteError
 ): error is

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -211,5 +211,5 @@ export type Popup =
       type: PopupType.SAMLReauthRequired
       organizationName: string
       endpoint: string
-      retryAction: RetryAction
+      retryAction?: RetryAction
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -53,6 +53,7 @@ export enum PopupType {
   CreateTutorialRepository,
   ConfirmExitTutorial,
   PushRejectedDueToMissingWorkflowScope,
+  SAMLReauthRequired,
 }
 
 export type Popup =
@@ -205,4 +206,9 @@ export type Popup =
       type: PopupType.PushRejectedDueToMissingWorkflowScope
       rejectedPath: string
       repository: Repository
+    }
+  | {
+      type: PopupType.SAMLReauthRequired
+      organizationName: string
+      endpoint: string
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -211,4 +211,5 @@ export type Popup =
       type: PopupType.SAMLReauthRequired
       organizationName: string
       endpoint: string
+      retryAction: RetryAction
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -108,6 +108,7 @@ import { enableTutorial } from '../lib/feature-flag'
 import { ConfirmExitTutorial } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { WorkflowPushRejectedDialog } from './workflow-push-rejected/workflow-push-rejected'
+import { SAMLReauthRequiredDialog } from './saml-reauth-required/saml-reauth-required'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1859,6 +1859,15 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
           />
         )
+      case PopupType.SAMLReauthRequired:
+        return (
+          <SAMLReauthRequired
+            onDismissed={this.onPopupDismissed}
+            rejectedPath={popup.rejectedPath}
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
+          />
+        )
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1862,11 +1862,11 @@ export class App extends React.Component<IAppProps, IAppState> {
         )
       case PopupType.SAMLReauthRequired:
         return (
-          <SAMLReauthRequired
+          <SAMLReauthRequiredDialog
             onDismissed={this.onPopupDismissed}
-            rejectedPath={popup.rejectedPath}
+            organizationName={popup.organizationName}
+            endpoint={popup.endpoint}
             dispatcher={this.props.dispatcher}
-            repository={popup.repository}
           />
         )
       default:

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1866,6 +1866,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={this.onPopupDismissed}
             organizationName={popup.organizationName}
             endpoint={popup.endpoint}
+            retryAction={popup.retryAction}
             dispatcher={this.props.dispatcher}
           />
         )

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -580,6 +580,12 @@ export async function samlReauthRequired(error: Error, dispatcher: Dispatcher) {
   return null
 }
 
+/**
+ * Extract lines from Git's stderr output starting with the
+ * prefix `remote: `. Useful to extract server-specific
+ * error messages from network operations (fetch, push, pull,
+ * etc).
+ */
 function getRemoteMessage(stderr: string) {
   const needle = 'remote: '
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -574,6 +574,7 @@ export async function samlReauthRequired(error: Error, dispatcher: Dispatcher) {
     type: PopupType.SAMLReauthRequired,
     organizationName,
     endpoint,
+    retryAction: e.metadata.retryAction,
   })
 
   return null

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -7,7 +7,7 @@ import { Dispatcher } from '.'
 import { ExternalEditorError } from '../../lib/editors/shared'
 import { ErrorWithMetadata } from '../../lib/error-with-metadata'
 import { AuthenticationErrors } from '../../lib/git/authentication'
-import { GitError } from '../../lib/git/core'
+import { GitError, isAuthFailureError } from '../../lib/git/core'
 import { ShellError } from '../../lib/shells'
 import { UpstreamAlreadyExistsError } from '../../lib/stores/upstream-already-exists-error'
 
@@ -527,4 +527,64 @@ export async function refusedWorkflowUpdate(
   })
 
   return null
+}
+
+const samlReauthErrorMessageRe = /`([^']+)' organization has enabled or enforced SAML SSO.*?you must re-authorize/s
+
+/**
+ * Attempts to detect whether an error is the result of a failed push
+ * due to insufficient OAuth permissions (missing workflow scope)
+ */
+export async function samlReauthRequired(error: Error, dispatcher: Dispatcher) {
+  const e = asErrorWithMetadata(error)
+  if (!e) {
+    return error
+  }
+
+  const gitError = asGitError(e.underlyingError)
+  if (!gitError || gitError.result.gitError === null) {
+    return error
+  }
+
+  if (!isAuthFailureError(gitError.result.gitError)) {
+    return
+  }
+
+  const { repository } = e.metadata
+
+  if (!(repository instanceof Repository)) {
+    return error
+  }
+
+  if (repository.gitHubRepository === null) {
+    return error
+  }
+
+  const remoteMessage = getRemoteMessage(gitError.result.stderr)
+  const match = samlReauthErrorMessageRe.exec(remoteMessage)
+
+  if (!match) {
+    return
+  }
+
+  const organizationName = match[1]
+  const endpoint = repository.gitHubRepository.endpoint
+
+  dispatcher.showPopup({
+    type: PopupType.SAMLReauthRequired,
+    organizationName,
+    endpoint,
+  })
+
+  return null
+}
+
+function getRemoteMessage(stderr: string) {
+  const needle = 'remote: '
+
+  return stderr
+    .split(/\r?\n/)
+    .filter(x => x.startsWith(needle))
+    .map(x => x.substr(needle.length))
+    .join('\n')
 }

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -547,7 +547,7 @@ export async function samlReauthRequired(error: Error, dispatcher: Dispatcher) {
   }
 
   if (!isAuthFailureError(gitError.result.gitError)) {
-    return
+    return error
   }
 
   const { repository } = e.metadata
@@ -564,7 +564,7 @@ export async function samlReauthRequired(error: Error, dispatcher: Dispatcher) {
   const match = samlReauthErrorMessageRe.exec(remoteMessage)
 
   if (!match) {
-    return
+    return error
   }
 
   const organizationName = match[1]

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -22,6 +22,7 @@ import {
   rebaseConflictsHandler,
   localChangesOverwrittenHandler,
   refusedWorkflowUpdate,
+  samlReauthRequired,
 } from './dispatcher'
 import {
   AppStore,
@@ -280,6 +281,7 @@ dispatcher.registerErrorHandler(mergeConflictHandler)
 dispatcher.registerErrorHandler(lfsAttributeMismatchHandler)
 dispatcher.registerErrorHandler(gitAuthenticationErrorHandler)
 dispatcher.registerErrorHandler(pushNeedsPullHandler)
+dispatcher.registerErrorHandler(samlReauthRequired)
 dispatcher.registerErrorHandler(backgroundTaskHandler)
 dispatcher.registerErrorHandler(missingRepositoryHandler)
 dispatcher.registerErrorHandler(localChangesOverwrittenHandler)

--- a/app/src/ui/saml-reauth-required/saml-reauth-required.tsx
+++ b/app/src/ui/saml-reauth-required/saml-reauth-required.tsx
@@ -9,6 +9,9 @@ interface ISAMLReauthRequiredDialogProps {
   readonly organizationName: string
   readonly endpoint: string
 
+  /** The action to retry if applicable. */
+  readonly retryAction?: RetryAction
+
   readonly onDismissed: () => void
 }
 interface ISAMLReauthRequiredDialogState {
@@ -67,6 +70,10 @@ export class SAMLReauthRequiredDialog extends React.Component<
       await this.props.dispatcher.beginEnterpriseSignIn()
     }
     await this.props.dispatcher.requestBrowserAuthentication()
+
+    if (this.props.retryAction !== undefined) {
+      this.props.dispatcher.performRetry(this.props.retryAction)
+    }
 
     this.props.onDismissed()
   }

--- a/app/src/ui/saml-reauth-required/saml-reauth-required.tsx
+++ b/app/src/ui/saml-reauth-required/saml-reauth-required.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Dispatcher } from '../dispatcher'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { getDotComAPIEndpoint } from '../../lib/api'
+import { RetryAction } from '../../models/retry-actions'
 
 interface ISAMLReauthRequiredDialogProps {
   readonly dispatcher: Dispatcher

--- a/app/src/ui/saml-reauth-required/saml-reauth-required.tsx
+++ b/app/src/ui/saml-reauth-required/saml-reauth-required.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dispatcher } from '../dispatcher'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { getDotComAPIEndpoint } from '../../lib/api'
+
+interface ISAMLReauthRequiredDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly organizationName: string
+  readonly endpoint: string
+
+  readonly onDismissed: () => void
+}
+interface ISAMLReauthRequiredDialogState {
+  readonly loading: boolean
+}
+/**
+ * The dialog shown when a Git network operation is denied due to
+ * the organization owning the repository having enforced SAML
+ * SSO and the current session not being authorized.
+ */
+export class SAMLReauthRequiredDialog extends React.Component<
+  ISAMLReauthRequiredDialogProps,
+  ISAMLReauthRequiredDialogState
+> {
+  public constructor(props: ISAMLReauthRequiredDialogProps) {
+    super(props)
+    this.state = { loading: false }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        title={
+          __DARWIN__ ? 'Re-authorization Required' : 'Re-authorization required'
+        }
+        loading={this.state.loading}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSignIn}
+        type="error"
+      >
+        <DialogContent>
+          <p>
+            The "{this.props.organizationName}" organization has enabled or
+            enforced SAML SSO. To access this repository, you must sign in again
+            and grant GitHub Desktop permission to access the organization's
+            repositories.
+          </p>
+          <p>
+            Would you like to open a browser to grant GitHub Desktop permission
+            to access the repository?
+          </p>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup okButtonText="Grant" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onSignIn = async () => {
+    this.setState({ loading: true })
+
+    if (this.props.endpoint === getDotComAPIEndpoint()) {
+      await this.props.dispatcher.beginDotComSignIn()
+    } else {
+      await this.props.dispatcher.beginEnterpriseSignIn()
+    }
+    await this.props.dispatcher.requestBrowserAuthentication()
+
+    this.props.onDismissed()
+  }
+}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This introduces special case handling of a particular set of access denied errors related to SAML and SSO. When a user is signed in but their token hasn't yet been authorized for a particular SAML organization fetches, pushes, and pulls will fail with a specific error message from the server informing the user that they need to re-authorize (sign out and back in again).


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

![Screen Shot 2020-01-08 at 14 52 58](https://user-images.githubusercontent.com/634063/72278861-2fb85e80-3635-11ea-94bd-8109e2420fb4.png)

### After

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/634063/72278945-58d8ef00-3635-11ea-93e4-9db9b26bc8e7.png">

### Flow

![(null) 2020-01-13 18_53_26](https://user-images.githubusercontent.com/634063/72279251-04823f00-3636-11ea-8dbd-591e26c2b025.gif)


## Testing notes (requires membership in a SAML org)

1. In your primary browser, sign out of GitHub.com completely
2. In GitHub Desktop, sign out of your GitHub.com account.
3. Sign in using the web flow in GitHub Desktop but do not authorize the SAML org
  <img width="548" alt="image" src="https://user-images.githubusercontent.com/634063/72280330-6348b800-3638-11ea-9b1c-78fad027e604.png">
4. Attempt to fetch, push, or pull a private repository owned by your SAML org

Expected result is a dialog that allows you to sign in again using the Web flow where you have the ability to authorize the SAML org.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 