### PR TITLE
[Fork] De-duplicate pull request loading events

### DIFF
--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -47,26 +47,6 @@ export class PullRequestStore {
     })
   }
 
-  private emitIsLoadingPullRequests(
-    repository: GitHubRepository,
-    isLoadingPullRequests: boolean
-  ) {
-    this.emitter.emit('onIsLoadingPullRequest', {
-      repository,
-      isLoadingPullRequests,
-    })
-  }
-
-  /** Register a function to be called when the store updates. */
-  public onIsLoadingPullRequests(
-    fn: (repository: GitHubRepository, isLoadingPullRequests: boolean) => void
-  ): Disposable {
-    return this.emitter.on('onIsLoadingPullRequest', value => {
-      const { repository, isLoadingPullRequests } = value
-      fn(repository, isLoadingPullRequests)
-    })
-  }
-
   /** Loads all pull requests against the given repository. */
   public refreshPullRequests(repo: GitHubRepository, account: Account) {
     const dbId = repo.dbID
@@ -87,7 +67,6 @@ export class PullRequestStore {
     }
 
     this.lastRefreshForRepository.set(dbId, Date.now())
-    this.emitIsLoadingPullRequests(repo, true)
 
     const promise = this.fetchAndStorePullRequests(repo, account)
       .catch(err => {
@@ -95,7 +74,6 @@ export class PullRequestStore {
       })
       .then(() => {
         this.currentRefreshOperations.delete(dbId)
-        this.emitIsLoadingPullRequests(repo, false)
       })
 
     this.currentRefreshOperations.set(dbId, promise)


### PR DESCRIPTION
Noticed this issue while working on #8868, so here's a fix.

## The Situation

`PullRequestStore`currently handles pr loading events and it emits them before and after each `GitHubRepository` it loads them for. When this event is emitted, `PullRequestCoordinator` finds all related repositories (matches and forks) for that `GitHubRepository` and emits pr loading events for them to `AppStore`.

This means that when we load PRs from (up to) two `GitHubRepository`s in `PullRequestCoordinator.refreshPullRequests`, its very possible we'll put ourselves in a race condition with these pr loading events.

## Description

- move pull request loading event logic to the coordinator
- emit a single loading event per `Repository` when its refreshed.
- emit loading events for all local repos that have the same `GitHubRepository`