### PR TITLE
Pin AppVeyor node version to 10.17 for a bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform:
   - x64
 
 environment:
-  nodejs_version: '10'
+  nodejs_version: '10.17.0'
 
 cache:
   - '%USERPROFILE%\.electron'


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

We started seeing [failures building PRs on AppVeyor](https://ci.appveyor.com/project/github-windows/desktop/builds/30131681) where the error message came from node-gyp not being able to download an arm64 version of electron's node lib.

```
gyp http 200 https://atom.io/download/electron/v5.0.6/SHASUMS256.txt
62gyp http 403 https://atom.io/download/electron/v5.0.6/win-arm64/node.lib
63gyp WARN install got an error, rolling back install
64gyp ERR! configure error 
65gyp ERR! stack Error: 403 status code downloading arm64 node.lib
66gyp ERR! stack     at Request.<anonymous> (C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\lib\install.js:335:22)
67
```

This seems to be an issue with a particular set of node-gyp versions (see https://github.com/nodejs/node-gyp/issues/1933, https://github.com/nodejs/node-gyp/pull/1875) and I noticed while troubleshooting that a build from yesterday that succeeded on AppVeyor was using Node 10.17.0 whereas the builds that were failing today were using 10.18.0. Pinning to 10.17 worked around the issue in https://github.com/desktop/desktop/pull/8920 so let's just do that for now.