### PR TITLE
Lookup commit status using the PRs base repository

### DIFF
--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -176,7 +176,7 @@ export class PullRequestList extends React.Component<
         author={pr.author}
         matches={matches}
         dispatcher={this.props.dispatcher}
-        repository={this.props.repository}
+        repository={pr.base.gitHubRepository}
       />
     )
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -186,9 +186,8 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
 
   private renderPullRequestInfo() {
     const pr = this.props.currentPullRequest
-    const repository = this.props.repository.gitHubRepository
 
-    if (pr === null || repository === null) {
+    if (pr === null) {
       return null
     }
 
@@ -196,7 +195,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       <PullRequestBadge
         number={pr.pullRequestNumber}
         dispatcher={this.props.dispatcher}
-        repository={repository}
+        repository={pr.base.gitHubRepository}
       />
     )
   }


### PR DESCRIPTION
## Description

In https://github.com/desktop/desktop/pull/8929#pullrequestreview-343602548 @tierninho remarked that he was seeing error messages about failed fetches

> The `http.ts:148 GET https://api.github.com/repos/tierninho/TestWebAppProject/commits/refs/pull/67/head/status 404 (Not Found)` error is still shown in the console logs.

This is because the `<CommitStatus>` component (or rather consumers of that component) were built when there could only ever be one candidate repository for looking up a commit status. Since that's changed now with the fork flow it's time to update that assumption and rely on the pull requests base repository instead (since that's where any commit checks will run and apply).

Note that I expect the error raised by @tierninho is no longer reproducible as of https://github.com/desktop/desktop/pull/8937 since I think that removes the last instance where a PR badge or CommitStatus component is rendered for an upstream PR. Nevertheless we should future-proof this.