### PR TITLE
Show commit warning messages only if changed files are present

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -640,8 +640,8 @@ export class ChangesList extends React.Component<
         )}
         prepopulateCommitSummary={prepopulateCommitSummary}
         key={repository.id}
-        currentBranchProtected={currentBranchProtected}
-        hasWritePermissionForRepository={hasWritePermissionForRepository}
+        showBranchProtected={fileCount > 0 && currentBranchProtected}
+        showNoWriteAccess={fileCount > 0 && !hasWritePermissionForRepository}
         shouldNudge={this.props.shouldNudgeToCommit}
       />
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -54,8 +54,8 @@ interface ICommitMessageProps {
   readonly isCommitting: boolean
   readonly placeholder: string
   readonly prepopulateCommitSummary: boolean
-  readonly currentBranchProtected: boolean
-  readonly hasWritePermissionForRepository: boolean
+  readonly showBranchProtected: boolean
+  readonly showNoWriteAccess: boolean
 
   /**
    * Whether or not to show a field for adding co-authors to
@@ -458,13 +458,9 @@ export class CommitMessage extends React.Component<
       return null
     }
 
-    const {
-      currentBranchProtected,
-      hasWritePermissionForRepository,
-      repository,
-    } = this.props
+    const { showBranchProtected, showNoWriteAccess, repository } = this.props
 
-    if (!hasWritePermissionForRepository) {
+    if (showNoWriteAccess) {
       return (
         <PermissionsCommitWarning>
           You don't have write access to <strong>{repository.name}</strong>.
@@ -472,7 +468,7 @@ export class CommitMessage extends React.Component<
           ?
         </PermissionsCommitWarning>
       )
-    } else if (currentBranchProtected) {
+    } else if (showBranchProtected) {
       return (
         <PermissionsCommitWarning>
           <strong>{branch}</strong> is a protected branch. Want to{' '}


### PR DESCRIPTION
Closes #8795 

## Description

This PR makes it such that the warnings against committing to a protected branch or a repo for which a user does not have write access are displayed only when there are working directory changes. 

### Screenshots

![branch-protection](https://user-images.githubusercontent.com/7910250/72857414-68c68380-3c72-11ea-8767-cd9bc37ad511.gif)

![no-write-access](https://user-images.githubusercontent.com/7910250/72857360-403e8980-3c72-11ea-94ee-58838935fff4.gif)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improvement] Only display commit message warnings when file changes are present
