### PR TITLE
Update error message regex when push fails due to missing workflow scope

### DIFF
--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -517,17 +517,9 @@ export async function refusedWorkflowUpdate(
     return error
   }
 
-  const rejectedPath = match[1]
-  const pathIsLikelyWorkflowFile =
-    rejectedPath.startsWith('.github/') && rejectedPath.indexOf('workflow') >= 0
-
-  if (!pathIsLikelyWorkflowFile) {
-    return error
-  }
-
   dispatcher.showPopup({
     type: PopupType.PushRejectedDueToMissingWorkflowScope,
-    rejectedPath,
+    rejectedPath: match[1],
     repository,
   })
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -476,8 +476,7 @@ export async function localChangesOverwrittenHandler(
 
   return null
 }
-
-const rejectedPathRe = /^ ! \[remote rejected\] .*? -> .*? \(refusing to allow an integration to create or update (.*?)\)$/m
+const rejectedPathRe = /^ ! \[remote rejected\] .*? -> .*? \(refusing to allow an OAuth App to create or update workflow `(.*?)` without `workflow` scope\)/m
 
 /**
  * Attempts to detect whether an error is the result of a failed push

--- a/app/src/ui/workflow-push-rejected/workflow-push-rejected.tsx
+++ b/app/src/ui/workflow-push-rejected/workflow-push-rejected.tsx
@@ -33,6 +33,7 @@ export class WorkflowPushRejectedDialog extends React.Component<
   public render() {
     return (
       <Dialog
+        id="workflow-push-rejected"
         title={__DARWIN__ ? 'Push Rejected' : 'Push rejected'}
         loading={this.state.loading}
         onDismissed={this.props.onDismissed}
@@ -42,7 +43,7 @@ export class WorkflowPushRejectedDialog extends React.Component<
         <DialogContent>
           <p>
             The push was rejected by the server for containing a modification to
-            a workflow file ( <Ref>{this.props.rejectedPath}</Ref>). In order to
+            the workflow file <Ref>{this.props.rejectedPath}</Ref>. In order to
             be able to push to workflow files GitHub Desktop needs to request
             additional permissions.
           </p>

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -396,6 +396,12 @@ dialog {
   &#lfs-attribute-mismatch {
     width: 400px;
   }
+
+  &#workflow-push-rejected {
+    .ref-component {
+      display: inline-block;
+    }
+  }
 }
 
 .warning-helper-text {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Follow-up to https://github.com/desktop/desktop/pull/8357.

## Description

Today I learned from @riha that we no longer provide an easy route to adding a workflow scope when needed. He had an old token and tried to push a workflow file and instead of being greeted by the nice dialog from #8357 he got the generic push failed dialog with raw Git output.

Turns out github.com updated their error message to be more user friendly (and I applaud the intention). Unfortunately for us that meant that Desktop no longer detects the specific workflow error.

Ideally we'd have some sort of language neutral error code to rely on here but since we don't we can only adapt to the new state of affairs. Luckily this dialog will become less and less important as more users automatically acquire the workflow scope as part of signing in for the first time.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### Before

![image](https://user-images.githubusercontent.com/634063/72927996-7bff4f00-3d57-11ea-9ad9-47d022d3393e.png)

### After

![image](https://user-images.githubusercontent.com/634063/72927875-4c504700-3d57-11ea-82ee-9aeb5ea862d7.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Detect and inform when push fails due to missing workflow scope