### PR TITLE
Git dumb terminal

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -124,7 +124,7 @@ export async function git(
   }
 
   const opts = { ...defaultOptions, ...options }
-  opts.env = { TERM: 'dumb', ...opts.env }
+  opts.env = { TERM: undefined, ...opts.env }
 
   const commandName = `${name}: git ${args.join(' ')}`
 

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -124,11 +124,12 @@ export async function git(
   }
 
   const opts = { ...defaultOptions, ...options }
+  opts.env = { TERM: 'dumb', ...opts.env }
 
   const commandName = `${name}: git ${args.join(' ')}`
 
   const result = await GitPerf.measure(commandName, () =>
-    GitProcess.exec(args, path, options)
+    GitProcess.exec(args, path, opts)
   ).catch(err => {
     // If this is an exception thrown by Node.js (as opposed to
     // dugite) let's keep the salient details but include the name of

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -124,6 +124,11 @@ export async function git(
   }
 
   const opts = { ...defaultOptions, ...options }
+
+  // Explicitly unset TERM so that if Desktop was launched
+  // from a terminal or if the system environment variables
+  // have TERM set Git won't consider us as a smart terminal.
+  // See https://github.com/git/git/blob/a7312d1a2/editor.c#L11-L15
   opts.env = { TERM: undefined, ...opts.env }
 
   const commandName = `${name}: git ${args.join(' ')}`


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

TL;DR: Our update to Git 2.23 broke our progress parsing

While testing yesterday's beta release I noticed that progress bars in the app didn't seem to behave normally and spotted some odd characters in the description text.

![image](https://user-images.githubusercontent.com/634063/72963188-dc71a900-3db6-11ea-94b3-3804ea4eea48.png)

<img width="221" alt="image" src="https://user-images.githubusercontent.com/634063/72968002-e1d4f080-3dc2-11ea-89e6-08222e66ed0c.png">

This `[K` prefix  comes from a [change made in Git 2.22.1](https://github.com/git/git/commit/5b12e3123b7b70e3875404a4ffe571ca079364fe) which was [reverted in Git 2.24.0](https://github.com/git/git/commit/bbf47568ad7e91ab0962b314c054a2da03232c72). Unfortunately we (I) up and decided to upgrade us to Git 2.23 a while back so now we  have to deal with this.

The behavior requires that the `TERM` environment variable is set which, if you launch GitHub Desktop from the terminal (using the `github .` CLI command which I frequently do) as I frequently do, it will be.

As luck would have it the workaround is pretty straightforward. We can unset the TERM environment variable in order to make the [`is_terminal_dumb()` method](https://github.com/git/git/blob/a7312d1a28ff3ab0a5a5427b35f01d943103cba8/editor.c#L11-L15) in Git return true and thereby reverting us to (almost) the same behavior as we had in 2.19.

This is a prudent change regardless of Git version so we should keep this once we upgrade to 2.24+.

I am unfortunately under the impression that given that this is a regression which we haven't shipped to prod yet we should attempt to land this ahead of the next production release.

### Testing notes

1. Close all open GitHub Desktop processes (including any dev environment you may have open).
2. Launch GitHub Desktop from the terminal using either `github` or `open -a "GitHub Desktop"`
3. Verify that the TERM environment variable is set in devtools
  ![image](https://user-images.githubusercontent.com/634063/72967494-c0273980-3dc1-11ea-87b5-e80ff3ebac65.png)
4. Clone a large enough repository (atom/atom is a good bet) that you can monitor the clone progress and verify that the progress bar doesn't update as it should and that the subtext starts with `[K`.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Progress bars failed to update properly when Desktop was launched from a terminal.
