### PR TITLE
[Fork] PR list call to action

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -206,6 +206,7 @@ export class BranchesContainer extends React.Component<
         filterText={this.state.pullRequestFilterText}
         onFilterTextChanged={this.onPullRequestFilterTextChanged}
         onItemClick={this.onPullRequestClicked}
+        onShowPullRequest={this.onShowPullRequest}
         onDismiss={this.onDismiss}
         renderPostFilter={this.renderPullRequestPostFilter}
         dispatcher={this.props.dispatcher}
@@ -329,6 +330,11 @@ export class BranchesContainer extends React.Component<
   private onCreatePullRequest = () => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     this.props.dispatcher.createPullRequest(this.props.repository)
+  }
+
+  private onShowPullRequest = () => {
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    this.props.dispatcher.showPullRequest(this.props.repository)
   }
 
   private onPullRequestClicked = (pullRequest: PullRequest) => {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -206,7 +206,6 @@ export class BranchesContainer extends React.Component<
         filterText={this.state.pullRequestFilterText}
         onFilterTextChanged={this.onPullRequestFilterTextChanged}
         onItemClick={this.onPullRequestClicked}
-        onShowPullRequest={this.onShowPullRequest}
         onDismiss={this.onDismiss}
         renderPostFilter={this.renderPullRequestPostFilter}
         dispatcher={this.props.dispatcher}
@@ -330,11 +329,6 @@ export class BranchesContainer extends React.Component<
   private onCreatePullRequest = () => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     this.props.dispatcher.createPullRequest(this.props.repository)
-  }
-
-  private onShowPullRequest = () => {
-    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
-    this.props.dispatcher.showPullRequest(this.props.repository)
   }
 
   private onPullRequestClicked = (pullRequest: PullRequest) => {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -80,17 +80,10 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
       )
     }
 
-    if (this.props.isOnDefaultBranch) {
-      return (
-        <div className="call-to-action">
-          Would you like to{' '}
-          <LinkButton onClick={this.props.onCreateBranch}>
-            create a new branch
-          </LinkButton>{' '}
-          and get going on your next project?
-        </div>
-      )
-    } else if (
+    // if there's a current pull request and
+    // there's an upstream github repo, we assume
+    // its an upstream pull request
+    if (
       this.props.selectedPullRequest !== null &&
       this.props.upstreamRepositoryName !== null &&
       this.props.upstreamPullRequestsUrl !== null
@@ -102,6 +95,16 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
           </LinkButton>
           {' for '}
           <strong>{this.props.upstreamRepositoryName}</strong> on GitHub
+        </div>
+      )
+    } else if (this.props.isOnDefaultBranch) {
+      return (
+        <div className="call-to-action">
+          Would you like to{' '}
+          <LinkButton onClick={this.props.onCreateBranch}>
+            create a new branch
+          </LinkButton>{' '}
+          and get going on your next project?
         </div>
       )
     } else {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -31,6 +31,9 @@ interface INoPullRequestsProps {
   /** Called when the user wants to create a pull request. */
   readonly onCreatePullRequest: () => void
 
+  /** Called when the user wants to view the current pull request. */
+  readonly onShowPullRequest: () => void
+
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 }
@@ -89,8 +92,11 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
     ) {
       return (
         <div className="call-to-action">
-          Would you like to <LinkButton>show your pull request</LinkButton> in{' '}
-          <strong>{this.props.upstreamRepositoryName}</strong>?
+          Would you like to{' '}
+          <LinkButton onClick={this.props.onShowPullRequest}>
+            show your pull request
+          </LinkButton>{' '}
+          in <strong>{this.props.upstreamRepositoryName}</strong>?
         </div>
       )
     } else {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -31,9 +31,6 @@ interface INoPullRequestsProps {
   /** Called when the user wants to create a pull request. */
   readonly onCreatePullRequest: () => void
 
-  /** Called when the user wants to view the current pull request. */
-  readonly onShowPullRequest: () => void
-
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
 }
@@ -92,11 +89,8 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
     ) {
       return (
         <div className="call-to-action">
-          Would you like to{' '}
-          <LinkButton onClick={this.props.onShowPullRequest}>
-            show your pull request
-          </LinkButton>{' '}
-          in <strong>{this.props.upstreamRepositoryName}</strong>?
+          Would you like to <LinkButton>show your pull request</LinkButton> in{' '}
+          <strong>{this.props.upstreamRepositoryName}</strong>?
         </div>
       )
     } else {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -13,8 +13,15 @@ interface INoPullRequestsProps {
   /** The name of the repository. */
   readonly repositoryName: string
 
-  /** The name of the GitHubRepository's parent, if it has one. */
+  /** The name of the GitHubRepository's parent.
+   * `null` if there is no parent.
+   */
   readonly upstreamRepositoryName: string | null
+
+  /** The URL of the GitHubRepository's parent's pull request list.
+   * `null` if there is no parent.
+   */
+  readonly upstreamPullRequestsUrl: string | null
 
   /** The currently selected pull request */
   readonly selectedPullRequest: PullRequest | null
@@ -85,12 +92,15 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
       )
     } else if (
       this.props.selectedPullRequest !== null &&
-      this.props.upstreamRepositoryName !== null
+      this.props.upstreamRepositoryName !== null &&
+      this.props.upstreamPullRequestsUrl !== null
     ) {
       return (
         <div className="call-to-action">
-          Would you like to <LinkButton>show your pull request</LinkButton> in{' '}
-          <strong>{this.props.upstreamRepositoryName}</strong>?
+          <LinkButton uri={this.props.upstreamPullRequestsUrl}>
+            View pull requests for{' '}
+            <strong>{this.props.upstreamRepositoryName}</strong> on GitHub
+          </LinkButton>
         </div>
       )
     } else {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -98,9 +98,10 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
       return (
         <div className="call-to-action">
           <LinkButton uri={this.props.upstreamPullRequestsUrl}>
-            View pull requests for{' '}
-            <strong>{this.props.upstreamRepositoryName}</strong> on GitHub
+            View pull requests
           </LinkButton>
+          {' for '}
+          <strong>{this.props.upstreamRepositoryName}</strong> on GitHub
         </div>
       )
     } else {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
+import { PullRequest } from '../../models/pull-request'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -11,6 +12,12 @@ const BlankSlateImage = encodePathAsUrl(
 interface INoPullRequestsProps {
   /** The name of the repository. */
   readonly repositoryName: string
+
+  /** The name of the GitHubRepository's parent, if it has one. */
+  readonly upstreamRepositoryName: string | null
+
+  /** The currently selected pull request */
+  readonly selectedPullRequest: PullRequest | null
 
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
@@ -74,6 +81,19 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
             create a new branch
           </LinkButton>{' '}
           and get going on your next project?
+        </div>
+      )
+    } else if (
+      this.props.selectedPullRequest !== null &&
+      this.props.upstreamRepositoryName !== null
+    ) {
+      return (
+        <div className="call-to-action">
+          Would you like to{' '}
+          <LinkButton>
+            show your pull request in {this.props.upstreamRepositoryName}
+          </LinkButton>
+          ?
         </div>
       )
     } else {

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -89,11 +89,8 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
     ) {
       return (
         <div className="call-to-action">
-          Would you like to{' '}
-          <LinkButton>
-            show your pull request in {this.props.upstreamRepositoryName}
-          </LinkButton>
-          ?
+          Would you like to <LinkButton>show your pull request</LinkButton> in{' '}
+          <strong>{this.props.upstreamRepositoryName}</strong>?
         </div>
       )
     } else {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -160,6 +160,12 @@ export class PullRequestList extends React.Component<
             ? this.props.repository.parent.fullName
             : null
         }
+        upstreamPullRequestsUrl={
+          this.props.repository.parent !== null &&
+          this.props.repository.parent.htmlURL !== null
+            ? `${this.props.repository.parent.htmlURL}/pulls`
+            : null
+        }
         selectedPullRequest={this.props.selectedPullRequest}
         isOnDefaultBranch={this.props.isOnDefaultBranch}
         onCreateBranch={this.props.onCreateBranch}

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -155,6 +155,12 @@ export class PullRequestList extends React.Component<
         isSearch={this.props.filterText.length > 0}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
         repositoryName={this.props.repositoryName}
+        upstreamRepositoryName={
+          this.props.repository.parent !== null
+            ? this.props.repository.parent.fullName
+            : null
+        }
+        selectedPullRequest={this.props.selectedPullRequest}
         isOnDefaultBranch={this.props.isOnDefaultBranch}
         onCreateBranch={this.props.onCreateBranch}
         onCreatePullRequest={this.props.onCreatePullRequest}

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -52,6 +52,9 @@ interface IPullRequestListProps {
   /** Called when the user opts to create a pull request */
   readonly onCreatePullRequest: () => void
 
+  /** Called when the user opts to view a pull request */
+  readonly onShowPullRequest: () => void
+
   /** Called to render content after the filter. */
   readonly renderPostFilter?: () => JSX.Element | null
 
@@ -164,6 +167,7 @@ export class PullRequestList extends React.Component<
         isOnDefaultBranch={this.props.isOnDefaultBranch}
         onCreateBranch={this.props.onCreateBranch}
         onCreatePullRequest={this.props.onCreatePullRequest}
+        onShowPullRequest={this.props.onShowPullRequest}
       />
     )
   }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -52,9 +52,6 @@ interface IPullRequestListProps {
   /** Called when the user opts to create a pull request */
   readonly onCreatePullRequest: () => void
 
-  /** Called when the user opts to view a pull request */
-  readonly onShowPullRequest: () => void
-
   /** Called to render content after the filter. */
   readonly renderPostFilter?: () => JSX.Element | null
 
@@ -167,7 +164,6 @@ export class PullRequestList extends React.Component<
         isOnDefaultBranch={this.props.isOnDefaultBranch}
         onCreateBranch={this.props.onCreateBranch}
         onCreatePullRequest={this.props.onCreatePullRequest}
-        onShowPullRequest={this.props.onShowPullRequest}
       />
     )
   }

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -174,5 +174,8 @@
 
   .call-to-action {
     font-size: var(--font-size-sm);
+    .link-button-component {
+      display: unset;
+    }
   }
 }


### PR DESCRIPTION
this is a revisiting of #8936 and #8937 

## Description

- adds a version of the PR list that includes a link to view the current PR online if its in an upstream repo
- the hope is that if someone sees the PR badge on the branch dropdown and they open the PR list looking for their PR, they'll see this link as a path forward
- its also worth nothing this is likely a temporary design while we work towards redesigning the PR list (cc @ampinsk)

### Screenshots

<img width="623" alt="Screen Shot 2020-01-23 at 1 12 24 PM" src="https://user-images.githubusercontent.com/964912/73024513-8e729a80-3de2-11ea-8fcc-09e1cb3ed502.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Link in Pull Request list to view the current pull request on GitHub

## Testing notes

1. Select a fork in desktop
2. Open a pull request from your current branch that targets the upstream repository (aka make a PR from a branch in `outofambit/desktop` to be merged into `desktop/desktop`)
3. See pr badge in branch dropdown button
4. Open branch list to PR tab and see new message
