### PR TITLE
Add Number Array Helpers for Local Storage

### DIFF
--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -87,3 +87,44 @@ export function getNumber(
 export function setNumber(key: string, value: number) {
   localStorage.setItem(key, value.toString())
 }
+
+/**
+ * Retrieve an array of `number` values from a given local
+ * storage entry, if found. The array will be empty if the
+ * key doesn't exist or if the values cannot be converted
+ * into numbers
+ *
+ * @param key local storage entry to read
+ */
+export function getNumberArray(key: string): ReadonlyArray<number> {
+  const numbersAsText = localStorage.getItem(key)
+  let values = new Array<number>()
+  if (numbersAsText !== null) {
+    try {
+      values = numbersAsText
+        .split(NumberArrayDelimiter)
+        .map(n => parseInt(n, 10))
+        .filter(n => !isNaN(n))
+    } catch {
+      // clear array, just in case
+      values.splice(-1)
+    }
+  }
+
+  return values
+}
+
+/**
+ * Set the provided key in local storage to a list of numeric values, or update the
+ * existing value if a key is already defined.
+ *
+ * Stores the string representation of the number, delimited.
+ *
+ * @param key local storage entry to update
+ * @param values the numbers to set
+ */
+export function setNumberArray(key: string, values: ReadonlyArray<number>) {
+  localStorage.setItem(key, values.join(NumberArrayDelimiter))
+}
+/** Default delimiter for stringifying and parsing arrays of numbers */
+const NumberArrayDelimiter = ','

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -103,7 +103,7 @@ export function getNumberArray(key: string): ReadonlyArray<number> {
     try {
       values = numbersAsText
         .split(NumberArrayDelimiter)
-        .map(n => parseFloat(n))
+        .map(parseFloat)
         .filter(n => !isNaN(n))
     } catch {
       // clear array, just in case

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -103,7 +103,7 @@ export function getNumberArray(key: string): ReadonlyArray<number> {
     try {
       values = numbersAsText
         .split(NumberArrayDelimiter)
-        .map(n => parseInt(n, 10))
+        .map(n => parseFloat(n))
         .filter(n => !isNaN(n))
     } catch {
       // clear array, just in case

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -97,21 +97,10 @@ export function setNumber(key: string, value: number) {
  * @param key local storage entry to read
  */
 export function getNumberArray(key: string): ReadonlyArray<number> {
-  const numbersAsText = localStorage.getItem(key)
-  let values = new Array<number>()
-  if (numbersAsText !== null) {
-    try {
-      values = numbersAsText
-        .split(NumberArrayDelimiter)
-        .map(parseFloat)
-        .filter(n => !isNaN(n))
-    } catch {
-      // clear array, just in case
-      values.splice(-1)
-    }
-  }
-
-  return values
+  return (localStorage.getItem(key) || '')
+    .split(NumberArrayDelimiter)
+    .map(parseFloat)
+    .filter(n => !isNaN(n))
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -201,7 +201,14 @@ import { RepositoryStateCache } from './repository-state-cache'
 import { readEmoji } from '../read-emoji'
 import { GitStoreCache } from './git-store-cache'
 import { GitErrorContext } from '../git-error-context'
-import { setNumber, setBoolean, getBoolean, getNumber } from '../local-storage'
+import {
+  setNumber,
+  setBoolean,
+  getBoolean,
+  getNumber,
+  getNumberArray,
+  setNumberArray,
+} from '../local-storage'
 import { ExternalEditorError } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
 import {
@@ -267,7 +274,6 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  *  in the repository switcher dropdown
  */
 const RecentRepositoriesLength = 3
-const RecentRepositoriesDelimiter = ','
 
 const defaultSidebarWidth: number = 250
 const sidebarWidthConfigKey: string = 'sidebar-width'
@@ -1481,7 +1487,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     previousRepositoryId: number | null,
     currentRepositoryId: number
   ) {
-    const recentRepositories = this.getStoredRecentRepositories().filter(
+    const recentRepositories = getNumberArray(RecentRepositoriesKey).filter(
       el => el !== currentRepositoryId && el !== previousRepositoryId
     )
     if (previousRepositoryId !== null) {
@@ -1491,28 +1497,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       0,
       RecentRepositoriesLength
     )
-    localStorage.setItem(
-      RecentRepositoriesKey,
-      slicedRecentRepositories.join(RecentRepositoriesDelimiter)
-    )
+    setNumberArray(RecentRepositoriesKey, slicedRecentRepositories)
     this.recentRepositories = slicedRecentRepositories
     this.emitUpdate()
-  }
-
-  private getStoredRecentRepositories() {
-    const storedIds = localStorage.getItem(RecentRepositoriesKey)
-    let storedRepositories: Array<number> = []
-    if (storedIds) {
-      try {
-        storedRepositories = storedIds
-          .split(RecentRepositoriesDelimiter)
-          .map(n => parseInt(n, 10))
-          .filter(n => !isNaN(n))
-      } catch {
-        storedRepositories = []
-      }
-    }
-    return storedRepositories
   }
 
   // finish `_selectRepository`s refresh tasks


### PR DESCRIPTION
supports #8971 

## Description

- extracts some logic written for storing recent repositories as a list of numbers in Local Storage into helpers so we can use them elsewhere in the codebase (like #8980)
