### PR TITLE
[Forks] Metrics, Part 1

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -329,6 +329,18 @@ export interface IDailyMeasures {
    * (`0` is tutorial created, first step is `1`)
    */
   readonly highestTutorialStepCompleted: number
+
+  /**
+   * _[Forks]_
+   * How many commits did the user make in a repo they
+   * don't have `write` access to?
+   */
+  readonly commitsInRepositoryWithoutWriteAccess: number
+
+  /** _[Forks]_
+   * How many forks did the user create from Desktop?
+   */
+  readonly forksCreated: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -335,7 +335,7 @@ export interface IDailyMeasures {
    * How many commits did the user make in a repo they
    * don't have `write` access to?
    */
-  readonly commitsInRepositoryWithoutWriteAccess: number
+  readonly commitsToRepositoryWithoutWriteAccess: number
 
   /** _[Forks]_
    * How many forks did the user create from Desktop?

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -123,6 +123,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tutorialCompleted: false,
   // this is `-1` because `0` signifies "tutorial created"
   highestTutorialStepCompleted: -1,
+  commitsInRepositoryWithoutWriteAccess: 0,
+  forksCreated: 0,
 }
 
 interface IOnboardingStats {
@@ -1274,6 +1276,19 @@ export class StatsStore implements IStatsStore {
         step,
         m.highestTutorialStepCompleted
       ),
+    }))
+  }
+
+  public recordCommitInRepositoryWithoutWriteAccess() {
+    return this.updateDailyMeasures(m => ({
+      commitsInRepositoryWithoutWriteAccess:
+        m.commitsInRepositoryWithoutWriteAccess + 1,
+    }))
+  }
+
+  public recordForkCreated() {
+    return this.updateDailyMeasures(m => ({
+      forksCreated: m.forksCreated + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1281,7 +1281,7 @@ export class StatsStore implements IStatsStore {
 
   public recordCommitInRepositoryWithoutWriteAccess() {
     return this.updateDailyMeasures(m => ({
-      commitsInRepositoryWithoutWriteAccess:
+      commitsToRepositoryWithoutWriteAccess:
         m.commitsInRepositoryWithoutWriteAccess + 1,
     }))
   }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -123,7 +123,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tutorialCompleted: false,
   // this is `-1` because `0` signifies "tutorial created"
   highestTutorialStepCompleted: -1,
-  commitsInRepositoryWithoutWriteAccess: 0,
+  commitsToRepositoryWithoutWriteAccess: 0,
   forksCreated: 0,
 }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1282,7 +1282,7 @@ export class StatsStore implements IStatsStore {
   public recordCommitInRepositoryWithoutWriteAccess() {
     return this.updateDailyMeasures(m => ({
       commitsToRepositoryWithoutWriteAccess:
-        m.commitsInRepositoryWithoutWriteAccess + 1,
+        m.commitsToRepositoryWithoutWriteAccess + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1279,7 +1279,7 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  public recordCommitInRepositoryWithoutWriteAccess() {
+  public recordCommitToRepositoryWithoutWriteAccess() {
     return this.updateDailyMeasures(m => ({
       commitsToRepositoryWithoutWriteAccess:
         m.commitsToRepositoryWithoutWriteAccess + 1,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2549,7 +2549,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           repository.gitHubRepository !== null &&
           !hasWritePermission(repository.gitHubRepository)
         ) {
-          this.statsStore.recordCommitInRepositoryWithoutWriteAccess()
+          this.statsStore.recordCommitToRepositoryWithoutWriteAccess()
         }
       }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2544,6 +2544,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
             }
           }
         }
+
+        if (
+          repository.gitHubRepository !== null &&
+          !hasWritePermission(repository.gitHubRepository)
+        ) {
+          this.statsStore.recordCommitInRepositoryWithoutWriteAccess()
+        }
       }
 
       await this._refreshRepository(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2245,7 +2245,9 @@ export class Dispatcher {
   }
 
   /**
-   * Fork created
+   * Increments the `forksCreated ` metric` indicating that the user has
+   * elected to create a fork when presented with a dialog informing
+   * them that they don't have write access to the current repository.
    */
   public recordForkCreated() {
     return this.statsStore.recordForkCreated()

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2243,4 +2243,11 @@ export class Dispatcher {
   public recordTutorialRepoCreated() {
     return this.statsStore.recordTutorialRepoCreated()
   }
+
+  /**
+   * Fork created
+   */
+  public recordForkCreated() {
+    return this.statsStore.recordForkCreated()
+  }
 }

--- a/app/src/ui/forks/create-fork-dialog.tsx
+++ b/app/src/ui/forks/create-fork-dialog.tsx
@@ -48,6 +48,7 @@ export class CreateForkDialog extends React.Component<
         gitHubRepository.owner.login,
         gitHubRepository.name
       )
+      this.props.dispatcher.recordForkCreated()
       await this.props.dispatcher.convertRepositoryToFork(
         this.props.repository,
         fork


### PR DESCRIPTION
first part of #8971 

## Description

Instruments two new metrics:

- `commitsInRepositoryWithoutWriteAccess` - How many commits did the user make in a repo they don't have `write` access to?
- `forksCreated` - How many forks did the user create from Desktop?