### PR TITLE
[Forks] Metrics, Part 2

### DIFF
--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -87,3 +87,44 @@ export function getNumber(
 export function setNumber(key: string, value: number) {
   localStorage.setItem(key, value.toString())
 }
+
+/**
+ * Retrieve an array of `number` values from a given local
+ * storage entry, if found. The array will be empty if the
+ * key doesn't exist or if the values cannot be converted
+ * into numbers
+ *
+ * @param key local storage entry to read
+ */
+export function getNumberArray(key: string): ReadonlyArray<number> {
+  const numbersAsText = localStorage.getItem(key)
+  let values = new Array<number>()
+  if (numbersAsText !== null) {
+    try {
+      values = numbersAsText
+        .split(NumberArrayDelimiter)
+        .map(n => parseInt(n, 10))
+        .filter(n => !isNaN(n))
+    } catch {
+      // clear array, just in case
+      values.splice(-1)
+    }
+  }
+
+  return values
+}
+
+/**
+ * Set the provided key in local storage to a list of numeric values, or update the
+ * existing value if a key is already defined.
+ *
+ * Stores the string representation of the number, delimited.
+ *
+ * @param key local storage entry to update
+ * @param values the numbers to set
+ */
+export function setNumberArray(key: string, values: ReadonlyArray<number>) {
+  localStorage.setItem(key, values.join(NumberArrayDelimiter))
+}
+/** Default delimiter for stringifying and parsing arrays of numbers */
+const NumberArrayDelimiter = ','

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -414,6 +414,8 @@ export class StatsStore implements IStatsStore {
     await this.db.launches.clear()
     await this.db.dailyMeasures.clear()
 
+    localStorage.removeItem(RepositoriesCommittedInWithoutWriteAccessKey)
+
     this.enableUiActivityMonitoring()
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1315,6 +1315,13 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /**
+   * Record that the user made a commit in a repository they don't
+   * have `write` access to. Dedupes based on the database ID provided
+   *
+   * @param gitHubRepositoryDbId database ID for the GitHubRepository of
+   *                             the local repo this commit was made in
+   */
   public recordRepositoryCommitedInWithoutWriteAccess(
     gitHubRepositoryDbId: number
   ) {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -296,6 +296,10 @@ interface ICalculatedStats {
   /**
    * _[Forks]_
    * How many repos did the user commit in without having `write` access?
+   *
+   * This is a hack in that its really a "computed daily measure" and the
+   * moment we have another one of those we should consider refactoring
+   * them into their own interface
    */
   readonly repositoriesCommittedInWithoutWriteAccess: number
 }
@@ -414,6 +418,9 @@ export class StatsStore implements IStatsStore {
     await this.db.launches.clear()
     await this.db.dailyMeasures.clear()
 
+    // This is a one-off, and the moment we have another
+    // computed daily measure we should consider refactoring
+    // them into their own interface
     localStorage.removeItem(RepositoriesCommittedInWithoutWriteAccessKey)
 
     this.enableUiActivityMonitoring()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2537,6 +2537,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
           !hasWritePermission(repository.gitHubRepository)
         ) {
           this.statsStore.recordCommitInRepositoryWithoutWriteAccess()
+          if (repository.gitHubRepository.dbID !== null) {
+            this.statsStore.recordRepositoryCommitedInWithoutWriteAccess(
+              repository.gitHubRepository.dbID
+            )
+          }
         }
       }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -201,7 +201,14 @@ import { RepositoryStateCache } from './repository-state-cache'
 import { readEmoji } from '../read-emoji'
 import { GitStoreCache } from './git-store-cache'
 import { GitErrorContext } from '../git-error-context'
-import { setNumber, setBoolean, getBoolean, getNumber } from '../local-storage'
+import {
+  setNumber,
+  setBoolean,
+  getBoolean,
+  getNumber,
+  getNumberArray,
+  setNumberArray,
+} from '../local-storage'
 import { ExternalEditorError } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
 import {
@@ -267,7 +274,6 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  *  in the repository switcher dropdown
  */
 const RecentRepositoriesLength = 3
-const RecentRepositoriesDelimiter = ','
 
 const defaultSidebarWidth: number = 250
 const sidebarWidthConfigKey: string = 'sidebar-width'
@@ -1481,7 +1487,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     previousRepositoryId: number | null,
     currentRepositoryId: number
   ) {
-    const recentRepositories = this.getStoredRecentRepositories().filter(
+    const recentRepositories = getNumberArray(RecentRepositoriesKey).filter(
       el => el !== currentRepositoryId && el !== previousRepositoryId
     )
     if (previousRepositoryId !== null) {
@@ -1491,28 +1497,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       0,
       RecentRepositoriesLength
     )
-    localStorage.setItem(
-      RecentRepositoriesKey,
-      slicedRecentRepositories.join(RecentRepositoriesDelimiter)
-    )
+    setNumberArray(RecentRepositoriesKey, slicedRecentRepositories)
     this.recentRepositories = slicedRecentRepositories
     this.emitUpdate()
-  }
-
-  private getStoredRecentRepositories() {
-    const storedIds = localStorage.getItem(RecentRepositoriesKey)
-    let storedRepositories: Array<number> = []
-    if (storedIds) {
-      try {
-        storedRepositories = storedIds
-          .split(RecentRepositoriesDelimiter)
-          .map(n => parseInt(n, 10))
-          .filter(n => !isNaN(n))
-      } catch {
-        storedRepositories = []
-      }
-    }
-    return storedRepositories
   }
 
   // finish `_selectRepository`s refresh tasks


### PR DESCRIPTION
🌵 🌵 **review after #8979 #8978 please, it depends on them!** 🌵 🌵

Closes #8971 

## Description

Adds this metric:
- `repositoriesCommittedInWithoutWriteAccess` - How many repos did the user commit in without having `write` access?

Unique repositories is important for this measure We don't want to count the same repository twice in a metrics reporting period (every 24 hours). So, this uses the database ID of the GitHubRepository for each commit to see if this repository has been counted before. (we store them in local storage and clear it out when we report the measure). This is far from perfect but it should be relatively stable unless the user is removing and then re-adding a lot repos from desktop with in a 24 hour period.
