### PR TITLE
Changed "make a fork" verbiage to "create a fork"

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -464,8 +464,8 @@ export class CommitMessage extends React.Component<
       return (
         <PermissionsCommitWarning>
           You don't have write access to <strong>{repository.name}</strong>.
-          Want to <LinkButton onClick={this.onMakeFork}>make a fork</LinkButton>
-          ?
+          Want to{' '}
+          <LinkButton onClick={this.onMakeFork}>create a fork</LinkButton>?
         </PermissionsCommitWarning>
       )
     } else if (showBranchProtected) {

--- a/app/src/ui/forks/create-fork-dialog.tsx
+++ b/app/src/ui/forks/create-fork-dialog.tsx
@@ -26,7 +26,7 @@ interface ICreateForkDialogState {
 }
 
 /**
- * Dialog offering to make a fork of the given repository
+ * Dialog offering to create a fork of the given repository
  */
 export class CreateForkDialog extends React.Component<
   ICreateForkDialogProps,
@@ -101,7 +101,7 @@ function renderCreateForkDialogContent(
       <DialogContent>
         {`It looks like you don’t have write access to `}
         <strong>{repository.gitHubRepository.fullName}</strong>
-        {`. Do you want to make a fork of this repository at `}
+        {`. Do you want to create a fork of this repository at `}
         <strong>
           {`${account.login}/${repository.gitHubRepository.name}`}
         </strong>
@@ -143,7 +143,7 @@ function renderCreateForkDialogError(
     <>
       <DialogContent>
         <div>
-          {`Making your fork `}
+          {`Creating your fork `}
           <strong>
             {`${account.login}/${repository.gitHubRepository.name}`}
           </strong>


### PR DESCRIPTION
As I was doing some final QA on 2.3, I noticed that we're using "make a fork" for the fork language. We use "create" in several places across the repo and it seems more consistent and well understood to use it here as well.

This is fine to be a follow on PR from 2.3 and just go out whenever the next prod release goes out.

Release notes: No notes
