### PR TITLE
Explicitly configure TERM env var to skirt around Git progress issue on Windows

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -125,7 +125,7 @@ export async function git(
 
   const opts = { ...defaultOptions, ...options }
 
-  // Explicitly unset TERM so that if Desktop was launched
+  // Explicitly set TERM to 'dumb' so that if Desktop was launched
   // from a terminal or if the system environment variables
   // have TERM set Git won't consider us as a smart terminal.
   // See https://github.com/git/git/blob/a7312d1a2/editor.c#L11-L15

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -129,7 +129,7 @@ export async function git(
   // from a terminal or if the system environment variables
   // have TERM set Git won't consider us as a smart terminal.
   // See https://github.com/git/git/blob/a7312d1a2/editor.c#L11-L15
-  opts.env = { TERM: undefined, ...opts.env }
+  opts.env = { TERM: 'dumb', ...opts.env }
 
   const commandName = `${name}: git ${args.join(' ')}`
 


### PR DESCRIPTION
On Windows we apparently have to explicitly set `TERM` to `dumb` for the [`is_terminal_dumb`](https://github.com/git/git/blob/a7312d1a28ff3ab0a5a5427b35f01d943103cba8/editor.c#L11-L15) check to return true. See https://github.com/desktop/desktop/pull/8962

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

On Windows we have to explicitly set it to 'dumb' for the is_terminal_dumb check to return true. See #8962 for the background

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="714" alt="screen_shot_2020-01-29_at_11 37 08_am" src="https://user-images.githubusercontent.com/634063/73381483-1f0b1800-42c6-11ea-9493-325d4c47da3f.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Inaccurate Git Progress parsing on Window