### PR TITLE
Race condition in re-entrant checkoutBranch can cause stash and move operations to fail silently

### DIFF
--- a/app/src/lib/git-error-context.ts
+++ b/app/src/lib/git-error-context.ts
@@ -1,3 +1,5 @@
+import { Branch } from '../models/branch'
+
 type MergeOrPullConflictsErrorContext = {
   /** The Git operation that triggered the conflicted state */
   readonly kind: 'merge' | 'pull'
@@ -13,7 +15,7 @@ type CheckoutBranchErrorContext = {
   readonly kind: 'checkout'
 
   /** The branch associated with the current tip of the repository, "ours" in Git terminology */
-  readonly branchToCheckout: string
+  readonly branchToCheckout: Branch
 }
 
 /** A custom shape of data for actions to provide to help with error handling */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5246,22 +5246,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
 
-      const gitStore = this.gitStoreCache.get(repository)
-
       const localBranchName = `pr/${pullRequest.pullRequestNumber}`
-      const doesBranchExist =
-        gitStore.allBranches.find(branch => branch.name === localBranchName) !=
-        null
+      const existingBranch = this.getLocalBranch(repository, localBranchName)
 
-      if (!doesBranchExist) {
+      if (existingBranch === null) {
         await this._createBranch(
           repository,
           localBranchName,
           `${remoteName}/${head.ref}`
         )
+      } else {
+        await this._checkoutBranch(repository, existingBranch)
       }
-
-      await this._checkoutBranch(repository, localBranchName)
     }
 
     this.statsStore.recordPRBranchCheckout()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5212,6 +5212,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
         }
       }
       const branch = this.getLocalBranch(repository, head.ref)
+
+      // N.B: This looks weird, and it is. _checkoutBranch used
+      // to behave this way (silently ignoring checkout) when given
+      // a string and not a Branch model. When rewriting _checkoutBranch
+      // to remove the support for string branch names the behavior
+      // was moved up to this method to not alter the current behavior.
+      //
+      // https://youtu.be/IjmtVKOAHPM
       if (branch !== null) {
         await this._checkoutBranch(repository, branch)
       }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3089,7 +3089,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             },
             gitContext: {
               kind: 'checkout',
-              branchToCheckout: foundBranch.name,
+              branchToCheckout: foundBranch,
             },
           }
         )
@@ -5426,7 +5426,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _moveChangesToBranchAndCheckout(
     repository: Repository,
-    branchToCheckout: string
+    branchToCheckout: Branch
   ) {
     if (!enableStashing()) {
       return
@@ -5439,7 +5439,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const isStashCreated = await gitStore.performFailableOperation(() => {
       return createDesktopStashEntry(
         repository,
-        branchToCheckout,
+        branchToCheckout.name,
         getUntrackedFiles(workingDirectory)
       )
     })
@@ -5450,7 +5450,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const transientStashEntry = await getLastDesktopStashEntryForBranch(
       repository,
-      branchToCheckout
+      branchToCheckout.name
     )
     const strategy: UncommittedChangesStrategy = {
       kind: UncommittedChangesStrategyKind.MoveToNewBranch,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5219,7 +5219,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
           )
         }
       }
-      await this._checkoutBranch(repository, head.ref)
+      const branch = this.getLocalBranch(repository, head.ref)
+      if (branch !== null) {
+        await this._checkoutBranch(repository, branch)
+      }
     } else {
       const cloneURL = forceUnwrap(
         "This pull request's clone URL is not populated but should be",

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5215,7 +5215,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       // N.B: This looks weird, and it is. _checkoutBranch used
       // to behave this way (silently ignoring checkout) when given
-      // a string and not a Branch model. When rewriting _checkoutBranch
+      // a branch name string that does not correspond to a local branch
+      // in the git store. When rewriting _checkoutBranch
       // to remove the support for string branch names the behavior
       // was moved up to this method to not alter the current behavior.
       //

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -25,5 +25,5 @@ export type RetryAction =
   | {
       type: RetryActionType.Checkout
       repository: Repository
-      branch: Branch | string
+      branch: Branch
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -486,7 +486,7 @@ export class Dispatcher {
   /** Check out the given branch. */
   public checkoutBranch(
     repository: Repository,
-    branch: Branch | string,
+    branch: Branch,
     uncommittedChangesStrategy?: UncommittedChangesStrategy
   ): Promise<Repository> {
     return this.appStore._checkoutBranch(
@@ -1532,10 +1532,9 @@ export class Dispatcher {
     await this.appStore._refreshRepository(repository)
 
     const state = this.repositoryStateManager.get(repository)
+    const branches = state.branchesState.allBranches
 
     if (pr == null && branch != null) {
-      const branches = state.branchesState.allBranches
-
       // I don't want to invoke Git functionality from the dispatcher, which
       // would help by using getDefaultRemote here to get the definitive ref,
       // so this falls back to finding any remote branch matching the name
@@ -1557,8 +1556,10 @@ export class Dispatcher {
         shouldCheckoutBranch = tip.branch.nameWithoutRemote !== branch
       }
 
-      if (shouldCheckoutBranch) {
-        await this.checkoutBranch(repository, branch)
+      const localBranch = branches.find(b => b.upstreamWithoutRemote === branch)
+
+      if (shouldCheckoutBranch && localBranch !== undefined) {
+        await this.checkoutBranch(repository, localBranch)
       }
     }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2195,7 +2195,7 @@ export class Dispatcher {
    */
   public async moveChangesToBranchAndCheckout(
     repository: Repository,
-    branchToCheckout: string
+    branchToCheckout: Branch
   ) {
     return this.appStore._moveChangesToBranchAndCheckout(
       repository,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1558,6 +1558,13 @@ export class Dispatcher {
 
       const localBranch = branches.find(b => b.upstreamWithoutRemote === branch)
 
+      // N.B: This looks weird, and it is. _checkoutBranch used
+      // to behave this way (silently ignoring checkout) when given
+      // a string and not a Branch model. When rewriting _checkoutBranch
+      // to remove the support for string branch names the behavior
+      // was moved up to this method to not alter the current behavior.
+      //
+      // https://youtu.be/IjmtVKOAHPM
       if (shouldCheckoutBranch && localBranch !== undefined) {
         await this.checkoutBranch(repository, localBranch)
       }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1560,7 +1560,8 @@ export class Dispatcher {
 
       // N.B: This looks weird, and it is. _checkoutBranch used
       // to behave this way (silently ignoring checkout) when given
-      // a string and not a Branch model. When rewriting _checkoutBranch
+      // a branch name string that does not correspond to a local branch
+      // in the git store. When rewriting _checkoutBranch
       // to remove the support for string branch names the behavior
       // was moved up to this method to not alter the current behavior.
       //


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I stumbled upon this today as I was creating a new branch and wanted to bring along some changes I had made. After typing in the new branch name and choosing to bring along changes I was left on the branch I started on. The new branch had been created and the stash had been created for it but Desktop hadn't switched to the new branch or popped the transient stash entry.

In digging through this I discovered that this is due to a race condition due to the re-entrant nature of `_checkoutBranch`. I've been able to consistently reproduce this recently and I was able to narrow it down to the recent Git/dugite upgrade (#8920). I can't see any reason why the dugite upgrade should affect this behavior so I'm forced to assume that thanks to the performance improvements in Git 2.23 (which I've been able to measure) this race condition is easier to trigger on my machine.

In order to reproduce we need to engineer a scenario where https://github.com/desktop/desktop/pull/7474 comes into play. I.e. the initial checkout fails because it can't cleanly checkout the branch without overwriting local changes. See the "Steps to reproduce" section below for details on how I chose to do that.

The flow goes something like this.

1. The branch is created by `_createBranch` which returns a **branch model** (this will be important later on) that's created by shelling out to Git (i.e. the Git store is not updated).
1. `_checkoutBranch` is called with `UncommittedChangesStrategyKind.MoveToNewBranch` and a **branch model**
1. `_checkoutBranch` attempts to  checkout the branch which fails since it would overwrite local changes
https://github.com/desktop/desktop/blob/df6772f01029bb659cc31815fa19643476a8e121/app/src/lib/stores/app-store.ts#L3076-L3096
1. The `performFailableOperation` from :point_up: catches the `DugiteError.LocalChangesOverwritten` and emits that error and attaches the **branch name** (important) as extra metadata
1. The `localChangesOverwrittenHandler` error handler catches this specific error and calls the `_moveChangesToBranchAndCheckout` method with the **branch name** that it wants to checkout
https://github.com/desktop/desktop/blob/df6772f01029bb659cc31815fa19643476a8e121/app/src/ui/dispatcher/error-handlers.ts#L475
1. We eventually make it back into the `_checkoutBranch` method where this 👇 hack takes the **branch name** and attempts to resolve it to a **branch model**
https://github.com/desktop/desktop/blob/df6772f01029bb659cc31815fa19643476a8e121/app/src/lib/stores/app-store.ts#L3042-L3049
1. Whether or not it's able to resolve that branch model depends entirely on whether the original `checkoutBranch` method has had time to refresh the repository state since the `getLocalBranch` method depends on the cached branch state in the repository state cache.

### The real solution

I was never a big fan of the re-entrant error-handler approach as can be seen in my [comment from the initial PR](https://github.com/desktop/desktop/pull/7474#discussion_r286883784) and I think the best solution would be to move this logic inline instead of relying on an error handler.

We filed https://github.com/desktop/desktop/issues/7617 to track implementing an inline logic approach and it turns out @probablycorey already did most of the work in https://github.com/desktop/desktop/pull/8076 but it was ultimately closed. I think we should resurrect that work and bring it over the finish line. That's a decently sized chunk of work though which is why I'm opening this intermediate PR as a stop-gap measure.

### The intermediate solution

This PR doesn't implement the nice solution that I'm proposing in the previous section but rather plugs this hole by passing along the same branch model that was returned from `_createBranch` all the way through the error handler and back and removes the ability to call `_checkoutBranch` with a branch name.

### Testing

#### Steps to reproduce

1. Create a new repository
2. Create, and commit, a file `README.txt` with some random contents in it
3. Create a new branch `branch-a` make some changes to `README.txt`, and commit them
4. Switch back to `master` and make some conflicting changes to `README.txt`
5. Switch back to `branch-a`
6. Make some changes to `README.txt` but **don't** commit them.
7. From within desktop choose to create a new branch based on `master`, call it `branch-b`. When asked if you want to bring your changes with you say yes

#### Expected result

`branch-b` is checked out and one conflicted file (`README.txt`) exists in your working directory

#### Actual result (sometimes, since this is a race condition)

`branch-a` is still checked out and you have no changes in your working directory. If you switch to `branch-b` the stashed changes show up.

#### Demo

![2020-02-03 18-50-01 2020-02-03 18_50_23](https://user-images.githubusercontent.com/634063/73677205-0e87e280-46b6-11ea-880f-938aeb52e831.gif)

