### PR TITLE
Revamp draft release task

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@types/mini-css-extract-plugin": "^0.2.0",
     "@types/mri": "^1.1.0",
     "@types/node": "10.12.18",
+    "@types/prettier": "^1.19.0",
     "@types/react": "^16.3.16",
     "@types/react-css-transition-replace": "^2.1.3",
     "@types/react-dom": "^16.0.5",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "jest-extended": "^0.11.2",
     "jest-junit": "^5.0.0",
     "jest-localstorage-mock": "^2.3.0",
-    "json-pretty": "^0.0.1",
     "klaw-sync": "^3.0.0",
     "legal-eagle": "0.16.0",
     "mini-css-extract-plugin": "^0.4.0",

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -62,24 +62,27 @@ function parseChannel(arg: string): Channel {
  * @param entries release notes for the next release
  */
 function printInstructions(nextVersion: string, entries: Array<string>) {
-  const object: any = {}
-  object[nextVersion] = entries.sort()
-
   const baseSteps = [
     'Revise the release notes according to https://github.com/desktop/desktop/blob/development/docs/process/writing-release-notes.md',
+    'Lint them with: yarn draft-release:format',
     'Commit these changes (on a "release" branch) and push them to GitHub',
     'Read this to perform the release: https://github.com/desktop/desktop/blob/development/docs/process/releasing-updates.md',
   ]
   if (entries.length === 0) {
     printSteps(baseSteps)
   } else {
-    printSteps([
+    const object: any = {}
+    object[nextVersion] = entries.sort()
+    const steps = [
       `Concatenate this to the beginning of the 'releases' element in the changelog.json as a starting point:\n${format(
         JSON.stringify(object),
-        { parser: 'json' }
+        {
+          parser: 'json',
+        }
       )}\n`,
       ...baseSteps,
-    ])
+    ]
+    printSteps(steps)
   }
 }
 
@@ -104,6 +107,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
   const noChangesFound = lines.every(l => l.trim().length === 0)
 
   if (noChangesFound) {
+    console.warn('No new changes found to add to the changelog.')
     // print instructions with no changelog included
     printInstructions(nextVersion, [])
     return

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -175,6 +175,5 @@ function makeNewChangelog(
 ) {
   const newChangelogEntries: any = {}
   newChangelogEntries[nextVersion] = entries
-
   return { releases: { ...newChangelogEntries, ...currentChangelogEntries } }
 }

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -92,6 +92,7 @@ function printInstructions(nextVersion: string, entries: Array<string>) {
  * adds a number to the beginning fo each line and prints them in sequence
  */
 function printSteps(steps: ReadonlyArray<string>) {
+  console.log("Here's what you should do next:\n")
   console.log(steps.map((value, index) => `${index + 1}. ${value}`).join('\n'))
 }
 
@@ -167,8 +168,6 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
 
     printInstructions(nextVersion, newEntries)
   }
-
-  console.log("Here's what you should do next:\n")
 }
 
 /**

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -133,11 +133,12 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
   }
 
   const currentChangelog = require(changelogPath)
-  const newEntries = await makeNewChangelogEntries(
-    previousVersion,
-    channel,
-    lines
-  )
+  // if it's a new production release, make sure we only include
+  // entries since the latest production release
+  const newEntries =
+    channel === 'production'
+      ? [...getChangelogEntriesSince(previousVersion)]
+      : [...(await convertToChangelogFormat(lines))]
 
   if (currentChangelog.releases[nextVersion] === undefined) {
     console.log('Adding draft release notes to changelog.json...')
@@ -168,24 +169,6 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
   }
 
   console.log("Here's what you should do next:\n")
-}
-
-/**
- * Formats git log lines into our changelog format,
- *
- * @param previousVersion last version released
- * @param channel the release channel ('production' or something else)
- * @param lines git log entries (from `getLogLines`)
- */
-async function makeNewChangelogEntries(
-  previousVersion: string,
-  channel: string,
-  lines: ReadonlyArray<string>
-) {
-  const changelogEntries = await convertToChangelogFormat(lines)
-  return channel === 'production'
-    ? [...getChangelogEntriesSince(previousVersion)]
-    : [...changelogEntries]
 }
 
 /**

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -66,11 +66,8 @@ function printInstructions(nextVersion: string, entries: Array<string>) {
   object[nextVersion] = entries.sort()
 
   const baseSteps = [
-    `Remove any entries of contributions that don't affect the end user`,
-    'Update the release notes to have user-friendly summary lines',
-    'For issues prefixed with [???], look at the PR to update the prefix to one of: [New], [Added], [Fixed], [Improved], [Removed]',
-    'Sort the entries so that the prefixes are ordered in this way: [New], [Added], [Fixed], [Improved], [Removed]',
-    'Commit the changes (on a "release" branch) and push them to GitHub',
+    'Revise the release notes according to https://github.com/desktop/desktop/blob/development/docs/process/writing-release-notes.md',
+    'Commit these changes (on a "release" branch) and push them to GitHub',
     'Read this to perform the release: https://github.com/desktop/desktop/blob/development/docs/process/releasing-updates.md',
   ]
   if (entries.length === 0) {

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -13,10 +13,9 @@ import { execSync } from 'child_process'
 
 import { writeFileSync } from 'fs'
 import { join } from 'path'
+import { format } from 'prettier'
 
 const changelogPath = join(__dirname, '..', '..', 'changelog.json')
-
-const jsonStringify: (obj: any) => string = require('json-pretty')
 
 /**
  * Returns the latest release tag, according to git and semver
@@ -66,16 +65,29 @@ function printInstructions(nextVersion: string, entries: Array<string>) {
   const object: any = {}
   object[nextVersion] = entries.sort()
 
-  const steps = [
-    `Update the app/package.json 'version' to '${nextVersion}' (make sure this aligns with semver format of 'major.minor.patch')`,
-    `Concatenate this to the beginning of the 'releases' element in the changelog.json as a starting point:\n${jsonStringify(
-      object
-    )}\n`,
-    'Revise the release notes according to https://github.com/desktop/desktop/blob/development/docs/process/writing-release-notes.md',
-    'Commit the changes (on development or as new branch) and push them to GitHub',
+  const baseSteps = [
+    `Remove any entries of contributions that don't affect the end user`,
+    'Update the release notes to have user-friendly summary lines',
+    'For issues prefixed with [???], look at the PR to update the prefix to one of: [New], [Added], [Fixed], [Improved], [Removed]',
+    'Sort the entries so that the prefixes are ordered in this way: [New], [Added], [Fixed], [Improved], [Removed]',
+    'Commit the changes (on a "release" branch) and push them to GitHub',
     'Read this to perform the release: https://github.com/desktop/desktop/blob/development/docs/process/releasing-updates.md',
   ]
+  if (entries.length === 0) {
+    printSteps(baseSteps)
+  } else {
+    printSteps([
+      `Concatenate this to the beginning of the 'releases' element in the changelog.json as a starting point:\n${format(
+        JSON.stringify(object),
+        { parser: 'json' }
+      )}\n`,
+      ...baseSteps,
+    ])
+  }
+}
 
+// adds a number to the beginning fo each line and prints them in sequence
+function printSteps(steps: ReadonlyArray<string>) {
   console.log(steps.map((value, index) => `${index + 1}. ${value}`).join('\n'))
 }
 
@@ -97,34 +109,66 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
   if (noChangesFound) {
     // print instructions with no changelog included
     printInstructions(nextVersion, [])
+    return
+  }
+  console.log(`Setting app version to "${nextVersion}" in app/package.json...`)
+  // this can throw and that's okay!
+  execSync(`npm version ${nextVersion} --allow-same-version`, {
+    cwd: join(__dirname, '..', '..', 'app'),
+    encoding: 'utf8',
+  })
+  console.log(`Set!`)
+
+  const currentChangelog = require(changelogPath)
+  const newEntries = await getNewEntries(previousVersion, channel, lines)
+
+  if (currentChangelog.releases[nextVersion] === undefined) {
+    console.log('Adding draft release notes to changelog.json...')
+    const changelog = makeNewChangelog(
+      nextVersion,
+      currentChangelog,
+      newEntries
+    )
+    // this might throw and that's ok (for now!)
+    writeFileSync(
+      changelogPath,
+      format(JSON.stringify(changelog), {
+        parser: 'json',
+      })
+    )
+    printInstructions(nextVersion, [])
   } else {
     console.log(
-      `Setting app version to "${nextVersion}" in app/package.json...`
+      `Looks like there are already release notes for ${nextVersion} in changelog.json.`
     )
-    // this can throw and that's okay!
-    execSync(`npm version ${nextVersion}`, {
-      cwd: 'app',
-      encoding: 'utf8',
-    })
-    console.log(`Set!`)
 
-    const changelogEntries = await convertToChangelogFormat(lines)
-    const changelog = require(changelogPath)
-    changelog.releases[nextVersion] = changelogEntries
-
-    // this might throw and that's ok (for now!)
-    writeFileSync(changelogPath, jsonStringify(changelog))
-
-    console.log("Here's what you should do next:\n")
-
-    if (channel === 'production') {
-      // make sure we only include entries since the latest production release
-      const existingChangelog = getChangelogEntriesSince(previousVersion)
-      const entries = [...existingChangelog]
-      printInstructions(nextVersion, entries)
-    } else if (channel === 'beta') {
-      const entries = [...changelogEntries]
-      printInstructions(nextVersion, entries)
-    }
+    printInstructions(nextVersion, newEntries)
   }
+
+  console.log("Here's what you should do next:\n")
+}
+
+async function getNewEntries(
+  previousVersion: string,
+  channel: string,
+  lines: ReadonlyArray<string>
+) {
+  const changelogEntries = await convertToChangelogFormat(lines)
+  return channel === 'production'
+    ? [...getChangelogEntriesSince(previousVersion)]
+    : [...changelogEntries]
+}
+
+function makeNewChangelog(
+  nextVersion: string,
+  currentChangelog: any,
+  entries: ReadonlyArray<string>
+) {
+  const newChangelog: any = { releases: {} }
+  newChangelog.releases[nextVersion] = entries
+
+  for (const k of Object.keys(currentChangelog.releases)) {
+    newChangelog.releases[k] = currentChangelog.releases[k]
+  }
+  return newChangelog
 }

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -12,7 +12,9 @@ import { getNextVersionNumber } from './version'
 import { execSync } from 'child_process'
 
 import { writeFileSync } from 'fs'
-const changelog = require('changelog.json')
+import { join } from 'path'
+
+const changelogPath = join(__dirname, '..', '..', 'changelog.json')
 
 const jsonStringify: (obj: any) => string = require('json-pretty')
 
@@ -107,11 +109,11 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
     console.log(`Set!`)
 
     const changelogEntries = await convertToChangelogFormat(lines)
-
-    changelog[nextVersion] = changelogEntries
+    const changelog = require(changelogPath)
+    changelog.releases[nextVersion] = changelogEntries
 
     // this might throw and that's ok (for now!)
-    writeFileSync('changelog.json', jsonStringify(changelog))
+    writeFileSync(changelogPath, jsonStringify(changelog))
 
     console.log("Here's what you should do next:\n")
 

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -68,6 +68,8 @@ function printInstructions(nextVersion: string, entries: Array<string>) {
     'Commit these changes (on a "release" branch) and push them to GitHub',
     'Read this to perform the release: https://github.com/desktop/desktop/blob/development/docs/process/releasing-updates.md',
   ]
+  // if an empty list, we assume the new entries have already been
+  // written to the changelog file
   if (entries.length === 0) {
     printSteps(baseSteps)
   } else {
@@ -86,7 +88,9 @@ function printInstructions(nextVersion: string, entries: Array<string>) {
   }
 }
 
-// adds a number to the beginning fo each line and prints them in sequence
+/**
+ * adds a number to the beginning fo each line and prints them in sequence
+ */
 function printSteps(steps: ReadonlyArray<string>) {
   console.log(steps.map((value, index) => `${index + 1}. ${value}`).join('\n'))
 }
@@ -116,6 +120,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
 
   try {
     // this can throw
+    // sets the npm version in app/
     execSync(`npm version ${nextVersion} --allow-same-version`, {
       cwd: join(__dirname, '..', '..', 'app'),
       encoding: 'utf8',
@@ -172,6 +177,11 @@ async function getNewEntries(
     : [...changelogEntries]
 }
 
+/**
+ * Returns the current changelog with new entries added.
+ * Ensures that the new entry will appear at the beginning
+ * of the object when printed.
+ */
 function makeNewChangelog(
   nextVersion: string,
   currentChangelogEntries: any,

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -133,7 +133,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
     console.log('Adding draft release notes to changelog.json...')
     const changelog = makeNewChangelog(
       nextVersion,
-      currentChangelog,
+      currentChangelog.releases,
       newEntries
     )
     try {
@@ -173,14 +173,11 @@ async function getNewEntries(
 
 function makeNewChangelog(
   nextVersion: string,
-  currentChangelog: any,
+  currentChangelogEntries: any,
   entries: ReadonlyArray<string>
 ) {
-  const newChangelog: any = { releases: {} }
-  newChangelog.releases[nextVersion] = entries
+  const newChangelogEntries: any = {}
+  newChangelogEntries[nextVersion] = entries
 
-  for (const k of Object.keys(currentChangelog.releases)) {
-    newChangelog.releases[k] = currentChangelog.releases[k]
-  }
-  return newChangelog
+  return { releases: { ...newChangelogEntries, ...currentChangelogEntries } }
 }

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -73,8 +73,7 @@ function printInstructions(nextVersion: string, entries: Array<string>) {
   if (entries.length === 0) {
     printSteps(baseSteps)
   } else {
-    const object: any = {}
-    object[nextVersion] = entries.sort()
+    const object = { [nextVersion]: entries.sort() }
     const steps = [
       `Concatenate this to the beginning of the 'releases' element in the changelog.json as a starting point:\n${format(
         JSON.stringify(object),
@@ -133,7 +132,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
     Please manually set it to ${nextVersion} in app/package.json.`)
   }
 
-  const currentChangelog = require(changelogPath)
+  const currentChangelog: IChangelog = require(changelogPath)
   // if it's a new production release, make sure we only include
   // entries since the latest production release
   const newEntries =
@@ -177,12 +176,16 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
  */
 function makeNewChangelog(
   nextVersion: string,
-  currentChangelog: { releases: Object },
+  currentChangelog: IChangelog,
   entries: ReadonlyArray<string>
-) {
-  const newChangelogEntries: any = {}
-  newChangelogEntries[nextVersion] = entries
+): IChangelog {
   return {
-    releases: { ...newChangelogEntries, ...currentChangelog.releases },
+    releases: { [nextVersion]: entries, ...currentChangelog.releases },
   }
+}
+
+type ChangelogReleases = { [key: string]: ReadonlyArray<string> }
+
+interface IChangelog {
+  releases: ChangelogReleases
 }

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -138,7 +138,9 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
   const newEntries =
     channel === 'production'
       ? [...getChangelogEntriesSince(previousVersion)]
-      : [...(await convertToChangelogFormat(lines))]
+      : channel === 'beta'
+      ? [...(await convertToChangelogFormat(lines))]
+      : []
 
   if (currentChangelog.releases[nextVersion] === undefined) {
     console.log('Adding draft release notes to changelog.json...')

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -132,6 +132,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
     Please manually set it to ${nextVersion} in app/package.json.`)
   }
 
+  console.log('Determining changelog entries...')
   const currentChangelog: IChangelog = require(changelogPath)
   // if it's a new production release, make sure we only include
   // entries since the latest production release
@@ -141,6 +142,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
       : channel === 'beta'
       ? [...(await convertToChangelogFormat(lines))]
       : []
+  console.log('Determined!')
 
   if (currentChangelog.releases[nextVersion] === undefined) {
     console.log('Adding draft release notes to changelog.json...')
@@ -157,6 +159,7 @@ export async function run(args: ReadonlyArray<string>): Promise<void> {
           parser: 'json',
         })
       )
+      console.log('Added!')
       printInstructions(nextVersion, [])
     } catch (e) {
       console.warn(`Writing the changelog failed 😿\n(${e.message})`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6367,11 +6367,6 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-pretty@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/json-pretty/-/json-pretty-0.0.1.tgz#e0a36567490838781f712d250c04a2fb96334265"
-  integrity sha1-4KNlZ0kIOHgfcS0lDASi+5YzQmU=
-
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,6 +448,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.24.tgz#d4606afd8cf6c609036b854360367d1b2c78931f"
   integrity sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==
 
+"@types/prettier@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.0.tgz#a2502fb7ce9b6626fdbfc2e2a496f472de1bdd05"
+  integrity sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==
+
 "@types/prop-types@*":
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"


### PR DESCRIPTION
## Overview

updates our draft release task to be a little more helpful. it now

* no longer aborts at the start if there are uncommitted changes in your local repo
* updates the desktop version number for you in `app/package.json`
* places draft release notes in `changelog.json` for you (unless the version already has an entry, in which case if prints it out on the console like before)
* has updated instructional text to explain all of this!
