### PR TITLE
Encode the branch name before including it as part of the URI

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -815,7 +815,9 @@ export class API {
     name: string,
     branch: string
   ): Promise<IAPIPushControl> {
-    const path = `repos/${owner}/${name}/branches/${branch}/push_control`
+    const path = `repos/${owner}/${name}/branches/${encodeURIComponent(
+      branch
+    )}/push_control`
 
     const headers: any = {
       Accept: 'application/vnd.github.phandalin-preview',


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

While investigating https://github.com/desktop/desktop/issues/9081 I saw an error message in the log file about Desktop being "unable to check if branch is potentially pushable".

Turns out if you include a `#` character (or potentially other URI-unsafe characters) in the branch name (which is legal) that will end up cutting of the full API request URI.

<img width="534" alt="image" src="https://user-images.githubusercontent.com/634063/74171546-089e7e00-4c2f-11ea-862d-73387ebe6a73.png">

:point_up: Should be  requesting

`https://api.github.com/repos/niik/Hello-World/branches/Issue-%231/push_control`

but is actually requesting

`https://api.github.com/repos/niik/Hello-World/branches/Issue-#1/push_control`

which gets trimmed by chromium (since requests don't send the fragment to the  server) to

`https://api.github.com/repos/niik/Hello-World/branches/Issue-`

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Protected branches containing certain reserved characters would not get classified as protected
