### PR TITLE
Guard against unexpected push control API response

### DIFF
--- a/app/src/lib/helpers/push-control.ts
+++ b/app/src/lib/helpers/push-control.ts
@@ -43,5 +43,8 @@ export function isBranchPushable(pushControl: IAPIPushControl) {
   const noMergeRequirements =
     requiredStatusCheckCount === 0 && required_approving_review_count === 0
 
+  // We check for !== false so that if a future version of the API decides to
+  // remove or rename that property we'll revert to assuming that the user
+  // _does_ have access rather than assuming that they _don't_.
   return allow_actor !== false && noMergeRequirements
 }

--- a/app/src/lib/helpers/push-control.ts
+++ b/app/src/lib/helpers/push-control.ts
@@ -27,6 +27,13 @@ export function isBranchPushable(pushControl: IAPIPushControl) {
     required_approving_review_count,
   } = pushControl
 
+  // See https://github.com/desktop/desktop/issues/9054#issuecomment-582768322
+  // We'll guard against this being undefined until we can determine the
+  // root cause and fix that.
+  const requiredStatusCheckCount = Array.isArray(required_status_checks)
+    ? required_status_checks.length
+    : 0
+
   // If user is admin and branch is not admin-enforced,
   // required status checks and reviews get zeroed out in API response (no merge requirements).
   // If user is admin and branch is admin-enforced,
@@ -34,7 +41,7 @@ export function isBranchPushable(pushControl: IAPIPushControl) {
   // If user is allowed to push based on `Restrict who can push` setting, they must still
   // respect the merge requirements, and can't push if checks or reviews are required for merging
   const noMergeRequirements =
-    required_status_checks.length === 0 && required_approving_review_count === 0
+    requiredStatusCheckCount === 0 && required_approving_review_count === 0
 
   return allow_actor && noMergeRequirements
 }

--- a/app/src/lib/helpers/push-control.ts
+++ b/app/src/lib/helpers/push-control.ts
@@ -43,5 +43,5 @@ export function isBranchPushable(pushControl: IAPIPushControl) {
   const noMergeRequirements =
     requiredStatusCheckCount === 0 && required_approving_review_count === 0
 
-  return allow_actor && noMergeRequirements
+  return allow_actor !== false && noMergeRequirements
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -877,8 +877,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const owner = gitHubRepo.owner.login
         const api = API.fromAccount(account)
 
-        const hasWritePermissionForRepository =
-          gitHubRepo === null || hasWritePermission(gitHubRepo)
+        const hasWritePermissionForRepository = hasWritePermission(gitHubRepo)
 
         const pushControl = await api.fetchPushControl(owner, name, branchName)
         const currentBranchProtected =

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -873,13 +873,27 @@ export class AppStore extends TypedBaseStore<IAppState> {
           return
         }
 
+        // If the user doesn't have write access to the repository
+        // it doesn't matter if the branch is protected or not and
+        // we can avoid the API call. See the `showNoWriteAccess`
+        // prop in the `CommitMessage` component where we specifically
+        // test for this scenario and show a message specifically
+        // about write access before showing a branch protection
+        // warning.
+        if (!hasWritePermission(gitHubRepo)) {
+          this.repositoryStateCache.updateChangesState(repository, () => ({
+            currentBranchProtected: false,
+          }))
+          this.emitUpdate()
+          return
+        }
+
         const name = gitHubRepo.name
         const owner = gitHubRepo.owner.login
         const api = API.fromAccount(account)
 
         const pushControl = await api.fetchPushControl(owner, name, branchName)
-        const currentBranchProtected =
-          hasWritePermission(gitHubRepo) && !isBranchPushable(pushControl)
+        const currentBranchProtected = !isBranchPushable(pushControl)
 
         this.repositoryStateCache.updateChangesState(repository, () => ({
           currentBranchProtected,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -877,11 +877,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const owner = gitHubRepo.owner.login
         const api = API.fromAccount(account)
 
-        const hasWritePermissionForRepository = hasWritePermission(gitHubRepo)
-
         const pushControl = await api.fetchPushControl(owner, name, branchName)
         const currentBranchProtected =
-          hasWritePermissionForRepository && !isBranchPushable(pushControl)
+          hasWritePermission(gitHubRepo) && !isBranchPushable(pushControl)
 
         this.repositoryStateCache.updateChangesState(repository, () => ({
           currentBranchProtected,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

See https://github.com/desktop/desktop/issues/9054#issuecomment-582768322 and https://github.com/desktop/desktop/issues/9053.

```
2020-02-06T07:08:44.310Z - error: [ui] Error performing periodic fetch for 'musicapps/MusicApps'
TypeError: Cannot read property 'length' of undefined
    at Object.t.isBranchPushable (/webpack:/app/src/lib/helpers/push-control.ts:37:28)
    at Ve.refreshBranchProtectionState (/webpack:/app/src/lib/stores/app-store.ts:887:9)
    at /webpack:/app/src/lib/stores/app-store.ts:4012:9
    at Ve.withPushPullFetch (/webpack:/app/src/lib/stores/app-store.ts:3609:7)
    at Ve.performFetch (/webpack:/app/src/lib/stores/app-store.ts:3974:5)
    at t.BackgroundFetcher.performAndScheduleFetch (/webpack:/app/src/lib/stores/helpers/background-fetcher.ts:97:9)
```

This appears to be coming from the `.length` property access in https://github.com/desktop/desktop/blob/ede708400a30be98b64cc7b844dfda9c137c7cd1/app/src/lib/helpers/push-control.ts#L37 and means that _at least_ the `required_status_checks` property is undefined (I suspect that's not the only property though).

While I absolutely think we should get to the bottom of what's actually going on (I have some theories but haven't been able to conclusively prove any of them yet) this is a stop-gap measure that should avoid the problem by being much more defensive when interpreting the data returned from the API.

Priority 2 since it's affecting users in a meaningful way occurs during critical flows (checkout, push, pull, fetch).