### PR TITLE
Proxy (p)refactor of create tutorial repository dialog

### DIFF
--- a/app/src/lib/friendly-endpoint-name.ts
+++ b/app/src/lib/friendly-endpoint-name.ts
@@ -1,0 +1,16 @@
+import * as URL from 'url'
+import { Account } from '../models/account'
+import { getDotComAPIEndpoint } from './api'
+
+/**
+ * Generate a human-friendly description of the Account endpoint.
+ *
+ * Accounts on GitHub.com will return the string 'GitHub.com'
+ * whereas GitHub Enterprise Server accounts will return the
+ * hostname without the protocol and/or path.
+ */
+export function friendlyEndpointName(account: Account) {
+  return account.endpoint === getDotComAPIEndpoint()
+    ? 'GitHub.com'
+    : URL.parse(account.endpoint).hostname || account.endpoint
+}

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1227,8 +1227,13 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  /**
+  /*
    * Onboarding tutorial metrics
+   */
+
+  /**
+   * Onboarding tutorial has been started, the user has
+   * clicked the button to start the onboarding tutorial.
    */
   public recordTutorialStarted() {
     return this.updateDailyMeasures(() => ({
@@ -1236,6 +1241,9 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
+  /**
+   * Onboarding tutorial has been successfully created
+   */
   public recordTutorialRepoCreated() {
     return this.updateDailyMeasures(() => ({
       tutorialRepoCreated: true,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5587,8 +5587,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       const apiRepository = await createTutorialRepository(
         account,
-        path,
         name,
+        path,
         this.setCreateTutorialProgress
       )
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5634,7 +5634,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     state: Partial<ICreateTutorialRepositoryPopupProps>
   ) {
     if (
-      this.currentPopup &&
+      this.currentPopup !== null &&
       this.currentPopup.type === PopupType.CreateTutorialRepository
     ) {
       this.currentPopup = { ...this.currentPopup, ...state }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5578,6 +5578,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repository
   }
 
+  /**
+   * Create a tutorial repository using the given account. The account
+   * determines which host (i.e. GitHub.com or a GHES instance) that
+   * the tutorial repository should be created on.
+   *
+   * @param account The account (and thereby the GitHub host) under
+   *                which the repository is to be created created
+   */
   public async _createTutorialRepository(account: Account) {
     try {
       await this.statsStore.recordTutorialStarted()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5594,12 +5594,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       await this._addTutorialRepository(path, account.endpoint, apiRepository)
       await this.statsStore.recordTutorialRepoCreated()
-
-      this._closePopup(PopupType.CreateTutorialRepository)
     } catch (err) {
-      this.setCreateTutorialRepositoryProps({ progress: undefined })
-      this._closePopup(PopupType.CreateTutorialRepository)
-
       sendNonFatalException('tutorialRepoCreation', err)
 
       if (err instanceof GitError) {
@@ -5611,6 +5606,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
           )
         )
       }
+    } finally {
+      this.setCreateTutorialRepositoryProps({ progress: undefined })
+      this._closePopup(PopupType.CreateTutorialRepository)
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5615,7 +5615,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         )
       }
     } finally {
-      this.setCreateTutorialRepositoryProps({ progress: undefined })
       this._closePopup(PopupType.CreateTutorialRepository)
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -60,11 +60,7 @@ import {
   IRevertProgress,
   IRebaseProgress,
 } from '../../models/progress'
-import {
-  Popup,
-  PopupType,
-  ICreateTutorialRepositoryPopupProps,
-} from '../../models/popup'
+import { Popup, PopupType } from '../../models/popup'
 import { IGitAccount } from '../../models/git-account'
 import { themeChangeMonitor } from '../../ui/lib/theme-change-monitor'
 import { getAppPath } from '../../ui/lib/app-proxy'

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5624,19 +5624,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     value: number,
     description?: string
   ) => {
-    this.setCreateTutorialRepositoryProps({
-      progress: { kind: 'generic', title, value, description },
-    })
-  }
-
-  private setCreateTutorialRepositoryProps(
-    state: Partial<ICreateTutorialRepositoryPopupProps>
-  ) {
     if (
       this.currentPopup !== null &&
       this.currentPopup.type === PopupType.CreateTutorialRepository
     ) {
-      this.currentPopup = { ...this.currentPopup, ...state }
+      this.currentPopup = {
+        ...this.currentPopup,
+        progress: { kind: 'generic', title, value, description },
+      }
       this.emitUpdate()
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5593,7 +5593,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
         account,
         name,
         path,
-        this.setCreateTutorialProgress
+        (title, value, description) => {
+          if (
+            this.currentPopup !== null &&
+            this.currentPopup.type === PopupType.CreateTutorialRepository
+          ) {
+            this.currentPopup = {
+              ...this.currentPopup,
+              progress: { kind: 'generic', title, value, description },
+            }
+            this.emitUpdate()
+          }
+        }
       )
 
       await this._addTutorialRepository(path, account.endpoint, apiRepository)
@@ -5612,23 +5623,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     } finally {
       this._closePopup(PopupType.CreateTutorialRepository)
-    }
-  }
-
-  private setCreateTutorialProgress = (
-    title: string,
-    value: number,
-    description?: string
-  ) => {
-    if (
-      this.currentPopup !== null &&
-      this.currentPopup.type === PopupType.CreateTutorialRepository
-    ) {
-      this.currentPopup = {
-        ...this.currentPopup,
-        progress: { kind: 'generic', title, value, description },
-      }
-      this.emitUpdate()
     }
   }
 }

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -1,3 +1,145 @@
+import * as URL from 'url'
+import * as Path from 'path'
+
+import { Account } from '../../../models/account'
+import { writeFile, pathExists, ensureDir } from 'fs-extra'
+import { API, getDotComAPIEndpoint } from '../../api'
+import { APIError } from '../../http'
+import {
+  executionOptionsWithProgress,
+  PushProgressParser,
+} from '../../progress'
+import { envForAuthentication } from '../../git/authentication'
+import { git } from '../../git'
+
+const nl = __WIN32__ ? '\r\n' : '\n'
+const InititalReadmeContents =
+  `# Welcome to GitHub Desktop!${nl}${nl}` +
+  `This is your README. READMEs are where you can communicate ` +
+  `what your project is and how to use it.${nl}${nl}` +
+  `Write your name on line 6, save it, and then head ` +
+  `back to GitHub Desktop.${nl}`
+
+async function createAPIRepository(account: Account, name: string) {
+  const api = new API(account.endpoint, account.token)
+
+  try {
+    return await api.createRepository(
+      null,
+      name,
+      'GitHub Desktop tutorial repository',
+      true
+    )
+  } catch (err) {
+    if (
+      err instanceof APIError &&
+      err.responseStatus === 422 &&
+      err.apiError !== null
+    ) {
+      if (err.apiError.message === 'Repository creation failed.') {
+        if (
+          err.apiError.errors &&
+          err.apiError.errors.some(
+            x => x.message === 'name already exists on this account'
+          )
+        ) {
+          throw new Error(
+            'You already have a repository named ' +
+              `"${name}" on your account at ${friendlyEndpointName(
+                account
+              )}.\n\n` +
+              'Please delete the repository and try again.'
+          )
+        }
+      }
+    }
+
+    throw err
+  }
+}
+
+async function pushRepo(
+  path: string,
+  account: Account,
+  progressCb: (title: string, value: number, description?: string) => void
+) {
+  const pushTitle = `Pushing repository to ${friendlyEndpointName(account)}`
+  progressCb(pushTitle, 0)
+
+  const pushOpts = await executionOptionsWithProgress(
+    {
+      env: envForAuthentication(account),
+    },
+    new PushProgressParser(),
+    progress => {
+      if (progress.kind === 'progress') {
+        progressCb(pushTitle, progress.percent, progress.details.text)
+      }
+    }
+  )
+
+  const args = ['push', '-u', 'origin', 'master']
+  await git(args, path, 'tutorial:push', pushOpts)
+}
+
+/**
+ * Creates a repository on the remote (as specified by the Account
+ * parameter), initializes an empty repository at the given path,
+ * sets up the expected tutorial contents, and pushes the repository'
+ * to the remote.
+ *
+ * @param path    The path on the local machine where the tutorial
+ *                repository is to be created
+ *
+ * @param account The account (and thereby the GitHub host) under
+ *                which the repository is to be created created
+ */
+export async function createTutorialRepository(
+  account: Account,
+  name: string,
+  path: string,
+  progressCb: (title: string, value: number, description?: string) => void
+) {
+  const endpointName = friendlyEndpointName(account)
+  progressCb(`Creating repository on ${endpointName}`, 0)
+
+  if (await pathExists(path)) {
+    throw new Error(
+      `The path '${path}' already exists. Please move it ` +
+        'out of the way, or remove it, and then try again.'
+    )
+  }
+
+  const repo = await createAPIRepository(account, name)
+
+  progressCb('Initializing local repository', 0.2)
+
+  await ensureDir(path)
+  await git(['init'], path, 'tutorial:init')
+
+  await writeFile(Path.join(path, 'README.md'), InititalReadmeContents)
+
+  await git(['add', '--', 'README.md'], path, 'tutorial:add')
+  await git(
+    ['commit', '-m', 'Initial commit', '--', 'README.md'],
+    path,
+    'tutorial:commit'
+  )
+  await git(
+    ['remote', 'add', 'origin', repo.clone_url],
+    path,
+    'tutorial:add-remote'
+  )
+
+  await pushRepo(path, account, (title, value, description) => {
+    progressCb(title, 0.3 + value * 0.6, description)
+  })
+
+  progressCb('Finalizing tutorial repository', 0.9)
+
+  return repo
+}
+
 /**
  * Generate a human-friendly description of the Account endpoint.
  *

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -1,3 +1,10 @@
+/**
+ * Generate a human-friendly description of the Account endpoint.
+ *
+ * Accounts on GitHub.com will return the string 'GitHub.com'
+ * whereas GitHub Enterprise Server accounts will return the
+ * hostname without the protocol and/or path.
+ */
 export function friendlyEndpointName(account: Account) {
   return account.endpoint === getDotComAPIEndpoint()
     ? 'GitHub.com'

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -1,9 +1,8 @@
-import * as URL from 'url'
 import * as Path from 'path'
 
 import { Account } from '../../../models/account'
 import { writeFile, pathExists, ensureDir } from 'fs-extra'
-import { API, getDotComAPIEndpoint } from '../../api'
+import { API } from '../../api'
 import { APIError } from '../../http'
 import {
   executionOptionsWithProgress,
@@ -11,6 +10,7 @@ import {
 } from '../../progress'
 import { envForAuthentication } from '../../git/authentication'
 import { git } from '../../git'
+import { friendlyEndpointName } from '../../friendly-endpoint-name'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InititalReadmeContents =
@@ -138,17 +138,4 @@ export async function createTutorialRepository(
   progressCb('Finalizing tutorial repository', 0.9)
 
   return repo
-}
-
-/**
- * Generate a human-friendly description of the Account endpoint.
- *
- * Accounts on GitHub.com will return the string 'GitHub.com'
- * whereas GitHub Enterprise Server accounts will return the
- * hostname without the protocol and/or path.
- */
-export function friendlyEndpointName(account: Account) {
-  return account.endpoint === getDotComAPIEndpoint()
-    ? 'GitHub.com'
-    : URL.parse(account.endpoint).hostname || account.endpoint
 }

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -85,7 +85,7 @@ async function pushRepo(
 /**
  * Creates a repository on the remote (as specified by the Account
  * parameter), initializes an empty repository at the given path,
- * sets up the expected tutorial contents, and pushes the repository'
+ * sets up the expected tutorial contents, and pushes the repository
  * to the remote.
  *
  * @param path    The path on the local machine where the tutorial

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -1,0 +1,5 @@
+export function friendlyEndpointName(account: Account) {
+  return account.endpoint === getDotComAPIEndpoint()
+    ? 'GitHub.com'
+    : URL.parse(account.endpoint).hostname || account.endpoint
+}

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -9,6 +9,7 @@ import { PreferencesTab } from './preferences'
 import { ICommitContext } from './commit'
 import { IStashEntry } from './stash-entry'
 import { Account } from '../models/account'
+import { Progress } from './progress'
 
 export enum PopupType {
   RenameBranch = 1,
@@ -221,4 +222,5 @@ export type Popup =
 
 export interface ICreateTutorialRepositoryPopupProps {
   account: Account
+  progress?: Progress
 }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -199,7 +199,9 @@ export type Popup =
     }
   | {
       type: PopupType.CreateTutorialRepository
-    } & ICreateTutorialRepositoryPopupProps
+      account: Account
+      progress?: Progress
+    }
   | {
       type: PopupType.ConfirmExitTutorial
     }
@@ -219,8 +221,3 @@ export type Popup =
       repository: RepositoryWithGitHubRepository
       account: Account
     }
-
-export interface ICreateTutorialRepositoryPopupProps {
-  account: Account
-  progress?: Progress
-}

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -198,8 +198,7 @@ export type Popup =
     }
   | {
       type: PopupType.CreateTutorialRepository
-      account: Account
-    }
+    } & ICreateTutorialRepositoryPopupProps
   | {
       type: PopupType.ConfirmExitTutorial
     }
@@ -219,3 +218,7 @@ export type Popup =
       repository: RepositoryWithGitHubRepository
       account: Account
     }
+
+export interface ICreateTutorialRepositoryPopupProps {
+  account: Account
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -17,7 +17,7 @@ import { updateStore, UpdateStatus } from './lib/update-store'
 import { RetryAction } from '../models/retry-actions'
 import { shouldRenderApplicationMenu } from './lib/features'
 import { matchExistingRepository } from '../lib/repository-matching'
-import { getDotComAPIEndpoint, IAPIRepository } from '../lib/api'
+import { getDotComAPIEndpoint } from '../lib/api'
 import { ILaunchStats, SamplesURL } from '../lib/stats'
 import { getVersion, getName } from './lib/app-proxy'
 import { getOS } from '../lib/get-os'
@@ -1845,11 +1845,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <CreateTutorialRepositoryDialog
             key="create-tutorial-repository-dialog"
-            dispatcher={this.props.dispatcher}
             account={popup.account}
+            progress={popup.progress}
             onDismissed={this.onPopupDismissed}
-            onTutorialRepositoryCreated={this.onTutorialRepositoryCreated}
-            onError={this.onTutorialRepositoryError}
+            onCreateTutorialRepository={this.onCreateTutorialRepository}
           />
         )
       }
@@ -1905,21 +1904,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.closePopup()
   }
 
-  private onTutorialRepositoryError = (error: Error) => {
-    this.props.dispatcher.closePopup(PopupType.CreateTutorialRepository)
-    this.props.dispatcher.postError(error)
-  }
-
-  private onTutorialRepositoryCreated = (
-    path: string,
-    account: Account,
-    apiRepository: IAPIRepository
-  ) => {
-    return this.props.dispatcher.addTutorialRepository(
-      path,
-      account.endpoint,
-      apiRepository
-    )
+  private onCreateTutorialRepository = (account: Account) => {
+    this.props.dispatcher.createTutorialRepository(account)
   }
 
   private onShowRebaseConflictsBanner = (

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -690,7 +690,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
   }
 
-  private onCreateTutorialRepository = () => {
+  private showCreateTutorialRepositoryPopup = () => {
     if (!enableTutorial()) {
       return
     }
@@ -2455,7 +2455,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           onCreate={this.showCreateRepository}
           onClone={this.showCloneRepo}
           onAdd={this.showAddLocalRepo}
-          onCreateTutorialRepository={this.onCreateTutorialRepository}
+          onCreateTutorialRepository={this.showCreateTutorialRepositoryPopup}
           onResumeTutorialRepository={this.onResumeTutorialRepository}
           tutorialPaused={this.isTutorialPaused()}
           apiRepositories={state.apiRepositories}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2256,6 +2256,12 @@ export class Dispatcher {
   public recordForkCreated() {
     return this.statsStore.recordForkCreated()
   }
+
+  /**
+   * Create a tutorial repository using the given account. The account
+   * determines which host (i.e. GitHub.com or a GHES instance) that
+   * the tutorial repository should be created on.
+   */
   public createTutorialRepository(account: Account) {
     return this.appStore._createTutorialRepository(account)
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2236,19 +2236,6 @@ export class Dispatcher {
   }
 
   /**
-   * Onboarding tutorial has been started
-   */
-  public recordTutorialStarted() {
-    return this.statsStore.recordTutorialStarted()
-  }
-  /**
-   * Onboarding tutorial has been successfully created
-   */
-  public recordTutorialRepoCreated() {
-    return this.statsStore.recordTutorialRepoCreated()
-  }
-
-  /**
    * Increments the `forksCreated ` metric` indicating that the user has
    * elected to create a fork when presented with a dialog informing
    * them that they don't have write access to the current repository.

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2248,6 +2248,9 @@ export class Dispatcher {
    * Create a tutorial repository using the given account. The account
    * determines which host (i.e. GitHub.com or a GHES instance) that
    * the tutorial repository should be created on.
+   *
+   * @param account The account (and thereby the GitHub host) under
+   *                which the repository is to be created created
    */
   public createTutorialRepository(account: Account) {
     return this.appStore._createTutorialRepository(account)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2256,4 +2256,7 @@ export class Dispatcher {
   public recordForkCreated() {
     return this.statsStore.recordForkCreated()
   }
+  public createTutorialRepository(account: Account) {
+    return this.appStore._createTutorialRepository(account)
+  }
 }

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -1,29 +1,11 @@
 import * as React from 'react'
-import * as URL from 'url'
-import * as Path from 'path'
 
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Account } from '../../models/account'
-import {
-  getDotComAPIEndpoint,
-  getHTMLURL,
-  API,
-  IAPIRepository,
-} from '../../lib/api'
+import { getHTMLURL } from '../../lib/api'
 import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
-import { getDefaultDir } from '../lib/default-dir'
-import { writeFile, pathExists, ensureDir } from 'fs-extra'
-import { git, GitError } from '../../lib/git'
-import { envForAuthentication } from '../../lib/git/authentication'
-import {
-  PushProgressParser,
-  executionOptionsWithProgress,
-} from '../../lib/progress'
 import { Progress } from '../../models/progress'
-import { Dispatcher } from '../dispatcher'
-import { APIError } from '../../lib/http'
-import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { friendlyEndpointName } from '../../lib/stores/helpers/create-tutorial-repository'
 
@@ -34,8 +16,6 @@ interface ICreateTutorialRepositoryDialogProps {
    */
   readonly account: Account
 
-  readonly dispatcher: Dispatcher
-
   /**
    * Event triggered when the dialog is dismissed by the user in the
    * ways described in the Dialog component's dismissable prop.
@@ -43,42 +23,13 @@ interface ICreateTutorialRepositoryDialogProps {
   readonly onDismissed: () => void
 
   /**
-   * Event triggered when the tutorial repository has been created
-   * locally, initialized with the expected tutorial contents, and
-   * pushed to the remote.
-   *
-   * @param path    The path on the local machine where the tutorial
-   *                repository was created
+   * Called when the user has indicated that the tutorial repository
+   * should be created
    *
    * @param account The account (and thereby the GitHub host) under
-   *                which the repository was created
-   *
-   * @param apiRepository The repository information as returned by
-   *                      the GitHub API as the repository was created.
+   *                which the repository is to be created
    */
-  readonly onTutorialRepositoryCreated: (
-    path: string,
-    account: Account,
-    apiRepository: IAPIRepository
-  ) => Promise<void>
-
-  /**
-   * Event triggered when the component encounters an error while
-   * attempting to create the tutorial repository. Consumers are
-   * intended to display an error message to the end user in response
-   * to this event.
-   */
-  readonly onError: (error: Error) => void
-}
-
-interface ICreateTutorialRepositoryDialogState {
-  /**
-   * Whether or not the dialog is currently in the process of creating
-   * the tutorial repository. When true this will render a spinning
-   * progress icon in the dialog header (if the dialog has a header) as
-   * well as temporarily disable dismissal of the dialog.
-   */
-  readonly loading: boolean
+  readonly onCreateTutorialRepository: (account: Account) => void
 
   /**
    * The current progress in creating the tutorial repository. Undefined
@@ -87,168 +38,23 @@ interface ICreateTutorialRepositoryDialogState {
   readonly progress?: Progress
 }
 
-const nl = __WIN32__ ? '\r\n' : '\n'
-const InititalReadmeContents =
-  `# Welcome to GitHub Desktop!${nl}${nl}` +
-  `This is your README. READMEs are where you can communicate ` +
-  `what your project is and how to use it.${nl}${nl}` +
-  `Write your name on line 6, save it, and then head ` +
-  `back to GitHub Desktop.${nl}`
-
 /**
  * A dialog component reponsible for initializing, publishing, and adding
  * a tutorial repository to the application.
  */
 export class CreateTutorialRepositoryDialog extends React.Component<
-  ICreateTutorialRepositoryDialogProps,
-  ICreateTutorialRepositoryDialogState
+  ICreateTutorialRepositoryDialogProps
 > {
-  public constructor(props: ICreateTutorialRepositoryDialogProps) {
-    super(props)
-    this.state = { loading: false }
-  }
-
-  private async createAPIRepository(account: Account, name: string) {
-    const api = new API(account.endpoint, account.token)
-
-    try {
-      return await api.createRepository(
-        null,
-        name,
-        'GitHub Desktop tutorial repository',
-        true
-      )
-    } catch (err) {
-      if (
-        err instanceof APIError &&
-        err.responseStatus === 422 &&
-        err.apiError !== null
-      ) {
-        if (err.apiError.message === 'Repository creation failed.') {
-          if (
-            err.apiError.errors &&
-            err.apiError.errors.some(
-              x => x.message === 'name already exists on this account'
-            )
-          ) {
-            throw new Error(
-              'You already have a repository named ' +
-                `"${name}" on your account at ${friendlyEndpointName(
-                  account
-                )}.\n\n` +
-                'Please delete the repository and try again.'
-            )
-          }
-        }
-      }
-
-      throw err
-    }
-  }
-
-  private async pushRepo(
-    path: string,
-    account: Account,
-    progressCb: (title: string, value: number, description?: string) => void
-  ) {
-    const pushTitle = `Pushing repository to ${friendlyEndpointName(account)}`
-    progressCb(pushTitle, 0)
-
-    const pushOpts = await executionOptionsWithProgress(
-      {
-        env: envForAuthentication(account),
-      },
-      new PushProgressParser(),
-      progress => {
-        if (progress.kind === 'progress') {
-          progressCb(pushTitle, progress.percent, progress.details.text)
-        }
-      }
-    )
-
-    const args = ['push', '-u', 'origin', 'master']
-    await git(args, path, 'tutorial:push', pushOpts)
-  }
-
-  public onSubmit = async () => {
-    this.props.dispatcher.recordTutorialStarted()
-
-    const { account } = this.props
-    const endpointName = friendlyEndpointName(account)
-    this.setState({ loading: true })
-
-    const name = 'desktop-tutorial'
-
-    try {
-      const path = Path.resolve(getDefaultDir(), name)
-
-      if (await pathExists(path)) {
-        throw new Error(
-          `The path '${path}' already exists. Please move it ` +
-            'out of the way, or remove it, and then try again.'
-        )
-      }
-
-      this.setProgress(`Creating repository on ${endpointName}`, 0)
-
-      const repo = await this.createAPIRepository(account, name)
-
-      this.setProgress('Initializing local repository', 0.2)
-
-      await ensureDir(path)
-      await git(['init'], path, 'tutorial:init')
-
-      await writeFile(Path.join(path, 'README.md'), InititalReadmeContents)
-
-      await git(['add', '--', 'README.md'], path, 'tutorial:add')
-      await git(
-        ['commit', '-m', 'Initial commit', '--', 'README.md'],
-        path,
-        'tutorial:commit'
-      )
-      await git(
-        ['remote', 'add', 'origin', repo.clone_url],
-        path,
-        'tutorial:add-remote'
-      )
-
-      await this.pushRepo(path, account, (title, value, description) => {
-        this.setProgress(title, 0.3 + value * 0.6, description)
-      })
-
-      this.setProgress('Finalizing tutorial repository', 0.9)
-      await this.props.onTutorialRepositoryCreated(path, account, repo)
-      this.props.dispatcher.recordTutorialRepoCreated()
-      this.props.onDismissed()
-    } catch (err) {
-      this.setState({ loading: false, progress: undefined })
-
-      sendNonFatalException('tutorialRepoCreation', err)
-
-      if (err instanceof GitError) {
-        this.props.onError(err)
-      } else {
-        this.props.onError(
-          new Error(
-            `Failed creating the tutorial repository.\n\n${err.message}`
-          )
-        )
-      }
-    }
-  }
-
-  private setProgress(title: string, value: number, description?: string) {
-    this.setState({
-      progress: { kind: 'generic', title, value, description },
-    })
-  }
+  public onSubmit = () =>
+    this.props.onCreateTutorialRepository(this.props.account)
 
   private renderProgress() {
-    if (this.state.progress === undefined) {
+    const { progress } = this.props
+
+    if (progress === undefined) {
       return null
     }
 
-    const { progress } = this.state
     const description = progress.description ? (
       <div className="description">{progress.description}</div>
     ) : null
@@ -263,7 +69,8 @@ export class CreateTutorialRepositoryDialog extends React.Component<
   }
 
   public render() {
-    const { account } = this.props
+    const { account, progress } = this.props
+    const loading = progress !== undefined
 
     return (
       <Dialog
@@ -271,9 +78,9 @@ export class CreateTutorialRepositoryDialog extends React.Component<
         title="Start tutorial"
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
-        dismissable={!this.state.loading}
-        loading={this.state.loading}
-        disabled={this.state.loading}
+        dismissable={!loading}
+        loading={loading}
+        disabled={loading}
       >
         <DialogContent>
           <div>

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -7,7 +7,7 @@ import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
 import { Progress } from '../../models/progress'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { friendlyEndpointName } from '../../lib/stores/helpers/create-tutorial-repository'
+import { friendlyEndpointName } from '../../lib/friendly-endpoint-name'
 
 interface ICreateTutorialRepositoryDialogProps {
   /**

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -25,6 +25,7 @@ import { Dispatcher } from '../dispatcher'
 import { APIError } from '../../lib/http'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { friendlyEndpointName } from '../../lib/stores/helpers/create-tutorial-repository'
 
 interface ICreateTutorialRepositoryDialogProps {
   /**
@@ -292,10 +293,4 @@ export class CreateTutorialRepositoryDialog extends React.Component<
       </Dialog>
     )
   }
-}
-
-function friendlyEndpointName(account: Account) {
-  return account.endpoint === getDotComAPIEndpoint()
-    ? 'GitHub.com'
-    : URL.parse(account.endpoint).hostname || account.endpoint
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

As part of the proxy work I'm doing I've tentatively settled on an approach which means that all network Git operations are going to have to originate from within the App Store. The only network Git operation that doesn't originate from the AppStore today is the `push` operation within the `CreateTutorialRepositoryDialog` component.

In refactoring this I realized that the change was becoming rather large and thus a good candidate to be extracted and reviewed on its own.

Also, [@outofambit totes foresaw this happening](https://github.com/desktop/desktop/pull/8244#discussion_r323884417)

### Notes for the reviewer

This is in essence a refactor and no functionality should have changed. Evidence of altered logic are probably a mistake worth calling out in the review.

One notable exceptions is that the `CreateTutorialRepository` component used to have a separate `loading` state which was set to true when the create operation started and reset to false once it ended. This state determined whether the dialog would be enabled (i.e. whether the create/cancel buttons could be clicked), whether it was dismissable, and whether it should show the progress spinner or not. This state has been replaced by a variable derived from the presence of a progress property. Functionally to the user there should be no difference.
 
As a side effect of :point_up: I've slightly reordered the `createTutorialRepository` method to immediately set a progress upon commencing the creation.