### PR TITLE
Parse Proxy Auto-Configuration strings

### DIFF
--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -48,6 +48,13 @@ import { Url } from 'url'
  *   "PROXY proxy1.foo.com:8080; PROXY proxy2.foo.com:8080; DIRECT"
  *   "SOCKS socksproxy"
  *   "DIRECT"
+ *
+ * Other notes:
+ *
+ * From https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
+ *    When you set a host name to use, do not assume that there's
+ *    any particular single port number used widely for proxies.
+ *    Specify it!
  */
 export function parsePACString(pacString: string): Array<Url> | null {
   return null

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -64,7 +64,8 @@ export function parsePACString(pacString: string): Array<string> | null {
   const urls = new Array<string>()
 
   for (const spec of specs) {
-    // We stop at the first DIRECT.
+    // No point in continuing after we get a DIRECT since we
+    // have no way of implementing a fallback logic in cURL/Git
     if (spec.startsWith('DIRECT')) {
       break
     }

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -99,6 +99,13 @@ function urlFromProtocolAndEndpoint(protocol: string, endpoint: string) {
   // because cURL defaults to port 1080 for all proxy protocols, see
   //
   // https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
+  //
+  // HTTP is an alias for PROXY (or vice versa idk). I don't believe
+  // we'll ever see an 'HTTP' protocol from Chromium based on my reading of
+  // https://github.com/chromium/chromium/blob/2ca8c5037021/net/base/proxy_server.cc#L164-L184
+  // but we'll suppor it nonetheless.
+  //
+  // SOCKS is an alias for SOCKS4
   switch (protocol) {
     case 'PROXY':
     case 'HTTP':

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -95,16 +95,16 @@ function urlFromProtocolAndEndpoint(protocol: string, endpoint: string) {
   // because cURL defaults to port 1080 for all proxy protocols, see
   //
   // https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
-  switch (protocol.toLowerCase()) {
-    case 'proxy':
-    case 'http':
+  switch (protocol) {
+    case 'PROXY':
+    case 'HTTP':
       return `http://${endpoint}`
-    case 'https':
+    case 'HTTPS':
       return `https://${endpoint}`
-    case 'socks':
-    case 'socks4':
+    case 'SOCKS':
+    case 'SOCKS4':
       return `socks4://${endpoint}`
-    case 'socks5':
+    case 'SOCKS5':
       return `socks5://${endpoint}`
   }
 

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -69,7 +69,7 @@ export function parsePACString(pacString: string): Array<string> | null {
       return urls.length > 0 ? urls : null
     }
 
-    const [protocol, endpoint] = spec.split(' ', 2)
+    const [protocol, endpoint] = spec.split(/\s+/, 2)
 
     if (endpoint !== undefined) {
       const url = urlFromProtocolAndEndpoint(protocol, endpoint)

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -20,7 +20,7 @@
  * parsers.
  *
  * See the following links for a high-level step-through of the logic involed
- * in getting
+ * in getting the PAC string from Electron/Chromium
  *
  * https://github.com/electron/electron/blob/d9321f4df751/shell/browser/net/resolve_proxy_helper.cc#L77
  * https://github.com/chromium/chromium/blob/98b0e0a61e78/net/proxy_resolution/proxy_list.cc#L134-L143

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -106,16 +106,16 @@ function urlFromProtocolAndEndpoint(protocol: string, endpoint: string) {
   // but we'll suppor it nonetheless.
   //
   // SOCKS is an alias for SOCKS4
-  switch (protocol) {
-    case 'PROXY':
-    case 'HTTP':
+  switch (protocol.toLowerCase()) {
+    case 'proxy':
+    case 'http':
       return `http://${endpoint}`
-    case 'HTTPS':
+    case 'https':
       return `https://${endpoint}`
-    case 'SOCKS':
-    case 'SOCKS4':
+    case 'socks':
+    case 'socks4':
       return `socks4://${endpoint}`
-    case 'SOCKS5':
+    case 'socks5':
       return `socks5://${endpoint}`
   }
 

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -58,7 +58,7 @@
  *    Specify it!
  */
 export function parsePACString(pacString: string): Array<string> | null {
-  // Happy path
+  // Happy path, this will be the case for the vast majority of users
   if (pacString === 'DIRECT') {
     return null
   }

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -1,0 +1,54 @@
+import { Url } from 'url'
+
+/**
+ * Parse a Proxy Auto Configuration (PAC) string into one or more cURL-
+ * compatible proxy URLs.
+ *
+ * Note that this method is not intended to be a fully compliant PAC parser
+ * nor is it indended to handle common PAC string mistakes (such as including
+ * the protocol in the host portion of the spec). It's specifically designed
+ * to translate PAC strings returned from Electron's resolveProxy method which
+ * in turn relies on Chromium's `ProxyList::ToPacString()` implementatiton.
+ *
+ * Proxy protocols not supported by cURL (QUIC) will be silently omitted.
+ *
+ * The format of a PAC string is included below for reference but we're in a
+ * special situation since what we get from Electron isn't the raw output from
+ * the PAC script but rather a PAC-formatted version of Chromiums internal proxy
+ * state. As such we can take several shortcuts not available to generic PAC
+ * parsers.
+ *
+ * See the following links for a high-level step-through of the logic involed
+ * in getting
+ *
+ * https://github.com/electron/electron/blob/d9321f4df751/shell/browser/net/resolve_proxy_helper.cc#L77
+ * https://github.com/chromium/chromium/blob/98b0e0a61e78/net/proxy_resolution/proxy_list.cc#L134-L143
+ * https://github.com/chromium/chromium/blob/2ca8c5037021/net/base/proxy_server.cc#L164-L184
+ *
+ * PAC string BNF
+ * --------------
+ *
+ * From https://dxr.mozilla.org/mozilla-central/source/netwerk/base/ProxyAutoConfig.h#48
+ *
+ *  result      = proxy-spec *( proxy-sep proxy-spec )
+ *  proxy-spec  = direct-type | proxy-type LWS proxy-host [":" proxy-port]
+ *  direct-type = "DIRECT"
+ *  proxy-type  = "PROXY" | "HTTP" | "HTTPS" | "SOCKS" | "SOCKS4" | "SOCKS5"
+ *  proxy-sep   = ";" LWS
+ *  proxy-host  = hostname | ipv4-address-literal
+ *  proxy-port  = <any 16-bit unsigned integer>
+ *  LWS         = *( SP | HT )
+ *  SP          = <US-ASCII SP, space (32)>
+ *  HT          = <US-ASCII HT, horizontal-tab (9)>
+ *
+ * NOTE: direct-type and proxy-type are case insensitive
+ * NOTE: SOCKS implies SOCKS4
+ *
+ * Examples:
+ *   "PROXY proxy1.foo.com:8080; PROXY proxy2.foo.com:8080; DIRECT"
+ *   "SOCKS socksproxy"
+ *   "DIRECT"
+ */
+export function parsePACString(pacString: string): Array<Url> | null {
+  return null
+}

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -69,7 +69,7 @@ export function parsePACString(pacString: string): Array<string> | null {
   for (const spec of specs) {
     // No point in continuing after we get a DIRECT since we
     // have no way of implementing a fallback logic in cURL/Git
-    if (spec.startsWith('DIRECT')) {
+    if (spec.match(/^direct/i)) {
       break
     }
 

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -2,6 +2,9 @@
  * Parse a Proxy Auto Configuration (PAC) string into one or more cURL-
  * compatible proxy URLs.
  *
+ * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file
+ * for a good primer on PAC files.
+ *
  * Note that this method is not intended to be a fully compliant PAC parser
  * nor is it indended to handle common PAC string mistakes (such as including
  * the protocol in the host portion of the spec). It's specifically designed

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -66,7 +66,7 @@ export function parsePACString(pacString: string): Array<string> | null {
   for (const spec of specs) {
     // We stop at the first DIRECT.
     if (spec.startsWith('DIRECT')) {
-      return urls.length > 0 ? urls : null
+      break
     }
 
     const [protocol, endpoint] = spec.split(/\s+/, 2)
@@ -82,7 +82,7 @@ export function parsePACString(pacString: string): Array<string> | null {
     }
   }
 
-  return urls
+  return urls.length > 0 ? urls : null
 }
 
 function urlFromProtocolAndEndpoint(protocol: string, endpoint: string) {

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -60,7 +60,7 @@ export function parsePACString(pacString: string): Array<string> | null {
     return null
   }
 
-  const specs = pacString.split(/;\s*/)
+  const specs = pacString.trim().split(/\s*;\s*/)
   const urls = new Array<string>()
 
   for (const spec of specs) {
@@ -69,7 +69,7 @@ export function parsePACString(pacString: string): Array<string> | null {
       return urls.length > 0 ? urls : null
     }
 
-    const [protocol, endpoint] = spec.trim().split(' ', 2)
+    const [protocol, endpoint] = spec.split(' ', 2)
 
     if (endpoint !== undefined) {
       const url = urlFromProtocolAndEndpoint(protocol, endpoint)

--- a/app/src/lib/parse-pac-string.ts
+++ b/app/src/lib/parse-pac-string.ts
@@ -86,6 +86,15 @@ export function parsePACString(pacString: string): Array<string> | null {
 }
 
 function urlFromProtocolAndEndpoint(protocol: string, endpoint: string) {
+  // Note that we explicitly want to preserve the port number (if provided).
+  // If we run these through url.parse or the URL constructor they will
+  // both attempt to be smart and remove the default port. So if a PAC
+  // string specified `PROXY myproxy:80` we'll generate `http://myproxy:80`
+  // which will get turned into `http://myproxy` by URL libraries since
+  // they think 80 is redundant. In our case it's not redundant though
+  // because cURL defaults to port 1080 for all proxy protocols, see
+  //
+  // https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html
   switch (protocol.toLowerCase()) {
     case 'proxy':
     case 'http':

--- a/app/test/unit/parse-pac-string-test.ts
+++ b/app/test/unit/parse-pac-string-test.ts
@@ -1,0 +1,53 @@
+import { parsePACString } from '../../src/lib/parse-pac-string'
+
+describe('parsePACString', () => {
+  it('returns no url for DIRECT', () => {
+    expect(parsePACString('DIRECT')).toBeNull()
+  })
+
+  it('parses Chromium PAC strings', () => {
+    expect(parsePACString('PROXY myproxy:80;DIRECT')).toEqual([
+      'http://myproxy:80',
+    ])
+
+    expect(parsePACString('PROXY myproxy:80')).toEqual(['http://myproxy:80'])
+    expect(parsePACString('PROXY myproxy:80; HTTPS secureproxy:443')).toEqual([
+      'http://myproxy:80',
+      'https://secureproxy:443',
+    ])
+
+    expect(
+      parsePACString(
+        'PROXY a:1;HTTP b:2;HTTPS c:3;SOCKS d:4;SOCKS4 e:5;SOCKS5 f:5;DIRECT'
+      )
+    ).toEqual([
+      'http://a:1',
+      'http://b:2',
+      'https://c:3',
+      'socks4://d:4',
+      'socks4://e:5',
+      'socks5://f:5',
+    ])
+  })
+
+  // not strictly necessary as Chromium doesn't add space inbetween
+  it('parses PAC strings with white space between specs', () => {
+    expect(
+      parsePACString(
+        'PROXY a:1; HTTP b:2 ;\tHTTPS c:3\t;\tSOCKS d:4 ; SOCKS4 e:5  ;  SOCKS5 f:5  ; DIRECT'
+      )
+    ).toEqual([
+      'http://a:1',
+      'http://b:2',
+      'https://c:3',
+      'socks4://d:4',
+      'socks4://e:5',
+      'socks5://f:5',
+    ])
+  })
+
+  it("skips protocols cURL doesn't understand", () => {
+    const urls = parsePACString('QUIC qhost:1;PROXY phost:2;DIRECT')
+    expect(urls).toEqual(['http://phost:2'])
+  })
+})

--- a/app/test/unit/parse-pac-string-test.ts
+++ b/app/test/unit/parse-pac-string-test.ts
@@ -50,4 +50,9 @@ describe('parsePACString', () => {
     const urls = parsePACString('QUIC qhost:1;PROXY phost:2;DIRECT')
     expect(urls).toEqual(['http://phost:2'])
   })
+
+  it('skips invalid specs', () => {
+    const urls = parsePACString('PROXY;HTTPS;DIRECT')
+    expect(urls).toBeNull()
+  })
 })


### PR DESCRIPTION
I'm extracting the PAC parser from my ongoing work to better support proxies in order to lessen the review burden of the final work. Note that this PR will add an unused function and that's okay.

In order to know what to tell Git (or cURL rather) what (if any) proxy it should be using we'll first need to figure out what the system is set up to use. For that we'll leverage the, poorly documented, [resolveProxy](https://www.electronjs.org/docs/api/session#sesresolveproxyurl) method in Electron. The method returns a PAC string which we'll need to parse in order to convert it to something that's usable for cURL which is the entire purpose of this method.

The code is documented (perhaps overly so) with several references that's useful if you've never heard of PAC files or PAC strings. The best primer IMO is [MDN's article on PAC files](https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file).

We don't have to support all the weird variants or the raw output of an actual `FindProxyForURL` if a user's organization has one set up since Chromium will do an initial parsing round and reformat before handing it off to us.

TL;DR Chops and mashes some strings with more documentation than logic