### PR TITLE
Open a pull request from a GitHub.com PR page in your fork in Desktop

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -791,8 +791,6 @@ export class API {
 
   /**
    * Fetch a single pull request in the given repository
-   *
-   * TODO: consider caching?
    */
   public async fetchPullRequest(owner: string, name: string, prNumber: string) {
     try {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -790,6 +790,22 @@ export class API {
   }
 
   /**
+   * Fetch a single pull request in the given repository
+   *
+   * TODO: consider caching?
+   */
+  public async fetchPullRequest(owner: string, name: string, prNumber: string) {
+    try {
+      const path = `/repos/${owner}/${name}/pulls/${prNumber}`
+      const response = await this.request('GET', path)
+      return await parsedResponse<IAPIPullRequest>(response)
+    } catch (e) {
+      log.warn(`failed fetching PR for ${owner}/${name}/pulls/${prNumber}`, e)
+      throw e
+    }
+  }
+
+  /**
    * Get the combined status for the given ref.
    *
    * Note: Contrary to many other methods in this class this will not

--- a/app/src/lib/repository-matching.ts
+++ b/app/src/lib/repository-matching.ts
@@ -163,8 +163,12 @@ export function urlMatchesCloneURL(
     return false
   }
 
-  const firstIdentifier = parseRepositoryIdentifier(gitHubRepository.cloneURL)
-  const secondIdentifier = parseRepositoryIdentifier(url)
+  return urlsMatch(gitHubRepository.cloneURL, url)
+}
+
+export function urlsMatch(url1: string, url2: string) {
+  const firstIdentifier = parseRepositoryIdentifier(url1)
+  const secondIdentifier = parseRepositoryIdentifier(url2)
 
   return (
     firstIdentifier !== null &&

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3358,6 +3358,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
       : null
   }
 
+  public async getDefaultAndUpstreamRemotes(repository: Repository) {
+    const gitStore = this.gitStoreCache.get(repository)
+    if (!gitStore.defaultRemote || !gitStore.upstreamRemote) {
+      await gitStore.loadRemotes()
+    }
+
+    return {
+      default: gitStore.defaultRemote,
+      upstream: gitStore.upstreamRemote,
+    }
+  }
+
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _pushError(error: Error): Promise<void> {
     const newErrors = Array.from(this.errors)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3367,7 +3367,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public async getDefaultAndUpstreamRemotes(repository: Repository) {
     const gitStore = this.gitStoreCache.get(repository)
-    if (!gitStore.defaultRemote || !gitStore.upstreamRemote) {
+    if (!gitStore.remotesLoaded()) {
       await gitStore.loadRemotes()
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3365,18 +3365,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       : null
   }
 
-  public async getDefaultAndUpstreamRemotes(repository: Repository) {
-    const gitStore = this.gitStoreCache.get(repository)
-    if (!gitStore.remotesLoaded()) {
-      await gitStore.loadRemotes()
-    }
-
-    return {
-      default: gitStore.defaultRemote,
-      upstream: gitStore.upstreamRemote,
-    }
-  }
-
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _pushError(error: Error): Promise<void> {
     const newErrors = Array.from(this.errors)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1640,6 +1640,20 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.pullRequestCoordinator.stopPullRequestUpdater()
   }
 
+  public async fetchPullRequest(repository: Repository, pr: string) {
+    const account = getAccountForRepository(this.accounts, repository)
+    const githubRepo = repository.gitHubRepository
+    if (!account || !githubRepo) {
+      return null
+    }
+    const api = API.fromAccount(account)
+    return await api.fetchPullRequest(
+      githubRepo.owner.login,
+      githubRepo.name,
+      pr
+    )
+  }
+
   private shouldBackgroundFetch(
     repository: Repository,
     lastPush: Date | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -81,6 +81,7 @@ import {
   IAPIOrganization,
   IAPIBranch,
   IAPIRepository,
+  getEndpointForRepository,
 } from '../api'
 import { shell } from '../app-shell'
 import {
@@ -1640,18 +1641,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.pullRequestCoordinator.stopPullRequestUpdater()
   }
 
-  public async fetchPullRequest(repository: Repository, pr: string) {
-    const account = getAccountForRepository(this.accounts, repository)
-    const githubRepo = repository.gitHubRepository
-    if (!account || !githubRepo) {
+  public async fetchPullRequest(repoUrl: string, pr: string) {
+    const endpoint = getEndpointForRepository(repoUrl)
+    const account = getAccountForEndpoint(this.accounts, endpoint)
+    if (!account) {
       return null
     }
+
     const api = API.fromAccount(account)
-    return await api.fetchPullRequest(
-      githubRepo.owner.login,
-      githubRepo.name,
-      pr
-    )
+    const { owner, name } = parseRemote(repoUrl)
+    return await api.fetchPullRequest(owner, name, pr)
   }
 
   private shouldBackgroundFetch(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -266,6 +266,7 @@ import {
   findAssociatedPullRequest,
   isPullRequestAssociatedWithBranch,
 } from '../helpers/pull-request-matching'
+import { parseRemote } from '../../lib/remote-parsing'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3358,16 +3358,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       : null
   }
 
-  public async getDefaultAndUpstreamRemotes(repository: Repository) {
+  public async getUpstreamRemote(repository: Repository) {
     const gitStore = this.gitStoreCache.get(repository)
-    if (!gitStore.defaultRemote || !gitStore.upstreamRemote) {
+    if (!gitStore.upstreamRemote) {
       await gitStore.loadRemotes()
     }
 
-    return {
-      default: gitStore.defaultRemote,
-      upstream: gitStore.upstreamRemote,
-    }
+    return gitStore.upstreamRemote
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1650,14 +1650,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async fetchPullRequest(repoUrl: string, pr: string) {
     const endpoint = getEndpointForRepository(repoUrl)
     const account = getAccountForEndpoint(this.accounts, endpoint)
-    if (!account) {
-      return null
-    }
 
-    const api = API.fromAccount(account)
-    const remoteUrl = parseRemote(repoUrl)
-    if (remoteUrl && remoteUrl.owner && remoteUrl.name) {
-      return await api.fetchPullRequest(remoteUrl.owner, remoteUrl.name, pr)
+    if (account) {
+      const api = API.fromAccount(account)
+      const remoteUrl = parseRemote(repoUrl)
+      if (remoteUrl && remoteUrl.owner && remoteUrl.name) {
+        return await api.fetchPullRequest(remoteUrl.owner, remoteUrl.name, pr)
+      }
     }
     return null
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3357,13 +3357,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
       : null
   }
 
-  public async getUpstreamRemote(repository: Repository) {
+  public async getDefaultAndUpstreamRemotes(repository: Repository) {
     const gitStore = this.gitStoreCache.get(repository)
-    if (!gitStore.upstreamRemote) {
+    if (!gitStore.defaultRemote || !gitStore.upstreamRemote) {
       await gitStore.loadRemotes()
     }
 
-    return gitStore.upstreamRemote
+    return {
+      default: gitStore.defaultRemote,
+      upstream: gitStore.upstreamRemote,
+    }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1650,8 +1650,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const api = API.fromAccount(account)
-    const { owner, name } = parseRemote(repoUrl)
-    return await api.fetchPullRequest(owner, name, pr)
+    const remoteUrl = parseRemote(repoUrl)
+    if (remoteUrl && remoteUrl.owner && remoteUrl.name) {
+      return await api.fetchPullRequest(remoteUrl.owner, remoteUrl.name, pr)
+    }
+    return null
   }
 
   private shouldBackgroundFetch(

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1071,10 +1071,6 @@ export class GitStore extends BaseStore {
     this.emitUpdate()
   }
 
-  public remotesLoaded() {
-    return this._remotes !== null
-  }
-
   private initializeRemotes() {
     return {
       _defaultRemote: null,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1203,7 +1203,7 @@ export class GitStore extends BaseStore {
    * This will be `null` if the repository isn't a fork, or if the fork doesn't
    * have an upstream remote.
    */
-  private get upstreamRemote(): IRemote | null {
+  public get upstreamRemote(): IRemote | null {
     return this._upstreamRemote
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1432,29 +1432,51 @@ export class Dispatcher {
 
     /**
      * Open PR in Desktop Scenarios
-     * 
-     * Possible remotes: 
+     *
+     * Possible remotes:
      * upstream, my-fork, not-my-fork
      *
      * Possibe PR source -> target scenarios:
      * upstream -> upstream : if both repos in Desktop, open upstream
      * upstream -> upstream : if only fork in Desktop, open fork
-     * my-fork -> my-fork : open my-fork
-     * my-fork -> upstream : open my-fork / fallback to open upstream, cloning if needed
+     * my-fork -> my-fork : open my-fork, cloning if needed
+     * my-fork -> upstream : open my-fork, cloning if needed
      * not-my-fork -> upstream : open my-fork / fallback to open upstream, cloning if needed
      * upstream -> fork : open upstream
-     * 
+     *
      * Logic:
      * Check source.
      * If source is in Desktop, open it
      * If source is not in Desktop, but fork is, open fork
      * If source and target are fork that is not in Desktop, clone and open fork
      * Fallback to opening upstream, cloning if needed (current behavior)
-     * 
-     * 
      *
-     * If you only have your fork in Desktop and upstream is the PR source, open it in your fork. 
-     * If you only have your fork in Desktop and someone else's fork is the PR source, open it in your fork. 
+     *
+     * If fork exists, open fork. otherwise do default (PR1)
+     * If both exist, open source repo (is that covered by ^?)
+     *
+     * If neither exists, then what do? (PR2)
+     *
+     *
+     *
+     * If source is in Desktop:
+     * If source is in Desktop as a fork, open fork and checkout fork branch
+     * If source is in Desktop as upstream, open upstream and checkout upstream branch
+     *
+     * If neither source nor target is in Desktop, clone and open source unless there is a sibling fork
+     *
+     * If source is not in Desktop:
+     * ... and it is an upstream but fork is in Desktop, open fork (and checkout upstream branch?)
+     * ... and it is an upstream with no fork in Desktop, clone and open upstream and checkout upstream branch
+     * ... and it is a fork with upstream in Desktop, open upstream and checkout fork's branch
+     * ... and if is a fork with no upstream (no forks or upstreams in Desktop), clone and open source???
+     * ... and if is a fork with no upstream but there is another fork in Desktop, open fork and checkout branch from source PR???
+     *
+     * If source is not in Desktop, try to clone the source
+     *
+     *
+     * If you only have your fork in Desktop and upstream is the PR source, open it in your fork.
+     * If you only have your fork in Desktop and someone else's fork is the PR source, open it in your fork.
      * If you have both repos (upstream and your fork) in Desktop, open the PR in the right one (based on the source of the PR).
      */
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1619,7 +1619,6 @@ export class Dispatcher {
       // we need to refetch for a forked PR and check that out
       await this.fetchRefspec(repository, `pull/${pr}/head:${branch}`)
     }
-    debugger
 
     // ensure a fresh clone repository has it's in-memory state
     // up-to-date before performing the "Clone in Desktop" steps

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2,12 +2,7 @@ import { remote } from 'electron'
 import { Disposable, IDisposable } from 'event-kit'
 import * as Path from 'path'
 
-import {
-  IAPIOrganization,
-  IAPIRefStatus,
-  IAPIRepository,
-  IAPIPullRequest,
-} from '../../lib/api'
+import { IAPIOrganization, IAPIRefStatus, IAPIRepository } from '../../lib/api'
 import { shell } from '../../lib/app-shell'
 import {
   CompareAction,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1405,11 +1405,13 @@ export class Dispatcher {
 
     await Promise.all(
       repositories.map(async repo => {
-        const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
-        if (remotes.default && urlsMatch(remotes.default.url, url)) {
-          upstreams.push(repo)
-        } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
-          forks.push(repo)
+        if (repo instanceof Repository) {
+          const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
+          if (remotes.default && urlsMatch(remotes.default.url, url)) {
+            upstreams.push(repo)
+          } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
+            forks.push(repo)
+          }
         }
       })
     )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1463,8 +1463,9 @@ export class Dispatcher {
       return
     }
 
-    // If you only have your fork in Desktop and upstream is the PR source, open it in your fork.
-    // If you only have your fork in Desktop and someone else 's fork is the PR source, open it in your fork.
+    // If you only have your fork in Desktop, open your fork.
+    // Checkout branch based on PR source -- `handleCloneInDesktopOptions`
+    // handles cases when source is upstream or someone else's fork
     if (forks.length > 0 && upstreams.length === 0) {
       const fork = forks[0]
       await this.selectRepository(fork)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1404,21 +1404,21 @@ export class Dispatcher {
     const forks: Array<Repository> = []
     const upstreams: Array<Repository> = []
 
-    await Promise.all(
-      repositories.map(async repo => {
-        if (
-          repo instanceof Repository &&
-          isRepositoryWithGitHubRepository(repo)
-        ) {
-          const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
-          if (remotes.default && urlsMatch(remotes.default.url, url)) {
-            upstreams.push(repo)
-          } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
-            forks.push(repo)
-          }
+    for (const repo of repositories) {
+      // ensure that repo is not an instance of CloningRepository
+      if (
+        repo instanceof Repository &&
+        isRepositoryWithGitHubRepository(repo)
+      ) {
+        const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
+        if (remotes.default && urlsMatch(remotes.default.url, url)) {
+          upstreams.push(repo)
+        } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
+          forks.push(repo)
         }
-      })
-    )
+      }
+    }
+
     return { forks, upstreams }
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1433,11 +1433,15 @@ export class Dispatcher {
     const { forks, upstreams } = await this.getForkAndUpstreamRepos(url)
 
     if (forks.length > 0) {
-      // open the fork corresponding to the PR source
-      const pullRequest =
-        pr && upstreams.length > 0
-          ? await this.appStore.fetchPullRequest(upstreams[0], pr)
-          : null
+      // fetch PR from upstream and open fork corresponding to PR source
+      let pullRequest,
+        i = 0
+      if (pr) {
+        while (!pullRequest && upstreams[i]) {
+          pullRequest = await this.appStore.fetchPullRequest(upstreams[i], pr)
+          i++
+        }
+      }
 
       const sourceUrl =
         pullRequest && pullRequest.head.repo && pullRequest.head.repo.html_url

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1396,23 +1396,26 @@ export class Dispatcher {
     }
   }
 
-  private async getForkRepos(url: string) {
+  private async getForkAndUpstreamRepos(url: string) {
     const state = this.appStore.getState()
     const repositories = state.repositories
 
     const forks: Array<Repository> = []
+    const upstreams: Array<Repository> = []
 
     await Promise.all(
       repositories.map(async repo => {
         if (repo instanceof Repository) {
-          const upstream = await this.appStore.getUpstreamRemote(repo)
-          if (upstream && urlsMatch(upstream.url, url)) {
+          const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
+          if (remotes.default && urlsMatch(remotes.default.url, url)) {
+            upstreams.push(repo)
+          } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
             forks.push(repo)
           }
         }
       })
     )
-    return forks
+    return { forks, upstreams }
   }
 
   private async openRepositoryFromUrl(action: IOpenRepositoryFromURLAction) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -68,6 +68,7 @@ import { PullRequest } from '../../models/pull-request'
 import {
   Repository,
   RepositoryWithGitHubRepository,
+  isRepositoryWithGitHubRepository,
 } from '../../models/repository'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import {
@@ -1405,7 +1406,10 @@ export class Dispatcher {
 
     await Promise.all(
       repositories.map(async repo => {
-        if (repo instanceof Repository) {
+        if (
+          repo instanceof Repository &&
+          isRepositoryWithGitHubRepository(repo)
+        ) {
           const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
           if (remotes.default && urlsMatch(remotes.default.url, url)) {
             upstreams.push(repo)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2,7 +2,12 @@ import { remote } from 'electron'
 import { Disposable, IDisposable } from 'event-kit'
 import * as Path from 'path'
 
-import { IAPIOrganization, IAPIRefStatus, IAPIRepository } from '../../lib/api'
+import {
+  IAPIOrganization,
+  IAPIRefStatus,
+  IAPIRepository,
+  IAPIPullRequest,
+} from '../../lib/api'
 import { shell } from '../../lib/app-shell'
 import {
   CompareAction,
@@ -1415,6 +1420,25 @@ export class Dispatcher {
       })
     )
     return { forks, upstreams }
+  }
+
+  private async fetchPullRequestForRepos(
+    pr: string,
+    repositories: ReadonlyArray<Repository>
+  ): Promise<IAPIPullRequest | null> {
+    if (!pr) {
+      return null
+    }
+    for (let i = 0; i < repositories.length; i++) {
+      const pullRequest = await this.appStore.fetchPullRequest(
+        repositories[i],
+        pr
+      )
+      if (pullRequest) {
+        return pullRequest
+      }
+    }
+    return null
   }
 
   private async openRepositoryFromUrl(action: IOpenRepositoryFromURLAction) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1410,10 +1410,12 @@ export class Dispatcher {
         repo instanceof Repository &&
         isRepositoryWithGitHubRepository(repo)
       ) {
-        const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
-        if (remotes.default && urlsMatch(remotes.default.url, url)) {
+        const defaultUrl = repo.gitHubRepository.htmlURL
+        const upstreamUrl =
+          repo.gitHubRepository.parent && repo.gitHubRepository.parent.htmlURL
+        if (defaultUrl && urlsMatch(defaultUrl, url)) {
           upstreams.push(repo)
-        } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
+        } else if (upstreamUrl && urlsMatch(upstreamUrl, url)) {
           forks.push(repo)
         }
       }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1405,13 +1405,11 @@ export class Dispatcher {
 
     await Promise.all(
       repositories.map(async repo => {
-        if (repo instanceof Repository) {
-          const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
-          if (remotes.default && urlsMatch(remotes.default.url, url)) {
-            upstreams.push(repo)
-          } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
-            forks.push(repo)
-          }
+        const remotes = await this.appStore.getDefaultAndUpstreamRemotes(repo)
+        if (remotes.default && urlsMatch(remotes.default.url, url)) {
+          upstreams.push(repo)
+        } else if (remotes.upstream && urlsMatch(remotes.upstream.url, url)) {
+          forks.push(repo)
         }
       })
     )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1419,67 +1419,6 @@ export class Dispatcher {
   }
 
   private async openRepositoryFromUrl(action: IOpenRepositoryFromURLAction) {
-    /**
-     * For url+pr get source
-     *   - add method in api.ts `fetchPullRequest` that returns source url, to be passed to `openOrCloneRepository`
-     * Check repos in desktop where url is "upstream" (identify repo as fork)
-     * Check repos in desktop where url is "origin" (identify repo as upstream)
-     *
-     * If only fork, open in fork
-     * If both fork and upstream, check source of PR and open there. If source is neither, default to upstream (current behaviour)
-     * Otherwise (only upstream or neither), do default
-     */
-
-    /**
-     * Open PR in Desktop Scenarios
-     *
-     * Possible remotes:
-     * upstream, my-fork, not-my-fork
-     *
-     * Possibe PR source -> target scenarios:
-     * upstream -> upstream : if both repos in Desktop, open upstream
-     * upstream -> upstream : if only fork in Desktop, open fork
-     * my-fork -> my-fork : open my-fork, cloning if needed
-     * my-fork -> upstream : open my-fork, cloning if needed
-     * not-my-fork -> upstream : open my-fork / fallback to open upstream, cloning if needed
-     * upstream -> fork : open upstream
-     *
-     * Logic:
-     * Check source.
-     * If source is in Desktop, open it
-     * If source is not in Desktop, but fork is, open fork
-     * If source and target are fork that is not in Desktop, clone and open fork
-     * Fallback to opening upstream, cloning if needed (current behavior)
-     *
-     *
-     * If fork exists, open fork. otherwise do default (PR1)
-     * If both exist, open source repo (is that covered by ^?)
-     *
-     * If neither exists, then what do? (PR2)
-     *
-     *
-     *
-     * If source is in Desktop:
-     * If source is in Desktop as a fork, open fork and checkout fork branch
-     * If source is in Desktop as upstream, open upstream and checkout upstream branch
-     *
-     * If neither source nor target is in Desktop, clone and open source unless there is a sibling fork
-     *
-     * If source is not in Desktop:
-     * ... and it is an upstream but fork is in Desktop, open fork (and checkout upstream branch?)
-     * ... and it is an upstream with no fork in Desktop, clone and open upstream and checkout upstream branch
-     * ... and it is a fork with upstream in Desktop, open upstream and checkout fork's branch
-     * ... and if is a fork with no upstream (no forks or upstreams in Desktop), clone and open source???
-     * ... and if is a fork with no upstream but there is another fork in Desktop, open fork and checkout branch from source PR???
-     *
-     * If source is not in Desktop, try to clone the source
-     *
-     *
-     * If you only have your fork in Desktop and upstream is the PR source, open it in your fork.
-     * If you only have your fork in Desktop and someone else's fork is the PR source, open it in your fork.
-     * If you have both repos (upstream and your fork) in Desktop, open the PR in the right one (based on the source of the PR).
-     */
-
     const { url, pr } = action
     const pullRequest = pr
       ? await this.appStore.fetchPullRequest(url, pr)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9012 

## Description

This PR introduces behavior supportive of workflows where contributions are made from forks.

Previously, clicking the "open this in GitHub Desktop" link for a **PR made from a fork** on github.com would open the upstream repo, cloning if necessary. In order to make contributions locally from your fork, you would have to open your fork of the repo manually in the app.

With the changes introduced here, Desktop opens a user's fork repo when it makes sense to. We check the source of the PR, and if it is in Desktop (either as a fork or upstream) then we open the source repo and checkout the branch corresponding to the PR. If the source is not in Desktop, but the user has a fork in Desktop (ex: the source is another fork that doesn't belong to the user), we open the user's fork and checkout a branch corresponding to the PR. And in cases other than this we fallback to the current behavior of opening the upstream repo, cloning if needed. 

/ cc @outofambit @billygriffin @tierninho 

### Behavior and test cases

Clone the following repos and open them in Desktop accordingly based on the setup instructions for each scenario:
**Fork:** https://github.com/kuychaco/urban-potato
**Upstream:** https://github.com/not-kuychaco/urban-potato

Note: start out each scenario with a repo focused in Desktop that has nothing to do with the fork or upstream being tested (to test that Desktop correctly switches to the correct repo). 

**Only fork in Desktop, no upstream:**
Note: _The fork opened in Desktop should be the PR source (ex: for https://github.com/not-kuychaco/urban-potato/pull/2, https://github.com/kuychaco/urban-potato is the PR source so clone and open that fork in Desktop)._ 
Before testing each of the following scenarios, make sure master branch is checked out in fork repo, and non-fork repo is the focused repo in Desktop (this tests that Desktop correctly switches to the fork repo, and correctly switches from the default branch to the source branch)
* PR in upstream with fork as source —> opens fork in Desktop and source branch is checked out (https://github.com/not-kuychaco/urban-potato/pull/2) 
* PR in upstream with upstream as source —> opens fork in Desktop and source branch is checked out (https://github.com/not-kuychaco/urban-potato/pull/3)
* PR in upstream with someone else’s fork as source —> opens fork in Desktop and `pr/#` branch is checked out  (https://github.com/not-kuychaco/urban-potato/pull/5)

**Fork AND upstream in Desktop:**
Note: before testing each of the following scenarios, make sure master branch is checked out in fork and upstream repos, and non-fork and non-upstream repo is the focused repo in Desktop (this tests that Desktop correctly switches to the fork repo, and correctly switches from the default branch to the source branch)
* PR in upstream with fork as source —> opens fork in Desktop and source branch is checked out (https://github.com/not-kuychaco/urban-potato/pull/2) 
* PR in upstream with upstream as source —> opens upstream in Desktop and source branch is checked out (https://github.com/not-kuychaco/urban-potato/pull/3)
* PR in upstream with someone else’s fork as source —> opens upstream in Desktop and `pr/#` branch is checked out  (https://github.com/not-kuychaco/urban-potato/pull/5)

**Only upstream in Desktop, no forks:**
Note: before testing each of the following scenarios, make sure master branch is checked out in upstream repo, and non-upstream repo is the focused repo in Desktop (this tests that Desktop correctly switches to the upstream repo, and correctly switches from the default branch to the source branch)
* PR in upstream with fork as source —> opens upstream in Desktop and `pr/#` branch is checked out (https://github.com/not-kuychaco/urban-potato/pull/2) 
* PR in upstream with upstream as source —> opens upstream in Desktop and source branch is checked out (https://github.com/not-kuychaco/urban-potato/pull/3)
* PR in upstream with someone else’s fork as source —> opens upstream in Desktop and `pr/#` branch is checked out  (https://github.com/not-kuychaco/urban-potato/pull/5)

**No fork or upstream in Desktop:**
* open PR listed in upstream repo —> clone repository dialogue opens with upstream url preloaded (https://github.com/not-kuychaco/urban-potato/pulls)
* open PR listed in fork repo —> clone repository dialogue opens with fork url preloaded (https://github.com/kuychaco/urban-potato/pulls)

## Release notes

Notes: [Added] Open a pull request from a GitHub.com PR page in your fork in Desktop
