### PR TITLE
Determine remote endpoint for Git network operations

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -115,3 +115,7 @@ export function enableTutorial(): boolean {
 export function enableCreateForkFlow(): boolean {
   return true
 }
+
+export function enableAutomaticGitProxyConfiguration(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -116,6 +116,10 @@ export function enableCreateForkFlow(): boolean {
   return true
 }
 
+/**
+ * Whether or not to enable support for automatically resolving the
+ * system-configured proxy url and passing that to Git.
+ */
 export function enableAutomaticGitProxyConfiguration(): boolean {
   return enableDevelopmentFeatures()
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -116,10 +116,6 @@ export function enableCreateForkFlow(): boolean {
   return true
 }
 
-/**
- * Whether or not to enable support for automatically resolving the
- * system-configured proxy url and passing that to Git.
- */
 export function enableAutomaticGitProxyConfiguration(): boolean {
   return enableDevelopmentFeatures()
 }

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -115,7 +115,3 @@ export function enableTutorial(): boolean {
 export function enableCreateForkFlow(): boolean {
   return true
 }
-
-export function enableAutomaticGitProxyConfiguration(): boolean {
-  return enableDevelopmentFeatures()
-}

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -3,10 +3,14 @@ import { getBranches } from './for-each-ref'
 import { Repository } from '../../models/repository'
 import { Branch, BranchType } from '../../models/branch'
 import { IGitAccount } from '../../models/git-account'
-import { envForAuthentication } from './authentication'
 import { formatAsLocalRef } from './refs'
 import { deleteRef } from './update-ref'
 import { GitError as DugiteError } from 'dugite'
+import { getRemoteURL } from './remote'
+import {
+  envForRemoteOperation,
+  getFallbackUrlForProxyResolve,
+} from './environment'
 
 /**
  * Create a new branch from the given start point.
@@ -73,22 +77,30 @@ export async function deleteBranch(
     await deleteLocalBranch(repository, branch.name)
   }
 
-  const remote = branch.remote
+  const remoteName = branch.remote
 
-  if (includeRemote && remote) {
+  if (includeRemote && remoteName) {
     const networkArguments = await gitNetworkArguments(repository, account)
+    const remoteUrl =
+      (await getRemoteURL(repository, remoteName).catch(err => {
+        // If we can't get the URL then it's very unlikely Git will be able to
+        // either and the push will fail. The URL is only used to resolve the
+        // proxy though so it's not critical.
+        log.error(`Could not resolve remote url for remote ${remoteName}`, err)
+        return null
+      })) || getFallbackUrlForProxyResolve(account, repository)
 
     const args = [
       ...networkArguments,
       'push',
-      remote,
+      remoteName,
       `:${branch.nameWithoutRemote}`,
     ]
 
     // If the user is not authenticated, the push is going to fail
     // Let this propagate and leave it to the caller to handle
     const result = await git(args, repository.path, 'deleteRemoteBranch', {
-      env: envForAuthentication(account),
+      env: envForRemoteOperation(account, remoteUrl),
       expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
     })
 
@@ -97,7 +109,7 @@ export async function deleteBranch(
     // error we can safely remote our remote ref which is what would
     // happen if the push didn't fail.
     if (result.gitError === DugiteError.BranchDeletionFailed) {
-      const ref = `refs/remotes/${remote}/${branch.nameWithoutRemote}`
+      const ref = `refs/remotes/${remoteName}/${branch.nameWithoutRemote}`
       await deleteRef(repository, ref)
     }
   }

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -100,7 +100,7 @@ export async function deleteBranch(
     // If the user is not authenticated, the push is going to fail
     // Let this propagate and leave it to the caller to handle
     const result = await git(args, repository.path, 'deleteRemoteBranch', {
-      env: envForRemoteOperation(account, remoteUrl),
+      env: await envForRemoteOperation(account, remoteUrl),
       expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
     })
 

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -67,7 +67,7 @@ export async function checkoutBranch(
   progressCallback?: ProgressCallback
 ): Promise<true> {
   let opts: IGitExecutionOptions = {
-    env: envForRemoteOperation(
+    env: await envForRemoteOperation(
       account,
       getFallbackUrlForProxyResolve(account, repository)
     ),

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -7,8 +7,12 @@ import {
   CheckoutProgressParser,
   executionOptionsWithProgress,
 } from '../progress'
-import { envForAuthentication, AuthenticationErrors } from './authentication'
+import { AuthenticationErrors } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
+import {
+  envForRemoteOperation,
+  getFallbackUrlForProxyResolve,
+} from './environment'
 
 export type ProgressCallback = (progress: ICheckoutProgress) => void
 
@@ -63,7 +67,10 @@ export async function checkoutBranch(
   progressCallback?: ProgressCallback
 ): Promise<true> {
   let opts: IGitExecutionOptions = {
-    env: envForAuthentication(account),
+    env: envForRemoteOperation(
+      account,
+      getFallbackUrlForProxyResolve(account, repository)
+    ),
     expectedErrors: AuthenticationErrors,
   }
 

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -2,7 +2,7 @@ import { git, IGitExecutionOptions, gitNetworkArguments } from './core'
 import { ICloneProgress } from '../../models/progress'
 import { CloneOptions } from '../../models/clone-options'
 import { CloneProgressParser, executionOptionsWithProgress } from '../progress'
-import { envForAuthentication } from './authentication'
+import { envForRemoteOperation } from './environment'
 
 /**
  * Clones a repository from a given url into to the specified path.
@@ -32,7 +32,7 @@ export async function clone(
 ): Promise<void> {
   const networkArguments = await gitNetworkArguments(null, options.account)
 
-  const env = envForAuthentication(options.account)
+  const env = envForRemoteOperation(options.account, url)
 
   const args = [...networkArguments, 'clone', '--recursive']
 

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -32,7 +32,7 @@ export async function clone(
 ): Promise<void> {
   const networkArguments = await gitNetworkArguments(null, options.account)
 
-  const env = envForRemoteOperation(options.account, url)
+  const env = await envForRemoteOperation(options.account, url)
 
   const args = [...networkArguments, 'clone', '--recursive']
 

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -60,7 +60,7 @@ export function getFallbackUrlForProxyResolve(
  *                  pointing to another host entirely. Used to resolve which
  *                  proxy (if any) should be used for the operation.
  */
-export function envForRemoteOperation(
+export async function envForRemoteOperation(
   account: IGitAccount | null,
   remoteUrl: string
 ) {

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -18,7 +18,10 @@ import { IGitAccount } from '../../models/git-account'
  *                  pointing to another host entirely. Used to resolve which
  *                  proxy (if any) should be used for the operation.
  */
-export function envForRemoteOperation(account: IGitAccount, remoteUrl: string) {
+export function envForRemoteOperation(
+  account: IGitAccount | null,
+  remoteUrl: string
+) {
   return {
     ...envForAuthentication(account),
   }

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -1,0 +1,25 @@
+import { envForAuthentication } from './authentication'
+import { IGitAccount } from '../../models/git-account'
+
+/**
+ * Create a set of environment variables to use when invoking a Git
+ * subcommand that needs to communicate with a remote (i.e. fetch, clone,
+ * push, pull, ls-remote, etc etc).
+ *
+ * The environment variables deal with setting up sane defaults, configuring
+ * authentication, and resolving proxy urls if necessary.
+ *
+ * @param account   The authentication information (if available) to provide
+ *                  to Git for use when connectingt to the remote
+ * @param remoteUrl The primary remote URL for this operation. Note that Git
+ *                  might connect to other remotes in order to fulfill the
+ *                  operation. As an example, a clone of
+ *                  https://github.com/desktop/desktop could containt a submodule
+ *                  pointing to another host entirely. Used to resolve which
+ *                  proxy (if any) should be used for the operation.
+ */
+export function envForRemoteOperation(account: IGitAccount, remoteUrl: string) {
+  return {
+    ...envForAuthentication(account),
+  }
+}

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -1,5 +1,47 @@
 import { envForAuthentication } from './authentication'
 import { IGitAccount } from '../../models/git-account'
+import { getDotComAPIEndpoint } from '../api'
+import { Repository } from '../../models/repository'
+
+/**
+ * For many remote operations it's well known what the primary remote
+ * url is (clone, push, fetch etc). But in some cases it's not as easy.
+ *
+ * Two examples are checkout, and revert where neither would need to
+ * hit the network in vanilla Git usage but do need to when LFS gets
+ * involved.
+ *
+ * What's the primary url when using LFS then? Most likely it's gonna
+ * be on the same as the default remote but it could theoretically
+ * be on a different server as well. That's too advanced for our usage
+ * at the moment though so we'll just need to figure out some reasonable
+ * url to fall back on.
+ */
+export function getFallbackUrlForProxyResolve(
+  account: IGitAccount | null,
+  repository: Repository
+) {
+  // If we've got an account with an endpoint that means we've already done the
+  // heavy lifting to figure out what the most likely endpoint is gonna be
+  // so we'll try to leverage that.
+  if (account !== null) {
+    // A GitHub.com Account will have api.github.com as its endpoint
+    return account.endpoint === getDotComAPIEndpoint()
+      ? 'https://github.com'
+      : account.endpoint
+  }
+
+  if (repository.gitHubRepository !== null) {
+    if (repository.gitHubRepository.cloneURL !== null) {
+      return repository.gitHubRepository.cloneURL
+    }
+  }
+
+  // If all else fails let's assume that whatever network resource
+  // Git is gonna hit it's gonna be using the same proxy as it would
+  // if it was a GitHub.com endpoint
+  return 'https://github.com'
+}
 
 /**
  * Create a set of environment variables to use when invoking a Git

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -5,6 +5,7 @@ import { IFetchProgress } from '../../models/progress'
 import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
+import { IRemote } from '../../models/remote'
 
 async function getFetchArgs(
   repository: Repository,
@@ -56,7 +57,7 @@ async function getFetchArgs(
 export async function fetch(
   repository: Repository,
   account: IGitAccount | null,
-  remote: string,
+  remote: IRemote,
   progressCallback?: (progress: IFetchProgress) => void
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
@@ -65,7 +66,7 @@ export async function fetch(
   }
 
   if (progressCallback) {
-    const title = `Fetching ${remote}`
+    const title = `Fetching ${remote.name}`
     const kind = 'fetch'
 
     opts = await executionOptionsWithProgress(
@@ -86,15 +87,26 @@ export async function fetch(
           progress.kind === 'progress' ? progress.details.text : progress.text
         const value = progress.percent
 
-        progressCallback({ kind, title, description, value, remote })
+        progressCallback({
+          kind,
+          title,
+          description,
+          value,
+          remote: remote.name,
+        })
       }
     )
 
     // Initial progress
-    progressCallback({ kind, title, value: 0, remote })
+    progressCallback({ kind, title, value: 0, remote: remote.name })
   }
 
-  const args = await getFetchArgs(repository, remote, account, progressCallback)
+  const args = await getFetchArgs(
+    repository,
+    remote.name,
+    account,
+    progressCallback
+  )
   await git(args, repository.path, 'fetch', opts)
 }
 

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -62,7 +62,7 @@ export async function fetch(
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
-    env: envForRemoteOperation(account, remote.url),
+    env: await envForRemoteOperation(account, remote.url),
   }
 
   if (progressCallback) {
@@ -119,7 +119,7 @@ export async function fetchRefspec(
 ): Promise<void> {
   const options = {
     successExitCodes: new Set([0, 128]),
-    env: envForRemoteOperation(account, remote.url),
+    env: await envForRemoteOperation(account, remote.url),
   }
 
   const networkArguments = await gitNetworkArguments(repository, account)

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -3,7 +3,6 @@ import { Repository } from '../../models/repository'
 import { IGitAccount } from '../../models/git-account'
 import { IFetchProgress } from '../../models/progress'
 import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
-import { envForAuthentication } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
@@ -115,17 +114,17 @@ export async function fetch(
 export async function fetchRefspec(
   repository: Repository,
   account: IGitAccount | null,
-  remote: string,
+  remote: IRemote,
   refspec: string
 ): Promise<void> {
   const options = {
     successExitCodes: new Set([0, 128]),
-    env: envForAuthentication(account),
+    env: envForRemoteOperation(account, remote.url),
   }
 
   const networkArguments = await gitNetworkArguments(repository, account)
 
-  const args = [...networkArguments, 'fetch', remote, refspec]
+  const args = [...networkArguments, 'fetch', remote.name, refspec]
 
   await git(args, repository.path, 'fetchRefspec', options)
 }

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -6,6 +6,7 @@ import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 import { IRemote } from '../../models/remote'
+import { envForRemoteOperation } from './environment'
 
 async function getFetchArgs(
   repository: Repository,
@@ -62,7 +63,7 @@ export async function fetch(
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
-    env: envForAuthentication(account),
+    env: envForRemoteOperation(account, remote.url),
   }
 
   if (progressCallback) {

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -56,7 +56,7 @@ export async function pull(
   progressCallback?: (progress: IPullProgress) => void
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
-    env: envForRemoteOperation(account, remote.url),
+    env: await envForRemoteOperation(account, remote.url),
     expectedErrors: AuthenticationErrors,
   }
 

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -61,7 +61,7 @@ export async function pull(
   }
 
   if (progressCallback) {
-    const title = `Pulling ${remote}`
+    const title = `Pulling ${remote.name}`
     const kind = 'pull'
 
     opts = await executionOptionsWithProgress(

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -8,9 +8,10 @@ import { Repository } from '../../models/repository'
 import { IPullProgress } from '../../models/progress'
 import { IGitAccount } from '../../models/git-account'
 import { PullProgressParser, executionOptionsWithProgress } from '../progress'
-import { envForAuthentication, AuthenticationErrors } from './authentication'
+import { AuthenticationErrors } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 import { IRemote } from '../../models/remote'
+import { envForRemoteOperation } from './environment'
 
 async function getPullArgs(
   repository: Repository,
@@ -55,7 +56,7 @@ export async function pull(
   progressCallback?: (progress: IPullProgress) => void
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
-    env: envForAuthentication(account),
+    env: envForRemoteOperation(account, remote.url),
     expectedErrors: AuthenticationErrors,
   }
 

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -10,6 +10,7 @@ import { IGitAccount } from '../../models/git-account'
 import { PullProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication, AuthenticationErrors } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
+import { IRemote } from '../../models/remote'
 
 async function getPullArgs(
   repository: Repository,
@@ -50,7 +51,7 @@ async function getPullArgs(
 export async function pull(
   repository: Repository,
   account: IGitAccount | null,
-  remote: string,
+  remote: IRemote,
   progressCallback?: (progress: IPullProgress) => void
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
@@ -81,15 +82,26 @@ export async function pull(
 
         const value = progress.percent
 
-        progressCallback({ kind, title, description, value, remote })
+        progressCallback({
+          kind,
+          title,
+          description,
+          value,
+          remote: remote.name,
+        })
       }
     )
 
     // Initial progress
-    progressCallback({ kind, title, value: 0, remote })
+    progressCallback({ kind, title, value: 0, remote: remote.name })
   }
 
-  const args = await getPullArgs(repository, remote, account, progressCallback)
+  const args = await getPullArgs(
+    repository,
+    remote.name,
+    account,
+    progressCallback
+  )
   const result = await git(args, repository.path, 'pull', opts)
 
   if (result.gitErrorDescription) {

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -11,6 +11,7 @@ import { IPushProgress } from '../../models/progress'
 import { IGitAccount } from '../../models/git-account'
 import { PushProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForAuthentication, AuthenticationErrors } from './authentication'
+import { IRemote } from '../../models/remote'
 
 export type PushOptions = {
   readonly forceWithLease: boolean
@@ -41,7 +42,7 @@ export type PushOptions = {
 export async function push(
   repository: Repository,
   account: IGitAccount | null,
-  remote: string,
+  remote: IRemote,
   localBranch: string,
   remoteBranch: string | null,
   options?: PushOptions,
@@ -52,7 +53,7 @@ export async function push(
   const args = [
     ...networkArguments,
     'push',
-    remote,
+    remote.name,
     remoteBranch ? `${localBranch}:${remoteBranch}` : localBranch,
   ]
 
@@ -88,7 +89,7 @@ export async function push(
           title,
           description,
           value,
-          remote,
+          remote: remote.name,
           branch: localBranch,
         })
       }
@@ -99,7 +100,7 @@ export async function push(
       kind: 'push',
       title,
       value: 0,
-      remote,
+      remote: remote.name,
       branch: localBranch,
     })
   }

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -74,7 +74,7 @@ export async function push(
 
   if (progressCallback) {
     args.push('--progress')
-    const title = `Pushing to ${remote}`
+    const title = `Pushing to ${remote.name}`
     const kind = 'push'
 
     opts = await executionOptionsWithProgress(

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -68,7 +68,7 @@ export async function push(
   expectedErrors.add(DugiteError.ProtectedBranchForcePush)
 
   let opts: IGitExecutionOptions = {
-    env: envForRemoteOperation(account, remote.url),
+    env: await envForRemoteOperation(account, remote.url),
     expectedErrors,
   }
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -10,8 +10,9 @@ import { Repository } from '../../models/repository'
 import { IPushProgress } from '../../models/progress'
 import { IGitAccount } from '../../models/git-account'
 import { PushProgressParser, executionOptionsWithProgress } from '../progress'
-import { envForAuthentication, AuthenticationErrors } from './authentication'
+import { AuthenticationErrors } from './authentication'
 import { IRemote } from '../../models/remote'
+import { envForRemoteOperation } from './environment'
 
 export type PushOptions = {
   readonly forceWithLease: boolean
@@ -67,7 +68,7 @@ export async function push(
   expectedErrors.add(DugiteError.ProtectedBranchForcePush)
 
   let opts: IGitExecutionOptions = {
-    env: envForAuthentication(account),
+    env: envForRemoteOperation(account, remote.url),
     expectedErrors,
   }
 

--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -65,3 +65,26 @@ export async function setRemoteURL(
   await git(['remote', 'set-url', name, url], repository.path, 'setRemoteURL')
   return true
 }
+
+/**
+ * Get the URL for the remote that matches the given name.
+ *
+ * Returns null if the remote could not be found
+ */
+export async function getRemoteURL(
+  repository: Repository,
+  name: string
+): Promise<string | null> {
+  const result = await git(
+    ['remote', 'get-url', name],
+    repository.path,
+    'getRemoteURL',
+    { successExitCodes: new Set([0, 128]) }
+  )
+
+  if (result.exitCode !== 0) {
+    return null
+  }
+
+  return result.stdout
+}

--- a/app/src/lib/git/revert.ts
+++ b/app/src/lib/git/revert.ts
@@ -37,7 +37,7 @@ export async function revertCommit(
 
   let opts: IGitExecutionOptions = {}
   if (progressCallback) {
-    const env = envForRemoteOperation(
+    const env = await envForRemoteOperation(
       account,
       getFallbackUrlForProxyResolve(account, repository)
     )

--- a/app/src/lib/git/revert.ts
+++ b/app/src/lib/git/revert.ts
@@ -1,5 +1,4 @@
 import { git, gitNetworkArguments, IGitExecutionOptions } from './core'
-import { envForAuthentication } from './authentication'
 
 import { Repository } from '../../models/repository'
 import { Commit } from '../../models/commit'
@@ -8,6 +7,10 @@ import { IGitAccount } from '../../models/git-account'
 
 import { executionOptionsWithProgress } from '../progress/from-process'
 import { RevertProgressParser } from '../progress/revert'
+import {
+  envForRemoteOperation,
+  getFallbackUrlForProxyResolve,
+} from './environment'
 
 /**
  * Creates a new commit that reverts the changes of a previous commit
@@ -34,7 +37,10 @@ export async function revertCommit(
 
   let opts: IGitExecutionOptions = {}
   if (progressCallback) {
-    const env = envForAuthentication(account)
+    const env = envForRemoteOperation(
+      account,
+      getFallbackUrlForProxyResolve(account, repository)
+    )
     opts = await executionOptionsWithProgress(
       { env, trackLFSProgress: true },
       new RevertProgressParser(),

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3539,7 +3539,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
             await pushRepo(
               repository,
               account,
-              remote,
+              safeRemote,
               branch.name,
               branch.upstreamWithoutRemote,
               options,
@@ -3554,7 +3554,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
             await gitStore.fetchRemotes(
               account,
-              [remote],
+              [safeRemote],
               false,
               fetchProgress => {
                 this.updatePushPullFetchProgress(repository, {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3495,13 +3495,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
           repository,
         }
 
+        const safeRemote: IRemote = { name: remoteName, url: remote.url }
         const gitStore = this.gitStoreCache.get(repository)
         await gitStore.performFailableOperation(
           async () => {
             await pushRepo(
               repository,
               account,
-              remoteName,
+              remote,
               branch.name,
               branch.upstreamWithoutRemote,
               options,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3706,7 +3706,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
           await gitStore.performFailableOperation(
             () =>
-              pullRepo(repository, account, remote.name, progress => {
+              pullRepo(repository, account, remote, progress => {
                 this.updatePushPullFetchProgress(repository, {
                   ...progress,
                   value: progress.value * pullWeight,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3496,6 +3496,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
         }
 
         const safeRemote: IRemote = { name: remoteName, url: remote.url }
+
+        if (safeRemote.name !== remote.name) {
+          sendNonFatalException(
+            'remoteNameMismatch',
+            new Error('The current remote name differs from the branch remote')
+          )
+        }
+
         const gitStore = this.gitStoreCache.get(repository)
         await gitStore.performFailableOperation(
           async () => {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3495,6 +3495,35 @@ export class AppStore extends TypedBaseStore<IAppState> {
           repository,
         }
 
+        // This is most likely not necessary and is only here out of
+        // an abundance of caution. We're introducing support for
+        // automatically configuring Git proxies based on system
+        // proxy settings and therefore need to pass along the remote
+        // url to functions such as push, pull, fetch etc.
+        //
+        // Prior to this we relied primarily on the `branch.remote`
+        // property and used the `remote.name` as a fallback in case the
+        // branch object didn't have a remote name (i.e. if it's not
+        // published yet).
+        //
+        // The remote.name is derived from the current tip first and falls
+        // back to using the defaultRemote if the current tip isn't valid
+        // or if the current branch isn't published. There's however no
+        // guarantee that they'll be refreshed at the exact same time so
+        // there's a theoretical possibility that `branch.remote` and
+        // `remote.name` could be out of sync. I have no reason to suspect
+        // that's the case and if it is then we already have problems as
+        // the `fetchRemotes` call after the push already relies on the
+        // `remote` and not the `branch.remote`. All that said this is
+        // a critical path in the app and somehow breaking pushing would
+        // be near unforgivable so I'm introducing this `safeRemote`
+        // temporarily to ensure that there's no risk of us using an
+        // out of sync remote name while still providing envForRemoteOperation
+        // with an url to use when resolving proxies.
+        //
+        // I'm also adding a non fatal exception if this ever happens
+        // so that we can confidently remove this safeguard in a future
+        // release.
         const safeRemote: IRemote = { name: remoteName, url: remote.url }
 
         if (safeRemote.name !== remote.name) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -849,7 +849,7 @@ export class GitStore extends BaseStore {
       const remote = remotes[i]
       const startProgressValue = i * weight
 
-      await this.fetchRemote(account, remote.name, backgroundTask, progress => {
+      await this.fetchRemote(account, remote, backgroundTask, progress => {
         if (progress && progressCallback) {
           progressCallback({
             ...progress,
@@ -871,7 +871,7 @@ export class GitStore extends BaseStore {
    */
   public async fetchRemote(
     account: IGitAccount | null,
-    remote: string,
+    remote: IRemote,
     backgroundTask: boolean,
     progressCallback?: (fetchProgress: IFetchProgress) => void
   ): Promise<void> {
@@ -880,9 +880,7 @@ export class GitStore extends BaseStore {
       repository: this.repository,
     }
     await this.performFailableOperation(
-      () => {
-        return fetchRepo(this.repository, account, remote, progressCallback)
-      },
+      () => fetchRepo(this.repository, account, remote, progressCallback),
       { backgroundTask, retryAction }
     )
   }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -903,7 +903,7 @@ export class GitStore extends BaseStore {
 
     for (const remote of remotes) {
       await this.performFailableOperation(() =>
-        fetchRefspec(this.repository, account, remote.name, refspec)
+        fetchRefspec(this.repository, account, remote, refspec)
       )
     }
   }

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -8,10 +8,10 @@ import {
   executionOptionsWithProgress,
   PushProgressParser,
 } from '../../progress'
-import { envForAuthentication } from '../../git/authentication'
 import { git } from '../../git'
 import { friendlyEndpointName } from '../../friendly-endpoint-name'
 import { IRemote } from '../../../models/remote'
+import { envForRemoteOperation } from '../../git/environment'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InititalReadmeContents =
@@ -70,7 +70,7 @@ async function pushRepo(
 
   const pushOpts = await executionOptionsWithProgress(
     {
-      env: envForAuthentication(account),
+      env: envForRemoteOperation(account, remote.url),
     },
     new PushProgressParser(),
     progress => {

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -11,6 +11,7 @@ import {
 import { envForAuthentication } from '../../git/authentication'
 import { git } from '../../git'
 import { friendlyEndpointName } from '../../friendly-endpoint-name'
+import { IRemote } from '../../../models/remote'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InititalReadmeContents =
@@ -61,6 +62,7 @@ async function createAPIRepository(account: Account, name: string) {
 async function pushRepo(
   path: string,
   account: Account,
+  remote: IRemote,
   progressCb: (title: string, value: number, description?: string) => void
 ) {
   const pushTitle = `Pushing repository to ${friendlyEndpointName(account)}`
@@ -78,7 +80,7 @@ async function pushRepo(
     }
   )
 
-  const args = ['push', '-u', 'origin', 'master']
+  const args = ['push', '-u', remote.name, 'master']
   await git(args, path, 'tutorial:push', pushOpts)
 }
 
@@ -125,13 +127,16 @@ export async function createTutorialRepository(
     path,
     'tutorial:commit'
   )
+
+  const remote: IRemote = { name: 'origin', url: repo.clone_url }
+
   await git(
-    ['remote', 'add', 'origin', repo.clone_url],
+    ['remote', 'add', remote.name, remote.url],
     path,
     'tutorial:add-remote'
   )
 
-  await pushRepo(path, account, (title, value, description) => {
+  await pushRepo(path, account, remote, (title, value, description) => {
     progressCb(title, 0.3 + value * 0.6, description)
   })
 

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -70,7 +70,7 @@ async function pushRepo(
 
   const pushOpts = await executionOptionsWithProgress(
     {
-      env: envForRemoteOperation(account, remote.url),
+      env: await envForRemoteOperation(account, remote.url),
     },
     new PushProgressParser(),
     progress => {

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -16,8 +16,8 @@ import { setupLocalConfig } from '../../../helpers/local-config'
 import { IRemote } from '../../../../src/models/remote'
 
 const featureBranch = 'this-is-a-feature'
-const origin: IRemote = { name: 'origin', url: 'file://' }
-const remoteBranch = `${origin}/${featureBranch}`
+const remote: IRemote = { name: 'origin', url: 'file://' }
+const remoteBranch = `${remote.name}/${featureBranch}`
 
 describe('git/pull', () => {
   describe('ahead and behind of tracking branch', () => {
@@ -52,7 +52,7 @@ describe('git/pull', () => {
       }
 
       await makeCommit(repository, changesForLocalRepository)
-      await fetch(repository, null, origin)
+      await fetch(repository, null, remote)
     })
 
     describe('with pull.rebase=false and pull.ff=false set in config', () => {
@@ -67,7 +67,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })
@@ -83,10 +83,7 @@ describe('git/pull', () => {
       })
 
       it('is ahead of tracking branch', async () => {
-        const range = revSymmetricDifference(
-          featureBranch,
-          `${origin}/${featureBranch}`
-        )
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
 
         const aheadBehind = await getAheadBehind(repository, range)
         expect(aheadBehind).toEqual({
@@ -105,7 +102,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })
@@ -116,10 +113,7 @@ describe('git/pull', () => {
       })
 
       it('is ahead of tracking branch', async () => {
-        const range = revSymmetricDifference(
-          featureBranch,
-          `${origin}/${featureBranch}`
-        )
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
 
         const aheadBehind = await getAheadBehind(repository, range)
         expect(aheadBehind).toEqual({
@@ -138,7 +132,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })
@@ -149,10 +143,7 @@ describe('git/pull', () => {
       })
 
       it('is ahead of tracking branch', async () => {
-        const range = revSymmetricDifference(
-          featureBranch,
-          `${origin}/${featureBranch}`
-        )
+        const range = revSymmetricDifference(featureBranch, remoteBranch)
 
         const aheadBehind = await getAheadBehind(repository, range)
         expect(aheadBehind).toEqual({
@@ -171,7 +162,7 @@ describe('git/pull', () => {
       })
 
       it(`throws an error as the user blocks merge commits on pull`, () => {
-        expect(pull(repository, null, origin)).rejects.toThrow()
+        expect(pull(repository, null, remote)).rejects.toThrow()
       })
     })
   })

--- a/app/test/unit/git/pull/ahead-and-behind-test.ts
+++ b/app/test/unit/git/pull/ahead-and-behind-test.ts
@@ -13,9 +13,10 @@ import {
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/git'
 import { setupLocalConfig } from '../../../helpers/local-config'
+import { IRemote } from '../../../../src/models/remote'
 
 const featureBranch = 'this-is-a-feature'
-const origin = 'origin'
+const origin: IRemote = { name: 'origin', url: 'file://' }
 const remoteBranch = `${origin}/${featureBranch}`
 
 describe('git/pull', () => {

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -16,8 +16,8 @@ import { setupLocalConfig } from '../../../helpers/local-config'
 import { IRemote } from '../../../../src/models/remote'
 
 const featureBranch = 'this-is-a-feature'
-const origin: IRemote = { name: 'origin', url: 'file://' }
-const remoteBranch = `${origin}/${featureBranch}`
+const remote: IRemote = { name: 'origin', url: 'file://' }
+const remoteBranch = `${remote.name}/${featureBranch}`
 
 describe('git/pull', () => {
   describe('only ahead of tracking branch', () => {
@@ -40,7 +40,7 @@ describe('git/pull', () => {
       }
 
       await makeCommit(repository, changesForLocalRepository)
-      await fetch(repository, null, origin)
+      await fetch(repository, null, remote)
     })
 
     describe('by default', () => {
@@ -50,7 +50,7 @@ describe('git/pull', () => {
       beforeEach(async () => {
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })
@@ -85,7 +85,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })
@@ -119,7 +119,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })

--- a/app/test/unit/git/pull/only-ahead-test.ts
+++ b/app/test/unit/git/pull/only-ahead-test.ts
@@ -13,9 +13,10 @@ import {
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/git'
 import { setupLocalConfig } from '../../../helpers/local-config'
+import { IRemote } from '../../../../src/models/remote'
 
 const featureBranch = 'this-is-a-feature'
-const origin = 'origin'
+const origin: IRemote = { name: 'origin', url: 'file://' }
 const remoteBranch = `${origin}/${featureBranch}`
 
 describe('git/pull', () => {

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -16,8 +16,8 @@ import { setupLocalConfig } from '../../../helpers/local-config'
 import { IRemote } from '../../../../src/models/remote'
 
 const featureBranch = 'this-is-a-feature'
-const origin: IRemote = { name: 'origin', url: 'file://' }
-const remoteBranch = `${origin}/${featureBranch}`
+const remote: IRemote = { name: 'origin', url: 'file://' }
+const remoteBranch = `${remote.name}/${featureBranch}`
 
 describe('git/pull', () => {
   describe('only behind tracking branch', () => {
@@ -52,7 +52,7 @@ describe('git/pull', () => {
       await makeCommit(remoteRepository, firstCommit)
       await makeCommit(remoteRepository, secondCommit)
 
-      await fetch(repository, null, origin)
+      await fetch(repository, null, remote)
     })
 
     describe('with pull.rebase=false and pull.ff=false set in config', () => {
@@ -67,7 +67,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })
@@ -102,7 +102,7 @@ describe('git/pull', () => {
 
         previousTip = await getTipOrError(repository)
 
-        await pull(repository, null, origin)
+        await pull(repository, null, remote)
 
         newTip = await getTipOrError(repository)
       })

--- a/app/test/unit/git/pull/only-behind-test.ts
+++ b/app/test/unit/git/pull/only-behind-test.ts
@@ -13,9 +13,10 @@ import {
 } from '../../../helpers/repository-scaffolding'
 import { getTipOrError, getRefOrError } from '../../../helpers/git'
 import { setupLocalConfig } from '../../../helpers/local-config'
+import { IRemote } from '../../../../src/models/remote'
 
 const featureBranch = 'this-is-a-feature'
-const origin = 'origin'
+const origin: IRemote = { name: 'origin', url: 'file://' }
 const remoteBranch = `${origin}/${featureBranch}`
 
 describe('git/pull', () => {


### PR DESCRIPTION
*This is another continuation of the proxy support started in #9126 and #9127.*

Now that we're going to start looking up the proxy to use for Git network operations we're going to have to have an understanding of what the remote endpoint is gonna be for any given network operation.

Corporate proxies are often set up so that a script determines which proxy to use based on the url that the client wants to access (for https urls the script usually only gets the protocol and domain). See #9127 for details on that. 

Unfortunately for us there's not a 1:1 correlation between git command and url. Take the simplest case of `git clone URL` for example. While the initial request will be to `URL` it's possible that the repository could contain submodules pointing to other hosts. It's also possible that the repository is set up to use LFS in which case there may be subsequent requests to a dedicated LFS server.

While there might be multiple endpoints accessed by a single Git call we only have the ability to provide Git one proxy url per protocol (http/https) so we're gonna have do do a best-effort guess at a reasonable host. We're also gonna assume that the vast majority of repositories these days do all of their communications over http**s**.

It's also worth noting that the model we've used to provide Git with authentication details (username/password) has been based on the premise that the same credentials will work for any submodule and/or LFS instance accessed during the operation.

I've introduced a substitute method for `envForAuthentication` called `envForRemoteOperation`. This will now be the centralized location for determining the proxy url. The actual process of setting the required environment variables will come in a follow up pr.

## Notes for the reviewer

This PR touches sensitive parts of the codebase such as fetch, push, and pull. Please keep a lookout for anything that looks off or alters the behavior of either of these operations in a way not described below.

### Affected operations

**deleteBranch**

`deleteBranch` is also responsible for deleting the branch on the remote which means that it's essentially a `push` operation. Here I've had to introduce a new git operation to load the url of the branch remote. The risk of not being able to resolve the remote url is slim here but there's a fallback anyway

**Expected altered behavior**: One extra Git exec to lookup the remote url of the remote tracking branch

**checkout and revert**

While not a network operation in Git's eyes it's possible that the repository is set up to use LFS which might have to communicate with its server on checkout or revert. While we can't tell for certain what the LFS server url is (without shelling out to git lfs) it's a pretty safe bet that the account endpoint is a decent substitute given that that's what Git LFS will use to authenticate.

**Expected altered behavior**: None

**clone**

We use whatever url is provided as the remote url

**Expected altered behavior**: None

**fetch and fetchRefSpec**

We already had access to `IRemote` objects a few levels up in the call chain to the changes in here are just forwarding that information down rather than only using the `name` property of the `IRemote`

**Expected altered behavior**: None

**push**

This one got a bit complicated because I really didn't want to risk introducing any new behavior here. See the code for a long comment explaining the tradeoff.

**Expected altered behavior**: None

**Tutorial repository creation**

Simply a refactor to pass the known remote url to `envForRemoteOperation`

**Expected altered behavior**: None
