### PR TITLE
Add "create github issue" menu item

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -115,3 +115,11 @@ export function enableTutorial(): boolean {
 export function enableCreateForkFlow(): boolean {
   return true
 }
+
+/**
+ * Should we show the "Create Issue on GitHub" item under
+ * "Repository" in the app menu?
+ */
+export function enableCreateGitHubIssueFromMenu(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -247,6 +247,10 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.setEnabled('view-repository-on-github', isHostedOnGitHub)
     menuStateBuilder.setEnabled(
+      'create-issue-in-repository-on-github',
+      isHostedOnGitHub
+    )
+    menuStateBuilder.setEnabled(
       'create-pull-request',
       isHostedOnGitHub && !branchIsUnborn && !onDetachedHead
     )

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -323,6 +323,15 @@ export function buildDefaultMenu({
       },
       separator,
       {
+        id: 'create-issue-in-repository-on-github',
+        label: __DARWIN__
+          ? 'Create Issue on GitHub'
+          : 'Create &Issue on GitHub',
+        accelerator: 'CmdOrCtrl+Shift+I',
+        click: emit('create-issue-in-repository-on-github'),
+      },
+      separator,
+      {
         label: __DARWIN__ ? 'Repository Settings…' : 'Repository &settings…',
         id: 'show-repository-settings',
         click: emit('show-repository-settings'),

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -330,7 +330,7 @@ export function buildDefaultMenu({
         id: 'create-issue-in-repository-on-github',
         label: __DARWIN__
           ? 'Create Issue on GitHub'
-          : 'Create &Issue on GitHub',
+          : 'Create &issue on GitHub',
         accelerator: 'CmdOrCtrl+Shift+I',
         click: emit('create-issue-in-repository-on-github'),
         visible: enableCreateGitHubIssueFromMenu(),

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -5,7 +5,11 @@ import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { ensureDir } from 'fs-extra'
 import { openDirectorySafe } from '../shell'
-import { enableRebaseDialog, enableStashing } from '../../lib/feature-flag'
+import {
+  enableRebaseDialog,
+  enableStashing,
+  enableCreateGitHubIssueFromMenu,
+} from '../../lib/feature-flag'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { DefaultEditorLabel } from '../../ui/lib/context-menu'
 
@@ -329,6 +333,7 @@ export function buildDefaultMenu({
           : 'Create &Issue on GitHub',
         accelerator: 'CmdOrCtrl+Shift+I',
         click: emit('create-issue-in-repository-on-github'),
+        visible: enableCreateGitHubIssueFromMenu(),
       },
       separator,
       {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -36,3 +36,4 @@ export type MenuEvent =
   | 'hide-stashed-changes'
   | 'test-prune-branches'
   | 'find-text'
+  | 'create-issue-in-repository-on-github'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -31,3 +31,4 @@ export type MenuIDs =
   | 'create-pull-request'
   | 'compare-to-branch'
   | 'toggle-stashed-changes'
+  | 'create-issue-in-repository-on-github'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1111,7 +1111,6 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (url) {
       this.props.dispatcher.openInBrowser(`${url}/issues/new/choose`)
-      return
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -352,6 +352,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.viewRepositoryOnGitHub()
       case 'compare-on-github':
         return this.compareBranchOnDotcom()
+      case 'create-issue-in-repository-on-github':
+        return this.createIssueInRepositoryOnGitHub()
       case 'open-in-shell':
         return this.openCurrentRepositoryInShell()
       case 'clone-repository':
@@ -1098,6 +1100,20 @@ export class App extends React.Component<IAppProps, IAppState> {
       type: PopupType.RepositorySettings,
       repository,
     })
+  }
+
+  /**
+   * Opens a browser to the issue creation page
+   * of the current GitHub repository.
+   */
+  private createIssueInRepositoryOnGitHub() {
+    const url = this.getCurrentRepositoryGitHubURL()
+
+    if (url) {
+      // TODO: use 'issues/new/choose' for repos with issue templates
+      this.props.dispatcher.openInBrowser(`${url}/issues/new`)
+      return
+    }
   }
 
   private viewRepositoryOnGitHub() {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1110,8 +1110,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     const url = this.getCurrentRepositoryGitHubURL()
 
     if (url) {
-      // TODO: use 'issues/new/choose' for repos with issue templates
-      this.props.dispatcher.openInBrowser(`${url}/issues/new`)
+      this.props.dispatcher.openInBrowser(`${url}/issues/new/choose`)
       return
     }
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #8989 

## Description

- adds menu item that opens the "new issue" page on github for the current repo
- menu item is disabled when user is in a non-github repo
- feature flagged
- repos without issue templates will see a less than ideal web page (empty template list with a small link to open a blank issue at the bottom), but this is getting fixed on server-side github

### Screenshots

<img width="274" alt="screenshot of create issue menu item" src="https://user-images.githubusercontent.com/964912/74952771-bd266580-53ce-11ea-8478-7a9c9f6176e8.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Add menu shortcut to create GitHub issues
