### PR TITLE
Never schedule more than one animation frame on resize

### DIFF
--- a/app/src/ui/diff/code-mirror-host.tsx
+++ b/app/src/ui/diff/code-mirror-host.tsx
@@ -136,7 +136,7 @@ export class CodeMirrorHost extends React.Component<ICodeMirrorHostProps, {}> {
             cancelAnimationFrame(this.resizeDebounceId)
             this.resizeDebounceId = null
           }
-          requestAnimationFrame(this.onResized)
+          this.resizeDebounceId = requestAnimationFrame(this.onResized)
         }
       }
     })

--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -463,7 +463,7 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
             cancelAnimationFrame(this.resizeDebounceId)
             this.resizeDebounceId = null
           }
-          requestAnimationFrame(this.onResized)
+          this.resizeDebounceId = requestAnimationFrame(this.onResized)
         }
       }
     })


### PR DESCRIPTION
Spotted this silly mistake while working on something completely different. I appears I forgot to assign the id from `requestAnimationFrame` in https://github.com/desktop/desktop/commit/0e46fea83047ef187b0b2213105f5faa95368258 and that made its way through copy-paste into https://github.com/desktop/desktop/commit/7ad6df0e92c721c1c1032e07e6feb7f0b49074e9 and that.

The effect is just some unnecessary computation when resizing which obviously hasn't been big enough of an issue for any of us to notice up until now, therefore super low priority but tossing in 2.4 just so that it doesn't get lost in the void.