### PR TITLE
Add GitHubRepository test fixture utility

### DIFF
--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -4,8 +4,7 @@ import { getDotComAPIEndpoint } from '../../src/lib/api'
 
 let id_counter = 0
 
-// TODO: rename me!
-export function plainGitHubRepo({
+export function gitHubRepoFixture({
   owner,
   name,
   parent,

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -40,6 +40,9 @@ export function gitHubRepoFixture({
   endpoint,
   isPrivate,
 }: IGitHubRepoFixtureOptions): GitHubRepository {
+  const htmlUrl = `${
+    endpoint !== undefined ? endpoint : 'https://github.com'
+  }/${owner}/${name}`
   return new GitHubRepository(
     name,
     new Owner(
@@ -49,13 +52,9 @@ export function gitHubRepoFixture({
     ),
     id_counter++,
     isPrivate !== undefined ? isPrivate : null,
-    endpoint !== undefined
-      ? `${endpoint}/${owner}/${name}`
-      : `https://github.com/${owner}/${name}`,
+    htmlUrl,
     defaultBranch || 'master',
-    endpoint !== undefined
-      ? `${endpoint}/${owner}/${name}.git`
-      : `https://github.com/${owner}/${name}.git`,
+    `${htmlUrl}.git`,
     null,
     parent
   )

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -4,19 +4,38 @@ import { getDotComAPIEndpoint } from '../../src/lib/api'
 
 let id_counter = 0
 
+/**
+ * Most of these fields are passed on to the
+ * GitHubRepository constructor directly.
+ *
+ * Notable exception: `endpoint`
+ */
+interface IGitHubRepoFixtureOptions {
+  owner: string
+  name: string
+  parent?: GitHubRepository
+  defaultBranch?: string
+  /**
+   * Defaults to github.com if omitted.
+   * We make an attempt at constructing a meaningful non-github.com
+   * clone url and html url from this, even if its ''.
+   */
+  endpoint?: string
+}
+
+/**
+ * Makes a fairly standard `GitHubRepository` for use in tests.
+ * Ensures a unique `dbID` for each, during a test run.
+ * @param options
+ * @returns a new GitHubRepository model
+ */
 export function gitHubRepoFixture({
   owner,
   name,
   parent,
   defaultBranch,
   endpoint,
-}: {
-  owner: string
-  name: string
-  parent?: GitHubRepository
-  defaultBranch?: string
-  endpoint?: string
-}) {
+}: IGitHubRepoFixtureOptions): GitHubRepository {
   return new GitHubRepository(
     name,
     new Owner(

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -1,0 +1,40 @@
+import { GitHubRepository } from '../../src/models/github-repository'
+import { Owner } from '../../src/models/owner'
+import { getDotComAPIEndpoint } from '../../src/lib/api'
+
+let id_counter = 0
+
+// TODO: rename me!
+export function plainGitHubRepo({
+  owner,
+  name,
+  parent,
+  defaultBranch,
+  endpoint,
+}: {
+  owner: string
+  name: string
+  parent?: GitHubRepository
+  defaultBranch?: string
+  endpoint?: string
+}) {
+  return new GitHubRepository(
+    name,
+    new Owner(
+      owner,
+      endpoint !== undefined ? endpoint : getDotComAPIEndpoint(),
+      null
+    ),
+    id_counter++,
+    null,
+    endpoint !== undefined
+      ? `${endpoint}/${owner}/${name}`
+      : `https://github.com/${owner}/${name}`,
+    defaultBranch || 'master',
+    endpoint !== undefined
+      ? `${endpoint}/${owner}/${name}.git`
+      : `https://github.com/${owner}/${name}.git`,
+    null,
+    parent
+  )
+}

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -14,7 +14,10 @@ interface IGitHubRepoFixtureOptions {
   owner: string
   name: string
   parent?: GitHubRepository
+  /** defaults to 'master' */
   defaultBranch?: string
+  isPrivate?: boolean
+
   /**
    * Defaults to github.com if omitted.
    * We make an attempt at constructing a meaningful non-github.com
@@ -35,6 +38,7 @@ export function gitHubRepoFixture({
   parent,
   defaultBranch,
   endpoint,
+  isPrivate,
 }: IGitHubRepoFixtureOptions): GitHubRepository {
   return new GitHubRepository(
     name,
@@ -44,7 +48,7 @@ export function gitHubRepoFixture({
       null
     ),
     id_counter++,
-    null,
+    isPrivate !== undefined ? isPrivate : null,
     endpoint !== undefined
       ? `${endpoint}/${owner}/${name}`
       : `https://github.com/${owner}/${name}`,

--- a/app/test/unit/find-upstream-remote-test.ts
+++ b/app/test/unit/find-upstream-remote-test.ts
@@ -2,11 +2,11 @@ import {
   findUpstreamRemote,
   UpstreamRemoteName,
 } from '../../src/lib/stores/helpers/find-upstream-remote'
-import { plainGitHubRepo } from '../helpers/github-repo-builder'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 describe('findUpstreamRemote', () => {
   it('finds the upstream', () => {
-    const parent = plainGitHubRepo({
+    const parent = gitHubRepoFixture({
       name: 'github-release-stats',
       owner: 'somsubhra',
     })

--- a/app/test/unit/find-upstream-remote-test.ts
+++ b/app/test/unit/find-upstream-remote-test.ts
@@ -2,21 +2,14 @@ import {
   findUpstreamRemote,
   UpstreamRemoteName,
 } from '../../src/lib/stores/helpers/find-upstream-remote'
-import { GitHubRepository } from '../../src/models/github-repository'
-import { Owner } from '../../src/models/owner'
+import { plainGitHubRepo } from '../helpers/github-repo-builder'
 
 describe('findUpstreamRemote', () => {
   it('finds the upstream', () => {
-    const parent = new GitHubRepository(
-      'github-release-stats',
-      new Owner('somsubhra', 'https://api.github.com', null),
-      null,
-      false,
-      'https://github.com/Somsubhra/github-release-stats',
-      'master',
-      'https://github.com/Somsubhra/github-release-stats.git',
-      null
-    )
+    const parent = plainGitHubRepo({
+      name: 'github-release-stats',
+      owner: 'somsubhra',
+    })
     const remotes = [
       {
         name: 'upstream',

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -7,7 +7,7 @@ import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
 import { Repository } from '../../src/models/repository'
 import { IRemote } from '../../src/models/remote'
 import { ComparisonCache } from '../../src/lib/comparison-cache'
-import { plainGitHubRepo } from '../helpers/github-repo-builder'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 function createTestCommit(sha: string) {
   return new Commit(
@@ -35,7 +35,7 @@ function createTestGhRepo(
   defaultBranch: string | null = null,
   parent: GitHubRepository | null = null
 ) {
-  return plainGitHubRepo({
+  return gitHubRepoFixture({
     owner: owner,
     name: 'my-cool-repo',
     defaultBranch: `${

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -3,11 +3,11 @@ import { Branch, BranchType } from '../../src/models/branch'
 import { Commit } from '../../src/models/commit'
 import { CommitIdentity } from '../../src/models/commit-identity'
 import { GitHubRepository } from '../../src/models/github-repository'
-import { Owner } from '../../src/models/owner'
 import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
 import { Repository } from '../../src/models/repository'
 import { IRemote } from '../../src/models/remote'
 import { ComparisonCache } from '../../src/lib/comparison-cache'
+import { plainGitHubRepo } from '../helpers/github-repo-builder'
 
 function createTestCommit(sha: string) {
   return new Commit(
@@ -35,29 +35,16 @@ function createTestGhRepo(
   defaultBranch: string | null = null,
   parent: GitHubRepository | null = null
 ) {
-  if (owner.indexOf('/') !== -1) {
-    throw new Error(
-      'Providing a slash in the repository name is no longer supported, please update your test'
-    )
-  }
-
-  const cloneURL = `https://github.com/${owner}/my-cool-repo.git`
-
-  return new GitHubRepository(
-    name,
-    new Owner('', '', null),
-    null,
-    false,
-    '',
-    `${
+  return plainGitHubRepo({
+    owner: owner,
+    name: 'my-cool-repo',
+    defaultBranch: `${
       defaultBranch !== null && defaultBranch.indexOf('/') !== -1
         ? defaultBranch.split('/')[1]
         : defaultBranch
     }`,
-    cloneURL,
-    'write',
-    parent
-  )
+    parent: parent || undefined,
+  })
 }
 
 function createTestPrRef(branch: Branch, ghRepo: GitHubRepository) {

--- a/app/test/unit/name-of-test.ts
+++ b/app/test/unit/name-of-test.ts
@@ -1,5 +1,5 @@
 import { Repository, nameOf } from '../../src/models/repository'
-import { plainGitHubRepo } from '../helpers/github-repo-builder'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 const repoPath = '/some/cool/path'
 
@@ -13,7 +13,7 @@ describe('nameOf', () => {
   })
 
   it('Returns the name of the repo', () => {
-    const ghRepo = plainGitHubRepo({ owner: 'desktop', name: 'name' })
+    const ghRepo = gitHubRepoFixture({ owner: 'desktop', name: 'name' })
     const repo = new Repository(repoPath, -1, ghRepo, false)
 
     const name = nameOf(repo)

--- a/app/test/unit/name-of-test.ts
+++ b/app/test/unit/name-of-test.ts
@@ -1,6 +1,5 @@
 import { Repository, nameOf } from '../../src/models/repository'
-import { GitHubRepository } from '../../src/models/github-repository'
-import { Owner } from '../../src/models/owner'
+import { plainGitHubRepo } from '../helpers/github-repo-builder'
 
 const repoPath = '/some/cool/path'
 
@@ -14,11 +13,7 @@ describe('nameOf', () => {
   })
 
   it('Returns the name of the repo', () => {
-    const ghRepo = new GitHubRepository(
-      'name',
-      new Owner('desktop', '', null),
-      null
-    )
+    const ghRepo = plainGitHubRepo({ owner: 'desktop', name: 'name' })
     const repo = new Repository(repoPath, -1, ghRepo, false)
 
     const name = nameOf(repo)

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -3,10 +3,8 @@ import {
   KnownRepositoryGroup,
 } from '../../src/ui/repositories-list/group-repositories'
 import { Repository, ILocalRepositoryState } from '../../src/models/repository'
-import { GitHubRepository } from '../../src/models/github-repository'
-import { Owner } from '../../src/models/owner'
-import { getDotComAPIEndpoint } from '../../src/lib/api'
 import { CloningRepository } from '../../src/models/cloning-repository'
+import { plainGitHubRepo } from '../helpers/github-repo-builder'
 
 describe('repository list grouping', () => {
   const repositories: Array<Repository | CloningRepository> = [
@@ -14,17 +12,13 @@ describe('repository list grouping', () => {
     new Repository(
       'repo2',
       2,
-      new GitHubRepository(
-        'my-repo2',
-        new Owner('me', getDotComAPIEndpoint(), null),
-        1
-      ),
+      plainGitHubRepo({ owner: 'me', name: 'my-repo2' }),
       false
     ),
     new Repository(
       'repo3',
       3,
-      new GitHubRepository('my-repo3', new Owner('', '', null), 1),
+      plainGitHubRepo({ owner: '', name: 'my-repo3', endpoint: '' }),
       false
     ),
   ]
@@ -59,22 +53,14 @@ describe('repository list grouping', () => {
     const repoB = new Repository(
       'b',
       2,
-      new GitHubRepository(
-        'b',
-        new Owner('me', getDotComAPIEndpoint(), null),
-        1
-      ),
+      plainGitHubRepo({ owner: 'me', name: 'b' }),
       false
     )
     const repoC = new Repository('c', 2, null, false)
     const repoD = new Repository(
       'd',
       2,
-      new GitHubRepository(
-        'd',
-        new Owner('me', getDotComAPIEndpoint(), null),
-        1
-      ),
+      plainGitHubRepo({ owner: 'me', name: 'd' }),
       false
     )
     const repoZ = new Repository('z', 3, null, false)
@@ -105,41 +91,33 @@ describe('repository list grouping', () => {
     const repoA = new Repository(
       'repo',
       1,
-      new GitHubRepository(
-        'repo',
-        new Owner('user1', getDotComAPIEndpoint(), null),
-        1
-      ),
+      plainGitHubRepo({ owner: 'user1', name: 'repo' }),
       false
     )
     const repoB = new Repository(
       'repo',
       2,
-      new GitHubRepository(
-        'repo',
-        new Owner('user2', getDotComAPIEndpoint(), null),
-        2
-      ),
+      plainGitHubRepo({ owner: 'user2', name: 'repo' }),
       false
     )
     const repoC = new Repository(
       'enterprise-repo',
       3,
-      new GitHubRepository(
-        'enterprise-repo',
-        new Owner('business', '', null),
-        1
-      ),
+      plainGitHubRepo({
+        owner: 'business',
+        name: 'enterprise-repo',
+        endpoint: '',
+      }),
       false
     )
     const repoD = new Repository(
       'enterprise-repo',
       3,
-      new GitHubRepository(
-        'enterprise-repo',
-        new Owner('silliness', '', null),
-        1
-      ),
+      plainGitHubRepo({
+        owner: 'silliness',
+        name: 'enterprise-repo',
+        endpoint: '',
+      }),
       false
     )
 

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -18,7 +18,11 @@ describe('repository list grouping', () => {
     new Repository(
       'repo3',
       3,
-      gitHubRepoFixture({ owner: '', name: 'my-repo3', endpoint: '' }),
+      gitHubRepoFixture({
+        owner: '',
+        name: 'my-repo3',
+        endpoint: 'github.big-corp.com',
+      }),
       false
     ),
   ]

--- a/app/test/unit/repositories-list-grouping-test.ts
+++ b/app/test/unit/repositories-list-grouping-test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../src/ui/repositories-list/group-repositories'
 import { Repository, ILocalRepositoryState } from '../../src/models/repository'
 import { CloningRepository } from '../../src/models/cloning-repository'
-import { plainGitHubRepo } from '../helpers/github-repo-builder'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 describe('repository list grouping', () => {
   const repositories: Array<Repository | CloningRepository> = [
@@ -12,13 +12,13 @@ describe('repository list grouping', () => {
     new Repository(
       'repo2',
       2,
-      plainGitHubRepo({ owner: 'me', name: 'my-repo2' }),
+      gitHubRepoFixture({ owner: 'me', name: 'my-repo2' }),
       false
     ),
     new Repository(
       'repo3',
       3,
-      plainGitHubRepo({ owner: '', name: 'my-repo3', endpoint: '' }),
+      gitHubRepoFixture({ owner: '', name: 'my-repo3', endpoint: '' }),
       false
     ),
   ]
@@ -53,14 +53,14 @@ describe('repository list grouping', () => {
     const repoB = new Repository(
       'b',
       2,
-      plainGitHubRepo({ owner: 'me', name: 'b' }),
+      gitHubRepoFixture({ owner: 'me', name: 'b' }),
       false
     )
     const repoC = new Repository('c', 2, null, false)
     const repoD = new Repository(
       'd',
       2,
-      plainGitHubRepo({ owner: 'me', name: 'd' }),
+      gitHubRepoFixture({ owner: 'me', name: 'd' }),
       false
     )
     const repoZ = new Repository('z', 3, null, false)
@@ -91,19 +91,19 @@ describe('repository list grouping', () => {
     const repoA = new Repository(
       'repo',
       1,
-      plainGitHubRepo({ owner: 'user1', name: 'repo' }),
+      gitHubRepoFixture({ owner: 'user1', name: 'repo' }),
       false
     )
     const repoB = new Repository(
       'repo',
       2,
-      plainGitHubRepo({ owner: 'user2', name: 'repo' }),
+      gitHubRepoFixture({ owner: 'user2', name: 'repo' }),
       false
     )
     const repoC = new Repository(
       'enterprise-repo',
       3,
-      plainGitHubRepo({
+      gitHubRepoFixture({
         owner: 'business',
         name: 'enterprise-repo',
         endpoint: '',
@@ -113,7 +113,7 @@ describe('repository list grouping', () => {
     const repoD = new Repository(
       'enterprise-repo',
       3,
-      plainGitHubRepo({
+      gitHubRepoFixture({
         owner: 'silliness',
         name: 'enterprise-repo',
         endpoint: '',

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -5,6 +5,7 @@ import {
 } from '../../src/lib/repository-matching'
 import { Account } from '../../src/models/account'
 import { GitHubRepository } from '../../src/models/github-repository'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 describe('repository-matching', () => {
   describe('matchGitHubRepository', () => {
@@ -144,26 +145,11 @@ describe('repository-matching', () => {
   })
 
   describe('cloneUrlMatches', () => {
-    const repository: GitHubRepository = {
-      dbID: 1,
+    const repository = gitHubRepoFixture({
       name: 'desktop',
-      fullName: 'shiftkey/desktop',
-      cloneURL: 'https://github.com/shiftkey/desktop.git',
-      owner: {
-        login: 'shiftkey',
-        id: 1234,
-        endpoint: 'https://api.github.com/',
-        hash: 'whatever',
-      },
+      owner: 'shiftkey',
       isPrivate: false,
-      htmlURL: 'https://github.com/shiftkey/desktop',
-      defaultBranch: 'master',
-      parent: null,
-      endpoint: 'https://api.github.com/',
-      fork: true,
-      hash: 'whatever',
-      permissions: 'write',
-    }
+    })
 
     const repositoryWithoutCloneURL: GitHubRepository = {
       dbID: 1,

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -4,8 +4,8 @@ import {
   EmojiMatch,
   HyperlinkMatch,
 } from '../../src/lib/text-token-parser'
-import { GitHubRepository } from '../../src/models/github-repository'
 import { Repository } from '../../src/models/repository'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 const emoji = new Map<string, string>([[':shipit:', '/some/path.png']])
 
@@ -36,32 +36,15 @@ describe('Tokenizer', () => {
 
   describe('with GitHub repository', () => {
     const host = 'https://github.com'
-    const endpoint = 'https://api.github.com'
     const login = 'shiftkey'
     const name = 'some-repo'
     const htmlURL = `${host}/${login}/${name}`
-    const cloneURL = `${host}/${login}/${name}.git`
 
-    const gitHubRepository: GitHubRepository = {
-      dbID: 1,
+    const gitHubRepository = gitHubRepoFixture({
       name,
-      owner: {
-        endpoint,
-        login,
-        hash: '',
-        id: null,
-      },
-      cloneURL,
-      endpoint: 'https://api.github.com',
-      fullName: `${login}/${name}`,
+      owner: login,
       isPrivate: false,
-      fork: false,
-      htmlURL: htmlURL,
-      defaultBranch: 'master',
-      hash: '',
-      parent: null,
-      permissions: null,
-    }
+    })
 
     const repository = new Repository(
       'some/path/to/repo',


### PR DESCRIPTION
supports further work related to #8989 

## Description

We call the `GitHubRepository` constructor directly in many places in our unit tests. Since we enumerate the arguments separately, this means that anytime we update the `GitHubRepository` constructor with new fields, a bunch of tests break even if they don't use that field. I've run into this multiple times while working on forks and issues integration in desktop.

This PR adds a little factory function to wrap the GitHubRepository constructor to minimize churn in our unit tests.
