### PR TITLE
Disable creating issues from desktop on repos that have issues disabled

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -104,6 +104,7 @@ export interface IAPIRepository {
   readonly default_branch: string
   readonly pushed_at: string
   readonly parent?: IAPIRepository
+  readonly has_issues?: boolean
 
   /**
    * The high-level permissions that the currently authenticated

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -104,7 +104,7 @@ export interface IAPIRepository {
   readonly default_branch: string
   readonly pushed_at: string
   readonly parent?: IAPIRepository
-  readonly has_issues?: boolean
+  readonly has_issues: boolean
 
   /**
    * The high-level permissions that the currently authenticated

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -103,8 +103,9 @@ export interface IAPIRepository {
   readonly fork: boolean
   readonly default_branch: string
   readonly pushed_at: string
-  readonly parent?: IAPIRepository
   readonly has_issues: boolean
+  readonly archived: boolean
+  readonly parent?: IAPIRepository
 
   /**
    * The high-level permissions that the currently authenticated

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -22,6 +22,8 @@ export interface IDatabaseGitHubRepository {
   /** The last time a prune was attempted on the repository */
   readonly lastPruneDate: number | null
 
+  readonly issuesEnabled: boolean | null
+
   readonly permissions?: 'read' | 'write' | 'admin' | null
 }
 

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -23,6 +23,7 @@ export interface IDatabaseGitHubRepository {
   readonly lastPruneDate: number | null
 
   readonly issuesEnabled?: boolean
+  readonly isArchived?: boolean
 
   readonly permissions?: 'read' | 'write' | 'admin' | null
 }

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -22,7 +22,7 @@ export interface IDatabaseGitHubRepository {
   /** The last time a prune was attempted on the repository */
   readonly lastPruneDate: number | null
 
-  readonly issuesEnabled: boolean | null
+  readonly issuesEnabled?: boolean | null
 
   readonly permissions?: 'read' | 'write' | 'admin' | null
 }

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -22,7 +22,7 @@ export interface IDatabaseGitHubRepository {
   /** The last time a prune was attempted on the repository */
   readonly lastPruneDate: number | null
 
-  readonly issuesEnabled?: boolean | null
+  readonly issuesEnabled?: boolean
 
   readonly permissions?: 'read' | 'write' | 'admin' | null
 }

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -166,7 +166,8 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     selectedState !== null &&
     selectedState.repository instanceof Repository &&
     isRepositoryWithGitHubRepository(selectedState.repository) &&
-    selectedState.repository.gitHubRepository.issuesEnabled !== false
+    selectedState.repository.gitHubRepository.issuesEnabled !== false &&
+    selectedState.repository.gitHubRepository.isArchived !== true
 
   if (selectedState && selectedState.type === SelectionType.Repository) {
     repositorySelected = true

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -1,7 +1,10 @@
 import { MenuIDs } from '../models/menu-ids'
 import { merge } from './merge'
 import { IAppState, SelectionType } from '../lib/app-state'
-import { Repository } from '../models/repository'
+import {
+  Repository,
+  isRepositoryWithGitHubRepository,
+} from '../models/repository'
 import { CloningRepository } from '../models/cloning-repository'
 import { TipState } from '../models/tip'
 import { updateMenuState as ipcUpdateMenuState } from '../ui/main-process-proxy'
@@ -158,6 +161,12 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let branchIsUnborn = false
   let rebaseInProgress = false
   let branchHasStashEntry = false
+  // check that its a github repo and if so, that is has issues enabled
+  const repoIssuesEnabled =
+    selectedState !== null &&
+    selectedState.repository instanceof Repository &&
+    isRepositoryWithGitHubRepository(selectedState.repository) &&
+    selectedState.repository.gitHubRepository.issuesEnabled !== false
 
   if (selectedState && selectedState.type === SelectionType.Repository) {
     repositorySelected = true
@@ -248,7 +257,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     menuStateBuilder.setEnabled('view-repository-on-github', isHostedOnGitHub)
     menuStateBuilder.setEnabled(
       'create-issue-in-repository-on-github',
-      isHostedOnGitHub
+      repoIssuesEnabled
     )
     menuStateBuilder.setEnabled(
       'create-pull-request',

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -91,7 +91,8 @@ export class RepositoriesStore extends TypedBaseStore<
       dbRepo.defaultBranch,
       dbRepo.cloneURL,
       dbRepo.permissions,
-      parent
+      parent,
+      dbRepo.issuesEnabled
     )
   }
 
@@ -390,6 +391,11 @@ export class RepositoriesStore extends TypedBaseStore<
       .equals([owner.id!, gitHubRepository.name])
       .first()
 
+    const issuesEnabled =
+      gitHubRepository.has_issues !== undefined
+        ? gitHubRepository.has_issues
+        : null
+
     // If we can't resolve permissions for the current repository
     // chances are that it's because it's the parent repository of
     // another repository and we ended up here because the "actual"
@@ -415,6 +421,7 @@ export class RepositoriesStore extends TypedBaseStore<
       parentID: parent ? parent.dbID : null,
       lastPruneDate: null,
       permissions,
+      issuesEnabled,
     }
     if (existingRepo) {
       updatedGitHubRepo = { ...updatedGitHubRepo, id: existingRepo.id }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -91,6 +91,7 @@ export class RepositoriesStore extends TypedBaseStore<
       dbRepo.defaultBranch,
       dbRepo.cloneURL,
       dbRepo.issuesEnabled,
+      dbRepo.isArchived,
       dbRepo.permissions,
       parent
     )
@@ -415,8 +416,9 @@ export class RepositoriesStore extends TypedBaseStore<
       cloneURL: gitHubRepository.clone_url,
       parentID: parent ? parent.dbID : null,
       lastPruneDate: null,
-      permissions,
       issuesEnabled: gitHubRepository.has_issues,
+      isArchived: gitHubRepository.archived,
+      permissions,
     }
     if (existingRepo) {
       updatedGitHubRepo = { ...updatedGitHubRepo, id: existingRepo.id }
@@ -432,6 +434,7 @@ export class RepositoriesStore extends TypedBaseStore<
       updatedGitHubRepo.defaultBranch,
       updatedGitHubRepo.cloneURL,
       updatedGitHubRepo.issuesEnabled,
+      updatedGitHubRepo.isArchived,
       updatedGitHubRepo.permissions,
       parent
     )

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -90,9 +90,9 @@ export class RepositoriesStore extends TypedBaseStore<
       dbRepo.htmlURL,
       dbRepo.defaultBranch,
       dbRepo.cloneURL,
+      dbRepo.issuesEnabled,
       dbRepo.permissions,
-      parent,
-      dbRepo.issuesEnabled
+      parent
     )
   }
 
@@ -391,11 +391,6 @@ export class RepositoriesStore extends TypedBaseStore<
       .equals([owner.id!, gitHubRepository.name])
       .first()
 
-    const issuesEnabled =
-      gitHubRepository.has_issues !== undefined
-        ? gitHubRepository.has_issues
-        : null
-
     // If we can't resolve permissions for the current repository
     // chances are that it's because it's the parent repository of
     // another repository and we ended up here because the "actual"
@@ -421,7 +416,7 @@ export class RepositoriesStore extends TypedBaseStore<
       parentID: parent ? parent.dbID : null,
       lastPruneDate: null,
       permissions,
-      issuesEnabled,
+      issuesEnabled: gitHubRepository.has_issues,
     }
     if (existingRepo) {
       updatedGitHubRepo = { ...updatedGitHubRepo, id: existingRepo.id }
@@ -436,6 +431,7 @@ export class RepositoriesStore extends TypedBaseStore<
       updatedGitHubRepo.htmlURL,
       updatedGitHubRepo.defaultBranch,
       updatedGitHubRepo.cloneURL,
+      updatedGitHubRepo.issuesEnabled,
       updatedGitHubRepo.permissions,
       parent
     )

--- a/app/src/models/github-repository.ts
+++ b/app/src/models/github-repository.ts
@@ -20,7 +20,8 @@ export class GitHubRepository {
     public readonly cloneURL: string | null = null,
     /** The user's permissions for this github repository. `null` if unknown. */
     public readonly permissions: GitHubRepositoryPermission = null,
-    public readonly parent: GitHubRepository | null = null
+    public readonly parent: GitHubRepository | null = null,
+    public readonly issuesEnabled: boolean | null = null
   ) {}
 
   public get endpoint(): string {

--- a/app/src/models/github-repository.ts
+++ b/app/src/models/github-repository.ts
@@ -18,10 +18,10 @@ export class GitHubRepository {
     public readonly htmlURL: string | null = null,
     public readonly defaultBranch: string | null = 'master',
     public readonly cloneURL: string | null = null,
+    public readonly issuesEnabled: boolean | null = null,
     /** The user's permissions for this github repository. `null` if unknown. */
     public readonly permissions: GitHubRepositoryPermission = null,
-    public readonly parent: GitHubRepository | null = null,
-    public readonly issuesEnabled: boolean | null = null
+    public readonly parent: GitHubRepository | null = null
   ) {}
 
   public get endpoint(): string {

--- a/app/src/models/github-repository.ts
+++ b/app/src/models/github-repository.ts
@@ -19,6 +19,7 @@ export class GitHubRepository {
     public readonly defaultBranch: string | null = 'master',
     public readonly cloneURL: string | null = null,
     public readonly issuesEnabled: boolean | null = null,
+    public readonly isArchived: boolean | null = null,
     /** The user's permissions for this github repository. `null` if unknown. */
     public readonly permissions: GitHubRepositoryPermission = null,
     public readonly parent: GitHubRepository | null = null

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -43,6 +43,7 @@ const repository = new Repository(
     fork: false,
     hash: '',
     permissions: null,
+    issuesEnabled: null,
   },
   true
 )

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -42,8 +42,9 @@ const repository = new Repository(
     fullName: 'desktop/desktop',
     fork: false,
     hash: '',
-    permissions: null,
     issuesEnabled: null,
+    isArchived: false,
+    permissions: null,
   },
   true
 )

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -56,7 +56,7 @@ export function gitHubRepoFixture({
     defaultBranch || 'master',
     `${htmlUrl}.git`,
     null,
-    parent,
-    null
+    null,
+    parent
   )
 }

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -56,6 +56,7 @@ export function gitHubRepoFixture({
     defaultBranch || 'master',
     `${htmlUrl}.git`,
     null,
-    parent
+    parent,
+    null
   )
 }

--- a/app/test/helpers/github-repo-builder.ts
+++ b/app/test/helpers/github-repo-builder.ts
@@ -57,6 +57,7 @@ export function gitHubRepoFixture({
     `${htmlUrl}.git`,
     null,
     null,
+    null,
     parent
   )
 }

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -81,6 +81,7 @@ export async function setupRepository(
       fork: false,
       default_branch: defaultBranchName,
       pushed_at: 'string',
+      has_issues: true,
       permissions: {
         pull: true,
         push: true,

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -82,6 +82,7 @@ export async function setupRepository(
       default_branch: defaultBranchName,
       pushed_at: 'string',
       has_issues: true,
+      archived: false,
       permissions: {
         pull: true,
         push: true,

--- a/app/test/unit/octicon-test.ts
+++ b/app/test/unit/octicon-test.ts
@@ -1,33 +1,7 @@
 import { OcticonSymbol, iconForRepository } from '../../src/ui/octicons'
 import { CloningRepository } from '../../src/models/cloning-repository'
 import { Repository } from '../../src/models/repository'
-import { GitHubRepository } from '../../src/models/github-repository'
-
-function getTestRepository(
-  isPrivate: boolean,
-  isFork: boolean = false
-): GitHubRepository {
-  return {
-    dbID: 1,
-    name: 'some-repo',
-    owner: {
-      endpoint: 'https://api.github.com',
-      login: 'shiftkey',
-      hash: '',
-      id: null,
-    },
-    endpoint: 'https://api.github.com',
-    fullName: 'shiftkey/some-repo',
-    isPrivate: isPrivate,
-    fork: isFork,
-    cloneURL: 'https://github.com/shiftkey/some-repo.git',
-    htmlURL: 'https://github.com/shiftkey/some-repo',
-    defaultBranch: 'master',
-    hash: '',
-    parent: null,
-    permissions: null,
-  }
-}
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 describe('octicon/iconForRepository', () => {
   it('shows download icon for cloning repository', () => {
@@ -46,7 +20,11 @@ describe('octicon/iconForRepository', () => {
   })
 
   it('shows repo icon for public GitHub repository', () => {
-    const gitHubRepository = getTestRepository(false)
+    const gitHubRepository = gitHubRepoFixture({
+      owner: 'me',
+      name: 'my-repo',
+      isPrivate: false,
+    })
     const repository = new Repository(
       'C:/some/path/to/repo',
       1,
@@ -57,8 +35,12 @@ describe('octicon/iconForRepository', () => {
     expect(icon).toEqual(OcticonSymbol.repo)
   })
 
-  it('shows lock icon for public GitHub repository', () => {
-    const gitHubRepository = getTestRepository(true)
+  it('shows lock icon for private GitHub repository', () => {
+    const gitHubRepository = gitHubRepoFixture({
+      owner: 'me',
+      name: 'my-repo',
+      isPrivate: true,
+    })
     const repository = new Repository(
       'C:/some/path/to/repo',
       1,
@@ -70,7 +52,12 @@ describe('octicon/iconForRepository', () => {
   })
 
   it('shows fork icon for forked GitHub repository', () => {
-    const gitHubRepository = getTestRepository(false, true)
+    const gitHubRepository = gitHubRepoFixture({
+      owner: 'me',
+      name: 'my-repo',
+      isPrivate: false,
+      parent: gitHubRepoFixture({ owner: 'you', name: 'my-repo' }),
+    })
     const repository = new Repository(
       'C:/some/path/to/repo',
       1,

--- a/app/test/unit/repositories-clone-grouping-test.ts
+++ b/app/test/unit/repositories-clone-grouping-test.ts
@@ -44,6 +44,7 @@ describe('clone repository grouping', () => {
         fork: true,
         default_branch: '',
         pushed_at: '1995-12-17T03:24:00',
+        has_issues: true,
         permissions: {
           pull: true,
           push: true,
@@ -60,6 +61,7 @@ describe('clone repository grouping', () => {
         fork: false,
         default_branch: '',
         pushed_at: '1995-12-17T03:24:00',
+        has_issues: true,
         permissions: {
           pull: true,
           push: true,
@@ -76,6 +78,7 @@ describe('clone repository grouping', () => {
         fork: false,
         default_branch: '',
         pushed_at: '1995-12-17T03:24:00',
+        has_issues: true,
         permissions: {
           pull: true,
           push: true,

--- a/app/test/unit/repositories-clone-grouping-test.ts
+++ b/app/test/unit/repositories-clone-grouping-test.ts
@@ -45,6 +45,7 @@ describe('clone repository grouping', () => {
         default_branch: '',
         pushed_at: '1995-12-17T03:24:00',
         has_issues: true,
+        archived: false,
         permissions: {
           pull: true,
           push: true,
@@ -62,6 +63,7 @@ describe('clone repository grouping', () => {
         default_branch: '',
         pushed_at: '1995-12-17T03:24:00',
         has_issues: true,
+        archived: false,
         permissions: {
           pull: true,
           push: true,
@@ -79,6 +81,7 @@ describe('clone repository grouping', () => {
         default_branch: '',
         pushed_at: '1995-12-17T03:24:00',
         has_issues: true,
+        archived: false,
         permissions: {
           pull: true,
           push: true,

--- a/app/test/unit/repositories-database-test.ts
+++ b/app/test/unit/repositories-database-test.ts
@@ -20,6 +20,7 @@ describe('RepositoriesDatabase', () => {
       parentID: null,
       lastPruneDate: null,
       permissions: 'write',
+      issuesEnabled: true,
     }
     const originalId = await db.gitHubRepositories.add({ ...gitHubRepo })
     const duplicateId = await db.gitHubRepositories.add({ ...gitHubRepo })

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -49,6 +49,7 @@ describe('RepositoriesStore', () => {
       fork: false,
       default_branch: 'master',
       pushed_at: '1995-12-17T03:24:00',
+      has_issues: true,
       permissions: {
         pull: true,
         push: true,

--- a/app/test/unit/repositories-store-test.ts
+++ b/app/test/unit/repositories-store-test.ts
@@ -50,6 +50,7 @@ describe('RepositoriesStore', () => {
       default_branch: 'master',
       pushed_at: '1995-12-17T03:24:00',
       has_issues: true,
+      archived: false,
       permissions: {
         pull: true,
         push: true,

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -169,8 +169,9 @@ describe('repository-matching', () => {
       endpoint: 'https://api.github.com/',
       fork: true,
       hash: 'whatever',
-      permissions: null,
       issuesEnabled: true,
+      isArchived: false,
+      permissions: null,
     }
 
     it('returns true for exact match', () => {

--- a/app/test/unit/repository-matching-test.ts
+++ b/app/test/unit/repository-matching-test.ts
@@ -170,6 +170,7 @@ describe('repository-matching', () => {
       fork: true,
       hash: 'whatever',
       permissions: null,
+      issuesEnabled: true,
     }
 
     it('returns true for exact match', () => {

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -10,29 +10,7 @@ import {
 import { DiffSelection, DiffSelectionType } from '../../src/models/diff'
 import { HistoryTabMode, IDisplayHistory } from '../../src/lib/app-state'
 import { IGitHubUser } from '../../src/lib/databases'
-
-function createSampleGitHubRepository(): GitHubRepository {
-  return {
-    dbID: 1,
-    name: 'desktop',
-    owner: {
-      endpoint: 'https://api.github.com',
-      login: 'desktop',
-      hash: '',
-      id: null,
-    },
-    endpoint: 'https://api.github.com',
-    fullName: 'shiftkey/some-repo',
-    isPrivate: false,
-    fork: false,
-    cloneURL: 'https://github.com/desktop/desktop.git',
-    htmlURL: 'https://github.com/desktop/desktop',
-    defaultBranch: 'master',
-    hash: '',
-    parent: null,
-    permissions: 'write',
-  }
-}
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
 function createSamplePullRequest(gitHubRepository: GitHubRepository) {
   return new PullRequest(
@@ -63,7 +41,10 @@ describe('RepositoryStateCache', () => {
   })
 
   it('can update branches state for a repository', () => {
-    const gitHubRepository = createSampleGitHubRepository()
+    const gitHubRepository = gitHubRepoFixture({
+      name: 'desktop',
+      owner: 'desktop',
+    })
     const firstPullRequest = createSamplePullRequest(gitHubRepository)
 
     const cache = new RepositoryStateCache(defaultGetUsersFunc)


### PR DESCRIPTION
continues https://github.com/desktop/desktop/pull/9142#pullrequestreview-364568677

## Description

- store GitHub API result, which can include the `has_issues` field
- use this to decide if we should enable the "create issue on github" menu item or not
- some more test cleanup

## Testing

1. create a repo on github
1. disable issues in repo settings
1. clone repo into desktop
1. verify that "Create Issues" menu item is disabled when in that repo in desktop.

would be great to verify the same steps for a repo that is archived, too!