### PR TITLE
Add Support for Notepad++

### DIFF
--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -377,6 +377,7 @@ These editors are currently supported:
 
  - [Atom](https://atom.io/)
  - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
+ - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)
  - [Typora](https://typora.io/)
  - [SlickEdit](https://www.slickedit.com)
@@ -386,8 +387,9 @@ These are defined in an enum at the top of the file:
 ```ts
 export enum ExternalEditor {
   Atom = 'Atom',
-  VisualStudioCode = 'Visual Studio Code',
-  VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
+  VSCode = 'Visual Studio Code',
+  VSCodeInsiders = 'Visual Studio Code (Insiders)',
+  VSCodium = 'VSCodium',
   SublimeText = 'Sublime Text',
   Typora = 'Typora',
   SlickEdit = 'SlickEdit',

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -25,12 +25,14 @@ The source for the editor integration on Windows is found in
 These editors are currently supported:
 
  - [Atom](https://atom.io/) - stable, Beta and Nightly
- - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
+ - [Visual Studio Code](https://code.visualstudio.com/)
+ - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)
  - [ColdFusion Builder](https://www.adobe.com/products/coldfusion-builder.html)
  - [Typora](https://typora.io/)
  - [SlickEdit](https://www.slickedit.com)
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
+ - [JetBrains Phpstorm](https://www.jetbrains.com/phpstorm/)
 
 These are defined in an enum at the top of the file:
 
@@ -39,12 +41,15 @@ export enum ExternalEditor {
   Atom = 'Atom',
   AtomBeta = 'Atom Beta',
   AtomNightly = 'Atom Nightly',
-  VisualStudioCode = 'Visual Studio Code',
-  VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
+  VSCode = 'Visual Studio Code',
+  VSCodeInsiders = 'Visual Studio Code (Insiders)',
+  VSCodium = 'Visual Studio Codium',
   SublimeText = 'Sublime Text',
   CFBuilder = 'ColdFusion Builder',
   Typora = 'Typora',
   SlickEdit = 'SlickEdit',
+  Webstorm = 'JetBrains Webstorm',
+  Phpstorm = 'JetBrains Phpstorm',
 }
 ```
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -261,19 +261,19 @@ These editors are currently supported:
  - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)
  - [BBEdit](http://www.barebones.com/products/bbedit/)
- - [PhpStorm](https://www.jetbrains.com/phpstorm/)
- - [RubyMine](https://www.jetbrains.com/rubymine/)
+ - [JetBrains PhpStorm](https://www.jetbrains.com/phpstorm/)
+ - [JetBrains RubyMine](https://www.jetbrains.com/rubymine/)
  - [TextMate](https://macromates.com)
  - [Brackets](http://brackets.io/)
      - To use Brackets the Command Line shortcut must be installed.
        - This can be done by opening Brackets, choosing File > Install Command Line Shortcut
- - [WebStorm](https://www.jetbrains.com/webstorm/)
+ - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
  - [Typora](https://typora.io/)
  - [CodeRunner](https://coderunnerapp.com/)
  - [SlickEdit](https://www.slickedit.com)
- - [IntelliJ IDEA](https://www.jetbrains.com/idea/)
+ - [JetBrains IntelliJ IDEA](https://www.jetbrains.com/idea/)
  - [Xcode](https://developer.apple.com/xcode/)
- - [GoLand](https://www.jetbrains.com/go/)
+ - [JetBrains GoLand](https://www.jetbrains.com/go/)
  - [Android Studio](https://developer.android.com/studio)
 
 These are defined in an enum at the top of the file:

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -33,6 +33,7 @@ These editors are currently supported:
  - [SlickEdit](https://www.slickedit.com)
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
  - [JetBrains Phpstorm](https://www.jetbrains.com/phpstorm/)
+ - [Notepad++](https://notepad-plus-plus.org/)
 
 These are defined in an enum at the top of the file:
 
@@ -50,6 +51,7 @@ export enum ExternalEditor {
   SlickEdit = 'SlickEdit',
   Webstorm = 'JetBrains Webstorm',
   Phpstorm = 'JetBrains Phpstorm',
+  NotepadPlusPlus = 'Notepad++',
 }
 ```
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -256,29 +256,32 @@ These editors are currently supported:
  - [Atom](https://atom.io/)
  - [MacVim](https://macvim-dev.github.io/macvim/)
  - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
+ - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)
  - [BBEdit](http://www.barebones.com/products/bbedit/)
  - [PhpStorm](https://www.jetbrains.com/phpstorm/)
  - [RubyMine](https://www.jetbrains.com/rubymine/)
- - [IntelliJ IDEA](https://www.jetbrains.com/idea/)
  - [TextMate](https://macromates.com)
  - [Brackets](http://brackets.io/)
      - To use Brackets the Command Line shortcut must be installed.
        - This can be done by opening Brackets, choosing File > Install Command Line Shortcut
  - [WebStorm](https://www.jetbrains.com/webstorm/)
  - [Typora](https://typora.io/)
+ - [CodeRunner](https://coderunnerapp.com/)
  - [SlickEdit](https://www.slickedit.com)
+ - [IntelliJ IDEA](https://www.jetbrains.com/idea/)
+ - [Xcode](https://developer.apple.com/xcode/)
  - [GoLand](https://www.jetbrains.com/go/)
 
 These are defined in an enum at the top of the file:
 
 ```ts
-
 export enum ExternalEditor {
   Atom = 'Atom',
   MacVim = 'MacVim',
-  VisualStudioCode = 'Visual Studio Code',
-  VisualStudioCodeInsiders = 'Visual Studio Code (Insiders)',
+  VSCode = 'Visual Studio Code',
+  VSCodeInsiders = 'Visual Studio Code (Insiders)',
+  VSCodium = 'VSCodium',
   SublimeText = 'Sublime Text',
   BBEdit = 'BBEdit',
   PhpStorm = 'PhpStorm',
@@ -287,7 +290,11 @@ export enum ExternalEditor {
   Brackets = 'Brackets',
   WebStorm = 'WebStorm',
   Typora = 'Typora',
+  CodeRunner = 'CodeRunner',
   SlickEdit = 'SlickEdit',
+  IntelliJ = 'IntelliJ',
+  Xcode = 'Xcode',
+  GoLand = 'GoLand',
 }
 ```
 


### PR DESCRIPTION
Closes #9235

## Description

- Updates docs on editors to be up-to-date across the board.
- Add support for Notepad++ on Windows.

### Screenshots

## Release notes

Notes: - Adds Notepad++ as a supported editor