### PR TITLE
Enable automatic Git proxy configuration on beta

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -123,7 +123,7 @@ export function enableCreateForkFlow(): boolean {
  * CRL distribution points and/or an offiline revocation server.
  */
 export function enableSchannelCheckRevokeOptOut(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }
 
 /**
@@ -131,7 +131,7 @@ export function enableSchannelCheckRevokeOptOut(): boolean {
  * system-configured proxy url and passing that to Git.
  */
 export function enableAutomaticGitProxyConfiguration(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }
 
 /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

For the upcoming beta release. This turns on the automatic Git proxy configuration (#9154) as well as the windows-specific certificate revocation opt-out  (#9188)
