### PR TITLE
Use not truncated url as href to get opened by the browser 

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -35,6 +35,7 @@
     "fs-admin": "^0.12.0",
     "fs-extra": "^6.0.0",
     "fuzzaldrin-plus": "^0.6.0",
+    "get-urls": "^9.2.0",
     "keytar": "^5.0.0",
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -202,6 +202,7 @@ export class Tokenizer {
 
   private scanForHyperlink(
     text: string,
+    url: string,
     index: number,
     repository?: GitHubRepository
   ): LookupResult | null {
@@ -228,7 +229,7 @@ export class Tokenizer {
           const idText = issueMatch[1]
           this._results.push({
             kind: TokenType.Link,
-            url: maybeHyperlink,
+            url: url || maybeHyperlink,
             text: `#${idText}`,
           })
           return { nextIndex }
@@ -239,7 +240,7 @@ export class Tokenizer {
     // just render a hyperlink with the full URL
     this._results.push({
       kind: TokenType.Link,
-      url: maybeHyperlink,
+      url: url || maybeHyperlink,
       text: maybeHyperlink,
     })
     return { nextIndex }
@@ -260,7 +261,8 @@ export class Tokenizer {
   }
 
   private tokenizeNonGitHubRepository(
-    text: string
+    text: string,
+    url: string
   ): ReadonlyArray<TokenResult> {
     let i = 0
     while (i < text.length) {
@@ -272,7 +274,7 @@ export class Tokenizer {
 
         case 'h':
           i = this.inspectAndMove(element, i, () =>
-            this.scanForHyperlink(text, i)
+            this.scanForHyperlink(text, url, i)
           )
           break
 
@@ -289,6 +291,7 @@ export class Tokenizer {
 
   private tokenizeGitHubRepository(
     text: string,
+    url: string,
     repository: GitHubRepository
   ): ReadonlyArray<TokenResult> {
     let i = 0
@@ -313,7 +316,7 @@ export class Tokenizer {
 
         case 'h':
           i = this.inspectAndMove(element, i, () =>
-            this.scanForHyperlink(text, i, repository)
+            this.scanForHyperlink(text, url, i, repository)
           )
           break
 
@@ -332,15 +335,17 @@ export class Tokenizer {
    * Scan the string for tokens that match with entities an application
    * might be interested in.
    *
+   * It overrides hyperlink url if url param is provided.
+   *
    * @returns an array of tokens representing the scan results.
    */
-  public tokenize(text: string): ReadonlyArray<TokenResult> {
+  public tokenize(text: string, url: string = ''): ReadonlyArray<TokenResult> {
     this.reset()
 
     if (this.repository) {
-      return this.tokenizeGitHubRepository(text, this.repository)
+      return this.tokenizeGitHubRepository(text, url, this.repository)
     } else {
-      return this.tokenizeNonGitHubRepository(text)
+      return this.tokenizeNonGitHubRepository(text, url)
     }
   }
 }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as classNames from 'classnames'
+import * as getUrls from 'get-urls'
 
 import { FileChange } from '../../models/status'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -75,6 +76,14 @@ const maxSummaryLength = 72
  */
 function trimTrailingWhitespace(value: string) {
   return value.replace(/\s+$/, '')
+}
+
+/**
+ * Helper function that returns url part of the text.
+ */
+function getUrl(text: string): string {
+  const urls = [...getUrls(trimTrailingWhitespace(text))]
+  return urls[0]
 }
 
 /**
@@ -321,6 +330,7 @@ export class CommitSummary extends React.Component<
             emoji={this.props.emoji}
             repository={this.props.repository}
             text={this.state.summary}
+            url={getUrl(this.props.commit.summary)}
           />
 
           <ul className="commit-summary-meta">

--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -14,6 +14,12 @@ interface IRichTextProps {
   /** The raw text to inspect for things to highlight */
   readonly text: string
 
+  /**
+   * Optional string to override rich text's url
+   * (Useful for truncated text with url inside)
+   */
+  readonly url?: string
+
   /** Should URLs be rendered as clickable links. Default true. */
   readonly renderUrlsAsLinks?: boolean
 
@@ -34,6 +40,7 @@ interface IRichTextProps {
 export class RichText extends React.Component<IRichTextProps, {}> {
   public render() {
     const str = this.props.text
+    const url = this.props.url
 
     // If we've been given an empty string then return null so that we don't end
     // up introducing an extra empty <span>.
@@ -43,7 +50,7 @@ export class RichText extends React.Component<IRichTextProps, {}> {
 
     const tokenizer = new Tokenizer(this.props.emoji, this.props.repository)
 
-    const elements = tokenizer.tokenize(str).map((token, index) => {
+    const elements = tokenizer.tokenize(str, url).map((token, index) => {
       switch (token.kind) {
         case TokenType.Emoji:
           return (

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -124,6 +124,25 @@ describe('Tokenizer', () => {
       expect(mention.url).toBe(expectedUri)
     })
 
+    it('overrides hyperlink url when url param is provided', () => {
+      const expectedURL = 'https://github.com'
+      const text = `Note: we keep a "black list" of authentication methods for which we do
+not want to enable http.emptyAuth automatically. 
+
+This fixes https://github.com/shiftkey/some-repo/issues/1034
+`
+
+      const tokenizer = new Tokenizer(emoji, repository)
+      const results = tokenizer.tokenize(text, expectedURL)
+      expect(results).toHaveLength(3)
+
+      const hyperLink = results[1] as HyperlinkMatch
+
+      expect(hyperLink.kind).toBe(TokenType.Link)
+      expect(hyperLink.text).toBe('#1034')
+      expect(hyperLink.url).toBe(expectedURL)
+    })
+
     it('ignores http prefix when no text after', () => {
       const text = `fix double http:// in avatar URLs`
 
@@ -457,6 +476,27 @@ Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
       expect(results).toHaveLength(1)
       expect(results[0].kind).toBe(TokenType.Text)
       expect(results[0].text).toBe(text)
+    })
+
+    it('overrides hyperlink url when url param is provided', () => {
+      const expectedURL = 'https://github.com'
+      const text = `Note: we keep a "black list" of authentication methods for which we do
+not want to enable http.emptyAuth automatically. 
+
+This fixes https://github.com/shiftkey/some-repo/issues/1034
+`
+
+      const tokenizer = new Tokenizer(emoji)
+      const results = tokenizer.tokenize(text, expectedURL)
+      expect(results).toHaveLength(3)
+
+      const hyperLink = results[1] as HyperlinkMatch
+
+      expect(hyperLink.kind).toBe(TokenType.Link)
+      expect(hyperLink.text).toBe(
+        'https://github.com/shiftkey/some-repo/issues/1034'
+      )
+      expect(hyperLink.url).toBe(expectedURL)
     })
 
     it('renders plain link for full URL', () => {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -566,6 +566,14 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
+get-urls@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/get-urls/-/get-urls-9.2.0.tgz#df05cfad3ad984a34a5794209b837dd507af53fd"
+  integrity sha512-ErGHKhzGIrtobqmNNxjy7yxe4cEmAp9SMerzmFpldn0CkEr2EC+SvIiyef038JDjl2LVng7MMw8YunUKM7k3ww==
+  dependencies:
+    normalize-url "^4.3.0"
+    url-regex "^5.0.0"
+
 github-from-package@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
@@ -662,6 +670,11 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+ip-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.1.0.tgz#5ad62f685a14edb421abebc2fff8db94df67b455"
+  integrity sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -902,7 +915,7 @@ noop-logger@^0.1.1:
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
   integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
-normalize-url@^4.1.0:
+normalize-url@^4.1.0, normalize-url@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
@@ -1475,6 +1488,11 @@ textarea-caret@^3.0.2:
   resolved "https://registry.yarnpkg.com/textarea-caret/-/textarea-caret-3.0.2.tgz#f360c48699aa1abf718680a43a31a850665c2caf"
   integrity sha1-82DEhpmqGr9xhoCkOjGoUGZcLK8=
 
+tlds@^1.203.0:
+  version "1.207.0"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.207.0.tgz#459264e644cf63ddc0965fece3898913286b1afd"
+  integrity sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==
+
 to-buffer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
@@ -1513,6 +1531,14 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+url-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-5.0.0.tgz#8f5456ab83d898d18b2f91753a702649b873273a"
+  integrity sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==
+  dependencies:
+    ip-regex "^4.1.0"
+    tlds "^1.203.0"
 
 username@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This PR fixes an issue that was created in #9185 

## Description

- Urls within commit summary get cut off and make clicking url unworkable to open on the browser. My plan was mentioned here https://github.com/desktop/desktop/issues/9185#issuecomment-594044174. So I have added a new prop called url to `<RichText>` component and used it through tokenization process to override default url if it is given. My main motivation was keeping to current structure if extra `url` prop is not provided, so it shouldn't break any prior logic. I have also added two simple test cases for github and non-github repositories. 

- To get url in a string, I used https://github.com/sindresorhus/get-urls lib. (new dependency)