### PR TITLE
Offer branching from upstream default branch in forks

### DIFF
--- a/app/src/lib/branch.ts
+++ b/app/src/lib/branch.ts
@@ -1,0 +1,24 @@
+import { Branch, BranchType } from '../models/branch'
+import { UpstreamRemoteName } from './stores'
+
+/**
+ * Finds the remote branch for a branch in the upstream repository
+ *
+ * For example:
+ * If official/funnel has the default branch `development`,
+ * then running this on the branches from the fork outofambit/funnel
+ * will find the branch `remotes/upstream/development`
+ *
+ * @param upstreamDefaultBranchName short name of the branch in the upstream repo
+ * @param branches all the branches in the local repo
+ */
+export function findUpstreamRemoteBranch(
+  branchName: string,
+  branches: ReadonlyArray<Branch>
+) {
+  return branches.find(
+    b =>
+      b.type === BranchType.Remote &&
+      b.name === `${UpstreamRemoteName}/${branchName}`
+  )
+}

--- a/app/src/lib/branch.ts
+++ b/app/src/lib/branch.ts
@@ -5,9 +5,10 @@ import { UpstreamRemoteName } from './stores'
  * Finds the remote branch for a branch in the upstream repository
  *
  * For example:
- * If official/funnel has the default branch `development`,
- * then running this on the branches from the fork outofambit/funnel
- * will find the branch `remotes/upstream/development`
+ * If official/funnel has the branch `development`, then running
+ * this on the branches from the fork outofambit/funnel with
+ * `development` as the specified branch name will find the 
+ * branch `remotes/upstream/development`
  *
  * @param branchName short name of the branch in the upstream repo
  * @param branches all the branches in the local repo

--- a/app/src/lib/branch.ts
+++ b/app/src/lib/branch.ts
@@ -9,7 +9,7 @@ import { UpstreamRemoteName } from './stores'
  * then running this on the branches from the fork outofambit/funnel
  * will find the branch `remotes/upstream/development`
  *
- * @param upstreamDefaultBranchName short name of the branch in the upstream repo
+ * @param branchName short name of the branch in the upstream repo
  * @param branches all the branches in the local repo
  */
 export function findUpstreamRemoteBranch(

--- a/app/src/lib/branch.ts
+++ b/app/src/lib/branch.ts
@@ -7,7 +7,7 @@ import { UpstreamRemoteName } from './stores'
  * For example:
  * If official/funnel has the branch `development`, then running
  * this on the branches from the fork outofambit/funnel with
- * `development` as the specified branch name will find the 
+ * `development` as the specified branch name will find the
  * branch `remotes/upstream/development`
  *
  * @param branchName short name of the branch in the upstream repo

--- a/app/src/lib/create-branch.ts
+++ b/app/src/lib/create-branch.ts
@@ -4,6 +4,7 @@ import { StartPoint, Branch } from '../models/branch'
 type BranchInfo = {
   readonly tip: Tip
   readonly defaultBranch: Branch | null
+  readonly upstreamDefaultBranch: Branch | null
 }
 
 export function getStartPoint(
@@ -14,7 +15,14 @@ export function getStartPoint(
     return StartPoint.Head
   }
 
-  if (preferred === StartPoint.DefaultBranch && props.defaultBranch) {
+  if (
+    preferred === StartPoint.UpstreamDefaultBranch &&
+    props.upstreamDefaultBranch !== null
+  ) {
+    return preferred
+  }
+
+  if (preferred === StartPoint.DefaultBranch && props.defaultBranch !== null) {
     return preferred
   }
 
@@ -29,7 +37,9 @@ export function getStartPoint(
     return preferred
   }
 
-  if (props.defaultBranch) {
+  if (props.upstreamDefaultBranch) {
+    return StartPoint.UpstreamDefaultBranch
+  } else if (props.defaultBranch) {
     return StartPoint.DefaultBranch
   } else if (props.tip.kind === TipState.Valid) {
     return StartPoint.CurrentBranch

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -148,3 +148,10 @@ export function enableCreateGitHubIssueFromMenu(): boolean {
 export function enableUpdateRemoteUrl(): boolean {
   return enableBetaFeatures()
 }
+/**
+ * Should we show the fork-specific, "branch from the upstream
+ * default branch" version of the create branch dialog?
+ */
+export function enableForkyCreateBranchUI(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -29,6 +29,13 @@ export async function createBranch(
   const args =
     startPoint !== null ? ['branch', name, startPoint] : ['branch', name]
 
+  // if we're branching directly from a remote branch, we don't want to track it
+  // tracking it will make the rest of desktop think we want to push to that
+  // remote branch's upstream (which would likely be the upstream of the fork)
+  if (startPoint !== null && startPoint.startsWith('remotes/')) {
+    args.push('--no-track')
+  }
+
   await git(args, repository.path, 'createBranch')
   const branches = await getBranches(repository, `refs/heads/${name}`)
   if (branches.length > 0) {

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -11,6 +11,7 @@ import {
   envForRemoteOperation,
   getFallbackUrlForProxyResolve,
 } from './environment'
+import { enableForkyCreateBranchUI } from '../feature-flag'
 
 /**
  * Create a new branch from the given start point.
@@ -32,7 +33,11 @@ export async function createBranch(
   // if we're branching directly from a remote branch, we don't want to track it
   // tracking it will make the rest of desktop think we want to push to that
   // remote branch's upstream (which would likely be the upstream of the fork)
-  if (startPoint !== null && startPoint.startsWith('remotes/')) {
+  if (
+    enableForkyCreateBranchUI() &&
+    startPoint !== null &&
+    startPoint.startsWith('remotes/')
+  ) {
     args.push('--no-track')
   }
 

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -24,6 +24,8 @@ export enum StartPoint {
   CurrentBranch = 'CurrentBranch',
   DefaultBranch = 'DefaultBranch',
   Head = 'Head',
+  /** Only valid for forks */
+  UpstreamDefaultBranch = 'UpstreamDefaultBranch',
 }
 
 /**

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -10,12 +10,7 @@ import {
   HistoryTabMode,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
-import {
-  AppStore,
-  GitHubUserStore,
-  IssuesStore,
-  UpstreamRemoteName,
-} from '../lib/stores'
+import { AppStore, GitHubUserStore, IssuesStore } from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
 import { shell } from '../lib/app-shell'
 import { updateStore, UpdateStatus } from './lib/update-store'
@@ -29,7 +24,7 @@ import { getOS } from '../lib/get-os'
 import { validatedRepositoryPath } from '../lib/stores/helpers/validated-repository-path'
 import { MenuEvent } from '../main-process/menu'
 import { Repository } from '../models/repository'
-import { Branch, BranchType } from '../models/branch'
+import { Branch } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
 import { Account } from '../models/account'
@@ -117,6 +112,7 @@ import { getUncommittedChangesStrategy } from '../models/uncommitted-changes-str
 import { SAMLReauthRequiredDialog } from './saml-reauth-required/saml-reauth-required'
 import { CreateForkDialog } from './forks/create-fork-dialog'
 import { SChannelNoRevocationCheckDialog } from './schannel-no-revocation-check/schannel-no-revocation-check'
+import { findUpstreamRemoteBranch } from '../lib/branch'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1495,11 +1491,9 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         const upstreamDefaultBranch =
           upstreamDefaultBranchName !== null
-            ? branchesState.allBranches.find(
-                b =>
-                  b.type === BranchType.Remote &&
-                  b.name ===
-                    `${UpstreamRemoteName}/${upstreamDefaultBranchName}`
+            ? findUpstreamRemoteBranch(
+                upstreamDefaultBranchName,
+                branchesState.allBranches
               ) || null
             : null
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -104,7 +104,7 @@ import { StashAndSwitchBranch } from './stash-changes/stash-and-switch-branch-di
 import { OverwriteStash } from './stash-changes/overwrite-stashed-changes-dialog'
 import { ConfirmDiscardStashDialog } from './stashing/confirm-discard-stash'
 import { CreateTutorialRepositoryDialog } from './no-repositories/create-tutorial-repository-dialog'
-import { enableTutorial } from '../lib/feature-flag'
+import { enableTutorial, enableForkyCreateBranchUI } from '../lib/feature-flag'
 import { ConfirmExitTutorial } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { WorkflowPushRejectedDialog } from './workflow-push-rejected/workflow-push-rejected'
@@ -1481,6 +1481,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         // upstream github repo, if there is one
         const upstreamGhRepo: GitHubRepository | null =
+          enableForkyCreateBranchUI() &&
           repository.gitHubRepository !== null &&
           repository.gitHubRepository.parent !== null
             ? repository.gitHubRepository.parent

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1479,28 +1479,23 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
-        // upstream github repo, if there is one
-        const upstreamGhRepo: GitHubRepository | null =
+        let upstreamGhRepo: GitHubRepository | null = null
+        let upstreamDefaultBranch: Branch | null = null
+
+        if (
           enableForkyCreateBranchUI() &&
           repository.gitHubRepository !== null &&
           repository.gitHubRepository.parent !== null
-            ? repository.gitHubRepository.parent
-            : null
-
-        // default branch name, if there is one
-        const upstreamDefaultBranchName: string | null =
-          upstreamGhRepo !== null && upstreamGhRepo.defaultBranch !== null
-            ? upstreamGhRepo.defaultBranch
-            : null
-
-        // get the corresponding branch, if we have it
-        const upstreamDefaultBranch: Branch | null =
-          upstreamDefaultBranchName !== null
-            ? findUpstreamRemoteBranch(
-                upstreamDefaultBranchName,
+        ) {
+          upstreamGhRepo = repository.gitHubRepository.parent
+          if (upstreamGhRepo.defaultBranch !== null) {
+            upstreamDefaultBranch =
+              findUpstreamRemoteBranch(
+                upstreamGhRepo.defaultBranch,
                 branchesState.allBranches
               ) || null
-            : null
+          }
+        }
 
         return (
           <CreateBranch

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -10,7 +10,12 @@ import {
   HistoryTabMode,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
-import { AppStore, GitHubUserStore, IssuesStore } from '../lib/stores'
+import {
+  AppStore,
+  GitHubUserStore,
+  IssuesStore,
+  UpstreamRemoteName,
+} from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
 import { shell } from '../lib/app-shell'
 import { updateStore, UpdateStatus } from './lib/update-store'
@@ -24,7 +29,7 @@ import { getOS } from '../lib/get-os'
 import { validatedRepositoryPath } from '../lib/stores/helpers/validated-repository-path'
 import { MenuEvent } from '../main-process/menu'
 import { Repository } from '../models/repository'
-import { Branch } from '../models/branch'
+import { Branch, BranchType } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
 import { Account } from '../models/account'
@@ -1477,13 +1482,36 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
+        const upstreamRepo =
+          repository.gitHubRepository !== null &&
+          repository.gitHubRepository.parent !== null
+            ? repository.gitHubRepository.parent
+            : null
+
+        const upstreamDefaultBranchName =
+          upstreamRepo !== null && upstreamRepo.defaultBranch !== null
+            ? upstreamRepo.defaultBranch
+            : null
+
+        const upstreamDefaultBranch =
+          upstreamDefaultBranchName !== null
+            ? branchesState.allBranches.find(
+                b =>
+                  b.type === BranchType.Remote &&
+                  b.name ===
+                    `${UpstreamRemoteName}/${upstreamDefaultBranchName}`
+              ) || null
+            : null
+
         return (
           <CreateBranch
             key="create-branch"
             tip={branchesState.tip}
             defaultBranch={branchesState.defaultBranch}
+            upstreamDefaultBranch={upstreamDefaultBranch}
             allBranches={branchesState.allBranches}
             repository={repository}
+            upstreamRepository={upstreamRepo}
             onDismissed={this.onPopupDismissed}
             dispatcher={this.props.dispatcher}
             initialName={popup.initialName || ''}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -113,6 +113,7 @@ import { SAMLReauthRequiredDialog } from './saml-reauth-required/saml-reauth-req
 import { CreateForkDialog } from './forks/create-fork-dialog'
 import { SChannelNoRevocationCheckDialog } from './schannel-no-revocation-check/schannel-no-revocation-check'
 import { findUpstreamRemoteBranch } from '../lib/branch'
+import { GitHubRepository } from '../models/github-repository'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1478,18 +1479,21 @@ export class App extends React.Component<IAppProps, IAppState> {
           return null
         }
 
-        const upstreamRepo =
+        // upstream github repo, if there is one
+        const upstreamGhRepo: GitHubRepository | null =
           repository.gitHubRepository !== null &&
           repository.gitHubRepository.parent !== null
             ? repository.gitHubRepository.parent
             : null
 
-        const upstreamDefaultBranchName =
-          upstreamRepo !== null && upstreamRepo.defaultBranch !== null
-            ? upstreamRepo.defaultBranch
+        // default branch name, if there is one
+        const upstreamDefaultBranchName: string | null =
+          upstreamGhRepo !== null && upstreamGhRepo.defaultBranch !== null
+            ? upstreamGhRepo.defaultBranch
             : null
 
-        const upstreamDefaultBranch =
+        // get the corresponding branch, if we have it
+        const upstreamDefaultBranch: Branch | null =
           upstreamDefaultBranchName !== null
             ? findUpstreamRemoteBranch(
                 upstreamDefaultBranchName,
@@ -1505,7 +1509,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             upstreamDefaultBranch={upstreamDefaultBranch}
             allBranches={branchesState.allBranches}
             repository={repository}
-            upstreamRepository={upstreamRepo}
+            upstreamGitHubRepository={upstreamGhRepo}
             onDismissed={this.onPopupDismissed}
             dispatcher={this.props.dispatcher}
             initialName={popup.initialName || ''}

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -299,7 +299,7 @@ export class CreateBranch extends React.Component<
         return
       }
 
-      startPoint = upstreamDefaultBranch.name
+      startPoint = `remotes/${upstreamDefaultBranch.name}`
     }
 
     if (name.length > 0) {

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -32,7 +32,6 @@ import {
   UncommittedChangesStrategyKind,
 } from '../../models/uncommitted-changes-strategy'
 import { GitHubRepository } from '../../models/github-repository'
-import { UpstreamRemoteName } from '../../lib/stores'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -156,7 +155,7 @@ export class CreateBranch extends React.Component<
       ) {
         return this.renderForkBranchSelection(
           tip.branch.name,
-          this.props.upstreamDefaultBranch.name,
+          this.props.upstreamDefaultBranch,
           this.props.upstreamRepository.fullName
         )
       }
@@ -331,9 +330,9 @@ export class CreateBranch extends React.Component<
    */
   private renderRegularBranchSelection(
     currentBranchName: string,
-    defaultBranchName: string | null
+    defaultBranch: Branch | null
   ) {
-    if (defaultBranchName === null || defaultBranchName === currentBranchName) {
+    if (defaultBranch === null || defaultBranch.name === currentBranchName) {
       return (
         <p>
           Your new branch will be based on your currently checked out branch (
@@ -345,7 +344,7 @@ export class CreateBranch extends React.Component<
     } else {
       const items = [
         {
-          title: defaultBranchName,
+          title: defaultBranch.name,
           description:
             "The default branch in your repository. Pick this to start on something new that's not dependent on your current branch.",
         },
@@ -371,22 +370,24 @@ export class CreateBranch extends React.Component<
    */
   private renderForkBranchSelection(
     currentBranchName: string,
-    upstreamDefaultBranchName: string,
+    upstreamDefaultBranch: Branch,
     upstreamRepositoryFullName: string
   ) {
     // we assume here that the upstream and this
     // fork will have the same default branch name
-    if (upstreamDefaultBranchName === currentBranchName) {
+    if (currentBranchName === upstreamDefaultBranch.nameWithoutRemote) {
       return (
         <p>
-          Your new branch will be based on {upstreamRepositoryFullName}'s{' '}
-          {defaultBranchLink} (<Ref>{upstreamDefaultBranchName}</Ref>).
+          Your new branch will be based on{' '}
+          <strong>{upstreamRepositoryFullName}</strong>
+          's {defaultBranchLink} (
+          <Ref>{upstreamDefaultBranch.nameWithoutRemote}</Ref>).
         </p>
       )
     } else {
       const items = [
         {
-          title: `${UpstreamRemoteName}/${upstreamDefaultBranchName}`,
+          title: upstreamDefaultBranch.name,
           description:
             "The default branch of the upstream repository. Pick this to start on something new that's not dependent on your current branch.",
         },

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -99,10 +99,11 @@ export class CreateBranch extends React.Component<
       currentError: null,
       proposedName: props.initialName,
       sanitizedName: '',
-      startPoint: getStartPoint(props, StartPoint.DefaultBranch),
+      startPoint: getStartPoint(props, StartPoint.UpstreamDefaultBranch),
       isCreatingBranch: false,
       tipAtCreateStart: props.tip,
-      defaultBranchAtCreateStart: props.defaultBranch,
+      defaultBranchAtCreateStart:
+        props.upstreamDefaultBranch || props.defaultBranch,
     }
   }
 

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -167,7 +167,7 @@ export class CreateBranch extends React.Component<
       }
 
       const defaultBranch = this.state.isCreatingBranch
-        ? getBranchForStartPoint(this.state.startPoint, this.props)
+        ? this.props.defaultBranch
         : this.state.defaultBranchAtCreateStart
 
       return this.renderRegularBranchSelection(tip.branch.name, defaultBranch)

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -165,10 +165,7 @@ export class CreateBranch extends React.Component<
         ? this.props.defaultBranch
         : this.state.defaultBranchAtCreateStart
 
-      return this.renderRegularBranchSelection(
-        tip.branch.name,
-        defaultBranch !== null ? defaultBranch.name : null
-      )
+      return this.renderRegularBranchSelection(tip.branch.name, defaultBranch)
     } else {
       return assertNever(tip, `Unknown tip kind ${tipKind}`)
     }

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -95,15 +95,16 @@ export class CreateBranch extends React.Component<
   public constructor(props: ICreateBranchProps) {
     super(props)
 
+    const startPoint = getStartPoint(props, StartPoint.UpstreamDefaultBranch)
+
     this.state = {
       currentError: null,
       proposedName: props.initialName,
       sanitizedName: '',
-      startPoint: getStartPoint(props, StartPoint.UpstreamDefaultBranch),
+      startPoint,
       isCreatingBranch: false,
       tipAtCreateStart: props.tip,
-      defaultBranchAtCreateStart:
-        props.upstreamDefaultBranch || props.defaultBranch,
+      defaultBranchAtCreateStart: getDefaultBranch(startPoint, props),
     }
   }
 
@@ -121,7 +122,10 @@ export class CreateBranch extends React.Component<
     if (!this.state.isCreatingBranch) {
       this.setState({
         tipAtCreateStart: nextProps.tip,
-        defaultBranchAtCreateStart: nextProps.defaultBranch,
+        defaultBranchAtCreateStart: getDefaultBranch(
+          this.state.startPoint,
+          nextProps
+        ),
       })
     }
   }
@@ -162,7 +166,7 @@ export class CreateBranch extends React.Component<
       }
 
       const defaultBranch = this.state.isCreatingBranch
-        ? this.props.defaultBranch
+        ? getDefaultBranch(this.state.startPoint, this.props)
         : this.state.defaultBranchAtCreateStart
 
       return this.renderRegularBranchSelection(tip.branch.name, defaultBranch)
@@ -424,3 +428,17 @@ const defaultBranchLink = (
     default branch
   </LinkButton>
 )
+
+function getDefaultBranch(
+  startPoint: StartPoint,
+  branchInfo: {
+    readonly defaultBranch: Branch | null
+    readonly upstreamDefaultBranch: Branch | null
+  }
+) {
+  return startPoint === StartPoint.UpstreamDefaultBranch
+    ? branchInfo.upstreamDefaultBranch
+    : startPoint === StartPoint.DefaultBranch
+    ? branchInfo.upstreamDefaultBranch
+    : null
+}

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -442,6 +442,6 @@ function getBranchForStartPoint(
   return startPoint === StartPoint.UpstreamDefaultBranch
     ? branchInfo.upstreamDefaultBranch
     : startPoint === StartPoint.DefaultBranch
-    ? branchInfo. defaultBranch
+    ? branchInfo.defaultBranch
     : null
 }

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -431,7 +431,7 @@ const defaultBranchLink = (
   </LinkButton>
 )
 
-/** Given a some branches and a start point, return the proper branch */
+/** Given some branches and a start point, return the proper branch */
 function getBranchForStartPoint(
   startPoint: StartPoint,
   branchInfo: {
@@ -442,6 +442,6 @@ function getBranchForStartPoint(
   return startPoint === StartPoint.UpstreamDefaultBranch
     ? branchInfo.upstreamDefaultBranch
     : startPoint === StartPoint.DefaultBranch
-    ? branchInfo.upstreamDefaultBranch
+    ? branchInfo. defaultBranch
     : null
 }

--- a/app/test/unit/create-branch-test.ts
+++ b/app/test/unit/create-branch-test.ts
@@ -33,6 +33,8 @@ const defaultBranch = {
   nameWithoutRemote: 'my-default-branch',
 }
 
+const upstreamDefaultBranch = null
+
 const someOtherBranch = {
   name: 'some-other-branch',
   upstream: null,
@@ -51,7 +53,10 @@ describe('create-branch/getStartPoint', () => {
     }
 
     const action = (startPoint: StartPoint) => {
-      return getStartPoint({ tip, defaultBranch }, startPoint)
+      return getStartPoint(
+        { tip, defaultBranch, upstreamDefaultBranch },
+        startPoint
+      )
     }
 
     it('returns current HEAD when HEAD requested', () => {
@@ -74,7 +79,10 @@ describe('create-branch/getStartPoint', () => {
     }
 
     const action = (startPoint: StartPoint) => {
-      return getStartPoint({ tip, defaultBranch }, startPoint)
+      return getStartPoint(
+        { tip, defaultBranch, upstreamDefaultBranch },
+        startPoint
+      )
     }
 
     it('returns current HEAD when HEAD requested', () => {
@@ -97,7 +105,10 @@ describe('create-branch/getStartPoint', () => {
     }
 
     const action = (startPoint: StartPoint) => {
-      return getStartPoint({ tip, defaultBranch }, startPoint)
+      return getStartPoint(
+        { tip, defaultBranch, upstreamDefaultBranch },
+        startPoint
+      )
     }
 
     it('returns current HEAD when HEAD requested', () => {


### PR DESCRIPTION
Closes #7762

## Description

This got a bit more involved than I had anticipated.

- adds extra props for the create branch dialog to include information from the repo's upstream, if it has one
- modifies render logic in the create branch dialog to default to a "fork scenario" where the upstream default branch is used instead of the local default branch
- small tweak in create branch git logic to keep desktop from thinking a new branch based on the upstream default branch is a local copy of the upstream default branch
- adds a feature flag for this

### Screenshots
When creating a branch from your fork's default branch, the default is to start from the upstream/default branch
![fork-new-branch-def](https://user-images.githubusercontent.com/964912/76809594-8f072c00-67a8-11ea-9ad3-e79887845957.gif)

When creating a branch from another branch on your fork, you choose between starting from where you are on your fork or starting from upstream/default
![fork-new-branch-not-def](https://user-images.githubusercontent.com/964912/76809600-929ab300-67a8-11ea-9509-769df5b0f51f.gif)


## Release notes

Notes: [Improved] Offer upstream default branch as starting place for new branches in forks
