### PR TITLE
Default "create an issue" to create issue in parent repository

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -139,6 +139,7 @@ export function enableAutomaticGitProxyConfiguration(): boolean {
  * "Repository" in the app menu?
  */
 export function enableCreateGitHubIssueFromMenu(): boolean {
+  console.error(enableBetaFeatures())
   return enableBetaFeatures()
 }
 

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -139,7 +139,6 @@ export function enableAutomaticGitProxyConfiguration(): boolean {
  * "Repository" in the app menu?
  */
 export function enableCreateGitHubIssueFromMenu(): boolean {
-  console.error(enableBetaFeatures())
   return enableBetaFeatures()
 }
 

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -162,7 +162,10 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let rebaseInProgress = false
   let branchHasStashEntry = false
   // check that its a github repo and if so, that is has issues enabled
-  const repoIssuesEnabled = getRepoIssuesEnabled(state)
+  const repoIssuesEnabled =
+    selectedState !== null &&
+    selectedState.repository instanceof Repository &&
+    getRepoIssuesEnabled(selectedState.repository)
 
   if (selectedState && selectedState.type === SelectionType.Repository) {
     repositorySelected = true
@@ -379,14 +382,9 @@ function getNoRepositoriesBuilder(state: IAppState): MenuStateBuilder {
   return menuStateBuilder
 }
 
-function getRepoIssuesEnabled(state: IAppState): boolean {
-  const selectedState = state.selectedState
-  if (
-    selectedState !== null &&
-    selectedState.repository instanceof Repository &&
-    isRepositoryWithGitHubRepository(selectedState.repository)
-  ) {
-    const ghRepo = selectedState.repository.gitHubRepository
+function getRepoIssuesEnabled(repository: Repository): boolean {
+  if (isRepositoryWithGitHubRepository(repository)) {
+    const ghRepo = repository.gitHubRepository
 
     if (ghRepo.parent) {
       // issues enabled on parent repo

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -388,21 +388,16 @@ function getRepoIssuesEnabled(state: IAppState): boolean {
   ) {
     const ghRepo = selectedState.repository.gitHubRepository
 
-    if (
-      ghRepo.parent &&
-      ghRepo.parent.issuesEnabled !== false &&
-      ghRepo.parent.isArchived !== true
-    ) {
+    if (ghRepo.parent) {
       // issues enabled on parent repo
-      return true
+      return (
+        ghRepo.parent.issuesEnabled !== false &&
+        ghRepo.parent.isArchived !== true
+      )
     }
 
-    if (ghRepo.issuesEnabled !== false && ghRepo.isArchived !== true) {
-      // issues enabled on repo
-      return true
-    }
-
-    return false
+    // issues enabled on repo
+    return ghRepo.issuesEnabled !== false && ghRepo.isArchived !== true
   }
 
   return false

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -162,12 +162,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let rebaseInProgress = false
   let branchHasStashEntry = false
   // check that its a github repo and if so, that is has issues enabled
-  const repoIssuesEnabled =
-    selectedState !== null &&
-    selectedState.repository instanceof Repository &&
-    isRepositoryWithGitHubRepository(selectedState.repository) &&
-    selectedState.repository.gitHubRepository.issuesEnabled !== false &&
-    selectedState.repository.gitHubRepository.isArchived !== true
+  const repoIssuesEnabled = getRepoIssuesEnabled(state)
 
   if (selectedState && selectedState.type === SelectionType.Repository) {
     repositorySelected = true
@@ -382,6 +377,35 @@ function getNoRepositoriesBuilder(state: IAppState): MenuStateBuilder {
   }
 
   return menuStateBuilder
+}
+
+function getRepoIssuesEnabled(state: IAppState): boolean {
+  const selectedState = state.selectedState
+  if (
+    selectedState !== null &&
+    selectedState.repository instanceof Repository &&
+    isRepositoryWithGitHubRepository(selectedState.repository)
+  ) {
+    const ghRepo = selectedState.repository.gitHubRepository
+
+    if (
+      ghRepo.parent &&
+      ghRepo.parent.issuesEnabled !== false &&
+      ghRepo.parent.isArchived !== true
+    ) {
+      // issues enabled on parent repo
+      return true
+    }
+
+    if (ghRepo.issuesEnabled !== false && ghRepo.isArchived !== true) {
+      // issues enabled on repo
+      return true
+    }
+
+    return false
+  }
+
+  return false
 }
 
 /**

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1108,7 +1108,11 @@ export class App extends React.Component<IAppProps, IAppState> {
    * of the current GitHub repository.
    */
   private createIssueInRepositoryOnGitHub() {
-    const url = this.getCurrentRepositoryGitHubURL()
+    // Default to creating issue on parent repo
+    // See https://github.com/desktop/desktop/issues/9232 for rationale
+    const url =
+      this.getParentRepositoryGitHubURL() ||
+      this.getCurrentRepositoryGitHubURL()
 
     if (url) {
       this.props.dispatcher.openInBrowser(`${url}/issues/new/choose`)
@@ -1122,6 +1126,23 @@ export class App extends React.Component<IAppProps, IAppState> {
       this.props.dispatcher.openInBrowser(url)
       return
     }
+  }
+
+  /** Returns the URL to the parent repository if hosted on GitHub */
+  private getParentRepositoryGitHubURL() {
+    const repository = this.getRepository()
+
+    if (
+      !repository ||
+      repository instanceof CloningRepository ||
+      !repository.gitHubRepository ||
+      repository.gitHubRepository.parent === null ||
+      repository.gitHubRepository.parent.htmlURL === null
+    ) {
+      return null
+    }
+
+    return repository.gitHubRepository.parent.htmlURL
   }
 
   /** Returns the URL to the current repository if hosted on GitHub */


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9232

## Description

Currently clicking "Create Issue on GitHub" creates an issue on the current repository opened in Desktop. 

With this PR, if the current repo is a fork and the parent repo (upstream) has issues enabled, then clicking "Create Issue on GitHub" creates an issue on the parent/upstream repository. 

If there is a parent/upstream and issues are disabled (or the repo has been archived) then the "Create Issue on GitHub" menu item is disabled/greyed out. We believe that in the vast majority of use cases a fork exists in order to allow someone to contribute to the upstream repository, so we assume issue creation is also intended for the upstream repository.

And if there is no parent/upstream associated with the current repository, then clicking "Create Issue on GitHub" creates an issue on the current repository opened in Desktop (current behavior).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
