### PR TITLE
Make dark theme first class

### DIFF
--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -19,7 +19,10 @@ interface IAppearanceProps {
 
 const themes: ReadonlyArray<ISegmentedItem> = [
   { title: 'Light', description: 'The default theme of GitHub Desktop' },
-  { title: 'Dark', description: 'GitHub Desktop is for you too, creatures of the night' }
+  {
+    title: 'Dark',
+    description: 'GitHub Desktop is for you too, creatures of the night',
+  },
 ]
 
 export class Appearance extends React.Component<IAppearanceProps, {}> {

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -19,11 +19,7 @@ interface IAppearanceProps {
 
 const themes: ReadonlyArray<ISegmentedItem> = [
   { title: 'Light', description: 'The default theme of GitHub Desktop' },
-  {
-    title: 'Dark (beta)',
-    description:
-      'A beta version of our dark theme. Still under development. Please report any issues you may find to our issue tracker.',
-  },
+  { title: 'Dark', description: 'GitHub Desktop is for you too, creatures of the night' }
 ]
 
 export class Appearance extends React.Component<IAppearanceProps, {}> {


### PR DESCRIPTION
## Description

This PR takes the dark theme out of beta. I'm not wedded to the language, so if others don't like it or have better suggestions, please feel free to weigh in.

### Screenshots

<img width="612" alt="Screen Shot 2020-03-16 at 6 55 14 AM" src="https://user-images.githubusercontent.com/5091167/76760378-2a6db200-6753-11ea-81e8-5f3182d7383a.png">

## Release notes

Notes: GitHub Desktop dark theme is generally available
