### PR TITLE
Set min-height of FilterList to make it scrollable under any situation

### DIFF
--- a/app/styles/ui/_filter-list.scss
+++ b/app/styles/ui/_filter-list.scss
@@ -19,6 +19,9 @@
   &-container {
     display: flex;
     flex: 1;
+    // The filter-list-container div should be scrollable if its contents
+    // are larger than the available space.
+    min-height: 0;
   }
 }
 


### PR DESCRIPTION
Closes #9175

## Description

This PR adds the `min-height` property to the `.filter-list-container` selector. This allows it to shrink its height to a value smaller than its content size and show a scrollbar whenever there are too many items to fit on the screen.

### Alternative solutions

I've tested using `overflow: auto` instead and it also works completely fine, so a solution could be to just use that (which is a more explicit rule).

I've ended up choosing `min-height` since it feels less disruptive (specially since the `FilterList` container is used in many places), but I'm not attached to this decision and I would be happy to change it.

### Screenshots

![demo](https://user-images.githubusercontent.com/408035/76868252-e7046800-6866-11ea-9db7-8d667908a577.gif)

## Release notes

Notes:

- Fix layout bug on post-welcome screen for big displays.