### PR TITLE
Use the correct scroll variable from the state to persist scroll

### DIFF
--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -163,7 +163,7 @@ export class RepositoryView extends React.Component<
 
     const scrollTop =
       this.previousSection === RepositorySectionTab.History
-        ? this.state.compareListScrollTop
+        ? this.state.changesListScrollTop
         : undefined
     this.previousSection = RepositorySectionTab.Changes
 


### PR DESCRIPTION
Closes #9061

## Description

This PR fixes an issue when switching from the History tab to the Changes tab after scrolling.

The fix consists on using the correct variable that stores the scroll position of the Changes tab instead of the scroll position of the History tab. The error was probably introduced by mistake in https://github.com/desktop/desktop/pull/8307

### Screenshots

Before:

![before](https://user-images.githubusercontent.com/408035/76884988-d95adc80-687e-11ea-9073-6b3d79a9e562.gif)

After:

![after](https://user-images.githubusercontent.com/408035/76885009-e11a8100-687e-11ea-8bc5-4b9921d93c15.gif)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

- Fixed empty spaces shown on the "Changes" tab after switching from the "History" tab.