### PR TITLE
Add issue creation metric

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -341,6 +341,11 @@ export interface IDailyMeasures {
    * How many forks did the user create from Desktop?
    */
   readonly forksCreated: number
+
+  /**
+   * How many times has the user begun creating an issue from Desktop?
+   */
+  readonly issuesCreated: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -345,7 +345,7 @@ export interface IDailyMeasures {
   /**
    * How many times has the user begun creating an issue from Desktop?
    */
-  readonly issuesCreated: number
+  readonly issueCreationWebpageOpenedCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -135,6 +135,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   highestTutorialStepCompleted: -1,
   commitsToRepositoryWithoutWriteAccess: 0,
   forksCreated: 0,
+  issuesCreated: 0,
 }
 
 interface IOnboardingStats {
@@ -1345,6 +1346,12 @@ export class StatsStore implements IStatsStore {
   public recordForkCreated() {
     return this.updateDailyMeasures(m => ({
       forksCreated: m.forksCreated + 1,
+    }))
+  }
+
+  public recordIssueCreated() {
+    return this.updateDailyMeasures(m => ({
+      issuesCreated: m.issuesCreated + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -135,7 +135,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   highestTutorialStepCompleted: -1,
   commitsToRepositoryWithoutWriteAccess: 0,
   forksCreated: 0,
-  issuesCreated: 0,
+  issueCreationWebpageOpenedCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1349,9 +1349,9 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  public recordIssueCreated() {
+  public recordIssueCreationWebpageOpened() {
     return this.updateDailyMeasures(m => ({
-      issuesCreated: m.issuesCreated + 1,
+      issueCreationWebpageOpenedCount: m.issueCreationWebpageOpenedCount + 1,
     }))
   }
 

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -128,7 +128,7 @@ export function getGitHubHtmlUrl(repository: Repository): string | null {
   ) {
     return repository.gitHubRepository.parent.htmlURL
   }
-  if (repository.gitHubRepository.htmlURL) {
+  if (repository.gitHubRepository.htmlURL !== null) {
     return repository.gitHubRepository.htmlURL
   }
   return null

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -112,3 +112,24 @@ export function nameOf(repository: Repository) {
 
   return gitHubRepository !== null ? gitHubRepository.fullName : repository.name
 }
+
+/**
+ * Get the GitHub html URL for a repository, if it has one.
+ * Will return the parent GitHub repository's URL if it has one.
+ * Otherwise, returns null.
+ */
+export function getGitHubHtmlUrl(repository: Repository): string | null {
+  if (repository.gitHubRepository === null) {
+    return null
+  }
+  if (
+    repository.gitHubRepository.parent !== null &&
+    repository.gitHubRepository.parent.htmlURL !== null
+  ) {
+    return repository.gitHubRepository.parent.htmlURL
+  }
+  if (repository.gitHubRepository.htmlURL) {
+    return repository.gitHubRepository.htmlURL
+  }
+  return null
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1110,14 +1110,11 @@ export class App extends React.Component<IAppProps, IAppState> {
    * of the current GitHub repository.
    */
   private createIssueInRepositoryOnGitHub() {
-    // Default to creating issue on parent repo
-    // See https://github.com/desktop/desktop/issues/9232 for rationale
-    const url =
-      this.getParentRepositoryGitHubURL() ||
-      this.getCurrentRepositoryGitHubURL()
-
-    if (url) {
-      this.props.dispatcher.openInBrowser(`${url}/issues/new/choose`)
+    const repository = this.getRepository()
+    // this will likely never be null since we disable the
+    // issue creation menu item for non-GitHub repositories
+    if (repository instanceof Repository) {
+      this.props.dispatcher.openIssueCreationPage(repository)
     }
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1127,23 +1127,6 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
   }
 
-  /** Returns the URL to the parent repository if hosted on GitHub */
-  private getParentRepositoryGitHubURL() {
-    const repository = this.getRepository()
-
-    if (
-      !repository ||
-      repository instanceof CloningRepository ||
-      !repository.gitHubRepository ||
-      repository.gitHubRepository.parent === null ||
-      repository.gitHubRepository.parent.htmlURL === null
-    ) {
-      return null
-    }
-
-    return repository.gitHubRepository.parent.htmlURL
-  }
-
   /** Returns the URL to the current repository if hosted on GitHub */
   private getCurrentRepositoryGitHubURL() {
     const repository = this.getRepository()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -356,7 +356,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       case 'compare-on-github':
         return this.compareBranchOnDotcom()
       case 'create-issue-in-repository-on-github':
-        return this.createIssueInRepositoryOnGitHub()
+        return this.openIssueCreationOnGitHub()
       case 'open-in-shell':
         return this.openCurrentRepositoryInShell()
       case 'clone-repository':
@@ -1109,7 +1109,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    * Opens a browser to the issue creation page
    * of the current GitHub repository.
    */
-  private createIssueInRepositoryOnGitHub() {
+  private openIssueCreationOnGitHub() {
     const repository = this.getRepository()
     // this will likely never be null since we disable the
     // issue creation menu item for non-GitHub repositories

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2357,7 +2357,7 @@ export class Dispatcher {
     // See https://github.com/desktop/desktop/issues/9232 for rationale
     const url = getGitHubHtmlUrl(repository)
     if (url !== null) {
-      this.statsStore.recordIssueCreated()
+      this.statsStore.recordIssueCreationWebpageOpened()
       return this.appStore._openInBrowser(`${url}/issues/new/choose`)
     } else {
       return false

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -69,6 +69,7 @@ import {
   Repository,
   RepositoryWithGitHubRepository,
   isRepositoryWithGitHubRepository,
+  getGitHubHtmlUrl,
 } from '../../models/repository'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import {
@@ -2348,5 +2349,18 @@ export class Dispatcher {
    */
   public createTutorialRepository(account: Account) {
     return this.appStore._createTutorialRepository(account)
+  }
+
+  /** Open the issue creation page for a GitHub repository in a browser */
+  public async openIssueCreationPage(repository: Repository): Promise<boolean> {
+    // Default to creating issue on parent repo
+    // See https://github.com/desktop/desktop/issues/9232 for rationale
+    const url = getGitHubHtmlUrl(repository)
+    if (url !== null) {
+      this.statsStore.recordIssueCreated()
+      return this.appStore._openInBrowser(`${url}/issues/new/choose`)
+    } else {
+      return false
+    }
   }
 }


### PR DESCRIPTION
closes #9304 

## Description

- adds a measure (`issueCreationWebpageOpenedCount`) which counts how many times the user open the issue creation page on dot com from github desktop
- some small refactoring for the "get parent or fork URL" logic

cc @rafeca @billygriffin 