### PR TITLE
Redirect to upstream repo when clicking on "View on GitHub"

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1119,7 +1119,9 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private viewRepositoryOnGitHub() {
-    const url = this.getCurrentRepositoryGitHubURL()
+    const url =
+      this.getParentRepositoryGitHubURL() ||
+      this.getCurrentRepositoryGitHubURL()
 
     if (url) {
       this.props.dispatcher.openInBrowser(url)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -23,7 +23,7 @@ import { getVersion, getName } from './lib/app-proxy'
 import { getOS } from '../lib/get-os'
 import { validatedRepositoryPath } from '../lib/stores/helpers/validated-repository-path'
 import { MenuEvent } from '../main-process/menu'
-import { Repository } from '../models/repository'
+import { Repository, getGitHubHtmlUrl } from '../models/repository'
 import { Branch } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
@@ -1119,13 +1119,14 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private viewRepositoryOnGitHub() {
-    const url =
-      this.getParentRepositoryGitHubURL() ||
-      this.getCurrentRepositoryGitHubURL()
+    const repository = this.getRepository()
 
-    if (url) {
-      this.props.dispatcher.openInBrowser(url)
-      return
+    if (repository instanceof Repository) {
+      const url = getGitHubHtmlUrl(repository)
+
+      if (url) {
+        this.props.dispatcher.openInBrowser(url)
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9312

## Description

This PR changes the redirection URL when clicking the "View on GitHub" main menu item to open the upstream repository when the current repository is a fork.

## Release notes

Notes: no-notes
