### PR TITLE
Fetch the aheadBehind state when the info doesn't exist

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1042,6 +1042,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
           inferredBranch.tip.sha
         )
 
+        // In the case that the aheadBehindCache doesn't have the needed data, try to
+        // request it directly from AheadBehindUpdater. This usually happens on initial load
+        // before AheadBehindUpdater has run though all the branches.
         if (
           aheadBehindOfInferredBranch === null &&
           this.currentAheadBehindUpdater

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1036,24 +1036,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
         compareState.aheadBehindCache
       )
 
-      if (inferredBranch !== null) {
-        aheadBehindOfInferredBranch = compareState.aheadBehindCache.get(
+      if (inferredBranch !== null && this.currentAheadBehindUpdater !== null) {
+        aheadBehindOfInferredBranch = await this.currentAheadBehindUpdater.executeAsyncTask(
           tip.branch.tip.sha,
           inferredBranch.tip.sha
         )
-
-        // In the case that the aheadBehindCache doesn't have the needed data, try to
-        // request it directly from AheadBehindUpdater. This usually happens on initial load
-        // before AheadBehindUpdater has run though all the branches.
-        if (
-          aheadBehindOfInferredBranch === null &&
-          this.currentAheadBehindUpdater
-        ) {
-          aheadBehindOfInferredBranch = await this.currentAheadBehindUpdater.executeAsyncTask(
-            tip.branch.tip.sha,
-            inferredBranch.tip.sha
-          )
-        }
       }
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1041,6 +1041,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
           tip.branch.tip.sha,
           inferredBranch.tip.sha
         )
+
+        if (
+          aheadBehindOfInferredBranch === null &&
+          this.currentAheadBehindUpdater
+        ) {
+          aheadBehindOfInferredBranch = await this.currentAheadBehindUpdater.executeAsyncTask(
+            tip.branch.tip.sha,
+            inferredBranch.tip.sha
+          )
+        }
       }
     }
 

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -66,6 +66,22 @@ export class AheadBehindUpdater {
     this.aheadBehindQueue.end()
   }
 
+  public async executeAsyncTask(
+    from: string,
+    to: string
+  ): Promise<IAheadBehind | null> {
+    return new Promise((resolve, reject) => {
+      if (this.comparisonCache.has(from, to)) {
+        resolve(this.comparisonCache.get(from, to))
+        return
+      }
+
+      this.executeTask(from, to, (error, result) =>
+        error !== null ? reject(error) : resolve(result)
+      )
+    })
+  }
+
   private executeTask = (
     from: string,
     to: string,


### PR DESCRIPTION
Partially addresses #5293

## Description

This PR partially addresses https://github.com/desktop/desktop/issues/6875 by fixing the point 1. stated in https://github.com/desktop/desktop/issues/6875#issuecomment-600621130.

There are still 2 pending issues with the prompt that I'm planning to address as separate PRs:

1. The prompt sometimes disappears just after it gets displayed. This is related to the point 2. in https://github.com/desktop/desktop/issues/6875#issuecomment-600621130.
2. The base branch used for the comparison is not consistent: most of the times `upstream/master` is used, but sometimes it defaults to just `master`.

### Screenshots

Before. Prompt only shown after opening the "Select branch..." dropdown:

![before](https://user-images.githubusercontent.com/408035/77056483-c1946d00-69d2-11ea-938d-e046ebdab109.gif)

Now. Prompt shown immediately:

![demo](https://user-images.githubusercontent.com/408035/77056575-e4268600-69d2-11ea-83f5-d47dede4328e.gif)

## Release notes

Notes: [Fixed] Display more consistently the prompt to notify when the current branch is outdated.
