### PR TITLE
More consistent logic for showing/hiding the NBBD prompt

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -643,6 +643,9 @@ export interface ICompareState {
   /** Show the diverging notification banner */
   readonly isDivergingBranchBannerVisible: boolean
 
+  /** Has the user dismissed the notification banner? */
+  readonly isDivergingBranchBannerDismissed: boolean
+
   /** Show the diverging notification nudge on the tab */
   readonly isDivergingBranchNudgeVisible: boolean
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -643,6 +643,9 @@ export interface ICompareState {
   /** Show the diverging notification banner */
   readonly isDivergingBranchBannerVisible: boolean
 
+  /** Show the diverging notification nudge on the tab */
+  readonly isDivergingBranchNudgeVisible: boolean
+
   /** The current state of the compare form, based on user input */
   readonly formState: IDisplayHistory | ICompareBranch
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -640,14 +640,8 @@ export interface ICompareBranch {
 }
 
 export interface ICompareState {
-  /** Show the diverging notification banner */
-  readonly isDivergingBranchBannerVisible: boolean
-
-  /** Has the user dismissed the notification banner? */
-  readonly isDivergingBranchBannerDismissed: boolean
-
-  /** Show the diverging notification nudge on the tab */
-  readonly isDivergingBranchNudgeVisible: boolean
+  /** The current state of the NBBD banner */
+  readonly divergingBranchBannerState: IDivergingBranchBannerState
 
   /** The current state of the compare form, based on user input */
   readonly formState: IDisplayHistory | ICompareBranch
@@ -699,6 +693,17 @@ export interface ICompareState {
     branch: Branch | null
     aheadBehind: IAheadBehind | null
   }
+}
+
+export interface IDivergingBranchBannerState {
+  /** Show the diverging notification banner */
+  readonly isPromptVisible: boolean
+
+  /** Has the user dismissed the notification banner? */
+  readonly isPromptDismissed: boolean
+
+  /** Show the diverging notification nudge on the tab */
+  readonly isNudgeVisible: boolean
 }
 
 export interface ICompareFormUpdate {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1042,6 +1042,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
           inferredBranch.tip.sha
         )
 
+        // In the case that the aheadBehindCache doesn't have the needed data, try to
+        // request it directly from AheadBehindUpdater. This usually happens on initial load
+        // before AheadBehindUpdater has run though all the branches.
         if (
           aheadBehindOfInferredBranch === null &&
           this.currentAheadBehindUpdater

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1077,11 +1077,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
         prevInferredBranchState.aheadBehind
       )
 
-      // we only want to show the banner when the the number
+      // We want to always show the banner if the current branch is behind
+      // the inferred branch.
+      this._setDivergingBranchBannerVisibility(repository, currentCount > 0)
+
+      // we only want to show the nudge when the the number
       // commits behind has changed since the last it was visible
       const countChanged = currentCount > 0 && previousCount !== currentCount
-      this._setDivergingBranchBannerVisibility(repository, countChanged)
+      this._setDivergingBranchNudgeVisibility(repository, countChanged)
     } else {
+      this._setDivergingBranchNudgeVisibility(repository, false)
       this._setDivergingBranchBannerVisibility(repository, false)
     }
 
@@ -4617,6 +4622,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public _setDivergingBranchBannerVisibility(
     repository: Repository,
     visible: boolean
@@ -4632,6 +4638,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (visible) {
         this.statsStore.recordDivergingBranchBannerDisplayed()
       }
+
+      this.emitUpdate()
+    }
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setDivergingBranchNudgeVisibility(
+    repository: Repository,
+    visible: boolean
+  ) {
+    const state = this.repositoryStateCache.get(repository)
+    const { compareState } = state
+
+    if (compareState.isDivergingBranchNudgeVisible !== visible) {
+      this.repositoryStateCache.updateCompareState(repository, () => ({
+        isDivergingBranchNudgeVisible: visible,
+      }))
 
       this.emitUpdate()
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4632,20 +4632,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const currentBannerState = this.repositoryStateCache.get(repository)
       .compareState.divergingBranchBannerState
 
-    const newBannerState = {
-      isPromptVisible:
-        divergingBranchBannerState.isPromptVisible !== undefined
-          ? divergingBranchBannerState.isPromptVisible
-          : currentBannerState.isPromptVisible,
-      isNudgeVisible:
-        divergingBranchBannerState.isNudgeVisible !== undefined
-          ? divergingBranchBannerState.isNudgeVisible
-          : currentBannerState.isNudgeVisible,
-      isPromptDismissed:
-        divergingBranchBannerState.isPromptDismissed !== undefined
-          ? divergingBranchBannerState.isPromptDismissed
-          : currentBannerState.isPromptDismissed,
-    }
+    const newBannerState = { ...currentBannerState, ...divergingBranchBannerState }
 
     // If none of the flags changed, we can skip updating the state.
     if (shallowEquals(currentBannerState, newBannerState)) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1041,6 +1041,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
           tip.branch.tip.sha,
           inferredBranch.tip.sha
         )
+
+        if (
+          aheadBehindOfInferredBranch === null &&
+          this.currentAheadBehindUpdater
+        ) {
+          aheadBehindOfInferredBranch = await this.currentAheadBehindUpdater.executeAsyncTask(
+            tip.branch.tip.sha,
+            inferredBranch.tip.sha
+          )
+        }
       }
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4632,7 +4632,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const currentBannerState = this.repositoryStateCache.get(repository)
       .compareState.divergingBranchBannerState
 
-    const newBannerState = { ...currentBannerState, ...divergingBranchBannerState }
+    const newBannerState = {
+      ...currentBannerState,
+      ...divergingBranchBannerState,
+    }
 
     // If none of the flags changed, we can skip updating the state.
     if (shallowEquals(currentBannerState, newBannerState)) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4660,6 +4660,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _setDivergingBranchBannerDismissed(
+    repository: Repository,
+    visible: boolean
+  ) {
+    const state = this.repositoryStateCache.get(repository)
+    const { compareState } = state
+
+    if (compareState.isDivergingBranchBannerDismissed !== visible) {
+      this.repositoryStateCache.updateCompareState(repository, () => ({
+        isDivergingBranchBannerDismissed: visible,
+      }))
+
+      this.emitUpdate()
+    }
+  }
+
   public _reportStats() {
     // ensure the user has seen and acknowledged the current usage stats setting
     if (!this.showWelcomeFlow && !hasSeenUsageStatsNote()) {

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -66,6 +66,22 @@ export class AheadBehindUpdater {
     this.aheadBehindQueue.end()
   }
 
+  public async executeAsyncTask(
+    from: string,
+    to: string
+  ): Promise<IAheadBehind | null> {
+    return new Promise((resolve, reject) => {
+      if (this.comparisonCache.has(from, to)) {
+        resolve(this.comparisonCache.get(from, to))
+        return
+      }
+
+      this.executeTask(from, to, (error, result) =>
+        error !== null ? reject(error) : resolve(result)
+      )
+    })
+  }
+
   private executeTask = (
     from: string,
     to: string,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -149,6 +149,7 @@ function getInitialRepositoryState(): IRepositoryState {
     },
     compareState: {
       isDivergingBranchBannerVisible: false,
+      isDivergingBranchNudgeVisible: false,
       formState: {
         kind: HistoryTabMode.History,
       },

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -149,6 +149,7 @@ function getInitialRepositoryState(): IRepositoryState {
     },
     compareState: {
       isDivergingBranchBannerVisible: false,
+      isDivergingBranchBannerDismissed: false,
       isDivergingBranchNudgeVisible: false,
       formState: {
         kind: HistoryTabMode.History,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -148,9 +148,11 @@ function getInitialRepositoryState(): IRepositoryState {
       rebasedBranches: new Map<string, string>(),
     },
     compareState: {
-      isDivergingBranchBannerVisible: false,
-      isDivergingBranchBannerDismissed: false,
-      isDivergingBranchNudgeVisible: false,
+      divergingBranchBannerState: {
+        isPromptVisible: false,
+        isPromptDismissed: false,
+        isNudgeVisible: false,
+      },
       formState: {
         kind: HistoryTabMode.History,
       },

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -690,16 +690,23 @@ export class Dispatcher {
   }
 
   /**
-   * Set the divering branch notification banner's visibility
+   * Set the divering branch notification nudge's visibility
    */
-  public setDivergingBranchBannerVisibility(
+  public setDivergingBranchNudgeVisibility(
     repository: Repository,
     isVisible: boolean
   ) {
-    return this.appStore._setDivergingBranchBannerVisibility(
+    return this.appStore._setDivergingBranchNudgeVisibility(
       repository,
       isVisible
     )
+  }
+
+  /**
+   * Hide the divering branch notification banner
+   */
+  public dismissDivergingBranchBanner(repository: Repository) {
+    return this.appStore._setDivergingBranchBannerDismissed(repository, true)
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -696,17 +696,18 @@ export class Dispatcher {
     repository: Repository,
     isVisible: boolean
   ) {
-    return this.appStore._setDivergingBranchNudgeVisibility(
-      repository,
-      isVisible
-    )
+    return this.appStore._updateDivergingBranchBannerState(repository, {
+      isNudgeVisible: isVisible,
+    })
   }
 
   /**
    * Hide the divering branch notification banner
    */
   public dismissDivergingBranchBanner(repository: Repository) {
-    return this.appStore._setDivergingBranchBannerDismissed(repository, true)
+    return this.appStore._updateDivergingBranchBannerState(repository, {
+      isPromptDismissed: true,
+    })
   }
 
   /**

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -183,7 +183,10 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderNotificationBanner() {
-    if (!this.props.compareState.isDivergingBranchBannerVisible) {
+    if (
+      !this.props.compareState.isDivergingBranchBannerVisible ||
+      this.props.compareState.isDivergingBranchBannerDismissed
+    ) {
       return null
     }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -85,6 +85,13 @@ export class CompareSidebar extends React.Component<
     }
   }
 
+  public componentDidMount() {
+    this.props.dispatcher.setDivergingBranchNudgeVisibility(
+      this.props.repository,
+      false
+    )
+  }
+
   public componentWillReceiveProps(nextProps: ICompareSidebarProps) {
     const newFormState = nextProps.compareState.formState
     const oldFormState = this.props.compareState.formState
@@ -556,10 +563,7 @@ export class CompareSidebar extends React.Component<
 
   private onNotificationBannerDismissed = (reason: DismissalReason) => {
     if (reason === DismissalReason.Close) {
-      this.props.dispatcher.setDivergingBranchBannerVisibility(
-        this.props.repository,
-        false
-      )
+      this.props.dispatcher.dismissDivergingBranchBanner(this.props.repository)
     }
     this.props.dispatcher.recordDivergingBranchBannerDismissal()
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -30,6 +30,7 @@ import {
   DismissalReason,
 } from '../notification/new-commits-banner'
 import { MergeCallToActionWithConflicts } from './merge-call-to-action-with-conflicts'
+import { assertNever } from '../../lib/fatal-error'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -558,13 +559,15 @@ export class CompareSidebar extends React.Component<
     this.props.dispatcher.recordDivergingBranchBannerDismissal()
 
     switch (reason) {
-      case 'close':
+      case DismissalReason.Close:
         this.setState({ hasConsumedNotification: false })
         break
-      case 'compare':
-      case 'merge':
+      case DismissalReason.Compare:
+      case DismissalReason.Merge:
         this.setState({ hasConsumedNotification: true })
         break
+      default:
+        assertNever(reason, 'Unknown reason')
     }
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -552,10 +552,12 @@ export class CompareSidebar extends React.Component<
   }
 
   private onNotificationBannerDismissed = (reason: DismissalReason) => {
-    this.props.dispatcher.setDivergingBranchBannerVisibility(
-      this.props.repository,
-      false
-    )
+    if (reason === DismissalReason.Close) {
+      this.props.dispatcher.setDivergingBranchBannerVisibility(
+        this.props.repository,
+        false
+      )
+    }
     this.props.dispatcher.recordDivergingBranchBannerDismissal()
 
     switch (reason) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -190,10 +190,9 @@ export class CompareSidebar extends React.Component<
   }
 
   private renderNotificationBanner() {
-    if (
-      !this.props.compareState.isDivergingBranchBannerVisible ||
-      this.props.compareState.isDivergingBranchBannerDismissed
-    ) {
+    const bannerState = this.props.compareState.divergingBranchBannerState
+
+    if (!bannerState.isPromptVisible || bannerState.isPromptDismissed) {
       return null
     }
 

--- a/app/src/ui/notification/new-commits-banner.tsx
+++ b/app/src/ui/notification/new-commits-banner.tsx
@@ -8,7 +8,11 @@ import { Repository } from '../../models/repository'
 import { HistoryTabMode, ComparisonMode } from '../../lib/app-state'
 import { PopupType } from '../../models/popup'
 
-export type DismissalReason = 'close' | 'compare' | 'merge'
+export enum DismissalReason {
+  Close = 'close',
+  Compare = 'compare',
+  Merge = 'merge',
+}
 
 interface INewCommitsBannerProps {
   readonly dispatcher: Dispatcher
@@ -86,7 +90,7 @@ export class NewCommitsBanner extends React.Component<
   }
 
   private onDismissed = () => {
-    this.props.onDismiss('close')
+    this.props.onDismiss(DismissalReason.Close)
   }
 
   private onComparedClicked = () => {
@@ -98,7 +102,7 @@ export class NewCommitsBanner extends React.Component<
       comparisonMode: ComparisonMode.Behind,
     })
     dispatcher.recordDivergingBranchBannerInitiatedCompare()
-    this.props.onDismiss('compare')
+    this.props.onDismiss(DismissalReason.Compare)
   }
 
   private onMergeClicked = () => {
@@ -110,6 +114,6 @@ export class NewCommitsBanner extends React.Component<
       repository,
     })
     dispatcher.recordDivergingBranchBannerInitatedMerge()
-    this.props.onDismiss('merge')
+    this.props.onDismiss(DismissalReason.Merge)
   }
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -135,7 +135,7 @@ export class RepositoryView extends React.Component<
 
         <div className="with-indicator">
           <span>History</span>
-          {this.props.state.compareState.isDivergingBranchBannerVisible ? (
+          {this.props.state.compareState.isDivergingBranchNudgeVisible ? (
             <Octicon
               className="indicator"
               symbol={OcticonSymbol.primitiveDot}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -135,7 +135,8 @@ export class RepositoryView extends React.Component<
 
         <div className="with-indicator">
           <span>History</span>
-          {this.props.state.compareState.isDivergingBranchNudgeVisible ? (
+          {this.props.state.compareState.divergingBranchBannerState
+            .isNudgeVisible ? (
             <Octicon
               className="indicator"
               symbol={OcticonSymbol.primitiveDot}


### PR DESCRIPTION
Partially addresses #5293

This branch is based on https://github.com/desktop/desktop/pull/9319

## Description

This PR partially addresses #6875 by fixing the point 2. stated in https://github.com/desktop/desktop/issues/6875#issuecomment-600621130 .

In order to fix this, I've decided to add a third flag that controls whether the user has currently dismissed the banner (this way if the user dismisses the banner, it doesn't get shown again when the diverging logic gets executed afterwards).

In terms of behaviour, I've tried to follow what was stated in [the original NBBD issue](https://github.com/desktop/desktop/issues/4646). This is a quick summary:

* The blue nudge is shown whenever when the number of commits behind is different from the last time Desktop checked, and it gets hidden when the user clicks on the history tab.
* The prompt is shown whenever the current branch is behind the inferred branch. It stays visible until the user dismisses the prompt by clicking on the "x" button.

Something important to note is that this whole logic gets reset every time the user changes branches (or the app gets restarted). This means that if the user checks out a branch and goes back to the current branch, they'll see the blue nudge and the prompt again even if they have dismissed the prompt.

This is caused by the way the NBBD flags are stored, we could probably persist them in a different place to keep the state for longer.

cc/ @billygriffin, @nerdneha , @ampinsk 

### Screenshots

Before:

![before](https://user-images.githubusercontent.com/408035/77074439-265ec000-69f1-11ea-9a5f-782a346e7d8e.gif)

After:

![after-2](https://user-images.githubusercontent.com/408035/77074472-324a8200-69f1-11ea-9eb5-1fe315dfcc55.gif)

## Release notes

Notes: no-notes
