### PR TITLE
add instrumentation for schannel revocation check error encountered

### DIFF
--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -23,6 +23,7 @@ import {
   enableSchannelCheckRevokeOptOut,
 } from '../../lib/feature-flag'
 import { RetryActionType } from '../../models/retry-actions'
+import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
 
 /** An error which also has a code property. */
 interface IErrorWithCode extends Error {
@@ -680,6 +681,7 @@ export async function schannelUnableToCheckRevocationForCertificate(
     return error
   }
 
+  sendNonFatalException('schannelUnableToCheckRevocationForCertificate', error)
   dispatcher.showPopup({
     type: PopupType.SChannelNoRevocationCheck,
     url: match[1],


### PR DESCRIPTION
so we can see how prevalent this error is for our users. reported every time we show the popup, whether or not the user chooses to accept the workaround offered there.

uses our "non-fatal" exception reporting, not formal metrics.

cc @billygriffin 