### PR TITLE
add noTrack option for createBranch

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -11,7 +11,6 @@ import {
   envForRemoteOperation,
   getFallbackUrlForProxyResolve,
 } from './environment'
-import { enableForkyCreateBranchUI } from '../feature-flag'
 
 /**
  * Create a new branch from the given start point.
@@ -25,7 +24,8 @@ import { enableForkyCreateBranchUI } from '../feature-flag'
 export async function createBranch(
   repository: Repository,
   name: string,
-  startPoint: string | null
+  startPoint: string | null,
+  noTrack?: boolean
 ): Promise<Branch | null> {
   const args =
     startPoint !== null ? ['branch', name, startPoint] : ['branch', name]
@@ -33,11 +33,7 @@ export async function createBranch(
   // if we're branching directly from a remote branch, we don't want to track it
   // tracking it will make the rest of desktop think we want to push to that
   // remote branch's upstream (which would likely be the upstream of the fork)
-  if (
-    enableForkyCreateBranchUI() &&
-    startPoint !== null &&
-    startPoint.startsWith('remotes/')
-  ) {
+  if (noTrack) {
     args.push('--no-track')
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2995,11 +2995,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     startPoint: string | null,
     uncommittedChangesStrategy: UncommittedChangesStrategy = getUncommittedChangesStrategy(
       this.uncommittedChangesStrategyKind
-    )
+    ),
+    noTrackOption: boolean = false
   ): Promise<Repository> {
     const gitStore = this.gitStoreCache.get(repository)
     const branch = await gitStore.performFailableOperation(() =>
-      createBranch(repository, name, startPoint)
+      createBranch(repository, name, startPoint, noTrackOption)
     )
 
     if (branch == null) {

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -271,6 +271,7 @@ export class CreateBranch extends React.Component<
     const name = this.state.sanitizedName
 
     let startPoint: string | null = null
+    let noTrack = false
 
     const {
       defaultBranch,
@@ -301,7 +302,8 @@ export class CreateBranch extends React.Component<
         return
       }
 
-      startPoint = `remotes/${upstreamDefaultBranch.name}`
+      startPoint = upstreamDefaultBranch.name
+      noTrack = true
     }
 
     if (name.length > 0) {
@@ -319,7 +321,8 @@ export class CreateBranch extends React.Component<
         repository,
         name,
         startPoint,
-        strategy
+        strategy,
+        noTrack
       )
       timer.done()
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -476,13 +476,15 @@ export class Dispatcher {
     repository: Repository,
     name: string,
     startPoint: string | null,
-    uncommittedChangesStrategy?: UncommittedChangesStrategy
+    uncommittedChangesStrategy?: UncommittedChangesStrategy,
+    noTrackOption: boolean = false
   ): Promise<Repository> {
     return this.appStore._createBranch(
       repository,
       name,
       startPoint,
-      uncommittedChangesStrategy
+      uncommittedChangesStrategy,
+      noTrackOption
     )
   }
 


### PR DESCRIPTION
follow up to #9268 

refactor the "remotes/"-specific logic in favor of explicitly passing a "no track" option.

this significantly reduces the risk associated with that work, and is a much more sound solution in general!