### PR TITLE
Infer branch for NDDB more consistently

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1030,7 +1030,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     let aheadBehindOfInferredBranch: IAheadBehind | null = null
     if (
       tip.kind === TipState.Valid &&
-      compareState.aheadBehindCache !== null &&
       aheadBehindUpdater !== null
     ) {
       inferredBranch = await inferComparisonBranch(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1037,9 +1037,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         allBranches,
         currentPullRequest,
-        tip.branch,
-        getRemotes,
-        aheadBehindUpdater
+        getRemotes
       )
 
       if (inferredBranch !== null) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1025,16 +1025,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ? cachedDefaultBranch
         : null
 
+    const aheadBehindUpdater = this.currentAheadBehindUpdater
     let inferredBranch: Branch | null = null
     let aheadBehindOfInferredBranch: IAheadBehind | null = null
-    if (tip.kind === TipState.Valid && compareState.aheadBehindCache !== null) {
+    if (
+      tip.kind === TipState.Valid &&
+      compareState.aheadBehindCache !== null &&
+      aheadBehindUpdater !== null
+    ) {
       inferredBranch = await inferComparisonBranch(
         repository,
         allBranches,
         currentPullRequest,
         tip.branch,
         getRemotes,
-        compareState.aheadBehindCache
+        aheadBehindUpdater
       )
 
       if (inferredBranch !== null) {
@@ -1046,11 +1051,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // In the case that the aheadBehindCache doesn't have the needed data, try to
         // request it directly from AheadBehindUpdater. This usually happens on initial load
         // before AheadBehindUpdater has run though all the branches.
-        if (
-          aheadBehindOfInferredBranch === null &&
-          this.currentAheadBehindUpdater
-        ) {
-          aheadBehindOfInferredBranch = await this.currentAheadBehindUpdater.executeAsyncTask(
+        if (aheadBehindOfInferredBranch === null) {
+          aheadBehindOfInferredBranch = await aheadBehindUpdater.executeAsyncTask(
             tip.branch.tip.sha,
             inferredBranch.tip.sha
           )

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1028,10 +1028,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const aheadBehindUpdater = this.currentAheadBehindUpdater
     let inferredBranch: Branch | null = null
     let aheadBehindOfInferredBranch: IAheadBehind | null = null
-    if (
-      tip.kind === TipState.Valid &&
-      aheadBehindUpdater !== null
-    ) {
+    if (tip.kind === TipState.Valid && aheadBehindUpdater !== null) {
       inferredBranch = await inferComparisonBranch(
         repository,
         allBranches,

--- a/app/src/lib/stores/helpers/infer-comparison-branch.ts
+++ b/app/src/lib/stores/helpers/infer-comparison-branch.ts
@@ -4,7 +4,6 @@ import { GitHubRepository } from '../../../models/github-repository'
 import { IRemote } from '../../../models/remote'
 import { Repository } from '../../../models/repository'
 import { urlMatchesCloneURL } from '../../repository-matching'
-import { AheadBehindUpdater } from './ahead-behind-updater'
 
 type RemotesGetter = (repository: Repository) => Promise<ReadonlyArray<IRemote>>
 
@@ -20,34 +19,40 @@ type RemotesGetter = (repository: Repository) => Promise<ReadonlyArray<IRemote>>
  * @param repository The repository the branch belongs to
  * @param branches The list of all branches for the repository
  * @param currentPullRequest The pull request to use for finding the branch
- * @param currentBranch The branch we want the parent of
  * @param getRemotes callback used to get all remotes for the current repository
- * @param aheadBehindUpdater module used to get the number of commits ahead/behind the current branch is from another branch
  */
 
 export async function inferComparisonBranch(
   repository: Repository,
   branches: ReadonlyArray<Branch>,
   currentPullRequest: PullRequest | null,
-  currentBranch: Branch,
-  getRemotes: RemotesGetter,
-  aheadBehindUpdater: AheadBehindUpdater
+  getRemotes: RemotesGetter
 ): Promise<Branch | null> {
   if (currentPullRequest !== null) {
-    return getTargetBranchOfPullRequest(branches, currentPullRequest)
+    const prBranch = getTargetBranchOfPullRequest(branches, currentPullRequest)
+    if (prBranch !== null) {
+      return prBranch
+    }
   }
 
   const ghRepo = repository.gitHubRepository
+
   if (ghRepo !== null) {
-    return ghRepo.fork === true && currentBranch !== null
-      ? getDefaultBranchOfFork(
-          repository,
-          branches,
-          currentBranch,
-          getRemotes,
-          aheadBehindUpdater
-        )
-      : getDefaultBranchOfGitHubRepo(branches, ghRepo)
+    if (ghRepo.fork) {
+      const upstreamBranch = await getDefaultBranchOfForkedGitHubRepo(
+        repository,
+        branches,
+        getRemotes
+      )
+      if (upstreamBranch !== null) {
+        return upstreamBranch
+      }
+    }
+
+    const originBranch = getDefaultBranchOfGitHubRepo(branches, ghRepo)
+    if (originBranch !== null) {
+      return originBranch
+    }
   }
 
   return getMasterBranch(branches)
@@ -73,47 +78,6 @@ function getTargetBranchOfPullRequest(
   pr: PullRequest
 ): Branch | null {
   return findBranch(branches, pr.base.ref)
-}
-
-/**
- * For `inferComparisonBranch` case where inferring for a forked repository
- *
- * Returns the default branch of the fork if it's ahead of `currentBranch`.
- * Otherwise, the default branch of the parent is returned.
- */
-async function getDefaultBranchOfFork(
-  repository: Repository,
-  branches: ReadonlyArray<Branch>,
-  currentBranch: Branch,
-  getRemotes: RemotesGetter,
-  aheadBehindUpdater: AheadBehindUpdater
-): Promise<Branch | null> {
-  // this is guaranteed to exist since this function
-  // is only called if the ghRepo is not null
-  const ghRepo = repository.gitHubRepository!
-  const defaultBranch = getDefaultBranchOfGitHubRepo(branches, ghRepo)
-  if (defaultBranch === null) {
-    return getMasterBranch(branches)
-  }
-
-  const aheadBehind = await aheadBehindUpdater.executeAsyncTask(
-    currentBranch.tip.sha,
-    defaultBranch.tip.sha
-  )
-
-  // we want to return the default branch of the fork if it's ahead
-  // of the current branch; see https://github.com/desktop/desktop/issues/4766#issue-325764371
-  if (aheadBehind !== null && aheadBehind.ahead > 0) {
-    return defaultBranch
-  }
-
-  const potentialDefault = await getDefaultBranchOfForkedGitHubRepo(
-    repository,
-    branches,
-    getRemotes
-  )
-
-  return potentialDefault
 }
 
 async function getDefaultBranchOfForkedGitHubRepo(

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -1,5 +1,3 @@
-jest.mock('../../src/lib/git')
-
 import { inferComparisonBranch } from '../../src/lib/stores/helpers/infer-comparison-branch'
 import { Branch, BranchType } from '../../src/models/branch'
 import { Commit } from '../../src/models/commit'
@@ -9,12 +7,6 @@ import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
 import { Repository } from '../../src/models/repository'
 import { IRemote } from '../../src/models/remote'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
-import { AheadBehindUpdater } from '../../src/lib/stores/helpers/ahead-behind-updater'
-import { getAheadBehind } from '../../src/lib/git'
-
-const mockedGetAheadBehind: jest.Mock<
-  typeof getAheadBehind
-> = getAheadBehind as any
 
 function createTestCommit(sha: string) {
   return new Commit(
@@ -81,25 +73,13 @@ describe('inferComparisonBranch', () => {
     createTestBranch('fork', '6', 'origin'),
   ]
 
-  beforeEach(() => {
-    mockedGetAheadBehind.mockReturnValue(
-      Promise.resolve({
-        ahead: 0,
-        behind: 0,
-      })
-    )
-  })
-
   it('Returns the master branch when given unhosted repo', async () => {
     const repo = createTestRepo()
-    const aheadBehindUpdater = new AheadBehindUpdater(repo, () => {})
     const branch = await inferComparisonBranch(
       repo,
       branches,
       null,
-      branches[0],
-      mockGetRemotes,
-      aheadBehindUpdater
+      mockGetRemotes
     )
 
     expect(branch).not.toBeNull()
@@ -109,15 +89,12 @@ describe('inferComparisonBranch', () => {
   it('Returns the default branch of a GitHub repository', async () => {
     const ghRepo: GitHubRepository = createTestGhRepo('test', 'default')
     const repo = createTestRepo(ghRepo)
-    const aheadBehindUpdater = new AheadBehindUpdater(repo, () => {})
 
     const branch = await inferComparisonBranch(
       repo,
       branches,
       null,
-      branches[0],
-      mockGetRemotes,
-      aheadBehindUpdater
+      mockGetRemotes
     )
 
     expect(branch).not.toBeNull()
@@ -127,7 +104,6 @@ describe('inferComparisonBranch', () => {
   it('Returns the branch associated with the PR', async () => {
     const ghRepo: GitHubRepository = createTestGhRepo('test', 'default')
     const repo = createTestRepo(ghRepo)
-    const aheadBehindUpdater = new AheadBehindUpdater(repo, () => {})
     const head = createTestPrRef(branches[4], ghRepo)
     const base = createTestPrRef(branches[5], ghRepo)
     const pr: PullRequest = createTestPr(head, base)
@@ -136,44 +112,14 @@ describe('inferComparisonBranch', () => {
       repo,
       branches,
       pr,
-      branches[0],
-      mockGetRemotes,
-      aheadBehindUpdater
+      mockGetRemotes
     )
 
     expect(branch).not.toBeNull()
     expect(branch!.upstream).toBe(branches[5].upstream)
   })
 
-  it('Returns the default branch of the fork if it is ahead of the current branch', async () => {
-    const currentBranch = branches[3]
-    const defaultBranch = branches[6]
-    const parent = createTestGhRepo('parent', 'parent')
-    const fork = createTestGhRepo('fork', 'fork', parent)
-    const repo = createTestRepo(fork)
-    const aheadBehindUpdater = new AheadBehindUpdater(repo, () => {})
-
-    mockedGetAheadBehind.mockReturnValue(
-      Promise.resolve({
-        ahead: 1,
-        behind: 0,
-      })
-    )
-
-    const branch = await inferComparisonBranch(
-      repo,
-      branches,
-      null,
-      currentBranch,
-      mockGetRemotes,
-      aheadBehindUpdater
-    )
-
-    expect(branch).not.toBeNull()
-    expect(branch!.name).toBe(defaultBranch.name)
-  })
-
-  it("Returns the default branch of the fork's parent branch if the fork is not ahead of the current branch", async () => {
+  it("Returns the default branch of the fork's parent branch", async () => {
     const defaultBranchOfParent = branches[5]
     const defaultBranchOfFork = branches[4]
     const parent = createTestGhRepo(
@@ -182,7 +128,7 @@ describe('inferComparisonBranch', () => {
     )
     const fork = createTestGhRepo('fork', defaultBranchOfFork.name, parent)
     const repo = createTestRepo(fork)
-    const aheadBehindUpdater = new AheadBehindUpdater(repo, () => {})
+
     const mockGetRemotes = (repo: Repository) => {
       const remotes: ReadonlyArray<IRemote> = [
         { name: 'origin', url: fork.cloneURL! },
@@ -196,9 +142,7 @@ describe('inferComparisonBranch', () => {
       repo,
       branches,
       null,
-      defaultBranchOfParent,
-      mockGetRemotes,
-      aheadBehindUpdater
+      mockGetRemotes
     )
 
     expect(branch).not.toBeNull()


### PR DESCRIPTION
Partially addresses #5293

This branch is based on #9320

## Description

This PR changes the logic to infer the branch used for the NDDB to follow the rules that the code comments suggest:

> The branch returned is determined by the following conditions:
>  1. Given a pull request -> target branch of PR	 
>  2. Given a forked repository -> default branch on `upstream`
>  3. Given a hosted repository -> default branch on `origin`
>  4. Fallback -> `master` branch

Before, there was some logic to default to branch on `origin` if the current branch was behind it, but this logic didn't work correctly all the time and it caused this inconsistencies. With this PR the logic is now deterministic and a little bit simpler.

### Screenshots

Before:

![before](https://user-images.githubusercontent.com/408035/77199148-a6b41c80-6ae8-11ea-8f09-daaf0c2e8255.gif)

With this fix, the inferred branch stays as `upstream/master` no matter which actions the user takes.

## Release notes

Notes: no-notes
