### PR TITLE
Add support for Android Studio on macOS

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -351,7 +351,10 @@ export async function getAvailableEditors(): Promise<
   }
 
   if (androidStudioPath) {
-    results.push({ editor: ExternalEditor.AndroidStudio, path: androidStudioPath })
+    results.push({
+      editor: ExternalEditor.AndroidStudio,
+      path: androidStudioPath,
+    })
   }
 
   return results

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -22,6 +22,7 @@ export enum ExternalEditor {
   IntelliJ = 'IntelliJ',
   Xcode = 'Xcode',
   GoLand = 'GoLand',
+  AndroidStudio = 'Android Studio',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -81,6 +82,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.GoLand) {
     return ExternalEditor.GoLand
   }
+  if (label === ExternalEditor.AndroidStudio) {
+    return ExternalEditor.AndroidStudio
+  }
   return null
 }
 
@@ -132,6 +136,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.apple.dt.Xcode']
     case ExternalEditor.GoLand:
       return ['com.jetbrains.goland']
+    case ExternalEditor.AndroidStudio:
+      return ['com.google.android.studio']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -191,6 +197,8 @@ function getExecutableShim(
       return '/usr/bin/xed'
     case ExternalEditor.GoLand:
       return Path.join(installPath, 'Contents', 'MacOS', 'goland')
+    case ExternalEditor.AndroidStudio:
+      return Path.join(installPath, 'Contents', 'MacOS', 'studio')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -244,6 +252,7 @@ export async function getAvailableEditors(): Promise<
     intellijPath,
     xcodePath,
     golandPath,
+    androidStudioPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),
@@ -263,6 +272,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.IntelliJ),
     findApplication(ExternalEditor.Xcode),
     findApplication(ExternalEditor.GoLand),
+    findApplication(ExternalEditor.AndroidStudio),
   ])
 
   if (atomPath) {
@@ -338,6 +348,10 @@ export async function getAvailableEditors(): Promise<
 
   if (golandPath) {
     results.push({ editor: ExternalEditor.GoLand, path: golandPath })
+  }
+
+  if (androidStudioPath) {
+    results.push({ editor: ExternalEditor.AndroidStudio, path: androidStudioPath })
   }
 
   return results

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -264,6 +264,7 @@ These editors are currently supported:
  - [Typora](https://typora.io/)
  - [SlickEdit](https://www.slickedit.com)
  - [GoLand](https://www.jetbrains.com/go/)
+ - [Android Studio](https://developer.android.com/studio)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

- Add support for Android Studio on macOS

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
- Add support for Android Studio on macOS
