### PR TITLE
Display PRs from upstream repository in forks

### DIFF
--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -149,7 +149,7 @@ export class PullRequestCoordinator {
       gitHubRepository,
       this.repositories
     )
-    // mark all matching repos for parent as now loading
+    // mark all matching repos as now loading
     for (const match of matches) {
       this.emitIsLoadingPullRequests(match, true)
     }

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -154,7 +154,6 @@ export class PullRequestCoordinator {
       this.emitIsLoadingPullRequests(match, true)
     }
 
-    // mark all matching repos as now loading
     await this.pullRequestStore.refreshPullRequests(gitHubRepository, account)
 
     // mark all matching repos as done loading

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -266,20 +266,10 @@ export class PullRequestCoordinator {
 function findRepositoriesForGitHubRepository(
   gitHubRepository: GitHubRepository,
   repositories: ReadonlyArray<RepositoryWithGitHubRepository>
-): Array<RepositoryWithGitHubRepository> {
+): ReadonlyArray<RepositoryWithGitHubRepository> {
   const { dbID } = gitHubRepository
-  const matches = new Array<RepositoryWithGitHubRepository>()
 
-  for (const r of repositories) {
-    if (r.gitHubRepository.dbID === dbID) {
-      matches.push(r)
-    } else if (
-      r.gitHubRepository.parent !== null &&
-      r.gitHubRepository.parent.dbID === dbID
-    ) {
-      matches.push(r)
-    }
-  }
-
-  return matches
+  return repositories.filter(
+    repository => getNonForkGitHubRepository(repository).dbID === dbID
+  )
 }

--- a/app/src/lib/stores/pull-request-coordinator.ts
+++ b/app/src/lib/stores/pull-request-coordinator.ts
@@ -100,7 +100,14 @@ export class PullRequestCoordinator {
 
         // emit updates for matches
         for (const match of matches) {
-          fn(match, pullRequests)
+          if (match.gitHubRepository.parent) {
+            // matches that are forks need to include the PRs from upstreams
+            this.getPullRequestsFor(match.gitHubRepository.parent).then(prs =>
+              fn(match, [...prs, ...pullRequests])
+            )
+          } else {
+            fn(match, pullRequests)
+          }
         }
       }
     )

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -133,3 +133,13 @@ export function getGitHubHtmlUrl(repository: Repository): string | null {
   }
   return null
 }
+
+/**
+ * Returns the GitHubRepository when a non-fork repository is passed. Returns the parent
+ * GitHubRepository otherwise.
+ */
+export function getNonForkGitHubRepository(
+  repository: RepositoryWithGitHubRepository
+): GitHubRepository {
+  return repository.gitHubRepository.parent || repository.gitHubRepository
+}

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -119,19 +119,11 @@ export function nameOf(repository: Repository) {
  * Otherwise, returns null.
  */
 export function getGitHubHtmlUrl(repository: Repository): string | null {
-  if (repository.gitHubRepository === null) {
+  if (!isRepositoryWithGitHubRepository(repository)) {
     return null
   }
-  if (
-    repository.gitHubRepository.parent !== null &&
-    repository.gitHubRepository.parent.htmlURL !== null
-  ) {
-    return repository.gitHubRepository.parent.htmlURL
-  }
-  if (repository.gitHubRepository.htmlURL !== null) {
-    return repository.gitHubRepository.htmlURL
-  }
-  return null
+
+  return getNonForkGitHubRepository(repository).htmlURL
 }
 
 /**

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -346,17 +346,24 @@ export class BranchesContainer extends React.Component<
 }
 
 /**
- *  Returns which Pull Requests to display
- *  (For now, filters out any pull requests targeting upstream)
+ * Returns which Pull Requests to display
+ *
+ * If the current repository is a fork, it only shows the PRs
+ * targeting the upstream repository.
  */
 function getPullRequestsWithBaseRepository(
-  repository: Repository,
+  { gitHubRepository }: Repository,
   pullRequests: ReadonlyArray<PullRequest>
 ) {
-  const { gitHubRepository } = repository
-  return gitHubRepository !== null
-    ? pullRequests.filter(
-        pr => pr.base.gitHubRepository.hash === gitHubRepository.hash
-      )
-    : pullRequests
+  if (gitHubRepository === null) {
+    return pullRequests
+  }
+
+  const hashToMatch = gitHubRepository.parent
+    ? gitHubRepository.parent.hash
+    : gitHubRepository.hash
+
+  return pullRequests.filter(
+    pr => pr.base.gitHubRepository.hash === hashToMatch
+  )
 }

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
-import { PullRequest } from '../../models/pull-request'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -12,19 +11,6 @@ const BlankSlateImage = encodePathAsUrl(
 interface INoPullRequestsProps {
   /** The name of the repository. */
   readonly repositoryName: string
-
-  /** The name of the GitHubRepository's parent.
-   * `null` if there is no parent.
-   */
-  readonly upstreamRepositoryName: string | null
-
-  /** The URL of the GitHubRepository's parent's pull request list.
-   * `null` if there is no parent.
-   */
-  readonly upstreamPullRequestsUrl: string | null
-
-  /** The currently selected pull request */
-  readonly selectedPullRequest: PullRequest | null
 
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
@@ -80,24 +66,7 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
       )
     }
 
-    // if there's a current pull request and
-    // there's an upstream github repo, we assume
-    // its an upstream pull request
-    if (
-      this.props.selectedPullRequest !== null &&
-      this.props.upstreamRepositoryName !== null &&
-      this.props.upstreamPullRequestsUrl !== null
-    ) {
-      return (
-        <div className="call-to-action">
-          <LinkButton uri={this.props.upstreamPullRequestsUrl}>
-            View pull requests
-          </LinkButton>
-          {' for '}
-          <strong>{this.props.upstreamRepositoryName}</strong> on GitHub
-        </div>
-      )
-    } else if (this.props.isOnDefaultBranch) {
+    if (this.props.isOnDefaultBranch) {
       return (
         <div className="call-to-action">
           Would you like to{' '}

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -11,7 +11,14 @@ import { PullRequest } from '../../models/pull-request'
 import { NoPullRequests } from './no-pull-requests'
 import { IMatches } from '../../lib/fuzzy-find'
 import { Dispatcher } from '../dispatcher'
-import { GitHubRepository } from '../../models/github-repository'
+import {
+  RepositoryWithGitHubRepository,
+  getNonForkGitHubRepository,
+} from '../../models/repository'
+import { Button } from '../lib/button'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { FoldoutType } from '../../lib/app-state'
+import { startTimer } from '../lib/timing'
 
 interface IPullRequestListItem extends IFilterListItem {
   readonly id: string
@@ -28,35 +35,17 @@ interface IPullRequestListProps {
   /** The currently selected pull request */
   readonly selectedPullRequest: PullRequest | null
 
-  /** The name of the repository. */
-  readonly repositoryName: string
-
   /** Is the default branch currently checked out? */
   readonly isOnDefaultBranch: boolean
-
-  /** The current filter text to render */
-  readonly filterText: string
-
-  /** Called when the user clicks on a pull request. */
-  readonly onItemClick: (pullRequest: PullRequest) => void
 
   /** Called when the user wants to dismiss the foldout. */
   readonly onDismiss: () => void
 
-  /** Callback to fire when the filter text is changed */
-  readonly onFilterTextChanged: (filterText: string) => void
-
   /** Called when the user opts to create a branch */
   readonly onCreateBranch: () => void
 
-  /** Called when the user opts to create a pull request */
-  readonly onCreatePullRequest: () => void
-
-  /** Called to render content after the filter. */
-  readonly renderPostFilter?: () => JSX.Element | null
-
   /** Callback fired when user selects a new pull request */
-  readonly onSelectionChanged?: (
+  readonly onSelectionChanged: (
     pullRequest: PullRequest | null,
     source: SelectionSource
   ) => void
@@ -70,15 +59,14 @@ interface IPullRequestListProps {
   ) => void
 
   readonly dispatcher: Dispatcher
-  readonly repository: GitHubRepository
+  readonly repository: RepositoryWithGitHubRepository
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
-
-  readonly renderListHeader?: () => JSX.Element | null
 }
 
 interface IPullRequestListState {
+  readonly filterText: string
   readonly groupedItems: ReadonlyArray<IFilterListGroup<IPullRequestListItem>>
   readonly selectedItem: IPullRequestListItem | null
 }
@@ -116,6 +104,7 @@ export class PullRequestList extends React.Component<
     const selectedItem = resolveSelectedItem(group, props, null)
 
     this.state = {
+      filterText: '',
       groupedItems: [group],
       selectedItem,
     }
@@ -139,15 +128,15 @@ export class PullRequestList extends React.Component<
         groups={this.state.groupedItems}
         selectedItem={this.state.selectedItem}
         renderItem={this.renderPullRequest}
-        filterText={this.props.filterText}
-        onFilterTextChanged={this.props.onFilterTextChanged}
+        filterText={this.state.filterText}
+        onFilterTextChanged={this.onFilterTextChanged}
         invalidationProps={this.props.pullRequests}
         onItemClick={this.onItemClick}
         onSelectionChanged={this.onSelectionChanged}
         onFilterKeyDown={this.props.onFilterKeyDown}
-        renderGroupHeader={this.props.renderListHeader}
+        renderGroupHeader={this.renderListHeader}
         renderNoItems={this.renderNoItems}
-        renderPostFilter={this.props.renderPostFilter}
+        renderPostFilter={this.renderPostFilter}
       />
     )
   }
@@ -155,12 +144,12 @@ export class PullRequestList extends React.Component<
   private renderNoItems = () => {
     return (
       <NoPullRequests
-        isSearch={this.props.filterText.length > 0}
+        isSearch={this.state.filterText.length > 0}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
-        repositoryName={this.props.repositoryName}
+        repositoryName={this.getRepositoryName()}
         isOnDefaultBranch={this.props.isOnDefaultBranch}
         onCreateBranch={this.props.onCreateBranch}
-        onCreatePullRequest={this.props.onCreatePullRequest}
+        onCreatePullRequest={this.onCreatePullRequest}
       />
     )
   }
@@ -184,22 +173,72 @@ export class PullRequestList extends React.Component<
     )
   }
 
-  private onItemClick = (item: IPullRequestListItem) => {
-    if (this.props.onItemClick) {
-      this.props.onItemClick(item.pullRequest)
-    }
+  private onItemClick = (
+    item: IPullRequestListItem,
+    source: SelectionSource
+  ) => {
+    const pullRequest = item.pullRequest
+
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    const timer = startTimer(
+      'checkout pull request from list',
+      this.props.repository
+    )
+    this.props.dispatcher
+      .checkoutPullRequest(this.props.repository, pullRequest)
+      .then(() => timer.done())
+
+    this.props.onSelectionChanged(pullRequest, source)
   }
 
   private onSelectionChanged = (
     selectedItem: IPullRequestListItem | null,
     source: SelectionSource
   ) => {
-    if (this.props.onSelectionChanged) {
-      this.props.onSelectionChanged(
-        selectedItem != null ? selectedItem.pullRequest : null,
-        source
-      )
-    }
+    this.props.onSelectionChanged(
+      selectedItem != null ? selectedItem.pullRequest : null,
+      source
+    )
+  }
+
+  private getRepositoryName(): string {
+    return getNonForkGitHubRepository(this.props.repository).fullName
+  }
+
+  private renderListHeader = () => {
+    return (
+      <div className="filter-list-group-header">
+        Pull requests in {this.getRepositoryName()}
+      </div>
+    )
+  }
+
+  private onRefreshPullRequests = () => {
+    this.props.dispatcher.refreshPullRequests(this.props.repository)
+  }
+
+  private renderPostFilter = () => {
+    return (
+      <Button
+        disabled={this.props.isLoadingPullRequests}
+        onClick={this.onRefreshPullRequests}
+        tooltip="Refresh the list of pull requests"
+      >
+        <Octicon
+          symbol={OcticonSymbol.sync}
+          className={this.props.isLoadingPullRequests ? 'spin' : undefined}
+        />
+      </Button>
+    )
+  }
+
+  private onFilterTextChanged = (text: string) => {
+    this.setState({ filterText: text })
+  }
+
+  private onCreatePullRequest = () => {
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    this.props.dispatcher.createPullRequest(this.props.repository)
   }
 }
 

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -74,6 +74,8 @@ interface IPullRequestListProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
+
+  readonly renderListHeader?: () => JSX.Element | null
 }
 
 interface IPullRequestListState {
@@ -143,6 +145,7 @@ export class PullRequestList extends React.Component<
         onItemClick={this.onItemClick}
         onSelectionChanged={this.onSelectionChanged}
         onFilterKeyDown={this.props.onFilterKeyDown}
+        renderGroupHeader={this.props.renderListHeader}
         renderNoItems={this.renderNoItems}
         renderPostFilter={this.props.renderPostFilter}
       />
@@ -155,18 +158,6 @@ export class PullRequestList extends React.Component<
         isSearch={this.props.filterText.length > 0}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
         repositoryName={this.props.repositoryName}
-        upstreamRepositoryName={
-          this.props.repository.parent !== null
-            ? this.props.repository.parent.fullName
-            : null
-        }
-        upstreamPullRequestsUrl={
-          this.props.repository.parent !== null &&
-          this.props.repository.parent.htmlURL !== null
-            ? `${this.props.repository.parent.htmlURL}/pulls`
-            : null
-        }
-        selectedPullRequest={this.props.selectedPullRequest}
         isOnDefaultBranch={this.props.isOnDefaultBranch}
         onCreateBranch={this.props.onCreateBranch}
         onCreatePullRequest={this.props.onCreatePullRequest}

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -110,6 +110,10 @@
       margin-right: var(--spacing-half);
     }
   }
+
+  .filter-list-group-header {
+    @include ellipsis;
+  }
 }
 
 .branches-list {


### PR DESCRIPTION
Closes #6383

## Description

This PR changes the filtering logic of the PRs list to display the pull requests made on the upstream repository when the current repository is a fork.

As part of this PR, I've removed the logic that adds a link to the list of PRs on the upstream repository  when there are no PRs (which was added in https://github.com/desktop/desktop/pull/8965). Now, the logic is not needed since the shown PRs are the ones in the upstream repository already.

Instead of removing that logic, we can also change it to show a link to the PRs page of the forked repository, but I feel that this would create more confusion than help users (since the most normal use case is to have PRs on the upstream repo).

### Screenshots

<img width="929" alt="Screenshot 2020-03-23 at 14 05 47" src="https://user-images.githubusercontent.com/408035/77319620-6edaee00-6d0f-11ea-9263-0d1e8b4884ec.png">

### Test plan

On a forked repository:

- The PRs from the upstream repository should be shown.
- An empty screen should be shown when there are no PRs on the upstream repository.
- All repository names on the PRs screens should mention the upstream repository.

On a non-forked repository:

- The PRs from the origin repository should be shown.
- An empty screen should be shown when there are no PRs on the origin repository.
- All repository names on the PRs screens should mention the origin repository.

## Release notes

Notes: [Improved] Show the list of pull requests from the upstream repository on forks
