### PR TITLE
Fix scroll position of history tab when switching repositories

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2510,6 +2510,9 @@ export class App extends React.Component<IAppProps, IAppState> {
 
       return (
         <RepositoryView
+          // When switching repositories we want to remount the RepositoryView
+          // component to reset the scroll positions.
+          key={selectedState.repository.hash}
           repository={selectedState.repository}
           state={selectedState.state}
           dispatcher={this.props.dispatcher}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -101,17 +101,6 @@ export class RepositoryView extends React.Component<
     }
   }
 
-  public componentDidUpdate(prevProps: IRepositoryViewProps) {
-    // When switching repositories we want to reset the scroll positions
-    // since keeping them can cause out of bounds issues on the virtual list.
-    if (this.props.repository !== prevProps.repository) {
-      this.setState({
-        changesListScrollTop: 0,
-        compareListScrollTop: 0,
-      })
-    }
-  }
-
   private onChangesListScrolled = (scrollTop: number) => {
     this.setState({ changesListScrollTop: scrollTop })
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -101,6 +101,17 @@ export class RepositoryView extends React.Component<
     }
   }
 
+  public componentDidUpdate(prevProps: IRepositoryViewProps) {
+    // When switching repositories we want to reset the scroll positions
+    // since keeping them can cause out of bounds issues on the virtual list.
+    if (this.props.repository !== prevProps.repository) {
+      this.setState({
+        changesListScrollTop: 0,
+        compareListScrollTop: 0,
+      })
+    }
+  }
+
   private onChangesListScrolled = (scrollTop: number) => {
     this.setState({ changesListScrollTop: scrollTop })
   }


### PR DESCRIPTION
Closes #9341

## Description

This PR fixes the problem described in #9341 by resetting the scroll positions of the changes tab and the history tab when changing repositories.

The root cause of the issue was that the scroll position of the tabs is kept as part of the state of the `RepositoryView` component.

Since the component `RepositoryView` doesn't get unmounted when switching repositories, the scroll position from a different repository was maintained when switching repositories. This could cause issues when e.g switching from a repository where either list of changes or commits was very large to another repository with very little changes or commits (since the persisted scroll position could get out of range on the new repository).

### Screenshots

Video of the issue:

![demo](https://user-images.githubusercontent.com/408035/77356389-78cc1380-6d46-11ea-9dc2-0984e5a407ab.gif)


## Release notes

Notes: [Fixed] Restored missing commits on the History tab when switching repositories. 
