### PR TITLE
Allow shrinking for resizable lists with a footer

### DIFF
--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -12,6 +12,7 @@
 
   .branches-list {
     width: 350px;
+    min-height: 0;
   }
 }
 

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 
   .commit {
     display: flex;

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -20,6 +20,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 
   .filter-list .filter-field-row {
     margin: 0;
@@ -36,6 +37,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    min-height: 0;
   }
 
   .merge-status {


### PR DESCRIPTION
Fixes a regression due to our electron upgrade where vertical lists in vertically resizable containers would no longer shrink after growing.

### Before fix

![broken-shrinking](https://user-images.githubusercontent.com/964912/77362289-edcf2700-6d0d-11ea-9d35-bdd9b439c847.gif)

### After fix

![branches-fix](https://user-images.githubusercontent.com/964912/77361937-608bd280-6d0d-11ea-946d-f0d336765a62.gif)
![compare-fix](https://user-images.githubusercontent.com/964912/77361946-62ee2c80-6d0d-11ea-9f0d-a4766caf4345.gif)
