### PR TITLE
Add indicator for unpushed commits

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -21,7 +21,7 @@ interface ICommitProps {
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
-  readonly isLocalRepository: boolean
+  readonly showUnpushedIndicator: boolean
 }
 
 interface ICommitListItemState {
@@ -91,7 +91,7 @@ export class CommitListItem extends React.Component<
   }
 
   private renderPushIndicator() {
-    if (this.props.isLocalRepository || !this.props.isLocal) {
+    if (!this.props.showUnpushedIndicator) {
       return null
     }
 

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -11,6 +11,7 @@ import { CommitAttribution } from '../lib/commit-attribution'
 import { IGitHubUser } from '../../lib/databases/github-user-database'
 import { AvatarStack } from '../lib/avatar-stack'
 import { IMenuItem } from '../../lib/menu-item'
+import { Octicon, OcticonSymbol } from '../octicons'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -79,12 +80,25 @@ export class CommitListItem extends React.Component<
             </div>
           </div>
         </div>
+        {this.renderPushIndicator()}
       </div>
     )
   }
 
   public shouldComponentUpdate(nextProps: ICommitProps): boolean {
     return this.props.commit.sha !== nextProps.commit.sha
+  }
+
+  private renderPushIndicator() {
+    if (!this.props.isLocal) {
+      return null
+    }
+
+    return (
+      <div className="unpushed-indicator">
+        <Octicon symbol={OcticonSymbol.arrowUp} />
+      </div>
+    )
   }
 
   private onCopySHA = () => {

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -81,7 +81,7 @@ export class CommitListItem extends React.Component<
             </div>
           </div>
         </div>
-        {this.renderPushIndicator()}
+        {this.renderUnpushedIndicator()}
       </div>
     )
   }
@@ -93,7 +93,7 @@ export class CommitListItem extends React.Component<
     )
   }
 
-  private renderPushIndicator() {
+  private renderUnpushedIndicator() {
     if (!this.props.showUnpushedIndicator) {
       return null
     }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -21,6 +21,7 @@ interface ICommitProps {
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
+  readonly isLocalRepository: boolean
 }
 
 interface ICommitListItemState {
@@ -90,7 +91,7 @@ export class CommitListItem extends React.Component<
   }
 
   private renderPushIndicator() {
-    if (!this.props.isLocal) {
+    if (this.props.isLocalRepository || !this.props.isLocal) {
       return null
     }
 

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -87,7 +87,10 @@ export class CommitListItem extends React.Component<
   }
 
   public shouldComponentUpdate(nextProps: ICommitProps): boolean {
-    return this.props.commit.sha !== nextProps.commit.sha
+    return (
+      this.props.commit.sha !== nextProps.commit.sha ||
+      this.props.showUnpushedIndicator !== nextProps.showUnpushedIndicator
+    )
   }
 
   private renderPushIndicator() {

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -95,8 +95,10 @@ export class CommitListItem extends React.Component<
     }
 
     return (
-      <div className="unpushed-indicator">
-        <Octicon symbol={OcticonSymbol.arrowUp} />
+      <div className="unpushed-indicator-container">
+        <div className="unpushed-indicator">
+          <Octicon symbol={OcticonSymbol.arrowUp} />
+        </div>
       </div>
     )
   }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -96,7 +96,10 @@ export class CommitListItem extends React.Component<
 
     return (
       <div className="unpushed-indicator-container">
-        <div className="unpushed-indicator">
+        <div
+          className="unpushed-indicator"
+          title="This commit hasn't been pushed to the remote repository yet"
+        >
           <Octicon symbol={OcticonSymbol.arrowUp} />
         </div>
       </div>

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -137,6 +137,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           invalidationProps={{
             commits: this.props.commitSHAs,
             gitHubUsers: this.props.gitHubUsers,
+            localCommitSHAs: this.props.localCommitSHAs,
           }}
           setScrollTop={this.props.compareListScrollTop}
         />

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -72,14 +72,15 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       return null
     }
 
-    const isLocal = this.props.localCommitSHAs.indexOf(commit.sha) > -1
+    const isLocal = this.props.localCommitSHAs.includes(commit.sha)
+    const showUnpushedIndicator = isLocal && !this.props.isLocalRepository
 
     return (
       <CommitListItem
         key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
         isLocal={isLocal}
-        isLocalRepository={this.props.isLocalRepository}
+        showUnpushedIndicator={showUnpushedIndicator}
         commit={commit}
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -52,6 +52,9 @@ interface ICommitListProps {
 
   /* The scrollTop of the compareList. It is stored to allow for scroll position persistence */
   readonly compareListScrollTop?: number
+
+  /* Whether the repository is local (it has no remotes) */
+  readonly isLocalRepository: boolean
 }
 
 /** A component which displays the list of commits. */
@@ -76,6 +79,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
         isLocal={isLocal}
+        isLocalRepository={this.props.isLocalRepository}
         commit={commit}
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -33,6 +33,7 @@ import { MergeCallToActionWithConflicts } from './merge-call-to-action-with-conf
 
 interface ICompareSidebarProps {
   readonly repository: Repository
+  readonly isLocalRepository: boolean
   readonly compareState: ICompareState
   readonly gitHubUsers: Map<string, IGitHubUser>
   readonly emoji: Map<string, string>
@@ -254,6 +255,7 @@ export class CompareSidebar extends React.Component<
     return (
       <CommitList
         gitHubRepository={this.props.repository.gitHubRepository}
+        isLocalRepository={this.props.isLocalRepository}
         commitLookup={this.props.commitLookup}
         commitSHAs={commitSHAs}
         selectedSHA={this.props.selectedCommitSha}

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -211,6 +211,7 @@ export class ConfigureGitUser extends React.Component<
             gitHubUsers={null}
             gitHubRepository={null}
             isLocal={false}
+            isLocalRepository={false}
           />
         </div>
       </div>

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -211,7 +211,7 @@ export class ConfigureGitUser extends React.Component<
             gitHubUsers={null}
             gitHubRepository={null}
             isLocal={false}
-            isLocalRepository={false}
+            showUnpushedIndicator={false}
           />
         </div>
       </div>

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -211,6 +211,7 @@ export class RepositoryView extends React.Component<
     return (
       <CompareSidebar
         repository={this.props.repository}
+        isLocalRepository={this.props.state.remote === null}
         compareState={this.props.state.compareState}
         selectedCommitSha={this.props.state.commitSelection.sha}
         currentBranch={currentBranch}

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -41,6 +41,10 @@
       }
     }
 
+    .unpushed-indicator-container {
+      padding-left: var(--spacing);
+    }
+
     .unpushed-indicator {
       height: 16px;
       border-radius: 8px;

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -40,5 +40,34 @@
         @include ellipsis;
       }
     }
+
+    .unpushed-indicator {
+      height: 16px;
+      border-radius: 8px;
+      padding: 0 6px;
+
+      background: var(--list-item-badge-background-color);
+      color: var(--list-item-badge-color);
+    }
+  }
+
+  .list-item.selected {
+    .commit {
+      .unpushed-indicator {
+        background: var(--list-item-selected-badge-background-color);
+        color: var(--list-item-selected-badge-color);
+      }
+    }
+  }
+
+  .focus-within {
+    .list-item.selected {
+      .commit {
+        .unpushed-indicator {
+          background: var(--list-item-selected-active-badge-background-color);
+          color: var(--list-item-selected-active-badge-color);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #5873

## Description

This PR adds a small indicator for commits that haven't been pushed to any remote repository (local commits).

Some considerations:

- The indicator will be shown also for repositories with no upstream, meaning that all their commits will have the indicator. I think we should not show the indicator in that scenario, but don't have strong opinions on it (@billygriffin what do you think?).

### Screenshots

Normal mode:

<img width="461" alt="Screenshot 2020-03-26 at 18 30 27" src="https://user-images.githubusercontent.com/408035/77678882-20895180-6f92-11ea-94be-4aa216a99b15.png">
<img width="513" alt="Screenshot 2020-03-26 at 18 30 33" src="https://user-images.githubusercontent.com/408035/77678895-22ebab80-6f92-11ea-9a30-ad58a7fda40a.png">

Dark mode:

<img width="629" alt="Screenshot 2020-03-26 at 18 30 55" src="https://user-images.githubusercontent.com/408035/77679002-444c9780-6f92-11ea-831f-97992fe9f0e2.png">
<img width="666" alt="Screenshot 2020-03-26 at 18 31 01" src="https://user-images.githubusercontent.com/408035/77679013-47478800-6f92-11ea-83ff-5bb8680f54a3.png">


Long commit text:

<img width="571" alt="Screenshot 2020-03-26 at 18 46 49" src="https://user-images.githubusercontent.com/408035/77678971-3bf45c80-6f92-11ea-9f0f-23a5a511cfff.png">


## Release notes

Notes: [Added] Add indicators to commits that haven't been pushed
