### PR TITLE
Add support to Rider on Mac

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -22,7 +22,7 @@ export enum ExternalEditor {
   IntelliJ = 'IntelliJ',
   Xcode = 'Xcode',
   GoLand = 'GoLand',
-  Rider = 'Rider'
+  Rider = 'Rider',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -198,7 +198,7 @@ function getExecutableShim(
     case ExternalEditor.GoLand:
       return Path.join(installPath, 'Contents', 'MacOS', 'goland')
     case ExternalEditor.Rider:
-        return Path.join(installPath, 'Contents', 'MacOS', 'rider')
+      return Path.join(installPath, 'Contents', 'MacOS', 'rider')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -252,7 +252,7 @@ export async function getAvailableEditors(): Promise<
     intellijPath,
     xcodePath,
     golandPath,
-    riderPath
+    riderPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -22,6 +22,7 @@ export enum ExternalEditor {
   IntelliJ = 'IntelliJ',
   Xcode = 'Xcode',
   GoLand = 'GoLand',
+  Rider = 'Rider'
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -81,6 +82,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.GoLand) {
     return ExternalEditor.GoLand
   }
+  if (label === ExternalEditor.Rider) {
+    return ExternalEditor.Rider
+  }
   return null
 }
 
@@ -132,6 +136,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.apple.dt.Xcode']
     case ExternalEditor.GoLand:
       return ['com.jetbrains.goland']
+    case ExternalEditor.Rider:
+      return ['com.jetbrains.rider']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -191,6 +197,8 @@ function getExecutableShim(
       return '/usr/bin/xed'
     case ExternalEditor.GoLand:
       return Path.join(installPath, 'Contents', 'MacOS', 'goland')
+    case ExternalEditor.Rider:
+        return Path.join(installPath, 'Contents', 'MacOS', 'rider')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -244,6 +252,7 @@ export async function getAvailableEditors(): Promise<
     intellijPath,
     xcodePath,
     golandPath,
+    riderPath
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),
@@ -263,6 +272,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.IntelliJ),
     findApplication(ExternalEditor.Xcode),
     findApplication(ExternalEditor.GoLand),
+    findApplication(ExternalEditor.Rider),
   ])
 
   if (atomPath) {
@@ -338,6 +348,10 @@ export async function getAvailableEditors(): Promise<
 
   if (golandPath) {
     results.push({ editor: ExternalEditor.GoLand, path: golandPath })
+  }
+
+  if (riderPath) {
+    results.push({ editor: ExternalEditor.Rider, path: riderPath })
   }
 
   return results

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -275,7 +275,7 @@ These editors are currently supported:
  - [Xcode](https://developer.apple.com/xcode/)
  - [JetBrains GoLand](https://www.jetbrains.com/go/)
  - [Android Studio](https://developer.android.com/studio)
- - [Rider](https://www.jetbrains.com/rider/)
+ - [JetBrains Rider](https://www.jetbrains.com/rider/)
 
 These are defined in an enum at the top of the file:
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -264,6 +264,7 @@ These editors are currently supported:
  - [Typora](https://typora.io/)
  - [SlickEdit](https://www.slickedit.com)
  - [GoLand](https://www.jetbrains.com/go/)
+ - [Rider](https://www.jetbrains.com/rider/)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
Add support for JetBrains Rider #9365

Partially addresses #9365 (Windows support is still missing)

## Description

- Support JetBrains Rider as an external editor

### Screenshots


## Release notes

Notes: JetBrains Rider supported
