### PR TITLE
Implementing Discard Unselected Changes

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -172,6 +172,9 @@ export interface IAppState {
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnDiscardChanges: boolean
 
+  /** Whether we should show a confirmation dialog */
+  readonly askForConfirmationOnDiscardUnselectedChanges: boolean
+
   /** Should the app prompt the user to confirm a force push? */
   readonly askForConfirmationOnForcePush: boolean
 

--- a/app/src/lib/discard-unselected.ts
+++ b/app/src/lib/discard-unselected.ts
@@ -1,0 +1,105 @@
+import { Repository } from '../models/repository'
+import { WorkingDirectoryFileChange } from '../models/status'
+import { DiffLineType, DiffType } from '../models/diff'
+import { getWorkingDirectoryDiff } from './git/diff'
+import * as FSE from 'fs-extra'
+
+/**
+ * Discard unselected differences
+ *
+ * @param repository The repository containing the branches to merge
+ * @param file File to discard
+ */
+export async function discardUnselectedChanges(
+  repository: Repository,
+  file: WorkingDirectoryFileChange
+): Promise<void> {
+  const curData = new Array<string>()
+  const fileData = await FSE.readFile(repository.path + '/' + file.path)
+  const fileText = fileData.toString()
+  // Getting line ending, \r or \r\n or \n
+  const lineending = getLineBreakChar(fileText)
+  const lines = fileText.split(/\r?\n/)
+  lines.forEach(value => {
+    curData.push(value)
+  })
+
+  const diff = await getWorkingDirectoryDiff(repository, file)
+  if (diff.kind !== DiffType.Text) {
+    throw new Error(`Unexpected diff result returned: '${diff.kind}'`)
+  }
+  let curSourceLine = 0
+  const newData = Array<string>()
+
+  diff.hunks.forEach((hunk, hunkIndex) => {
+    for (let i = 0; i < hunk.lines.length; ++i) {
+      const newLineNumber = hunk.lines[i].newLineNumber
+      if (newLineNumber != null) {
+        proceedCopy(
+          curData,
+          newData,
+          curSourceLine,
+          newLineNumber - 1,
+          lineending
+        )
+        curSourceLine = newLineNumber - 1
+        break
+      }
+    }
+    hunk.lines.forEach((line, lineIndex) => {
+      const absoluteIndex = hunk.unifiedDiffStart + lineIndex
+      if (line.type === DiffLineType.Hunk) {
+      } else if (!file.selection.isSelected(absoluteIndex)) {
+        if (line.type === DiffLineType.Add) {
+          curSourceLine++
+        }
+        if (line.type === DiffLineType.Delete) {
+          newData.push(line.content + lineending)
+        }
+      } else {
+        if (line.type !== DiffLineType.Delete) {
+          newData.push(line.content + lineending)
+          curSourceLine++
+        }
+      }
+    })
+  })
+
+  proceedCopy(curData, newData, curSourceLine, curData.length, lineending)
+  const lastLine = newData.pop()
+  if (lastLine != null) {
+    newData.push(lastLine.substr(0, lastLine.length - lineending.length))
+  } else {
+    throw new Error('last line error')
+  }
+
+  let newFileText = ''
+  newData.forEach(value => (newFileText += value))
+  await FSE.writeFile(repository.path + '/' + file.path, newFileText)
+}
+
+function proceedCopy(
+  srcData: Array<string>,
+  dstData: Array<string>,
+  start: number,
+  end: number,
+  lineending: string
+): void {
+  for (let i = start; i < end; i++) {
+    dstData.push(srcData[i] + lineending)
+  }
+}
+
+function getLineBreakChar(str: string): string {
+  const indexOfLF = str.indexOf('\n', 1)
+  if (indexOfLF === -1) {
+    if (str.indexOf('\r') !== -1) {
+      return '\r'
+    }
+    return '\n'
+  }
+  if (str[indexOfLF - 1] === '\r') {
+    return '\r\n'
+  }
+  return '\n'
+}

--- a/app/src/lib/discard-unselected.ts
+++ b/app/src/lib/discard-unselected.ts
@@ -6,7 +6,6 @@ import * as FSE from 'fs-extra'
 
 /**
  * Discard unselected differences
- *
  * @param repository The repository containing the branches to merge
  * @param file File to discard
  */
@@ -23,14 +22,12 @@ export async function discardUnselectedChanges(
   lines.forEach(value => {
     curData.push(value)
   })
-
   const diff = await getWorkingDirectoryDiff(repository, file)
   if (diff.kind !== DiffType.Text) {
     throw new Error(`Unexpected diff result returned: '${diff.kind}'`)
   }
   let curSourceLine = 0
   const newData = Array<string>()
-
   diff.hunks.forEach((hunk, hunkIndex) => {
     for (let i = 0; i < hunk.lines.length; ++i) {
       const newLineNumber = hunk.lines[i].newLineNumber
@@ -72,7 +69,6 @@ export async function discardUnselectedChanges(
   } else {
     throw new Error('last line error')
   }
-
   let newFileText = ''
   newData.forEach(value => (newFileText += value))
   await FSE.writeFile(repository.path + '/' + file.path, newFileText)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2229,7 +2229,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     await discardUnselectedChanges(repository, file)
     await this._changeFileIncluded(repository, file, true)
-
     this.updateMenuLabelsForSelectedRepository()
     this.emitUpdate()
     this.updateChangesWorkingDirectoryDiff(repository)
@@ -4541,10 +4540,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     value: boolean
   ): Promise<void> {
     this.confirmDiscardUnselectedChanges = value
-
     setBoolean(confirmDiscardUnselectedChangesKey, value)
     this.emitUpdate()
-
     return Promise.resolve()
   }
 

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -15,6 +15,7 @@ export enum PopupType {
   RenameBranch = 1,
   DeleteBranch,
   ConfirmDiscardChanges,
+  ConfirmDiscardUnselectedChanges,
   Preferences,
   MergeBranch,
   RepositorySettings,
@@ -73,6 +74,12 @@ export type Popup =
       files: ReadonlyArray<WorkingDirectoryFileChange>
       showDiscardChangesSetting?: boolean
       discardingAllChanges?: boolean
+    }
+  | {
+      type: PopupType.ConfirmDiscardUnselectedChanges
+      repository: Repository
+      file: WorkingDirectoryFileChange
+      showDiscardChangesSetting?: boolean
     }
   | { type: PopupType.Preferences; initialSelectedTab?: PreferencesTab }
   | {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -53,7 +53,7 @@ import {
   registerContextualMenuActionDispatcher,
   sendReady,
 } from './main-process-proxy'
-import { DiscardChanges } from './discard-changes'
+import { DiscardChanges, DiscardUnselectedChanges } from './discard-changes'
 import { Welcome } from './welcome'
 import { AppMenuBar } from './app-menu'
 import { UpdateAvailable, renderBanner } from './banners'
@@ -1341,6 +1341,27 @@ export class App extends React.Component<IAppProps, IAppState> {
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
           />
         )
+      case PopupType.ConfirmDiscardUnselectedChanges:
+        const showSettingUnselected =
+          popup.showDiscardChangesSetting === undefined
+            ? true
+            : popup.showDiscardChangesSetting
+        return (
+          <DiscardUnselectedChanges
+            key="discard-unselected-changes"
+            repository={popup.repository}
+            dispatcher={this.props.dispatcher}
+            file={popup.file}
+            confirmDiscardUnselectedChanges={
+              this.state.askForConfirmationOnDiscardUnselectedChanges
+            }
+            showDiscardChangesSetting={showSettingUnselected}
+            onDismissed={this.onPopupDismissed}
+            onConfirmDiscardUnselectedChangesChanged={
+              this.onConfirmDiscardUnselectedChangesChanged
+            }
+          />
+        )
       case PopupType.Preferences:
         return (
           <Preferences
@@ -1353,6 +1374,9 @@ export class App extends React.Component<IAppProps, IAppState> {
             }
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
+            }
+            confirmDiscardUnselectedChanges={
+              this.state.askForConfirmationOnDiscardUnselectedChanges
             }
             confirmForcePush={this.state.askForConfirmationOnForcePush}
             uncommittedChangesStrategyKind={
@@ -2100,6 +2124,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setConfirmDiscardChangesSetting(value)
   }
 
+  private onConfirmDiscardUnselectedChangesChanged = (value: boolean) => {
+    this.props.dispatcher.setConfirmDiscardUnselectedChangesSetting(value)
+  }
+
   private renderAppError() {
     return (
       <AppError
@@ -2528,6 +2556,9 @@ export class App extends React.Component<IAppProps, IAppState> {
           focusCommitMessage={state.focusCommitMessage}
           askForConfirmationOnDiscardChanges={
             state.askForConfirmationOnDiscardChanges
+          }
+          askForConfirmationOnDiscardUnselectdChanges={
+            state.askForConfirmationOnDiscardUnselectedChanges
           }
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1352,7 +1352,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             dispatcher={this.props.dispatcher}
             file={popup.file}
-            confirmDiscardUnselectedChanges={
+            confirmDiscardUnselected={
               this.state.askForConfirmationOnDiscardUnselectedChanges
             }
             showDiscardChangesSetting={showSettingUnselected}
@@ -1375,7 +1375,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmDiscardChanges={
               this.state.askForConfirmationOnDiscardChanges
             }
-            confirmDiscardUnselectedChanges={
+            confirmDiscardUnselected={
               this.state.askForConfirmationOnDiscardUnselectedChanges
             }
             confirmForcePush={this.state.askForConfirmationOnForcePush}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -311,10 +311,8 @@ export class ChangesList extends React.Component<
 
   private onDiscardUnselectedChanges = (files: ReadonlyArray<string>) => {
     const workingDirectory = this.props.workingDirectory
-
     if (files.length === 1) {
       const modifiedFile = workingDirectory.files.find(f => f.path === files[0])
-
       if (modifiedFile != null) {
         if (this.props.askForConfirmationOnDiscardUnselectedChanges) {
           this.props.dispatcher.showPopup({
@@ -363,7 +361,6 @@ export class ChangesList extends React.Component<
     const label = __DARWIN__
       ? `Discard Unselected Changes`
       : `Discard unselected changes`
-
     return this.props.askForConfirmationOnDiscardUnselectedChanges
       ? `${label}…`
       : label

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -361,8 +361,8 @@ export class ChangesList extends React.Component<
     files: ReadonlyArray<string>
   ) => {
     const label = __DARWIN__
-      ? `Discard Unselected Lines`
-      : `Discard unselected lines`
+      ? `Discard Unselected Changes`
+      : `Discard unselected changes`
 
     return this.props.askForConfirmationOnDiscardUnselectedChanges
       ? `${label}…`

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -56,6 +56,7 @@ interface IChangesSidebarProps {
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly askForConfirmationOnDiscardUnselectedChanges: boolean
   readonly accounts: ReadonlyArray<Account>
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
@@ -402,6 +403,9 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           onDiscardChanges={this.onDiscardChanges}
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
+          }
+          askForConfirmationOnDiscardUnselectedChanges={
+            this.props.askForConfirmationOnDiscardUnselectedChanges
           }
           onDiscardChangesFromFiles={this.onDiscardChangesFromFiles}
           onOpenItem={this.onOpenItem}

--- a/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { WorkingDirectoryFileChange } from '../../models/status'
@@ -40,7 +39,6 @@ export class DiscardUnselectedChanges extends React.Component<
 > {
   public constructor(props: IDiscardUnselectedLinesProps) {
     super(props)
-
     this.state = {
       isDiscardingChanges: false,
       confirmDiscardUnselected: this.props.confirmDiscardUnselected,
@@ -55,7 +53,6 @@ export class DiscardUnselectedChanges extends React.Component<
 
   public render() {
     const isDiscardingChanges = this.state.isDiscardingChanges
-
     return (
       <Dialog
         id="discard-changes"
@@ -115,12 +112,10 @@ export class DiscardUnselectedChanges extends React.Component<
 
   private discard = async () => {
     this.setState({ isDiscardingChanges: true })
-
     await this.props.dispatcher.discardUnselectedChanges(
       this.props.repository,
       this.props.file
     )
-
     this.props.onConfirmDiscardUnselectedChangesChanged(
       this.state.confirmDiscardUnselected
     )
@@ -131,7 +126,6 @@ export class DiscardUnselectedChanges extends React.Component<
     event: React.FormEvent<HTMLInputElement>
   ) => {
     const value = !event.currentTarget.checked
-
     this.setState({ confirmDiscardUnselected: value })
   }
 }

--- a/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
@@ -12,7 +12,7 @@ interface IDiscardUnselectedLinesProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly file: WorkingDirectoryFileChange
-  readonly confirmDiscardUnselectedChanges: boolean
+  readonly confirmDiscardUnselected: boolean
   /**
    * Determines whether to show the option
    * to ask for confirmation when discarding
@@ -30,7 +30,7 @@ interface IDiscardUnselectedLinesState {
    */
   readonly isDiscardingChanges: boolean
 
-  readonly confirmDiscardUnselectedChanges: boolean
+  readonly confirmDiscardUnselected: boolean
 }
 
 /** A component to confirm and then discard changes. */
@@ -43,8 +43,7 @@ export class DiscardUnselectedChanges extends React.Component<
 
     this.state = {
       isDiscardingChanges: false,
-      confirmDiscardUnselectedChanges: this.props
-        .confirmDiscardUnselectedChanges,
+      confirmDiscardUnselected: this.props.confirmDiscardUnselected,
     }
   }
 
@@ -88,7 +87,7 @@ export class DiscardUnselectedChanges extends React.Component<
         <Checkbox
           label="Do not show this message again"
           value={
-            this.state.confirmDiscardUnselectedChanges
+            this.state.confirmDiscardUnselected
               ? CheckboxValue.Off
               : CheckboxValue.On
           }
@@ -121,7 +120,7 @@ export class DiscardUnselectedChanges extends React.Component<
     )
 
     this.props.onConfirmDiscardUnselectedChangesChanged(
-      this.state.confirmDiscardUnselectedChanges
+      this.state.confirmDiscardUnselected
     )
     this.props.onDismissed()
   }
@@ -131,6 +130,6 @@ export class DiscardUnselectedChanges extends React.Component<
   ) => {
     const value = !event.currentTarget.checked
 
-    this.setState({ confirmDiscardUnselectedChanges: value })
+    this.setState({ confirmDiscardUnselected: value })
   }
 }

--- a/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { WorkingDirectoryFileChange } from '../../models/status'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { toPlatformCase } from '../../lib/platform-case'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IDiscardUnselectedLinesProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly file: WorkingDirectoryFileChange
+  readonly confirmDiscardUnselectedChanges: boolean
+  /**
+   * Determines whether to show the option
+   * to ask for confirmation when discarding
+   * changes
+   */
+  readonly showDiscardChangesSetting: boolean
+  readonly onDismissed: () => void
+  readonly onConfirmDiscardUnselectedChangesChanged: (optOut: boolean) => void
+}
+
+interface IDiscardUnselectedLinesState {
+  /**
+   * Whether or not we're currently in the process of discarding
+   * changes. This is used to display a loading state
+   */
+  readonly isDiscardingChanges: boolean
+
+  readonly confirmDiscardUnselectedChanges: boolean
+}
+
+/** A component to confirm and then discard changes. */
+export class DiscardUnselectedChanges extends React.Component<
+  IDiscardUnselectedLinesProps,
+  IDiscardUnselectedLinesState
+> {
+  public constructor(props: IDiscardUnselectedLinesProps) {
+    super(props)
+
+    this.state = {
+      isDiscardingChanges: false,
+      confirmDiscardUnselectedChanges: this.props
+        .confirmDiscardUnselectedChanges,
+    }
+  }
+
+  private getOkButtonLabel() {
+    return __DARWIN__ ? 'Discard Unselected Lines' : 'Discard unselected lines'
+  }
+
+  public render() {
+    const isDiscardingChanges = this.state.isDiscardingChanges
+
+    return (
+      <Dialog
+        id="discard-changes"
+        title={toPlatformCase('Confirm Discard Unselected Lines')}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.discard}
+        dismissable={isDiscardingChanges ? false : true}
+        loading={isDiscardingChanges}
+        disabled={isDiscardingChanges}
+        type="warning"
+      >
+        <DialogContent>
+          {this.renderFileList()}
+          <p className="alert">Discarded changes cannot be restored!!!</p>
+          {this.renderConfirmDiscardChanges()}
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={this.getOkButtonLabel()}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderConfirmDiscardChanges() {
+    if (this.props.showDiscardChangesSetting) {
+      return (
+        <Checkbox
+          label="Do not show this message again"
+          value={
+            this.state.confirmDiscardUnselectedChanges
+              ? CheckboxValue.Off
+              : CheckboxValue.On
+          }
+          onChange={this.onConfirmDiscardUnselectedChangesChanged}
+        />
+      )
+    } else {
+      // since we ignore the users option to not show
+      // confirmation, we don't want to show a checkbox
+      // that will have no effect
+      return null
+    }
+  }
+
+  private renderFileList() {
+    return (
+      <div>
+        <p>Are you sure you want to discard all unselected changes to</p>
+        <p>{this.props.file.path}</p>
+      </div>
+    )
+  }
+
+  private discard = async () => {
+    this.setState({ isDiscardingChanges: true })
+
+    await this.props.dispatcher.discardUnselectedChanges(
+      this.props.repository,
+      this.props.file
+    )
+
+    this.props.onConfirmDiscardUnselectedChangesChanged(
+      this.state.confirmDiscardUnselectedChanges
+    )
+    this.props.onDismissed()
+  }
+
+  private onConfirmDiscardUnselectedChangesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ confirmDiscardUnselectedChanges: value })
+  }
+}

--- a/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
@@ -69,7 +69,7 @@ export class DiscardUnselectedChanges extends React.Component<
       >
         <DialogContent>
           {this.renderFileList()}
-          <p className="alert">Discarded changes cannot be restored!!!</p>
+          <p className="alert">NOTE: discarded changes cannot be restored.</p>
           {this.renderConfirmDiscardChanges()}
         </DialogContent>
 

--- a/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-unselected-changes-dialog.tsx
@@ -48,7 +48,9 @@ export class DiscardUnselectedChanges extends React.Component<
   }
 
   private getOkButtonLabel() {
-    return __DARWIN__ ? 'Discard Unselected Lines' : 'Discard unselected lines'
+    return __DARWIN__
+      ? 'Discard Unselected Changes'
+      : 'Discard unselected changes'
   }
 
   public render() {
@@ -57,7 +59,7 @@ export class DiscardUnselectedChanges extends React.Component<
     return (
       <Dialog
         id="discard-changes"
-        title={toPlatformCase('Confirm Discard Unselected Lines')}
+        title={toPlatformCase('Confirm Discard Unselected Changes')}
         onDismissed={this.props.onDismissed}
         onSubmit={this.discard}
         dismissable={isDiscardingChanges ? false : true}

--- a/app/src/ui/discard-changes/index.ts
+++ b/app/src/ui/discard-changes/index.ts
@@ -1,1 +1,2 @@
 export { DiscardChanges } from './discard-changes-dialog'
+export { DiscardUnselectedChanges } from './discard-unselected-changes-dialog'

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -647,6 +647,14 @@ export class Dispatcher {
     return this.appStore._discardChanges(repository, files)
   }
 
+  /** Discard unselected changes to the given file */
+  public discardUnselectedChanges(
+    repository: Repository,
+    file: WorkingDirectoryFileChange
+  ): Promise<void> {
+    return this.appStore._discardUnselectedChanges(repository, file)
+  }
+
   /** Undo the given commit. */
   public undoCommit(repository: Repository, commit: Commit): Promise<void> {
     return this.appStore._undoCommit(repository, commit)
@@ -1581,6 +1589,15 @@ export class Dispatcher {
    */
   public setConfirmDiscardChangesSetting(value: boolean): Promise<void> {
     return this.appStore._setConfirmDiscardChangesSetting(value)
+  }
+
+  /**
+   * Sets the user's preference so that confirmation to discard unselected changes is not asked
+   */
+  public setConfirmDiscardUnselectedChangesSetting(
+    value: boolean
+  ): Promise<void> {
+    return this.appStore._setConfirmDiscardUnselectedChangesSetting(value)
   }
 
   /**

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -10,7 +10,7 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
-  readonly confirmDiscardUnselectedChanges: boolean
+  readonly confirmDiscardUnselected: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
   readonly schannelCheckRevoke: boolean | null
@@ -29,7 +29,7 @@ interface IAdvancedPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
-  readonly confirmDiscardUnselectedChanges: boolean
+  readonly confirmDiscardUnselected: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
 }
@@ -45,8 +45,7 @@ export class Advanced extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
-      confirmDiscardUnselectedChanges: this.props
-        .confirmDiscardUnselectedChanges,
+      confirmDiscardUnselected: this.props.confirmDiscardUnselected,
       confirmForcePush: this.props.confirmForcePush,
       uncommittedChangesStrategyKind: this.props.uncommittedChangesStrategyKind,
     }
@@ -75,7 +74,7 @@ export class Advanced extends React.Component<
   ) => {
     const value = event.currentTarget.checked
 
-    this.setState({ confirmDiscardUnselectedChanges: value })
+    this.setState({ confirmDiscardUnselected: value })
     this.props.onConfirmDiscardUnselectedChangesChanged(value)
   }
 
@@ -198,7 +197,7 @@ export class Advanced extends React.Component<
           <Checkbox
             label="Discarding unselected changes"
             value={
-              this.state.confirmDiscardUnselectedChanges
+              this.state.confirmDiscardUnselected
                 ? CheckboxValue.On
                 : CheckboxValue.Off
             }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -10,11 +10,13 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmDiscardUnselectedChanges: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
   readonly schannelCheckRevoke: boolean | null
   readonly onOptOutofReportingchanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
+  readonly onConfirmDiscardUnselectedChangesChanged: (checked: boolean) => void
   readonly onConfirmRepositoryRemovalChanged: (checked: boolean) => void
   readonly onConfirmForcePushChanged: (checked: boolean) => void
   readonly onUncommittedChangesStrategyKindChanged: (
@@ -27,6 +29,7 @@ interface IAdvancedPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmDiscardUnselectedChanges: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
 }
@@ -42,6 +45,8 @@ export class Advanced extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      confirmDiscardUnselectedChanges: this.props
+        .confirmDiscardUnselectedChanges,
       confirmForcePush: this.props.confirmForcePush,
       uncommittedChangesStrategyKind: this.props.uncommittedChangesStrategyKind,
     }
@@ -63,6 +68,15 @@ export class Advanced extends React.Component<
 
     this.setState({ confirmDiscardChanges: value })
     this.props.onConfirmDiscardChangesChanged(value)
+  }
+
+  private onConfirmDiscardUnselectedChangesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ confirmDiscardUnselectedChanges: value })
+    this.props.onConfirmDiscardUnselectedChangesChanged(value)
   }
 
   private onConfirmForcePushChanged = (
@@ -180,6 +194,15 @@ export class Advanced extends React.Component<
                 : CheckboxValue.Off
             }
             onChange={this.onConfirmDiscardChangesChanged}
+          />
+          <Checkbox
+            label="Discarding unselected changes"
+            value={
+              this.state.confirmDiscardUnselectedChanges
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onConfirmDiscardUnselectedChangesChanged}
           />
           <Checkbox
             label="Force pushing"

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -73,7 +73,6 @@ export class Advanced extends React.Component<
     event: React.FormEvent<HTMLInputElement>
   ) => {
     const value = event.currentTarget.checked
-
     this.setState({ confirmDiscardUnselected: value })
     this.props.onConfirmDiscardUnselectedChangesChanged(value)
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -42,6 +42,7 @@ interface IPreferencesProps {
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmDiscardUnselectedChanges: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
   readonly selectedExternalEditor: ExternalEditor | null
@@ -60,6 +61,7 @@ interface IPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
+  readonly confirmDiscardUnselectedChanges: boolean
   readonly confirmForcePush: boolean
   readonly automaticallySwitchTheme: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
@@ -98,6 +100,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
+      confirmDiscardUnselectedChanges: false,
       confirmForcePush: false,
       uncommittedChangesStrategyKind: uncommittedChangesStrategyKindDefault,
       automaticallySwitchTheme: false,
@@ -160,6 +163,8 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
+      confirmDiscardUnselectedChanges: this.props
+        .confirmDiscardUnselectedChanges,
       confirmForcePush: this.props.confirmForcePush,
       uncommittedChangesStrategyKind: this.props.uncommittedChangesStrategyKind,
       availableShells,
@@ -308,6 +313,9 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             confirmRepositoryRemoval={this.state.confirmRepositoryRemoval}
             confirmDiscardChanges={this.state.confirmDiscardChanges}
+            confirmDiscardUnselectedChanges={
+              this.state.confirmDiscardUnselectedChanges
+            }
             confirmForcePush={this.state.confirmForcePush}
             uncommittedChangesStrategyKind={
               this.state.uncommittedChangesStrategyKind
@@ -317,6 +325,9 @@ export class Preferences extends React.Component<
               this.onConfirmRepositoryRemovalChanged
             }
             onConfirmDiscardChangesChanged={this.onConfirmDiscardChangesChanged}
+            onConfirmDiscardUnselectedChangesChanged={
+              this.onConfirmDiscardUnselectedChangesChanged
+            }
             onConfirmForcePushChanged={this.onConfirmForcePushChanged}
             onUncommittedChangesStrategyKindChanged={
               this.onUncommittedChangesStrategyKindChanged
@@ -352,6 +363,10 @@ export class Preferences extends React.Component<
 
   private onConfirmDiscardChangesChanged = (value: boolean) => {
     this.setState({ confirmDiscardChanges: value })
+  }
+
+  private onConfirmDiscardUnselectedChangesChanged = (value: boolean) => {
+    this.setState({ confirmDiscardUnselectedChanges: value })
   }
 
   private onConfirmForcePushChanged = (value: boolean) => {
@@ -485,6 +500,9 @@ export class Preferences extends React.Component<
     await this.props.dispatcher.setShell(this.state.selectedShell)
     await this.props.dispatcher.setConfirmDiscardChangesSetting(
       this.state.confirmDiscardChanges
+    )
+    await this.props.dispatcher.setConfirmDiscardUnselectedChangesSetting(
+      this.state.confirmDiscardUnselectedChanges
     )
 
     await this.props.dispatcher.setUncommittedChangesStrategyKindSetting(

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -42,7 +42,7 @@ interface IPreferencesProps {
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
-  readonly confirmDiscardUnselectedChanges: boolean
+  readonly confirmDiscardUnselected: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
   readonly selectedExternalEditor: ExternalEditor | null
@@ -61,7 +61,7 @@ interface IPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
-  readonly confirmDiscardUnselectedChanges: boolean
+  readonly confirmDiscardUnselected: boolean
   readonly confirmForcePush: boolean
   readonly automaticallySwitchTheme: boolean
   readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
@@ -100,7 +100,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
-      confirmDiscardUnselectedChanges: false,
+      confirmDiscardUnselected: false,
       confirmForcePush: false,
       uncommittedChangesStrategyKind: uncommittedChangesStrategyKindDefault,
       automaticallySwitchTheme: false,
@@ -163,8 +163,7 @@ export class Preferences extends React.Component<
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
-      confirmDiscardUnselectedChanges: this.props
-        .confirmDiscardUnselectedChanges,
+      confirmDiscardUnselected: this.props.confirmDiscardUnselected,
       confirmForcePush: this.props.confirmForcePush,
       uncommittedChangesStrategyKind: this.props.uncommittedChangesStrategyKind,
       availableShells,
@@ -313,9 +312,7 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             confirmRepositoryRemoval={this.state.confirmRepositoryRemoval}
             confirmDiscardChanges={this.state.confirmDiscardChanges}
-            confirmDiscardUnselectedChanges={
-              this.state.confirmDiscardUnselectedChanges
-            }
+            confirmDiscardUnselected={this.state.confirmDiscardUnselected}
             confirmForcePush={this.state.confirmForcePush}
             uncommittedChangesStrategyKind={
               this.state.uncommittedChangesStrategyKind
@@ -366,7 +363,7 @@ export class Preferences extends React.Component<
   }
 
   private onConfirmDiscardUnselectedChangesChanged = (value: boolean) => {
-    this.setState({ confirmDiscardUnselectedChanges: value })
+    this.setState({ confirmDiscardUnselected: value })
   }
 
   private onConfirmForcePushChanged = (value: boolean) => {
@@ -502,7 +499,7 @@ export class Preferences extends React.Component<
       this.state.confirmDiscardChanges
     )
     await this.props.dispatcher.setConfirmDiscardUnselectedChangesSetting(
-      this.state.confirmDiscardUnselectedChanges
+      this.state.confirmDiscardUnselected
     )
 
     await this.props.dispatcher.setUncommittedChangesStrategyKindSetting(

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -47,6 +47,7 @@ interface IRepositoryViewProps {
   readonly imageDiffType: ImageDiffType
   readonly hideWhitespaceInDiff: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly askForConfirmationOnDiscardUnselectdChanges: boolean
   readonly focusCommitMessage: boolean
   readonly accounts: ReadonlyArray<Account>
 
@@ -185,6 +186,9 @@ export class RepositoryView extends React.Component<
         focusCommitMessage={this.props.focusCommitMessage}
         askForConfirmationOnDiscardChanges={
           this.props.askForConfirmationOnDiscardChanges
+        }
+        askForConfirmationOnDiscardUnselectedChanges={
+          this.props.askForConfirmationOnDiscardUnselectdChanges
         }
         accounts={this.props.accounts}
         externalEditorLabel={this.props.externalEditorLabel}

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -265,6 +265,9 @@ dialog {
         padding-left: var(--spacing-half);
       }
     }
+    .alert {
+      color: var(--dialog-error-color);
+    }
   }
 
   .dialog-footer {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #2402

## Description
I implemented 'Discard Unselected Changes'.
You can see the 'Discard unselected changes' menu in Right-click menu which is shown when you do Right-click a file in Changes View.
I knew that many people want to discard only some changed lines from their changed files. I think this implementing is not exactly same as the feature which is described at #2402 , but if you use this feature, result will be same as you want.
If you want to discard lines, select a changed file and select all lines what you want to remain, deselect lines what you want to discard. Then right-click the file in Changes View and click 'Discard unselected changes'.
Warning! Your discarding will not be able to recover! Please take care.

This is very useful. I did use also this new feature to make a commit for this implementing.

I'm first in TypeScript and React. So please review meticulously.
Any suggestions and advices can be helpful to me.
Thanks.
-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![K-025](https://user-images.githubusercontent.com/7362974/77840822-73e3e580-71c6-11ea-8890-223d20ea1ab4.png)
![K-030](https://user-images.githubusercontent.com/7362974/77848611-e7a2e400-7200-11ea-9d71-563ac9fd481b.png)
![K-028](https://user-images.githubusercontent.com/7362974/77840833-7ba38a00-71c6-11ea-97da-bd9e0b7a0df9.png)
![K-029](https://user-images.githubusercontent.com/7362974/77840835-7d6d4d80-71c6-11ea-8bad-9cf66a0428a5.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Discard Unselected Changes Added
