### PR TITLE
Fix issue #7710: remove _hideStashedChanges invoke when switching sections

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2178,8 +2178,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }))
     this.emitUpdate()
 
-    this._hideStashedChanges(repository)
-
     if (selectedSection === RepositorySectionTab.History) {
       return this.refreshHistorySection(repository)
     } else if (selectedSection === RepositorySectionTab.Changes) {


### PR DESCRIPTION
Because the _hideStashedChanges method will update the selectedFileIDs to all files, which causes all changed files seelcted when click Changes tab

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #7710

## Description
When we click History tab from Changes, the _hideStashedChanges  method will be invoked, and _hideStashedChanges  will refresh selectedFileIDs to all changed files, and set diff to null. Then when we click Changes back, all files will be selected, instead of the file we selected before, and the diff view doesn't show diff content.

This will also update the design below: 
when we click Changes tab, it always show the change list instead of the Stash, even the Stash was checked before. 
Now it will show Stash if the Stash was checked before. Maybe you need to verify whether it's ok.

### Screenshots
All changed files are selected when click Changes tab:
![image](https://user-images.githubusercontent.com/5396286/77936565-a5070780-72e5-11ea-9f12-ca058af16594.png)

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
