### PR TITLE
Lighter scrollbars in dark theme

### DIFF
--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -42,7 +42,7 @@ body.theme-dark {
    *
    * Note: Only applies to win32 platforms
    */
-  --scroll-bar-thumb-background-color: rgba(67, 76, 87, 0.7);
+  --scroll-bar-thumb-background-color: rgba(255, 255, 255, 0.2);
 
   /**
    * Background color for custom scroll bars in their active state.
@@ -50,7 +50,7 @@ body.theme-dark {
    *
    * Note: Only applies to win32 platforms
    */
-  --scroll-bar-thumb-background-color-active: rgba(67, 76, 87, 0.8);
+  --scroll-bar-thumb-background-color-active: rgba(255, 255, 255, 0.5);
 
   // Box
   //

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -42,7 +42,7 @@ body.theme-dark {
    *
    * Note: Only applies to win32 platforms
    */
-  --scroll-bar-thumb-background-color: rgba(0, 0, 0, 0.7);
+  --scroll-bar-thumb-background-color: rgba(67, 76, 87, 0.7);
 
   /**
    * Background color for custom scroll bars in their active state.
@@ -50,7 +50,7 @@ body.theme-dark {
    *
    * Note: Only applies to win32 platforms
    */
-  --scroll-bar-thumb-background-color-active: rgba(0, 0, 0, 0.8);
+  --scroll-bar-thumb-background-color-active: rgba(67, 76, 87, 0.8);
 
   // Box
   //


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9114

## Description

The scrollbars on the dark theme are very hard to see.  Changing from black to light gray.

### Screenshots

![image](https://user-images.githubusercontent.com/55799997/77982413-ebeb0200-72d1-11ea-8e18-527ee09557b2.png)

## Release notes

Notes: no-notes
