### PR TITLE
Use correct install locaition of Typora to fix Typora detect issue

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -405,7 +405,7 @@ function getExecutableShim(
     case ExternalEditor.CFBuilder:
       return Path.join(installLocation, 'CFBuilder.exe')
     case ExternalEditor.Typora:
-      return Path.join(installLocation, 'bin', 'typora.exe')
+      return Path.join(installLocation, 'typora.exe')
     case ExternalEditor.SlickEdit:
       return Path.join(installLocation, 'win', 'vs.exe')
     case ExternalEditor.Webstorm:


### PR DESCRIPTION
There is no bin folder in the install location of Typora, remove the bin folder to make the detect work.

Closes #9417


### Screenshots
![image](https://user-images.githubusercontent.com/5396286/77983710-40c66100-7342-11ea-8782-20433b07e716.png)


Notes:
I didn't verify this fix on Windows 7, I only verified on Windows 10
I didn't verify this fix for other version of Typora, I only tested for version 0.9.86 - the latest version by now.
