### PR TITLE
Simplify branch tip object

### DIFF
--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -2,14 +2,9 @@ import { git } from './core'
 import { GitError } from 'dugite'
 
 import { Repository } from '../../models/repository'
-import { Commit } from '../../models/commit'
 import { Branch, BranchType } from '../../models/branch'
 import { CommitIdentity } from '../../models/commit-identity'
 import { ForkedRemotePrefix } from '../../models/remote'
-import {
-  getTrailerSeparatorCharacters,
-  parseRawUnfoldedTrailers,
-} from './interpret-trailers'
 
 const ForksReferencesPrefix = `refs/remotes/${ForkedRemotePrefix}`
 
@@ -29,11 +24,7 @@ export async function getBranches(
     '%(objectname:short)', // short SHA
     '%(author)',
     '%(committer)',
-    '%(parent)', // parent SHAs
     '%(symref)',
-    '%(subject)',
-    '%(body)',
-    '%(trailers:unfold,only)',
     `%${delimiter}`, // indicate end-of-line as %(body) may contain newlines
   ].join('%00')
 
@@ -65,8 +56,6 @@ export async function getBranches(
     return []
   }
 
-  const trailerSeparators = await getTrailerSeparatorCharacters(repository)
-
   const branches = []
 
   for (const [ix, line] of lines.entries()) {
@@ -93,22 +82,11 @@ export async function getBranches(
       throw new Error(`Couldn't parse committer identity for '${shortSha}'`)
     }
 
-    const parentSHAs = pieces[7].split(' ')
-    const symref = pieces[8]
-    const summary = pieces[9]
-    const body = pieces[10]
-    const trailers = parseRawUnfoldedTrailers(pieces[11], trailerSeparators)
-
-    const tip = new Commit(
+    const symref = pieces[7]
+    const branchTip = {
       sha,
-      shortSha,
-      summary,
-      body,
       author,
-      committer,
-      parentSHAs,
-      trailers
-    )
+    }
 
     const type = ref.startsWith('refs/head')
       ? BranchType.Local
@@ -128,7 +106,7 @@ export async function getBranches(
     }
 
     branches.push(
-      new Branch(name, upstream.length > 0 ? upstream : null, tip, type)
+      new Branch(name, upstream.length > 0 ? upstream : null, branchTip, type)
     )
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -280,14 +280,6 @@ export class GitStore extends BaseStore {
     this.refreshDefaultBranch()
     this.refreshRecentBranches(recentBranchNames)
     this.checkPullWithRebase()
-
-    const commits = this._allBranches.map(b => b.tip)
-
-    for (const commit of commits) {
-      this.commitLookup.set(commit.sha, commit)
-    }
-
-    this.emitNewCommitsLoaded(commits)
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/helpers/tutorial-assessor.ts
+++ b/app/src/lib/stores/helpers/tutorial-assessor.ts
@@ -105,10 +105,12 @@ export class OnboardingTutorialAssessor {
     const { tip } = branchesState
 
     if (tip.kind === TipState.Valid) {
+      const commit = repositoryState.commitLookup.get(tip.branch.tip.sha)
+
       // For some reason sometimes the initial commit has a parent sha
       // listed as an empty string...
       // For now I'm filtering those out. Would be better to prevent that from happening
-      return tip.branch.tip.parentSHAs.some(x => x.length > 0)
+      return commit !== undefined && commit.parentSHAs.some(x => x.length > 0)
     }
 
     return false

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -1,5 +1,6 @@
 import { Commit } from './commit'
 import { removeRemotePrefix } from '../lib/remove-remote-prefix'
+import { CommitIdentity } from './commit-identity'
 
 // NOTE: The values here matter as they are used to sort
 // local and remote branches, Local should come before Remote
@@ -17,6 +18,12 @@ export interface IAheadBehind {
 /** The result of comparing two refs in a repository. */
 export interface ICompareResult extends IAheadBehind {
   readonly commits: ReadonlyArray<Commit>
+}
+
+/** Basic data about the latest commit on the branch. */
+export interface IBranchTip {
+  readonly sha: string
+  readonly author: CommitIdentity
 }
 
 /** Default rules for where to create a branch from */
@@ -57,13 +64,13 @@ export class Branch {
    *
    * @param name The short name of the branch. E.g., `master`.
    * @param upstream The remote-prefixed upstream name. E.g., `origin/master`.
-   * @param tip The commit associated with this branch
+   * @param tip Basic information (sha and author) of the latest commit on the branch.
    * @param type The type of branch, e.g., local or remote.
    */
   public constructor(
     public readonly name: string,
     public readonly upstream: string | null,
-    public readonly tip: Commit,
+    public readonly tip: IBranchTip,
     public readonly type: BranchType
   ) {}
 

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -164,7 +164,6 @@ export class ConfigureGitUser extends React.Component<
       author,
       author,
       [],
-      [],
       []
     )
     const emoji = new Map()

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -164,6 +164,7 @@ export class ConfigureGitUser extends React.Component<
       author,
       author,
       [],
+      [],
       []
     )
     const emoji = new Map()

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -80,7 +80,7 @@ describe('git/branch', () => {
       expect(onBranch.branch.tip.sha).toEqual(
         'dfa96676b65e1c0ed43ca25492252a5e384c8efd'
       )
-      expect(onBranch.branch.tip.shortSha).toEqual('dfa9667')
+      expect(onBranch.branch.tip.author.name).toEqual('Brendan Forster')
     })
 
     it('returns non-origin remote', async () => {

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -24,25 +24,12 @@ describe('git/checkout', () => {
       type: BranchType.Local,
       tip: {
         sha: '',
-        shortSha: '',
-        summary: '',
-        body: '',
         author: {
           name: '',
           email: '',
           date: new Date(),
           tzOffset: 0,
         },
-        committer: {
-          name: '',
-          email: '',
-          date: new Date(),
-          tzOffset: 0,
-        },
-        authoredByCommitter: true,
-        parentSHAs: [],
-        trailers: [],
-        coAuthors: [],
       },
       remote: null,
     }

--- a/app/test/unit/git/for-each-ref-test.ts
+++ b/app/test/unit/git/for-each-ref-test.ts
@@ -29,10 +29,7 @@ describe('git/for-each-ref', () => {
       expect(commitWithBody.tip.sha).toBe(
         'dfa96676b65e1c0ed43ca25492252a5e384c8efd'
       )
-      expect(commitWithBody.tip.shortSha).toBe('dfa9667')
-      expect(commitWithBody.tip.summary).toBe('this is a commit title')
-      expect(commitWithBody.tip.body).toContain('lucky last')
-      expect(commitWithBody.tip.parentSHAs).toHaveLength(1)
+      expect(commitWithBody.tip.author.name).toBe('Brendan Forster')
 
       const commitNoBody = branches[1]
       expect(commitNoBody.name).toBe('commit-with-no-body')
@@ -40,18 +37,13 @@ describe('git/for-each-ref', () => {
       expect(commitNoBody.tip.sha).toBe(
         '49ec1e05f39eef8d1ab6200331a028fb3dd96828'
       )
-      expect(commitNoBody.tip.shortSha).toBe('49ec1e0')
-      expect(commitNoBody.tip.summary).toBe('this is a commit title')
-      expect(commitNoBody.tip.body).toHaveLength(0)
-      expect(commitNoBody.tip.parentSHAs).toHaveLength(1)
+      expect(commitNoBody.tip.author.name).toBe('Brendan Forster')
 
       const master = branches[2]
       expect(master.name).toBe('master')
       expect(master.upstream).toBeNull()
       expect(master.tip.sha).toBe('b9ccfc3307240b86447bca2bd6c51a4bb4ade493')
-      expect(master.tip.shortSha).toBe('b9ccfc3')
-      expect(master.tip.summary).toBe('stubbed a README')
-      expect(master.tip.parentSHAs).toHaveLength(1)
+      expect(master.tip.author.name).toBe('Brendan Forster')
     })
 
     it('should return empty list for empty repo', async () => {

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -9,7 +9,6 @@ import {
   rebase,
   RebaseResult,
 } from '../../../../src/lib/git/rebase'
-import { Commit } from '../../../../src/models/commit'
 import {
   AppFileStatusKind,
   CommittedFileChange,
@@ -17,6 +16,7 @@ import {
 import { createRepository } from '../../../helpers/repository-builder-rebase-test'
 import { getStatusOrThrow } from '../../../helpers/status'
 import { getBranchOrError } from '../../../helpers/git'
+import { IBranchTip } from '../../../../src/models/branch'
 
 const baseBranchName = 'base-branch'
 const featureBranchName = 'this-is-a-feature'
@@ -162,7 +162,7 @@ describe('git/rebase', () => {
   })
 
   describe('continue after resolving conflicts', () => {
-    let beforeRebaseTip: Commit
+    let beforeRebaseTip: IBranchTip
     let result: RebaseResult
     let status: IStatusResult
 
@@ -238,7 +238,7 @@ describe('git/rebase', () => {
   })
 
   describe('continue with additional changes unrelated to conflicted files', () => {
-    let beforeRebaseTip: Commit
+    let beforeRebaseTip: IBranchTip
     let filesInRebasedCommit: ReadonlyArray<CommittedFileChange>
     let result: RebaseResult
     let status: IStatusResult

--- a/app/test/unit/group-branches-test.ts
+++ b/app/test/unit/group-branches-test.ts
@@ -1,28 +1,26 @@
 import { groupBranches } from '../../src/ui/branches'
 import { Branch, BranchType } from '../../src/models/branch'
-import { Commit } from '../../src/models/commit'
 import { CommitIdentity } from '../../src/models/commit-identity'
 
 describe('Branches grouping', () => {
   const author = new CommitIdentity('Hubot', 'hubot@github.com', new Date())
 
-  const commit = new Commit(
-    '300acef',
-    '300acef',
-    'summary',
-    'body',
+  const branchTip = {
+    sha: '300acef',
     author,
-    author,
-    [],
-    []
-  )
+  }
 
-  const currentBranch = new Branch('master', null, commit, BranchType.Local)
-  const defaultBranch = new Branch('master', null, commit, BranchType.Local)
+  const currentBranch = new Branch('master', null, branchTip, BranchType.Local)
+  const defaultBranch = new Branch('master', null, branchTip, BranchType.Local)
   const recentBranches = [
-    new Branch('some-recent-branch', null, commit, BranchType.Local),
+    new Branch('some-recent-branch', null, branchTip, BranchType.Local),
   ]
-  const otherBranch = new Branch('other-branch', null, commit, BranchType.Local)
+  const otherBranch = new Branch(
+    'other-branch',
+    null,
+    branchTip,
+    BranchType.Local
+  )
 
   const allBranches = [currentBranch, ...recentBranches, otherBranch]
 

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -1,6 +1,5 @@
 import { inferComparisonBranch } from '../../src/lib/stores/helpers/infer-comparison-branch'
 import { Branch, BranchType } from '../../src/models/branch'
-import { Commit } from '../../src/models/commit'
 import { CommitIdentity } from '../../src/models/commit-identity'
 import { GitHubRepository } from '../../src/models/github-repository'
 import { PullRequest, PullRequestRef } from '../../src/models/pull-request'
@@ -9,25 +8,20 @@ import { IRemote } from '../../src/models/remote'
 import { ComparisonCache } from '../../src/lib/comparison-cache'
 import { gitHubRepoFixture } from '../helpers/github-repo-builder'
 
-function createTestCommit(sha: string) {
-  return new Commit(
-    sha,
-    sha.slice(0, 7),
-    '',
-    '',
-    new CommitIdentity('tester', 'tester@test.com', new Date()),
-    new CommitIdentity('tester', 'tester@test.com', new Date()),
-    [],
-    []
-  )
-}
-
 function createTestBranch(
   name: string,
   sha: string,
   remote: string | null = null
 ) {
-  return new Branch(name, remote, createTestCommit(sha), BranchType.Local)
+  return new Branch(
+    name,
+    remote,
+    {
+      sha,
+      author: new CommitIdentity('tester', 'tester@test.com', new Date()),
+    },
+    BranchType.Local
+  )
 }
 
 function createTestGhRepo(


### PR DESCRIPTION
## Description

This PR changes the `tip` object of the `Branch` model to not store a full commit, but only the basic information that's needed by the UI (which is the `sha` of the tip and its `CommitIdentity`.

This allows https://github.com/desktop/desktop/pull/9383 to work fine without needing to have `Commit` objects with `null` tags (which can cause unexpected issues in the future).

See https://github.com/desktop/desktop/pull/9383#issuecomment-606515192

### Screenshots

N/A

## Release notes

Notes: no-notes
