### PR TITLE
Resolved Accelerator Conflict

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -331,9 +331,7 @@ export function buildDefaultMenu({
         label: __DARWIN__
           ? 'Create Issue on GitHub'
           : 'Create &issue on GitHub',
-        accelerator: (() => {
-          return 'CmdOrCtrl+I'
-        })(),
+        accelerator: 'CmdOrCtrl+I',
         click: emit('create-issue-in-repository-on-github'),
         visible: enableCreateGitHubIssueFromMenu(),
       },

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -332,7 +332,7 @@ export function buildDefaultMenu({
           ? 'Create Issue on GitHub'
           : 'Create &issue on GitHub',
         accelerator: (() => {
-          return __DARWIN__ ? 'Cmd+Shift+I' : 'Ctrl+I'
+          return 'CmdOrCtrl+I'
         })(),
         click: emit('create-issue-in-repository-on-github'),
         visible: enableCreateGitHubIssueFromMenu(),

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -331,7 +331,9 @@ export function buildDefaultMenu({
         label: __DARWIN__
           ? 'Create Issue on GitHub'
           : 'Create &issue on GitHub',
-        accelerator: 'CmdOrCtrl+Shift+I',
+        accelerator: (() => {
+          return __DARWIN__ ? 'Cmd+Shift+I' : 'Ctrl+I'
+        })(),
         click: emit('create-issue-in-repository-on-github'),
         visible: enableCreateGitHubIssueFromMenu(),
       },


### PR DESCRIPTION
Fixes: https://github.com/desktop/desktop/issues/9364

## Description

On Windows and Linux, the keyboard shortcut `Ctrl+Shift+I` was assigned to two actions: 
1) open developer tools, and 
2) create issue in repository on GitHub.

Staying consistent with Chrome, retained `Ctrl+Shift+I` for opening developer tools, and
changed the shortcut to create an issue to `Ctrl+I` for just these platforms (MacOS retains `Cmd+Shift+I` since its shortcut to launch developer tools does not overlap).

**TODO**: Keyboard shortcuts on [help page](https://help.github.com/en/desktop/getting-started-with-github-desktop/keyboard-shortcuts-in-github-desktop) need updating.

## Release notes

Notes: The keyboard shortcut to launch developer tools on Windows now works as expected.
 Updated the keyboard shortcut to create a new issue in a repository to just `Ctrl+I` for Windows. 
