### PR TITLE
Use the non-fork repository on the commit message TokenParser

### DIFF
--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -1,4 +1,8 @@
-import { Repository } from '../models/repository'
+import {
+  Repository,
+  isRepositoryWithGitHubRepository,
+  getNonForkGitHubRepository,
+} from '../models/repository'
 import { GitHubRepository } from '../models/github-repository'
 import { getHTMLURL } from './api'
 
@@ -59,8 +63,8 @@ export class Tokenizer {
   public constructor(emoji: Map<string, string>, repository?: Repository) {
     this.emoji = emoji
 
-    if (repository) {
-      this.repository = repository.gitHubRepository
+    if (repository && isRepositoryWithGitHubRepository(repository)) {
+      this.repository = getNonForkGitHubRepository(repository)
     }
   }
 


### PR DESCRIPTION
Closes #9334

This PR is based on https://github.com/desktop/desktop/pull/9340 since it uses the `getNonForkGitHubRepository` method created on that PR

## Description

This PR changes the `GitHub` repository object that's used by the commit message tokenizer to be able to link to PRs/issues on the upstream repository when working with a fork.

I've verified this by opening a fork of the `react` project and clicking on a PR link from a commit message. e.g:

<img width="448" alt="Screenshot 2020-04-01 at 13 43 14" src="https://user-images.githubusercontent.com/408035/78133481-cb7c8e00-741e-11ea-9fbc-d22f5e5d2ec2.png">

### Screenshots

N/A

## Release notes

Notes: [Fixed] Link to upstream repository from commit messages on forks.
