### PR TITLE
Add create tag dialog

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -168,3 +168,10 @@ export function enableForkyCreateBranchUI(): boolean {
 export function enableGitTagsDisplay(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/**
+ * Should we allow users to create git tags from the app?
+ */
+export function enableGitTagsCreation(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -370,7 +370,7 @@ function getDescriptionForError(error: DugiteError): string | null {
     case DugiteError.RemoteAlreadyExists:
       return null
     case DugiteError.TagAlreadyExists:
-      return null
+      return 'A tag with that name already exists'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/parse-app-url.ts
+++ b/app/src/lib/parse-app-url.ts
@@ -1,5 +1,5 @@
 import * as URL from 'url'
-import { testForInvalidChars } from './sanitize-branch'
+import { testForInvalidChars } from './sanitize-ref-name'
 
 export interface IOAuthAction {
   readonly name: 'oauth'

--- a/app/src/lib/sanitize-ref-name.ts
+++ b/app/src/lib/sanitize-ref-name.ts
@@ -4,12 +4,12 @@
 // the magic sequence @{, consecutive dots, leading and trailing dot, ref ending in .lock
 const invalidCharacterRegex = /[\x00-\x20\x7F~^:?*\[\\|""<>]+|@{|\.\.+|^\.|\.$|\.lock$|\/$/g
 
-/** Sanitize a proposed branch name by replacing illegal characters. */
-export function sanitizedBranchName(name: string): string {
+/** Sanitize a proposed reference name by replacing illegal characters. */
+export function sanitizedRefName(name: string): string {
   return name.replace(invalidCharacterRegex, '-').replace(/^[-\+]*/g, '')
 }
 
-/** Validate a branch does not contain any invalid characters */
+/** Validate that a reference does not contain any invalid characters */
 export function testForInvalidChars(name: string): boolean {
   return invalidCharacterRegex.test(name)
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3040,6 +3040,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return repo
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _createTag(
+    repository: Repository,
+    name: string,
+    targetCommitSha: string
+  ): Promise<void> {
+    const gitStore = this.gitStoreCache.get(repository)
+
+    await gitStore.createTag(name, targetCommitSha)
+
+    this._closePopup()
+  }
+
   private updateCheckoutProgress(
     repository: Repository,
     checkoutProgress: ICheckoutProgress | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3066,6 +3066,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public _getAllTags(repository: Repository): Promise<ReadonlyArray<string>> {
+    const gitStore = this.gitStoreCache.get(repository)
+
+    return gitStore.getAllTags()
+  }
+
   private getLocalBranch(
     repository: Repository,
     branch: string

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -63,6 +63,7 @@ import {
   getSymbolicRef,
   getConfigValue,
   removeRemote,
+  createTag,
 } from '../git'
 import { GitError as DugiteError } from '../../lib/git'
 import { GitError } from 'dugite'
@@ -255,6 +256,19 @@ export class GitStore extends BaseStore {
 
     this.storeCommits(commits, false)
     return commits.map(c => c.sha)
+  }
+
+  public async createTag(name: string, targetCommitSha: string) {
+    const foundCommit = await this.performFailableOperation(async () => {
+      await createTag(this.repository, name, targetCommitSha)
+
+      return getCommit(this.repository, targetCommitSha)
+    })
+
+    if (foundCommit != null) {
+      this.commitLookup.set(targetCommitSha, foundCommit)
+      this.emitNewCommitsLoaded([foundCommit])
+    }
   }
 
   /** The list of ordered SHAs. */

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -64,6 +64,7 @@ import {
   getConfigValue,
   removeRemote,
   createTag,
+  getAllTags,
 } from '../git'
 import { GitError as DugiteError } from '../../lib/git'
 import { GitError } from 'dugite'
@@ -256,6 +257,10 @@ export class GitStore extends BaseStore {
 
     this.storeCommits(commits, false)
     return commits.map(c => c.sha)
+  }
+
+  public async getAllTags(): Promise<ReadonlyArray<string>> {
+    return getAllTags(this.repository)
   }
 
   public async createTag(name: string, targetCommitSha: string) {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -57,6 +57,7 @@ export enum PopupType {
   SAMLReauthRequired,
   CreateFork,
   SChannelNoRevocationCheck,
+  CreateTag,
 }
 
 export type Popup =
@@ -225,4 +226,10 @@ export type Popup =
   | {
       type: PopupType.SChannelNoRevocationCheck
       url: string
+    }
+  | {
+      type: PopupType.CreateTag
+      repository: Repository
+      targetCommitSha: string
+      initialName?: string
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -114,6 +114,7 @@ import { CreateForkDialog } from './forks/create-fork-dialog'
 import { SChannelNoRevocationCheckDialog } from './schannel-no-revocation-check/schannel-no-revocation-check'
 import { findUpstreamRemoteBranch } from '../lib/branch'
 import { GitHubRepository } from '../models/github-repository'
+import { CreateTag } from './create-tag'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1937,6 +1938,18 @@ export class App extends React.Component<IAppProps, IAppState> {
             url={popup.url}
           />
         )
+      case PopupType.CreateTag: {
+        return (
+          <CreateTag
+            key="create-tag"
+            repository={popup.repository}
+            onDismissed={this.onPopupDismissed}
+            dispatcher={this.props.dispatcher}
+            targetCommitSha={popup.targetCommitSha}
+            initialName={popup.initialName}
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
-import { sanitizedBranchName } from '../../lib/sanitize-branch'
+import { sanitizedRefName } from '../../lib/sanitize-ref-name'
 import { Branch, StartPoint } from '../../models/branch'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -252,7 +252,7 @@ export class CreateBranch extends React.Component<
   }
 
   private updateBranchName(name: string) {
-    const sanitizedName = sanitizedBranchName(name)
+    const sanitizedName = sanitizedRefName(name)
     const alreadyExists =
       this.props.allBranches.findIndex(b => b.name === sanitizedName) > -1
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react'
+
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { sanitizedBranchName } from '../../lib/sanitize-branch'
+import { TextBox } from '../lib/text-box'
+import { Row } from '../lib/row'
+import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
+
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { startTimer } from '../lib/timing'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { Ref } from '../lib/ref'
+
+interface ICreateTagProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly onDismissed: () => void
+  readonly targetCommitSha: string
+  readonly initialName?: string
+}
+
+interface ICreateTagState {
+  readonly currentError: Error | null
+  readonly proposedName: string
+  readonly sanitizedName: string
+
+  /**
+   * Note: once tag creation has been initiated this value stays at true
+   * and will never revert to being false. If the tag creation operation
+   * fails this dialog will still be dismissed and an error dialog will be
+   * shown in its place.
+   */
+  readonly isCreatingTag: boolean
+}
+
+/** The Create Tag component. */
+export class CreateTag extends React.Component<
+  ICreateTagProps,
+  ICreateTagState
+> {
+  public constructor(props: ICreateTagProps) {
+    super(props)
+
+    this.state = {
+      currentError: null,
+      proposedName: props.initialName || '',
+      sanitizedName: '',
+      isCreatingTag: false,
+    }
+  }
+
+  public componentDidMount() {
+    if (this.state.proposedName.length) {
+      this.updateTagName(this.state.proposedName)
+    }
+  }
+
+  public render() {
+    const disabled =
+      this.state.proposedName.length <= 0 ||
+      !!this.state.currentError ||
+      /^\s*$/.test(this.state.sanitizedName)
+    const error = this.state.currentError
+
+    return (
+      <Dialog
+        id="create-tag"
+        title={__DARWIN__ ? 'Create a Tag' : 'Create a tag'}
+        onSubmit={this.createTag}
+        onDismissed={this.props.onDismissed}
+        loading={this.state.isCreatingTag}
+        disabled={this.state.isCreatingTag}
+      >
+        {error ? <DialogError>{error.message}</DialogError> : null}
+
+        <DialogContent>
+          <Row>
+            <TextBox
+              label="Name"
+              value={this.state.proposedName}
+              autoFocus={true}
+              onValueChanged={this.updateTagName}
+            />
+          </Row>
+
+          {this.renderTagNameWarning()}
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? 'Create Tag' : 'Create tag'}
+            okButtonDisabled={disabled}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private renderTagNameWarning() {
+    const proposedName = this.state.proposedName
+    const sanitizedName = this.state.sanitizedName
+
+    if (proposedName.length > 0 && /^\s*$/.test(sanitizedName)) {
+      return (
+        <Row className="warning-helper-text">
+          <Octicon symbol={OcticonSymbol.alert} />
+          <p>
+            <Ref>{proposedName}</Ref> is not a valid tag name.
+          </p>
+        </Row>
+      )
+    } else if (proposedName !== sanitizedName) {
+      return (
+        <Row className="warning-helper-text">
+          <Octicon symbol={OcticonSymbol.alert} />
+          <p>
+            Will be created as <Ref>{sanitizedName}</Ref>.
+          </p>
+        </Row>
+      )
+    } else {
+      return null
+    }
+  }
+
+  private updateTagName = (name: string) => {
+    this.setState({
+      proposedName: name,
+      sanitizedName: sanitizedBranchName(name),
+    })
+  }
+
+  private createTag = async () => {
+    const name = this.state.sanitizedName
+    const repository = this.props.repository
+
+    if (name.length > 0) {
+      this.setState({ isCreatingTag: true })
+
+      const timer = startTimer('create tag', repository)
+      await this.props.dispatcher.createTag(
+        repository,
+        name,
+        this.props.targetCommitSha
+      )
+      timer.done()
+    }
+  }
+}

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
-import { sanitizedBranchName } from '../../lib/sanitize-branch'
+import { sanitizedRefName } from '../../lib/sanitize-ref-name'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
@@ -127,7 +127,7 @@ export class CreateTag extends React.Component<
   private updateTagName = (name: string) => {
     this.setState({
       proposedName: name,
-      sanitizedName: sanitizedBranchName(name),
+      sanitizedName: sanitizedRefName(name),
     })
   }
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -115,8 +115,7 @@ export class CreateTag extends React.Component<
   }
 
   private renderTagNameWarning() {
-    const proposedName = this.state.proposedName
-    const sanitizedName = this.state.sanitizedName
+    const { proposedName, sanitizedName } = this.state
 
     if (proposedName.length > 0 && /^\s*$/.test(sanitizedName)) {
       return (

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -36,7 +36,7 @@ interface ICreateTagState {
   readonly localTags: Set<string>
 }
 
-const MAX_TAG_NAME_LENGTH = 245
+const MaxTagNameLength = 245
 
 /** The Create Tag component. */
 export class CreateTag extends React.Component<

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -37,12 +37,6 @@ interface ICreateTagState {
 
 const MaxTagNameLength = 245
 
-/**
- * Regular expression to check whether a tag name
- * consists only of whitespace characters.
- */
-const AllWhiteSpaceRegex = /^\s*$/
-
 /** The Create Tag component. */
 export class CreateTag extends React.Component<
   ICreateTagProps,
@@ -139,7 +133,9 @@ export class CreateTag extends React.Component<
       )
     }
 
-    if (proposedName.length > 0 && AllWhiteSpaceRegex.test(sanitizedName)) {
+    // Show an error if the sanitization logic causes the tag name to be an empty
+    // string (we only want to show this if the user has already typed something).
+    if (proposedName.length > 0 && sanitizedName.length === 0) {
       return <>Invalid tag name.</>
     }
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -36,6 +36,8 @@ interface ICreateTagState {
   readonly localTags: Set<string>
 }
 
+const MAX_TAG_NAME_LENGTH = 245
+
 /** The Create Tag component. */
 export class CreateTag extends React.Component<
   ICreateTagProps,
@@ -139,18 +141,27 @@ export class CreateTag extends React.Component<
     }
   }
 
+  private getCurrentError(sanitizedTagName: string): Error | null {
+    if (sanitizedTagName.length > MAX_TAG_NAME_LENGTH) {
+      return new Error(
+        `The tag name cannot be longer than ${MAX_TAG_NAME_LENGTH} characters`
+      )
+    }
+
+    const alreadyExists = this.state.localTags.has(sanitizedTagName)
+    if (alreadyExists) {
+      return new Error(`A tag named ${sanitizedTagName} already exists`)
+    }
+    return null
+  }
+
   private updateTagName = (name: string) => {
     const sanitizedName = sanitizedRefName(name)
-    const alreadyExists = this.state.localTags.has(sanitizedName)
-
-    const currentError = alreadyExists
-      ? new Error(`A tag named ${sanitizedName} already exists`)
-      : null
 
     this.setState({
       proposedName: name,
       sanitizedName,
-      currentError,
+      currentError: this.getCurrentError(sanitizedName),
     })
   }
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -141,9 +141,9 @@ export class CreateTag extends React.Component<
   }
 
   private getCurrentError(sanitizedTagName: string): Error | null {
-    if (sanitizedTagName.length > MAX_TAG_NAME_LENGTH) {
+    if (sanitizedTagName.length > MaxTagNameLength) {
       return new Error(
-        `The tag name cannot be longer than ${MAX_TAG_NAME_LENGTH} characters`
+        `The tag name cannot be longer than ${MaxTagNameLength} characters`
       )
     }
 

--- a/app/src/ui/create-tag/index.ts
+++ b/app/src/ui/create-tag/index.ts
@@ -1,0 +1,1 @@
+export { CreateTag } from './create-tag-dialog'

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -499,6 +499,22 @@ export class Dispatcher {
     return this.appStore._createTag(repository, name, targetCommitSha)
   }
 
+  /**
+   * Show the tag creation dialog.
+   */
+  public showCreateTagDialog(
+    repository: Repository,
+    targetCommitSha: string,
+    initialName?: string
+  ): Promise<void> {
+    return this.showPopup({
+      type: PopupType.CreateTag,
+      repository,
+      targetCommitSha,
+      initialName,
+    })
+  }
+
   /** Check out the given branch. */
   public checkoutBranch(
     repository: Repository,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -488,6 +488,17 @@ export class Dispatcher {
     )
   }
 
+  /**
+   * Create a new tag on the given target commit.
+   */
+  public createTag(
+    repository: Repository,
+    name: string,
+    targetCommitSha: string
+  ): Promise<void> {
+    return this.appStore._createTag(repository, name, targetCommitSha)
+  }
+
   /** Check out the given branch. */
   public checkoutBranch(
     repository: Repository,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -500,6 +500,13 @@ export class Dispatcher {
   }
 
   /**
+   * Create a new tag on the given target commit.
+   */
+  public getAllTags(repository: Repository): Promise<ReadonlyArray<string>> {
+    return this.appStore._getAllTags(repository)
+  }
+
+  /**
    * Show the tag creation dialog.
    */
   public showCreateTagDialog(

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -12,6 +12,7 @@ import { IGitHubUser } from '../../lib/databases/github-user-database'
 import { AvatarStack } from '../lib/avatar-stack'
 import { IMenuItem } from '../../lib/menu-item'
 import { Octicon, OcticonSymbol } from '../octicons'
+import { enableGitTagsCreation } from '../../lib/feature-flag'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -150,11 +151,17 @@ export class CommitListItem extends React.Component<
         },
         enabled: this.props.onRevertCommit !== undefined,
       },
-      {
+    ]
+
+    if (enableGitTagsCreation()) {
+      items.push({
         label: 'Create Tag…',
         action: this.onCreateTag,
         enabled: !!this.props.onCreateTag,
-      },
+      })
+    }
+
+    items.push(
       { type: 'separator' },
       {
         label: 'Copy SHA',
@@ -164,8 +171,8 @@ export class CommitListItem extends React.Component<
         label: viewOnGitHubLabel,
         action: this.onViewOnGitHub,
         enabled: !this.props.isLocal && !!gitHubRepository,
-      },
-    ]
+      }
+    )
 
     showContextualMenu(items)
   }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -20,6 +20,7 @@ interface ICommitProps {
   readonly isLocal: boolean
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
+  readonly onCreateTag?: (targetCommitSha: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
   readonly showUnpushedIndicator: boolean
 }
@@ -120,6 +121,12 @@ export class CommitListItem extends React.Component<
     }
   }
 
+  private onCreateTag = () => {
+    if (this.props.onCreateTag) {
+      this.props.onCreateTag(this.props.commit.sha)
+    }
+  }
+
   private onContextMenu = (event: React.MouseEvent<any>) => {
     event.preventDefault()
 
@@ -142,6 +149,11 @@ export class CommitListItem extends React.Component<
           }
         },
         enabled: this.props.onRevertCommit !== undefined,
+      },
+      {
+        label: 'Create Tag…',
+        action: this.onCreateTag,
+        enabled: !!this.props.onCreateTag,
       },
       { type: 'separator' },
       {

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -157,7 +157,7 @@ export class CommitListItem extends React.Component<
       items.push({
         label: 'Create Tag…',
         action: this.onCreateTag,
-        enabled: !!this.props.onCreateTag,
+        enabled: this.props.onCreateTag !== undefined,
       })
     }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -44,6 +44,9 @@ interface ICommitListProps {
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
 
+  /** Callback to fire to open the dialog to create a new tag on the given commit */
+  readonly onCreateTag: (targetCommitSha: string) => void
+
   /**
    * Optional callback that fires on page scroll in order to allow passing
    * a new scrollTop value up to the parent component for storing.
@@ -84,6 +87,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         commit={commit}
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}
+        onCreateTag={this.props.onCreateTag}
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -270,6 +270,7 @@ export class CompareSidebar extends React.Component<
         }
         onCommitSelected={this.onCommitSelected}
         onScroll={this.onScroll}
+        onCreateTag={this.onCreateTag}
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
@@ -574,6 +575,13 @@ export class CompareSidebar extends React.Component<
     if (this.state.hasConsumedNotification) {
       this.props.dispatcher.recordDivergingBranchBannerInfluencedMerge()
     }
+  }
+
+  private onCreateTag = (targetCommitSha: string) => {
+    this.props.dispatcher.showCreateTagDialog(
+      this.props.repository,
+      targetCommitSha
+    )
   }
 }
 

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
-import { sanitizedBranchName } from '../../lib/sanitize-branch'
+import { sanitizedRefName } from '../../lib/sanitize-ref-name'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
@@ -57,7 +57,7 @@ export class RenameBranch extends React.Component<
           </Row>
           {renderBranchNameWarning(
             this.state.newName,
-            sanitizedBranchName(this.state.newName)
+            sanitizedRefName(this.state.newName)
           )}
           {renderBranchHasRemoteWarning(this.props.branch)}
           {renderStashWillBeLostWarning(this.props.stash)}
@@ -78,7 +78,7 @@ export class RenameBranch extends React.Component<
   }
 
   private renameBranch = () => {
-    const name = sanitizedBranchName(this.state.newName)
+    const name = sanitizedRefName(this.state.newName)
     this.props.dispatcher.renameBranch(
       this.props.repository,
       this.props.branch,

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -357,6 +357,9 @@ dialog {
   &#generic-git-auth {
     width: 450px;
   }
+  &#create-tag {
+    width: 400px;
+  }
 
   &#confirm-remove-repository {
     width: 450px;

--- a/app/test/unit/sanitize-ref-name-test.ts
+++ b/app/test/unit/sanitize-ref-name-test.ts
@@ -1,57 +1,57 @@
-import { sanitizedBranchName } from '../../src/lib/sanitize-branch'
+import { sanitizedRefName } from '../../src/lib/sanitize-ref-name'
 
 describe('sanitizedBranchName', () => {
   it('leaves a good branch name alone', () => {
     const branchName = 'this-is/fine'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('this-is/fine')
   })
 
   it('replaces invalid characters with dashes', () => {
     const branchName = '.this..is\\not fine:yo?|is-it'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('this-is-not-fine-yo-is-it')
   })
 
   it('does not allow branch name to end in slash', () => {
     const branchName = 'hello/'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('hello-')
   })
 
   it('does not allow name to start with plus', () => {
     const branchName = '++but-can-still-keep-the-rest'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('but-can-still-keep-the-rest')
   })
 
   it('does not allow name to start with minus', () => {
     const branchName = '--but-can-still-keep-the-rest'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('but-can-still-keep-the-rest')
   })
 
   it('does not allow name to end in `.lock`', () => {
     const branchName = 'foo.lock.lock'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('foo.lock-')
   })
 
   it('replaces newlines with dash', () => {
     const branchName = 'hello\r\nworld'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('hello-world')
   })
 
   it('removes starting dot', () => {
     const branchName = '.first.dot.is.not.ok'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe('first.dot.is.not.ok')
   })
 
   it('allows double dashes after first character', () => {
     const branchName = 'branch--name'
-    const result = sanitizedBranchName(branchName)
+    const result = sanitizedRefName(branchName)
     expect(result).toBe(branchName)
   })
 })


### PR DESCRIPTION
Closes #9429

This PR is based on https://github.com/desktop/desktop/pull/9432 since it needs to use the `createTag()` method.

## Description

This PR contains the UI changes to display a dialog that allows users to create tags.

Steps to complete this PR:

- [x] Add entry points that trigger the dialog by calling `dispatcher.showCreateTagDialog()`
- [x] Implement the dialog UI.
- [x] Plug the dialog logic to the `createTag()` method added in https://github.com/desktop/desktop/pull/9432.
- [x] Sanitize tag names.
- [x] Handle errors when creating a tag.
- [x] Early warnings when trying to create a tag with a name that already exists.
- [x] Add feature flag to not expose the dialog before release.

### Screenshots

The current design of the dialog, mimicking the create branch dialog and following the design specs:

<img width="539" alt="Screenshot 2020-04-02 at 18 44 29" src="https://user-images.githubusercontent.com/408035/78275638-27740f00-7512-11ea-8c6d-22ff83022301.png">

<img width="509" alt="Screenshot 2020-04-02 at 18 45 10" src="https://user-images.githubusercontent.com/408035/78275649-2b079600-7512-11ea-98ba-45ce66a9cc75.png">

<img width="468" alt="Screenshot 2020-04-03 at 18 37 49" src="https://user-images.githubusercontent.com/408035/78384318-41792480-75da-11ea-8138-a1fc7fd56a72.png">


## Release notes

Notes: no-notes
