### PR TITLE
History Graph in comparison view

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -612,6 +612,7 @@ export enum HistoryTabMode {
 export enum ComparisonMode {
   Ahead = 'Ahead',
   Behind = 'Behind',
+  Graph = 'Graph',
 }
 
 /**
@@ -630,7 +631,10 @@ export interface ICompareBranch {
   readonly kind: HistoryTabMode.Compare
 
   /** The chosen comparison mode determines which commits to show */
-  readonly comparisonMode: ComparisonMode.Ahead | ComparisonMode.Behind
+  readonly comparisonMode:
+    | ComparisonMode.Ahead
+    | ComparisonMode.Behind
+    | ComparisonMode.Graph
 
   /** The branch to compare against the base branch */
   readonly comparisonBranch: Branch
@@ -710,7 +714,10 @@ export interface IViewHistory {
 export interface ICompareToBranch {
   readonly kind: HistoryTabMode.Compare
   readonly branch: Branch
-  readonly comparisonMode: ComparisonMode.Ahead | ComparisonMode.Behind
+  readonly comparisonMode:
+    | ComparisonMode.Ahead
+    | ComparisonMode.Behind
+    | ComparisonMode.Graph
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1309,6 +1309,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _loadCommitsFromBranch(
+    repository: Repository,
+    branch: Branch
+  ): Promise<string[]> {
+    const gitStore = this.gitStoreCache.get(repository)
+    const commits = await gitStore.loadCommitBatch(branch.name)
+
+    if (commits === null) {
+      throw Error('no commits from ' + branch.name)
+    }
+
+    return commits
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _loadNextCommitBatch(repository: Repository): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1469,8 +1469,8 @@ export class GitStore extends BaseStore {
 
     return {
       commits,
-      ahead: ahead,
-      behind: behind,
+      ahead,
+      behind,
     }
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1457,21 +1457,11 @@ export class GitStore extends BaseStore {
       behind = aheadBehind.behind
     }
 
-    let commits = await getCommits(
+    const commits = await getCommits(
       this.repository,
       revisionRange,
       commitsToLoad
     )
-
-    // Additional load commits from branch
-    if (comparisonMode === ComparisonMode.Graph) {
-      const branchCommits = await getCommits(
-        this.repository,
-        branch.name,
-        commitsToLoad
-      )
-      commits = commits.concat(branchCommits)
-    }
 
     if (commits.length > 0) {
       this.storeCommits(commits, true)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -232,7 +232,10 @@ export class GitStore extends BaseStore {
   }
 
   /** Load a batch of commits from the repository, using a given commitish object as the starting point */
-  public async loadCommitBatch(commitish: string) {
+  public async loadCommitBatch(
+    commitish: string,
+    additionalArgs: ReadonlyArray<string> = []
+  ) {
     if (this.requestsInFight.has(LoadingHistoryRequestKey)) {
       return null
     }
@@ -245,7 +248,7 @@ export class GitStore extends BaseStore {
     this.requestsInFight.add(requestKey)
 
     const commits = await this.performFailableOperation(() =>
-      getCommits(this.repository, commitish, CommitBatchSize)
+      getCommits(this.repository, commitish, CommitBatchSize, additionalArgs)
     )
 
     this.requestsInFight.delete(requestKey)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1935,6 +1935,10 @@ export class Dispatcher {
     return this.appStore._updateCompareForm(repository, newState)
   }
 
+  public loadCommitsFromBranch(repository: Repository, branch: Branch) {
+    return this.appStore._loadCommitsFromBranch(repository, branch)
+  }
+
   /**
    *  update the manual resolution method for a file
    */

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1935,8 +1935,8 @@ export class Dispatcher {
     return this.appStore._updateCompareForm(repository, newState)
   }
 
-  public loadCommitsFromBranch(repository: Repository, branch: Branch) {
-    return this.appStore._loadCommitsFromBranch(repository, branch)
+  public loadCommitsForGraph(repository: Repository, currentBranch: Branch, compareBranch: Branch) {
+    return this.appStore._loadCommitsForGraph(repository, currentBranch, compareBranch)
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1935,10 +1935,6 @@ export class Dispatcher {
     return this.appStore._updateCompareForm(repository, newState)
   }
 
-  public loadCommitsForGraph(repository: Repository, currentBranch: Branch, compareBranch: Branch) {
-    return this.appStore._loadCommitsForGraph(repository, currentBranch, compareBranch)
-  }
-
   /**
    *  update the manual resolution method for a file
    */

--- a/app/src/ui/history/commit-graph.tsx
+++ b/app/src/ui/history/commit-graph.tsx
@@ -1,20 +1,68 @@
 import * as React from 'react'
-interface ICommitGraphProps {}
+import { Commit } from '../../models/commit'
+//import { OcticonSymbol } from '../octicons'
+import { Branch } from '../../models/branch'
+import { getPersistedTheme, ApplicationTheme } from '../lib/application-theme'
+
+interface ICommitGraphProps {
+  readonly commitSHAs: ReadonlyArray<string>
+  readonly commitLookup: Map<string, Commit>
+  readonly currentBranch: Branch
+  readonly compareBranch: Branch
+  readonly height: number
+}
 
 interface ICommitGraphState {}
+
+class Node {
+  public sha: string = ''
+  public isLeft: boolean = true
+  public parentSHAs: string[] = []
+}
+
+class NodePos {
+  public x: number = 0
+  public y: number = 1
+}
 
 export class CommitGraph extends React.Component<
   ICommitGraphProps,
   ICommitGraphState
 > {
   private canvas: HTMLCanvasElement | null = null
-  private ctx: CanvasRenderingContext2D | null = null
+  private nodeList: Array<Node> = []
+  private nodeMap: Map<string, Node> = new Map<string, Node>()
+  private apartX = 15
 
   public constructor(props: ICommitGraphProps) {
     super(props)
     this.state = {
       focusedBranch: null,
       hasConsumedNotification: false,
+    }
+
+    let currentCommit: Commit | undefined = this.props.currentBranch.tip
+    let compareCommit: Commit | undefined = this.props.compareBranch.tip
+    for (let i = 0; i < this.props.commitSHAs.length; ++i) {
+      const commit = this.props.commitLookup.get(this.props.commitSHAs[i])
+      if (commit === undefined) {
+        continue
+      }
+      const node = new Node()
+      node.sha = commit.sha
+      commit.parentSHAs.forEach(sha => node.parentSHAs.push(sha))
+      this.nodeList.push(node)
+      this.nodeMap.set(commit.sha, node)
+      if (currentCommit !== undefined && commit.sha === currentCommit.sha) {
+        node.isLeft = true
+        currentCommit = this.props.commitLookup.get(commit.parentSHAs[0])
+      } else if (
+        compareCommit !== undefined &&
+        commit.sha === compareCommit.sha
+      ) {
+        node.isLeft = false
+        compareCommit = this.props.commitLookup.get(commit.parentSHAs[0])
+      }
     }
   }
 
@@ -27,19 +75,143 @@ export class CommitGraph extends React.Component<
     this.draw(0)
   }
 
+  private drawBezier(
+    ctx: CanvasRenderingContext2D,
+    prevPos: NodePos,
+    x: number,
+    y: number,
+    top: boolean
+  ) {
+    if (top) {
+      if (y - prevPos.y > this.props.height * 1.1) {
+        ctx.beginPath()
+        ctx.moveTo(x, y)
+        ctx.lineTo(x, prevPos.y + this.props.height)
+        ctx.stroke()
+      }
+      ctx.beginPath()
+      ctx.moveTo(x, prevPos.y + this.props.height)
+      ctx.bezierCurveTo(
+        x,
+        prevPos.y + this.props.height * 0.3,
+        prevPos.x,
+        prevPos.y + this.props.height * 0.7,
+        prevPos.x,
+        prevPos.y
+      )
+      ctx.stroke()
+    } else {
+      if (y - prevPos.y > this.props.height * 1.1) {
+        ctx.beginPath()
+        ctx.moveTo(prevPos.x, prevPos.y)
+        ctx.lineTo(prevPos.x, y - this.props.height)
+        ctx.stroke()
+      }
+      ctx.beginPath()
+      ctx.moveTo(prevPos.x, y - this.props.height)
+      ctx.bezierCurveTo(
+        prevPos.x,
+        y - this.props.height * 0.3,
+        x,
+        y - this.props.height * 0.7,
+        x,
+        y
+      )
+      ctx.stroke()
+    }
+  }
+
   public draw(scrollTop: number) {
     if (this.canvas != null) {
       this.canvas.width = this.canvas.clientWidth
       this.canvas.height = this.canvas.clientHeight
-      this.ctx = this.canvas.getContext('2d')
-      if (this.ctx != null) {
-        this.ctx.fillStyle = 'rgb(200,0,0)'
-        this.ctx.fillRect(10, 10 - scrollTop, 50, 50)
+      const ctx = this.canvas.getContext('2d')
+      if (ctx != null) {
+        ctx.translate(0, -scrollTop)
+        if (getPersistedTheme() === ApplicationTheme.Light) {
+          ctx.fillStyle = 'rgb(255,255,255)'
+          ctx.strokeStyle = 'rgb(170,170,170)'
+        } else {
+          ctx.fillStyle = '#24292e'
+          ctx.strokeStyle = '#586069'
+        }
+        ctx.lineWidth = 2
+        const positionMap = new Map<string, NodePos[]>()
+        let beforeIsLeft = false
+        for (let i = 0; i < this.nodeList.length; ++i) {
+          const node = this.nodeList[i]
+          let x = this.apartX
+          const y = this.props.height / 2 + i * this.props.height
+          if (!node.isLeft) {
+            x += this.apartX
+          }
+          node.parentSHAs.forEach(sha => {
+            const parentNode = this.nodeMap.get(sha)
+            if (parentNode !== undefined) {
+              const nodePos = new NodePos()
+              nodePos.x = x
+              nodePos.y = y
+              let posList = positionMap.get(sha)
+              if (posList === undefined) {
+                posList = []
+                positionMap.set(sha, posList)
+              }
+              posList.push(nodePos)
+            }
+          })
+          const prevPosList = positionMap.get(node.sha)
+          if (prevPosList !== undefined) {
+            prevPosList.forEach(prevPos => {
+              if (prevPos.x !== x) {
+                if (prevPos.x < x) {
+                  if (beforeIsLeft) {
+                    this.drawBezier(ctx, prevPos, x, y, true)
+                  } else {
+                    this.drawBezier(ctx, prevPos, x, y, false)
+                  }
+                } else {
+                  if (beforeIsLeft) {
+                    this.drawBezier(ctx, prevPos, x, y, false)
+                  } else {
+                    this.drawBezier(ctx, prevPos, x, y, true)
+                  }
+                }
+              } else {
+                ctx.beginPath()
+                ctx.moveTo(prevPos.x, prevPos.y)
+                ctx.lineTo(x, y)
+                ctx.stroke()
+              }
+            })
+          }
+          beforeIsLeft = node.isLeft
+          /*ctx.save()
+					ctx.translate(x, y)
+          const path = new Path2D(OcticonSymbol.mail.d)
+          ctx.stroke(path)
+          ctx.restore()*/
+        }
 
-        this.ctx.fillStyle = 'rgba(0, 0, 200, 0.5)'
-        this.ctx.fillRect(30, 30 - scrollTop, 50, 50)
-
-        //this.ctx.bezierCurveTo()
+        if (getPersistedTheme() === ApplicationTheme.Light) {
+          ctx.fillStyle = 'rgb(170,170,170)'
+          ctx.strokeStyle = 'rgb(255,255,255)'
+        } else {
+          ctx.fillStyle = '#586069'
+          ctx.strokeStyle = '#24292e'
+        }
+        ctx.lineWidth = 1
+        for (let i = 0; i < this.nodeList.length; ++i) {
+          const node = this.nodeList[i]
+          let x = this.apartX
+          const y = this.props.height / 2 + i * this.props.height
+          if (!node.isLeft) {
+            x += this.apartX
+          }
+          ctx.beginPath()
+          ctx.arc(x, y, 4, 0, Math.PI * 2)
+          ctx.fill()
+          ctx.stroke()
+        }
       }
     }
   }

--- a/app/src/ui/history/commit-graph.tsx
+++ b/app/src/ui/history/commit-graph.tsx
@@ -67,8 +67,8 @@ export class CommitGraph extends React.Component<
       this.backgroundColor = '#24292e'
       this.strokeColor = '#6a737d'
     }
-    let currentCommit: Commit | undefined = this.props.currentBranch.tip
-    let compareCommit: Commit | undefined = this.props.compareBranch.tip
+    let currentCommitSHA: string = this.props.currentBranch.tip.sha
+    let compareCommitSHA: string = this.props.compareBranch.tip.sha
     for (let i = 0; i < this.props.commitSHAs.length; ++i) {
       const commit = this.props.commitLookup.get(this.props.commitSHAs[i])
       if (commit === undefined) {
@@ -79,15 +79,12 @@ export class CommitGraph extends React.Component<
       commit.parentSHAs.forEach(sha => node.parentSHAs.push(sha))
       this.nodeList.push(node)
       this.nodeMap.set(commit.sha, node)
-      if (currentCommit !== undefined && commit.sha === currentCommit.sha) {
+      if (commit.sha === currentCommitSHA) {
         node.isLeft = true
-        currentCommit = this.props.commitLookup.get(commit.parentSHAs[0])
-      } else if (
-        compareCommit !== undefined &&
-        commit.sha === compareCommit.sha
-      ) {
+        currentCommitSHA = commit.parentSHAs[0]
+      } else if (commit.sha === compareCommitSHA) {
         node.isLeft = false
-        compareCommit = this.props.commitLookup.get(commit.parentSHAs[0])
+        compareCommitSHA = commit.parentSHAs[0]
       }
     }
 

--- a/app/src/ui/history/commit-graph.tsx
+++ b/app/src/ui/history/commit-graph.tsx
@@ -41,6 +41,8 @@ class Link {
   public bezierTop: boolean = false
 }
 
+const APART_X = 15
+
 export class CommitGraph extends React.Component<
   ICommitGraphProps,
   ICommitGraphState
@@ -49,7 +51,8 @@ export class CommitGraph extends React.Component<
   private nodeList: Array<Node> = []
   private nodeMap: Map<string, Node> = new Map<string, Node>()
   private linkList: Array<Link> = []
-  private apartX = 15
+  private strokeColor: string = ''
+  private backgroundColor: string = ''
 
   public constructor(props: ICommitGraphProps) {
     super(props)
@@ -57,7 +60,13 @@ export class CommitGraph extends React.Component<
       focusedBranch: null,
       hasConsumedNotification: false,
     }
-
+    if (getPersistedTheme() === ApplicationTheme.Light) {
+      this.backgroundColor = '#FFFFFF'
+      this.strokeColor = '#959da5'
+    } else {
+      this.backgroundColor = '#24292e'
+      this.strokeColor = '#6a737d'
+    }
     let currentCommit: Commit | undefined = this.props.currentBranch.tip
     let compareCommit: Commit | undefined = this.props.compareBranch.tip
     for (let i = 0; i < this.props.commitSHAs.length; ++i) {
@@ -86,10 +95,10 @@ export class CommitGraph extends React.Component<
     let beforeIsLeft = false
     for (let i = 0; i < this.nodeList.length; ++i) {
       const node = this.nodeList[i]
-      let x = this.apartX
+      let x = APART_X
       const y = this.props.height / 2 + i * this.props.height
       if (!node.isLeft) {
-        x += this.apartX
+        x += APART_X
       }
       node.nodePos.x = x
       node.nodePos.y = y
@@ -201,13 +210,8 @@ export class CommitGraph extends React.Component<
       const ctx = this.canvas.getContext('2d')
       if (ctx != null) {
         ctx.translate(0, -scrollTop)
-        if (getPersistedTheme() === ApplicationTheme.Light) {
-          ctx.fillStyle = 'rgb(255,255,255)'
-          ctx.strokeStyle = 'rgb(170,170,170)'
-        } else {
-          ctx.fillStyle = '#24292e'
-          ctx.strokeStyle = '#586069'
-        }
+        ctx.fillStyle = this.backgroundColor
+        ctx.strokeStyle = this.strokeColor
         ctx.lineWidth = 2
         for (let i = 0; i < this.linkList.length; ++i) {
           const link = this.linkList[i]
@@ -301,33 +305,18 @@ export class CommitGraph extends React.Component<
     switch (icon) {
       case NodeIcon.NORMAL:
         ctx.lineWidth = 1
-        if (getPersistedTheme() === ApplicationTheme.Light) {
-          ctx.fillStyle = 'rgb(170,170,170)'
-          ctx.strokeStyle = 'rgb(255,255,255)'
-        } else {
-          ctx.fillStyle = '#586069'
-          ctx.strokeStyle = '#24292e'
-        }
+        ctx.fillStyle = this.strokeColor
+        ctx.strokeStyle = this.backgroundColor
         break
       case NodeIcon.HEAD:
         ctx.lineWidth = 3
-        if (getPersistedTheme() === ApplicationTheme.Light) {
-          ctx.fillStyle = 'rgb(255,255,255)'
-          ctx.strokeStyle = 'rgb(170,170,170)'
-        } else {
-          ctx.fillStyle = '#24292e'
-          ctx.strokeStyle = '#586069'
-        }
+        ctx.fillStyle = this.backgroundColor
+        ctx.strokeStyle = this.strokeColor
         break
       default:
         ctx.lineWidth = 1
-        if (getPersistedTheme() === ApplicationTheme.Light) {
-          ctx.fillStyle = 'rgb(255,255,255)'
-          ctx.strokeStyle = 'rgb(170,170,170)'
-        } else {
-          ctx.fillStyle = '#24292e'
-          ctx.strokeStyle = '#586069'
-        }
+        ctx.fillStyle = this.backgroundColor
+        ctx.strokeStyle = this.strokeColor
     }
   }
 }

--- a/app/src/ui/history/commit-graph.tsx
+++ b/app/src/ui/history/commit-graph.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+interface ICommitGraphProps {}
+
+interface ICommitGraphState {}
+
+export class CommitGraph extends React.Component<
+  ICommitGraphProps,
+  ICommitGraphState
+> {
+  private canvas: HTMLCanvasElement | null = null
+  private ctx: CanvasRenderingContext2D | null = null
+
+  public constructor(props: ICommitGraphProps) {
+    super(props)
+    this.state = {
+      focusedBranch: null,
+      hasConsumedNotification: false,
+    }
+  }
+
+  public render() {
+    return <canvas ref={this.refCanvas} />
+  }
+
+  private refCanvas = (canvas: HTMLCanvasElement) => {
+    this.canvas = canvas
+    this.draw(0)
+  }
+
+  public draw(scrollTop: number) {
+    if (this.canvas != null) {
+      this.canvas.width = this.canvas.clientWidth
+      this.canvas.height = this.canvas.clientHeight
+      this.ctx = this.canvas.getContext('2d')
+      if (this.ctx != null) {
+        this.ctx.fillStyle = 'rgb(200,0,0)'
+        this.ctx.fillRect(10, 10 - scrollTop, 50, 50)
+
+        this.ctx.fillStyle = 'rgba(0, 0, 200, 0.5)'
+        this.ctx.fillRect(30, 30 - scrollTop, 50, 50)
+
+        //this.ctx.bezierCurveTo()
+      }
+    }
+  }
+}

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -36,7 +36,7 @@ interface ICommitListProps {
   readonly onCommitSelected: (commit: Commit) => void
 
   /** Callback that fires when a scroll event has occurred */
-  readonly onScroll: (start: number, end: number) => void
+  readonly onScroll: (start: number, end: number, scrollTop: number) => void
 
   /** Callback to fire to revert a given commit in the current repository */
   readonly onRevertCommit: ((commit: Commit) => void) | undefined
@@ -97,7 +97,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const numberOfRows = Math.ceil(clientHeight / RowHeight)
     const top = Math.floor(scrollTop / RowHeight)
     const bottom = top + numberOfRows
-    this.props.onScroll(top, bottom)
+    this.props.onScroll(top, bottom, scrollTop)
 
     // Pass new scroll value so the scroll position will be remembered (if the callback has been supplied).
     if (this.props.onCompareListScrolled != null) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -90,7 +90,7 @@ export class CompareSidebar extends React.Component<
       focusedBranch: null,
       hasConsumedNotification: false,
       graph: null,
-      compareBranch: compareBranch,
+      compareBranch,
     }
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -81,11 +81,16 @@ export class CompareSidebar extends React.Component<
   public constructor(props: ICompareSidebarProps) {
     super(props)
 
+    let compareBranch: Branch | null = null
+    if (props.compareState.formState.kind === HistoryTabMode.Compare) {
+      const compareBranchState = props.compareState.formState as ICompareBranch
+      compareBranch = compareBranchState.comparisonBranch
+    }
     this.state = {
       focusedBranch: null,
       hasConsumedNotification: false,
       graph: null,
-      compareBranch: null,
+      compareBranch: compareBranch,
     }
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -379,24 +379,11 @@ export class CompareSidebar extends React.Component<
         : ComparisonMode.Graph
     const branch = formState.comparisonBranch
 
-    if (comparisonMode === ComparisonMode.Graph) {
-      if (
-        this.props.currentBranch !== null &&
-        this.state.compareBranch !== null
-      ) {
-        this.props.dispatcher.loadCommitsForGraph(
-          this.props.repository,
-          this.props.currentBranch,
-          this.state.compareBranch
-        )
-      }
-    } else {
-      this.props.dispatcher.executeCompare(this.props.repository, {
-        kind: HistoryTabMode.Compare,
-        branch,
-        comparisonMode,
-      })
-    }
+    this.props.dispatcher.executeCompare(this.props.repository, {
+      kind: HistoryTabMode.Compare,
+      branch,
+      comparisonMode,
+    })
   }
 
   private renderTabBar(formState: ICompareBranch) {

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -40,6 +40,15 @@
     min-height: 0;
   }
 
+  .compare-graph {
+    flex: 1;
+    display: flex;
+
+    canvas {
+      width: 60px;
+    }
+  }
+
   .merge-status {
     background: var(--background-color);
     border-width: 0 var(--spacing-half);

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -45,7 +45,8 @@
     display: flex;
 
     canvas {
-      width: 60px;
+      border-right: var(--base-border);
+      width: 45px;
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #1634

## Description
I implemented ''History Graph" in comparison view.
You should select comparison branch in history view. Then you can see the 'Graph' button.
This is not a full graph according to #1634, it will show you only 2 branch's graph.

### Screenshots
![K-041](https://user-images.githubusercontent.com/7362974/78351569-fd8a1d80-75e1-11ea-9c1f-1d70fee4e9cf.png)
![K-040](https://user-images.githubusercontent.com/7362974/78351574-ffec7780-75e1-11ea-9b60-eb16910d6c7f.png)
![K-037](https://user-images.githubusercontent.com/7362974/78351580-024ed180-75e2-11ea-8d4c-6a02575e90b1.png)
![K-036](https://user-images.githubusercontent.com/7362974/78351584-04189500-75e2-11ea-8a5f-ee8a2bc107ee.png)

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->


## Release notes
History Graph in comparison view.

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
