### PR TITLE
enable win32 progress bars for beta

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -21,8 +21,9 @@ function enableDevelopmentFeatures(): boolean {
   return false
 }
 
+/** Should we show progress bars on the Windows app taskbar icon? */
 export function enableProgressBarOnIcon(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }
 
 /** Should the app enable beta features? */


### PR DESCRIPTION
follow up from #8587 so we can see how it does on beta

look in the bottom left:
![screenshot](https://user-images.githubusercontent.com/17869438/68236212-c3b0ed00-002a-11ea-890f-b2cc6b2abfbc.png)