### PR TITLE
Use flex-shrink on the author selector modal

### DIFF
--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -18,6 +18,7 @@
   overflow-y: auto;
 
   li {
+    flex-shrink: 0;
     height: 29px;
     padding: 0 var(--spacing);
   }


### PR DESCRIPTION

Closes https://github.com/desktop/desktop/issues/9467

## Description

This PR fixes a layout bug that appeared after [upgrading to Electron v7](https://github.com/desktop/desktop/pull/8967) on the modal that appears when searching for co-authors.

### Screenshots

Now the modal is shown correctly:

<img width="371" alt="Screenshot 2020-04-08 at 11 59 43" src="https://user-images.githubusercontent.com/408035/78771477-7f869780-7990-11ea-9f94-595677319bca.png">

## Release notes

Notes: [Fixed] Fix layout of the co-author auto-complete list.
