### PR TITLE
Remove progress bar when there's no push/pull in progress

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3477,7 +3477,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (pushPullFetchProgress !== null) {
         remote.getCurrentWindow().setProgressBar(pushPullFetchProgress.value)
       } else {
-        remote.getCurrentWindow().setProgressBar(0)
+        remote.getCurrentWindow().setProgressBar(-1)
       }
     }
     if (this.selectedRepository === repository) {


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9479

## Description

This PR fixes https://github.com/desktop/desktop/issues/9479 by setting the progress bar value to a negative number as suggested [by the electron docs](https://www.electronjs.org/docs/tutorial/progress-bar).

I've tested this on macOS and Windows.

## Release notes

Notes: no-notes
