### PR TITLE
Push tags when pushing changes to repository

### DIFF
--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -69,7 +69,7 @@ export async function push(
 
   if (!remoteBranch) {
     args.push('--set-upstream')
-  } else if (options.forceWithLease) {
+  } else if (options.forceWithLease === true) {
     args.push('--force-with-lease')
   }
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -15,6 +15,12 @@ import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
 
 export type PushOptions = {
+  /**
+   * Force-push the branch without losing changes in the remote that
+   * haven't been fetched.
+   *
+   * See https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-force-with-lease
+   */
   readonly forceWithLease: boolean
 }
 
@@ -31,8 +37,8 @@ export type PushOptions = {
  *
  * @param remoteBranch - The remote branch to push to
  *
- * @param setUpstream - Whether or not to update the tracking information
- *                      of the specified branch to point to the remote.
+ * @param options - Optional customizations for the push execution.
+ *                  see PushOptions for more information.
  *
  * @param progressCallback - An optional function which will be invoked
  *                           with information about the current progress
@@ -46,7 +52,9 @@ export async function push(
   remote: IRemote,
   localBranch: string,
   remoteBranch: string | null,
-  options?: PushOptions,
+  options: PushOptions = {
+    forceWithLease: false,
+  },
   progressCallback?: (progress: IPushProgress) => void
 ): Promise<void> {
   const networkArguments = await gitNetworkArguments(repository, account)
@@ -60,7 +68,7 @@ export async function push(
 
   if (!remoteBranch) {
     args.push('--set-upstream')
-  } else if (options !== undefined && options.forceWithLease) {
+  } else if (options.forceWithLease) {
     args.push('--force-with-lease')
   }
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -13,6 +13,7 @@ import { PushProgressParser, executionOptionsWithProgress } from '../progress'
 import { AuthenticationErrors } from './authentication'
 import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
+import { enableGitTagsCreation } from '../feature-flag'
 
 export type PushOptions = {
   /**
@@ -70,6 +71,10 @@ export async function push(
     args.push('--set-upstream')
   } else if (options.forceWithLease) {
     args.push('--force-with-lease')
+  }
+
+  if (enableGitTagsCreation()) {
+    args.push('--follow-tags')
   }
 
   const expectedErrors = new Set<DugiteError>(AuthenticationErrors)


### PR DESCRIPTION
Partially addresses https://github.com/desktop/desktop/issues/9435

This PR is based on https://github.com/desktop/desktop/pull/9440 since I need to use the `enableGitTagsCreation()` feature flag.

## Description

This PR adds the `--follow-tags` argument to the push commands done on Desktop to be able to push the relevant annotated tags (note that non-annotated tags won't get automatically pushed).

See the [official docs](https://git-scm.com/docs/git-push#Documentation/git-push.txt---follow-tags) about the `--follow-tags` argument for more information.

An important note is that the docs are a bit misleading, since `--follow-tags` will push any annotated tag that is reachable from any ref available on the remote repository (not only the tags reachable from refs that are getting pushed).

Next steps (to be done in separate PRs):

-  [ ] Display the push/pull button as pushable when there are unpushed tags locally.

### Screenshots

N/A

## Release notes

Notes: no-notes
