### PR TITLE
Add fetchTagsToPush() git method

### DIFF
--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -2,6 +2,7 @@ import { git, gitNetworkArguments } from './core'
 import { Repository } from '../../models/repository'
 import { IGitAccount } from '../../models/git-account'
 import { IRemote } from '../../models/remote'
+import { envForRemoteOperation } from './environment'
 
 /**
  * Create a new tag on the given target commit.
@@ -36,7 +37,7 @@ export async function getAllTags(
 }
 
 /**
- * Fetches the unpushed tags from the remote repository (it does a network request).
+ * Fetches the tags that will get pushed to the remote repository (it does a network request).
  *
  * @param repository  - The repository in which to check for unpushed tags
  * @param account     - The account to use when authenticating with the remote
@@ -51,6 +52,7 @@ export async function fetchTagsToPush(
   branchName: string
 ): Promise<ReadonlyArray<string>> {
   const networkArguments = await gitNetworkArguments(repository, account)
+
   const args = [
     ...networkArguments,
     'push',
@@ -61,7 +63,9 @@ export async function fetchTagsToPush(
     '--porcelain',
   ]
 
-  const result = await git(args, repository.path, 'fetchUnpushedTags')
+  const result = await git(args, repository.path, 'fetchTagsToPush', {
+    env: await envForRemoteOperation(account, remote.url),
+  })
 
   const lines = result.stdout.split('\n')
   let currentLine = 1

--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -41,7 +41,6 @@ export async function getAllTags(
  *
  * @param repository  - The repository in which to check for unpushed tags
  * @param account     - The account to use when authenticating with the remote
- *
  * @param remote      - The remote to check for unpushed tags
  * @param branchName  - The branch that will be used on the push command
  */

--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -70,6 +70,7 @@ export async function fetchTagsToPush(
   let currentLine = 1
   const unpushedTags = []
 
+  // the last line of this porcelain command is always 'Done'
   while (lines[currentLine] !== 'Done') {
     const line = lines[currentLine]
     const parts = line.split('\t')

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -1,19 +1,46 @@
+import * as path from 'path'
+import * as FSE from 'fs-extra'
 import { Repository } from '../../../src/models/repository'
 import {
   getCommit,
   createTag,
   getCommits,
   getAllTags,
+  getRemotes,
+  fetchTagsToPush,
+  push,
+  createBranch,
+  createCommit,
+  checkoutBranch,
 } from '../../../src/lib/git'
-
-import { setupFixtureRepository } from '../../helpers/repositories'
+import {
+  setupFixtureRepository,
+  setupLocalForkOfRepository,
+} from '../../helpers/repositories'
+import { Account } from '../../../src/models/account'
+import { getDotComAPIEndpoint } from '../../../src/lib/api'
+import { IRemote } from '../../../src/models/remote'
+import { findDefaultRemote } from '../../../src/lib/stores/helpers/find-default-remote'
+import { getStatusOrThrow } from '../../helpers/status'
+import { getBranchOrError } from '../../helpers/git'
 
 describe('git/tag', () => {
   let repository: Repository
+  let account: Account
 
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
+
+    account = new Account(
+      'monalisa',
+      getDotComAPIEndpoint(),
+      '',
+      [],
+      '',
+      -1,
+      'Mona Lisa'
+    )
   })
 
   describe('createTag', () => {
@@ -68,6 +95,61 @@ describe('git/tag', () => {
         'my-new-tag',
         'another-tag',
       ])
+    })
+  })
+
+  describe('fetchTagsToPush', () => {
+    let remoteRepository: Repository
+    let originRemote: IRemote
+
+    beforeEach(async () => {
+      const path = await setupFixtureRepository('test-repo-with-tags')
+      remoteRepository = new Repository(path, -1, null, false)
+      repository = await setupLocalForkOfRepository(remoteRepository)
+
+      const remotes = await getRemotes(repository)
+      originRemote = findDefaultRemote(remotes)!
+    })
+
+    it('returns an empty array when there are no tags to get pushed', async () => {
+      expect(
+        await fetchTagsToPush(repository, account, originRemote, 'master')
+      ).toIncludeAllMembers([])
+    })
+
+    it("returns local tags that haven't been pushed", async () => {
+      await createTag(repository, 'my-new-tag', 'HEAD')
+
+      expect(
+        await fetchTagsToPush(repository, account, originRemote, 'master')
+      ).toEqual(['my-new-tag'])
+    })
+
+    it('returns an empty array after pushing', async () => {
+      await createTag(repository, 'my-new-tag', 'HEAD')
+
+      await push(repository, account, originRemote, 'master', null)
+
+      expect(
+        await fetchTagsToPush(repository, account, originRemote, 'master')
+      ).toEqual([])
+    })
+
+    it('does not return a tag created o a non-pushed branch', async () => {
+      // Create a tag on a local branch that's not pushed to the remote.
+      const branch = await createBranch(repository, 'new-branch', 'master')
+
+      await FSE.writeFile(path.join(repository.path, 'README.md'), 'Hi world\n')
+      const status = await getStatusOrThrow(repository)
+      const files = status.workingDirectory.files
+
+      await checkoutBranch(repository, account, branch!)
+      const commitSha = await createCommit(repository, 'a commit', files)
+      await createTag(repository, 'my-new-tag', commitSha!)
+
+      expect(
+        await fetchTagsToPush(repository, account, originRemote, 'master')
+      ).toEqual([])
     })
   })
 })

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -22,7 +22,6 @@ import { getDotComAPIEndpoint } from '../../../src/lib/api'
 import { IRemote } from '../../../src/models/remote'
 import { findDefaultRemote } from '../../../src/lib/stores/helpers/find-default-remote'
 import { getStatusOrThrow } from '../../helpers/status'
-import { getBranchOrError } from '../../helpers/git'
 
 describe('git/tag', () => {
   let repository: Repository

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -134,7 +134,7 @@ describe('git/tag', () => {
       ).toEqual([])
     })
 
-    it('does not return a tag created o a non-pushed branch', async () => {
+    it('does not return a tag created on a non-pushed branch', async () => {
       // Create a tag on a local branch that's not pushed to the remote.
       const branch = await createBranch(repository, 'new-branch', 'master')
 


### PR DESCRIPTION
Partially addresses #9435

This branch is based on https://github.com/desktop/desktop/pull/9481

## Description

This PR uses `git push --follow-tags --dry-run` to be able to predict whether any new tag will get pushed as part of the push command.

The next step here is to use the `fetchTagsToPush()` method to check whether the push/pull button should be shown as push.

We can avoid doing network requests when not necessary by only calling this method when no local commits need to be pushed (otherwise, the button will already be shown as "push").

### Screenshots

N/A

## Release notes

Notes: no-notes
