### PR TITLE
Use abbreviated time durations in commit list

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,6 +39,7 @@
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",
     "moment": "^2.24.0",
+    "moment-duration-format": "^2.3.2",
     "mri": "^1.1.0",
     "p-limit": "^2.2.0",
     "primer-support": "^4.0.0",

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -59,7 +59,9 @@ export class CommitListItem extends React.Component<
 
   public render() {
     const commit = this.props.commit
-    const author = commit.author
+    const {
+      author: { date },
+    } = commit
 
     return (
       <div className="commit" onContextMenu={this.onContextMenu}>
@@ -77,8 +79,7 @@ export class CommitListItem extends React.Component<
                 gitHubRepository={this.props.gitHubRepository}
                 commit={commit}
               />
-              {' • '}
-              <RelativeTime date={author.date} />
+              {renderRelativeTime(date)}
             </div>
           </div>
         </div>
@@ -158,4 +159,13 @@ export class CommitListItem extends React.Component<
 
     showContextualMenu(items)
   }
+}
+
+function renderRelativeTime(date: Date) {
+  return (
+    <>
+      {` • `}
+      <RelativeTime date={date} />
+    </>
+  )
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -165,7 +165,7 @@ function renderRelativeTime(date: Date) {
   return (
     <>
       {` • `}
-      <RelativeTime date={date} />
+      <RelativeTime date={date} abbreviate={true} />
     </>
   )
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -76,7 +76,8 @@ export class CommitListItem extends React.Component<
               <CommitAttribution
                 gitHubRepository={this.props.gitHubRepository}
                 commit={commit}
-              />{' '}
+              />
+              {' • '}
               <RelativeTime date={author.date} />
             </div>
           </div>

--- a/app/src/ui/lib/commit-attribution.tsx
+++ b/app/src/ui/lib/commit-attribution.tsx
@@ -34,19 +34,18 @@ export class CommitAttribution extends React.Component<
     return <span className="author">{author.name}</span>
   }
 
-  private renderAuthors(
-    authors: ReadonlyArray<CommitIdentity | GitAuthor>,
-    committerAttribution: boolean
-  ) {
+  private renderAuthors(authors: ReadonlyArray<CommitIdentity | GitAuthor>) {
     if (authors.length === 1) {
       return (
         <span className="authors">{this.renderAuthorInline(authors[0])}</span>
       )
-    } else if (authors.length === 2 && !committerAttribution) {
+    } else if (authors.length === 2) {
+      const title = authors.map(a => a.name).join(', ')
+
       return (
-        <span className="authors">
+        <span className="authors" title={title}>
           {this.renderAuthorInline(authors[0])}
-          {' and '}
+          {`, `}
           {this.renderAuthorInline(authors[1])}
         </span>
       )
@@ -61,22 +60,11 @@ export class CommitAttribution extends React.Component<
     }
   }
 
-  private renderCommitter(committer: CommitIdentity) {
-    return (
-      <span className="committer">
-        {' and '}
-        {this.renderAuthorInline(committer)}
-        {' committed'}
-      </span>
-    )
-  }
-
   public render() {
     const commit = this.props.commit
     const { author, committer, coAuthors } = commit
 
-    const authors: Array<CommitIdentity | GitAuthor> = [author, ...coAuthors]
-
+    // do we need to attribute the committer separately from the author?
     const committerAttribution =
       !commit.authoredByCommitter &&
       !(
@@ -84,11 +72,13 @@ export class CommitAttribution extends React.Component<
         isWebFlowCommitter(commit, this.props.gitHubRepository)
       )
 
+    const authors: Array<CommitIdentity | GitAuthor> = committerAttribution
+      ? [author, committer, ...coAuthors]
+      : [author, ...coAuthors]
+
     return (
       <span className="commit-attribution-component">
-        {this.renderAuthors(authors, committerAttribution)}
-        {committerAttribution ? ' authored' : ' committed'}
-        {committerAttribution ? this.renderCommitter(committer) : null}
+        {this.renderAuthors(authors)}
       </span>
     )
   }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -862,6 +862,11 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment-duration-format@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
+  integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
+
 moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "@types/legal-eagle": "^0.15.0",
     "@types/memoize-one": "^3.1.1",
     "@types/mini-css-extract-plugin": "^0.2.0",
+    "@types/moment-duration-format": "^2.2.2",
     "@types/mri": "^1.1.0",
     "@types/node": "10.12.18",
     "@types/prettier": "^1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,6 +453,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/moment-duration-format@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/moment-duration-format/-/moment-duration-format-2.2.2.tgz#da0c9501861661d19fdb62415907a93c44709a81"
+  integrity sha512-CuYswsMI3y5uR5sD9i/VUqIbZrsYN2eaCs7nH3qpDl2CZlNI48mjMf4ve2RpQ/65irprtnQVetfnea9my+jqcg==
+  dependencies:
+    moment ">=2.14.0"
+
 "@types/mri@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/mri/-/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
@@ -7116,6 +7123,11 @@ moment@2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
   integrity sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=
+
+moment@>=2.14.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes #9428

## Description

- these only replace our time durations that are more than 1 minute or less than a week long
  - we still use "just now" for less than a minute
  - more than a week gets an absolute date

### Screenshots

<img width="385" alt="Screen Shot 2020-04-09 at 4 35 35 PM" src="https://user-images.githubusercontent.com/964912/78949750-6b6e9300-7a81-11ea-92ad-78f452d34385.png">
