### PR TITLE
add explicit onDismissed handler for force push warn dialog

### DIFF
--- a/app/src/ui/rebase/warn-force-push-dialog.tsx
+++ b/app/src/ui/rebase/warn-force-push-dialog.tsx
@@ -73,6 +73,7 @@ export class WarnForcePushDialog extends React.Component<
         <DialogFooter>
           <OkCancelButtonGroup
             okButtonText={__DARWIN__ ? 'Begin Rebase' : 'Begin rebase'}
+            onCancelButtonClick={this.props.onDismissed}
           />
         </DialogFooter>
       </Dialog>


### PR DESCRIPTION
Closes #9507

## Description

- this is a workaround for a bug introduced in #8599, where non-dismissable dialogs that use the OkCancelButtonGroup and don't pass an explicit onCancel handler will fail to dismiss
- i have an idea for a more permanent fix, but want to vet it a little more
- i also did a quick audit and didn't find any other popups that also have this problem

cc @tierninho @billygriffin 