### PR TITLE
Tweaks to displayed tags on commit view

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -338,14 +338,20 @@ export class CommitSummary extends React.Component<
               />
             </li>
 
-            <li className="commit-summary-meta-item" aria-label="SHA">
+            <li
+              className="commit-summary-meta-item without-truncation"
+              aria-label="SHA"
+            >
               <span aria-hidden="true">
                 <Octicon symbol={OcticonSymbol.gitCommit} />
               </span>
               <span className="sha">{shortSHA}</span>
             </li>
 
-            <li className="commit-summary-meta-item" title={filesDescription}>
+            <li
+              className="commit-summary-meta-item without-truncation"
+              title={filesDescription}
+            >
               <span aria-hidden="true">
                 <Octicon symbol={OcticonSymbol.diff} />
               </span>
@@ -355,15 +361,20 @@ export class CommitSummary extends React.Component<
             {this.renderTags()}
 
             {enableHideWhitespaceInDiffOption() && (
-              <Checkbox
-                label="Hide Whitespace"
-                value={
-                  this.props.hideWhitespaceInDiff
-                    ? CheckboxValue.On
-                    : CheckboxValue.Off
-                }
-                onChange={this.onHideWhitespaceInDiffChanged}
-              />
+              <li
+                className="commit-summary-meta-item without-truncation"
+                title={filesDescription}
+              >
+                <Checkbox
+                  label="Hide Whitespace"
+                  value={
+                    this.props.hideWhitespaceInDiff
+                      ? CheckboxValue.On
+                      : CheckboxValue.Off
+                  }
+                  onChange={this.onHideWhitespaceInDiffChanged}
+                />
+              </li>
             )}
           </ul>
         </div>
@@ -390,7 +401,7 @@ export class CommitSummary extends React.Component<
           <Octicon symbol={OcticonSymbol.tag} />
         </span>
 
-        {tags.join(', ')}
+        <span className="tags">{tags.join(', ')}</span>
       </li>
     )
   }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -396,7 +396,7 @@ export class CommitSummary extends React.Component<
     }
 
     return (
-      <li className="commit-summary-meta-item">
+      <li className="commit-summary-meta-item" title={tags.join('\n')}>
         <span aria-label="Tags">
           <Octicon symbol={OcticonSymbol.tag} />
         </span>

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -15,7 +15,6 @@ import {
   enableHideWhitespaceInDiffOption,
   enableGitTagsDisplay,
 } from '../../lib/feature-flag'
-import { caseInsensitiveCompare } from '../../lib/compare'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
@@ -396,15 +395,13 @@ export class CommitSummary extends React.Component<
       return null
     }
 
-    const sortedTags = [...tags].sort(caseInsensitiveCompare)
-
     return (
-      <li className="commit-summary-meta-item" title={sortedTags.join('\n')}>
+      <li className="commit-summary-meta-item" title={tags.join('\n')}>
         <span aria-label="Tags">
           <Octicon symbol={OcticonSymbol.tag} />
         </span>
 
-        <span className="tags">{sortedTags.join(', ')}</span>
+        <span className="tags">{tags.join(', ')}</span>
       </li>
     )
   }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -15,6 +15,7 @@ import {
   enableHideWhitespaceInDiffOption,
   enableGitTagsDisplay,
 } from '../../lib/feature-flag'
+import { caseInsensitiveCompare } from '../../lib/compare'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
@@ -395,13 +396,15 @@ export class CommitSummary extends React.Component<
       return null
     }
 
+    const sortedTags = [...tags].sort(caseInsensitiveCompare)
+
     return (
-      <li className="commit-summary-meta-item" title={tags.join('\n')}>
+      <li className="commit-summary-meta-item" title={sortedTags.join('\n')}>
         <span aria-label="Tags">
           <Octicon symbol={OcticonSymbol.tag} />
         </span>
 
-        <span className="tags">{tags.join(', ')}</span>
+        <span className="tags">{sortedTags.join(', ')}</span>
       </li>
     )
   }

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -121,14 +121,11 @@
     list-style: none;
     margin: 0;
     padding: 0 var(--spacing) var(--spacing);
-
-    .checkbox-component {
-      margin-left: auto;
-    }
   }
 
   &-meta-item:not(.without-truncation) {
-    @include ellipsis;
+    flex-shrink: 1;
+    min-width: 0;
   }
 
   &-meta-item {
@@ -137,6 +134,7 @@
     min-width: 0;
     margin-right: var(--spacing);
     font-size: var(--font-size-sm);
+    flex-shrink: 0;
 
     .avatar,
     .octicon {
@@ -147,6 +145,11 @@
 
     .sha {
       user-select: text;
+    }
+
+    .tags {
+      @include ellipsis;
+      flex-shrink: 1;
     }
   }
 


### PR DESCRIPTION
Partially addresses https://github.com/desktop/desktop/issues/9427

## Description

This PR implements a few tweaks to the display of tags on the commit details view:

1. Better wrapping of text when there are a lot of tags (or very long ones).
2. Tags are now sorted alphabetically.
3. Now a tooltip is shown when hovering for a few seconds on the tag list to see the whole list of tags.

### Screenshots

Before:

<img width="950" alt="Screenshot 2020-04-14 at 17 45 24" src="https://user-images.githubusercontent.com/408035/79244966-c0424d00-7e77-11ea-9013-25638009cb0f.png">


After:

<img width="954" alt="Screenshot 2020-04-14 at 17 44 50" src="https://user-images.githubusercontent.com/408035/79244884-b02a6d80-7e77-11ea-8e34-0cc9d4a503c8.png">

(notice that the author name is not wrapped anymore).

## Release notes

Notes: no-notes
