### PR TITLE
Disable undoing commits that have tags associated

### DIFF
--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -309,7 +309,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   private onUndo = () => {
     const commit = this.props.mostRecentLocalCommit
 
-    if (commit) {
+    if (commit && commit.tags.length === 0) {
       this.props.dispatcher.undoCommit(this.props.repository, commit)
     }
   }

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -317,7 +317,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
   private renderMostRecentLocalCommit() {
     const commit = this.props.mostRecentLocalCommit
     let child: JSX.Element | null = null
-    if (commit) {
+
+    // We don't allow undoing commits that have tags associated to them, since then
+    // the commit won't be completely deleted because the tag will still point to it.
+    if (commit && commit.tags.length === 0) {
       child = (
         <UndoCommit
           isPushPullFetchInProgress={this.props.isPushPullFetchInProgress}


### PR DESCRIPTION
Related issue: https://github.com/desktop/desktop/issues/9429

Related discussion: https://github.com/desktop/desktop/pull/9440#pullrequestreview-391100749

## Description

This PR removes the "undo" UI when the most recent local commit has any tags associated to it.

This prevents users from keeping "orphaned tags" pointing to commits that were meant to be deleted, which can cause confusion to users (specially since the deleted commits won't be visible from Desktop but the tag will still exist).

Another option we've considered to solve this is to still allow undoing commits with associated tags, but displaying a message warning the user that any associated tag will get deleted. We've finally decided to just prevent undoing commits with tags since this approach is much simpler to implement and this scenario seems quite rare (we'll reevaluate if we find otherwise in the future).

### Screenshots

N/A

## Release notes

Notes: no-notes
