### PR TITLE
Fix incorrect clone url handling

### DIFF
--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -27,19 +27,19 @@ interface IGitRemoteURL {
 const remoteRegexes: ReadonlyArray<{ protocol: Protocol; regex: RegExp }> = [
   {
     protocol: 'https',
-    regex: new RegExp('^https?://(?:.+@)?(.+)/(.+)/(.+?)(?:/|.git/?)?$'),
+    regex: new RegExp('^https?://(?:.+@)?([^/]+)/([^/]+)/(.+?)(?:/|.git/?)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^git@(.+):(.+)/(.+?)(?:/|.git)?$'),
+    regex: new RegExp('^git@([^/]+):([^/]+)/(.+?)(?:/|.git)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^git:(.+)/(.+)/(.+?)(?:/|.git)?$'),
+    regex: new RegExp('^git:([^/]+)/([^/]+)/(.+?)(?:/|.git)?$'),
   },
   {
     protocol: 'ssh',
-    regex: new RegExp('^ssh://git@(.+)/(.+)/(.+?)(?:/|.git)?$'),
+    regex: new RegExp('^ssh://git@([^/]+)/([^/]+)/(.+?)(?:/|.git)?$'),
   },
 ]
 

--- a/app/src/lib/remote-parsing.ts
+++ b/app/src/lib/remote-parsing.ts
@@ -51,6 +51,11 @@ export function parseRemote(url: string): IGitRemoteURL | null {
       continue
     }
 
+    // We have extra slashes in our path so we need to just take the first one
+    if ((result[3].match(/\//g) || []).length > 0) {
+      result[3] = result[3].split('/')[0]
+    }
+
     const hostname = result[1]
     const owner = result[2]
     const name = result[3]

--- a/app/test/unit/remote-parsing-test.ts
+++ b/app/test/unit/remote-parsing-test.ts
@@ -34,7 +34,7 @@ describe('URL remote parsing', () => {
   })
 
   it('parses HTTPS URLs which are too long', () => {
-    const remote = parseRemote('https//github.com/hubot/repo/extra/path')
+    const remote = parseRemote('https://github.com/hubot/repo/extra/path')
     expect(remote).not.toBeNull()
     expect(remote!.hostname).toBe('github.com')
     expect(remote!.owner).toBe('hubot')

--- a/app/test/unit/remote-parsing-test.ts
+++ b/app/test/unit/remote-parsing-test.ts
@@ -33,6 +33,14 @@ describe('URL remote parsing', () => {
     expect(remote!.name).toBe('repo')
   })
 
+  it('parses HTTPS URLs which are too long', () => {
+    const remote = parseRemote('https//github.com/hubot/repo/extra/path')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo')
+  })
+
   it('parses SSH URLs', () => {
     const remote = parseRemote('git@github.com:hubot/repo.git')
     expect(remote).not.toBeNull()
@@ -51,6 +59,14 @@ describe('URL remote parsing', () => {
 
   it('parses SSH URLs with a trailing slash', () => {
     const remote = parseRemote('git@github.com:hubot/repo/')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo')
+  })
+
+  it('parses SSH URLs which are too long', () => {
+    const remote = parseRemote('git@github.com:hubot/repo/extra/path')
     expect(remote).not.toBeNull()
     expect(remote!.hostname).toBe('github.com')
     expect(remote!.owner).toBe('hubot')
@@ -81,6 +97,14 @@ describe('URL remote parsing', () => {
     expect(remote!.name).toBe('repo')
   })
 
+  it('parses git URLs which are too long', () => {
+    const remote = parseRemote('git:github.com/hubot/repo/extra/path')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo')
+  })
+
   it('parses SSH URLs with the ssh prefix', () => {
     const remote = parseRemote('ssh://git@github.com/hubot/repo')
     expect(remote).not.toBeNull()
@@ -91,6 +115,14 @@ describe('URL remote parsing', () => {
 
   it('parses SSH URLs with the ssh prefix and trailing slash', () => {
     const remote = parseRemote('ssh://git@github.com/hubot/repo/')
+    expect(remote).not.toBeNull()
+    expect(remote!.hostname).toBe('github.com')
+    expect(remote!.owner).toBe('hubot')
+    expect(remote!.name).toBe('repo')
+  })
+
+  it('parses SSH URLs with the ssh prefix and which are too long', () => {
+    const remote = parseRemote('ssh://git@github.com/hubot/repo/extra/path')
     expect(remote).not.toBeNull()
     expect(remote!.hostname).toBe('github.com')
     expect(remote!.owner).toBe('hubot')


### PR DESCRIPTION
Closes #7914

This is a redoing of #7977 (sorry it took so long but I'm back!)

## Description

- When using the clone from URL tab on the clone new repository dialog, if a user put a URL that was to long (extra folders or what not) the parsed URL would try to clone the full URL instead of the actual base repository. 

### Solution

To fix this I changed the regex for parsing repositories to not match the `/` character until in the last expression (I tried to also do this in the last match, but my regex magic isn't good enough so I'm open for help with that). Then when the expression returns it will check the last match and see if it has any `/` characters and if so just take the first string after splitting it as that should be our base repository.

## Release notes

Notes: Fixed bug where the cloning a repository using a URL with extra info at the end of it would result in an authentication error instead of parsing it correctly.
