### PR TITLE
Always return URL of current repository

### DIFF
--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -114,8 +114,7 @@ export function nameOf(repository: Repository) {
 }
 
 /**
- * Get the GitHub html URL for a repository, if it has one.
- * Will return the parent GitHub repository's URL if it has one.
+ * Returns the GitHub html URL for a repository, if it has one.
  * Otherwise, returns null.
  */
 export function getGitHubHtmlUrl(repository: Repository): string | null {
@@ -123,7 +122,7 @@ export function getGitHubHtmlUrl(repository: Repository): string | null {
     return null
   }
 
-  return getNonForkGitHubRepository(repository).htmlURL
+  return repository.gitHubRepository.htmlURL
 }
 
 /**


### PR DESCRIPTION
Regardless if a parent exists (i.e. if the repository is forked)

## Description
This will allow "open on GitHub" to open the repository open in Desktop regardless of the existence of a parent, instead of opening the repo from which it was forked. (that is confusing).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
"Open on GitHub" opens the current repository, not the one from which it was forked.