### PR TITLE
Use the `fetchTagsToPush()` output to display the push/pull information

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,7 +37,7 @@
     "fuzzaldrin-plus": "^0.6.0",
     "keytar": "^5.0.0",
     "mem": "^4.3.0",
-    "memoize-one": "^4.0.3",
+    "memoize-one": "^5.1.1",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
     "mri": "^1.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -37,7 +37,7 @@
     "fuzzaldrin-plus": "^0.6.0",
     "keytar": "^5.0.0",
     "mem": "^4.3.0",
-    "memoize-one": "^5.1.1",
+    "memoize-one": "^4.0.3",
     "moment": "^2.24.0",
     "moment-duration-format": "^2.3.2",
     "mri": "^1.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^7.0.1",
     "fuzzaldrin-plus": "^0.6.0",
     "keytar": "^5.0.0",
+    "lru-cache": "^5.1.1",
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",
     "moment": "^2.24.0",

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -385,6 +385,9 @@ export interface IRepositoryState {
   /** The state of the current branch in relation to its upstream. */
   readonly aheadBehind: IAheadBehind | null
 
+  /** The tags that will get pushed if the user performs a push operation. */
+  readonly tagsToPush: ReadonlyArray<string> | null
+
   /** Is a push/pull/fetch in progress? */
   readonly isPushPullFetchInProgress: boolean
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -421,6 +421,8 @@ export interface IRepositoryState {
    * null if no such operation is in flight.
    */
   readonly revertProgress: IRevertProgress | null
+
+  readonly localTags: Set<string> | null
 }
 
 export interface IBranchesState {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -422,7 +422,7 @@ export interface IRepositoryState {
    */
   readonly revertProgress: IRevertProgress | null
 
-  readonly localTags: Set<string> | null
+  readonly localTags: Map<string, string> | null
 }
 
 export interface IBranchesState {

--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -1,8 +1,9 @@
-import { git, gitNetworkArguments } from './core'
+import { git, gitNetworkArguments, GitError } from './core'
 import { Repository } from '../../models/repository'
 import { IGitAccount } from '../../models/git-account'
 import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
+import { IGitResult } from 'dugite'
 
 /**
  * Create a new tag on the given target commit.
@@ -62,16 +63,28 @@ export async function fetchTagsToPush(
     '--porcelain',
   ]
 
-  const result = await git(args, repository.path, 'fetchTagsToPush', {
-    env: await envForRemoteOperation(account, remote.url),
-  })
+  let result: IGitResult | null = null
 
-  const lines = result.stdout.split('\n')
+  try {
+    result = await git(args, repository.path, 'fetchTagsToPush', {
+      env: await envForRemoteOperation(account, remote.url),
+      successExitCodes: new Set([0, 1]),
+    })
+  } catch (e) {
+    // Even if we receive an unexpected error code, we try to
+    // do the best effort to try to parse the stdout to find unpushed tags.
+    // If we can't even parse the stdout, we return an empty array of unpushed tags.
+    if (e instanceof GitError) {
+      result = e.result
+    }
+  }
+
+  const lines = result ? result.stdout.split('\n') : []
   let currentLine = 1
   const unpushedTags = []
 
   // the last line of this porcelain command is always 'Done'
-  while (lines[currentLine] !== 'Done') {
+  while (currentLine < lines.length && lines[currentLine] !== 'Done') {
     const line = lines[currentLine]
     const parts = line.split('\t')
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -276,6 +276,7 @@ import { parseRemote } from '../../lib/remote-parsing'
 import { createTutorialRepository } from './helpers/create-tutorial-repository'
 import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import { getDefaultDir } from '../../ui/lib/default-dir'
+import { clearTagsToPushCache } from './helpers/fetch-tags-to-push-memoized'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -3734,6 +3735,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    // Clear the cache to make sure that the tags to push information
+    // is refetched after a push/pull.
+    clearTagsToPushCache(this.gitStoreCache.get(repository).currentRemote)
+
     this.repositoryStateCache.update(repository, () => ({
       isPushPullFetchInProgress: true,
     }))
@@ -3741,9 +3746,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     try {
       await fn()
-      await this.gitStoreCache
-        .get(repository)
-        .fetchTagsToPush(account, { forceFetch: true })
     } finally {
       this.repositoryStateCache.update(repository, () => ({
         isPushPullFetchInProgress: false,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3743,7 +3743,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       await fn()
       await this.gitStoreCache
         .get(repository)
-        .fetchTagsToPush(account)
+        .fetchTagsToPush(account, { forceFetch: true })
     } finally {
       this.repositoryStateCache.update(repository, () => ({
         isPushPullFetchInProgress: false,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -832,6 +832,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitLookup: gitStore.commitLookup,
       localCommitSHAs: gitStore.localCommitSHAs,
       aheadBehind: gitStore.aheadBehind,
+      tagsToPush: gitStore.tagsToPush,
       remote: gitStore.currentRemote,
       lastFetched: gitStore.lastFetched,
     }))

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2773,6 +2773,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._initializeCompare(repository)
 
     this.updateCurrentTutorialStep(repository)
+
+    this.withAuthenticatingUser(repository, (_, account) =>
+      gitStore.fetchTagsToPush(account)
+    )
   }
 
   private async updateStashEntryCountMetric(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -832,6 +832,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.update(repository, () => ({
       commitLookup: gitStore.commitLookup,
       localCommitSHAs: gitStore.localCommitSHAs,
+      localTags: gitStore.localTags,
       aheadBehind: gitStore.aheadBehind,
       tagsToPush: gitStore.tagsToPush,
       remote: gitStore.currentRemote,
@@ -2775,6 +2776,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.updateCurrentTutorialStep(repository)
 
+    await gitStore.loadLocalTags()
+
     this.withAuthenticatingUser(repository, (_, account) =>
       gitStore.fetchTagsToPush(account)
     )
@@ -3092,13 +3095,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (this.selectedRepository === repository) {
       this.emitUpdate()
     }
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
-  public _getAllTags(repository: Repository): Promise<ReadonlyArray<string>> {
-    const gitStore = this.gitStoreCache.get(repository)
-
-    return gitStore.getAllTags()
   }
 
   private getLocalBranch(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2714,7 +2714,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _refreshTags(repository: Repository): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 
-    return gitStore.loadLocalTags()
+    return gitStore.refreshTags()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -400,7 +400,7 @@ export class GitStore extends BaseStore {
       this._tagsToPush = null
       return
     }
-    const branchName = this.tip.branch.name
+    const currentBranch = this.tip.branch
 
     const tagsToPush = await this.performFailableOperation(async () => {
       const localTags = await this.getAllTags()
@@ -409,8 +409,9 @@ export class GitStore extends BaseStore {
         this.repository,
         account,
         currentRemote,
-        branchName,
+        currentBranch.name,
         localTags,
+        currentBranch.tip.sha,
         options
       )
     })

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -86,6 +86,7 @@ import { getStashes, getStashedFiles } from '../git/stash'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { PullRequest } from '../../models/pull-request'
 import { fetchTagsToPushMemoized } from './helpers/fetch-tags-to-push-memoized'
+import { shallowEquals } from '../equality'
 
 /** The number of commits to load from history per batch. */
 const CommitBatchSize = 100
@@ -468,9 +469,14 @@ export class GitStore extends BaseStore {
         currentBranch.tip.sha
       )
     )
+
+    const previousTagsToPush = this._tagsToPush
+
     this._tagsToPush = tagsToPush !== undefined ? tagsToPush : null
 
-    this.emitUpdate()
+    if (!shallowEquals(previousTagsToPush, this._tagsToPush)) {
+      this.emitUpdate()
+    }
   }
 
   /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -385,10 +385,7 @@ export class GitStore extends BaseStore {
         .shift() || null
   }
 
-  public async fetchTagsToPush(
-    account: IGitAccount | null,
-    options: { forceFetch: boolean } = { forceFetch: false }
-  ) {
+  public async fetchTagsToPush(account: IGitAccount | null) {
     const currentRemote = this._currentRemote
 
     if (currentRemote === null) {
@@ -411,8 +408,7 @@ export class GitStore extends BaseStore {
         currentRemote,
         currentBranch.name,
         localTags,
-        currentBranch.tip.sha,
-        options
+        currentBranch.tip.sha
       )
     })
     this._tagsToPush = tagsToPush !== undefined ? tagsToPush : null

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -114,7 +114,7 @@ export class GitStore extends BaseStore {
 
   private _defaultBranch: Branch | null = null
 
-  private _localTags: Set<string> | null = null
+  private _localTags: Map<string, string> | null = null
 
   private _allBranches: ReadonlyArray<Branch> = []
 
@@ -265,7 +265,7 @@ export class GitStore extends BaseStore {
   }
 
   public async refreshTags() {
-    this._localTags = new Set(await getAllTags(this.repository))
+    this._localTags = await getAllTags(this.repository)
 
     this.emitUpdate()
   }
@@ -298,7 +298,7 @@ export class GitStore extends BaseStore {
     return this._tagsToPush
   }
 
-  public get localTags(): Set<string> | null {
+  public get localTags(): Map<string, string> | null {
     return this._localTags
   }
 
@@ -420,7 +420,7 @@ export class GitStore extends BaseStore {
         account,
         currentRemote,
         currentBranch.name,
-        Array.from(localTags),
+        localTags,
         currentBranch.tip.sha
       )
     )

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -266,7 +266,11 @@ export class GitStore extends BaseStore {
     return getAllTags(this.repository)
   }
 
-  public async createTag(name: string, targetCommitSha: string) {
+  public async createTag(
+    account: IGitAccount | null,
+    name: string,
+    targetCommitSha: string
+  ) {
     const foundCommit = await this.performFailableOperation(async () => {
       await createTag(this.repository, name, targetCommitSha)
 
@@ -276,6 +280,8 @@ export class GitStore extends BaseStore {
     if (foundCommit instanceof Commit) {
       this.storeCommits([foundCommit], true)
     }
+
+    this.fetchTagsToPush(account)
   }
 
   /** The list of ordered SHAs. */

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -65,7 +65,6 @@ import {
   removeRemote,
   createTag,
   getAllTags,
-  fetchTagsToPush,
 } from '../git'
 import { GitError as DugiteError } from '../../lib/git'
 import { GitError } from 'dugite'
@@ -404,24 +403,16 @@ export class GitStore extends BaseStore {
     const branchName = this.tip.branch.name
 
     const tagsToPush = await this.performFailableOperation(async () => {
-      if (options.forceFetch) {
-        return fetchTagsToPush(
-          this.repository,
-          account,
-          currentRemote,
-          branchName
-        )
-      } else {
-        const localTags = await this.getAllTags()
+      const localTags = await this.getAllTags()
 
-        return fetchTagsToPushMemoized(
-          localTags,
-          this.repository,
-          account,
-          currentRemote,
-          branchName
-        )
-      }
+      return fetchTagsToPushMemoized(
+        this.repository,
+        account,
+        currentRemote,
+        branchName,
+        localTags,
+        options
+      )
     })
     this._tagsToPush = tagsToPush !== undefined ? tagsToPush : null
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -264,7 +264,7 @@ export class GitStore extends BaseStore {
     return commits.map(c => c.sha)
   }
 
-  public async loadLocalTags() {
+  public async refreshTags() {
     this._localTags = new Set(await getAllTags(this.repository))
 
     this.emitUpdate()
@@ -285,7 +285,7 @@ export class GitStore extends BaseStore {
       this.storeCommits([foundCommit], true)
     }
 
-    await this.loadLocalTags()
+    await this.refreshTags()
     this.fetchTagsToPush(account)
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -919,10 +919,7 @@ export class GitStore extends BaseStore {
       repository: this.repository,
     }
     await this.performFailableOperation(
-      async () => {
-        await fetchRepo(this.repository, account, remote, progressCallback)
-        await this.fetchTagsToPush(account)
-      },
+      () => fetchRepo(this.repository, account, remote, progressCallback),
       { backgroundTask, retryAction }
     )
   }

--- a/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
+++ b/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
@@ -1,0 +1,60 @@
+import memoizeOne from 'memoize-one'
+import { fetchTagsToPush } from '../../git'
+
+type FetchTagsArguments = Parameters<typeof fetchTagsToPush>
+type MemoizedFetchTagsArguments = Parameters<typeof fetchTagsToMemoize>
+
+/**
+ * Memoized version of the fetchTagsToPush git method.
+ *
+ * This method will return a cached result of the tags array when called multiple
+ * times with the same arguments, this is done to avoid doing too many network
+ * requests.
+ *
+ * @param repository  - The repository in which to check for unpushed tags
+ * @param account     - The account to use when authenticating with the remote
+ * @param remote      - The remote to check for unpushed tags
+ * @param branchName  - The branch that will be used on the push command
+ * @param localTags   - The current list of local tags. This is only used for memoization purposes
+ */
+export const fetchTagsToPushMemoized = memoizeOne(
+  fetchTagsToMemoize,
+  (newArgs, lastArgs) =>
+    serializeArguments(newArgs as MemoizedFetchTagsArguments) ===
+    serializeArguments(lastArgs as MemoizedFetchTagsArguments)
+)
+
+/**
+ * Temporary function to use on the memoization to make typescript happy.
+ *
+ * @param _localTags - The current list of local tags. This is only used for memoization.
+ * @param fetchTagsArguments - The original arguments of the fetchTagsToPush() method.
+ */
+function fetchTagsToMemoize(
+  _localTags: ReadonlyArray<string>, // only used for cache invalidation.
+  ...fetchTagsArguments: FetchTagsArguments
+) {
+  return fetchTagsToPush(...fetchTagsArguments)
+}
+
+/**
+ * Helper that creates a serializable value for the memoization
+ * based on the function arguments.
+ *
+ * @param arguments  - Array with the arguments that are used for memoization.
+ */
+function serializeArguments([
+  localTags,
+  repository,
+  account,
+  remote,
+  branchName,
+]: MemoizedFetchTagsArguments) {
+  return JSON.stringify([
+    repository.hash,
+    account ? [account.endpoint, account.login] : null,
+    remote.url,
+    branchName,
+    localTags,
+  ])
+}

--- a/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
+++ b/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
@@ -25,7 +25,7 @@ export const fetchTagsToPushMemoized = memoizeOne(fetchTagsToMemoize, ((
 ) => {
   // When forceFetch is true, we consider the arguments different to
   // force a call to the original method.
-  if (newArgs[5].forceFetch) {
+  if (newArgs[6].forceFetch) {
     return false
   }
 
@@ -48,6 +48,7 @@ function fetchTagsToMemoize(
   remote: IRemote,
   branchName: string,
   _localTags: ReadonlyArray<string>, // only used for cache invalidation.
+  _currentTipSha: string, // only used for cache invalidation.
   _options: { forceFetch: boolean } // only used for cache invalidation.
 ) {
   return fetchTagsToPush(repository, account, remote, branchName)
@@ -65,6 +66,7 @@ function serializeArguments([
   remote,
   branchName,
   localTags,
+  currentTipSha,
 ]: MemoizedFetchTagsArguments) {
   return JSON.stringify([
     repository.hash,
@@ -72,5 +74,6 @@ function serializeArguments([
     remote.url,
     branchName,
     localTags,
+    currentTipSha,
   ])
 }

--- a/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
+++ b/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
@@ -3,24 +3,21 @@ import { Repository } from '../../../models/repository'
 import { IGitAccount } from '../../../models/git-account'
 import { IRemote } from '../../../models/remote'
 
-type MemoizedFetchTagsArguments = Parameters<typeof fetchTagsToPushMemoized>
-
-const cachedTagsToPush = new Map<string, ReadonlyArray<string>>()
+const cache = new Map<string, Map<string, ReadonlyArray<string>>>()
 
 /**
  * Memoized version of the fetchTagsToPush git method.
  *
  * This method will return a cached result of the tags array when called multiple
- * times with the same arguments, this is done to avoid doing too many network
+ * times with the same arguments. This is done to avoid doing too many network
  * requests.
  *
  * @param repository  - The repository in which to check for unpushed tags
  * @param account     - The account to use when authenticating with the remote
  * @param remote      - The remote to check for unpushed tags
  * @param branchName  - The branch that will be used on the push command
- * @param localTags   - The current list of local tags. This is only used for memoization purposes
+ * @param localTags   - The current list of local tags. This is only used for memoization
  * @param currentTipSha - The sha of the current HEAD commit. This is only used for memoization
- * @param options       - Pass {forceFetch: true} to disable the memoization
  */
 export async function fetchTagsToPushMemoized(
   repository: Repository,
@@ -28,42 +25,53 @@ export async function fetchTagsToPushMemoized(
   remote: IRemote,
   branchName: string,
   localTags: ReadonlyArray<string>,
-  currentTipSha: string,
-  options: { forceFetch: boolean }
+  currentTipSha: string
 ) {
-  const key = serializeArguments([
-    repository,
-    account,
-    remote,
-    branchName,
-    localTags,
-    currentTipSha,
-    options,
-  ])
+  const key = serializeArguments(branchName, localTags, currentTipSha)
 
-  let result = cachedTagsToPush.get(key)
+  let cachedTagsToPush = cache.get(remote.name)
+  let result = cachedTagsToPush && cachedTagsToPush.get(key)
 
-  if (options.forceFetch || !result) {
+  if (result === undefined) {
     result = await fetchTagsToPush(repository, account, remote, branchName)
+
+    // Store the returned result in the cache.
+    cachedTagsToPush = cachedTagsToPush || new Map()
     cachedTagsToPush.set(key, result)
+    cache.set(remote.name, cachedTagsToPush)
   }
 
   return result
 }
 
 /**
+ * Clear the cache for the passed remote.
+ *
+ * @param remote Remote repository object.
+ */
+export function clearTagsToPushCache(remote: IRemote | null) {
+  if (remote === null) {
+    return
+  }
+
+  const remoteCache = cache.get(remote.name)
+  if (remoteCache) {
+    remoteCache.clear()
+  }
+}
+
+/**
  * Helper that creates a serializable value for the memoization
  * based on the function arguments.
  *
- * @param arguments  - Array with the arguments that are used for memoization.
+ * @param branchName  - The branch that will be used on the push command
+ * @param localTags   - The current list of local tags
+ * @param currentTipSha - The sha of the current HEAD commit
  */
-function serializeArguments([
-  _repository, // the local repository doesn't alter the output of fetchTags()
-  _account, // the used account doesn't alter the output of fetchTags()
-  remote,
-  branchName,
-  localTags,
-  currentTipSha,
-]: MemoizedFetchTagsArguments) {
-  return JSON.stringify([remote.url, branchName, localTags, currentTipSha])
+function serializeArguments(
+  branchName: string,
+  localTags: ReadonlyArray<string>,
+  currentTipSha: string
+) {
+  return JSON.stringify([branchName, localTags, currentTipSha])
 }

--- a/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
+++ b/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
@@ -62,19 +62,12 @@ function fetchTagsToMemoize(
  * @param arguments  - Array with the arguments that are used for memoization.
  */
 function serializeArguments([
-  repository,
-  account,
+  _repository, // the local repository doesn't alter the output of fetchTags()
+  _account, // the used account doesn't alter the output of fetchTags()
   remote,
   branchName,
   localTags,
   currentTipSha,
 ]: MemoizedFetchTagsArguments) {
-  return JSON.stringify([
-    repository.hash,
-    account ? [account.endpoint, account.login] : null,
-    remote.url,
-    branchName,
-    localTags,
-    currentTipSha,
-  ])
+  return JSON.stringify([remote.url, branchName, localTags, currentTipSha])
 }

--- a/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
+++ b/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
@@ -35,12 +35,13 @@ export const fetchTagsToPushMemoized = memoizeOne(fetchTagsToMemoize, ((
 /**
  * Temporary function to use on the memoization to make typescript happy.
  *
- * @param repository  - The repository in which to check for unpushed tags
- * @param account     - The account to use when authenticating with the remote
- * @param remote      - The remote to check for unpushed tags
- * @param branchName  - The branch that will be used on the push command
- * @param _localTags  - The current list of local tags. This is only used for memoization.
- * @param _options    - Pass {forceFetch: true} to disable the memoization.
+ * @param repository     - The repository in which to check for unpushed tags
+ * @param account        - The account to use when authenticating with the remote
+ * @param remote         - The remote to check for unpushed tags
+ * @param branchName     - The branch that will be used on the push command
+ * @param _localTags     - The current list of local tags. This is only used for memoization.
+ * @param _currentTipSha - The sha of the current HEAD commit. This is only used for memoization.
+ * @param _options       - Pass {forceFetch: true} to disable the memoization.
  */
 function fetchTagsToMemoize(
   repository: Repository,

--- a/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
+++ b/app/src/lib/stores/helpers/fetch-tags-to-push-memoized.ts
@@ -24,7 +24,7 @@ export async function fetchTagsToPushMemoized(
   account: IGitAccount | null,
   remote: IRemote,
   branchName: string,
-  localTags: ReadonlyArray<string>,
+  localTags: Map<string, string>,
   currentTipSha: string
 ) {
   const key = serializeArguments(branchName, localTags, currentTipSha)
@@ -70,8 +70,8 @@ export function clearTagsToPushCache(remote: IRemote | null) {
  */
 function serializeArguments(
   branchName: string,
-  localTags: ReadonlyArray<string>,
+  localTags: Map<string, string>,
   currentTipSha: string
 ) {
-  return JSON.stringify([branchName, localTags, currentTipSha])
+  return JSON.stringify([branchName, Array.from(localTags), currentTipSha])
 }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -177,6 +177,7 @@ function getInitialRepositoryState(): IRepositoryState {
     gitHubUsers: new Map<string, IGitHubUser>(),
     commitLookup: new Map<string, Commit>(),
     localCommitSHAs: [],
+    tagsToPush: null,
     aheadBehind: null,
     remote: null,
     isPushPullFetchInProgress: false,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -177,6 +177,7 @@ function getInitialRepositoryState(): IRepositoryState {
     gitHubUsers: new Map<string, IGitHubUser>(),
     commitLookup: new Map<string, Commit>(),
     localCommitSHAs: [],
+    localTags: new Set(),
     tagsToPush: null,
     aheadBehind: null,
     remote: null,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -177,7 +177,7 @@ function getInitialRepositoryState(): IRepositoryState {
     gitHubUsers: new Map<string, IGitHubUser>(),
     commitLookup: new Map<string, Commit>(),
     localCommitSHAs: [],
-    localTags: new Set(),
+    localTags: null,
     tagsToPush: null,
     aheadBehind: null,
     remote: null,

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -232,4 +232,5 @@ export type Popup =
       repository: Repository
       targetCommitSha: string
       initialName?: string
+      localTags: Set<string> | null
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -232,5 +232,5 @@ export type Popup =
       repository: Repository
       targetCommitSha: string
       initialName?: string
-      localTags: Set<string> | null
+      localTags: Map<string, string> | null
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2308,6 +2308,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         dispatcher={this.props.dispatcher}
         repository={selection.repository}
         aheadBehind={state.aheadBehind}
+        numTagsToPush={state.tagsToPush !== null ? state.tagsToPush.length : 0}
         remoteName={remoteName}
         lastFetched={state.lastFetched}
         networkActionInProgress={state.isPushPullFetchInProgress}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1947,6 +1947,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             targetCommitSha={popup.targetCommitSha}
             initialName={popup.initialName}
+            localTags={popup.localTags}
           />
         )
       }

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -607,7 +607,7 @@ export class NoChanges extends React.Component<
     }
 
     const description = `You have ${itemsToPushDescriptions.join(
-      ' and '
+      ' with '
     )} waiting to be pushed to ${isGitHub ? 'GitHub' : 'the remote'}.`
 
     const discoverabilityContent = (

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -319,7 +319,12 @@ export class NoChanges extends React.Component<
     this.props.dispatcher.recordSuggestedStepOpenInExternalEditor()
 
   private renderRemoteAction() {
-    const { remote, aheadBehind, branchesState } = this.props.repositoryState
+    const {
+      remote,
+      aheadBehind,
+      branchesState,
+      tagsToPush,
+    } = this.props.repositoryState
     const { tip, defaultBranch, currentPullRequest } = branchesState
 
     if (tip.kind !== TipState.Valid) {
@@ -347,8 +352,11 @@ export class NoChanges extends React.Component<
       return this.renderPullBranchAction(tip, remote, aheadBehind)
     }
 
-    if (aheadBehind.ahead > 0) {
-      return this.renderPushBranchAction(tip, remote, aheadBehind)
+    if (
+      aheadBehind.ahead > 0 ||
+      (tagsToPush !== null && tagsToPush.length > 0)
+    ) {
+      return this.renderPushBranchAction(tip, remote, aheadBehind, tagsToPush)
     }
 
     if (enableNoChangesCreatePRBlankslateAction()) {
@@ -566,7 +574,8 @@ export class NoChanges extends React.Component<
   private renderPushBranchAction(
     tip: IValidBranch,
     remote: IRemote,
-    aheadBehind: IAheadBehind
+    aheadBehind: IAheadBehind,
+    tagsToPush: ReadonlyArray<string> | null
   ) {
     const itemId: MenuIDs = 'push'
     const menuItem = this.getMenuItemInfo(itemId)
@@ -578,13 +587,28 @@ export class NoChanges extends React.Component<
 
     const isGitHub = this.props.repository.gitHubRepository !== null
 
-    const description = (
-      <>
-        You have{' '}
-        {aheadBehind.ahead === 1 ? 'one local commit' : 'local commits'} waiting
-        to be pushed to {isGitHub ? 'GitHub' : 'the remote'}.
-      </>
-    )
+    const itemsToPushTypes = []
+    const itemsToPushDescriptions = []
+
+    if (aheadBehind.ahead > 0) {
+      itemsToPushTypes.push('commits')
+      itemsToPushDescriptions.push(
+        aheadBehind.ahead === 1
+          ? '1 local commit'
+          : `${aheadBehind.ahead} local commits`
+      )
+    }
+
+    if (tagsToPush !== null && tagsToPush.length > 0) {
+      itemsToPushTypes.push('tags')
+      itemsToPushDescriptions.push(
+        tagsToPush.length === 1 ? '1 tag' : `${tagsToPush.length} tags`
+      )
+    }
+
+    const description = `You have ${itemsToPushDescriptions.join(
+      ' and '
+    )} waiting to be pushed to ${isGitHub ? 'GitHub' : 'the remote'}.`
 
     const discoverabilityContent = (
       <>
@@ -593,9 +617,9 @@ export class NoChanges extends React.Component<
       </>
     )
 
-    const title = `Push ${aheadBehind.ahead} ${
-      aheadBehind.ahead === 1 ? 'commit' : 'commits'
-    } to the ${remote.name} remote`
+    const title = `Push ${itemsToPushTypes.join(' and ')} to the ${
+      remote.name
+    } remote`
 
     const buttonText = `Push ${remote.name}`
 

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -607,7 +607,7 @@ export class NoChanges extends React.Component<
     }
 
     const description = `You have ${itemsToPushDescriptions.join(
-      ' with '
+      ' and '
     )} waiting to be pushed to ${isGitHub ? 'GitHub' : 'the remote'}.`
 
     const discoverabilityContent = (

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -18,6 +18,7 @@ interface ICreateTagProps {
   readonly onDismissed: () => void
   readonly targetCommitSha: string
   readonly initialName?: string
+  readonly localTags: Set<string> | null
 }
 
 interface ICreateTagState {
@@ -31,8 +32,6 @@ interface ICreateTagState {
    * shown in its place.
    */
   readonly isCreatingTag: boolean
-
-  readonly localTags: Set<string>
 }
 
 const MaxTagNameLength = 245
@@ -51,22 +50,7 @@ export class CreateTag extends React.Component<
       proposedName,
       sanitizedName: sanitizedRefName(proposedName),
       isCreatingTag: false,
-      localTags: new Set(),
     }
-  }
-
-  public async componentDidMount() {
-    // Get the existing tags so we can warn the user that the chosen tag already
-    // exists before submitting.
-    // Since this is just an UX improvement, we don't need to block the rendering
-    // of the dialog (or show any loader) while we get the tags.
-    const localTags = await this.props.dispatcher.getAllTags(
-      this.props.repository
-    )
-
-    this.setState({
-      localTags: new Set(localTags),
-    })
   }
 
   public render() {
@@ -139,7 +123,8 @@ export class CreateTag extends React.Component<
       return <>Invalid tag name.</>
     }
 
-    const alreadyExists = this.state.localTags.has(sanitizedName)
+    const alreadyExists =
+      this.props.localTags && this.props.localTags.has(sanitizedName)
     if (alreadyExists) {
       return (
         <>

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -18,7 +18,7 @@ interface ICreateTagProps {
   readonly onDismissed: () => void
   readonly targetCommitSha: string
   readonly initialName?: string
-  readonly localTags: Set<string> | null
+  readonly localTags: Map<string, string> | null
 }
 
 interface ICreateTagState {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -500,18 +500,12 @@ export class Dispatcher {
   }
 
   /**
-   * Create a new tag on the given target commit.
-   */
-  public getAllTags(repository: Repository): Promise<ReadonlyArray<string>> {
-    return this.appStore._getAllTags(repository)
-  }
-
-  /**
    * Show the tag creation dialog.
    */
   public showCreateTagDialog(
     repository: Repository,
     targetCommitSha: string,
+    localTags: Set<string> | null,
     initialName?: string
   ): Promise<void> {
     return this.showPopup({
@@ -519,6 +513,7 @@ export class Dispatcher {
       repository,
       targetCommitSha,
       initialName,
+      localTags,
     })
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -512,7 +512,7 @@ export class Dispatcher {
   public showCreateTagDialog(
     repository: Repository,
     targetCommitSha: string,
-    localTags: Set<string> | null,
+    localTags: Map<string, string> | null,
     initialName?: string
   ): Promise<void> {
     return this.showPopup({

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -328,6 +328,13 @@ export class Dispatcher {
     return this.appStore._refreshOrRecoverRepository(repository)
   }
 
+  /**
+   * Refreshes the list of local tags. This would be used, e.g., when the app gains focus.
+   */
+  public refreshTags(repository: Repository): Promise<void> {
+    return this.appStore._refreshTags(repository)
+  }
+
   /** Show the popup. This will close any current popup. */
   public showPopup(popup: Popup): Promise<void> {
     return this.appStore._showPopup(popup)

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -48,6 +48,7 @@ interface ICompareSidebarProps {
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
   readonly compareListScrollTop?: number
+  readonly localTags: Set<string> | null
 }
 
 interface ICompareSidebarState {
@@ -594,7 +595,8 @@ export class CompareSidebar extends React.Component<
   private onCreateTag = (targetCommitSha: string) => {
     this.props.dispatcher.showCreateTagDialog(
       this.props.repository,
-      targetCommitSha
+      targetCommitSha,
+      this.props.localTags
     )
   }
 }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -48,7 +48,7 @@ interface ICompareSidebarProps {
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
   readonly compareListScrollTop?: number
-  readonly localTags: Set<string> | null
+  readonly localTags: Map<string, string> | null
 }
 
 interface ICompareSidebarState {

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -296,7 +296,7 @@ document.body.classList.add(`platform-${process.platform}`)
 
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
-ipcRenderer.on('focus', () => {
+ipcRenderer.on('focus', async () => {
   const { selectedState } = appStore.getState()
 
   // Refresh the currently selected repository on focus (if
@@ -305,7 +305,8 @@ ipcRenderer.on('focus', () => {
     selectedState &&
     !(selectedState.type === SelectionType.CloningRepository)
   ) {
-    dispatcher.refreshRepository(selectedState.repository)
+    await dispatcher.refreshTags(selectedState.repository)
+    await dispatcher.refreshRepository(selectedState.repository)
   }
 
   dispatcher.setAppFocusState(true)

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -221,6 +221,7 @@ export class RepositoryView extends React.Component<
         emoji={this.props.emoji}
         commitLookup={this.props.state.commitLookup}
         localCommitSHAs={this.props.state.localCommitSHAs}
+        localTags={this.props.state.localTags}
         dispatcher={this.props.dispatcher}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}

--- a/app/src/ui/toolbar/push-pull-button.tsx
+++ b/app/src/ui/toolbar/push-pull-button.tsx
@@ -56,19 +56,24 @@ interface IPushPullButtonProps {
 
   /** Whether this component should show its onboarding tutorial nudge arrow */
   readonly shouldNudge: boolean
+
+  /**
+   * The number of tags that would get pushed if the user performed a push.
+   */
+  readonly numTagsToPush: number
 }
 
-function renderAheadBehind(aheadBehind: IAheadBehind) {
+function renderAheadBehind(aheadBehind: IAheadBehind, numTagsToPush: number) {
   const { ahead, behind } = aheadBehind
-  if (ahead === 0 && behind === 0) {
+  if (ahead === 0 && behind === 0 && numTagsToPush === 0) {
     return null
   }
 
   const content = new Array<JSX.Element>()
-  if (ahead > 0) {
+  if (ahead > 0 || numTagsToPush > 0) {
     content.push(
       <span key="ahead">
-        {ahead}
+        {ahead + numTagsToPush}
         <Octicon symbol={OcticonSymbol.arrowSmallUp} />
       </span>
     )
@@ -189,6 +194,7 @@ function publishBranchButton(
 function fetchButton(
   remoteName: string,
   aheadBehind: IAheadBehind,
+  numTagsToPush: number,
   lastFetched: Date | null,
   onClick: () => void
 ) {
@@ -201,7 +207,7 @@ function fetchButton(
       icon={OcticonSymbol.sync}
       onClick={onClick}
     >
-      {renderAheadBehind(aheadBehind)}
+      {renderAheadBehind(aheadBehind, numTagsToPush)}
     </ToolbarButton>
   )
 }
@@ -209,6 +215,7 @@ function fetchButton(
 function pullButton(
   remoteName: string,
   aheadBehind: IAheadBehind,
+  numTagsToPush: number,
   lastFetched: Date | null,
   pullWithRebase: boolean,
   onClick: () => void
@@ -225,7 +232,7 @@ function pullButton(
       icon={OcticonSymbol.arrowDown}
       onClick={onClick}
     >
-      {renderAheadBehind(aheadBehind)}
+      {renderAheadBehind(aheadBehind, numTagsToPush)}
     </ToolbarButton>
   )
 }
@@ -233,6 +240,7 @@ function pullButton(
 function pushButton(
   remoteName: string,
   aheadBehind: IAheadBehind,
+  numTagsToPush: number,
   lastFetched: Date | null,
   onClick: () => void
 ) {
@@ -244,7 +252,7 @@ function pushButton(
       icon={OcticonSymbol.arrowUp}
       onClick={onClick}
     >
-      {renderAheadBehind(aheadBehind)}
+      {renderAheadBehind(aheadBehind, numTagsToPush)}
     </ToolbarButton>
   )
 }
@@ -262,6 +270,7 @@ const forcePushIcon = new OcticonSymbol(
 function forcePushButton(
   remoteName: string,
   aheadBehind: IAheadBehind,
+  numTagsToPush: number,
   lastFetched: Date | null,
   onClick: () => void
 ) {
@@ -273,7 +282,7 @@ function forcePushButton(
       icon={forcePushIcon}
       onClick={onClick}
     >
-      {renderAheadBehind(aheadBehind)}
+      {renderAheadBehind(aheadBehind, numTagsToPush)}
     </ToolbarButton>
   )
 }
@@ -307,6 +316,7 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
       progress,
       networkActionInProgress,
       aheadBehind,
+      numTagsToPush,
       remoteName,
       repository,
       tipState,
@@ -343,14 +353,21 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
 
     const { ahead, behind } = aheadBehind
 
-    if (ahead === 0 && behind === 0) {
-      return fetchButton(remoteName, aheadBehind, lastFetched, this.fetch)
+    if (ahead === 0 && behind === 0 && numTagsToPush === 0) {
+      return fetchButton(
+        remoteName,
+        aheadBehind,
+        numTagsToPush,
+        lastFetched,
+        this.fetch
+      )
     }
 
     if (isForcePush) {
       return forcePushButton(
         remoteName,
         aheadBehind,
+        numTagsToPush,
         lastFetched,
         this.forcePushWithLease
       )
@@ -360,12 +377,19 @@ export class PushPullButton extends React.Component<IPushPullButtonProps, {}> {
       return pullButton(
         remoteName,
         aheadBehind,
+        numTagsToPush,
         lastFetched,
         pullWithRebase || false,
         this.pull
       )
     }
 
-    return pushButton(remoteName, aheadBehind, lastFetched, this.push)
+    return pushButton(
+      remoteName,
+      aheadBehind,
+      numTagsToPush,
+      lastFetched,
+      this.push
+    )
   }
 }

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -150,5 +150,23 @@ describe('git/tag', () => {
         await fetchTagsToPush(repository, account, originRemote, 'master')
       ).toEqual([])
     })
+
+    it('returns unpushed tags even if it fails to push the branch', async () => {
+      // Create a new commit on the remote repository so the `git push` command
+      // that fetchUnpushedTags() does fails.
+      await FSE.writeFile(
+        path.join(remoteRepository.path, 'README.md'),
+        'Hi world\n'
+      )
+      const status = await getStatusOrThrow(remoteRepository)
+      const files = status.workingDirectory.files
+      await createCommit(remoteRepository, 'a commit', files)
+
+      await createTag(repository, 'my-new-tag', 'HEAD')
+
+      expect(
+        await fetchTagsToPush(repository, account, originRemote, 'master')
+      ).toEqual(['my-new-tag'])
+    })
   })
 })

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -83,17 +83,17 @@ describe('git/tag', () => {
 
   describe('getAllTags', () => {
     it('returns an empty array when the repository has no tags', async () => {
-      expect(await getAllTags(repository)).toEqual([])
+      expect(await getAllTags(repository)).toEqual(new Map())
     })
 
     it('returns all the created tags', async () => {
-      await createTag(repository, 'my-new-tag', 'HEAD')
-      await createTag(repository, 'another-tag', 'HEAD')
+      const commit = await getCommit(repository, 'HEAD')
+      await createTag(repository, 'my-new-tag', commit!.sha)
+      await createTag(repository, 'another-tag', commit!.sha)
 
-      expect(await getAllTags(repository)).toIncludeAllMembers([
-        'my-new-tag',
-        'another-tag',
-      ])
+      expect(await getAllTags(repository)).toEqual(
+        new Map([['my-new-tag', commit!.sha], ['another-tag', commit!.sha]])
+      )
     })
   })
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -796,10 +796,10 @@ mem@^4.3.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.3.tgz#cdfdd942853f1a1b4c71c5336b8c49da0bf0273c"
-  integrity sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==
+memoize-one@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 mimic-fn@^2.0.0:
   version "2.1.0"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -796,10 +796,10 @@ mem@^4.3.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
-  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+memoize-one@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.3.tgz#cdfdd942853f1a1b4c71c5336b8c49da0bf0273c"
+  integrity sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==
 
 mimic-fn@^2.0.0:
   version "2.1.0"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -775,6 +775,13 @@ lru-cache@^4.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@primer/octicons": "^9.1.0",
+    "@types/lru-cache": "^5.1.0",
     "@typescript-eslint/eslint-plugin": "1.10.2",
     "@typescript-eslint/parser": "1.10.2",
     "airbnb-browser-shims": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,6 +424,11 @@
   resolved "https://registry.yarnpkg.com/@types/loglevel/-/loglevel-1.5.3.tgz#adfce55383edc5998a2170ad581b3e23d6adb5b8"
   integrity sha512-TzzIZihV+y9kxSg5xJMkyIkaoGkXi50isZTtGHObNHRqAAwjGNjSCNPI7AUAv0tZUKTq9f2cdkCUd/2JVZUTrA==
 
+"@types/lru-cache@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
+
 "@types/memoize-one@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/memoize-one/-/memoize-one-3.1.1.tgz#0e21a1b91dc031fb59c1e1657b807ca9aec77475"


### PR DESCRIPTION
Partially addresses #9435

This branch is based on #9492

## Description

This PR plugs the `fetchTagsToPush()` method introduced in #9492 with the application state logic and the UI to change two components based on wether there are tags pending to be pushed:

1. The push/pull button on the toolbar.
   <img width="248" alt="Screenshot 2020-04-17 at 22 29 20" src="https://user-images.githubusercontent.com/408035/79728005-8943bf80-82ed-11ea-8650-cea05d9127b4.png">
2. The prompt to push displayed on the no changes view.
   <img width="592" alt="Screenshot 2020-04-17 at 22 30 02" src="https://user-images.githubusercontent.com/408035/79728045-982a7200-82ed-11ea-8283-91291b65595b.png">

### Changes in the push/pull button

- Now the button will show the "Push" action when there are tags to be pushed (even if there are no commits to be pushed).
- The number that appears next to the up arrow is meant to show the number of items to push (where a new commit with a new tag is counted as one). This means that:
  - When there are commits + tags to be pushed, it'll be the number of commits + tags.
  - When there are only commits to be pushed, i't will be the number of commits.
  - When there are only tags to be pushed, it'll be the number of tags.
- No other changes are done to this component.

### Changes in the prompt to push changes

- Now the prompt to push is going to be shown when there are tags to be pushed (even if there are no commits to be pushed).
- The title/description of the prompt changes depending on whether there are tags or/and commits to be pushed:
  - Only commits:
    <img width="607" alt="Screenshot 2020-04-20 at 10 18 33" src="https://user-images.githubusercontent.com/408035/79729873-53eca100-82f0-11ea-917f-7b5bfe437a58.png">
  - Only tags:
    <img width="609" alt="Screenshot 2020-04-20 at 10 15 37" src="https://user-images.githubusercontent.com/408035/79729546-e93b6580-82ef-11ea-872b-cf8554ef0cbc.png">
  - Commits and tags:
    <img width="611" alt="Screenshot 2020-04-20 at 10 17 28" src="https://user-images.githubusercontent.com/408035/79890871-68b85a00-8400-11ea-852e-182dc5b84cf8.png">

## Technical considerations

There are two important factors that have driven to the current implementation:

1. The `fetchTagsToPush()` method needs to perform a network request, which makes it much slower than any other local git operation.
2. `fetchTagsToPush()` can return different values when any of these values change:
   - Remote repository to push (in the case the repository has multiple remotes).
   - Currently checked out branch (if the checked out branch changes, `--follow-tags` may push unpushed tags from the newly checked out branch).
   - Ancestor commits of the current branch (if another branch with unpushed tags is merged into the current branch).
   - Existing local tags.
   - Existing remote tags (a tag previously marked as unpushed can get pushed from the terminal).

In order to keep the UI updated when any of the previous values change, we try to fetch the remote tags every time that `dispatcher.refreshRepository()` is called. Additionally, we also call it after a new tag is created via the Desktop UI.

`dispatcher.refreshRepository()` is called very often (when most of the repository state attributes change), which on one side it solves our problem of keeping the UI updated but on the other side causes too many calls to `fetchTagsToPush()` which will cause network requests.

#### Caching to the resque

In order to minimize the number of network requests, we've introduced a memoization layer that takes care of only calling the real `fetchTagsToPush()` method only when one of the values that can alter its output changes.

The values are the following:

- remote repository.
- checked out branch name.
- existing local tags.
- SHA of the HEAD commit of the current branch.

#### When we do bypass cache?

With this caching system we make sure that any meaningful change in the local repository will cause an invalidation of the cache . Unfortunately, we don't have any way to control the changes that happen in the remote repository and invalidate the cache in these scenarios.

To fix this, there's a method to clear the cache for a specific remote repository. This is used to force network requests after the user fetches, pulls or pushes from the remote repository. This way we solve the potential case where tags are created (or removed) from the remote without Desktop knowing (Desktop will get updated after the user syncs with the remote).

## Known limitations

Due to the way that pushing/fetching tags is implemented in `git`, when a tag gets either deleted or modified in the remote repository, weird things can happen:

1. If a tag gets deleted from the remote repository, Desktop won't know whether thee tag missing from the remote has been deleted or is a local unpushed tag. Because of this, Desktop will push again the tag to the remote next time the user pushes their changes.
2. In a similar fashion, if a tag gets modified in the remote repository (it gets deleted and recreated pointing to a different commit), Desktop won't update the local tag when fetching changes. Instead it'll keep the local tag pointing to the old commit. Interestingly, when pushing Desktop won't give any error (`git push --follow-tags` ignore conflicting tags in this scenario).

Note that these two scenarios and behaviours are not Desktop-specific: the same applies when using the official `git` CLI.

Since these scenarios are quite rare, and because `git` by default behaves in a similar way, we've decided to acknowledge that these are known limitations and we're not currently going to address them (we'll revisit if we learn that this causes friction to many users).

## Screenshots

N/A

## Release notes

Notes: no-notes
