### PR TITLE
Refresh commit list after tagging

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -270,9 +270,8 @@ export class GitStore extends BaseStore {
       return getCommit(this.repository, targetCommitSha)
     })
 
-    if (foundCommit != null) {
-      this.commitLookup.set(targetCommitSha, foundCommit)
-      this.emitNewCommitsLoaded([foundCommit])
+    if (foundCommit instanceof Commit) {
+      this.storeCommits([foundCommit], true)
     }
   }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -166,5 +166,5 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
  * Makes a hash of the commit's data that will be shown in a CommitListItem
  */
 function commitListItemHash(commit: Commit): string {
-  return `${commit.sha} ${commit.summary} ${commit.tags}`
+  return `${commit.sha} ${commit.tags}`
 }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -64,11 +64,7 @@ interface ICommitListProps {
 
 /** A component which displays the list of commits. */
 export class CommitList extends React.Component<ICommitListProps, {}> {
-  private commitsHash = memoize(this.makeCommitsHash, arrayEquals)
-
-  private makeCommitsHash(commits: ReadonlyArray<Commit>): string {
-    return commits.map(commitListItemHash).join(' ')
-  }
+  private commitsHash = memoize(makeCommitsHash, arrayEquals)
 
   private getVisibleCommits(): ReadonlyArray<Commit> {
     const commits = new Array<Commit>()
@@ -177,4 +173,8 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
  */
 function commitListItemHash(commit: Commit): string {
   return `${commit.sha} ${commit.tags}`
+}
+
+function makeCommitsHash(commits: ReadonlyArray<Commit>): string {
+  return commits.map(commitListItemHash).join(' ')
 }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -64,11 +64,23 @@ interface ICommitListProps {
 
 /** A component which displays the list of commits. */
 export class CommitList extends React.Component<ICommitListProps, {}> {
-  private commitLookupHash = memoize(
-    (lookupValues: ReadonlyArray<Commit>) =>
-      lookupValues.map(commitListItemHash).join(' '),
-    arrayEquals
-  )
+  private commitsHash = memoize(this.makeCommitsHash, arrayEquals)
+
+  private makeCommitsHash(commits: ReadonlyArray<Commit>): string {
+    return commits.map(commitListItemHash).join(' ')
+  }
+
+  private getVisibleCommits(): ReadonlyArray<Commit> {
+    const commits = new Array<Commit>()
+    for (const sha of this.props.commitSHAs) {
+      const commitMaybe = this.props.commitLookup.get(sha)
+      // this should never be undefined, but just in case
+      if (commitMaybe !== undefined) {
+        commits.push(commitMaybe)
+      }
+    }
+    return commits
+  }
 
   private renderCommit = (row: number) => {
     const sha = this.props.commitSHAs[row]
@@ -151,9 +163,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
             commits: this.props.commitSHAs,
             gitHubUsers: this.props.gitHubUsers,
             localCommitSHAs: this.props.localCommitSHAs,
-            commitLookupHash: this.commitLookupHash([
-              ...this.props.commitLookup.values(),
-            ]),
+            commitLookupHash: this.commitsHash(this.getVisibleCommits()),
           }}
           setScrollTop={this.props.compareListScrollTop}
         />


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9555

_(this branch based off of #9537, please review that first!)_

## Description

- forces the commit list to re-render whenever the store of commit information passed to it changes in a way that would affect the list item rendering
- updated `key` prop for commit list items to allow such re-rendering even when the commit sha has not changed

### Screenshots

![tag-now](https://user-images.githubusercontent.com/964912/79795913-8951b880-8309-11ea-8630-66e89d1b7146.gif)

