### PR TITLE
disable link navigation within desktop windows

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -26,6 +26,7 @@ import { now } from './now'
 import { showUncaughtException } from './show-uncaught-exception'
 import { IMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
+import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -561,13 +562,17 @@ app.on('web-contents-created', (event, contents) => {
   contents.on('new-window', (event, url) => {
     // Prevent links or window.open from opening new windows
     event.preventDefault()
-    log.warn(`Prevented new window to: ${url}`)
+    const errMsg = `Prevented new window to: ${url}`
+    log.warn(errMsg)
+    sendNonFatalException('newWindowPrevented', Error(errMsg))
   })
   // prevent link navigation within our windows
   // see https://www.electronjs.org/docs/tutorial/security#12-disable-or-limit-navigation
   contents.on('will-navigate', (event, url) => {
     event.preventDefault()
-    log.warn(`Prevented navigation to: ${url}`)
+    const errMsg = `Prevented navigation to: ${url}`
+    log.warn(errMsg)
+    sendNonFatalException('willNavigatePrevented', Error(errMsg))
   })
 })
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -563,6 +563,12 @@ app.on('web-contents-created', (event, contents) => {
     event.preventDefault()
     log.warn(`Prevented new window to: ${url}`)
   })
+  // prevent link navigation within our windows
+  // see https://www.electronjs.org/docs/tutorial/security#12-disable-or-limit-navigation
+  contents.on('will-navigate', (event, url) => {
+    event.preventDefault()
+    log.warn(`Prevented navigation to: ${url}`)
+  })
 })
 
 app.on(


### PR DESCRIPTION
Closes #9551

## Description

prevents link navigation from executing within desktop windows, since we never show content that isn't rendered by desktop itself
