### PR TITLE
Calculate the start point of the branch on the create branch dialog from the passed properties

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -121,10 +121,15 @@ export class CreateBranch extends React.Component<
     })
 
     if (!this.state.isCreatingBranch) {
+      const defaultStartPoint = getStartPoint(
+        nextProps,
+        StartPoint.UpstreamDefaultBranch
+      )
+
       this.setState({
         tipAtCreateStart: nextProps.tip,
         defaultBranchAtCreateStart: getBranchForStartPoint(
-          this.state.startPoint,
+          defaultStartPoint,
           nextProps
         ),
       })


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9608

## Description

This fixes the issue described in https://github.com/desktop/desktop/issues/9608 by calculating the default branch using the passed props instead of the current dialog state.

An alternative would have been to completely get rid of the `defaultBranchAtCreateStart` state property and recalculate that value on every render, but I'm unsure if that could mess up things while the branch is being created, based on this comment on the code:

> Whether or not the dialog is currently creating a branch. This affects
> the dialog loading state as well as the rendering of the branch selector.
>
> When the dialog is creating a branch we take the tip and defaultBranch
> as they were in props at the time of creation and stick them in state
> so that we can maintain the layout of the branch selection parts even
> as the Tip changes during creation.
>
> Note: once branch creation has been initiated this value stays at true
> and will never revert to being false. If the branch creation operation
> fails this dialog will still be dismissed and an error dialog will be
> shown in its place.

### Screenshots

N/A

## Release notes

Notes: [Fixed] Solved issue on the create branch dialog when refocusing the Desktop window.
