### PR TITLE
Touch bar support

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -587,7 +587,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    const compareURL = `${htmlURL}/compare/${branchTip.branch.upstreamWithoutRemote}`
+    const compareURL = `${htmlURL}/compare/${
+      branchTip.branch.upstreamWithoutRemote
+    }`
     this.props.dispatcher.openInBrowser(compareURL)
   }
 
@@ -918,7 +920,9 @@ export class App extends React.Component<IAppProps, IAppState> {
                         .name
                     : assertNever(
                         this.state.selectedState.state.branchesState.tip,
-                        `Unknown tip state: ${this.state.selectedState.state.branchesState.tip!.kind}`
+                        `Unknown tip state: ${
+                          this.state.selectedState.state.branchesState.tip!.kind
+                        }`
                       ),
                 click: () =>
                   this.props.dispatcher.showFoldout({
@@ -927,8 +931,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               }),
               new TouchBar.TouchBarButton({
                 label: 'push/pull',
-                click: () =>
-                  console.log('tbd'),
+                click: () => console.log('tbd'),
               }),
             ]
           : []),

--- a/app/src/ui/dialog/ok-cancel-button-group.tsx
+++ b/app/src/ui/dialog/ok-cancel-button-group.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as classNames from 'classnames'
 import { Button } from '../lib/button'
 import { remote } from 'electron'
-import { addTouchBar, removeTouchBar } from '../touch-bar'
+import { addTouchBar, removeTouchBar, updateTouchBar } from '../touch-bar'
 
 interface IOkCancelButtonGroupProps {
   /**
@@ -96,7 +96,7 @@ export class OkCancelButtonGroup extends React.Component<
     this.touchBarId = addTouchBar(this.renderTouchBar())
   }
   public componentDidUpdate() {
-    removeTouchBar(this.touchBarId!, this.renderTouchBar())
+    updateTouchBar(this.touchBarId!, this.renderTouchBar())
   }
   public componentWillUnmount() {
     removeTouchBar(this.touchBarId!)

--- a/app/src/ui/dialog/ok-cancel-button-group.tsx
+++ b/app/src/ui/dialog/ok-cancel-button-group.tsx
@@ -109,7 +109,8 @@ export class OkCancelButtonGroup extends React.Component<
         ? null
         : new TouchBar.TouchBarButton({
             label: String(this.props.cancelButtonText || 'Cancel'),
-            backgroundColor: this.props.destructive === true ? '#0366d6' : undefined,
+            backgroundColor:
+              this.props.destructive === true ? '#0366d6' : undefined,
             click: () => {
               if (this.props.onCancelButtonClick !== undefined) {
                 this.props.onCancelButtonClick({} as any)
@@ -192,7 +193,7 @@ export class OkCancelButtonGroup extends React.Component<
     }
   }
 
-  private getRef = (b: HTMLButtonElement | null) => this.okButton = b
+  private getRef = (b: HTMLButtonElement | null) => (this.okButton = b)
 
   private renderOkButton() {
     return (

--- a/app/src/ui/toolbar/branch-button.tsx
+++ b/app/src/ui/toolbar/branch-button.tsx
@@ -16,12 +16,12 @@ import * as React from 'react'
 import { BranchesTab } from '../../models/branches-tab'
 
 interface IBranchToolbarButtonProps {
-  currentFoldout: Foldout | null
-  currentOnboardingTutorialStep: TutorialStep
-  dispatcher: Dispatcher
-  selectedBranchesTab: BranchesTab
-  selection: PossibleSelections | null
-  uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
+  readonly currentFoldout: Foldout | null
+  readonly currentOnboardingTutorialStep: TutorialStep
+  readonly dispatcher: Dispatcher
+  readonly selectedBranchesTab: BranchesTab
+  readonly selection: PossibleSelections | null
+  readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
 }
 
 export function BranchToolbarButton({

--- a/app/src/ui/toolbar/branch-button.tsx
+++ b/app/src/ui/toolbar/branch-button.tsx
@@ -1,0 +1,73 @@
+import {
+  SelectionType,
+  Foldout,
+  PossibleSelections,
+  FoldoutType,
+} from '../../lib/app-state'
+import { Dispatcher } from '../dispatcher'
+import { BranchDropdown } from './branch-dropdown'
+import { DropdownState } from './dropdown'
+import { TutorialStep } from '../../models/tutorial-step'
+import {
+  getUncommittedChangesStrategy,
+  UncommittedChangesStrategyKind,
+} from '../../models/uncommitted-changes-strategy'
+import * as React from 'react'
+import { BranchesTab } from '../../models/branches-tab'
+
+interface IBranchToolbarButtonProps {
+  currentFoldout: Foldout | null
+  currentOnboardingTutorialStep: TutorialStep
+  dispatcher: Dispatcher
+  selectedBranchesTab: BranchesTab
+  selection: PossibleSelections | null
+  uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
+}
+
+export function BranchToolbarButton({
+  currentFoldout,
+  currentOnboardingTutorialStep,
+  dispatcher,
+  selectedBranchesTab,
+  selection,
+  uncommittedChangesStrategyKind,
+}: IBranchToolbarButtonProps): JSX.Element | null {
+  if (selection == null || selection.type !== SelectionType.Repository) {
+    return null
+  }
+
+  const isOpen =
+    currentFoldout !== null && currentFoldout.type === FoldoutType.Branch
+
+  const repository = selection.repository
+  const { branchesState, changesState } = selection.state
+  const hasAssociatedStash = changesState.stashEntry !== null
+  const hasChanges = changesState.workingDirectory.files.length > 0
+
+  const onBranchDropdownStateChanged = (newState: DropdownState) => {
+    if (newState === 'open') {
+      dispatcher.showFoldout({ type: FoldoutType.Branch })
+    } else {
+      dispatcher.closeFoldout(FoldoutType.Branch)
+    }
+  }
+
+  return (
+    <BranchDropdown
+      dispatcher={dispatcher}
+      isOpen={isOpen}
+      onDropDownStateChanged={onBranchDropdownStateChanged}
+      repository={repository}
+      repositoryState={selection.state}
+      selectedTab={selectedBranchesTab}
+      pullRequests={branchesState.openPullRequests}
+      currentPullRequest={branchesState.currentPullRequest}
+      isLoadingPullRequests={branchesState.isLoadingPullRequests}
+      shouldNudge={currentOnboardingTutorialStep === TutorialStep.CreateBranch}
+      selectedUncommittedChangesStrategy={getUncommittedChangesStrategy(
+        uncommittedChangesStrategyKind
+      )}
+      couldOverwriteStash={hasChanges && hasAssociatedStash}
+    />
+  )
+}

--- a/app/src/ui/toolbar/repository-button.tsx
+++ b/app/src/ui/toolbar/repository-button.tsx
@@ -7,12 +7,12 @@ import { CloningRepository } from '../../models/cloning-repository'
 import * as React from 'react'
 
 interface IRepositoryToolbarButtonProps {
-  currentFoldout: Foldout | null
-  dispatcher: Dispatcher
-  renderRepositoryList: () => JSX.Element
-  repositories: ReadonlyArray<Repository | CloningRepository>
-  selection: PossibleSelections | null
-  sidebarWidth: number
+  readonly currentFoldout: Foldout | null
+  readonly dispatcher: Dispatcher
+  readonly renderRepositoryList: () => JSX.Element
+  readonly repositories: ReadonlyArray<Repository | CloningRepository>
+  readonly selection: PossibleSelections | null
+  readonly sidebarWidth: number
 }
 
 export function RepositoryToolbarButton({

--- a/app/src/ui/toolbar/repository-button.tsx
+++ b/app/src/ui/toolbar/repository-button.tsx
@@ -1,0 +1,77 @@
+import { OcticonSymbol, iconForRepository } from '../octicons'
+import { PossibleSelections, FoldoutType, Foldout } from '../../lib/app-state'
+import { ToolbarDropdown, DropdownState } from '.'
+import { Dispatcher } from '../dispatcher'
+import { Repository } from '../../models/repository'
+import { CloningRepository } from '../../models/cloning-repository'
+import * as React from 'react'
+
+interface IRepositoryToolbarButtonProps {
+  currentFoldout: Foldout | null
+  dispatcher: Dispatcher
+  renderRepositoryList: () => JSX.Element
+  repositories: ReadonlyArray<Repository | CloningRepository>
+  selection: PossibleSelections | null
+  sidebarWidth: number
+}
+
+export function RepositoryToolbarButton({
+  currentFoldout,
+  dispatcher,
+  repositories,
+  renderRepositoryList,
+  selection,
+  sidebarWidth,
+}: IRepositoryToolbarButtonProps) {
+  const repository = selection ? selection.repository : null
+
+  let icon: OcticonSymbol
+  let title: string
+  if (repository) {
+    icon = iconForRepository(repository)
+    title = repository.name
+  } else if (repositories.length > 0) {
+    icon = OcticonSymbol.repo
+    title = __DARWIN__ ? 'Select a Repository' : 'Select a repository'
+  } else {
+    icon = OcticonSymbol.repo
+    title = __DARWIN__ ? 'No Repositories' : 'No repositories'
+  }
+
+  const isOpen =
+    currentFoldout && currentFoldout.type === FoldoutType.Repository
+
+  const currentState: DropdownState = isOpen ? 'open' : 'closed'
+
+  const tooltip = repository && !isOpen ? repository.path : undefined
+
+  const foldoutStyle: React.CSSProperties = {
+    position: 'absolute',
+    marginLeft: 0,
+    width: sidebarWidth,
+    minWidth: sidebarWidth,
+    height: '100%',
+    top: 0,
+  }
+
+  const onRepositoryDropdownStateChanged = (newState: DropdownState) => {
+    if (newState === 'open') {
+      dispatcher.showFoldout({ type: FoldoutType.Repository })
+    } else {
+      dispatcher.closeFoldout(FoldoutType.Repository)
+    }
+  }
+
+  return (
+    <ToolbarDropdown
+      icon={icon}
+      title={title}
+      description={__DARWIN__ ? 'Current Repository' : 'Current repository'}
+      tooltip={tooltip}
+      foldoutStyle={foldoutStyle}
+      onDropdownStateChanged={onRepositoryDropdownStateChanged}
+      dropdownContentRenderer={renderRepositoryList}
+      dropdownState={currentState}
+    />
+  )
+}

--- a/app/src/ui/toolbar/toolbar.tsx
+++ b/app/src/ui/toolbar/toolbar.tsx
@@ -1,16 +1,117 @@
 import * as React from 'react'
+import {
+  PossibleSelections,
+  Foldout,
+  SelectionType,
+  IRepositoryState,
+} from '../../lib/app-state'
+import { Repository } from '../../models/repository'
+import { CloningRepository } from '../../models/cloning-repository'
+import { Dispatcher } from '../dispatcher'
+import { RepositoryToolbarButton } from './repository-button'
+import { BranchToolbarButton } from './branch-button'
+import { TutorialStep } from '../../models/tutorial-step'
+import { BranchesTab } from '../../models/branches-tab'
+import { UncommittedChangesStrategyKind } from '../../models/uncommitted-changes-strategy'
+import { PushPullButton } from './push-pull-button'
+import { RevertProgress } from './revert-progress'
+import { TipState } from '../../models/tip'
+import { isCurrentBranchForcePush } from '../../lib/rebase'
 
 interface IToolbarProps {
-  readonly id?: string
+  currentFoldout: Foldout | null
+  currentOnboardingTutorialStep: TutorialStep
+  dispatcher: Dispatcher
+  renderRepositoryList: () => JSX.Element
+  repositories: ReadonlyArray<Repository | CloningRepository>
+  selectedBranchesTab: BranchesTab
+  selection: PossibleSelections | null
+  sidebarWidth: number
+  uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
 }
 
 /** The main application toolbar component. */
-export class Toolbar extends React.Component<IToolbarProps, {}> {
-  public render() {
-    return (
-      <div id={this.props.id} className="toolbar">
-        {this.props.children}
+export function Toolbar({
+  currentFoldout,
+  currentOnboardingTutorialStep,
+  dispatcher,
+  renderRepositoryList,
+  repositories,
+  selectedBranchesTab,
+  selection,
+  sidebarWidth,
+  uncommittedChangesStrategyKind,
+}: IToolbarProps) {
+  return (
+    <div id="desktop-app-toolbar" className="toolbar">
+      <div className="sidebar-section" style={{ width: sidebarWidth }}>
+        <RepositoryToolbarButton
+          currentFoldout={currentFoldout}
+          dispatcher={dispatcher}
+          renderRepositoryList={renderRepositoryList}
+          repositories={repositories}
+          selection={selection}
+          sidebarWidth={sidebarWidth}
+        />
       </div>
-    )
-  }
+      <BranchToolbarButton
+        currentFoldout={currentFoldout}
+        dispatcher={dispatcher}
+        currentOnboardingTutorialStep={currentOnboardingTutorialStep}
+        selectedBranchesTab={selectedBranchesTab}
+        uncommittedChangesStrategyKind={uncommittedChangesStrategyKind}
+        selection={selection}
+      />
+      {selection && selection.type === SelectionType.Repository ? (
+        selection.state.revertProgress ? (
+          <RevertProgress progress={selection.state.revertProgress} />
+        ) : (
+          renderPushPullButton(
+            dispatcher,
+            currentOnboardingTutorialStep,
+            selection
+          )
+        )
+      ) : null}
+    </div>
+  )
 }
+
+const renderPushPullButton = (
+  dispatcher: Dispatcher,
+  currentOnboardingTutorialStep: TutorialStep,
+  {
+    repository,
+    state,
+    state: { changesState, branchesState },
+  }: {
+    type: SelectionType.Repository
+    repository: Repository
+    state: IRepositoryState
+  }
+) => (
+  <PushPullButton
+    dispatcher={dispatcher}
+    repository={repository}
+    aheadBehind={state.aheadBehind}
+    remoteName={
+      branchesState.tip.kind === TipState.Valid &&
+      branchesState.tip.branch.remote !== null
+        ? branchesState.tip.branch.remote
+        : state.remote
+        ? state.remote.name
+        : null
+    }
+    lastFetched={state.lastFetched}
+    networkActionInProgress={state.isPushPullFetchInProgress}
+    progress={state.pushPullFetchProgress}
+    tipState={branchesState.tip.kind}
+    pullWithRebase={branchesState.pullWithRebase}
+    rebaseInProgress={
+      changesState.conflictState !== null &&
+      changesState.conflictState.kind === 'rebase'
+    }
+    isForcePush={isCurrentBranchForcePush(branchesState, state.aheadBehind)}
+    shouldNudge={currentOnboardingTutorialStep === TutorialStep.PushBranch}
+  />
+)

--- a/app/src/ui/toolbar/toolbar.tsx
+++ b/app/src/ui/toolbar/toolbar.tsx
@@ -19,15 +19,15 @@ import { TipState } from '../../models/tip'
 import { isCurrentBranchForcePush } from '../../lib/rebase'
 
 interface IToolbarProps {
-  currentFoldout: Foldout | null
-  currentOnboardingTutorialStep: TutorialStep
-  dispatcher: Dispatcher
-  renderRepositoryList: () => JSX.Element
-  repositories: ReadonlyArray<Repository | CloningRepository>
-  selectedBranchesTab: BranchesTab
-  selection: PossibleSelections | null
-  sidebarWidth: number
-  uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
+  readonly currentFoldout: Foldout | null
+  readonly currentOnboardingTutorialStep: TutorialStep
+  readonly dispatcher: Dispatcher
+  readonly renderRepositoryList: () => JSX.Element
+  readonly repositories: ReadonlyArray<Repository | CloningRepository>
+  readonly selectedBranchesTab: BranchesTab
+  readonly selection: PossibleSelections | null
+  readonly sidebarWidth: number
+  readonly uncommittedChangesStrategyKind: UncommittedChangesStrategyKind
 }
 
 /** The main application toolbar component. */

--- a/app/src/ui/touch-bar.ts
+++ b/app/src/ui/touch-bar.ts
@@ -1,0 +1,29 @@
+import { TouchBar, remote } from 'electron'
+
+const touchBars = new Array<TouchBar | null>()
+const win = remote.getCurrentWindow()
+
+function getTouchBar(): TouchBar | null {
+  for (let i = touchBars.length - 1; i >= 0; i--) {
+    if (touchBars[i]) {
+      return touchBars[i]
+    }
+  }
+  return null
+}
+
+export function addTouchBar(bar: TouchBar): number {
+  touchBars.push(bar)
+  win.setTouchBar(getTouchBar())
+  return touchBars.length - 1
+}
+
+export function updateTouchBar(id: number, bar: TouchBar) {
+  touchBars[id] = bar
+  win.setTouchBar(getTouchBar())
+}
+
+export function removeTouchBar(id: number) {
+  touchBars[id] = null
+  win.setTouchBar(getTouchBar())
+}


### PR DESCRIPTION
Closes #8186.

## Description

- mimic the toolbar in the Touch Bar for quick access
- display dialog buttons in the Touch Bar
- other things?

TODO:
- icons for toolbar buttons
- push/pull button labels
- display up/down arrows
- popup for repo and branch lists

### Screenshots

<img width="1085" alt="Touch Bar Shot 2020-04-26 at 12 03 12" src="https://user-images.githubusercontent.com/25517624/80312916-e93ada00-87b5-11ea-91b8-be1181d6c3ca.png">

<img width="1085" alt="Touch Bar Shot 2020-04-26 at 12 02 07" src="https://user-images.githubusercontent.com/25517624/80312878-c4defd80-87b5-11ea-963f-19c449687839.png">

## Release notes

Notes: Add buttons to the Touch Bar on macOS
