### PR TITLE
Measure number of tags created from GitHub Desktop

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -346,6 +346,11 @@ export interface IDailyMeasures {
    * How many times has the user begun creating an issue from Desktop?
    */
   readonly issueCreationWebpageOpenedCount: number
+
+  /**
+   * How many tags have been created from the Desktop UI?
+   */
+  readonly tagsCreatedInDesktop: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -136,6 +136,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   commitsToRepositoryWithoutWriteAccess: 0,
   forksCreated: 0,
   issueCreationWebpageOpenedCount: 0,
+  tagsCreatedInDesktop: 0,
 }
 
 interface IOnboardingStats {
@@ -1352,6 +1353,12 @@ export class StatsStore implements IStatsStore {
   public recordIssueCreationWebpageOpened() {
     return this.updateDailyMeasures(m => ({
       issueCreationWebpageOpenedCount: m.issueCreationWebpageOpenedCount + 1,
+    }))
+  }
+
+  public recordTagCreatedInDesktop() {
+    return this.updateDailyMeasures(m => ({
+      tagsCreatedInDesktop: m.tagsCreatedInDesktop + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3086,6 +3086,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await this.withAuthenticatingUser(repository, (_, account) =>
       gitStore.createTag(account, name, targetCommitSha)
     )
+    this.statsStore.recordTagCreatedInDesktop()
 
     this._closePopup()
   }


### PR DESCRIPTION
Partially addresses https://github.com/desktop/desktop/issues/9612

This PR is based on https://github.com/desktop/desktop/pull/9576

## Description

This PR adds instrumentation of the number of tags that get created from the Desktop UI to let us learn how much is this feature used.

### Screenshots

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
