### PR TITLE
Measure number of created tags outside of Desktop

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -351,6 +351,11 @@ export interface IDailyMeasures {
    * How many tags have been created from the Desktop UI?
    */
   readonly tagsCreatedInDesktop: number
+
+  /**
+   * How many tags have been created in total.
+   */
+  readonly tagsCreated: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -137,6 +137,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   forksCreated: 0,
   issueCreationWebpageOpenedCount: 0,
   tagsCreatedInDesktop: 0,
+  tagsCreated: 0,
 }
 
 interface IOnboardingStats {
@@ -1359,6 +1360,12 @@ export class StatsStore implements IStatsStore {
   public recordTagCreatedInDesktop() {
     return this.updateDailyMeasures(m => ({
       tagsCreatedInDesktop: m.tagsCreatedInDesktop + 1,
+    }))
+  }
+
+  public recordTagCreated(numCreatedTags: number) {
+    return this.updateDailyMeasures(m => ({
+      tagsCreated: m.tagsCreated + numCreatedTags,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -435,6 +435,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.gitStoreCache = new GitStoreCache(
       shell,
+      this.statsStore,
       (repo, store) => this.onGitStoreUpdated(repo, store),
       (repo, commits) => this.loadAndCacheUsers(repo, this.accounts, commits),
       error => this.emitError(error)

--- a/app/src/lib/stores/git-store-cache.ts
+++ b/app/src/lib/stores/git-store-cache.ts
@@ -2,6 +2,7 @@ import { GitStore } from './git-store'
 import { Repository } from '../../models/repository'
 import { IAppShell } from '../app-shell'
 import { Commit } from '../../models/commit'
+import { StatsStore } from '../stats'
 
 export class GitStoreCache {
   /** GitStores keyed by their hash. */
@@ -9,6 +10,7 @@ export class GitStoreCache {
 
   public constructor(
     private readonly shell: IAppShell,
+    private readonly statsStore: StatsStore,
     private readonly onGitStoreUpdated: (
       repository: Repository,
       gitStore: GitStore
@@ -29,7 +31,7 @@ export class GitStoreCache {
   public get(repository: Repository): GitStore {
     let gitStore = this.gitStores.get(repository.hash)
     if (gitStore === undefined) {
-      gitStore = new GitStore(repository, this.shell)
+      gitStore = new GitStore(repository, this.shell, this.statsStore)
       gitStore.onDidUpdate(() => this.onGitStoreUpdated(repository, gitStore!))
       gitStore.onDidLoadNewCommits(commits =>
         this.onDidLoadNewCommits(repository, commits)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -99,8 +99,6 @@ const RecentBranchesLimit = 5
 
 /** The store for a repository's git data. */
 export class GitStore extends BaseStore {
-  private readonly shell: IAppShell
-
   /** The commits keyed by their SHA. */
   public readonly commitLookup = new Map<string, Commit>()
 
@@ -109,8 +107,6 @@ export class GitStore extends BaseStore {
   private _history: ReadonlyArray<string> = new Array()
 
   private readonly requestsInFight = new Set<string>()
-
-  private readonly repository: Repository
 
   private _tip: Tip = { kind: TipState.Unknown }
 
@@ -147,14 +143,11 @@ export class GitStore extends BaseStore {
   private _stashEntryCount = 0
 
   public constructor(
-    repository: Repository,
-    shell: IAppShell,
-    private statsStore: StatsStore
+    private readonly repository: Repository,
+    private readonly shell: IAppShell,
+    private readonly statsStore: StatsStore
   ) {
     super()
-
-    this.repository = repository
-    this.shell = shell
   }
 
   private emitNewCommitsLoaded(commits: ReadonlyArray<Commit>) {

--- a/app/test/helpers/repository-builder-branch-pruner.ts
+++ b/app/test/helpers/repository-builder-branch-pruner.ts
@@ -6,6 +6,8 @@ import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cach
 import { Repository } from '../../src/models/repository'
 import { IAPIRepository } from '../../src/lib/api'
 import { shell } from './test-app-shell'
+import { StatsStore, StatsDatabase } from '../../src/lib/stats'
+import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
 
 export async function createRepository() {
   const repo = await setupEmptyRepository()
@@ -113,7 +115,14 @@ async function primeCaches(
   repository: Repository,
   repositoriesStateCache: RepositoryStateCache
 ) {
-  const gitStore = new GitStore(repository, shell)
+  const gitStore = new GitStore(
+    repository,
+    shell,
+    new StatsStore(
+      new StatsDatabase('test-StatsDatabase'),
+      new UiActivityMonitor()
+    )
+  )
 
   // rather than re-create the branches and stuff as objects, these calls
   // will run the underlying Git operations and update the GitStore state

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -13,6 +13,8 @@ import {
   createRepository as createPrunedRepository,
   setupRepository,
 } from '../helpers/repository-builder-branch-pruner'
+import { StatsStore, StatsDatabase } from '../../src/lib/stats'
+import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
 
 describe('BranchPruner', () => {
   const onGitStoreUpdated = () => {}
@@ -27,6 +29,10 @@ describe('BranchPruner', () => {
   beforeEach(async () => {
     gitStoreCache = new GitStoreCache(
       shell,
+      new StatsStore(
+        new StatsDatabase('test-StatsDatabase'),
+        new UiActivityMonitor()
+      ),
       onGitStoreUpdated,
       onDidLoadNewCommits,
       onDidError

--- a/app/test/unit/git-store-cache-test.ts
+++ b/app/test/unit/git-store-cache-test.ts
@@ -1,9 +1,12 @@
 import { Repository } from '../../src/models/repository'
 import { GitStoreCache } from '../../src/lib/stores/git-store-cache'
 import { shell } from '../helpers/test-app-shell'
+import { StatsStore, StatsDatabase } from '../../src/lib/stats'
+import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
 
 describe('GitStoreCache', () => {
   let repository: Repository
+  let statsStore: StatsStore
 
   const onGitStoreUpdated = () => {}
   const onDidLoadNewCommits = () => {}
@@ -11,11 +14,16 @@ describe('GitStoreCache', () => {
 
   beforeEach(() => {
     repository = new Repository('/something/path', 1, null, false)
+    statsStore = new StatsStore(
+      new StatsDatabase('test-StatsDatabase'),
+      new UiActivityMonitor()
+    )
   })
 
   it('returns same instance of GitStore', () => {
     const cache = new GitStoreCache(
       shell,
+      statsStore,
       onGitStoreUpdated,
       onDidLoadNewCommits,
       onDidError
@@ -30,6 +38,7 @@ describe('GitStoreCache', () => {
   it('returns different instance of GitStore after removing', () => {
     const cache = new GitStoreCache(
       shell,
+      statsStore,
       onGitStoreUpdated,
       onDidLoadNewCommits,
       onDidError

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -22,13 +22,24 @@ import {
   git,
   checkoutBranch,
 } from '../../../src/lib/git'
+import { StatsStore, StatsDatabase } from '../../../src/lib/stats'
+import { UiActivityMonitor } from '../../../src/ui/lib/ui-activity-monitor'
 
 describe('git/branch', () => {
+  let statsStore: StatsStore
+
+  beforeEach(() => {
+    statsStore = new StatsStore(
+      new StatsDatabase('test-StatsDatabase'),
+      new UiActivityMonitor()
+    )
+  })
+
   describe('tip', () => {
     it('returns unborn for new repository', async () => {
       const repository = await setupEmptyRepository()
 
-      const store = new GitStore(repository, shell)
+      const store = new GitStore(repository, shell, statsStore)
       await store.loadStatus()
       const tip = store.tip
 
@@ -42,7 +53,7 @@ describe('git/branch', () => {
 
       await GitProcess.exec(['checkout', '-b', 'not-master'], repository.path)
 
-      const store = new GitStore(repository, shell)
+      const store = new GitStore(repository, shell, statsStore)
       await store.loadStatus()
       const tip = store.tip
 
@@ -55,7 +66,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('detached-head')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell)
+      const store = new GitStore(repository, shell, statsStore)
       await store.loadStatus()
       const tip = store.tip
 
@@ -70,7 +81,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('repo-with-many-refs')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell)
+      const store = new GitStore(repository, shell, statsStore)
       await store.loadStatus()
       const tip = store.tip
 
@@ -87,7 +98,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('repo-with-multiple-remotes')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell)
+      const store = new GitStore(repository, shell, statsStore)
       await store.loadStatus()
       const tip = store.tip
 
@@ -102,7 +113,7 @@ describe('git/branch', () => {
       const path = await setupFixtureRepository('repo-with-multiple-remotes')
       const repository = new Repository(path, -1, null, false)
 
-      const store = new GitStore(repository, shell)
+      const store = new GitStore(repository, shell, statsStore)
       await store.loadStatus()
       const tip = store.tip
 

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -11,8 +11,19 @@ import { GitStore } from '../../../src/lib/stores'
 import { Branch, BranchType } from '../../../src/models/branch'
 import { getStatusOrThrow } from '../../helpers/status'
 import { GitProcess } from 'dugite'
+import { StatsStore, StatsDatabase } from '../../../src/lib/stats'
+import { UiActivityMonitor } from '../../../src/ui/lib/ui-activity-monitor'
 
 describe('git/checkout', () => {
+  let statsStore: StatsStore
+
+  beforeEach(() => {
+    statsStore = new StatsStore(
+      new StatsDatabase('test-StatsDatabase'),
+      new UiActivityMonitor()
+    )
+  })
+
   it('throws when invalid characters are used for branch name', async () => {
     const repository = await setupEmptyRepository()
 
@@ -60,7 +71,7 @@ describe('git/checkout', () => {
 
     await checkoutBranch(repository, null, branches[0])
 
-    const store = new GitStore(repository, shell)
+    const store = new GitStore(repository, shell, statsStore)
     await store.loadStatus()
     const tip = store.tip
 
@@ -95,7 +106,7 @@ describe('git/checkout', () => {
 
     await checkoutBranch(repository, null, firstRemoteBranch)
 
-    const store = new GitStore(repository, shell)
+    const store = new GitStore(repository, shell, statsStore)
     await store.loadStatus()
     const tip = store.tip
 

--- a/app/test/unit/stores/updates/update-remote-url-test.ts
+++ b/app/test/unit/stores/updates/update-remote-url-test.ts
@@ -5,6 +5,8 @@ import { updateRemoteUrl } from '../../../../src/lib/stores/updates/update-remot
 import { shell } from '../../../helpers/test-app-shell'
 import { setupFixtureRepository } from '../../../helpers/repositories'
 import { addRemote } from '../../../../src/lib/git'
+import { StatsStore, StatsDatabase } from '../../../../src/lib/stats'
+import { UiActivityMonitor } from '../../../../src/ui/lib/ui-activity-monitor'
 
 describe('Update remote url', () => {
   const apiRepository: IAPIRepository = {
@@ -45,7 +47,14 @@ describe('Update remote url', () => {
       apiRepo
     )
     await addRemote(repository, 'origin', remoteUrl || apiRepo.clone_url)
-    gitStore = new GitStore(repository, shell)
+    gitStore = new GitStore(
+      repository,
+      shell,
+      new StatsStore(
+        new StatsDatabase('test-StatsDatabase'),
+        new UiActivityMonitor()
+      )
+    )
     await gitStore.loadRemotes()
     const gitHubRepository = repository.gitHubRepository!
 


### PR DESCRIPTION
Closes #9612

This PR is based on https://github.com/desktop/desktop/pull/9637

## Description

This PR adds a new measure to be logged which counts the number of tags that are being created (both from Desktop and from any external program).

This will help us know the percentage of people use the create tag feature so we can plan how to improve it in the future.

An important consideration/known limitation is that we're only going to be able to detect tags created for a repository when that repository is opened in Desktop (since we don't persist in disk the local tags). This means that the total tags measure will only actually contain the number of created tags while a repository is open in Desktop. Even with this limitation, I think that the measure can be useful since it'll give us data about whether users are going to the terminal to create a tag even with Desktop opened.

### Screenshots

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
