### PR TITLE
Windows: make it safer to Open in Command Prompt (in cmd.exe)

### DIFF
--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -1,12 +1,13 @@
-import { spawn } from 'child_process'
+import { spawn, SpawnOptions } from 'child_process'
 import * as Path from 'path'
 
 function captureCommandOutput(
   command: string,
-  args?: string[] | undefined
+  args?: string[] | undefined,
+  options: SpawnOptions = {}
 ): Promise<boolean> {
   return new Promise<boolean>((resolve, reject) => {
-    const cp = spawn(command, args)
+    const cp = spawn(command, args, options)
 
     cp.on('error', error => {
       log.warn(`Unable to spawn ${command}`, error)
@@ -40,7 +41,7 @@ export function isGitOnPath(): Promise<boolean> {
     // is found, one per line, and return 0, or print an error and
     // return 1 if it cannot be found
     log.info(`calling captureCommandOutput(where git)`)
-    return captureCommandOutput(wherePath, ['git'])
+    return captureCommandOutput(wherePath, ['git'], { cwd: windowsRoot })
   }
 
   if (__LINUX__) {

--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -5,33 +5,38 @@ function captureCommandOutput(
   command: string,
   args?: string[] | undefined,
   options: SpawnOptions = {}
-): Promise<boolean> {
-  return new Promise<boolean>((resolve, reject) => {
+): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve, reject) => {
     const cp = spawn(command, args, options)
 
     cp.on('error', error => {
       log.warn(`Unable to spawn ${command}`, error)
-      resolve(false)
+      resolve(undefined)
+    })
+
+    const chunks = new Array<Buffer>()
+    let total = 0
+
+    cp.stdout.on('data', (chunk: Buffer) => {
+      chunks.push(chunk)
+      total += chunk.length
     })
 
     cp.on('close', function(code) {
       if (code !== 0) {
-        resolve(false)
+        resolve(undefined)
       } else {
-        resolve(true)
+        resolve(
+          Buffer.concat(chunks, total)
+            .toString()
+            .replace(/\r?\n[^]*/m, '')
+        )
       }
     })
   })
 }
 
-export function isGitOnPath(): Promise<boolean> {
-  // Modern versions of macOS ship with a Git shim that guides you through
-  // the process of setting everything up. We trust this is available, so
-  // don't worry about looking for it here.
-  if (__DARWIN__) {
-    return Promise.resolve(true)
-  }
-
+export function findGitOnPath(): Promise<string | undefined> {
   // adapted from http://stackoverflow.com/a/34953561/1363815
   if (__WIN32__) {
     const windowsRoot = process.env.SystemRoot || 'C:\\Windows'
@@ -44,11 +49,27 @@ export function isGitOnPath(): Promise<boolean> {
     return captureCommandOutput(wherePath, ['git'], { cwd: windowsRoot })
   }
 
-  if (__LINUX__) {
+  if (__DARWIN__ || __LINUX__) {
     // `which` will print the path and return 0 when the executable
     // is found under PATH, or return 1 if it cannot be found
     return captureCommandOutput('which', ['git'])
   }
 
-  return Promise.resolve(false)
+  return Promise.resolve(undefined)
+}
+
+export function isGitOnPath(): Promise<boolean> {
+  // Modern versions of macOS ship with a Git shim that guides you through
+  // the process of setting everything up. We trust this is available, so
+  // don't worry about looking for it here.
+  if (__DARWIN__) {
+    return Promise.resolve(true)
+  }
+
+  return findGitOnPath().then(
+    (path: string | undefined) =>
+      new Promise<boolean>((resolve, reject) => {
+        resolve(path !== undefined)
+      })
+  )
 }

--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -58,7 +58,7 @@ export function findGitOnPath(): Promise<string | undefined> {
   return Promise.resolve(undefined)
 }
 
-export function isGitOnPath(): Promise<boolean> {
+export async function isGitOnPath(): Promise<boolean> {
   // Modern versions of macOS ship with a Git shim that guides you through
   // the process of setting everything up. We trust this is available, so
   // don't worry about looking for it here.

--- a/app/src/lib/is-git-on-path.ts
+++ b/app/src/lib/is-git-on-path.ts
@@ -66,10 +66,5 @@ export async function isGitOnPath(): Promise<boolean> {
     return Promise.resolve(true)
   }
 
-  return findGitOnPath().then(
-    (path: string | undefined) =>
-      new Promise<boolean>((resolve, reject) => {
-        resolve(path !== undefined)
-      })
-  )
+  return (await findGitOnPath()) !== undefined
 }

--- a/app/src/lib/shells/found-shell.ts
+++ b/app/src/lib/shells/found-shell.ts
@@ -1,4 +1,5 @@
 export interface IFoundShell<T> {
   readonly shell: T
   readonly path: string
+  readonly extraArgs?: string[]
 }

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -364,16 +364,36 @@ export function launch(
   switch (shell) {
     case Shell.PowerShell:
       const psCommand = `"Set-Location -LiteralPath '${path}'"`
-      return spawn('START', ['powershell', '-NoExit', '-Command', psCommand], {
-        shell: true,
-        cwd: path,
-      })
+      return spawn(
+        'START',
+        [
+          '"PowerShell"',
+          `"${foundShell.path}"`,
+          '-NoExit',
+          '-Command',
+          psCommand,
+        ],
+        {
+          shell: true,
+          cwd: path,
+        }
+      )
     case Shell.PowerShellCore:
       const psCoreCommand = `"Set-Location -LiteralPath '${path}'"`
-      return spawn('START', ['pwsh', '-NoExit', '-Command', psCoreCommand], {
-        shell: true,
-        cwd: path,
-      })
+      return spawn(
+        'START',
+        [
+          '"PowerShell Core"',
+          `"${foundShell.path}"`,
+          '-NoExit',
+          '-Command',
+          psCoreCommand,
+        ],
+        {
+          shell: true,
+          cwd: path,
+        }
+      )
     case Shell.Hyper:
       const hyperPath = `"${foundShell.path}"`
       log.info(`launching ${shell} at path: ${hyperPath}`)
@@ -400,9 +420,19 @@ export function launch(
         }
       )
     case Shell.WSL:
-      return spawn('START', ['wsl'], { shell: true, cwd: path })
+      return spawn('START', ['"WSL"', `"${foundShell.path}"`], {
+        shell: true,
+        cwd: path,
+      })
     case Shell.Cmd:
-      return spawn('START', ['cmd'], { shell: true, cwd: path })
+      return spawn(
+        'START',
+        ['"Command Prompt"', `"${foundShell.path}"`],
+        {
+          shell: true,
+          cwd: path,
+        }
+      )
     case Shell.WindowTerminal:
       const windowsTerminalPath = `"${foundShell.path}"`
       log.info(`launching ${shell} at path: ${windowsTerminalPath}`)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Not associated with any open issue.

## Description

Just like https://github.com/git-for-windows/MINGW-packages/commit/82172388b, we would like a command prompt that runs `cmd.exe` _not_ to pick up any `git` executable/script in the current working directory.

At the same time, we also do not want `Open in Command Prompt` to execute a `cmd.bat` in the current directory, so we'll safeguard against that, too.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/127790/80372911-8ec47b00-8894-11ea-9a17-50c7bddcfe9f.png)

Note that there is a freshly-built `git.exe` in my current working directory, and due to the missing `.dll` files (they are in `C:\git-sdk-64\mingw64\bin`, not in `C:\git-sdk-64\usr\src\git`), it does not even start, but instead fails with code `-1073741515` (which is `0xC0000135` in hex, translating to `STATUS_DLL_NOT_FOUND`, see [here](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55) for further details).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
