### PR TITLE
Update publish repo failed error

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -647,7 +647,7 @@ export class API {
           throw new Error(
             `Unable to create repository for organization '${
               org.login
-            }'. Verify that it exists, that it's a paid organization, and that you have permission to create a repository there.`
+            }'. Verify that the repository does not already exist and that you have permission to create a repository there.`
           )
         }
         throw e


### PR DESCRIPTION
## Description

This updates the error people get when publishing a repository to an organization fails. They should verify that the repo does NOT already exist (as opposed to does exist, which seemed to be an oversight - thanks @jwargo!) and that they have permission to create repos in the org.

I removed the part about verifying that it's a paid org, because with the recent announcement of free orgs, that is no longer accurate. People can publish private repos in free orgs now. 🎉 

#### Release notes:

"Fix error message when publishing a private repository fails"
