### PR TITLE
no more branch filtering for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,13 +11,6 @@ cache:
   - .eslintcache
   - '%LOCALAPPDATA%\Yarn\Cache\v4'
 
-branches:
-  only:
-    - development
-    - /releases\/.+/
-    - /^__release-.*/
-    - /epic\/.*/
-
 skip_tags: true
 
 version: '{build}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ cache:
   - '%LOCALAPPDATA%\Yarn\Cache\v4'
 
 skip_tags: true
+skip_branch_with_pr: true
 
 version: '{build}'
 


### PR DESCRIPTION
we have had a configuration setting in our appveyor.yml that tells appveyor to only build specific branches in the desktop repo. i have no idea why this has worked for us for so long, but it's clearly not anymore.

appveyor offers very few tools to debug your config, so this is the simplest thing that should just work. this may increase the number of appveyor builds beyond what it was before this broke, so we should keep an eye on that.