### PR TITLE
Emphasize sign in via browser on welcome screen

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1349,9 +1349,7 @@ export class Dispatcher {
   }
 
   /**
-   * Initiate an OAuth sign in using the system configured browser.
-   * This method must only be called when the store is in the authentication
-   * step or an error will be thrown.
+   * Initiate an OAuth sign in using the system configured browser to GitHub.com.
    *
    * The promise returned will only resolve once the user has successfully
    * authenticated. If the user terminates the sign-in process by closing

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1349,6 +1349,22 @@ export class Dispatcher {
   }
 
   /**
+   * Initiate an OAuth sign in using the system configured browser.
+   * This method must only be called when the store is in the authentication
+   * step or an error will be thrown.
+   *
+   * The promise returned will only resolve once the user has successfully
+   * authenticated. If the user terminates the sign-in process by closing
+   * their browser before the protocol handler is invoked, by denying the
+   * protocol handler to execute or by providing the wrong credentials
+   * this promise will never complete.
+   */
+  public async requestBrowserAuthenticationToDotcom(): Promise<void> {
+    await this.beginDotComSignIn()
+    return this.requestBrowserAuthentication()
+  }
+
+  /**
    * Attempt to complete the sign in flow with the given OTP token.\
    * This method must only be called when the store is in the
    * TwoFactorAuthentication step or an error will be thrown.

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -88,7 +88,6 @@ export class AuthenticationForm extends React.Component<
     const disabled = this.props.loading
     return (
       <>
-        <hr />
         <TextBox
           label="Username or email address"
           disabled={disabled}
@@ -139,8 +138,13 @@ export class AuthenticationForm extends React.Component<
   }
 
   private renderSignInWithBrowser() {
+    if (this.props.endpoint === getDotComAPIEndpoint()) {
+      return
+    }
+
     return (
       <>
+        {this.props.supportsBasicAuth && <hr />}
         {this.renderAuthIntroMessage()}
 
         <Button

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -74,9 +74,8 @@ export class AuthenticationForm extends React.Component<
   public render() {
     return (
       <Form className="sign-in-form" onSubmit={this.signIn}>
-        {this.renderUsernamePassword()}
-
         {this.renderSignInWithBrowser()}
+        {this.renderUsernamePassword()}
       </Form>
     )
   }
@@ -88,7 +87,8 @@ export class AuthenticationForm extends React.Component<
 
     const disabled = this.props.loading
     return (
-      <div>
+      <>
+        <hr />
         <TextBox
           label="Username or email address"
           disabled={disabled}
@@ -105,8 +105,8 @@ export class AuthenticationForm extends React.Component<
 
         {this.renderError()}
 
-        {this.renderActions()}
-      </div>
+        <div className="sign-in-footer">{this.renderActions()}</div>
+      </>
     )
   }
 
@@ -139,37 +139,29 @@ export class AuthenticationForm extends React.Component<
   }
 
   private renderSignInWithBrowser() {
-    const basicAuth = this.props.supportsBasicAuth
-    const browserSignInLink = (
-      <LinkButton
-        className="welcome-link-button link-with-icon"
-        onClick={this.signInWithBrowser}
-      >
-        Sign in using your browser
-        <Octicon symbol={OcticonSymbol.linkExternal} />
-      </LinkButton>
-    )
-
-    const browserSignInButton = (
-      <Button type="submit" onClick={this.signInWithBrowser}>
-        Sign in using your browser
-      </Button>
-    )
-
     return (
-      <div>
-        {basicAuth ? <hr className="short-rule" /> : null}
-        {basicAuth ? null : this.renderEndpointRequiresWebFlow()}
+      <>
+        {this.renderAuthIntroMessage()}
 
-        <div className="sign-in-footer">
-          {basicAuth ? browserSignInLink : browserSignInButton}
-          {basicAuth ? null : this.renderActions()}
-        </div>
-      </div>
+        <Button type="submit" onClick={this.signInWithBrowser}>
+          Sign in using your browser
+          <Octicon symbol={OcticonSymbol.linkExternal} />
+        </Button>
+
+        {this.props.supportsBasicAuth ? null : this.props.additionalButtons}
+      </>
     )
   }
 
-  private renderEndpointRequiresWebFlow() {
+  private renderAuthIntroMessage() {
+    if (this.props.supportsBasicAuth) {
+      return (
+        <p>
+          To improve the security of your account, we recommend you to sign in
+          through your browser.
+        </p>
+      )
+    }
     if (this.props.endpoint === getDotComAPIEndpoint()) {
       return (
         <>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -143,7 +143,11 @@ export class AuthenticationForm extends React.Component<
       <>
         {this.renderAuthIntroMessage()}
 
-        <Button type="submit" onClick={this.signInWithBrowser}>
+        <Button
+          type="submit"
+          className="button-with-icon"
+          onClick={this.signInWithBrowser}
+        >
           Sign in using your browser
           <Octicon symbol={OcticonSymbol.linkExternal} />
         </Button>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -147,7 +147,7 @@ export class AuthenticationForm extends React.Component<
     return (
       <>
         {this.props.supportsBasicAuth && <hr />}
-        {this.renderAuthIntroMessage()}
+        {this.props.supportsBasicAuth && this.renderEndpointRequiresWebFlow()}
 
         <Button
           type="submit"
@@ -163,15 +163,7 @@ export class AuthenticationForm extends React.Component<
     )
   }
 
-  private renderAuthIntroMessage() {
-    if (this.props.supportsBasicAuth) {
-      return (
-        <p>
-          To improve the security of your account, we recommend you to sign in
-          through your browser.
-        </p>
-      )
-    }
+  private renderEndpointRequiresWebFlow() {
     if (this.props.endpoint === getDotComAPIEndpoint()) {
       return (
         <>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -138,6 +138,8 @@ export class AuthenticationForm extends React.Component<
   }
 
   private renderSignInWithBrowser() {
+    // we don't render this here because the user will have already
+    // had the option to sign in via the browser earlier in the sign-in flow
     if (this.props.endpoint === getDotComAPIEndpoint()) {
       return
     }

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -17,6 +17,7 @@ import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
 import { getWelcomeMessage } from '../../lib/2fa'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Button } from '../lib/button'
 
 interface ISignInProps {
   readonly dispatcher: Dispatcher
@@ -210,6 +211,22 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
 
     return (
       <DialogContent>
+        <Row className="sign-in-with-browser">
+          <Button
+            className="button-with-icon"
+            type="submit"
+            onClick={this.onSignInWithBrowser}
+            disabled={disableSubmit}
+          >
+            Sign in using your browser
+            <Octicon symbol={OcticonSymbol.linkExternal} />
+          </Button>
+        </Row>
+
+        <div className="horizontal-rule">
+          <span className="horizontal-rule-content">or</span>
+        </div>
+
         <Row>
           <TextBox
             label="Username or email address"
@@ -231,21 +248,6 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
             uri={state.forgotPasswordUrl}
           >
             Forgot password?
-          </LinkButton>
-        </Row>
-
-        <div className="horizontal-rule">
-          <span className="horizontal-rule-content">or</span>
-        </div>
-
-        <Row className="sign-in-with-browser">
-          <LinkButton
-            className="link-with-icon"
-            onClick={this.onSignInWithBrowser}
-            disabled={disableSubmit}
-          >
-            Sign in using your browser
-            <Octicon symbol={OcticonSymbol.linkExternal} />
           </LinkButton>
         </Row>
       </DialogContent>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -111,7 +111,11 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     this.setState({ otpToken })
   }
 
-  private onSignInWithBrowser = () => {
+  private onSignInWithBrowser = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault()
+
     this.props.dispatcher.requestBrowserAuthentication()
   }
 

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -69,8 +69,8 @@ export class Start extends React.Component<IStartProps, {}> {
     if (event) {
       event.preventDefault()
     }
-    this.props.advance(WelcomeStep.SignInToDotCom)
 
+    this.props.advance(WelcomeStep.SignInToDotComWithBrowser)
     this.props.dispatcher.requestBrowserAuthenticationToDotcom()
   }
 

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -4,6 +4,7 @@ import { LinkButton } from '../lib/link-button'
 import { Dispatcher } from '../dispatcher'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Button } from '../lib/button'
+import { Loading } from '../lib/loading'
 
 /**
  * The URL to the sign-up page on GitHub.com. Used in conjunction
@@ -15,6 +16,7 @@ export const CreateAccountURL = 'https://github.com/join?source=github-desktop'
 interface IStartProps {
   readonly advance: (step: WelcomeStep) => void
   readonly dispatcher: Dispatcher
+  readonly loadingBrowserAuth: boolean
 }
 
 /** The first step of the Welcome flow. */
@@ -40,14 +42,20 @@ export class Start extends React.Component<IStartProps, {}> {
           <Button
             type="submit"
             className="button-with-icon"
+            disabled={this.props.loadingBrowserAuth}
             onClick={this.signInWithBrowser}
           >
+            {this.props.loadingBrowserAuth && <Loading />}
             Sign in to GitHub.com
             <Octicon symbol={OcticonSymbol.linkExternal} />
           </Button>
-          <Button onClick={this.signInToEnterprise}>
-            Sign in to GitHub Enterprise Server
-          </Button>
+          {this.props.loadingBrowserAuth ? (
+            <Button onClick={this.cancelBrowserAuth}>Cancel</Button>
+          ) : (
+            <Button onClick={this.signInToEnterprise}>
+              Sign in to GitHub Enterprise Server
+            </Button>
+          )}
         </div>
 
         <div>
@@ -72,6 +80,10 @@ export class Start extends React.Component<IStartProps, {}> {
 
     this.props.advance(WelcomeStep.SignInToDotComWithBrowser)
     this.props.dispatcher.requestBrowserAuthenticationToDotcom()
+  }
+
+  private cancelBrowserAuth = () => {
+    this.props.advance(WelcomeStep.Start)
   }
 
   private signInToDotCom = () => {

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import { WelcomeStep } from './welcome'
 import { LinkButton } from '../lib/link-button'
+import { Dispatcher } from '../dispatcher'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { Button } from '../lib/button'
 
 /**
  * The URL to the sign-up page on GitHub.com. Used in conjunction
@@ -11,6 +14,7 @@ export const CreateAccountURL = 'https://github.com/join?source=github-desktop'
 
 interface IStartProps {
   readonly advance: (step: WelcomeStep) => void
+  readonly dispatcher: Dispatcher
 }
 
 /** The first step of the Welcome flow. */
@@ -27,25 +31,28 @@ export class Start extends React.Component<IStartProps, {}> {
 
         <p className="welcome-text">
           New to GitHub?{' '}
-          <LinkButton uri={CreateAccountURL}>
+          <LinkButton uri={CreateAccountURL} className="create-account-link">
             Create your free account.
           </LinkButton>
         </p>
 
-        <hr className="short-rule" />
-
-        <div>
-          <LinkButton className="welcome-button" onClick={this.signInToDotCom}>
+        <div className="welcome-main-buttons">
+          <Button
+            type="submit"
+            className="button-with-icon"
+            onClick={this.signInWithBrowser}
+          >
             Sign in to GitHub.com
-          </LinkButton>
+            <Octicon symbol={OcticonSymbol.linkExternal} />
+          </Button>
+          <Button onClick={this.signInToEnterprise}>
+            Sign in to GitHub Enterprise Server
+          </Button>
         </div>
 
         <div>
-          <LinkButton
-            className="welcome-button"
-            onClick={this.signInToEnterprise}
-          >
-            Sign in to GitHub Enterprise Server
+          <LinkButton onClick={this.signInToDotCom} className="basic-auth-link">
+            Sign in to GitHub.com using your username and password
           </LinkButton>
         </div>
 
@@ -56,6 +63,15 @@ export class Start extends React.Component<IStartProps, {}> {
         </div>
       </div>
     )
+  }
+
+  private signInWithBrowser = (event?: React.MouseEvent<HTMLButtonElement>) => {
+    if (event) {
+      event.preventDefault()
+    }
+    this.props.advance(WelcomeStep.SignInToDotCom)
+
+    this.props.dispatcher.requestBrowserAuthenticationToDotcom()
   }
 
   private signInToDotCom = () => {

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -145,10 +145,17 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
     switch (step) {
       case WelcomeStep.Start:
       case WelcomeStep.SignInToDotComWithBrowser:
+        const loadingBrowserAuth =
+          step === WelcomeStep.SignInToDotComWithBrowser &&
+          signInState !== null &&
+          signInState.kind === SignInStep.Authentication &&
+          signInState.loading
+
         return (
           <Start
             advance={this.advanceToStep}
             dispatcher={this.props.dispatcher}
+            loadingBrowserAuth={loadingBrowserAuth}
           />
         )
 

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -16,6 +16,7 @@ import { UsageOptOut } from './usage-opt-out'
 /** The steps along the Welcome flow. */
 export enum WelcomeStep {
   Start = 'Start',
+  SignInToDotComWithBrowser = 'SignInToDotComWithBrowser',
   SignInToDotCom = 'SignInToDotCom',
   SignInToEnterprise = 'SignInToEnterprise',
   ConfigureGit = 'ConfigureGit',
@@ -82,6 +83,10 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
       return true
     }
 
+    if (this.state.currentStep === WelcomeStep.SignInToDotComWithBrowser) {
+      return true
+    }
+
     if (this.state.currentStep === WelcomeStep.SignInToEnterprise) {
       return true
     }
@@ -139,6 +144,7 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
 
     switch (step) {
       case WelcomeStep.Start:
+      case WelcomeStep.SignInToDotComWithBrowser:
         return (
           <Start
             advance={this.advanceToStep}

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -139,7 +139,12 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
 
     switch (step) {
       case WelcomeStep.Start:
-        return <Start advance={this.advanceToStep} />
+        return (
+          <Start
+            advance={this.advanceToStep}
+            dispatcher={this.props.dispatcher}
+          />
+        )
 
       case WelcomeStep.SignInToDotCom:
         return (

--- a/app/src/ui/workflow-push-rejected/workflow-push-rejected.tsx
+++ b/app/src/ui/workflow-push-rejected/workflow-push-rejected.tsx
@@ -62,8 +62,7 @@ export class WorkflowPushRejectedDialog extends React.Component<
   private onSignIn = async () => {
     this.setState({ loading: true })
 
-    await this.props.dispatcher.beginDotComSignIn()
-    await this.props.dispatcher.requestBrowserAuthentication()
+    await this.props.dispatcher.requestBrowserAuthenticationToDotcom()
 
     this.props.dispatcher.push(this.props.repository)
     this.props.onDismissed()

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -38,7 +38,7 @@
   }
 
   &.button-with-icon .octicon {
-    margin-left: var(--spacing-half);
+    margin-left: var(--spacing);
   }
 }
 

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -36,6 +36,10 @@
   .octicon {
     vertical-align: middle;
   }
+
+  &.button-with-icon .octicon {
+    margin-left: var(--spacing-half);
+  }
 }
 
 .button-component[type='submit'] {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -376,6 +376,10 @@ dialog {
     .sign-in-with-browser {
       display: block;
       text-align: center;
+
+      .button-component {
+        width: 100%;
+      }
     }
 
     .forgot-password-row,

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -113,6 +113,11 @@
       padding-right: var(--spacing-double);
       margin: 0 var(--spacing-double) var(--spacing) 0;
     }
+
+    .octicon.spin {
+      margin-right: var(--spacing);
+      margin-left: 0;
+    }
   }
 }
 

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -49,12 +49,6 @@
     }
   }
 
-  .button-component {
-    .octicon {
-      margin-left: var(--spacing-half);
-    }
-  }
-
   #configure-git-user .form-component {
     div:last-child {
       margin-top: var(--spacing);

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -24,6 +24,10 @@
     .actions {
       margin-top: var(--spacing-double);
     }
+
+    hr {
+      margin: var(--spacing-double) 0;
+    }
   }
 
   #sign-in-enterprise {
@@ -36,8 +40,18 @@
     }
 
     .actions {
-      display: inline;
-      margin-top: var(--spacing);
+      display: inline-block;
+      margin-top: var(--spacing-double);
+    }
+
+    hr {
+      margin: var(--spacing-double) 0;
+    }
+  }
+
+  .button-component {
+    .octicon {
+      margin-left: var(--spacing-half);
     }
   }
 

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -96,6 +96,24 @@
       transform: translateX(100%);
     }
   }
+
+  .create-account-link {
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .basic-auth-link {
+    font-size: var(--font-size);
+  }
+
+  .welcome-main-buttons {
+    margin-top: var(--spacing-quad);
+
+    .button-component {
+      padding-left: var(--spacing-double);
+      padding-right: var(--spacing-double);
+      margin: 0 var(--spacing-double) var(--spacing) 0;
+    }
+  }
 }
 
 .welcome-title,

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -141,10 +141,14 @@
   width: 100%;
 }
 
-.welcome-left,
+.welcome-left {
+  flex-grow: 1;
+  width: 60%;
+}
+
 .welcome-right {
   flex-grow: 1;
-  width: 50%;
+  width: 40%;
 }
 
 .welcome-left {


### PR DESCRIPTION
Addresses the first part of https://github.com/desktop/desktop/issues/9231

## Description

This PR implements the transition phase outlined in https://github.com/desktop/desktop/issues/9231#issuecomment-603545527 from the user/pass authentication to the browser authentication.

After talking to @ampinsk, we decided to tweak a bit the designs from https://github.com/desktop/desktop/issues/9231#issuecomment-603545527 to make the implementation much easier. The main change is that instead of showing the user/password form directly on the welcome screen, we're showing a link to sign in via user/pass which takes the user to a separate screen where they can enter their credentials.

The other important change that has been made is changing the widths of the 2 columns of the welcome screen: they are currently 50/50 but in this PR I've changed it to 60/40 to acccomodate the extra horizontal space.

Here's is the difference between the two widths when opening Desktop for the first time (the initial window has a width of 960px).

**Before: **

<img src="https://user-images.githubusercontent.com/408035/80582150-83955a80-8a0e-11ea-98f3-ce60d825cf4d.png" width="500"/>

**Now: **

<img src="https://user-images.githubusercontent.com/408035/80582083-6a8ca980-8a0e-11ea-91f2-514186556531.png" width="500"/>

@ampinsk what do you think about this change? maybe we can change a bit the right background image to fill the full height... (or keep the previous proportions and figure out a different solution).

## Screenshots

Welcome screen:

![image](https://user-images.githubusercontent.com/408035/80602238-278efe00-8a2f-11ea-98a5-f745338ccb8d.png)

Loading welcome screen (after pressing the sign in via browser button:

![image](https://user-images.githubusercontent.com/408035/80602096-fd3d4080-8a2e-11ea-84a2-edbfee194c67.png)

Screen showing the soon-to-be-deprecated user/password authentication:

![image](https://user-images.githubusercontent.com/408035/80580318-a4a87c00-8a0b-11ea-8c09-7d6d3140d829.png)

Sign in screen via the settings dialog:

![image](https://user-images.githubusercontent.com/408035/80580433-cf92d000-8a0b-11ea-9ca3-e8defb00ebbe.png)

## Release notes

Notes: [Improved] Emphasize the sign in via browser flow when opening Desktop for the first time.  
