### PR TITLE
Show unpushed indicator on commits that have unpushed tags

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -16,6 +16,7 @@ import {
   enableGitTagsDisplay,
   enableGitTagsCreation,
 } from '../../lib/feature-flag'
+import { arrayEquals } from '../../lib/equality'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -27,6 +28,7 @@ interface ICommitProps {
   readonly onCreateTag?: (targetCommitSha: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
   readonly showUnpushedIndicator: boolean
+  readonly unpushedIndicatorTitle?: string
 }
 
 interface ICommitListItemState {
@@ -100,7 +102,9 @@ export class CommitListItem extends React.Component<
   public shouldComponentUpdate(nextProps: ICommitProps): boolean {
     return (
       this.props.commit.sha !== nextProps.commit.sha ||
-      this.props.showUnpushedIndicator !== nextProps.showUnpushedIndicator
+      this.props.showUnpushedIndicator !== nextProps.showUnpushedIndicator ||
+      this.props.unpushedIndicatorTitle !== nextProps.unpushedIndicatorTitle ||
+      !arrayEquals(this.props.commit.tags, nextProps.commit.tags)
     )
   }
 
@@ -112,7 +116,7 @@ export class CommitListItem extends React.Component<
     return (
       <div
         className="unpushed-indicator"
-        title="This commit hasn't been pushed to the remote repository yet"
+        title={this.props.unpushedIndicatorTitle}
       >
         <Octicon symbol={OcticonSymbol.arrowUp} />
       </div>

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -129,7 +129,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     numUnpushedTags: number
   ) {
     if (isLocalCommit) {
-      return "This commit has not been pushed to the remote repository"
+      return 'This commit has not been pushed to the remote repository'
     }
 
     if (numUnpushedTags > 0) {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -60,6 +60,9 @@ interface ICommitListProps {
 
   /* Whether the repository is local (it has no remotes) */
   readonly isLocalRepository: boolean
+
+  /* Tags that haven't been pushed yet. This is used to show the unpushed indicator */
+  readonly tagsToPush: ReadonlyArray<string> | null
 }
 
 /** A component which displays the list of commits. */
@@ -91,8 +94,15 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       return null
     }
 
+    const tagsToPushSet = new Set(this.props.tagsToPush || [])
+
     const isLocal = this.props.localCommitSHAs.includes(commit.sha)
-    const showUnpushedIndicator = isLocal && !this.props.isLocalRepository
+    const hasUnpushedTags = commit.tags.some(tagName =>
+      tagsToPushSet.has(tagName)
+    )
+
+    const showUnpushedIndicator =
+      (isLocal || hasUnpushedTags) && this.props.isLocalRepository === false
 
     return (
       <CommitListItem
@@ -160,6 +170,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
             gitHubUsers: this.props.gitHubUsers,
             localCommitSHAs: this.props.localCommitSHAs,
             commitLookupHash: this.commitsHash(this.getVisibleCommits()),
+            tagsToPush: this.props.tagsToPush,
           }}
           setScrollTop={this.props.compareListScrollTop}
         />

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -97,19 +97,23 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const tagsToPushSet = new Set(this.props.tagsToPush || [])
 
     const isLocal = this.props.localCommitSHAs.includes(commit.sha)
-    const hasUnpushedTags = commit.tags.some(tagName =>
+    const numUnpushedTags = commit.tags.filter(tagName =>
       tagsToPushSet.has(tagName)
-    )
+    ).length
 
     const showUnpushedIndicator =
-      (isLocal || hasUnpushedTags) && this.props.isLocalRepository === false
+      (isLocal || numUnpushedTags > 0) && this.props.isLocalRepository === false
 
     return (
       <CommitListItem
-        key={commitListItemHash(commit)}
+        key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
         isLocal={isLocal}
         showUnpushedIndicator={showUnpushedIndicator}
+        unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
+          isLocal,
+          numUnpushedTags
+        )}
         commit={commit}
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}
@@ -118,6 +122,23 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />
     )
+  }
+
+  private getUnpushedIndicatorTitle(
+    isLocalCommit: boolean,
+    numUnpushedTags: number
+  ) {
+    if (isLocalCommit) {
+      return "This commit hasn't been pushed to the remote repository yet"
+    }
+
+    if (numUnpushedTags > 0) {
+      return `This commit has ${numUnpushedTags} tag${
+        numUnpushedTags > 1 ? 's' : ''
+      } to push`
+    }
+
+    return undefined
   }
 
   private onSelectedRowChanged = (row: number) => {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -129,7 +129,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     numUnpushedTags: number
   ) {
     if (isLocalCommit) {
-      return "This commit hasn't been pushed to the remote repository yet"
+      return "This commit has not been pushed to the remote repository"
     }
 
     if (numUnpushedTags > 0) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -49,6 +49,7 @@ interface ICompareSidebarProps {
   readonly onCompareListScrolled: (scrollTop: number) => void
   readonly compareListScrollTop?: number
   readonly localTags: Map<string, string> | null
+  readonly tagsToPush: ReadonlyArray<string> | null
 }
 
 interface ICompareSidebarState {
@@ -288,6 +289,7 @@ export class CompareSidebar extends React.Component<
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
+        tagsToPush={this.props.tagsToPush}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -227,6 +227,7 @@ export class RepositoryView extends React.Component<
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onCompareListScrolled={this.onCompareListScrolled}
         compareListScrollTop={scrollTop}
+        tagsToPush={this.props.state.tagsToPush}
       />
     )
   }


### PR DESCRIPTION
Related issue: https://github.com/desktop/desktop/issues/9424

## Description

This PR uses the data about unpushed tags to display the unpushed indicator on the commits that have unpushed tags (even if these commits are already in the remote).

Note that only annotated tags are taken into account for the unpushed indicator (since lightweight tags are never pushed to the remote by Desktop).

### Screenshots

![demo](https://user-images.githubusercontent.com/408035/80605063-d6810900-8a32-11ea-99bd-9856a1f3e410.gif)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
