### PR TITLE
Make the CommitListItem a PureComponent

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -16,7 +16,6 @@ import {
   enableGitTagsDisplay,
   enableGitTagsCreation,
 } from '../../lib/feature-flag'
-import { arrayEquals } from '../../lib/equality'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -36,7 +35,7 @@ interface ICommitListItemState {
 }
 
 /** A component which displays a single commit in a commit list. */
-export class CommitListItem extends React.Component<
+export class CommitListItem extends React.PureComponent<
   ICommitProps,
   ICommitListItemState
 > {
@@ -96,15 +95,6 @@ export class CommitListItem extends React.Component<
           {this.renderUnpushedIndicator()}
         </div>
       </div>
-    )
-  }
-
-  public shouldComponentUpdate(nextProps: ICommitProps): boolean {
-    return (
-      this.props.commit.sha !== nextProps.commit.sha ||
-      this.props.showUnpushedIndicator !== nextProps.showUnpushedIndicator ||
-      this.props.unpushedIndicatorTitle !== nextProps.unpushedIndicatorTitle ||
-      !arrayEquals(this.props.commit.tags, nextProps.commit.tags)
     )
   }
 


### PR DESCRIPTION
Addresses the comment in https://github.com/desktop/desktop/pull/9667#discussion_r417961274

## Description

This PR removes the `shoouldComponentUpdate` method in the `CommitListItem` in favor of making it a `PureComponent` (which would be equivalent to have a `shouldComponentUpdate` method that checks for shallow equality of all the props).

Since we don't mutate objects that are passed as props in Desktop, using a pure component and therefore shallow equality to compare props should not cause issues.

By removing the `shouldComponentUpdate` method we can avoid issues where the UI doesn't get updated because we forget to add the property to that method (I've fell into this issue two times 🤡: https://github.com/desktop/desktop/pull/9366#pullrequestreview-383106502 and the one that was fixed by https://github.com/desktop/desktop/pull/9578). 

@tierninho In terms of testing, I've checked that the commits in the history/compare list get updated correctly when making changes (e.g tags, unpushed indicator, etc) but you can doublecheck that (plus any edge case related to that).

### Screenshots

N/A

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
