### PR TITLE
Fix Desktop Welcome 2FA Confirmation Step

### DIFF
--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -72,17 +72,9 @@ export class AuthenticationForm extends React.Component<
   }
 
   public render() {
-    const content = this.props.supportsBasicAuth ? (
-      this.renderEndpointRequiresWebFlow()
-    ) : this.props.endpoint === getDotComAPIEndpoint() ? (
-      this.renderUsernamePassword()
-    ) : (
-      <>
-        {this.props.endpoint !== getDotComAPIEndpoint() &&
-          this.renderSignInWithBrowser()}
-        {this.renderUsernamePassword()}
-      </>
-    )
+    const content = this.props.supportsBasicAuth
+      ? this.renderEndpointRequiresWebFlow()
+      : this.renderSignInForm()
 
     return (
       <Form className="sign-in-form" onSubmit={this.signIn}>
@@ -154,10 +146,33 @@ export class AuthenticationForm extends React.Component<
     )
   }
 
+  /**
+   * Show the sign in locally form
+   *
+   * Also displays an option to sign in with browser for
+   * enterprise users (but not for dot com users since
+   * they will have already been offered this option
+   * earlier in the UI flow).
+   */
+  private renderSignInForm() {
+    return this.props.endpoint === getDotComAPIEndpoint() ? (
+      this.renderUsernamePassword()
+    ) : (
+      <>
+        {this.renderSignInWithBrowser()}
+        {this.renderUsernamePassword()}
+      </>
+    )
+  }
+
+  /**
+   * Show a message informing the user they must sign in via the web flow
+   * and a button to do so
+   */
   private renderEndpointRequiresWebFlow() {
     return (
       <>
-        {getWebSignInRequiredMessage(this.props.endpoint)}
+        {getEndpointRequiresWebFlowMessage(this.props.endpoint)}
 
         {this.renderSignInWithBrowserButton()}
       </>
@@ -206,7 +221,7 @@ export class AuthenticationForm extends React.Component<
   }
 }
 
-function getWebSignInRequiredMessage(endpoint: string): JSX.Element {
+function getEndpointRequiresWebFlowMessage(endpoint: string): JSX.Element {
   if (endpoint === getDotComAPIEndpoint()) {
     return (
       <>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -143,14 +143,7 @@ export class AuthenticationForm extends React.Component<
         {this.props.supportsBasicAuth && <hr />}
         {this.props.supportsBasicAuth && this.renderEndpointRequiresWebFlow()}
 
-        <Button
-          type="submit"
-          className="button-with-icon"
-          onClick={this.signInWithBrowser}
-        >
-          Sign in using your browser
-          <Octicon symbol={OcticonSymbol.linkExternal} />
-        </Button>
+        {this.renderSignInWithBrowserButton}
 
         {this.props.supportsBasicAuth ? null : this.props.additionalButtons}
       </>
@@ -180,6 +173,19 @@ export class AuthenticationForm extends React.Component<
         </p>
       )
     }
+  }
+
+  private renderSignInWithBrowserButton() {
+    return (
+      <Button
+        type="submit"
+        className="button-with-icon"
+        onClick={this.signInWithBrowser}
+      >
+        Sign in using your browser
+        <Octicon symbol={OcticonSymbol.linkExternal} />
+      </Button>
+    )
   }
 
   private renderError() {

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -140,12 +140,19 @@ export class AuthenticationForm extends React.Component<
   private renderSignInWithBrowser() {
     return (
       <>
-        {this.props.supportsBasicAuth && <hr />}
+        {this.renderSignInWithBrowserButton}
+
+        {this.props.additionalButtons}
+      </>
+    )
+  }
+
+  private renderEndpointRequiresWebFlowContent() {
+    return (
+      <>
         {this.props.supportsBasicAuth && this.renderEndpointRequiresWebFlow()}
 
         {this.renderSignInWithBrowserButton}
-
-        {this.props.supportsBasicAuth ? null : this.props.additionalButtons}
       </>
     )
   }

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -73,7 +73,7 @@ export class AuthenticationForm extends React.Component<
 
   public render() {
     const content = this.props.supportsBasicAuth ? (
-      this.renderEndpointRequiresWebFlowContent()
+      this.renderEndpointRequiresWebFlow()
     ) : this.props.endpoint === getDotComAPIEndpoint() ? (
       this.renderUsernamePassword()
     ) : (
@@ -154,39 +154,14 @@ export class AuthenticationForm extends React.Component<
     )
   }
 
-  private renderEndpointRequiresWebFlowContent() {
+  private renderEndpointRequiresWebFlow() {
     return (
       <>
-        {this.props.supportsBasicAuth && this.renderEndpointRequiresWebFlow()}
+        {getWebSignInRequiredMessage(this.props.endpoint)}
 
         {this.renderSignInWithBrowserButton()}
       </>
     )
-  }
-
-  private renderEndpointRequiresWebFlow() {
-    if (this.props.endpoint === getDotComAPIEndpoint()) {
-      return (
-        <>
-          <p>
-            To improve the security of your account, GitHub now requires you to
-            sign in through your browser.
-          </p>
-          <p>
-            Your browser will redirect you back to GitHub Desktop once you've
-            signed in. If your browser asks for your permission to launch GitHub
-            Desktop please allow it to.
-          </p>
-        </>
-      )
-    } else {
-      return (
-        <p>
-          Your GitHub Enterprise Server instance requires you to sign in with
-          your browser.
-        </p>
-      )
-    }
   }
 
   private renderSignInWithBrowserButton() {
@@ -228,5 +203,30 @@ export class AuthenticationForm extends React.Component<
 
   private signIn = () => {
     this.props.onSubmit(this.state.username, this.state.password)
+  }
+}
+
+function getWebSignInRequiredMessage(endpoint: string): JSX.Element {
+  if (endpoint === getDotComAPIEndpoint()) {
+    return (
+      <>
+        <p>
+          To improve the security of your account, GitHub now requires you to
+          sign in through your browser.
+        </p>
+        <p>
+          Your browser will redirect you back to GitHub Desktop once you've
+          signed in. If your browser asks for your permission to launch GitHub
+          Desktop please allow it to.
+        </p>
+      </>
+    )
+  } else {
+    return (
+      <p>
+        Your GitHub Enterprise Server instance requires you to sign in with your
+        browser.
+      </p>
+    )
   }
 }

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -92,10 +92,6 @@ export class AuthenticationForm extends React.Component<
   }
 
   private renderUsernamePassword() {
-    if (!this.props.supportsBasicAuth) {
-      return null
-    }
-
     const disabled = this.props.loading
     return (
       <>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -72,10 +72,21 @@ export class AuthenticationForm extends React.Component<
   }
 
   public render() {
+    const content = this.props.supportsBasicAuth ? (
+      this.renderEndpointRequiresWebFlowContent()
+    ) : this.props.endpoint === getDotComAPIEndpoint() ? (
+      this.renderUsernamePassword()
+    ) : (
+      <>
+        {this.props.endpoint !== getDotComAPIEndpoint() &&
+          this.renderSignInWithBrowser()}
+        {this.renderUsernamePassword()}
+      </>
+    )
+
     return (
       <Form className="sign-in-form" onSubmit={this.signIn}>
-        {this.renderSignInWithBrowser()}
-        {this.renderUsernamePassword()}
+        {content}
       </Form>
     )
   }

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -73,8 +73,8 @@ export class AuthenticationForm extends React.Component<
 
   public render() {
     const content = this.props.supportsBasicAuth
-      ? this.renderEndpointRequiresWebFlow()
-      : this.renderSignInForm()
+      ? this.renderSignInForm()
+      : this.renderEndpointRequiresWebFlow()
 
     return (
       <Form className="sign-in-form" onSubmit={this.signIn}>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -138,12 +138,6 @@ export class AuthenticationForm extends React.Component<
   }
 
   private renderSignInWithBrowser() {
-    // we don't render this here because the user will have already
-    // had the option to sign in via the browser earlier in the sign-in flow
-    if (this.props.endpoint === getDotComAPIEndpoint()) {
-      return
-    }
-
     return (
       <>
         {this.props.supportsBasicAuth && <hr />}

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -147,7 +147,7 @@ export class AuthenticationForm extends React.Component<
   private renderSignInWithBrowser() {
     return (
       <>
-        {this.renderSignInWithBrowserButton}
+        {this.renderSignInWithBrowserButton()}
 
         {this.props.additionalButtons}
       </>
@@ -159,7 +159,7 @@ export class AuthenticationForm extends React.Component<
       <>
         {this.props.supportsBasicAuth && this.renderEndpointRequiresWebFlow()}
 
-        {this.renderSignInWithBrowserButton}
+        {this.renderSignInWithBrowserButton()}
       </>
     )
   }


### PR DESCRIPTION
closes #9686

## Description

this was an interesting collision of conditions. the issue was not 2FA verification itself, it was the next step in the flow, which should have been a "you must sign in via the browser" message. that flow is restored here. There is also some refactoring of the logic within the auth form component here since that contributed significantly to this bug.

(this video is a little chopped up, because i skipped places where i entered sensitive account info)
![welcome-ghd](https://user-images.githubusercontent.com/964912/81023975-d3b55800-8e26-11ea-89f2-8a60f61324df.gif)

## Testing

This required some build modifications (using non-dev client id and secrets) to reproduce and test without another beta, so I've verified this locally. @tierninho has agreed to test this flow more in the next beta release.