### PR TITLE
Fix nativeTheme test errors

### DIFF
--- a/app/src/ui/lib/theme-change-monitor.ts
+++ b/app/src/ui/lib/theme-change-monitor.ts
@@ -11,11 +11,13 @@ class ThemeChangeMonitor implements IDisposable {
   }
 
   public dispose() {
-    remote.nativeTheme.removeAllListeners()
+    if (remote.nativeTheme) {
+      remote.nativeTheme.removeAllListeners()
+    }
   }
 
   private subscribe = () => {
-    if (!supportsDarkMode()) {
+    if (!supportsDarkMode() || !remote.nativeTheme) {
       return
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2019
 
 platform:
   - x64


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9699 

## Description

- This PR fixes `nativeTheme` undefined errors in Windows 1809+ and Windows Server 2019+ environments. See #9699 for more details.

### Screenshots

n/a

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Fix nativeTheme undefined errors in Windows test environments
