### PR TITLE
Add manual resolution options for conflict files with markers

### DIFF
--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -2,7 +2,6 @@ import { Repository } from '../../models/repository'
 import {
   WorkingDirectoryFileChange,
   isConflictedFileStatus,
-  isManualConflict,
   GitStatusEntry,
 } from '../../models/status'
 import {
@@ -29,12 +28,6 @@ export async function stageManualConflictResolution(
   // if somehow the file isn't in a conflicted state
   if (!isConflictedFileStatus(status)) {
     log.error(`tried to manually resolve unconflicted file (${file.path})`)
-    return
-  }
-  if (!isManualConflict(status)) {
-    log.error(
-      `tried to manually resolve conflicted file with markers (${file.path})`
-    )
     return
   }
 

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -3,6 +3,7 @@ import {
   WorkingDirectoryFileChange,
   isConflictedFileStatus,
   GitStatusEntry,
+  isConflictWithMarkers,
 } from '../../models/status'
 import {
   ManualConflictResolution,
@@ -28,6 +29,13 @@ export async function stageManualConflictResolution(
   // if somehow the file isn't in a conflicted state
   if (!isConflictedFileStatus(status)) {
     log.error(`tried to manually resolve unconflicted file (${file.path})`)
+    return
+  }
+
+  if (isConflictWithMarkers(status) && status.conflictMarkerCount === 0) {
+    // If somehow the user used the Desktop UI to solve the conflict via ours/theirs
+    // but afterwards resolved manually the conflicts via an editor, used the manually
+    // resolved file.
     return
   }
 

--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -72,13 +72,18 @@ export function hasUnresolvedConflicts(
   status: ConflictedFileStatus,
   manualResolution?: ManualConflictResolution
 ) {
+  // if there's a manual resolution, the file does not have unresolved conflicts
+  if (manualResolution !== undefined) {
+    return false
+  }
+
   if (isConflictWithMarkers(status)) {
     // text file may have conflict markers present
     return status.conflictMarkerCount > 0
   }
 
-  // binary file doesn't contain markers, so we check the manual resolution
-  return manualResolution === undefined
+  // binary file doesn't contain markers
+  return true
 }
 
 /** the possible git status entries for a manually conflicted file status

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -89,7 +89,6 @@ export const renderUnmergedFile: React.FunctionComponent<{
   }
   if (
     isManualConflict(props.status) &&
-    props.manualResolution === undefined &&
     hasUnresolvedConflicts(props.status, props.manualResolution)
   ) {
     return renderManualConflictedFile({
@@ -378,14 +377,18 @@ const renderResolvedFileStatusSummary: React.FunctionComponent<{
   manualResolution?: ManualConflictResolution
   branch?: string
 }> = props => {
+  if (
+    isConflictWithMarkers(props.status) &&
+    props.status.conflictMarkerCount === 0
+  ) {
+    return <div className="file-conflicts-status">No conflicts remaining</div>
+  }
+
   const statusString = resolvedFileStatusString(
     props.status,
     props.manualResolution,
     props.branch
   )
-  if (props.manualResolution === undefined) {
-    return <div className="file-conflicts-status">{statusString}</div>
-  }
 
   return (
     <div className="file-conflicts-status">


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/8248

## Description

This PR adds the option to use mine/theirs to resolve conflicts of non-binary files.

If a user uses the mine/theirs option and afterwards fixes manually the conflict (via editing the file and removing the conflict markers), then the mine/theirs selection will get ignored and the manually edited file will be used on the merge commit (this gets displayed in the UI).

### Screenshots

Context menu with the two new menu items:

![image](https://user-images.githubusercontent.com/408035/81000379-7df0a800-8e46-11ea-988a-c2b0c84cb91c.png)

Conflict dialog after selecting a manual resolution:

![image](https://user-images.githubusercontent.com/408035/81000551-b85a4500-8e46-11ea-8389-3a1e6cac8e66.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Give option to use mine / theirs changes for conflicts on non-binary files
