### PR TITLE
mock remote.nativeTheme for tests

### DIFF
--- a/app/test/__mocks__/electron.ts
+++ b/app/test/__mocks__/electron.ts
@@ -15,6 +15,11 @@ export const remote = {
   autoUpdater: {
     on: jest.fn(),
   },
+  nativeTheme: {
+    addListener: jest.fn(),
+    removeAllListeners: jest.fn(),
+    shouldUseDarkColors: jest.fn().mockImplementation(() => true),
+  },
 }
 
 export const ipcRenderer = {


### PR DESCRIPTION
closes #9699
supersedes #9700 

## Description

adds a jest mock for `remote.nativeTheme`

i opted for this approach to ensure we don't affect non-test environment behavior (even though that is highly unlikely). we already mock other parts of the electron api for tests, so this also follows that approach.

(i tried this out in #9680 to make sure it worked. the tests are still failing there but for a different reason now, so WIN 😛)

cc @shiftkey @dennisameling