### PR TITLE
Minor Design Revisions for Welcome Sign in Flow

### DIFF
--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -8,6 +8,10 @@ import { TextBox } from './text-box'
 import { Errors } from './errors'
 import { getDotComAPIEndpoint } from '../../lib/api'
 
+/** Text to let the user know their browser will send them back to GH Desktop */
+export const BrowserRedirectMessage =
+  "Your browser will redirect you back to GitHub Desktop once you've signed in. If your browser asks for your permission to launch GitHub Desktop please allow it to."
+
 interface IAuthenticationFormProps {
   /**
    * The URL to the host which we're currently authenticating
@@ -225,15 +229,8 @@ function getEndpointRequiresWebFlowMessage(endpoint: string): JSX.Element {
   if (endpoint === getDotComAPIEndpoint()) {
     return (
       <>
-        <p>
-          To improve the security of your account, GitHub now requires you to
-          sign in through your browser.
-        </p>
-        <p>
-          Your browser will redirect you back to GitHub Desktop once you've
-          signed in. If your browser asks for your permission to launch GitHub
-          Desktop please allow it to.
-        </p>
+        <p>GitHub now requires you to sign in with your browser.</p>
+        <p>{BrowserRedirectMessage}</p>
       </>
     )
   } else {

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -177,8 +177,8 @@ export class AuthenticationForm extends React.Component<
     return (
       <>
         {getEndpointRequiresWebFlowMessage(this.props.endpoint)}
-
         {this.renderSignInWithBrowserButton()}
+        {this.props.additionalButtons}
       </>
     )
   }

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -22,7 +22,13 @@ interface IAuthenticationFormProps {
    */
   readonly endpoint: string
 
-  /** Does the server support basic auth? */
+  /**
+   * Does the server support basic auth?
+   * If the server responds that it doesn't, the user will be prompted to use
+   * that server's web sign in flow.
+   *
+   * ("Basic auth" is logging in via user + password entered directly in Desktop.)
+   */
   readonly supportsBasicAuth: boolean
 
   /**
@@ -38,7 +44,10 @@ interface IAuthenticationFormProps {
    */
   readonly onBrowserSignInRequested: () => void
 
-  /** An array of additional buttons to render after the "Sign In" button. */
+  /**
+   * An array of additional buttons to render after the "Sign In" button.
+   * (Usually, a 'cancel' button)
+   */
   readonly additionalButtons?: ReadonlyArray<JSX.Element>
 
   /**

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -5,6 +5,7 @@ import { Dispatcher } from '../dispatcher'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Button } from '../lib/button'
 import { Loading } from '../lib/loading'
+import { BrowserRedirectMessage } from '../lib/authentication-form'
 
 /**
  * The URL to the sign-up page on GitHub.com. Used in conjunction
@@ -25,11 +26,15 @@ export class Start extends React.Component<IStartProps, {}> {
     return (
       <div id="start">
         <h1 className="welcome-title">Welcome to GitHub&nbsp;Desktop</h1>
-        <p className="welcome-text">
-          GitHub Desktop is a seamless way to contribute to projects on GitHub
-          and GitHub Enterprise Server. Sign in below to get started with your
-          existing projects.
-        </p>
+        {!this.props.loadingBrowserAuth ? (
+          <p className="welcome-text">
+            GitHub Desktop is a seamless way to contribute to projects on GitHub
+            and GitHub Enterprise Server. Sign in below to get started with your
+            existing projects.
+          </p>
+        ) : (
+          <p>{BrowserRedirectMessage}</p>
+        )}
 
         <p className="welcome-text">
           New to GitHub?{' '}

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -57,12 +57,17 @@ export class Start extends React.Component<IStartProps, {}> {
             </Button>
           )}
         </div>
-
-        <div>
-          <LinkButton onClick={this.signInToDotCom} className="basic-auth-link">
-            Sign in to GitHub.com using your username and password
-          </LinkButton>
-        </div>
+        {/* don't render this link if the user is already mid-browser sign in */}
+        {!this.props.loadingBrowserAuth && (
+          <div>
+            <LinkButton
+              onClick={this.signInToDotCom}
+              className="basic-auth-link"
+            >
+              Sign in to GitHub.com using your username and password
+            </LinkButton>
+          </div>
+        )}
 
         <div className="skip-action-container">
           <LinkButton className="skip-button" onClick={this.skip}>

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -27,21 +27,25 @@ export class Start extends React.Component<IStartProps, {}> {
       <div id="start">
         <h1 className="welcome-title">Welcome to GitHub&nbsp;Desktop</h1>
         {!this.props.loadingBrowserAuth ? (
-          <p className="welcome-text">
-            GitHub Desktop is a seamless way to contribute to projects on GitHub
-            and GitHub Enterprise Server. Sign in below to get started with your
-            existing projects.
-          </p>
+          <>
+            <p className="welcome-text">
+              GitHub Desktop is a seamless way to contribute to projects on
+              GitHub and GitHub Enterprise Server. Sign in below to get started
+              with your existing projects.
+            </p>
+            <p className="welcome-text">
+              New to GitHub?{' '}
+              <LinkButton
+                uri={CreateAccountURL}
+                className="create-account-link"
+              >
+                Create your free account.
+              </LinkButton>
+            </p>
+          </>
         ) : (
           <p>{BrowserRedirectMessage}</p>
         )}
-
-        <p className="welcome-text">
-          New to GitHub?{' '}
-          <LinkButton uri={CreateAccountURL} className="create-account-link">
-            Create your free account.
-          </LinkButton>
-        </p>
 
         <div className="welcome-main-buttons">
           <Button

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -208,14 +208,14 @@
   justify-content: center;
   align-items: center;
   display: flex;
-  padding: var(--spacing-quad);
+  padding: var(--spacing-quad) 0 0 var(--spacing-quad);
   position: relative;
   overflow: hidden;
 
   .welcome-graphic {
-    height: auto;
-    max-height: 100%;
-    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: left;
   }
 }
 


### PR DESCRIPTION
Fixes a couple design issues following https://github.com/desktop/desktop/pull/9688 and https://github.com/desktop/desktop/pull/9663

## Description

- make right side welcome image fill the height of its container
- update copy and add cancel button on "authenticating in browser" screen
- remove sign in with username and password link while user is on "authenticating in browser" screen

### Screenshots

![welcome-resize-2](https://user-images.githubusercontent.com/964912/81230040-a6db7f00-8fa5-11ea-8acb-0351fedd08b1.gif)
<img width="1072" alt="Screen Shot 2020-05-06 at 2 23 57 PM" src="https://user-images.githubusercontent.com/964912/81229992-962b0900-8fa5-11ea-8209-16eaa0f1ef2a.png">
<img width="1072" alt="Screen Shot 2020-05-06 at 2 22 40 PM" src="https://user-images.githubusercontent.com/964912/81230000-99be9000-8fa5-11ea-8df0-3489a6c7f49f.png">

cc/ @ampinsk 