### PR TITLE
Flip feature flags for tags

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -176,12 +176,12 @@ export function enableNDDBBanner(): boolean {
  * Should we show the git tag information in the app UI?
  */
 export function enableGitTagsDisplay(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 /**
  * Should we allow users to create git tags from the app?
  */
 export function enableGitTagsCreation(): boolean {
-  return enableBetaFeatures()
+  return true
 }


### PR DESCRIPTION
Closes #9731

## Description

This flips the tag creation and tag viewing feature flags so they're enabled for production in addition to beta.
