### PR TITLE
Wrap call to get all tags with performFailableOperation()

### DIFF
--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -265,7 +265,15 @@ export class GitStore extends BaseStore {
 
   public async refreshTags() {
     const previousTags = this._localTags
-    this._localTags = await getAllTags(this.repository)
+    const newTags = await this.performFailableOperation(() =>
+      getAllTags(this.repository)
+    )
+
+    if (newTags === undefined) {
+      return
+    }
+
+    this._localTags = newTags
 
     if (previousTags !== null) {
       // We don't await for the emition of updates to finish


### PR DESCRIPTION
## Description

This will prevent potential git errors affect other push/pull operations.

Now, when an error happens while getting the local tags, an error dialog will get shown (the message shown in the screenshot is the standard one for the most unknown errors, but it will vary depending on the error type):

![image](https://user-images.githubusercontent.com/408035/81709922-8d897580-9472-11ea-8b32-29fcff84b630.png)
