### PR TITLE
move moment plugin setup

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -4,6 +4,8 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as Path from 'path'
 
+import * as moment from 'moment'
+
 import { ipcRenderer, remote } from 'electron'
 
 import { App } from './app'
@@ -85,6 +87,11 @@ process.env['LOCAL_GIT_DIRECTORY'] = Path.resolve(__dirname, 'git')
 //   https://github.com/WICG/focus-ring
 //   Focus Ring! -- A11ycasts #16: https://youtu.be/ilj2P5-5CjI
 require('wicg-focus-ring')
+
+// setup this moment.js plugin so we can use easier
+// syntax for formatting time duration
+const momentDurationFormatSetup = require('moment-duration-format')
+momentDurationFormatSetup(moment)
 
 const startTime = performance.now()
 

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react'
 import * as moment from 'moment'
-const momentDurationFormatSetup = require('moment-duration-format')
-
-// setup moment plugin
-momentDurationFormatSetup(moment)
 
 interface IRelativeTimeProps {
   /**


### PR DESCRIPTION
This PR moves the setup for `moment-duration-format` to the primary ui renderer file.