### PR TITLE
Stop using whitelist and blacklist in our code base

### DIFF
--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -152,7 +152,7 @@ async function getEnvironmentFromShell(
  */
 function mergeEnvironmentVariables(env: IndexLookup) {
   for (const key in env) {
-    if (DenylistedNames.has(key)) {
+    if (ExcludedEnvironmentVars.has(key)) {
       continue
     }
 

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -10,7 +10,7 @@ type IndexLookup = {
 /**
  * The names of any env vars that we shouldn't copy from the shell environment.
  */
-const BlacklistedNames = new Set(['LOCAL_GIT_DIRECTORY'])
+const DenylistedNames = new Set(['LOCAL_GIT_DIRECTORY'])
 
 /**
  * Inspect whether the current process needs to be patched to get important
@@ -152,7 +152,7 @@ async function getEnvironmentFromShell(
  */
 function mergeEnvironmentVariables(env: IndexLookup) {
   for (const key in env) {
-    if (BlacklistedNames.has(key)) {
+    if (DenylistedNames.has(key)) {
       continue
     }
 

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -10,7 +10,7 @@ type IndexLookup = {
 /**
  * The names of any env vars that we shouldn't copy from the shell environment.
  */
-const DenylistedNames = new Set(['LOCAL_GIT_DIRECTORY'])
+const ExcludedEnvironmentVars = new Set(['LOCAL_GIT_DIRECTORY'])
 
 /**
  * Inspect whether the current process needs to be patched to get important

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -114,7 +114,7 @@ are unable to find another cygwin DLL.
 
 Enabling Mandatory ASLR affects the MSYS2 core library, which is relied upon by Git for Windows to emulate process forking.
 
-**Not supported:** this is an upstream limitation of MSYS2, and it is recommend that you either disable Mandatory ASLR or whitelist all executables under `<Git>\usr\bin` which depend on MSYS2.
+**Not supported:** this is an upstream limitation of MSYS2, and it is recommend that you either disable Mandatory ASLR or allowlist all executables under `<Git>\usr\bin` which depend on MSYS2.
 
 ### I get a black screen when launching Desktop
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -114,7 +114,7 @@ are unable to find another cygwin DLL.
 
 Enabling Mandatory ASLR affects the MSYS2 core library, which is relied upon by Git for Windows to emulate process forking.
 
-**Not supported:** this is an upstream limitation of MSYS2, and it is recommend that you either disable Mandatory ASLR or allowlist all executables under `<Git>\usr\bin` which depend on MSYS2.
+**Not supported:** this is an upstream limitation of MSYS2, and it is recommend that you either disable Mandatory ASLR or explicitly allow all executables under `<Git>\usr\bin` which depend on MSYS2.
 
 ### I get a black screen when launching Desktop
 


### PR DESCRIPTION
This is a simple change, and I'd prefer us not to be a part of the problem with language perpetuating stereotypes of associating "white" with things that are safe, and "black" with things that are suspect or shouldn't be permitted.

This PR should not affect anything in terms of app behavior. If I missed other instances, please call those out as well.

Notes: No notes
