### PR TITLE
exempts known git auth errors from clone retry error handler

### DIFF
--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -188,7 +188,10 @@ export async function gitAuthenticationErrorHandler(
   return null
 }
 
-/** Handle git clone errors to give chance to retry error. */
+/**
+ * Handle git clone errors to give chance to retry error.
+ * Doesn't handle auth errors.
+ */
 export async function gitCloneErrorHandler(
   error: Error,
   dispatcher: Dispatcher
@@ -204,6 +207,12 @@ export async function gitCloneErrorHandler(
 
   const gitError = asGitError(e.underlyingError)
   if (!gitError) {
+    return error
+  }
+
+  const dugiteError = gitError.result.gitError
+  // don't catch this if this its an auth error
+  if (dugiteError !== null && AuthenticationErrors.has(dugiteError)) {
     return error
   }
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -277,6 +277,7 @@ const dispatcher = new Dispatcher(
 )
 
 dispatcher.registerErrorHandler(defaultErrorHandler)
+dispatcher.registerErrorHandler(gitCloneErrorHandler)
 dispatcher.registerErrorHandler(upstreamAlreadyExistsHandler)
 dispatcher.registerErrorHandler(externalEditorErrorHandler)
 dispatcher.registerErrorHandler(openShellErrorHandler)
@@ -292,7 +293,6 @@ dispatcher.registerErrorHandler(missingRepositoryHandler)
 dispatcher.registerErrorHandler(localChangesOverwrittenHandler)
 dispatcher.registerErrorHandler(rebaseConflictsHandler)
 dispatcher.registerErrorHandler(refusedWorkflowUpdate)
-dispatcher.registerErrorHandler(gitCloneErrorHandler)
 
 document.body.classList.add(`platform-${process.platform}`)
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9776

## Description

- exempts known git auth errors from getting handled by the retry clone handler
- reorders error handlers so that auth error handler is always checked first.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Restore option to enter credentials for non-GitHub clone operations
