### PR TITLE
Fix for Enter key in Clone Repository Dialog

### DIFF
--- a/app/src/ui/tab-bar.tsx
+++ b/app/src/ui/tab-bar.tsx
@@ -160,7 +160,7 @@ class TabBarItem extends React.Component<ITabBarItemProps, {}> {
         onClick={this.onClick}
         role="tab"
         aria-selected={selected}
-        tabIndex={selected ? 0 : -1}
+        tabIndex={selected ? undefined : -1}
         onKeyDown={this.onKeyDown}
         type="button"
       >


### PR DESCRIPTION
Closes #5234 
Closes #8804

## Description

- This PR fixes unexpected behavior when trying to clone a repository from Github site and interact with Enter/Return key without using pointing devices.
When dialog is shown, focus is firstly put on "URL or username/repository" input because that input has autoFocus property set. But then, `focusFirstSuitableChild()` function (called on dialog component mounted) puts focus to tab bar button, because of it's higher precedence. Here Enter/Return key doesn't submit the form because they are simple buttons and there are no listeners on that button.
So I've added tabIndex={1} to the "URL or username/repository" input, which ha higher precedence of tab bar button. I think this should be the default action, also because that input has autoFocus property set.
- Only applies to Clone repository dialog so it's not a breaking change.
- Others dialog with the same wrong behaviour maybe fixed in other PR.

### Screenshots

None

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: PR ready for review
