### PR TITLE
Remove old feature flags

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -41,77 +41,9 @@ export function enableReadmeOverwriteWarning(): boolean {
   return enableBetaFeatures()
 }
 
-/** Should the app automatically prune branches that are no longer actively being used */
-export function enableBranchPruning(): boolean {
-  return true
-}
-
-/**
- * Whether or not to activate the "Create PR" blankslate action.
- *
- * The state of the feature as of writing this is that the underlying
- * data source required to power this feature is not reliable enough
- * and needs looking at so we aren't ready to move this to production
- * just yet.
- */
-export function enableNoChangesCreatePRBlankslateAction(): boolean {
-  return true
-}
-
-/**
- *  Enables a new UI for the repository picker that supports
- *  grouping and filtering (GitHub) repositories by owner/organization.
- */
-export function enableGroupRepositoriesByOwner(): boolean {
-  return true
-}
-
-/** Should the app show the "rebase current branch" dialog? */
-export function enableRebaseDialog(): boolean {
-  return true
-}
-
-/** Should the app show the "stash changes" dialog? */
-export function enableStashing(): boolean {
-  return true
-}
-
-/**
- * Should the application query for branch protection information and store this
- * to help the maintainers understand how broadly branch protections are
- * encountered?
- */
-export function enableBranchProtectionChecks(): boolean {
-  return true
-}
-
 /** Should the app detect Windows Subsystem for Linux as a valid shell? */
 export function enableWSLDetection(): boolean {
   return enableBetaFeatures()
-}
-
-/**
- * Should the application warn the user when they are about to commit to a
- * protected branch, and encourage them into a flow to move their changes to
- * a new branch?
- *
- * As this builds upon existing branch protection features in the codebase, this
- * flag is linked to to `enableBranchProtectionChecks()`.
- */
-export function enableBranchProtectionWarningFlow(): boolean {
-  return true
-}
-
-export function enableHideWhitespaceInDiffOption(): boolean {
-  return true
-}
-
-/**
- * Should we enable the onboarding tutorial. This includes the initial
- * configuration of the tutorial repo as well as the tutorial itself.
- */
-export function enableTutorial(): boolean {
-  return true
 }
 
 /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -81,7 +81,6 @@ import { formatCommitMessage } from '../format-commit-message'
 import { GitAuthor } from '../../models/git-author'
 import { IGitAccount } from '../../models/git-account'
 import { BaseStore } from './base-store'
-import { enableStashing } from '../feature-flag'
 import { getStashes, getStashedFiles } from '../git/stash'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { PullRequest } from '../../models/pull-request'
@@ -1095,10 +1094,6 @@ export class GitStore extends BaseStore {
    * Refreshes the list of GitHub Desktop created stash entries for the repository
    */
   public async loadStashEntries(): Promise<void> {
-    if (!enableStashing()) {
-      return
-    }
-
     const map = new Map<string, IStashEntry>()
     const stash = await getStashes(this.repository)
 
@@ -1150,10 +1145,6 @@ export class GitStore extends BaseStore {
    * Updates the latest stash entry with a list of files that it changes
    */
   private async loadFilesForCurrentStashEntry() {
-    if (!enableStashing()) {
-      return
-    }
-
     const stashEntry = this.currentBranchStashEntry
 
     if (

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -13,7 +13,6 @@ import { Repository } from '../../models/repository'
 import { fatalError } from '../fatal-error'
 import { IAPIRepository, IAPIBranch, IAPIRepositoryPermissions } from '../api'
 import { TypedBaseStore } from './base-store'
-import { enableBranchProtectionChecks } from '../feature-flag'
 
 /** The store for local repositories. */
 export class RepositoriesStore extends TypedBaseStore<
@@ -489,10 +488,6 @@ export class RepositoriesStore extends TypedBaseStore<
     gitHubRepository: GitHubRepository,
     protectedBranches: ReadonlyArray<IAPIBranch>
   ): Promise<void> {
-    if (!enableBranchProtectionChecks()) {
-      return
-    }
-
     const dbID = gitHubRepository.dbID
     if (!dbID) {
       return fatalError(

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -5,11 +5,7 @@ import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
 import { ensureDir } from 'fs-extra'
 import { openDirectorySafe } from '../shell'
-import {
-  enableRebaseDialog,
-  enableStashing,
-  enableCreateGitHubIssueFromMenu,
-} from '../../lib/feature-flag'
+import { enableCreateGitHubIssueFromMenu } from '../../lib/feature-flag'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { DefaultEditorLabel } from '../../ui/lib/context-menu'
 
@@ -212,7 +208,6 @@ export function buildDefaultMenu({
         click: isStashedChangesVisible
           ? emit('hide-stashed-changes')
           : emit('show-stashed-changes'),
-        visible: enableStashing(),
       },
       {
         label: __DARWIN__ ? 'Toggle Full Screen' : 'Toggle &full screen',
@@ -403,7 +398,6 @@ export function buildDefaultMenu({
         id: 'rebase-branch',
         accelerator: 'CmdOrCtrl+Shift+E',
         click: emit('rebase-branch'),
-        visible: enableRebaseDialog(),
       },
       separator,
       {

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -2,7 +2,6 @@ import * as Path from 'path'
 
 import { GitHubRepository } from './github-repository'
 import { IAheadBehind } from './branch'
-import { enableTutorial } from '../lib/feature-flag'
 
 function getBaseName(path: string): string {
   const baseName = Path.basename(path)
@@ -67,7 +66,7 @@ export class Repository {
    * of Git and GitHub.
    */
   public get isTutorialRepository() {
-    return enableTutorial() && this._isTutorialRepository === true
+    return this._isTutorialRepository === true
   }
 }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -104,7 +104,7 @@ import { StashAndSwitchBranch } from './stash-changes/stash-and-switch-branch-di
 import { OverwriteStash } from './stash-changes/overwrite-stashed-changes-dialog'
 import { ConfirmDiscardStashDialog } from './stashing/confirm-discard-stash'
 import { CreateTutorialRepositoryDialog } from './no-repositories/create-tutorial-repository-dialog'
-import { enableTutorial, enableForkyCreateBranchUI } from '../lib/feature-flag'
+import { enableForkyCreateBranchUI } from '../lib/feature-flag'
 import { ConfirmExitTutorial } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { WorkflowPushRejectedDialog } from './workflow-push-rejected/workflow-push-rejected'
@@ -698,10 +698,6 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private showCreateTutorialRepositoryPopup = () => {
-    if (!enableTutorial()) {
-      return
-    }
-
     const account = this.getDotComAccount() || this.getEnterpriseAccount()
 
     if (account === null) {
@@ -731,7 +727,6 @@ export class App extends React.Component<IAppProps, IAppState> {
         : null
 
     const isTutorialRepository =
-      enableTutorial() &&
       selectedRepository &&
       selectedRepository.isTutorialRepository
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -727,8 +727,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         : null
 
     const isTutorialRepository =
-      selectedRepository &&
-      selectedRepository.isTutorialRepository
+      selectedRepository && selectedRepository.isTutorialRepository
 
     return isTutorialRepository ? selectedRepository : null
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -34,7 +34,6 @@ import { basename } from 'path'
 import { ICommitContext } from '../../models/commit'
 import { RebaseConflictState } from '../../lib/app-state'
 import { ContinueRebase } from './continue-rebase'
-import { enableStashing } from '../../lib/feature-flag'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { IStashEntry } from '../../models/stash-entry'
 import * as classNames from 'classnames'
@@ -662,9 +661,6 @@ export class ChangesList extends React.Component<
   }
 
   private renderStashedChanges() {
-    if (!enableStashing()) {
-      return null
-    }
     if (this.props.stashEntry === null) {
       return null
     }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -27,7 +27,6 @@ import { IMenuItem } from '../../lib/menu-item'
 import { ICommitContext } from '../../models/commit'
 import { startTimer } from '../lib/timing'
 import { PermissionsCommitWarning } from './permissions-commit-warning'
-import { enableBranchProtectionWarningFlow } from '../../lib/feature-flag'
 import { LinkButton } from '../lib/link-button'
 import { FoldoutType } from '../../lib/app-state'
 
@@ -454,10 +453,6 @@ export class CommitMessage extends React.Component<
   }
 
   private renderPermissionsCommitWarning = (branch: string) => {
-    if (!enableBranchProtectionWarningFlow()) {
-      return null
-    }
-
     const { showBranchProtected, showNoWriteAccess, repository } = this.props
 
     if (showNoWriteAccess) {

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -3,10 +3,6 @@ import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 import { Repository } from '../../models/repository'
 import { LinkButton } from '../lib/link-button'
-import {
-  enableNoChangesCreatePRBlankslateAction,
-  enableStashing,
-} from '../../lib/feature-flag'
 import { MenuIDs } from '../../models/menu-ids'
 import { IMenu, MenuItem } from '../../models/app-menu'
 import memoizeOne from 'memoize-one'
@@ -359,25 +355,19 @@ export class NoChanges extends React.Component<
       return this.renderPushBranchAction(tip, remote, aheadBehind, tagsToPush)
     }
 
-    if (enableNoChangesCreatePRBlankslateAction()) {
-      const isGitHub = this.props.repository.gitHubRepository !== null
-      const hasOpenPullRequest = currentPullRequest !== null
-      const isDefaultBranch =
-        defaultBranch !== null && tip.branch.name === defaultBranch.name
+    const isGitHub = this.props.repository.gitHubRepository !== null
+    const hasOpenPullRequest = currentPullRequest !== null
+    const isDefaultBranch =
+      defaultBranch !== null && tip.branch.name === defaultBranch.name
 
-      if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
-        return this.renderCreatePullRequestAction(tip)
-      }
+    if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
+      return this.renderCreatePullRequestAction(tip)
     }
 
     return null
   }
 
   private renderViewStashAction() {
-    if (!enableStashing()) {
-      return null
-    }
-
     const { changesState, branchesState } = this.props.repositoryState
 
     const { tip } = branchesState

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -11,10 +11,7 @@ import { getAvatarUsersForCommit, IAvatarUser } from '../../models/avatar'
 import { AvatarStack } from '../lib/avatar-stack'
 import { CommitAttribution } from '../lib/commit-attribution'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
-import {
-  enableHideWhitespaceInDiffOption,
-  enableGitTagsDisplay,
-} from '../../lib/feature-flag'
+import { enableGitTagsDisplay } from '../../lib/feature-flag'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
@@ -360,22 +357,20 @@ export class CommitSummary extends React.Component<
             </li>
             {this.renderTags()}
 
-            {enableHideWhitespaceInDiffOption() && (
-              <li
-                className="commit-summary-meta-item without-truncation"
-                title={filesDescription}
-              >
-                <Checkbox
-                  label="Hide Whitespace"
-                  value={
-                    this.props.hideWhitespaceInDiff
-                      ? CheckboxValue.On
-                      : CheckboxValue.Off
-                  }
-                  onChange={this.onHideWhitespaceInDiffChanged}
-                />
-              </li>
-            )}
+            <li
+              className="commit-summary-meta-item without-truncation"
+              title={filesDescription}
+            >
+              <Checkbox
+                label="Hide Whitespace"
+                value={
+                  this.props.hideWhitespaceInDiff
+                    ? CheckboxValue.On
+                    : CheckboxValue.Off
+                }
+                onChange={this.onHideWhitespaceInDiffChanged}
+              />
+            </li>
           </ul>
         </div>
 

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -13,7 +13,6 @@ import { CloneableRepositoryFilterList } from '../clone-repository/cloneable-rep
 import { IAPIRepository } from '../../lib/api'
 import { assertNever } from '../../lib/fatal-error'
 import { ClickSource } from '../lib/list'
-import { enableTutorial } from '../../lib/feature-flag'
 
 interface INoRepositoriesProps {
   /** A function to call when the user chooses to create a repository. */
@@ -357,10 +356,6 @@ export class NoRepositoriesView extends React.Component<
   }
 
   private renderTutorialRepositoryButton() {
-    if (!enableTutorial()) {
-      return null
-    }
-
     // No tutorial if you're not signed in.
     if (
       this.props.dotComAccount === null &&

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -162,10 +162,7 @@ export class RepositoriesList extends React.Component<
     const label = this.getGroupLabel(identifier)
 
     return (
-      <div
-        key={identifier}
-        className="filter-list-group-header group-repositories-by-owner"
-      >
+      <div key={identifier} className="filter-list-group-header">
         {label}
       </div>
     )

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -20,7 +20,6 @@ import { IMenuItem } from '../../lib/menu-item'
 import { PopupType } from '../../models/popup'
 import { encodePathAsUrl } from '../../lib/path'
 import memoizeOne from 'memoize-one'
-import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
 
 const BlankSlateImage = encodePathAsUrl(__dirname, 'static/empty-no-repo.svg')
 
@@ -161,9 +160,8 @@ export class RepositoriesList extends React.Component<
   private renderGroupHeader = (id: string) => {
     const identifier = id as RepositoryGroupIdentifier
     const label = this.getGroupLabel(identifier)
-    const className = enableGroupRepositoriesByOwner()
-      ? 'filter-list-group-header group-repositories-by-owner'
-      : 'filter-list-group-header'
+    const className = 'filter-list-group-header group-repositories-by-owner'
+
     return (
       <div key={identifier} className={className}>
         {label}
@@ -193,7 +191,6 @@ export class RepositoriesList extends React.Component<
     )
 
     const groups =
-      enableGroupRepositoriesByOwner() &&
       this.props.repositories.length > recentRepositoriesThreshold
         ? [
             makeRecentRepositoriesGroup(

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -160,10 +160,12 @@ export class RepositoriesList extends React.Component<
   private renderGroupHeader = (id: string) => {
     const identifier = id as RepositoryGroupIdentifier
     const label = this.getGroupLabel(identifier)
-    const className = 'filter-list-group-header group-repositories-by-owner'
 
     return (
-      <div key={identifier} className={className}>
+      <div
+        key={identifier}
+        className="filter-list-group-header group-repositories-by-owner"
+      >
         {label}
       </div>
     )

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -11,7 +11,6 @@ import {
   RevealInFileManagerLabel,
   DefaultEditorLabel,
 } from '../lib/context-menu'
-import { enableGroupRepositoriesByOwner } from '../../lib/feature-flag'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -71,9 +70,7 @@ export class RepositoryListItem extends React.Component<
       prefix = `${gitHubRepo.owner.login}/`
     }
 
-    const className = enableGroupRepositoriesByOwner()
-      ? 'repository-list-item group-repositories-by-owner'
-      : 'repository-list-item'
+    const className = 'repository-list-item group-repositories-by-owner'
 
     return (
       <div
@@ -81,23 +78,6 @@ export class RepositoryListItem extends React.Component<
         className={className}
         title={repoTooltip}
       >
-        {!enableGroupRepositoriesByOwner() && (
-          <div
-            className="change-indicator-wrapper"
-            title={
-              hasChanges
-                ? 'There are uncommitted changes in this repository'
-                : ''
-            }
-          >
-            {hasChanges ? (
-              <Octicon
-                className="change-indicator"
-                symbol={OcticonSymbol.primitiveDot}
-              />
-            ) : null}
-          </div>
-        )}
         <Octicon
           className="icon-for-repository"
           symbol={iconForRepository(repository)}
@@ -113,7 +93,7 @@ export class RepositoryListItem extends React.Component<
         {repository instanceof Repository &&
           renderRepoIndicators({
             aheadBehind: this.props.aheadBehind,
-            hasChanges: enableGroupRepositoriesByOwner() && hasChanges,
+            hasChanges: hasChanges,
           })}
       </div>
     )
@@ -220,9 +200,8 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
 }
 
 const renderChangesIndicator = () => {
-  const classNames = enableGroupRepositoriesByOwner()
-    ? 'change-indicator-wrapper group-repositories-by-owner'
-    : 'change-indicator-wrapper'
+  const classNames = 'change-indicator-wrapper group-repositories-by-owner'
+
   return (
     <div
       className={classNames}

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -73,7 +73,7 @@ export class RepositoryListItem extends React.Component<
     return (
       <div
         onContextMenu={this.onContextMenu}
-        className="repository-list-item group-repositories-by-owner"
+        className="repository-list-item"
         title={repoTooltip}
       >
         <Octicon
@@ -198,11 +198,9 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
 }
 
 const renderChangesIndicator = () => {
-  const classNames = 'change-indicator-wrapper group-repositories-by-owner'
-
   return (
     <div
-      className={classNames}
+      className="change-indicator-wrapper"
       title="There are uncommitted changes in this repository"
     >
       <Octicon symbol={OcticonSymbol.primitiveDot} />

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -70,12 +70,10 @@ export class RepositoryListItem extends React.Component<
       prefix = `${gitHubRepo.owner.login}/`
     }
 
-    const className = 'repository-list-item group-repositories-by-owner'
-
     return (
       <div
         onContextMenu={this.onContextMenu}
-        className={className}
+        className="repository-list-item group-repositories-by-owner"
         title={repoTooltip}
       >
         <Octicon

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -26,7 +26,7 @@ import { IMenu } from '../models/app-menu'
 import { StashDiffViewer } from './stashing'
 import { StashedChangesLoadStates } from '../models/stash-entry'
 import { TutorialPanel, TutorialWelcome, TutorialDone } from './tutorial'
-import { enableTutorial, enableNDDBBanner } from '../lib/feature-flag'
+import { enableNDDBBanner } from '../lib/feature-flag'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { ExternalEditor } from '../lib/editors'
 
@@ -367,10 +367,7 @@ export class RepositoryView extends React.Component<
     }
 
     if (workingDirectory.files.length === 0) {
-      if (
-        enableTutorial() &&
-        this.props.currentTutorialStep !== TutorialStep.NotApplicable
-      ) {
+      if (this.props.currentTutorialStep !== TutorialStep.NotApplicable) {
         return this.renderTutorialPane()
       } else {
         return (
@@ -472,10 +469,7 @@ export class RepositoryView extends React.Component<
   }
 
   private maybeRenderTutorialPanel(): JSX.Element | null {
-    if (
-      enableTutorial() &&
-      isValidTutorialStep(this.props.currentTutorialStep)
-    ) {
+    if (isValidTutorialStep(this.props.currentTutorialStep)) {
       return (
         <TutorialPanel
           dispatcher={this.props.dispatcher}

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -109,7 +109,7 @@
     }
   }
 
-  .filter-list-group-header.group-repositories-by-owner {
+  .filter-list-group-header {
     padding-top: var(--spacing);
   }
 

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -34,10 +34,6 @@
     // name and truncate accordingly
     width: 100%;
 
-    &:not(.group-repositories-by-owner) {
-      padding-left: 0;
-    }
-
     .icon-for-repository {
       // Some room between the icon and repository name
       margin-right: var(--spacing-half);
@@ -83,10 +79,6 @@
       .octicon {
         color: var(--tab-bar-active-color);
         width: auto;
-      }
-
-      &:not(.group-repositories-by-owner) {
-        margin-right: var(--spacing-half);
       }
     }
 


### PR DESCRIPTION

## Description

This PR removes the checks for old feature flags that have been set to true for more than 6 months. The list of removed flags is the following:

* enableBranchPruning	
* enableNoChangesCreatePRBlankslateAction	
* enableGroupRepositoriesByOwner	
* enableRebaseDialog	
* enableStashing	
* enableBranchProtectionChecks	
* enableBranchProtectionWarningFlow	
* enableHideWhitespaceInDiffOption	
* enableTutorial	

In terms of functionality nothing should change (the logic should be the same). In order to reduce the chances of manual errors while deleting the checks I've done the process in two steps: first replaced every function call by a `true` and then perform the dead code elimination manually.

Since this PR changes a bunch of files I suggest waiting a few days to merge it (to minimize the risk of merging this before we need to release a potential emergency v2.5.1 hotfix).