### PR TITLE
Center tags text vertically in history view

### DIFF
--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -50,6 +50,7 @@
       margin-left: var(--spacing);
       color: var(--list-item-badge-color);
       height: 16px;
+      line-height: 16px;
       max-width: 50%;
 
       .tag-indicator {


### PR DESCRIPTION
## Description

This PR fixes the vertical alignment of tag names in the history view, which used to be 1px too low. 

Slack reference: https://github.slack.com/archives/C9E33R811/p1589311861095500

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/408035/81817598-40b6a500-952d-11ea-8502-26debb41f45d.png)

Now:

![image](https://user-images.githubusercontent.com/408035/81817647-4b713a00-952d-11ea-851a-3b8a768facfe.png)

## Release notes

Notes: [Improved] Vertically align tag names in history view 