### PR TITLE
Tweak list scrollbars on Windows

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -89,13 +89,28 @@ export class CommitListItem extends React.PureComponent<
             </div>
           </div>
         </div>
-        <div className="commit-indicators">
-          {enableGitTagsDisplay() &&
-            renderCommitListItemTags(this.props.commit.tags)}
-          {this.renderUnpushedIndicator()}
-        </div>
+        {this.renderCommitIndicators()}
       </div>
     )
+  }
+
+  private renderCommitIndicators() {
+    const tagIndicator = enableGitTagsDisplay()
+      ? renderCommitListItemTags(this.props.commit.tags)
+      : null
+
+    const unpushedIndicator = this.renderUnpushedIndicator()
+
+    if (tagIndicator || unpushedIndicator) {
+      return (
+        <div className="commit-indicators">
+          {tagIndicator}
+          {unpushedIndicator}
+        </div>
+      )
+    }
+
+    return null
   }
 
   private renderUnpushedIndicator() {

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -51,8 +51,8 @@
         // Positioning
         position: absolute;
         top: 0px;
-        right: 3px;
-        width: 15px;
+        right: 1px;
+        width: 12px;
 
         // Only support vertical scrolling for now
         overflow-y: auto;

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -71,6 +71,7 @@
       display: flex;
       justify-content: flex-end;
       align-items: center;
+      margin-right: var(--spacing-half);
     }
 
     .change-indicator-wrapper {

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -16,7 +16,9 @@
 
     border-bottom: var(--base-border);
 
-    padding: 0 var(--spacing);
+    // We need to give a bit more padding to the right to make place for the scrollbar
+    padding-right: calc(var(--spacing) + var(--spacing-half));
+    padding-left: var(--spacing);
 
     .info {
       display: flex;


### PR DESCRIPTION
Related slack conversation: https://github.slack.com/archives/C9E33R811/p1589311914096700

## Description

This PR improves a bit the size/margins of scrollbars in lists (specially on Windows machines) to avoid overlapping them into useful information (like commit/repo indicators or tag names).

This PR contains 4 tweaks (each on its own commit):

1. Move list scrollbars on Windows 2px to the right and make them slightly thinner.

    **Before and after:**
    ![image](https://user-images.githubusercontent.com/408035/81824309-a018b300-9535-11ea-9fe9-13603bfbc1f6.png)
2. Add more padding to commit indicators to make sure that they don't overlap with the scrollbar.

    **Before and after:**
    ![image](https://user-images.githubusercontent.com/408035/81824812-2cc37100-9536-11ea-9f5b-17e35c1c6e5c.png)
3. Add more padding to repository indicators to make sure that they don't overlap with the scrollbar.

    **Before and after:**
    ![image](https://user-images.githubusercontent.com/408035/81825602-1e298980-9537-11ea-9d7a-ef1540d4f4e6.png)
4. Use the whole width for commit message when there are no commit indicators.

    **Before and after:**
    ![image](https://user-images.githubusercontent.com/408035/81825994-92642d00-9537-11ea-90f6-c86c266647c2.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Tweak size of scrollbars in Windows machines.
