### PR TITLE
Add "Copy GitHub URL" to history commit right-click menu

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -116,6 +116,7 @@ import { findUpstreamRemoteBranch } from '../lib/branch'
 import { GitHubRepository } from '../models/github-repository'
 import { CreateTag } from './create-tag'
 import { RetryCloneDialog } from './clone-repository/retry-clone-dialog'
+import { clipboard } from 'electron'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2550,6 +2551,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           issuesStore={this.props.issuesStore}
           gitHubUserStore={this.props.gitHubUserStore}
           onViewCommitOnGitHub={this.onViewCommitOnGitHub}
+          onCopyGitHubURL={this.onCopyGitHubURL}
           imageDiffType={state.imageDiffType}
           hideWhitespaceInDiff={state.hideWhitespaceInDiff}
           focusCommitMessage={state.focusCommitMessage}
@@ -2643,6 +2645,24 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     if (baseURL) {
       this.props.dispatcher.openInBrowser(`${baseURL}/commit/${SHA}`)
+    }
+  }
+
+  private onCopyGitHubURL = async (SHA: string) => {
+    const repository = this.getRepository()
+
+    if (
+      !repository ||
+      repository instanceof CloningRepository ||
+      !repository.gitHubRepository
+    ) {
+      return
+    }
+
+    const baseURL = repository.gitHubRepository.htmlURL
+
+    if (baseURL) {
+      clipboard.writeText(`${baseURL}/commit/${SHA}`)
     }
   }
 

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -24,6 +24,7 @@ interface ICommitProps {
   readonly isLocal: boolean
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
+  readonly onCopyGitHubURL?: (sha: string) => void
   readonly onCreateTag?: (targetCommitSha: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
   readonly showUnpushedIndicator: boolean
@@ -123,6 +124,12 @@ export class CommitListItem extends React.PureComponent<
     }
   }
 
+  private onCopyGitHubURL = () => {
+    if (this.props.onCopyGitHubURL) {
+      this.props.onCopyGitHubURL(this.props.commit.sha)
+    }
+  }
+
   private onCreateTag = () => {
     if (this.props.onCreateTag) {
       this.props.onCreateTag(this.props.commit.sha)
@@ -167,6 +174,11 @@ export class CommitListItem extends React.PureComponent<
       {
         label: 'Copy SHA',
         action: this.onCopySHA,
+      },
+      {
+        label: 'Copy GitHub URL',
+        action: this.onCopyGitHubURL,
+        enabled: !this.props.isLocal && !!gitHubRepository,
       },
       {
         label: viewOnGitHubLabel,

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -46,6 +46,9 @@ interface ICommitListProps {
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
 
+  /** Callback to Copy to clipboard a given commit on GitHub */
+  readonly onCopyGitHubURL: (sha: string) => void
+
   /** Callback to fire to open the dialog to create a new tag on the given commit */
   readonly onCreateTag: (targetCommitSha: string) => void
 
@@ -120,6 +123,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onCreateTag={this.props.onCreateTag}
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+        onCopyGitHubURL={this.props.onCopyGitHubURL}
       />
     )
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -46,6 +46,7 @@ interface ICompareSidebarProps {
   readonly selectedCommitSha: string | null
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
+  readonly onCopyGitHubURL: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
   readonly compareListScrollTop?: number
   readonly localTags: Map<string, string> | null
@@ -278,6 +279,7 @@ export class CompareSidebar extends React.Component<
         localCommitSHAs={this.props.localCommitSHAs}
         emoji={this.props.emoji}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+        onCopyGitHubURL={this.props.onCopyGitHubURL}
         onRevertCommit={
           ableToRevertCommit(this.props.compareState.formState)
             ? this.props.onRevertCommit

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -44,6 +44,7 @@ interface IRepositoryViewProps {
   readonly issuesStore: IssuesStore
   readonly gitHubUserStore: GitHubUserStore
   readonly onViewCommitOnGitHub: (SHA: string) => void
+  readonly onCopyGitHubURL: (SHA: string) => void
   readonly imageDiffType: ImageDiffType
   readonly hideWhitespaceInDiff: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
@@ -225,6 +226,7 @@ export class RepositoryView extends React.Component<
         dispatcher={this.props.dispatcher}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+        onCopyGitHubURL={this.props.onCopyGitHubURL}
         onCompareListScrolled={this.onCompareListScrolled}
         compareListScrollTop={scrollTop}
         tagsToPush={this.props.state.tagsToPush}


### PR DESCRIPTION
Feature Request
## Description

This Commit add a "Copy GitHub URL" to the right-click on commits in history tab.
When working with GitHub Desktop client, after a commit I need to reference that commit in a issue tracker, it can be on the same GitHub repo, but it can be other GitHub repo or even other issue tracker like JIRA.

### Currently to get a Full URL to a commit I need to:
1. Right-Click a Commit
2. Click on "View on GitHub"
3. Wait for browser to open a new tab and load the commit URL
4. Double Click the browser URL
5. Type Copy Shortcut [Cmd+C] / [Ctrl+C]
6. Close the current tab [Cmd+W] / [Ctrl+W]

### With the new button we can get the full URL to a commit in the clipboard with:
1. Right-Click a Commit
2. Click on "Copy GitHub URL"


The URL is on the clipboard ready to paste on your issue tracker.

### Screenshots

<img width="687" alt="Screenshot 2020-05-13 at 18 42 35" src="https://user-images.githubusercontent.com/43767/81846765-82a21400-954a-11ea-9cea-9c44edde3fe4.png">
## Release notes
Notes: Add a new button to Copy GitHub URL to a commit.
