### PR TITLE
Add --no-verify arg to fetchTagsToPush command to avoid executing unwanted hooks

### DIFF
--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -84,6 +84,7 @@ export async function fetchTagsToPush(
     branchName,
     '--follow-tags',
     '--dry-run',
+    '--no-verify',
     '--porcelain',
   ]
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9787

## Description

This PR adds the `--no-verify` CLI argument to the command that checks which tags that need to be pushed. In this case we don't need to run any hook (and in fact running hooks can have unintended side-effects) so we need to tell `git` to not run them.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Do not execute push hooks when checking for tags to push
