### PR TITLE
Add delete tags functionality

### DIFF
--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -22,6 +22,21 @@ export async function createTag(
 }
 
 /**
+ * Delete a tag.
+ *
+ * @param repository        - The repository in which to create the new tag.
+ * @param name              - The name of the tag to delete.
+ */
+export async function deleteTag(
+  repository: Repository,
+  name: string
+): Promise<void> {
+  const args = ['tag', '-d', name]
+
+  await git(args, repository.path, 'deleteTag')
+}
+
+/**
  * Gets all the local tags. Returns a Map with the tag name and the commit it points to.
  *
  * @param repository    The repository in which to get all the tags from.

--- a/app/src/lib/menu-item.ts
+++ b/app/src/lib/menu-item.ts
@@ -18,6 +18,11 @@ export interface IMenuItem {
    * See https://electronjs.org/docs/api/menu-item#roles
    */
   readonly role?: Electron.MenuItemConstructorOptions['role']
+
+  /**
+   * Submenu that will appear when hovering this menu item.
+   */
+  readonly submenu?: ReadonlyArray<IMenuItem>
 }
 
 /**

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -356,6 +356,11 @@ export interface IDailyMeasures {
    * How many tags have been created in total.
    */
   readonly tagsCreated: number
+
+  /**
+   * How many tags have been deleted.
+   */
+  readonly tagsDeleted: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -138,6 +138,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   issueCreationWebpageOpenedCount: 0,
   tagsCreatedInDesktop: 0,
   tagsCreated: 0,
+  tagsDeleted: 0,
 }
 
 interface IOnboardingStats {
@@ -1366,6 +1367,12 @@ export class StatsStore implements IStatsStore {
   public recordTagCreated(numCreatedTags: number) {
     return this.updateDailyMeasures(m => ({
       tagsCreated: m.tagsCreated + numCreatedTags,
+    }))
+  }
+
+  public recordTagDeleted() {
+    return this.updateDailyMeasures(m => ({
+      tagsDeleted: m.tagsDeleted + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3071,8 +3071,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     await gitStore.deleteTag(name)
-
-    this.statsStore.recordTagDeleted()
   }
 
   private updateCheckoutProgress(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3066,6 +3066,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._closePopup()
   }
 
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _deleteTag(repository: Repository, name: string): Promise<void> {
+    const gitStore = this.gitStoreCache.get(repository)
+
+    await gitStore.deleteTag(name)
+  }
+
   private updateCheckoutProgress(
     repository: Repository,
     checkoutProgress: ICheckoutProgress | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3071,6 +3071,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     await gitStore.deleteTag(name)
+
+    this.statsStore.recordTagDeleted()
   }
 
   private updateCheckoutProgress(

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -65,6 +65,7 @@ import {
   removeRemote,
   createTag,
   getAllTags,
+  deleteTag,
 } from '../git'
 import { GitError as DugiteError } from '../../lib/git'
 import { GitError } from 'dugite'
@@ -342,6 +343,16 @@ export class GitStore extends BaseStore {
     this.addTagToPush(name)
   }
 
+  public async deleteTag(name: string) {
+    await this.performFailableOperation(async () => {
+      await deleteTag(this.repository, name)
+    })
+
+    await this.refreshTags()
+
+    this.removeTagToPush(name)
+  }
+
   /** The list of ordered SHAs. */
   public get history(): ReadonlyArray<string> {
     return this._history
@@ -451,6 +462,15 @@ export class GitStore extends BaseStore {
     this._tagsToPush = [...this._tagsToPush, tagName]
 
     storeTagsToPush(this.repository, this._tagsToPush)
+    this.emitUpdate()
+  }
+
+  private removeTagToPush(tagToDelete: string) {
+    this._tagsToPush = this._tagsToPush.filter(
+      tagName => tagName !== tagToDelete
+    )
+
+    this.storeTagsToPush()
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -344,13 +344,19 @@ export class GitStore extends BaseStore {
   }
 
   public async deleteTag(name: string) {
-    await this.performFailableOperation(async () => {
+    const result = await this.performFailableOperation(async () => {
       await deleteTag(this.repository, name)
+      return true
     })
 
-    await this.refreshTags()
+    if (result === undefined) {
+      return
+    }
 
+    await this.refreshTags()
     this.removeTagToPush(name)
+
+    this.statsStore.recordTagDeleted()
   }
 
   /** The list of ordered SHAs. */

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -470,7 +470,7 @@ export class GitStore extends BaseStore {
       tagName => tagName !== tagToDelete
     )
 
-    this.storeTagsToPush()
+    storeTagsToPush(this.repository, this._tagsToPush)
     this.emitUpdate()
   }
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -438,8 +438,8 @@ app.on('ready', () => {
   ipcMain.on(
     'show-contextual-menu',
     (event: Electron.IpcMainEvent, items: ReadonlyArray<IMenuItem>) => {
-      const menu = buildContextMenu(items, ix =>
-        event.sender.send('contextual-menu-action', ix)
+      const menu = buildContextMenu(items, indices =>
+        event.sender.send('contextual-menu-action', indices)
       )
 
       const window = BrowserWindow.fromWebContents(event.sender)

--- a/app/src/main-process/menu/build-context-menu.ts
+++ b/app/src/main-process/menu/build-context-menu.ts
@@ -39,44 +39,49 @@ function getEditMenuItems(): ReadonlyArray<MenuItem> {
  *                 the renderer.
  * @param onClick  A callback function for when one of the menu items
  *                 constructed from the template is clicked. Callback
- *                 is passed the index of the menu item in the template
- *                 as the first argument and the template item itself
- *                 as the second argument. Note that the callback will
- *                 not be called when expanded/automatically created
- *                 edit menu items are clicked.
+ *                 is passed an array of indices corresponding to the
+ *                 positions of each of the parent menus of the clicked
+ *                 item (so when clicking a top-level menu item an array
+ *                 with a single element will be passed). Note that the
+ *                 callback will not be called when expanded/automatically
+ *                 created edit menu items are clicked.
  */
 export function buildContextMenu(
   template: ReadonlyArray<IMenuItem>,
-  onClick: (ix: number, item: IMenuItem) => void
+  onClick: (indices: ReadonlyArray<number>) => void
 ): Menu {
-  const menuItems = new Array<MenuItem>()
+  return buildRecursiveContextMenu(template, onClick)
+}
 
-  for (const [ix, item] of template.entries()) {
-    // Special case editMenu in context menus. What we
-    // mean by this is that we want to insert all edit
-    // related menu items into the menu at this spot, we
-    // don't want a sub menu
+function buildRecursiveContextMenu(
+  menuItems: ReadonlyArray<IMenuItem>,
+  actionFn: (indices: ReadonlyArray<number>) => void,
+  currentIndices: ReadonlyArray<number> = []
+): Menu {
+  const menu = new Menu()
+
+  for (const [idx, item] of menuItems.entries()) {
     if (roleEquals(item.role, 'editmenu')) {
-      menuItems.push(...getEditMenuItems())
+      for (const editItem of getEditMenuItems()) {
+        menu.append(editItem)
+      }
     } else {
-      // TODO: We're always overriding the click function here.
-      // It's possible that we might want to add a role-based
-      // menu item without a custom click function at some point
-      // in the future.
-      menuItems.push(
+      const indices = [...currentIndices, idx]
+
+      menu.append(
         new MenuItem({
           label: item.label,
           type: item.type,
           enabled: item.enabled,
           role: item.role,
-          click: () => onClick(ix, item),
+          click: () => actionFn(indices),
+          submenu: item.submenu
+            ? buildRecursiveContextMenu(item.submenu, actionFn, indices)
+            : undefined,
         })
       )
     }
   }
-
-  const menu = new Menu()
-  menuItems.forEach(x => menu.append(x))
 
   return menu
 }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -59,6 +59,7 @@ export enum PopupType {
   CreateFork,
   SChannelNoRevocationCheck,
   CreateTag,
+  DeleteTag,
   LocalChangesOverwritten,
   RebaseConflicts,
   RetryClone,
@@ -243,4 +244,9 @@ export type Popup =
       repository: Repository | CloningRepository
       retryAction: RetryAction
       errorMessage: string
+    }
+  | {
+      type: PopupType.DeleteTag
+      repository: Repository
+      tagName: string
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -116,6 +116,7 @@ import { findUpstreamRemoteBranch } from '../lib/branch'
 import { GitHubRepository } from '../models/github-repository'
 import { CreateTag } from './create-tag'
 import { RetryCloneDialog } from './clone-repository/retry-clone-dialog'
+import { DeleteTag } from './delete-tag'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -1943,6 +1944,17 @@ export class App extends React.Component<IAppProps, IAppState> {
             targetCommitSha={popup.targetCommitSha}
             initialName={popup.initialName}
             localTags={popup.localTags}
+          />
+        )
+      }
+      case PopupType.DeleteTag: {
+        return (
+          <DeleteTag
+            key="delete-tag"
+            repository={popup.repository}
+            onDismissed={this.onPopupDismissed}
+            dispatcher={this.props.dispatcher}
+            tagName={popup.tagName}
           />
         )
       }

--- a/app/src/ui/delete-tag/delete-tag-dialog.tsx
+++ b/app/src/ui/delete-tag/delete-tag-dialog.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react'
+
+import { Dispatcher } from '../dispatcher'
+import { Repository } from '../../models/repository'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Ref } from '../lib/ref'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IDeleteTagProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly tagName: string
+  readonly onDismissed: () => void
+}
+
+interface IDeleteTagState {
+  readonly isDeleting: boolean
+}
+
+export class DeleteTag extends React.Component<
+  IDeleteTagProps,
+  IDeleteTagState
+> {
+  public constructor(props: IDeleteTagProps) {
+    super(props)
+
+    this.state = {
+      isDeleting: false,
+    }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="delete-tag"
+        title={__DARWIN__ ? 'Delete Tag' : 'Delete tag'}
+        type="warning"
+        onSubmit={this.DeleteTag}
+        onDismissed={this.props.onDismissed}
+        disabled={this.state.isDeleting}
+        loading={this.state.isDeleting}
+      >
+        <DialogContent>
+          <p>
+            Are you sure you want to delete the tag{' '}
+            <Ref>{this.props.tagName}</Ref>?
+          </p>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup destructive={true} okButtonText="Delete" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private DeleteTag = async () => {
+    const { dispatcher, repository, tagName } = this.props
+
+    this.setState({ isDeleting: true })
+
+    await dispatcher.deleteTag(repository, tagName)
+    await dispatcher.closePopup()
+  }
+}

--- a/app/src/ui/delete-tag/delete-tag-dialog.tsx
+++ b/app/src/ui/delete-tag/delete-tag-dialog.tsx
@@ -59,6 +59,6 @@ export class DeleteTag extends React.Component<
     this.setState({ isDeleting: true })
 
     await dispatcher.deleteTag(repository, tagName)
-    await dispatcher.closePopup()
+    this.props.onDismissed()
   }
 }

--- a/app/src/ui/delete-tag/index.ts
+++ b/app/src/ui/delete-tag/index.ts
@@ -1,0 +1,1 @@
+export { DeleteTag } from './delete-tag-dialog'

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -531,6 +531,20 @@ export class Dispatcher {
     })
   }
 
+  /**
+   * Show the confirmation dialog to delete a tag.
+   */
+  public showDeleteTagDialog(
+    repository: Repository,
+    tagName: string
+  ): Promise<void> {
+    return this.showPopup({
+      type: PopupType.DeleteTag,
+      repository,
+      tagName,
+    })
+  }
+
   /** Check out the given branch. */
   public checkoutBranch(
     repository: Repository,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -507,6 +507,13 @@ export class Dispatcher {
   }
 
   /**
+   * Deletes the passed tag.
+   */
+  public deleteTag(repository: Repository, name: string): Promise<void> {
+    return this.appStore._deleteTag(repository, name)
+  }
+
+  /**
    * Show the tag creation dialog.
    */
   public showCreateTagDialog(

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -25,9 +25,11 @@ interface ICommitProps {
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
   readonly onCreateTag?: (targetCommitSha: string) => void
+  readonly onDeleteTag?: (tagName: string) => void
   readonly gitHubUsers: Map<string, IGitHubUser> | null
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
+  readonly unpushedTags?: ReadonlyArray<string>
 }
 
 interface ICommitListItemState {
@@ -175,6 +177,17 @@ export class CommitListItem extends React.PureComponent<
         action: this.onCreateTag,
         enabled: this.props.onCreateTag !== undefined,
       })
+
+      const deleteTagsMenuItem = this.getDeleteTagsMenuItem()
+
+      if (deleteTagsMenuItem !== null) {
+        items.push(
+          {
+            type: 'separator',
+          },
+          deleteTagsMenuItem
+        )
+      }
     }
 
     items.push(
@@ -191,6 +204,35 @@ export class CommitListItem extends React.PureComponent<
     )
 
     showContextualMenu(items)
+  }
+
+  private getDeleteTagsMenuItem(): IMenuItem | null {
+    const { unpushedTags, onDeleteTag } = this.props
+
+    if (
+      onDeleteTag == null ||
+      unpushedTags == null ||
+      unpushedTags.length === 0
+    ) {
+      return null
+    }
+
+    if (unpushedTags.length === 1) {
+      return {
+        label: `Delete tag ${unpushedTags[0]}`,
+        action: () => onDeleteTag(unpushedTags[0]),
+      }
+    }
+
+    return {
+      label: 'Delete tag…',
+      submenu: unpushedTags.map(tagName => {
+        return {
+          label: tagName,
+          action: () => onDeleteTag(tagName),
+        }
+      }),
+    }
   }
 }
 

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -210,8 +210,8 @@ export class CommitListItem extends React.PureComponent<
     const { unpushedTags, onDeleteTag, commit } = this.props
 
     if (
-      onDeleteTag == null ||
-      unpushedTags == null ||
+      onDeleteTag === undefined ||
+      unpushedTags === undefined ||
       commit.tags.length === 0
     ) {
       return null

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -207,29 +207,36 @@ export class CommitListItem extends React.PureComponent<
   }
 
   private getDeleteTagsMenuItem(): IMenuItem | null {
-    const { unpushedTags, onDeleteTag } = this.props
+    const { unpushedTags, onDeleteTag, commit } = this.props
 
     if (
       onDeleteTag == null ||
       unpushedTags == null ||
-      unpushedTags.length === 0
+      commit.tags.length === 0
     ) {
       return null
     }
 
-    if (unpushedTags.length === 1) {
+    if (commit.tags.length === 1) {
+      const tagName = commit.tags[0]
+
       return {
-        label: `Delete tag ${unpushedTags[0]}`,
-        action: () => onDeleteTag(unpushedTags[0]),
+        label: `Delete tag ${tagName}`,
+        action: () => onDeleteTag(tagName),
+        enabled: unpushedTags.includes(tagName),
       }
     }
 
+    // Convert tags to a Set to avoid O(n^2)
+    const unpushedTagsSet = new Set(unpushedTags)
+
     return {
       label: 'Delete tag…',
-      submenu: unpushedTags.map(tagName => {
+      submenu: commit.tags.map(tagName => {
         return {
           label: tagName,
           action: () => onDeleteTag(tagName),
+          enabled: unpushedTagsSet.has(tagName),
         }
       }),
     }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -49,6 +49,9 @@ interface ICommitListProps {
   /** Callback to fire to open the dialog to create a new tag on the given commit */
   readonly onCreateTag: (targetCommitSha: string) => void
 
+  /** Callback to fire to delete an unpushed tag */
+  readonly onDeleteTag: (tagName: string) => void
+
   /**
    * Optional callback that fires on page scroll in order to allow passing
    * a new scrollTop value up to the parent component for storing.
@@ -97,12 +100,13 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const tagsToPushSet = new Set(this.props.tagsToPush || [])
 
     const isLocal = this.props.localCommitSHAs.includes(commit.sha)
-    const numUnpushedTags = commit.tags.filter(tagName =>
+    const unpushedTags = commit.tags.filter(tagName =>
       tagsToPushSet.has(tagName)
-    ).length
+    )
 
     const showUnpushedIndicator =
-      (isLocal || numUnpushedTags > 0) && this.props.isLocalRepository === false
+      (isLocal || unpushedTags.length > 0) &&
+      this.props.isLocalRepository === false
 
     return (
       <CommitListItem
@@ -112,12 +116,14 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         showUnpushedIndicator={showUnpushedIndicator}
         unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
           isLocal,
-          numUnpushedTags
+          unpushedTags.length
         )}
+        unpushedTags={unpushedTags}
         commit={commit}
         gitHubUsers={this.props.gitHubUsers}
         emoji={this.props.emoji}
         onCreateTag={this.props.onCreateTag}
+        onDeleteTag={this.props.onDeleteTag}
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
       />

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -604,7 +604,7 @@ export class CompareSidebar extends React.Component<
   }
 
   private onDeleteTag = (tagName: string) => {
-    this.props.dispatcher.deleteTag(this.props.repository, tagName)
+    this.props.dispatcher.showDeleteTagDialog(this.props.repository, tagName)
   }
 }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -286,6 +286,7 @@ export class CompareSidebar extends React.Component<
         onCommitSelected={this.onCommitSelected}
         onScroll={this.onScroll}
         onCreateTag={this.onCreateTag}
+        onDeleteTag={this.onDeleteTag}
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
@@ -600,6 +601,10 @@ export class CompareSidebar extends React.Component<
       targetCommitSha,
       this.props.localTags
     )
+  }
+
+  private onDeleteTag = (tagName: string) => {
+    this.props.dispatcher.deleteTag(this.props.repository, tagName)
   }
 }
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -75,7 +75,7 @@ export function registerContextualMenuActionDispatcher() {
   ipcRenderer.on(
     'contextual-menu-action',
     (event: Electron.IpcRendererEvent, indices: number[]) => {
-      if (currentContextualMenuItems == null) {
+      if (currentContextualMenuItems === null) {
         return
       }
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -74,16 +74,25 @@ let currentContextualMenuItems: ReadonlyArray<IMenuItem> | null = null
 export function registerContextualMenuActionDispatcher() {
   ipcRenderer.on(
     'contextual-menu-action',
-    (event: Electron.IpcRendererEvent, index: number) => {
-      if (!currentContextualMenuItems) {
-        return
-      }
-      if (index >= currentContextualMenuItems.length) {
+    (event: Electron.IpcRendererEvent, indices: number[]) => {
+      if (currentContextualMenuItems == null) {
         return
       }
 
-      const item = currentContextualMenuItems[index]
-      const action = item.action
+      let foundMenuItem: IMenuItem = {
+        submenu: currentContextualMenuItems,
+      }
+
+      // Traverse the submenus of the context menu until we find the appropiate index.
+      for (const index of indices) {
+        if (foundMenuItem == null || foundMenuItem.submenu == null) {
+          return
+        }
+
+        foundMenuItem = foundMenuItem.submenu[index]
+      }
+
+      const action = foundMenuItem.action
       if (action) {
         action()
         currentContextualMenuItems = null

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -79,26 +79,34 @@ export function registerContextualMenuActionDispatcher() {
         return
       }
 
-      let foundMenuItem: IMenuItem = {
-        submenu: currentContextualMenuItems,
-      }
+      const menuItem = findSubmenuItem(currentContextualMenuItems, indices)
 
-      // Traverse the submenus of the context menu until we find the appropiate index.
-      for (const index of indices) {
-        if (foundMenuItem == null || foundMenuItem.submenu == null) {
-          return
-        }
-
-        foundMenuItem = foundMenuItem.submenu[index]
-      }
-
-      const action = foundMenuItem.action
-      if (action) {
-        action()
+      if (menuItem !== undefined && menuItem.action !== undefined) {
+        menuItem.action()
         currentContextualMenuItems = null
       }
     }
   )
+}
+
+function findSubmenuItem(
+  currentContextualMenuItems: ReadonlyArray<IMenuItem>,
+  indices: ReadonlyArray<number>
+): IMenuItem | undefined {
+  let foundMenuItem: IMenuItem | undefined = {
+    submenu: currentContextualMenuItems,
+  }
+
+  // Traverse the submenus of the context menu until we find the appropiate index.
+  for (const index of indices) {
+    if (foundMenuItem === undefined || foundMenuItem.submenu === undefined) {
+      return undefined
+    }
+
+    foundMenuItem = foundMenuItem.submenu[index]
+  }
+
+  return foundMenuItem
 }
 
 /** Show the given menu items in a contextual menu. */

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -12,6 +12,7 @@ import {
   createBranch,
   createCommit,
   checkoutBranch,
+  deleteTag,
 } from '../../../src/lib/git'
 import {
   setupFixtureRepository,
@@ -78,6 +79,17 @@ describe('git/tag', () => {
       expect(createTag(repository, 'my-new-tag', 'HEAD')).rejects.toThrow(
         /already exists/i
       )
+    })
+  })
+
+  describe('deleteTag', () => {
+    it('deletes a tag with the given name', async () => {
+      await createTag(repository, 'my-new-tag', 'HEAD')
+      await deleteTag(repository, 'my-new-tag')
+
+      const commit = await getCommit(repository, 'HEAD')
+      expect(commit).not.toBeNull()
+      expect(commit!.tags).toEqual([])
     })
   })
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9770

This PR is based on https://github.com/desktop/desktop/pull/9828

## Description

This PR adds the functionality to delete tags that haven't been pushed yet from GitHub Desktop.

In order to do so, a new context menu item has been added to commits that have unpushed tags. If the commit has one single unpushed tag, the menu iten will show a text like "Delete tag v1.0.0", but if there are more than one unpushed tags, the menu item will display a "Delete tags..." text and will show the tags that can get deleted via a submenu.

In order to implement that, the context menu behaviour has been changed to support submenus in context menus (see commit 55443cd).

@tierninho in order to test this PR you'll have to run `yarn build:dev` beforehand, since it modifies code from the main process.

### Screenshots

![demo](https://user-images.githubusercontent.com/408035/81962146-9d8c8b00-9613-11ea-9828-5d6dd6ac71c6.gif)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Allow to delete tags that have not been pushed to the remote repository
