### PR TITLE
add storage for fork repo workflow settings

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -1,5 +1,6 @@
 import Dexie from 'dexie'
 import { BaseDatabase } from './base-database'
+import { WorkflowPreferences } from '../../models/workflow-preferences'
 
 export interface IDatabaseOwner {
   readonly id?: number | null
@@ -47,6 +48,8 @@ export interface IDatabaseRepository {
 
   /** The last time the stash entries were checked for the repository */
   readonly lastStashCheckDate: number | null
+
+  readonly workflowPreferences?: WorkflowPreferences
 
   /**
    * True if the repository is a tutorial repository created as part

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -49,7 +49,7 @@ export interface IDatabaseRepository {
   /** The last time the stash entries were checked for the repository */
   readonly lastStashCheckDate: number | null
 
-  readonly workflowPreferences: WorkflowPreferences
+  readonly workflowPreferences?: WorkflowPreferences
 
   /**
    * True if the repository is a tutorial repository created as part

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -49,7 +49,7 @@ export interface IDatabaseRepository {
   /** The last time the stash entries were checked for the repository */
   readonly lastStashCheckDate: number | null
 
-  readonly workflowPreferences?: WorkflowPreferences
+  readonly workflowPreferences: WorkflowPreferences
 
   /**
    * True if the repository is a tutorial repository created as part

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3328,7 +3328,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository.id,
       skeletonGitHubRepository,
       repository.missing,
-      undefined,
+      {},
       false
     )
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3328,6 +3328,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository.id,
       skeletonGitHubRepository,
       repository.missing,
+      undefined,
       false
     )
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -182,6 +182,7 @@ export class RepositoriesStore extends TypedBaseStore<
             missing: false,
             lastStashCheckDate: null,
             isTutorialRepository: true,
+            workflowPreferences: {},
           },
           existingRepoId
         )
@@ -222,6 +223,7 @@ export class RepositoriesStore extends TypedBaseStore<
             gitHubRepositoryID: null,
             missing: false,
             lastStashCheckDate: null,
+            workflowPreferences: {},
           })
         }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -182,7 +182,6 @@ export class RepositoriesStore extends TypedBaseStore<
             missing: false,
             lastStashCheckDate: null,
             isTutorialRepository: true,
-            workflowPreferences: {},
           },
           existingRepoId
         )
@@ -223,7 +222,6 @@ export class RepositoriesStore extends TypedBaseStore<
             gitHubRepositoryID: null,
             missing: false,
             lastStashCheckDate: null,
-            workflowPreferences: {},
           })
         }
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -133,6 +133,7 @@ export class RepositoriesStore extends TypedBaseStore<
             repo.id!,
             gitHubRepository,
             repo.missing,
+            repo.workflowPreferences,
             repo.isTutorialRepository
           )
           inflatedRepos.push(inflatedRepo)
@@ -261,6 +262,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.id,
       repository.gitHubRepository,
       missing,
+      repository.workflowPreferences,
       repository.isTutorialRepository
     )
   }
@@ -289,6 +291,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.id,
       repository.gitHubRepository,
       false,
+      repository.workflowPreferences,
       repository.isTutorialRepository
     )
   }
@@ -480,6 +483,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.id,
       updatedGitHubRepo,
       repository.missing,
+      repository.workflowPreferences,
       repository.isTutorialRepository
     )
   }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -3,6 +3,7 @@ import * as Path from 'path'
 import { GitHubRepository } from './github-repository'
 import { IAheadBehind } from './branch'
 import { enableTutorial } from '../lib/feature-flag'
+import { WorkflowPreferences } from './workflow-preferences'
 
 function getBaseName(path: string): string {
   const baseName = Path.basename(path)
@@ -39,6 +40,7 @@ export class Repository {
     public readonly id: number,
     public readonly gitHubRepository: GitHubRepository | null,
     public readonly missing: boolean,
+    public readonly workflowPreferences?: WorkflowPreferences,
     private readonly _isTutorialRepository?: boolean
   ) {
     this.mainWorkTree = { path }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -40,7 +40,7 @@ export class Repository {
     public readonly id: number,
     public readonly gitHubRepository: GitHubRepository | null,
     public readonly missing: boolean,
-    public readonly workflowPreferences?: WorkflowPreferences,
+    public readonly workflowPreferences: WorkflowPreferences = {},
     private readonly _isTutorialRepository?: boolean
   ) {
     this.mainWorkTree = { path }

--- a/app/src/models/workflow-preferences.ts
+++ b/app/src/models/workflow-preferences.ts
@@ -1,11 +1,7 @@
-export enum ForkContributionTargets {
+export enum ForkContributionTarget {
   Parent = 'parent',
   Self = 'self',
 }
-
-export type ForkContributionTarget =
-  | ForkContributionTargets.Parent
-  | ForkContributionTargets.Self
 
 /**
  * Collection of configurable settings regarding how the user may work with a repository.

--- a/app/src/models/workflow-preferences.ts
+++ b/app/src/models/workflow-preferences.ts
@@ -1,0 +1,18 @@
+export enum ForkContributionTargets {
+  Parent = 'parent',
+  Self = 'self',
+}
+
+export type ForkContributionTarget =
+  | ForkContributionTargets.Parent
+  | ForkContributionTargets.Self
+
+/**
+ * Collection of configurable settings regarding how the user may work with a repository.
+ */
+export type WorkflowPreferences = {
+  /**
+   * What repo does the user want to contribute to with this fork?
+   */
+  readonly forkContributionTarget?: ForkContributionTarget
+}


### PR DESCRIPTION
Supports #9679 

## Description

- add a database persisted collection of repo workflow settings to the `Repository` model
- includes a setting for whether a fork is mean to contribute upstream or to itself
