### PR TITLE
use fork workflow preferences if possible

### DIFF
--- a/app/src/lib/branch.ts
+++ b/app/src/lib/branch.ts
@@ -18,7 +18,7 @@ import {
 export function findDefaultUpstreamBranch(
   repository: RepositoryWithGitHubRepository,
   branches: ReadonlyArray<Branch>
-) {
+): Branch | null {
   const githubRepository = getNonForkGitHubRepository(repository)
 
   // This is a bit hacky... we checked if the result of calling
@@ -33,9 +33,11 @@ export function findDefaultUpstreamBranch(
     return null
   }
 
-  return branches.find(
+  const foundBranch = branches.find(
     b =>
       b.type === BranchType.Remote &&
       b.name === `${UpstreamRemoteName}/${githubRepository.defaultBranch}`
   )
+
+  return foundBranch !== undefined ? foundBranch : null
 }

--- a/app/src/lib/branch.ts
+++ b/app/src/lib/branch.ts
@@ -1,25 +1,41 @@
 import { Branch, BranchType } from '../models/branch'
 import { UpstreamRemoteName } from './stores'
+import {
+  RepositoryWithGitHubRepository,
+  getNonForkGitHubRepository,
+} from '../models/repository'
 
 /**
- * Finds the remote branch for a branch in the upstream repository
+ * Finds the default branch of the upstream repository of the passed repository.
  *
- * For example:
- * If official/funnel has the branch `development`, then running
- * this on the branches from the fork outofambit/funnel with
- * `development` as the specified branch name will find the
- * branch `remotes/upstream/development`
+ * When the passed repository is not a fork or the fork is configured to use itself
+ * as the ForkContributionTarget, then this method will return null. Otherwise it'll
+ * return the default branch of the upstream repository.
  *
- * @param branchName short name of the branch in the upstream repo
- * @param branches all the branches in the local repo
+ * @param repository The repository to use.
+ * @param branches all the branches in the local repo.
  */
-export function findUpstreamRemoteBranch(
-  branchName: string,
+export function findDefaultUpstreamBranch(
+  repository: RepositoryWithGitHubRepository,
   branches: ReadonlyArray<Branch>
 ) {
+  const githubRepository = getNonForkGitHubRepository(repository)
+
+  // This is a bit hacky... we checked if the result of calling
+  // getNonForkGitHubRepository() is the same as the associated
+  // gitHubRepository. When this happens, we know that either the
+  // repository is not a fork or that it's a fork with
+  // ForkContributionTarget=Self.
+  //
+  // TODO: Make this method return the default branch of the
+  // origin repository instead of null in this scenario.
+  if (githubRepository === repository.gitHubRepository) {
+    return null
+  }
+
   return branches.find(
     b =>
       b.type === BranchType.Remote &&
-      b.name === `${UpstreamRemoteName}/${branchName}`
+      b.name === `${UpstreamRemoteName}/${githubRepository.defaultBranch}`
   )
 }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -3,7 +3,10 @@ import * as Path from 'path'
 import { GitHubRepository } from './github-repository'
 import { IAheadBehind } from './branch'
 import { enableTutorial } from '../lib/feature-flag'
-import { WorkflowPreferences } from './workflow-preferences'
+import {
+  WorkflowPreferences,
+  ForkContributionTargets,
+} from './workflow-preferences'
 
 function getBaseName(path: string): string {
   const baseName = Path.basename(path)
@@ -129,11 +132,23 @@ export function getGitHubHtmlUrl(repository: Repository): string | null {
 }
 
 /**
- * Returns the GitHubRepository when a non-fork repository is passed. Returns the parent
- * GitHubRepository otherwise.
+ * Attempts to honor the Repository's workflow preference for GitHubRepository contributions.
+ * Falls back to returning the GitHubRepository when a non-fork repository
+ * is passed, returns the parent GitHubRepository otherwise.
  */
 export function getNonForkGitHubRepository(
   repository: RepositoryWithGitHubRepository
 ): GitHubRepository {
+  if (
+    repository.workflowPreferences !== undefined &&
+    repository.workflowPreferences.forkContributionTarget !== undefined
+  ) {
+    switch (repository.workflowPreferences.forkContributionTarget) {
+      case ForkContributionTargets.Self:
+        return repository.gitHubRepository
+      case ForkContributionTargets.Parent:
+        return repository.gitHubRepository.parent || repository.gitHubRepository
+    }
+  }
   return repository.gitHubRepository.parent || repository.gitHubRepository
 }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -5,8 +5,9 @@ import { IAheadBehind } from './branch'
 import { enableTutorial } from '../lib/feature-flag'
 import {
   WorkflowPreferences,
-  ForkContributionTargets,
+  ForkContributionTarget,
 } from './workflow-preferences'
+import { assertNever } from '../lib/fatal-error'
 
 function getBaseName(path: string): string {
   const baseName = Path.basename(path)
@@ -139,16 +140,30 @@ export function getGitHubHtmlUrl(repository: Repository): string | null {
 export function getNonForkGitHubRepository(
   repository: RepositoryWithGitHubRepository
 ): GitHubRepository {
-  if (
-    repository.workflowPreferences !== undefined &&
-    repository.workflowPreferences.forkContributionTarget !== undefined
-  ) {
-    switch (repository.workflowPreferences.forkContributionTarget) {
-      case ForkContributionTargets.Self:
-        return repository.gitHubRepository
-      case ForkContributionTargets.Parent:
-        return repository.gitHubRepository.parent || repository.gitHubRepository
-    }
+  if (repository.gitHubRepository.parent === null) {
+    // If the repository is not a fork, we don't have to worry about anything.
+    return repository.gitHubRepository
   }
-  return repository.gitHubRepository.parent || repository.gitHubRepository
+
+  const forkContributionTarget = getForkContributionTarget(repository)
+
+  switch (forkContributionTarget) {
+    case ForkContributionTarget.Self:
+      return repository.gitHubRepository
+    case ForkContributionTarget.Parent:
+      return repository.gitHubRepository.parent
+  }
+
+  return assertNever(forkContributionTarget, 'Invalid fork contribution target')
+}
+
+/**
+ * Returns a non-undefined forkContributionTarget for the specified repository.
+ */
+export function getForkContributionTarget(
+  repository: Repository
+): ForkContributionTarget {
+  return repository.workflowPreferences.forkContributionTarget !== undefined
+    ? repository.workflowPreferences.forkContributionTarget
+    : ForkContributionTarget.Parent
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -23,7 +23,12 @@ import { getVersion, getName } from './lib/app-proxy'
 import { getOS } from '../lib/get-os'
 import { validatedRepositoryPath } from '../lib/stores/helpers/validated-repository-path'
 import { MenuEvent } from '../main-process/menu'
-import { Repository, getGitHubHtmlUrl } from '../models/repository'
+import {
+  Repository,
+  getGitHubHtmlUrl,
+  getNonForkGitHubRepository,
+  isRepositoryWithGitHubRepository,
+} from '../models/repository'
 import { Branch } from '../models/branch'
 import { PreferencesTab } from '../models/preferences'
 import { findItemByAccessKey, itemIsSelectable } from '../models/app-menu'
@@ -1469,10 +1474,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         if (
           enableForkyCreateBranchUI() &&
-          repository.gitHubRepository !== null &&
-          repository.gitHubRepository.parent !== null
+          isRepositoryWithGitHubRepository(repository)
         ) {
-          upstreamGhRepo = repository.gitHubRepository.parent
+          upstreamGhRepo = getNonForkGitHubRepository(repository)
+
           if (upstreamGhRepo.defaultBranch !== null) {
             upstreamDefaultBranch =
               findUpstreamRemoteBranch(

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -117,7 +117,7 @@ import { getUncommittedChangesStrategy } from '../models/uncommitted-changes-str
 import { SAMLReauthRequiredDialog } from './saml-reauth-required/saml-reauth-required'
 import { CreateForkDialog } from './forks/create-fork-dialog'
 import { SChannelNoRevocationCheckDialog } from './schannel-no-revocation-check/schannel-no-revocation-check'
-import { findUpstreamRemoteBranch } from '../lib/branch'
+import { findDefaultUpstreamBranch } from '../lib/branch'
 import { GitHubRepository } from '../models/github-repository'
 import { CreateTag } from './create-tag'
 import { RetryCloneDialog } from './clone-repository/retry-clone-dialog'
@@ -1477,14 +1477,9 @@ export class App extends React.Component<IAppProps, IAppState> {
           isRepositoryWithGitHubRepository(repository)
         ) {
           upstreamGhRepo = getNonForkGitHubRepository(repository)
-
-          if (upstreamGhRepo.defaultBranch !== null) {
-            upstreamDefaultBranch =
-              findUpstreamRemoteBranch(
-                upstreamGhRepo.defaultBranch,
-                branchesState.allBranches
-              ) || null
-          }
+          upstreamDefaultBranch =
+            findDefaultUpstreamBranch(repository, branchesState.allBranches) ||
+            null
         }
 
         return (

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1471,9 +1471,10 @@ export class App extends React.Component<IAppProps, IAppState> {
           isRepositoryWithGitHubRepository(repository)
         ) {
           upstreamGhRepo = getNonForkGitHubRepository(repository)
-          upstreamDefaultBranch =
-            findDefaultUpstreamBranch(repository, branchesState.allBranches) ||
-            null
+          upstreamDefaultBranch = findDefaultUpstreamBranch(
+            repository,
+            branchesState.allBranches
+          )
         }
 
         return (


### PR DESCRIPTION
~~👋🏼 _based on https://github.com/desktop/desktop/pull/9805, please review that first!_~~ - Done!

Supports #9679

## Description

- Modify logic in `getNonForkGitHubRepository` to respect the new workflow setting

## Notes

- maintains previous logic default if the workflow setting hasn't been set
- @rafeca and i consolidated the majority of, if not all, fork determining logic in desktop into this method
