### PR TITLE
Use canonical stash references to avoid ambiguous references

### DIFF
--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -42,7 +42,7 @@ type StashResult = {
 export async function getStashes(repository: Repository): Promise<StashResult> {
   const delimiter = '1F'
   const delimiterString = String.fromCharCode(parseInt(delimiter, 16))
-  const format = ['%gd', '%H', '%gs'].join(`%x${delimiter}`)
+  const format = ['%gD', '%H', '%gs'].join(`%x${delimiter}`)
 
   const result = await git(
     ['log', '-g', '-z', `--pretty=${format}`, 'refs/stash'],

--- a/app/src/models/stash-entry.ts
+++ b/app/src/models/stash-entry.ts
@@ -1,7 +1,7 @@
 import { CommittedFileChange } from './status'
 
 export interface IStashEntry {
-  /** The name of the entry i.e., `stash@{0}` */
+  /** The fully qualified name of the entry i.e., `refs/stash@{0}` */
   readonly name: string
 
   /** The name of the branch at the time the entry was created. */

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -191,7 +191,7 @@ describe('git/stash', () => {
     it('does not fail when attempting to delete when stash is empty', async () => {
       let didFail = false
       const doesNotExist: IStashEntry = {
-        name: 'stash@{0}',
+        name: 'refs/stash@{0}',
         branchName: 'master',
         stashSha: 'xyz',
         files: { kind: StashedChangesLoadStates.NotLoaded },
@@ -209,7 +209,7 @@ describe('git/stash', () => {
     it("does not fail when attempting to delete stash entry that doesn't exist", async () => {
       let didFail = false
       const doesNotExist: IStashEntry = {
-        name: 'stash@{4}',
+        name: 'refs/stash@{4}',
         branchName: 'master',
         stashSha: 'xyz',
         files: { kind: StashedChangesLoadStates.NotLoaded },

--- a/app/test/unit/git/stash-test.ts
+++ b/app/test/unit/git/stash-test.ts
@@ -55,6 +55,7 @@ describe('git/stash', () => {
       const entries = stash.desktopEntries
       expect(entries).toHaveLength(1)
       expect(entries[0].branchName).toBe('master')
+      expect(entries[0].name).toBe('refs/stash@{0}')
     })
   })
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9844

## Description

When a repository contains a branch named `stash` it's impossible to restore a saved stash in desktop.

When we compile the list of stashes available in the application we do so by executing

`git log -g --pretty="%gd %H %gs" refs/stash` which is the equivalent of `git stash list` (in fact it's exactly what `git stash list` [does internally](https://github.com/git/git/blob/ae92ac8ae3838e72840f5d019195bb9c0c9e7b0e/builtin/stash.c#L695-L700)). Running that command will produce a list similar to

```
stash@{0} 848424c2ae536be49a55f240ce6a2440d1e63664 On wip-dantes-nine-circles-of-focus: !!GitHub_Desktop<wip-dantes-nine-circles-of-focus>
stash@{1} 3bd027ba54d0cb8fecda6c0ee24fccdb3053394f On proxy-docs: !!GitHub_Desktop<proxy-docs>
```

When the user then choses to restore a stash we run `git stash pop stash@{0}` using the name provided to us from the `%gd` format string. `%gd` being the [shortened reflog selector](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emgdem). `git stash pop` then gets confused trying to pick between `refs/stash@{0}` and `refs/heads/stash@{0}`

```
Markuss-MacBook-Pro:conflict-test markus$ git stash pop stash@{0}
warning: refname 'stash' is ambiguous.
warning: refname 'stash' is ambiguous.
warning: refname 'stash' is ambiguous.
warning: refname 'stash' is ambiguous.
warning: refname 'stash' is ambiguous.
warning: refname 'stash' is ambiguous.
```

By changing from `%gd` to `%gD`, the [canonical or "fully qualified" reflog selector](https://git-scm.com/docs/git-log#Documentation/git-log.txt-emgDem) we can avoid that ambiguity

```
Markuss-MacBook-Pro:desktop markus$ git log -g --pretty="%gD %H %gs" refs/stash
refs/stash@{0} 848424c2ae536be49a55f240ce6a2440d1e63664 On wip-dantes-nine-circles-of-focus: !!GitHub_Desktop<wip-dantes-nine-circles-of-focus>
refs/stash@{1} 3bd027ba54d0cb8fecda6c0ee24fccdb3053394f On proxy-docs: !!GitHub_Desktop<proxy-docs>
```

Our `git pop` command then becomes `git pop refs/stash@{0}` which isn't ambiguous and the pop succeeds.

The only place where we use the `name` property of the `IStashEntry` interface is when doing `git stash pop` and `git stash drop`, both of which are perfectly happy accepting the fully qualified ref.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
[Fixed] Restore stash would fail due to ambiguous reference when repository contains a branch named "stash"