### PR TITLE
Fix Ctrl+W shortcut not working in dialogs

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -593,6 +593,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
         onMouseDown={this.onDialogMouseDown}
         className={className}
         aria-labelledby={this.state.titleId}
+        tabIndex={-1}
       >
         {this.renderHeader()}
 


### PR DESCRIPTION
Closes #9826

## Description

- Adds tabIndex={-1} to `<dialog>` Element. So when clicking on non interactive elements, `<dialog>` Element is focused instead of body. This ensures working of shortcuts, like `Ctrl+W`.

Ready for review

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
