### PR TITLE
Support deleting tags from outside desktop

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3061,7 +3061,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     await gitStore.createTag(name, targetCommitSha)
-    this.statsStore.recordTagCreatedInDesktop()
 
     this._closePopup()
   }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -275,6 +275,15 @@ export class GitStore extends BaseStore {
 
     this._localTags = newTags
 
+    // Remove any unpushed tag that cannot be found in the list
+    // of local tags. This can happen when the user deletes an
+    // unpushed tag from outside of Desktop.
+    for (const tagToPush of this._tagsToPush) {
+      if (!this._localTags.has(tagToPush)) {
+        this.removeTagToPush(tagToPush)
+      }
+    }
+
     if (previousTags !== null) {
       // We don't await for the emition of updates to finish
       // to make this method return earlier.

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -347,10 +347,14 @@ export class GitStore extends BaseStore {
       return true
     })
 
-    if (result !== undefined) {
-      await this.refreshTags()
-      this.addTagToPush(name)
+    if (result === undefined) {
+      return
     }
+
+    await this.refreshTags()
+    this.addTagToPush(name)
+
+    this.statsStore.recordTagCreatedInDesktop()
   }
 
   /** The list of ordered SHAs. */


### PR DESCRIPTION
## Description

@niik discovered an edge case with the [latest](https://github.com/desktop/desktop/pull/9828) PR that changed the way to push tags in Desktop: if an unpushed tag gets deleted from outside, Desktop will still try to push it on the next push operation since it won't know that it doesn't exist anymore.

This PR addresses this issue by pruning unpushed tags that cannot be found locally every time we refresh the list of tags (which happens when the Desktop window gets focused, when we fetch/pull and when the user creates/deletes a tag).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
