### PR TITLE
Perform refreshTags operation inside refreshRepository()

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1537,7 +1537,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     previouslySelectedRepository: Repository | CloningRepository | null
   ): Promise<Repository | null> {
-    await this._refreshTags(repository)
     this._refreshRepository(repository)
 
     if (isRepositoryWithGitHubRepository(repository)) {
@@ -2693,13 +2692,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _refreshTags(repository: Repository): Promise<void> {
-    const gitStore = this.gitStoreCache.get(repository)
-
-    return gitStore.refreshTags()
-  }
-
-  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _refreshRepository(repository: Repository): Promise<void> {
     if (repository.missing) {
       return
@@ -2750,6 +2742,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.refreshAuthor(repository),
       refreshSectionPromise,
     ])
+
+    await gitStore.refreshTags()
 
     // this promise is fire-and-forget, so no need to await it
     this.updateStashEntryCountMetric(
@@ -3843,7 +3837,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
           // any new branch will immediately report as protected
           await this.refreshBranchProtectionState(repository)
 
-          await this._refreshTags(repository)
           await this._refreshRepository(repository)
 
           this.updatePushPullFetchProgress(repository, {
@@ -4036,7 +4029,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const gitStore = this.gitStoreCache.get(repository)
         await gitStore.fetchRefspec(account, refspec)
 
-        await this._refreshTags(repository)
         return this._refreshRepository(repository)
       }
     )
@@ -4125,7 +4117,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // any new branch will immediately report as protected
         await this.refreshBranchProtectionState(repository)
 
-        await this._refreshTags(repository)
         await this._refreshRepository(repository)
 
         this.updatePushPullFetchProgress(repository, {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -328,13 +328,6 @@ export class Dispatcher {
     return this.appStore._refreshOrRecoverRepository(repository)
   }
 
-  /**
-   * Refreshes the list of local tags. This would be used, e.g., when the app gains focus.
-   */
-  public refreshTags(repository: Repository): Promise<void> {
-    return this.appStore._refreshTags(repository)
-  }
-
   /** Show the popup. This will close any current popup. */
   public showPopup(popup: Popup): Promise<void> {
     return this.appStore._showPopup(popup)

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -305,7 +305,7 @@ document.body.classList.add(`platform-${process.platform}`)
 
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
 
-ipcRenderer.on('focus', async () => {
+ipcRenderer.on('focus', () => {
   const { selectedState } = appStore.getState()
 
   // Refresh the currently selected repository on focus (if
@@ -314,8 +314,7 @@ ipcRenderer.on('focus', async () => {
     selectedState &&
     !(selectedState.type === SelectionType.CloningRepository)
   ) {
-    await dispatcher.refreshTags(selectedState.repository)
-    await dispatcher.refreshRepository(selectedState.repository)
+    dispatcher.refreshRepository(selectedState.repository)
   }
 
   dispatcher.setAppFocusState(true)


### PR DESCRIPTION
## Description

As suggested by @niik, we prefer to do all refresh-related tasks inside the `refreshRepository()` method so in the future we have the assurance that calling `refreshRepository()` will update all the repo data.

Initially I opted out to call `refreshTags()` independently to be able to choose exactly when we need to refresh the list of tags: there are not many situations where we need to do that, while `refreshRepository()` is called in many more scenarios where we know that the list of tags won't change (e.g when creating a commit, switching branches, performing a merge, etc). Anyways, we tradeoff a really tiny bit of performance when executing these operations to gain predictability when calling `refreshRepository()`.

If in the future we find that the `refreshRepository()` becomes a bottleneck we can always try to make that method smarter by only updating the stuff that needs to be updated based on the action that triggered the call (we don't seem to need that for now though).

## Release notes

Notes: no-notes
