### PR TITLE
Wait until the repository is cloned in order to checkout a PR

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2960,12 +2960,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (currentPopup.type === PopupType.CloneRepository) {
-      this._completeOpenInDesktop(() => Promise.resolve(null))
-    }
-
     if (popupType !== undefined && currentPopup.type !== popupType) {
       return
+    }
+
+    if (currentPopup.type === PopupType.CloneRepository) {
+      this._completeOpenInDesktop(() => Promise.resolve(null))
     }
 
     this.currentPopup = null


### PR DESCRIPTION


Closes https://github.com/desktop/desktop/issues/9540

## Description

This PR fixes the issues described in https://github.com/desktop/desktop/issues/9540 by making sure that the `_completeOpenInDesktop` promise doesn't get resolved when a different modal gets closed.

### Context

When opening the clone repository modal, Desktop tries to close a few popups ([source](https://github.com/desktop/desktop/blob/713f8e878bdf535bd3186cecae153de9ebbf6e3a/app/src/lib/stores/app-store.ts#L2095-L2096) even if they're not actually opened.

If these calls got executed after the clone repository modal got opened, they caused the `_completeOpenInDesktop` promise to get resolved prematurely (before the user actually cloned the repo) and then the logic that tries to checkout the PR branch after cloning would fail.

The fix consists on moving the condition that checks if the dialog to close is the current opened dialog to be executed before resolving the promise.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Fix "Open in GitHub Desktop" when the repository has not been cloned yet.
