### PR TITLE
What's a little space between friends?

### DIFF
--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -142,7 +142,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
 
       if (checkoutProgress.value > 0) {
         const friendlyProgress = Math.round(checkoutProgress.value * 100)
-        description = `${description} (${friendlyProgress} %)`
+        description = `${description} (${friendlyProgress}%)`
       }
 
       progressValue = checkoutProgress.value

--- a/app/src/ui/window/zoom-info.tsx
+++ b/app/src/ui/window/zoom-info.tsx
@@ -88,7 +88,7 @@ export class ZoomInfo extends React.Component<IZoomInfoProps, IZoomInfoState> {
       return null
     }
 
-    const zoomPercent = `${(this.state.windowZoomFactor * 100).toFixed(0)} %`
+    const zoomPercent = `${(this.state.windowZoomFactor * 100).toFixed(0)}%`
 
     return (
       <div>


### PR DESCRIPTION
Happy Friday everyone!

Did y'all know there's [no consensus in the English language](https://english.stackexchange.com/a/3284) for whether to include a space in between the number and the percent sign (i.e. `100 %` vs `100%`)?

While I myself like a little bit of social distance every now again that's obviously not everyone's cup of tea. In fact, some people, like our very own @joshaber feels pretty strongly about this.

> <img width="377" alt="image" src="https://user-images.githubusercontent.com/634063/83286767-c2225e80-a1e0-11ea-8929-c6d933760919.png">

[According to Wikipedia](https://en.wikipedia.org/wiki/Percent_sign#Spacing) there seems to be more style guides recommending no space than there are recommending a space

> English style guides prescribe writing the percent sign following the number without any space between (e.g. 50%).[1][2][3][4][5][6][7] However, the International System of Units and ISO 31-0 standard prescribe a space between the number and percent sign

Now, I'm an International System of Units kind of a kid but since Git itself will report percentages without spaces and there's some evidence for a convergence towards no space in English I say we let consistency win while at the same time throwing a bone to our old friend, I'm sure he could use one to close the week.

Are there any other strong feelings about spacing?