### PR TITLE
Guard against ownerless repositories

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -534,7 +534,16 @@ export class API {
     IAPIRepository
   > | null> {
     try {
-      return await this.fetchAll<IAPIRepository>('user/repos')
+      const repositories = await this.fetchAll<IAPIRepository>('user/repos')
+      // "But wait, repositories can't have a null owner" you say.
+      // Ordinarily you'd be correct but turns out there's super
+      // rare circumstances where a user has been deleted but the
+      // repository hasn't. Such cases are usually addressed swiftly
+      // but in some cases like GitHub Enterprise Server instances
+      // they can linger for longer than we'd like so we'll make
+      // sure to exclude any such dangling repository, chances are
+      // they won't be cloneable anyway.
+      return repositories.filter(x => x.owner !== null)
     } catch (error) {
       log.warn(`fetchRepositories: ${error}`)
       return null


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9895

## Description

#9895 was caused by a repository living on a private GitHub Enterprise Server instance not having an owner. This is incredibly rare but can happen if the owner (user or organization) is deleted but the repository isn't (due to some random error). Normally these instances are found and dealt with pretty swiftly on GitHub.com but for GitHub Enterprise Server they can linger for a while.

We're discussing a more holistic solution with the responsible teams on GitHub.com but until such a solution is in place and all GitHub Enterprise Server instances out there has been upgraded we don't want to crash the app if one of these repositories shows up.

An unfortunate factor here is that this error will happen in the welcome flow making it impossible for users to get into the app proper and do their work.

I've opted to only address this in the `fetchRepositories` endpoint because that's where it's most likely to occur (a user loading all the repositories they have permission to clone). I'm not so concerned with the other endpoints such a creating, forking, and fetching a specific repository since the window in which this condition could occur for those is so small.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes