### PR TITLE
Put browser authorization button in its own form

### DIFF
--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -212,17 +212,14 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     return (
       <DialogContent>
         <Row className="sign-in-with-browser">
-          <form>
-            <Button
-              className="button-with-icon"
-              type="submit"
-              onClick={this.onSignInWithBrowser}
-              disabled={disableSubmit}
-            >
-              Sign in using your browser
-              <Octicon symbol={OcticonSymbol.linkExternal} />
-            </Button>
-          </form>
+          <Button
+            className="button-with-icon button-component-primary"
+            onClick={this.onSignInWithBrowser}
+            disabled={disableSubmit}
+          >
+            Sign in using your browser
+            <Octicon symbol={OcticonSymbol.linkExternal} />
+          </Button>
         </Row>
 
         <div className="horizontal-rule">

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -111,11 +111,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     this.setState({ otpToken })
   }
 
-  private onSignInWithBrowser = (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    event.preventDefault()
-
+  private onSignInWithBrowser = () => {
     this.props.dispatcher.requestBrowserAuthentication()
   }
 

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -216,15 +216,17 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
     return (
       <DialogContent>
         <Row className="sign-in-with-browser">
-          <Button
-            className="button-with-icon"
-            type="submit"
-            onClick={this.onSignInWithBrowser}
-            disabled={disableSubmit}
-          >
-            Sign in using your browser
-            <Octicon symbol={OcticonSymbol.linkExternal} />
-          </Button>
+          <form>
+            <Button
+              className="button-with-icon"
+              type="submit"
+              onClick={this.onSignInWithBrowser}
+              disabled={disableSubmit}
+            >
+              Sign in using your browser
+              <Octicon symbol={OcticonSymbol.linkExternal} />
+            </Button>
+          </form>
         </Row>
 
         <div className="horizontal-rule">

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -42,7 +42,8 @@
   }
 }
 
-.button-component[type='submit'] {
+.button-component[type='submit'],
+.button-component-primary {
   background-color: var(--button-background);
   color: var(--button-text-color);
   border: 1px solid var(--button-background);


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9899

## Description

This PR fixes https://github.com/desktop/desktop/issues/9899 by creating a separate `<form />` element that isolates the "Sign in via browser" button from the rest of the form.

Since that button (for styling purposes) has a `submit` type, Chromium inferred that this was the main button for the `Dialog` form, which meant that:

1. When clicking on the button, the dialog form was submitted.
2. When pressing enter on the user/password inputs, the button got "pressed".

The first point was worked around by adding a `preventDefault` call to the button click event handler, but the second point was never worked around and has caused  https://github.com/desktop/desktop/issues/9899

### Alternate solution

There's another valid solution to this issue which consists on removing the `type="submit"` attribute from the button. Unfortunately, the current styleguide does not allow to display a button as "primary" (with a blue background) without having it with a `submit` type. We could fix that by creating a custom `buttom-component-primary` which had the same styles as `button[type='submit']`.

I think both the alternate solution and the chosen solution are valid, but I've leaned towards this solution since it doesn't require adding more CSS and it feels slightly more semantically correct to make that button of type `submit` in its own form (since it's a separate action from the main dialog purpose).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Pressing "enter" on the user/password inputs when authenticating won't open the browser flow.
