### PR TITLE
Avoid resetting changes state when not showing stash

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2342,6 +2342,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _hideStashedChanges(repository: Repository) {
     const { changesState } = this.repositoryStateCache.get(repository)
 
+    // makes this safe to call even when the stash ui is not visible
     if (changesState.selection.kind !== ChangesSelectionKind.Stash) {
       return
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2340,6 +2340,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public _hideStashedChanges(repository: Repository) {
+    const { changesState } = this.repositoryStateCache.get(repository)
+
+    if (changesState.selection.kind !== ChangesSelectionKind.Stash) {
+      return
+    }
+
     this.repositoryStateCache.updateChangesState(repository, state => {
       const files = state.workingDirectory.files
       const selectedFileIds = files


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

References #7710

## Description

This is a follow up to #9412 which fixed the problem described in #7710. This PR addresses a conceptual issue with regards to `_hideStashedChanges`.

After #9412 `_hideStashedChanges`  Prior to this PR `_hideStashedChanges` would always reset the changes state to show the working directory changes (selecting all of the changes in the working directory since it didn't have the context that the `<Changes>` component has about previous selection). This small change makes the method a noop when there's no stash visible.

See https://github.com/desktop/desktop/pull/9412#pullrequestreview-419442826