### PR TITLE
2.5.2 Release

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -123,5 +123,5 @@ export function enableGitTagsCreation(): boolean {
  * main repository when opening a fork?
  */
 export function enableForkSettings(): boolean {
-  return enableBetaFeatures()
+  return true
 }

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "2.5.2": [
+      "[Fixed] Enable setting to more easily work with maintained forks"
+    ],
     "2.5.1": [
       "[Added] Provide a setting to more easily work with maintained forks - #9679",
       "[Added] Support deleting tags that have not been pushed - #9796",


### PR DESCRIPTION
This hotfix release is based on https://github.com/desktop/desktop/pull/9923 (to not include commits that have been merged in `master` since the most recent release) and contains a commit to enable the `enableForkSettings` feature flag