### PR TITLE
Token-aware text wrapping of commit summaries

### DIFF
--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -263,9 +263,7 @@ export class Tokenizer {
     }
   }
 
-  private tokenizeNonGitHubRepository(
-    text: string
-  ): ReadonlyArray<TokenResult> {
+  private tokenizeNonGitHubRepository(text: string): TokenResult[] {
     let i = 0
     while (i < text.length) {
       const element = text[i]
@@ -294,7 +292,7 @@ export class Tokenizer {
   private tokenizeGitHubRepository(
     text: string,
     repository: GitHubRepository
-  ): ReadonlyArray<TokenResult> {
+  ): TokenResult[] {
     let i = 0
     while (i < text.length) {
       const element = text[i]
@@ -338,7 +336,7 @@ export class Tokenizer {
    *
    * @returns an array of tokens representing the scan results.
    */
-  public tokenize(text: string): ReadonlyArray<TokenResult> {
+  public tokenize(text: string): TokenResult[] {
     this.reset()
 
     if (this.repository) {

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -263,7 +263,9 @@ export class Tokenizer {
     }
   }
 
-  private tokenizeNonGitHubRepository(text: string): TokenResult[] {
+  private tokenizeNonGitHubRepository(
+    text: string
+  ): ReadonlyArray<TokenResult> {
     let i = 0
     while (i < text.length) {
       const element = text[i]
@@ -292,7 +294,7 @@ export class Tokenizer {
   private tokenizeGitHubRepository(
     text: string,
     repository: GitHubRepository
-  ): TokenResult[] {
+  ): ReadonlyArray<TokenResult> {
     let i = 0
     while (i < text.length) {
       const element = text[i]
@@ -336,7 +338,7 @@ export class Tokenizer {
    *
    * @returns an array of tokens representing the scan results.
    */
-  public tokenize(text: string): TokenResult[] {
+  public tokenize(text: string): ReadonlyArray<TokenResult> {
     this.reset()
 
     if (this.repository) {

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -26,7 +26,7 @@ export function wrapRichTextCommitMessage(
   bodyText: string,
   tokenizer: Tokenizer,
   maxSummaryLength = MaxSummaryLength
-) {
+): { summary: ReadonlyArray<TokenResult>; body: ReadonlyArray<TokenResult> } {
   const tokens = tokenizer.tokenize(summaryText.trimRight())
 
   const summary = new Array<TokenResult>()

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -11,6 +11,9 @@ const MaxSummaryLength = 72
  * of the problem and https://github.com/desktop/desktop/pull/2575 for
  * the initial naive implementation.
  *
+ * Note that this method doesn't wrap multibyte chars like unicode emojis
+ * correctly (i.e. it could end up splitting a multibyte char).
+ *
  * @param summaryText The commit message summary text (i.e. the first line)
  * @param bodyText    The commit message body text
  * @param tokenizer   The tokenizer to use when converting the raw text to

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -1,0 +1,93 @@
+import { Tokenizer, TokenType, TokenResult } from './text-token-parser'
+import { assertNever } from './fatal-error'
+
+const MaxSummaryLength = 72
+
+export function wrapRichTextCommitMessage(
+  summaryText: string,
+  bodyText: string,
+  tokenizer: Tokenizer,
+  maxSummaryLength = MaxSummaryLength
+) {
+  const tokens = tokenizer.tokenize(summaryText.trimRight())
+
+  const summary = new Array<TokenResult>()
+  const overflow = new Array<TokenResult>()
+
+  let remainder = maxSummaryLength
+
+  for (const token of tokens) {
+    if (remainder <= 0) {
+      // There's no room left in the summary, everything needs to
+      // go into the overflow
+      overflow.push(token)
+    } else if (remainder >= token.text.length) {
+      // The token fits without us having to think about wrapping!
+      summary.push(token)
+      remainder -= token.text.length
+    } else {
+      // There's not enough room to include the token in its entirety,
+      // we've got to make a decision between hard wrapping or pushing
+      // to overflow.
+      if (token.kind === TokenType.Text) {
+        // We always hard-wrap text, it'd be nice if we could attempt
+        // to break at word boundaries in the future but that's too
+        // complex for now.
+        summary.push({
+          kind: TokenType.Text,
+          text: token.text.substr(0, remainder),
+        })
+        overflow.push({
+          kind: TokenType.Text,
+          text: token.text.substr(remainder),
+        })
+      } else if (token.kind === TokenType.Emoji) {
+        // There's room for improvement here, we look at the length of
+        // token.text which could be something like ":white_square_button:"
+        // which would still only take up a little bit more space than a
+        // regular character when rendered as an image.
+        overflow.push(token)
+      } else if (token.kind === TokenType.Link) {
+        // Hard wrapping an issue link is confusing so we treat them
+        // as atomic. For all other links (@mentions or https://...)
+        // We want at least the first couple of characters of the link
+        // text showing otherwise we'll end up with weird links like "h"
+        // or "@"
+        if (!token.text.startsWith('#') && remainder > 5) {
+          summary.push({
+            kind: TokenType.Link,
+            url: token.text,
+            text: token.text.substr(0, remainder),
+          })
+          overflow.push({
+            kind: TokenType.Link,
+            url: token.text,
+            text: token.text.substr(remainder),
+          })
+        } else {
+          overflow.push(token)
+        }
+      } else {
+        return assertNever(token, `Unknown token type`)
+      }
+
+      remainder = 0
+    }
+  }
+
+  const body = tokenizer.tokenize(bodyText.trimRight())
+
+  if (overflow.length > 0) {
+    summary.push({ kind: TokenType.Text, text: '…' })
+    if (body.length > 0) {
+      body.unshift({ kind: TokenType.Text, text: `…` }, ...overflow, {
+        kind: TokenType.Text,
+        text: '\n\n',
+      })
+    } else {
+      body.unshift({ kind: TokenType.Text, text: `…` }, ...overflow)
+    }
+  }
+
+  return { summary, body }
+}

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -94,18 +94,20 @@ export function wrapRichTextCommitMessage(
   let body = tokenizer.tokenize(bodyText.trimRight())
 
   if (overflow.length > 0) {
-    const ellipsis = text('…')
-    summary.push(ellipsis)
+    summary.push(ellipsis())
     if (body.length > 0) {
-      body = [ellipsis, ...overflow, text('\n\n'), ...body]
+      body = [ellipsis(), ...overflow, text('\n\n'), ...body]
     } else {
-      body = [ellipsis, ...overflow]
+      body = [ellipsis(), ...overflow]
     }
   }
 
   return { summary, body }
 }
 
+function ellipsis() {
+  return text('…')
+}
 function text(text: string): PlainText {
   return { kind: TokenType.Text, text }
 }

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -91,21 +91,15 @@ export function wrapRichTextCommitMessage(
     }
   }
 
-  const body = tokenizer.tokenize(bodyText.trimRight())
+  let body = tokenizer.tokenize(bodyText.trimRight())
 
   if (overflow.length > 0) {
     const ellipsis = text('…')
     summary.push(ellipsis)
     if (body.length > 0) {
-      return {
-        summary,
-        body: [ellipsis, ...overflow, text('\n\n'), ...body],
-      }
+      body = [ellipsis, ...overflow, text('\n\n'), ...body]
     } else {
-      return {
-        summary,
-        body: [ellipsis, ...overflow],
-      }
+      body = [ellipsis, ...overflow]
     }
   }
 

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -3,6 +3,24 @@ import { assertNever } from './fatal-error'
 
 const MaxSummaryLength = 72
 
+/**
+ * A method used to wrap long commit summaries and put any overflow
+ * into the commit body while taking rich text into consideration.
+ *
+ * See https://github.com/desktop/desktop/issues/9185 for a description
+ * of the problem and https://github.com/desktop/desktop/pull/2575 for
+ * the initial naive implementation.
+ *
+ * @param summaryText The commit message summary text (i.e. the first line)
+ * @param bodyText    The commit message body text
+ * @param tokenizer   The tokenizer to use when converting the raw text to
+ *                    rich text tokens
+ * @param maxSummaryLength  The maximum width of the commit summary (defaults
+ *                          to 72), note that this does not include any ellipsis
+ *                          that may be appended when wrapping. In other words
+ *                          it's possible that the commit summary ends up being
+ *                          maxSummaryLength + 1 long when rendered.
+ */
 export function wrapRichTextCommitMessage(
   summaryText: string,
   bodyText: string,

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -104,12 +104,23 @@ export function wrapRichTextCommitMessage(
   if (overflow.length > 0) {
     summary.push({ kind: TokenType.Text, text: '…' })
     if (body.length > 0) {
-      body.unshift({ kind: TokenType.Text, text: `…` }, ...overflow, {
-        kind: TokenType.Text,
-        text: '\n\n',
-      })
+      return {
+        summary,
+        body: [
+          { kind: TokenType.Text, text: `…` },
+          ...overflow,
+          {
+            kind: TokenType.Text,
+            text: '\n\n',
+          },
+          ...body,
+        ],
+      }
     } else {
-      body.unshift({ kind: TokenType.Text, text: `…` }, ...overflow)
+      return {
+        summary,
+        body: [{ kind: TokenType.Text, text: `…` }, ...overflow],
+      }
     }
   }
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -142,7 +142,10 @@ function createState(
   if (overflow.length > 0) {
     summary.push({ kind: TokenType.Text, text: '…' })
     if (body.length > 0) {
-      body.unshift({ kind: TokenType.Text, text: `…${overflow}\n\n` })
+      body.unshift({ kind: TokenType.Text, text: `…` }, ...overflow, {
+        kind: TokenType.Text,
+        text: '\n\n',
+      })
     } else {
       body.unshift({ kind: TokenType.Text, text: `…${overflow}` })
     }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -147,7 +147,7 @@ function createState(
         text: '\n\n',
       })
     } else {
-      body.unshift({ kind: TokenType.Text, text: `…${overflow}` })
+      body.unshift({ kind: TokenType.Text, text: `…` }, ...overflow)
     }
   }
   const avatarUsers = getAvatarUsersForCommit(

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -124,11 +124,25 @@ function createState(
       } else if (token.kind === TokenType.Emoji) {
         overflow.push(token)
       } else if (token.kind === TokenType.Link) {
-        summary.push({
-          kind: TokenType.Link,
-          url: token.text,
-          text: token.text.substr(0, remainder),
-        })
+        // Hard wrapping an issue link is confusing so we treat them
+        // as atomic. For all other links (@mentions or https://...)
+        // We want at least the first couple of characters of the link
+        // text showing otherwise we'll end up with weird links like "h"
+        // or "@"
+        if (!token.text.startsWith('#') && remainder > 5) {
+          summary.push({
+            kind: TokenType.Link,
+            url: token.text,
+            text: token.text.substr(0, remainder),
+          })
+          overflow.push({
+            kind: TokenType.Link,
+            url: token.text,
+            text: token.text.substr(remainder),
+          })
+        } else {
+          overflow.push(token)
+        }
       } else {
         return assertNever(token, `Unknown token type`)
       }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -319,7 +319,7 @@ export class CommitSummary extends React.Component<
   }
 
   private renderDescription() {
-    if (!this.state.body) {
+    if (this.state.body.length === 0) {
       return null
     }
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -107,12 +107,21 @@ function createState(
 
   for (const token of tokens) {
     if (remainder <= 0) {
+      // There's no room left in the summary, everything needs to
+      // go into the overflow
       overflow.push(token)
     } else if (remainder >= token.text.length) {
+      // The token fits without us having to think about wrapping!
       summary.push(token)
       remainder -= token.text.length
     } else {
+      // There's not enough room to include the token in its entirety,
+      // we've got to make a decision between hard wrapping or pushing
+      // to overflow.
       if (token.kind === TokenType.Text) {
+        // We always hard-wrap text, it'd be nice if we could attempt
+        // to break at word boundaries in the future but that's too
+        // complex for now.
         summary.push({
           kind: TokenType.Text,
           text: token.text.substr(0, remainder),
@@ -122,6 +131,10 @@ function createState(
           text: token.text.substr(remainder),
         })
       } else if (token.kind === TokenType.Emoji) {
+        // There's room for improvement here, we look at the length of
+        // token.text which could be something like ":white_square_button:"
+        // which would still only take up a little bit more space than a
+        // regular character when rendered as an image.
         overflow.push(token)
       } else if (token.kind === TokenType.Link) {
         // Hard wrapping an issue link is confusing so we treat them

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -12,7 +12,7 @@ import { AvatarStack } from '../lib/avatar-stack'
 import { CommitAttribution } from '../lib/commit-attribution'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { enableGitTagsDisplay } from '../../lib/feature-flag'
-import { Tokenizer, TokenType } from '../../lib/text-token-parser'
+import { Tokenizer, TokenType, TokenResult } from '../../lib/text-token-parser'
 import { assertNever } from '../../lib/fatal-error'
 
 interface ICommitSummaryProps {
@@ -47,7 +47,7 @@ interface ICommitSummaryState {
    * Note that this may differ from the body property in the commit object
    * passed through props, see the createState method for more details.
    */
-  readonly summary: string
+  readonly summary: ReadonlyArray<TokenResult>
 
   /**
    * The commit message body, i.e. anything after the first line of text in the
@@ -55,7 +55,7 @@ interface ICommitSummaryState {
    * commit object passed through props, see the createState method for more
    * details.
    */
-  readonly body: string
+  readonly body: ReadonlyArray<TokenResult>
 
   /**
    * Whether or not the commit body text overflows its container. Used in
@@ -91,30 +91,44 @@ function trimTrailingWhitespace(value: string) {
  *
  * @param props        The current commit summary prop object.
  */
-function createState(isOverflowed: boolean, props: ICommitSummaryProps) {
+function createState(
+  isOverflowed: boolean,
+  props: ICommitSummaryProps
+): ICommitSummaryState {
   const tokenizer = new Tokenizer(props.emoji, props.repository)
   const tokens = tokenizer.tokenize(
     trimTrailingWhitespace(props.commit.summary)
   )
 
-  let summary = ''
-  let overflow = ''
+  const summary = new Array<TokenResult>()
+  const overflow = new Array<TokenResult>()
+
   let remainder = maxSummaryLength
 
   for (const token of tokens) {
     if (remainder <= 0) {
-      overflow = overflow + token.text
+      overflow.push(token)
     } else if (remainder >= token.text.length) {
-      summary = summary + token.text
+      summary.push(token)
       remainder -= token.text.length
     } else {
       if (token.kind === TokenType.Text) {
-        summary = summary + token.text.substr(0, remainder)
-        overflow = overflow + token.text.substr(remainder)
+        summary.push({
+          kind: TokenType.Text,
+          text: token.text.substr(0, remainder),
+        })
+        overflow.push({
+          kind: TokenType.Text,
+          text: token.text.substr(remainder),
+        })
       } else if (token.kind === TokenType.Emoji) {
-        overflow = overflow + token.text
+        overflow.push(token)
       } else if (token.kind === TokenType.Link) {
-        summary = summary + token.text
+        summary.push({
+          kind: TokenType.Link,
+          url: token.text,
+          text: token.text.substr(0, remainder),
+        })
       } else {
         return assertNever(token, `Unknown token type`)
       }
@@ -123,29 +137,16 @@ function createState(isOverflowed: boolean, props: ICommitSummaryProps) {
     }
   }
 
-  let body = trimTrailingWhitespace(props.commit.body)
+  const body = tokenizer.tokenize(trimTrailingWhitespace(props.commit.body))
 
   if (overflow.length > 0) {
-    summary = summary + '…'
+    summary.push({ kind: TokenType.Text, text: '…' })
     if (body.length > 0) {
-      body = `…${overflow}\n\n${body}`
+      body.unshift({ kind: TokenType.Text, text: `…${overflow}\n\n` })
     } else {
-      body = `…${overflow}`
+      body.unshift({ kind: TokenType.Text, text: `…${overflow}` })
     }
   }
-
-  // if (summary.length > maxSummaryLength) {
-  //   // Truncate at least 3 characters off the end to avoid just an ellipsis
-  //   // followed by 1-2 characters in the body. This matches dotcom behavior.
-  //   const truncationMargin = 3
-  //   const truncateLength = maxSummaryLength - truncationMargin
-  //   const remainder = summary.substr(truncateLength)
-
-  //   // Don't join the the body with newlines if it's empty
-  //   body = body.length > 0 ? `…${remainder}\n\n${body}` : `…${remainder}`
-  //   summary = `${summary.substr(0, truncateLength)}…`
-  // }
-
   const avatarUsers = getAvatarUsersForCommit(
     props.repository.gitHubRepository,
     props.gitHubUsers,

--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -12,7 +12,12 @@ interface IRichTextProps {
   /** A lookup of emoji characters to map to image resources */
   readonly emoji: Map<string, string>
 
-  /** The raw text to inspect for things to highlight */
+  /**
+   * The raw text to inspect for things to highlight or an array
+   * of tokens already compiled by the `Tokenizer` class in
+   * `text-token-parser.ts`. If a string is provided the component
+   * will call upon the Tokenizer to product a list of tokens.
+   */
   readonly text: string | ReadonlyArray<TokenResult>
 
   /** Should URLs be rendered as clickable links. Default true. */

--- a/app/test/unit/wrap-rich-text-commit-message-test.ts
+++ b/app/test/unit/wrap-rich-text-commit-message-test.ts
@@ -94,4 +94,16 @@ describe('wrapRichTextCommitMessage', () => {
       'https://github.com/niik/commit-summary-wrap-tests/issues/1'
     )
   })
+
+  it('handles multiple links', async () => {
+    const summaryText =
+      'Multiple links are fine https://github.com/niik/commit-summary-wrap-tests/issues/1 https://github.com/niik/commit-summary-wrap-tests/issues/2 https://github.com/niik/commit-summary-wrap-tests/issues/3 https://github.com/niik/commit-summary-wrap-tests/issues/4'
+    const { summary, body } = wrap(summaryText, '')
+
+    expect(summary.length).toBe(8)
+    expect(body.length).toBe(0)
+
+    const flattened = summary.map(x => x.text).join('')
+    expect(flattened).toBe('Multiple links are fine #1 #2 #3 #4')
+  })
 })

--- a/app/test/unit/wrap-rich-text-commit-message-test.ts
+++ b/app/test/unit/wrap-rich-text-commit-message-test.ts
@@ -122,4 +122,36 @@ describe('wrapRichTextCommitMessage', () => {
     const flattened = summary.map(x => x.text).join('')
     expect(flattened).toBe('Multiple links are fine #1 #2 #3 #4')
   })
+
+  it('wraps links properly', async () => {
+    const summaryText =
+      'Link should be truncated but open our release notes https://desktop.github.com/release-notes/'
+    const { summary, body } = wrap(summaryText, '')
+
+    expect(summary.length).toBe(3)
+    expect(body.length).toBe(2)
+
+    expect(summary[0].kind).toBe(TokenType.Text)
+    expect(summary[0].text).toBe(
+      'Link should be truncated but open our release notes '
+    )
+
+    expect(summary[1].kind).toBe(TokenType.Link)
+    expect(summary[1].text).toBe('https://desktop.gith')
+    expect((summary[1] as HyperlinkMatch).url).toBe(
+      'https://desktop.github.com/release-notes/'
+    )
+
+    expect(summary[2].kind).toBe(TokenType.Text)
+    expect(summary[2].text).toBe('…')
+
+    expect(body[0].kind).toBe(TokenType.Text)
+    expect(body[0].text).toBe('…')
+
+    expect(body[1].kind).toBe(TokenType.Link)
+    expect(body[1].text).toBe('ub.com/release-notes/')
+    expect((body[1] as HyperlinkMatch).url).toBe(
+      'https://desktop.github.com/release-notes/'
+    )
+  })
 })

--- a/app/test/unit/wrap-rich-text-commit-message-test.ts
+++ b/app/test/unit/wrap-rich-text-commit-message-test.ts
@@ -21,8 +21,8 @@ describe('wrapRichTextCommitMessage', () => {
   const tokenizer = new Tokenizer(emojis, repo)
 
   /** helper */
-  function wrap(summary: string, body?: string) {
-    return wrapRichTextCommitMessage(summary, '', tokenizer)
+  function wrap(summary: string, body: string = '') {
+    return wrapRichTextCommitMessage(summary, body, tokenizer)
   }
 
   it("doesn't wrap at exactly 72 chars", async () => {

--- a/app/test/unit/wrap-rich-text-commit-message-test.ts
+++ b/app/test/unit/wrap-rich-text-commit-message-test.ts
@@ -1,0 +1,97 @@
+import { wrapRichTextCommitMessage } from '../../src/lib/wrap-rich-text-commit-message'
+import {
+  TokenType,
+  Tokenizer,
+  HyperlinkMatch,
+} from '../../src/lib/text-token-parser'
+import { gitHubRepoFixture } from '../helpers/github-repo-builder'
+import { Repository } from '../../src/models/repository'
+
+describe('wrapRichTextCommitMessage', () => {
+  const emojis = new Map<string, string>()
+  const repo = new Repository(
+    '.',
+    -1,
+    gitHubRepoFixture({
+      owner: 'niik',
+      name: 'commit-summary-wrap-tests',
+    }),
+    false
+  )
+  const tokenizer = new Tokenizer(emojis, repo)
+
+  /** helper */
+  function wrap(summary: string, body?: string) {
+    return wrapRichTextCommitMessage(summary, '', tokenizer)
+  }
+
+  it("doesn't wrap at exactly 72 chars", async () => {
+    const summaryText =
+      'weshouldnothardwrapthislongsummarywhichisexactly72charactersyeswetotally'
+    const { summary, body } = wrap(summaryText)
+
+    expect(summary.length).toBe(1)
+    expect(body.length).toBe(0)
+
+    expect(summary[0].kind).toBe(TokenType.Text)
+    expect(summary[0].text).toBe(summaryText)
+  })
+
+  it('hard wraps text longer than 72 chars', async () => {
+    const summaryText =
+      'weshouldabsolutelyhardwrapthislongsummarywhichexceeds72charactersyeswetotallyshould'
+    const { summary, body } = wrap(summaryText)
+
+    expect(summary.length).toBe(2)
+    expect(body.length).toBe(2)
+
+    expect(summary[0].kind).toBe(TokenType.Text)
+    expect(summary[0].text).toBe(summaryText.substr(0, 72))
+    expect(summary[1].kind).toBe(TokenType.Text)
+    expect(summary[1].text).toBe('…')
+
+    expect(body[0].kind).toBe(TokenType.Text)
+    expect(body[0].text).toBe('…')
+    expect(body[1].kind).toBe(TokenType.Text)
+    expect(body[1].text).toBe(summaryText.substr(72))
+  })
+
+  it('hard wraps text longer than 72 chars and joins it with the body', async () => {
+    const summaryText =
+      'weshouldabsolutelyhardwrapthislongsummarywhichexceeds72charactersyeswetotallyshould'
+    const bodyText = 'oh hi'
+    const { summary, body } = wrap(summaryText, bodyText)
+
+    expect(summary.length).toBe(2)
+    expect(body.length).toBe(4)
+
+    expect(summary[0].kind).toBe(TokenType.Text)
+    expect(summary[0].text).toBe(summaryText.substr(0, 72))
+    expect(summary[1].kind).toBe(TokenType.Text)
+    expect(summary[1].text).toBe('…')
+
+    expect(body[0].text).toBe('…')
+    expect(body[1].text).toBe(summaryText.substr(72))
+    expect(body[2].text).toBe('\n\n')
+    expect(body[3].text).toBe(bodyText)
+  })
+
+  it('takes issue link shortening into consideration', async () => {
+    const summaryText =
+      'This issue link should be shortened to well under 72 characters: https://github.com/niik/commit-summary-wrap-tests/issues/1'
+    const { summary, body } = wrap(summaryText, '')
+
+    expect(summary.length).toBe(2)
+    expect(body.length).toBe(0)
+
+    expect(summary[0].kind).toBe(TokenType.Text)
+    expect(summary[0].text).toBe(
+      'This issue link should be shortened to well under 72 characters: '
+    )
+    expect(summary[1].kind).toBe(TokenType.Link)
+    expect(summary[1].text).toBe('#1')
+    expect((summary[1] as HyperlinkMatch).url).toBe(
+      'https://github.com/niik/commit-summary-wrap-tests/issues/1'
+    )
+  })
+})

--- a/app/test/unit/wrap-rich-text-commit-message-test.ts
+++ b/app/test/unit/wrap-rich-text-commit-message-test.ts
@@ -76,6 +76,22 @@ describe('wrapRichTextCommitMessage', () => {
     expect(body[3].text).toBe(bodyText)
   })
 
+  it('handles summaries which are exactly 72 chars after link shortening', async () => {
+    const summaryText =
+      'This issue summary should be exactly 72 chars including the issue no: https://github.com/niik/commit-summary-wrap-tests/issues/1'
+    const { summary, body } = wrap(summaryText)
+
+    expect(summary.length).toBe(2)
+    expect(body.length).toBe(0)
+
+    expect(summary[0].kind).toBe(TokenType.Text)
+    expect(summary[0].text).toBe(
+      'This issue summary should be exactly 72 chars including the issue no: '
+    )
+    expect(summary[1].kind).toBe(TokenType.Link)
+    expect(summary[1].text).toBe('#1')
+  })
+
   it('takes issue link shortening into consideration', async () => {
     const summaryText =
       'This issue link should be shortened to well under 72 characters: https://github.com/niik/commit-summary-wrap-tests/issues/1'


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9185 

## Description

As described in https://github.com/desktop/desktop/issues/9185 our naive text wrapping efforts implemented in https://github.com/desktop/desktop/pull/2575 suffer from a major problem when commit summaries contains links that gets wrapped.

![image](https://user-images.githubusercontent.com/120441/75432035-130a8880-594e-11ea-8020-aeb315fc61b5.png)

Since the wrapper operates on the raw text of the commit summary before the `Tokenizer` class (used by the `RichText` component) has had a chance to work it happily hard wraps in the middle of a url. When the `RichText` component then gets a chance to work on it it creates a link out of the link that remains.

This was a limitation that was called out in #2575

> [...] a fairly simple fix we think will work alright for now. Note that this might cause links to break if we truncate them in the middle. The solution for this would be to do a pre-pass with the tokenizer and truncate using tokens instead but that's a bigger task that I'm not convinced that we need right now.

In reviewing #9259 it became clear that that assumption no longer held true and we needed to look into a robust way of doing wrapping that was Token aware.

In this PR I've made it possible to provide the `RichText` component with a list of tokens as well as a string for the component to tokenize. I've also updated the `CommitSummary` to tokenize both the commit summary and the body before providing them to the `RichText` component.

Finally I've implemented a token-aware wrapper function that hopefully covers most of the many edge-cases involved in doing this type of wrapping. I've set up https://github.com/niik/commit-summary-wrap-tests/commits/master as a list of commits with weird behaviors that should be accounted for and intend to keep adding commits there as I encounter them.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Here's a few before and afters

**Before**
<img width="460" alt="image" src="https://user-images.githubusercontent.com/634063/83668393-26be2e80-a5d0-11ea-93c4-552e6fbfce47.png">

**After**

<img width="444" alt="image" src="https://user-images.githubusercontent.com/634063/83668478-4fdebf00-a5d0-11ea-88a6-a127a82d6016.png">

Here the wrapper takes into account the fact that the link has been resolved as an issue link and thereby shortened to just two characters.

**Before**

<img width="474" alt="image" src="https://user-images.githubusercontent.com/634063/83668635-93d1c400-a5d0-11ea-8a6a-0482d3034d43.png">

**After**

<img width="396" alt="image" src="https://user-images.githubusercontent.com/634063/83668652-992f0e80-a5d0-11ea-8ddd-41838a77caff.png">

**Before**

<img width="469" alt="image" src="https://user-images.githubusercontent.com/634063/83668686-a8ae5780-a5d0-11ea-8c6c-d790470d8d66.png">

This  illustrates the main problem described in #9185.

**After**

<img width="482" alt="image" src="https://user-images.githubusercontent.com/634063/83668754-bfed4500-a5d0-11ea-9d75-0a886b38ff00.png">

While the link is hard-wrapped both parts are clickable and go to the same URL.

**Before**

<img width="398" alt="image" src="https://user-images.githubusercontent.com/634063/83668818-dd221380-a5d0-11ea-8a1e-8bff29606e57.png">

Not aware of emojis, splits after 72 characters (counting ':one:` as five characters)

**After**

<img width="432" alt="image" src="https://user-images.githubusercontent.com/634063/83668859-f0cd7a00-a5d0-11ea-92d3-22c2f30cfb81.png">

Emojis are counted as two regular characters so we're  able to fit a lot of them in  the commit summary.

## Notes

This does not solve (but it doesn't make the situation any worse either) the problem of multibyte unicode characters (native emoji). They can still get wrapped in the middle. I don't intend to address that as part of this PR.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Links are no longer broken when text wrapping needs to take place in commit summaries
