### PR TITLE
Static analysis rule to prevent mutable array props

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -535,7 +535,7 @@ export type ChangesWorkingDirectorySelection = {
    * The ID of the selected files. The files themselves can be looked up in
    * the `workingDirectory` property in `IChangesState`.
    */
-  readonly selectedFileIDs: string[]
+  readonly selectedFileIDs: ReadonlyArray<string>
   readonly diff: IDiff | null
 }
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -95,7 +95,7 @@ interface IChangesListProps {
   readonly repository: Repository
   readonly workingDirectory: WorkingDirectoryStatus
   readonly rebaseConflictState: RebaseConflictState | null
-  readonly selectedFileIDs: string[]
+  readonly selectedFileIDs: ReadonlyArray<string>
   readonly onFileSelectionChanged: (rows: ReadonlyArray<number>) => void
   readonly onIncludeChanged: (path: string, include: boolean) => void
   readonly onSelectAll: (selectAll: boolean) => void

--- a/tslint-rules/reactReadonlyPropsAndStateRule.ts
+++ b/tslint-rules/reactReadonlyPropsAndStateRule.ts
@@ -46,7 +46,7 @@ class ReactReadonlyPropsAndStateWalker extends Lint.RuleWalker {
       if (propertySignature.type) {
         const typeString = propertySignature.type.getFullText()
 
-        if (/^Array<.*>$/.test(typeString) || typeString.endsWith('[]')) {
+        if (/^\s*Array<.*>$/.test(typeString) || typeString.endsWith('[]')) {
           this.addFailure(
             this.createFailure(
               propertySignature.type.getStart(),

--- a/tslint-rules/reactReadonlyPropsAndStateRule.ts
+++ b/tslint-rules/reactReadonlyPropsAndStateRule.ts
@@ -42,6 +42,20 @@ class ReactReadonlyPropsAndStateWalker extends Lint.RuleWalker {
 
         this.addFailure(this.createFailure(start, width, error))
       }
+
+      if (propertySignature.type) {
+        const typeString = propertySignature.type.getFullText()
+
+        if (/^Array<.*>$/.test(typeString) || typeString.endsWith('[]')) {
+          this.addFailure(
+            this.createFailure(
+              propertySignature.type.getStart(),
+              propertySignature.type.getWidth(),
+              'Prop and State arrays should be read only (ReadOnlyArray)'
+            )
+          )
+        }
+      }
     })
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->
## Description

In https://github.com/desktop/desktop/pull/9931#discussion_r435170621 @rafeca expressed a concern that we could end up passing mutable arrays as props. That sparked my curiosity as to whether we were doing so today or not so I added this little naive checker to our `ReadOnlyPropsAndState` TSLint rule.

Turns out we've been good immutable proponents and there was only one instance that I could find of mutable arrays in props.

I think having this rule is a good way to ensure we keep up the good work.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/634063/83756277-20cb5a80-a66f-11ea-91aa-457467074211.png)
