### PR TITLE
Remove redundant progress text from Git error messages

### DIFF
--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -25,7 +25,7 @@ export function parseCarriageReturn(text: string) {
   }
 
   const lines = new Array<string>('')
-  const crLfOrEnd = /(.*?)([\r\n$])/gm
+  const crLfOrEnd = /(.*?)([\r\n]|$)/gm
 
   let col = 0
   let match

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -34,7 +34,6 @@ export function parseCarriageReturn(text: string) {
   const crLfOrEnd = /([\s\S]*?)([\r\n]|$)/g
   const lines = new Array<string>('')
 
-  let col = 0
   let match
 
   while ((match = crLfOrEnd.exec(text)) !== null) {
@@ -48,15 +47,11 @@ export function parseCarriageReturn(text: string) {
 
     if (match[1].length > 0) {
       const line = lines[lines.length - 1]
-      const before = line.substring(0, col)
-      const after = line.substring(col + match[1].length)
-      col += match[1].length
-      lines[lines.length - 1] = `${before}${match[1]}${after}`
+      const remainder = line.substring(match[1].length)
+      lines[lines.length - 1] = `${match[1]}${remainder}`
     }
 
-    if (match[2] === '\r') {
-      col = 0
-    } else if (match[2] === '\n') {
+    if (match[2] === '\n') {
       lines.push('')
     }
   }

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -24,12 +24,12 @@ export function parseCarriageReturn(text: string) {
     return text
   }
 
-  // In JavaScript `.` will never match a newline character since
-  // there's no Regex modifier to allow that which is why the
-  // first group doesn't have to be lazy. The second group matches
-  // the next following \r or \n character or the end of the string.
-  // Matching the end of the string lets us avoid dealing with
-  // leftover characters outside of the matching loop.
+  // `.` will never match a newline character unless we set
+  // the dotAll flag (/s) which is why the first group doesn't
+  // have to be lazy. The second group matches the next following
+  // \r or \n character or the end of the string. Matching the
+  // end of the string lets us avoid dealing with leftover
+  // characters outside of the matching loop.
   const crLfOrEnd = /(.*)([\r\n]|$)/gm
   const lines = new Array<string>('')
 

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -31,6 +31,14 @@ export function parseCarriageReturn(text: string) {
   let match
 
   while ((match = crLfOrEnd.exec(text)) !== null) {
+    // If we match the $ (end of string) we'll get a zero
+    // with match, this is a known problem in JS so we'll
+    // need to bump the regexp cursor to ensure it fails to
+    // match on the next round
+    if (match.index === crLfOrEnd.lastIndex) {
+      crLfOrEnd.lastIndex++
+    }
+
     if (match[1].length > 0) {
       const line = lines[lines.length - 1]
       const before = line.substring(0, col)

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -1,3 +1,22 @@
+/**
+ * Parses carriage returns the same way a terminal would, i.e by
+ * moving the cursor and (potentially) overwriting text.
+ *
+ * Git (and many other CLI tools) use this trick to present the
+ * user with nice looking progress. When writing something like...
+ *
+ * 'Downloading: 1%  \r'
+ * 'Downloading: 2%  \r'
+ *
+ * ...to the terminal he user is gonna perceieve it as if the 1 just
+ * magically changes to a two.
+ *
+ * The carriage return character for all of you kids out there
+ * that haven't yet played with a manual typewriter refers to the
+ * "carriage" which held the character arms, see
+ *
+ *  https://en.wikipedia.org/wiki/Carriage_return#Typewriters
+ */
 export function parseCarriageReturn(text: string) {
   // Happy path, there are no carriage returns in
   // the text, making this method a noop.
@@ -8,20 +27,20 @@ export function parseCarriageReturn(text: string) {
   const lines = new Array<string>('')
   const crLfOrEnd = /(.*?)([\r\n$])/gm
 
-  let columnIx = 0
+  let col = 0
   let match
 
   while ((match = crLfOrEnd.exec(text)) !== null) {
     if (match[1].length > 0) {
       const line = lines[lines.length - 1]
-      const before = line.substring(0, columnIx)
-      const after = line.substring(columnIx + match[1].length)
-      columnIx += match[1].length
+      const before = line.substring(0, col)
+      const after = line.substring(col + match[1].length)
+      col += match[1].length
       lines[lines.length - 1] = `${before}${match[1]}${after}`
     }
 
     if (match[2] === '\r') {
-      columnIx = 0
+      col = 0
     } else if (match[2] === '\n') {
       lines.push('')
     }

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -8,16 +8,15 @@ export function parseCarriageReturn(text: string) {
   const lines = new Array<string>('')
   const crOrLf = /[\r\n]/gm
 
-  let lineIx = 0
   let columnIx = 0
   let p = 0
 
   function merge(s: string) {
-    const line = lines[lineIx]
+    const line = lines[lines.length - 1]
     const before = line.substring(0, columnIx)
     const after = line.substring(columnIx + s.length)
     columnIx += s.length
-    lines[lineIx] = `${before}${s}${after}`
+    lines[lines.length - 1] = `${before}${s}${after}`
   }
 
   let m
@@ -30,7 +29,7 @@ export function parseCarriageReturn(text: string) {
     if (m[0] === '\r') {
       columnIx = 0
     } else if (m[0] === '\n') {
-      lines[++lineIx] = ''
+      lines.push('')
     }
 
     p = m.index + 1

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -6,37 +6,25 @@ export function parseCarriageReturn(text: string) {
   }
 
   const lines = new Array<string>('')
-  const crOrLf = /[\r\n]/gm
+  const crLfOrEnd = /(.*?)([\r\n$])/gm
 
   let columnIx = 0
-
-  function overwrite(s: string) {
-    const line = lines[lines.length - 1]
-    const before = line.substring(0, columnIx)
-    const after = line.substring(columnIx + s.length)
-    columnIx += s.length
-    lines[lines.length - 1] = `${before}${s}${after}`
-  }
-
   let match
-  let pos = 0
 
-  while ((match = crOrLf.exec(text)) !== null) {
-    if (match.index > pos) {
-      overwrite(text.substring(pos, match.index))
+  while ((match = crLfOrEnd.exec(text)) !== null) {
+    if (match[1].length > 0) {
+      const line = lines[lines.length - 1]
+      const before = line.substring(0, columnIx)
+      const after = line.substring(columnIx + match[1].length)
+      columnIx += match[1].length
+      lines[lines.length - 1] = `${before}${match[1]}${after}`
     }
 
-    if (match[0] === '\r') {
+    if (match[2] === '\r') {
       columnIx = 0
-    } else if (match[0] === '\n') {
+    } else if (match[2] === '\n') {
       lines.push('')
     }
-
-    pos = match.index + 1
-  }
-
-  if (pos < text.length) {
-    overwrite(text.substring(pos))
   }
 
   return lines.join('\n')

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -24,13 +24,14 @@ export function parseCarriageReturn(text: string) {
     return text
   }
 
-  // `.` will never match a newline character unless we set
-  // the dotAll flag (/s) which is why the first group doesn't
-  // have to be lazy. The second group matches the next following
-  // \r or \n character or the end of the string. Matching the
-  // end of the string lets us avoid dealing with leftover
-  // characters outside of the matching loop.
-  const crLfOrEnd = /(.*)([\r\n]|$)/gm
+  // JavaScript `.` includes unicode line and paragraph break
+  // characters which is why we use [\s\S] instead of '.'. The
+  // first group matches lazily (as few times as possible) and
+  // tthe second group matches the next following \r or \n
+  // character or the end of the string. Matching the end of the
+  // string lets us avoid dealing with leftover characters outside
+  // of the matching loop.
+  const crLfOrEnd = /([\s\S]*?)([\r\n]|$)/g
   const lines = new Array<string>('')
 
   let col = 0

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -24,6 +24,12 @@ export function parseCarriageReturn(text: string) {
     return text
   }
 
+  // In JavaScript `.` will never match a newline character since
+  // there's no Regex modifier to allow that which is why the
+  // first group doesn't have to be lazy. The second group matches
+  // the next following \r or \n character or the end of the string.
+  // Matching the end of the string lets us avoid dealing with
+  // leftover characters outside of the matching loop.
   const crLfOrEnd = /(.*)([\r\n]|$)/gm
   const lines = new Array<string>('')
 

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -38,7 +38,7 @@ export function parseCarriageReturn(text: string) {
 
   while ((match = crLfOrEnd.exec(text)) !== null) {
     // If we match the $ (end of string) we'll get a zero
-    // with match, this is a known problem in JS so we'll
+    // width match, this is a known problem in JS so we'll
     // need to bump the regexp cursor to ensure it fails to
     // match on the next round
     if (match.index === crLfOrEnd.lastIndex) {

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -1,0 +1,43 @@
+export function parseCarriageReturn(text: string) {
+  // Happy path,
+  if (text.indexOf('\r') < 0) {
+    return text
+  }
+
+  const lines = new Array<string>('')
+  const crOrLf = /[\r\n]/gm
+
+  let lineIx = 0
+  let columnIx = 0
+  let p = 0
+
+  function merge(s: string) {
+    const line = lines[lineIx]
+    const before = line.substring(0, columnIx)
+    const after = line.substring(columnIx + s.length)
+    columnIx += s.length
+    lines[lineIx] = `${before}${s}${after}`
+  }
+
+  let m
+
+  while ((m = crOrLf.exec(text)) !== null) {
+    if (m.index > p) {
+      merge(text.substring(p, m.index))
+    }
+
+    if (m[0] === '\r') {
+      columnIx = 0
+    } else if (m[0] === '\n') {
+      lines[++lineIx] = ''
+    }
+
+    p = m.index + 1
+  }
+
+  if (p < text.length) {
+    merge(text.substring(p))
+  }
+
+  return lines.join('\n')
+}

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -9,9 +9,8 @@ export function parseCarriageReturn(text: string) {
   const crOrLf = /[\r\n]/gm
 
   let columnIx = 0
-  let p = 0
 
-  function merge(s: string) {
+  function overwrite(s: string) {
     const line = lines[lines.length - 1]
     const before = line.substring(0, columnIx)
     const after = line.substring(columnIx + s.length)
@@ -19,24 +18,25 @@ export function parseCarriageReturn(text: string) {
     lines[lines.length - 1] = `${before}${s}${after}`
   }
 
-  let m
+  let match
+  let pos = 0
 
-  while ((m = crOrLf.exec(text)) !== null) {
-    if (m.index > p) {
-      merge(text.substring(p, m.index))
+  while ((match = crOrLf.exec(text)) !== null) {
+    if (match.index > pos) {
+      overwrite(text.substring(pos, match.index))
     }
 
-    if (m[0] === '\r') {
+    if (match[0] === '\r') {
       columnIx = 0
-    } else if (m[0] === '\n') {
+    } else if (match[0] === '\n') {
       lines.push('')
     }
 
-    p = m.index + 1
+    pos = match.index + 1
   }
 
-  if (p < text.length) {
-    merge(text.substring(p))
+  if (pos < text.length) {
+    overwrite(text.substring(pos))
   }
 
   return lines.join('\n')

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -8,7 +8,7 @@
  * 'Downloading: 1%  \r'
  * 'Downloading: 2%  \r'
  *
- * ...to the terminal he user is gonna perceieve it as if the 1 just
+ * ...to the terminal the user is gonna perceive it as if the 1 just
  * magically changes to a two.
  *
  * The carriage return character for all of you kids out there

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -24,8 +24,8 @@ export function parseCarriageReturn(text: string) {
     return text
   }
 
+  const crLfOrEnd = /(.*)([\r\n]|$)/gm
   const lines = new Array<string>('')
-  const crLfOrEnd = /(.*?)([\r\n]|$)/gm
 
   let col = 0
   let match

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -47,8 +47,16 @@ export function parseCarriageReturn(text: string) {
 
     if (match[1].length > 0) {
       const line = lines[lines.length - 1]
-      const remainder = line.substring(match[1].length)
-      lines[lines.length - 1] = `${match[1]}${remainder}`
+
+      if (line.length <= match[1].length) {
+        // Happy path, the new line is equal to or longer
+        // than the previous, we can just use the new one
+        // without creating any new strings.
+        lines[lines.length - 1] = match[1]
+      } else {
+        const remainder = line.substring(match[1].length)
+        lines[lines.length - 1] = `${match[1]}${remainder}`
+      }
     }
 
     if (match[2] === '\n') {

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -37,10 +37,9 @@ export function parseCarriageReturn(text: string) {
   let match
 
   while ((match = crLfOrEnd.exec(text)) !== null) {
-    // If we match the $ (end of string) we'll get a zero
-    // width match, this is a known problem in JS so we'll
-    // need to bump the regexp cursor to ensure it fails to
-    // match on the next round
+    // If we match the $ (end of string) we'll get a zero width
+    // match, so we'll need to bump the regexp cursor to ensure
+    // it fails to match on the next round
     if (match.index === crLfOrEnd.lastIndex) {
       crLfOrEnd.lastIndex++
     }

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -27,7 +27,7 @@ export function parseCarriageReturn(text: string) {
   // JavaScript `.` includes unicode line and paragraph break
   // characters which is why we use [\s\S] instead of '.'. The
   // first group matches lazily (as few times as possible) and
-  // tthe second group matches the next following \r or \n
+  // the second group matches the next following \r or \n
   // character or the end of the string. Matching the end of the
   // string lets us avoid dealing with leftover characters outside
   // of the matching loop.

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -1,5 +1,6 @@
 export function parseCarriageReturn(text: string) {
-  // Happy path,
+  // Happy path, there are no carriage returns in
+  // the text, making this method a noop.
   if (text.indexOf('\r') < 0) {
     return text
   }

--- a/app/src/lib/parse-carriage-return.ts
+++ b/app/src/lib/parse-carriage-return.ts
@@ -24,44 +24,15 @@ export function parseCarriageReturn(text: string) {
     return text
   }
 
-  // JavaScript `.` includes unicode line and paragraph break
-  // characters which is why we use [\s\S] instead of '.'. The
-  // first group matches lazily (as few times as possible) and
-  // the second group matches the next following \r or \n
-  // character or the end of the string. Matching the end of the
-  // string lets us avoid dealing with leftover characters outside
-  // of the matching loop.
-  const crLfOrEnd = /([\s\S]*?)([\r\n]|$)/g
-  const lines = new Array<string>('')
-
-  let match
-
-  while ((match = crLfOrEnd.exec(text)) !== null) {
-    // If we match the $ (end of string) we'll get a zero width
-    // match, so we'll need to bump the regexp cursor to ensure
-    // it fails to match on the next round
-    if (match.index === crLfOrEnd.lastIndex) {
-      crLfOrEnd.lastIndex++
-    }
-
-    if (match[1].length > 0) {
-      const line = lines[lines.length - 1]
-
-      if (line.length <= match[1].length) {
-        // Happy path, the new line is equal to or longer
+  return text
+    .split('\n')
+    .map(line =>
+      line.split('\r').reduce((buf, cur) =>
+        // Happy path, if the new line is equal to or longer
         // than the previous, we can just use the new one
         // without creating any new strings.
-        lines[lines.length - 1] = match[1]
-      } else {
-        const remainder = line.substring(match[1].length)
-        lines[lines.length - 1] = `${match[1]}${remainder}`
-      }
-    }
-
-    if (match[2] === '\n') {
-      lines.push('')
-    }
-  }
-
-  return lines.join('\n')
+        cur.length >= buf.length ? cur : cur + buf.substring(cur.length)
+      )
+    )
+    .join('\n')
 }

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -111,7 +111,6 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
   }
 
   private renderErrorMessage(error: Error) {
-    let monospace = false
     const e = error instanceof ErrorWithMetadata ? error.underlyingError : error
 
     if (e instanceof GitError) {
@@ -119,13 +118,12 @@ export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
       // If the error message is the same as stderr or stdout then we know
       // it's output from git and we'll display it in fixed-width font
       if (e.message === e.result.stderr || e.message === e.result.stdout) {
-        monospace = true
+        const formattedMessage = this.formatGitErrorMessage(e.message)
+        return <p className="monospace">{formattedMessage}</p>
       }
     }
 
-    const className = monospace ? 'monospace' : undefined
-
-    return <p className={className}>{this.formatGitErrorMessage(e.message)}</p>
+    return <p>{e.message}</p>
   }
 
   private getTitle(error: Error) {

--- a/app/src/ui/app-error.tsx
+++ b/app/src/ui/app-error.tsx
@@ -19,6 +19,7 @@ import { ErrorWithMetadata } from '../lib/error-with-metadata'
 import { RetryActionType, RetryAction } from '../models/retry-actions'
 import { Ref } from './lib/ref'
 import memoizeOne from 'memoize-one'
+import { parseCarriageReturn } from '../lib/parse-carriage-return'
 
 interface IAppErrorProps {
   /** The list of queued, app-wide, errors  */
@@ -51,7 +52,7 @@ interface IAppErrorState {
  */
 export class AppError extends React.Component<IAppErrorProps, IAppErrorState> {
   private dialogContent: HTMLDivElement | null = null
-  private formatGitErrorMessage = memoizeOne(carriageReturnFormatter)
+  private formatGitErrorMessage = memoizeOne(parseCarriageReturn)
 
   public constructor(props: IAppErrorProps) {
     super(props)
@@ -329,43 +330,4 @@ function isErrorWithMetaData(error: Error): error is ErrorWithMetadata {
 
 function isGitError(error: Error): error is GitError {
   return error instanceof GitError
-}
-
-function carriageReturnFormatter(text: string) {
-  const lines = new Array<string>('')
-  const crOrLf = /[\r\n]/gm
-
-  let lineIx = 0
-  let columnIx = 0
-  let p = 0
-
-  function merge(s: string) {
-    const line = lines[lineIx]
-    const before = line.substring(0, columnIx)
-    const after = line.substring(columnIx + s.length)
-    columnIx += s.length
-    lines[lineIx] = `${before}${s}${after}`
-  }
-
-  let m
-
-  while ((m = crOrLf.exec(text)) !== null) {
-    if (m.index > p) {
-      merge(text.substring(p, m.index))
-    }
-
-    if (m[0] === '\r') {
-      columnIx = 0
-    } else if (m[0] === '\n') {
-      lines[++lineIx] = ''
-    }
-
-    p = m.index + 1
-  }
-
-  if (p < text.length) {
-    merge(text.substring(p))
-  }
-
-  return lines.join('\n')
 }

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -87,5 +87,6 @@ describe('parseCarriageReturn', () => {
 
   it('handles strings terminating without newline or CR', () => {
     expect(parseCarriageReturn('foo\rbar')).toBe('bar')
+    expect(parseCarriageReturn('foo\r\r\r\r\rbar')).toBe('bar')
   })
 })

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -2,6 +2,8 @@ import { parseCarriageReturn } from '../../src/lib/parse-carriage-return'
 
 describe('parseCarriageReturn', () => {
   it('parses git clone output correctly', () => {
+    // The actual, raw, output of a `git clone` call which fails due to a
+    // duplicate ref clash (refspec tomfoolery)
     const cloneOutput =
       "Cloning into '/Users/markus/Documents/GitHub/delete-branch-test'...\n" +
       'remote: Enumerating objects: 8, done.        \n' +

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -79,4 +79,9 @@ describe('parseCarriageReturn', () => {
     expect(parseCarriageReturn('foo')).toBe('foo')
     expect(parseCarriageReturn('foo\nbar')).toBe('foo\nbar')
   })
+
+  it('handles terminating carriage returns', () => {
+    expect(parseCarriageReturn('foo\r')).toBe('foo')
+    expect(parseCarriageReturn('foo\nbar\r')).toBe('foo\nbar')
+  })
 })

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -104,4 +104,8 @@ describe('parseCarriageReturn', () => {
       'Foobar'
     )
   })
+
+  it("handles Windows' new lines", () => {
+    expect(parseCarriageReturn('A\r\nB\r\nC\r\nD\r\n')).toBe('A\nB\nC\nD\n')
+  })
 })

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -1,0 +1,75 @@
+import { parseCarriageReturn } from '../../src/lib/parse-carriage-return'
+
+describe('parseCarriageReturn', () => {
+  it('parses git clone output correctly', () => {
+    const cloneOutput =
+      "Cloning into '/Users/markus/Documents/GitHub/delete-branch-test'...\n" +
+      'remote: Enumerating objects: 8, done.        \n' +
+      'remote: Counting objects:  12% (1/8)        \r' +
+      'remote: Counting objects:  25% (2/8)        \r' +
+      'remote: Counting objects:  37% (3/8)        \r' +
+      'remote: Counting objects:  50% (4/8)        \r' +
+      'remote: Counting objects:  62% (5/8)        \r' +
+      'remote: Counting objects:  75% (6/8)        \r' +
+      'remote: Counting objects:  87% (7/8)        \r' +
+      'remote: Counting objects: 100% (8/8)        \r' +
+      'remote: Counting objects: 100% (8/8), done.        \n' +
+      'remote: Compressing objects:  16% (1/6)        \r' +
+      'remote: Compressing objects:  33% (2/6)        \r' +
+      'remote: Compressing objects:  50% (3/6)        \r' +
+      'remote: Compressing objects:  66% (4/6)        \r' +
+      'remote: Compressing objects:  83% (5/6)        \r' +
+      'remote: Compressing objects: 100% (6/6)        \r' +
+      'remote: Compressing objects: 100% (6/6), done.        \n' +
+      'remote: Total 8 (delta 1), reused 7 (delta 0), pack-reused 0        \n' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  12% (1/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  25% (2/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  37% (3/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  50% (4/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  62% (5/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  75% (6/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects:  87% (7/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects: 100% (8/8)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Receiving objects: 100% (8/8), done.\n' +
+      '\r' +
+      '                                                                                \r' +
+      'Resolving deltas:   0% (0/1)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Resolving deltas: 100% (1/1)\r' +
+      '\r' +
+      '                                                                                \r' +
+      'Resolving deltas: 100% (1/1), done.\n' +
+      "fatal: multiple updates for ref 'refs/remotes/origin/pr/1' not allowed\n"
+
+    const expected =
+      "Cloning into '/Users/markus/Documents/GitHub/delete-branch-test'...\n" +
+      'remote: Enumerating objects: 8, done.        \n' +
+      'remote: Counting objects: 100% (8/8), done.        \n' +
+      'remote: Compressing objects: 100% (6/6), done.        \n' +
+      'remote: Total 8 (delta 1), reused 7 (delta 0), pack-reused 0        \n' +
+      'Receiving objects: 100% (8/8), done.                                            \n' +
+      'Resolving deltas: 100% (1/1), done.                                             \n' +
+      "fatal: multiple updates for ref 'refs/remotes/origin/pr/1' not allowed\n"
+
+    expect(parseCarriageReturn(cloneOutput)).toBe(expected)
+  })
+})

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -98,4 +98,10 @@ describe('parseCarriageReturn', () => {
       'foo\u2028bar\u2029foo'
     )
   })
+
+  it('handles remaining characters from previous lines', () => {
+    expect(parseCarriageReturn('foobar\rfooba\rfoob\rfoo\r\fo\rF\r')).toBe(
+      'Foobar'
+    )
+  })
 })

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -89,4 +89,13 @@ describe('parseCarriageReturn', () => {
     expect(parseCarriageReturn('foo\rbar')).toBe('bar')
     expect(parseCarriageReturn('foo\r\r\r\r\rbar')).toBe('bar')
   })
+
+  it('treats unicode line separator and paragraph separator as flow text', () => {
+    // https://www.regular-expressions.info/dot.html
+    // [...] JavaScript adds the Unicode line separator \u2028 and paragraph
+    // separator \u2029 on top of that
+    expect(parseCarriageReturn('foo\rfoo\u2028bar\u2029foo')).toBe(
+      'foo\u2028bar\u2029foo'
+    )
+  })
 })

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -74,4 +74,9 @@ describe('parseCarriageReturn', () => {
 
     expect(parseCarriageReturn(cloneOutput)).toBe(expected)
   })
+
+  it("has no problems with strings that don't contain carriage returns", () => {
+    expect(parseCarriageReturn('foo')).toBe('foo')
+    expect(parseCarriageReturn('foo\nbar')).toBe('foo\nbar')
+  })
 })

--- a/app/test/unit/parse-carriage-return-test.ts
+++ b/app/test/unit/parse-carriage-return-test.ts
@@ -84,4 +84,8 @@ describe('parseCarriageReturn', () => {
     expect(parseCarriageReturn('foo\r')).toBe('foo')
     expect(parseCarriageReturn('foo\nbar\r')).toBe('foo\nbar')
   })
+
+  it('handles strings terminating without newline or CR', () => {
+    expect(parseCarriageReturn('foo\rbar')).toBe('bar')
+  })
 })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

~~:cactus: This depends on #9944, please review that first 🌵~~

## Description

When looking at #9944 I was struck once again by how bad our error messages from Git commands that show some sort of progress are:

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/634063/83896658-cc9aa600-a754-11ea-906c-79776e894d76.png">

While somewhat improved in https://github.com/desktop/desktop/pull/8964...

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/634063/72996054-42cbeb00-3dfa-11ea-886e-a78866ce46e5.png">

There's still a whole lot of redundant text in there that users don't care about and which often times ends up making it really hard to find the actual error message.

The reason for all of this is that Git (and many other CLI tools) leverage an old trick from the typewriter era called the carriage return character to make it seem like they're just updating a single character in the users' terminal.

![giphy](https://user-images.githubusercontent.com/634063/83896963-3a46d200-a755-11ea-9006-edd72e16d7f1.gif)


When the users sees something like `Progress: 1%` that then changes to `Progress: 2%` what Git actually does is it writes `Progress: 1%` followed by a carriage return character (`\r`) which sends the "carriage" back to the leftmost position and then it overwrites the existing text with `Progress: 2%`. Since we didn't handle carriage returns we got, and displayed each of those updates which for clones and fetches of large repositories could be enormous.

This PR changes that by introducing a parser that emulates how a terminal would interpret carriage returns so now we only show the last progress line for each type of progress reported.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

![Screen Shot 2020-06-05 at 13 06 29](https://user-images.githubusercontent.com/634063/83897307-bccf9180-a755-11ea-9477-1c0356d5a4be.png)

#### After

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/634063/83897349-c8bb5380-a755-11ea-80b2-f064b49873dd.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Removed redundant progress text in Git error messages
