### PR TITLE
Fix strings capitalization in discard dialog

### DIFF
--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -60,16 +60,16 @@ export class DiscardChanges extends React.Component<
     if (this.props.discardingAllChanges) {
       return __DARWIN__ ? 'Discard All Changes' : 'Discard all changes'
     }
-    return __DARWIN__ ? 'Discard changes' : 'Discard changes'
+    return __DARWIN__ ? 'Discard Changes' : 'Discard changes'
   }
 
   private getDialogTitle() {
     if (this.props.discardingAllChanges) {
       return __DARWIN__
         ? 'Confirm Discard All Changes'
-        : 'Confirm Discard all changes'
+        : 'Confirm discard all changes'
     }
-    return __DARWIN__ ? 'Confirm Discard changes' : 'Confirm Discard changes'
+    return __DARWIN__ ? 'Confirm Discard Changes' : 'Confirm discard changes'
   }
 
   public render() {


### PR DESCRIPTION
When the `toPlatformCase()` helper was removed from the codebase in https://github.com/desktop/desktop/pull/9940, a few issues with capitalization appeared, which were then copied to https://github.com/desktop/desktop/pull/9729 and discovered during the code review.

This PR fixes this.

