### PR TITLE
Do not execute compare action on mousedown events

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -547,14 +547,6 @@ export class CompareSidebar extends React.Component<
     branch: Branch | null,
     source: SelectionSource
   ) => {
-    if (source.kind === 'mouseclick' && branch != null) {
-      this.props.dispatcher.executeCompare(this.props.repository, {
-        kind: HistoryTabMode.Compare,
-        comparisonMode: ComparisonMode.Behind,
-        branch,
-      })
-    }
-
     this.setState({
       focusedBranch: branch,
     })


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9971

## Description

This PR removes the call to `executeCompare()` that was performed on mousdedown events against the compare branch list.

### Context

Before this PR, two `executeCompare()` calls got executed when clicking on an item on the compare branch list: the first one happens on the `mousedown` event (the one I'm removing) and the second one on the `click` event (which happens after the `mouseup` event).

This caused an issue when the first `executeCompare()` call finished before the click event happened:

The `executeCompare()` action would update the filter text of the branch list with the selected branch name, causing the filter to be applied and therefore the branch list to get updated.

Then, when the second `executeCompare()` function was called it could potentially use another branch since the list elements could get updated.

In most situations where using a branch name as a filter won't match other branch names this didn't cause an issue, since after the first `executeCompare()`, the list of branches would only contain a single branch (the clicked branch) and the second `executeCompare()` action would be done against no item (and therefore ignored) or against the correct branch:

<img width="433" alt="Screen Shot 2020-06-10 at 10 50 10" src="https://user-images.githubusercontent.com/408035/84247297-2eb62b00-ab08-11ea-9788-afeaf6ea1f1b.png">

But this could cause an issue in some scenarios where a branch name is a subset of another branch name, for example when having a branch called `X` and another one called `XY`. In this case the initial list would sort the branches by most recent ones:

<img width="407" alt="Screen Shot 2020-06-10 at 10 52 36" src="https://user-images.githubusercontent.com/408035/84247556-90769500-ab08-11ea-9773-f0d3a97a267c.png">

But once the user clicks on the `X` branch and the `executeCompare()` action gets called, the filtering gets applied and the order of displayed branches changes:

<img width="443" alt="Screen Shot 2020-06-10 at 10 53 57" src="https://user-images.githubusercontent.com/408035/84247779-cd428c00-ab08-11ea-9e11-84e68c0d04b2.png">

(this can be seen more clearly on the "Screenshots" section below).


### About this PR

The call that I removed was introduced in https://github.com/desktop/desktop/pull/4412 to address an issue that is not present anymore in the compare branch UI (I've tested it with the changes of this PR), and I think that this is because with https://github.com/desktop/desktop/pull/4751 (which was merged a bit later) the whole need of the two `executeCompare()` calls is not needed anymore.

Still, the logic of the compare branches UI is quite complex and I had a bit of trouble understanding all the different scenarios and how things play together, so it's possible that I'm missing something (I also found a couple of existing bugs while testing this PR which I'll document separately).

### Screenshots

**Before**:

![before](https://user-images.githubusercontent.com/408035/84254585-b5233a80-ab11-11ea-8b3f-b7652d2af9b7.gif)


**After**:

![after](https://user-images.githubusercontent.com/408035/84254608-bbb1b200-ab11-11ea-933a-df6f9765c3ea.gif)


## Release notes

Notes: [Fixed] Select Branch to Compare no longer selects wrong branches
