### PR TITLE
Promise helper cleanup

### DIFF
--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -46,9 +46,5 @@ export function promiseWithMinimumTimeout<T>(
  * @param timeout the time to wait before resolving the promise (in milliseconds)
  */
 export async function timeout(timeout: number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    window.setTimeout(() => {
-      resolve()
-    }, timeout)
-  })
+  return new Promise(resolve => window.setTimeout(resolve, timeout))
 }

--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -7,35 +7,13 @@
  *
  *
  * @param action the promise work to track
- * @param timeout the minimum time to wait before resolving the promise (in milliseconds)
+ * @param timeoutMs the minimum time to wait before resolving the promise (in milliseconds)
  */
 export function promiseWithMinimumTimeout<T>(
   action: () => Promise<T>,
-  timeout: number
+  timeoutMs: number
 ): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    let timeoutExpired = false
-    let result: T | null = null
-
-    const resolveIfBothDone = () => {
-      if (result != null && timeoutExpired) {
-        resolve(result)
-        result = null
-      }
-    }
-
-    window.setTimeout(() => {
-      timeoutExpired = true
-      resolveIfBothDone()
-    }, timeout)
-
-    action()
-      .then(r => {
-        result = r
-        resolveIfBothDone()
-      })
-      .catch(reject)
-  })
+  return Promise.all([action(), timeout(timeoutMs)]).then(x => x[0])
 }
 
 /**

--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -5,7 +5,6 @@
  * This is ideal for scenarios where a promises may complete quickly, but the
  * caller wants to introduce a minimum latency so that any dependent UI is
  *
- *
  * @param action the promise work to track
  * @param timeoutMs the minimum time to wait before resolving the promise (in milliseconds)
  */

--- a/app/test/unit/promise-with-timeout-test.ts
+++ b/app/test/unit/promise-with-timeout-test.ts
@@ -64,24 +64,8 @@ describe('promiseWithMinimumTimeout', () => {
   })
 
   it('handles actions returning null', async () => {
-    const resolveMock = jest.fn().mockImplementation(resolve => resolve(null))
-
-    const slowPromise = new Promise<number>(resolve => {
-      window.setTimeout(() => resolveMock(resolve), 1000)
-    })
-
-    const promise = promiseWithMinimumTimeout(() => slowPromise, 500)
-
-    // timeout completes
+    const promise = promiseWithMinimumTimeout(() => Promise.resolve(null), 500)
     jest.advanceTimersByTime(500)
-    expect(resolveMock.mock.calls).toHaveLength(0)
-
-    // promise completes
-    jest.advanceTimersByTime(500)
-    expect(resolveMock.mock.calls).toHaveLength(1)
-
-    const result = await promise
-
-    expect(result).toBe(null)
+    expect(await promise).toBe(null)
   })
 })

--- a/app/test/unit/promise-with-timeout-test.ts
+++ b/app/test/unit/promise-with-timeout-test.ts
@@ -62,4 +62,26 @@ describe('promiseWithMinimumTimeout', () => {
 
     expect(result).toBe(42)
   })
+
+  it('handles actions returning null', async () => {
+    const resolveMock = jest.fn().mockImplementation(resolve => resolve(null))
+
+    const slowPromise = new Promise<number>(resolve => {
+      window.setTimeout(() => resolveMock(resolve), 1000)
+    })
+
+    const promise = promiseWithMinimumTimeout(() => slowPromise, 500)
+
+    // timeout completes
+    jest.advanceTimersByTime(500)
+    expect(resolveMock.mock.calls).toHaveLength(0)
+
+    // promise completes
+    jest.advanceTimersByTime(500)
+    expect(resolveMock.mock.calls).toHaveLength(1)
+
+    const result = await promise
+
+    expect(result).toBe(null)
+  })
 })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Happened to open this file today while looking the generic `delay()` promise helper that I knew we had lying around here somewhere and was caught trying to understand the `promiseWithMinimumTimeout` function.

Am I missing something or is it needlessly complicated for what it's trying to do?