### PR TITLE
Default value discard changes modal

### DIFF
--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -50,13 +50,9 @@ export class DiscardSelection extends React.Component<
   IDiscardSelectionProps,
   IDiscardSelectionState
 > {
-  public constructor(props: IDiscardSelectionProps) {
-    super(props)
-
-    this.state = {
-      isDiscardingSelection: false,
-      confirmDiscardSelection: true,
-    }
+  public state: IDiscardSelectionState = {
+    isDiscardingSelection: false,
+    confirmDiscardSelection: true,
   }
 
   private getOkButtonLabel() {

--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -50,9 +50,13 @@ export class DiscardSelection extends React.Component<
   IDiscardSelectionProps,
   IDiscardSelectionState
 > {
-  public state: IDiscardSelectionState = {
-    isDiscardingSelection: false,
-    confirmDiscardSelection: true,
+  public constructor(props: IDiscardSelectionProps) {
+    super(props)
+
+    this.state = {
+      isDiscardingSelection: false,
+      confirmDiscardSelection: true,
+    }
   }
 
   private getOkButtonLabel() {

--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -55,7 +55,7 @@ export class DiscardSelection extends React.Component<
 
     this.state = {
       isDiscardingSelection: false,
-      confirmDiscardSelection: false,
+      confirmDiscardSelection: true,
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/9988

## Description

When creating the new discard selection modal in https://github.com/desktop/desktop/pull/9729 I've copy-pasta'd it from the `<DiscardChangesDialog />` which has a property called `confirmDiscardSelection`.

In the new `<DiscardSelectionDialog />` I decided to remove this props since it's not needed for the new dialog and set a default value for the state to `false`. Unfortunately I made a mistake and put the default value to `false` when it should be `true` (since the value of the checkbox is the negation of this state property).

A bit unrelated but to give some context, in the `<DiscardChangesDialog />` passing the `confirmDiscardSelection` is currently needed because that dialog could get opened even when the `confirmDiscardSelection` was set to `false` (this is because when discarding all files the dialog is shown even if the user chose to not show the discard changes dialog again).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Set default value of checkbox of Discard line confirmation dialogue to false.
