### PR TITLE
Hide horizontal scroll in AppError dialog

### DIFF
--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -326,6 +326,7 @@ dialog {
         // but make sure we wrap if necessary.
         white-space: pre-wrap;
         overflow-wrap: break-word;
+        overflow-x: hidden;
 
         &.monospace {
           font-family: var(--font-family-monospace);
@@ -334,7 +335,6 @@ dialog {
 
       max-height: 400px;
       overflow-y: auto;
-      overflow-x: hidden;
     }
   }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -334,6 +334,7 @@ dialog {
 
       max-height: 400px;
       overflow-y: auto;
+      overflow-x: hidden;
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

While confirming #9945 on Windows I noticed a horizontal scroll bar that I hadn't seen on macOS before

<img width="629" alt="Screen Shot 2020-06-15 at 13 14 10" src="https://user-images.githubusercontent.com/634063/84653958-a7552700-af0e-11ea-981d-ad1e30fdacda.png">

The AppError component is set up to hard-wrap in order to never overflow its horizontal bounds (https://github.com/desktop/desktop/blob/21ab3ce0d6f3e8b36a5c6794df7388bf4bcca72b/app/styles/ui/_dialog.scss#L325-L328) but there's still an issue with trailing white space exceeding the bounds

<img width="412" alt="image" src="https://user-images.githubusercontent.com/634063/84655213-d4a2d480-af10-11ea-9d9c-b3200cccd0b9.png">

###  After

<img width="632" alt="Screen Shot 2020-06-15 at 13 14 16" src="https://user-images.githubusercontent.com/634063/84653962-a7edbd80-af0e-11ea-9ba0-2a1e6a3c9039.png">