### PR TITLE
Promise timeout helper

### DIFF
--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -12,7 +12,7 @@ export function promiseWithMinimumTimeout<T>(
   action: () => Promise<T>,
   timeoutMs: number
 ): Promise<T> {
-  return Promise.all([action(), timeout(timeoutMs)]).then(x => x[0])
+  return Promise.all([action(), sleep(timeoutMs)]).then(x => x[0])
 }
 
 /**
@@ -22,6 +22,6 @@ export function promiseWithMinimumTimeout<T>(
  *
  * @param timeout the time to wait before resolving the promise (in milliseconds)
  */
-export async function timeout(timeout: number): Promise<void> {
+export async function sleep(timeout: number): Promise<void> {
   return new Promise(resolve => window.setTimeout(resolve, timeout))
 }

--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -26,6 +26,15 @@ export async function sleep(timeout: number): Promise<void> {
   return new Promise(resolve => window.setTimeout(resolve, timeout))
 }
 
+/**
+ * Helper function which lets callers define a maximum time to wait for
+ * a promise to complete after which a default value is returned instead.
+ *
+ * @param promise The promise to wait on
+ * @param timeout The maximum time to wait in milliseconds
+ * @param fallbackValue The default value to return should the promise
+ *                      not complete within `timeout` milliseconds.
+ */
 export async function timeout<T>(
   promise: Promise<T>,
   timeout: number,

--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -39,9 +39,9 @@ export async function timeout<T>(
   promise: Promise<T>,
   timeout: number,
   fallbackValue: T
-) {
+): Promise<T> {
   let timeoutId: number | null = null
-  const timeoutPromise = new Promise(resolve => {
+  const timeoutPromise = new Promise<T>(resolve => {
     timeoutId = window.setTimeout(() => resolve(fallbackValue), timeout)
   })
 

--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -25,3 +25,20 @@ export function promiseWithMinimumTimeout<T>(
 export async function sleep(timeout: number): Promise<void> {
   return new Promise(resolve => window.setTimeout(resolve, timeout))
 }
+
+export async function timeout<T>(
+  promise: Promise<T>,
+  timeout: number,
+  fallbackValue: T
+) {
+  let timeoutId: number | null = null
+  const timeoutPromise = new Promise(resolve => {
+    timeoutId = window.setTimeout(() => resolve(fallbackValue), timeout)
+  })
+
+  Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId)
+    }
+  })
+}

--- a/app/src/lib/promise.ts
+++ b/app/src/lib/promise.ts
@@ -45,7 +45,7 @@ export async function timeout<T>(
     timeoutId = window.setTimeout(() => resolve(fallbackValue), timeout)
   })
 
-  Promise.race([promise, timeoutPromise]).finally(() => {
+  return Promise.race([promise, timeoutPromise]).finally(() => {
     if (timeoutId !== null) {
       window.clearTimeout(timeoutId)
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -197,7 +197,7 @@ import {
 import { TypedBaseStore } from './base-store'
 import { AheadBehindUpdater } from './helpers/ahead-behind-updater'
 import { MergeResult } from '../../models/merge'
-import { promiseWithMinimumTimeout, timeout } from '../promise'
+import { promiseWithMinimumTimeout, sleep } from '../promise'
 import { BackgroundFetcher } from './helpers/background-fetcher'
 import { inferComparisonBranch } from './helpers/infer-comparison-branch'
 import { validatedRepositoryPath } from './helpers/validated-repository-path'
@@ -4359,7 +4359,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       // this timeout is intended to defer the action from running immediately
       // after the progress UI is shown, to better show that rebase is
       // progressing rather than suddenly appearing and disappearing again
-      await timeout(500)
+      await sleep(500)
       await step.rebaseAction()
     }
   }

--- a/app/src/ui/banners/banner.tsx
+++ b/app/src/ui/banners/banner.tsx
@@ -9,7 +9,7 @@ interface IBannerProps {
 }
 
 export class Banner extends React.Component<IBannerProps, {}> {
-  private timeoutId: NodeJS.Timer | null = null
+  private timeoutId: number | null = null
 
   public render() {
     return (
@@ -37,7 +37,7 @@ export class Banner extends React.Component<IBannerProps, {}> {
 
   public componentDidMount = () => {
     if (this.props.timeout !== undefined) {
-      this.timeoutId = setTimeout(() => {
+      this.timeoutId = window.setTimeout(() => {
         this.props.onDismissed()
       }, this.props.timeout)
     }
@@ -45,7 +45,7 @@ export class Banner extends React.Component<IBannerProps, {}> {
 
   public componentWillUnmount = () => {
     if (this.props.timeout !== undefined && this.timeoutId !== null) {
-      clearTimeout(this.timeoutId)
+      window.clearTimeout(this.timeoutId)
     }
   }
 }

--- a/app/test/unit/promise-test.ts
+++ b/app/test/unit/promise-test.ts
@@ -1,0 +1,17 @@
+import { timeout, sleep } from '../../src/lib/promise'
+
+jest.useFakeTimers()
+
+describe('timeout', () => {
+  it('falls back to the fallback value if promise takes too long', async () => {
+    const promise = timeout(sleep(1000).then(() => 'foo'), 500, 'bar')
+    jest.advanceTimersByTime(500)
+    expect(await promise).toBe('bar')
+  })
+
+  it('returns the promise result if it finishes in time', async () => {
+    const promise = timeout(Promise.resolve('foo'), 500, 'bar')
+    jest.advanceTimersByTime(500)
+    expect(await promise).toBe('foo')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "jsx": "react",
     "strict": true,
     "noEmit": true,
-    "outDir": "./out"
+    "outDir": "./out",
+    "lib": ["ES2017", "DOM", "DOM.Iterable", "ES2018.Promise"]
   },
   "plugins": [
     {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Extracted from #10020 to help lessen the review burden. We needed a promise timeout function, i.e. a helper method that would return a fallback value should the original promise take too long to  resolve.

While we could have implemented this by composing the old `timeout` method in a race like this

```ts
Promise.race([promise, timeout(500).then(() => fallbackValue)])
```

It felt like a useful enough helper method that we wanted to avoid keeping the timer (and thereby the closure encompassing `fallbackValue`) alive for any longer than necessary. Imagine this super contrived scenario:

```ts
timeout(someExpensivePromise, 3600000, someGinormousDiffOrSomething)
```

If we composed like above then `someGinormousDiffOrSomething` would be kept alive for an hour even if `someExpensivePromise` resolves immediately.

### Rename

We already had a promise helper method called `timeout`. After spending a few minutes trying to come up with a different name for this new helper we concluded that renaming the old helper to `sleep` would both rid us of the need to come up with a creative name as well as make it more clear what that method did.

### ES2018

In order to implement this timeout method elegantly we needed `Promise.prototype.finally` which is part of ES2018. After investigating https://kangax.github.io/compat-table/es2016plus/ we were confident that the version of Chrome that we run on (78) supports all of ES2018. Nevertheless we didn't want to take the step to upgrade to ES2018 in this PR and opted instead to only specifically include that part of ES2018 in our TSConfig. We'd be happy to entertain the thought of moving us to ES2018 fully in a separate PR.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
