### PR TITLE
Allow users to stash changes without switching branches

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -104,6 +104,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'rename-branch',
   'delete-branch',
   'discard-all-changes',
+  'stash-all-changes',
   'preferences',
   'update-branch',
   'compare-to-branch',
@@ -280,6 +281,11 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
       repositoryActive && hasChangedFiles && !rebaseInProgress
     )
 
+    menuStateBuilder.setEnabled(
+      'stash-all-changes',
+      hasChangedFiles && onBranch && !rebaseInProgress
+    )
+
     menuStateBuilder.setEnabled('compare-to-branch', !onDetachedHead)
     menuStateBuilder.setEnabled('toggle-stashed-changes', branchHasStashEntry)
 
@@ -311,6 +317,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     menuStateBuilder.disable('rename-branch')
     menuStateBuilder.disable('delete-branch')
     menuStateBuilder.disable('discard-all-changes')
+    menuStateBuilder.disable('stash-all-changes')
     menuStateBuilder.disable('update-branch')
     menuStateBuilder.disable('merge-branch')
     menuStateBuilder.disable('rebase-branch')

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -155,6 +155,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
   let onBranch = false
   let onDetachedHead = false
   let hasChangedFiles = false
+  let hasConflicts = false
   let hasDefaultBranch = false
   let hasPublishedBranch = false
   let networkActionInProgress = false
@@ -203,6 +204,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     const { conflictState, workingDirectory } = selectedState.state.changesState
 
     rebaseInProgress = conflictState !== null && conflictState.kind === 'rebase'
+    hasConflicts = changesState.conflictState !== null
     hasChangedFiles = workingDirectory.files.length > 0
   }
 
@@ -283,7 +285,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.setEnabled(
       'stash-all-changes',
-      hasChangedFiles && onBranch && !rebaseInProgress
+      hasChangedFiles && onBranch && !rebaseInProgress && !hasConflicts
     )
 
     menuStateBuilder.setEnabled('compare-to-branch', !onDetachedHead)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3221,21 +3221,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.uncommittedChangesStrategyKind
     )
   ): Promise<IStashEntry | null> {
+    const {
+      changesState,
+      branchesState: { tip },
+    } = this.repositoryStateCache.get(repository)
+    const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
+
     if (
+      currentBranch !== null &&
       uncommittedChangesStrategy.kind ===
-      UncommittedChangesStrategyKind.StashOnCurrentBranch
+        UncommittedChangesStrategyKind.StashOnCurrentBranch
     ) {
-      await this._createStashForCurrentBranch(repository, false)
+      await this._createStashAndDropPreviousEntry(
+        repository,
+        currentBranch.name
+      )
+      this.statsStore.recordStashCreatedOnCurrentBranch()
     } else if (
       uncommittedChangesStrategy.kind ===
       UncommittedChangesStrategyKind.MoveToNewBranch
     ) {
-      const { changesState } = this.repositoryStateCache.get(repository)
       const hasDeletedFiles = changesState.workingDirectory.files.some(
         file => file.status.kind === AppFileStatusKind.Deleted
       )
       const { transientStashEntry } = uncommittedChangesStrategy
-
       if (hasDeletedFiles && !transientStashEntry) {
         const gitStore = this.gitStoreCache.get(repository)
         const stashCreated = await gitStore.performFailableOperation(() => {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3277,12 +3277,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    if (currentBranch !== null) {
-      await this._createStashAndDropPreviousEntry(
+    if (showConfirmationDialog && hasExistingStash) {
+      return this._showPopup({
+        type: PopupType.ConfirmOverwriteStash,
+        branchToCheckout: null,
         repository,
-        currentBranch.name
-      )
-      this.statsStore.recordStashCreatedOnCurrentBranch()
+      })
     }
 
     await this._createStashAndDropPreviousEntry(repository, currentBranch.name)

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -368,6 +368,12 @@ export function buildDefaultMenu({
         accelerator: 'CmdOrCtrl+Shift+Backspace',
         click: emit('discard-all-changes'),
       },
+      {
+        label: __DARWIN__ ? 'Stash All Changes…' : '&Stash all changes…',
+        id: 'stash-all-changes',
+        accelerator: 'CmdOrCtrl+Shift+S',
+        click: emit('stash-all-changes'),
+      },
       separator,
       {
         label: __DARWIN__

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -12,6 +12,7 @@ export type MenuEvent =
   | 'rename-branch'
   | 'delete-branch'
   | 'discard-all-changes'
+  | 'stash-all-changes'
   | 'show-preferences'
   | 'choose-repository'
   | 'open-working-directory'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -3,6 +3,7 @@ export type MenuIDs =
   | 'rename-branch'
   | 'delete-branch'
   | 'discard-all-changes'
+  | 'stash-all-changes'
   | 'preferences'
   | 'update-branch'
   | 'merge-branch'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -209,7 +209,7 @@ export type Popup =
   | {
       type: PopupType.ConfirmOverwriteStash
       repository: Repository
-      branchToCheckout: Branch
+      branchToCheckout: Branch | null
     }
   | {
       type: PopupType.ConfirmDiscardStash

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -343,6 +343,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.deleteBranch()
       case 'discard-all-changes':
         return this.discardAllChanges()
+      case 'stash-all-changes':
+        return this.stashAllChanges()
       case 'show-preferences':
         return this.props.dispatcher.showPopup({ type: PopupType.Preferences })
       case 'open-working-directory':
@@ -676,6 +678,14 @@ export class App extends React.Component<IAppProps, IAppState> {
       showDiscardChangesSetting: false,
       discardingAllChanges: true,
     })
+  }
+
+  private stashAllChanges() {
+    const repository = this.getRepository()
+
+    if (repository !== null && repository instanceof Repository) {
+      this.props.dispatcher.createStashForCurrentBranch(repository)
+    }
   }
 
   private showAddLocalRepo = () => {

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -32,7 +32,7 @@ import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
 import { basename } from 'path'
 import { ICommitContext } from '../../models/commit'
-import { RebaseConflictState } from '../../lib/app-state'
+import { RebaseConflictState, ConflictState } from '../../lib/app-state'
 import { ContinueRebase } from './continue-rebase'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { IStashEntry } from '../../models/stash-entry'
@@ -94,6 +94,11 @@ function getIncludeAllValue(
 interface IChangesListProps {
   readonly repository: Repository
   readonly workingDirectory: WorkingDirectoryStatus
+  /**
+   * An object containing the conflicts in the working directory.
+   * When null it means that there are no conflicts.
+   */
+  readonly conflictState: ConflictState | null
   readonly rebaseConflictState: RebaseConflictState | null
   readonly selectedFileIDs: ReadonlyArray<string>
   readonly onFileSelectionChanged: (rows: ReadonlyArray<number>) => void
@@ -345,7 +350,10 @@ export class ChangesList extends React.Component<
       {
         label: __DARWIN__ ? 'Stash All Changes…' : 'Stash all changes…',
         action: this.onStashChanges,
-        enabled: hasLocalChanges && this.props.branch !== null,
+        enabled:
+          hasLocalChanges &&
+          this.props.branch !== null &&
+          this.props.conflictState === null,
       },
     ]
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -119,6 +119,9 @@ interface IChangesListProps {
    * @param path The path of the file relative to the root of the repository
    */
   readonly onOpenItem: (path: string) => void
+  /**
+   * The currently checked out branch (null if no branch is checked out).
+   */
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly gitHubUser: IGitHubUser | null
@@ -272,6 +275,10 @@ export class ChangesList extends React.Component<
     )
   }
 
+  private onStashChanges = () => {
+    this.props.dispatcher.createStashForCurrentBranch(this.props.repository)
+  }
+
   private onDiscardChanges = (files: ReadonlyArray<string>) => {
     const workingDirectory = this.props.workingDirectory
 
@@ -327,11 +334,18 @@ export class ChangesList extends React.Component<
       return
     }
 
+    const hasLocalChanges = this.props.workingDirectory.files.length > 0
+
     const items: IMenuItem[] = [
       {
         label: __DARWIN__ ? 'Discard All Changes…' : 'Discard all changes…',
         action: this.onDiscardAllChanges,
-        enabled: this.props.workingDirectory.files.length > 0,
+        enabled: hasLocalChanges,
+      },
+      {
+        label: __DARWIN__ ? 'Stash All Changes…' : 'Stash all changes…',
+        action: this.onStashChanges,
+        enabled: hasLocalChanges && this.props.branch !== null,
       },
     ]
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -396,6 +396,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
           workingDirectory={workingDirectory}
+          conflictState={conflictState}
           rebaseConflictState={rebaseConflictState}
           selectedFileIDs={selectedFileIDs}
           onFileSelectionChanged={this.onFileSelectionChanged}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2325,6 +2325,24 @@ export class Dispatcher {
     return this.commitStatusStore.subscribe(repository, ref, callback)
   }
 
+  /**
+   * Creates a stash for the current branch. Note that this will
+   * override any stash that already exists for the current branch.
+   *
+   * @param repository
+   * @param showConfirmationDialog  Whether to show a confirmation
+   *                                dialog if an existing stash exists.
+   */
+  public createStashForCurrentBranch(
+    repository: Repository,
+    showConfirmationDialog: boolean = true
+  ) {
+    return this.appStore._createStashForCurrentBranch(
+      repository,
+      showConfirmationDialog
+    )
+  }
+
   /** Drops the given stash in the given repository */
   public dropStash(repository: Repository, stashEntry: IStashEntry) {
     return this.appStore._dropStashEntry(repository, stashEntry)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2330,8 +2330,8 @@ export class Dispatcher {
    * override any stash that already exists for the current branch.
    *
    * @param repository
-   * @param showConfirmationDialog  Whether to show a confirmation
-   *                                dialog if an existing stash exists.
+   * @param showConfirmationDialog  Whether to show a confirmation dialog if an
+   *                                existing stash exists (defaults to true).
    */
   public createStashForCurrentBranch(
     repository: Repository,

--- a/app/src/ui/stash-changes/overwrite-stashed-changes-dialog.tsx
+++ b/app/src/ui/stash-changes/overwrite-stashed-changes-dialog.tsx
@@ -10,7 +10,7 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 interface IOverwriteStashProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
-  readonly branchToCheckout: Branch
+  readonly branchToCheckout: Branch | null
   readonly onDismissed: () => void
 }
 
@@ -67,11 +67,15 @@ export class OverwriteStash extends React.Component<
     })
 
     try {
-      await dispatcher.checkoutBranch(
-        repository,
-        branchToCheckout,
-        stashOnCurrentBranch
-      )
+      if (branchToCheckout !== null) {
+        await dispatcher.checkoutBranch(
+          repository,
+          branchToCheckout,
+          stashOnCurrentBranch
+        )
+      } else {
+        await dispatcher.createStashForCurrentBranch(repository, false)
+      }
     } finally {
       this.setState({
         isCheckingOutBranch: false,

--- a/app/src/ui/stash-changes/overwrite-stashed-changes-dialog.tsx
+++ b/app/src/ui/stash-changes/overwrite-stashed-changes-dialog.tsx
@@ -15,7 +15,7 @@ interface IOverwriteStashProps {
 }
 
 interface IOverwriteStashState {
-  readonly isCheckingOutBranch: boolean
+  readonly isLoading: boolean
 }
 
 /**
@@ -29,7 +29,7 @@ export class OverwriteStash extends React.Component<
     super(props)
 
     this.state = {
-      isCheckingOutBranch: false,
+      isLoading: false,
     }
   }
 
@@ -41,8 +41,8 @@ export class OverwriteStash extends React.Component<
         id="overwrite-stash"
         type="warning"
         title={title}
-        loading={this.state.isCheckingOutBranch}
-        disabled={this.state.isCheckingOutBranch}
+        loading={this.state.isLoading}
+        disabled={this.state.isLoading}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >
@@ -63,7 +63,7 @@ export class OverwriteStash extends React.Component<
     const { dispatcher, repository, branchToCheckout, onDismissed } = this.props
 
     this.setState({
-      isCheckingOutBranch: true,
+      isLoading: true,
     })
 
     try {
@@ -78,7 +78,7 @@ export class OverwriteStash extends React.Component<
       }
     } finally {
       this.setState({
-        isCheckingOutBranch: false,
+        isLoading: false,
       })
     }
 


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/8197

Paired with @niik 

## Description

This PR adds the option to stash all local changes without having to checkout a different branch by adding two context menu items (one in the application menu, on the "Branch" submenu and the other on the context menu that appears when right-clicking on the changed files header:

<img width="590" alt="Screen Shot 2020-06-17 at 18 51 43" src="https://user-images.githubusercontent.com/408035/84926384-9867a380-b0cb-11ea-85b3-aec16e36e33a.png">

<img width="797" alt="Screen Shot 2020-06-17 at 18 51 07" src="https://user-images.githubusercontent.com/408035/84926342-8423a680-b0cb-11ea-8c28-d35ff86e6c48.png">

This PR reuses the logic that keeps the changes on the current branch when checking out another PR, which means:

* The stash will get associated to the currently checked out branch (it will only be accessible from this branch within Desktop).
* If a stash already exists on the currently checked out branch, when stashing again it will get "overwritten" (a dialog will appear to inform the user about this).

### Product considerations

* The stash menu items will get disabled state when any of the following conditions is true:
  * There are no local changes.
  * The current HEAD is in a detached state (no branch currently checked out).
  * There is an unresolved git conflict.
* If there's an existing stash entry on the current branch, the following dialog will get shown (it's the same that gets shown when this scenario happens while switching branches):
* The <kbd>Cmd + Shift + S</kbd> keyboard shortcut has been added for this feature. It's not used anywhere in Desktop and by doing a quick search it doesn't seem to be used by global shortcuts in either macOS or Windows.

<img width="760" alt="Screen Shot 2020-06-17 at 19 33 14" src="https://user-images.githubusercontent.com/408035/84930339-65c0a980-b0d1-11ea-8dcb-228bc461ecf4.png">


## Release notes

Notes: [Added] Allow users to stash changes without switching branches
