### PR TITLE
Disable stash menu item when there are conflicts and make ellipsis optional

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -9,7 +9,7 @@ import { CloningRepository } from '../models/cloning-repository'
 import { TipState } from '../models/tip'
 import { updateMenuState as ipcUpdateMenuState } from '../ui/main-process-proxy'
 import { AppMenu, MenuItem } from '../models/app-menu'
-import { AppFileStatusKind } from '../models/status'
+import { hasConflictedFiles } from './status'
 
 export interface IMenuItemState {
   readonly enabled?: boolean
@@ -207,9 +207,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     rebaseInProgress = conflictState !== null && conflictState.kind === 'rebase'
     hasConflicts =
       changesState.conflictState !== null ||
-      workingDirectory.files.some(
-        x => x.status.kind === AppFileStatusKind.Conflicted
-      )
+      hasConflictedFiles(workingDirectory)
     hasChangedFiles = workingDirectory.files.length > 0
   }
 

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -9,6 +9,7 @@ import { CloningRepository } from '../models/cloning-repository'
 import { TipState } from '../models/tip'
 import { updateMenuState as ipcUpdateMenuState } from '../ui/main-process-proxy'
 import { AppMenu, MenuItem } from '../models/app-menu'
+import { AppFileStatusKind } from '../models/status'
 
 export interface IMenuItemState {
   readonly enabled?: boolean

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -204,7 +204,11 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     const { conflictState, workingDirectory } = selectedState.state.changesState
 
     rebaseInProgress = conflictState !== null && conflictState.kind === 'rebase'
-    hasConflicts = changesState.conflictState !== null
+    hasConflicts =
+      changesState.conflictState !== null ||
+      workingDirectory.files.some(
+        x => x.status.kind === AppFileStatusKind.Conflicted
+      )
     hasChangedFiles = workingDirectory.files.length > 0
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1950,12 +1950,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const isStashedChangesVisible =
       changesState.selection.kind === ChangesSelectionKind.Stash
 
+    const askForConfirmationWhenStashingAllChanges =
+      changesState.stashEntry !== null
+
     updatePreferredAppMenuItemLabels({
       ...labels,
       defaultBranchName,
       isForcePushForCurrentRepository,
       isStashedChangesVisible,
       hasCurrentPullRequest: currentPullRequest !== null,
+      askForConfirmationWhenStashingAllChanges,
     })
   }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -21,6 +21,12 @@ const showPullRequestLabel = __DARWIN__
 const defaultBranchNameValue = __DARWIN__ ? 'Default Branch' : 'default branch'
 const confirmRepositoryRemovalLabel = __DARWIN__ ? 'Remove…' : '&Remove…'
 const repositoryRemovalLabel = __DARWIN__ ? 'Remove' : '&Remove'
+const confirmStashAllChangesLabel = __DARWIN__
+  ? 'Stash All Changes…'
+  : '&Stash all changes…'
+const stashAllChangesLabel = __DARWIN__
+  ? 'Stash All Changes'
+  : '&Stash all changes'
 
 enum ZoomDirection {
   Reset,
@@ -37,6 +43,7 @@ export function buildDefaultMenu({
   defaultBranchName = defaultBranchNameValue,
   isForcePushForCurrentRepository = false,
   isStashedChangesVisible = false,
+  askForConfirmationWhenStashingAllChanges = true,
 }: MenuLabelsEvent): Electron.Menu {
   defaultBranchName = truncateWithEllipsis(defaultBranchName, 25)
 
@@ -369,7 +376,9 @@ export function buildDefaultMenu({
         click: emit('discard-all-changes'),
       },
       {
-        label: __DARWIN__ ? 'Stash All Changes…' : '&Stash all changes…',
+        label: askForConfirmationWhenStashingAllChanges
+          ? confirmStashAllChangesLabel
+          : stashAllChangesLabel,
         id: 'stash-all-changes',
         accelerator: 'CmdOrCtrl+Shift+S',
         click: emit('stash-all-changes'),

--- a/app/src/models/menu-labels.ts
+++ b/app/src/models/menu-labels.ts
@@ -50,5 +50,10 @@ export type MenuLabelsEvent = {
    */
   readonly isStashedChangesVisible?: boolean
 
+  /**
+   * Whether or not attempting to stash working directory changes will result
+   * in a confirmation dialog asking the user whether they want to override
+   * their existing stash or not.
+   */
   readonly askForConfirmationWhenStashingAllChanges?: boolean
 }

--- a/app/src/models/menu-labels.ts
+++ b/app/src/models/menu-labels.ts
@@ -49,4 +49,6 @@ export type MenuLabelsEvent = {
    * Specify whether a stashed change is accessible in the current branch.
    */
   readonly isStashedChangesVisible?: boolean
+
+  readonly askForConfirmationWhenStashingAllChanges?: boolean
 }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -38,6 +38,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { IStashEntry } from '../../models/stash-entry'
 import * as classNames from 'classnames'
 import { hasWritePermission } from '../../models/github-repository'
+import { hasConflictedFiles } from '../../lib/status'
 
 const RowHeight = 29
 const StashIcon = new OcticonSymbol(
@@ -66,7 +67,7 @@ function getIncludeAllValue(
     // untracked files will be skipped by the rebase, so we need to ensure that
     // the "Include All" checkbox matches this state
     const onlyUntrackedFilesFound = workingDirectory.files.every(
-      f => f.status.kind === AppFileStatusKind.Untracked
+      (f) => f.status.kind === AppFileStatusKind.Untracked
     )
 
     if (onlyUntrackedFilesFound) {
@@ -74,7 +75,7 @@ function getIncludeAllValue(
     }
 
     const onlyTrackedFilesFound = workingDirectory.files.every(
-      f => f.status.kind !== AppFileStatusKind.Untracked
+      (f) => f.status.kind !== AppFileStatusKind.Untracked
     )
 
     // show "Mixed" if we have a mixture of tracked and untracked changes
@@ -288,7 +289,9 @@ export class ChangesList extends React.Component<
     const workingDirectory = this.props.workingDirectory
 
     if (files.length === 1) {
-      const modifiedFile = workingDirectory.files.find(f => f.path === files[0])
+      const modifiedFile = workingDirectory.files.find(
+        (f) => f.path === files[0]
+      )
 
       if (modifiedFile != null) {
         this.props.onDiscardChanges(modifiedFile)
@@ -296,8 +299,8 @@ export class ChangesList extends React.Component<
     } else {
       const modifiedFiles = new Array<WorkingDirectoryFileChange>()
 
-      files.forEach(file => {
-        const modifiedFile = workingDirectory.files.find(f => f.path === file)
+      files.forEach((file) => {
+        const modifiedFile = workingDirectory.files.find((f) => f.path === file)
 
         if (modifiedFile != null) {
           modifiedFiles.push(modifiedFile)
@@ -343,9 +346,7 @@ export class ChangesList extends React.Component<
     const hasStash = this.props.stashEntry !== null
     const hasConflicts =
       this.props.conflictState !== null ||
-      this.props.workingDirectory.files.some(
-        x => x.status.kind === AppFileStatusKind.Conflicted
-      )
+      hasConflictedFiles(this.props.workingDirectory)
 
     const stashAllChangesLabel = __DARWIN__
       ? 'Stash All Changes'
@@ -479,18 +480,20 @@ export class ChangesList extends React.Component<
           // Filter out any .gitignores that happens to be selected, ignoring
           // those doesn't make sense.
           this.props.onIgnore(
-            paths.filter(path => Path.basename(path) !== GitIgnoreFileName)
+            paths.filter((path) => Path.basename(path) !== GitIgnoreFileName)
           )
         },
         // Enable this action as long as there's something selected which isn't
         // a .gitignore file.
-        enabled: paths.some(path => Path.basename(path) !== GitIgnoreFileName),
+        enabled: paths.some(
+          (path) => Path.basename(path) !== GitIgnoreFileName
+        ),
       })
     }
     // Five menu items should be enough for everyone
     Array.from(extensions)
       .slice(0, 5)
-      .forEach(extension => {
+      .forEach((extension) => {
         items.push({
           label: __DARWIN__
             ? `Ignore All ${extension} Files (Add to .gitignore)`
@@ -608,7 +611,7 @@ export class ChangesList extends React.Component<
 
     if (rebaseConflictState !== null) {
       const hasUntrackedChanges = workingDirectory.files.some(
-        f => f.status.kind === AppFileStatusKind.Untracked
+        (f) => f.status.kind === AppFileStatusKind.Untracked
       )
 
       return (
@@ -634,7 +637,7 @@ export class ChangesList extends React.Component<
       fileCount > 0 && includeAllValue !== CheckboxValue.Off
 
     const filesSelected = workingDirectory.files.filter(
-      f => f.selection.getSelectionType() !== DiffSelectionType.None
+      (f) => f.selection.getSelectionType() !== DiffSelectionType.None
     )
 
     // When a single file is selected, we use a default commit summary

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -340,11 +340,19 @@ export class ChangesList extends React.Component<
     }
 
     const hasLocalChanges = this.props.workingDirectory.files.length > 0
+    const hasStash = this.props.stashEntry !== null
     const hasConflicts =
       this.props.conflictState !== null ||
       this.props.workingDirectory.files.some(
         x => x.status.kind === AppFileStatusKind.Conflicted
       )
+
+    const stashAllChangesLabel = __DARWIN__
+      ? 'Stash All Changes'
+      : 'Stash all changes'
+    const confirmStashAllChangesLabel = __DARWIN__
+      ? 'Stash All Changes…'
+      : 'Stash all changes…'
 
     const items: IMenuItem[] = [
       {
@@ -353,7 +361,7 @@ export class ChangesList extends React.Component<
         enabled: hasLocalChanges,
       },
       {
-        label: __DARWIN__ ? 'Stash All Changes…' : 'Stash all changes…',
+        label: hasStash ? confirmStashAllChangesLabel : stashAllChangesLabel,
         action: this.onStashChanges,
         enabled: hasLocalChanges && this.props.branch !== null && !hasConflicts,
       },

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -67,7 +67,7 @@ function getIncludeAllValue(
     // untracked files will be skipped by the rebase, so we need to ensure that
     // the "Include All" checkbox matches this state
     const onlyUntrackedFilesFound = workingDirectory.files.every(
-      (f) => f.status.kind === AppFileStatusKind.Untracked
+      f => f.status.kind === AppFileStatusKind.Untracked
     )
 
     if (onlyUntrackedFilesFound) {
@@ -75,7 +75,7 @@ function getIncludeAllValue(
     }
 
     const onlyTrackedFilesFound = workingDirectory.files.every(
-      (f) => f.status.kind !== AppFileStatusKind.Untracked
+      f => f.status.kind !== AppFileStatusKind.Untracked
     )
 
     // show "Mixed" if we have a mixture of tracked and untracked changes
@@ -289,9 +289,7 @@ export class ChangesList extends React.Component<
     const workingDirectory = this.props.workingDirectory
 
     if (files.length === 1) {
-      const modifiedFile = workingDirectory.files.find(
-        (f) => f.path === files[0]
-      )
+      const modifiedFile = workingDirectory.files.find(f => f.path === files[0])
 
       if (modifiedFile != null) {
         this.props.onDiscardChanges(modifiedFile)
@@ -299,8 +297,8 @@ export class ChangesList extends React.Component<
     } else {
       const modifiedFiles = new Array<WorkingDirectoryFileChange>()
 
-      files.forEach((file) => {
-        const modifiedFile = workingDirectory.files.find((f) => f.path === file)
+      files.forEach(file => {
+        const modifiedFile = workingDirectory.files.find(f => f.path === file)
 
         if (modifiedFile != null) {
           modifiedFiles.push(modifiedFile)
@@ -480,20 +478,18 @@ export class ChangesList extends React.Component<
           // Filter out any .gitignores that happens to be selected, ignoring
           // those doesn't make sense.
           this.props.onIgnore(
-            paths.filter((path) => Path.basename(path) !== GitIgnoreFileName)
+            paths.filter(path => Path.basename(path) !== GitIgnoreFileName)
           )
         },
         // Enable this action as long as there's something selected which isn't
         // a .gitignore file.
-        enabled: paths.some(
-          (path) => Path.basename(path) !== GitIgnoreFileName
-        ),
+        enabled: paths.some(path => Path.basename(path) !== GitIgnoreFileName),
       })
     }
     // Five menu items should be enough for everyone
     Array.from(extensions)
       .slice(0, 5)
-      .forEach((extension) => {
+      .forEach(extension => {
         items.push({
           label: __DARWIN__
             ? `Ignore All ${extension} Files (Add to .gitignore)`
@@ -611,7 +607,7 @@ export class ChangesList extends React.Component<
 
     if (rebaseConflictState !== null) {
       const hasUntrackedChanges = workingDirectory.files.some(
-        (f) => f.status.kind === AppFileStatusKind.Untracked
+        f => f.status.kind === AppFileStatusKind.Untracked
       )
 
       return (
@@ -637,7 +633,7 @@ export class ChangesList extends React.Component<
       fileCount > 0 && includeAllValue !== CheckboxValue.Off
 
     const filesSelected = workingDirectory.files.filter(
-      (f) => f.selection.getSelectionType() !== DiffSelectionType.None
+      f => f.selection.getSelectionType() !== DiffSelectionType.None
     )
 
     // When a single file is selected, we use a default commit summary

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -340,6 +340,11 @@ export class ChangesList extends React.Component<
     }
 
     const hasLocalChanges = this.props.workingDirectory.files.length > 0
+    const hasConflicts =
+      this.props.conflictState !== null ||
+      this.props.workingDirectory.files.some(
+        x => x.status.kind === AppFileStatusKind.Conflicted
+      )
 
     const items: IMenuItem[] = [
       {
@@ -350,10 +355,7 @@ export class ChangesList extends React.Component<
       {
         label: __DARWIN__ ? 'Stash All Changes…' : 'Stash all changes…',
         action: this.onStashChanges,
-        enabled:
-          hasLocalChanges &&
-          this.props.branch !== null &&
-          this.props.conflictState === null,
+        enabled: hasLocalChanges && this.props.branch !== null && !hasConflicts,
       },
     ]
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

While testing #10032 @tierninho [found two issues](https://github.com/desktop/desktop/pull/10032#pullrequestreview-432808924) that we decided to address in a separate PR.

> remove the ... from the references as there is no secondary action needed by the user, as it would imply.

This is a great shout. We'll modify the label based on whether there's a current stash entry or not.

> If any of the files are conflicted, then the Stash feature does not work after selecting it and no error message is shown.

There are cases when there are files marked as conflicted in the index without there being a merge or rebase action in progress (like the revert commit case we found yesterday for example). So in addition to checking for a conflicted state we should check to see if there are any conflicted files in the working directory.
