### PR TITLE
Refactor logic to open context menus

### DIFF
--- a/app/src/lib/menu-item.ts
+++ b/app/src/lib/menu-item.ts
@@ -25,6 +25,9 @@ export interface IMenuItem {
   readonly submenu?: ReadonlyArray<this>
 }
 
+/**
+ * A menu item data structure that can be serialized and sent via IPC.
+ */
 export interface ISerializableMenuItem extends IMenuItem {
   readonly action: undefined
 }

--- a/app/src/lib/menu-item.ts
+++ b/app/src/lib/menu-item.ts
@@ -22,7 +22,11 @@ export interface IMenuItem {
   /**
    * Submenu that will appear when hovering this menu item.
    */
-  readonly submenu?: ReadonlyArray<IMenuItem>
+  readonly submenu?: ReadonlyArray<this>
+}
+
+export interface ISerializableMenuItem extends IMenuItem {
+  readonly action: undefined
 }
 
 /**

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -435,15 +435,25 @@ app.on('ready', () => {
     }
   )
 
-  ipcMain.on(
+  /**
+   * Handle the action to show a contextual menu.
+   *
+   * It responds an array of indices that maps to the path to reach
+   * the menu (or submenu) item that was clicked or null if the menu
+   * was closed without clicking on any item.
+   */
+  ipcMain.handle(
     'show-contextual-menu',
-    (event: Electron.IpcMainEvent, items: ReadonlyArray<IMenuItem>) => {
-      const menu = buildContextMenu(items, indices =>
-        event.sender.send('contextual-menu-action', indices)
-      )
+    (
+      event: Electron.IpcMainInvokeEvent,
+      items: ReadonlyArray<IMenuItem>
+    ): Promise<ReadonlyArray<number> | null> => {
+      return new Promise(resolve => {
+        const menu = buildContextMenu(items, indices => resolve(indices))
 
-      const window = BrowserWindow.fromWebContents(event.sender)
-      menu.popup({ window })
+        const window = BrowserWindow.fromWebContents(event.sender)
+        menu.popup({ window, callback: () => resolve(null) })
+      })
     }
   )
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -24,7 +24,7 @@ import {
 } from '../lib/source-map-support'
 import { now } from './now'
 import { showUncaughtException } from './show-uncaught-exception'
-import { IMenuItem } from '../lib/menu-item'
+import { ISerializableMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 
@@ -446,7 +446,7 @@ app.on('ready', () => {
     'show-contextual-menu',
     (
       event: Electron.IpcMainInvokeEvent,
-      items: ReadonlyArray<IMenuItem>
+      items: ReadonlyArray<ISerializableMenuItem>
     ): Promise<ReadonlyArray<number> | null> => {
       return new Promise(resolve => {
         const menu = buildContextMenu(items, indices => resolve(indices))

--- a/app/src/main-process/menu/build-context-menu.ts
+++ b/app/src/main-process/menu/build-context-menu.ts
@@ -1,4 +1,4 @@
-import { IMenuItem } from '../../lib/menu-item'
+import { ISerializableMenuItem } from '../../lib/menu-item'
 import { Menu, MenuItem } from 'electron'
 
 /**
@@ -47,14 +47,14 @@ function getEditMenuItems(): ReadonlyArray<MenuItem> {
  *                 created edit menu items are clicked.
  */
 export function buildContextMenu(
-  template: ReadonlyArray<IMenuItem>,
+  template: ReadonlyArray<ISerializableMenuItem>,
   onClick: (indices: ReadonlyArray<number>) => void
 ): Menu {
   return buildRecursiveContextMenu(template, onClick)
 }
 
 function buildRecursiveContextMenu(
-  menuItems: ReadonlyArray<IMenuItem>,
+  menuItems: ReadonlyArray<ISerializableMenuItem>,
   actionFn: (indices: ReadonlyArray<number>) => void,
   currentIndices: ReadonlyArray<number> = []
 ): Menu {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -53,11 +53,7 @@ import {
   RevertProgress,
 } from './toolbar'
 import { OcticonSymbol, iconForRepository } from './octicons'
-import {
-  showCertificateTrustDialog,
-  registerContextualMenuActionDispatcher,
-  sendReady,
-} from './main-process-proxy'
+import { showCertificateTrustDialog, sendReady } from './main-process-proxy'
 import { DiscardChanges } from './discard-changes'
 import { Welcome } from './welcome'
 import { AppMenuBar } from './app-menu'
@@ -188,8 +184,6 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   public constructor(props: IAppProps) {
     super(props)
-
-    registerContextualMenuActionDispatcher()
 
     props.dispatcher.loadInitialState().then(() => {
       this.loading = false

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -59,36 +59,6 @@ export function getAppMenu() {
   ipcRenderer.send('get-app-menu')
 }
 
-/**
- * There's currently no way for us to know when a contextual menu is closed (see
- * https://github.com/electron/electron/issues/9441). So we'll store the latest
- * contextual menu items we presented and assume any actions we receive are
- * coming from it.
- */
-let currentContextualMenuItems: ReadonlyArray<IMenuItem> | null = null
-
-/**
- * Register a global handler for dispatching contextual menu actions. This
- * should be called only once, around app load time.
- */
-export function registerContextualMenuActionDispatcher() {
-  ipcRenderer.on(
-    'contextual-menu-action',
-    (event: Electron.IpcRendererEvent, indices: number[]) => {
-      if (currentContextualMenuItems === null) {
-        return
-      }
-
-      const menuItem = findSubmenuItem(currentContextualMenuItems, indices)
-
-      if (menuItem !== undefined && menuItem.action !== undefined) {
-        menuItem.action()
-        currentContextualMenuItems = null
-      }
-    }
-  )
-}
-
 function findSubmenuItem(
   currentContextualMenuItems: ReadonlyArray<IMenuItem>,
   indices: ReadonlyArray<number>
@@ -110,9 +80,19 @@ function findSubmenuItem(
 }
 
 /** Show the given menu items in a contextual menu. */
-export function showContextualMenu(items: ReadonlyArray<IMenuItem>) {
-  currentContextualMenuItems = items
-  ipcRenderer.send('show-contextual-menu', items)
+export async function showContextualMenu(items: ReadonlyArray<IMenuItem>) {
+  const indices: ReadonlyArray<number> | null = await ipcRenderer.invoke(
+    'show-contextual-menu',
+    items
+  )
+
+  if (indices !== null) {
+    const menuItem = findSubmenuItem(items, indices)
+
+    if (menuItem !== undefined && menuItem.action !== undefined) {
+      menuItem.action()
+    }
+  }
 }
 
 /** Update the menu item labels with the user's preferred apps. */


### PR DESCRIPTION
This PR does a small refactor to the logic to address two separate things:

1. Potential race conditions that could potentially be caused if a "open contextMenu" action happens at roughly the same time as the user clicks on an item of an already opened context menu. See [this comment](https://github.com/desktop/desktop/pull/9796#discussion_r429218437) and [this other one](https://github.com/desktop/desktop/pull/9796#discussion_r429241288) for more information:
    > This makes we wonder whether apart from fixing this specific undefined issue we should think about adding some logic to warranty that the currentContextualMenuItems object doesn't change between the time when the context menu gets opened and the time that an item gets clicked: e.g it would also be very bad if a user clicks on a tag to delete it and we end up deleting a different one because a new tag appears on the list at the appropriate moment (we can do this in a separate PR!).

2. It removes the `action` property from the menu items before sending them via IPC. This is not necessary right now but it will prepare us for an upcoming [breaking change](https://github.com/electron/electron/blob/master/docs/breaking-changes.md#behavior-changed-values-sent-over-ipc-are-now-serialized-with-structured-clone-algorithm) in Electron v8, which disallows to send functions or other non-serializable values.

## Context

In order to fix 1), I've chosen to use the Electron [`invoke` API](https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args) which allows to do Request/Response communication between the renderer process and the main process.

With this, and the fact that now Electron can notify when a context menu gets closed, we can safely implement a cross-process async method that opens the context menu and resolves whenever the user clicks on an item or discards the menu.


## Alternative solutions

I considered two other solutions to solve 1):

* Creating the `Menu` directly from the renderer process (as explained in the [Electron docs](https://www.electronjs.org/docs/api/menu#render-process)). At first sight this seems to be the simplest and most robust approach, but I discarded it since as I understand this would cause sync calls to the main process when creating the menu items which could potentially block the UI (based on [this doc](https://www.electronjs.org/docs/api/remote)). If my assumptions are wrong I think we can reconsider this approach.
* Adding a softer protection that ensures that click events correspond to the stored `currentContextualMenuItems` array (by generating unique random ids each time we open a context menu). This would prevent the problem by ignoring these click events but make the solution even more complex than it is right now.

## Potential drawbacks of this solution

The only drawback that I could find is that in the case that Electron for some reason doesn't emit the correspondant callback when the menu in closed, this could lead to a small leak of memory, since the `Promise` returned on the `invoke` call would never get fulfilled. Even if this happened the amount of memory allocated would be very small (I think it would be 1 Promise on the main process, another Promise on the renderer process and the event object used for the invocation).

I've done some tests on macOS by opening/closing the context menu multiple times with very fast transitions and couldn't find cases where the close menu event doesn't get fired, so I'm not concerned about this potential issue.
