### PR TITLE
Exclude the vendor directory from code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,5 +1,4 @@
 name: 'GitHub Desktop CodeQL config'
 
 paths-ignore:
-  - '/vendor/'
-  - 'vendor/yarn*.js
+  - 'vendor/yarn*.js'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
 name: 'GitHub Desktop CodeQL config'
 
 paths-ignore:
-  - 'vendor/yarn*.js'
+  - 'vendor/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,3 +2,4 @@ name: 'GitHub Desktop CodeQL config'
 
 paths-ignore:
   - '/vendor/'
+  - 'vendor/yarn*.js

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: 'GitHub Desktop CodeQL config'
+
+paths-ignore:
+  - '/vendor/'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
 name: 'GitHub Desktop CodeQL config'
 
 paths-ignore:
-  - 'vendor/**'
+  - 'vendor'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,8 @@ name: 'Code scanning - action'
 
 on:
   push:
+    branches:
+      - development
   pull_request:
   schedule:
     - cron: '0 19 * * 0'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,8 @@ jobs:
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
 
         # Override language selection by uncommenting this and choosing your languages
         # with:


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description

We're getting Code Scanning issues reported by our [vendored yarn](https://github.com/desktop/desktop/blob/d9279df6ff51f96d34e4a491390e326a26e074cd/vendor/). There's no risk of that file creating security vulnerabilities in GitHub Desktop so in order to reduce the noise we're gonna ignore it.