### PR TITLE
Fix mentioning of users from a fork

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -45,6 +45,7 @@ import {
   Repository,
   isRepositoryWithGitHubRepository,
   RepositoryWithGitHubRepository,
+  getNonForkGitHubRepository,
 } from '../../models/repository'
 import {
   CommittedFileChange,
@@ -1622,12 +1623,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private refreshMentionables(repository: Repository) {
+    if (!isRepositoryWithGitHubRepository(repository)) {
+      return
+    }
+
     const account = getAccountForRepository(this.accounts, repository)
     if (!account) {
       return
     }
 
-    const gitHubRepository = repository.gitHubRepository
+    const gitHubRepository = getNonForkGitHubRepository(repository)
     if (!gitHubRepository) {
       return
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1541,7 +1541,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this._refreshRepository(repository)
 
     if (isRepositoryWithGitHubRepository(repository)) {
-      this._refreshIssues(repository.gitHubRepository)
+      // Load issues from the upstream or fork depending
+      // on workflow preferences.
+      const ghRepo = getNonForkGitHubRepository(repository)
+
+      this._refreshIssues(ghRepo)
+
       this.pullRequestCoordinator.getAllPullRequests(repository).then(prs => {
         this.onPullRequestChanged(repository, prs)
       })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1546,6 +1546,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const ghRepo = getNonForkGitHubRepository(repository)
 
       this._refreshIssues(ghRepo)
+      this.refreshMentionables(ghRepo)
 
       this.pullRequestCoordinator.getAllPullRequests(repository).then(prs => {
         this.onPullRequestChanged(repository, prs)
@@ -1569,7 +1570,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.startPullRequestUpdater(repository)
 
     this.startAheadBehindUpdater(repository)
-    this.refreshMentionables(repository)
     this.startBackgroundPruner(repository)
 
     this.addUpstreamRemoteIfNeeded(repository)
@@ -1627,22 +1627,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  private refreshMentionables(repository: Repository) {
-    if (!isRepositoryWithGitHubRepository(repository)) {
-      return
-    }
-
-    const account = getAccountForRepository(this.accounts, repository)
+  private refreshMentionables(repository: GitHubRepository) {
+    const account = getAccountForEndpoint(this.accounts, repository.endpoint)
     if (!account) {
       return
     }
 
-    const gitHubRepository = getNonForkGitHubRepository(repository)
-    if (!gitHubRepository) {
-      return
-    }
-
-    this.gitHubUserStore.updateMentionables(gitHubRepository, account)
+    this.gitHubUserStore.updateMentionables(repository, account)
   }
 
   private startPullRequestUpdater(repository: Repository) {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -9,7 +9,11 @@ import {
   isRebaseConflictState,
   ChangesSelectionKind,
 } from '../../lib/app-state'
-import { Repository } from '../../models/repository'
+import {
+  Repository,
+  getNonForkGitHubRepository,
+  isRepositoryWithGitHubRepository,
+} from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { IGitHubUser } from '../../lib/databases'
 import { IssuesStore, GitHubUserStore } from '../../lib/stores'
@@ -103,8 +107,12 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
       ]
 
       // Issues autocompletion is only available for GitHub repositories.
-      const gitHubRepository = props.repository.gitHubRepository
-      if (gitHubRepository) {
+      const { repository } = props
+      const gitHubRepository = isRepositoryWithGitHubRepository(repository)
+        ? getNonForkGitHubRepository(repository)
+        : null
+
+      if (gitHubRepository !== null) {
         autocompletionProviders.push(
           new IssuesAutocompletionProvider(
             props.issuesStore,

--- a/app/src/ui/repository-settings/fork-contribution-target-description.tsx
+++ b/app/src/ui/repository-settings/fork-contribution-target-description.tsx
@@ -32,6 +32,10 @@ export function ForkSettingsDescription(props: IForkSettingsDescription) {
         New branches will be based on{' '}
         <strong>{targetRepository.fullName}</strong>'s default branch.
       </li>
+      <li>
+        Autocompletion of user and issues will be based on{' '}
+        <strong>{targetRepository.fullName}</strong>.
+      </li>
     </ul>
   )
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description

Pulling this out of my hack day work since it can stand on its own. 

If you clone a fork today and try to autocomplete users or issues those issues and mentionable users will always be derived from the fork which for the majority case means that users will not be able to autocomplete (forks are overwhelmingly used only to contribute to the upstream).

Since we introduced the workflow preferences in https://github.com/desktop/desktop/pull/9842 we've let users tell us how they want to work with their fork.

This PR takes that preference into account so that if say @billygriffin attempts to autocomplete issues or users in https://github.com/billygriffin/desktop with the "To contribute to the parent repository" setting selected he'll now see the issues and mentionable users from https://github.com/desktop/desktop instead.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/634063/85748693-8b206980-b708-11ea-9414-193e666290e1.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Autocompleting issues or users in forks now respect configured fork behavior
