### PR TITLE
Strip some ampersands, revisited

### DIFF
--- a/app/src/ui/app-menu/app-menu.tsx
+++ b/app/src/ui/app-menu/app-menu.tsx
@@ -74,7 +74,7 @@ function menuPaneClassNameFromId(id: string) {
     // Get rid of the leading @. for auto-generated ids
     .replace(/^@\./, '')
     // No accelerator key modifier necessary
-    .replace(/&/m, '')
+    .replace(/&/g, '')
     // Get rid of stuff that's not safe for css class names
     .replace(/[^a-z0-9_]+/gi, '-')
     // Get rid of redundant underscores


### PR DESCRIPTION
## Description

This is a follow up to #10073. The intention in that PR was to make the regular expression match globally but I seem to have accidentally typoed a `m` instead of a `g` and unfortunately we didn't catch it in review. I only caught it when the CodeQL alert didn't go away after merging.

I guess this is a real risk when reviewing code that you've paired on.