### PR TITLE
Read PATH environment variable using registry-js

### DIFF
--- a/app/src/lib/process/win32.ts
+++ b/app/src/lib/process/win32.ts
@@ -17,16 +17,13 @@ function isStringRegistryValue(rv: RegistryValue): rv is RegistryStringEntry {
 
 /** Get the path segments in the user's `Path`. */
 export function getPathSegments(): ReadonlyArray<string> {
-  const HKCU = HKEY.HKEY_CURRENT_USER
-  const value = enumerateValues(HKCU, 'Environment\\Path').find(
-    isStringRegistryValue
-  )
-
-  if (value === undefined) {
-    throw new Error('Could not find PATH environment variable')
+  for (const value of enumerateValues(HKEY.HKEY_CURRENT_USER, 'Environment')) {
+    if (value.name === 'Path' && isStringRegistryValue(value)) {
+      return value.data.split(';').filter(x => x.length > 0)
+    }
   }
 
-  return value.data.split(';').filter(x => x.length > 0)
+  throw new Error('Could not find PATH environment variable')
 }
 
 /** Set the user's `Path`. */

--- a/app/src/lib/process/win32.ts
+++ b/app/src/lib/process/win32.ts
@@ -9,7 +9,10 @@ import {
 } from 'registry-js'
 
 function isStringRegistryValue(rv: RegistryValue): rv is RegistryStringEntry {
-  return rv.type === RegistryValueType.REG_SZ
+  return (
+    rv.type === RegistryValueType.REG_SZ ||
+    rv.type === RegistryValueType.REG_EXPAND_SZ
+  )
 }
 
 /** Get the path segments in the user's `Path`. */

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -50,9 +50,13 @@ async function installCLI(): Promise<void> {
   await ensureDir(binPath)
   await writeBatchScriptCLITrampoline(binPath)
   await writeShellScriptCLITrampoline(binPath)
-  const paths = await getPathSegments()
-  if (paths.indexOf(binPath) < 0) {
-    await setPathSegments([...paths, binPath])
+  try {
+    const paths = getPathSegments()
+    if (paths.indexOf(binPath) < 0) {
+      await setPathSegments([...paths, binPath])
+    }
+  } catch (e) {
+    log.error('Failed inserting bin path into PATH environment variable', e)
   }
 }
 
@@ -131,10 +135,14 @@ function createShortcut(locations: ShortcutLocations): Promise<void> {
 async function handleUninstall(): Promise<void> {
   await removeShortcut()
 
-  const paths = await getPathSegments()
-  const binPath = getBinPath()
-  const pathsWithoutBinPath = paths.filter(p => p !== binPath)
-  return setPathSegments(pathsWithoutBinPath)
+  try {
+    const paths = getPathSegments()
+    const binPath = getBinPath()
+    const pathsWithoutBinPath = paths.filter(p => p !== binPath)
+    return setPathSegments(pathsWithoutBinPath)
+  } catch (e) {
+    log.error('Failed removing bin path from PATH environment variable', e)
+  }
 }
 
 function removeShortcut(): Promise<void> {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

References, and may close #10100

## Description

Excerpt from https://github.com/desktop/desktop/issues/10100#issuecomment-651730371

> We currently load the `PATH` env var through powershell:
> 
> https://github.com/desktop/desktop/blob/d6f7518f43bd7f9f55e56737e2845474fe2c7ebb/app/src/lib/process/win32.ts#L20-L38
> 
> This was introduced in https://github.com/desktop/desktop/pull/1925/commits/9820f7f988e04ea4b268f1462f6dbe6bb6d8c473#diff-fc992a6c0da9f6047bd328ec09982ec2R111 and copied from Atom https://github.com/atom/atom/pull/10326/files.
> 
> The reason for this odd-looking way of loading the path variable is that the previous method of using `reg.exe query HKCU\Environment` could fail due to a ban on registry modification in a group policy on Windows even though reg.exe was only reading a value, not modifying it. This peculiarity was the reason behind implementing our own registry library (https://github.com/desktop/desktop/pull/3492).

This PR removed the powershell workaround in favor of using `registry-js` to read the PATH env var.

## Testing

@tierninho This isn't a high priority but when you've got time I'd appreciate if you could test this out. It only affects Windows but ideally we'd test it on both Windows 7 and Windows 10 and with a user that contains non-ascii characters and preferably a space as well. If you haven't got one I've been using `Håkan Bråkan`. I'm building a one-off installer for this and I'll update once the build is done.

Rough test plan

1. Inspect the `PATH` environment variable: (see https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/)
1. Install GitHub Desktop
1. Verify that a `...\AppData\Local\GitHubDesktop\bin` entry was appended to the path list and no other changes occurred
1. Uninstall GitHub Desktop
1. Verify that the `...\AppData\Local\GitHubDesktop\bin` entry was removed from the path list and no other changes occurred

And obviously any other ideas you have on how to break this!