### PR TITLE
Cache mentionables retrieved from IndexedDB while auto-completing

### DIFF
--- a/app/src/lib/databases/github-user-database.ts
+++ b/app/src/lib/databases/github-user-database.ts
@@ -131,11 +131,7 @@ export class GitHubUserDatabase extends BaseDatabase {
       .equals(gitHubRepositoryID)
       .toArray()
 
-    return mentionables.map(mentionable => {
-      // Exclude the githubRepositoryID prop
-      const { login, email, avatarURL, name } = mentionable
-      return { login, email, avatarURL, name }
-    })
+    return mentionables.map(toMentionableUser)
   }
 
   /**
@@ -162,4 +158,10 @@ export class GitHubUserDatabase extends BaseDatabase {
 
     return this.mentionableCache.put(entry)
   }
+}
+
+function toMentionableUser(mentionable: IDBMentionableUser): IMentionableUser {
+  // Exclude the githubRepositoryID prop
+  const { login, email, avatarURL, name } = mentionable
+  return { login, email, avatarURL, name }
 }

--- a/app/src/lib/databases/github-user-database.ts
+++ b/app/src/lib/databases/github-user-database.ts
@@ -29,6 +29,11 @@ export interface IMentionableUser {
 }
 
 interface IDBMentionableUser extends IMentionableUser {
+  /**
+   * The id corresponding to the dbID property of the
+   * `GitHubRepository` instance that this user is associated
+   * with
+   */
   readonly gitHubRepositoryID: number
 }
 

--- a/app/src/lib/databases/github-user-database.ts
+++ b/app/src/lib/databases/github-user-database.ts
@@ -138,11 +138,6 @@ export class GitHubUserDatabase extends BaseDatabase {
     })
   }
 
-  public filterMentionableUsers(
-    gitHubRepositoryID: number,
-    predicate: (user: IDBMentionableUser) => boolean
-  ) {}
-
   /**
    * Get the cache entry (or undefined if no cache entry has
    * been written yet) for the `gitHubRepositoryID`. The

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -73,7 +73,7 @@ export class GitHubUserStore extends BaseStore {
     repository: GitHubRepository,
     account: Account
   ): Promise<void> {
-    assertPersisted(repository, this.updateMentionables.name)
+    assertPersisted(repository)
 
     const api = API.fromAccount(account)
 
@@ -129,7 +129,7 @@ export class GitHubUserStore extends BaseStore {
   public async getMentionableUsers(
     repository: GitHubRepository
   ): Promise<ReadonlyArray<IMentionableUser>> {
-    assertPersisted(repository, this.getMentionableUsers.name)
+    assertPersisted(repository)
     return this.database.getAllMentionablesForRepository(repository.dbID)
   }
 
@@ -151,7 +151,7 @@ export class GitHubUserStore extends BaseStore {
     query: string,
     maxHits: number = 100
   ): Promise<ReadonlyArray<IMentionableUser>> {
-    assertPersisted(repository, this.getMentionableUsersMatching.name)
+    assertPersisted(repository)
 
     const users =
       this.queryCache?.repository.dbID === repository.dbID
@@ -209,12 +209,11 @@ export class GitHubUserStore extends BaseStore {
 }
 
 function assertPersisted(
-  repo: GitHubRepository,
-  methodName: string
+  repo: GitHubRepository
 ): asserts repo is GitHubRepository & { dbID: number } {
   if (repo.dbID === null) {
     throw new Error(
-      `${methodName} requires a GitHubRepository instance that's been inserted into the database`
+      `Need a GitHubRepository that's been inserted into the database`
     )
   }
 }

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -121,6 +121,7 @@ export class GitHubUserStore extends BaseStore {
       this.queryCache.repository.dbID === repository.dbID
     ) {
       this.queryCache = null
+      this.clearCachePruneTimeout()
     }
   }
 

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -142,7 +142,7 @@ export class GitHubUserStore extends BaseStore {
   public async getMentionableUsersMatching(
     repository: GitHubRepository,
     query: string,
-    maxHits: number = 5
+    maxHits: number = 100
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsersMatching.name)
 

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -144,7 +144,7 @@ export class GitHubUserStore extends BaseStore {
     query: string,
     maxHits: number = 5
   ): Promise<ReadonlyArray<IMentionableUser>> {
-    assertPersisted(repository, this.getMentionableUsers.name)
+    assertPersisted(repository, this.getMentionableUsersMatching.name)
 
     const cache = this.queryCache
     let users

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -153,11 +153,9 @@ export class GitHubUserStore extends BaseStore {
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsersMatching.name)
 
-    const cache = this.queryCache
-
     const users =
-      cache?.repository.dbID === repository.dbID
-        ? cache.users
+      this.queryCache?.repository.dbID === repository.dbID
+        ? this.queryCache.users
         : await this.getMentionableUsers(repository)
 
     this.setQueryCache(repository, users)

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -160,7 +160,7 @@ export class GitHubUserStore extends BaseStore {
     console.timeEnd('getMentionableUsers')
 
     const hits = []
-    const needle = text.toLowerCase()
+    const needle = query.toLowerCase()
 
     // Simple substring comparison on login and real name
     for (let i = 0; i < users.length && hits.length < maxHits; i++) {

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -141,8 +141,8 @@ export class GitHubUserStore extends BaseStore {
    */
   public async getMentionableUsersMatching(
     repository: GitHubRepository,
-    maxHits: number = 100
     query: string,
+    maxHits: number = 5
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsers.name)
     console.time('getMentionableUsers')

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -145,7 +145,6 @@ export class GitHubUserStore extends BaseStore {
     maxHits: number = 5
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsers.name)
-    console.time('getMentionableUsers')
 
     const cache = this.queryCache
     let users
@@ -156,8 +155,6 @@ export class GitHubUserStore extends BaseStore {
       users = await this.getMentionableUsers(repository)
       this.setQueryCache(repository, users)
     }
-
-    console.timeEnd('getMentionableUsers')
 
     const hits = []
     const needle = query.toLowerCase()

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -13,6 +13,12 @@ import { getStealthEmailForUser, getLegacyStealthEmailForUser } from '../email'
 /** Don't fetch mentionables more often than every 10 minutes */
 const MaxFetchFrequency = 10 * 60 * 1000
 
+/**
+ * The max time (in milliseconds) that we'll keep a mentionable query
+ * cache around before pruning it.
+ */
+const QueryCacheTimeout = 60 * 1000
+
 interface IQueryCache {
   readonly repository: GitHubRepository
   readonly users: ReadonlyArray<IMentionableUser>
@@ -190,11 +196,10 @@ export class GitHubUserStore extends BaseStore {
   ) {
     this.clearCachePruneTimeout()
     this.queryCache = { repository, users }
-    // Clear mentionables cache after one minute
     this.pruneQueryCacheTimeoutId = window.setTimeout(() => {
       this.pruneQueryCacheTimeoutId = null
       this.queryCache = null
-    }, 60 * 1000)
+    }, QueryCacheTimeout)
   }
 
   private clearCachePruneTimeout() {

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -154,14 +154,13 @@ export class GitHubUserStore extends BaseStore {
     assertPersisted(repository, this.getMentionableUsersMatching.name)
 
     const cache = this.queryCache
-    let users
 
-    if (cache !== null && cache.repository.dbID === repository.dbID) {
-      users = cache.users
-    } else {
-      users = await this.getMentionableUsers(repository)
-      this.setQueryCache(repository, users)
-    }
+    const users =
+      cache?.repository.dbID === repository.dbID
+        ? cache.users
+        : await this.getMentionableUsers(repository)
+
+    this.setQueryCache(repository, users)
 
     const hits = []
     const needle = query.toLowerCase()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

🌵 This is based on #10120, please review that first 🌵 

## Description

This was extracted from #10120 which is big enough as it is this isn't a required piece of #10120.

When autocompleting users (i.e. after typing `@` in the commit message box) we currently do an IndexedDB lookup retrieving all users for a particular GitHubRepository for each keystroke that the user makes. So after typing `@niik` we would have done 5 requests to IndexedDB to load all mentionable users for the current repository.

While not a huge performance issue (especially not after #10120 and the denormalized mentionable table) it does add up in pathological cases (in this case we're looking at git/git which maxes the limit at 1000 mentionable users).

Before this PR I was seeing ~17ms per keystroke being spent finding which users to display. After this change I'm seeing ~2ms per keystroke (after the initial one obviously). That's down from ~100ms per keystroke before #10120.
