### PR TITLE
Dialog now clears filters on esc and closes on double esc

### DIFF
--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -436,7 +436,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     }
   }
 
-  private onDialogCancel = (e: Event) => {
+  private onDialogCancel = (e: Event | React.SyntheticEvent) => {
     e.preventDefault()
     this.onDismiss()
   }
@@ -526,19 +526,20 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
     if (!e) {
       if (this.dialogElement) {
         this.dialogElement.removeEventListener('cancel', this.onDialogCancel)
-        this.dialogElement.removeEventListener('keydown', this.onKeyDown)
       }
     } else {
       e.addEventListener('cancel', this.onDialogCancel)
-      e.addEventListener('keydown', this.onKeyDown)
     }
 
     this.dialogElement = e
   }
 
-  private onKeyDown = (event: KeyboardEvent) => {
+  private onKeyDown = (event: React.KeyboardEvent) => {
     const shortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
     if ((shortcutKey && event.key === 'w') || event.key === 'Escape') {
+      if (event.defaultPrevented) {
+        return
+      }
       this.onDialogCancel(event)
     }
   }
@@ -591,6 +592,7 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
         ref={this.onDialogRef}
         id={this.props.id}
         onMouseDown={this.onDialogMouseDown}
+        onKeyDown={this.onKeyDown}
         className={className}
         aria-labelledby={this.state.titleId}
         tabIndex={-1}

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -535,11 +535,11 @@ export class Dialog extends React.Component<IDialogProps, IDialogState> {
   }
 
   private onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.defaultPrevented) {
+      return
+    }
     const shortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
     if ((shortcutKey && event.key === 'w') || event.key === 'Escape') {
-      if (event.defaultPrevented) {
-        return
-      }
       this.onDialogCancel(event)
     }
   }


### PR DESCRIPTION


<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #6369

## Description

- <kbd>ESC</kbd> clears the filters in the dialog (only if there is something in the filters, otherwise it closes it)
- Double <kbd>ESC</kbd> closes the dialog
Also implemented the changes requested by @niik in #6531
### Screenshots
![clone](https://user-images.githubusercontent.com/29285479/86395487-01910e80-bca9-11ea-8dd7-ba50ef03fe11.gif)

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
