### PR TITLE
Reuse existing search dialogs in text diffs

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -198,7 +198,7 @@ function showSearch(cm: Editor) {
   ) {
     searchLabel.style.display = 'none'
     searchField.placeholder = 'Search'
-    searchField.style.width = null!
+    delete searchField.style.width
   }
 }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -170,7 +170,7 @@ function showSearch(cm: Editor) {
   // focus there instead of opening another dialog since CodeMirror
   // doesn't auto-close dialogs when opening a new one.
   const existingSearchField = wrapper.querySelector(
-    ':scope.dialog-opened .CodeMirror-dialog .CodeMirror-search-field'
+    ':scope > .CodeMirror-dialog .CodeMirror-search-field'
   )
 
   if (existingSearchField !== null) {

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -189,7 +189,6 @@ function showSearch(cm: Editor) {
   }
 
   dialog.classList.add('CodeMirror-search-dialog')
-  const searchLabel = dialog.querySelector('.CodeMirror-search-label')
   const searchField = dialog.querySelector('.CodeMirror-search-field')
 
   if (searchField instanceof HTMLInputElement) {

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -184,7 +184,7 @@ function showSearch(cm: Editor) {
 
   const dialog = wrapper.querySelector('.CodeMirror-dialog')
 
-  if (!dialog) {
+  if (dialog === null) {
     return
   }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -166,10 +166,6 @@ const diffGutterName = 'diff-gutter'
 function showSearch(cm: Editor) {
   const wrapper = cm.getWrapperElement()
 
-  if (!wrapper) {
-    return
-  }
-
   // Is there already a dialog open? If so we'll attempt to move
   // focus there instead of opening another dialog since CodeMirror
   // doesn't auto-close dialogs when opening a new one.

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -192,11 +192,7 @@ function showSearch(cm: Editor) {
   const searchLabel = dialog.querySelector('.CodeMirror-search-label')
   const searchField = dialog.querySelector('.CodeMirror-search-field')
 
-  if (
-    searchLabel instanceof HTMLElement &&
-    searchField instanceof HTMLInputElement
-  ) {
-    searchLabel.style.display = 'none'
+  if (searchField instanceof HTMLInputElement) {
     searchField.placeholder = 'Search'
     delete searchField.style.width
   }

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -194,7 +194,7 @@ function showSearch(cm: Editor) {
 
   if (searchField instanceof HTMLInputElement) {
     searchField.placeholder = 'Search'
-    delete searchField.style.width
+    searchField.style.removeProperty('width')
   }
 }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -164,12 +164,27 @@ interface ITextDiffProps {
 const diffGutterName = 'diff-gutter'
 
 function showSearch(cm: Editor) {
-  cm.execCommand('findPersistent')
   const wrapper = cm.getWrapperElement()
 
   if (!wrapper) {
     return
   }
+
+  // Is there already a dialog open? If so we'll attempt to move
+  // focus there instead of opening another dialog since CodeMirror
+  // doesn't auto-close dialogs when opening a new one.
+  const existingSearchField = wrapper.querySelector(
+    ':scope.dialog-opened .CodeMirror-dialog .CodeMirror-search-field'
+  )
+
+  if (existingSearchField !== null) {
+    if (existingSearchField instanceof HTMLElement) {
+      existingSearchField.focus()
+    }
+    return
+  }
+
+  cm.execCommand('findPersistent')
 
   const dialog = wrapper.querySelector('.CodeMirror-dialog')
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -72,6 +72,7 @@
     padding: var(--spacing-half) var(--spacing);
     box-shadow: var(--base-box-shadow);
 
+    .CodeMirror-search-label,
     .CodeMirror-search-hint {
       display: none;
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #9563

## Description

Turns out the CodeMirror search extension doesn't guarantee that there will only be one dialog open at a time, instead it relies on the `onBlur` event to close the existing dialog when a new one opens. Unfortunately for us this doesn't work when invoked through the app menu `find-text` event.

So to work around that we'll ensure that we don't open a new search dialog if we can find an existing one in the codemirror instance.

Also includes some small cleanup items.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Never show more than one search field at a time in text diffs