### PR TITLE
Don't wrap PathText in Monospaced component

### DIFF
--- a/app/src/ui/changes/oversized-files-warning.tsx
+++ b/app/src/ui/changes/oversized-files-warning.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { LinkButton } from '../lib/link-button'
-import { Monospaced } from '../lib/monospaced'
 import { PathText } from '../lib/path-text'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
@@ -64,13 +63,13 @@ export class OversizedFiles extends React.Component<IOversizedFilesProps> {
   private renderFileList() {
     return (
       <div className="files-list">
-        {this.props.oversizedFiles.map(fileName => (
-          <ul key={fileName}>
-            <Monospaced>
+        <ul>
+          {this.props.oversizedFiles.map(fileName => (
+            <li key={fileName}>
               <PathText path={fileName} />
-            </Monospaced>
-          </ul>
-        ))}
+            </li>
+          ))}
+        </ul>
       </div>
     )
   }

--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -5,7 +5,6 @@ import { Dispatcher } from '../dispatcher'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { PathText } from '../lib/path-text'
-import { Monospaced } from '../lib/monospaced'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { TrashNameLabel } from '../lib/context-menu'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
@@ -141,9 +140,7 @@ export class DiscardChanges extends React.Component<
           <ul>
             {this.props.files.map(p => (
               <li key={p.id}>
-                <Monospaced>
-                  <PathText path={p.path} />
-                </Monospaced>
+                <PathText path={p.path} />
               </li>
             ))}
           </ul>

--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -5,7 +5,6 @@ import { Dispatcher } from '../dispatcher'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { PathText } from '../lib/path-text'
-import { Monospaced } from '../lib/monospaced'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { ITextDiff, DiffSelection } from '../../models/diff'
@@ -82,9 +81,7 @@ export class DiscardSelection extends React.Component<
         <DialogContent>
           <p>
             Are you sure you want to discard the selected changes to
-            <Monospaced>
-              <PathText path={this.props.file.path} />
-            </Monospaced>
+            <PathText path={this.props.file.path} />
           </p>
 
           <Checkbox

--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -79,7 +79,7 @@ export class DiscardSelection extends React.Component<
         type="warning"
       >
         <DialogContent>
-          <p>Are you sure you want to discard the selected changes to</p>
+          <p>Are you sure you want to discard the selected changes to:</p>
 
           <ul>
             <li>

--- a/app/src/ui/discard-changes/discard-selection-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-selection-dialog.tsx
@@ -79,10 +79,13 @@ export class DiscardSelection extends React.Component<
         type="warning"
       >
         <DialogContent>
-          <p>
-            Are you sure you want to discard the selected changes to
-            <PathText path={this.props.file.path} />
-          </p>
+          <p>Are you sure you want to discard the selected changes to</p>
+
+          <ul>
+            <li>
+              <PathText path={this.props.file.path} />
+            </li>
+          </ul>
 
           <Checkbox
             label="Do not show this message again"

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -3,9 +3,9 @@ import * as React from 'react'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
-import { Monospaced } from '../lib/monospaced'
 import { RetryAction } from '../../models/retry-actions'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Ref } from '../lib/ref'
 
 interface IGenericGitAuthenticationProps {
   /** The hostname with which the user tried to authenticate. */
@@ -53,9 +53,8 @@ export class GenericGitAuthentication extends React.Component<
       >
         <DialogContent>
           <p>
-            We were unable to authenticate with{' '}
-            <Monospaced>{this.props.hostname}</Monospaced>. Please enter your
-            username and password to try again.
+            We were unable to authenticate with <Ref>{this.props.hostname}</Ref>
+            . Please enter your username and password to try again.
           </p>
 
           <Row>

--- a/app/src/ui/lfs/initialize-lfs.tsx
+++ b/app/src/ui/lfs/initialize-lfs.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Repository } from '../../models/repository'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
-import { Monospaced } from '../lib/monospaced'
 import { PathText } from '../lib/path-text'
 import { LinkButton } from '../lib/link-button'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
@@ -81,9 +80,7 @@ export class InitializeLFS extends React.Component<IInitializeLFSProps, {}> {
           <ul>
             {this.props.repositories.map(r => (
               <li key={r.id}>
-                <Monospaced>
-                  <PathText path={r.path} />
-                </Monospaced>
+                <PathText path={r.path} />
               </li>
             ))}
           </ul>

--- a/app/src/ui/lib/monospaced.tsx
+++ b/app/src/ui/lib/monospaced.tsx
@@ -1,8 +1,0 @@
-import * as React from 'react'
-
-/** A component for monospaced text. */
-export class Monospaced extends React.Component<{}, {}> {
-  public render() {
-    return <span className="monospaced">{this.props.children}</span>
-  }
-}

--- a/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
+++ b/app/src/ui/merge-conflicts/commit-conflicts-warning.tsx
@@ -5,7 +5,6 @@ import { Repository } from '../../models/repository'
 import { ICommitContext } from '../../models/commit'
 import { WorkingDirectoryFileChange } from '../../models/status'
 import { PathText } from '../lib/path-text'
-import { Monospaced } from '../lib/monospaced'
 import { DefaultCommitMessage } from '../../models/commit-message'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
@@ -47,11 +46,13 @@ export class CommitConflictsWarning extends React.Component<
   private renderFiles(files: ReadonlyArray<WorkingDirectoryFileChange>) {
     return (
       <div className="conflicted-files-text">
-        {files.map(f => (
-          <Monospaced key={f.path}>
-            <PathText path={f.path} />
-          </Monospaced>
-        ))}
+        <ul>
+          {files.map(f => (
+            <li key={f.path}>
+              <PathText path={f.path} />
+            </li>
+          ))}
+        </ul>
       </div>
     )
   }

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { join } from 'path'
 import { LinkButton } from '../lib/link-button'
 import { Button } from '../lib/button'
-import { Monospaced } from '../lib/monospaced'
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -15,6 +14,7 @@ import { encodePathAsUrl } from '../../lib/path'
 import { ExternalEditor } from '../../lib/editors'
 import { PopupType } from '../../models/popup'
 import { PreferencesTab } from '../../models/preferences'
+import { Ref } from '../lib/ref'
 
 const TutorialPanelImage = encodePathAsUrl(
   __dirname,
@@ -187,7 +187,7 @@ export class TutorialPanel extends React.Component<
             <p className="description">
               Open this repository in your preferred text editor. Edit the
               {` `}
-              <Monospaced>README.md</Monospaced>
+              <Ref>README.md</Ref>
               {` `}
               file, save it, and come back.
             </p>

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -56,7 +56,6 @@
 @import 'ui/no-repositories';
 @import 'ui/terms-and-conditions';
 @import 'ui/ref';
-@import 'ui/monospaced';
 @import 'ui/initialize-lfs';
 @import 'ui/ci-status';
 @import 'ui/pull-request-badge';

--- a/app/styles/ui/_discard-changes.scss
+++ b/app/styles/ui/_discard-changes.scss
@@ -10,4 +10,8 @@
       margin-bottom: 0;
     }
   }
+
+  .path-text-component {
+    font-family: var(--font-family-monospace);
+  }
 }

--- a/app/styles/ui/_discard-changes.scss
+++ b/app/styles/ui/_discard-changes.scss
@@ -1,9 +1,8 @@
 #discard-changes {
   .dialog-content ul {
     list-style: none;
-    margin: 0;
+    margin: var(--spacing) 0;
     padding: 0;
-    margin-bottom: var(--spacing);
 
     li {
       padding-left: 0;

--- a/app/styles/ui/_initialize-lfs.scss
+++ b/app/styles/ui/_initialize-lfs.scss
@@ -8,6 +8,7 @@
     li {
       padding-left: 0;
       margin-bottom: 0;
+      font-family: var(--font-family-monospace);
     }
   }
 }

--- a/app/styles/ui/_monospaced.scss
+++ b/app/styles/ui/_monospaced.scss
@@ -1,3 +1,0 @@
-span.monospaced {
-  font-family: var(--font-family-monospace);
-}

--- a/app/styles/ui/changes/_oversized-files-warning.scss
+++ b/app/styles/ui/changes/_oversized-files-warning.scss
@@ -5,7 +5,19 @@
     .files-list {
       max-height: 175px;
       overflow-y: auto;
-      -webkit-margin-after: 1em;
+      font-family: var(--font-family-monospace);
+      margin-bottom: var(--spacing);
+
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+
+        li {
+          padding-left: 0;
+          margin-bottom: 0;
+        }
+      }
     }
 
     .recommendation {

--- a/app/styles/ui/dialogs/_commit-conflicts-warning.scss
+++ b/app/styles/ui/dialogs/_commit-conflicts-warning.scss
@@ -1,3 +1,14 @@
-.conflicted-files-text {
-  margin-bottom: 10px;
+#commit-conflict-markers-warning {
+  .dialog-content ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    margin-bottom: var(--spacing);
+
+    li {
+      padding-left: 0;
+      margin-bottom: 0;
+      font-family: var(--font-family-monospace);
+    }
+  }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description

Stumbled upon this in my DevTools console just now

![Warning validateDOMNesting( ) div cannot appear as a descendant of](https://user-images.githubusercontent.com/634063/86589882-c33c6d80-bf8e-11ea-9151-3674ad714199.png)

Turns out this had become quite the widespread pattern in the app so I went through the instances I could find and removed them. After I'd done that there was only two spots left where we used the component and given that I'm not a big fan of mandating such specific design properties through the component structure I figured I might as well just remove it entirely.

Along the way I found some oddities (like the repeated `ul` in the oversized files warning dialog) so I've attempted to ensure that the lists in the various dialogs match up.

## Screenshots

<img width="467" alt="image" src="https://user-images.githubusercontent.com/634063/86591570-1ebc2a80-bf92-11ea-81de-89b190a383f4.png">

<img width="613" alt="image" src="https://user-images.githubusercontent.com/634063/86592205-4eb7fd80-bf93-11ea-90fa-08cbd687d195.png">

<img width="613" alt="image" src="https://user-images.githubusercontent.com/634063/86591731-66db4d00-bf92-11ea-9a96-583375558ecd.png">

<img width="291" alt="image" src="https://user-images.githubusercontent.com/634063/86592411-b79f7580-bf93-11ea-9370-b4b63363320a.png">

<img width="418" alt="image" src="https://user-images.githubusercontent.com/634063/86592747-51ffb900-bf94-11ea-92e5-ae05850b9fc6.png">

<img width="430" alt="image" src="https://user-images.githubusercontent.com/634063/86592756-56c46d00-bf94-11ea-8f84-4fa87f42a02e.png">

<img width="423" alt="image" src="https://user-images.githubusercontent.com/634063/86592930-9a1edb80-bf94-11ea-8f27-50a6426bdef2.png">
