### PR TITLE
Update API type to reflect reality

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -208,7 +208,11 @@ export interface IAPIMentionableUser {
 
   readonly login: string
 
-  readonly name: string
+  /**
+   * The user's real name or null if the user hasn't provided
+   * a real name for their public profile.
+   */
+  readonly name: string | null
 }
 
 /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This affects nothing at all, I just happened to see in a sample API request I was making that the name property could be null so I figured I should just update the type now rather than wait for it to become a problem for us.
