### PR TITLE
Autocompletion tweaks, consistency between providers

### DIFF
--- a/app/src/lib/databases/issues-database.ts
+++ b/app/src/lib/databases/issues-database.ts
@@ -28,6 +28,13 @@ export class IssuesDatabase extends BaseDatabase {
       clearIssues
     )
   }
+
+  public getIssuesForRepository(gitHubRepositoryID: number) {
+    return this.issues
+      .where('gitHubRepositoryID')
+      .equals(gitHubRepositoryID)
+      .toArray()
+  }
 }
 
 function clearIssues(transaction: Dexie.Transaction) {

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -116,10 +116,7 @@ export class GitHubUserStore extends BaseStore {
       response.etag
     )
 
-    if (
-      this.queryCache !== null &&
-      this.queryCache.repository.dbID === repository.dbID
-    ) {
+    if (this.queryCache?.repository.dbID === repository.dbID) {
       this.queryCache = null
       this.clearCachePruneTimeout()
     }

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -164,8 +164,7 @@ export class GitHubUserStore extends BaseStore {
     const needle = query.toLowerCase()
 
     // Simple substring comparison on login and real name
-    for (let i = 0; i < users.length && hits.length < maxHits; i++) {
-      const user = users[i]
+    for (const user of users) {
       const ix = `${user.login} ${user.name}`
         .trim()
         .toLowerCase()
@@ -185,6 +184,7 @@ export class GitHubUserStore extends BaseStore {
       .sort(
         (x, y) => compare(x.ix, y.ix) || compare(x.user.login, y.user.login)
       )
+      .slice(0, maxHits)
       .map(h => h.user)
   }
 

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -9,6 +9,7 @@ import {
 import { compare } from '../compare'
 import { BaseStore } from './base-store'
 import { getStealthEmailForUser, getLegacyStealthEmailForUser } from '../email'
+import { DefaultMaxHits } from '../../ui/autocompletion/common'
 
 /** Don't fetch mentionables more often than every 10 minutes */
 const MaxFetchFrequency = 10 * 60 * 1000
@@ -146,7 +147,7 @@ export class GitHubUserStore extends BaseStore {
   public async getMentionableUsersMatching(
     repository: GitHubRepository,
     query: string,
-    maxHits: number = 25
+    maxHits: number = DefaultMaxHits
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsersMatching.name)
 

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -146,7 +146,7 @@ export class GitHubUserStore extends BaseStore {
   public async getMentionableUsersMatching(
     repository: GitHubRepository,
     query: string,
-    maxHits: number = 5
+    maxHits: number = 25
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsersMatching.name)
 

--- a/app/src/lib/stores/github-user-store.ts
+++ b/app/src/lib/stores/github-user-store.ts
@@ -149,7 +149,7 @@ export class GitHubUserStore extends BaseStore {
   public async getMentionableUsersMatching(
     repository: GitHubRepository,
     query: string,
-    maxHits: number = 100
+    maxHits: number = 5
   ): Promise<ReadonlyArray<IMentionableUser>> {
     assertPersisted(repository, this.getMentionableUsersMatching.name)
 

--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -6,6 +6,14 @@ import { fatalError } from '../fatal-error'
 
 /** The hard limit on the number of issue results we'd ever return. */
 const IssueResultsHardLimit = 100
+/** An autocompletion hit for an issue. */
+export interface IIssueHit {
+  /** The title of the issue. */
+  readonly title: string
+
+  /** The issue's number. */
+  readonly number: number
+}
 
 /** The store for GitHub issues. */
 export class IssuesStore {
@@ -140,7 +148,7 @@ export class IssuesStore {
   public async getIssuesMatching(
     repository: GitHubRepository,
     text: string
-  ): Promise<ReadonlyArray<IIssue>> {
+  ): Promise<ReadonlyArray<IIssueHit>> {
     assertPersisted(repository, this.getIssuesMatching.name)
 
     if (!text.length) {

--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -161,7 +161,7 @@ export class IssuesStore {
   public async getIssuesMatching(
     repository: GitHubRepository,
     text: string,
-    maxHits = 5
+    maxHits = 25
   ): Promise<ReadonlyArray<IIssueHit>> {
     assertPersisted(repository, this.getIssuesMatching.name)
 

--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -44,7 +44,7 @@ export class IssuesStore {
   private async getLatestUpdatedAt(
     repository: GitHubRepository
   ): Promise<Date | null> {
-    assertPersisted(repository, this.getLatestUpdatedAt.name)
+    assertPersisted(repository)
 
     const db = this.db
 
@@ -94,7 +94,7 @@ export class IssuesStore {
     issues: ReadonlyArray<IAPIIssue>,
     repository: GitHubRepository
   ): Promise<void> {
-    assertPersisted(repository, this.storeIssues.name)
+    assertPersisted(repository)
 
     const issuesToDelete = issues.filter(i => i.state === 'closed')
     const issuesToUpsert = issues
@@ -152,7 +152,7 @@ export class IssuesStore {
   }
 
   private async getAllIssueHitsFor(repository: GitHubRepository) {
-    assertPersisted(repository, this.getAllIssueHitsFor.name)
+    assertPersisted(repository)
 
     const hits = await this.db.getIssuesForRepository(repository.dbID)
     return hits.map(i => ({ number: i.number, title: i.title }))
@@ -164,7 +164,7 @@ export class IssuesStore {
     text: string,
     maxHits = DefaultMaxHits
   ): Promise<ReadonlyArray<IIssueHit>> {
-    assertPersisted(repository, this.getIssuesMatching.name)
+    assertPersisted(repository)
 
     const issues =
       this.queryCache?.repository.dbID === repository.dbID
@@ -223,12 +223,11 @@ export class IssuesStore {
 }
 
 function assertPersisted(
-  repo: GitHubRepository,
-  methodName: string
+  repo: GitHubRepository
 ): asserts repo is GitHubRepository & { dbID: number } {
   if (repo.dbID === null) {
     throw new Error(
-      `${methodName} requires a GitHubRepository instance that's been inserted into the database`
+      `Need a GitHubRepository that's been inserted into the database`
     )
   }
 }

--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -3,6 +3,7 @@ import { API, IAPIIssue } from '../api'
 import { Account } from '../../models/account'
 import { GitHubRepository } from '../../models/github-repository'
 import { compare, compareDescending } from '../compare'
+import { DefaultMaxHits } from '../../ui/autocompletion/common'
 
 /** An autocompletion hit for an issue. */
 export interface IIssueHit {
@@ -161,7 +162,7 @@ export class IssuesStore {
   public async getIssuesMatching(
     repository: GitHubRepository,
     text: string,
-    maxHits = 25
+    maxHits = DefaultMaxHits
   ): Promise<ReadonlyArray<IIssueHit>> {
     assertPersisted(repository, this.getIssuesMatching.name)
 

--- a/app/src/ui/autocompletion/common.ts
+++ b/app/src/ui/autocompletion/common.ts
@@ -1,0 +1,5 @@
+/**
+ * The default maximum number of hits to return from
+ * either of the autocompletion providers.
+ */
+export const DefaultMaxHits = 25

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -29,7 +29,7 @@ export class EmojiAutocompletionProvider
   implements IAutocompletionProvider<IEmojiHit> {
   public readonly kind = 'emoji'
 
-  private emoji: Map<string, string>
+  private readonly emoji: Map<string, string>
 
   public constructor(emoji: Map<string, string>) {
     this.emoji = emoji

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -42,10 +42,10 @@ export class EmojiAutocompletionProvider
   public async getAutocompletionItems(
     text: string
   ): Promise<ReadonlyArray<IEmojiHit>> {
-    // Empty strings is falsy, this is the happy path to avoid
-    // sorting and matching when the user types a ':'. We want
-    // to open the popup with suggestions as fast as possible.
-    if (!text) {
+    // This is the happy path to avoid sorting and matching
+    // when the user types a ':'. We want to open the popup
+    // with suggestions as fast as possible.
+    if (text.length === 0) {
       return Array.from(this.emoji.keys()).map<IEmojiHit>(emoji => {
         return { emoji: emoji, matchStart: 0, matchLength: 0 }
       })

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { IAutocompletionProvider } from './index'
 import { compare } from '../../lib/compare'
+import { DefaultMaxHits } from './common'
 
 /**
  * Interface describing a autocomplete match for the given search
@@ -41,7 +42,7 @@ export class EmojiAutocompletionProvider
 
   public async getAutocompletionItems(
     text: string,
-    maxHits = 25
+    maxHits = DefaultMaxHits
   ): Promise<ReadonlyArray<IEmojiHit>> {
     // This is the happy path to avoid sorting and matching
     // when the user types a ':'. We want to open the popup

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -40,15 +40,16 @@ export class EmojiAutocompletionProvider
   }
 
   public async getAutocompletionItems(
-    text: string
+    text: string,
+    maxHits = 25
   ): Promise<ReadonlyArray<IEmojiHit>> {
     // This is the happy path to avoid sorting and matching
     // when the user types a ':'. We want to open the popup
     // with suggestions as fast as possible.
     if (text.length === 0) {
-      return Array.from(this.emoji.keys()).map<IEmojiHit>(emoji => {
-        return { emoji: emoji, matchStart: 0, matchLength: 0 }
-      })
+      return [...this.emoji.keys()]
+        .map(emoji => ({ emoji, matchStart: 0, matchLength: 0 }))
+        .slice(0, maxHits)
     }
 
     const results = new Array<IEmojiHit>()
@@ -72,12 +73,14 @@ export class EmojiAutocompletionProvider
     //
     // If both those start and length are equal we sort
     // alphabetically
-    return results.sort(
-      (x, y) =>
-        compare(x.matchStart, y.matchStart) ||
-        compare(x.emoji.length, y.emoji.length) ||
-        compare(x.emoji, y.emoji)
-    )
+    return results
+      .sort(
+        (x, y) =>
+          compare(x.matchStart, y.matchStart) ||
+          compare(x.emoji.length, y.emoji.length) ||
+          compare(x.emoji, y.emoji)
+      )
+      .slice(0, maxHits)
   }
 
   public renderItem(hit: IEmojiHit) {

--- a/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/issues-autocompletion-provider.tsx
@@ -1,21 +1,12 @@
 import * as React from 'react'
 import { IAutocompletionProvider } from './index'
-import { IssuesStore } from '../../lib/stores'
+import { IssuesStore, IIssueHit } from '../../lib/stores/issues-store'
 import { Dispatcher } from '../dispatcher'
 import { GitHubRepository } from '../../models/github-repository'
 import { ThrottledScheduler } from '../lib/throttled-scheduler'
 
 /** The interval we should use to throttle the issues update. */
 const UpdateIssuesThrottleInterval = 1000 * 60
-
-/** An autocompletion hit for an issue. */
-export interface IIssueHit {
-  /** The title of the issue. */
-  readonly title: string
-
-  /** The issue's number. */
-  readonly number: number
-}
 
 /** The autocompletion provider for issues in a GitHub repository. */
 export class IssuesAutocompletionProvider


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

🌵 Depends upon #10121, please review that first 🌵 

## Description

Continuation of #10121. Attempts to provide a consistent logic between issues, user, and emoji autocompletion providers. Introduces an exact replica of the cache implemented for the user autocompletion in #10121.