### PR TITLE
Create <RadioButton/> component

### DIFF
--- a/app/src/ui/lib/radio-button.tsx
+++ b/app/src/ui/lib/radio-button.tsx
@@ -4,6 +4,9 @@ import { createUniqueId, releaseUniqueId } from './id-pool'
 interface IRadioButtonProps<T> {
   /**
    * Called when the user selects this radio button.
+   *
+   * The function will be called with the value of the RadioButton
+   * and the original event that triggered the change.
    */
   readonly onSelected: (
     value: T,

--- a/app/src/ui/lib/radio-button.tsx
+++ b/app/src/ui/lib/radio-button.tsx
@@ -41,7 +41,7 @@ export class RadioButton<T extends string> extends React.Component<
     super(props)
 
     this.state = {
-      inputId: createUniqueId(`TextBox_${this.props.value}`),
+      inputId: createUniqueId(`RadioButton_${this.props.value}`),
     }
   }
 

--- a/app/src/ui/lib/radio-button.tsx
+++ b/app/src/ui/lib/radio-button.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { createUniqueId, releaseUniqueId } from './id-pool'
+
+interface IRadioButtonProps<T> {
+  /**
+   * Called when the user selects this radio button.
+   */
+  readonly onSelected: (
+    value: T,
+    event: React.FormEvent<HTMLInputElement>
+  ) => void
+
+  /**
+   * Whether the radio button is selected.
+   */
+  readonly checked: boolean
+
+  /**
+   * The label of the radio button.
+   */
+  readonly label: string | JSX.Element
+
+  /**
+   * The value of the radio button.
+   */
+  readonly value: T
+}
+
+interface IRadioButtonState {
+  readonly inputId: string
+}
+
+export class RadioButton<T extends string> extends React.Component<
+  IRadioButtonProps<T>,
+  IRadioButtonState
+> {
+  public constructor(props: IRadioButtonProps<T>) {
+    super(props)
+
+    this.state = {
+      inputId: createUniqueId(`TextBox_${this.props.value}`),
+    }
+  }
+
+  public componentWillUnmount() {
+    releaseUniqueId(this.state.inputId)
+  }
+
+  public render() {
+    return (
+      <div className="radio-button-component">
+        <input
+          type="radio"
+          id={this.state.inputId}
+          value={this.props.value}
+          checked={this.props.checked}
+          onChange={this.onSelected}
+        />
+        <label htmlFor={this.state.inputId}>{this.props.label}</label>
+      </div>
+    )
+  }
+
+  private onSelected = (evt: React.FormEvent<HTMLInputElement>) => {
+    this.props.onSelected(this.props.value, evt)
+  }
+}

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -5,6 +5,7 @@ import { LinkButton } from '../lib/link-button'
 import { SamplesURL } from '../../lib/stats'
 import { UncommittedChangesStrategyKind } from '../../models/uncommitted-changes-strategy'
 import { enableSchannelCheckRevokeOptOut } from '../../lib/feature-flag'
+import { RadioButton } from '../lib/radio-button'
 
 interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
@@ -84,10 +85,8 @@ export class Advanced extends React.Component<
   }
 
   private onUncommittedChangesStrategyKindChanged = (
-    event: React.FormEvent<HTMLInputElement>
+    value: UncommittedChangesStrategyKind
   ) => {
-    const value = event.currentTarget.value as UncommittedChangesStrategyKind
-
     this.setState({ uncommittedChangesStrategyKind: value })
     this.props.onUncommittedChangesStrategyKindChanged(value)
   }
@@ -113,53 +112,36 @@ export class Advanced extends React.Component<
       <DialogContent>
         <div className="advanced-section">
           <h2>If I have changes and I switch branches...</h2>
-          <div className="radio-component">
-            <input
-              type="radio"
-              id={UncommittedChangesStrategyKind.AskForConfirmation}
-              value={UncommittedChangesStrategyKind.AskForConfirmation}
-              checked={
-                this.state.uncommittedChangesStrategyKind ===
-                UncommittedChangesStrategyKind.AskForConfirmation
-              }
-              onChange={this.onUncommittedChangesStrategyKindChanged}
-            />
-            <label htmlFor={UncommittedChangesStrategyKind.AskForConfirmation}>
-              Ask me where I want the changes to go
-            </label>
-          </div>
-          <div className="radio-component">
-            <input
-              type="radio"
-              id={UncommittedChangesStrategyKind.MoveToNewBranch}
-              value={UncommittedChangesStrategyKind.MoveToNewBranch}
-              checked={
-                this.state.uncommittedChangesStrategyKind ===
-                UncommittedChangesStrategyKind.MoveToNewBranch
-              }
-              onChange={this.onUncommittedChangesStrategyKindChanged}
-            />
-            <label htmlFor={UncommittedChangesStrategyKind.MoveToNewBranch}>
-              Always bring my changes to my new branch
-            </label>
-          </div>
-          <div className="radio-component">
-            <input
-              type="radio"
-              id={UncommittedChangesStrategyKind.StashOnCurrentBranch}
-              value={UncommittedChangesStrategyKind.StashOnCurrentBranch}
-              checked={
-                this.state.uncommittedChangesStrategyKind ===
-                UncommittedChangesStrategyKind.StashOnCurrentBranch
-              }
-              onChange={this.onUncommittedChangesStrategyKindChanged}
-            />
-            <label
-              htmlFor={UncommittedChangesStrategyKind.StashOnCurrentBranch}
-            >
-              Always stash and leave my changes on the current branch
-            </label>
-          </div>
+
+          <RadioButton
+            value={UncommittedChangesStrategyKind.AskForConfirmation}
+            checked={
+              this.state.uncommittedChangesStrategyKind ===
+              UncommittedChangesStrategyKind.AskForConfirmation
+            }
+            label="Ask me where I want the changes to go"
+            onSelected={this.onUncommittedChangesStrategyKindChanged}
+          />
+
+          <RadioButton
+            value={UncommittedChangesStrategyKind.MoveToNewBranch}
+            checked={
+              this.state.uncommittedChangesStrategyKind ===
+              UncommittedChangesStrategyKind.MoveToNewBranch
+            }
+            label="Always bring my changes to my new branch"
+            onSelected={this.onUncommittedChangesStrategyKindChanged}
+          />
+
+          <RadioButton
+            value={UncommittedChangesStrategyKind.StashOnCurrentBranch}
+            checked={
+              this.state.uncommittedChangesStrategyKind ===
+              UncommittedChangesStrategyKind.StashOnCurrentBranch
+            }
+            label="Always stash and leave my changes on the current branch"
+            onSelected={this.onUncommittedChangesStrategyKindChanged}
+          />
         </div>
         <div className="advanced-section">
           <h2>Show a confirmation dialog before...</h2>

--- a/app/src/ui/repository-settings/fork-settings.tsx
+++ b/app/src/ui/repository-settings/fork-settings.tsx
@@ -3,6 +3,7 @@ import { DialogContent } from '../dialog'
 import { ForkContributionTarget } from '../../models/workflow-preferences'
 import { RepositoryWithForkedGitHubRepository } from '../../models/repository'
 import { ForkSettingsDescription } from './fork-contribution-target-description'
+import { RadioButton } from '../lib/radio-button'
 
 interface IForkSettingsProps {
   readonly forkContributionTarget: ForkContributionTarget
@@ -12,11 +13,6 @@ interface IForkSettingsProps {
   ) => void
 }
 
-enum RadioButtonId {
-  Parent = 'ForkContributionTargetParent',
-  Self = 'ForkContributionTargetSelf',
-}
-
 /** A view for creating or modifying the repository's gitignore file */
 export class ForkSettings extends React.Component<IForkSettingsProps, {}> {
   public render() {
@@ -24,33 +20,23 @@ export class ForkSettings extends React.Component<IForkSettingsProps, {}> {
       <DialogContent>
         <h2>I'll be using this fork…</h2>
 
-        <div className="radio-component">
-          <input
-            type="radio"
-            id={RadioButtonId.Parent}
-            value={ForkContributionTarget.Parent}
-            checked={
-              this.props.forkContributionTarget ===
-              ForkContributionTarget.Parent
-            }
-            onChange={this.onForkContributionTargetChanged}
-          />
-          <label htmlFor={RadioButtonId.Parent}>
-            To contribute to the parent repository
-          </label>
-        </div>
-        <div className="radio-component">
-          <input
-            type="radio"
-            id={RadioButtonId.Self}
-            value={ForkContributionTarget.Self}
-            checked={
-              this.props.forkContributionTarget === ForkContributionTarget.Self
-            }
-            onChange={this.onForkContributionTargetChanged}
-          />
-          <label htmlFor={RadioButtonId.Self}>For my own purposes</label>
-        </div>
+        <RadioButton
+          value={ForkContributionTarget.Parent}
+          checked={
+            this.props.forkContributionTarget === ForkContributionTarget.Parent
+          }
+          label="To contribute to the parent repository"
+          onSelected={this.onForkContributionTargetChanged}
+        />
+
+        <RadioButton
+          value={ForkContributionTarget.Self}
+          checked={
+            this.props.forkContributionTarget === ForkContributionTarget.Self
+          }
+          label="For my own purposes"
+          onSelected={this.onForkContributionTargetChanged}
+        />
 
         <ForkSettingsDescription
           repository={this.props.repository}
@@ -60,11 +46,7 @@ export class ForkSettings extends React.Component<IForkSettingsProps, {}> {
     )
   }
 
-  private onForkContributionTargetChanged = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    const value = event.currentTarget.value as ForkContributionTarget
-
+  private onForkContributionTargetChanged = (value: ForkContributionTarget) => {
     this.props.onForkContributionTargetChanged(value)
   }
 }

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -35,6 +35,7 @@
 @import 'ui/configure-git-user';
 @import 'ui/form';
 @import 'ui/text-box';
+@import 'ui/radio-button';
 @import 'ui/button';
 @import 'ui/select';
 @import 'ui/row';

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -14,21 +14,6 @@
       .checkbox-component:not(:last-child) {
         margin-bottom: var(--spacing-half);
       }
-
-      .radio-component {
-        &:not(:last-child) {
-          margin-bottom: var(--spacing-half);
-        }
-
-        input {
-          margin: 0;
-
-          // Only add a right margin if there's a label attached to it
-          &:not(:last-child) {
-            margin-right: var(--spacing-half);
-          }
-        }
-      }
     }
   }
 

--- a/app/styles/ui/_radio-button.scss
+++ b/app/styles/ui/_radio-button.scss
@@ -1,0 +1,12 @@
+.radio-button-component {
+  & + .radio-button-component {
+    margin-top: var(--spacing-half);
+  }
+
+  label {
+    margin: 0;
+
+    // Only add a right margin if there's a label attached to it
+    margin-left: var(--spacing-half);
+  }
+}

--- a/app/styles/ui/_radio-button.scss
+++ b/app/styles/ui/_radio-button.scss
@@ -5,8 +5,6 @@
 
   label {
     margin: 0;
-
-    // Only add a right margin if there's a label attached to it
     margin-left: var(--spacing-half);
   }
 }

--- a/app/styles/ui/dialogs/_repository-settings.scss
+++ b/app/styles/ui/dialogs/_repository-settings.scss
@@ -31,15 +31,4 @@
       margin-bottom: 0;
     }
   }
-
-  .radio-component {
-    &:not(:last-child) {
-      margin-bottom: var(--spacing-half);
-    }
-
-    input {
-      margin: 0;
-      margin-right: var(--spacing-half);
-    }
-  }
 }


### PR DESCRIPTION
Related issue: https://github.com/github/desktop/issues/642

## Description

This PR adds a new `<RadioButton />` component that can be used to create radio buttons with a label:

<img width="376" alt="Screen Shot 2020-07-24 at 10 35 28" src="https://user-images.githubusercontent.com/408035/88374084-69fb7900-cd99-11ea-8702-418b82d95c1b.png">

This new component doesn't have much logic (nor anything complex to do), but it still simplifies a couple of things that had to be done every time a radio button is used:

1. Create a unique id for the radio button to be able to link the label to it (we didn't always use a globally unique id since creating and releasing unique ids is quite tedious).
2. Pass directly the `value` of the radio button on the `onSelected` callback. Until now we were reading the value from the event and manually casting it to the desired type, now we benefit from TypeScript generics avoiding the potential bugs caused by manually casting values.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
