### PR TITLE
Create <RefNameTextBox/> component

### DIFF
--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -45,7 +45,7 @@ interface ICreateBranchProps {
 
 interface ICreateBranchState {
   readonly currentError: Error | null
-  readonly sanitizedName: string
+  readonly branchName: string
   readonly startPoint: StartPoint
 
   /**
@@ -89,7 +89,7 @@ export class CreateBranch extends React.Component<
 
     this.state = {
       currentError: null,
-      sanitizedName: props.initialName,
+      branchName: props.initialName,
       startPoint,
       isCreatingBranch: false,
       tipAtCreateStart: props.tip,
@@ -171,9 +171,9 @@ export class CreateBranch extends React.Component<
 
   public render() {
     const disabled =
-      this.state.sanitizedName.length <= 0 ||
+      this.state.branchName.length <= 0 ||
       !!this.state.currentError ||
-      /^\s*$/.test(this.state.sanitizedName)
+      /^\s*$/.test(this.state.branchName)
     const error = this.state.currentError
 
     return (
@@ -196,7 +196,7 @@ export class CreateBranch extends React.Component<
           />
 
           {renderBranchNameExistsOnRemoteWarning(
-            this.state.sanitizedName,
+            this.state.branchName,
             this.props.allBranches
           )}
 
@@ -217,22 +217,22 @@ export class CreateBranch extends React.Component<
     this.updateBranchName(name)
   }
 
-  private updateBranchName(sanitizedName: string) {
+  private updateBranchName(branchName: string) {
     const alreadyExists =
-      this.props.allBranches.findIndex(b => b.name === sanitizedName) > -1
+      this.props.allBranches.findIndex(b => b.name === branchName) > -1
 
     const currentError = alreadyExists
-      ? new Error(`A branch named ${sanitizedName} already exists`)
+      ? new Error(`A branch named ${branchName} already exists`)
       : null
 
     this.setState({
-      sanitizedName,
+      branchName,
       currentError,
     })
   }
 
   private createBranch = async () => {
-    const name = this.state.sanitizedName
+    const name = this.state.branchName
 
     let startPoint: string | null = null
     let noTrack = false

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -2,9 +2,7 @@ import * as React from 'react'
 
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
-import { sanitizedRefName } from '../../lib/sanitize-ref-name'
 import { Branch, StartPoint } from '../../models/branch'
-import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
 import { Ref } from '../lib/ref'
 import { LinkButton } from '../lib/link-button'
@@ -20,10 +18,7 @@ import {
   IValidBranch,
 } from '../../models/tip'
 import { assertNever } from '../../lib/fatal-error'
-import {
-  renderBranchNameWarning,
-  renderBranchNameExistsOnRemoteWarning,
-} from '../lib/branch-name-warnings'
+import { renderBranchNameExistsOnRemoteWarning } from '../lib/branch-name-warnings'
 import { getStartPoint } from '../../lib/create-branch'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { startTimer } from '../lib/timing'
@@ -32,6 +27,7 @@ import {
   UncommittedChangesStrategyKind,
 } from '../../models/uncommitted-changes-strategy'
 import { GitHubRepository } from '../../models/github-repository'
+import { RefNameTextBox } from '../lib/ref-name-text-box'
 
 interface ICreateBranchProps {
   readonly repository: Repository
@@ -49,7 +45,6 @@ interface ICreateBranchProps {
 
 interface ICreateBranchState {
   readonly currentError: Error | null
-  readonly proposedName: string
   readonly sanitizedName: string
   readonly startPoint: StartPoint
 
@@ -94,18 +89,11 @@ export class CreateBranch extends React.Component<
 
     this.state = {
       currentError: null,
-      proposedName: props.initialName,
-      sanitizedName: '',
+      sanitizedName: props.initialName,
       startPoint,
       isCreatingBranch: false,
       tipAtCreateStart: props.tip,
       defaultBranchAtCreateStart: getBranchForStartPoint(startPoint, props),
-    }
-  }
-
-  public componentDidMount() {
-    if (this.state.proposedName.length) {
-      this.updateBranchName(this.state.proposedName)
     }
   }
 
@@ -183,7 +171,7 @@ export class CreateBranch extends React.Component<
 
   public render() {
     const disabled =
-      this.state.proposedName.length <= 0 ||
+      this.state.sanitizedName.length <= 0 ||
       !!this.state.currentError ||
       /^\s*$/.test(this.state.sanitizedName)
     const error = this.state.currentError
@@ -200,19 +188,12 @@ export class CreateBranch extends React.Component<
         {error ? <DialogError>{error.message}</DialogError> : null}
 
         <DialogContent>
-          <Row>
-            <TextBox
-              label="Name"
-              value={this.state.proposedName}
-              autoFocus={true}
-              onValueChanged={this.onBranchNameChange}
-            />
-          </Row>
-
-          {renderBranchNameWarning(
-            this.state.proposedName,
-            this.state.sanitizedName
-          )}
+          <RefNameTextBox
+            label="Name"
+            initialValue={this.props.initialName}
+            autoFocus={true}
+            onValueChange={this.onBranchNameChange}
+          />
 
           {renderBranchNameExistsOnRemoteWarning(
             this.state.sanitizedName,
@@ -236,8 +217,7 @@ export class CreateBranch extends React.Component<
     this.updateBranchName(name)
   }
 
-  private updateBranchName(name: string) {
-    const sanitizedName = sanitizedRefName(name)
+  private updateBranchName(sanitizedName: string) {
     const alreadyExists =
       this.props.allBranches.findIndex(b => b.name === sanitizedName) > -1
 
@@ -246,7 +226,6 @@ export class CreateBranch extends React.Component<
       : null
 
     this.setState({
-      proposedName: name,
       sanitizedName,
       currentError,
     })

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -191,7 +191,6 @@ export class CreateBranch extends React.Component<
           <RefNameTextBox
             label="Name"
             initialValue={this.props.initialName}
-            autoFocus={true}
             onValueChange={this.onBranchNameChange}
           />
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -2,15 +2,12 @@ import * as React from 'react'
 
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
-import { sanitizedRefName } from '../../lib/sanitize-ref-name'
-import { TextBox } from '../lib/text-box'
-import { Row } from '../lib/row'
 import { Dialog, DialogError, DialogContent, DialogFooter } from '../dialog'
 
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { startTimer } from '../lib/timing'
-import { Octicon, OcticonSymbol } from '../octicons'
 import { Ref } from '../lib/ref'
+import { RefNameTextBox } from '../lib/ref-name-text-box'
 
 interface ICreateTagProps {
   readonly repository: Repository
@@ -22,8 +19,7 @@ interface ICreateTagProps {
 }
 
 interface ICreateTagState {
-  readonly proposedName: string
-  readonly sanitizedName: string
+  readonly tagName: string
 
   /**
    * Note: once tag creation has been initiated this value stays at true
@@ -44,18 +40,15 @@ export class CreateTag extends React.Component<
   public constructor(props: ICreateTagProps) {
     super(props)
 
-    const proposedName = props.initialName || ''
-
     this.state = {
-      proposedName,
-      sanitizedName: sanitizedRefName(proposedName),
+      tagName: props.initialName || '',
       isCreatingTag: false,
     }
   }
 
   public render() {
     const error = this.getCurrentError()
-    const disabled = error !== null || this.state.proposedName.length === 0
+    const disabled = error !== null || this.state.tagName.length === 0
 
     return (
       <Dialog
@@ -69,16 +62,12 @@ export class CreateTag extends React.Component<
         {error && <DialogError>{error}</DialogError>}
 
         <DialogContent>
-          <Row>
-            <TextBox
-              label="Name"
-              value={this.state.proposedName}
-              autoFocus={true}
-              onValueChanged={this.updateTagName}
-            />
-          </Row>
-
-          {this.renderTagNameWarning()}
+          <RefNameTextBox
+            label="Name"
+            initialValue={this.props.initialName}
+            autoFocus={true}
+            onValueChange={this.updateTagName}
+          />
         </DialogContent>
 
         <DialogFooter>
@@ -91,44 +80,19 @@ export class CreateTag extends React.Component<
     )
   }
 
-  private renderTagNameWarning() {
-    const { proposedName, sanitizedName } = this.state
-
-    if (proposedName !== sanitizedName) {
-      return (
-        <Row className="warning-helper-text">
-          <Octicon symbol={OcticonSymbol.alert} />
-          <p>
-            Will be created as <Ref>{sanitizedName}</Ref>.
-          </p>
-        </Row>
-      )
-    } else {
-      return null
-    }
-  }
-
   private getCurrentError(): JSX.Element | null {
-    const { sanitizedName, proposedName } = this.state
-
-    if (sanitizedName.length > MaxTagNameLength) {
+    if (this.state.tagName.length > MaxTagNameLength) {
       return (
         <>The tag name cannot be longer than {MaxTagNameLength} characters</>
       )
     }
 
-    // Show an error if the sanitization logic causes the tag name to be an empty
-    // string (we only want to show this if the user has already typed something).
-    if (proposedName.length > 0 && sanitizedName.length === 0) {
-      return <>Invalid tag name.</>
-    }
-
     const alreadyExists =
-      this.props.localTags && this.props.localTags.has(sanitizedName)
+      this.props.localTags && this.props.localTags.has(this.state.tagName)
     if (alreadyExists) {
       return (
         <>
-          A tag named <Ref>{sanitizedName}</Ref> already exists
+          A tag named <Ref>{this.state.tagName}</Ref> already exists
         </>
       )
     }
@@ -136,15 +100,14 @@ export class CreateTag extends React.Component<
     return null
   }
 
-  private updateTagName = (name: string) => {
+  private updateTagName = (tagName: string) => {
     this.setState({
-      proposedName: name,
-      sanitizedName: sanitizedRefName(name),
+      tagName,
     })
   }
 
   private createTag = async () => {
-    const name = this.state.sanitizedName
+    const name = this.state.tagName
     const repository = this.props.repository
 
     if (name.length > 0) {

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -65,7 +65,6 @@ export class CreateTag extends React.Component<
           <RefNameTextBox
             label="Name"
             initialValue={this.props.initialName}
-            autoFocus={true}
             onValueChange={this.updateTagName}
           />
         </DialogContent>

--- a/app/src/ui/lib/branch-name-warnings.tsx
+++ b/app/src/ui/lib/branch-name-warnings.tsx
@@ -6,32 +6,6 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { Ref } from './ref'
 import { IStashEntry } from '../../models/stash-entry'
 
-export function renderBranchNameWarning(
-  proposedName: string,
-  sanitizedName: string
-) {
-  if (proposedName.length > 0 && /^\s*$/.test(sanitizedName)) {
-    return (
-      <Row className="warning-helper-text">
-        <Octicon symbol={OcticonSymbol.alert} />
-        <p>
-          <Ref>{proposedName}</Ref> is not a valid branch name.
-        </p>
-      </Row>
-    )
-  } else if (proposedName !== sanitizedName) {
-    return (
-      <Row className="warning-helper-text">
-        <Octicon symbol={OcticonSymbol.alert} />
-        <p>
-          Will be created as <Ref>{sanitizedName}</Ref>.
-        </p>
-      </Row>
-    )
-  } else {
-    return null
-  }
-}
 export function renderBranchHasRemoteWarning(branch: Branch) {
   if (branch.upstream != null) {
     return (

--- a/app/src/ui/lib/fancy-text-box.tsx
+++ b/app/src/ui/lib/fancy-text-box.tsx
@@ -63,9 +63,9 @@ export class FancyTextBox extends React.Component<
     this.setState({ isFocused: true })
   }
 
-  private onBlur = () => {
+  private onBlur = (value: string) => {
     if (this.props.onBlur !== undefined) {
-      this.props.onBlur()
+      this.props.onBlur(value)
     }
 
     this.setState({ isFocused: false })

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -80,7 +80,6 @@ export class RefNameTextBox extends React.Component<
         <TextBox
           label={this.props.label}
           value={this.state.proposedValue}
-          autoFocus={this.props.autoFocus}
           onValueChanged={this.onValueChange}
           onBlur={this.onBlur}
         />

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -92,12 +92,11 @@ export class RefNameTextBox extends React.Component<
 
   private onValueChange = (proposedValue: string) => {
     const sanitizedValue = sanitizedRefName(proposedValue)
+    const previousSanitizedValue = this.state.sanitizedValue
 
     this.setState({ proposedValue, sanitizedValue })
 
-    // If the sanitized value didn't change we don't need to
-    // call the onValue change prop.
-    if (sanitizedValue === this.state.sanitizedValue) {
+    if (sanitizedValue === previousSanitizedValue) {
       return
     }
 

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -60,7 +60,7 @@ export class RefNameTextBox extends React.Component<
     const proposedValue = props.initialValue || ''
 
     this.state = {
-      proposedValue: proposedValue,
+      proposedValue,
       sanitizedValue: sanitizedRefName(proposedValue),
     }
   }

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -111,13 +111,8 @@ export class RefNameTextBox extends React.Component<
     if (this.props.onBlur !== undefined) {
       // It's possible (although rare) that we receive the onBlur
       // event before the sanitized value has been committed to the
-      // state so we need to check for that condition and sanitize
-      // the value ourselves if that's the case.
-      const sanitizedValue =
-        proposedValue === this.state.proposedValue
-          ? this.state.sanitizedValue
-          : sanitizedRefName(proposedValue)
-
+      // state so we need to use the value received from the onBlur
+      // event instead of the one stored in state.
       this.props.onBlur(sanitizedRefName(proposedValue))
     }
   }

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -19,11 +19,6 @@ interface IRefNameProps {
   readonly label?: string | JSX.Element
 
   /**
-   * Whether to autofocus the input component.
-   */
-  readonly autoFocus?: boolean
-
-  /**
    * Called when the user changes the ref name.
    *
    * A sanitized value for the ref name is passed.

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -112,7 +112,7 @@ export class RefNameTextBox extends React.Component<
     if (this.props.onBlur !== undefined) {
       // It's possible (although rare) that we receive the onBlur
       // event before the sanitized value has been committed to the
-      // state so we need to check fot that condition and sanitize
+      // state so we need to check for that condition and sanitize
       // the value ourselves if that's the case.
       const sanitizedValue =
         proposedValue === this.state.proposedValue

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -125,9 +125,7 @@ export class RefNameTextBox extends React.Component<
     }
 
     const renderWarningMessage =
-      this.props.renderWarningMessage !== undefined
-        ? this.props.renderWarningMessage
-        : this.defaultRenderWarningMessage
+      this.props.renderWarningMessage ?? this.defaultRenderWarningMessage
 
     return (
       <div className="warning-helper-text">

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -28,7 +28,7 @@ interface IRefNameProps {
    *
    * A sanitized value for the ref name is passed.
    */
-  readonly onValueChange: (sanitizedValue: string) => void
+  readonly onValueChange?: (sanitizedValue: string) => void
 
   /**
    * Called when the user-entered ref name is not valid.
@@ -41,6 +41,13 @@ interface IRefNameProps {
     sanitizedValue: string,
     proposedValue: string
   ) => JSX.Element | string
+
+  /**
+   * Callback used when the component loses focus.
+   *
+   * A sanitized value for the ref name is passed.
+   */
+  readonly onBlur?: (sanitizedValue: string) => void
 }
 
 interface IRefNameState {
@@ -64,7 +71,10 @@ export class RefNameTextBox extends React.Component<
   }
 
   public componentDidMount() {
-    if (this.state.sanitizedValue !== this.props.initialValue) {
+    if (
+      this.state.sanitizedValue !== this.props.initialValue &&
+      this.props.onValueChange !== undefined
+    ) {
       this.props.onValueChange(this.state.sanitizedValue)
     }
   }
@@ -77,6 +87,7 @@ export class RefNameTextBox extends React.Component<
           value={this.state.proposedValue}
           autoFocus={this.props.autoFocus}
           onValueChanged={this.onValueChange}
+          onBlur={this.onBlur}
         />
 
         {this.renderRefValueWarning()}
@@ -98,7 +109,26 @@ export class RefNameTextBox extends React.Component<
       return
     }
 
+    if (this.props.onValueChange === undefined) {
+      return
+    }
+
     this.props.onValueChange(sanitizedValue)
+  }
+
+  private onBlur = (proposedValue: string) => {
+    if (this.props.onBlur !== undefined) {
+      // It's possible (although rare) that we receive the onBlur
+      // event before the sanitized value has been committed to the
+      // state so we need to check fot that condition and sanitize
+      // the value ourselves if that's the case.
+      const sanitizedValue =
+        proposedValue === this.state.proposedValue
+          ? this.state.sanitizedValue
+          : sanitizedRefName(proposedValue)
+
+      this.props.onBlur(sanitizedRefName(sanitizedValue))
+    }
   }
 
   private renderRefValueWarning() {

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -93,10 +93,7 @@ export class RefNameTextBox extends React.Component<
   private onValueChange = (proposedValue: string) => {
     const sanitizedValue = sanitizedRefName(proposedValue)
 
-    this.setState({
-      proposedValue,
-      sanitizedValue,
-    })
+    this.setState({ proposedValue, sanitizedValue })
 
     // If the sanitized value didn't change we don't need to
     // call the onValue change prop.

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react'
+
+import { sanitizedRefName } from '../../lib/sanitize-ref-name'
+import { TextBox } from './text-box'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { Ref } from './ref'
+
+interface IRefNameProps {
+  /**
+   * The initial value for the ref name.
+   *
+   * Note that updates to this prop will be ignored.
+   */
+  readonly initialValue?: string
+
+  /**
+   * The label of the text box.
+   */
+  readonly label?: string | JSX.Element
+
+  /**
+   * Whether to autofocus the input component.
+   */
+  readonly autoFocus?: boolean
+
+  /**
+   * Called when the user changes the ref name.
+   *
+   * A sanitized value for the ref name is passed.
+   */
+  readonly onValueChange: (sanitizedValue: string) => void
+
+  /**
+   * Called when the user-entered ref name is not valid.
+   *
+   * This gives the opportunity to the caller to specify
+   * a custom warning message explaining that the sanitized
+   * value will be used instead.
+   */
+  readonly renderWarningMessage?: (
+    sanitizedValue: string,
+    proposedValue: string
+  ) => JSX.Element | string
+}
+
+interface IRefNameState {
+  readonly proposedValue: string
+  readonly sanitizedValue: string
+}
+
+export class RefNameTextBox extends React.Component<
+  IRefNameProps,
+  IRefNameState
+> {
+  public constructor(props: IRefNameProps) {
+    super(props)
+
+    const proposedValue = props.initialValue || ''
+
+    this.state = {
+      proposedValue: proposedValue,
+      sanitizedValue: sanitizedRefName(proposedValue),
+    }
+  }
+
+  public componentDidMount() {
+    if (this.state.sanitizedValue !== this.props.initialValue) {
+      this.props.onValueChange(this.state.sanitizedValue)
+    }
+  }
+
+  public render() {
+    return (
+      <div className="ref-name-text-box">
+        <TextBox
+          label={this.props.label}
+          value={this.state.proposedValue}
+          autoFocus={this.props.autoFocus}
+          onValueChanged={this.onValueChange}
+        />
+
+        {this.renderRefValueWarning()}
+      </div>
+    )
+  }
+
+  private onValueChange = (proposedValue: string) => {
+    const sanitizedValue = sanitizedRefName(proposedValue)
+
+    this.setState({
+      proposedValue,
+      sanitizedValue,
+    })
+
+    // If the sanitized value didn't change we don't need to
+    // call the onValue change prop.
+    if (sanitizedValue === this.state.sanitizedValue) {
+      return
+    }
+
+    this.props.onValueChange(sanitizedValue)
+  }
+
+  private renderRefValueWarning() {
+    const { proposedValue, sanitizedValue } = this.state
+
+    if (proposedValue === sanitizedValue) {
+      return null
+    }
+
+    const renderWarningMessage =
+      this.props.renderWarningMessage !== undefined
+        ? this.props.renderWarningMessage
+        : this.defaultRenderWarningMessage
+
+    return (
+      <div className="warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+
+        <p>{renderWarningMessage(sanitizedValue, proposedValue)}</p>
+      </div>
+    )
+  }
+
+  private defaultRenderWarningMessage(
+    sanitizedValue: string,
+    proposedValue: string
+  ) {
+    // If the proposed value ends up being sanitized as
+    // an empty string we show a message saying that the
+    // proposed value is invalid.
+    if (sanitizedValue.length === 0) {
+      return (
+        <>
+          <Ref>{proposedValue}</Ref> is not a valid name.
+        </>
+      )
+    }
+
+    return (
+      <>
+        Will be created as <Ref>{sanitizedValue}</Ref>.
+      </>
+    )
+  }
+}

--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -119,7 +119,7 @@ export class RefNameTextBox extends React.Component<
           ? this.state.sanitizedValue
           : sanitizedRefName(proposedValue)
 
-      this.props.onBlur(sanitizedRefName(sanitizedValue))
+      this.props.onBlur(sanitizedRefName(proposedValue))
     }
   }
 

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -82,6 +82,8 @@ export interface ITextBoxProps {
 
   /**
    * Callback used when the component loses focus.
+   *
+   * The function is called with the current text value of the text input.
    */
   readonly onBlur?: (value: string) => void
 

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -83,7 +83,7 @@ export interface ITextBoxProps {
   /**
    * Callback used when the component loses focus.
    */
-  readonly onBlur?: () => void
+  readonly onBlur?: (value: string) => void
 
   /**
    * Callback used when the user has cleared the search text.
@@ -252,7 +252,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
       value === ''
     ) {
       if (this.props.onBlur) {
-        this.props.onBlur()
+        this.props.onBlur(value)
         if (this.inputElement !== null) {
           this.inputElement.blur()
         }
@@ -299,7 +299,7 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
 
   private onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     if (this.props.onBlur !== undefined) {
-      this.props.onBlur()
+      this.props.onBlur(event.target.value)
     }
   }
 }

--- a/app/src/ui/rename-branch/rename-branch-dialog.tsx
+++ b/app/src/ui/rename-branch/rename-branch-dialog.tsx
@@ -3,17 +3,14 @@ import * as React from 'react'
 import { Dispatcher } from '../dispatcher'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
-import { sanitizedRefName } from '../../lib/sanitize-ref-name'
-import { TextBox } from '../lib/text-box'
-import { Row } from '../lib/row'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import {
-  renderBranchNameWarning,
   renderBranchHasRemoteWarning,
   renderStashWillBeLostWarning,
 } from '../lib/branch-name-warnings'
 import { IStashEntry } from '../../models/stash-entry'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { RefNameTextBox } from '../lib/ref-name-text-box'
 
 interface IRenameBranchProps {
   readonly dispatcher: Dispatcher
@@ -38,8 +35,6 @@ export class RenameBranch extends React.Component<
   }
 
   public render() {
-    const disabled =
-      !this.state.newName.length || /^\s*$/.test(this.state.newName)
     return (
       <Dialog
         id="rename-branch"
@@ -48,17 +43,11 @@ export class RenameBranch extends React.Component<
         onSubmit={this.renameBranch}
       >
         <DialogContent>
-          <Row>
-            <TextBox
-              label="Name"
-              value={this.state.newName}
-              onValueChanged={this.onNameChange}
-            />
-          </Row>
-          {renderBranchNameWarning(
-            this.state.newName,
-            sanitizedRefName(this.state.newName)
-          )}
+          <RefNameTextBox
+            label="Name"
+            initialValue={this.props.branch.name}
+            onValueChange={this.onNameChange}
+          />
           {renderBranchHasRemoteWarning(this.props.branch)}
           {renderStashWillBeLostWarning(this.props.stash)}
         </DialogContent>
@@ -66,7 +55,7 @@ export class RenameBranch extends React.Component<
         <DialogFooter>
           <OkCancelButtonGroup
             okButtonText={`Rename ${this.props.branch.name}`}
-            okButtonDisabled={disabled}
+            okButtonDisabled={this.state.newName.length === 0}
           />
         </DialogFooter>
       </Dialog>
@@ -78,11 +67,10 @@ export class RenameBranch extends React.Component<
   }
 
   private renameBranch = () => {
-    const name = sanitizedRefName(this.state.newName)
     this.props.dispatcher.renameBranch(
       this.props.repository,
       this.props.branch,
-      name
+      this.state.newName
     )
     this.props.onDismissed()
   }

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -35,6 +35,7 @@
 @import 'ui/configure-git-user';
 @import 'ui/form';
 @import 'ui/text-box';
+@import 'ui/ref-name-text-box';
 @import 'ui/radio-button';
 @import 'ui/button';
 @import 'ui/select';

--- a/app/styles/ui/_ref-name-text-box.scss
+++ b/app/styles/ui/_ref-name-text-box.scss
@@ -1,0 +1,8 @@
+.ref-name-text-box {
+  margin-bottom: var(--spacing);
+
+  .warning-helper-text {
+    display: flex;
+    margin-top: var(--spacing);
+  }
+}


### PR DESCRIPTION
Related issue: github/desktop#642

~~⚠️ This PR is based on https://github.com/desktop/desktop/pull/10260 (it does not depend on it, but since the followup PR is going to depend on both I've opted to create a linear PR dependency).~~


## Description

This PR creates a new component called `<RefNameTextBox/>` that handles the sanitization needed when asking users to enter a name for a git reference (branch name, tag name, etc).

This component does 3 things that used to be done every time we wanted to ask the user for a ref name:

1. Sanitize the user-entered value to a ref name compatible with git.
2. Display a warning if the sanitized value is different than the value that the user provided.
3. Display a different warning if the santization results in an empty string.

<img width="379" alt="Screen Shot 2020-07-24 at 12 12 13" src="https://user-images.githubusercontent.com/408035/88381624-08420b80-cda7-11ea-9d10-4a37e4769ae2.png">



### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
