### PR TITLE
Remove react-addons-shallow-compare npm dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -47,7 +47,6 @@
     "queue": "^4.4.2",
     "quick-lru": "^3.0.0",
     "react": "^16.8.4",
-    "react-addons-shallow-compare": "^15.6.2",
     "react-css-transition-replace": "^3.0.3",
     "react-dom": "^16.8.4",
     "react-transition-group": "^1.2.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -481,7 +481,7 @@ eyes@0.1.x:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
-fbjs@^0.8.16, fbjs@^0.8.4:
+fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   integrity sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=
@@ -1189,14 +1189,6 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-addons-shallow-compare@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz#198a00b91fc37623db64a28fd17b596ba362702f"
-  integrity sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
 
 react-css-transition-replace@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
This npm package is deprecated and it's not used anywhere in Desktop's codebase