### PR TITLE
Unborn branches are branches too (kinda)

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -490,8 +490,6 @@ export class CommitMessage extends React.Component<
   }
 
   public render() {
-    const branchName = this.props.branch ? this.props.branch : 'master'
-
     const isSummaryWhiteSpace = this.state.summary.match(/^\s+$/g)
     const buttonEnabled =
       this.canCommit() && !this.props.isCommitting && !isSummaryWhiteSpace
@@ -509,6 +507,19 @@ export class CommitMessage extends React.Component<
     const summaryInputClassName = classNames('summary-field', 'nudge-arrow', {
       'nudge-arrow-left': this.props.shouldNudge,
     })
+
+    const branchName = this.props.branch
+    const commitVerb = loading ? 'Committing' : 'Commit'
+    const commitTitle =
+      branchName !== null ? `${commitVerb} to ${branchName}` : commitVerb
+    const commitButtonContents =
+      branchName !== null ? (
+        <>
+          {commitVerb} to <strong>{branchName}</strong>
+        </>
+      ) : (
+        commitVerb
+      )
 
     return (
       <div
@@ -564,9 +575,7 @@ export class CommitMessage extends React.Component<
           disabled={!buttonEnabled}
         >
           {loading}
-          <span title={`Commit to ${branchName}`}>
-            {loading ? 'Committing' : 'Commit'} to <strong>{branchName}</strong>
-          </span>
+          <span title={commitTitle}>{commitButtonContents}</span>
         </Button>
       </div>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -442,8 +442,19 @@ export class CommitMessage extends React.Component<
     return <div className={className}>{this.renderCoAuthorToggleButton()}</div>
   }
 
-  private renderPermissionsCommitWarning = (branch: string) => {
-    const { showBranchProtected, showNoWriteAccess, repository } = this.props
+  private renderPermissionsCommitWarning() {
+    const {
+      showBranchProtected,
+      showNoWriteAccess,
+      repository,
+      branch,
+    } = this.props
+
+    if (branch === null) {
+      // If the branch is null that means we haven't loaded the tip yet or
+      // we're on a detached head.
+      return null
+    }
 
     if (showNoWriteAccess) {
       return (
@@ -544,7 +555,7 @@ export class CommitMessage extends React.Component<
 
         {this.renderCoAuthorInput()}
 
-        {this.renderPermissionsCommitWarning(branchName)}
+        {this.renderPermissionsCommitWarning()}
 
         <Button
           type="submit"

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -450,12 +450,6 @@ export class CommitMessage extends React.Component<
       branch,
     } = this.props
 
-    if (branch === null) {
-      // If the branch is null that means we haven't loaded the tip yet or
-      // we're on a detached head.
-      return null
-    }
-
     if (showNoWriteAccess) {
       return (
         <PermissionsCommitWarning>
@@ -465,6 +459,14 @@ export class CommitMessage extends React.Component<
         </PermissionsCommitWarning>
       )
     } else if (showBranchProtected) {
+      if (branch === null) {
+        // If the branch is null that means we haven't loaded the tip yet or
+        // we're on a detached head. We shouldn't ever end up here with
+        // showBranchProtected being true without a branch but who knows
+        // what fun and exiting edge cases the future might hold
+        return null
+      }
+
       return (
         <PermissionsCommitWarning>
           <strong>{branch}</strong> is a protected branch. Want to{' '}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -163,7 +163,14 @@ export class RepositoryView extends React.Component<
 
   private renderChangesSidebar(): JSX.Element {
     const tip = this.props.state.branchesState.tip
-    const branch = tip.kind === TipState.Valid ? tip.branch : null
+
+    let branchName: string | null = null
+
+    if (tip.kind === TipState.Valid) {
+      branchName = tip.branch.name
+    } else if (tip.kind === TipState.Unborn) {
+      branchName = tip.ref
+    }
 
     const localCommitSHAs = this.props.state.localCommitSHAs
     const mostRecentLocalCommitSHA =
@@ -187,7 +194,7 @@ export class RepositoryView extends React.Component<
         repository={this.props.repository}
         dispatcher={this.props.dispatcher}
         changes={this.props.state.changesState}
-        branch={branch ? branch.name : null}
+        branch={branchName}
         commitAuthor={this.props.state.commitAuthor}
         emoji={this.props.emoji}
         mostRecentLocalCommit={mostRecentLocalCommit}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10318 

## Description

If the currently checked out branch is unborn we would use the correct name in the branch dropdown but fail to resolve its name in the commit button and instead fall back to `master`.

This bug has existed since forever but given how rare it is to operate with unborn branches except _just_  after repository initialization I'm not surprised we haven't hit this before. But with more and more people choosing to use a branch name other than `master` it will only become more and more prevalent so it's best we fix it now.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

**Before (left) and after (right)**

![baf](https://user-images.githubusercontent.com/634063/89323602-3ddbd400-d686-11ea-9261-ed2ccd29e61b.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Correct branch name in commit button when on an unborn branch
