### PR TITLE
Font tweaks for electron 9

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -48,7 +48,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // Typography
   //
   // Font, line-height, and color for body text, headings, and more.
-  --font-family-sans-serif: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Arial, sans-serif;
+  --font-family-sans-serif: system-ui, sans-serif;
   --font-family-monospace: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   /**

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -49,7 +49,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   //
   // Font, line-height, and color for body text, headings, and more.
   --font-family-sans-serif: system-ui, sans-serif;
-  --font-family-monospace: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --font-family-monospace: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
 
   /**
    * Font weight to use for semibold text

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -48,8 +48,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // Typography
   //
   // Font, line-height, and color for body text, headings, and more.
-  --font-family-sans-serif: system-ui, sans-serif;
-  --font-family-monospace: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+  $emoji_fallback_fonts: 'Apple Color Emoji', 'Segoe UI', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  --font-family-sans-serif: system-ui, sans-serif, #{$emoji_fallback_fonts};
+  --font-family-monospace: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace, #{$emoji_fallback_fonts};
 
   /**
    * Font weight to use for semibold text


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This introduces the same emoji font fallback chain that GitHub.com uses in order to work around the rendering of certain emoji on Windows (see https://github.com/electron/electron/issues/24426).

While we're at it I'm also replacing our system font fallback chain with the new [system-ui](https://www.chromestatus.com/feature/5640395337760768) font-alias that lets us leverage Chromium's logic for determining what the system font is.

Lastly I've updated our monospace font stack to match that of GitHub.com (by adding SFMono-Regular as the highest priority monospace font).

Ideally I would like to use the [ui-sans-serif and ui-monospace](https://caniuse.com/#feat=extended-system-fonts) font aliases but we'll have to wait a while for them to be supported

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Note that there's no difference on Windows and the exact before state depends on the fonts installed on the system.

<img src="https://user-images.githubusercontent.com/634063/89413937-e8590300-d729-11ea-9952-b9ba79b16c39.gif"  width="703" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Use system monospace font for diffs on macOS