### PR TITLE
Fix keyboard navigation in PR list

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -55,8 +55,14 @@ interface IBranchesContainerProps {
 }
 
 interface IBranchesContainerState {
-  readonly selectedBranch: Branch | null
+  /**
+   * A copy of the last seen currentPullRequest property
+   * from props. Used in order to be able to detect when
+   * the selected PR in props changes in getDerivedStateFromProps
+   */
+  readonly currentPullRequest: PullRequest | null
   readonly selectedPullRequest: PullRequest | null
+  readonly selectedBranch: Branch | null
   readonly branchFilterText: string
 }
 
@@ -65,12 +71,27 @@ export class BranchesContainer extends React.Component<
   IBranchesContainerProps,
   IBranchesContainerState
 > {
+  public static getDerivedStateFromProps(
+    props: IBranchesContainerProps,
+    state: IBranchesContainerProps
+  ): Partial<IBranchesContainerState> | null {
+    if (state.currentPullRequest !== props.currentPullRequest) {
+      return {
+        currentPullRequest: props.currentPullRequest,
+        selectedPullRequest: props.currentPullRequest,
+      }
+    }
+
+    return null
+  }
+
   public constructor(props: IBranchesContainerProps) {
     super(props)
 
     this.state = {
       selectedBranch: props.currentBranch,
       selectedPullRequest: props.currentPullRequest,
+      currentPullRequest: props.currentPullRequest,
       branchFilterText: '',
     }
   }
@@ -187,7 +208,7 @@ export class BranchesContainer extends React.Component<
       <PullRequestList
         key="pr-list"
         pullRequests={this.props.pullRequests}
-        selectedPullRequest={this.props.currentPullRequest}
+        selectedPullRequest={this.state.selectedPullRequest}
         isOnDefaultBranch={!!isOnDefaultBranch}
         onSelectionChanged={this.onPullRequestSelectionChanged}
         onCreateBranch={this.onCreateBranch}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This was caught as part of #9737, we have a `selectedBranch` state property for the PR list but it's only ever written to and never used for the actual selection. The consequences of this is that you can't navigate the PR list using the up/down keys.

The PR list receives the currently "selected" (i.e. checked out) pull request via props but we need to keep track of what they user has currently selected in the list but not necessarily checked out. By leveraging `getDerivedStateFromProps` we can reset the selection should the currently checked out branch in a repo change while still keeping track of the currently selected/focused/highlighted PR in the list.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Pull request list is now keyboard accessible
