### PR TITLE
Remove old badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [GitHub Desktop](https://desktop.github.com) [![CI Build Status](https://github.com/desktop/desktop/workflows/CI/badge.svg)](https://github.com/desktop/desktop/actions?query=workflow%3ACI+branch%3Adevelopment)
+# [GitHub Desktop](https://desktop.github.com)
 
 GitHub Desktop is an open source [Electron](https://electron.atom.io)-based
 GitHub app. It is written in [TypeScript](http://www.typescriptlang.org) and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [GitHub Desktop](https://desktop.github.com) [![CI Build Status](https://img.shields.io/github/workflow/status/desktop/desktop/CI?style=flat-square)](https://github.com/desktop/desktop/actions?query=workflow%3ACI+branch%3Adevelopment)
+# [GitHub Desktop](https://desktop.github.com) [![CI Build Status](https://github.com/desktop/desktop/workflows/CI/badge.svg)](https://github.com/desktop/desktop/actions?query=workflow%3ACI+branch%3Adevelopment)
 
 GitHub Desktop is an open source [Electron](https://electron.atom.io)-based
 GitHub app. It is written in [TypeScript](http://www.typescriptlang.org) and

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-# [GitHub Desktop](https://desktop.github.com)
-
-[![Travis](https://img.shields.io/travis/desktop/desktop.svg?style=flat-square&label=Travis+CI)](https://travis-ci.org/desktop/desktop)
-[![CircleCI](https://img.shields.io/circleci/project/github/desktop/desktop.svg?style=flat-square&label=CircleCI)](https://circleci.com/gh/desktop/desktop)
-[![AppVeyor Build Status](https://img.shields.io/appveyor/ci/github-windows/desktop/development.svg?style=flat-square&label=AppVeyor&logo=appveyor)](https://ci.appveyor.com/project/github-windows/desktop/branch/development)
-[![license](https://img.shields.io/github/license/desktop/desktop.svg?style=flat-square)](https://github.com/desktop/desktop/blob/development/LICENSE)
-![90+% TypeScript](https://img.shields.io/github/languages/top/desktop/desktop.svg?style=flat-square&colorB=green)
+# [GitHub Desktop](https://desktop.github.com) [![CI Build Status](https://img.shields.io/github/workflow/status/desktop/desktop/CI?style=flat-square)](https://github.com/desktop/desktop/actions?query=workflow%3ACI+branch%3Adevelopment)
 
 GitHub Desktop is an open source [Electron](https://electron.atom.io)-based
 GitHub app. It is written in [TypeScript](http://www.typescriptlang.org) and


### PR DESCRIPTION
Now that we use GitHub Actions as our CI provider, it's time to remove the old badges.

I've taken the freedom of removing the License and the TypeScript badges, since that information is easily available in the GitHub repository page.

I've kept only the build badge pointing to the status of our CI, but I'm also open to completely remove it since the build status is also relatively easy to find from GitHub.

----

**[Rendered version of Readme.md](https://github.com/desktop/desktop/blob/remove-old-badges-from-readme/README.md)**