### PR TITLE
Ensure that dugite gets to calculate its own GIT_EXEC_PATH

### DIFF
--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -92,6 +92,12 @@ enableSourceMaps()
 // see https://github.com/desktop/dugite/pull/85
 process.env['LOCAL_GIT_DIRECTORY'] = Path.resolve(__dirname, 'git')
 
+// Ensure that dugite infers the GIT_EXEC_PATH
+// based on the LOCAL_GIT_DIRECTORY env variable
+// instead of just blindly trusting what's set in
+// the current environment. See https://git.io/JJ7KF
+delete process.env.GIT_EXEC_PATH
+
 momentDurationFormatSetup(moment)
 
 const startTime = performance.now()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

As of https://github.com/desktop/dugite/commit/8c7540fff9ce3a573b2da982706edea11652f8ab dugite started respecting user-set `GIT_EXEC_PATH` environment variables. `GIT_EXEC_PATH` is used by Git to locate support sub-command binaries such as `git-receive-pack`. Prior to that change dugite would always infer the exec path from the Git installation location.

I had a suspicion that this might have been a reason for #10345 (i.e. some other tool setting GIT_EXEC_PATH) but it doesn't appear as if my suspicions were correct. Nevertheless I think this is a worthwhile change. We want dugite to use the bundled Git which is why we set `LOCAL_GIT_DIRECTORY` so it makes little sense for us to allow using a different `GIT_EXEC_PATH`.
