### PR TITLE
Use `x` octicon as the clear button for input type="search" components

### DIFF
--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -27,5 +27,24 @@
   input {
     @include textboxish;
     @include textboxish-disabled;
+
+    // Customize the "clear" icon on search text inputs to match our
+    // theme icons and colors.
+    //
+    // To do so, we're creating an opaque 16x16 element with the background color
+    // that we want the icon to appear in and then apply the icon path
+    // as a mask, that way we can control the color dynamically based on
+    // our variables instead of hardcoding it in the SVG.
+    &[type='search']::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      width: 16px;
+      height: 16px;
+      margin-right: 0;
+      background-color: var(--text-color);
+      // The following SVG corresponds to the `x` octicon in 16px size:
+      // https://github.com/primer/octicons/blob/4661c1e0aa30c7d252318d2b003af782a6891089/icons/x-16.svg#L1
+      -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
+      -webkit-mask-repeat: no-repeat;
+    }
   }
 }


### PR DESCRIPTION
## Description

When upgrading to Electron v9, the form controls styling was changed (more info in https://github.com/desktop/desktop/pull/10220).

This caused a small issue with the close icon which was specially appreciable on the dark theme. This PR fixes this by tweaking the CSS and using a CSS `mask` to display the icon.

### Screenshots

**Before:**

<img width="537" alt="Screen Shot 2020-08-17 at 11 47 36" src="https://user-images.githubusercontent.com/408035/90382787-83819f00-e07f-11ea-9268-17297873957d.png">

<img width="527" alt="Screen Shot 2020-08-17 at 11 47 51" src="https://user-images.githubusercontent.com/408035/90382799-88465300-e07f-11ea-801f-1b6c381aa7f4.png">


**After:**

<img width="539" alt="Screen Shot 2020-08-17 at 11 47 14" src="https://user-images.githubusercontent.com/408035/90382816-8c727080-e07f-11ea-830d-c77d52707c26.png">

<img width="508" alt="Screen Shot 2020-08-17 at 11 47 00" src="https://user-images.githubusercontent.com/408035/90382828-91372480-e07f-11ea-92f3-2ac1db4a73ef.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Styling of clear icons on text boxes
