### PR TITLE
Fix label alignment in radio-button component styles

### DIFF
--- a/app/styles/ui/_radio-button.scss
+++ b/app/styles/ui/_radio-button.scss
@@ -1,9 +1,16 @@
 .radio-button-component {
+  display: flex;
+  align-items: center;
+
   & + .radio-button-component {
     margin-top: var(--spacing-half);
   }
 
-  label {
+  & > input {
+    margin: 0;
+  }
+
+  & > label {
     margin: 0;
     margin-left: var(--spacing-half);
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

While reviewing #10262 I noticed that the alignment of the radio button in the Advanced and Git tabs the preferences dialog looked off and didn't align with the checkbox components.

While I haven't verified there's a chance this happened unintentionally in https://github.com/desktop/desktop/pull/10260.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

<img width="617" alt="image" src="https://user-images.githubusercontent.com/634063/90416147-631f0800-e0b2-11ea-9662-8c62938b98f7.png">


#### After

<img width="619" alt="image" src="https://user-images.githubusercontent.com/634063/90416127-5bf7fa00-e0b2-11ea-90b1-901250060862.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
