### PR TITLE
Disable spellchecking for the time being

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -43,6 +43,7 @@ export class AppWindow {
         disableBlinkFeatures: 'Auxclick',
         nodeIntegration: true,
         enableRemoteModule: true,
+        spellcheck: false,
       },
       acceptFirstMouse: true,
     }

--- a/app/src/main-process/crash-window.ts
+++ b/app/src/main-process/crash-window.ts
@@ -37,6 +37,7 @@ export class CrashWindow {
         // See https://developers.google.com/web/updates/2016/10/auxclick
         disableBlinkFeatures: 'Auxclick',
         nodeIntegration: true,
+        spellcheck: false,
       },
     }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I noticed some squiggly red lines under a typo of mine in the latest beta and was surprised because I thought @say25's PR #9767 that dealt with enabling spell checking hadn't been merged. Turns out is hasn't but Electron enabled spellchecking by default in Electron 9.

<img width="240" alt="image" src="https://user-images.githubusercontent.com/634063/90422721-8dc18e80-e0bb-11ea-979f-9ff75c90555a.png">

Unfortunately it only marks unknown words as misspelled but doesn't let the user pick a substitute or add a false-positive to the dictionary. There are [ways of enabling suggestions and opt-outs](https://www.electronjs.org/docs/all#how-do-i-put-the-results-of-the-spellchecker-in-my-context-menu) in the context menu but it'll require a bit more work for us due to our custom context menus for the commit message.

So instead of shipping a half-baked solution I'm turning off spell checking now so that we can use #9767 to discuss a more holistic solution to spellchecking in Desktop including the ability to turn it on/off in preferences.
