### PR TITLE
Add AspNet and Diff/Patch Syntax Highlights

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -121,6 +121,13 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     },
   },
   {
+    install: () => import('codemirror/mode/diff/diff'),
+    mappings: {
+      '.diff': 'text/x-diff',
+      '.patch': 'text/x-diff',
+    },
+  },
+  {
     install: () => import('codemirror/mode/clike/clike'),
     mappings: {
       '.m': 'text/x-objectivec',

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -527,7 +527,7 @@ function getInnerModeName(
  * @param stream       The StringStream for the current line
  * @param state        The current mode state (if any)
  * @param addModeClass Whether or not to append the current (inner) mode name
- *                     as an extra CSS clas to the token, indicating the mode
+ *                     as an extra CSS class to the token, indicating the mode
  *                     that produced it, prefixed with "cm-m-". For example,
  *                     tokens from the XML mode will get the cm-m-xml class.
  */

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -72,6 +72,8 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
   {
     install: () => import('codemirror/mode/htmlembedded/htmlembedded'),
     mappings: {
+      '.aspx': 'application/x-aspx',
+      '.cshtml': 'application/x-aspx',
       '.jsp': 'application/x-jsp',
     },
   },
@@ -114,6 +116,8 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
       '.vbproj': 'text/xml',
       '.svg': 'text/xml',
       '.resx': 'text/xml',
+      '.props': 'text/xml',
+      '.targets': 'text/xml',
     },
   },
   {

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -6,9 +6,9 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 ## Supported languages
 
-We currently support syntax highlighting for the following languages.
+We currently support syntax highlighting for the following languages and file types.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, sh/bash, Swift, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, JavaServer Pages, PowerShell, Docker, Visual Basic, Fortran, Lua, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz and Pascal.
+JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal and Docker.
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]

## Description

- Added syntax highlighting for some Asp.Net Files
   - Extension Examples
       -  [.props](https://github.com/PostgreSQLCopyHelper/PostgreSQLCopyHelper/blob/master/Directory.Build.props)
       - [.targets](https://github.com/npgsql/npgsql/blob/dev/Directory.Build.targets)
       - [.aspx](https://github.com/aspnet/samples/blob/master/samples/aspnet/WebApi/WebFormSample/WebForm/About.aspx)
       - [.cshtml](https://github.com/aspnet/samples/blob/master/samples/aspnet/WebApi/Todo/Todo.Web/Views/Home/Index.cshtml)
  - Added syntax highlighting for diff files

### Related PRs

- https://github.com/desktop/highlighter-tests/pull/41

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added syntax highlight for .props, .targets, .aspx, .cshtml and .patch/.diff files
