### PR TITLE
Allow to rename the default branch

### DIFF
--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -242,7 +242,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.setEnabled(
       'rename-branch',
-      onNonDefaultBranch && !branchIsUnborn && !onDetachedHead
+      !branchIsUnborn && !onDetachedHead
     )
     menuStateBuilder.setEnabled(
       'delete-branch',

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -192,6 +192,8 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     if (tip.kind === TipState.Valid) {
       if (defaultBranch !== null) {
         onNonDefaultBranch = tip.branch.name !== defaultBranch.name
+      } else {
+        onNonDefaultBranch = true
       }
 
       hasPublishedBranch = !!tip.branch.upstream

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -244,7 +244,9 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
 
     menuStateBuilder.setEnabled(
       'rename-branch',
-      !branchIsUnborn && !onDetachedHead
+      (onNonDefaultBranch || !hasPublishedBranch) &&
+        !branchIsUnborn &&
+        !onDetachedHead
     )
     menuStateBuilder.setEnabled(
       'delete-branch',

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3461,18 +3461,33 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     return this.withAuthenticatingUser(repository, async (r, account) => {
       const { branchesState } = this.repositoryStateCache.get(r)
-      const { defaultBranch } = branchesState
+      let branchToCheckout = branchesState.defaultBranch
 
-      if (defaultBranch == null) {
+      // If the default branch is null, use the most recent branch excluding the branch
+      // the branch to delete as the branch to checkout.
+      if (branchToCheckout === null) {
+        let i = 0
+
+        while (i < branchesState.recentBranches.length) {
+          if (branchesState.recentBranches[i].name !== branch.name) {
+            branchToCheckout = branchesState.recentBranches[i]
+            break
+          }
+          i++
+        }
+      }
+
+      if (branchToCheckout === null) {
         throw new Error(
-          `A default branch cannot be found for this repository, so the app is unable to identify which branch to switch to before removing the current branch.`
+          `It's not possible to delete the only existing branch in a repository.`
         )
       }
 
+      const nonNullBranchToCheckout = branchToCheckout
       const gitStore = this.gitStoreCache.get(r)
 
       await gitStore.performFailableOperation(() =>
-        checkoutBranch(r, account, defaultBranch)
+        checkoutBranch(r, account, nonNullBranchToCheckout)
       )
       await gitStore.performFailableOperation(() =>
         deleteBranch(r, branch, account, includeRemote)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -465,7 +465,12 @@ export class GitStore extends BaseStore {
     // priority to local branches by sorting them before remotes
     this._defaultBranch =
       this._allBranches
-        .filter(b => b.name === defaultBranchName)
+        .filter(
+          b =>
+            (b.name === defaultBranchName &&
+              b.upstreamWithoutRemote === null) ||
+            b.upstreamWithoutRemote === defaultBranchName
+        )
         .sort((x, y) => compare(x.type, y.type))
         .shift() || null
   }


### PR DESCRIPTION
## Description

This PR removes the check that prevents the default branch of a repository to be renamed. This action will work fine for local repositories, non-GitHub repositories and GitHub repositories but it causes some minor side effects:

### Local repositories and non-GitHub repositories

When the default branch of a local repository is different than the globally configured default branch in Desktop (see https://github.com/desktop/desktop/pull/10262), then it won't be detected as the default branch:

* The unused branch pruner won't be executed since it won't find the default branch of the repo.
* In the different places where the branches list is displayed, we won't show the default branch at the top of the list.
* The popup asking whether to create a new branch from the current branch or the default branch won't be shown.

Note that none of these side-effects are exclusive to renaming the default branch: This same behaviour will be visible when a user changes its default branch setting in GitHub Desktop and opens an old local repository that has a different default branch than the currently configured.

Also, these side-effects look quite minor to me and taking into account that the main use case of GitHub Desktop is to use it with GitHub repositories I don't think these should block us from shipping this.

### GitHub repositories

When renaming the default branch of a GitHub repository, an expected popup warning the user that the branch also exists on the remote is displayed:

<img width="622" alt="Screen Shot 2020-08-21 at 09 45 36" src="https://user-images.githubusercontent.com/408035/90865704-19287180-e393-11ea-9232-654be807e27c.png">

After renaming the branch, the local branch with the old name tracks the remote branch that has the previous name (as expected):

```sh
$ git branch -vv
* main   0641c9c [origin/master] some commit
```

This seems to work nicely for all the git operations, but as a side effect GitHub Desktop is not able to recognize the renamed branch as the default branch. This seems to be caused by the fact that now the local branch name does not match the default branch name returned by the GitHub API.

We could fix that by tweaking the logic that calculates the default branch on GitHub repositories and take into account branch tracking information in `git` to do a mapping between local and remote branches.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Allow to rename the default branch of a repository
