### PR TITLE
improved detection for publishable builds when running CI

### DIFF
--- a/script/build-platforms.ts
+++ b/script/build-platforms.ts
@@ -32,48 +32,6 @@ export function getSha() {
   )
 }
 
-export function isRunningOnFork() {
-  if (isCircleCI() && process.env.CIRCLE_PR_USERNAME != null) {
-    return true
-  }
-
-  if (
-    isAppveyor() &&
-    process.env.APPVEYOR_PULL_REQUEST_NUMBER != null &&
-    process.env.APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME !== 'desktop/desktop'
-  ) {
-    return true
-  }
-
-  if (
-    isTravis() &&
-    process.env.TRAVIS_PULL_REQUEST_SLUG != null &&
-    // empty string denotes a `push` build
-    process.env.TRAVIS_PULL_REQUEST_SLUG !== '' &&
-    process.env.TRAVIS_PULL_REQUEST_SLUG !== 'desktop/desktop'
-  ) {
-    return true
-  }
-
-  if (
-    isAzurePipelines() &&
-    process.env.SYSTEM_PULLREQUEST_ISFORK != null &&
-    process.env.SYSTEM_PULLREQUEST_ISFORK === 'True'
-  ) {
-    return true
-  }
-
-  if (
-    isGitHubActions() &&
-    process.env.GITHUB_HEAD_REF !== undefined &&
-    process.env.GITHUB_HEAD_REF.length > 0
-  ) {
-    return true
-  }
-
-  return false
-}
-
 export function isTravis() {
   return process.platform === 'linux' && process.env.TRAVIS === 'true'
 }

--- a/script/build.ts
+++ b/script/build.ts
@@ -75,7 +75,7 @@ moveAnalysisFiles()
 if (
   (isCircleCI() || isGitHubActions()) &&
   process.platform === 'darwin' &&
-  isPublishable()
+  isPublishableBuild
 ) {
   console.log('Setting up keychain…')
   cp.execSync(path.join(__dirname, 'setup-macos-keychain'))

--- a/script/build.ts
+++ b/script/build.ts
@@ -72,11 +72,7 @@ generateLicenseMetadata(outRoot)
 
 moveAnalysisFiles()
 
-if (
-  (isCircleCI() || isGitHubActions()) &&
-  process.platform === 'darwin' &&
-  isPublishableBuild
-) {
+if (isGitHubActions() && process.platform === 'darwin' && isPublishableBuild) {
   console.log('Setting up keychain…')
   cp.execSync(path.join(__dirname, 'setup-macos-keychain'))
 }

--- a/script/build.ts
+++ b/script/build.ts
@@ -40,7 +40,7 @@ import {
   isPublishable,
   getIconFileName,
 } from './dist-info'
-import { isRunningOnFork, isCircleCI, isGitHubActions } from './build-platforms'
+import { isCircleCI, isGitHubActions } from './build-platforms'
 
 import { updateLicenseDump } from './licenses/update-license-dump'
 import { verifyInjectedSassVariables } from './validate-sass/validate-all'
@@ -75,7 +75,7 @@ moveAnalysisFiles()
 if (
   (isCircleCI() || isGitHubActions()) &&
   process.platform === 'darwin' &&
-  !isRunningOnFork()
+  isPublishable()
 ) {
   console.log('Setting up keychain…')
   cp.execSync(path.join(__dirname, 'setup-macos-keychain'))

--- a/script/test-setup.ts
+++ b/script/test-setup.ts
@@ -4,13 +4,13 @@ import * as fs from 'fs'
 import * as cp from 'child_process'
 import { getLogFiles } from './review-logs'
 import { getProductName } from '../app/package-info'
-import { getDistPath } from './dist-info'
-import { isCircleCI, isRunningOnFork, isGitHubActions } from './build-platforms'
+import { getDistPath, isPublishable } from './dist-info'
+import { isCircleCI, isGitHubActions } from './build-platforms'
 
 if (
   (isCircleCI() || isGitHubActions()) &&
   process.platform === 'darwin' &&
-  !isRunningOnFork()
+  isPublishable()
 ) {
   const archive = `${getDistPath()}/${getProductName()}.app`
   try {

--- a/script/test-setup.ts
+++ b/script/test-setup.ts
@@ -5,13 +5,9 @@ import * as cp from 'child_process'
 import { getLogFiles } from './review-logs'
 import { getProductName } from '../app/package-info'
 import { getDistPath, isPublishable } from './dist-info'
-import { isCircleCI, isGitHubActions } from './build-platforms'
+import { isGitHubActions } from './build-platforms'
 
-if (
-  (isCircleCI() || isGitHubActions()) &&
-  process.platform === 'darwin' &&
-  isPublishable()
-) {
+if (isGitHubActions() && process.platform === 'darwin' && isPublishable()) {
   const archive = `${getDistPath()}/${getProductName()}.app`
   try {
     console.log('validating signature of Desktop app')


### PR DESCRIPTION
:wave: I hope you're all doing well. Congrats on a shiny new release today - can't wait to try it out myself! Also, no rush on this PR - I can workaround it in the meantime, but seeing this project leverage Actions will make maintaining the fork much easier for me. Kudos!

This is an infrastructure fix for an issue I've started to encounter over in `shiftkey/desktop` since https://github.com/desktop/desktop/pull/9680 was merged into `development`. 

### Description

When I pushed `development` to my fork I see that the CI build on macOS tries to setup the keychain, which it doesn't have access to, and errors.

https://github.com/shiftkey/desktop/runs/1022917605#step:8:403

```
Setting up keychain…
...
security: SecKeychainItemImport: Unknown format in import.
security: SecItemCopyMatching: The specified item could not be found in the keychain.

    at checkExecSyncError (child_process.js:621:11)
    at Object.execSync (child_process.js:657:15)
...
```

I believe it's related to this new check inside `script/build-platforms.ts`:

https://github.com/desktop/desktop/blob/ac3b9e8b871ca57187bcfe5f6332ceaad546be8b/script/build-platforms.ts#L66-L72

My testing indicates that `GITHUB_HEAD_REF` is not always present, and my current working theory is that it's only available for `pull_request` events. I poked at the default branch in my fork to add some tracing output, triggered a `push` event and got these values for the two important environment variables.

https://github.com/shiftkey/desktop/runs/1023228953?check_suite_focus=true#step:6:396

```
Found environment variables GITHUB_REPOSITORY='shiftkey/desktop' and GITHUB_HEAD_REF=''
```

As discussed with @niik below, this PR removes the `isRunningOnFork()` check in favour of the more explicit `isPublishable()` which uses the branch name to determine whether this build should be published (and thus we need to set the keychain).

This PR should trigger a `pull_request` workflow, and avoid setting up the keychain, as these recent PRs indicate is the desired behaviour:

 - `pull_request` event from fork - https://github.com/desktop/desktop/pull/10410 - [[failing console message]](https://github.com/desktop/desktop/runs/1008518373#step:8:409)
 - `pull_request` event from local branch - https://github.com/desktop/desktop/pull/10407 - [[failing console message]](https://github.com/desktop/desktop/runs/1002520685#step:8:407)

There's also some `isCircleCI()` checks in here which are no longer necessary - I won't remove them all, just the ones relevant to this PR.

TODO:

 - [x] confirm CI does not try and setup keychain by default
 - [x] confirm changes work on `shiftkey/desktop`  - https://github.com/shiftkey/desktop/runs/1026751693#step:6:402

## Release notes

Notes: improved detection for publishable builds when running CI
