### PR TITLE
Ditch the publish step timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,3 @@ jobs:
           S3_KEY: ${{ secrets.S3_KEY }}
           S3_SECRET: ${{ secrets.S3_SECRET }}
           S3_BUCKET: github-desktop
-        timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows
-    timeout-minutes: 40
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

The last couple of releases we've done using GitHub Actions have timed out on Windows during the publish step. We've bumped the limit before (https://github.com/desktop/desktop/commit/3ae2720cfa153c6e5385fcc01bb89c704fa2c4da) but the last deploy succeeded with 13 seconds to spare so I'm removing the publish step-specific timeout.