### PR TITLE
refactor: Rename MergeResult to MergeTreeResult

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -13,7 +13,7 @@ import { CloneRepositoryTab } from '../models/clone-repository-tab'
 import { BranchesTab } from '../models/branches-tab'
 import { PullRequest } from '../models/pull-request'
 import { IAuthor } from '../models/author'
-import { MergeResult } from '../models/merge'
+import { MergeTreeResult } from '../models/merge'
 import { ICommitMessage } from '../models/commit-message'
 import {
   IRevertProgress,
@@ -644,7 +644,7 @@ export interface ICompareState {
   readonly formState: IDisplayHistory | ICompareBranch
 
   /** The result of merging the compare branch into the current branch, if a branch selected */
-  readonly mergeStatus: MergeResult | null
+  readonly mergeStatus: MergeTreeResult | null
 
   /** Whether the branch list should be expanded or hidden */
   readonly showBranchList: boolean

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -5,7 +5,7 @@ import { git } from './core'
 import { GitError } from 'dugite'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
-import { MergeResult } from '../../models/merge'
+import { MergeTreeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
 import { parseMergeResult } from '../merge-tree-parser'
 import { spawnAndComplete } from './spawn'
@@ -74,7 +74,7 @@ export async function mergeTree(
   repository: Repository,
   ours: Branch,
   theirs: Branch
-): Promise<MergeResult | null> {
+): Promise<MergeTreeResult | null> {
   const mergeBase = await getMergeBase(repository, ours.tip.sha, theirs.tip.sha)
 
   if (mergeBase === null) {

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -7,7 +7,7 @@ import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { MergeTreeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
-import { parseMergeResult } from '../merge-tree-parser'
+import { parseMergeTreeResult } from '../merge-tree-parser'
 import { spawnAndComplete } from './spawn'
 
 /** Merge the named branch into the current branch. */
@@ -98,7 +98,7 @@ export async function mergeTree(
     return { kind: ComputedAction.Clean, entries: [] }
   }
 
-  return parseMergeResult(output)
+  return parseMergeTreeResult(output)
 }
 
 /**

--- a/app/src/lib/merge-tree-parser.ts
+++ b/app/src/lib/merge-tree-parser.ts
@@ -92,7 +92,7 @@ const blobEntryRe = /^\s{2}(result|our|their|base)\s+(\d{6})\s([0-9a-f]{40})\s(.
  * @param text the stdout from a `git merge-tree` command
  *
  */
-export function parseMergeResult(text: string): MergeTreeResult {
+export function parseMergeTreeResult(text: string): MergeTreeResult {
   const entries = new Array<IMergeTreeEntry>()
 
   const lines = text.split('\n')

--- a/app/src/lib/merge-tree-parser.ts
+++ b/app/src/lib/merge-tree-parser.ts
@@ -1,4 +1,4 @@
-import { IMergeEntry, MergeResult } from '../models/merge'
+import { IMergeTreeEntry, MergeTreeResult } from '../models/merge'
 import { ComputedAction } from '../models/computed-action'
 
 interface IBlobSource {
@@ -9,10 +9,10 @@ interface IBlobSource {
 }
 
 function updateCurrentMergeEntry(
-  entry: IMergeEntry | undefined,
+  entry: IMergeTreeEntry | undefined,
   context: string,
   blobSource: IBlobSource
-): IMergeEntry {
+): IMergeTreeEntry {
   const currentMergeEntry = entry || {
     context,
     diff: '',
@@ -92,13 +92,13 @@ const blobEntryRe = /^\s{2}(result|our|their|base)\s+(\d{6})\s([0-9a-f]{40})\s(.
  * @param text the stdout from a `git merge-tree` command
  *
  */
-export function parseMergeResult(text: string): MergeResult {
-  const entries = new Array<IMergeEntry>()
+export function parseMergeResult(text: string): MergeTreeResult {
+  const entries = new Array<IMergeTreeEntry>()
 
   const lines = text.split('\n')
 
   let mergeEntryHeader: string | undefined
-  let currentMergeEntry: IMergeEntry | undefined
+  let currentMergeEntry: IMergeTreeEntry | undefined
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -196,7 +196,7 @@ import {
 } from '../window-state'
 import { TypedBaseStore } from './base-store'
 import { AheadBehindUpdater } from './helpers/ahead-behind-updater'
-import { MergeResult } from '../../models/merge'
+import { MergeTreeResult } from '../../models/merge'
 import { promiseWithMinimumTimeout, sleep } from '../promise'
 import { BackgroundFetcher } from './helpers/background-fetcher'
 import { inferComparisonBranch } from './helpers/infer-comparison-branch'
@@ -1224,7 +1224,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.currentAheadBehindUpdater.insert(from, to, aheadBehind)
     }
 
-    const loadingMerge: MergeResult = {
+    const loadingMerge: MergeTreeResult = {
       kind: ComputedAction.Loading,
     }
 
@@ -4270,7 +4270,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _mergeBranch(
     repository: Repository,
     branch: string,
-    mergeStatus: MergeResult | null
+    mergeStatus: MergeTreeResult | null
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 

--- a/app/src/models/merge.ts
+++ b/app/src/models/merge.ts
@@ -6,7 +6,7 @@ interface IBlobResult {
   readonly path: string
 }
 
-export interface IMergeEntry {
+export interface IMergeTreeEntry {
   readonly context: string
   readonly base?: IBlobResult
   readonly result?: IBlobResult
@@ -16,26 +16,26 @@ export interface IMergeEntry {
   readonly hasConflicts?: boolean
 }
 
-export type MergeSuccess = {
+export type MergeTreeSuccess = {
   readonly kind: ComputedAction.Clean
-  readonly entries: ReadonlyArray<IMergeEntry>
+  readonly entries: ReadonlyArray<IMergeTreeEntry>
 }
 
-export type MergeError = {
+export type MergeTreeError = {
   readonly kind: ComputedAction.Conflicts
   readonly conflictedFiles: number
 }
 
-export type MergeUnsupported = {
+export type MergeTreeUnsupported = {
   readonly kind: ComputedAction.Invalid
 }
 
-export type MergeLoading = {
+export type MergeTreeLoading = {
   readonly kind: ComputedAction.Loading
 }
 
-export type MergeResult =
-  | MergeSuccess
-  | MergeError
-  | MergeUnsupported
-  | MergeLoading
+export type MergeTreeResult =
+  | MergeTreeSuccess
+  | MergeTreeError
+  | MergeTreeUnsupported
+  | MergeTreeLoading

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -88,7 +88,7 @@ import {
   StatusCallBack,
   ICombinedRefCheck,
 } from '../../lib/stores/commit-status-store'
-import { MergeResult } from '../../models/merge'
+import { MergeTreeResult } from '../../models/merge'
 import {
   UncommittedChangesStrategy,
   UncommittedChangesStrategyKind,
@@ -891,7 +891,7 @@ export class Dispatcher {
   public mergeBranch(
     repository: Repository,
     branch: string,
-    mergeStatus: MergeResult | null
+    mergeStatus: MergeTreeResult | null
   ): Promise<void> {
     return this.appStore._mergeBranch(repository, branch, mergeStatus)
   }

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -6,13 +6,13 @@ import { Branch } from '../../models/branch'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { ActionStatusIcon } from '../lib/action-status-icon'
-import { MergeResult } from '../../models/merge'
+import { MergeTreeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
 
 interface IMergeCallToActionWithConflictsProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
-  readonly mergeStatus: MergeResult | null
+  readonly mergeStatus: MergeTreeResult | null
   readonly currentBranch: Branch
   readonly comparisonBranch: Branch
   readonly commitsBehind: number
@@ -70,7 +70,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
   private renderMergeDetails(
     currentBranch: Branch,
     comparisonBranch: Branch,
-    mergeStatus: MergeResult | null,
+    mergeStatus: MergeTreeResult | null,
     behindCount: number
   ) {
     if (mergeStatus === null) {

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -15,7 +15,7 @@ import {
 import { BranchList, IBranchListItem, renderDefaultBranch } from '../branches'
 import { revSymmetricDifference } from '../../lib/git'
 import { IMatches } from '../../lib/fuzzy-find'
-import { MergeResult } from '../../models/merge'
+import { MergeTreeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
 import { ActionStatusIcon } from '../lib/action-status-icon'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
@@ -62,7 +62,7 @@ interface IMergeState {
   readonly selectedBranch: Branch | null
 
   /** The merge result of comparing the selected branch to the current branch */
-  readonly mergeStatus: MergeResult | null
+  readonly mergeStatus: MergeTreeResult | null
 
   /**
    * The number of commits that would be brought in by the merge.
@@ -145,7 +145,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
   }
 
   private renderMergeStatusMessage(
-    mergeStatus: MergeResult,
+    mergeStatus: MergeTreeResult,
     branch: Branch,
     currentBranch: Branch,
     commitCount: number

--- a/app/test/unit/git/parse-merge-result-test.ts
+++ b/app/test/unit/git/parse-merge-result-test.ts
@@ -2,7 +2,7 @@ import * as Path from 'path'
 import * as FSE from 'fs-extra'
 import * as glob from 'glob'
 
-import { parseMergeResult } from '../../../src/lib/merge-tree-parser'
+import { parseMergeTreeResult } from '../../../src/lib/merge-tree-parser'
 
 import { MergeTreeSuccess, MergeTreeError } from '../../../src/models/merge'
 import { ComputedAction } from '../../../src/models/computed-action'
@@ -42,7 +42,7 @@ describe('parseMergeResult', () => {
     const filePath = Path.resolve(relativePath)
     const input = await FSE.readFile(filePath, { encoding: 'utf8' })
 
-    const result = parseMergeResult(input)
+    const result = parseMergeTreeResult(input)
     expect(result.kind).toBe(ComputedAction.Clean)
 
     const mergeResult = result as MergeTreeSuccess
@@ -60,7 +60,7 @@ describe('parseMergeResult', () => {
     const filePath = Path.resolve(relativePath)
     const input = await FSE.readFile(filePath, { encoding: 'utf8' })
 
-    const result = parseMergeResult(input)
+    const result = parseMergeTreeResult(input)
     expect(result.kind).toBe(ComputedAction.Conflicts)
 
     const mergeResult = result as MergeTreeError
@@ -76,7 +76,7 @@ describe('parseMergeResult', () => {
       it(`can parse conflicts from merging ${theirs} into ${ours}`, async () => {
         const input = await FSE.readFile(f, { encoding: 'utf8' })
 
-        const result = parseMergeResult(input)
+        const result = parseMergeTreeResult(input)
         expect(result.kind).toBe(ComputedAction.Conflicts)
 
         const mergeResult = result as MergeTreeError
@@ -94,7 +94,7 @@ describe('parseMergeResult', () => {
       it(`can parse conflicts from merging ${theirs} into ${ours}`, async () => {
         const input = await FSE.readFile(f, { encoding: 'utf8' })
 
-        const result = parseMergeResult(input)
+        const result = parseMergeTreeResult(input)
         expect(result.kind).toBe(ComputedAction.Conflicts)
 
         const mergeResult = result as MergeTreeError
@@ -112,7 +112,7 @@ describe('parseMergeResult', () => {
       it(`can parse conflicts from merging ${theirs} into ${ours}`, async () => {
         const input = await FSE.readFile(f, { encoding: 'utf8' })
 
-        const result = parseMergeResult(input)
+        const result = parseMergeTreeResult(input)
         expect(result.kind).toBe(ComputedAction.Conflicts)
 
         const mergeResult = result as MergeTreeError

--- a/app/test/unit/git/parse-merge-result-test.ts
+++ b/app/test/unit/git/parse-merge-result-test.ts
@@ -4,7 +4,7 @@ import * as glob from 'glob'
 
 import { parseMergeResult } from '../../../src/lib/merge-tree-parser'
 
-import { MergeSuccess, MergeError } from '../../../src/models/merge'
+import { MergeTreeSuccess, MergeTreeError } from '../../../src/models/merge'
 import { ComputedAction } from '../../../src/models/computed-action'
 
 const filenameRegex = /merge\-(.*)\-into\-(.*).txt/
@@ -45,7 +45,7 @@ describe('parseMergeResult', () => {
     const result = parseMergeResult(input)
     expect(result.kind).toBe(ComputedAction.Clean)
 
-    const mergeResult = result as MergeSuccess
+    const mergeResult = result as MergeTreeSuccess
     expect(mergeResult.entries).toHaveLength(21)
     mergeResult.entries.forEach(e => {
       expect(e.diff).not.toBe('')
@@ -63,7 +63,7 @@ describe('parseMergeResult', () => {
     const result = parseMergeResult(input)
     expect(result.kind).toBe(ComputedAction.Conflicts)
 
-    const mergeResult = result as MergeError
+    const mergeResult = result as MergeTreeError
     expect(mergeResult.conflictedFiles).toBe(1)
   })
 
@@ -79,7 +79,7 @@ describe('parseMergeResult', () => {
         const result = parseMergeResult(input)
         expect(result.kind).toBe(ComputedAction.Conflicts)
 
-        const mergeResult = result as MergeError
+        const mergeResult = result as MergeTreeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
       })
     }
@@ -97,7 +97,7 @@ describe('parseMergeResult', () => {
         const result = parseMergeResult(input)
         expect(result.kind).toBe(ComputedAction.Conflicts)
 
-        const mergeResult = result as MergeError
+        const mergeResult = result as MergeTreeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
       })
     }
@@ -115,7 +115,7 @@ describe('parseMergeResult', () => {
         const result = parseMergeResult(input)
         expect(result.kind).toBe(ComputedAction.Conflicts)
 
-        const mergeResult = result as MergeError
+        const mergeResult = result as MergeTreeError
         expect(mergeResult.conflictedFiles).toBeGreaterThan(0)
       })
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This type is only used to communicate the status or result of a `git merge-tree` operation. This rename will open us up to be able to use MergeResult to communicate the result of a `git merge` operation. I'm opening this ahead of another PR in order to minimize the clutter of all the renames in that PR.

**There should be no logical effects on this change whatsoever, it's straight up a rename of a type and a method**

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes