### PR TITLE
Avoid potentially expensive and potentially network dependent findAccountForRemoteURL in push

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -21,6 +21,7 @@ import {
   setNumberArray,
 } from '../local-storage'
 import { PushOptions } from '../git'
+import { IGitAccount } from '../../models/git-account'
 
 const StatsEndpoint = 'https://central.github.com/api/usage/desktop'
 
@@ -819,13 +820,10 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  public async recordPush(
-    githubAccount: Account | null,
-    options?: PushOptions
-  ) {
-    if (githubAccount === null) {
+  public async recordPush(account: IGitAccount | null, options?: PushOptions) {
+    if (account === null) {
       await this.recordPushToGenericRemote(options)
-    } else if (githubAccount.endpoint === getDotComAPIEndpoint()) {
+    } else if (account.endpoint === getDotComAPIEndpoint()) {
       await this.recordPushToGitHub(options)
     } else {
       await this.recordPushToGitHubEnterprise(options)

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -21,7 +21,6 @@ import {
   setNumberArray,
 } from '../local-storage'
 import { PushOptions } from '../git'
-import { IGitAccount } from '../../models/git-account'
 
 const StatsEndpoint = 'https://central.github.com/api/usage/desktop'
 
@@ -820,10 +819,13 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  public async recordPush(account: IGitAccount | null, options?: PushOptions) {
-    if (account === null) {
+  public async recordPush(
+    githubAccount: Account | null,
+    options?: PushOptions
+  ) {
+    if (githubAccount === null) {
       await this.recordPushToGenericRemote(options)
-    } else if (account.endpoint === getDotComAPIEndpoint()) {
+    } else if (githubAccount.endpoint === getDotComAPIEndpoint()) {
       await this.recordPushToGitHub(options)
     } else {
       await this.recordPushToGitHubEnterprise(options)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -118,7 +118,6 @@ import {
 } from '../editors'
 import { assertNever, fatalError, forceUnwrap } from '../fatal-error'
 
-import { findAccountForRemoteURL } from '../find-account'
 import { formatCommitMessage } from '../format-commit-message'
 import { getGenericHostname, getGenericUsername } from '../generic-git-auth'
 import { getAccountForRepository } from '../get-account-for-repository'
@@ -3676,14 +3675,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.updatePushPullFetchProgress(repository, null)
 
         this.updateMenuLabelsForSelectedRepository()
-
-        const { accounts } = this.getState()
-        const githubAccount = await findAccountForRemoteURL(
-          remote.url,
-          accounts
-        )
-
-        this.statsStore.recordPush(githubAccount, options)
+        this.statsStore.recordPush(account, options)
       }
     })
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3675,7 +3675,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.updatePushPullFetchProgress(repository, null)
 
         this.updateMenuLabelsForSelectedRepository()
-        this.statsStore.recordPush(account, options)
+
+        // Note that we're using `getAccountForRepository` here instead
+        // of the `account` instance we've got and that's because recordPush
+        // needs to be able to differentiate between a GHES account and a
+        // generic account and it can't do that only based on the endpoint.
+        this.statsStore.recordPush(
+          getAccountForRepository(this.accounts, repository),
+          options
+        )
       }
     })
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Ran into this while reviewing another PR. In https://github.com/desktop/desktop/pull/5050 we added metrics to see how many  times a day users  were pushing to either GitHub.com, GitHub Enterprise Server, or other Git hosts.

The `recordPush` method was set up to take an `Account` instance which we used to determine which type of host the push was targeting based on its `endpoint` property. This is all find but since the `_push` app store method didn't have easy access to the `Account` but only `IGitAccount` the decision was made to leverage `findAccountForRemoteURL` to resolve the correct account based on the remote url.

`findAccountForRemoteURL` is a tricky beast though. In some scenarios (likely not in the one we're looking at in _push though) it can start issuing API requests to differentiate between a GHES and a GitHub.com account. Instead we'll leverage the synchronous `getAccountForRepository` method which is what `withAuthenticatingUser` is using to provide the `IGitAccount` to `_push`:

https://github.com/desktop/desktop/blob/47d420132dbc04d76bf5d159ed9f6e531cb89aba/app/src/lib/stores/app-store.ts#L5020-L5062

In fact we were so inclined we could straight up use the `IGitAccount` instance and do something like `recordPush(account instanceof Account ? account : null)` but that's relying on implementation details that we absolutely shouldn't be relying on in this method.