### PR TITLE
Differentiate between draft and regular PRs

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -385,6 +385,7 @@ export interface IAPIPullRequest {
   readonly head: IAPIPullRequestRef
   readonly base: IAPIPullRequestRef
   readonly state: 'open' | 'closed'
+  readonly draft?: boolean
 }
 
 /** The metadata about a GitHub server. */

--- a/app/src/lib/databases/pull-request-database.ts
+++ b/app/src/lib/databases/pull-request-database.ts
@@ -38,6 +38,11 @@ export interface IPullRequest {
 
   /** The login of the author. */
   readonly author: string
+
+  /**
+   * The draft state of the PR or undefined if state is unknown
+   */
+  readonly draft: boolean
 }
 
 /**
@@ -106,6 +111,11 @@ export class PullRequestDatabase extends BaseDatabase {
     this.conditionalVersion(7, {
       pullRequests: '[base.repoId+number]',
       pullRequestsLastUpdated: 'repoId',
+    })
+
+    this.conditionalVersion(8, {}, async tx => {
+      tx.table('pullRequests').clear()
+      tx.table('pullRequestsLastUpdated').clear()
     })
   }
 

--- a/app/src/lib/databases/pull-request-database.ts
+++ b/app/src/lib/databases/pull-request-database.ts
@@ -114,6 +114,15 @@ export class PullRequestDatabase extends BaseDatabase {
     })
 
     this.conditionalVersion(8, {}, async tx => {
+      /**
+       * We're introducing the `draft` property on PRs in version 8 in order
+       * to be able to differentiate between draft and regular PRs. While
+       * we could just make the draft property optional and infer a missing
+       * value to be false that will mean all PRs will be treated as non-draft
+       * and unless the draft PRs get updated at some point in the future we'll
+       * never pick up on it so we'll clear the db to seed it with fresh data
+       * from the API.
+       */
       tx.table('pullRequests').clear()
       tx.table('pullRequestsLastUpdated').clear()
     })

--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -213,7 +213,8 @@ export class PullRequestStore {
           record.number,
           new PullRequestRef(record.head.ref, record.head.sha, headRepository),
           new PullRequestRef(record.base.ref, record.base.sha, baseRepository),
-          record.author
+          record.author,
+          record.draft ?? false
         )
       )
     }
@@ -344,6 +345,7 @@ export class PullRequestStore {
           repoId: baseGitHubRepo.dbID,
         },
         author: pr.user.login,
+        draft: pr.draft ?? false,
       })
     }
 

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -31,6 +31,7 @@ export class PullRequest {
     public readonly pullRequestNumber: number,
     public readonly head: PullRequestRef,
     public readonly base: PullRequestRef,
-    public readonly author: string
+    public readonly author: string,
+    public readonly draft: boolean
   ) {}
 }

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -21,6 +21,9 @@ export interface IPullRequestListItemProps {
   /** The author login. */
   readonly author: string
 
+  /** Whether or not the PR is in draft mode. */
+  readonly draft: boolean
+
   /**
    * Whether or not this list item is a skeleton item
    * put in place while the pull request information is
@@ -58,6 +61,7 @@ export class PullRequestListItem extends React.Component<
     const matches = this.props.matches
     const className = classNames('pull-request-item', {
       loading: this.props.loading === true,
+      draft: this.props.draft,
     })
 
     return (

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -52,7 +52,9 @@ export class PullRequestListItem extends React.Component<
     }
 
     const timeAgo = moment(this.props.created).fromNow()
-    return `#${this.props.number} opened ${timeAgo} by ${this.props.author}`
+    const subtitle = `#${this.props.number} opened ${timeAgo} by ${this.props.author}`
+
+    return this.props.draft ? `${subtitle} • Draft` : subtitle
   }
 
   public render() {

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -61,6 +61,7 @@ export class PullRequestListItem extends React.Component<
     const matches = this.props.matches
     const className = classNames('pull-request-item', {
       loading: this.props.loading === true,
+      open: !this.props.draft,
       draft: this.props.draft,
     })
 

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -166,6 +166,7 @@ export class PullRequestList extends React.Component<
         number={pr.pullRequestNumber}
         created={pr.created}
         author={pr.author}
+        draft={pr.draft}
         matches={matches}
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -441,6 +441,10 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --status-pending-color: #{$yellow-700};
   --status-error-color: #{$red-500};
   --status-success-color: #{$green-500};
+
+  // PR status icon colors
+  --pr-open-icon-color: #{$green-500};
+  --pr-draft-icon-color: #{$gray-500};
 }
 
 ::backdrop {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -337,7 +337,7 @@ body.theme-dark {
 
   // PR status icon colors
   --pr-open-icon-color: #{$green-500};
-  --pr-draft-icon-color: #{$gray-500};
+  --pr-draft-icon-color: #{$gray-400};
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -334,6 +334,10 @@ body.theme-dark {
   --status-pending-color: #{$yellow-700};
   --status-error-color: #{$red-500};
   --status-success-color: #{$green-500};
+
+  // PR status icon colors
+  --pr-open-icon-color: #{$green-500};
+  --pr-draft-icon-color: #{$gray-500};
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -4,14 +4,14 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  width: 350px;
+  width: 365px;
 
   & > .tab-bar {
     border-top: var(--base-border);
   }
 
   .branches-list {
-    width: 350px;
+    width: 365px;
     min-height: 0;
   }
 }
@@ -96,7 +96,7 @@
       flex-direction: column;
       min-width: 0;
       flex-grow: 1;
-      margin-right: var(--spacing);
+      margin-right: var(--spacing-half);
 
       .title {
         @include ellipsis;
@@ -171,7 +171,7 @@
 }
 
 .no-pull-requests {
-  width: 350px;
+  width: 365px;
   display: flex;
   flex-direction: column;
 

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -84,6 +84,13 @@
       margin-top: 2px;
     }
 
+    &.open .icon {
+      color: var(--pr-open-icon-color);
+    }
+    &.draft .icon {
+      color: var(--pr-draft-icon-color);
+    }
+
     .info {
       display: flex;
       flex-direction: column;

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -45,7 +45,7 @@ function createTestPrRef(branch: Branch, ghRepo: GitHubRepository) {
 }
 
 function createTestPr(head: PullRequestRef, base: PullRequestRef) {
-  return new PullRequest(new Date(), '', 1, head, base, '')
+  return new PullRequest(new Date(), '', 1, head, base, '', false)
 }
 
 function createTestRepo(ghRepo: GitHubRepository | null = null) {

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -26,7 +26,8 @@ function createSamplePullRequest(gitHubRepository: GitHubRepository) {
       sha: 'deadbeef',
       gitHubRepository,
     },
-    'shiftkey'
+    'shiftkey',
+    false
   )
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #7170

## Description

As we're increasingly seeing draft PRs in desktop it's become more noticeable that we don't differentiate between draft and regular PRs in desktop. It's a small fix and I figured it'd go nicely along with the other visual improvements we're making in the next production release (#10224, #10396).

Similar to how GitHub.com is differentiating between draft and regular PRs Desktop will change the color of "regular" open PRs to be green and draft PRs to be a more muted gray. For accessibility we'll also add a "draft" text to the description (second line) of PR list items.

I have increased the width of the PR/Branches foldout by 15px and reduce the margin to the status icon by 5px to give us enough room to include the draft state text without truncating.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="389" alt="image" src="https://user-images.githubusercontent.com/634063/91541571-d3ccec80-e91c-11ea-9d39-b896426e0ba9.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/634063/91542209-c3694180-e91d-11ea-8f68-2210aa5d6539.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Differentiate between regular and draft PRs by icon color and text