### PR TITLE
Only focus compare branch input when the compareState changes

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -129,6 +129,10 @@ export class CompareSidebar extends React.Component<
   public componentDidUpdate(prevProps: ICompareSidebarProps) {
     const { showBranchList } = this.props.compareState
 
+    if (showBranchList === prevProps.compareState.showBranchList) {
+      return
+    }
+
     if (this.textbox !== null) {
       if (showBranchList) {
         this.textbox.focus()


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/10479

Potentially addresses https://github.com/desktop/desktop/issues/10473 and https://github.com/desktop/desktop/issues/10463

## Description

This PR addresses the problem where clicking on a branch to compare re-focus the branch input and prevents the compare view from appearing.

It's quite probable that this has existed for a long time, but somehow may be only reproducible when the mouse events and the update from the store come in a certain order, and recent changes may have caused that the ordering has subtly changed and it's more reproducible now.

This seems to have been introduced in https://github.com/desktop/desktop/commit/e7295f44795988c8566be9ea308ac79f1329c32b, where a small refactor on the focus logic did not keep the checks to only do the focus when the compareState changes.

By testing this locally this fix solves the problem, but I wonder if we even need to do the focus on `componentDidUpdate()` (it looks like this was done to allow focusing the input when clicking "Compare Branches..." from the application menu, but the focus seems to be done regardless of this logic).


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Clicking on a branch to compare now opens the compare view
