### PR TITLE
Use UNIX line endings in WSL GitHub helper script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 /app/test/fixtures/** -text
+/app/static/win32/github.sh eol=lf


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10461

## Description

WSL (Windows Subsystem for Linux) is a unix environment for real and the bash that ships with it expects UNIX line endings.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Fixed error when running the github shell command in WSL on Windows