### PR TITLE
Don't discard all submodules when no submodules are specified

### DIFF
--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -80,6 +80,10 @@ export async function resetSubmodulePaths(
   repository: Repository,
   paths: ReadonlyArray<string>
 ): Promise<void> {
+  if (paths.length === 0) {
+    return
+  }
+
   await git(
     ['submodule', 'update', '--recursive', '--force', '--', ...paths],
     repository.path,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1491,7 +1491,10 @@ export class GitStore extends BaseStore {
     // 3. Checkout all the files that we've discarded that existed in the previous
     //    commit from the index.
     await this.performFailableOperation(async () => {
-      await resetSubmodulePaths(this.repository, submodulePaths)
+      if (submodulePaths.length > 0) {
+        await resetSubmodulePaths(this.repository, submodulePaths)
+      }
+
       await resetPaths(
         this.repository,
         GitResetMode.Mixed,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10469

## Description

https://github.com/desktop/desktop/pull/8218/commits/4cad2f5efa7d9578a0f1dbef7c0294fde212e13d  (which was part of #8218) introduced an unfortunate behavioral change

```diff
diff --git a/app/src/lib/git/submodule.ts b/app/src/lib/git/submodule.ts
index 497889aae0..2d15ed3b7b 100644
--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -80,11 +80,9 @@ export async function resetSubmodulePaths(
   repository: Repository,
   paths: ReadonlyArray<string>
 ): Promise<void> {
-  for (const path of paths) {
-    await git(
-      ['submodule', 'update', '--recursive', '--', path],
-      repository.path,
-      'updateSubmodule'
-    )
-  }
+  await git(
+    ['submodule', 'update', '--recursive', '--', ...paths],
+    repository.path,
+    'updateSubmodule'
+  )
 }
```

The intent behind this change was to leverage Git's own functionality for discarding changes in multiple submodules instead of repeatedly executing `git submodule update --recursive --` for each submodule. Unfortunately the removal of the for-loop removed the short-circuit of not calling Git at all if no submodules was provided. Turns out that if `git submodule update` is called without any paths it will enumerate all submodules and update them.

Reviewed in isolation the change looked good assuming that the caller was responsible for not calling the method if it didn't have any specific submodules to update but unfortunate that wasn't the case here:

https://github.com/desktop/desktop/blob/d7e7f602cf49556ef5162bdd2cb8c6be62091424/app/src/lib/stores/git-store.ts#L1493-L1500

Users will not notice this unless the submodule update fails which it might if the submodule isn't checked out and the clone fails (for example).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Discarding changed could fail due to incorrect attempt to update unrelated submodules