### PR TITLE
Release 2.5.5-beta2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.5-beta1",
+  "version": "2.5.5-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,14 @@
 {
   "releases": {
+    "2.5.5-beta2": [
+      "[Added] Differentiate between draft and regular PRs - #7170",
+      "[Fixed] Only focus compare branch input when the compareState changes - #10485",
+      "[Fixed] Don't discard all submodules when no submodules are specified - #10469",
+      "[Fixed] Use UNIX line endings in WSL GitHub helper script - #10461",
+      "[Improved] Allow renaming the default branch before publishing - #10415",
+      "[Improved] Show loading indicator when committing a merge - #10458",
+      "[Improved] Show confirmation that branch is already up to date when merging from default branch - #9095"
+    ],
     "2.5.5-beta1": [
       "[Added] Show status of GitHub Action runs for pull requests - #9819. Thanks @Raul6469!",
       "[Added] Add AspNet and Diff/Patch Syntax Highlights - #10410. Thanks @say25!",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming second beta of the v2.5.5 series? Well you've just found it, congratulations! :tada:

We're targeting a release on September 8 or 9.

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
  No new feature flags
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
  No new metrics