### PR TITLE
Fix keyboard submit in merge and rebase dialog

### DIFF
--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -19,7 +19,7 @@ import {
   BranchGroupIdentifier,
 } from './group-branches'
 import { NoBranches } from './no-branches'
-import { SelectionDirection } from '../lib/list'
+import { SelectionDirection, ClickSource } from '../lib/list'
 
 const RowHeight = 30
 
@@ -58,7 +58,7 @@ interface IBranchListProps {
   ) => void
 
   /** Called when an item is clicked. */
-  readonly onItemClick?: (item: Branch) => void
+  readonly onItemClick?: (item: Branch, source: ClickSource) => void
 
   /**
    * This function will be called when the selection changes as a result of a

--- a/app/src/ui/branches/branch-list.tsx
+++ b/app/src/ui/branches/branch-list.tsx
@@ -252,9 +252,9 @@ export class BranchList extends React.Component<
     ) : null
   }
 
-  private onItemClick = (item: IBranchListItem) => {
+  private onItemClick = (item: IBranchListItem, source: ClickSource) => {
     if (this.props.onItemClick) {
-      this.props.onItemClick(item.branch)
+      this.props.onItemClick(item.branch, source)
     }
   }
 

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -335,6 +335,10 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
   }
 
   private merge = () => {
+    if (!this.canMergeSelectedBranch()) {
+      return
+    }
+
     const branch = this.state.selectedBranch
     if (!branch) {
       return

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -264,7 +264,12 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       this.state.mergeStatus === null ||
       this.state.mergeStatus.kind !== ComputedAction.Invalid
 
-    return !selectedBranchIsCurrentBranch && isBehind && canMergeBranch
+    return (
+      selectedBranch !== null &&
+      !selectedBranchIsCurrentBranch &&
+      isBehind &&
+      canMergeBranch
+    )
   }
 
   public render() {

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -110,12 +110,9 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     }
 
     source.event.preventDefault()
+    const { selectedBranch } = this.state
 
-    if (this.state.selectedBranch !== branch) {
-      this.setState({ selectedBranch: branch }, async () => {
-        await this.updateMergeStatus(branch)
-      })
-    } else {
+    if (selectedBranch !== null && selectedBranch.name === branch.name) {
       this.merge()
     }
   }

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -20,6 +20,7 @@ import { ComputedAction } from '../../models/computed-action'
 import { ActionStatusIcon } from '../lib/action-status-icon'
 import { promiseWithMinimumTimeout } from '../../lib/promise'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
+import { ClickSource } from '../lib/list'
 
 interface IMergeProps {
   readonly dispatcher: Dispatcher
@@ -101,6 +102,22 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
 
   private onFilterTextChanged = (filterText: string) => {
     this.setState({ filterText })
+  }
+
+  private onItemClick = (branch: Branch, source: ClickSource) => {
+    if (source.kind !== 'keyboard' || source.event.key !== 'Enter') {
+      return
+    }
+
+    source.event.preventDefault()
+
+    if (this.state.selectedBranch !== branch) {
+      this.setState({ selectedBranch: branch }, async () => {
+        await this.updateMergeStatus(branch)
+      })
+    } else {
+      this.merge()
+    }
   }
 
   private onSelectionChanged = async (selectedBranch: Branch | null) => {
@@ -288,6 +305,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
             onSelectionChanged={this.onSelectionChanged}
             canCreateNewBranch={false}
             renderBranch={this.renderBranch}
+            onItemClick={this.onItemClick}
           />
         </DialogContent>
         <DialogFooter>

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -258,7 +258,7 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
   public render() {
     const selectedBranch = this.state.selectedBranch
     const currentBranch = this.props.currentBranch
-    const disabled = this.canMergeSelectedBranch()
+    const disabled = !this.canMergeSelectedBranch()
 
     // the amount of characters to allow before we truncate was chosen arbitrarily
     const currentBranchName = truncateWithEllipsis(

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -260,16 +260,14 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
       currentBranch !== null &&
       selectedBranch.name === currentBranch.name
 
-    const validBranchState =
-      selectedBranchIsCurrentBranch &&
-      this.state.commitCount !== undefined &&
-      this.state.commitCount > 0
+    const isBehind =
+      this.state.commitCount !== undefined && this.state.commitCount > 0
 
     const canMergeBranch =
       this.state.mergeStatus === null ||
       this.state.mergeStatus.kind !== ComputedAction.Invalid
 
-    return validBranchState && canMergeBranch
+    return !selectedBranchIsCurrentBranch && isBehind && canMergeBranch
   }
 
   public render() {

--- a/app/src/ui/merge-branch/merge.tsx
+++ b/app/src/ui/merge-branch/merge.tsx
@@ -234,23 +234,31 @@ export class Merge extends React.Component<IMergeProps, IMergeState> {
     return renderDefaultBranch(item, matches, this.props.currentBranch)
   }
 
-  public render() {
+  private canMergeSelectedBranch() {
     const selectedBranch = this.state.selectedBranch
     const currentBranch = this.props.currentBranch
 
-    const selectedBranchIsNotCurrentBranch =
-      selectedBranch === null ||
-      currentBranch === null ||
-      currentBranch.name === selectedBranch.name
+    const selectedBranchIsCurrentBranch =
+      selectedBranch !== null &&
+      currentBranch !== null &&
+      selectedBranch.name === currentBranch.name
 
-    const invalidBranchState =
-      selectedBranchIsNotCurrentBranch || this.state.commitCount === 0
+    const validBranchState =
+      selectedBranchIsCurrentBranch &&
+      this.state.commitCount !== undefined &&
+      this.state.commitCount > 0
 
-    const cannotMergeBranch =
-      this.state.mergeStatus != null &&
-      this.state.mergeStatus.kind === ComputedAction.Invalid
+    const canMergeBranch =
+      this.state.mergeStatus === null ||
+      this.state.mergeStatus.kind !== ComputedAction.Invalid
 
-    const disabled = invalidBranchState || cannotMergeBranch
+    return validBranchState && canMergeBranch
+  }
+
+  public render() {
+    const selectedBranch = this.state.selectedBranch
+    const currentBranch = this.props.currentBranch
+    const disabled = this.canMergeSelectedBranch()
 
     // the amount of characters to allow before we truncate was chosen arbitrarily
     const currentBranchName = truncateWithEllipsis(

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -225,6 +225,7 @@ export class ChooseBranchDialog extends React.Component<
 
   private canRebaseSelectedBranch() {
     return (
+      this.state.selectedBranch !== null &&
       !this.selectedBranchIsCurrentBranch() &&
       this.selectedBranchIsAheadOfCurrentBranch()
     )

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -375,6 +375,10 @@ export class ChooseBranchDialog extends React.Component<
       return
     }
 
+    if (!this.canRebaseSelectedBranch()) {
+      return
+    }
+
     this.props.dispatcher.startRebase(
       repository,
       selectedBranch,

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -216,8 +216,10 @@ export class ChooseBranchDialog extends React.Component<
   }
 
   public render() {
+    const { selectedBranch } = this.state
     const { currentBranch } = this.props
 
+    const tooltip = this.selectedBranchIsCurrentBranch()
       ? 'You are not able to rebase this branch onto itself'
       : !this.selectedBranchIsAheadOfCurrentBranch()
       ? 'There are no commits on the current branch to rebase'

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -199,13 +199,8 @@ export class ChooseBranchDialog extends React.Component<
     source.event.preventDefault()
 
     const { selectedBranch } = this.state
-    const { currentBranch } = this.props
 
-    if (selectedBranch === null || selectedBranch.name !== branch.name) {
-      this.setState({ selectedBranch: branch }, async () => {
-        await this.updateRebaseStatus(branch, currentBranch)
-      })
-    } else {
+    if (selectedBranch !== null && selectedBranch.name === branch.name) {
       this.startRebase()
     }
   }

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -190,25 +190,36 @@ export class ChooseBranchDialog extends React.Component<
     return renderDefaultBranch(item, matches, this.props.currentBranch)
   }
 
+  private selectedBranchIsCurrentBranch() {
+    const currentBranch = this.props.currentBranch
+    const { selectedBranch } = this.state
+    return (
+      selectedBranch !== null &&
+      currentBranch !== null &&
+      selectedBranch.name === currentBranch.name
+    )
+  }
+
+  private selectedBranchIsAheadOfCurrentBranch() {
+    const { rebasePreview } = this.state
+
+    return rebasePreview !== null && rebasePreview.kind === ComputedAction.Clean
+      ? rebasePreview.commits.length > 0
+      : false
+  }
+
+  private canRebaseSelectedBranch() {
+    return (
+      !this.selectedBranchIsCurrentBranch() &&
+      this.selectedBranchIsAheadOfCurrentBranch()
+    )
+  }
+
   public render() {
-    const { selectedBranch, rebasePreview } = this.state
     const { currentBranch } = this.props
 
-    const selectedBranchIsNotCurrentBranch =
-      selectedBranch === null ||
-      currentBranch === null ||
-      currentBranch.name === selectedBranch.name
-
-    const noCommitsToRebase =
-      rebasePreview !== null && rebasePreview.kind === ComputedAction.Clean
-        ? rebasePreview.commits.length === 0
-        : true
-
-    const disabled = selectedBranchIsNotCurrentBranch || noCommitsToRebase
-
-    const tooltip = selectedBranchIsNotCurrentBranch
       ? 'You are not able to rebase this branch onto itself'
-      : noCommitsToRebase
+      : !this.selectedBranchIsAheadOfCurrentBranch()
       ? 'There are no commits on the current branch to rebase'
       : undefined
 
@@ -244,13 +255,13 @@ export class ChooseBranchDialog extends React.Component<
             onSelectionChanged={this.onSelectionChanged}
             canCreateNewBranch={false}
             renderBranch={this.renderBranch}
+            onItemClick={this.onItemClick}
           />
         </DialogContent>
         <DialogFooter>
           {this.renderRebaseStatus()}
           <OkCancelButtonGroup
             okButtonText="Start rebase"
-            okButtonDisabled={disabled}
             okButtonTitle={tooltip}
             cancelButtonVisible={false}
           />


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10511 

## Description

This allows users to initiate a merge or rebase by pressing Enter while focused on the list of branches or the filter text box (assuming there's a match) in the merge and rebase dialogs.

Since the only way to start a merge or rebase prior to this PR was clicking the button I've also had to rearrange the validation logic a bit to ensure that we don't simply rely on the button's enabled state to determine whether we can proceed or not.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Pressing Enter in the merge or rebase dialog will now start the merge or rebase