### PR TITLE
Release GitHub Desktop v2.5.5

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -80,6 +80,10 @@ export async function resetSubmodulePaths(
   repository: Repository,
   paths: ReadonlyArray<string>
 ): Promise<void> {
+  if (paths.length === 0) {
+    return
+  }
+
   await git(
     ['submodule', 'update', '--recursive', '--force', '--', ...paths],
     repository.path,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1485,7 +1485,10 @@ export class GitStore extends BaseStore {
     // 3. Checkout all the files that we've discarded that existed in the previous
     //    commit from the index.
     await this.performFailableOperation(async () => {
-      await resetSubmodulePaths(this.repository, submodulePaths)
+      if (submodulePaths.length > 0) {
+        await resetSubmodulePaths(this.repository, submodulePaths)
+      }
+
       await resetPaths(
         this.repository,
         GitResetMode.Mixed,

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -129,6 +129,10 @@ export class CompareSidebar extends React.Component<
   public componentDidUpdate(prevProps: ICompareSidebarProps) {
     const { showBranchList } = this.props.compareState
 
+    if (showBranchList === prevProps.compareState.showBranchList) {
+      return
+    }
+
     if (this.textbox !== null) {
       if (showBranchList) {
         this.textbox.focus()

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,9 @@
 {
   "releases": {
+    "2.5.5": [
+      "[Fixed] Don't update submodules when discarding files - #10469",
+      "[Fixed] Clicking on a branch in the compare branch list resets focus to the filter text box - #10485"
+    ],
     "2.5.4": [
       "[Added] Suggest to stash changes when trying to do an operation that requires a clean working directory - #10053",
       "[Added] Autocomplete users and issues from upstream repository when working in a fork - #10084",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

🌵 This branch is based on the already-released 2.5.4 branch. After releasing we need to retarget this PR to development 🌵 

## Description

Looking for the PR for the upcoming v2.5.5 patch release? Well you've just found it, congratulations! :tada:

This released is based off the previous 2.5.4 production release with #10507 and #10485 cherry-picked on top of it. These bugs were deemed impactful enough to warrant an out-of-band release.

We're targeting a release on September 8 or 9.

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
  No new feature flags
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
  No new metrics