### PR TITLE
Flip default branch name preference feature flag and update default value

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -138,5 +138,5 @@ export function enableDiscardLines(): boolean {
  * Should we allow to change the default branch when creating new repositories?
  */
 export function enableDefaultBranchSetting(): boolean {
-  return enableBetaFeatures()
+  return true
 }

--- a/app/src/lib/helpers/default-branch.ts
+++ b/app/src/lib/helpers/default-branch.ts
@@ -1,9 +1,22 @@
 import { getGlobalConfigValue, setGlobalConfigValue } from '../git'
 import { enableDefaultBranchSetting } from '../feature-flag'
 
+/**
+ * The default branch name that Desktop's embedded version of Git
+ * will use when initializing a new repository.
+ */
 export const DefaultBranchInGit = 'master'
+
+/**
+ * The default branch name that GitHub Desktop will use when
+ * initializing a new repository.
+ */
 export const DefaultBranchInDesktop = 'main'
 
+/**
+ * The name of the Git configuration variable which holds what
+ * branch name Git will use when initializing a new repository.
+ */
 const DefaultBranchSettingName = 'init.defaultBranch'
 
 /**

--- a/app/src/lib/helpers/default-branch.ts
+++ b/app/src/lib/helpers/default-branch.ts
@@ -23,7 +23,7 @@ const DefaultBranchSettingName = 'init.defaultBranch'
  * The branch names that Desktop shows by default as radio buttons on the
  * form that allows users to change default branch name.
  */
-export const SuggestedBranchNames: ReadonlyArray<string> = ['master', 'main']
+export const SuggestedBranchNames: ReadonlyArray<string> = ['main', 'master']
 
 /**
  * Returns the configured default branch when creating new repositories

--- a/app/src/lib/helpers/default-branch.ts
+++ b/app/src/lib/helpers/default-branch.ts
@@ -2,6 +2,7 @@ import { getGlobalConfigValue, setGlobalConfigValue } from '../git'
 import { enableDefaultBranchSetting } from '../feature-flag'
 
 export const DefaultBranchInGit = 'master'
+export const DefaultBranchInDesktop = 'main'
 
 const DefaultBranchSettingName = 'init.defaultBranch'
 
@@ -26,7 +27,7 @@ async function getConfiguredDefaultBranch(): Promise<string | null> {
  * Returns the configured default branch when creating new repositories
  */
 export async function getDefaultBranch(): Promise<string> {
-  return (await getConfiguredDefaultBranch()) ?? DefaultBranchInGit
+  return (await getConfiguredDefaultBranch()) ?? DefaultBranchInDesktop
 }
 
 /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This is in advance of the next production release and enables the default branch name preference flow (https://github.com/desktop/desktop/pull/10262) for production as well as updates the default value for new repositories created in Desktop.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] New settings to customize the default branch name to use for new repositories
[New] Repositories are created with 'main' as the initial branch name