### PR TITLE
Fix accidental merge of 2.5.5 release

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.5-beta1",
+  "version": "2.5.5",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,9 @@
 {
   "releases": {
+    "2.5.5": [
+      "[Fixed] Don't update submodules when discarding files - #10469",
+      "[Fixed] Clicking on a branch in the compare branch list resets focus to the filter text box - #10485"
+    ],
     "2.5.5-beta1": [
       "[Added] Show status of GitHub Action runs for pull requests - #9819. Thanks @Raul6469!",
       "[Added] Add AspNet and Diff/Patch Syntax Highlights - #10410. Thanks @say25!",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

When merging #10524 I forgot to retarget it to development 🤦 This brings development up to date with the latest production release by incorporating the 2.5.5 patch release.
