### PR TITLE
Show which files are blocking a merge-like operation

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -264,4 +264,5 @@ export type Popup =
       type: PopupType.LocalChangesOverwritten
       repository: Repository
       retryAction: RetryAction
+      files: Array<string>
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -264,5 +264,5 @@ export type Popup =
       type: PopupType.LocalChangesOverwritten
       repository: Repository
       retryAction: RetryAction
-      files: Array<string>
+      files: ReadonlyArray<string>
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1994,6 +1994,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             hasExistingStash={existingStash !== null}
             retryAction={popup.retryAction}
             onDismissed={onPopupDismissedFn}
+            files={popup.files}
           />
         )
       default:

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -24,6 +24,7 @@ import {
 } from '../../lib/feature-flag'
 import { RetryActionType } from '../../models/retry-actions'
 import { sendNonFatalException } from '../../lib/helpers/non-fatal-exception'
+import { parseFilesToBeOverwritten } from '../lib/parse-files-to-be-overwritten'
 
 /** An error which also has a code property. */
 interface IErrorWithCode extends Error {
@@ -731,26 +732,7 @@ export async function localChangesOverwrittenHandler(
     return error
   }
 
-  const files = new Array<string>()
-  const { stderr } = gitError.result
-  let inFilesList = false
-
-  for (const line of stderr.split('\n')) {
-    if (!inFilesList) {
-      if (
-        line.startsWith('error:') &&
-        line.includes('files would be overwritten') &&
-        line.endsWith(':')
-      ) {
-        inFilesList = true
-      }
-    } else {
-      if (!line.startsWith('\t')) {
-        break
-      }
-      files.push(line.trimLeft())
-    }
-  }
+  const files = parseFilesToBeOverwritten(gitError)
 
   dispatcher.showPopup({
     type: PopupType.LocalChangesOverwritten,

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -732,7 +732,7 @@ export async function localChangesOverwrittenHandler(
     return error
   }
 
-  const files = parseFilesToBeOverwritten(gitError)
+  const files = parseFilesToBeOverwritten(gitError.result.stderr)
 
   dispatcher.showPopup({
     type: PopupType.LocalChangesOverwritten,

--- a/app/src/ui/lib/parse-files-to-be-overwritten.ts
+++ b/app/src/ui/lib/parse-files-to-be-overwritten.ts
@@ -1,0 +1,31 @@
+import { GitError } from '../../lib/git'
+import { GitError as DugiteError } from 'dugite'
+
+export function parseFilesToBeOverwritten(error: GitError) {
+  const dugiteError = error.result.gitError
+  const files = new Array<string>()
+
+  if (
+    dugiteError !== DugiteError.LocalChangesOverwritten &&
+    dugiteError !== DugiteError.MergeWithLocalChanges &&
+    dugiteError !== DugiteError.RebaseWithLocalChanges
+  ) {
+    return files
+  }
+
+  const { stderr } = error.result
+  const lines = stderr.split('\n')
+
+  const start = lines.findIndex(
+    l =>
+      l.startsWith('error:') &&
+      l.includes('files would be overwritten') &&
+      l.endsWith(':')
+  )
+
+  for (let i = start; i < lines.length && lines[i].startsWith('\t'); i++) {
+    files.push(lines[i].trimLeft())
+  }
+
+  return files
+}

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -10,6 +10,7 @@ import { Repository } from '../../models/repository'
 import { RetryAction, RetryActionType } from '../../models/retry-actions'
 import { Dispatcher } from '../dispatcher'
 import { assertNever } from '../../lib/fatal-error'
+import { PathText } from '../lib/path-text'
 
 interface ILocalChangesOverwrittenDialogProps {
   readonly repository: Repository
@@ -26,6 +27,8 @@ interface ILocalChangesOverwrittenDialogProps {
    * Callback to use when the dialog gets closed.
    */
   readonly onDismissed: () => void
+
+  readonly files: Array<string>
 }
 interface ILocalChangesOverwrittenDialogState {
   readonly stashingAndRetrying: boolean
@@ -41,9 +44,15 @@ export class LocalChangesOverwrittenDialog extends React.Component<
   }
 
   public render() {
+    const overwrittenText =
+      this.props.files.length > 0
+        ? ' The following files would be overwritten:'
+        : null
+
     return (
       <Dialog
         title="Error"
+        id="local-changes-overwritten"
         loading={this.state.stashingAndRetrying}
         disabled={this.state.stashingAndRetrying}
         onDismissed={this.props.onDismissed}
@@ -53,12 +62,32 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         <DialogContent>
           <p>
             Unable to {this.getRetryActionName()} when changes are present on
-            your branch.
+            your branch.{overwrittenText}
           </p>
+          {this.renderFiles()}
           {this.renderStashText()}
         </DialogContent>
         {this.renderFooter()}
       </Dialog>
+    )
+  }
+
+  private renderFiles() {
+    const { files } = this.props
+    if (files.length === 0) {
+      return null
+    }
+
+    return (
+      <div className="files-list">
+        <ul>
+          {files.map(fileName => (
+            <li key={fileName}>
+              <PathText path={fileName} />
+            </li>
+          ))}
+        </ul>
+      </div>
     )
   }
 

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -28,7 +28,7 @@ interface ILocalChangesOverwrittenDialogProps {
    */
   readonly onDismissed: () => void
 
-  readonly files: Array<string>
+  readonly files: ReadonlyArray<string>
 }
 interface ILocalChangesOverwrittenDialogState {
   readonly stashingAndRetrying: boolean

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -28,6 +28,10 @@ interface ILocalChangesOverwrittenDialogProps {
    */
   readonly onDismissed: () => void
 
+  /**
+   * The files that prevented the operation from completing, i.e. the files
+   * that would be overwritten.
+   */
   readonly files: ReadonlyArray<string>
 }
 interface ILocalChangesOverwrittenDialogState {

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -80,3 +80,4 @@
 @import 'ui/suggested-actions/suggested-action';
 @import 'ui/suggested-actions/suggested-action-group';
 @import 'ui/config-lock-file-exists';
+@import 'ui/local-changes-overwritten';

--- a/app/styles/ui/_local-changes-overwritten.scss
+++ b/app/styles/ui/_local-changes-overwritten.scss
@@ -1,0 +1,21 @@
+#local-changes-overwritten {
+  .dialog-content {
+    .files-list {
+      max-height: 175px;
+      overflow-y: auto;
+      font-family: var(--font-family-monospace);
+      margin-bottom: var(--spacing);
+
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+
+        li {
+          padding-left: 0;
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/app/test/unit/parse-files-to-be-overwritten-test.ts
+++ b/app/test/unit/parse-files-to-be-overwritten-test.ts
@@ -28,4 +28,74 @@ describe('parseFilesToBeOverwritten', () => {
     expect(result.gitError).toBe(DugiteError.MergeWithLocalChanges)
     expect(parseFilesToBeOverwritten(result.stderr)).toEqual(['a', 'b'])
   })
+
+  it("isn't able to parse files from pull rebase error", async () => {
+    const parent = await setupEmptyRepository()
+    await writeFile(join(parent.path, 'a'), '1')
+    await writeFile(join(parent.path, 'b'), '2')
+    await git(['add', 'a', 'b'], parent.path, 'add')
+    await git(['commit', '-m', 'initial'], parent.path, 'add')
+
+    await writeFile(join(parent.path, 'a'), '3')
+    await writeFile(join(parent.path, 'b'), '4')
+    await git(['add', 'a', 'b'], parent.path, 'add')
+    await git(['commit', '-m', 'second'], parent.path, 'add')
+
+    const fork = await cloneLocalRepository(parent)
+    await git(['reset', 'HEAD^'], fork.path, 'reset')
+    const result = await git(['pull', '--rebase'], fork.path, 'pull', {
+      expectedErrors: new Set([DugiteError.RebaseWithLocalChanges]),
+    })
+
+    expect(result.gitError).toBe(DugiteError.RebaseWithLocalChanges)
+    expect(parseFilesToBeOverwritten(result.stderr)).toEqual([])
+  })
+
+  it('parses files from merge error', async () => {
+    const repo = await setupEmptyRepository()
+    await writeFile(join(repo.path, 'a'), '1')
+    await writeFile(join(repo.path, 'b'), '2')
+    await git(['add', 'a', 'b'], repo.path, 'add')
+    await git(['commit', '-m', 'initial'], repo.path, 'add')
+
+    await writeFile(join(repo.path, 'a'), '3')
+    await writeFile(join(repo.path, 'b'), '4')
+    await git(['add', 'a', 'b'], repo.path, 'add')
+    await git(['commit', '-m', 'second'], repo.path, 'add')
+
+    await git(['reset', 'HEAD^'], repo.path, 'reset')
+    const result = await git(['merge', 'HEAD@{1}'], repo.path, 'merge', {
+      expectedErrors: new Set([DugiteError.MergeWithLocalChanges]),
+    })
+
+    expect(result.gitError).toBe(DugiteError.MergeWithLocalChanges)
+    expect(parseFilesToBeOverwritten(result.stderr)).toEqual(['a', 'b'])
+  })
+
+  it('parses files from checkout error', async () => {
+    const repo = await setupEmptyRepository()
+    await writeFile(join(repo.path, 'a'), '1')
+    await writeFile(join(repo.path, 'b'), '2')
+    await git(['add', 'a', 'b'], repo.path, 'add')
+    await git(['commit', '-m', 'initial'], repo.path, 'add')
+
+    await git(['branch', 'feature-branch'], repo.path, 'branch')
+
+    await writeFile(join(repo.path, 'a'), '3')
+    await writeFile(join(repo.path, 'b'), '4')
+
+    await git(['commit', '-am', 'second'], repo.path, 'add')
+
+    await git(['checkout', 'feature-branch'], repo.path, 'checkout')
+
+    await writeFile(join(repo.path, 'a'), '5')
+    await writeFile(join(repo.path, 'b'), '6')
+
+    const result = await git(['checkout', 'master'], repo.path, 'checkout', {
+      expectedErrors: new Set([DugiteError.LocalChangesOverwritten]),
+    })
+
+    expect(result.gitError).toBe(DugiteError.LocalChangesOverwritten)
+    expect(parseFilesToBeOverwritten(result.stderr)).toEqual(['a', 'b'])
+  })
 })

--- a/app/test/unit/parse-files-to-be-overwritten-test.ts
+++ b/app/test/unit/parse-files-to-be-overwritten-test.ts
@@ -1,0 +1,31 @@
+import { setupEmptyRepository } from '../helpers/repositories'
+import { writeFile } from 'fs-extra'
+import { join } from 'path'
+import { git } from '../../src/lib/git'
+import { cloneLocalRepository } from '../helpers/repository-scaffolding'
+import { GitError as DugiteError } from 'dugite'
+import { parseFilesToBeOverwritten } from '../../src/ui/lib/parse-files-to-be-overwritten'
+
+describe('parseFilesToBeOverwritten', () => {
+  it('parses files from pull error', async () => {
+    const parent = await setupEmptyRepository()
+    await writeFile(join(parent.path, 'a'), '1')
+    await writeFile(join(parent.path, 'b'), '2')
+    await git(['add', 'a', 'b'], parent.path, 'add')
+    await git(['commit', '-m', 'initial'], parent.path, 'add')
+
+    await writeFile(join(parent.path, 'a'), '3')
+    await writeFile(join(parent.path, 'b'), '4')
+    await git(['add', 'a', 'b'], parent.path, 'add')
+    await git(['commit', '-m', 'second'], parent.path, 'add')
+
+    const fork = await cloneLocalRepository(parent)
+    await git(['reset', 'HEAD^'], fork.path, 'reset')
+    const result = await git(['pull'], fork.path, 'pull', {
+      expectedErrors: new Set([DugiteError.MergeWithLocalChanges]),
+    })
+
+    expect(result.gitError).toBe(DugiteError.MergeWithLocalChanges)
+    expect(parseFilesToBeOverwritten(result.stderr)).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10441

## Description

In #10053 we added a custom error dialog for when a pull, checkout, merge, or rebase fails due to there being changes in the working directory. In the dialog we added a quick way to stash all changes and continue the operation.

Since then we've been made aware (in #10441, and #10549) that some users depended on the raw error message from Git to know which specific files in their working directory was preventing the operation.

In this PR we parse those details out of the raw error message and incorporate them into the dialog, hopefully producing a satisfying result for all.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before #10053 

![image](https://user-images.githubusercontent.com/634063/92771237-ff2eed00-f39a-11ea-8b72-fc8723543cf3.png)

#### In production today (2.5.5)


![image](https://user-images.githubusercontent.com/634063/92771373-21286f80-f39b-11ea-9aa3-b49178a14839.png)


#### After this PR

![image](https://user-images.githubusercontent.com/634063/92771499-39988a00-f39b-11ea-9e68-60004e58c2bd.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Show which uncommitted changes prevented a merge, pull, or checkout operation from completing