### PR TITLE
Toggle Fullscreen Info Popup

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -216,6 +216,9 @@ export interface IAppState {
   /** Whether we should automatically change the currently selected appearance (aka theme) */
   readonly automaticallySwitchTheme: boolean
 
+  /** Whether we should display a toast notification when the user enters fullscreen */
+  readonly displayFullscreenInfoToast: boolean
+
   /**
    * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -72,6 +72,8 @@ import {
   setPersistedTheme,
   getAutoSwitchPersistedTheme,
   setAutoSwitchPersistedTheme,
+  getDisplayFullscreenInfoToast,
+  setDisplayFullscreenInfoToast,
 } from '../../ui/lib/application-theme'
 import {
   getAppMenu,
@@ -417,6 +419,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.Light
   private automaticallySwitchTheme = false
+  private displayFullscreenInfoToast = true
 
   private hasUserViewedStash = false
 
@@ -751,6 +754,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
       automaticallySwitchTheme: this.automaticallySwitchTheme,
+      displayFullscreenInfoToast: this.displayFullscreenInfoToast,
       apiRepositories: this.apiRepositoriesStore.getState(),
       optOutOfUsageTracking: this.statsStore.getOptOut(),
       currentOnboardingTutorialStep: this.currentOnboardingTutorialStep,
@@ -1841,6 +1845,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.emitUpdate()
       }
     })
+
+    this.displayFullscreenInfoToast = getDisplayFullscreenInfoToast()
 
     this.emitUpdateNow()
 
@@ -5574,6 +5580,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setAutomaticallySwitchTheme(automaticallySwitchTheme: boolean) {
     setAutoSwitchPersistedTheme(automaticallySwitchTheme)
     this.automaticallySwitchTheme = automaticallySwitchTheme
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the application-wide full screen prompt display
+   */
+  public _setDisplayFullscreenInfoToast(displaysFullscreenToast: boolean) {
+    setDisplayFullscreenInfoToast(displaysFullscreenToast)
+    this.displayFullscreenInfoToast = displaysFullscreenToast
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1378,6 +1378,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
             automaticallySwitchTheme={this.state.automaticallySwitchTheme}
+            displaysFullscreenInfoToast={this.state.displayFullscreenInfoToast}
           />
         )
       case PopupType.MergeBranch: {
@@ -2144,7 +2145,12 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private renderFullScreenInfo() {
-    return <FullScreenInfo windowState={this.state.windowState} />
+    return (
+      <FullScreenInfo
+        windowState={this.state.windowState}
+        displaysFullScreenInfo={this.state.displayFullscreenInfoToast}
+      />
+    )
   }
 
   private clearError = (error: Error) => this.props.dispatcher.clearError(error)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2243,6 +2243,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set the displays fullscreen info popover toggle
+   */
+  public onDisplayFullscreenInfoToastChanged(displays: boolean) {
+    return this.appStore._setDisplayFullscreenInfoToast(displays)
+  }
+
+  /**
    * Increments either the `repoWithIndicatorClicked` or
    * the `repoWithoutIndicatorClicked` metric
    */

--- a/app/src/ui/lib/application-theme.ts
+++ b/app/src/ui/lib/application-theme.ts
@@ -74,3 +74,23 @@ export function getAutoSwitchPersistedTheme(): boolean {
 export function setAutoSwitchPersistedTheme(autoSwitchTheme: boolean) {
   setBoolean(automaticallySwitchApplicationThemeKey, autoSwitchTheme)
 }
+
+// The key under which the decision to display a full screen popover is persisted
+// in localStorage.
+const displayFullscreenInfoToastKey = 'displaysFullscreenInfoToast'
+
+/**
+ * Load the whether or not the user wishes to show the fullscreen info popover from the persistent
+ * store (localStorage). If no preference is stored the default
+ * value (true) will be returned.
+ */
+export function getDisplayFullscreenInfoToast(): boolean {
+  return getBoolean(displayFullscreenInfoToastKey, true)
+}
+
+/**
+ * Store whether or not the user wishes to show the fullscreen info popover in the persistent store (localStorage).
+ */
+export function setDisplayFullscreenInfoToast(displayFullscreenToast: boolean) {
+  setBoolean(displayFullscreenInfoToastKey, displayFullscreenToast)
+}

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -14,6 +14,8 @@ interface IAppearanceProps {
   readonly onSelectedThemeChanged: (theme: ApplicationTheme) => void
   readonly automaticallySwitchTheme: boolean
   readonly onAutomaticallySwitchThemeChanged: (checked: boolean) => void
+  readonly displayFullscreenInfoToast: boolean
+  readonly onDisplayFullscreenInfoToastChanged: (checked: boolean) => void
 }
 
 const themes: ReadonlyArray<ISegmentedItem<ApplicationTheme>> = [
@@ -49,11 +51,20 @@ export class Appearance extends React.Component<IAppearanceProps, {}> {
     this.props.onAutomaticallySwitchThemeChanged(value)
   }
 
+  private onDisplayFullscreenInfoToastChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.props.onDisplayFullscreenInfoToastChanged(value)
+  }
+
   public render() {
     return (
       <DialogContent>
         {this.renderThemeOptions()}
         {this.renderAutoSwitcherOption()}
+        {this.renderShowFullscreenInfoToastOption()}
       </DialogContent>
     )
   }
@@ -85,6 +96,22 @@ export class Appearance extends React.Component<IAppearanceProps, {}> {
               : CheckboxValue.Off
           }
           onChange={this.onAutomaticallySwitchThemeChanged}
+        />
+      </Row>
+    )
+  }
+
+  public renderShowFullscreenInfoToastOption() {
+    return (
+      <Row>
+        <Checkbox
+          label="Display exit shortcut when entering fullscreen."
+          value={
+            this.props.displayFullscreenInfoToast
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onDisplayFullscreenInfoToastChanged}
         />
       </Row>
     )

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -52,6 +52,7 @@ interface IPreferencesProps {
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
   readonly automaticallySwitchTheme: boolean
+  readonly displaysFullscreenInfoToast: boolean
 }
 
 interface IPreferencesState {
@@ -307,6 +308,10 @@ export class Preferences extends React.Component<
             onAutomaticallySwitchThemeChanged={
               this.onAutomaticallySwitchThemeChanged
             }
+            displayFullscreenInfoToast={this.props.displaysFullscreenInfoToast}
+            onDisplayFullscreenInfoToastChanged={
+              this.onDisplayFullscreenInfoToastChanged
+            }
           />
         )
         break
@@ -406,6 +411,14 @@ export class Preferences extends React.Component<
   ) => {
     this.props.dispatcher.onAutomaticallySwitchThemeChanged(
       automaticallySwitchTheme
+    )
+  }
+
+  private onDisplayFullscreenInfoToastChanged = (
+    displaysFullscreenInfoToast: boolean
+  ) => {
+    this.props.dispatcher.onDisplayFullscreenInfoToastChanged(
+      displaysFullscreenInfoToast
     )
   }
 

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -4,6 +4,7 @@ import { WindowState } from '../../lib/window-state'
 
 interface IFullScreenInfoProps {
   readonly windowState: WindowState
+  readonly displaysFullScreenInfo: boolean
 }
 
 interface IFullScreenInfoState {
@@ -87,7 +88,7 @@ export class FullScreenInfo extends React.Component<
   }
 
   private renderFullScreenNotification() {
-    if (!this.state.renderInfo) {
+    if (!this.state.renderInfo || !this.props.displaysFullScreenInfo) {
       return null
     }
 


### PR DESCRIPTION
Closes #7916

## Description

- Users now have the option to switch OFF the `Press [key command] to exit fullscreen` popup that appears when:
  - Expanding GitHub to fullscreen
  - and when macOS users switch back to fullscreen GitHub from Mission Control
 - The preference is ON by default (the current behavior)
 - Opt-out from the Preferences -> Appearance menu. 
 - @tierninho explained in issue #7916 that a viable solution to the issues presented by others in that discussion would be preference to disable this feature. This implementation attempts to address the issue with one of the recommended solutions. This PR may also be of interest to @ampinsk.
 - Preferences copy may need to be tweaked for clearer understanding of what this toggle does

### Screenshots

<img width="1596" alt="Screen Shot 2020-09-10 at 3 57 52 PM" src="https://user-images.githubusercontent.com/2374407/92805046-65f1dd80-f37e-11ea-8b28-868a114a7caf.png">

## Release notes

Notes: [Added] Option in Appearance Preferences to disable the fullscreen info popup.