### PR TITLE
Only show full screen toast notification when making the app window full-screen

### DIFF
--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -42,7 +42,11 @@ export class FullScreenInfo extends React.Component<
     }
 
     if (state.computedWindowState !== props.windowState) {
-      return { computedWindowState: props.windowState }
+      return {
+        computedWindowState: props.windowState,
+        renderInfo: props.windowState === 'full-screen',
+        renderTransitionGroup: props.windowState === 'full-screen',
+      }
     }
 
     return null
@@ -66,44 +70,28 @@ export class FullScreenInfo extends React.Component<
     prevProps: IFullScreenInfoProps,
     prevState: IFullScreenInfoState
   ) {
-    // If the window state hasn't change we don't have to do anything
-    if (prevState.computedWindowState === this.state.computedWindowState) {
-      return
+    if (prevState.renderInfo !== this.state.renderInfo) {
+      if (this.state.renderInfo) {
+        this.infoDisappearTimeoutId = window.setTimeout(
+          this.onInfoDisappearTimeout,
+          holdDuration
+        )
+      } else if (this.infoDisappearTimeoutId !== null) {
+        window.clearTimeout(this.infoDisappearTimeoutId)
+      }
     }
 
-    // Clean up any stray timeout
-    if (this.infoDisappearTimeoutId !== null) {
-      window.clearTimeout(this.infoDisappearTimeoutId)
-    }
-
-    if (this.transitionGroupDisappearTimeoutId !== null) {
-      window.clearTimeout(this.transitionGroupDisappearTimeoutId)
-    }
-
-    if (this.state.computedWindowState === 'full-screen') {
-      this.infoDisappearTimeoutId = window.setTimeout(
-        this.onInfoDisappearTimeout,
-        holdDuration
-      )
-
-      this.transitionGroupDisappearTimeoutId = window.setTimeout(
-        this.onTransitionGroupDisappearTimeout,
-        toastTransitionTimeout.appear +
-          holdDuration +
-          toastTransitionTimeout.exit
-      )
-
-      this.setState({
-        renderTransitionGroup: true,
-        renderInfo: true,
-      })
-    } else if (this.state.renderInfo || this.state.renderTransitionGroup) {
-      // We're no longer in full-screen, let's get rid of the notification
-      // immediately without any transitions.
-      this.setState({
-        renderTransitionGroup: false,
-        renderInfo: false,
-      })
+    if (prevState.renderTransitionGroup !== this.state.renderTransitionGroup) {
+      if (this.state.renderTransitionGroup) {
+        this.transitionGroupDisappearTimeoutId = window.setTimeout(
+          this.onTransitionGroupDisappearTimeout,
+          toastTransitionTimeout.appear +
+            holdDuration +
+            toastTransitionTimeout.exit
+        )
+      } else if (this.transitionGroupDisappearTimeoutId !== null) {
+        window.clearTimeout(this.transitionGroupDisappearTimeoutId)
+      }
     }
   }
 

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -14,7 +14,7 @@ interface IFullScreenInfoState {
    * "real" window state regardless of whether the app is in
    * the background or not.
    */
-  readonly computedWindowState: Exclude<WindowState, 'hidden'>
+  readonly windowState?: Exclude<WindowState, 'hidden'>
 }
 
 const toastTransitionTimeout = { appear: 100, exit: 250 }
@@ -41,11 +41,13 @@ export class FullScreenInfo extends React.Component<
       return null
     }
 
-    if (state.computedWindowState !== props.windowState) {
+    if (state.windowState !== props.windowState) {
+      const fullScreen = props.windowState === 'full-screen'
+
       return {
-        computedWindowState: props.windowState,
-        renderInfo: props.windowState === 'full-screen',
-        renderTransitionGroup: props.windowState === 'full-screen',
+        windowState: props.windowState,
+        renderInfo: fullScreen,
+        renderTransitionGroup: fullScreen,
       }
     }
 
@@ -61,8 +63,6 @@ export class FullScreenInfo extends React.Component<
     this.state = {
       renderInfo: false,
       renderTransitionGroup: false,
-      computedWindowState:
-        props.windowState === 'hidden' ? 'normal' : props.windowState,
     }
   }
 

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -3,6 +3,8 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import { WindowState } from '../../lib/window-state'
 
 interface IFullScreenInfoProps {
+  // react-unused-props-and-state doesn't understand getDerivedStateFromProps
+  // tslint:disable-next-line:react-unused-props-and-state
   readonly windowState: WindowState
 }
 

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -78,8 +78,8 @@ export class FullScreenInfo extends React.Component<
           this.onInfoDisappearTimeout,
           holdDuration
         )
-      } else if (this.infoDisappearTimeoutId !== null) {
-        window.clearTimeout(this.infoDisappearTimeoutId)
+      } else {
+        this.clearInfoDisappearTimeout()
       }
     }
 
@@ -91,9 +91,28 @@ export class FullScreenInfo extends React.Component<
             holdDuration +
             toastTransitionTimeout.exit
         )
-      } else if (this.transitionGroupDisappearTimeoutId !== null) {
-        window.clearTimeout(this.transitionGroupDisappearTimeoutId)
+      } else {
+        this.clearTransitionGroupDisappearTimeout()
       }
+    }
+  }
+
+  public componentWillUnmount() {
+    this.clearInfoDisappearTimeout()
+    this.clearTransitionGroupDisappearTimeout()
+  }
+
+  private clearInfoDisappearTimeout() {
+    if (this.infoDisappearTimeoutId !== null) {
+      window.clearTimeout(this.infoDisappearTimeoutId)
+      this.infoDisappearTimeoutId = null
+    }
+  }
+
+  private clearTransitionGroupDisappearTimeout() {
+    if (this.transitionGroupDisappearTimeoutId !== null) {
+      window.clearTimeout(this.transitionGroupDisappearTimeoutId)
+      this.transitionGroupDisappearTimeoutId = null
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #7916 

## Description

@Sam-spencer opened #10554 and made me aware of a macOS bug where we show the full screen notification every time the user switches back to the app while it's in full screen mode.

<img width="281" alt="image" src="https://user-images.githubusercontent.com/634063/92890632-933e9a00-f417-11ea-9bcd-9d303d848175.png">

When looking at the window state changes that happen when switching back to a full-screened app on macOS we see the following

user full-screens the app: `normal -> hidden ->  full-screen`
user moves focus to another app: `full-screen -> hidden`
user moves focus back to desktop: `hidden -> full-screen`.

This is due to our decision early on to merge a window's visibility state with the window state in https://github.com/desktop/desktop/blob/260d1987c31d14536f3fbb31923bdf27e2cb3979/app/src/lib/window-state.ts#L11-L23

For the purposes of the full screen notification we don't care about the visibility of the window though, just whether the window was full-screened or not. As such I think the solution here is to ignore transitions from any window state to 'hidden' and only look at transitions between minimized, normal, maximized, and full-screen.

This PR makes the `FullScreenInfo` component ignore the `hidden` state and I've also taken the time to modernize it to remove the deprecated `componentWillReceiveProps` lifecycle method and favoring `getDerivedStateFromProps` (to react to the prop change) and `componentDidUpdate` to schedule the timers to remove the notification after a set time.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Full screen notification would show on macOS when focusing an already full-screen Window