### PR TITLE
Repository indicator optimizations, round two

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2841,7 +2841,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
 
     if (await this.shouldBackgroundFetch(repository, lastPush)) {
-      await this._fetch(repository, FetchType.BackgroundTask)
+      await this.withAuthenticatingUser(repository, (repository, account) => {
+        const isBackgroundTask = true
+
+        return this.withPushPullFetch(repository, account, () =>
+          gitStore.fetch(account, isBackgroundTask, p =>
+            this.updatePushPullFetchProgress(repository, p)
+          )
+        )
+      })
     }
 
     lookup.set(repository.id, {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2834,18 +2834,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    this.updateSidebarIndicator(repository, status)
+    this.emitUpdate()
+
     const lastPush = await inferLastPushForRepository(
       this.accounts,
       gitStore,
       repository
     )
     const shouldFetch = await this.shouldBackgroundFetch(repository, lastPush)
-
-    lookup.set(repository.id, {
-      aheadBehind: gitStore.aheadBehind,
-      changedFilesCount: status.workingDirectory.files.length,
-    })
-    this.emitUpdate()
 
     if (!shouldFetch) {
       return

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2887,6 +2887,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           this.updatePushPullFetchProgress(repo, progress)
         )
       )
+      this.updatePushPullFetchProgress(repo, null)
 
       return gitStore.aheadBehind
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2842,7 +2842,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const shouldFetch = await this.shouldBackgroundFetch(repository, lastPush)
 
     lookup.set(repository.id, {
-      aheadBehind: lookup.get(repository.id)?.aheadBehind ?? null,
+      aheadBehind: gitStore.aheadBehind,
       changedFilesCount: status.workingDirectory.files.length,
     })
     this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2842,20 +2842,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
       gitStore,
       repository
     )
-    const shouldFetch = await this.shouldBackgroundFetch(repository, lastPush)
 
-    if (!shouldFetch) {
-      return
+    if (await this.shouldBackgroundFetch(repository, lastPush)) {
+      const aheadBehind = await this.fetchForRepositoryIndicator(repository)
+
+      const existing = lookup.get(repository.id)
+      lookup.set(repository.id, {
+        aheadBehind: aheadBehind,
+        changedFilesCount: existing?.changedFilesCount ?? 0,
+      })
+      this.emitUpdate()
     }
-
-    const aheadBehind = await this.fetchForRepositoryIndicator(repository)
-
-    const existing = lookup.get(repository.id)
-    lookup.set(repository.id, {
-      aheadBehind: aheadBehind,
-      changedFilesCount: existing?.changedFilesCount ?? 0,
-    })
-    this.emitUpdate()
   }
 
   private getRepositoriesForIndicatorRefresh = () => {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2888,7 +2888,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const isBackgroundTask = true
       const gitStore = this.gitStoreCache.get(repo)
 
-      await this.withPushPullFetch(repo, account, () =>
+      await this.withPushPullFetch(repo, () =>
         gitStore.fetch(account, isBackgroundTask, p =>
           this.updatePushPullFetchProgress(repo, p)
         )
@@ -3593,7 +3593,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    return this.withPushPullFetch(repository, account, async () => {
+    return this.withPushPullFetch(repository, async () => {
       const { tip } = state.branchesState
 
       if (tip.kind === TipState.Unborn) {
@@ -3784,7 +3784,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private async withPushPullFetch(
     repository: Repository,
-    account: IGitAccount | null,
     fn: () => Promise<void>
   ): Promise<void> {
     const state = this.repositoryStateCache.get(repository)
@@ -3819,7 +3818,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     account: IGitAccount | null
   ): Promise<void> {
-    return this.withPushPullFetch(repository, account, async () => {
+    return this.withPushPullFetch(repository, async () => {
       const gitStore = this.gitStoreCache.get(repository)
       const remote = gitStore.currentRemote
 
@@ -4174,7 +4173,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     fetchType: FetchType,
     remotes?: IRemote[]
   ): Promise<void> {
-    await this.withPushPullFetch(repository, account, async () => {
+    await this.withPushPullFetch(repository, async () => {
       const gitStore = this.gitStoreCache.get(repository)
 
       try {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2889,8 +2889,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const gitStore = this.gitStoreCache.get(repo)
 
       await this.withPushPullFetch(repo, () =>
-        gitStore.fetch(account, isBackgroundTask, p =>
-          this.updatePushPullFetchProgress(repo, p)
+        gitStore.fetch(account, isBackgroundTask, progress =>
+          this.updatePushPullFetchProgress(repo, progress)
         )
       )
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2849,6 +2849,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const existing = lookup.get(repository.id)
       lookup.set(repository.id, {
         aheadBehind: aheadBehind,
+        // We don't need to update changedFilesCount here since it was already
+        // set when calling `updateSidebarIndicator()` with the status object.
         changedFilesCount: existing?.changedFilesCount ?? 0,
       })
       this.emitUpdate()

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -949,9 +949,14 @@ export class GitStore extends BaseStore {
           currentBranch.upstream
         )
         this._aheadBehind = await getAheadBehind(this.repository, range)
-        this.emitUpdate()
+      } else {
+        this._aheadBehind = null
       }
+    } else {
+      this._aheadBehind = null
     }
+
+    this.emitUpdate()
   }
 
   /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This is a follow-up to #10119 and a precursor to being able to disable background updates for repository indicators.

Prior to this PR the repository indicator updater would call `AppStore.performFetch` when fetching repositories. `performFetch` does a fair bit more work than just a fetch, such as a full repository refresh, branch protection updates, and branch fast forwards.

https://github.com/desktop/desktop/blob/5f2038cac8b3ba26f31790d46089afa3b6b2decd/app/src/lib/stores/app-store.ts#L4179-L4192

Since all we need for the repository indicators is an ahead/behind status for the current branch (which we'll get from both [status](https://github.com/desktop/desktop/blob/5f2038cac8b3ba26f31790d46089afa3b6b2decd/app/src/lib/stores/git-store.ts#L1050), and from [running fetch](https://github.com/desktop/desktop/blob/5f2038cac8b3ba26f31790d46089afa3b6b2decd/app/src/lib/stores/git-store.ts#L951)) we can take a shortcut here. We're never run repository indicator refreshes on the currently selected repository and we'll run a full repository refresh when a repository is selected so we're not missing anything.

The second change here is about updating the repository indicator for a repository as soon as we get the results back from `status` instead of waiting for the fetch. That's just a nice little ux improvement.