### PR TITLE
Update rebase progress parser to parse output from the merge rebase backend

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -273,42 +273,41 @@ async function readRebaseHead(repository: Repository): Promise<string | null> {
 }
 
 /** Regex for identifying when rebase applied each commit onto the base branch */
-const rebaseApplyingRe = /^Applying: (.*)/
+const rebasingRe = /^Rebasing \((\d+)\/(\d+)\)$/
 
 /**
  * A parser to read and emit rebase progress from Git `stderr`
  */
 class GitRebaseParser {
-  public constructor(
-    private rebasedCommitCount: number,
-    private readonly totalCommitCount: number
-  ) {}
+  public constructor(private readonly commits: ReadonlyArray<CommitOneLine>) {}
 
   public parse(line: string): IRebaseProgress | null {
-    const match = rebaseApplyingRe.exec(line)
-    if (match === null || match.length !== 2) {
+    const match = rebasingRe.exec(line)
+    if (match === null || match.length !== 3) {
       // Git will sometimes emit other output (for example, when it tries to
       // resolve conflicts) and this does not match the expected output
       return null
     }
 
-    const currentCommitSummary = match[1]
-    this.rebasedCommitCount++
+    const rebasedCommitCount = parseInt(match[1], 10)
+    const totalCommitCount = parseInt(match[2], 10)
 
-    const progress = this.rebasedCommitCount / this.totalCommitCount
-    const value = formatRebaseValue(progress)
-
-    // TODO: dig into why we sometimes get an extra progress event reported
-    if (this.rebasedCommitCount > this.totalCommitCount) {
-      this.rebasedCommitCount = this.totalCommitCount
+    if (isNaN(rebasedCommitCount) || isNaN(totalCommitCount)) {
+      return null
     }
+
+    const currentCommitSummary =
+      this.commits[rebasedCommitCount - 1]?.summary ?? ''
+
+    const progress = rebasedCommitCount / totalCommitCount
+    const value = formatRebaseValue(progress)
 
     return {
       kind: 'rebase',
-      title: `Rebasing commit ${this.rebasedCommitCount} of ${this.totalCommitCount} commits`,
+      title: `Rebasing commit ${rebasedCommitCount} of ${totalCommitCount} commits`,
       value,
-      rebasedCommitCount: this.rebasedCommitCount,
-      totalCommitCount: this.totalCommitCount,
+      rebasedCommitCount: rebasedCommitCount,
+      totalCommitCount: totalCommitCount,
       currentCommitSummary,
     }
   }
@@ -322,7 +321,7 @@ function configureOptionsForRebase(
     return options
   }
 
-  const { rebasedCommitCount, totalCommitCount, progressCallback } = progress
+  const { commits, progressCallback } = progress
 
   return merge(options, {
     processCallback: (process: ChildProcess) => {
@@ -331,7 +330,7 @@ function configureOptionsForRebase(
       if (process.stderr === null) {
         return
       }
-      const parser = new GitRebaseParser(rebasedCommitCount, totalCommitCount)
+      const parser = new GitRebaseParser(commits)
 
       byline(process.stderr).on('data', (line: string) => {
         const progress = parser.parse(line)
@@ -379,11 +378,8 @@ export async function rebase(
       return RebaseResult.Error
     }
 
-    const totalCommitCount = commits.length
-
     options = configureOptionsForRebase(baseOptions, {
-      rebasedCommitCount: 0,
-      totalCommitCount,
+      commits,
       progressCallback,
     })
   }
@@ -492,12 +488,8 @@ export async function continueRebase(
       return RebaseResult.Aborted
     }
 
-    const { progress } = snapshot
-    const { rebasedCommitCount, totalCommitCount } = progress
-
     options = configureOptionsForRebase(baseOptions, {
-      rebasedCommitCount,
-      totalCommitCount,
+      commits: snapshot.commits,
       progressCallback,
     })
   }

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -276,7 +276,7 @@ async function readRebaseHead(repository: Repository): Promise<string | null> {
 const rebaseApplyingRe = /^Applying: (.*)/
 
 /**
- * A parser to read and emit rebase progress from Git `stdout`
+ * A parser to read and emit rebase progress from Git `stderr`
  */
 class GitRebaseParser {
   public constructor(
@@ -327,14 +327,13 @@ function configureOptionsForRebase(
   return merge(options, {
     processCallback: (process: ChildProcess) => {
       // If Node.js encounters a synchronous runtime error while spawning
-      // `stdout` will be undefined and the error will be emitted asynchronously
-      if (!process.stdout) {
+      // `stderr` will be undefined and the error will be emitted asynchronously
+      if (process.stderr === null) {
         return
       }
       const parser = new GitRebaseParser(rebasedCommitCount, totalCommitCount)
 
-      // rebase emits progress messages on `stdout`, not `stderr`
-      byline(process.stdout).on('data', (line: string) => {
+      byline(process.stderr).on('data', (line: string) => {
         const progress = parser.parse(line)
 
         if (progress != null) {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -65,7 +65,6 @@ export enum PopupType {
   CreateTag,
   DeleteTag,
   LocalChangesOverwritten,
-  RebaseConflicts,
   ChooseForkSettings,
   ConfirmDiscardSelection,
 }

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -25,10 +25,7 @@ export type RebaseInternalState = {
  * Options to pass in to rebase progress reporting
  */
 export type RebaseProgressOptions = {
-  /** The number of commits already rebased as part of the operation */
-  rebasedCommitCount: number
-  /** The number of commits to be rebased as part of the operation */
-  totalCommitCount: number
+  commits: ReadonlyArray<CommitOneLine>
   /** The callback to fire when rebase progress is reported */
   progressCallback: (progress: IRebaseProgress) => void
 }

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -1,7 +1,6 @@
 import {
   IStatusResult,
   continueRebase,
-  git,
   getStatus,
 } from '../../../../src/lib/git'
 import {

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -25,8 +25,7 @@ const featureBranchName = 'this-is-a-feature'
 describe('git/rebase', () => {
   describe('skips a normal repository', () => {
     it('returns null for rebase progress', async () => {
-      const repository = await setupEmptyDirectory()
-
+      const repository = setupEmptyDirectory()
       const progress = await getRebaseSnapshot(repository)
 
       expect(progress).toEqual(null)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

In #10077 we upgraded to Git v2.26.2 in which the default rebase backend changed from `apply` to `merge`. Unbeknownst to us at the time was that switching the backend would also affect rebase progress parsing. The result of which meant that our rebase dialogs were stuck on the initial commit for the duration of the rebase.

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/634063/93471290-71e81d00-f8f3-11ea-9212-8f16af9354a4.png">
 
Unfortunately there weren't any tests that would have caught this so I've taken the time to add some which hopefully lets us catch any change in behavior in the rebase space in the future.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Show each step and the overall progress in while applying a rebase