### PR TITLE
Reuse local branch if already checked out when checking out a PR

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5504,7 +5504,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     // Find a remote branch matching the given name or a local branch
-    // whose upstream tracking branch matches the given name (i.e someon
+    // whose upstream tracking branch matches the given name (i.e someone
     // has already checked out the remote branch)
     const findBranch = (name: string) =>
       gitStore.allBranches.find(branch =>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -15,7 +15,7 @@ import {
 import { Account } from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
 import { IAuthor } from '../../models/author'
-import { Branch, IAheadBehind } from '../../models/branch'
+import { Branch, IAheadBehind, BranchType } from '../../models/branch'
 import { BranchesTab } from '../../models/branches-tab'
 import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloningRepository } from '../../models/cloning-repository'
@@ -5503,8 +5503,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const gitStore = this.gitStoreCache.get(repository)
 
+    // Find a remote branch matching the given name or a local branch
+    // whose upstream tracking branch matches the given name (i.e someon
+    // has already checked out the remote branch)
     const findBranch = (name: string) =>
-      gitStore.allBranches.find(branch => branch.name === name) || null
+      gitStore.allBranches.find(branch =>
+        branch.type === BranchType.Local
+          ? branch.upstream === name
+          : branch.name === name
+      ) ?? null
 
     // If we don't have a default remote here, it's probably going
     // to just crash and burn on checkout, but that's okay


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I was trying to check out one of my own PRs (#10593) in Desktop just now and noticed some funky behavior. Instead of simply checking out the local branch that I had used to create the PR in the first place desktop created a new fork-like remote (but with the same URL as desktop/desktop) and checked out a new branch using the `pr/number` format that we use for checking out contributor PRs.

The problem was that when attempting to locate the remote branch in `_getPullRequestHeadBranchInRepo` Desktop only looked for branches whose name exactly matched `origin/disable-repository-indicators` but since I had already checked that branch out there's no such branch in `gitStore.allBranches`, instead there's the local branch `disable-repository-indicators` which has an `.upstream` property of `origin/disable-repository-indicators`.

Likely related to #9382. Note that this regression luckily hasn't made it to production yet, but it does exist on the beta channel.

### Screenshots

#### Before

![2020-09-18 12-10-49 2020-09-18 12_12_02](https://user-images.githubusercontent.com/634063/93586378-833f3100-f9a8-11ea-8edf-abee340184f4.gif)

#### After

![2020-09-18 12-12-08 2020-09-18 12_12_27](https://user-images.githubusercontent.com/634063/93586395-8afed580-f9a8-11ea-9ad3-2d69fa78e41d.gif)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Checking out a PR attempts to locate an existing branch tracking the PR base branch