### PR TITLE
Remove duplicated logic in PR checkout logic

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5551,8 +5551,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
       remote = gitStore.upstreamRemote
     }
 
-    // If we don't have a remote here, it's probably going
-    // to just crash and burn on checkout, but that's okay
     if (remote !== null) {
       return this.findPullRequestHeadInRemote(repository, remote, headRefName)
     }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1259,10 +1259,10 @@ export class GitStore extends BaseStore {
       parent.cloneURL
     )
 
-    await this.performFailableOperation(() =>
-      addRemote(this.repository, UpstreamRemoteName, url)
-    )
-    this._upstreamRemote = { name: UpstreamRemoteName, url }
+    this._upstreamRemote =
+      (await this.performFailableOperation(() =>
+        addRemote(this.repository, UpstreamRemoteName, url)
+      )) ?? null
   }
 
   /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1328,7 +1328,7 @@ export class GitStore extends BaseStore {
    * This will be `null` if the repository isn't a fork, or if the fork doesn't
    * have an upstream remote.
    */
-  private get upstreamRemote(): IRemote | null {
+  public get upstreamRemote(): IRemote | null {
     return this._upstreamRemote
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

~~🌵 Based on #10598, please review that first 🌵~~

## Description

When opening #10598 I spotted [this comment of mine](https://github.com/desktop/desktop/pull/9382#pullrequestreview-476640503) in the original PR for unifying the PR logic:

> I've got [..] some changes that I've made as I've been reviewing that I intend to open as a separate PR once this has merged so that we can review them on their own.

Turns out I had a branch lying around that I never got around to pushing so here it is. Rebased on top of #10598. 

The diff may look a bit intimidating but I recommend disabling whitespace changes to make it a bit easier to see what's really changed. The motivation behind this work was to remove the duplicated logic in `_getPullRequestHeadBranchInRepo` by refactoring that into `findPullRequestHeadInRemote`. In order to do so I also had to expose the `upstreamRemote` property on the `GitStore`.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes