### PR TITLE
Increase base font size slightly

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -64,7 +64,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   // Pixel value used to responsively scale all typography. Applied to the `<html>` element.
   // When adding a new font-size variable, please update the fix-emoji-spacing.ts file.
-  --font-size: 12px;
+  --font-size: 13px;
   --font-size-sm: 11px;
   --font-size-md: 14px;
   --font-size-lg: 28px;

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -336,6 +336,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    */
 
   --diff-line-padding-y: 2px;
+  --diff-font-size: 12px;
 
   --diff-text-color: #{$gray-900};
   --diff-border-color: #{$gray-200};

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -62,6 +62,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    */
   --font-weight-light: 300;
 
+  /**
+   * Font weight to use for medium text
+   */
+  --font-weight-med: 500;
+
   // Pixel value used to responsively scale all typography. Applied to the `<html>` element.
   // When adding a new font-size variable, please update the fix-emoji-spacing.ts file.
   --font-size: 13px;

--- a/app/styles/ui/_about.scss
+++ b/app/styles/ui/_about.scss
@@ -15,20 +15,6 @@ dialog#about {
     p.no-padding {
       margin-bottom: 0;
     }
-
-    .version-text {
-      cursor: pointer;
-      .octicon {
-        color: transparentize(black, 0.5);
-        height: 12px;
-        margin-bottom: -1px;
-        transition: color 0.4s;
-        cursor: pointer;
-      }
-      &:hover .octicon {
-        color: black;
-      }
-    }
   }
 
   .logo {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -10,7 +10,7 @@
   height: 100%;
   color: var(--diff-text-color);
   background: var(--background-color);
-  font-size: var(--font-size-sm);
+  font-size: var(--diff-font-size);
   font-family: var(--font-family-monospace);
 
   span {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -36,7 +36,6 @@
       fill: var(--error-color);
       display: inline-block;
       margin-left: 3px;
-      margin-bottom: -1px;
     }
   }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -142,6 +142,7 @@
   .diff-line-number {
     width: 50%;
     padding: 0 var(--spacing-half);
+    font-size: var(--font-size-sm);
   }
 
   &.diff-add,

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -146,6 +146,15 @@
     font-size: var(--font-size-sm);
     color: var(--diff-line-number-color);
     text-align: right;
+
+    // We want the line numbers to be aligned towards the top
+    // of the cell in case the diff line is wrapped but we also
+    // want the line number to align vertically centered with the
+    // diff line text on non-wrapped lines so we set the line height
+    // to the same height as a diff line. Note that this needs to
+    // be adjusted if the line height of a diff row changes due to
+    // font size changes or other.
+    line-height: 22px;
   }
 
   &.diff-add,

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -140,9 +140,12 @@
   }
 
   .diff-line-number {
+    display: inline-block;
     width: 50%;
     padding: 0 var(--spacing-half);
     font-size: var(--font-size-sm);
+    color: var(--diff-line-number-color);
+    text-align: right;
   }
 
   &.diff-add,
@@ -155,12 +158,6 @@
   &.read-only .after {
     border-right-width: 1px;
   }
-}
-
-.diff-line-number {
-  display: inline-block;
-  color: var(--diff-line-number-color);
-  text-align: right;
 }
 
 .CodeMirror-linebackground {

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -30,7 +30,6 @@
       flex-shrink: 0;
       vertical-align: text-bottom;
       position: relative;
-      top: 1px;
       align-self: center;
     }
 

--- a/app/styles/ui/changes/_no-changes.scss
+++ b/app/styles/ui/changes/_no-changes.scss
@@ -1,5 +1,5 @@
 #no-changes {
-  padding: var(--spacing-quad);
+  padding: var(--spacing-triple);
   width: 100%;
   min-height: 100%;
   display: flex;

--- a/app/styles/ui/changes/_undo-commit.scss
+++ b/app/styles/ui/changes/_undo-commit.scss
@@ -16,6 +16,10 @@
     flex-direction: column;
     font-size: var(--font-size-sm);
 
+    .summary {
+      font-size: var(--font-size);
+    }
+
     .summary,
     .ago {
       @include ellipsis;

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -42,13 +42,13 @@
       }
 
       .version {
-        font-size: 14px;
+        font-size: var(--font-size-md);
         font-weight: var(--font-weight-semibold);
         margin-bottom: 0;
       }
 
       .date {
-        font-size: 11px;
+        font-size: var(--font-size-sm);
         color: var(--text-secondary-color);
       }
     }
@@ -92,7 +92,7 @@
       .section {
         margin: var(--spacing-double) 0;
         .header {
-          font-size: 12px;
+          font-size: var(--font-size);
           font-weight: var(--font-weight-semibold);
         }
       }

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -35,7 +35,7 @@
       }
 
       .summary {
-        font-weight: var(--font-weight-semibold);
+        font-weight: var(--font-weight-med);
       }
 
       .summary,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

As part of the minor visual refresh we're doing (see #10223, #10396) we've come to realize that our base font size of 12px doesn't align with the default operating font size or that of other popular electron applications such as VS Code. As such we've decided to increase it ever so slightly to 13px and the diff font size to 12px (up from 11px).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

<img width="1072" alt="Screen Shot 2020-09-24 at 18 33 27" src="https://user-images.githubusercontent.com/634063/94174014-fa873000-fe94-11ea-87c1-41d02495cdea.png">

#### After

<img width="1072" alt="Screen Shot 2020-09-24 at 18 30 33" src="https://user-images.githubusercontent.com/634063/94173997-f65b1280-fe94-11ea-8629-d62212283f55.png">