### PR TITLE
Fix notification sticking around when app is launched in full screen

### DIFF
--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -68,6 +68,16 @@ export class FullScreenInfo extends React.Component<
     }
   }
 
+  public componentDidMount() {
+    if (this.state.renderInfo) {
+      this.scheduleInfoDisappear()
+    }
+
+    if (this.state.renderTransitionGroup) {
+      this.scheduleTransitionGroupDisappear()
+    }
+  }
+
   public componentDidUpdate(
     prevProps: IFullScreenInfoProps,
     prevState: IFullScreenInfoState

--- a/app/src/ui/window/full-screen-info.tsx
+++ b/app/src/ui/window/full-screen-info.tsx
@@ -74,10 +74,7 @@ export class FullScreenInfo extends React.Component<
   ) {
     if (prevState.renderInfo !== this.state.renderInfo) {
       if (this.state.renderInfo) {
-        this.infoDisappearTimeoutId = window.setTimeout(
-          this.onInfoDisappearTimeout,
-          holdDuration
-        )
+        this.scheduleInfoDisappear()
       } else {
         this.clearInfoDisappearTimeout()
       }
@@ -85,12 +82,7 @@ export class FullScreenInfo extends React.Component<
 
     if (prevState.renderTransitionGroup !== this.state.renderTransitionGroup) {
       if (this.state.renderTransitionGroup) {
-        this.transitionGroupDisappearTimeoutId = window.setTimeout(
-          this.onTransitionGroupDisappearTimeout,
-          toastTransitionTimeout.appear +
-            holdDuration +
-            toastTransitionTimeout.exit
-        )
+        this.scheduleTransitionGroupDisappear()
       } else {
         this.clearTransitionGroupDisappearTimeout()
       }
@@ -102,11 +94,25 @@ export class FullScreenInfo extends React.Component<
     this.clearTransitionGroupDisappearTimeout()
   }
 
+  private scheduleInfoDisappear() {
+    this.infoDisappearTimeoutId = window.setTimeout(
+      this.onInfoDisappearTimeout,
+      holdDuration
+    )
+  }
+
   private clearInfoDisappearTimeout() {
     if (this.infoDisappearTimeoutId !== null) {
       window.clearTimeout(this.infoDisappearTimeoutId)
       this.infoDisappearTimeoutId = null
     }
+  }
+
+  private scheduleTransitionGroupDisappear() {
+    this.transitionGroupDisappearTimeoutId = window.setTimeout(
+      this.onTransitionGroupDisappearTimeout,
+      toastTransitionTimeout.appear + holdDuration + toastTransitionTimeout.exit
+    )
   }
 
   private clearTransitionGroupDisappearTimeout() {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

See https://github.com/desktop/desktop/pull/10561#issuecomment-698834936

> [...] there's an issue if the app is launched with the window already maximised - the notification is displayed and never disappears!

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Full screen notification is removed after a few seconds when starting the app in full screen