### PR TITLE
Align resolve button text and size icon appropriately

### DIFF
--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -73,11 +73,7 @@ dialog#rebase-conflicts-list {
         justify-content: center;
 
         .resolve-arrow-menu {
-          .octicon {
-            margin-left: var(--spacing-half);
-            width: 10px;
-            height: 14px;
-          }
+          line-height: 18px;
         }
       }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

In #10224 we upgraded the version of octicons that we ship and this little fella missed our careful audit of changes. We had an explicit height and width set for the arrow down octicon that didn't align with the dimensions of the new icon causing the text in the button to be misaligned.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before
![Screen Shot 2020-09-25 at 14 23 11](https://user-images.githubusercontent.com/634063/94266985-23fa9700-ff3b-11ea-89a0-8f31ed5b786f.png)

#### After
<img width="521" alt="Screen Shot 2020-09-25 at 14 22 59" src="https://user-images.githubusercontent.com/634063/94266992-265cf100-ff3b-11ea-8f4d-5f2fff18bb15.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes