### PR TITLE
Release 2.5.6-beta3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.6-beta2",
+  "version": "2.5.6-beta3",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -2,7 +2,7 @@
   "releases": {
     "2.5.6-beta3": [
       "[Improved] Email address validation in welcome flow and preferences dialog - #10214. Thanks @Pragya007!",
-      "[Imrproved] Show helpful error when attempting to clone non-existent or inaccessible GitHub repositories - #5661. Thanks @kanishk98!",
+      "[Improved] Show helpful error when attempting to clone non-existent or inaccessible GitHub repositories - #5661. Thanks @kanishk98!",
       "[Fixed] Full screen notification is removed after a few seconds when starting the app in full screen",
       "[Fixed] Align resolve button text and size icon appropriately - #10646"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,11 @@
 {
   "releases": {
+    "2.5.6-beta3": [
+      "[Improved] Email address validation in welcome flow and preferences dialog - #10214. Thanks @Pragya007!",
+      "[Imrproved] Show helpful error when attempting to clone non-existent or inaccessible GitHub repositories - #5661. Thanks @kanishk98!",
+      "[Fixed] Full screen notification is removed after a few seconds when starting the app in full screen",
+      "[Fixed] Align resolve button text and size icon appropriately - #10646"
+    ],
     "2.5.6-beta2": [
       "[New] Newly created repositories use 'main' as the default branch name - #10527",
       "[New] Users can configure the default branch name in Preferences/Options - #10527",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming third beta of the v2.5.6 series? Well you've just found it, congratulations! :tada:

We're targeting a release on September 25th.

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
 - no new feature flags
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
 - no new metrics