### PR TITLE
Add support for Nova as external editor on macOS

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -218,7 +218,7 @@ function getExecutableShim(
     case ExternalEditor.Rider:
       return Path.join(installPath, 'Contents', 'MacOS', 'rider')
     case ExternalEditor.Nova:
-      return Path.join(installPath, 'Contents', 'MacOS', 'Nova')
+      return Path.join(installPath, 'Contents', 'SharedSupport', 'nova')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -394,6 +394,6 @@ export async function getAvailableEditors(): Promise<
   if (novaPath) {
     results.push({ editor: ExternalEditor.Nova, path: novaPath })
   }
-  
+
   return results
 }

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -26,6 +26,7 @@ export enum ExternalEditor {
   GoLand = 'GoLand',
   AndroidStudio = 'Android Studio',
   Rider = 'Rider',
+  Nova = 'Nova',
 }
 
 export function parse(label: string): ExternalEditor | null {
@@ -94,6 +95,9 @@ export function parse(label: string): ExternalEditor | null {
   if (label === ExternalEditor.Rider) {
     return ExternalEditor.Rider
   }
+  if (label === ExternalEditor.Nova) {
+    return ExternalEditor.Nova
+  }
   return null
 }
 
@@ -146,6 +150,8 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
       return ['com.google.android.studio']
     case ExternalEditor.Rider:
       return ['com.jetbrains.rider']
+    case ExternalEditor.Nova:
+      return ['com.panic.Nova']
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -211,6 +217,8 @@ function getExecutableShim(
       return Path.join(installPath, 'Contents', 'MacOS', 'studio')
     case ExternalEditor.Rider:
       return Path.join(installPath, 'Contents', 'MacOS', 'rider')
+    case ExternalEditor.Nova:
+      return Path.join(installPath, 'Contents', 'MacOS', 'Nova')
     default:
       return assertNever(editor, `Unknown external editor: ${editor}`)
   }
@@ -267,6 +275,7 @@ export async function getAvailableEditors(): Promise<
     golandPath,
     androidStudioPath,
     riderPath,
+    novaPath,
   ] = await Promise.all([
     findApplication(ExternalEditor.Atom),
     findApplication(ExternalEditor.MacVim),
@@ -289,6 +298,7 @@ export async function getAvailableEditors(): Promise<
     findApplication(ExternalEditor.GoLand),
     findApplication(ExternalEditor.AndroidStudio),
     findApplication(ExternalEditor.Rider),
+    findApplication(ExternalEditor.Nova),
   ])
 
   if (atomPath) {
@@ -381,5 +391,9 @@ export async function getAvailableEditors(): Promise<
     results.push({ editor: ExternalEditor.Rider, path: riderPath })
   }
 
+  if (novaPath) {
+    results.push({ editor: ExternalEditor.Nova, path: novaPath })
+  }
+  
   return results
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10645 

## Description

Enables autodiscovery of [Nova](https://nova.app) on macOS for use as external editor. 

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
