### PR TITLE
Remove ambiguous log message

### DIFF
--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -88,7 +88,7 @@ export async function envForProxy(
   resolve: (url: string) => Promise<string | undefined> = resolveGitProxy
 ): Promise<NodeJS.ProcessEnv | undefined> {
   if (!enableAutomaticGitProxyConfiguration()) {
-    return undefined
+    return
   }
 
   const protocolMatch = /^(https?):\/\//i.exec(remoteUrl)

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -91,6 +91,14 @@ export async function envForProxy(
     return undefined
   }
 
+  const protocolMatch = /^(https?):\/\//i.exec(remoteUrl)
+
+  // We can only resolve and use a proxy for the protocols where cURL
+  // would be involved (i.e http and https). git:// relies on ssh.
+  if (protocolMatch === null) {
+    return
+  }
+
   // We'll play it safe and say that if the user has configured
   // the ALL_PROXY environment variable they probably know what
   // they're doing and wouldn't want us to override it with a
@@ -99,15 +107,6 @@ export async function envForProxy(
   // https://github.com/curl/curl/blob/14916a82e/lib/url.c#L2180-L2185
   if ('ALL_PROXY' in env || 'all_proxy' in env) {
     log.info(`proxy url not resolved, ALL_PROXY already set`)
-    return
-  }
-
-  const protocolMatch = /^(https?):\/\//i.exec(remoteUrl)
-
-  // We can only resolve and use a proxy for the protocols where cURL
-  // would be involved (i.e http and https). git:// relies on ssh.
-  if (protocolMatch === null) {
-    log.info(`proxy url not resolved, protocol not supported`)
     return
   }
 

--- a/app/src/lib/git/environment.ts
+++ b/app/src/lib/git/environment.ts
@@ -99,6 +99,11 @@ export async function envForProxy(
     return
   }
 
+  // Note that HTTPS here doesn't mean that the proxy is HTTPS, only
+  // that all requests to HTTPS protocols should be proxied. The
+  // proxy protocol is defined by the url returned by `this.resolve()`
+  const proto = protocolMatch[1].toLowerCase() // http or https
+
   // We'll play it safe and say that if the user has configured
   // the ALL_PROXY environment variable they probably know what
   // they're doing and wouldn't want us to override it with a
@@ -109,11 +114,6 @@ export async function envForProxy(
     log.info(`proxy url not resolved, ALL_PROXY already set`)
     return
   }
-
-  // Note that HTTPS here doesn't mean that the proxy is HTTPS, only
-  // that all requests to HTTPS protocols should be proxied. The
-  // proxy protocol is defined by the url returned by `this.resolve()`
-  const proto = protocolMatch[1].toLowerCase() // http or https
 
   // Lower case environment variables due to
   // https://ec.haxx.se/usingcurl/usingcurl-proxies#http_proxy-in-lower-case-only


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description

The following log message appears when the **Git remote** URL is using a non-http protocol (i.e. ssh, or raw git) but is extremely easily mistaken for a message saying that the **proxy** url protocol isn't supported.

```
proxy url not resolved, protocol not supported
```

Some examples of this confusion

- https://github.com/desktop/desktop/issues/10694#issuecomment-702098073
- https://github.com/desktop/desktop/issues/10344#issuecomment-674212351
- https://github.com/desktop/desktop/issues/10335#issuecomment-669347078
- https://github.com/desktop/desktop/issues/9787#issuecomment-628248366

I say we just remove it entirely rather than replace it. If we realize it's a condition we want to catch in the future we can alway add it back in with a less ambiguous wording.

cc @steveward 
