### PR TITLE
Adding pointer for tab bar items

### DIFF
--- a/app/styles/ui/_no-repositories.scss
+++ b/app/styles/ui/_no-repositories.scss
@@ -121,6 +121,7 @@
 
       .tab-bar-item {
         border-bottom: 0;
+        cursor: pointer;
       }
     }
     .clone-selected-repository {


### PR DESCRIPTION
Adding visual pointer to help show that tab-bar-items are clickable. 

This PR is not related to a reported issue.

## Description

- Adds css property to use mouse pointer when focusing 

### Screenshots

![tab-item-pointer](https://user-images.githubusercontent.com/1183659/95333892-5ed5c680-087b-11eb-9d10-ddeadfa3867a.gif)

## Release notes

Notes: Adding visual pointer to help show that tab-bar-items are clickable. 
