### PR TITLE
Diff options popover

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "file-metadata": "^1.0.0",
     "file-uri-to-path": "^2.0.0",
     "file-url": "^2.0.2",
+    "focus-trap-react": "^8.1.0",
     "fs-admin": "^0.15.0",
     "fs-extra": "^7.0.1",
     "fuzzaldrin-plus": "^0.6.0",

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -4,8 +4,8 @@ import { AppFileStatus } from '../../models/status'
 import { IDiff, DiffType } from '../../models/diff'
 import { Octicon, OcticonSymbol, iconForStatus } from '../octicons'
 import { mapStatus } from '../../lib/status'
-import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { enableSideBySideDiffs } from '../../lib/feature-flag'
+import { DiffOptions } from '../diff/diff-options'
 
 interface IChangedFileDetailsProps {
   readonly path: string
@@ -34,14 +34,9 @@ export class ChangedFileDetails extends React.Component<
         {this.renderDecorator()}
 
         {enableSideBySideDiffs() && (
-          <Checkbox
-            label="Split View"
-            value={
-              this.props.showSideBySideDiff
-                ? CheckboxValue.On
-                : CheckboxValue.Off
-            }
-            onChange={this.onShowSideBySideDiffChanged}
+          <DiffOptions
+            onShowSideBySideDiffChanged={this.props.onShowSideBySideDiffChanged}
+            showSideBySideDiff={this.props.showSideBySideDiff}
           />
         )}
 
@@ -52,12 +47,6 @@ export class ChangedFileDetails extends React.Component<
         />
       </div>
     )
-  }
-
-  private onShowSideBySideDiffChanged = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    this.props.onShowSideBySideDiffChanged(event.currentTarget.checked)
   }
 
   private renderDecorator() {

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -24,6 +24,7 @@ export class DiffOptions extends React.Component<
   IDiffOptionsState
 > {
   private diffOptionsRef: HTMLDivElement | null = null
+  private popoverRef: HTMLDivElement | null = null
 
   private focusOutTimeout: number | null = null
 
@@ -47,6 +48,10 @@ export class DiffOptions extends React.Component<
       this.diffOptionsRef.addEventListener('focusin', this.onFocusIn)
       this.diffOptionsRef.addEventListener('focusout', this.onFocusOut)
     }
+  }
+
+  private onPopoverRef = (popoverRef: HTMLDivElement | null) => {
+    this.popoverRef = popoverRef
   }
 
   private onFocusIn = (event: FocusEvent) => {
@@ -78,6 +83,18 @@ export class DiffOptions extends React.Component<
     this.onClose()
   }
 
+  private onDocumentMouseDown = (event: MouseEvent) => {
+    if (this.popoverRef === null) {
+      return
+    }
+
+    if (event.target instanceof Node) {
+      if (!this.popoverRef.contains(event.target)) {
+        this.onClose()
+      }
+    }
+  }
+
   private onTogglePopover = (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault()
     if (this.state.isOpen) {
@@ -106,7 +123,9 @@ export class DiffOptions extends React.Component<
     }
   }
 
-  public componentDidMount() {}
+  public componentWillUnmount() {
+    document.removeEventListener('mousedown', this.onDocumentMouseDown)
+  }
 
   public render() {
     return (
@@ -125,7 +144,7 @@ export class DiffOptions extends React.Component<
 
   private renderPopover() {
     return (
-      <div className="popover" tabIndex={-1}>
+      <div className="popover" tabIndex={-1} ref={this.onPopoverRef}>
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
       </div>

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -116,9 +116,7 @@ export class DiffOptions extends React.Component<
   private renderShowSideBySide() {
     return (
       <section>
-        <h3>
-          Diff display <div className="call-to-action-bubble">Beta</div>
-        </h3>
+        <h3>Diff display</h3>
         <RadioButton
           value="Unified"
           checked={!this.props.showSideBySideDiff}
@@ -128,7 +126,12 @@ export class DiffOptions extends React.Component<
         <RadioButton
           value="Split"
           checked={this.props.showSideBySideDiff}
-          label="Split"
+          label={
+            <>
+              <div>Split</div>
+              <div className="call-to-action-bubble">Beta</div>
+            </>
+          }
           onSelected={this.onSideBySideSelected}
         />
       </section>

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Octicon, OcticonSymbol } from '../octicons'
+import { RadioButton } from '../lib/radio-button'
 
 interface IDiffOptionsProps {
   readonly hideWhitespaceChanges?: boolean
@@ -38,17 +39,12 @@ export class DiffOptions extends React.Component<
     }
   }
 
-  private onShowSideBySideDiffChanged = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    this.props.onShowSideBySideDiffChanged(event.currentTarget.checked)
-  }
-
   public render() {
     return (
       <div className="diff-options-component">
         <button onClick={this.onOpen}>
           <Octicon symbol={OcticonSymbol.gear} />
+          <Octicon symbol={OcticonSymbol.triangleDown} />
           <div className="call-to-action-bubble">New</div>
         </button>
         {this.state.isOpen && this.renderPopover()}
@@ -60,14 +56,37 @@ export class DiffOptions extends React.Component<
     return (
       <div className="popover">
         {this.renderHideWhitespaceChanges()}
-        <Checkbox
-          value={
-            this.props.showSideBySideDiff ? CheckboxValue.On : CheckboxValue.Off
-          }
-          onChange={this.onShowSideBySideDiffChanged}
-          label={__DARWIN__ ? 'Side by Side' : 'Side by side'}
-        />
+        {this.renderShowSideBySide()}
       </div>
+    )
+  }
+
+  private onUnifiedSelected = () => {
+    this.props.onShowSideBySideDiffChanged(false)
+  }
+  private onSideBySideSelected = () => {
+    this.props.onShowSideBySideDiffChanged(true)
+  }
+
+  private renderShowSideBySide() {
+    return (
+      <section>
+        <h3>
+          Diff display <div className="call-to-action-bubble">Beta</div>
+        </h3>
+        <RadioButton
+          value="Unified"
+          checked={!this.props.showSideBySideDiff}
+          label="Unified"
+          onSelected={this.onUnifiedSelected}
+        />
+        <RadioButton
+          value="Split"
+          checked={this.props.showSideBySideDiff}
+          label="Split"
+          onSelected={this.onSideBySideSelected}
+        />
+      </section>
     )
   }
 
@@ -76,17 +95,20 @@ export class DiffOptions extends React.Component<
       return null
     }
     return (
-      <Checkbox
-        value={
-          this.props.hideWhitespaceChanges
-            ? CheckboxValue.On
-            : CheckboxValue.Off
-        }
-        onChange={this.onHideWhitespaceChangesChanged}
-        label={
-          __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
-        }
-      />
+      <section>
+        <h3>Whitespace</h3>
+        <Checkbox
+          value={
+            this.props.hideWhitespaceChanges
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onHideWhitespaceChangesChanged}
+          label={
+            __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
+          }
+        />
+      </section>
     )
   }
 }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -83,7 +83,7 @@ export class DiffOptions extends React.Component<
 
   private onLostFocusWithin = () => {
     this.focusOutTimeout = null
-    this.onClose()
+    this.closePopover()
   }
 
   private onDocumentMouseDown = (event: MouseEvent) => {
@@ -93,7 +93,7 @@ export class DiffOptions extends React.Component<
 
     if (event.target instanceof Node) {
       if (!this.popoverRef.contains(event.target)) {
-        this.onClose()
+        this.closePopover()
       }
     }
   }
@@ -101,13 +101,13 @@ export class DiffOptions extends React.Component<
   private onTogglePopover = (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault()
     if (this.state.isOpen) {
-      this.onClose()
+      this.closePopover()
     } else {
-      this.onOpen()
+      this.openPopover()
     }
   }
 
-  private onOpen = () => {
+  private openPopover = () => {
     this.setState(prevState => {
       if (!prevState.isOpen) {
         document.addEventListener('mousedown', this.onDocumentMouseDown)
@@ -117,7 +117,7 @@ export class DiffOptions extends React.Component<
     })
   }
 
-  private onClose = () => {
+  private closePopover = () => {
     this.setState(prevState => {
       if (prevState.isOpen) {
         if (this.state.showNewCallout) {

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { RadioButton } from '../lib/radio-button'
+import { getBoolean, setBoolean } from '../../lib/local-storage'
 
 interface IDiffOptionsProps {
   readonly hideWhitespaceChanges?: boolean
@@ -15,6 +16,7 @@ interface IDiffOptionsProps {
 
 interface IDiffOptionsState {
   readonly isOpen: boolean
+  readonly showNewCallout: boolean
 }
 
 export class DiffOptions extends React.Component<
@@ -23,12 +25,30 @@ export class DiffOptions extends React.Component<
 > {
   public constructor(props: IDiffOptionsProps) {
     super(props)
-    this.state = { isOpen: false }
+    this.state = {
+      isOpen: false,
+      showNewCallout: getBoolean('has-seen-split-diff-option') !== true,
+    }
   }
 
-  private onOpen = (event: React.FormEvent<HTMLButtonElement>) => {
+  private onTogglePopover = (event: React.FormEvent<HTMLButtonElement>) => {
     event.preventDefault()
-    this.setState({ isOpen: !this.state.isOpen })
+    if (this.state.isOpen) {
+      this.onClose()
+    } else {
+      this.onOpen()
+    }
+  }
+
+  private onOpen = () => {
+    this.setState({ isOpen: true })
+  }
+
+  private onClose = () => {
+    if (this.state.showNewCallout) {
+      setBoolean('has-seen-split-diff-option', true)
+    }
+    this.setState({ isOpen: false, showNewCallout: false })
   }
 
   private onHideWhitespaceChangesChanged = (
@@ -42,10 +62,12 @@ export class DiffOptions extends React.Component<
   public render() {
     return (
       <div className="diff-options-component">
-        <button onClick={this.onOpen}>
+        <button onClick={this.onTogglePopover}>
           <Octicon symbol={OcticonSymbol.gear} />
           <Octicon symbol={OcticonSymbol.triangleDown} />
-          <div className="call-to-action-bubble">New</div>
+          {this.state.showNewCallout && (
+            <div className="call-to-action-bubble">New</div>
+          )}
         </button>
         {this.state.isOpen && this.renderPopover()}
       </div>

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -51,9 +51,6 @@ export class DiffOptions extends React.Component<
   }
 
   private onPopoverRef = (popoverRef: HTMLDivElement | null) => {
-    if (popoverRef) {
-      popoverRef.focus()
-    }
     this.popoverRef = popoverRef
   }
 
@@ -145,7 +142,11 @@ export class DiffOptions extends React.Component<
 
   public render() {
     return (
-      <div className="diff-options-component" ref={this.onDiffOptionsRef}>
+      <div
+        className="diff-options-component"
+        ref={this.onDiffOptionsRef}
+        onKeyDown={this.onKeyDown}
+      >
         <button onClick={this.onTogglePopover}>
           <Octicon symbol={OcticonSymbol.gear} />
           <Octicon symbol={OcticonSymbol.triangleDown} />

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -51,6 +51,9 @@ export class DiffOptions extends React.Component<
   }
 
   private onPopoverRef = (popoverRef: HTMLDivElement | null) => {
+    if (popoverRef) {
+      popoverRef.focus()
+    }
     this.popoverRef = popoverRef
   }
 

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { Octicon, OcticonSymbol } from '../octicons'
+
+interface IDiffOptionsProps {
+  readonly hideWhitespaceChanges: boolean
+  readonly onHideWhitespaceChangesChanged: (
+    hideWhitespaceChanges: boolean
+  ) => void
+}
+
+interface IDiffOptionsState {
+  readonly isOpen: boolean
+}
+
+export class DiffOptions extends React.Component<
+  IDiffOptionsProps,
+  IDiffOptionsState
+> {
+  public constructor(props: IDiffOptionsProps) {
+    super(props)
+    this.state = { isOpen: false }
+  }
+
+  private onOpen = (event: React.FormEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    this.setState({ isOpen: !this.state.isOpen })
+  }
+
+  private onHideWhitespaceChangesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onHideWhitespaceChangesChanged(event.currentTarget.checked)
+  }
+  public render() {
+    return (
+      <div className="diff-options-component">
+        <button onClick={this.onOpen}>
+          <Octicon symbol={OcticonSymbol.gear} />
+          <div className="call-to-action-bubble">New</div>
+        </button>
+        {this.state.isOpen && this.renderPopover()}
+      </div>
+    )
+  }
+
+  private renderPopover() {
+    return (
+      <div className="popover">
+        <Checkbox
+          value={
+            this.props.hideWhitespaceChanges
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onHideWhitespaceChangesChanged}
+          label={
+            __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
+          }
+        />
+        <Checkbox
+          value={
+            this.props.hideWhitespaceChanges
+              ? CheckboxValue.On
+              : CheckboxValue.Off
+          }
+          onChange={this.onHideWhitespaceChangesChanged}
+          label={__DARWIN__ ? 'Side by Side' : 'Side by side'}
+        />
+      </div>
+    )
+  }
+}

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -3,10 +3,13 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Octicon, OcticonSymbol } from '../octicons'
 
 interface IDiffOptionsProps {
-  readonly hideWhitespaceChanges: boolean
-  readonly onHideWhitespaceChangesChanged: (
+  readonly hideWhitespaceChanges?: boolean
+  readonly onHideWhitespaceChangesChanged?: (
     hideWhitespaceChanges: boolean
   ) => void
+
+  readonly showSideBySideDiff: boolean
+  readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
 }
 
 interface IDiffOptionsState {
@@ -30,8 +33,17 @@ export class DiffOptions extends React.Component<
   private onHideWhitespaceChangesChanged = (
     event: React.FormEvent<HTMLInputElement>
   ) => {
-    this.props.onHideWhitespaceChangesChanged(event.currentTarget.checked)
+    if (this.props.onHideWhitespaceChangesChanged !== undefined) {
+      this.props.onHideWhitespaceChangesChanged(event.currentTarget.checked)
+    }
   }
+
+  private onShowSideBySideDiffChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onShowSideBySideDiffChanged(event.currentTarget.checked)
+  }
+
   public render() {
     return (
       <div className="diff-options-component">
@@ -47,27 +59,34 @@ export class DiffOptions extends React.Component<
   private renderPopover() {
     return (
       <div className="popover">
+        {this.renderHideWhitespaceChanges()}
         <Checkbox
           value={
-            this.props.hideWhitespaceChanges
-              ? CheckboxValue.On
-              : CheckboxValue.Off
+            this.props.showSideBySideDiff ? CheckboxValue.On : CheckboxValue.Off
           }
-          onChange={this.onHideWhitespaceChangesChanged}
-          label={
-            __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
-          }
-        />
-        <Checkbox
-          value={
-            this.props.hideWhitespaceChanges
-              ? CheckboxValue.On
-              : CheckboxValue.Off
-          }
-          onChange={this.onHideWhitespaceChangesChanged}
+          onChange={this.onShowSideBySideDiffChanged}
           label={__DARWIN__ ? 'Side by Side' : 'Side by side'}
         />
       </div>
+    )
+  }
+
+  private renderHideWhitespaceChanges() {
+    if (this.props.hideWhitespaceChanges === undefined) {
+      return null
+    }
+    return (
+      <Checkbox
+        value={
+          this.props.hideWhitespaceChanges
+            ? CheckboxValue.On
+            : CheckboxValue.Off
+        }
+        onChange={this.onHideWhitespaceChangesChanged}
+        label={
+          __DARWIN__ ? 'Hide Whitespace Changes' : 'Hide whitespace changes'
+        }
+      />
     )
   }
 }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -108,14 +108,27 @@ export class DiffOptions extends React.Component<
   }
 
   private onOpen = () => {
-    this.setState({ isOpen: true })
+    this.setState(prevState => {
+      if (!prevState.isOpen) {
+        document.addEventListener('mousedown', this.onDocumentMouseDown)
+        return { isOpen: true }
+      }
+      return null
+    })
   }
 
   private onClose = () => {
-    if (this.state.showNewCallout) {
-      setBoolean('has-seen-split-diff-option', true)
-    }
-    this.setState({ isOpen: false, showNewCallout: false })
+    this.setState(prevState => {
+      if (prevState.isOpen) {
+        if (this.state.showNewCallout) {
+          setBoolean('has-seen-split-diff-option', true)
+        }
+        document.removeEventListener('mousedown', this.onDocumentMouseDown)
+        return { isOpen: false, showNewCallout: false }
+      }
+
+      return null
+    })
   }
 
   private onHideWhitespaceChangesChanged = (

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -26,6 +26,7 @@ export class DiffOptions extends React.Component<
   IDiffOptionsState
 > {
   private focusTrapOptions: FocusTrapOptions
+  private diffOptionsRef = React.createRef<HTMLDivElement>()
 
   public constructor(props: IDiffOptionsProps) {
     super(props)
@@ -35,7 +36,7 @@ export class DiffOptions extends React.Component<
     }
 
     this.focusTrapOptions = {
-      clickOutsideDeactivates: true,
+      allowOutsideClick: true,
       escapeDeactivates: true,
       onDeactivate: this.closePopover,
     }
@@ -53,6 +54,7 @@ export class DiffOptions extends React.Component<
   private openPopover = () => {
     this.setState(prevState => {
       if (!prevState.isOpen) {
+        document.addEventListener('mousedown', this.onDocumentMouseDown)
         return { isOpen: true }
       }
       return null
@@ -65,11 +67,25 @@ export class DiffOptions extends React.Component<
         if (this.state.showNewCallout) {
           setBoolean('has-seen-split-diff-option', true)
         }
+        document.removeEventListener('mousedown', this.onDocumentMouseDown)
         return { isOpen: false, showNewCallout: false }
       }
 
       return null
     })
+  }
+
+  public componentWillUnmount() {
+    document.removeEventListener('mousedown', this.onDocumentMouseDown)
+  }
+
+  private onDocumentMouseDown = (event: MouseEvent) => {
+    const { current: ref } = this.diffOptionsRef
+    const { target } = event
+
+    if (ref !== null && target instanceof Node && !ref.contains(target)) {
+      this.closePopover()
+    }
   }
 
   private onHideWhitespaceChangesChanged = (
@@ -82,7 +98,7 @@ export class DiffOptions extends React.Component<
 
   public render() {
     return (
-      <div className="diff-options-component">
+      <div className="diff-options-component" ref={this.diffOptionsRef}>
         <button onClick={this.onTogglePopover}>
           <Octicon symbol={OcticonSymbol.gear} />
           <Octicon symbol={OcticonSymbol.triangleDown} />

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -21,6 +21,8 @@ interface IDiffOptionsState {
   readonly showNewCallout: boolean
 }
 
+const HasSeenSplitDiffKey = 'has-seen-split-diff-option'
+
 export class DiffOptions extends React.Component<
   IDiffOptionsProps,
   IDiffOptionsState
@@ -32,7 +34,7 @@ export class DiffOptions extends React.Component<
     super(props)
     this.state = {
       isOpen: false,
-      showNewCallout: getBoolean('has-seen-split-diff-option') !== true,
+      showNewCallout: getBoolean(HasSeenSplitDiffKey) !== true,
     }
 
     this.focusTrapOptions = {
@@ -65,7 +67,7 @@ export class DiffOptions extends React.Component<
     this.setState(prevState => {
       if (prevState.isOpen) {
         if (this.state.showNewCallout) {
-          setBoolean('has-seen-split-diff-option', true)
+          setBoolean(HasSeenSplitDiffKey, true)
         }
         document.removeEventListener('mousedown', this.onDocumentMouseDown)
         return { isOpen: false, showNewCallout: false }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -136,6 +136,15 @@ export class DiffOptions extends React.Component<
     }
   }
 
+  private onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (this.state.isOpen) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        this.closePopover()
+      }
+    }
+  }
+
   public componentWillUnmount() {
     document.removeEventListener('mousedown', this.onDocumentMouseDown)
   }

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -98,7 +98,7 @@ export class DiffOptions extends React.Component<
   private renderPopover() {
     return (
       <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
-        <div className="popover" tabIndex={-1}>
+        <div className="popover">
           {this.renderHideWhitespaceChanges()}
           {this.renderShowSideBySide()}
         </div>

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -50,13 +50,10 @@ export class DiffOptions extends React.Component<
   }
 
   private onFocusIn = (event: FocusEvent) => {
-    console.log('focusin', event.target)
     this.clearFocusOutTimeout()
   }
 
   private onFocusOut = (event: Event) => {
-    console.log('focusout', event.target)
-
     // When keyboard focus moves from one descendant within the
     // menu bar to another we will receive one 'focusout' event
     // followed quickly by a 'focusin' event. As such we

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -178,6 +178,7 @@ export class SideBySideDiff extends React.Component<
   }
 
   public render() {
+    const diffRows = getDiffRows(this.props.diff, this.props.showSideBySideDiff)
     return (
       <div
         className={classNames([
@@ -199,10 +200,7 @@ export class SideBySideDiff extends React.Component<
                 deferredMeasurementCache={listRowsHeightCache}
                 width={width}
                 height={height}
-                rowCount={
-                  getDiffRows(this.props.diff, this.props.showSideBySideDiff)
-                    .length
-                }
+                rowCount={diffRows.length}
                 rowHeight={this.getRowHeight}
                 rowRenderer={this.renderRow}
                 // The following properties are passed to the list

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -178,21 +178,17 @@ export class SideBySideDiff extends React.Component<
   }
 
   public render() {
-    const diffRows = getDiffRows(this.props.diff, this.props.showSideBySideDiff)
+    const rows = getDiffRows(this.props.diff, this.props.showSideBySideDiff)
+    const containerClassName = classNames('side-by-side-diff-container', {
+      'unified-diff': !this.props.showSideBySideDiff,
+      [`selecting-${this.state.selectingTextInRow}`]:
+        this.props.showSideBySideDiff &&
+        this.state.selectingTextInRow !== undefined,
+      editable: canSelect(this.props.file),
+    })
+
     return (
-      <div
-        className={classNames([
-          {
-            'side-by-side-diff-container': true,
-            'unified-diff': !this.props.showSideBySideDiff,
-            [`selecting-${this.state.selectingTextInRow}`]:
-              this.props.showSideBySideDiff &&
-              this.state.selectingTextInRow !== undefined,
-            editable: canSelect(this.props.file),
-          },
-        ])}
-        onMouseDown={this.onMouseDown}
-      >
+      <div className={containerClassName} onMouseDown={this.onMouseDown}>
         <div className="side-by-side-diff cm-s-default">
           <AutoSizer onResize={this.clearListRowsHeightCache}>
             {({ height, width }) => (
@@ -200,7 +196,7 @@ export class SideBySideDiff extends React.Component<
                 deferredMeasurementCache={listRowsHeightCache}
                 width={width}
                 height={height}
-                rowCount={diffRows.length}
+                rowCount={rows.length}
                 rowHeight={this.getRowHeight}
                 rowRenderer={this.renderRow}
                 // The following properties are passed to the list

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -160,13 +160,6 @@ export class CommitSummary extends React.Component<
     this.props.onHideWhitespaceInDiffChanged(value)
   }
 
-  private onShowSideBySideDiffChanged = (
-    event: React.FormEvent<HTMLInputElement>
-  ) => {
-    const value = event.currentTarget.checked
-    this.props.onShowSideBySideDiffChanged(value)
-  }
-
   private onResized = () => {
     if (this.descriptionRef) {
       const descriptionBottom = this.descriptionRef.getBoundingClientRect()
@@ -360,20 +353,22 @@ export class CommitSummary extends React.Component<
             </li>
             {this.renderTags()}
 
-            <li
-              className="commit-summary-meta-item without-truncation"
-              title="Hide Whitespace"
-            >
-              <Checkbox
-                label="Hide Whitespace"
-                value={
-                  this.props.hideWhitespaceInDiff
-                    ? CheckboxValue.On
-                    : CheckboxValue.Off
-                }
-                onChange={this.onHideWhitespaceInDiffChanged}
-              />
-            </li>
+            {enableSideBySideDiffs() || (
+              <li
+                className="commit-summary-meta-item without-truncation"
+                title="Hide Whitespace"
+              >
+                <Checkbox
+                  label="Hide Whitespace"
+                  value={
+                    this.props.hideWhitespaceInDiff
+                      ? CheckboxValue.On
+                      : CheckboxValue.Off
+                  }
+                  onChange={this.onHideWhitespaceInDiffChanged}
+                />
+              </li>
+            )}
 
             {enableSideBySideDiffs() && (
               <>
@@ -386,20 +381,10 @@ export class CommitSummary extends React.Component<
                       this.props.onHideWhitespaceInDiffChanged
                     }
                     hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
-                  />
-                </li>
-                <li
-                  className="commit-summary-meta-item without-truncation"
-                  title="Split View"
-                >
-                  <Checkbox
-                    label="Split View"
-                    value={
-                      this.props.showSideBySideDiff
-                        ? CheckboxValue.On
-                        : CheckboxValue.Off
+                    showSideBySideDiff={this.props.showSideBySideDiff}
+                    onShowSideBySideDiffChanged={
+                      this.props.onShowSideBySideDiffChanged
                     }
-                    onChange={this.onShowSideBySideDiffChanged}
                   />
                 </li>
               </>

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../lib/feature-flag'
 import { Tokenizer, TokenResult } from '../../lib/text-token-parser'
 import { wrapRichTextCommitMessage } from '../../lib/wrap-rich-text-commit-message'
+import { DiffOptions } from '../diff/diff-options'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
@@ -375,20 +376,33 @@ export class CommitSummary extends React.Component<
             </li>
 
             {enableSideBySideDiffs() && (
-              <li
-                className="commit-summary-meta-item without-truncation"
-                title="Split View"
-              >
-                <Checkbox
-                  label="Split View"
-                  value={
-                    this.props.showSideBySideDiff
-                      ? CheckboxValue.On
-                      : CheckboxValue.Off
-                  }
-                  onChange={this.onShowSideBySideDiffChanged}
-                />
-              </li>
+              <>
+                <li
+                  className="commit-summary-meta-item without-truncation"
+                  title="Split View"
+                >
+                  <DiffOptions
+                    onHideWhitespaceChangesChanged={
+                      this.props.onHideWhitespaceInDiffChanged
+                    }
+                    hideWhitespaceChanges={this.props.hideWhitespaceInDiff}
+                  />
+                </li>
+                <li
+                  className="commit-summary-meta-item without-truncation"
+                  title="Split View"
+                >
+                  <Checkbox
+                    label="Split View"
+                    value={
+                      this.props.showSideBySideDiff
+                        ? CheckboxValue.On
+                        : CheckboxValue.Off
+                    }
+                    onChange={this.onShowSideBySideDiffChanged}
+                  />
+                </li>
+              </>
             )}
           </ul>
         </div>

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -82,3 +82,4 @@
 @import 'ui/config-lock-file-exists';
 @import 'ui/local-changes-overwritten';
 @import 'ui/side-by-side-diff';
+@import 'ui/diff-options';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -448,6 +448,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   // PR status icon colors
   --pr-open-icon-color: #{$green-500};
   --pr-draft-icon-color: #{$gray-500};
+
+  --call-to-action-bubble-background-color: #{$blue};
+  --call-to-action-bubble-color: #{$white};
 }
 
 ::backdrop {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -449,8 +449,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --pr-open-icon-color: #{$green-500};
   --pr-draft-icon-color: #{$gray-500};
 
-  --call-to-action-bubble-background-color: #{$blue};
-  --call-to-action-bubble-color: #{$white};
+  --call-to-action-bubble-border-color: #{$green};
+  --call-to-action-bubble-color: #{$green};
 }
 
 ::backdrop {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -341,6 +341,9 @@ body.theme-dark {
   // PR status icon colors
   --pr-open-icon-color: #{$green-500};
   --pr-draft-icon-color: #{$gray-400};
+
+  --call-to-action-bubble-background-color: #{$blue};
+  --call-to-action-bubble-color: #{$white};
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -12,7 +12,6 @@
 
     display: flex;
     flex-direction: row;
-    align-items: center;
 
     color: var(--text-color);
 

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -1,0 +1,72 @@
+.diff-options-component {
+  position: relative;
+
+  > button {
+    -webkit-appearance: none;
+    font-family: inherit;
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    color: var(--text-color);
+
+    &:hover {
+      color: var(--text-secondary-color);
+    }
+
+    .call-to-action-bubble {
+      font-size: var(--font-size-sm);
+      text-transform: uppercase;
+      background: var(--notification-bubble-background-color);
+      color: var(--notification-bubble-color);
+      padding: 2px 3px;
+      border-radius: var(--border-radius);
+    }
+  }
+
+  .popover {
+    position: absolute;
+    left: 28px;
+    margin-left: -250px;
+    top: 27px;
+    z-index: var(--foldout-z-index);
+
+    background: var(--background-color);
+    color: var(--text-color);
+    border-radius: var(--border-radius);
+    border: var(--base-border);
+
+    padding: var(--spacing-double);
+    width: 250px;
+
+    box-shadow: var(--base-box-shadow);
+
+    // Carets
+    &::before,
+    &::after {
+      position: absolute;
+      right: 20px;
+      display: inline-block;
+      content: '';
+    }
+
+    &::before {
+      top: -16px;
+      margin-right: -9px;
+      border: 8px solid transparent;
+      border-bottom-color: var(--box-border-color);
+    }
+
+    &::after {
+      top: -14px;
+      margin-right: -8px;
+      border: 7px solid transparent;
+      border-bottom-color: var(--background-color);
+    }
+  }
+}

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -20,18 +20,47 @@
       color: var(--text-secondary-color);
     }
 
-    .call-to-action-bubble {
-      font-size: var(--font-size-sm);
-      text-transform: uppercase;
-      background: var(--call-to-action-bubble-background-color);
-      color: var(--call-to-action-bubble-color);
-      padding: 2px 3px;
-      border-radius: var(--border-radius);
-      margin-left: var(--spacing-third);
+    .octicon {
+      margin-right: 0;
     }
   }
 
+  .call-to-action-bubble {
+    font-weight: var(--font-weight-semibold);
+    display: inline-block;
+    font-size: var(--font-size-xs);
+    border: 1px solid var(--call-to-action-bubble-border-color);
+    color: var(--call-to-action-bubble-color);
+    padding: 1px 5px;
+    border-radius: var(--border-radius);
+    margin-left: var(--spacing-third);
+  }
+
+  label {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  h3 {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  section + section {
+    margin-top: var(--spacing);
+  }
+
+  section.button-group {
+    display: flex;
+    flex-direction: row;
+  }
+
   .popover {
+    font-size: var(--font-size);
+    font-family: var(--font-family-sans-serif);
+
     position: absolute;
     left: 28px;
     margin-left: -250px;

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -1,5 +1,6 @@
 .diff-options-component {
   position: relative;
+  display: flex;
 
   > button {
     -webkit-appearance: none;
@@ -22,10 +23,11 @@
     .call-to-action-bubble {
       font-size: var(--font-size-sm);
       text-transform: uppercase;
-      background: var(--notification-bubble-background-color);
-      color: var(--notification-bubble-color);
+      background: var(--call-to-action-bubble-background-color);
+      color: var(--call-to-action-bubble-color);
       padding: 2px 3px;
       border-radius: var(--border-radius);
+      margin-left: var(--spacing-third);
     }
   }
 
@@ -53,6 +55,7 @@
       right: 20px;
       display: inline-block;
       content: '';
+      pointer-events: none;
     }
 
     &::before {

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -22,7 +22,7 @@
 
     @include octicon-status;
 
-    .checkbox-component {
+    .diff-options-component {
       margin-right: var(--spacing-half);
     }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -513,6 +513,20 @@ file-url@^2.0.2:
   resolved "https://registry.yarnpkg.com/file-url/-/file-url-2.0.2.tgz#e951784d79095127d3713029ab063f40818ca2ae"
   integrity sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4=
 
+focus-trap-react@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.1.0.tgz#9f7625779633c9d3b05d73501eaf9a295876a753"
+  integrity sha512-mk7aqFrx03py5c2yGNPii6j0TgkRtRtCBn7ybYAbQUE9zcL12KgKfR7wIAQC7OLj6qkv7M6sAooRqBZ3JnX8yA==
+  dependencies:
+    focus-trap "^6.1.0"
+
+focus-trap@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.0.tgz#836a4851b389b71fe26d4dcdfb43d5c8d6f2bfc6"
+  integrity sha512-TQf1gJ5UgAY2ZMXrTDls6ah10kJmh35w/4COQHncLILwAK7hme4tiOwYnq2JOU88pqu1LoPqO9Yn7EbvmnzRRQ==
+  dependencies:
+    tabbable "^5.1.0"
+
 fs-admin@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/fs-admin/-/fs-admin-0.15.0.tgz#ffa7daab2f1184ca81df73e7db8365ee1747410c"
@@ -1536,6 +1550,11 @@ supports-color@^4.0.0:
   integrity sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==
   dependencies:
     has-flag "^2.0.0"
+
+tabbable@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.0.tgz#b81115168d0a8359ba69003b6a99d05f8480a664"
+  integrity sha512-Y3nSukchqM5UchuZjhj/WyE79Qb4RM/Vx3x3oHO3UYKKpf70Hy3iVRxb61MzCavN74aZsKzvPl4KNG8tQUAjFQ==
 
 tar-fs@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Adds a button with a gear icon to the changes and history view that toggles a popover containing diff options. This replaces the checkbox we currently have for hiding/showing whitespace changes and the diff mode.

For discoverability reasons we show a little 'New' callout bubble next to the button. Both the popover and the new callout are new patterns in the app but I think they fit in nicely. The popover parts of the diff options component could and should be extracted into its own reusable container but I'm punting on that until we want to reuse it.

To a large extend this copies the GitHub.com UX for diff settings

![image](https://user-images.githubusercontent.com/634063/95386689-f543cf80-08ef-11eb-85fe-dbe49b04754e.png)


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/634063/95386367-7d75a500-08ef-11eb-9aff-9e00c9245d1f.png)

![image](https://user-images.githubusercontent.com/634063/95386398-8b2b2a80-08ef-11eb-9bee-3ce72dd8d1c7.png)