### PR TITLE
Include stdout and stderr in push error messages

### DIFF
--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -131,19 +131,12 @@ export async function push(
       const stderr = e.result.stderr.trim()
       const stdout = e.result.stdout.trim()
 
-      let message = ''
-      if (stderr.length > 0) {
-        // append stderr
-        message += stderr
-      }
-      if (stdout.length > 0) {
-        // append stdout
-        message += stdout
-      }
+      const combined = stderr.concat(stdout)
+      const message = combined.length > 0 ? `, with output: '${combined}'` : ''
 
       const exitCode = e.result.exitCode
       const error = new Error(
-        `Push failed - exit code ${exitCode} received ${message}`
+        `Push failed - exit code ${exitCode} received${message}`
       )
       error.name = 'push-failed'
       throw error


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #5439

## Description

Unlike when committing, when a push operation fails the full error is not shown. This is useful when using prepush hooks or similar as, without the error the user is left confused or having to run the prepush hook manually to figure out what went wrong. 

Have matched similar code achieving the same for commits in `app/src/lib/git/commit.ts`.

### Screenshots

#### BEFORE
![image](https://user-images.githubusercontent.com/3793131/95490152-ba917400-098f-11eb-8062-5cc698369e14.png)

#### AFTER
![image](https://user-images.githubusercontent.com/3793131/95490343-05ab8700-0990-11eb-95c1-6bd748866135.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Push errors now include the full error message
