### PR TITLE
Bind context menu clicks to file item

### DIFF
--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -8,12 +8,21 @@ import { Octicon, iconForStatus } from '../octicons'
 interface ICommittedFileItemProps {
   readonly availableWidth: number
   readonly file: CommittedFileChange
-  readonly onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void
+  readonly onContextMenu?: (
+    file: CommittedFileChange,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void
 }
 
 export class CommittedFileItem extends React.Component<
   ICommittedFileItemProps
 > {
+  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (this.props.onContextMenu !== undefined) {
+      this.props.onContextMenu(this.props.file, event)
+    }
+  }
+
   public render() {
     const { file } = this.props
     const status = file.status
@@ -29,7 +38,7 @@ export class CommittedFileItem extends React.Component<
       statusWidth
 
     return (
-      <div className="file" onContextMenu={this.props.onContextMenu}>
+      <div className="file" onContextMenu={this.onContextMenu}>
         <PathLabel
           path={file.path}
           status={file.status}

--- a/app/src/ui/history/committed-file-item.tsx
+++ b/app/src/ui/history/committed-file-item.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+
+import { CommittedFileChange } from '../../models/status'
+import { mapStatus } from '../../lib/status'
+import { PathLabel } from '../lib/path-label'
+import { Octicon, iconForStatus } from '../octicons'
+
+interface ICommittedFileItemProps {
+  readonly availableWidth: number
+  readonly file: CommittedFileChange
+  readonly onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void
+}
+
+export class CommittedFileItem extends React.Component<
+  ICommittedFileItemProps
+> {
+  public render() {
+    const { file } = this.props
+    const status = file.status
+    const fileStatus = mapStatus(status)
+
+    const listItemPadding = 10 * 2
+    const statusWidth = 16
+    const filePathPadding = 5
+    const availablePathWidth =
+      this.props.availableWidth -
+      listItemPadding -
+      filePathPadding -
+      statusWidth
+
+    return (
+      <div className="file" onContextMenu={this.props.onContextMenu}>
+        <PathLabel
+          path={file.path}
+          status={file.status}
+          availableWidth={availablePathWidth}
+        />
+
+        <Octicon
+          symbol={iconForStatus(status)}
+          className={'status status-' + fileStatus.toLowerCase()}
+          title={fileStatus}
+        />
+      </div>
+    )
+  }
+}

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react'
 
 import { CommittedFileChange } from '../../models/status'
-
-import { PathLabel } from '../lib/path-label'
 import { List } from '../lib/list'
-
-import { Octicon, iconForStatus } from '../octicons'
-import { mapStatus } from '../../lib/status'
+import { CommittedFileItem } from './committed-file-item'
 
 interface IFileListProps {
   readonly files: ReadonlyArray<CommittedFileChange>
@@ -26,33 +22,12 @@ export class FileList extends React.Component<IFileListProps> {
   }
 
   private renderFile = (row: number) => {
-    const file = this.props.files[row]
-    const status = file.status
-    const fileStatus = mapStatus(status)
-
-    const listItemPadding = 10 * 2
-    const statusWidth = 16
-    const filePathPadding = 5
-    const availablePathWidth =
-      this.props.availableWidth -
-      listItemPadding -
-      filePathPadding -
-      statusWidth
-
     return (
-      <div className="file" onContextMenu={this.props.onContextMenu}>
-        <PathLabel
-          path={file.path}
-          status={file.status}
-          availableWidth={availablePathWidth}
-        />
-
-        <Octicon
-          symbol={iconForStatus(status)}
-          className={'status status-' + fileStatus.toLowerCase()}
-          title={fileStatus}
-        />
-      </div>
+      <CommittedFileItem
+        file={this.props.files[row]}
+        availableWidth={this.props.availableWidth}
+        onContextMenu={this.props.onContextMenu}
+      />
     )
   }
 

--- a/app/src/ui/history/file-list.tsx
+++ b/app/src/ui/history/file-list.tsx
@@ -9,7 +9,10 @@ interface IFileListProps {
   readonly selectedFile: CommittedFileChange | null
   readonly onSelectedFileChanged: (file: CommittedFileChange) => void
   readonly availableWidth: number
-  readonly onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void
+  readonly onContextMenu?: (
+    file: CommittedFileChange,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => void
 }
 
 /**

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -245,15 +245,13 @@ export class SelectedCommit extends React.Component<
     )
   }
 
-  private onContextMenu = async (event: React.MouseEvent<HTMLDivElement>) => {
+  private onContextMenu = async (
+    file: CommittedFileChange,
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
     event.preventDefault()
 
-    if (this.props.selectedFile == null) {
-      return
-    }
-
-    const filePath = this.props.selectedFile.path
-    const fullPath = Path.join(this.props.repository.path, filePath)
+    const fullPath = Path.join(this.props.repository.path, file.path)
     const fileExistsOnDisk = await pathExists(fullPath)
     if (!fileExistsOnDisk) {
       showContextualMenu([
@@ -267,7 +265,7 @@ export class SelectedCommit extends React.Component<
       return
     }
 
-    const extension = Path.extname(filePath)
+    const extension = Path.extname(file.path)
 
     const isSafeExtension = isSafeFileExtension(extension)
     const openInExternalEditor = this.props.externalEditorLabel
@@ -281,7 +279,7 @@ export class SelectedCommit extends React.Component<
       },
       {
         label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(this.props.repository, filePath),
+        action: () => revealInFileManager(this.props.repository, file.path),
         enabled: fileExistsOnDisk,
       },
       {
@@ -291,7 +289,7 @@ export class SelectedCommit extends React.Component<
       },
       {
         label: OpenWithDefaultProgramLabel,
-        action: () => this.onOpenItem(filePath),
+        action: () => this.onOpenItem(file.path),
         enabled: isSafeExtension && fileExistsOnDisk,
       },
     ]


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10743

## Description

In the history view we relied on the currently selected file as per `props`. When right-clicking on a list item there's a race condition where the props.selected will always lose which meant that you'd have to first click to select, then right click for the context menu to bind to the correct item.

This solves it by applying the same approach that we do in the changes view, i.e. each row is its own component and can therefore tell the context menu event handler what file was clicked.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Actions in the context menu of a non-selected file in history no longer acts on the previously selected item
