### PR TITLE
docs: fix typos

### DIFF
--- a/docs/contributing/upgrading-dependencies.md
+++ b/docs/contributing/upgrading-dependencies.md
@@ -100,7 +100,7 @@ contribution is opened by the community.
 ### Application dependencies
 
 This group of dependencies represent the rest of the listed dependencies in
-`app/pacakge.json` - there are lots of small dependencies which are approachable
+`app/package.json` - there are lots of small dependencies which are approachable
 for external contributions.
 
 If you are interested in upgrading one of these, take a look at where it is

--- a/docs/contributing/working-with-packages.md
+++ b/docs/contributing/working-with-packages.md
@@ -41,7 +41,7 @@ To upgrade a package to it's latest version:
 > yarn upgrade --latest [package-name]
 ```
 
-To upgrade a package to a speific version (or [version range](https://docs.npmjs.com/misc/semver#x-ranges-12x-1x-12-)):
+To upgrade a package to a specific version (or [version range](https://docs.npmjs.com/misc/semver#x-ranges-12x-1x-12-)):
 
 ```sh
 > yarn upgrade [package-name]@[version]

--- a/docs/process/pull-requests.md
+++ b/docs/process/pull-requests.md
@@ -24,7 +24,7 @@ a consistent process for contributions from the core team and the community.
     applicable).
 
 Merged contributions are first published to the beta channel (we aim to publish
-new versions weekly if contributions are availlable) before then being
+new versions weekly if contributions are available) before then being
 published to the production channel (we aim to publish new versions on a monthly
 cadence).
 

--- a/docs/process/quality-process.md
+++ b/docs/process/quality-process.md
@@ -5,9 +5,9 @@ This document is a general outline of Quality Engineering practices for Desktop,
 The test cases are relevant to the latest build of Desktop, and the manifest is broken down into sections that include installation, setup, adding repositories, general use, and OS-specific cases, among others. As the manifest is a living document, it may sometimes include future features as Quality needs to stay slightly ahead of the roadmap.
 
 #### Testing Desktop
-Desktop curently releases new builds on a non-scheduled cadence, with both beta and production versions available to Quality to testing. For each build, Quality executes all or a sub-section of the manifest, along with exploratory testing. 
+Desktop currently releases new builds on a non-scheduled cadence, with both beta and production versions available to Quality to testing. For each build, Quality executes all or a sub-section of the manifest, along with exploratory testing. 
 
-In addition, all new features result in new or updated test cases, which are eventually added to the manifest. When a bug or concern is found, Quality files an Issue and the dicsussion with the core team and the open-source community begins. 
+In addition, all new features result in new or updated test cases, which are eventually added to the manifest. When a bug or concern is found, Quality files an Issue and the discussion with the core team and the open-source community begins. 
 
 #### Contributing or need more info
 As Desktop is an open-source project, any outside feedback is welcomed. Feel free to open a Pull Request or Issue (label:bug) to contribute, or you can start a conversation by creating a general Issue. 

--- a/docs/process/release-planning.md
+++ b/docs/process/release-planning.md
@@ -49,7 +49,7 @@ current milestone.
 
 The reviewer who approves the pull request may assign a milestone at the same
 time to propose when this pull request should be merged, and optionally add a
-comment to provice context around their choice.
+comment to provide context around their choice.
 
 These factors can be used when deciding on the chosen milestone:
 
@@ -60,7 +60,7 @@ These factors can be used when deciding on the chosen milestone:
  - **timing** - Are we close to a release? Maybe it can wait a couple of days...
 
 During the 24-hour approval window for merged pull request other maintainers may
-discuss the proposed milestone (or just :thumbsup: to acknowledege and agree
+discuss the proposed milestone (or just :thumbsup: to acknowledge and agree
 with the proposed milestone).
 
 Once the 24-hour approval window has expired the pull request can be merged by a
@@ -72,6 +72,6 @@ assigned to the same milestone.
 
 ### Community Contributions
 
-Similiar to bugfixes, community PRs and features should not have a milestone
+Similar to bugfixes, community PRs and features should not have a milestone
 assigned until they have been reviewed and approved, and should go through the
 same process.

--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -66,7 +66,7 @@ When naming the branch, ensure you use the `releases/[version]` pattern to ensur
 
 ### 3. Create Draft Release
 
-Run the script below (which relies on the your personal acccess token being set), which will determine the next version from what was previously published, based on the desired channel.
+Run the script below (which relies on the your personal access token being set), which will determine the next version from what was previously published, based on the desired channel.
 
 For `production` and `beta` releases, run:
 
@@ -132,7 +132,7 @@ Here's an example of the previous changelog draft after it has been edited:
 
 Add your new changelog entries to `changelog.json`, update the version in `app/package.json`, commit the changes, and push this branch to GitHub. This becomes the release branch, and lets other maintainers continue to merge into `development` without affecting your release.
 
-If a maintainer would like to backport a pull request to the next release, it is their responsibilty to co-ordinate with the release owner and ensure they are fine with accepting this work.
+If a maintainer would like to backport a pull request to the next release, it is their responsibility to co-ordinate with the release owner and ensure they are fine with accepting this work.
 
 Once your release branch is ready to review and ship, ask the other maintainers to review and approve the changes!
 

--- a/docs/process/testing.md
+++ b/docs/process/testing.md
@@ -50,8 +50,8 @@
     - [ ] If user logged in during sign-up process with repository lists for GitHub.com and/or Enterprise
     - [ ] Always show suggested steps: Clone repository, Add existing repository, Add new repository
     - [ ] If logged into GitHub, show button for creating tutorial
-      - [ ] Adding a repository will automically exit Onboarding
-        - [ ] User can revert to Onboarding if all respositories are removed
+      - [ ] Adding a repository will automatically exit Onboarding
+        - [ ] User can revert to Onboarding if all repositories are removed
       - [ ] Tutorial can only be started if there is no local or remote `desktop-tutorial` repository, else error surfaced
         - [ ] Repository is created as first step, with green checkmarks for each completed step. 
 	  - [ ] User can click `Exit Tutorial` anytime to return to Onboarding page
@@ -145,18 +145,18 @@
       - [ ] Dark theme is optional 
       - [ ] For Mac, users can opt to match system preference theme with checkbox
     - [ ] Advanced
-      - [ ] Stashing options include "Ask me..", "Alsways bring my changes...", and "Always stash...". "Ask Me" is default.
+      - [ ] Stashing options include "Ask me..", "Always bring my changes...", and "Always stash...". "Ask Me" is default.
       - [ ] Confirmation dialogue for removing repositories is checked by default; user can toggle
-        - [ ] Verify postive `ConfirmDiscardChanges` value in Dev Tools > Application > Local storage > file://
+        - [ ] Verify positive `ConfirmDiscardChanges` value in Dev Tools > Application > Local storage > file://
       - [ ] Confirmation dialogue for discarding files is checked by default; user can toggle
-        - [ ] Verify postive `ConfirmRepoRemoval` value in Dev Tools > Application > Local storage > file://
+        - [ ] Verify positive `ConfirmRepoRemoval` value in Dev Tools > Application > Local storage > file://
       - [ ] Confirmation dialogue for force pushing files is checked by default; user can toggle
-        - [ ] Verify postive `confirmForcePush` value in Dev Tools > Application > Local storage > file://
+        - [ ] Verify positive `confirmForcePush` value in Dev Tools > Application > Local storage > file://
       - [ ] `Save` button saves any changes made
       - [ ] `Cancel` button does not save any changes made; modal closed
       - [ ] Shared usage data option; selection carried through from Welcome flow
         - [ ] `anonymous usage data` link opens https://desktop.github.com/usage-data/
-        - [ ] Verify postive `stats-opt-out` value in Dev Tools > Application > Local storage > file://
+        - [ ] Verify positive `stats-opt-out` value in Dev Tools > Application > Local storage > file://
   - [ ] Install command line tool installs tool at `/usr/local/bin/github` (Mac only as Windows done automagically; Helper may require password, else error message)
     - [ ] If already installed, user sees: "The command line tool has been installed at /usr/local/bin/github"
     - [ ] Clicking `OK` closes modal
@@ -280,13 +280,13 @@
   
 ### Next Steps
  - [ ] Up to four suggested steps are shown at any given time, contingent on the state of the repository and/or branch
-   - [ ] First step is not always showm, and it can be `View Stash`, `Pull Origin`, `Pull Origin`, `Create Pull Request`, `Publish Repository`
+   - [ ] First step is not always shown, and it can be `View Stash`, `Pull Origin`, `Pull Origin`, `Create Pull Request`, `Publish Repository`
    - [ ] Other steps are `Open in [editor]` with Preferences/Options link, `Show in [Finder/Explorer]` and `View in GitHub`
 
 ### Repositories list
   - [ ] Current repository is always shown in top slot with respective icon; if repository exists
   - [ ] Opening list shows all repositories, categorized by owner in alpha format with a working filter
-    - [ ] If more than six repostories, a Recent group will appear at the top of the list; limit 3 repositories
+    - [ ] If more than six repositories, a Recent group will appear at the top of the list; limit 3 repositories
     - [ ] `ESC` clears the filter
     - [ ] Search filter match results in bold characters
     - [ ] A repository with uncommitted files shows a `•` next to name
@@ -370,12 +370,12 @@
     - [ ] `Push` with number of commits badge is decremented or reverts to `Fetch origin`
   - [ ] `Undo` button disabled if user is pushing commit
   - [ ] User can publish a new repository with no commits (aka unborn repository/branch)
-  - [ ] User can make new branch the default branch, by making the intial commit on the new branch
-  - [ ] User can select individual file(s) -- and individial lines of a file(s) -- to commit at a time
+  - [ ] User can make new branch the default branch, by making the initial commit on the new branch
+  - [ ] User can select individual file(s) -- and individual lines of a file(s) -- to commit at a time
   - [ ] Forked messaging shown if user cannot write to cloned repository and there are changes
     - [ ] If user opts to fork the repository, a confirmation dialogue surfaced. Errors caught within the dialogue.
     - [ ] Clicking confirm results in successful fork creation
-  - [ ] Protected branches messsaging shown if branch is protected and there are changes
+  - [ ] Protected branches messaging shown if branch is protected and there are changes
   
 ### Co-authoring (Changes tab)
   - [ ] clicking co-author icon toggles co-author field; or right-click within commit area
@@ -391,7 +391,7 @@
         - [ ] Navigating away from the Changes tab will clear red tags 
      - [ ] Toggling the co-author icon clears the field
   - [ ] All co-authors show up in History and diff view
-    - [ ] Commits with `Co-Authored-By: Name <username@github.com>`in the decription field reveal avatar of user    
+    - [ ] Commits with `Co-Authored-By: Name <username@github.com>`in the description field reveal avatar of user    
     - [ ] Hovering over an avatar reveals all tagged users
     - [ ] Hovering over the "people" text reveals all names/emails of tagged users
   - [ ] Undoing a commit re-enables the valid tags

--- a/docs/technical/rebase-flow.md
+++ b/docs/technical/rebase-flow.md
@@ -42,7 +42,7 @@ underlying Git implementation.
 The rebase flow that Desktop currently uses is the simple
 `git rebase <upstream> <branch>`. In the rest of this document I will refer to
 `<upstream>` as the **base branch** and `<branch>` as the **target branch**, to
-differenitate from the upstream remote.
+differentiate from the upstream remote.
 
 When `git` invokes `git rebase <upstream> <branch>` it performs these steps as
 setup:


### PR DESCRIPTION
## Description

Just some typos fixed in the docs.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
