### PR TITLE
Release 2.5.7-beta1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.6",
+  "version": "2.5.7-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,11 @@
 {
   "releases": {
+    "2.5.7-beta1": [
+      "[New] Split diffs! Toggle between viewing diffs in split or unified mode - #10617",
+      "[Fixed] Actions in the context menu of a non-selected file in history no longer acts on the previously selected item - #10743",
+      "[Added] Add `toml` syntax highlight - #10763. Thanks @samundra!",
+      "[Added] Add support for Nova as external editor on macOS - #10645. Thanks @greystate!"
+    ],
     "2.5.6": [
       "[New] Newly created repositories use 'main' as the default branch name - #10527",
       "[New] Users can configure the default branch name in Preferences/Options - #10527",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming first beta of the v2.5.7 series? Well you've just found it, congratulations! :tada:

We're targeting a release on October 12th.

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
 - #10770
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
 - no new metrics