### PR TITLE
chore: fix typos

### DIFF
--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -67,6 +67,6 @@ export async function stageManualConflictResolution(
       break
     }
     default:
-      assertNever(chosen, 'unnacounted for git status entry possibility')
+      assertNever(chosen, 'unaccounted for git status entry possibility')
   }
 }

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -14,7 +14,7 @@ import { IRemote } from '../../../models/remote'
 import { envForRemoteOperation } from '../../git/environment'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
-const InititalReadmeContents =
+const InitialReadmeContents =
   `# Welcome to GitHub Desktop!${nl}${nl}` +
   `This is your README. READMEs are where you can communicate ` +
   `what your project is and how to use it.${nl}${nl}` +
@@ -119,7 +119,7 @@ export async function createTutorialRepository(
   await ensureDir(path)
   await git(['init'], path, 'tutorial:init')
 
-  await writeFile(Path.join(path, 'README.md'), InititalReadmeContents)
+  await writeFile(Path.join(path, 'README.md'), InitialReadmeContents)
 
   await git(['add', '--', 'README.md'], path, 'tutorial:add')
   await git(

--- a/app/src/lib/stores/updates/update-remote-url.ts
+++ b/app/src/lib/stores/updates/update-remote-url.ts
@@ -27,11 +27,11 @@ export async function updateRemoteUrl(
   // manually configured their remote to use this format and we don't
   // want to change what they've done just to be safe
   const parsedRemoteUrl = URL.parse(remoteUrl)
-  const parsedUpdaedRemoteUrl = URL.parse(updatedRemoteUrl)
+  const parsedUpdatedRemoteUrl = URL.parse(updatedRemoteUrl)
   const protocolsMatch =
     parsedRemoteUrl.protocol !== null &&
-    parsedUpdaedRemoteUrl.protocol !== null &&
-    parsedRemoteUrl.protocol === parsedUpdaedRemoteUrl.protocol
+    parsedUpdatedRemoteUrl.protocol !== null &&
+    parsedRemoteUrl.protocol === parsedUpdatedRemoteUrl.protocol
 
   // Check if the default remote url has been manually changed from the
   // clone url retrieved from the GitHub API previously

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1866,7 +1866,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         const { repository, branchToCheckout: branchToCheckout } = popup
         return (
           <OverwriteStash
-            key="overwite-stash"
+            key="overwrite-stash"
             dispatcher={this.props.dispatcher}
             repository={repository}
             branchToCheckout={branchToCheckout}
@@ -2021,7 +2021,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
         if (conflictState === null || conflictState.kind === 'merge') {
           log.debug(
-            `[App.onShowRebasConflictsBanner] no conflict state found, ignoring...`
+            `[App.onShowRebaseConflictsBanner] no conflict state found, ignoring...`
           )
           return
         }

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -643,7 +643,7 @@ export class CloneRepository extends React.Component<
     try {
       this.cloneImpl(url.trim(), path)
     } catch (e) {
-      log.error(`CloneRepostiory: clone failed to complete to ${path}`, e)
+      log.error(`CloneRepository: clone failed to complete to ${path}`, e)
       this.setState({ loading: false })
       this.setSelectedTabState({ error: e })
     }

--- a/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
+++ b/app/src/ui/clone-repository/cloneable-repository-filter-list.tsx
@@ -3,7 +3,7 @@ import { Account } from '../../models/account'
 import { FilterList, IFilterListGroup } from '../lib/filter-list'
 import { IAPIRepository, getDotComAPIEndpoint, getHTMLURL } from '../../lib/api'
 import {
-  IClonableRepositoryListItem,
+  ICloneableRepositoryListItem,
   groupRepositories,
   YourRepositoriesIdentifier,
 } from './group-repositories'
@@ -83,7 +83,7 @@ const RowHeight = 31
  * the clone url of the provided repository.
  */
 function findMatchingListItem(
-  groups: ReadonlyArray<IFilterListGroup<IClonableRepositoryListItem>>,
+  groups: ReadonlyArray<IFilterListGroup<ICloneableRepositoryListItem>>,
   selectedRepository: IAPIRepository | null
 ) {
   if (selectedRepository !== null) {
@@ -106,7 +106,7 @@ function findMatchingListItem(
  */
 function findRepositoryForListItem(
   repositories: ReadonlyArray<IAPIRepository>,
-  listItem: IClonableRepositoryListItem
+  listItem: ICloneableRepositoryListItem
 ) {
   return repositories.find(r => r.clone_url === listItem.url) || null
 }
@@ -162,7 +162,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
     const selectedListItem = this.getSelectedListItem(groups, selectedItem)
 
     return (
-      <FilterList<IClonableRepositoryListItem>
+      <FilterList<ICloneableRepositoryListItem>
         className="clone-github-repo"
         rowHeight={RowHeight}
         selectedItem={selectedListItem}
@@ -182,7 +182,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
   }
 
   private onItemClick = (
-    item: IClonableRepositoryListItem,
+    item: ICloneableRepositoryListItem,
     source: ClickSource
   ) => {
     const { onItemClicked, repositories } = this.props
@@ -198,7 +198,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
     }
   }
 
-  private onSelectionChanged = (item: IClonableRepositoryListItem | null) => {
+  private onSelectionChanged = (item: ICloneableRepositoryListItem | null) => {
     if (item === null || this.props.repositories === null) {
       this.props.onSelectionChanged(null)
     } else {
@@ -221,7 +221,7 @@ export class CloneableRepositoryFilterList extends React.PureComponent<
   }
 
   private renderItem = (
-    item: IClonableRepositoryListItem,
+    item: ICloneableRepositoryListItem,
     matches: IMatches
   ) => {
     return (

--- a/app/src/ui/clone-repository/group-repositories.ts
+++ b/app/src/ui/clone-repository/group-repositories.ts
@@ -6,7 +6,7 @@ import { OcticonSymbol } from '../octicons'
 /** The identifier for the "Your Repositories" grouping. */
 export const YourRepositoriesIdentifier = 'your-repositories'
 
-export interface IClonableRepositoryListItem extends IFilterListItem {
+export interface ICloneableRepositoryListItem extends IFilterListItem {
   /** The identifier for the item. */
   readonly id: string
 
@@ -36,8 +36,8 @@ function getIcon(gitHubRepo: IAPIRepository): OcticonSymbol {
 
 function convert(
   repositories: ReadonlyArray<IAPIRepository>
-): ReadonlyArray<IClonableRepositoryListItem> {
-  const repos: ReadonlyArray<IClonableRepositoryListItem> = repositories.map(
+): ReadonlyArray<ICloneableRepositoryListItem> {
+  const repos: ReadonlyArray<ICloneableRepositoryListItem> = repositories.map(
     repo => {
       const icon = getIcon(repo)
 
@@ -57,7 +57,7 @@ function convert(
 export function groupRepositories(
   repositories: ReadonlyArray<IAPIRepository>,
   login: string
-): ReadonlyArray<IFilterListGroup<IClonableRepositoryListItem>> {
+): ReadonlyArray<IFilterListGroup<ICloneableRepositoryListItem>> {
   const userRepos = repositories.filter(repo => repo.owner.type === 'User')
   const orgRepos = repositories.filter(
     repo => repo.owner.type === 'Organization'

--- a/app/src/ui/lfs/attribute-mismatch.tsx
+++ b/app/src/ui/lfs/attribute-mismatch.tsx
@@ -65,7 +65,7 @@ export class AttributeMismatch extends React.Component<
             : 'Update existing Git LFS filters?'
         }
         onDismissed={this.props.onDismissed}
-        onSubmit={this.onSumit}
+        onSubmit={this.onSubmit}
       >
         <DialogContent>
           <p>
@@ -87,7 +87,7 @@ export class AttributeMismatch extends React.Component<
     )
   }
 
-  private onSumit = () => {
+  private onSubmit = () => {
     this.props.onUpdateExistingFilters()
     this.props.onDismissed()
   }

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -88,7 +88,7 @@ interface IListProps {
    * Consumers of this event do _not_ have to call event.preventDefault,
    * when this event is subscribed to the list will automatically call it.
    */
-  readonly onRowClick?: (row: number, soure: ClickSource) => void
+  readonly onRowClick?: (row: number, source: ClickSource) => void
 
   /**
    * This prop defines the behaviour of the selection of items within this list.

--- a/app/test/fixtures/merge-parser/desktop/failed-merge-master-into-stale-branch-really.txt
+++ b/app/test/fixtures/merge-parser/desktop/failed-merge-master-into-stale-branch-really.txt
@@ -9190,12 +9190,12 @@ merged
  import { IFilterListGroup } from '../lib/filter-list'
 +import { IMatches } from '../../lib/fuzzy-find'
  import {
-   IClonableRepositoryListItem,
+   ICloneableRepositoryListItem,
    groupRepositories,
 @@ -204,13 +205,13 @@
 
    private renderItem = (
-     item: IClonableRepositoryListItem,
+     item: ICloneableRepositoryListItem,
 -    matches: ReadonlyArray<number>
 +    matches: IMatches
    ) => {

--- a/app/test/fixtures/merge-parser/desktop/merge-no-more-dexie-into-offline-mode-y-u-no-work.txt
+++ b/app/test/fixtures/merge-parser/desktop/merge-no-more-dexie-into-offline-mode-y-u-no-work.txt
@@ -1188,8 +1188,8 @@ changed in both
  function convert(
 -  repositories: ReadonlyArray<IAPIRepository>
 +  repositories: ReadonlyArray<IRepositoryAPIResult>
- ): ReadonlyArray<IClonableRepositoryListItem> {
-   const repos: ReadonlyArray<IClonableRepositoryListItem> = repositories.map(
+ ): ReadonlyArray<ICloneableRepositoryListItem> {
+   const repos: ReadonlyArray<ICloneableRepositoryListItem> = repositories.map(
      repo => {
 @@ -55,7 +55,7 @@
  }
@@ -1198,7 +1198,7 @@ changed in both
 -  repositories: ReadonlyArray<IAPIRepository>,
 +  repositories: ReadonlyArray<IRepositoryAPIResult>,
    login: string
- ): ReadonlyArray<IFilterListGroup<IClonableRepositoryListItem>> {
+ ): ReadonlyArray<IFilterListGroup<ICloneableRepositoryListItem>> {
    const userRepos = repositories.filter(repo => repo.owner.type === 'User')
 merged
   result 100644 0046063ad8f56f2b7cb21d2a88898cdc0fa75a91 app/src/ui/publish-repository/publish-repository.tsx

--- a/app/test/fixtures/merge-parser/desktop/merge-rework-state-for-repositories-into-offline-mode-y-u-no-work.txt
+++ b/app/test/fixtures/merge-parser/desktop/merge-rework-state-for-repositories-into-offline-mode-y-u-no-work.txt
@@ -553,7 +553,7 @@ merged
 -import { IFilterListGroup } from '../lib/filter-list'
 -import { IMatches } from '../../lib/fuzzy-find'
  import {
-   IClonableRepositoryListItem,
+   ICloneableRepositoryListItem,
    groupRepositories,
 merged
   result 100644 409a64070c8e30188cda16fff34d038ffb51b8af app/src/ui/clone-repository/group-repositories.ts

--- a/app/test/fixtures/merge-parser/failed-merge-master-into-stale-branch-really.txt
+++ b/app/test/fixtures/merge-parser/failed-merge-master-into-stale-branch-really.txt
@@ -9190,12 +9190,12 @@ merged
  import { IFilterListGroup } from '../lib/filter-list'
 +import { IMatches } from '../../lib/fuzzy-find'
  import {
-   IClonableRepositoryListItem,
+   ICloneableRepositoryListItem,
    groupRepositories,
 @@ -204,13 +205,13 @@
 
    private renderItem = (
-     item: IClonableRepositoryListItem,
+     item: ICloneableRepositoryListItem,
 -    matches: ReadonlyArray<number>
 +    matches: IMatches
    ) => {


### PR DESCRIPTION
## Description

A few fixes for typos in the code. They're only in log statements or variable names, so should be safe of any side effects.

@niik, last PR on typos, that's pretty much all I found. The only other two had potential side-effects of changing, so I left them as is, which are [this one (Initated => Initiated)](https://github.com/desktop/desktop/blob/d6176b9b9f5873f9a4814296a863fc5c5d1be0d4/app/src/lib/stats/stats-store.ts#L789), and [this one (Clonable => Cloneable)](https://github.com/desktop/desktop/blob/d6176b9b9f5873f9a4814296a863fc5c5d1be0d4/app/src/ui/clone-repository/group-repositories.ts#L9).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
