### PR TITLE
Fix ours/theirs merge conflict resolution for files added in both branches

### DIFF
--- a/app/src/lib/git/add.ts
+++ b/app/src/lib/git/add.ts
@@ -1,0 +1,16 @@
+import { git } from './core'
+import { Repository } from '../../models/repository'
+import { WorkingDirectoryFileChange } from '../../models/status'
+
+/**
+ * Add a conflicted file to the index.
+ *
+ * Typically done after having resolved conflicts either manually
+ * or through checkout --theirs/--ours.
+ */
+export async function addConflictedFile(
+  repository: Repository,
+  file: WorkingDirectoryFileChange
+) {
+  await git(['add', file.path], repository.path, 'addConflictedFile')
+}

--- a/app/src/lib/git/add.ts
+++ b/app/src/lib/git/add.ts
@@ -12,5 +12,5 @@ export async function addConflictedFile(
   repository: Repository,
   file: WorkingDirectoryFileChange
 ) {
-  await git(['add', file.path], repository.path, 'addConflictedFile')
+  await git(['add', '--', file.path], repository.path, 'addConflictedFile')
 }

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -139,6 +139,10 @@ export async function createAndCheckoutBranch(
   )
 }
 
+/**
+ * Check out either stage #2 (ours) or #3 (theirs) for a conflicted
+ * file.
+ */
 export async function checkoutConflictedFile(
   repository: Repository,
   file: WorkingDirectoryFileChange,

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -14,6 +14,7 @@ import {
   getFallbackUrlForProxyResolve,
 } from './environment'
 import { WorkingDirectoryFileChange } from '../../models/status'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 
 export type ProgressCallback = (progress: ICheckoutProgress) => void
 

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -13,6 +13,7 @@ import {
   envForRemoteOperation,
   getFallbackUrlForProxyResolve,
 } from './environment'
+import { WorkingDirectoryFileChange } from '../../models/status'
 
 export type ProgressCallback = (progress: ICheckoutProgress) => void
 
@@ -135,5 +136,17 @@ export async function createAndCheckoutBranch(
     ['checkout', '-b', branchName],
     repository.path,
     'createAndCheckoutBranch'
+  )
+}
+
+export async function checkoutConflictedFile(
+  repository: Repository,
+  file: WorkingDirectoryFileChange,
+  resolution: ManualConflictResolution
+) {
+  await git(
+    ['checkout', `--${resolution}`, '--', file.path],
+    repository.path,
+    'checkoutConflictedFile'
   )
 }

--- a/app/src/lib/git/rm.ts
+++ b/app/src/lib/git/rm.ts
@@ -1,5 +1,6 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
+import { WorkingDirectoryFileChange } from '../../models/status'
 
 /**
  * Remove all files from the index
@@ -17,4 +18,14 @@ export async function unstageAllFiles(repository: Repository): Promise<void> {
     repository.path,
     'unstageAllFiles'
   )
+}
+
+/**
+ * Remove conflicted file from  working tree and index
+ */
+export async function removeConflictedFile(
+  repository: Repository,
+  file: WorkingDirectoryFileChange
+) {
+  await git(['rm', file.path], repository.path, 'removeConflictedFile')
 }

--- a/app/src/lib/git/rm.ts
+++ b/app/src/lib/git/rm.ts
@@ -27,5 +27,5 @@ export async function removeConflictedFile(
   repository: Repository,
   file: WorkingDirectoryFileChange
 ) {
-  await git(['rm', file.path], repository.path, 'removeConflictedFile')
+  await git(['rm', '--', file.path], repository.path, 'removeConflictedFile')
 }

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -9,7 +9,6 @@ import {
   ManualConflictResolution,
   ManualConflictResolutionKind,
 } from '../../models/manual-conflict-resolution'
-import { git } from './core'
 import { assertNever } from '../fatal-error'
 import { removeConflictedFile } from './rm'
 import { checkoutConflictedFile } from './checkout'

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -44,6 +44,18 @@ export async function stageManualConflictResolution(
       ? status.entry.them
       : status.entry.us
 
+  const addedInBoth =
+    status.entry.us === GitStatusEntry.Added &&
+    status.entry.them === GitStatusEntry.Added
+
+  if (chosen === GitStatusEntry.UpdatedButUnmerged || addedInBoth) {
+    await git(
+      ['checkout', `--${manualResolution}`, '--', file.path],
+      repository.path,
+      'checkoutConflictedFile'
+    )
+  }
+
   switch (chosen) {
     case GitStatusEntry.Deleted:
       await git(['rm', file.path], repository.path, 'removeConflictedFile')
@@ -52,15 +64,6 @@ export async function stageManualConflictResolution(
       await git(['add', file.path], repository.path, 'addConflictedFile')
       break
     case GitStatusEntry.UpdatedButUnmerged:
-      const choiceFlag =
-        manualResolution === ManualConflictResolutionKind.theirs
-          ? 'theirs'
-          : 'ours'
-      await git(
-        ['checkout', `--${choiceFlag}`, '--', file.path],
-        repository.path,
-        'checkoutConflictedFile'
-      )
       await git(['add', file.path], repository.path, 'addConflictedFile')
       break
     default:

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -5,10 +5,7 @@ import {
   GitStatusEntry,
   isConflictWithMarkers,
 } from '../../models/status'
-import {
-  ManualConflictResolution,
-  ManualConflictResolutionKind,
-} from '../../models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { assertNever } from '../fatal-error'
 import { removeConflictedFile } from './rm'
 import { checkoutConflictedFile } from './checkout'
@@ -42,7 +39,7 @@ export async function stageManualConflictResolution(
   }
 
   const chosen =
-    manualResolution === ManualConflictResolutionKind.theirs
+    manualResolution === ManualConflictResolution.theirs
       ? status.entry.them
       : status.entry.us
 

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -61,8 +61,6 @@ export async function stageManualConflictResolution(
       await git(['rm', file.path], repository.path, 'removeConflictedFile')
       break
     case GitStatusEntry.Added:
-      await git(['add', file.path], repository.path, 'addConflictedFile')
-      break
     case GitStatusEntry.UpdatedButUnmerged:
       await git(['add', file.path], repository.path, 'addConflictedFile')
       break

--- a/app/src/lib/git/stage.ts
+++ b/app/src/lib/git/stage.ts
@@ -45,15 +45,13 @@ export async function stageManualConflictResolution(
       : status.entry.us
 
   switch (chosen) {
-    case GitStatusEntry.Deleted: {
+    case GitStatusEntry.Deleted:
       await git(['rm', file.path], repository.path, 'removeConflictedFile')
       break
-    }
-    case GitStatusEntry.Added: {
+    case GitStatusEntry.Added:
       await git(['add', file.path], repository.path, 'addConflictedFile')
       break
-    }
-    case GitStatusEntry.UpdatedButUnmerged: {
+    case GitStatusEntry.UpdatedButUnmerged:
       const choiceFlag =
         manualResolution === ManualConflictResolutionKind.theirs
           ? 'theirs'
@@ -65,7 +63,6 @@ export async function stageManualConflictResolution(
       )
       await git(['add', file.path], repository.path, 'addConflictedFile')
       break
-    }
     default:
       assertNever(chosen, 'unnacounted for git status entry possibility')
   }

--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -9,10 +9,7 @@ import {
   WorkingDirectoryFileChange,
 } from '../models/status'
 import { assertNever } from './fatal-error'
-import {
-  ManualConflictResolution,
-  ManualConflictResolutionKind,
-} from '../models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 
 /**
  * Convert a given `AppFileStatusKind` value to a human-readable string to be
@@ -153,7 +150,7 @@ export function getUntrackedFiles(
 /** Filter working directory changes for resolved files  */
 export function getResolvedFiles(
   status: WorkingDirectoryStatus,
-  manualResolutions: Map<string, ManualConflictResolutionKind>
+  manualResolutions: Map<string, ManualConflictResolution>
 ) {
   return status.files.filter(
     f =>
@@ -165,7 +162,7 @@ export function getResolvedFiles(
 /** Filter working directory changes for conflicted files  */
 export function getConflictedFiles(
   status: WorkingDirectoryStatus,
-  manualResolutions: Map<string, ManualConflictResolutionKind>
+  manualResolutions: Map<string, ManualConflictResolution>
 ) {
   return status.files.filter(
     f =>

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -220,10 +220,7 @@ import {
   updateConflictState,
   selectWorkingDirectoryFiles,
 } from './updates/changes-state'
-import {
-  ManualConflictResolution,
-  ManualConflictResolutionKind,
-} from '../../models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { BranchPruner } from './helpers/branch-pruner'
 import { enableUpdateRemoteUrl } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
@@ -4569,7 +4566,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _finishConflictedMerge(
     repository: Repository,
     workingDirectory: WorkingDirectoryStatus,
-    manualResolutions: Map<string, ManualConflictResolutionKind>
+    manualResolutions: Map<string, ManualConflictResolution>
   ): Promise<string | undefined> {
     /**
      *  The assumption made here is that all other files that were part of this merge

--- a/app/src/models/manual-conflict-resolution.ts
+++ b/app/src/models/manual-conflict-resolution.ts
@@ -1,6 +1,6 @@
-// NOTE: These strings have semantic value, they're
-// passed directly as `--ours` and `--theirs` to
-// git checkout. Take care if ever
+// NOTE: These strings have semantic value, they're passed directly
+// as `--ours` and `--theirs` to git checkout. Please be careful
+// when modifying this type.
 export enum ManualConflictResolutionKind {
   theirs = 'theirs',
   ours = 'ours',

--- a/app/src/models/manual-conflict-resolution.ts
+++ b/app/src/models/manual-conflict-resolution.ts
@@ -1,11 +1,7 @@
 // NOTE: These strings have semantic value, they're passed directly
 // as `--ours` and `--theirs` to git checkout. Please be careful
 // when modifying this type.
-export enum ManualConflictResolutionKind {
+export enum ManualConflictResolution {
   theirs = 'theirs',
   ours = 'ours',
 }
-
-export type ManualConflictResolution =
-  | ManualConflictResolutionKind.theirs
-  | ManualConflictResolutionKind.ours

--- a/app/src/models/manual-conflict-resolution.ts
+++ b/app/src/models/manual-conflict-resolution.ts
@@ -1,3 +1,6 @@
+// NOTE: These strings have semantic value, they're
+// passed directly as `--ours` and `--theirs` to
+// git checkout. Take care if ever
 export enum ManualConflictResolutionKind {
   theirs = 'theirs',
   ours = 'ours',

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -12,10 +12,7 @@ import { Dispatcher } from '../../dispatcher'
 import { showContextualMenu } from '../../main-process-proxy'
 import { Octicon, OcticonSymbol } from '../../octicons'
 import { PathText } from '../path-text'
-import {
-  ManualConflictResolutionKind,
-  ManualConflictResolution,
-} from '../../../models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../../models/manual-conflict-resolution'
 import {
   OpenWithDefaultProgramLabel,
   RevealInFileManagerLabel,
@@ -339,7 +336,7 @@ function getManualResolutionMenuItems(
         dispatcher.updateManualConflictResolution(
           repository,
           relativeFilePath,
-          ManualConflictResolutionKind.ours
+          ManualConflictResolution.ours
         ),
     },
 
@@ -349,7 +346,7 @@ function getManualResolutionMenuItems(
         dispatcher.updateManualConflictResolution(
           repository,
           relativeFilePath,
-          ManualConflictResolutionKind.theirs
+          ManualConflictResolution.theirs
         ),
     },
   ]
@@ -360,10 +357,10 @@ function resolvedFileStatusString(
   manualResolution?: ManualConflictResolution,
   branch?: string
 ): string {
-  if (manualResolution === ManualConflictResolutionKind.ours) {
+  if (manualResolution === ManualConflictResolution.ours) {
     return getUnmergedStatusEntryDescription(status.entry.us, branch)
   }
-  if (manualResolution === ManualConflictResolutionKind.theirs) {
+  if (manualResolution === ManualConflictResolution.theirs) {
     return getUnmergedStatusEntryDescription(status.entry.them, branch)
   }
   return 'No conflicts remaining'
@@ -413,10 +410,10 @@ function getBranchForResolution(
   ourBranch?: string,
   theirBranch?: string
 ): string | undefined {
-  if (manualResolution === ManualConflictResolutionKind.ours) {
+  if (manualResolution === ManualConflictResolution.ours) {
     return ourBranch
   }
-  if (manualResolution === ManualConflictResolutionKind.theirs) {
+  if (manualResolution === ManualConflictResolution.theirs) {
     return theirBranch
   }
   return undefined

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -42,7 +42,7 @@ import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cach
 import { ApiRepositoriesStore } from '../../src/lib/stores/api-repositories-store'
 import { getStatusOrThrow } from '../helpers/status'
 import { AppFileStatusKind } from '../../src/models/status'
-import { ManualConflictResolutionKind } from '../../src/models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../src/models/manual-conflict-resolution'
 
 // enable mocked version
 jest.mock('../../src/lib/window-state')
@@ -201,7 +201,7 @@ describe('AppStore', () => {
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
-          new Map<string, ManualConflictResolutionKind>()
+          new Map<string, ManualConflictResolution>()
         )
         const newStatus = await getStatusOrThrow(repo)
         const trackedFiles = newStatus.workingDirectory.files.filter(
@@ -219,7 +219,7 @@ describe('AppStore', () => {
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
-          new Map<string, ManualConflictResolutionKind>()
+          new Map<string, ManualConflictResolution>()
         )
         const newStatus = await getStatusOrThrow(repo)
         const untrackedfiles = newStatus.workingDirectory.files.filter(
@@ -242,7 +242,7 @@ describe('AppStore', () => {
         await appStore._finishConflictedMerge(
           repo,
           status.workingDirectory,
-          new Map<string, ManualConflictResolutionKind>()
+          new Map<string, ManualConflictResolution>()
         )
         const newStatus = await getStatusOrThrow(repo)
         const modifiedFiles = newStatus.workingDirectory.files.filter(

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -579,6 +579,48 @@ describe('git/commit', () => {
         expect(newStatus.workingDirectory.files).toHaveLength(1)
       })
 
+      it('checks out our content for file added in both branches', async () => {
+        const status = await getStatusOrThrow(repository)
+        const trackedFiles = status.workingDirectory.files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        const manualResolutions = new Map([
+          ['baz', ManualConflictResolutionKind.ours],
+        ])
+        const sha = await createMergeCommit(
+          repository,
+          trackedFiles,
+          manualResolutions
+        )
+        expect(await FSE.readFile(path.join(repository.path, 'baz'))).toEqual(
+          'b1'
+        )
+        const newStatus = await getStatusOrThrow(repository)
+        expect(sha).toHaveLength(7)
+        expect(newStatus.workingDirectory.files).toHaveLength(1)
+      })
+
+      it('checks out their content for file added in both branches', async () => {
+        const status = await getStatusOrThrow(repository)
+        const trackedFiles = status.workingDirectory.files.filter(
+          f => f.status.kind !== AppFileStatusKind.Untracked
+        )
+        const manualResolutions = new Map([
+          ['baz', ManualConflictResolutionKind.theirs],
+        ])
+        const sha = await createMergeCommit(
+          repository,
+          trackedFiles,
+          manualResolutions
+        )
+        expect(await FSE.readFile(path.join(repository.path, 'baz'))).toEqual(
+          'b2'
+        )
+        const newStatus = await getStatusOrThrow(repository)
+        expect(sha).toHaveLength(7)
+        expect(newStatus.workingDirectory.files).toHaveLength(1)
+      })
+
       describe('binary file conflicts', () => {
         let fileName: string
         let fileContentsOurs: string, fileContentsTheirs: string

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -33,7 +33,7 @@ import {
   DiffType,
 } from '../../../src/models/diff'
 import { getStatusOrThrow } from '../../helpers/status'
-import { ManualConflictResolutionKind } from '../../../src/models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../../src/models/manual-conflict-resolution'
 import { isConflictedFile } from '../../../src/lib/status'
 
 async function getTextDiff(
@@ -543,7 +543,7 @@ describe('git/commit', () => {
           f => f.status.kind !== AppFileStatusKind.Untracked
         )
         const manualResolutions = new Map([
-          ['bar', ManualConflictResolutionKind.ours],
+          ['bar', ManualConflictResolution.ours],
         ])
         const sha = await createMergeCommit(
           repository,
@@ -564,7 +564,7 @@ describe('git/commit', () => {
           f => f.status.kind !== AppFileStatusKind.Untracked
         )
         const manualResolutions = new Map([
-          ['bar', ManualConflictResolutionKind.theirs],
+          ['bar', ManualConflictResolution.theirs],
         ])
         const sha = await createMergeCommit(
           repository,
@@ -585,7 +585,7 @@ describe('git/commit', () => {
           f => f.status.kind !== AppFileStatusKind.Untracked
         )
         const manualResolutions = new Map([
-          ['baz', ManualConflictResolutionKind.ours],
+          ['baz', ManualConflictResolution.ours],
         ])
         const sha = await createMergeCommit(
           repository,
@@ -606,7 +606,7 @@ describe('git/commit', () => {
           f => f.status.kind !== AppFileStatusKind.Untracked
         )
         const manualResolutions = new Map([
-          ['baz', ManualConflictResolutionKind.theirs],
+          ['baz', ManualConflictResolution.theirs],
         ])
         const sha = await createMergeCommit(
           repository,
@@ -666,7 +666,7 @@ describe('git/commit', () => {
           )
 
           const manualResolutions = new Map([
-            [file.path, ManualConflictResolutionKind.theirs],
+            [file.path, ManualConflictResolution.theirs],
           ])
           await createMergeCommit(repository, trackedFiles, manualResolutions)
 
@@ -699,7 +699,7 @@ describe('git/commit', () => {
           )
 
           const manualResolutions = new Map([
-            [file.path, ManualConflictResolutionKind.ours],
+            [file.path, ManualConflictResolution.ours],
           ])
           await createMergeCommit(repository, trackedFiles, manualResolutions)
 

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -592,9 +592,9 @@ describe('git/commit', () => {
           trackedFiles,
           manualResolutions
         )
-        expect(await FSE.readFile(path.join(repository.path, 'baz'))).toEqual(
-          'b1'
-        )
+        expect(
+          await FSE.readFile(path.join(repository.path, 'baz'), 'utf8')
+        ).toEqual('b2')
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)
@@ -613,9 +613,9 @@ describe('git/commit', () => {
           trackedFiles,
           manualResolutions
         )
-        expect(await FSE.readFile(path.join(repository.path, 'baz'))).toEqual(
-          'b2'
-        )
+        expect(
+          await FSE.readFile(path.join(repository.path, 'baz'), 'utf8')
+        ).toEqual('b1')
         const newStatus = await getStatusOrThrow(repository)
         expect(sha).toHaveLength(7)
         expect(newStatus.workingDirectory.files).toHaveLength(1)

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -16,7 +16,7 @@ import { setupEmptyDirectory } from '../../../helpers/repositories'
 import { getBranchOrError } from '../../../helpers/git'
 import { IRebaseProgress } from '../../../../src/models/progress'
 import { isConflictedFile } from '../../../../src/lib/status'
-import { ManualConflictResolutionKind } from '../../../../src/models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../../../src/models/manual-conflict-resolution'
 import { Repository } from '../../../../src/models/repository'
 
 const baseBranchName = 'base-branch'
@@ -141,7 +141,7 @@ describe('git/rebase', () => {
     })
 
     it('reports progress after resolving conflicts', async () => {
-      const strategy = ManualConflictResolutionKind.theirs
+      const strategy = ManualConflictResolution.theirs
       const progressCb = (p: IRebaseProgress) => progress.push(p)
 
       while (result === RebaseResult.ConflictsEncountered) {
@@ -181,12 +181,12 @@ describe('git/rebase', () => {
 
 async function resolveAndContinue(
   repository: Repository,
-  strategy: ManualConflictResolutionKind,
+  strategy: ManualConflictResolution,
   progressCb: (progress: IRebaseProgress) => void
 ) {
   const status = await getStatus(repository)
   const files = status?.workingDirectory.files ?? []
-  const resolutions = new Map<string, ManualConflictResolutionKind>()
+  const resolutions = new Map<string, ManualConflictResolution>()
 
   for (const file of files) {
     if (isConflictedFile(file.status)) {

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -3,10 +3,7 @@ import {
   createState,
   createStatus,
 } from '../../../helpers/changes-state-helper'
-import {
-  ManualConflictResolution,
-  ManualConflictResolutionKind,
-} from '../../../../src/models/manual-conflict-resolution'
+import { ManualConflictResolution } from '../../../../src/models/manual-conflict-resolution'
 import { IStatsStore } from '../../../../src/lib/stats'
 
 describe('updateConflictState', () => {
@@ -21,7 +18,7 @@ describe('updateConflictState', () => {
   })
 
   const manualResolutions = new Map<string, ManualConflictResolution>([
-    ['foo', ManualConflictResolutionKind.theirs],
+    ['foo', ManualConflictResolution.theirs],
   ])
 
   describe('merge conflicts', () => {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10820

## Description

We had an unaccounted for case in our manual conflict resolution logic. When a file was added in both the target and source branch Git will merge it into the working directory with conflict markers. When the user chooses to pick the file from the source or the target branch we need to check said version out before adding it to the index.

I also took the opportunity to clean up the logic a little.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Choosing to resolve a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit.
