### PR TITLE
Change existing assumptions that the default branch is 'master'

### DIFF
--- a/app/git-info.ts
+++ b/app/git-info.ts
@@ -9,7 +9,7 @@ import * as Path from 'path'
  * Will throw an error if the entry is not found in the packed-refs file
  *
  * @param gitDir The path to the Git repository's .git directory
- * @param ref    A qualified git ref such as 'refs/heads/master'
+ * @param ref    A qualified git ref such as 'refs/heads/main'
  */
 function readPackedRefsFile(gitDir: string, ref: string) {
   const packedRefsPath = Path.join(gitDir, 'packed-refs')
@@ -43,7 +43,7 @@ function readPackedRefsFile(gitDir: string, ref: string) {
  * Will throw an error for unborn HEAD.
  *
  * @param   gitDir The path to the Git repository's .git directory
- * @param   ref    A qualified git ref such as 'HEAD' or 'refs/heads/master'
+ * @param   ref    A qualified git ref such as 'HEAD' or 'refs/heads/main'
  * @returns        The ref SHA
  */
 function revParse(gitDir: string, ref: string): string {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -353,7 +353,7 @@ export interface IAPIBranch {
   /**
    * The name of the branch stored on the remote.
    *
-   * NOTE: this is NOT a fully-qualified ref (i.e. `refs/heads/master`)
+   * NOTE: this is NOT a fully-qualified ref (i.e. `refs/heads/main`)
    */
   readonly name: string
   /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -437,9 +437,14 @@ export interface IBranchesState {
   readonly tip: Tip
 
   /**
-   * The default branch for a given repository. Most commonly this
-   * will be the 'master' branch but GitHub users are able to change
-   * their default branch in the web UI.
+   * The default branch for a given repository. Historically it's been
+   * common to use 'master' as the default branch but as of September 2020
+   * GitHub Desktop and GitHub.com default to using 'main' as the default branch.
+   *
+   * GitHub Desktop users are able to configure the `init.defaultBranch` Git
+   * setting in preferences.
+   *
+   * GitHub.com users are able to change their default branch in the web UI.
    */
   readonly defaultBranch: Branch | null
 
@@ -682,9 +687,14 @@ export interface ICompareState {
   readonly recentBranches: ReadonlyArray<Branch>
 
   /**
-   * The default branch for a given repository. Most commonly this
-   * will be the 'master' branch but GitHub users are able to change
-   * their default branch in the web UI.
+   * The default branch for a given repository. Historically it's been
+   * common to use 'master' as the default branch but as of September 2020
+   * GitHub Desktop and GitHub.com default to using 'main' as the default branch.
+   *
+   * GitHub Desktop users are able to configure the `init.defaultBranch` Git
+   * setting in preferences.
+   *
+   * GitHub.com users are able to change their default branch in the web UI.
    */
   readonly defaultBranch: Branch | null
 

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -35,7 +35,7 @@ export interface IDatabaseProtectedBranch {
   /**
    * The branch name associated with the branch protection settings
    *
-   * NOTE: this is NOT a fully-qualified ref (i.e. `refs/heads/master`)
+   * NOTE: this is NOT a fully-qualified ref (i.e. `refs/heads/main`)
    */
   readonly name: string
 }

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -149,7 +149,7 @@ export async function getBranchesPointedAt(
     {
       // - 1 is returned if a common ancestor cannot be resolved
       // - 129 is returned if ref is malformed
-      //   "warning: ignoring broken ref refs/remotes/origin/master."
+      //   "warning: ignoring broken ref refs/remotes/origin/main."
       successExitCodes: new Set([0, 1, 129]),
     }
   )

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -67,7 +67,7 @@ export async function getMergeBase(
     {
       // - 1 is returned if a common ancestor cannot be resolved
       // - 128 is returned if a ref cannot be found
-      //   "warning: ignoring broken ref refs/remotes/origin/master."
+      //   "warning: ignoring broken ref refs/remotes/origin/main."
       successExitCodes: new Set([0, 1, 128]),
     }
   )

--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -3,9 +3,6 @@ import { Repository } from '../../models/repository'
 
 /**
  * Get the `limit` most recently checked out branches.
- *
- * @param defaultBranchName The name of the default branch (will be excluded
- *                          from the list of recent branches)
  */
 export async function getRecentBranches(
   repository: Repository,

--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -9,8 +9,7 @@ import { Repository } from '../../models/repository'
  */
 export async function getRecentBranches(
   repository: Repository,
-  limit: number,
-  defaultBranchName: string | undefined
+  limit: number
 ): Promise<ReadonlyArray<string>> {
   // "git reflog show" is just an alias for "git log -g --abbrev-commit --pretty=oneline"
   // but by using log we can give it a max number which should prevent us from balling out
@@ -43,12 +42,6 @@ export async function getRecentBranches(
   const lines = result.stdout.split('\n')
   const names = new Set<string>()
   const excludedNames = new Set<String>()
-
-  // The default branch already has its own section in the branch
-  // list so we exclude it here.
-  if (defaultBranchName !== undefined) {
-    excludedNames.add(defaultBranchName)
-  }
 
   for (const line of lines) {
     const result = regex.exec(line)

--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -1,10 +1,16 @@
 import { git } from './core'
 import { Repository } from '../../models/repository'
 
-/** Get the `limit` most recently checked out branches. */
+/**
+ * Get the `limit` most recently checked out branches.
+ *
+ * @param defaultBranchName The name of the default branch (will be excluded
+ *                          from the list of recent branches)
+ */
 export async function getRecentBranches(
   repository: Repository,
-  limit: number
+  limit: number,
+  defaultBranchName: string | undefined
 ): Promise<ReadonlyArray<string>> {
   // "git reflog show" is just an alias for "git log -g --abbrev-commit --pretty=oneline"
   // but by using log we can give it a max number which should prevent us from balling out
@@ -36,8 +42,13 @@ export async function getRecentBranches(
 
   const lines = result.stdout.split('\n')
   const names = new Set<string>()
-  // exclude master from recent branches
-  const excludedNames = new Set<String>(['master'])
+  const excludedNames = new Set<String>()
+
+  // The default branch already has its own section in the branch
+  // list so we exclude it here.
+  if (defaultBranchName !== undefined) {
+    excludedNames.add(defaultBranchName)
+  }
 
   for (const line of lines) {
     const result = regex.exec(line)

--- a/app/src/lib/git/refs.ts
+++ b/app/src/lib/git/refs.ts
@@ -6,8 +6,8 @@ import { Repository } from '../../models/repository'
  * is ambiguous are handled.
  *
  * Examples:
- *  - master -> refs/heads/master
- *  - heads/Microsoft/master -> refs/heads/Microsoft/master
+ *  - main -> refs/heads/main
+ *  - heads/Microsoft/main -> refs/heads/Microsoft/main
  *
  * @param branch The local branch name
  */

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -44,7 +44,7 @@ export interface IDailyMeasures {
   /** The number of times a branch is compared to an arbitrary branch */
   readonly branchComparisons: number
 
-  /** The number of times a branch is compared to `master` */
+  /** The number of times a branch is compared to the default branch */
   readonly defaultBranchComparisons: number
 
   /** The number of times a merge is initiated in the `compare` sidebar */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -644,7 +644,7 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  /** Record that a branch comparison has been made to the `master` branch */
+  /** Record that a branch comparison has been made to the default branch */
   public recordDefaultBranchComparison(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       defaultBranchComparisons: m.defaultBranchComparisons + 1,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1066,7 +1066,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         allBranches,
         currentPullRequest,
-        getRemotes
+        getRemotes,
+        cachedDefaultBranch
       )
 
       if (inferredBranch !== null) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -394,13 +394,12 @@ export class GitStore extends BaseStore {
 
     this._allBranches = this.mergeRemoteAndLocalBranches(localAndRemoteBranches)
 
-    await Promise.all([
-      async () => {
-        await this.refreshDefaultBranch()
-        await this.refreshRecentBranches(recentBranchNames)
-      },
-      this.checkPullWithRebase(),
-    ])
+    // refreshRecentBranches is dependent on having a default branch
+    await this.refreshDefaultBranch()
+    this.refreshRecentBranches(recentBranchNames)
+
+    await this.checkPullWithRebase()
+
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -381,10 +381,11 @@ export class GitStore extends BaseStore {
 
   /** Load all the branches. */
   public async loadBranches() {
+    const defaultBranch = this.defaultBranch?.name
     const [localAndRemoteBranches, recentBranchNames] = await Promise.all([
       this.performFailableOperation(() => getBranches(this.repository)) || [],
       this.performFailableOperation(() =>
-        getRecentBranches(this.repository, RecentBranchesLimit)
+        getRecentBranches(this.repository, RecentBranchesLimit, defaultBranch)
       ),
     ])
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -384,7 +384,10 @@ export class GitStore extends BaseStore {
     const [localAndRemoteBranches, recentBranchNames] = await Promise.all([
       this.performFailableOperation(() => getBranches(this.repository)) || [],
       this.performFailableOperation(() =>
-        getRecentBranches(this.repository, RecentBranchesLimit)
+        // Chances are that the recent branches list will contain the default
+        // branch which we filter out in refreshRecentBranches. So grab one
+        // more than we need to account for that.
+        getRecentBranches(this.repository, RecentBranchesLimit + 1)
       ),
     ])
 
@@ -565,6 +568,10 @@ export class GitStore extends BaseStore {
       }
 
       recentBranches.push(branch)
+
+      if (recentBranches.length >= RecentBranchesLimit) {
+        break
+      }
     }
 
     this._recentBranches = recentBranches

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -527,7 +527,7 @@ export class GitStore extends BaseStore {
       ) {
         // strip out everything related to the remote because this
         // is likely to be a tracked branch locally
-        // e.g. `master`, `develop`, etc
+        // e.g. `main`, `develop`, etc
         return match.substr(remoteNamespace.length)
       }
     }
@@ -567,7 +567,7 @@ export class GitStore extends BaseStore {
     return this._tip
   }
 
-  /** The default branch, or `master` if there is no default. */
+  /** The default branch or null if the default branch could not be inferred. */
   public get defaultBranch(): Branch | null {
     return this._defaultBranch
   }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -395,9 +395,10 @@ export class GitStore extends BaseStore {
     this._allBranches = this.mergeRemoteAndLocalBranches(localAndRemoteBranches)
 
     await Promise.all([
-      this.refreshDefaultBranch().then(() =>
-        this.refreshRecentBranches(recentBranchNames)
-      ),
+      async () => {
+        await this.refreshDefaultBranch()
+        await this.refreshRecentBranches(recentBranchNames)
+      },
       this.checkPullWithRebase(),
     ])
     this.emitUpdate()

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -381,11 +381,10 @@ export class GitStore extends BaseStore {
 
   /** Load all the branches. */
   public async loadBranches() {
-    const defaultBranch = this.defaultBranch?.name
     const [localAndRemoteBranches, recentBranchNames] = await Promise.all([
       this.performFailableOperation(() => getBranches(this.repository)) || [],
       this.performFailableOperation(() =>
-        getRecentBranches(this.repository, RecentBranchesLimit, defaultBranch)
+        getRecentBranches(this.repository, RecentBranchesLimit)
       ),
     ])
 
@@ -550,6 +549,12 @@ export class GitStore extends BaseStore {
 
     const recentBranches = new Array<Branch>()
     for (const name of recentBranchNames) {
+      // The default branch already has its own section in the branch
+      // list so we exclude it here.
+      if (name === this.defaultBranch?.name) {
+        continue
+      }
+
       const branch = branchesByName.get(name)
       if (!branch) {
         // This means the recent branch has been deleted. That's fine.

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -394,9 +394,12 @@ export class GitStore extends BaseStore {
 
     this._allBranches = this.mergeRemoteAndLocalBranches(localAndRemoteBranches)
 
-    this.refreshDefaultBranch()
-    this.refreshRecentBranches(recentBranchNames)
-    this.checkPullWithRebase()
+    await Promise.all([
+      this.refreshDefaultBranch().then(() =>
+        this.refreshRecentBranches(recentBranchNames)
+      ),
+      this.checkPullWithRebase(),
+    ])
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -190,7 +190,7 @@ export class BranchPruner {
       [...recentlyCheckedOutBranches.keys()].map(formatAsLocalRef)
     )
 
-    // get the locally cached branches of remotes (ie `remotes/origin/master`)
+    // get the locally cached branches of remotes (ie `remotes/origin/main`)
     const remoteBranches = (
       await getBranches(this.repository, `refs/remotes/`)
     ).map(b => formatAsLocalRef(b.name))

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -18,6 +18,7 @@ import moment from 'moment'
 const BackgroundPruneMinimumInterval = 1000 * 60 * 60 * 4
 const ReservedRefs = [
   'HEAD',
+  'refs/heads/main',
   'refs/heads/master',
   'refs/heads/gh-pages',
   'refs/heads/develop',

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -12,6 +12,7 @@ import { git } from '../../git'
 import { friendlyEndpointName } from '../../friendly-endpoint-name'
 import { IRemote } from '../../../models/remote'
 import { envForRemoteOperation } from '../../git/environment'
+import { DefaultBranchInGit } from '../../helpers/default-branch'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InititalReadmeContents =
@@ -63,6 +64,7 @@ async function pushRepo(
   path: string,
   account: Account,
   remote: IRemote,
+  remoteBranchName: string,
   progressCb: (title: string, value: number, description?: string) => void
 ) {
   const pushTitle = `Pushing repository to ${friendlyEndpointName(account)}`
@@ -80,7 +82,7 @@ async function pushRepo(
     }
   )
 
-  const args = ['push', '-u', remote.name, 'master']
+  const args = ['push', '-u', remote.name, remoteBranchName]
   await git(args, path, 'tutorial:push', pushOpts)
 }
 
@@ -113,11 +115,16 @@ export async function createTutorialRepository(
   }
 
   const repo = await createAPIRepository(account, name)
+  const branch = repo.default_branch ?? 'main'
 
   progressCb('Initializing local repository', 0.2)
 
   await ensureDir(path)
   await git(['init'], path, 'tutorial:init')
+
+  if (branch !== DefaultBranchInGit) {
+    await git(['checkout', '-b', branch], path, 'tutorial:rename-branch')
+  }
 
   await writeFile(Path.join(path, 'README.md'), InititalReadmeContents)
 
@@ -136,7 +143,7 @@ export async function createTutorialRepository(
     'tutorial:add-remote'
   )
 
-  await pushRepo(path, account, remote, (title, value, description) => {
+  await pushRepo(path, account, remote, branch, (title, value, description) => {
     progressCb(title, 0.3 + value * 0.6, description)
   })
 

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -126,7 +126,7 @@ export async function createTutorialRepository(
     await git(['checkout', '-b', branch], path, 'tutorial:rename-branch')
   }
 
-  await writeFile(Path.join(path, 'README.md'), InititalReadmeContents)
+  await writeFile(Path.join(path, 'README.md'), InitialReadmeContents)
 
   await git(['add', '--', 'README.md'], path, 'tutorial:add')
   await git(['commit', '-m', 'Initial commit'], path, 'tutorial:commit')

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -129,14 +129,9 @@ export async function createTutorialRepository(
   await writeFile(Path.join(path, 'README.md'), InititalReadmeContents)
 
   await git(['add', '--', 'README.md'], path, 'tutorial:add')
-  await git(
-    ['commit', '-m', 'Initial commit', '--', 'README.md'],
-    path,
-    'tutorial:commit'
-  )
+  await git(['commit', '-m', 'Initial commit'], path, 'tutorial:commit')
 
   const remote: IRemote = { name: 'origin', url: repo.clone_url }
-
   await git(
     ['remote', 'add', remote.name, remote.url],
     path,

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -12,7 +12,10 @@ import { git } from '../../git'
 import { friendlyEndpointName } from '../../friendly-endpoint-name'
 import { IRemote } from '../../../models/remote'
 import { envForRemoteOperation } from '../../git/environment'
-import { DefaultBranchInGit } from '../../helpers/default-branch'
+import {
+  DefaultBranchInGit,
+  DefaultBranchInDesktop,
+} from '../../helpers/default-branch'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InitialReadmeContents =
@@ -115,8 +118,7 @@ export async function createTutorialRepository(
   }
 
   const repo = await createAPIRepository(account, name)
-  const branch = repo.default_branch ?? 'main'
-
+  const branch = repo.default_branch ?? DefaultBranchInDesktop
   progressCb('Initializing local repository', 0.2)
 
   await ensureDir(path)

--- a/app/src/lib/stores/helpers/infer-comparison-branch.ts
+++ b/app/src/lib/stores/helpers/infer-comparison-branch.ts
@@ -19,19 +19,21 @@ type RemotesGetter = (repository: Repository) => Promise<ReadonlyArray<IRemote>>
  * 1. Given a pull request -> target branch of PR
  * 2. Given a forked repository -> default branch on `upstream`
  * 3. Given a hosted repository -> default branch on `origin`
- * 4. Fallback -> `master` branch
+ * 4. Fallback -> default branch
  *
  * @param repository The repository the branch belongs to
  * @param branches The list of all branches for the repository
  * @param currentPullRequest The pull request to use for finding the branch
  * @param getRemotes callback used to get all remotes for the current repository
+ * @param defaultBranch the current default branch or null if default branch is not known
  */
 
 export async function inferComparisonBranch(
   repository: Repository,
   branches: ReadonlyArray<Branch>,
   currentPullRequest: PullRequest | null,
-  getRemotes: RemotesGetter
+  getRemotes: RemotesGetter,
+  defaultBranch: Branch | null
 ): Promise<Branch | null> {
   if (currentPullRequest !== null) {
     const prBranch = getTargetBranchOfPullRequest(branches, currentPullRequest)
@@ -61,11 +63,7 @@ export async function inferComparisonBranch(
     }
   }
 
-  return getMasterBranch(branches)
-}
-
-function getMasterBranch(branches: ReadonlyArray<Branch>): Branch | null {
-  return findBranch(branches, 'master')
+  return defaultBranch
 }
 
 function getDefaultBranchOfGitHubRepo(

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -62,8 +62,8 @@ export class Branch {
   /**
    * A branch as loaded from Git.
    *
-   * @param name The short name of the branch. E.g., `master`.
-   * @param upstream The remote-prefixed upstream name. E.g., `origin/master`.
+   * @param name The short name of the branch. E.g., `main`.
+   * @param upstream The remote-prefixed upstream name. E.g., `origin/main`.
    * @param tip Basic information (sha and author) of the latest commit on the branch.
    * @param type The type of branch, e.g., local or remote.
    */

--- a/app/src/models/github-repository.ts
+++ b/app/src/models/github-repository.ts
@@ -16,7 +16,7 @@ export class GitHubRepository {
     public readonly dbID: number | null,
     public readonly isPrivate: boolean | null = null,
     public readonly htmlURL: string | null = null,
-    public readonly defaultBranch: string | null = 'master',
+    public readonly defaultBranch: string | null = null,
     public readonly cloneURL: string | null = null,
     public readonly issuesEnabled: boolean | null = null,
     public readonly isArchived: boolean | null = null,

--- a/app/src/models/tip.ts
+++ b/app/src/models/tip.ts
@@ -18,8 +18,8 @@ export interface IUnbornRepository {
   /**
    * The symbolic reference that the unborn repository points to currently.
    *
-   * Typically this will be "master" but a user can easily create orphaned
-   * branches externally.
+   * Typically this will be whatever `init.defaultBranch` is set to but a user
+   * can create orphaned branches themselves.
    */
   readonly ref: string
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -96,34 +96,34 @@ export class BranchesContainer extends React.Component<
     }
   }
 
-  private getBranchName = (): string => {
-    const { currentBranch, defaultBranch } = this.props
-    if (currentBranch != null) {
-      return currentBranch.name
-    }
-
-    if (defaultBranch != null) {
-      return defaultBranch.name
-    }
-
-    return 'master'
-  }
-
   public render() {
-    const branchName = this.getBranchName()
     return (
       <div className="branches-container">
         {this.renderTabBar()}
         {this.renderSelectedTab()}
-        <Row className="merge-button-row">
-          <Button className="merge-button" onClick={this.onMergeClick}>
-            <Octicon className="icon" symbol={OcticonSymbol.gitMerge} />
-            <span title={`Merge a branch into ${branchName}`}>
-              Choose a branch to merge into <strong>{branchName}</strong>
-            </span>
-          </Button>
-        </Row>
+        {this.renderMergeButtonRow()}
       </div>
+    )
+  }
+
+  private renderMergeButtonRow() {
+    const { currentBranch } = this.props
+
+    // This could happen if HEAD is detached, in that
+    // case it's better to not render anything at all.
+    if (currentBranch === null) {
+      return null
+    }
+
+    return (
+      <Row className="merge-button-row">
+        <Button className="merge-button" onClick={this.onMergeClick}>
+          <Octicon className="icon" symbol={OcticonSymbol.gitMerge} />
+          <span title={`Merge a branch into ${currentBranch.name}`}>
+            Choose a branch to merge into <strong>{currentBranch.name}</strong>
+          </span>
+        </Button>
+      </Row>
     )
   }
 

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -151,7 +151,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
    *
    * We don't want to call this handler on changes to the text box since that
    * will cause the text box to be hidden if the user types a branch name
-   * that starts with one of the suggested branch names (e.g `mastera`).
+   * that starts with one of the suggested branch names (e.g `mainXYZ`).
    *
    * @param defaultBranch string the selected default branch
    */

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -36,7 +36,7 @@ const repository = new Repository(
     isPrivate: false,
     parent: null,
     htmlURL: 'https://github.com/desktop/desktop',
-    defaultBranch: 'master',
+    defaultBranch: 'development',
     cloneURL: 'https://github.com/desktop/desktop',
     endpoint: getDotComAPIEndpoint(),
     fullName: 'desktop/desktop',

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -35,7 +35,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository, 'branch-1')
       await createAndCheckout(repository, 'branch-2')
 
-      const branches = await getRecentBranches(repository, 10, 'master')
+      const branches = await getRecentBranches(repository, 10)
       expect(branches).toContain('branch-1')
       expect(branches).toContain('branch-2')
     })
@@ -51,8 +51,7 @@ describe('git/reflog', () => {
 
       await renameBranch(repository, currentBranch!, 'branch-2-test')
 
-      const branches = await getRecentBranches(repository, 10, 'master')
-      expect(branches).not.toContain('master')
+      const branches = await getRecentBranches(repository, 10)
       expect(branches).not.toContain('branch-2')
       expect(branches).toContain('branch-1')
       expect(branches).toContain('branch-2-test')
@@ -64,7 +63,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository, 'branch-3')
       await createAndCheckout(repository, 'branch-4')
 
-      const branches = await getRecentBranches(repository, 2, 'master')
+      const branches = await getRecentBranches(repository, 2)
       expect(branches).toHaveLength(2)
       expect(branches).toContain('branch-4')
       expect(branches).toContain('branch-3')

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -35,7 +35,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository, 'branch-1')
       await createAndCheckout(repository, 'branch-2')
 
-      const branches = await getRecentBranches(repository, 10)
+      const branches = await getRecentBranches(repository, 10, 'master')
       expect(branches).toContain('branch-1')
       expect(branches).toContain('branch-2')
     })
@@ -51,7 +51,7 @@ describe('git/reflog', () => {
 
       await renameBranch(repository, currentBranch!, 'branch-2-test')
 
-      const branches = await getRecentBranches(repository, 10)
+      const branches = await getRecentBranches(repository, 10, 'master')
       expect(branches).not.toContain('master')
       expect(branches).not.toContain('branch-2')
       expect(branches).toContain('branch-1')
@@ -64,7 +64,7 @@ describe('git/reflog', () => {
       await createAndCheckout(repository, 'branch-3')
       await createAndCheckout(repository, 'branch-4')
 
-      const branches = await getRecentBranches(repository, 2)
+      const branches = await getRecentBranches(repository, 2, 'master')
       expect(branches).toHaveLength(2)
       expect(branches).toContain('branch-4')
       expect(branches).toContain('branch-3')

--- a/app/test/unit/infer-comparison-branch-test.ts
+++ b/app/test/unit/infer-comparison-branch-test.ts
@@ -73,7 +73,8 @@ describe('inferComparisonBranch', () => {
       repo,
       branches,
       null,
-      mockGetRemotes
+      mockGetRemotes,
+      branches[0]
     )
 
     expect(branch).not.toBeNull()
@@ -88,7 +89,8 @@ describe('inferComparisonBranch', () => {
       repo,
       branches,
       null,
-      mockGetRemotes
+      mockGetRemotes,
+      branches[0]
     )
 
     expect(branch).not.toBeNull()
@@ -106,7 +108,8 @@ describe('inferComparisonBranch', () => {
       repo,
       branches,
       pr,
-      mockGetRemotes
+      mockGetRemotes,
+      branches[0]
     )
 
     expect(branch).not.toBeNull()
@@ -136,7 +139,8 @@ describe('inferComparisonBranch', () => {
       repo,
       branches,
       null,
-      mockGetRemotes
+      mockGetRemotes,
+      branches[0]
     )
 
     expect(branch).not.toBeNull()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

As I was adding `main` as a reserved ref for the branch pruner (https://github.com/desktop/desktop/commit/747f91b98f751cbb6a2e2d736416f675654d5d6c) I decided it was time to bite the bullet and update the remaining pieces of our logic where we assume that the default branch name is `master`. Most of these changes have little effect as they're fallback values that rarely get hit but some do.

For example, we now respect the user's preference for default branch name when creating a tutorial repository. Assuming most who create a tutorial repository hasn't overridden the GitHub.com default value we'll now create tutorial repositories with `main` as the default branch.

A lot of the changes are also just comments where we used `master` as a placeholder for "the default branch". I've updated those as well. The remaining instances of the term master all reside in fixtures and I'll open a PR to deal with them after this has been merged because it's gonna involve hundreds of fixture files.
