### PR TITLE
Small partial commit in large text diff

### DIFF
--- a/app/src/lib/git/apply.ts
+++ b/app/src/lib/git/apply.ts
@@ -59,7 +59,7 @@ export async function applyPatchToIndex(
 
   const diff = await getWorkingDirectoryDiff(repository, file)
 
-  if (diff.kind !== DiffType.Text) {
+  if (diff.kind !== DiffType.Text && diff.kind !== DiffType.LargeText) {
     throw new Error(`Unexpected diff result returned: '${diff.kind}'`)
   }
 

--- a/app/src/lib/git/apply.ts
+++ b/app/src/lib/git/apply.ts
@@ -8,6 +8,7 @@ import { DiffType, ITextDiff, DiffSelection } from '../../models/diff'
 import { Repository, WorkingTree } from '../../models/repository'
 import { getWorkingDirectoryDiff } from './diff'
 import { formatPatch, formatPatchToDiscardChanges } from '../patch-formatter'
+import { assertNever } from '../fatal-error'
 
 export async function applyPatchToIndex(
   repository: Repository,
@@ -60,7 +61,20 @@ export async function applyPatchToIndex(
   const diff = await getWorkingDirectoryDiff(repository, file)
 
   if (diff.kind !== DiffType.Text && diff.kind !== DiffType.LargeText) {
-    throw new Error(`Unexpected diff result returned: '${diff.kind}'`)
+    const { kind } = diff
+    switch (diff.kind) {
+      case DiffType.Binary:
+      case DiffType.Image:
+        throw new Error(
+          `Can't create partial commit in binary file: ${file.path}`
+        )
+      case DiffType.Unrenderable:
+        throw new Error(
+          `File diff is too large to generate a partial commit: ${file.path}`
+        )
+      default:
+        assertNever(diff, `Unknown diff kind: ${kind}`)
+    }
   }
 
   const patch = await formatPatch(file, diff)

--- a/app/src/lib/git/update-index.ts
+++ b/app/src/lib/git/update-index.ts
@@ -68,7 +68,7 @@ async function updateIndex(
   paths: ReadonlyArray<string>,
   options: IUpdateIndexOptions = {}
 ) {
-  if (!paths.length) {
+  if (paths.length === 0) {
     return
   }
 

--- a/app/src/lib/git/update-index.ts
+++ b/app/src/lib/git/update-index.ts
@@ -119,9 +119,7 @@ export async function stageFiles(
       normal.push(file.path)
       if (file.status.kind === AppFileStatusKind.Renamed) {
         oldRenamed.push(file.status.oldPath)
-      }
-
-      if (file.status.kind === AppFileStatusKind.Deleted) {
+      } else if (file.status.kind === AppFileStatusKind.Deleted) {
         deletedFiles.push(file.path)
       }
     } else {
@@ -166,9 +164,7 @@ export async function stageFiles(
   // Finally we run through all files that have partial selections.
   // We don't care about renamed or not here since applyPatchToIndex
   // has logic to support that scenario.
-  if (partial.length) {
-    for (const file of partial) {
-      await applyPatchToIndex(repository, file)
-    }
+  for (const file of partial) {
+    await applyPatchToIndex(repository, file)
   }
 }

--- a/app/src/lib/git/update-index.ts
+++ b/app/src/lib/git/update-index.ts
@@ -158,9 +158,7 @@ export async function stageFiles(
   // This third step will only happen if we have files that have been marked
   // for deletion. This covers us for files that were blown away in the last
   // updateIndex call
-  if (deletedFiles.length > 0) {
-    await updateIndex(repository, deletedFiles, { forceRemove: true })
-  }
+  await updateIndex(repository, deletedFiles, { forceRemove: true })
 
   // Finally we run through all files that have partial selections.
   // We don't care about renamed or not here since applyPatchToIndex

--- a/app/src/lib/git/update-index.ts
+++ b/app/src/lib/git/update-index.ts
@@ -56,7 +56,8 @@ interface IUpdateIndexOptions {
 }
 
 /**
- * Updates the index with file contents from the working tree.
+ * Updates the index with file contents from the working tree. This method
+ * is a noop when no paths are provided.
  *
  * @param paths   A list of paths which are to be updated with file contents and
  *                status from the working directory.

--- a/app/src/lib/patch-formatter.ts
+++ b/app/src/lib/patch-formatter.ts
@@ -1,6 +1,11 @@
 import { assertNever } from '../lib/fatal-error'
 import { WorkingDirectoryFileChange, AppFileStatusKind } from '../models/status'
-import { DiffLineType, ITextDiff, DiffSelection } from '../models/diff'
+import {
+  DiffLineType,
+  ITextDiff,
+  DiffSelection,
+  ILargeTextDiff,
+} from '../models/diff'
 
 /**
  * Generates a string matching the format of a GNU unified diff header excluding
@@ -123,7 +128,7 @@ function formatHunkHeader(
  */
 export function formatPatch(
   file: WorkingDirectoryFileChange,
-  diff: ITextDiff
+  diff: ITextDiff | ILargeTextDiff
 ): string {
   let patch = ''
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10640

## Description

In https://github.com/desktop/desktop/pull/10159 we fixed a bug in order to enable partial committing in large files. Unfortunately I missed the case when the diff remains large even after the partial commit which in turn caused #10640. This once again enables partial commits of large **text** diffs.

While I was in there I cleaned up some minor stylistic stuff, improved the error message for this type of issue should it ever arise again, and added some documentation.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Small partial commit of very large text files no longer runs the risk of failing due to unexpected diff results.
