### PR TITLE
Page Up and Page Down support in lists + bonus Home/End range selection

### DIFF
--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -434,14 +434,7 @@ export class List extends React.Component<IListProps, IListState> {
     direction: SelectionDirection,
     source: SelectionSource
   ) {
-    const { selectedRows } = this.props
-    const lastSelection = selectedRows[selectedRows.length - 1] ?? 0
-
-    const newSelection = this.findNextPageSelectableRow(
-      lastSelection,
-      direction
-    )
-
+    const newSelection = this.getNextPageRowIndex(direction)
     this.moveSelectionTo(newSelection, source)
   }
 
@@ -450,13 +443,7 @@ export class List extends React.Component<IListProps, IListState> {
     source: SelectionSource
   ) {
     const { selectedRows } = this.props
-    const lastSelection = selectedRows[selectedRows.length - 1] ?? 0
-
-    const newSelection = this.findNextPageSelectableRow(
-      lastSelection,
-      direction
-    )
-
+    const newSelection = this.getNextPageRowIndex(direction)
     const firstSelection = selectedRows[0] ?? 0
     const range = createSelectionBetween(firstSelection, newSelection)
 
@@ -473,6 +460,13 @@ export class List extends React.Component<IListProps, IListState> {
     }
 
     this.scrollRowToVisible(newSelection)
+  }
+
+  private getNextPageRowIndex(direction: SelectionDirection) {
+    const { selectedRows } = this.props
+    const lastSelection = selectedRows[selectedRows.length - 1] ?? 0
+
+    return this.findNextPageSelectableRow(lastSelection, direction)
   }
 
   private getRowHeight(index: number) {
@@ -675,11 +669,9 @@ export class List extends React.Component<IListProps, IListState> {
     }
 
     if (this.props.onSelectedRangeChanged) {
-      this.props.onSelectedRangeChanged(
-        range[0],
-        range[range.length - 1],
-        source
-      )
+      const from = range[0] ?? 0
+      const to = range[range.length - 1] ?? 0
+      this.props.onSelectedRangeChanged(from, to, source)
     }
 
     this.scrollRowToVisible(row)

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -391,27 +391,24 @@ export class List extends React.Component<IListProps, IListState> {
       ? event.metaKey && event.key === 'ArrowDown'
       : event.key === 'End'
 
+    const isRangeSelection =
+      event.shiftKey &&
+      this.props.selectionMode !== undefined &&
+      this.props.selectionMode !== 'single'
+
     if (isHomeKey) {
       this.moveSelectionToFirstSelectableRow(source)
     } else if (isEndKey) {
       this.moveSelectionToLastSelectableRow(source)
     } else if (event.key === 'ArrowDown') {
-      if (
-        event.shiftKey &&
-        this.props.selectionMode &&
-        this.props.selectionMode !== 'single'
-      ) {
+      if (isRangeSelection) {
         this.addSelection('down', source)
       } else {
         this.moveSelection('down', source)
       }
       event.preventDefault()
     } else if (event.key === 'ArrowUp') {
-      if (
-        event.shiftKey &&
-        this.props.selectionMode &&
-        this.props.selectionMode !== 'single'
-      ) {
+      if (isRangeSelection) {
         this.addSelection('up', source)
       } else {
         this.moveSelection('up', source)
@@ -425,34 +422,26 @@ export class List extends React.Component<IListProps, IListState> {
       // 'select-all' custom DOM event.
       this.onSelectAll(event)
     } else if (event.key === 'PageDown') {
-      if (
-        event.shiftKey &&
-        this.props.selectionMode &&
-        this.props.selectionMode !== 'single'
-      ) {
-        this.addSelectionByPage('down', event)
+      if (isRangeSelection) {
+        this.addSelectionByPage('down', source)
       } else {
-        this.moveSelectionByPage('down', event)
+        this.moveSelectionByPage('down', source)
       }
+      event.preventDefault()
     } else if (event.key === 'PageUp') {
-      if (
-        event.shiftKey &&
-        this.props.selectionMode &&
-        this.props.selectionMode !== 'single'
-      ) {
-        this.addSelectionByPage('up', event)
+      if (isRangeSelection) {
+        this.addSelectionByPage('up', source)
       } else {
-        this.moveSelectionByPage('up', event)
+        this.moveSelectionByPage('up', source)
       }
+      event.preventDefault()
     }
   }
 
   private moveSelectionByPage(
     direction: SelectionDirection,
-    event: React.KeyboardEvent<any>
+    source: SelectionSource
   ) {
-    event.preventDefault()
-
     const { selectedRows } = this.props
     const lastSelection = selectedRows[selectedRows.length - 1] ?? 0
 
@@ -461,12 +450,12 @@ export class List extends React.Component<IListProps, IListState> {
       direction
     )
 
-    this.moveSelectionTo(newSelection, { kind: 'keyboard', event })
+    this.moveSelectionTo(newSelection, source)
   }
 
   private addSelectionByPage(
     direction: SelectionDirection,
-    event: React.KeyboardEvent<any>
+    source: SelectionSource
   ) {
     const { selectedRows } = this.props
     const lastSelection = selectedRows[selectedRows.length - 1] ?? 0
@@ -478,7 +467,6 @@ export class List extends React.Component<IListProps, IListState> {
 
     const firstSelection = selectedRows[0] ?? 0
     const range = createSelectionBetween(firstSelection, newSelection)
-    const source: SelectionSource = { kind: 'keyboard', event }
 
     if (this.props.onSelectionChanged) {
       this.props.onSelectionChanged(range, source)

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -368,11 +368,11 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private onKeyDown = (event: React.KeyboardEvent<any>) => {
-    this.props.selectedRows.forEach(row => {
-      if (this.props.onRowKeyDown) {
+    if (this.props.onRowKeyDown) {
+      for (const row of this.props.selectedRows) {
         this.props.onRowKeyDown(row, event)
       }
-    })
+    }
 
     // The consumer is given a change to prevent the default behavior for
     // keyboard navigation so that they can customize its behavior as needed.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10837 

## Description

This adds support for using the <kbd>PgUp</kbd> and <kbd>PgDown</kbd> keys in any of our lists in the app as well as using <kbd>Shift</kbd><kbd>PgUp</kbd> and <kbd>Shift</kbd><kbd>PgDown</kbd> for range selection where that's supported (currently only the file list).

Note that if you don't have <kbd>PgUp</kbd> and <kbd>PgDown</kbd> on your mac keyboard you can emulate it using 
<kbd>fn</kbd><kbd>↑</kbd> and <kbd>fn</kbd><kbd>↓</kbd>.

While I was in there I also added support for doing range selections using the Home and End keys (emulatable on a mac by using <kbd>Cmd</kbd><kbd>↑</kbd> and <kbd>Cmd</kbd><kbd>↓</kbd>).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Use Page down, Page up, Home, and End keys to navigate and select items in lists
