### PR TITLE
Fix no-response bot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,10 +1,10 @@
 # Configuration for no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response
-daysUntilClose: 14
+daysUntilClose: 7
 # Label requiring a response
 # TODO: also close `needs-reproduction` issues (blocked by https://github.com/probot/no-response/issues/11)
-responseRequiredLabel: more-information-needed
+responseRequiredLabel: more-info-needed
 # Comment to post when closing an issue due to lack of response.
 closeComment: >
   Thank you for your issue!


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->
Fixes our no-response bot which has been broken for a while due to a label change.


## Description

- Updated the `more-information-needed` label to `more-info-needed` since we changed that at some point.
- Reduced the days until close to 7 since we've been manually been closing stale `more-info-needed` issues in that time frame.

