### PR TITLE
Require that users fill out the issue template

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -18,3 +18,5 @@ requestInfoLabelToAdd: more-info-needed
 requestInfoOn:
   pullRequest: false
   issue: true
+
+checkIssueTemplate: true

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -11,7 +11,7 @@ requestInfoReplyComment: >
   allows the maintainers to spend more time fixing bugs, implementing
   enhancements, and reviewing and merging pull requests.
 
-  Thanks for understanding and meeting us halfway 😀
+  Thanks for understanding and meeting us halfway. 😀
 
 requestInfoLabelToAdd: more-info-needed
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Configures the [request info bot](https://probot.github.io/apps/request-info/) to take issue templates into account when determining if we require more information.

Since we added issue templates we've been doing this manually.