### PR TITLE
Image diff scaling fixes

### DIFF
--- a/app/src/ui/diff/image-diffs/image-container.tsx
+++ b/app/src/ui/diff/image-diffs/image-container.tsx
@@ -19,7 +19,9 @@ export class ImageContainer extends React.Component<IImageProps, {}> {
     const imageSource = `data:${image.mediaType};base64,${image.contents}`
 
     return (
-      <img src={imageSource} style={this.props.style} onLoad={this.onLoad} />
+      <div className="image-wrapper">
+        <img src={imageSource} style={this.props.style} onLoad={this.onLoad} />
+      </div>
     )
   }
 

--- a/app/src/ui/diff/image-diffs/modified-image-diff.tsx
+++ b/app/src/ui/diff/image-diffs/modified-image-diff.tsx
@@ -108,8 +108,8 @@ export class ModifiedImageDiff extends React.Component<
     this.resizedTimeoutID = null
 
     const containerSize = {
-      width: contentRect.width,
-      height: contentRect.height,
+      width: target.offsetWidth,
+      height: target.offsetHeight,
     }
     this.setState({ containerSize })
   }

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -28,10 +28,14 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
     const diffBytes = this.props.current.bytes - this.props.previous.bytes
     const diffBytesSign = diffBytes >= 0 ? '+' : '-'
 
+    const style: React.CSSProperties = {
+      maxWidth: this.props.maxSize.width,
+    }
+
     return (
       <div className="image-diff-container" ref={this.props.onContainerRef}>
         <div className="image-diff-two-up">
-          <div className="image-diff-previous">
+          <div className="image-diff-previous" style={style}>
             <div className="image-diff-header">Deleted</div>
             <ImageContainer
               image={this.props.previous}
@@ -46,7 +50,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
             </div>
           </div>
 
-          <div className="image-diff-current">
+          <div className="image-diff-current" style={style}>
             <div className="image-diff-header">Added</div>
             <ImageContainer
               image={this.props.current}

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -19,11 +19,11 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
     const zeroSize = { width: 0, height: 0 }
     const previousImageSize = this.props.previousImageSize || zeroSize
     const currentImageSize = this.props.currentImageSize || zeroSize
-    const diffPercent = percentDiff(
-      this.props.previous.bytes,
-      this.props.current.bytes
-    )
-    const diffBytes = this.props.current.bytes - this.props.previous.bytes
+
+    const { current, previous } = this.props
+
+    const diffPercent = percentDiff(previous.bytes, current.bytes)
+    const diffBytes = current.bytes - previous.bytes
     const diffBytesSign = diffBytes >= 0 ? '+' : ''
 
     const style: React.CSSProperties = {
@@ -36,7 +36,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
           <div className="image-diff-previous" style={style}>
             <div className="image-diff-header">Deleted</div>
             <ImageContainer
-              image={this.props.previous}
+              image={previous}
               onElementLoad={this.props.onPreviousImageLoad}
             />
 
@@ -44,14 +44,14 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
               <span className="strong">W:</span> {previousImageSize.width}
               px | <span className="strong">H:</span> {previousImageSize.height}
               px | <span className="strong">Size:</span>{' '}
-              {formatBytes(this.props.previous.bytes, 2, false)}
+              {formatBytes(previous.bytes, 2, false)}
             </div>
           </div>
 
           <div className="image-diff-current" style={style}>
             <div className="image-diff-header">Added</div>
             <ImageContainer
-              image={this.props.current}
+              image={current}
               onElementLoad={this.props.onCurrentImageLoad}
             />
 
@@ -59,7 +59,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
               <span className="strong">W:</span> {currentImageSize.width}
               px | <span className="strong">H:</span> {currentImageSize.height}
               px | <span className="strong">Size:</span>{' '}
-              {formatBytes(this.props.current.bytes, 2, false)}
+              {formatBytes(current.bytes, 2, false)}
             </div>
           </div>
         </div>

--- a/app/src/ui/diff/image-diffs/two-up.tsx
+++ b/app/src/ui/diff/image-diffs/two-up.tsx
@@ -5,6 +5,10 @@ import { ISize } from './sizing'
 import { formatBytes } from '../../lib/bytes'
 import classNames from 'classnames'
 
+function percentDiff(previous: number, current: number) {
+  return `${Math.abs(Math.round((current / previous) * 100))}%`
+}
+
 interface ITwoUpProps extends ICommonImageDiffProperties {
   readonly previousImageSize: ISize | null
   readonly currentImageSize: ISize | null
@@ -12,12 +16,6 @@ interface ITwoUpProps extends ICommonImageDiffProperties {
 
 export class TwoUp extends React.Component<ITwoUpProps, {}> {
   public render() {
-    const percentDiff = (previous: number, current: number) => {
-      const diff = Math.round((100 * (current - previous)) / previous)
-      const sign = diff > 0 ? '+' : ''
-      return sign + diff + '%'
-    }
-
     const zeroSize = { width: 0, height: 0 }
     const previousImageSize = this.props.previousImageSize || zeroSize
     const currentImageSize = this.props.currentImageSize || zeroSize
@@ -26,7 +24,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
       this.props.current.bytes
     )
     const diffBytes = this.props.current.bytes - this.props.previous.bytes
-    const diffBytesSign = diffBytes >= 0 ? '+' : '-'
+    const diffBytesSign = diffBytes >= 0 ? '+' : ''
 
     const style: React.CSSProperties = {
       maxWidth: this.props.maxSize.width,
@@ -46,7 +44,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
               <span className="strong">W:</span> {previousImageSize.width}
               px | <span className="strong">H:</span> {previousImageSize.height}
               px | <span className="strong">Size:</span>{' '}
-              {formatBytes(this.props.previous.bytes)}
+              {formatBytes(this.props.previous.bytes, 2, false)}
             </div>
           </div>
 
@@ -61,7 +59,7 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
               <span className="strong">W:</span> {currentImageSize.width}
               px | <span className="strong">H:</span> {currentImageSize.height}
               px | <span className="strong">Size:</span>{' '}
-              {formatBytes(this.props.current.bytes)}
+              {formatBytes(this.props.current.bytes, 2, false)}
             </div>
           </div>
         </div>
@@ -74,7 +72,11 @@ export class TwoUp extends React.Component<ITwoUpProps, {}> {
             })}
           >
             {diffBytes !== 0
-              ? `${diffBytesSign}${formatBytes(diffBytes)} (${diffPercent})`
+              ? `${diffBytesSign}${formatBytes(
+                  diffBytes,
+                  2,
+                  false
+                )} (${diffPercent})`
               : 'No size difference'}
           </span>
         </div>

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -351,7 +351,9 @@
 
   .image-diff-previous,
   .image-diff-current {
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     min-height: 0;
     min-width: 0;
 
@@ -434,10 +436,15 @@
       .image-diff-previous,
       .image-diff-current {
         position: absolute;
-        top: 0;
-        left: 0;
+        height: 100%;
+        width: 100%;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
         min-height: 0;
         min-width: 0;
+
         img {
           border: 0;
           background: transparent;
@@ -473,6 +480,9 @@
       position: absolute;
       margin: 0;
       overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       min-height: 0;
       min-width: 0;
 
@@ -526,6 +536,9 @@
         position: absolute;
         margin: 0;
         overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         min-height: 0;
         min-width: 0;
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -428,7 +428,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        img : {
+        img {
           border: 0;
           background: transparent;
         }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -522,7 +522,7 @@
         }
       }
 
-      .image-diff-previous {
+      .image-diff-current {
         right: 0;
       }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -354,6 +354,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     min-height: 0;
     min-width: 0;
 
@@ -439,12 +440,6 @@
         height: 100%;
         width: 100%;
 
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 0;
-        min-width: 0;
-
         img {
           border: 0;
           background: transparent;
@@ -478,13 +473,8 @@
     .image-diff-previous,
     .image-diff-current {
       position: absolute;
-      margin: 0;
-      overflow: hidden;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 0;
-      min-width: 0;
+      width: 100%;
+      height: 100%;
 
       img {
         border: 0;
@@ -534,13 +524,6 @@
       .image-diff-current {
         @include checkboard-background;
         position: absolute;
-        margin: 0;
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 0;
-        min-width: 0;
 
         img {
           border: 0;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -326,7 +326,7 @@
 .panel.image {
   display: flex;
   flex: 1;
-  padding-top: 10px;
+  padding: var(--spacing);
   // Workaround so images stay within diff view until
   // root issue with DPI scaling is addressed, see https://github.com/desktop/desktop/issues/2480
   overflow: hidden;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -330,7 +330,7 @@
 
   .tab-bar {
     width: 350px;
-    margin: 10px auto 0;
+    margin: var(--spacing) auto 0;
   }
 
   // https://stackoverflow.com/a/30792956/2114

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -327,16 +327,17 @@
   display: flex;
   flex: 1;
   padding: var(--spacing);
-  // Workaround so images stay within diff view until
-  // root issue with DPI scaling is addressed, see https://github.com/desktop/desktop/issues/2480
-  overflow: hidden;
 
   .tab-bar {
     width: 350px;
     margin: 10px auto 0;
-    // Workaround to allow toggling between different modes until
-    // root issue with DPI scaling is addressed, see https://github.com/desktop/desktop/issues/2480
-    z-index: 0;
+  }
+
+  // https://stackoverflow.com/a/30792956/2114
+  .image-wrapper {
+    min-width: 0;
+    min-height: 0;
+    text-align: center;
   }
 
   .image-diff-previous {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -327,6 +327,8 @@
   display: flex;
   flex: 1;
   padding: var(--spacing);
+  min-width: 0;
+  min-height: 0;
 
   .tab-bar {
     width: 350px;
@@ -350,6 +352,8 @@
   .image-diff-previous,
   .image-diff-current {
     text-align: center;
+    min-height: 0;
+    min-width: 0;
 
     img {
       @include checkboard-background;
@@ -378,11 +382,13 @@
   justify-content: center;
   align-items: center;
   min-height: 0;
+  min-width: 0;
 
   .image-diff-two-up {
     display: flex;
     max-height: 100%;
     min-height: 0;
+    min-width: 0;
     padding: 0 var(--spacing-double);
 
     .image-diff-previous {
@@ -412,6 +418,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  min-width: 0;
 
   .sizing-container {
     flex: 1;
@@ -419,6 +426,7 @@
     justify-content: center;
     align-items: center;
     min-height: 0;
+    min-width: 0;
 
     .image-container {
       position: relative;
@@ -428,6 +436,8 @@
         position: absolute;
         top: 0;
         left: 0;
+        min-height: 0;
+        min-width: 0;
         img {
           border: 0;
           background: transparent;
@@ -442,6 +452,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  min-width: 0;
 
   .slider {
     align-self: center;
@@ -455,12 +466,15 @@
     justify-content: center;
     align-items: center;
     min-height: 0;
+    min-width: 0;
 
     .image-diff-previous,
     .image-diff-current {
       position: absolute;
       margin: 0;
       overflow: hidden;
+      min-height: 0;
+      min-width: 0;
 
       img {
         border: 0;
@@ -487,6 +501,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  min-width: 0;
 
   .slider {
     align-self: center;
@@ -500,6 +515,7 @@
     justify-content: center;
     align-items: center;
     min-height: 0;
+    min-width: 0;
 
     .image-container {
       position: relative;
@@ -510,6 +526,8 @@
         position: absolute;
         margin: 0;
         overflow: hidden;
+        min-height: 0;
+        min-width: 0;
 
         img {
           border: 0;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -376,10 +376,12 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  min-height: 0;
 
   .image-diff-two-up {
     display: flex;
     max-height: 100%;
+    min-height: 0;
     padding: 0 var(--spacing-double);
 
     .image-diff-previous {
@@ -408,12 +410,14 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 
   .sizing-container {
     flex: 1;
     display: flex;
     justify-content: center;
     align-items: center;
+    min-height: 0;
 
     .image-container {
       position: relative;
@@ -436,6 +440,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 
   .slider {
     align-self: center;
@@ -448,6 +453,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    min-height: 0;
 
     .image-diff-previous,
     .image-diff-current {
@@ -479,6 +485,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 
   .slider {
     align-self: center;
@@ -491,6 +498,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    min-height: 0;
 
     .image-container {
       position: relative;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -477,16 +477,8 @@
       height: 100%;
 
       img {
-        border: 0;
         background: transparent;
       }
-    }
-
-    .image-diff-previous {
-      border: 1px solid var(--color-deleted);
-    }
-    .image-diff-current {
-      border: 1px solid var(--color-new);
     }
 
     .image-container {
@@ -526,17 +518,12 @@
         position: absolute;
 
         img {
-          border: 0;
           background: transparent;
         }
       }
 
       .image-diff-previous {
-        border: 1px solid var(--color-deleted);
         right: 0;
-      }
-      .image-diff-current {
-        border: 1px solid var(--color-new);
       }
 
       .swiper {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #2480
Closes #9717

## Description

This closes the long-standing bug with large images overflowing the diff boundary described in #2480. The majority of this PR is the same type of regression fixes that we've had to apply since Electron 9 like https://github.com/desktop/desktop/pull/10824 but while I was in there I took the opportunity to also align the image diffs more with the image diffs on GitHub.com.

As a results swap, onion, and difference now center the images, the size difference text in 2-up uses two decimal precision, the percentage calculation has been changed to match that of GitHub.com, and there's now a uniform padding for all image diffs. 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### Before

![image](https://user-images.githubusercontent.com/634063/96974843-09a3e100-151a-11eb-84b9-6871bcd927d6.png)

### After

![image](https://user-images.githubusercontent.com/634063/96974878-158fa300-151a-11eb-8ab1-fd2794205b42.png)

### Before

![image](https://user-images.githubusercontent.com/634063/96975045-47a10500-151a-11eb-8b0a-de234e0bfe50.png)

### After

![image](https://user-images.githubusercontent.com/634063/96975067-4e2f7c80-151a-11eb-9638-d97a5cebd09f.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Comparison of different size image changes no longer overflow the bounds of the diff view