### PR TITLE
Prevent accidental repository indicator refresh

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3027,7 +3027,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     // If the user is opening the repository list and we haven't yet
     // started to refresh the repository indicators let's do so.
-    if (foldout.type === FoldoutType.Repository) {
+    if (
+      foldout.type === FoldoutType.Repository &&
+      this.repositoryIndicatorsEnabled
+    ) {
       // N.B: RepositoryIndicatorUpdater.prototype.start is
       // idempotent.
       this.repositoryIndicatorUpdater.start()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Follow-up to #10593

## Description

Due to an unfortunate oversight in #10593 the repository status indicator updater could turn on when expanding the repository list sidebar.

When the application first launches it defers refreshing repository status indicators for 2 minutes as it can be costly and we don't want it to interfere with launch tasks. The exception is if the user opens the repository sidebar, if that happens we kick off the indicator updater immediately. Unfortunately that short-circuit didn't include a check for whether indicators where disabled or not.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
