### PR TITLE
Add workaround to "email address marked as private" error message

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -335,7 +335,7 @@ function getDescriptionForError(error: DugiteError): string | null {
     case DugiteError.CannotMergeUnrelatedHistories:
       return 'Unable to merge unrelated histories in this repository.'
     case DugiteError.PushWithPrivateEmail:
-      return 'Cannot push these commits as they contain an email address marked as private on GitHub.'
+      return 'Cannot push these commits as they contain an email address marked as private on GitHub. To workaround this go to https://github.com/settings/emails and uncheck the "Keep my email address private" checkbox. Then switch back to GitHub Desktop to push your commits. You can then enable the checkbox again.'
     case DugiteError.LFSAttributeDoesNotMatch:
       return 'Git LFS attribute found in global Git configuration does not match expected value.'
     case DugiteError.ProtectedBranchDeleteRejected:

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -335,7 +335,7 @@ function getDescriptionForError(error: DugiteError): string | null {
     case DugiteError.CannotMergeUnrelatedHistories:
       return 'Unable to merge unrelated histories in this repository.'
     case DugiteError.PushWithPrivateEmail:
-      return 'Cannot push these commits as they contain an email address marked as private on GitHub. To workaround this go to https://github.com/settings/emails and uncheck the "Keep my email address private" checkbox. Then switch back to GitHub Desktop to push your commits. You can then enable the checkbox again.'
+      return 'Cannot push these commits as they contain an email address marked as private on GitHub. To push anyway, visit https://github.com/settings/emails, uncheck "Keep my email address private", then switch back to GitHub Desktop to push your commits. You can then enable the setting again.'
     case DugiteError.LFSAttributeDoesNotMatch:
       return 'Git LFS attribute found in global Git configuration does not match expected value.'
     case DugiteError.ProtectedBranchDeleteRejected:


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Related to https://github.com/desktop/desktop/issues/5639.

## Description

Users can run into a scenario where they have commits that have been made with a non-private email address. If they attempt to push these commits and have the "Keep my email address private" option checked in https://github.com/settings/emails the push will fail. This PR updates the error message to provide the workaround of uncheck -> push -> re-check.

## Release notes

N/A 

## Notes:

Question for @niik: is it possible to have URLs be rendered as clickable links in error messages? 

For anyone: Is the last sentence necessary or is it implied? I don't want the error message to be unnecessarily lengthy.
