### PR TITLE
Realign the diff options component

### DIFF
--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -11,6 +11,7 @@
     margin: 0;
 
     display: flex;
+    align-items: center;
     flex-direction: row;
 
     color: var(--text-color);

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -17,6 +17,7 @@
     flex-direction: row;
     flex-shrink: 0;
     flex-grow: 0;
+    align-items: center;
 
     padding: var(--spacing-half) var(--spacing);
 
@@ -26,12 +27,12 @@
       margin-right: var(--spacing-half);
     }
 
-    .octicon {
+    .octicon.status {
       flex-shrink: 0;
       vertical-align: text-bottom;
       position: relative;
-      top: 1px;
       align-self: center;
+      flex-shrink: 0;
     }
 
     .line-endings {

--- a/app/styles/ui/changes/_changes-view.scss
+++ b/app/styles/ui/changes/_changes-view.scss
@@ -25,6 +25,7 @@
 
     .diff-options-component {
       margin-right: var(--spacing-half);
+      flex-shrink: 0;
     }
 
     .octicon.status {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

The  changes header assumed that there would only be one octicon in it and therefore applied styling that interfered with the new diff options component (#10756).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before

<img width="180" alt="image" src="https://user-images.githubusercontent.com/634063/97421737-24f16080-190d-11eb-8d27-95001ba2cbcf.png">

<img width="358" alt="image" src="https://user-images.githubusercontent.com/634063/97421754-291d7e00-190d-11eb-8ba0-2df368da8988.png">


#### After

<img width="161" alt="image" src="https://user-images.githubusercontent.com/634063/97421635-0b501900-190d-11eb-96a8-2701892ca719.png">

<img width="345" alt="image" src="https://user-images.githubusercontent.com/634063/97421656-1014cd00-190d-11eb-9e28-775d6ce47959.png">



## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
