### PR TITLE
Split diff metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -363,7 +363,7 @@ export interface IDailyMeasures {
   readonly tagsDeleted: number
 
   readonly diffModeChangeCount: number
-  readonly hasViewedDiffOptions: boolean
+  readonly diffOptionsViewedCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -362,6 +362,7 @@ export interface IDailyMeasures {
    */
   readonly tagsDeleted: number
 
+  readonly diffModeChangeCount: number
   readonly hasViewedDiffOptions: boolean
 }
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -361,6 +361,8 @@ export interface IDailyMeasures {
    * How many tags have been deleted.
    */
   readonly tagsDeleted: number
+
+  readonly hasViewedDiffOptions: boolean
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -367,6 +367,9 @@ export interface IDailyMeasures {
 
   /** Number of times the user has opened the diff options popover */
   readonly diffOptionsViewedCount: number
+
+  /** Number of times the user has switched to or from History/Changes */
+  readonly repositoryViewChangeCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -362,7 +362,10 @@ export interface IDailyMeasures {
    */
   readonly tagsDeleted: number
 
+  /** Number of times the user has changed between unified and split diffs */
   readonly diffModeChangeCount: number
+
+  /** Number of times the user has opened the diff options popover */
   readonly diffOptionsViewedCount: number
 }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -140,6 +140,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tagsCreatedInDesktop: 0,
   tagsCreated: 0,
   tagsDeleted: 0,
+  diffModeChangeCount: 0,
   hasViewedDiffOptions: false,
 }
 
@@ -1383,8 +1384,12 @@ export class StatsStore implements IStatsStore {
   }
 
   public recordDiffOptionsViewed() {
+    return this.updateDailyMeasures(m => ({ hasViewedDiffOptions: true }))
+  }
+
+  public recordDiffModeChanged() {
     return this.updateDailyMeasures(m => ({
-      hasViewedDiffOptions: true,
+      diffModeChangeCount: m.diffModeChangeCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -141,7 +141,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tagsCreated: 0,
   tagsDeleted: 0,
   diffModeChangeCount: 0,
-  hasViewedDiffOptions: false,
+  diffOptionsViewedCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1384,7 +1384,9 @@ export class StatsStore implements IStatsStore {
   }
 
   public recordDiffOptionsViewed() {
-    return this.updateDailyMeasures(m => ({ hasViewedDiffOptions: true }))
+    return this.updateDailyMeasures(m => ({
+      diffOptionsViewedCount: m.diffOptionsViewedCount + 1,
+    }))
   }
 
   public recordDiffModeChanged() {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -311,6 +311,10 @@ interface ICalculatedStats {
    */
   readonly repositoriesCommittedInWithoutWriteAccess: number
 
+  /**
+   * whether not to the user has chosent to view diffs in split, or unified (the
+   * default) diff view mode
+   */
   readonly diffMode: 'split' | 'unified'
 }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -609,7 +609,12 @@ export class StatsStore implements IStatsStore {
         ...defaultMeasures,
         ...measures,
       }
-      const newMeasures = merge(measuresWithDefaults, fn(measuresWithDefaults))
+      const delta = fn(measuresWithDefaults)
+      const newMeasures = merge(measuresWithDefaults, delta)
+
+      for (const [k, v] of Object.entries(delta)) {
+        console.log(`StatsStore: Updated metric ${k}: ${v}`)
+      }
 
       return this.db.dailyMeasures.put(newMeasures)
     })

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -609,12 +609,7 @@ export class StatsStore implements IStatsStore {
         ...defaultMeasures,
         ...measures,
       }
-      const delta = fn(measuresWithDefaults)
-      const newMeasures = merge(measuresWithDefaults, delta)
-
-      for (const [k, v] of Object.entries(delta)) {
-        console.log(`StatsStore: Updated metric ${k}: ${v}`)
-      }
+      const newMeasures = merge(measuresWithDefaults, fn(measuresWithDefaults))
 
       return this.db.dailyMeasures.put(newMeasures)
     })

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -142,6 +142,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tagsDeleted: 0,
   diffModeChangeCount: 0,
   diffOptionsViewedCount: 0,
+  repositoryViewChangeCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1386,6 +1387,12 @@ export class StatsStore implements IStatsStore {
   public recordDiffOptionsViewed() {
     return this.updateDailyMeasures(m => ({
       diffOptionsViewedCount: m.diffOptionsViewedCount + 1,
+    }))
+  }
+
+  public recordRepositoryViewChanged() {
+    return this.updateDailyMeasures(m => ({
+      repositoryViewChangeCount: m.repositoryViewChangeCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -21,6 +21,7 @@ import {
   setNumberArray,
 } from '../local-storage'
 import { PushOptions } from '../git'
+import { getShowSideBySideDiff } from '../../ui/lib/diff-mode'
 
 const StatsEndpoint = 'https://central.github.com/api/usage/desktop'
 
@@ -306,6 +307,8 @@ interface ICalculatedStats {
    * them into their own interface
    */
   readonly repositoriesCommittedInWithoutWriteAccess: number
+
+  readonly diffMode: 'split' | 'unified'
 }
 
 type DailyStats = ICalculatedStats &
@@ -465,6 +468,7 @@ export class StatsStore implements IStatsStore {
     const repositoriesCommittedInWithoutWriteAccess = getNumberArray(
       RepositoriesCommittedInWithoutWriteAccessKey
     ).length
+    const diffMode = getShowSideBySideDiff() ? 'split' : 'unified'
 
     return {
       eventType: 'usage',
@@ -481,6 +485,7 @@ export class StatsStore implements IStatsStore {
       guid: getGUID(),
       ...repositoryCounts,
       repositoriesCommittedInWithoutWriteAccess,
+      diffMode,
     }
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -140,6 +140,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   tagsCreatedInDesktop: 0,
   tagsCreated: 0,
   tagsDeleted: 0,
+  hasViewedDiffOptions: false,
 }
 
 interface IOnboardingStats {
@@ -1378,6 +1379,12 @@ export class StatsStore implements IStatsStore {
   public recordTagDeleted() {
     return this.updateDailyMeasures(m => ({
       tagsDeleted: m.tagsDeleted + 1,
+    }))
+  }
+
+  public recordDiffOptionsViewed() {
+    return this.updateDailyMeasures(m => ({
+      hasViewedDiffOptions: true,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -270,7 +270,7 @@ import { RepositoryIndicatorUpdater } from './helpers/repository-indicator-updat
 import { getAttributableEmailsFor } from '../email'
 import { TrashNameLabel } from '../../ui/lib/context-menu'
 import {
-  showSideBySideDiffDefault,
+  ShowSideBySideDiffDefault,
   getShowSideBySideDiff,
   setShowSideBySideDiff,
 } from '../../ui/lib/diff-mode'
@@ -393,7 +393,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInDiff: boolean = hideWhitespaceInDiffDefault
-  private showSideBySideDiff: boolean = showSideBySideDiffDefault
+  private showSideBySideDiff: boolean = ShowSideBySideDiffDefault
 
   private uncommittedChangesStrategyKind: UncommittedChangesStrategyKind = uncommittedChangesStrategyKindDefault
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -269,6 +269,11 @@ import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { RepositoryIndicatorUpdater } from './helpers/repository-indicator-updater'
 import { getAttributableEmailsFor } from '../email'
 import { TrashNameLabel } from '../../ui/lib/context-menu'
+import {
+  showSideBySideDiffDefault,
+  getShowSideBySideDiff,
+  setShowSideBySideDiff,
+} from '../../ui/lib/diff-mode'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -305,9 +310,6 @@ const imageDiffTypeKey = 'image-diff-type'
 
 const hideWhitespaceInDiffDefault = false
 const hideWhitespaceInDiffKey = 'hide-whitespace-in-diff'
-
-const showSideBySideDiffDefault = false
-const showSideBySideDiffKey = 'show-side-by-side-diff'
 
 const shellKey = 'shell'
 
@@ -1841,7 +1843,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         : parseInt(imageDiffTypeValue)
 
     this.hideWhitespaceInDiff = getBoolean(hideWhitespaceInDiffKey, false)
-    this.showSideBySideDiff = getBoolean(showSideBySideDiffKey, false)
+    this.showSideBySideDiff = getShowSideBySideDiff()
 
     this.automaticallySwitchTheme = getAutoSwitchPersistedTheme()
 
@@ -4755,7 +4757,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public _setShowSideBySideDiff(showSideBySideDiff: boolean) {
-    setBoolean(showSideBySideDiffKey, showSideBySideDiff)
+    setShowSideBySideDiff(showSideBySideDiff)
     this.showSideBySideDiff = showSideBySideDiff
 
     this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2199,9 +2199,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     selectedSection: RepositorySectionTab
   ): Promise<void> {
-    this.repositoryStateCache.update(repository, () => ({
-      selectedSection,
-    }))
+    this.repositoryStateCache.update(repository, (state) => {
+      if (state.selectedSection !== selectedSection) {
+        this.statsStore.recordRepositoryViewChanged()
+      }
+      return { selectedSection }
+    })
     this.emitUpdate()
 
     if (selectedSection === RepositorySectionTab.History) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4757,10 +4757,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public _setShowSideBySideDiff(showSideBySideDiff: boolean) {
-    setShowSideBySideDiff(showSideBySideDiff)
-    this.showSideBySideDiff = showSideBySideDiff
-
-    this.emitUpdate()
+    if (showSideBySideDiff !== this.showSideBySideDiff) {
+      setShowSideBySideDiff(showSideBySideDiff)
+      this.showSideBySideDiff = showSideBySideDiff
+      this.statsStore.recordDiffModeChanged()
+      this.emitUpdate()
+    }
   }
 
   public _setUpdateBannerVisibility(visibility: boolean) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2199,7 +2199,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     selectedSection: RepositorySectionTab
   ): Promise<void> {
-    this.repositoryStateCache.update(repository, (state) => {
+    this.repositoryStateCache.update(repository, state => {
       if (state.selectedSection !== selectedSection) {
         this.statsStore.recordRepositoryViewChanged()
       }

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -17,6 +17,7 @@ interface IChangedFileDetailsProps {
 
   /** Called when the user changes the side by side diffs setting. */
   readonly onShowSideBySideDiffChanged: (checked: boolean) => void
+  readonly onDiffOptionsOpened: () => void
 }
 
 /** Displays information about a file */
@@ -37,6 +38,7 @@ export class ChangedFileDetails extends React.Component<
           <DiffOptions
             onShowSideBySideDiffChanged={this.props.onShowSideBySideDiffChanged}
             showSideBySideDiff={this.props.showSideBySideDiff}
+            onDiffOptionsOpened={this.props.onDiffOptionsOpened}
           />
         )}
 

--- a/app/src/ui/changes/changed-file-details.tsx
+++ b/app/src/ui/changes/changed-file-details.tsx
@@ -17,6 +17,8 @@ interface IChangedFileDetailsProps {
 
   /** Called when the user changes the side by side diffs setting. */
   readonly onShowSideBySideDiffChanged: (checked: boolean) => void
+
+  /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
 

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -45,6 +45,7 @@ interface IChangesProps {
    * Whether we should display side by side diffs.
    */
   readonly showSideBySideDiff: boolean
+  readonly onDiffOptionsOpened: () => void
 }
 
 export class Changes extends React.Component<IChangesProps, {}> {
@@ -91,6 +92,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
           diff={diff}
           showSideBySideDiff={this.props.showSideBySideDiff}
           onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+          onDiffOptionsOpened={this.props.onDiffOptionsOpened}
         />
         <SeamlessDiffSwitcher
           repository={this.props.repository}

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -45,6 +45,8 @@ interface IChangesProps {
    * Whether we should display side by side diffs.
    */
   readonly showSideBySideDiff: boolean
+
+  /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
 

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -14,6 +14,8 @@ interface IDiffOptionsProps {
 
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
+
+  /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
 

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -14,6 +14,7 @@ interface IDiffOptionsProps {
 
   readonly showSideBySideDiff: boolean
   readonly onShowSideBySideDiffChanged: (showSideBySideDiff: boolean) => void
+  readonly onDiffOptionsOpened: () => void
 }
 
 interface IDiffOptionsState {
@@ -57,6 +58,7 @@ export class DiffOptions extends React.Component<
     this.setState(prevState => {
       if (!prevState.isOpen) {
         document.addEventListener('mousedown', this.onDocumentMouseDown)
+        this.props.onDiffOptionsOpened()
         return { isOpen: true }
       }
       return null

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2574,4 +2574,8 @@ export class Dispatcher {
   public setRepositoryIndicatorsEnabled(repositoryIndicatorsEnabled: boolean) {
     this.appStore._setRepositoryIndicatorsEnabled(repositoryIndicatorsEnabled)
   }
+
+  public recordDiffOptionsViewed() {
+    return this.statsStore.recordDiffOptionsViewed()
+  }
 }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -47,6 +47,7 @@ interface ICommitSummaryProps {
 
   /** Called when the user changes the side by side diffs setting. */
   readonly onShowSideBySideDiffChanged: (checked: boolean) => void
+  readonly onDiffOptionsOpened: () => void
 }
 
 interface ICommitSummaryState {
@@ -385,6 +386,7 @@ export class CommitSummary extends React.Component<
                     onShowSideBySideDiffChanged={
                       this.props.onShowSideBySideDiffChanged
                     }
+                    onDiffOptionsOpened={this.props.onDiffOptionsOpened}
                   />
                 </li>
               </>

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -47,6 +47,8 @@ interface ICommitSummaryProps {
 
   /** Called when the user changes the side by side diffs setting. */
   readonly onShowSideBySideDiffChanged: (checked: boolean) => void
+
+  /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -64,6 +64,8 @@ interface ISelectedCommitProps {
    * to change the diff presentation mode.
    */
   readonly onChangeImageDiffType: (type: ImageDiffType) => void
+
+  /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -64,6 +64,7 @@ interface ISelectedCommitProps {
    * to change the diff presentation mode.
    */
   readonly onChangeImageDiffType: (type: ImageDiffType) => void
+  readonly onDiffOptionsOpened: () => void
 }
 
 interface ISelectedCommitState {
@@ -162,6 +163,7 @@ export class SelectedCommit extends React.Component<
         showSideBySideDiff={this.props.showSideBySideDiff}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
         onShowSideBySideDiffChanged={this.onShowSideBySideDiffChanged}
+        onDiffOptionsOpened={this.props.onDiffOptionsOpened}
       />
     )
   }

--- a/app/src/ui/lib/diff-mode.tsx
+++ b/app/src/ui/lib/diff-mode.tsx
@@ -3,10 +3,18 @@ import { getBoolean, setBoolean } from '../../lib/local-storage'
 export const showSideBySideDiffDefault = false
 export const showSideBySideDiffKey = 'show-side-by-side-diff'
 
+/**
+ * Gets a value indicating whether not to present diffs in a split view mode
+ * as opposed to unified (the default).
+ */
 export function getShowSideBySideDiff(): boolean {
   return getBoolean(showSideBySideDiffKey, showSideBySideDiffDefault)
 }
 
+/**
+ * Sets a local storage key indicating whether not to present diffs in a split
+ * view mode as opposed to unified (the default).
+ */
 export function setShowSideBySideDiff(showSideBySideDiff: boolean) {
   setBoolean(showSideBySideDiffKey, showSideBySideDiff)
 }

--- a/app/src/ui/lib/diff-mode.tsx
+++ b/app/src/ui/lib/diff-mode.tsx
@@ -1,7 +1,7 @@
 import { getBoolean, setBoolean } from '../../lib/local-storage'
 
 export const showSideBySideDiffDefault = false
-export const showSideBySideDiffKey = 'show-side-by-side-diff'
+const showSideBySideDiffKey = 'show-side-by-side-diff'
 
 /**
  * Gets a value indicating whether not to present diffs in a split view mode

--- a/app/src/ui/lib/diff-mode.tsx
+++ b/app/src/ui/lib/diff-mode.tsx
@@ -1,0 +1,12 @@
+import { getBoolean, setBoolean } from '../../lib/local-storage'
+
+export const showSideBySideDiffDefault = false
+export const showSideBySideDiffKey = 'show-side-by-side-diff'
+
+export function getShowSideBySideDiff(): boolean {
+  return getBoolean(showSideBySideDiffKey, showSideBySideDiffDefault)
+}
+
+export function setShowSideBySideDiff(showSideBySideDiff: boolean) {
+  setBoolean(showSideBySideDiffKey, showSideBySideDiff)
+}

--- a/app/src/ui/lib/diff-mode.tsx
+++ b/app/src/ui/lib/diff-mode.tsx
@@ -1,6 +1,6 @@
 import { getBoolean, setBoolean } from '../../lib/local-storage'
 
-export const showSideBySideDiffDefault = false
+export const ShowSideBySideDiffDefault = false
 const showSideBySideDiffKey = 'show-side-by-side-diff'
 
 /**
@@ -8,7 +8,7 @@ const showSideBySideDiffKey = 'show-side-by-side-diff'
  * as opposed to unified (the default).
  */
 export function getShowSideBySideDiff(): boolean {
-  return getBoolean(showSideBySideDiffKey, showSideBySideDiffDefault)
+  return getBoolean(showSideBySideDiffKey, ShowSideBySideDiffDefault)
 }
 
 /**

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -351,8 +351,13 @@ export class RepositoryView extends React.Component<
         showSideBySideDiff={this.props.showSideBySideDiff}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}
+        onDiffOptionsOpened={this.onDiffOptionsOpened}
       />
     )
+  }
+
+  private onDiffOptionsOpened = () => {
+    this.props.dispatcher.recordDiffOptionsViewed()
   }
 
   private renderTutorialPane(): JSX.Element {
@@ -425,6 +430,7 @@ export class RepositoryView extends React.Component<
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
           }
+          onDiffOptionsOpened={this.onDiffOptionsOpened}
         />
       )
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Adds metrics for us to gauge the usage of split vs unified diffs.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
