### PR TITLE
Enable split diffs for production

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -130,7 +130,7 @@ export function enableDiscardLines(): boolean {
  * Note: side by side diffs will use the new diff viewer.
  */
 export function enableSideBySideDiffs(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Opening this up so that we don't forget to enable split diffs in production ahead of the next production release.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes