### PR TITLE
Fixes overflow issues with long branch names

### DIFF
--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -313,6 +313,11 @@ dialog {
       flex-shrink: 0;
       margin-right: var(--spacing);
     }
+
+    div { 
+      overflow-wrap: break-word;
+      overflow-x: hidden;
+    }
   }
 
   &#app-error {

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -314,7 +314,7 @@ dialog {
       margin-right: var(--spacing);
     }
 
-    div { 
+    div {
       overflow-wrap: break-word;
       overflow-x: hidden;
     }

--- a/app/styles/ui/_merge-status.scss
+++ b/app/styles/ui/_merge-status.scss
@@ -38,6 +38,8 @@
 
     strong {
       color: var(--text-color);
+      overflow-wrap: break-word;
+      overflow-x: hidden;
     }
   }
 


### PR DESCRIPTION
Fixes layout issues with long branch names overflowing `.merge-info strong` and `.dialog-error div`


Closes #5970

## Description

- A couple areas of the UI were causing overflow errors.  I was unsure if the strategy should be to truncate or wrap in these areas.  I chose to wrap as I felt having the vision of the entire branch name could prove useful.

### Screenshots

Before: 
 
![image](https://user-images.githubusercontent.com/42276144/98200835-721c9600-1efc-11eb-93b7-85ea960361d2.png)

After: 

![image](https://user-images.githubusercontent.com/42276144/98200850-7a74d100-1efc-11eb-9520-10131d549249.png)

Before: 

![image](https://user-images.githubusercontent.com/42276144/98200855-7f398500-1efc-11eb-8dea-4b334a09bef8.png)

After: 

![image](https://user-images.githubusercontent.com/42276144/98200866-83fe3900-1efc-11eb-8819-14b432bb7a02.png)



## Release notes

Notes: no-notes
