### PR TITLE
Bump dugite

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "1.91.3",
+    "dugite": "1.92.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -355,10 +355,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@1.91.3:
-  version "1.91.3"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.91.3.tgz#2903cbec72d7e9941b85e6850e7d1655c54df5dc"
-  integrity sha512-vZYWkdoUuC3VZeaXMQqBbE/D0VpXPob+H9nluwFocYTB3nDJuyA+dGFQA1WvY1Yg2jKDbiVTxviPMFvLamfJqw==
+dugite@1.92.0:
+  version "1.92.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.92.0.tgz#34a32a35ba5e69a61c62afa686a9a27944e0f5f0"
+  integrity sha512-Xra5E2ISwy+sCUrlcBkBsOpP85u5lsbaMnRpnvMJpO+KSoCGccMUimekGS+Ry8ZRni80gHw83MKSrdycaH2bZg==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Bumps dugite in order to get the latest Git LFS ([CVE-2020-27955](https://github.com/git-lfs/git-lfs/security/advisories/GHSA-4g4p-42wc-9f3m))

## Related issues and PRs

- https://github.com/desktop/dugite/pull/415
- https://github.com/desktop/dugite-native/pull/334