### PR TITLE
Release v2.5.8-beta1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.7-beta2",
+  "version": "2.5.8-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,6 @@
 {
   "releases": {
+    "2.5.8-beta1": ["[Improved] Upgrade embedded Git LFS - #10973"],
     "2.5.7-beta2": [
       "[New] Search text within split diffs - #10755",
       "[Improved] Use Page down, Page up, Home, and End keys to navigate and select items in lists - #10837",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

This is a hotfix release on top of 2.5.7-beta2 which bumps dugite in order to get the latest Git LFS ([CVE-2020-27955](https://github.com/git-lfs/git-lfs/security/advisories/GHSA-4g4p-42wc-9f3m))

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
 - no new feature flags
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
 - no new metrics