### PR TITLE
Fix broken issues links in release notes

### DIFF
--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -15,37 +15,20 @@ import { getDotComAPIEndpoint } from '../../lib/api'
 import { shell } from '../../lib/app-shell'
 import { ReleaseNotesUri } from '../lib/releases'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { GitHubRepository } from '../../models/github-repository'
+import { Owner } from '../../models/owner'
 
 // HACK: This is needed because the `Rich`Text` component
 // needs to know what repo to link issues against.
 // Since release notes are Desktop specific, we can't
 // rely on the repo info we keep in state, so we've
 // stubbed out this repo
-const repository = new Repository(
+const desktopOwner = new Owner('desktop', getDotComAPIEndpoint(), null)
+const desktopUrl = 'https://github.com/desktop/desktop'
+const desktopRepository = new Repository(
   '',
   -1,
-  {
-    dbID: null,
-    name: 'desktop',
-    owner: {
-      id: null,
-      login: 'desktop',
-      endpoint: getDotComAPIEndpoint(),
-      hash: '',
-    },
-    isPrivate: false,
-    parent: null,
-    htmlURL: 'https://github.com/desktop/desktop',
-    defaultBranch: 'development',
-    cloneURL: 'https://github.com/desktop/desktop',
-    endpoint: getDotComAPIEndpoint(),
-    fullName: 'desktop/desktop',
-    fork: false,
-    hash: '',
-    issuesEnabled: null,
-    isArchived: false,
-    permissions: null,
-  },
+  new GitHubRepository('desktop', desktopOwner, null, false, desktopUrl),
   true
 )
 
@@ -85,7 +68,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
             text={entry.message}
             emoji={this.props.emoji}
             renderUrlsAsLinks={true}
-            repository={repository}
+            repository={desktopRepository}
           />
         </li>
       )


### PR DESCRIPTION
As I was upgrading to  2.5.7 (#10973) I noticed that the issue number in the release notes dialog wasn't hyperlinked as I would have expected it to be.

<img width="632" alt="image" src="https://user-images.githubusercontent.com/634063/98353812-23681c80-2020-11eb-97bf-5f02cc933dde.png">

Turns out this was a bug due to us using an object conformant to a `GitHubRepository` which TypeScript is absolutely fine with but we were checking for an actual instance of `GitHubRepository`.

See https://github.com/desktop/desktop/blob/ef939e870341001c23f7ec439519c705b287b3a4/app/src/models/repository.ts#L110
See https://github.com/desktop/desktop/blob/ef939e870341001c23f7ec439519c705b287b3a4/app/src/lib/text-token-parser.ts#L66-L68

This was inadvertently broken in https://github.com/desktop/desktop/pull/9431