### PR TITLE
Restore Windows menu keyboard accessibility

### DIFF
--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -52,14 +52,6 @@ export function buildDefaultMenu({
     ? showPullRequestLabel
     : createPullRequestLabel
 
-  const shellLabel = __DARWIN__
-    ? `Open in ${selectedShell ?? platformDefaultShell}`
-    : `O&pen in ${selectedShell ?? platformDefaultShell}`
-
-  const editorLabel = __DARWIN__
-    ? `Open in ${selectedExternalEditor ?? 'External Editor'}`
-    : `&Open in ${selectedExternalEditor ?? 'external editor'}`
-
   const template = new Array<Electron.MenuItemConstructorOptions>()
   const separator: Electron.MenuItemConstructorOptions = { type: 'separator' }
 
@@ -303,7 +295,9 @@ export function buildDefaultMenu({
         click: emit('view-repository-on-github'),
       },
       {
-        label: shellLabel,
+        label: __DARWIN__
+          ? `Open in ${selectedShell ?? platformDefaultShell}`
+          : `O&pen in ${selectedShell ?? platformDefaultShell}`,
         id: 'open-in-shell',
         accelerator: 'Ctrl+`',
         click: emit('open-in-shell'),
@@ -319,7 +313,9 @@ export function buildDefaultMenu({
         click: emit('open-working-directory'),
       },
       {
-        label: editorLabel,
+        label: __DARWIN__
+          ? `Open in ${selectedExternalEditor ?? 'External Editor'}`
+          : `&Open in ${selectedExternalEditor ?? 'external editor'}`,
         id: 'open-external-editor',
         accelerator: 'CmdOrCtrl+Shift+A',
         click: emit('open-external-editor'),

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -7,11 +7,8 @@ import { ensureDir } from 'fs-extra'
 import { UNSAFE_openDirectory } from '../shell'
 import { enableCreateGitHubIssueFromMenu } from '../../lib/feature-flag'
 import { MenuLabelsEvent } from '../../models/menu-labels'
-import { DefaultEditorLabel } from '../../ui/lib/context-menu'
 
-const defaultShellLabel = __DARWIN__
-  ? 'Open in Terminal'
-  : 'Open in Command Prompt'
+const platformDefaultShell = __DARWIN__ ? 'Terminal' : 'Command Prompt'
 const createPullRequestLabel = __DARWIN__
   ? 'Create Pull Request'
   : 'Create &pull request'
@@ -55,13 +52,13 @@ export function buildDefaultMenu({
     ? showPullRequestLabel
     : createPullRequestLabel
 
-  const shellLabel =
-    selectedShell === null ? defaultShellLabel : `Open in ${selectedShell}`
+  const shellLabel = __DARWIN__
+    ? `Open in ${selectedShell ?? platformDefaultShell}`
+    : `O&pen in ${selectedShell ?? platformDefaultShell}`
 
-  const editorLabel =
-    selectedExternalEditor === null
-      ? DefaultEditorLabel
-      : `Open in ${selectedExternalEditor}`
+  const editorLabel = __DARWIN__
+    ? `Open in ${selectedExternalEditor ?? 'External Editor'}`
+    : `&Open in ${selectedExternalEditor ?? 'external editor'}`
 
   const template = new Array<Electron.MenuItemConstructorOptions>()
   const separator: Electron.MenuItemConstructorOptions = { type: 'separator' }

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -8,7 +8,7 @@ import { UNSAFE_openDirectory } from '../shell'
 import { enableCreateGitHubIssueFromMenu } from '../../lib/feature-flag'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 
-const platformDefaultShell = __DARWIN__ ? 'Terminal' : 'Command Prompt'
+const platformDefaultShell = __WIN32__ ? 'Command Prompt' : 'Terminal'
 const createPullRequestLabel = __DARWIN__
   ? 'Create Pull Request'
   : 'Create &pull request'

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -827,10 +827,10 @@ export class List extends React.Component<IListProps, IListState> {
     let content: JSX.Element[] | JSX.Element | null
 
     if (this.resizeObserver) {
-      content =
-        this.state.width && this.state.height
-          ? this.renderContents(this.state.width, this.state.height)
-          : null
+      content = this.renderContents(
+        this.state.width ?? 0,
+        this.state.height ?? 0
+      )
     } else {
       // Legacy in the event that we don't have ResizeObserver
       content = (


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11007

## Description

In https://github.com/desktop/desktop/pull/10866 I inadvertently introduced a bug that made it impossible to navigate application menus on Windows using the keyboard. The problem is well enough laid out in #11007 so I won't rehash it here.

In addition to fixing that issue this also adds access keys for the "Open in Terminal" and "Open In Editor" menu items to further reduce the amount of typing needed to get to either of those actions.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Restored keyboard navigation in application menus on Windows