### PR TITLE
Increase title bar height on Big Sur

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -57,7 +57,6 @@
     "strip-ansi": "^4.0.0",
     "textarea-caret": "^3.0.2",
     "tslib": "^2.0.0",
-    "ua-parser-js": "^0.7.12",
     "untildify": "^3.0.2",
     "username": "^2.3.0",
     "uuid": "^3.0.1",

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -40,7 +40,9 @@ export const isMacOsAndMojaveOrLater = memoizeOne(
 
 /** We're currently running macOS and it is at least Big Sur. */
 export const isMacOSBigSurOrLater = memoizeOne(
-  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('11.0.0')
+  // We're using 10.16 rather than 11.0 here due to
+  // https://github.com/electron/electron/issues/26419
+  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('10.16')
 )
 
 /** We're currently running Windows 10 and it is at least 1809 Preview Build 17666. */

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -1,6 +1,7 @@
 import { compare } from 'compare-versions'
 import * as OS from 'os'
 import { UAParser } from 'ua-parser-js'
+import memoizeOne from 'memoize-one'
 
 /** Get the OS we're currently running on. */
 export function getOS() {
@@ -32,6 +33,11 @@ export function isMacOsAndMojaveOrLater() {
   }
   return false
 }
+
+/** We're currently running macOS and it is at least Big Sur. */
+export const isMacOSBigSurOrLater = memoizeOne(
+  () => __DARWIN__ && compare(process.getSystemVersion(), '11.0.0', '>=')
+)
 
 /** We're currently running Windows 10 and it is at least 1809 Preview Build 17666. */
 export function isWindows10And1809Preview17666OrLater() {

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -2,10 +2,23 @@ import * as OS from 'os'
 import { compare } from 'compare-versions'
 import memoizeOne from 'memoize-one'
 
+function getSystemVersionSafe() {
+  // getSystemVersion only exists when running under Electron, and not when
+  // running unit tests which frequently end up calling this. There are no
+  // other known reasons why getSystemVersion() would return anything other
+  // than a string
+  return 'getSystemVersion' in process ? process.getSystemVersion() : undefined
+}
+
+function systemVersionGreaterThanOrEqualTo(version: string) {
+  const sysver = getSystemVersionSafe()
+  return sysver === undefined ? false : compare(sysver, version, '>=')
+}
+
 /** Get the OS we're currently running on. */
 export function getOS() {
   if (__DARWIN__) {
-    return `Mac OS ${process.getSystemVersion()}`
+    return `Mac OS ${getSystemVersionSafe()}`
   } else if (__WIN32__) {
     return `Windows ${OS.release()}`
   } else {
@@ -15,24 +28,15 @@ export function getOS() {
 
 /** We're currently running macOS and it is at least Mojave. */
 export const isMacOsAndMojaveOrLater = memoizeOne(
-  () => __DARWIN__ && compare(process.getSystemVersion(), '10.13.0', '>=')
+  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('10.13.0')
 )
 
 /** We're currently running macOS and it is at least Big Sur. */
 export const isMacOSBigSurOrLater = memoizeOne(
-  () => __DARWIN__ && compare(process.getSystemVersion(), '11.0.0', '>=')
+  () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('11.0.0')
 )
 
 /** We're currently running Windows 10 and it is at least 1809 Preview Build 17666. */
-export function isWindows10And1809Preview17666OrLater() {
-  if (__WIN32__) {
-    const version = OS.release()
-
-    if (version === undefined) {
-      return false
-    }
-
-    return compare(version, '10.0.17666', '>=')
-  }
-  return false
-}
+export const isWindows10And1809Preview17666OrLater = memoizeOne(
+  () => __WIN32__ && systemVersionGreaterThanOrEqualTo('10.0.17666')
+)

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -3,11 +3,17 @@ import { compare } from 'compare-versions'
 import memoizeOne from 'memoize-one'
 
 function getSystemVersionSafe() {
-  // getSystemVersion only exists when running under Electron, and not when
-  // running unit tests which frequently end up calling this. There are no
-  // other known reasons why getSystemVersion() would return anything other
-  // than a string
-  return 'getSystemVersion' in process ? process.getSystemVersion() : undefined
+  if (__DARWIN__) {
+    // getSystemVersion only exists when running under Electron, and not when
+    // running unit tests which frequently end up calling this. There are no
+    // other known reasons why getSystemVersion() would return anything other
+    // than a string
+    return 'getSystemVersion' in process
+      ? process.getSystemVersion()
+      : undefined
+  } else {
+    return OS.release()
+  }
 }
 
 function systemVersionGreaterThanOrEqualTo(version: string) {

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -34,7 +34,7 @@ export function getOS() {
 }
 
 /** We're currently running macOS and it is at least Mojave. */
-export const isMacOsAndMojaveOrLater = memoizeOne(
+export const isMacOSMojaveOrLater = memoizeOne(
   () => __DARWIN__ && systemVersionGreaterThanOrEqualTo('10.13.0')
 )
 

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -23,12 +23,13 @@ function systemVersionGreaterThanOrEqualTo(version: string) {
 
 /** Get the OS we're currently running on. */
 export function getOS() {
+  const version = getSystemVersionSafe()
   if (__DARWIN__) {
-    return `Mac OS ${getSystemVersionSafe()}`
+    return `Mac OS ${version}`
   } else if (__WIN32__) {
-    return `Windows ${OS.release()}`
+    return `Windows ${version}`
   } else {
-    return `${OS.type()} ${OS.release()}`
+    return `${OS.type()} ${version}`
   }
 }
 

--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -1,17 +1,11 @@
-import { compare } from 'compare-versions'
 import * as OS from 'os'
-import { UAParser } from 'ua-parser-js'
+import { compare } from 'compare-versions'
 import memoizeOne from 'memoize-one'
 
 /** Get the OS we're currently running on. */
 export function getOS() {
   if (__DARWIN__) {
-    // On macOS, OS.release() gives us the kernel version which isn't terribly
-    // meaningful to any human being, so we'll parse the User Agent instead.
-    // See https://github.com/desktop/desktop/issues/1130.
-    const parser = new UAParser()
-    const os = parser.getOS()
-    return `${os.name} ${os.version}`
+    return `Mac OS ${process.getSystemVersion()}`
   } else if (__WIN32__) {
     return `Windows ${OS.release()}`
   } else {
@@ -20,19 +14,9 @@ export function getOS() {
 }
 
 /** We're currently running macOS and it is at least Mojave. */
-export function isMacOsAndMojaveOrLater() {
-  if (__DARWIN__) {
-    const parser = new UAParser()
-    const os = parser.getOS()
-
-    if (os.version === undefined) {
-      return false
-    }
-
-    return compare(os.version, '10.13.0', '>=')
-  }
-  return false
-}
+export const isMacOsAndMojaveOrLater = memoizeOne(
+  () => __DARWIN__ && compare(process.getSystemVersion(), '10.13.0', '>=')
+)
 
 /** We're currently running macOS and it is at least Big Sur. */
 export const isMacOSBigSurOrLater = memoizeOne(

--- a/app/src/ui/dialog/dialog.tsx
+++ b/app/src/ui/dialog/dialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import classNames from 'classnames'
 import { DialogHeader } from './header'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
+import { getTitleBarHeight } from '../window/title-bar'
 
 /**
  * The time (in milliseconds) from when the dialog is mounted
@@ -17,9 +18,9 @@ const dismissGracePeriodMs = 250
 const DisableClickDismissalDelay = 500
 
 /**
- * Title bar height in pixels. Values taken from 'app/styles/_variables.scss'.
+ * Title bar height in pixels
  */
-const titleBarHeight = __DARWIN__ ? 22 : 28
+const titleBarHeight = getTitleBarHeight()
 
 interface IDialogProps {
   /**

--- a/app/src/ui/lib/dark-theme.ts
+++ b/app/src/ui/lib/dark-theme.ts
@@ -1,12 +1,12 @@
 import { remote } from 'electron'
 import {
-  isMacOsAndMojaveOrLater,
+  isMacOSMojaveOrLater,
   isWindows10And1809Preview17666OrLater,
 } from '../../lib/get-os'
 
 export function supportsDarkMode() {
   if (__DARWIN__) {
-    return isMacOsAndMojaveOrLater()
+    return isMacOSMojaveOrLater()
   } else if (__WIN32__) {
     // Its technically possible this would still work on prior versions of Windows 10 but 1809
     // was released October 2nd, 2018 that the feature can just be "attained" by upgrading

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -1,18 +1,15 @@
 import * as React from 'react'
-
+import memoizeOne from 'memoize-one'
 import { remote } from 'electron'
 import { WindowState } from '../../lib/window-state'
 import { WindowControls } from './window-controls'
 import { Octicon, OcticonSymbol } from '../octicons'
-import memoizeOne from 'memoize-one'
 import { isMacOSBigSurOrLater } from '../../lib/get-os'
 
-/**
- * Get the height (in pixels) of the title bar depending on the platform
- */
+/** Get the height (in pixels) of the title bar depending on the platform */
 export function getTitleBarHeight() {
   if (__DARWIN__) {
-    // Title bars got taller in Big Sur
+    // Big Sur has taller title bars, see #10980
     return isMacOSBigSurOrLater() ? 26 : 22
   }
 

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -5,12 +5,18 @@ import { WindowState } from '../../lib/window-state'
 import { WindowControls } from './window-controls'
 import { Octicon, OcticonSymbol } from '../octicons'
 import memoizeOne from 'memoize-one'
+import { isMacOSBigSurOrLater } from '../../lib/get-os'
 
 /**
  * Get the height (in pixels) of the title bar depending on the platform
  */
 export function getTitleBarHeight() {
-  return __DARWIN__ ? 22 : 28
+  if (__DARWIN__) {
+    // Title bars got taller in Big Sur
+    return isMacOSBigSurOrLater() ? 26 : 22
+  }
+
+  return 28
 }
 
 interface ITitleBarProps {

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -6,6 +6,13 @@ import { WindowControls } from './window-controls'
 import { Octicon, OcticonSymbol } from '../octicons'
 import memoizeOne from 'memoize-one'
 
+/**
+ * Get the height (in pixels) of the title bar depending on the platform
+ */
+export function getTitleBarHeight() {
+  return __DARWIN__ ? 22 : 28
+}
+
 interface ITitleBarProps {
   /**
    * The current state of the Window, ie maximized, minimized full-screen etc.
@@ -30,13 +37,16 @@ interface ITitleBarProps {
 
 export class TitleBar extends React.Component<ITitleBarProps> {
   private getStyle = memoizeOne((windowZoomFactor: number | undefined) => {
-    // See windowZoomFactor in ITitleBarProps, this is only
-    // applicable on macOS.
-    if (!__DARWIN__) {
-      return undefined
+    const style: React.CSSProperties = {
+      height: getTitleBarHeight(),
     }
 
-    return windowZoomFactor ? { zoom: 1 / windowZoomFactor } : undefined
+    // See windowZoomFactor in ITitleBarProps, this is only applicable on macOS.
+    if (__DARWIN__ && windowZoomFactor !== undefined) {
+      style.zoom = 1 / windowZoomFactor
+    }
+
+    return style
   })
 
   private onTitlebarDoubleClickDarwin = () => {

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -40,9 +40,7 @@ interface ITitleBarProps {
 
 export class TitleBar extends React.Component<ITitleBarProps> {
   private getStyle = memoizeOne((windowZoomFactor: number | undefined) => {
-    const style: React.CSSProperties = {
-      height: getTitleBarHeight(),
-    }
+    const style: React.CSSProperties = { height: getTitleBarHeight() }
 
     // See windowZoomFactor in ITitleBarProps, this is only applicable on macOS.
     if (__DARWIN__ && windowZoomFactor !== undefined) {
@@ -104,14 +102,12 @@ export class TitleBar extends React.Component<ITitleBarProps> {
       ? this.onTitlebarDoubleClickDarwin
       : undefined
 
-    const style = this.getStyle(this.props.windowZoomFactor)
-
     return (
       <div
         className={titleBarClass}
         id="desktop-app-title-bar"
         onDoubleClick={onTitlebarDoubleClick}
-        style={style}
+        style={this.getStyle(this.props.windowZoomFactor)}
       >
         {topResizeHandle}
         {leftResizeHandle}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1620,7 +1620,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-ua-parser-js@^0.7.12, ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
   integrity sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10980 

## Description

Seems macOS Big Sur (which is launching today) has a taller title bar making our traffic lights seem misaligned. Only judging from the screenshot in #10980 it looks like the title bar height increased by 4px so I've adjusted our title bar accordingly. Note that I haven't had a chance to actually test this on Big Sur yet.

While I was looking at this I noticed some needlessly complex logic to determine the current platform version which could be simplified thanks to https://github.com/electron/electron/pull/16599.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Adjust title bar height on Big Sur to match new platform convention
