### PR TITLE
Add required peer-dependency for focus-trap-react

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,7 @@
     "mri": "^1.1.0",
     "p-limit": "^2.2.0",
     "primer-support": "^4.0.0",
+    "prop-types": "^15.7.2",
     "queue": "^5.0.0",
     "quick-lru": "^3.0.0",
     "react": "^16.8.4",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1206,7 +1206,7 @@ prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I keep seeing this warning when building Desktop that react-focus-trap is lacking the [peer dependency](https://github.com/focus-trap/focus-trap-react/blob/d7597b200d47a85032876500d46205e33dc4d647/package.json#L87) prop-types. It doesn't seem to actually be affecting anything but we might as well humor it.