### PR TITLE
Release v2.6.0-beta1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.5.8-beta1",
+  "version": "2.6.0-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,12 @@
 {
   "releases": {
+    "2.6.0-beta1": [
+      "[Fixed] Proper title bar height on macOS Big Sur - #10980",
+      "[Fixed] Restore Windows menu keyboard accessibility - #11007",
+      "[Fixed] Fix broken issues links in release notes - #10977",
+      "[Fixed] Fixes overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
+      "[Removed] Sign in to GitHub.com with username/password is no longer supported"
+    ],
     "2.5.8-beta1": ["[Improved] Upgrade embedded Git LFS - #10973"],
     "2.5.7": ["[Improved] Upgrade embedded Git LFS - #10973"],
     "2.5.7-beta2": [


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming beta of the v2.6.0 series? Well you've just found it, congratulations! :tada:

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
 - #10965 - doesn't affect the beta release
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
 - #10964 - Needs merge on central