### PR TITLE
Release v2.6.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.6.0-beta1",
+  "version": "2.6.0",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,22 @@
 {
   "releases": {
+    "2.6.0": [
+      "[New] Split diffs! Toggle between viewing diffs in split or unified mode - #10617",
+      "[Added] Use Page down, Page up, Home, and End keys to navigate and select items in lists - #10837",
+      "[Added] Add `toml` syntax highlight - #10763. Thanks @samundra!",
+      "[Added] Add support for Nova as external editor on macOS - #10645. Thanks @greystate!",
+      "[Fixed] Restore Windows menu keyboard accessibility - #11007",
+      "[Fixed] Actions in the context menu of a non-selected file in history no longer acts on the previously selected item - #10743",
+      "[Fixed] Proper title bar height on macOS Big Sur - #10980",
+      "[Fixed] Fix broken issues links in release notes - #10977",
+      "[Fixed] Fixes overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
+      "[Fixed] Comparison of different size image changes no longer overflow the bounds of the diff view - #2480 #9717",
+      "[Fixed] Repository indicator refresh can no longer be manually triggered when disabled - #10905",
+      "[Fixed] Choosing to resolve a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
+      "[Fixed] Small partial commit of very large text files no longer runs the risk of failing due to unexpected diff results - #10640",
+      "[Fixed] Long commit message are scrollable once again - #10815",
+      "[Removed] Sign in to GitHub.com with username/password is no longer supported"
+    ],
     "2.6.0-beta1": [
       "[Fixed] Proper title bar height on macOS Big Sur - #10980",
       "[Fixed] Restore Windows menu keyboard accessibility - #11007",

--- a/changelog.json
+++ b/changelog.json
@@ -15,7 +15,7 @@
       "[Fixed] Resolving a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
       "[Fixed] Small partial commit of very large text files no longer intermittently fails due to unexpected diff results - #10640",
       "[Fixed] Long commit message are scrollable again - #10815",
-      "[Removed] Sign in to GitHub.com with username/password is no longer supported"
+      "[Removed] Sign in to GitHub.com with username/password is no longer supported to improve account security"
     ],
     "2.6.0-beta1": [
       "[Fixed] Proper title bar height on macOS Big Sur - #10980",

--- a/changelog.json
+++ b/changelog.json
@@ -12,7 +12,7 @@
       "[Fixed] Fix overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
       "[Fixed] Images fit correctly in the diff view when their sizes have changed - #2480 #9717",
       "[Fixed] Repository indicator refresh can no longer be manually triggered when disabled - #10905",
-      "[Fixed] Choosing to resolve a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
+      "[Fixed] Resolving a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
       "[Fixed] Small partial commit of very large text files no longer runs the risk of failing due to unexpected diff results - #10640",
       "[Fixed] Long commit message are scrollable once again - #10815",
       "[Removed] Sign in to GitHub.com with username/password is no longer supported"

--- a/changelog.json
+++ b/changelog.json
@@ -13,7 +13,7 @@
       "[Fixed] Images fit correctly in the diff view when their sizes have changed - #2480 #9717",
       "[Fixed] Repository indicator refresh can no longer be manually triggered when disabled - #10905",
       "[Fixed] Resolving a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
-      "[Fixed] Small partial commit of very large text files no longer runs the risk of failing due to unexpected diff results - #10640",
+      "[Fixed] Small partial commit of very large text files no longer intermittently fails due to unexpected diff results - #10640",
       "[Fixed] Long commit message are scrollable again - #10815",
       "[Removed] Sign in to GitHub.com with username/password is no longer supported"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -14,7 +14,7 @@
       "[Fixed] Repository indicator refresh can no longer be manually triggered when disabled - #10905",
       "[Fixed] Resolving a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
       "[Fixed] Small partial commit of very large text files no longer runs the risk of failing due to unexpected diff results - #10640",
-      "[Fixed] Long commit message are scrollable once again - #10815",
+      "[Fixed] Long commit message are scrollable again - #10815",
       "[Removed] Sign in to GitHub.com with username/password is no longer supported"
     ],
     "2.6.0-beta1": [

--- a/changelog.json
+++ b/changelog.json
@@ -10,7 +10,7 @@
       "[Fixed] Correct title bar height on macOS Big Sur - #10980",
       "[Fixed] Fix broken issues links in release notes - #10977",
       "[Fixed] Fix overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
-      "[Fixed] Comparison of different size image changes no longer overflow the bounds of the diff view - #2480 #9717",
+      "[Fixed] Images fit correctly in the diff view when their sizes have changed - #2480 #9717",
       "[Fixed] Repository indicator refresh can no longer be manually triggered when disabled - #10905",
       "[Fixed] Choosing to resolve a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",
       "[Fixed] Small partial commit of very large text files no longer runs the risk of failing due to unexpected diff results - #10640",

--- a/changelog.json
+++ b/changelog.json
@@ -6,7 +6,7 @@
       "[Added] Add `toml` syntax highlight - #10763. Thanks @samundra!",
       "[Added] Add support for Nova as external editor on macOS - #10645. Thanks @greystate!",
       "[Fixed] Restore Windows menu keyboard accessibility - #11007",
-      "[Fixed] Actions in the context menu of a non-selected file in history no longer acts on the previously selected item - #10743",
+      "[Fixed] Actions in context menu of a non-selected file act on the chosen one instead of the previous one - #10743",
       "[Fixed] Proper title bar height on macOS Big Sur - #10980",
       "[Fixed] Fix broken issues links in release notes - #10977",
       "[Fixed] Fixes overflow issues with long branch names - #5970. Thanks @juliarvalenti!",

--- a/changelog.json
+++ b/changelog.json
@@ -7,7 +7,7 @@
       "[Added] Add support for Nova as external editor on macOS - #10645. Thanks @greystate!",
       "[Fixed] Restore Windows menu keyboard accessibility - #11007",
       "[Fixed] Actions in context menu of a non-selected file act on the chosen one instead of the previous one - #10743",
-      "[Fixed] Proper title bar height on macOS Big Sur - #10980",
+      "[Fixed] Correct title bar height on macOS Big Sur - #10980",
       "[Fixed] Fix broken issues links in release notes - #10977",
       "[Fixed] Fixes overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
       "[Fixed] Comparison of different size image changes no longer overflow the bounds of the diff view - #2480 #9717",

--- a/changelog.json
+++ b/changelog.json
@@ -9,7 +9,7 @@
       "[Fixed] Actions in context menu of a non-selected file act on the chosen one instead of the previous one - #10743",
       "[Fixed] Correct title bar height on macOS Big Sur - #10980",
       "[Fixed] Fix broken issues links in release notes - #10977",
-      "[Fixed] Fixes overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
+      "[Fixed] Fix overflow issues with long branch names - #5970. Thanks @juliarvalenti!",
       "[Fixed] Comparison of different size image changes no longer overflow the bounds of the diff view - #2480 #9717",
       "[Fixed] Repository indicator refresh can no longer be manually triggered when disabled - #10905",
       "[Fixed] Choosing to resolve a conflicted file added in both the source and target branch no longer results in merge conflict markers appearing in the merge commit - #10820",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming v2.6.0 release? Well you've just found it, congratulations! :tada:

We're targeting a release on November 17th.

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
 - [enableSideBySideDiffs](https://github.com/desktop/desktop/commit/72393976605a7c44a9276aed3ce5b4167382a5eb) removed enabled for production
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
  - [x] #10964 - on central
  - [x] #10964 - on desktop.github.com