### PR TITLE
Feature flag unhandled rejections to beta only

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -146,3 +146,10 @@ export function enableExperimentalDiffViewer(): boolean {
 export function enableDefaultBranchSetting(): boolean {
   return true
 }
+
+/**
+ * Should we allow reporting unhandled rejections as if they were crashes?
+ */
+export function enableUnhandledRejectionReporting(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/helpers/non-fatal-exception.ts
+++ b/app/src/lib/helpers/non-fatal-exception.ts
@@ -34,7 +34,7 @@ export function sendNonFatalException(kind: string, error: Error) {
   const now = Date.now()
 
   if (
-    lastNonFatalException === undefined ||
+    lastNonFatalException !== undefined &&
     now - lastNonFatalException < minIntervalBetweenNonFatalExceptions
   ) {
     return

--- a/app/src/lib/helpers/non-fatal-exception.ts
+++ b/app/src/lib/helpers/non-fatal-exception.ts
@@ -1,24 +1,20 @@
 /**
- * Send a caught (ie. non-fatal) exception to the
- * non-fatal error bucket
+ * Send a caught (ie. non-fatal) exception to the non-fatal error bucket
  *
- * The intended use of this message is for getting insight into
- * areas of the code where we suspect alternate failure modes
- * other than those accounted for.
+ * The intended use of this message is for getting insight into areas of the
+ * code where we suspect alternate failure modes other than those accounted for.
  *
- * Example: In the Desktop tutorial creation logic we handle
- * all errors and our initial belief was that the only two failure
- * modes we would have to account for were either the repo existing
- * on disk or on the user's account. We now suspect that there might
- * be other reasons why the creation logic is failing and therefore
- * want to send all errors encountered during creation to central
- * where we can determine if there are additional failure modes
- * for us to consider.
+ * Example: In the Desktop tutorial creation logic we handle all errors and our
+ * initial belief was that the only two failure modes we would have to account
+ * for were either the repo existing on disk or on the user's account. We now
+ * suspect that there might be other reasons why the creation logic is failing
+ * and therefore want to send all errors encountered during creation to central
+ * where we can determine if there are additional failure modes for us to
+ * consider.
  *
- * @param kind - a grouping key that allows us to group all errors
- * originating in the same area of the code base or relating to the
- * same kind of failure (recommend a single non-hyphenated word)
- * Example: tutorialRepoCreation
+ * @param kind - a grouping key that allows us to group all errors originating
+ * in the same area of the code base or relating to the same kind of failure
+ * (recommend a single non-hyphenated word) Example: tutorialRepoCreation
  *
  * @param error - the caught error
  */

--- a/app/src/lib/helpers/non-fatal-exception.ts
+++ b/app/src/lib/helpers/non-fatal-exception.ts
@@ -23,6 +23,10 @@
  * @param error - the caught error
  */
 
+import { getHasOptedOutOfStats } from '../stats/stats-store'
+
 export function sendNonFatalException(kind: string, error: Error) {
-  process.emit('send-non-fatal-exception', error, { kind })
+  if (!getHasOptedOutOfStats()) {
+    process.emit('send-non-fatal-exception', error, { kind })
+  }
 }

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -370,6 +370,9 @@ export interface IDailyMeasures {
 
   /** Number of times the user has switched to or from History/Changes */
   readonly repositoryViewChangeCount: number
+
+  /** Number of times the user has encountered an unhandled rejection */
+  readonly unhandledRejectionCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -350,7 +350,7 @@ export class StatsStore implements IStatsStore {
     this.db = db
     this.uiActivityMonitor = uiActivityMonitor
 
-    const storedValue = getBoolean(StatsOptOutKey)
+    const storedValue = getHasOptedOutOfStats()
 
     this.optOut = storedValue || false
 
@@ -1536,4 +1536,12 @@ function getWelcomeWizardSignInMethod(): 'basic' | 'web' | undefined {
     log.error(`Could not parse welcome wizard sign in method`, ex)
     return undefined
   }
+}
+
+/**
+ * Return a value indicating whether the user has opted out of stats reporting
+ * or not.
+ */
+export function getHasOptedOutOfStats() {
+  return getBoolean(StatsOptOutKey)
 }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -143,6 +143,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   diffModeChangeCount: 0,
   diffOptionsViewedCount: 0,
   repositoryViewChangeCount: 0,
+  unhandledRejectionCount: 0,
 }
 
 interface IOnboardingStats {
@@ -361,6 +362,8 @@ export class StatsStore implements IStatsStore {
     }
 
     this.enableUiActivityMonitoring()
+
+    window.addEventListener('unhandledrejection', this.recordUnhandledRejection)
   }
 
   /** Should the app report its daily stats? */
@@ -1403,6 +1406,12 @@ export class StatsStore implements IStatsStore {
   public recordDiffModeChanged() {
     return this.updateDailyMeasures(m => ({
       diffModeChangeCount: m.diffModeChangeCount + 1,
+    }))
+  }
+
+  public recordUnhandledRejection() {
+    return this.updateDailyMeasures(m => ({
+      unhandledRejectionCount: m.unhandledRejectionCount + 1,
     }))
   }
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -26,7 +26,6 @@ import { now } from './now'
 import { showUncaughtException } from './show-uncaught-exception'
 import { ISerializableMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
-import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 import { stat } from 'fs-extra'
 import { isApplicationBundle } from '../lib/is-application-bundle'
 
@@ -633,17 +632,13 @@ app.on('web-contents-created', (event, contents) => {
   contents.on('new-window', (event, url) => {
     // Prevent links or window.open from opening new windows
     event.preventDefault()
-    const errMsg = `Prevented new window to: ${url}`
-    log.warn(errMsg)
-    sendNonFatalException('newWindowPrevented', Error(errMsg))
+    log.warn(`Prevented new window to: ${url}`)
   })
   // prevent link navigation within our windows
   // see https://www.electronjs.org/docs/tutorial/security#12-disable-or-limit-navigation
   contents.on('will-navigate', (event, url) => {
     event.preventDefault()
-    const errMsg = `Prevented navigation to: ${url}`
-    log.warn(errMsg)
-    sendNonFatalException('willNavigatePrevented', Error(errMsg))
+    log.warn(`Prevented navigation to: ${url}`)
   })
 })
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -203,16 +203,14 @@ process.on(
 )
 
 /**
- * Chromium won't crash on an unhandled rejection (similar to how
- * it won't crash on an unhandled error). We've taken the approach
- * that unhandled errors should crash the app and very likely we
- * should do the same thing for unhandled promise rejections but
- * that's a bit too risky to do until we've established some sense
- * of how often it happens. For now this simply stores the last
- * rejection so that we can pass it along with the crash report
- * if the app does crash. Note that this does not prevent the
- * default browser behavior of logging since we're not calling
- * `preventDefault` on the event.
+ * Chromium won't crash on an unhandled rejection (similar to how it won't crash
+ * on an unhandled error). We've taken the approach that unhandled errors should
+ * crash the app and very likely we should do the same thing for unhandled
+ * promise rejections but that's a bit too risky to do until we've established
+ * some sense of how often it happens. For now this simply stores the last
+ * rejection so that we can pass it along with the crash report if the app does
+ * crash. Note that this does not prevent the default browser behavior of
+ * logging since we're not calling `preventDefault` on the event.
  *
  * See https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event
  */

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -214,10 +214,8 @@ process.on(
  * See https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event
  */
 window.addEventListener('unhandledrejection', ev => {
-  if (ev.reason instanceof Error) {
-    if (enableUnhandledRejectionReporting()) {
-      sendNonFatalException('unhandledRejection', ev.reason)
-    }
+  if (enableUnhandledRejectionReporting() && ev.reason instanceof Error) {
+    sendNonFatalException('unhandledRejection', ev.reason)
   }
 })
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -78,7 +78,6 @@ import 'wicg-focus-ring'
 import momentDurationFormatSetup from 'moment-duration-format'
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 import { enableUnhandledRejectionReporting } from '../lib/feature-flag'
-import { getHasOptedOutOfStats } from '../lib/stats/stats-store'
 
 if (__DEV__) {
   installDevGlobals()
@@ -216,7 +215,7 @@ process.on(
  */
 window.addEventListener('unhandledrejection', ev => {
   if (ev.reason instanceof Error) {
-    if (enableUnhandledRejectionReporting() && !getHasOptedOutOfStats()) {
+    if (enableUnhandledRejectionReporting()) {
       sendNonFatalException('unhandledRejection', ev.reason)
     }
   }

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -77,6 +77,8 @@ import 'wicg-focus-ring'
 // syntax for formatting time duration
 import momentDurationFormatSetup from 'moment-duration-format'
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
+import { enableUnhandledRejectionReporting } from '../lib/feature-flag'
+import { getHasOptedOutOfStats } from '../lib/stats/stats-store'
 
 if (__DEV__) {
   installDevGlobals()
@@ -216,7 +218,9 @@ process.on(
  */
 window.addEventListener('unhandledrejection', ev => {
   if (ev.reason instanceof Error) {
-    sendNonFatalException('unhandledRejection', ev.reason)
+    if (enableUnhandledRejectionReporting() && !getHasOptedOutOfStats()) {
+      sendNonFatalException('unhandledRejection', ev.reason)
+    }
   }
 })
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

In #10978 we started keeping track of unhandled rejections. This was intended to be a beta-only thing but that got overlooked. This constrains non fatal exceptions to beta, and while I was in there I've added a throttle for all non fatal errors to prevent a too many errors being submitted from one client and made it opt-in.

There were two non fatal errors that I didn't see any need in reporting going forward as we've never seen them be hit. I believe they were added initially to verify that they were in fact not getting hit.

I've also added a metric key which aggregates the count of unhandled rejections to give us a high-level overview of our progress towards being able to treat unhandled promise rejections as unhandled errors (i.e. let them crash the app).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
