### PR TITLE
Fix split diff crashes by using loops instead of spreads

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -390,12 +390,12 @@ export class SideBySideDiff extends React.Component<
 
       const beforeSearchTokens = this.getSearchTokens(numRow, DiffColumn.Before)
       if (beforeSearchTokens !== undefined) {
-        beforeTokens.push(...beforeSearchTokens)
+        beforeSearchTokens.forEach(x => beforeTokens.push(x))
       }
 
       const afterSearchTokens = this.getSearchTokens(numRow, DiffColumn.After)
       if (afterSearchTokens !== undefined) {
-        afterTokens.push(...afterSearchTokens)
+        afterSearchTokens.forEach(x => afterTokens.push(x))
       }
 
       return { ...row, beforeTokens, afterTokens }
@@ -415,7 +415,7 @@ export class SideBySideDiff extends React.Component<
     const finalTokens = [...data.tokens]
 
     if (searchTokens !== undefined) {
-      finalTokens.push(...searchTokens)
+      searchTokens.forEach(x => finalTokens.push(x))
     }
     if (lineTokens !== null) {
       finalTokens.push(lineTokens)
@@ -802,7 +802,9 @@ const getDiffRows = memoize(function (
   const outputRows = new Array<SimplifiedDiffRow>()
 
   for (const hunk of diff.hunks) {
-    outputRows.push(...getDiffRowsFromHunk(hunk, showSideBySideDiff))
+    for (const row of getDiffRowsFromHunk(hunk, showSideBySideDiff)) {
+      outputRows.push(row)
+    }
   }
 
   return outputRows
@@ -842,7 +844,9 @@ function getDiffRowsFromHunk(
     if (modifiedLines.length > 0) {
       // If the current line is not added/deleted and we have any added/deleted
       // line stored, we need to process them.
-      rows.push(...getModifiedRows(modifiedLines, showSideBySideDiff))
+      for (const row of getModifiedRows(modifiedLines, showSideBySideDiff)) {
+        rows.push(row)
+      }
       modifiedLines = []
     }
 
@@ -877,7 +881,9 @@ function getDiffRowsFromHunk(
 
   // Do one more pass to process the remaining list of modified lines.
   if (modifiedLines.length > 0) {
-    rows.push(...getModifiedRows(modifiedLines, showSideBySideDiff))
+    for (const row of getModifiedRows(modifiedLines, showSideBySideDiff)) {
+      rows.push(row)
+    }
   }
 
   return rows


### PR DESCRIPTION
I hadn't anticipated these arrays ever growing so large but we've been getting multiple crash reports due to stack overflows thanks to spread/apply putting the arguments onto the stack, see https://stackoverflow.com/a/5081471/2114

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

We are seeing a few crashes in the latest release due to stack overflows inside of the split diff component. An example:

```
Maximum call stack size exceeded
Rm (app/src/ui/diff/side-by-side-diff.tsx:880:10)
app/src/ui/diff/side-by-side-diff.tsx:805:24
app/node_modules/memoize-one/dist/memoize-one.esm.js:28:27
Em.render (app/src/ui/diff/side-by-side-diff.tsx:203:18)
ko (app/node_modules/react-dom/cjs/react-dom.production.min.js:173:192)
Eo (app/node_modules/react-dom/cjs/react-dom.production.min.js:172:264)
Do (app/node_modules/react-dom/cjs/react-dom.production.min.js:180:30)
Bs (app/node_modules/react-dom/cjs/react-dom.production.min.js:232:22)
Hs (app/node_modules/react-dom/cjs/react-dom.production.min.js:233:284)
ka (app/node_modules/react-dom/cjs/react-dom.production.min.js:249:348)
```

This is due to us using spread to push an entire array into another. I hadn't anticipated these arrays ever growing so large but apparently they're sometimes big enough that putting them onto the stack isn't viable. See https://stackoverflow.com/a/5081471/2114 for a description of the problem.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fix] Very large text diffs could cause the app to crash when viewed in split diff mode