### PR TITLE
Handle users dropping strings and such onto the app

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1003,7 +1003,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       if (addedRepositories.length > 0) {
         this.props.dispatcher.recordAddExistingRepository()
       }
-    } else {
+    } else if (paths.length === 1) {
       // user may accidentally provide a folder within the repository
       // this ensures we use the repository root, if it is actually a repository
       // otherwise we consider it an untracked repository

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -989,11 +989,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private async handleDragAndDrop(fileList: FileList) {
-    const paths: string[] = []
-    for (let i = 0; i < fileList.length; i++) {
-      const file = fileList[i]
-      paths.push(file.path)
-    }
+    const paths = [...fileList].map(x => x.path)
 
     // If they're bulk adding repositories then just blindly try to add them.
     // But if they just dragged one, use the dialog so that they can initialize
@@ -1008,20 +1004,15 @@ export class App extends React.Component<IAppProps, IAppState> {
       // this ensures we use the repository root, if it is actually a repository
       // otherwise we consider it an untracked repository
       const first = paths[0]
-      const path = (await validatedRepositoryPath(first)) || first
+      const path = (await validatedRepositoryPath(first)) ?? first
 
-      const existingRepository = matchExistingRepository(
-        this.state.repositories,
-        path
-      )
+      const { repositories } = this.state
+      const existingRepository = matchExistingRepository(repositories, path)
 
       if (existingRepository) {
         await this.props.dispatcher.selectRepository(existingRepository)
       } else {
-        await this.showPopup({
-          type: PopupType.AddRepository,
-          path,
-        })
+        await this.showPopup({ type: PopupType.AddRepository, path })
       }
     }
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Dragging and dropping files and folders onto GitHub Desktop has been supported for a long time but the code didn't account for the case when the user drop something other than a file/directory (i.e. a piece of text or something). This makes sure we only act on actual FileItems in the drop.

This was discovered thanks to an unhandled rejections report.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
