### PR TITLE
Fix fullscreen keyboard shortcut in split diff mode

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -711,10 +711,11 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const isCmdOrCtrl = __DARWIN__ ? event.metaKey : event.ctrlKey
-    const isShortcutKey = isCmdOrCtrl && !event.shiftKey && !event.altKey
+    const isCmdOrCtrl = __DARWIN__
+      ? event.metaKey && !event.ctrlKey
+      : event.ctrlKey
 
-    if (isShortcutKey && event.key === 'f') {
+    if (isCmdOrCtrl && !event.shiftKey && !event.altKey && event.key === 'f') {
       event.preventDefault()
       this.showSearch()
     }

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -707,8 +707,14 @@ export class SideBySideDiff extends React.Component<
   }
 
   private onWindowKeyDown = (event: KeyboardEvent) => {
-    const isShortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
-    if (isShortcutKey && event.key === 'f' && !event.defaultPrevented) {
+    if (event.defaultPrevented) {
+      return
+    }
+
+    const isCmdOrCtrl = __DARWIN__ ? event.metaKey : event.ctrlKey
+    const isShortcutKey = isCmdOrCtrl && !event.shiftKey && !event.altKey
+
+    if (isShortcutKey && event.key === 'f') {
       event.preventDefault()
       this.showSearch()
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11069

## Description

Ensure only <kbd>Cmd</kbd> + <kbd>F</kbd> toggles the search field in side-by-side diffs (and no <kbd>Cmd</kbd> + <kbd>Ctrl</kbd> + <kbd>F</kbd>)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fix] The fullscreen keyboard shortcut on macOS now works when using split diff mode