### PR TITLE
Fix unbound metric record call

### DIFF
--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -364,7 +364,9 @@ export class StatsStore implements IStatsStore {
     this.enableUiActivityMonitoring()
 
     window.addEventListener('unhandledrejection', () =>
-      this.recordUnhandledRejection()
+      this.recordUnhandledRejection().catch(err =>
+        log.error(`Failed recording unhandled rejection`, err)
+      )
     )
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -363,7 +363,9 @@ export class StatsStore implements IStatsStore {
 
     this.enableUiActivityMonitoring()
 
-    window.addEventListener('unhandledrejection', this.recordUnhandledRejection)
+    window.addEventListener('unhandledrejection', () =>
+      this.recordUnhandledRejection()
+    )
   }
 
   /** Should the app report its daily stats? */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -363,11 +363,13 @@ export class StatsStore implements IStatsStore {
 
     this.enableUiActivityMonitoring()
 
-    window.addEventListener('unhandledrejection', () =>
-      this.recordUnhandledRejection().catch(err =>
+    window.addEventListener('unhandledrejection', async () => {
+      try {
+        this.recordUnhandledRejection()
+      } catch (err) {
         log.error(`Failed recording unhandled rejection`, err)
-      )
-    )
+      }
+    })
   }
 
   /** Should the app report its daily stats? */


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

In https://github.com/desktop/desktop/pull/11059 I added a metric for tracking the number of unhandled promise rejections seen in the wild. Unfortunately I glossed over the fact that it was being invoked in the wrong context which (funnily enough) meant that unhandled promise rejections would cause a crash. This is the intended end state but we sure don't want it just yet.

Note that #11059 hasn't shipped to prod or beta yet.