### PR TITLE
Parse enums using runtime enum type defintion

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -3,6 +3,7 @@ import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
 import { assertNever } from '../fatal-error'
 import appPath from 'app-path'
+import { parseEnumValue } from '../enum'
 
 export enum ExternalEditor {
   Atom = 'Atom',
@@ -30,75 +31,7 @@ export enum ExternalEditor {
 }
 
 export function parse(label: string): ExternalEditor | null {
-  if (label === ExternalEditor.Atom) {
-    return ExternalEditor.Atom
-  }
-  if (label === ExternalEditor.MacVim) {
-    return ExternalEditor.MacVim
-  }
-  if (label === ExternalEditor.VSCode) {
-    return ExternalEditor.VSCode
-  }
-  if (label === ExternalEditor.VSCodeInsiders) {
-    return ExternalEditor.VSCodeInsiders
-  }
-
-  if (label === ExternalEditor.VSCodium) {
-    return ExternalEditor.VSCodium
-  }
-
-  if (label === ExternalEditor.SublimeText) {
-    return ExternalEditor.SublimeText
-  }
-  if (label === ExternalEditor.BBEdit) {
-    return ExternalEditor.BBEdit
-  }
-  if (label === ExternalEditor.PhpStorm) {
-    return ExternalEditor.PhpStorm
-  }
-  if (label === ExternalEditor.PyCharm) {
-    return ExternalEditor.PyCharm
-  }
-  if (label === ExternalEditor.RubyMine) {
-    return ExternalEditor.RubyMine
-  }
-  if (label === ExternalEditor.TextMate) {
-    return ExternalEditor.TextMate
-  }
-  if (label === ExternalEditor.Brackets) {
-    return ExternalEditor.Brackets
-  }
-  if (label === ExternalEditor.WebStorm) {
-    return ExternalEditor.WebStorm
-  }
-  if (label === ExternalEditor.Typora) {
-    return ExternalEditor.Typora
-  }
-  if (label === ExternalEditor.CodeRunner) {
-    return ExternalEditor.CodeRunner
-  }
-  if (label === ExternalEditor.SlickEdit) {
-    return ExternalEditor.SlickEdit
-  }
-  if (label === ExternalEditor.IntelliJ) {
-    return ExternalEditor.IntelliJ
-  }
-  if (label === ExternalEditor.Xcode) {
-    return ExternalEditor.Xcode
-  }
-  if (label === ExternalEditor.GoLand) {
-    return ExternalEditor.GoLand
-  }
-  if (label === ExternalEditor.AndroidStudio) {
-    return ExternalEditor.AndroidStudio
-  }
-  if (label === ExternalEditor.Rider) {
-    return ExternalEditor.Rider
-  }
-  if (label === ExternalEditor.Nova) {
-    return ExternalEditor.Nova
-  }
-  return null
+  return parseEnumValue(ExternalEditor, label) ?? null
 }
 
 function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -2,6 +2,7 @@ import { pathExists } from 'fs-extra'
 
 import { IFoundEditor } from './found-editor'
 import { assertNever } from '../fatal-error'
+import { parseEnumValue } from '../enum'
 
 export enum ExternalEditor {
   Atom = 'Atom',
@@ -14,35 +15,7 @@ export enum ExternalEditor {
 }
 
 export function parse(label: string): ExternalEditor | null {
-  if (label === ExternalEditor.Atom) {
-    return ExternalEditor.Atom
-  }
-
-  if (label === ExternalEditor.VSCode) {
-    return ExternalEditor.VSCode
-  }
-
-  if (label === ExternalEditor.VSCodeInsiders) {
-    return ExternalEditor.VSCode
-  }
-
-  if (label === ExternalEditor.VSCodium) {
-    return ExternalEditor.VSCodium
-  }
-
-  if (label === ExternalEditor.SublimeText) {
-    return ExternalEditor.SublimeText
-  }
-
-  if (label === ExternalEditor.Typora) {
-    return ExternalEditor.Typora
-  }
-
-  if (label === ExternalEditor.SlickEdit) {
-    return ExternalEditor.SlickEdit
-  }
-
-  return null
+  return parseEnumValue(ExternalEditor, label) ?? null
 }
 
 async function getPathIfAvailable(path: string): Promise<string | null> {

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -11,6 +11,7 @@ import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
 
 import { assertNever } from '../fatal-error'
+import { parseEnumValue } from '../enum'
 
 export enum ExternalEditor {
   Atom = 'Atom',
@@ -30,50 +31,7 @@ export enum ExternalEditor {
 }
 
 export function parse(label: string): ExternalEditor | null {
-  if (label === ExternalEditor.Atom) {
-    return ExternalEditor.Atom
-  }
-  if (label === ExternalEditor.AtomBeta) {
-    return ExternalEditor.AtomBeta
-  }
-  if (label === ExternalEditor.AtomNightly) {
-    return ExternalEditor.AtomNightly
-  }
-  if (label === ExternalEditor.VSCode) {
-    return ExternalEditor.VSCode
-  }
-  if (label === ExternalEditor.VSCodeInsiders) {
-    return ExternalEditor.VSCodeInsiders
-  }
-  if (label === ExternalEditor.VSCodium) {
-    return ExternalEditor.VSCodium
-  }
-  if (label === ExternalEditor.SublimeText) {
-    return ExternalEditor.SublimeText
-  }
-  if (label === ExternalEditor.CFBuilder) {
-    return ExternalEditor.CFBuilder
-  }
-  if (label === ExternalEditor.Typora) {
-    return ExternalEditor.Typora
-  }
-  if (label === ExternalEditor.SlickEdit) {
-    return ExternalEditor.SlickEdit
-  }
-  if (label === ExternalEditor.Webstorm) {
-    return ExternalEditor.Webstorm
-  }
-  if (label === ExternalEditor.Phpstorm) {
-    return ExternalEditor.Phpstorm
-  }
-  if (label === ExternalEditor.NotepadPlusPlus) {
-    return ExternalEditor.NotepadPlusPlus
-  }
-  if (label === ExternalEditor.Rider) {
-    return ExternalEditor.Rider
-  }
-
-  return null
+  return parseEnumValue(ExternalEditor, label) ?? null
 }
 
 /**

--- a/app/src/lib/enum.ts
+++ b/app/src/lib/enum.ts
@@ -5,22 +5,10 @@ type StringEnum<T extends string> = {
 /**
  * Parse a string into the given (string) enum type. Returns undefined if the
  * enum type provided did not match any of the keys in the enum.
- *
- * Resist the urge to use Object.entries().find() to get this down to a
- * one-liner. I measured it and this is 200x faster and doesn't allocate any
- * unnecessary arrays.
  */
 export function parseEnumValue<T extends string>(
   enumObj: StringEnum<T>,
   value: string
 ): T | undefined {
-  for (const key in enumObj) {
-    if (
-      Object.prototype.hasOwnProperty.call(enumObj, key) &&
-      enumObj[key] === value
-    ) {
-      return enumObj[key]
-    }
-  }
-  return undefined
+  return Object.values(enumObj).find(v => v === value)
 }

--- a/app/src/lib/enum.ts
+++ b/app/src/lib/enum.ts
@@ -1,13 +1,9 @@
-type StringEnum<T extends string> = {
-  [key: string]: T
-}
-
 /**
  * Parse a string into the given (string) enum type. Returns undefined if the
  * enum type provided did not match any of the keys in the enum.
  */
 export function parseEnumValue<T extends string>(
-  enumObj: StringEnum<T>,
+  enumObj: Record<string, T>,
   value: string
 ): T | undefined {
   return Object.values(enumObj).find(v => v === value)

--- a/app/src/lib/enum.ts
+++ b/app/src/lib/enum.ts
@@ -1,3 +1,7 @@
+type StringEnum<T extends string> = {
+  [key: string]: T
+}
+
 /**
  * Parse a string into the given (string) enum type. Returns undefined if the
  * enum type provided did not match any of the keys in the enum.
@@ -6,13 +10,16 @@
  * one-liner. I measured it and this is 200x faster and doesn't allocate any
  * unnecessary arrays.
  */
-export function parseEnumValue<T>(
-  enumObj: Record<string, T>,
-  key: string
+export function parseEnumValue<T extends string>(
+  enumObj: StringEnum<T>,
+  value: string
 ): T | undefined {
-  for (const k in enumObj) {
-    if (k === key && Object.prototype.hasOwnProperty.call(enumObj, k)) {
-      return enumObj[k]
+  for (const key in enumObj) {
+    if (
+      Object.prototype.hasOwnProperty.call(enumObj, key) &&
+      enumObj[key] === value
+    ) {
+      return enumObj[key]
     }
   }
   return undefined

--- a/app/src/lib/enum.ts
+++ b/app/src/lib/enum.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse a string into the given (string) enum type. Returns undefined if the
+ * enum type provided did not match any of the keys in the enum.
+ *
+ * Resist the urge to use Object.entries().find() to get this down to a
+ * one-liner. I measured it and this is 200x faster and doesn't allocate any
+ * unnecessary arrays.
+ */
+export function parseEnumValue<T>(
+  enumObj: Record<string, T>,
+  key: string
+): T | undefined {
+  for (const k in enumObj) {
+    if (k === key && Object.prototype.hasOwnProperty.call(enumObj, k)) {
+      return enumObj[k]
+    }
+  }
+  return undefined
+}

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -170,7 +170,7 @@ const NumberArrayDelimiter = ','
  * @param key     The localStorage key to read from
  * @param enumObj The Enum type definition
  */
-export function getEnum<T>(
+export function getEnum<T extends string>(
   key: string,
   enumObj: Record<string, T>
 ): T | undefined {

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -1,3 +1,5 @@
+import { parseEnumValue } from './enum'
+
 /**
  * Returns the value for the provided key from local storage interpreted as a
  * boolean or the provided `defaultValue` if the key doesn't exist.
@@ -159,3 +161,11 @@ export function setStringArray(key: string, values: ReadonlyArray<string>) {
 
 /** Default delimiter for stringifying and parsing arrays of numbers */
 const NumberArrayDelimiter = ','
+
+export function getEnum<T>(
+  key: string,
+  enumObj: Record<string, T>
+): T | undefined {
+  const storedValue = localStorage.getItem(key)
+  return storedValue === null ? undefined : parseEnumValue(enumObj, storedValue)
+}

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -162,6 +162,14 @@ export function setStringArray(key: string, values: ReadonlyArray<string>) {
 /** Default delimiter for stringifying and parsing arrays of numbers */
 const NumberArrayDelimiter = ','
 
+/**
+ * Load a (string) enum based on its stored value. See `parseEnumValue` for more
+ * details on the conversion. Note that there's no `setEnum` companion method
+ * here since callers can just use `localStorage.setItem(key, enumValue)`
+ *
+ * @param key     The localStorage key to read from
+ * @param enumObj The Enum type definition
+ */
 export function getEnum<T>(
   key: string,
   enumObj: Record<string, T>

--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process'
 import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
 import appPath from 'app-path'
+import { parseEnumValue } from '../enum'
 
 export enum Shell {
   Terminal = 'Terminal',
@@ -15,31 +16,7 @@ export enum Shell {
 export const Default = Shell.Terminal
 
 export function parse(label: string): Shell {
-  if (label === Shell.Terminal) {
-    return Shell.Terminal
-  }
-
-  if (label === Shell.Hyper) {
-    return Shell.Hyper
-  }
-
-  if (label === Shell.iTerm2) {
-    return Shell.iTerm2
-  }
-
-  if (label === Shell.PowerShellCore) {
-    return Shell.PowerShellCore
-  }
-
-  if (label === Shell.Kitty) {
-    return Shell.Kitty
-  }
-
-  if (label === Shell.Alacritty) {
-    return Shell.Alacritty
-  }
-
-  return Default
+  return parseEnumValue(Shell, label) ?? Default
 }
 
 function getBundleID(shell: Shell): string {

--- a/app/src/lib/shells/linux.ts
+++ b/app/src/lib/shells/linux.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from 'child_process'
 import { pathExists } from 'fs-extra'
 import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
+import { parseEnumValue } from '../enum'
 
 export enum Shell {
   Gnome = 'GNOME Terminal',
@@ -17,39 +18,7 @@ export enum Shell {
 export const Default = Shell.Gnome
 
 export function parse(label: string): Shell {
-  if (label === Shell.Gnome) {
-    return Shell.Gnome
-  }
-
-  if (label === Shell.Mate) {
-    return Shell.Mate
-  }
-
-  if (label === Shell.Tilix) {
-    return Shell.Tilix
-  }
-
-  if (label === Shell.Terminator) {
-    return Shell.Terminator
-  }
-
-  if (label === Shell.Urxvt) {
-    return Shell.Urxvt
-  }
-
-  if (label === Shell.Konsole) {
-    return Shell.Konsole
-  }
-
-  if (label === Shell.Xterm) {
-    return Shell.Xterm
-  }
-
-  if (label === Shell.Terminology) {
-    return Shell.Terminology
-  }
-
-  return Default
+  return parseEnumValue(Shell, label) ?? Default
 }
 
 async function getPathIfAvailable(path: string): Promise<string | null> {

--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -7,6 +7,7 @@ import { assertNever } from '../fatal-error'
 import { IFoundShell } from './found-shell'
 import { enableWSLDetection } from '../feature-flag'
 import { findGitOnPath } from '../is-git-on-path'
+import { parseEnumValue } from '../enum'
 
 export enum Shell {
   Cmd = 'Command Prompt',
@@ -23,43 +24,7 @@ export enum Shell {
 export const Default = Shell.Cmd
 
 export function parse(label: string): Shell {
-  if (label === Shell.Cmd) {
-    return Shell.Cmd
-  }
-
-  if (label === Shell.PowerShell) {
-    return Shell.PowerShell
-  }
-
-  if (label === Shell.PowerShellCore) {
-    return Shell.PowerShellCore
-  }
-
-  if (label === Shell.Hyper) {
-    return Shell.Hyper
-  }
-
-  if (label === Shell.GitBash) {
-    return Shell.GitBash
-  }
-
-  if (label === Shell.Cygwin) {
-    return Shell.Cygwin
-  }
-
-  if (label === Shell.WSL) {
-    return Shell.WSL
-  }
-
-  if (label === Shell.WindowTerminal) {
-    return Shell.WindowTerminal
-  }
-
-  if (label === Shell.Alacritty) {
-    return Shell.Alacritty
-  }
-
-  return Default
+  return parseEnumValue(Shell, label) ?? Default
 }
 
 export async function getAvailableShells(): Promise<

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -212,6 +212,7 @@ import {
   getNumber,
   getNumberArray,
   setNumberArray,
+  getEnum,
 } from '../local-storage'
 import { ExternalEditorError } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -236,7 +237,6 @@ import {
 import {
   UncommittedChangesStrategy,
   defaultUncommittedChangesStrategy,
-  parseStrategy,
 } from '../../models/uncommitted-changes-strategy'
 import { IStashEntry, StashedChangesLoadStates } from '../../models/stash-entry'
 import { RebaseFlowStep, RebaseStep } from '../../models/rebase-flow-step'
@@ -1819,11 +1819,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnForcePushDefault
     )
 
-    const strategy = parseStrategy(
-      localStorage.getItem(uncommittedChangesStrategyKey)
-    )
     this.uncommittedChangesStrategy =
-      strategy || defaultUncommittedChangesStrategy
+      getEnum(uncommittedChangesStrategyKey, UncommittedChangesStrategy) ??
+      defaultUncommittedChangesStrategy
 
     this.updateSelectedExternalEditor(
       await this.lookupSelectedExternalEditor()

--- a/app/src/models/uncommitted-changes-strategy.ts
+++ b/app/src/models/uncommitted-changes-strategy.ts
@@ -6,22 +6,3 @@ export enum UncommittedChangesStrategy {
 
 export const defaultUncommittedChangesStrategy: UncommittedChangesStrategy =
   UncommittedChangesStrategy.AskForConfirmation
-
-/**
- * Parse a string into a valid `UncommittedChangesStrategy`,
- * if possible. Returns `null` if not.
- */
-export function parseStrategy(
-  strategy: string | null
-): UncommittedChangesStrategy | null {
-  switch (strategy) {
-    case UncommittedChangesStrategy.AskForConfirmation:
-      return UncommittedChangesStrategy.AskForConfirmation
-    case UncommittedChangesStrategy.StashOnCurrentBranch:
-      return UncommittedChangesStrategy.StashOnCurrentBranch
-    case UncommittedChangesStrategy.MoveToNewBranch:
-      return UncommittedChangesStrategy.MoveToNewBranch
-    default:
-      return null
-  }
-}

--- a/app/test/unit/enum-test.ts
+++ b/app/test/unit/enum-test.ts
@@ -1,0 +1,33 @@
+import { parseEnumValue } from '../../src/lib/enum'
+
+enum TestEnum {
+  Foo = 'foo',
+  Bar = 'bar is the thing',
+}
+
+describe('parseEnumValue', () => {
+  it('parses an enum type from a string', () => {
+    expect(parseEnumValue(TestEnum, 'foo')).toBe(TestEnum.Foo)
+    expect(parseEnumValue(TestEnum, TestEnum.Foo)).toBe(TestEnum.Foo)
+    expect(parseEnumValue(TestEnum, 'bar is the thing')).toBe(TestEnum.Bar)
+    expect(parseEnumValue(TestEnum, TestEnum.Bar)).toBe(TestEnum.Bar)
+  })
+
+  it("returns undefined when enum value doesn't exist", () => {
+    expect(parseEnumValue(TestEnum, 'baz')).toBe(undefined)
+  })
+
+  it('ignores inherited values', () => {
+    // Note: The only way I can think of that this would happen is if someone
+    // monkey-patches Object but we're not going to taint the test suite for
+    // that so we'll create a fake enum
+    const parent = Object.create(null)
+    parent.foo = 'bar'
+
+    const child = Object.create(parent)
+
+    expect('foo' in child).toBeTrue()
+    expect(child.foo).toBe('bar')
+    expect(parseEnumValue(child, 'bar')).toBe(undefined)
+  })
+})


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Enums,  unlike a lot of TypeScript features, are available at runtime. We can leverage this to get rid of some tedious manual parsing logic when converting string enums to and from strings persisted in localStorage.