### PR TITLE
Release v2.6.1-beta1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.6.0",
+  "version": "2.6.1-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,12 @@
 {
   "releases": {
+    "2.6.1-beta1": [
+      "[Fixed] Very large text diffs could cause the app to crash when viewed in split diff mode - #11064",
+      "[Fixed] Refactor checkout branch and stash logic - #9297 #10956 #8099 #7617",
+      "[Fixed] Let the user know when a checkout fails due to use of assume-unchanged or skip-worktree - #9297",
+      "[Fixed] Always show confirmation prompt before overwriting existing stash entry - #10956",
+      "[Fixed] The fullscreen keyboard shortcut on macOS now works when using split diff mode - #11069"
+    ],
     "2.6.0": [
       "[New] Split diffs! Toggle between viewing diffs in split or unified mode - #10617",
       "[Added] Use Page down, Page up, Home, and End keys to navigate and select items in lists - #10837",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming first beta of the v2.6.1 series? Well you've just found it, congratulations! :tada:

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
 - no feature flags
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
  - We have one new metric, unhandledRejectionCount: https://github.com/desktop/desktop/pull/11059/files#diff-2bd2cc372eef6b3d3a08e0bf51bd5896ff5eebbbfef3fd0a1a4a84ce1662ce65R146
  - [x] central
  - [x] desktop.github.com