### PR TITLE
Fix image swipe regression

### DIFF
--- a/app/src/ui/diff/image-diffs/swipe.tsx
+++ b/app/src/ui/diff/image-diffs/swipe.tsx
@@ -25,6 +25,14 @@ export class Swipe extends React.Component<
       width: this.props.maxSize.width,
     }
 
+    const swiperWidth = this.props.maxSize.width * (1 - this.state.percentage)
+
+    const currentStyle: React.CSSProperties = {
+      height: this.props.maxSize.height,
+      width: this.props.maxSize.width,
+      left: -(this.props.maxSize.width - swiperWidth),
+    }
+
     const maxSize: React.CSSProperties = {
       maxHeight: this.props.maxSize.height,
       maxWidth: this.props.maxSize.width,
@@ -34,24 +42,24 @@ export class Swipe extends React.Component<
       <div className="image-diff-swipe">
         <div className="sizing-container" ref={this.props.onContainerRef}>
           <div className="image-container" style={style}>
-            <div className="image-diff-current" style={style}>
+            <div className="image-diff-previous" style={style}>
               <ImageContainer
-                image={this.props.current}
-                onElementLoad={this.props.onCurrentImageLoad}
+                image={this.props.previous}
+                onElementLoad={this.props.onPreviousImageLoad}
                 style={maxSize}
               />
             </div>
             <div
               className="swiper"
               style={{
-                width: this.props.maxSize.width * (1 - this.state.percentage),
+                width: swiperWidth,
                 height: this.props.maxSize.height,
               }}
             >
-              <div className="image-diff-previous" style={style}>
+              <div className="image-diff-current" style={currentStyle}>
                 <ImageContainer
-                  image={this.props.previous}
-                  onElementLoad={this.props.onPreviousImageLoad}
+                  image={this.props.current}
+                  onElementLoad={this.props.onCurrentImageLoad}
                   style={maxSize}
                 />
               </div>

--- a/app/src/ui/diff/image-diffs/swipe.tsx
+++ b/app/src/ui/diff/image-diffs/swipe.tsx
@@ -16,7 +16,7 @@ export class Swipe extends React.Component<
   public constructor(props: ICommonImageDiffProperties) {
     super(props)
 
-    this.state = { percentage: 1 }
+    this.state = { percentage: 0 }
   }
 
   public render() {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -523,7 +523,6 @@
       }
 
       .swiper {
-        border-left: 1px solid var(--text-secondary-color);
         margin: 0;
         overflow: hidden;
         position: absolute;

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -511,10 +511,10 @@
 
     .image-container {
       position: relative;
+      @include checkboard-background;
 
       .image-diff-previous,
       .image-diff-current {
-        @include checkboard-background;
         position: absolute;
 
         img {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -522,10 +522,6 @@
         }
       }
 
-      .image-diff-current {
-        right: 0;
-      }
-
       .swiper {
         border-left: 1px solid var(--text-secondary-color);
         margin: 0;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11120 

## Description

As part of fixing the long standing image diff scaling problems in #10904 I probably (not verified that it originates from #10904 but it's very likely) introduced a regression for the swipe mode of image diffs which was reported in #11120. 

This fixes the regression and also aligns the swipe mode even further with GitHub.com's swipe mode by making the slider start at the leftmost position and by having the current version of the image sit on top of the previous version.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### Before

![20201125-before](https://user-images.githubusercontent.com/634063/100228694-5d438900-2f23-11eb-902d-3a0faf861fa9.gif)


### After

![20201125-after](https://user-images.githubusercontent.com/634063/100228717-66345a80-2f23-11eb-84c5-96b61169b385.gif)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] The image diff swipe mode overlays the two versions on top of each other again
