### PR TITLE
Update VSCode recommended extensions and workspace settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "msjsdiag.debugger-for-chrome",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint"
   ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "stkb.rewrap"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "ms-vscode.vscode-typescript-tslint-plugin",
     "msjsdiag.debugger-for-chrome",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     ".awcache": true,
     ".eslintcache": true
   },
+  "files.insertFinalNewline": true,
   "editor.tabSize": 2,
   "prettier.semi": false,
   "prettier.singleQuote": true,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I took a look at our recommended extensions list and realized it needed a bit of pruning. I've remove TSLint since we're relying on ESLint now and I removed some chrome debugger extension that I haven't seen anyone use. I've also added Rewrap since I've found that to be very helpful myself in making sure my jsdoc and other comments fit nicely within the 80 char guideline.

Lastly I've enabled `files.insertFinalNewline`. I was using an extension to ensure that I didn't accidentally commit files without a trailing newline but it's a core feature of VS Code now so we might as well turn it on.