### PR TITLE
Don't include results from our vendored yarn.js in search results

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,8 @@
     "**/dist": true,
     "**/node_modules": true,
     "**/out": true,
-    "app/test/fixtures": true
+    "app/test/fixtures": true,
+    "vendor": true
   },
   "files.exclude": {
     "**/.git": true,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Follow up to https://github.com/desktop/desktop/pull/11129 to not include our vendored yarn.js file in VS Code search results

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes