### PR TITLE
Refresh branches after creating a new branch

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -1,5 +1,4 @@
 import { git, gitNetworkArguments } from './core'
-import { getBranches } from './for-each-ref'
 import { Repository } from '../../models/repository'
 import { Branch, BranchType } from '../../models/branch'
 import { IGitAccount } from '../../models/git-account'
@@ -26,7 +25,7 @@ export async function createBranch(
   name: string,
   startPoint: string | null,
   noTrack?: boolean
-): Promise<Branch | null> {
+): Promise<void> {
   const args =
     startPoint !== null ? ['branch', name, startPoint] : ['branch', name]
 
@@ -38,12 +37,6 @@ export async function createBranch(
   }
 
   await git(args, repository.path, 'createBranch')
-  const branches = await getBranches(repository, `refs/heads/${name}`)
-  if (branches.length > 0) {
-    return branches[0]
-  }
-
-  return null
 }
 
 /** Rename the given branch to a new name. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3072,7 +3072,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
     const branch = await gitStore.createBranch(name, startPoint, noTrackOption)
 
-    if (branch !== null) {
+    if (branch !== undefined) {
       await this._checkoutBranch(repository, branch)
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -125,7 +125,6 @@ import {
   abortMerge,
   addRemote,
   checkoutBranch,
-  createBranch,
   createCommit,
   deleteBranch,
   formatAsLocalRef,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3105,16 +3105,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  private getLocalBranch(
-    repository: Repository,
-    branch: string
-  ): Branch | null {
-    const gitStore = this.gitStoreCache.get(repository)
-    return (
-      gitStore.allBranches.find(b => b.nameWithoutRemote === branch) || null
-    )
-  }
-
   /**
    * Checkout the given branch, using given stashing strategy or the default.
    *
@@ -5498,9 +5488,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
 
     const localBranchName = `pr/${prNumber}`
-    const existingBranch = this.getLocalBranch(repository, localBranchName)
+    const existingBranch = this.gitStoreCache
+      .get(repository)
+      .allBranches.find(b => b.nameWithoutRemote === branch)
 
-    if (existingBranch === null) {
+    if (existingBranch === undefined) {
       await this._createBranch(
         repository,
         localBranchName,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3068,13 +3068,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     name: string,
     startPoint: string | null,
     noTrackOption: boolean = false
-  ): Promise<Repository> {
+  ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
     const branch = await gitStore.createBranch(name, startPoint, noTrackOption)
 
-    return branch === null
-      ? repository
-      : this._checkoutBranch(repository, branch)
+    if (branch !== null) {
+      await this._checkoutBranch(repository, branch)
+    }
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3086,8 +3086,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
 
     await gitStore.createTag(name, targetCommitSha)
-
-    this._closePopup()
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3071,15 +3071,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     noTrackOption: boolean = false
   ): Promise<Repository> {
     const gitStore = this.gitStoreCache.get(repository)
-    const branch = await gitStore.performFailableOperation(() =>
-      createBranch(repository, name, startPoint, noTrackOption)
-    )
+    const branch = await gitStore.createBranch(name, startPoint, noTrackOption)
 
-    if (branch === null || branch === undefined) {
-      return repository
-    } else {
-      return this._checkoutBranch(repository, branch)
-    }
+    return branch === null
+      ? repository
+      : this._checkoutBranch(repository, branch)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3078,20 +3078,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _createTag(
-    repository: Repository,
-    name: string,
-    targetCommitSha: string
-  ): Promise<void> {
+  public async _createTag(repository: Repository, name: string, sha: string) {
     const gitStore = this.gitStoreCache.get(repository)
-
-    await gitStore.createTag(name, targetCommitSha)
+    await gitStore.createTag(name, sha)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
-  public async _deleteTag(repository: Repository, name: string): Promise<void> {
+  public async _deleteTag(repository: Repository, name: string) {
     const gitStore = this.gitStoreCache.get(repository)
-
     await gitStore.deleteTag(name)
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -340,16 +340,19 @@ export class GitStore extends BaseStore {
     startPoint: string | null,
     noTrackOption: boolean = false
   ) {
-    const branch =
-      (await this.performFailableOperation(() =>
-        createBranch(this.repository, name, startPoint, noTrackOption)
-      )) ?? null
+    const createdBranch = await this.performFailableOperation(async () => {
+      await createBranch(this.repository, name, startPoint, noTrackOption)
+      return true
+    })
 
-    if (branch !== null) {
+    if (createdBranch === true) {
       await this.loadBranches()
+      return this.allBranches.find(
+        x => x.type === BranchType.Local && x.name === name
+      )
     }
 
-    return branch
+    return undefined
   }
 
   public async createTag(name: string, targetCommitSha: string) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -66,6 +66,7 @@ import {
   getAllTags,
   deleteTag,
   MergeResult,
+  createBranch,
 } from '../git'
 import { GitError as DugiteError } from '../../lib/git'
 import { GitError } from 'dugite'
@@ -332,6 +333,23 @@ export class GitStore extends BaseStore {
     }
 
     this.storeCommits(commitsToStore)
+  }
+
+  public async createBranch(
+    name: string,
+    startPoint: string | null,
+    noTrackOption: boolean = false
+  ) {
+    const branch =
+      (await this.performFailableOperation(() =>
+        createBranch(this.repository, name, startPoint, noTrackOption)
+      )) ?? null
+
+    if (branch !== null) {
+      await this.loadBranches()
+    }
+
+    return branch
   }
 
   public async createTag(name: string, targetCommitSha: string) {

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -119,6 +119,8 @@ export class CreateTag extends React.Component<
         this.props.targetCommitSha
       )
       timer.done()
+
+      this.props.onDismissed()
     }
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -481,7 +481,7 @@ export class Dispatcher {
     name: string,
     startPoint: string | null,
     noTrackOption: boolean = false
-  ): Promise<Repository> {
+  ): Promise<void> {
     return this.appStore._createBranch(
       repository,
       name,

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -177,6 +177,7 @@ describe('git/branch', () => {
 
     it('deletes local branches', async () => {
       const name = 'test-branch'
+      await createBranch(repository, name, null)
       const [branch] = await getBranches(repository, `refs/heads/${name}`)
       assertNonNullable(branch, `Could not create branch ${name}`)
 

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../src/lib/git'
 import { StatsStore, StatsDatabase } from '../../../src/lib/stats'
 import { UiActivityMonitor } from '../../../src/ui/lib/ui-activity-monitor'
+import { assertNonNullable } from '../../../src/lib/fatal-error'
 
 describe('git/branch', () => {
   let statsStore: StatsStore
@@ -176,7 +177,9 @@ describe('git/branch', () => {
 
     it('deletes local branches', async () => {
       const name = 'test-branch'
-      const branch = await createBranch(repository, name, null)
+      const [branch] = await getBranches(repository, `refs/heads/${name}`)
+      assertNonNullable(branch, `Could not create branch ${name}`)
+
       const ref = `refs/heads/${name}`
 
       expect(branch).not.toBeNull()

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -15,8 +15,9 @@ async function createAndCheckout(
   repository: Repository,
   name: string
 ): Promise<void> {
-  const branch = await createBranch(repository, name, null)
-  if (branch == null) {
+  await createBranch(repository, name, null)
+  const [branch] = await getBranches(repository, `refs/heads/${name}`)
+  if (branch === undefined) {
     throw new Error(`Unable to create branch: ${name}`)
   }
   await checkoutBranch(repository, null, branch)

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -13,6 +13,7 @@ import {
   createCommit,
   checkoutBranch,
   deleteTag,
+  getBranches,
 } from '../../../src/lib/git'
 import {
   setupFixtureRepository,
@@ -23,6 +24,7 @@ import { getDotComAPIEndpoint } from '../../../src/lib/api'
 import { IRemote } from '../../../src/models/remote'
 import { findDefaultRemote } from '../../../src/lib/stores/helpers/find-default-remote'
 import { getStatusOrThrow } from '../../helpers/status'
+import { assertNonNullable } from '../../../src/lib/fatal-error'
 
 describe('git/tag', () => {
   let repository: Repository
@@ -153,7 +155,9 @@ describe('git/tag', () => {
 
     it('does not return a tag created on a non-pushed branch', async () => {
       // Create a tag on a local branch that's not pushed to the remote.
-      const branch = await createBranch(repository, 'new-branch', 'master')
+      await createBranch(repository, 'new-branch', 'master')
+      const [branch] = await getBranches(repository, `refs/heads/${name}`)
+      assertNonNullable(branch, `Could not create branch ${name}`)
 
       await FSE.writeFile(path.join(repository.path, 'README.md'), 'Hi world\n')
       const status = await getStatusOrThrow(repository)

--- a/app/test/unit/git/tag-test.ts
+++ b/app/test/unit/git/tag-test.ts
@@ -155,9 +155,10 @@ describe('git/tag', () => {
 
     it('does not return a tag created on a non-pushed branch', async () => {
       // Create a tag on a local branch that's not pushed to the remote.
-      await createBranch(repository, 'new-branch', 'master')
-      const [branch] = await getBranches(repository, `refs/heads/${name}`)
-      assertNonNullable(branch, `Could not create branch ${name}`)
+      const branchName = 'new-branch'
+      await createBranch(repository, branchName, 'master')
+      const [branch] = await getBranches(repository, `refs/heads/${branchName}`)
+      assertNonNullable(branch, `Could not create branch ${branchName}`)
 
       await FSE.writeFile(path.join(repository.path, 'README.md'), 'Hi world\n')
       const status = await getStatusOrThrow(repository)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11125

## Description

After creating a branch we now refresh the list of branches immediately rather than relying on checkoutBranch to do it for us as part of its `.refreshRepository`.

Since we always refresh the list of branches after creating a branch now we can just use that list rather than issuing a redundant for-each-ref command inside of the `createBranch` Git method.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Ensure newly created branches are shown even if the checkout is cancelled - #11125
