### PR TITLE
Fix starting as maximized

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -20,20 +20,20 @@ export class AppWindow {
   private minWidth = 960
   private minHeight = 660
 
-  private savedWindowState: windowStateKeeper.State | null = null
+  private shouldMaximizeOnShow: boolean = false
 
   public constructor() {
-    this.savedWindowState = windowStateKeeper({
+    const savedWindowState = windowStateKeeper({
       defaultWidth: this.minWidth,
       defaultHeight: this.minHeight,
       maximize: false,
     })
 
     const windowOptions: Electron.BrowserWindowConstructorOptions = {
-      x: this.savedWindowState.x,
-      y: this.savedWindowState.y,
-      width: this.savedWindowState.width,
-      height: this.savedWindowState.height,
+      x: savedWindowState.x,
+      y: savedWindowState.y,
+      width: savedWindowState.width,
+      height: savedWindowState.height,
       minWidth: this.minWidth,
       minHeight: this.minHeight,
       show: false,
@@ -60,7 +60,8 @@ export class AppWindow {
     }
 
     this.window = new BrowserWindow(windowOptions)
-    this.savedWindowState.manage(this.window)
+    savedWindowState.manage(this.window)
+    this.shouldMaximizeOnShow = savedWindowState.isMaximized
 
     let quitting = false
     app.on('before-quit', () => {
@@ -207,7 +208,7 @@ export class AppWindow {
 
   /** Show the window. */
   public show() {
-    if (this.savedWindowState?.isMaximized) {
+    if (this.shouldMaximizeOnShow) {
       this.window.maximize() // maximize will also call show()
     } else {
       this.window.show()

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -20,7 +20,8 @@ export class AppWindow {
   private minWidth = 960
   private minHeight = 660
 
-  private shouldMaximizeOnShow: boolean = false
+  // See https://github.com/desktop/desktop/pull/11162
+  private shouldMaximizeOnShow = false
 
   public constructor() {
     const savedWindowState = windowStateKeeper({

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -20,17 +20,20 @@ export class AppWindow {
   private minWidth = 960
   private minHeight = 660
 
+  private savedWindowState: windowStateKeeper.State | null = null
+
   public constructor() {
-    const savedWindowState = windowStateKeeper({
+    this.savedWindowState = windowStateKeeper({
       defaultWidth: this.minWidth,
       defaultHeight: this.minHeight,
+      maximize: false,
     })
 
     const windowOptions: Electron.BrowserWindowConstructorOptions = {
-      x: savedWindowState.x,
-      y: savedWindowState.y,
-      width: savedWindowState.width,
-      height: savedWindowState.height,
+      x: this.savedWindowState.x,
+      y: this.savedWindowState.y,
+      width: this.savedWindowState.width,
+      height: this.savedWindowState.height,
       minWidth: this.minWidth,
       minHeight: this.minHeight,
       show: false,
@@ -57,7 +60,7 @@ export class AppWindow {
     }
 
     this.window = new BrowserWindow(windowOptions)
-    savedWindowState.manage(this.window)
+    this.savedWindowState.manage(this.window)
 
     let quitting = false
     app.on('before-quit', () => {
@@ -204,7 +207,11 @@ export class AppWindow {
 
   /** Show the window. */
   public show() {
-    this.window.show()
+    if (this.savedWindowState?.isMaximized) {
+      this.window.maximize() // maximize will also call show()
+    } else {
+      this.window.show()
+    }
   }
 
   /** Send the menu event to the renderer. */

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -208,10 +208,9 @@ export class AppWindow {
 
   /** Show the window. */
   public show() {
+    this.window.show()
     if (this.shouldMaximizeOnShow) {
-      this.window.maximize() // maximize will also call show()
-    } else {
-      this.window.show()
+      this.window.maximize()
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #5631

## Description

- The problem itself was kinda weird, if the window was saved as maximized, it would always load as a "splash screen" with the default color ```#fff``` before the other components were done loading.
- So the problem is actually ```this.savedWindowState.manage(this.window)``` that will call ```window.maximize()``` if the saved state of ```isMaximized``` and the option ```maximize``` (which is true by default) are true. That in itself wouldn't be a problem if ```window.maximize()``` would not also call ```window.show()```.
- And by maximizing only when the window should show solves the issue.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Full screen won't start as a white screen anymore
