### PR TITLE
Use a custom bundle id for development

### DIFF
--- a/app/package-info.ts
+++ b/app/package-info.ts
@@ -16,5 +16,7 @@ export function getVersion() {
 }
 
 export function getBundleID() {
-  return appPackage.bundleID
+  return process.env.NODE_ENV === 'development'
+    ? `${appPackage.bundleID}Dev`
+    : appPackage.bundleID
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Waaaaay back in 2017 we introduced custom protocol handlers for browser authentication depending on whether you were using the development or the production app (https://github.com/desktop/desktop/pull/1927). For the longest time I've occasionally had problems performing the browser flow in the development app even though the dev app is set up to use the dev-specific protocol handler. I've ignored as I've always been able to work around it either by using the username/password flow or by flipping my default browser which has usually fixed it.

Now that username and password auth are gone though it's become more than just a nuisance and I had to dig into it. Turns out the way protocol handlers work on macOS is that they're registered to a bundle id like `com.github.GitHubClient` so while our `x-github-desktop-dev-auth` protocol was only registered by the dev version is ended up registering it to the same bundle id as the production app which caused a conflict where different tools and browsers resolved the conflict differently.

```
mdfind "kMDItemCFBundleIdentifier == 'com.github.GitHubClient'"
/Applications/GitHub Desktop.app
/Users/markus/GitHub/desktop/dist/GitHub Desktop-dev-darwin-x64/GitHub Desktop-dev.app
```

The solution is to use a separate `com.github.GitHubClientDev` bundle id for the dev app so that there's no ambiguity on what binary to actually launch.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
