### PR TITLE
Ensure GitHubRepository parentID is not undefined

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -154,6 +154,6 @@ async function ensureNoUndefinedParentID(tx: Dexie.Transaction) {
     .table<IDatabaseGitHubRepository, number>('gitHubRepositories')
     .toCollection()
     .filter(ghRepo => ghRepo.parentID === undefined)
-    .modify(() => ({ parentID: null }))
+    .modify({ parentID: null })
     .then(modified => log.info(`ensureNoUndefinedParentID: ${modified}`))
 }

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -47,7 +47,7 @@ export interface IDatabaseRepository {
   readonly missing: boolean
 
   /** The last time the stash entries were checked for the repository */
-  readonly lastStashCheckDate: number | null
+  readonly lastStashCheckDate?: number | null
 
   readonly workflowPreferences?: WorkflowPreferences
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -341,7 +341,7 @@ export class RepositoriesStore extends TypedBaseStore<
       )
     }
 
-    lastCheckDate = record.lastStashCheckDate
+    lastCheckDate = record.lastStashCheckDate ?? null
     if (lastCheckDate !== null) {
       this.lastStashCheckCache.set(repository.id, lastCheckDate)
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11176

## Description

In https://github.com/desktop/desktop/pull/2903 (October 2017!) we added the `parentID` property to the `IDatabaseGitHubRepository` and typed is as `number | null` but we never wrote a transition to ensure that any existing database records with an undefined `parentID` got reset to `null`. Fast forward a couple of years and I foolishly trusted the type signature of parentID and converted an `if(parentID)` truthiness check to a `if(parentID !== null)` explicit comparison (https://github.com/desktop/desktop/commit/d97b43f0b03d612d40356b3549478a6cb67b6b95).

This PR adds that transition that we should have written back in 2017. I was on the fence about whether to just change the type of `parentID` to `number | null | undefined` and had it not been for the fact that 2.6.1 will contain a transition on the GitHubRepository table anyway I probably would have done that but :shrug:

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Desktop would fail to launch for some users due to objects in the database using an old format