### PR TITLE
Emit queued isn't really queued

### DIFF
--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -639,7 +639,7 @@ export class RepositoriesStore extends TypedBaseStore<
    * Helper method to emit updates consistently
    * (This is the only way we emit updates from this store.)
    */
-  private async emitUpdatedRepositories() {
+  private emitUpdatedRepositories() {
     if (!this.emitQueued) {
       setImmediate(() => {
         this.getAll()

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -647,6 +647,7 @@ export class RepositoriesStore extends TypedBaseStore<
           .catch(e => log.error(`Failed emitting update`, e))
           .finally(() => (this.emitQueued = false))
       })
+      this.emitQueued = true
     }
   }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Spotted this while debugging #11193 (though it's not related). EmitUpdateQueued shouldn't be awaitable and it shouldn't schedule updates if another update is already scheduled.