### PR TITLE
Always wrap return values in promises when inside a Dexie transaction

### DIFF
--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -160,7 +160,8 @@ export class IssuesStore {
   ): Promise<ReadonlyArray<IIssueHit>> {
     const issues =
       this.queryCache?.repository.dbID === repository.dbID
-        ? this.queryCache?.issues
+        ? // Dexie gets confused if we return without wrapping in promise
+          await Promise.resolve(this.queryCache?.issues)
         : await this.getAllIssueHitsFor(repository)
 
     this.setQueryCache(repository, issues)

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -130,7 +130,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.id,
       repo.gitHubRepositoryID !== null
         ? await this.findGitHubRepositoryByID(repo.gitHubRepositoryID)
-        : null,
+        : await Promise.resolve(null), // Dexie gets confused if we return null
       repo.missing,
       repo.workflowPreferences,
       repo.isTutorialRepository
@@ -144,7 +144,7 @@ export class RepositoriesStore extends TypedBaseStore<
     const gitHubRepository = await this.db.gitHubRepositories.get(id)
     return gitHubRepository !== undefined
       ? this.toGitHubRepository(gitHubRepository)
-      : null
+      : Promise.resolve(null) // Dexie gets confused if we return null
   }
 
   /** Get all the local repositories. */
@@ -441,7 +441,7 @@ export class RepositoriesStore extends TypedBaseStore<
             gitHubRepository.parent,
             true
           )
-        : null
+        : await Promise.resolve(null) // Dexie gets confused if we return null
 
     const login = gitHubRepository.owner.login.toLowerCase()
     const owner = await this.putOwner(endpoint, login)


### PR DESCRIPTION
Closes #11192

## Description

Due to what I suspect is a bug in Dexie we must wrap our return values or we're more likely to run out of Dexies "micro-awaits" and cause a PrematureCommitError.

I was able to reliably reproduce #11192 after adding a lot of (50) local-only repositories to the app. I also tried upgrading to the latest version of Dexie where I couldn't reproduce it anymore but after digging into it some more it turns out the underlying problem wasn't solved, but the max "micro-awaits" had been lifted from 7 to 100 (https://github.com/dfahlander/Dexie.js/commit/3046e3684cb6092d31c634e36521364070a9f87b).

Problem was still reproducible running dexie@latest with ZONE_ECHO_LIMIT manually patched back down to 7.

There's a decent chance more of these instances exist in the app but this should at least get us back to a state better than or equal to 2.6.0.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Desktop would fail to launch for a small percentage of users that had several non-GitHub repositories in the app