### PR TITLE
Release v2.6.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.6.1-beta3",
+  "version": "2.6.1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,14 @@
 {
   "releases": {
+    "2.6.1": [
+      "[Improved] Clearer menu label for reverting commits - #10515. Thanks @halitogunc!",
+      "[Fixed] Refresh branches after creating a new branch - #11125",
+      "[Fixed] Correct image diff swipe mode layout - #11120",
+      "[Fixed] Very large text diffs could cause the app to crash when viewed in split diff mode - #11064",
+      "[Fixed] Let the user know when a checkout fails due to use of assume-unchanged or skip-worktree - #9297",
+      "[Fixed] Always show confirmation prompt before overwriting existing stash entry - #10956",
+      "[Fixed] The fullscreen keyboard shortcut on macOS now works when using split diff mode - #11069"
+    ],
     "2.6.1-beta3": [
       "[Fixed] Desktop would fail to launch for some users due to objects in the database using an old format - #11176",
       "[Fixed] Desktop would fail to launch for a small percentage of users that had several non-GitHub repositories in the app - #11192"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming v2.6.1 production release? Well you've just found it, congratulations! :tada:

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
  - enableNDDBBanner was removed
  - enableUnhjandledRejectionReporting was added
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
  - :new: unhandledRejectionCount was added
  - :fire: divergingBranchBannerDismissal, divergingBranchBannerInitatedMerge, divergingBranchBannerInitiatedCompare, divergingBranchBannerInfluencedMerge, and divergingBranchBannerDisplayed were removed