### PR TITLE
Replace "Enterprise Server" with "Enterprise"

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -76,7 +76,7 @@ const DotComOAuthScopes = ['repo', 'user', 'workflow']
 
 /**
  * The OAuth scopes we want to request from GitHub
- * Enterprise Server.
+ * Enterprise.
  */
 const EnterpriseOAuthScopes = ['repo', 'user']
 
@@ -631,7 +631,7 @@ export class API {
       // Ordinarily you'd be correct but turns out there's super
       // rare circumstances where a user has been deleted but the
       // repository hasn't. Such cases are usually addressed swiftly
-      // but in some cases like GitHub Enterprise Server instances
+      // but in some cases like GitHub Enterprise instances
       // they can linger for longer than we'd like so we'll make
       // sure to exclude any such dangling repository, chances are
       // they won't be cloneable anyway.
@@ -1310,7 +1310,7 @@ export function getHTMLURL(endpoint: string): string {
   // In the case of GitHub.com, the HTML site lives on the parent domain.
   //  E.g., https://api.github.com -> https://github.com
   //
-  // Whereas with Enterprise Server, it lives on the same domain but without the
+  // Whereas with Enterprise, it lives on the same domain but without the
   // API path:
   //  E.g., https://github.mycompany.com/api/v3 -> https://github.mycompany.com
   //

--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -44,7 +44,7 @@ export function lookupPreferredEmail(account: Account): string {
  */
 function isEmailPublic(email: IAPIEmail): boolean {
   // If an email doesn't have a visibility setting it means it's coming from an
-  // older Enterprise which doesn't have the concept of visibility.
+  // older Enterprise version which doesn't have the concept of visibility.
   return email.visibility === 'public' || !email.visibility
 }
 

--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -44,7 +44,7 @@ export function lookupPreferredEmail(account: Account): string {
  */
 function isEmailPublic(email: IAPIEmail): boolean {
   // If an email doesn't have a visibility setting it means it's coming from an
-  // older Enterprise Server which doesn't have the concept of visibility.
+  // older Enterprise which doesn't have the concept of visibility.
   return email.visibility === 'public' || !email.visibility
 }
 
@@ -67,7 +67,7 @@ function getStealthEmailHostForEndpoint(endpoint: string) {
  *
  * @param login    The user handle or "login"
  * @param endpoint The API endpoint that this login belongs to,
- *                 either GitHub.com or a GitHub Enterprise Server
+ *                 either GitHub.com or a GitHub Enterprise
  *                 instance
  */
 export function getLegacyStealthEmailForUser(login: string, endpoint: string) {
@@ -86,7 +86,7 @@ export function getLegacyStealthEmailForUser(login: string, endpoint: string) {
  *                 is available.
  * @param login    The user handle or "login"
  * @param endpoint The API endpoint that this login belongs to,
- *                 either GitHub.com or a GitHub Enterprise Server
+ *                 either GitHub.com or a GitHub Enterprise
  *                 instance
  */
 export function getStealthEmailForUser(
@@ -101,7 +101,7 @@ export function getStealthEmailForUser(
 /**
  * Produces a list of all email addresses that when used as the author email
  * in a commit we'll know will end up getting attributed to the given
- * account when pushed to GitHub.com or GitHub Enterprise Server.
+ * account when pushed to GitHub.com or GitHub Enterprise.
  *
  * The list of email addresses consists of all the email addresses we get
  * from the API (since this is for the currently signed in user we get

--- a/app/src/lib/enterprise.ts
+++ b/app/src/lib/enterprise.ts
@@ -1,5 +1,5 @@
 /**
- * The oldest officially supported version of GitHub Enterprise Server.
+ * The oldest officially supported version of GitHub Enterprise.
  * This information is used in user-facing text and shouldn't be
  * considered a hard limit, i.e. older versions of GitHub Enterprise
  * might (and probably do) work just fine but this should be a fairly

--- a/app/src/lib/find-account.ts
+++ b/app/src/lib/find-account.ts
@@ -74,11 +74,11 @@ export async function findAccountForRemoteURL(
 
     // This chunk of code is designed to sort the user's accounts in this order:
     //  - authenticated GitHub account
-    //  - GitHub Enterprise Server accounts
+    //  - GitHub Enterprise accounts
     //  - unauthenticated GitHub account (access public repositories)
     //
     // As this needs to be done efficiently, we consider endpoints not matching
-    // `getDotComAPIEndpoint()` to be GitHub Enterprise Server accounts, and accounts
+    // `getDotComAPIEndpoint()` to be GitHub Enterprise accounts, and accounts
     // without a token to be unauthenticated.
     const sortedAccounts = Array.from(allAccounts).sort((a1, a2) => {
       if (a1.endpoint === getDotComAPIEndpoint()) {

--- a/app/src/lib/friendly-endpoint-name.ts
+++ b/app/src/lib/friendly-endpoint-name.ts
@@ -6,7 +6,7 @@ import { getDotComAPIEndpoint } from './api'
  * Generate a human-friendly description of the Account endpoint.
  *
  * Accounts on GitHub.com will return the string 'GitHub.com'
- * whereas GitHub Enterprise Server accounts will return the
+ * whereas GitHub Enterprise accounts will return the
  * hostname without the protocol and/or path.
  */
 export function friendlyEndpointName(account: Account) {

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -91,7 +91,7 @@ export function getAbsoluteUrl(endpoint: string, path: string): string {
 
   // Our API endpoints are a bit sloppy in that they don't typically
   // include the trailing slash (i.e. we use https://api.github.com for
-  // dotcom and https://ghe.enterprise.local/api/v3 for Enterprise Server when
+  // dotcom and https://ghe.enterprise.local/api/v3 for Enterprise when
   // both of those should really include the trailing slash since that's
   // the qualified base). We'll work around our past since here by ensuring
   // that the endpoint ends with a trailing slash.

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -71,10 +71,10 @@ export interface IDailyMeasures {
   /** The number of times the user pushes with `--force-with-lease` to GitHub.com */
   readonly dotcomForcePushCount: number
 
-  /** The number of times the user pushed to a GitHub Enterprise Server instance */
+  /** The number of times the user pushed to a GitHub Enterprise instance */
   readonly enterprisePushCount: number
 
-  /** The number of times the user pushes with `--force-with-lease` to a GitHub Enterprise Server instance */
+  /** The number of times the user pushes with `--force-with-lease` to a GitHub Enterprise instance */
   readonly enterpriseForcePushCount: number
 
   /** The number of times the users pushes to a generic remote */
@@ -112,14 +112,14 @@ export interface IDailyMeasures {
 
   /**
    * The number of times the user made a commit to a repo hosted on
-   * a GitHub Enterprise Server instance
+   * a GitHub Enterprise instance
    */
   readonly enterpriseCommits: number
 
   /** The number of times the user made a commit to a repo hosted on Github.com */
   readonly dotcomCommits: number
 
-  /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise Server repository */
+  /** The number of times the user made a commit to a protected GitHub or GitHub Enterprise repository */
   readonly commitsToProtectedBranch: number
 
   /** The number of times the user made a commit to a repository with branch protections enabled */

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -198,7 +198,7 @@ interface IOnboardingStats {
    * Time (in seconds) from when the user first launched
    * the application and entered the welcome wizard until
    * the user performed their first push of a repository
-   * to GitHub.com or GitHub Enterprise Server. This metric
+   * to GitHub.com or GitHub Enterprise. This metric
    * does not track pushes to non-GitHub remotes.
    */
   readonly timeToFirstGitHubPush?: number
@@ -280,7 +280,7 @@ interface ICalculatedStats {
   /** Is the user logged in with a GitHub.com account? */
   readonly dotComAccount: boolean
 
-  /** Is the user logged in with an Enterprise Server account? */
+  /** Is the user logged in with an Enterprise account? */
   readonly enterpriseAccount: boolean
 
   /**
@@ -730,7 +730,7 @@ export class StatsStore implements IStatsStore {
   /**
    * Records that the user made a commit using an email address that
    * was not associated with the user's account on GitHub.com or GitHub
-   * Enterprise Server, meaning that the commit will not be attributed to the
+   * Enterprise, meaning that the commit will not be attributed to the
    * user's account.
    */
   public recordUnattributedCommit(): Promise<void> {
@@ -741,7 +741,7 @@ export class StatsStore implements IStatsStore {
 
   /**
    * Records that the user made a commit to a repository hosted on
-   * a GitHub Enterprise Server instance
+   * a GitHub Enterprise instance
    */
   public recordCommitToEnterprise(): Promise<void> {
     return this.updateDailyMeasures(m => ({
@@ -756,7 +756,7 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  /** Record the user made a commit to a protected GitHub or GitHub Enterprise Server repository */
+  /** Record the user made a commit to a protected GitHub or GitHub Enterprise repository */
   public recordCommitToProtectedBranch(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       commitsToProtectedBranch: m.commitsToProtectedBranch + 1,
@@ -822,7 +822,7 @@ export class StatsStore implements IStatsStore {
     createLocalStorageTimestamp(FirstPushToGitHubAtKey)
   }
 
-  /** Record that the user pushed to a GitHub Enterprise Server instance */
+  /** Record that the user pushed to a GitHub Enterprise instance */
   private async recordPushToGitHubEnterprise(
     options?: PushOptions
   ): Promise<void> {

--- a/app/src/lib/stores/sign-in-store.ts
+++ b/app/src/lib/stores/sign-in-store.ts
@@ -29,7 +29,7 @@ function getUnverifiedUserErrorMessage(login: string): string {
   return `Unable to authenticate. The account ${login} is lacking a verified email address. Please sign in to GitHub.com, confirm your email address in the Emails section under Personal settings, and try again.`
 }
 
-const EnterpriseTooOldMessage = `The GitHub Enterprise Server version does not support GitHub Desktop. Talk to your server's administrator about upgrading to the latest version of GitHub Enterprise Server.`
+const EnterpriseTooOldMessage = `The GitHub Enterprise version does not support GitHub Desktop. Talk to your server's administrator about upgrading to the latest version of GitHub Enterprise.`
 
 /**
  * An enumeration of the possible steps that the sign in
@@ -80,7 +80,7 @@ export interface ISignInState {
 
 /**
  * State interface representing the endpoint entry step.
- * This is the initial step in the Enterprise Server sign in
+ * This is the initial step in the Enterprise sign in
  * flow and is not present when signing in to GitHub.com
  */
 export interface IEndpointEntryState extends ISignInState {
@@ -92,7 +92,7 @@ export interface IEndpointEntryState extends ISignInState {
  * the user provides credentials and/or initiates a browser
  * OAuth sign in process. This step occurs as the first step
  * when signing in to GitHub.com and as the second step when
- * signing in to a GitHub Enterprise Server instance.
+ * signing in to a GitHub Enterprise instance.
  */
 export interface IAuthenticationState extends ISignInState {
   readonly kind: SignInStep.Authentication
@@ -101,7 +101,7 @@ export interface IAuthenticationState extends ISignInState {
    * The URL to the host which we're currently authenticating
    * against. This will be either https://api.github.com when
    * signing in against GitHub.com or a user-specified
-   * URL when signing in against a GitHub Enterprise Server
+   * URL when signing in against a GitHub Enterprise
    * instance.
    */
   readonly endpoint: string
@@ -109,7 +109,7 @@ export interface IAuthenticationState extends ISignInState {
   /**
    * A value indicating whether or not the endpoint supports
    * basic authentication (i.e. username and password). All
-   * GitHub Enterprise Server instances support OAuth (or web
+   * GitHub Enterprise instances support OAuth (or web
    * flow sign-in).
    */
   readonly supportsBasicAuth: boolean
@@ -124,7 +124,7 @@ export interface IAuthenticationState extends ISignInState {
  * State interface representing the TwoFactorAuthentication
  * step where the user provides an OTP token. This step
  * occurs after the authentication step both for GitHub.com,
- * and GitHub Enterprise Server when the user has enabled two
+ * and GitHub Enterprise when the user has enabled two
  * factor authentication on the host.
  */
 export interface ITwoFactorAuthenticationState extends ISignInState {
@@ -134,7 +134,7 @@ export interface ITwoFactorAuthenticationState extends ISignInState {
    * The URL to the host which we're currently authenticating
    * against. This will be either https://api.github.com when
    * signing in against GitHub.com or a user-specified
-   * URL when signing in against a GitHub Enterprise Server
+   * URL when signing in against a GitHub Enterprise
    * instance.
    */
   readonly endpoint: string
@@ -193,7 +193,7 @@ const ServerMetaDataTimeout = 2000
 
 /**
  * A store encapsulating all logic related to signing in a user
- * to GitHub.com, or a GitHub Enterprise Server instance.
+ * to GitHub.com, or a GitHub Enterprise instance.
  */
 export class SignInStore extends TypedBaseStore<SignInState | null> {
   private state: SignInState | null = null
@@ -267,7 +267,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
     }
 
     throw new Error(
-      `Unable to authenticate with the GitHub Enterprise Server instance. Verify that the URL is correct, that your GitHub Enterprise Server instance is running version ${minimumSupportedEnterpriseVersion} or later, that you have an internet connection and try again.`
+      `Unable to authenticate with the GitHub Enterprise instance. Verify that the URL is correct, that your GitHub Enterprise instance is running version ${minimumSupportedEnterpriseVersion} or later, that you have an internet connection and try again.`
     )
   }
 
@@ -488,7 +488,7 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
   }
 
   /**
-   * Initiate a sign in flow for a GitHub Enterprise Server instance.
+   * Initiate a sign in flow for a GitHub Enterprise instance.
    * This will put the store in the EndpointEntry step ready to
    * receive the url to the enterprise instance.
    */
@@ -532,11 +532,11 @@ export class SignInStore extends TypedBaseStore<SignInState | null> {
       let error = e
       if (e.name === InvalidURLErrorName) {
         error = new Error(
-          `The GitHub Enterprise Server instance address doesn't appear to be a valid URL. We're expecting something like https://github.example.com.`
+          `The GitHub Enterprise instance address doesn't appear to be a valid URL. We're expecting something like https://github.example.com.`
         )
       } else if (e.name === InvalidProtocolErrorName) {
         error = new Error(
-          'Unsupported protocol. Only http or https is supported when authenticating with GitHub Enterprise Server instances.'
+          'Unsupported protocol. Only http or https is supported when authenticating with GitHub Enterprise instances.'
         )
       }
 

--- a/app/src/lib/web-flow-committer.ts
+++ b/app/src/lib/web-flow-committer.ts
@@ -4,11 +4,11 @@ import { getDotComAPIEndpoint } from './api'
 
 /**
  * Best-effort attempt to figure out if this commit was committed using
- * the web flow on GitHub.com or GitHub Enterprise Server. Web flow
+ * the web flow on GitHub.com or GitHub Enterprise. Web flow
  * commits (such as PR merges) will have a special GitHub committer
  * with a noreply email address.
  *
- * For GitHub.com we can be spot on but for GitHub Enterprise Server it's
+ * For GitHub.com we can be spot on but for GitHub Enterprise it's
  * possible we could fail if they've set up a custom smtp host
  * that doesn't correspond to the hostname.
  */

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -1,7 +1,7 @@
 import { getDotComAPIEndpoint, IAPIEmail } from '../lib/api'
 
 /**
- * A GitHub account, representing the user found on GitHub The Website or GitHub Enterprise Server.
+ * A GitHub account, representing the user found on GitHub The Website or GitHub Enterprise.
  *
  * This contains a token that will be used for operations that require authentication.
  */
@@ -15,11 +15,11 @@ export class Account {
    * Create an instance of an account
    *
    * @param login The login name for this account
-   * @param endpoint The server for this account - GitHub or a GitHub Enterprise Server instance
+   * @param endpoint The server for this account - GitHub or a GitHub Enterprise instance
    * @param token The access token used to perform operations on behalf of this account
    * @param emails The current list of email addresses associated with the account
    * @param avatarURL The profile URL to render for this account
-   * @param id The GitHub.com or GitHub Enterprise Server database id for this account.
+   * @param id The GitHub.com or GitHub Enterprise database id for this account.
    * @param name The friendly name associated with this account
    */
   public constructor(

--- a/app/src/models/author.ts
+++ b/app/src/models/author.ts
@@ -19,7 +19,7 @@ export interface IAuthor {
   readonly email: string
 
   /**
-   * The GitHub.com or GitHub Enterprise Server login for
+   * The GitHub.com or GitHub Enterprise login for
    * this author or null if that information is not
    * available.
    */

--- a/app/src/models/avatar.ts
+++ b/app/src/models/avatar.ts
@@ -19,7 +19,7 @@ export interface IAvatarUser {
    * The endpoint of the repository that this user is associated with.
    * This will be https://api.github.com for GitHub.com-hosted
    * repositories, something like `https://github.example.com/api/v3`
-   * for GitHub Enterprise Server and null for local repositories or
+   * for GitHub Enterprise and null for local repositories or
    * repositories hosted on non-GitHub services.
    */
   readonly endpoint: string | null

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -90,7 +90,7 @@ export type RepositoryWithGitHubRepository = Repository & {
 /**
  * Identical to `Repository`, except it **must** have a `gitHubRepository`
  * which in turn must have a parent. In other words this is a GitHub (.com
- * or Enterprise Server) fork.
+ * or Enterprise) fork.
  */
 export type RepositoryWithForkedGitHubRepository = Repository & {
   readonly gitHubRepository: ForkedGitHubRepository

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -446,8 +446,8 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to it to
-              get access to your repositories.
+              If you have a GitHub Enterprise or AE account at work, sign in to
+              it to get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -446,7 +446,7 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise account at work, sign in to it to
+              If you have a GitHub Enterprise or AE account at work, sign in to it to
               get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -446,8 +446,8 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise account at work, sign in to
-              it to get access to your repositories.
+              If you have a GitHub Enterprise account at work, sign in to it to
+              get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -32,7 +32,7 @@ interface ICloneRepositoryProps {
   /** The logged in accounts. */
   readonly dotComAccount: Account | null
 
-  /** The logged in Enterprise Server account. */
+  /** The logged in Enterprise account. */
   readonly enterpriseAccount: Account | null
 
   /** The initial URL or `owner/name` shortcut to use. */
@@ -45,7 +45,7 @@ interface ICloneRepositoryProps {
   readonly onTabSelected: (tab: CloneRepositoryTab) => void
 
   /**
-   * A map keyed on a user account (GitHub.com or GitHub Enterprise Server)
+   * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated
    * user has explicit permission (:read, :write, or :admin) to access
    * as well as information about whether the list of repositories
@@ -90,7 +90,7 @@ interface ICloneRepositoryState {
 
   /**
    * The persisted state of the CloneGitHubRepository component for
-   * the GitHub Enterprise Server account.
+   * the GitHub Enterprise account.
    */
   readonly enterpriseTabState: IGitHubTabState
 
@@ -216,7 +216,7 @@ export class CloneRepository extends React.Component<
           selectedIndex={this.props.selectedTab}
         >
           <span>GitHub.com</span>
-          <span>GitHub Enterprise Server</span>
+          <span>GitHub Enterprise</span>
           <span>URL</span>
         </TabBar>
 
@@ -446,7 +446,7 @@ export class CloneRepository extends React.Component<
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise Server account at work, sign in to
+              If you have a GitHub Enterprise account at work, sign in to
               it to get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/lib/authentication-form.tsx
+++ b/app/src/ui/lib/authentication-form.tsx
@@ -17,7 +17,7 @@ interface IAuthenticationFormProps {
    * The URL to the host which we're currently authenticating
    * against. This will be either https://api.github.com when
    * signing in against GitHub.com or a user-specified
-   * URL when signing in against a GitHub Enterprise Server
+   * URL when signing in against a GitHub Enterprise
    * instance.
    */
   readonly endpoint: string
@@ -245,7 +245,7 @@ function getEndpointRequiresWebFlowMessage(endpoint: string): JSX.Element {
   } else {
     return (
       <p>
-        Your GitHub Enterprise Server instance requires you to sign in with your
+        Your GitHub Enterprise instance requires you to sign in with your
         browser.
       </p>
     )

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -85,7 +85,7 @@ function getAvatarUrlCandidates(
       }
     }
   } else if (endpoint !== null) {
-    // We're dealing with a repository hosted on GitHub Enterprise Server
+    // We're dealing with a repository hosted on GitHub Enterprise
     // so we're unable to get to the avatar by requesting the avatarURL due
     // to the private mode (see https://github.com/desktop/desktop/issues/821).
     // So we have no choice but to fall back to gravatar for now.

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -36,7 +36,7 @@ interface IEnterpriseServerEntryState {
   readonly serverAddress: string
 }
 
-/** An entry form for an Enterprise Server address. */
+/** An entry form for an Enterprise address. */
 export class EnterpriseServerEntry extends React.Component<
   IEnterpriseServerEntryProps,
   IEnterpriseServerEntryState
@@ -54,7 +54,7 @@ export class EnterpriseServerEntry extends React.Component<
     return (
       <Form onSubmit={this.onSubmit}>
         <TextBox
-          label="Enterprise Server address"
+          label="Enterprise address"
           autoFocus={true}
           disabled={disableEntry}
           onValueChanged={this.onServerAddressChanged}

--- a/app/src/ui/lib/enterprise-server-entry.tsx
+++ b/app/src/ui/lib/enterprise-server-entry.tsx
@@ -54,7 +54,7 @@ export class EnterpriseServerEntry extends React.Component<
     return (
       <Form onSubmit={this.onSubmit}>
         <TextBox
-          label="Enterprise address"
+          label="Enterprise or AE address"
           autoFocus={true}
           disabled={disableEntry}
           onValueChanged={this.onServerAddressChanged}

--- a/app/src/ui/lib/enterprise-validate-url.ts
+++ b/app/src/ui/lib/enterprise-validate-url.ts
@@ -1,6 +1,6 @@
 import * as URL from 'url'
 
-/** The protocols over which we can connect to Enterprise Server instances. */
+/** The protocols over which we can connect to Enterprise instances. */
 const AllowedProtocols = new Set(['https:', 'http:'])
 
 /** The name for errors thrown because of an invalid URL. */
@@ -10,7 +10,7 @@ export const InvalidURLErrorName = 'invalid-url'
 export const InvalidProtocolErrorName = 'invalid-protocol'
 
 /**
- * Validate the URL for a GitHub Enterprise Server instance.
+ * Validate the URL for a GitHub Enterprise instance.
  *
  * Returns the validated URL, or throws if the URL cannot be validated.
  */

--- a/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
+++ b/app/src/ui/no-repositories/create-tutorial-repository-dialog.tsx
@@ -11,7 +11,7 @@ import { friendlyEndpointName } from '../../lib/friendly-endpoint-name'
 
 interface ICreateTutorialRepositoryDialogProps {
   /**
-   * The GitHub.com, or GitHub Enterprise Server account that will
+   * The GitHub.com, or GitHub Enterprise account that will
    * be the owner of the tutorial repository.
    */
   readonly account: Account

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -36,11 +36,11 @@ interface INoRepositoriesProps {
   /** The logged in account for GitHub.com. */
   readonly dotComAccount: Account | null
 
-  /** The logged in account for GitHub Enterprise Server. */
+  /** The logged in account for GitHub Enterprise. */
   readonly enterpriseAccount: Account | null
 
   /**
-   * A map keyed on a user account (GitHub.com or GitHub Enterprise Server)
+   * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated
    * user has explicit permission (:read, :write, or :admin) to access
    * as well as information about whether the list of repositories
@@ -320,7 +320,7 @@ export class NoRepositoriesView extends React.Component<
     return (
       <TabBar selectedIndex={selectedIndex} onTabClicked={this.onTabClicked}>
         <span>GitHub.com</span>
-        <span>GitHub Enterprise Server</span>
+        <span>GitHub Enterprise</span>
       </TabBar>
     )
   }

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -92,8 +92,8 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise account at work, sign in to
-              it to get access to your repositories.
+              If you have a GitHub Enterprise account at work, sign in to it to
+              get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -32,7 +32,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
           ? this.renderAccount(this.props.dotComAccount)
           : this.renderSignIn(SignInType.DotCom)}
 
-        <h2>GitHub Enterprise Server</h2>
+        <h2>GitHub Enterprise</h2>
         {this.props.enterpriseAccount
           ? this.renderAccount(this.props.enterpriseAccount)
           : this.renderSignIn(SignInType.Enterprise)}
@@ -92,7 +92,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise Server account at work, sign in to
+              If you have a GitHub Enterprise account at work, sign in to
               it to get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -92,7 +92,7 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise account at work, sign in to it to
+              If you have a GitHub Enterprise or AE account at work, sign in to it to
               get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/preferences/accounts.tsx
+++ b/app/src/ui/preferences/accounts.tsx
@@ -92,8 +92,8 @@ export class Accounts extends React.Component<IAccountsProps, {}> {
             onAction={this.onEnterpriseSignIn}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to it to
-              get access to your repositories.
+              If you have a GitHub Enterprise or AE account at work, sign in to
+              it to get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -235,8 +235,8 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise account at work, sign in to
-              it to get access to your repositories.
+              If you have a GitHub Enterprise account at work, sign in to it to
+              get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -235,7 +235,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise account at work, sign in to it to
+              If you have a GitHub Enterprise or AE account at work, sign in to it to
               get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -235,8 +235,8 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise or AE account at work, sign in to it to
-              get access to your repositories.
+              If you have a GitHub Enterprise or AE account at work, sign in to
+              it to get access to your repositories.
             </div>
           </CallToAction>
         )

--- a/app/src/ui/publish-repository/publish.tsx
+++ b/app/src/ui/publish-repository/publish.tsx
@@ -140,7 +140,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
           selectedIndex={this.state.currentTab}
         >
           <span>GitHub.com</span>
-          <span>GitHub Enterprise Server</span>
+          <span>GitHub Enterprise</span>
         </TabBar>
 
         {currentTabState.error ? (
@@ -235,7 +235,7 @@ export class Publish extends React.Component<IPublishProps, IPublishState> {
             onAction={this.signInEnterprise}
           >
             <div>
-              If you have a GitHub Enterprise Server account at work, sign in to
+              If you have a GitHub Enterprise account at work, sign in to
               it to get access to your repositories.
             </div>
           </CallToAction>

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -199,8 +199,8 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         return (
           <DialogContent>
             <p>
-              Your GitHub Enterprise instance requires you to sign in
-              with your browser.
+              Your GitHub Enterprise instance requires you to sign in with your
+              browser.
             </p>
           </DialogContent>
         )

--- a/app/src/ui/sign-in/sign-in.tsx
+++ b/app/src/ui/sign-in/sign-in.tsx
@@ -169,7 +169,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
       <DialogContent>
         <Row>
           <TextBox
-            label="Enterprise Server address"
+            label="Enterprise address"
             value={this.state.endpoint}
             onValueChanged={this.onEndpointChanged}
             placeholder="https://github.example.com"
@@ -199,7 +199,7 @@ export class SignIn extends React.Component<ISignInProps, ISignInState> {
         return (
           <DialogContent>
             <p>
-              Your GitHub Enterprise Server instance requires you to sign in
+              Your GitHub Enterprise instance requires you to sign in
               with your browser.
             </p>
           </DialogContent>

--- a/app/src/ui/terms-and-conditions/terms-and-conditions.tsx
+++ b/app/src/ui/terms-and-conditions/terms-and-conditions.tsx
@@ -46,7 +46,7 @@ export class TermsAndConditions extends React.Component<
             the GitHub.com website or with an instance of GitHub Enterprise
             Server, your use of the Software will also be governed your
             applicable GitHub.com website Terms of Service and/or the license
-            agreement applicable to your instance of GitHub Enterprise Server
+            agreement applicable to your instance of GitHub Enterprise
             ("GitHub Terms").
           </p>
 

--- a/app/src/ui/terms-and-conditions/terms-and-conditions.tsx
+++ b/app/src/ui/terms-and-conditions/terms-and-conditions.tsx
@@ -46,8 +46,8 @@ export class TermsAndConditions extends React.Component<
             the GitHub.com website or with an instance of GitHub Enterprise
             Server, your use of the Software will also be governed your
             applicable GitHub.com website Terms of Service and/or the license
-            agreement applicable to your instance of GitHub Enterprise
-            ("GitHub Terms").
+            agreement applicable to your instance of GitHub Enterprise ("GitHub
+            Terms").
           </p>
 
           <p>

--- a/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
+++ b/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
@@ -25,7 +25,7 @@ interface IUntrustedCertificateProps {
  * certificate.
  *
  * An easy way to test this dialog is to attempt to sign in to GitHub
- * Enterprise Server using  one of the badssl.com domains, such
+ * Enterprise using  one of the badssl.com domains, such
  * as https://self-signed.badssl.com/
  */
 export class UntrustedCertificate extends React.Component<
@@ -52,9 +52,9 @@ export class UntrustedCertificate extends React.Component<
           </p>
           <p>In some cases, this may be expected. For example:</p>
           <ul>
-            <li>If this is a GitHub Enterprise Server trial.</li>
+            <li>If this is a GitHub Enterprise trial.</li>
             <li>
-              If your GitHub Enterprise Server instance is run on an unusual
+              If your GitHub Enterprise instance is run on an unusual
               top-level domain.
             </li>
           </ul>

--- a/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
+++ b/app/src/ui/untrusted-certificate/untrusted-certificate.tsx
@@ -54,8 +54,8 @@ export class UntrustedCertificate extends React.Component<
           <ul>
             <li>If this is a GitHub Enterprise trial.</li>
             <li>
-              If your GitHub Enterprise instance is run on an unusual
-              top-level domain.
+              If your GitHub Enterprise instance is run on an unusual top-level
+              domain.
             </li>
           </ul>
           <p>

--- a/app/src/ui/usage-stats-change/usage-stats-change.tsx
+++ b/app/src/ui/usage-stats-change/usage-stats-change.tsx
@@ -60,8 +60,8 @@ export class UsageStatsChange extends React.Component<
               <li>
                 <span>
                   <strong>
-                    If you are only signed into a GitHub Enterprise
-                    account, or only using Desktop with non-GitHub remotes
+                    If you are only signed into a GitHub Enterprise account, or
+                    only using Desktop with non-GitHub remotes
                   </strong>
                   , nothing is going to change.
                 </span>

--- a/app/src/ui/usage-stats-change/usage-stats-change.tsx
+++ b/app/src/ui/usage-stats-change/usage-stats-change.tsx
@@ -60,7 +60,7 @@ export class UsageStatsChange extends React.Component<
               <li>
                 <span>
                   <strong>
-                    If you are only signed into a GitHub Enterprise Server
+                    If you are only signed into a GitHub Enterprise
                     account, or only using Desktop with non-GitHub remotes
                   </strong>
                   , nothing is going to change.

--- a/app/src/ui/welcome/sign-in-enterprise.tsx
+++ b/app/src/ui/welcome/sign-in-enterprise.tsx
@@ -26,7 +26,7 @@ export class SignInEnterprise extends React.Component<
     return (
       <div id="sign-in-enterprise">
         <h1 className="welcome-title">
-          Sign in to your GitHub Enterprise Server
+          Sign in to your GitHub Enterprise
         </h1>
 
         <SignIn signInState={state} dispatcher={this.props.dispatcher}>

--- a/app/src/ui/welcome/sign-in-enterprise.tsx
+++ b/app/src/ui/welcome/sign-in-enterprise.tsx
@@ -25,9 +25,7 @@ export class SignInEnterprise extends React.Component<
 
     return (
       <div id="sign-in-enterprise">
-        <h1 className="welcome-title">
-          Sign in to your GitHub Enterprise
-        </h1>
+        <h1 className="welcome-title">Sign in to your GitHub Enterprise</h1>
 
         <SignIn signInState={state} dispatcher={this.props.dispatcher}>
           <Button onClick={this.cancel}>Cancel</Button>

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -30,8 +30,8 @@ export class Start extends React.Component<IStartProps, {}> {
           <>
             <p className="welcome-text">
               GitHub Desktop is a seamless way to contribute to projects on
-              GitHub and GitHub Enterprise. Sign in below to get started
-              with your existing projects.
+              GitHub and GitHub Enterprise. Sign in below to get started with
+              your existing projects.
             </p>
             <p className="welcome-text">
               New to GitHub?{' '}

--- a/app/src/ui/welcome/start.tsx
+++ b/app/src/ui/welcome/start.tsx
@@ -30,7 +30,7 @@ export class Start extends React.Component<IStartProps, {}> {
           <>
             <p className="welcome-text">
               GitHub Desktop is a seamless way to contribute to projects on
-              GitHub and GitHub Enterprise Server. Sign in below to get started
+              GitHub and GitHub Enterprise. Sign in below to get started
               with your existing projects.
             </p>
             <p className="welcome-text">
@@ -62,7 +62,7 @@ export class Start extends React.Component<IStartProps, {}> {
             <Button onClick={this.cancelBrowserAuth}>Cancel</Button>
           ) : (
             <Button onClick={this.signInToEnterprise}>
-              Sign in to GitHub Enterprise Server
+              Sign in to GitHub Enterprise
             </Button>
           )}
         </div>

--- a/app/test/unit/email-test.ts
+++ b/app/test/unit/email-test.ts
@@ -150,7 +150,7 @@ describe('emails', () => {
       )
     })
 
-    it('returns the noreply if there is no public address for GitHub Enterprise Server as well', () => {
+    it('returns the noreply if there is no public address for GitHub Enterprise as well', () => {
       const emails: IAPIEmail[] = [
         {
           email: 'shiftkey@example.com',
@@ -263,7 +263,7 @@ describe('emails', () => {
       ])
     })
 
-    it('returns stealth emails for GitHub Enterprise Server', () => {
+    it('returns stealth emails for GitHub Enterprise', () => {
       const endpoint = `https://github.example.com/api/v3`
       const account = new Account('niik', endpoint, '', [], '', 123, '')
       const attributable = getAttributableEmailsFor(account)

--- a/app/test/unit/find-account-test.ts
+++ b/app/test/unit/find-account-test.ts
@@ -109,7 +109,7 @@ describe('findAccountForRemoteURL', () => {
     expect(account!.login).toBe('joan')
   })
 
-  it('finds the account for GitHub Enterprise Server endpoint', async () => {
+  it('finds the account for GitHub Enterprise endpoint', async () => {
     const account = await findAccountForRemoteURL(
       'https://github.mycompany.com/inkscape/inkscape.git',
       accounts,

--- a/docs/contributing/github-enterprise-auth-from-dev-build.md
+++ b/docs/contributing/github-enterprise-auth-from-dev-build.md
@@ -5,5 +5,5 @@
    <img width="558" alt="New_OAuth_Application" src="https://user-images.githubusercontent.com/7910250/63631725-2ffd8200-c5e0-11e9-92e4-b2e5b61d9c89.png">
 1. Insert the Client ID and Client Secret into the [`app-info.ts` file](https://github.com/desktop/desktop/blob/e3991a8c73ab10ca12fcad23f7e367707051d985/app/app-info.ts#L28-L31)
 1. Build and run the Desktop-dev app
-1. Go to "Preferences", click the "Accounts" tab, and sign into GitHub Enterprise Server. Click "Continue With Browser" to proceed with the OAuth flow
+1. Go to "Preferences", click the "Accounts" tab, and sign into GitHub Enterprise. Click "Continue With Browser" to proceed with the OAuth flow
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -56,7 +56,7 @@ If you've made changes in the `main-process` folder you need to run `yarn
 build:dev` to rebuild the package, and then `yarn start` for these changes to be
 reflected in the running app.
 
-If you are using GitHub Enterprise Server with your development build of GitHub Desktop, you will need to follow a few extra steps to [authenticate properly](github-enterprise-auth-from-dev-build.md).
+If you are using GitHub Enterprise with your development build of GitHub Desktop, you will need to follow a few extra steps to [authenticate properly](github-enterprise-auth-from-dev-build.md).
 
 If you're still encountering issues with building, refer to our
 [troubleshooting](troubleshooting.md) guide for more common

--- a/docs/process/testing.md
+++ b/docs/process/testing.md
@@ -32,7 +32,7 @@
         - [ ] Browser login, [insert custom security measure], Authorize GitHub Desktop, “accept” link
     - [ ] User goes to Configure Git if successful
     - [ ] `Cancel` returns to initial Welcome Flow
-    - [ ] User served generic message if not authorized to access Enterprise server
+    - [ ] User served generic message if not authorized to access Enterprise
   - [ ] Skip "username+password" step
     - [ ] Configure Git
       - [ ] Name and email pulled from global `.gitconfig` file, if configured


### PR DESCRIPTION
Since GitHub is launching additional variants of GitHub Enterprise (GitHub AE in particular) and AE should work with the existing implementation of GitHub Enterprise Server in Desktop, we want to avoid confusion by changing references to Enterprise Server to just Enterprise.

We're also adding AE to a few places where it's potentially helpful in explaining that it's also valid for AE in addition to Enterprise Server. For example:

<img width="914" alt="Screen Shot 2020-12-16 at 3 49 50 PM" src="https://user-images.githubusercontent.com/5091167/102416102-7685a580-3fb6-11eb-9836-437fd60f4ab4.png">


Notes: No notes (open to including a note if we think it's useful)


