### PR TITLE
Error when repeatedly checking out a forked PR

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5310,8 +5310,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       (await addRemote(repository, forkRemoteName, headCloneUrl))
 
     const remoteRef = `${remote.name}/${headRefName}`
-    // Start by trying to find a local (i.e. refs/heads/xyz) branch that is
-    // tracking the remote ref.
+
+    // Start by trying to find a local branch that is tracking the remote ref.
     let existingBranch = gitStore.allBranches.find(
       x => x.type === BranchType.Local && x.upstream === remoteRef
     )

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5342,8 +5342,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // If quite possible that the PR was created after our last fetch of the
     // remote so let's fetch it and then try again.
     if (existingBranch === undefined) {
-      await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
-      existingBranch = findRemoteBranch(remoteRef)
+      try {
+        await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
+        existingBranch = findRemoteBranch(remoteRef)
+      } catch (e) {
+        log.error(`Failed fetching remote ${remote?.name}`, e)
+      }
     }
 
     if (existingBranch === undefined) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -166,6 +166,7 @@ import {
   IMatchedGitHubRepository,
   matchGitHubRepository,
   matchExistingRepository,
+  urlMatchesRemote,
 } from '../repository-matching'
 import {
   initializeRebaseFlowForConflictedRepository,
@@ -5294,119 +5295,77 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _checkoutPullRequest(
     repository: RepositoryWithGitHubRepository,
     prNumber: number,
-    ownerLogin: string,
+    headRepoOwner: string,
     headCloneUrl: string,
     headRefName: string
   ): Promise<void> {
-    const branch = await this._getPullRequestHeadBranchInRepo(
-      repository,
-      headCloneUrl,
-      headRefName
+    const gitStore = this.gitStoreCache.get(repository)
+    const remotes = await getRemotes(repository)
+    const forkRemoteName = forkPullRequestRemoteName(headRepoOwner)
+
+    // Find an existing remote (regardless if set up by us or outside of
+    // Desktop). If we can't find one we'll create a Desktop for remote.
+    const remote =
+      remotes.find(r => urlMatchesRemote(headCloneUrl, r)) ||
+      (await addRemote(repository, forkRemoteName, headCloneUrl))
+
+    const remoteRef = `${remote.name}/${headRefName}`
+    // Start by trying to find a local (i.e. refs/heads/xyz) branch that is
+    // tracking the remote ref.
+    let existingBranch = gitStore.allBranches.find(
+      x => x.type === BranchType.Local && x.upstream === remoteRef
     )
 
-    // N.B: This looks weird, and it is. _checkoutBranch used
-    // to behave this way (silently ignoring checkout) when given
-    // a branch name string that does not correspond to a local branch
-    // in the git store. When rewriting _checkoutBranch
-    // to remove the support for string branch names the behavior
-    // was moved up to this method to not alter the current behavior.
-    //
-    // https://youtu.be/IjmtVKOAHPM
-    if (branch !== null) {
-      await this._checkoutBranch(repository, branch)
+    // If we found one, let's check it out and get out of here, quick
+    if (existingBranch !== undefined) {
+      await this._checkoutBranch(repository, existingBranch)
       this.statsStore.recordPRBranchCheckout()
       return
     }
 
-    const remoteName = forkPullRequestRemoteName(ownerLogin)
-    const remotes = await getRemotes(repository)
-    const remote =
-      remotes.find(r => r.name === remoteName) ||
-      (await addRemote(repository, remoteName, headCloneUrl))
-
-    if (remote.url !== headCloneUrl) {
-      const error = new Error(
-        `Expected PR remote ${remoteName} url to be ${headCloneUrl} got ${remote.url}.`
+    const findRemoteBranch = (name: string, remote: IRemote) =>
+      gitStore.allBranches.find(
+        x =>
+          x.type === BranchType.Remote &&
+          x.remote === remote.name &&
+          x.name === name
       )
 
-      log.error(error.message)
-      return this.emitError(error)
+    // No such luck, let's see if we can at least find the remote branch then
+    existingBranch = findRemoteBranch(headRefName, remote)
+
+    // If quite possible that the PR was created after our last fetch of the
+    // remote so let's fetch it and then try again.
+    if (existingBranch === undefined) {
+      await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
+      existingBranch = findRemoteBranch(headRefName, remote)
     }
 
-    await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
-
-    const localBranchName = `pr/${prNumber}`
-    const existingBranch = this.gitStoreCache
-      .get(repository)
-      .allBranches.find(b => b.nameWithoutRemote === branch)
-
     if (existingBranch === undefined) {
-      await this._createBranch(
-        repository,
-        localBranchName,
-        `${remoteName}/${headRefName}`
+      this.emitError(
+        new Error(
+          `Couldn't find branch '${headRefName}' in remote '${remote.name}'. ` +
+            `A common cause for this is if the PR author has deleted their ` +
+            `branch or their forked repository.`
+        )
       )
+      return
+    }
+
+    // For fork remotes we checkout the ref as pr/[123] instead of using the
+    // head ref name since many PRs from forks are created from their default
+    // branch so we'll have a very high likelihood of a conflicting local branch
+    const isForkRemote =
+      remote.name !== gitStore.defaultRemote?.name &&
+      remote.name !== gitStore.upstreamRemote?.name
+
+    if (isForkRemote) {
+      await this._createBranch(repository, `pr/${prNumber}`, remoteRef)
     } else {
       await this._checkoutBranch(repository, existingBranch)
     }
 
     this.statsStore.recordPRBranchCheckout()
-  }
-
-  private async _getPullRequestHeadBranchInRepo(
-    repository: RepositoryWithGitHubRepository,
-    headCloneURL: string,
-    headRefName: string
-  ): Promise<Branch | null> {
-    const { cloneURL, parent } = repository.gitHubRepository
-    const gitStore = this.gitStoreCache.get(repository)
-
-    let remote = null
-
-    // Determine whether the ref is in the current repository or the parent
-    if (headCloneURL === cloneURL) {
-      remote = gitStore.defaultRemote
-    } else if (headCloneURL === parent?.cloneURL) {
-      remote = gitStore.upstreamRemote
-    }
-
-    if (remote !== null) {
-      return this.findPullRequestHeadInRemote(repository, remote, headRefName)
-    }
-
-    return null
-  }
-
-  private async findPullRequestHeadInRemote(
-    repository: Repository,
-    remote: IRemote,
-    headRefName: string
-  ) {
-    const gitStore = this.gitStoreCache.get(repository)
-
-    // Find a remote branch matching the given name or a local branch
-    // whose upstream tracking branch matches the given name (i.e someone
-    // has already checked out the remote branch)
-    const findBranch = (name: string) =>
-      gitStore.allBranches.find(branch =>
-        branch.type === BranchType.Local
-          ? branch.upstream === name
-          : branch.name === name
-      ) ?? null
-
-    const remoteRef = `${remote.name}/${headRefName}`
-    const branch = findBranch(remoteRef)
-
-    if (branch !== null) {
-      return branch
-    }
-
-    // Fetch the remote and try finding the branch again
-    if (branch === null) {
-      await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
-    }
-
-    return findBranch(remoteRef)
   }
 
   /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5323,22 +5323,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const findRemoteBranch = (name: string, remote: IRemote) =>
+    const findRemoteBranch = (name: string) =>
       gitStore.allBranches.find(
-        x =>
-          x.type === BranchType.Remote &&
-          x.remote === remote.name &&
-          x.name === name
+        x => x.type === BranchType.Remote && x.name === name
       )
 
     // No such luck, let's see if we can at least find the remote branch then
-    existingBranch = findRemoteBranch(headRefName, remote)
+    existingBranch = findRemoteBranch(remoteRef)
 
     // If quite possible that the PR was created after our last fetch of the
     // remote so let's fetch it and then try again.
     if (existingBranch === undefined) {
       await this._fetchRemote(repository, remote, FetchType.UserInitiatedTask)
-      existingBranch = findRemoteBranch(headRefName, remote)
+      existingBranch = findRemoteBranch(remoteRef)
     }
 
     if (existingBranch === undefined) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5306,7 +5306,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // Find an existing remote (regardless if set up by us or outside of
     // Desktop). If we can't find one we'll create a Desktop for remote.
     const remote =
-      remotes.find(r => urlMatchesRemote(headCloneUrl, r)) ||
+      remotes.find(r => urlMatchesRemote(headCloneUrl, r)) ??
       (await addRemote(repository, forkRemoteName, headCloneUrl))
 
     const remoteRef = `${remote.name}/${headRefName}`

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5312,7 +5312,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
         const forkRemoteName = forkPullRequestRemoteName(headRepoOwner)
         remote = await addRemote(repository, forkRemoteName, headCloneUrl)
       } catch (e) {
-        this.emitError(e)
+        this.emitError(
+          new Error(`Couldn't checkout PR, adding remote failed: ${e.message}`)
+        )
         return
       }
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1641,7 +1641,7 @@ export class Dispatcher {
     await this.appStore._checkoutPullRequest(
       repository,
       pullRequest.number,
-      pullRequest.user.login,
+      pullRequest.head.repo.owner.login,
       pullRequest.head.repo.clone_url,
       pullRequest.head.ref
     )
@@ -2010,7 +2010,7 @@ export class Dispatcher {
     return this.appStore._checkoutPullRequest(
       repository,
       pullRequest.pullRequestNumber,
-      pullRequest.author,
+      pullRequest.head.gitHubRepository.owner.login,
       pullRequest.head.gitHubRepository.cloneURL,
       pullRequest.head.ref
     )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11238

## Description

This was an inadvertent side-effect of #10957. In [this refactor commit](https://github.com/desktop/desktop/commit/2e70798475) I inlined a call to `getLocalBranch` and  forgot to change the branch variable to use the value that the previously inlined function was called with. The result being that Desktop got confused and thought that there wasn't any existing branch for the PR and attempted to create it anyway.

This logic has been on my list to improve for a long time. The logic is complex and not very well documented so I took the liberty of cleaning things up and making them more robust. As part of this change I've updated the logic for finding local branches for a PR to not rely merely on the `pr/number` ref name format but rather look for local branches that are already tracking the specific remote.

I've also changed the way we look up matching PRs from relying solely on a comparing remote urls to the PR repo CloneURL to instead use `urlMatchesRemote` which is protocol agnostic and able to see that `git@github.com:desktop/desktop.git` is actually the same thing as both `https://github.com/desktop/desktop` and `https://github.com/desktop/desktop.git`

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Checking out a pull request from a fork repeatedly now detects that there's already a branch that can be reused.