### PR TITLE
Don't attempt to check out the currently checked out branch

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3059,6 +3059,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { tip } = branchesState
     const hasChanges = changesState.workingDirectory.files.length > 0
 
+    // No point in checking out the currently checked out branch.
+    if (tip.kind === TipState.Valid && tip.branch.name === branch.name) {
+      return repository
+    }
+
     let strategy = explicitStrategy ?? this.uncommittedChangesStrategy
 
     // The user hasn't been presented with an explicit choice


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11235 

## Description

Turns out that we allow checking out the currently checked out branch which makes very little sense and causes some very confusing behavior when you've also got local changes (see #11235). Let's not do that any more.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Don't offer to stash or move changes when clicking on the currently checked out branch in the branch list.