### PR TITLE
Just use openPath on all platforms

### DIFF
--- a/app/src/main-process/shell.ts
+++ b/app/src/main-process/shell.ts
@@ -1,4 +1,3 @@
-import * as Url from 'url'
 import { shell } from 'electron'
 
 /**
@@ -16,30 +15,18 @@ import { shell } from 'electron'
  * @param path directory to open
  */
 export function UNSAFE_openDirectory(path: string) {
-  if (__DARWIN__) {
-    const directoryURL = Url.format({
-      pathname: path,
-      protocol: 'file:',
-      slashes: true,
-    })
+  // Add a trailing slash to the directory path.
+  //
+  // On Windows, if there's a file and a directory with the
+  // same name (e.g `C:\MyFolder\foo` and `C:\MyFolder\foo.exe`),
+  // when executing shell.openItem(`C:\MyFolder\foo`) then the EXE file
+  // will get opened.
+  // We can avoid this by adding a final backslash at the end of the path.
+  const pathname = __WIN32__ && !path.endsWith('\\') ? `${path}\\` : path
 
-    shell
-      .openExternal(directoryURL)
-      .catch(err => log.error(`Failed to open directory (${path})`, err))
-  } else {
-    // Add a trailing slash to the directory path.
-    //
-    // On Windows, if there's a file and a directory with the
-    // same name (e.g `C:\MyFolder\foo` and `C:\MyFolder\foo.exe`),
-    // when executing shell.openItem(`C:\MyFolder\foo`) then the EXE file
-    // will get opened.
-    // We can avoid this by adding a final backslash at the end of the path.
-    const pathname = __WIN32__ && !path.endsWith('\\') ? `${path}\\` : path
-
-    shell.openPath(pathname).then(err => {
-      if (err !== '') {
-        log.error(`Failed to open directory (${path}): ${err}`)
-      }
-    })
-  }
+  shell.openPath(pathname).then(err => {
+    if (err !== '') {
+      log.error(`Failed to open directory (${path}): ${err}`)
+    }
+  })
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

The issue described in https://github.com/desktop/desktop/pull/2968#issuecomment-334629549 doesn't appear to exist any more and the openExternal solution fails when opening paths that ends with a backslash which I happened to notice when I accidentally clones a repository to a path ending with `\`

I'd bet the issue we were seeing  was  https://github.com/electron/electron/issues/10477 which has been long since resolved.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes