### PR TITLE
Fix VSCodium identifiers for Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -421,7 +421,10 @@ function isExpectedInstallation(
         publisher === 'Microsoft Corporation'
       )
     case ExternalEditor.VSCodium:
-      return displayName === 'Visual Source Codium' && publisher === 'VSCodium'
+      return (
+        displayName.startsWith('VSCodium') &&
+        publisher === 'Microsoft Corporation'
+      )
     case ExternalEditor.SublimeText:
       return (
         displayName === 'Sublime Text' && publisher === 'Sublime HQ Pty Ltd'


### PR DESCRIPTION
#10446

## Description

Change the expected identifier details for VSCodium on Windows so it gets recognized as an editor.

## Release notes

Notes: no-notes