### PR TITLE
Add detection of Sublime Text 4 and 2 as editor on macOS.

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -47,7 +47,7 @@ function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
     case ExternalEditor.VSCodium:
       return ['com.visualstudio.code.oss']
     case ExternalEditor.SublimeText:
-      return ['com.sublimetext.3']
+      return ['com.sublimetext.4', 'com.sublimetext.3', 'com.sublimetext.2']
     case ExternalEditor.BBEdit:
       return ['com.barebones.bbedit']
     case ExternalEditor.PhpStorm:


### PR DESCRIPTION
Add detection of Sublime Text 4 and 2 as editor on macOS.
    
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

## Description

Sublime Text Dev/4 is now being detected and recognized as editor.
I followed same code paths as for ST3, the only change is bundle id, which is `com.sublimetext.4` and I named it `Sublime Text Dev`, which is disputable, we may call it `Sublime Text 4`, or `Sublime Text Dev 4`

Sublime Text 4 is even unannounced on offifcial site yet, but some hackers have it installed already either from [offical ST Discord chat server](https://discord.gg/D43Pecu) or via my brew tap: 

```
brew install yurikoles/yurikoles/sublime-text-dev-4
```

### Screenshots

UI isn't changed

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
