### PR TITLE
Fix "Couldn't find branch" error when checking out a PR from a fork

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -672,9 +672,10 @@ export interface ICompareState {
   /** The SHAs of commits to render in the compare list */
   readonly commitSHAs: ReadonlyArray<string>
 
-  /** A list of branches (remote and local) except for Desktop fork remote
-   * branches (see `Branch.isDesktopForkRemoteBranch`) and the default branch
-   * currently in the repository. */
+  /**
+   * A list of branches (remote and local) except the current branch, and
+   * Desktop fork remote branches (see `Branch.isDesktopForkRemoteBranch`)
+   **/
   readonly branches: ReadonlyArray<Branch>
 
   /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -672,8 +672,10 @@ export interface ICompareState {
   /** The SHAs of commits to render in the compare list */
   readonly commitSHAs: ReadonlyArray<string>
 
-  /** A list of all branches (remote and local) currently in the repository. */
-  readonly allBranches: ReadonlyArray<Branch>
+  /** A list of branches (remote and local) except for Desktop fork remote
+   * branches (see `Branch.isDesktopForkRemoteBranch`) and the default branch
+   * currently in the repository. */
+  readonly branches: ReadonlyArray<Branch>
 
   /**
    * A list of zero to a few (at time of writing 5 but check loadRecentBranches

--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -4,9 +4,6 @@ import { GitError } from 'dugite'
 import { Repository } from '../../models/repository'
 import { Branch, BranchType } from '../../models/branch'
 import { CommitIdentity } from '../../models/commit-identity'
-import { ForkedRemotePrefix } from '../../models/remote'
-
-const ForksReferencesPrefix = `refs/remotes/${ForkedRemotePrefix}`
 
 /** Get all the branches. */
 export async function getBranches(
@@ -94,14 +91,6 @@ export async function getBranches(
 
     if (symref.length > 0) {
       // exclude symbolic refs from the branch list
-      continue
-    }
-
-    if (ref.startsWith(ForksReferencesPrefix)) {
-      // hide refs from our known remotes as these are considered plumbing
-      // and can add noise to everywhere in the user interface where we
-      // display branches as forks will likely contain duplicates of the same
-      // ref names
       continue
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1026,10 +1026,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { tip } = branchesState
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
 
-    const allBranches =
-      currentBranch != null
-        ? branchesState.allBranches.filter(b => b.name !== currentBranch.name)
-        : branchesState.allBranches
+    const branches = branchesState.allBranches.filter(
+      b => b.name !== currentBranch?.name && !b.isDesktopForkRemoteBranch
+    )
     const recentBranches = currentBranch
       ? branchesState.recentBranches.filter(b => b.name !== currentBranch.name)
       : branchesState.recentBranches
@@ -1046,7 +1045,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         : null
 
     this.repositoryStateCache.updateCompareState(repository, () => ({
-      allBranches,
+      branches,
       recentBranches,
       defaultBranch,
     }))
@@ -1278,7 +1277,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         currentBranch,
         compareState.defaultBranch,
         compareState.recentBranches,
-        compareState.allBranches
+        compareState.branches
       )
     } else {
       this.currentAheadBehindUpdater.clear()

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -569,10 +569,15 @@ export class GitStore extends BaseStore {
       return
     }
 
-    const branchesByName = this._allBranches.reduce(
-      (map, branch) => map.set(branch.name, branch),
-      new Map<string, Branch>()
-    )
+    const branchesByName = new Map<string, Branch>()
+
+    for (const branch of this._allBranches) {
+      // This is slightly redundant as remote branches should never show up as
+      // having beed checked out in the reflog but it makes the intention clear.
+      if (branch.type === BranchType.Local) {
+        branchesByName.set(branch.name, branch)
+      }
+    }
 
     const recentBranches = new Array<Branch>()
     for (const name of recentBranchNames) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -573,7 +573,7 @@ export class GitStore extends BaseStore {
 
     for (const branch of this._allBranches) {
       // This is slightly redundant as remote branches should never show up as
-      // having beed checked out in the reflog but it makes the intention clear.
+      // having been checked out in the reflog but it makes the intention clear.
       if (branch.type === BranchType.Local) {
         branchesByName.set(branch.name, branch)
       }

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -104,7 +104,7 @@ export class AheadBehindUpdater {
     const newRefs = new Set<string>()
 
     const addBranch = (b: Branch | null) => {
-      if (b && b.isDesktopForkRemoteBranch && !cache.has(from, b.tip.sha)) {
+      if (b && !b.isDesktopForkRemoteBranch && !cache.has(from, b.tip.sha)) {
         newRefs.add(b.tip.sha)
       }
     }

--- a/app/src/lib/stores/helpers/ahead-behind-updater.ts
+++ b/app/src/lib/stores/helpers/ahead-behind-updater.ts
@@ -100,25 +100,22 @@ export class AheadBehindUpdater {
     this.clear()
 
     const from = currentBranch.tip.sha
+    const cache = this.comparisonCache
+    const newRefs = new Set<string>()
 
-    const filterBranchesNotInCache = (branches: ReadonlyArray<Branch>) => {
-      return branches
-        .map(b => b.tip.sha)
-        .filter(to => !this.comparisonCache.has(from, to))
+    const addBranch = (b: Branch | null) => {
+      if (b && b.isDesktopForkRemoteBranch && !cache.has(from, b.tip.sha)) {
+        newRefs.add(b.tip.sha)
+      }
     }
 
-    const otherBranches = [...recentBranches, ...allBranches]
+    addBranch(defaultBranch)
+    recentBranches.forEach(addBranch)
+    allBranches.forEach(addBranch)
 
-    const branches =
-      defaultBranch !== null ? [defaultBranch, ...otherBranches] : otherBranches
+    log.debug(`[AheadBehindUpdater] - found ${newRefs.size} new refs`)
 
-    const newRefsToCompare = new Set<string>(filterBranchesNotInCache(branches))
-
-    log.debug(
-      `[AheadBehindUpdater] - found ${newRefsToCompare.size} comparisons to perform`
-    )
-
-    for (const sha of newRefsToCompare) {
+    for (const sha of newRefs) {
       this.aheadBehindQueue.push(
         () =>
           new Promise<IAheadBehind | null>((resolve, reject) => {

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -149,7 +149,7 @@ function getInitialRepositoryState(): IRepositoryState {
       filterText: '',
       commitSHAs: [],
       aheadBehindCache: new ComparisonCache(),
-      allBranches: new Array<Branch>(),
+      branches: new Array<Branch>(),
       recentBranches: new Array<Branch>(),
       defaultBranch: null,
     },

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -1,6 +1,7 @@
 import { Commit } from './commit'
 import { removeRemotePrefix } from '../lib/remove-remote-prefix'
 import { CommitIdentity } from './commit-identity'
+import { ForkedRemotePrefix } from './remote'
 
 // NOTE: The values here matter as they are used to sort
 // local and remote branches, Local should come before Remote
@@ -111,5 +112,22 @@ export class Branch {
       const withoutRemote = removeRemotePrefix(this.name)
       return withoutRemote || this.name
     }
+  }
+
+  /**
+   * Gets a value indicating whether the branch is a remote branch belonging to
+   * one of Desktop's automatically created (and pruned) fork remotes. I.e. a
+   * remote branch from a branch which starts with `github-desktop-`.
+   *
+   * We hide branches from our known Desktop for remotes as these are considered
+   * plumbing and can add noise to everywhere in the user interface where we
+   * display branches as forks will likely contain duplicates of the same ref
+   * names
+   **/
+  public get isDesktopForkRemoteBranch() {
+    return (
+      this.type === BranchType.Remote &&
+      this.name.startsWith(ForkedRemotePrefix)
+    )
   }
 }

--- a/app/src/ui/branches/group-branches.ts
+++ b/app/src/ui/branches/group-branches.ts
@@ -1,6 +1,5 @@
-import { Branch, BranchType } from '../../models/branch'
+import { Branch } from '../../models/branch'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
-import { ForkedRemotePrefix } from '../../models/remote'
 
 export type BranchGroupIdentifier = 'default' | 'recent' | 'other'
 

--- a/app/src/ui/branches/group-branches.ts
+++ b/app/src/ui/branches/group-branches.ts
@@ -1,5 +1,6 @@
-import { Branch } from '../../models/branch'
+import { Branch, BranchType } from '../../models/branch'
 import { IFilterListGroup, IFilterListItem } from '../lib/filter-list'
+import { ForkedRemotePrefix } from '../../models/remote'
 
 export type BranchGroupIdentifier = 'default' | 'recent' | 'other'
 
@@ -54,8 +55,12 @@ export function groupBranches(
   }
 
   const remainingBranches = allBranches.filter(
-    b => b.name !== defaultBranchName && !recentBranchNames.has(b.name)
+    b =>
+      b.name !== defaultBranchName &&
+      !recentBranchNames.has(b.name) &&
+      !b.isDesktopForkRemoteBranch
   )
+
   const remainingItems = remainingBranches.map(b => ({
     text: [b.name],
     id: b.name,

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -132,7 +132,7 @@ export class CompareSidebar extends React.Component<
   }
 
   public render() {
-    const { allBranches, filterText, showBranchList } = this.props.compareState
+    const { branches, filterText, showBranchList } = this.props.compareState
     const placeholderText = getPlaceholderText(this.props.compareState)
 
     return (
@@ -144,7 +144,7 @@ export class CompareSidebar extends React.Component<
             placeholder={placeholderText}
             onFocus={this.onTextBoxFocused}
             value={filterText}
-            disabled={allBranches.length === 0}
+            disabled={!branches.some(b => !b.isDesktopForkRemoteBranch)}
             onRef={this.onTextBoxRef}
             onValueChanged={this.onBranchFilterTextChanged}
             onKeyDown={this.onBranchFilterKeyDown}
@@ -250,7 +250,7 @@ export class CompareSidebar extends React.Component<
   private renderFilterList() {
     const {
       defaultBranch,
-      allBranches,
+      branches,
       recentBranches,
       filterText,
     } = this.props.compareState
@@ -260,7 +260,7 @@ export class CompareSidebar extends React.Component<
         ref={this.onBranchesListRef}
         defaultBranch={defaultBranch}
         currentBranch={this.props.currentBranch}
-        allBranches={allBranches}
+        allBranches={branches}
         recentBranches={recentBranches}
         filterText={filterText}
         textbox={this.textbox!}
@@ -516,9 +516,9 @@ export class CompareSidebar extends React.Component<
 }
 
 function getPlaceholderText(state: ICompareState) {
-  const { allBranches, formState } = state
+  const { branches, formState } = state
 
-  if (allBranches.length === 0) {
+  if (!branches.some(b => !b.isDesktopForkRemoteBranch)) {
     return __DARWIN__ ? 'No Branches to Compare' : 'No branches to compare'
   } else if (formState.kind === HistoryTabMode.History) {
     return __DARWIN__

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -109,7 +109,9 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
     } else if (tip.kind === TipState.Unborn) {
       title = tip.ref
       tooltip = `Current branch is ${tip.ref}`
-      canOpen = branchesState.allBranches.length > 0
+      canOpen = branchesState.allBranches.some(
+        b => !b.isDesktopForkRemoteBranch
+      )
     } else if (tip.kind === TipState.Detached) {
       title = `On ${tip.currentSha.substr(0, 7)}`
       tooltip = 'Currently on a detached HEAD'

--- a/app/test/unit/create-branch-test.ts
+++ b/app/test/unit/create-branch-test.ts
@@ -28,6 +28,7 @@ const defaultBranch: Branch = {
   remote: null,
   upstreamWithoutRemote: null,
   nameWithoutRemote: 'my-default-branch',
+  isDesktopForkRemoteBranch: false,
 }
 
 const upstreamDefaultBranch = null
@@ -40,6 +41,7 @@ const someOtherBranch: Branch = {
   remote: null,
   upstreamWithoutRemote: null,
   nameWithoutRemote: 'some-other-branch',
+  isDesktopForkRemoteBranch: false,
 }
 
 describe('create-branch/getStartPoint', () => {

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -43,6 +43,7 @@ describe('git/checkout', () => {
         },
       },
       remote: null,
+      isDesktopForkRemoteBranch: false,
     }
 
     let errorRaised = false


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

When checking out a pull request from a fork prior to #11242 we attempted to look up whether a local branch existed already by looking for a branch named `pr/NUMBER`. This was brittle as it's possible that the user had already checked out the remote branch under another name, or conversely, that the user had a branch named "pr/NUMBER" which did not track the corresponding remote branch (@sergiou87 is fixing on the cause of the latter in https://github.com/desktop/desktop/pull/11266).

Unfortunately my testing of #11242 didn't uncover the fact that the `allBranches` property on `gitStore` didn't actually contain all branches. Forked remote branches were [intentionally excluded](https://github.com/desktop/desktop/blob/49a876e2250b208dc63fd9b7bbf272fffc1491b5/app/src/lib/git/for-each-ref.ts#L100-L106) in order not to clutter the interface. Not cluttering the interface is great but it's applied at too low of a level here.

In this PR I've lifted the filtering of remote fork branches to the presentation layer and audited all the dependents of `getBranches`.

A notable refactor here is the rename of `allBranches` to `branches` in `ICompareState`, that was done because `allBranches` was misleading given that it filtered not only remote fork branches but also the current branch.

I've also had to update the logic of the ahead-behind-updater so that it won't start calculating ahead/behind information for forked remote branches which aren't displayed in the UI (note that this will all be obsolete once #11160 lands).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Checking out a pull request from a fork for the first time now correctly identifies the remote branch to create the branch from.