### PR TITLE
Change how initial path is set when launching PowerShell (Core) terminals

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -369,31 +369,18 @@ export function launch(
 
   switch (shell) {
     case Shell.PowerShell:
-      const psCommand = `"Set-Location -LiteralPath '${path}'"`
-      return spawn(
-        'START',
-        [
-          '"PowerShell"',
-          `"${foundShell.path}"`,
-          '-NoExit',
-          '-Command',
-          psCommand,
-        ],
-        {
-          shell: true,
-          cwd: path,
-        }
-      )
+      return spawn('START', ['"PowerShell"', `"${foundShell.path}"`], {
+        shell: true,
+        cwd: path,
+      })
     case Shell.PowerShellCore:
-      const psCoreCommand = `"Set-Location -LiteralPath '${path}'"`
       return spawn(
         'START',
         [
           '"PowerShell Core"',
           `"${foundShell.path}"`,
-          '-NoExit',
-          '-Command',
-          psCoreCommand,
+          '-WorkingDirectory',
+          `"${path}"`,
         ],
         {
           shell: true,


### PR DESCRIPTION
## Description

This PR makes a couple of changes around setting the initial path when launching PowerShell (Core) terminals. Up until now, the app basically ran `Set-Location -LiteralPath` inside the new shell to switch to the initial directory. From now on…
- For PowerShell just rely on `cwd`.
- For PowerShell Core `cwd` is not enough, but we can use the `-WorkingDirectory` argument.

## Release notes

Notes: no-notes
