### PR TITLE
Contain focus in dropdowns using FocusTrap

### DIFF
--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -4,6 +4,8 @@ import { assertNever } from '../../lib/fatal-error'
 import { ToolbarButton, ToolbarButtonStyle } from './button'
 import { rectEquals } from '../lib/rect'
 import classNames from 'classnames'
+import FocusTrap from 'focus-trap-react'
+import { Options as FocusTrapOptions } from 'focus-trap'
 
 export type DropdownState = 'open' | 'closed'
 
@@ -142,10 +144,20 @@ export class ToolbarDropdown extends React.Component<
   IToolbarDropdownState
 > {
   private innerButton: ToolbarButton | null = null
+  private focusTrapOptions: FocusTrapOptions
 
   public constructor(props: IToolbarDropdownProps) {
     super(props)
     this.state = { clientRect: null }
+
+    this.focusTrapOptions = {
+      allowOutsideClick: true,
+
+      // Explicitly disable deactivation from the FocusTrap, since in that case
+      // we would lose the "source" of the event (keyboard vs pointer).
+      clickOutsideDeactivates: false,
+      escapeDeactivates: false,
+    }
   }
 
   private get isOpen() {
@@ -273,21 +285,23 @@ export class ToolbarDropdown extends React.Component<
     // bar to instantly close before even receiving the onDropdownStateChanged
     // event from us.
     return (
-      <div id="foldout-container" style={this.getFoldoutContainerStyle()}>
-        <div
-          className="overlay"
-          tabIndex={-1}
-          onClick={this.handleOverlayClick}
-        />
-        <div
-          className="foldout"
-          style={this.getFoldoutStyle()}
-          tabIndex={-1}
-          onKeyDown={this.onFoldoutKeyDown}
-        >
-          {this.props.dropdownContentRenderer()}
+      <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
+        <div id="foldout-container" style={this.getFoldoutContainerStyle()}>
+          <div
+            className="overlay"
+            tabIndex={-1}
+            onClick={this.handleOverlayClick}
+          />
+          <div
+            className="foldout"
+            style={this.getFoldoutStyle()}
+            tabIndex={-1}
+            onKeyDown={this.onFoldoutKeyDown}
+          >
+            {this.props.dropdownContentRenderer()}
+          </div>
         </div>
-      </div>
+      </FocusTrap>
     )
   }
 


### PR DESCRIPTION
## Description

This PR uses a `FocusTrap` to make sure the focus is contained within dropdowns when pressing tab.

![It's a trap](https://user-images.githubusercontent.com/1083228/102989225-8a308f00-4515-11eb-96d4-97e0948b86be.png)

### Screenshots

Before this PR:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/1083228/102988842-e2b35c80-4514-11eb-87c1-e745ce0ad194.gif)

After this PR:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/1083228/102988903-04144880-4515-11eb-9150-ce400ef4389e.gif)

*theme change not included

## Release notes

Notes: [Fixed] Pressing tab multiple times in a dropdown doesn't focus on outside elements anymore
