### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ install GitHub Desktop:
  - Windows users can install using [Chocolatey](https://chocolatey.org/) package manager:
       `c:\> choco install github-desktop`
  - macOS users can install using [Homebrew](https://brew.sh/) package manager:
-      `$ brew cask install github`
+      `$ brew install --cask github`
 
 Installers for various Linux distributions can be found on the
 [`shiftkey/desktop`](https://github.com/shiftkey/desktop) fork.


### PR DESCRIPTION


<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
Closes #[issue number]
-->

## Description

Fix error when installing using latest Homebrew in macOS. Just fix README.md.

### Screenshots

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/102998026-aeb65680-4569-11eb-8919-3ef725ce0419.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
