### PR TITLE
Fix crash clicking menus on Windows: disable FocusTrap for menus

### DIFF
--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -193,6 +193,11 @@ export class AppMenuBarButton extends React.Component<
         dropdownState={dropDownState}
         onDropdownStateChanged={this.onDropdownStateChanged}
         dropdownContentRenderer={this.dropDownContentRenderer}
+        // Disable the dropdown focus trap for menus. Items in the menus are not
+        // "tabbable", so the app crashes when this prop is set to true and the
+        // user opens a menu (on Windows).
+        // Besides, we use a custom "focus trap" for menus anyway.
+        focusTrapActive={false}
         showDisclosureArrow={false}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}

--- a/app/src/ui/app-menu/app-menu-bar-button.tsx
+++ b/app/src/ui/app-menu/app-menu-bar-button.tsx
@@ -197,7 +197,7 @@ export class AppMenuBarButton extends React.Component<
         // "tabbable", so the app crashes when this prop is set to true and the
         // user opens a menu (on Windows).
         // Besides, we use a custom "focus trap" for menus anyway.
-        focusTrapActive={false}
+        enableFocusTrap={false}
         showDisclosureArrow={false}
         onMouseEnter={this.onMouseEnter}
         onKeyDown={this.onKeyDown}

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -75,6 +75,9 @@ export interface IToolbarDropdownProps {
   /** The button's style. Defaults to `ToolbarButtonStyle.Standard`. */
   readonly style?: ToolbarButtonStyle
 
+  /** Wether the dropdown will trap focus or not. Defaults to true. */
+  readonly focusTrapActive?: boolean
+
   /**
    * Sets the styles for the dropdown's foldout. Useful for custom positioning
    * and sizes.
@@ -285,7 +288,10 @@ export class ToolbarDropdown extends React.Component<
     // bar to instantly close before even receiving the onDropdownStateChanged
     // event from us.
     return (
-      <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
+      <FocusTrap
+        active={this.props.focusTrapActive ?? true}
+        focusTrapOptions={this.focusTrapOptions}
+      >
         <div id="foldout-container" style={this.getFoldoutContainerStyle()}>
           <div
             className="overlay"

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -76,7 +76,7 @@ export interface IToolbarDropdownProps {
   readonly style?: ToolbarButtonStyle
 
   /** Wether the dropdown will trap focus or not. Defaults to true. */
-  readonly focusTrapActive?: boolean
+  readonly enableFocusTrap?: boolean
 
   /**
    * Sets the styles for the dropdown's foldout. Useful for custom positioning
@@ -289,7 +289,7 @@ export class ToolbarDropdown extends React.Component<
     // event from us.
     return (
       <FocusTrap
-        active={this.props.focusTrapActive ?? true}
+        active={this.props.enableFocusTrap ?? true}
         focusTrapOptions={this.focusTrapOptions}
       >
         <div id="foldout-container" style={this.getFoldoutContainerStyle()}>


### PR DESCRIPTION
## Description

With #11278 I introduced a regression in the Windows app where clicking on a menu would crash the app.

The problem is those menus are also `ToolbarDropdown` elements but the items are not "focusable" (at least [not as `FocusTrap` expects](https://github.com/focus-trap/tabbable/blob/master/src/index.js#L1-L13)). Since those menus have their own custom "focus trap", I've disabled the one used in other dropdowns.

## Release notes

Notes: no-notes
