### PR TITLE
Bump dugite to 1.94.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.93.0",
+    "dugite": "^1.94.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -355,10 +355,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.93.0:
-  version "1.93.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.93.0.tgz#897e9559347db383d534d274cae6d418d9dcc05e"
-  integrity sha512-2xeCD9zaJLscWX4hMQkCcq6YrUkQvj17gBIhJyBkqNRMTLwIzTuSfeu1wNUBvUvZJe9/WBeMy+YcbCkAEHqDNg==
+dugite@^1.94.0:
+  version "1.94.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.94.0.tgz#ca7431d822fec9b6adcd9e228fe0eda1dc936e85"
+  integrity sha512-PHrVEhVvVuisH+w2uvavlxzffbGb8XZhaKCM5k2iAsuWRIXBt1LLuSdW5H5iv6KFgcHEZ63QVb+6lPwPdtWU+A==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Upgrade dugite to 1.94.0 to get Git LFS 2.13.2 which fixes CVE-2021-21237.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Upgrade embedded Git LFS to 2.13.2
