### PR TITLE
Clean up editors code

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -26,7 +26,6 @@ import { Popup } from '../models/popup'
 import { SignInState } from './stores/sign-in-store'
 
 import { WindowState } from './window-state'
-import { ExternalEditor } from './editors'
 import { Shell } from './shells'
 
 import { ApplicationTheme } from '../ui/lib/application-theme'
@@ -177,7 +176,7 @@ export interface IAppState {
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 
   /** The external editor to use when opening repositories */
-  readonly selectedExternalEditor: ExternalEditor | null
+  readonly selectedExternalEditor: string | null
 
   /** The current setting for whether the user has disable usage reports */
   readonly optOutOfUsageTracking: boolean
@@ -189,7 +188,7 @@ export interface IAppState {
    *    based on the search order in `app/src/lib/editors/{platform}.ts`
    *  - If no editors found, this will remain `null`
    */
-  readonly resolvedExternalEditor: ExternalEditor | null
+  readonly resolvedExternalEditor: string | null
 
   /** What type of visual diff mode we should use to compare images */
   readonly imageDiffType: ImageDiffType

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -129,7 +129,7 @@ async function findApplication(
         return installPath
       }
 
-      log.debug(`App instalation for ${editor} not found at '${installPath}'`)
+      log.debug(`App installation for ${editor} not found at '${installPath}'`)
     } catch (error) {
       log.debug(`Unable to locate ${editor} installation`, error)
     }

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -1,7 +1,5 @@
-import * as Path from 'path'
 import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
-import { assertNever } from '../fatal-error'
 import appPath from 'app-path'
 import { parseEnumValue } from '../enum'
 
@@ -30,145 +28,127 @@ export enum ExternalEditor {
   Nova = 'Nova',
 }
 
+interface IDarwinExternalEditor {
+  readonly name: ExternalEditor
+  readonly bundleIdentifiers: string[]
+}
+
+export const editors: IDarwinExternalEditor[] = [
+  {
+    name: ExternalEditor.Atom,
+    bundleIdentifiers: ['com.github.atom'],
+  },
+  {
+    name: ExternalEditor.MacVim,
+    bundleIdentifiers: ['org.vim.MacVim'],
+  },
+  {
+    name: ExternalEditor.VSCode,
+    bundleIdentifiers: ['com.microsoft.VSCode'],
+  },
+  {
+    name: ExternalEditor.VSCodeInsiders,
+    bundleIdentifiers: ['com.microsoft.VSCodeInsiders'],
+  },
+  {
+    name: ExternalEditor.VSCodium,
+    bundleIdentifiers: ['com.visualstudio.code.oss'],
+  },
+  {
+    name: ExternalEditor.SublimeText,
+    bundleIdentifiers: [
+      'com.sublimetext.4',
+      'com.sublimetext.3',
+      'com.sublimetext.2',
+    ],
+  },
+  {
+    name: ExternalEditor.BBEdit,
+    bundleIdentifiers: ['com.barebones.bbedit'],
+  },
+  {
+    name: ExternalEditor.PhpStorm,
+    bundleIdentifiers: ['com.jetbrains.PhpStorm'],
+  },
+  {
+    name: ExternalEditor.PyCharm,
+    bundleIdentifiers: ['com.jetbrains.PyCharm'],
+  },
+  {
+    name: ExternalEditor.RubyMine,
+    bundleIdentifiers: ['com.jetbrains.RubyMine'],
+  },
+  {
+    name: ExternalEditor.IntelliJ,
+    bundleIdentifiers: ['com.jetbrains.intellij'],
+  },
+  {
+    name: ExternalEditor.TextMate,
+    bundleIdentifiers: ['com.macromates.TextMate'],
+  },
+  {
+    name: ExternalEditor.Brackets,
+    bundleIdentifiers: ['io.brackets.appshell'],
+  },
+  {
+    name: ExternalEditor.WebStorm,
+    bundleIdentifiers: ['com.jetbrains.WebStorm'],
+  },
+  {
+    name: ExternalEditor.Typora,
+    bundleIdentifiers: ['abnerworks.Typora'],
+  },
+  {
+    name: ExternalEditor.CodeRunner,
+    bundleIdentifiers: ['com.krill.CodeRunner'],
+  },
+  {
+    name: ExternalEditor.SlickEdit,
+    bundleIdentifiers: [
+      'com.slickedit.SlickEditPro2018',
+      'com.slickedit.SlickEditPro2017',
+      'com.slickedit.SlickEditPro2016',
+      'com.slickedit.SlickEditPro2015',
+    ],
+  },
+  {
+    name: ExternalEditor.Xcode,
+    bundleIdentifiers: ['com.apple.dt.Xcode'],
+  },
+  {
+    name: ExternalEditor.GoLand,
+    bundleIdentifiers: ['com.jetbrains.goland'],
+  },
+  {
+    name: ExternalEditor.AndroidStudio,
+    bundleIdentifiers: ['com.google.android.studio'],
+  },
+  {
+    name: ExternalEditor.Rider,
+    bundleIdentifiers: ['com.jetbrains.rider'],
+  },
+  {
+    name: ExternalEditor.Nova,
+    bundleIdentifiers: ['com.panic.Nova'],
+  },
+]
+
 export function parse(label: string): ExternalEditor | null {
   return parseEnumValue(ExternalEditor, label) ?? null
 }
 
-function getBundleIdentifiers(editor: ExternalEditor): ReadonlyArray<string> {
-  switch (editor) {
-    case ExternalEditor.Atom:
-      return ['com.github.atom']
-    case ExternalEditor.MacVim:
-      return ['org.vim.MacVim']
-    case ExternalEditor.VSCode:
-      return ['com.microsoft.VSCode']
-    case ExternalEditor.VSCodeInsiders:
-      return ['com.microsoft.VSCodeInsiders']
-    case ExternalEditor.VSCodium:
-      return ['com.visualstudio.code.oss']
-    case ExternalEditor.SublimeText:
-      return ['com.sublimetext.4', 'com.sublimetext.3', 'com.sublimetext.2']
-    case ExternalEditor.BBEdit:
-      return ['com.barebones.bbedit']
-    case ExternalEditor.PhpStorm:
-      return ['com.jetbrains.PhpStorm']
-    case ExternalEditor.PyCharm:
-      return ['com.jetbrains.PyCharm']
-    case ExternalEditor.RubyMine:
-      return ['com.jetbrains.RubyMine']
-    case ExternalEditor.IntelliJ:
-      return ['com.jetbrains.intellij']
-    case ExternalEditor.TextMate:
-      return ['com.macromates.TextMate']
-    case ExternalEditor.Brackets:
-      return ['io.brackets.appshell']
-    case ExternalEditor.WebStorm:
-      return ['com.jetbrains.WebStorm']
-    case ExternalEditor.Typora:
-      return ['abnerworks.Typora']
-    case ExternalEditor.CodeRunner:
-      return ['com.krill.CodeRunner']
-    case ExternalEditor.SlickEdit:
-      return [
-        'com.slickedit.SlickEditPro2018',
-        'com.slickedit.SlickEditPro2017',
-        'com.slickedit.SlickEditPro2016',
-        'com.slickedit.SlickEditPro2015',
-      ]
-    case ExternalEditor.Xcode:
-      return ['com.apple.dt.Xcode']
-    case ExternalEditor.GoLand:
-      return ['com.jetbrains.goland']
-    case ExternalEditor.AndroidStudio:
-      return ['com.google.android.studio']
-    case ExternalEditor.Rider:
-      return ['com.jetbrains.rider']
-    case ExternalEditor.Nova:
-      return ['com.panic.Nova']
-    default:
-      return assertNever(editor, `Unknown external editor: ${editor}`)
-  }
-}
-
-function getExecutableShim(
-  editor: ExternalEditor,
-  installPath: string
-): string {
-  switch (editor) {
-    case ExternalEditor.Atom:
-      return Path.join(installPath, 'Contents', 'Resources', 'app', 'atom.sh')
-    case ExternalEditor.VSCode:
-    case ExternalEditor.VSCodeInsiders:
-      return Path.join(
-        installPath,
-        'Contents',
-        'Resources',
-        'app',
-        'bin',
-        'code'
-      )
-    case ExternalEditor.VSCodium:
-      return Path.join(
-        installPath,
-        'Contents',
-        'Resources',
-        'app',
-        'bin',
-        'code'
-      )
-    case ExternalEditor.MacVim:
-      return Path.join(installPath, 'Contents', 'MacOS', 'MacVim')
-    case ExternalEditor.SublimeText:
-      return Path.join(installPath, 'Contents', 'SharedSupport', 'bin', 'subl')
-    case ExternalEditor.BBEdit:
-      return Path.join(installPath, 'Contents', 'Helpers', 'bbedit_tool')
-    case ExternalEditor.PhpStorm:
-      return Path.join(installPath, 'Contents', 'MacOS', 'phpstorm')
-    case ExternalEditor.PyCharm:
-      return Path.join(installPath, 'Contents', 'MacOS', 'pycharm')
-    case ExternalEditor.RubyMine:
-      return Path.join(installPath, 'Contents', 'MacOS', 'rubymine')
-    case ExternalEditor.TextMate:
-      return Path.join(installPath, 'Contents', 'Resources', 'mate')
-    case ExternalEditor.Brackets:
-      return Path.join(installPath, 'Contents', 'MacOS', 'Brackets')
-    case ExternalEditor.WebStorm:
-      return Path.join(installPath, 'Contents', 'MacOS', 'WebStorm')
-    case ExternalEditor.IntelliJ:
-      return Path.join(installPath, 'Contents', 'MacOS', 'idea')
-    case ExternalEditor.Typora:
-      return Path.join(installPath, 'Contents', 'MacOS', 'Typora')
-    case ExternalEditor.CodeRunner:
-      return Path.join(installPath, 'Contents', 'MacOS', 'CodeRunner')
-    case ExternalEditor.SlickEdit:
-      return Path.join(installPath, 'Contents', 'MacOS', 'vs')
-    case ExternalEditor.Xcode:
-      return '/usr/bin/xed'
-    case ExternalEditor.GoLand:
-      return Path.join(installPath, 'Contents', 'MacOS', 'goland')
-    case ExternalEditor.AndroidStudio:
-      return Path.join(installPath, 'Contents', 'MacOS', 'studio')
-    case ExternalEditor.Rider:
-      return Path.join(installPath, 'Contents', 'MacOS', 'rider')
-    case ExternalEditor.Nova:
-      return Path.join(installPath, 'Contents', 'SharedSupport', 'nova')
-    default:
-      return assertNever(editor, `Unknown external editor: ${editor}`)
-  }
-}
-
-async function findApplication(editor: ExternalEditor): Promise<string | null> {
-  const identifiers = getBundleIdentifiers(editor)
-  for (const identifier of identifiers) {
+async function findApplication(
+  editor: IDarwinExternalEditor
+): Promise<string | null> {
+  for (const identifier of editor.bundleIdentifiers) {
     try {
       const installPath = await appPath(identifier)
-      const path = getExecutableShim(editor, installPath)
-      const exists = await pathExists(path)
+      const exists = await pathExists(installPath)
       if (exists) {
-        return path
+        return installPath
       }
 
-      log.debug(`Command line interface for ${editor} not found at '${path}'`)
+      log.debug(`App instalation for ${editor} not found at '${installPath}'`)
     } catch (error) {
       log.debug(`Unable to locate ${editor} installation`, error)
     }
@@ -186,146 +166,23 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    macVimPath,
-    codePath,
-    codeInsidersPath,
-    codiumPath,
-    sublimePath,
-    bbeditPath,
-    phpStormPath,
-    pyCharmPath,
-    rubyMinePath,
-    textMatePath,
-    bracketsPath,
-    webStormPath,
-    typoraPath,
-    codeRunnerPath,
-    slickeditPath,
-    intellijPath,
-    xcodePath,
-    golandPath,
-    androidStudioPath,
-    riderPath,
-    novaPath,
-  ] = await Promise.all([
-    findApplication(ExternalEditor.Atom),
-    findApplication(ExternalEditor.MacVim),
-    findApplication(ExternalEditor.VSCode),
-    findApplication(ExternalEditor.VSCodeInsiders),
-    findApplication(ExternalEditor.VSCodium),
-    findApplication(ExternalEditor.SublimeText),
-    findApplication(ExternalEditor.BBEdit),
-    findApplication(ExternalEditor.PhpStorm),
-    findApplication(ExternalEditor.PyCharm),
-    findApplication(ExternalEditor.RubyMine),
-    findApplication(ExternalEditor.TextMate),
-    findApplication(ExternalEditor.Brackets),
-    findApplication(ExternalEditor.WebStorm),
-    findApplication(ExternalEditor.Typora),
-    findApplication(ExternalEditor.CodeRunner),
-    findApplication(ExternalEditor.SlickEdit),
-    findApplication(ExternalEditor.IntelliJ),
-    findApplication(ExternalEditor.Xcode),
-    findApplication(ExternalEditor.GoLand),
-    findApplication(ExternalEditor.AndroidStudio),
-    findApplication(ExternalEditor.Rider),
-    findApplication(ExternalEditor.Nova),
-  ])
+  const editorPaths = await Promise.all(
+    editors.map(editor =>
+      findApplication(editor).then(path => {
+        return { editor, path }
+      })
+    )
+  )
 
-  if (atomPath) {
-    results.push({ editor: ExternalEditor.Atom, path: atomPath })
-  }
+  for (const editorPath of editorPaths) {
+    const { editor, path } = editorPath
 
-  if (macVimPath) {
-    results.push({ editor: ExternalEditor.MacVim, path: macVimPath })
-  }
-
-  if (codePath) {
-    results.push({ editor: ExternalEditor.VSCode, path: codePath })
-  }
-
-  if (codeInsidersPath) {
-    results.push({
-      editor: ExternalEditor.VSCodeInsiders,
-      path: codeInsidersPath,
-    })
-  }
-
-  if (codiumPath) {
-    results.push({ editor: ExternalEditor.VSCodium, path: codiumPath })
-  }
-
-  if (sublimePath) {
-    results.push({ editor: ExternalEditor.SublimeText, path: sublimePath })
-  }
-
-  if (bbeditPath) {
-    results.push({ editor: ExternalEditor.BBEdit, path: bbeditPath })
-  }
-
-  if (phpStormPath) {
-    results.push({ editor: ExternalEditor.PhpStorm, path: phpStormPath })
-  }
-
-  if (pyCharmPath) {
-    results.push({ editor: ExternalEditor.PyCharm, path: pyCharmPath })
-  }
-
-  if (rubyMinePath) {
-    results.push({ editor: ExternalEditor.RubyMine, path: rubyMinePath })
-  }
-
-  if (textMatePath) {
-    results.push({ editor: ExternalEditor.TextMate, path: textMatePath })
-  }
-
-  if (bracketsPath) {
-    results.push({ editor: ExternalEditor.Brackets, path: bracketsPath })
-  }
-
-  if (webStormPath) {
-    results.push({ editor: ExternalEditor.WebStorm, path: webStormPath })
-  }
-
-  if (typoraPath) {
-    results.push({ editor: ExternalEditor.Typora, path: typoraPath })
-  }
-
-  if (codeRunnerPath) {
-    results.push({ editor: ExternalEditor.CodeRunner, path: codeRunnerPath })
-  }
-
-  if (slickeditPath) {
-    results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
-  }
-
-  if (intellijPath) {
-    results.push({ editor: ExternalEditor.IntelliJ, path: intellijPath })
-  }
-
-  if (xcodePath) {
-    results.push({ editor: ExternalEditor.Xcode, path: xcodePath })
-  }
-
-  if (golandPath) {
-    results.push({ editor: ExternalEditor.GoLand, path: golandPath })
-  }
-
-  if (androidStudioPath) {
-    results.push({
-      editor: ExternalEditor.AndroidStudio,
-      path: androidStudioPath,
-    })
-  }
-
-  if (riderPath) {
-    results.push({ editor: ExternalEditor.Rider, path: riderPath })
-  }
-
-  if (novaPath) {
-    results.push({ editor: ExternalEditor.Nova, path: novaPath })
+    if (path) {
+      results.push({
+        editor: editor.name,
+        path: path,
+      })
+    }
   }
 
   return results

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -1,61 +1,34 @@
 import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
 import appPath from 'app-path'
-import { parseEnumValue } from '../enum'
-
-export enum ExternalEditor {
-  Atom = 'Atom',
-  MacVim = 'MacVim',
-  VSCode = 'Visual Studio Code',
-  VSCodeInsiders = 'Visual Studio Code (Insiders)',
-  VSCodium = 'VSCodium',
-  SublimeText = 'Sublime Text',
-  BBEdit = 'BBEdit',
-  PhpStorm = 'PhpStorm',
-  PyCharm = 'PyCharm',
-  RubyMine = 'RubyMine',
-  TextMate = 'TextMate',
-  Brackets = 'Brackets',
-  WebStorm = 'WebStorm',
-  Typora = 'Typora',
-  CodeRunner = 'CodeRunner',
-  SlickEdit = 'SlickEdit',
-  IntelliJ = 'IntelliJ',
-  Xcode = 'Xcode',
-  GoLand = 'GoLand',
-  AndroidStudio = 'Android Studio',
-  Rider = 'Rider',
-  Nova = 'Nova',
-}
-
 interface IDarwinExternalEditor {
-  readonly name: ExternalEditor
+  readonly name: string
   readonly bundleIdentifiers: string[]
 }
 
 export const editors: IDarwinExternalEditor[] = [
   {
-    name: ExternalEditor.Atom,
+    name: 'Atom',
     bundleIdentifiers: ['com.github.atom'],
   },
   {
-    name: ExternalEditor.MacVim,
+    name: 'MacVim',
     bundleIdentifiers: ['org.vim.MacVim'],
   },
   {
-    name: ExternalEditor.VSCode,
+    name: 'Visual Studio Code',
     bundleIdentifiers: ['com.microsoft.VSCode'],
   },
   {
-    name: ExternalEditor.VSCodeInsiders,
+    name: 'Visual Studio Code (Insiders)',
     bundleIdentifiers: ['com.microsoft.VSCodeInsiders'],
   },
   {
-    name: ExternalEditor.VSCodium,
+    name: 'VSCodium',
     bundleIdentifiers: ['com.visualstudio.code.oss'],
   },
   {
-    name: ExternalEditor.SublimeText,
+    name: 'Sublime Text',
     bundleIdentifiers: [
       'com.sublimetext.4',
       'com.sublimetext.3',
@@ -63,47 +36,43 @@ export const editors: IDarwinExternalEditor[] = [
     ],
   },
   {
-    name: ExternalEditor.BBEdit,
+    name: 'BBEdit',
     bundleIdentifiers: ['com.barebones.bbedit'],
   },
   {
-    name: ExternalEditor.PhpStorm,
+    name: 'PhpStorm',
     bundleIdentifiers: ['com.jetbrains.PhpStorm'],
   },
   {
-    name: ExternalEditor.PyCharm,
+    name: 'PyCharm',
     bundleIdentifiers: ['com.jetbrains.PyCharm'],
   },
   {
-    name: ExternalEditor.RubyMine,
+    name: 'RubyMine',
     bundleIdentifiers: ['com.jetbrains.RubyMine'],
   },
   {
-    name: ExternalEditor.IntelliJ,
-    bundleIdentifiers: ['com.jetbrains.intellij'],
-  },
-  {
-    name: ExternalEditor.TextMate,
+    name: 'TextMate',
     bundleIdentifiers: ['com.macromates.TextMate'],
   },
   {
-    name: ExternalEditor.Brackets,
+    name: 'Brackets',
     bundleIdentifiers: ['io.brackets.appshell'],
   },
   {
-    name: ExternalEditor.WebStorm,
+    name: 'WebStorm',
     bundleIdentifiers: ['com.jetbrains.WebStorm'],
   },
   {
-    name: ExternalEditor.Typora,
+    name: 'Typora',
     bundleIdentifiers: ['abnerworks.Typora'],
   },
   {
-    name: ExternalEditor.CodeRunner,
+    name: 'CodeRunner',
     bundleIdentifiers: ['com.krill.CodeRunner'],
   },
   {
-    name: ExternalEditor.SlickEdit,
+    name: 'SlickEdit',
     bundleIdentifiers: [
       'com.slickedit.SlickEditPro2018',
       'com.slickedit.SlickEditPro2017',
@@ -112,30 +81,30 @@ export const editors: IDarwinExternalEditor[] = [
     ],
   },
   {
-    name: ExternalEditor.Xcode,
+    name: 'IntelliJ',
+    bundleIdentifiers: ['com.jetbrains.intellij'],
+  },
+  {
+    name: 'Xcode',
     bundleIdentifiers: ['com.apple.dt.Xcode'],
   },
   {
-    name: ExternalEditor.GoLand,
+    name: 'GoLand',
     bundleIdentifiers: ['com.jetbrains.goland'],
   },
   {
-    name: ExternalEditor.AndroidStudio,
+    name: 'Android Studio',
     bundleIdentifiers: ['com.google.android.studio'],
   },
   {
-    name: ExternalEditor.Rider,
+    name: 'Rider',
     bundleIdentifiers: ['com.jetbrains.rider'],
   },
   {
-    name: ExternalEditor.Nova,
+    name: 'Nova',
     bundleIdentifiers: ['com.panic.Nova'],
   },
 ]
-
-export function parse(label: string): ExternalEditor | null {
-  return parseEnumValue(ExternalEditor, label) ?? null
-}
 
 async function findApplication(
   editor: IDarwinExternalEditor
@@ -162,9 +131,9 @@ async function findApplication(
  * to register itself on a user's machine when installing.
  */
 export async function getAvailableEditors(): Promise<
-  ReadonlyArray<IFoundEditor<ExternalEditor>>
+  ReadonlyArray<IFoundEditor<string>>
 > {
-  const results: Array<IFoundEditor<ExternalEditor>> = []
+  const results: Array<IFoundEditor<string>> = []
 
   const editorPaths = await Promise.all(
     editors.map(editor =>

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -1,12 +1,24 @@
 import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
 import appPath from 'app-path'
+
+/** Represents an external editor on macOS */
 interface IDarwinExternalEditor {
+  /** Name of the editor. It will be used both as identifier and user-facing. */
   readonly name: string
+
+  /**
+   * List of bundle identifiers that are used by the app in its multiple
+   * versions.
+   **/
   readonly bundleIdentifiers: string[]
 }
 
-export const editors: IDarwinExternalEditor[] = [
+/**
+ * This list contains all the external editors supported on macOS. Add a new
+ * entry here to add support for your favorite editor.
+ **/
+const editors: IDarwinExternalEditor[] = [
   {
     name: 'Atom',
     bundleIdentifiers: ['com.github.atom'],

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -147,22 +147,11 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<string>> = []
 
-  const editorPaths = await Promise.all(
-    editors.map(editor =>
-      findApplication(editor).then(path => {
-        return { editor, path }
-      })
-    )
-  )
-
-  for (const editorPath of editorPaths) {
-    const { editor, path } = editorPath
+  for (const editor of editors) {
+    const path = await findApplication(editor)
 
     if (path) {
-      results.push({
-        editor: editor.name,
-        path: path,
-      })
+      results.push({ editor: editor.name, path })
     }
   }
 

--- a/app/src/lib/editors/index.ts
+++ b/app/src/lib/editors/index.ts
@@ -1,3 +1,2 @@
 export * from './lookup'
 export * from './launch'
-export { ExternalEditor, parse } from './shared'

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -23,6 +23,10 @@ export async function launchExternalEditor(
   }
   if (editor.usesShell) {
     spawn(`"${editorPath}"`, [`"${fullPath}"`], { shell: true })
+  } else if (__DARWIN__) {
+    // In macOS we can use `open`, which will open the right executable file
+    // for us, we only need the path to the editor .app folder.
+    spawn('open', ['-a', editorPath, fullPath])
   } else {
     spawn(editorPath, [fullPath])
   }

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -52,7 +52,7 @@ const editors: ILinuxExternalEditor[] = [
 ]
 
 async function getAvailablePath(paths: string[]): Promise<string | null> {
-  for (const path in paths) {
+  for (const path of paths) {
     if (await pathExists(path)) {
       return path
     }

--- a/app/src/lib/editors/linux.ts
+++ b/app/src/lib/editors/linux.ts
@@ -1,109 +1,76 @@
 import { pathExists } from 'fs-extra'
 
 import { IFoundEditor } from './found-editor'
-import { assertNever } from '../fatal-error'
-import { parseEnumValue } from '../enum'
 
-export enum ExternalEditor {
-  Atom = 'Atom',
-  VSCode = 'Visual Studio Code',
-  VSCodeInsiders = 'Visual Studio Code (Insiders)',
-  VSCodium = 'VSCodium',
-  SublimeText = 'Sublime Text',
-  Typora = 'Typora',
-  SlickEdit = 'SlickEdit',
+/** Represents an external editor on Linux */
+interface ILinuxExternalEditor {
+  /** Name of the editor. It will be used both as identifier and user-facing. */
+  readonly name: string
+
+  /** List of possible paths where the editor's executable might be located. */
+  readonly paths: string[]
 }
 
-export function parse(label: string): ExternalEditor | null {
-  return parseEnumValue(ExternalEditor, label) ?? null
-}
+/**
+ * This list contains all the external editors supported on Linux. Add a new
+ * entry here to add support for your favorite editor.
+ **/
+const editors: ILinuxExternalEditor[] = [
+  {
+    name: 'Atom',
+    paths: ['/usr/bin/atom'],
+  },
+  {
+    name: 'Visual Studio Code',
+    paths: ['/usr/bin/code'],
+  },
+  {
+    name: 'Visual Studio Code (Insiders)',
+    paths: ['/usr/bin/code-insiders'],
+  },
+  {
+    name: 'VSCodium',
+    paths: ['/usr/bin/codium'],
+  },
+  {
+    name: 'Sublime Text',
+    paths: ['/usr/bin/subl'],
+  },
+  {
+    name: 'Typora',
+    paths: ['/usr/bin/typora'],
+  },
+  {
+    name: 'SlickEdit',
+    paths: [
+      '/opt/slickedit-pro2018/bin/vs',
+      '/opt/slickedit-pro2017/bin/vs',
+      '/opt/slickedit-pro2016/bin/vs',
+      '/opt/slickedit-pro2015/bin/vs',
+    ],
+  },
+]
 
-async function getPathIfAvailable(path: string): Promise<string | null> {
-  return (await pathExists(path)) ? path : null
-}
-
-async function getEditorPath(editor: ExternalEditor): Promise<string | null> {
-  switch (editor) {
-    case ExternalEditor.Atom:
-      return getPathIfAvailable('/usr/bin/atom')
-    case ExternalEditor.VSCode:
-      return getPathIfAvailable('/usr/bin/code')
-    case ExternalEditor.VSCodeInsiders:
-      return getPathIfAvailable('/usr/bin/code-insiders')
-    case ExternalEditor.VSCodium:
-      return getPathIfAvailable('/usr/bin/codium')
-    case ExternalEditor.SublimeText:
-      return getPathIfAvailable('/usr/bin/subl')
-    case ExternalEditor.Typora:
-      return getPathIfAvailable('/usr/bin/typora')
-    case ExternalEditor.SlickEdit:
-      const possiblePaths = [
-        '/opt/slickedit-pro2018/bin/vs',
-        '/opt/slickedit-pro2017/bin/vs',
-        '/opt/slickedit-pro2016/bin/vs',
-        '/opt/slickedit-pro2015/bin/vs',
-      ]
-      for (const possiblePath of possiblePaths) {
-        const slickeditPath = await getPathIfAvailable(possiblePath)
-        if (slickeditPath) {
-          return slickeditPath
-        }
-      }
-      return null
-    default:
-      return assertNever(editor, `Unknown editor: ${editor}`)
+async function getAvailablePath(paths: string[]): Promise<string | null> {
+  for (const path in paths) {
+    if (await pathExists(path)) {
+      return path
+    }
   }
+
+  return null
 }
 
 export async function getAvailableEditors(): Promise<
-  ReadonlyArray<IFoundEditor<ExternalEditor>>
+  ReadonlyArray<IFoundEditor<string>>
 > {
-  const results: Array<IFoundEditor<ExternalEditor>> = []
+  const results: Array<IFoundEditor<string>> = []
 
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    codiumPath,
-    sublimePath,
-    typoraPath,
-    slickeditPath,
-  ] = await Promise.all([
-    getEditorPath(ExternalEditor.Atom),
-    getEditorPath(ExternalEditor.VSCode),
-    getEditorPath(ExternalEditor.VSCodeInsiders),
-    getEditorPath(ExternalEditor.VSCodium),
-    getEditorPath(ExternalEditor.SublimeText),
-    getEditorPath(ExternalEditor.Typora),
-    getEditorPath(ExternalEditor.SlickEdit),
-  ])
-
-  if (atomPath) {
-    results.push({ editor: ExternalEditor.Atom, path: atomPath })
-  }
-
-  if (codePath) {
-    results.push({ editor: ExternalEditor.VSCode, path: codePath })
-  }
-
-  if (codeInsidersPath) {
-    results.push({ editor: ExternalEditor.VSCode, path: codeInsidersPath })
-  }
-
-  if (codiumPath) {
-    results.push({ editor: ExternalEditor.VSCodium, path: codiumPath })
-  }
-
-  if (sublimePath) {
-    results.push({ editor: ExternalEditor.SublimeText, path: sublimePath })
-  }
-
-  if (typoraPath) {
-    results.push({ editor: ExternalEditor.Typora, path: typoraPath })
-  }
-
-  if (slickeditPath) {
-    results.push({ editor: ExternalEditor.SlickEdit, path: slickeditPath })
+  for (const editor of editors) {
+    const path = await getAvailablePath(editor.paths)
+    if (path) {
+      results.push({ editor: editor.name, path })
+    }
   }
 
   return results

--- a/app/src/lib/editors/lookup.ts
+++ b/app/src/lib/editors/lookup.ts
@@ -1,17 +1,17 @@
-import { ExternalEditor, ExternalEditorError } from './shared'
+import { ExternalEditorError } from './shared'
 import { IFoundEditor } from './found-editor'
 import { getAvailableEditors as getAvailableEditorsDarwin } from './darwin'
 import { getAvailableEditors as getAvailableEditorsWindows } from './win32'
 import { getAvailableEditors as getAvailableEditorsLinux } from './linux'
 
-let editorCache: ReadonlyArray<IFoundEditor<ExternalEditor>> | null = null
+let editorCache: ReadonlyArray<IFoundEditor<string>> | null = null
 
 /**
  * Resolve a list of installed editors on the user's machine, using the known
  * install identifiers that each OS supports.
  */
 export async function getAvailableEditors(): Promise<
-  ReadonlyArray<IFoundEditor<ExternalEditor>>
+  ReadonlyArray<IFoundEditor<string>>
 > {
   if (editorCache && editorCache.length > 0) {
     return editorCache
@@ -48,7 +48,7 @@ export async function getAvailableEditors(): Promise<
  */
 export async function findEditorOrDefault(
   name: string | null
-): Promise<IFoundEditor<ExternalEditor> | null> {
+): Promise<IFoundEditor<string> | null> {
   const editors = await getAvailableEditors()
   if (editors.length === 0) {
     return null

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -1,24 +1,3 @@
-import * as Darwin from './darwin'
-import * as Win32 from './win32'
-import * as Linux from './linux'
-
-export type ExternalEditor = Darwin.ExternalEditor | Win32.ExternalEditor
-
-/** Parse the label into the specified shell type. */
-export function parse(label: string): ExternalEditor | null {
-  if (__DARWIN__) {
-    return Darwin.parse(label)
-  } else if (__WIN32__) {
-    return Win32.parse(label)
-  } else if (__LINUX__) {
-    return Linux.parse(label)
-  }
-
-  throw new Error(
-    `Platform not currently supported for resolving editors: ${process.platform}`
-  )
-}
-
 /**
  * A found external editor on the user's machine
  */
@@ -26,7 +5,7 @@ export type FoundEditor = {
   /**
    * The friendly name of the editor, to be used in labels
    */
-  editor: ExternalEditor
+  editor: string
   /**
    * The executable associated with the editor to launch
    */

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -10,7 +10,6 @@ import {
 import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
 
-import { assertNever } from '../fatal-error'
 import { parseEnumValue } from '../enum'
 
 export enum ExternalEditor {
@@ -30,437 +29,560 @@ export enum ExternalEditor {
   Rider = 'JetBrains Rider',
 }
 
-export function parse(label: string): ExternalEditor | null {
-  return parseEnumValue(ExternalEditor, label) ?? null
-}
-
-/**
- * Resolve a set of registry keys associated with the installed application.
- *
- * This is because some tools (like VSCode) may support a 64-bit or 32-bit
- * version of the tool - we should use whichever they have installed.
- *
- * @param editor The external editor that may be installed locally.
- */
-function getRegistryKeys(
-  editor: ExternalEditor
-): ReadonlyArray<{ key: HKEY; subKey: string }> {
-  switch (editor) {
-    case ExternalEditor.Atom:
-      return [
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom',
-        },
-      ]
-    case ExternalEditor.AtomBeta:
-      return [
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-beta',
-        },
-      ]
-    case ExternalEditor.AtomNightly:
-      return [
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-nightly',
-        },
-      ]
-    case ExternalEditor.VSCode:
-      return [
-        // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1',
-        },
-        // 32-bit version of VSCode (user)
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D628A17A-9713-46BF-8D57-E671B46A741E}_is1',
-        },
-        // 64-bit version of VSCode (system) - was default before user scope installation
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1',
-        },
-        // 32-bit version of VSCode (system)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1',
-        },
-      ]
-    case ExternalEditor.VSCodeInsiders:
-      return [
-        // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1',
-        },
-        // 32-bit version of VSCode (user)
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{26F4A15E-E392-4887-8C09-7BC55712FD5B}_is1',
-        },
-        // 64-bit version of VSCode (system) - was default before user scope installation
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1',
-        },
-        // 32-bit version of VSCode (system)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C26E74D1-022E-4238-8B9D-1E7564A36CC9}_is1',
-        },
-      ]
-    case ExternalEditor.VSCodium:
-      return [
-        // 64-bit version of VSCodium (user)
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{2E1F05D1-C245-4562-81EE-28188DB6FD17}_is1',
-        },
-        // 32-bit version of VSCodium (user)
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C6065F05-9603-4FC4-8101-B9781A25D88E}}_is1',
-        },
-        // 64-bit version of VSCodium (system)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}_is1',
-        },
-        // 32-bit version of VSCodium (system)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{E34003BB-9E10-4501-8C11-BE3FAA83F23F}_is1',
-        },
-      ]
-    case ExternalEditor.SublimeText:
-      return [
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Sublime Text 3_is1',
-        },
-      ]
-    case ExternalEditor.CFBuilder:
-      return [
-        // 64-bit version of ColdFusionBuilder3
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Adobe ColdFusion Builder 3_is1',
-        },
-        // 64-bit version of ColdFusionBuilder2016
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Adobe ColdFusion Builder 2016',
-        },
-      ]
-    case ExternalEditor.Typora:
-      return [
-        // 64-bit version of Typora
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
-        },
-        // 32-bit version of Typora
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
-        },
-      ]
-    case ExternalEditor.SlickEdit:
-      return [
-        // 64-bit version of SlickEdit Pro 2018
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18406187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 32-bit version of SlickEdit Pro 2018
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18006187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Standard 2018
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18606187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 32-bit version of SlickEdit Standard 2018
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18206187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Pro 2017
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15406187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 32-bit version of SlickEdit Pro 2017
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15006187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Pro 2016 (21.0.1)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10C06187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Pro 2016 (21.0.0)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10406187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Pro 2015 (20.0.3)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0DC06187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Pro 2015 (20.0.2)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0D406187-F49E-4822-CAF2-1D25C0C83BA2}',
-        },
-        // 64-bit version of SlickEdit Pro 2014 (19.0.2)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}',
-        },
-      ]
-    case ExternalEditor.Webstorm:
-      return [
-        // Webstorm 2018.3
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2018.3',
-        },
-        // Webstorm 2019.2
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.2',
-        },
-        // Webstorm 2019.2.4
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.2.4',
-        },
-        // Webstorm 2019.3
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.3',
-        },
-        // Webstorm 2020.1
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2020.1',
-        },
-      ]
-    case ExternalEditor.Phpstorm:
-      return [
-        // PhpStorm 2019.2
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.2',
-        },
-        // PhpStorm 2019.2.4
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.2.4',
-        },
-        // PhpStorm 2019.3
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.3',
-        },
-        // PhpStorm 2020.1
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2020.1',
-        },
-      ]
-    case ExternalEditor.NotepadPlusPlus:
-      return [
-        // 64-bit version of Notepad++
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Notepad++',
-        },
-        // 32-bit version of Notepad++
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Notepad++',
-        },
-      ]
-    case ExternalEditor.Rider:
-      return [
-        // Rider 2019.3.4
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\JetBrains Rider 2019.3.4',
-        },
-      ]
-    default:
-      return assertNever(editor, `Unknown external editor: ${editor}`)
-  }
-}
-
-/**
- * Resolve the command-line interface for the editor.
- *
- * @param editor The external editor which is installed
- * @param installLocation The known install location of the editor
- */
-function getExecutableShim(
-  editor: ExternalEditor,
+interface IWindowsAppInformation {
+  displayName: string
+  publisher: string
   installLocation: string
-): string {
-  switch (editor) {
-    case ExternalEditor.Atom:
-      return Path.join(installLocation, 'bin', 'atom.cmd') // remember, CMD must 'useShell'
-    case ExternalEditor.AtomBeta:
-      return Path.join(installLocation, 'bin', 'atom-beta.cmd') // remember, CMD must 'useShell'
-    case ExternalEditor.AtomNightly:
-      return Path.join(installLocation, 'bin', 'atom-nightly.cmd') // remember, CMD must 'useShell'
-    case ExternalEditor.VSCode:
-      return Path.join(installLocation, 'bin', 'code.cmd') // remember, CMD must 'useShell'
-    case ExternalEditor.VSCodeInsiders:
-      return Path.join(installLocation, 'bin', 'code-insiders.cmd') // remember, CMD must 'useShell'
-    case ExternalEditor.VSCodium:
-      return Path.join(installLocation, 'bin', 'codium.cmd') // remember, CMD must 'useShell'
-    case ExternalEditor.SublimeText:
-      return Path.join(installLocation, 'subl.exe')
-    case ExternalEditor.CFBuilder:
-      return Path.join(installLocation, 'CFBuilder.exe')
-    case ExternalEditor.Typora:
-      return Path.join(installLocation, 'typora.exe')
-    case ExternalEditor.SlickEdit:
-      return Path.join(installLocation, 'win', 'vs.exe')
-    case ExternalEditor.Webstorm:
-      return Path.join(installLocation, 'bin', 'webstorm.exe')
-    case ExternalEditor.Phpstorm:
-      return Path.join(installLocation, 'bin', 'phpstorm.exe')
-    case ExternalEditor.NotepadPlusPlus:
-      return Path.join(installLocation)
-    case ExternalEditor.Rider:
-      return Path.join(installLocation, 'bin', 'rider64.exe')
-    default:
-      return assertNever(editor, `Unknown external editor: ${editor}`)
-  }
 }
 
-/**
- * Confirm the found installation matches the expected identifier details
- *
- * @param editor The external editor
- * @param displayName The display name as listed in the registry
- * @param publisher The publisher who created the installer
- */
-function isExpectedInstallation(
-  editor: ExternalEditor,
+type AppInformationExtractor = (
+  keys: ReadonlyArray<RegistryValue>
+) => IWindowsAppInformation
+
+type ExpectedInstallationChecker = (
   displayName: string,
   publisher: string
-): boolean {
-  switch (editor) {
-    case ExternalEditor.Atom:
-      return displayName === 'Atom' && publisher === 'GitHub Inc.'
-    case ExternalEditor.AtomBeta:
-      return displayName === 'Atom Beta' && publisher === 'GitHub Inc.'
-    case ExternalEditor.AtomNightly:
-      return displayName === 'Atom Nightly' && publisher === 'GitHub Inc.'
-    case ExternalEditor.VSCode:
-      return (
-        displayName.startsWith('Microsoft Visual Studio Code') &&
-        publisher === 'Microsoft Corporation'
-      )
-    case ExternalEditor.VSCodeInsiders:
-      return (
-        displayName.startsWith('Microsoft Visual Studio Code Insiders') &&
-        publisher === 'Microsoft Corporation'
-      )
-    case ExternalEditor.VSCodium:
-      return (
-        displayName.startsWith('VSCodium') &&
-        publisher === 'Microsoft Corporation'
-      )
-    case ExternalEditor.SublimeText:
-      return (
-        displayName === 'Sublime Text' && publisher === 'Sublime HQ Pty Ltd'
-      )
-    case ExternalEditor.CFBuilder:
-      return (
-        (displayName === 'Adobe ColdFusion Builder 3' ||
-          displayName === 'Adobe ColdFusion Builder 2016') &&
-        publisher === 'Adobe Systems Incorporated'
-      )
-    case ExternalEditor.Typora:
-      return displayName.startsWith('Typora') && publisher === 'typora.io'
-    case ExternalEditor.SlickEdit:
-      return (
-        displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.'
-      )
-    case ExternalEditor.Webstorm:
-      return (
-        displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.'
-      )
-    case ExternalEditor.Phpstorm:
-      return (
-        displayName.startsWith('PhpStorm') && publisher === 'JetBrains s.r.o.'
-      )
-    case ExternalEditor.NotepadPlusPlus:
-      return (
-        displayName.startsWith('Notepad++') && publisher === 'Notepad++ Team'
-      )
-    case ExternalEditor.Rider:
-      return (
-        displayName.startsWith('JetBrains Rider') &&
-        publisher === 'JetBrains s.r.o.'
-      )
-    default:
-      return assertNever(editor, `Unknown external editor: ${editor}`)
-  }
+) => boolean
+
+interface IWindowsExternalEditor {
+  readonly name: ExternalEditor
+
+  /**
+   * Set of registry keys associated with the installed application.
+   *
+   * Some tools (like VSCode) may support a 64-bit or 32-bit version of the
+   * tool - we should use whichever they have installed.
+   */
+  readonly registryKeys: ReadonlyArray<{ key: HKEY; subKey: string }>
+
+  readonly executableShimPath: ReadonlyArray<string>
+
+  readonly usesShell?: boolean
+
+  /**
+   * Function that maps the registry information to a list of known installer
+   * fields.
+   *
+   * Receives the collection of registry key-value pairs for the app.
+   */
+  readonly appInformationExtractor?: AppInformationExtractor
+
+  /**
+   * Confirm the found installation matches the expected identifier details
+   *
+   * @param editor The external editor
+   * @param displayName The display name as listed in the registry
+   * @param publisher The publisher who created the installer
+   */
+  readonly expectedInstallationChecker: ExpectedInstallationChecker
+}
+
+const editors: IWindowsExternalEditor[] = [
+  {
+    name: ExternalEditor.Atom,
+    registryKeys: [
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey: 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom',
+      },
+    ],
+    executableShimPath: ['bin', 'atom.cmd'], // remember, CMD must 'usesShell'
+    usesShell: true,
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName === 'Atom' && publisher === 'GitHub Inc.',
+  },
+  {
+    name: ExternalEditor.AtomBeta,
+    registryKeys: [
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-beta',
+      },
+    ],
+    executableShimPath: ['bin', 'atom-beta.cmd'], // remember, CMD must 'usesShell'
+    usesShell: true,
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName === 'Atom Beta' && publisher === 'GitHub Inc.',
+  },
+  {
+    name: ExternalEditor.AtomNightly,
+    registryKeys: [
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-nightly',
+      },
+    ],
+    executableShimPath: ['bin', 'atom-nightly.cmd'],
+    usesShell: true,
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName === 'Atom Nightly' && publisher === 'GitHub Inc.',
+  },
+  {
+    name: ExternalEditor.VSCode,
+    registryKeys: [
+      // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1',
+      },
+      // 32-bit version of VSCode (user)
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D628A17A-9713-46BF-8D57-E671B46A741E}_is1',
+      },
+      // 64-bit version of VSCode (system) - was default before user scope installation
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1',
+      },
+      // 32-bit version of VSCode (system)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1',
+      },
+    ],
+    executableShimPath: ['bin', 'code.cmd'],
+    usesShell: true,
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('Microsoft Visual Studio Code') &&
+      publisher === 'Microsoft Corporation',
+  },
+  {
+    name: ExternalEditor.VSCodeInsiders,
+    registryKeys: [
+      // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1',
+      },
+      // 32-bit version of VSCode (user)
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{26F4A15E-E392-4887-8C09-7BC55712FD5B}_is1',
+      },
+      // 64-bit version of VSCode (system) - was default before user scope installation
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1',
+      },
+      // 32-bit version of VSCode (system)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C26E74D1-022E-4238-8B9D-1E7564A36CC9}_is1',
+      },
+    ],
+    executableShimPath: ['bin', 'code-insiders.cmd'],
+    usesShell: true,
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('Microsoft Visual Studio Code Insiders') &&
+      publisher === 'Microsoft Corporation',
+  },
+  {
+    name: ExternalEditor.VSCodium,
+    registryKeys: [
+      // 64-bit version of VSCodium (user)
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{2E1F05D1-C245-4562-81EE-28188DB6FD17}_is1',
+      },
+      // 32-bit version of VSCodium (user)
+      {
+        key: HKEY.HKEY_CURRENT_USER,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C6065F05-9603-4FC4-8101-B9781A25D88E}}_is1',
+      },
+      // 64-bit version of VSCodium (system)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}_is1',
+      },
+      // 32-bit version of VSCodium (system)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{E34003BB-9E10-4501-8C11-BE3FAA83F23F}_is1',
+      },
+    ],
+    executableShimPath: ['bin', 'codium.cmd'],
+    usesShell: true,
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('VSCodium') &&
+      publisher === 'Microsoft Corporation',
+  },
+  {
+    name: ExternalEditor.SublimeText,
+    registryKeys: [
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Sublime Text 3_is1',
+      },
+    ],
+    executableShimPath: ['subl.exe'],
+    appInformationExtractor: keys => {
+      let displayName = ''
+      let publisher = ''
+      let installLocation = ''
+
+      for (const item of keys) {
+        // NOTE:
+        // Sublime Text appends the build number to the DisplayName value, so for
+        // forward-compatibility let's do a simple check for the identifier
+        if (
+          item.name === 'DisplayName' &&
+          item.type === RegistryValueType.REG_SZ &&
+          item.data.startsWith('Sublime Text')
+        ) {
+          displayName = 'Sublime Text'
+        } else if (
+          item.name === 'Publisher' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          publisher = item.data
+        } else if (
+          item.name === 'InstallLocation' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          installLocation = item.data
+        }
+      }
+
+      return { displayName, publisher, installLocation }
+    },
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName === 'Sublime Text' && publisher === 'Sublime HQ Pty Ltd',
+  },
+  {
+    name: ExternalEditor.CFBuilder,
+    registryKeys: [
+      // 64-bit version of ColdFusionBuilder3
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Adobe ColdFusion Builder 3_is1',
+      },
+      // 64-bit version of ColdFusionBuilder2016
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Adobe ColdFusion Builder 2016',
+      },
+    ],
+    executableShimPath: ['CFBuilder.exe'],
+    expectedInstallationChecker: (displayName, publisher) =>
+      (displayName === 'Adobe ColdFusion Builder 3' ||
+        displayName === 'Adobe ColdFusion Builder 2016') &&
+      publisher === 'Adobe Systems Incorporated',
+  },
+  {
+    name: ExternalEditor.Typora,
+    registryKeys: [
+      // 64-bit version of Typora
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
+      },
+      // 32-bit version of Typora
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
+      },
+    ],
+    executableShimPath: ['typora.exe'],
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('Typora') && publisher === 'typora.io',
+  },
+  {
+    name: ExternalEditor.SlickEdit,
+    registryKeys: [
+      // 64-bit version of SlickEdit Pro 2018
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18406187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 32-bit version of SlickEdit Pro 2018
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18006187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Standard 2018
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18606187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 32-bit version of SlickEdit Standard 2018
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18206187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Pro 2017
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15406187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 32-bit version of SlickEdit Pro 2017
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15006187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Pro 2016 (21.0.1)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10C06187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Pro 2016 (21.0.0)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10406187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Pro 2015 (20.0.3)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0DC06187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Pro 2015 (20.0.2)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0D406187-F49E-4822-CAF2-1D25C0C83BA2}',
+      },
+      // 64-bit version of SlickEdit Pro 2014 (19.0.2)
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}',
+      },
+    ],
+    executableShimPath: ['win', 'vs.exe'],
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.',
+  },
+  {
+    name: ExternalEditor.Webstorm,
+    registryKeys: [
+      // Webstorm 2018.3
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2018.3',
+      },
+      // Webstorm 2019.2
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.2',
+      },
+      // Webstorm 2019.2.4
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.2.4',
+      },
+      // Webstorm 2019.3
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.3',
+      },
+      // Webstorm 2020.1
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2020.1',
+      },
+    ],
+    executableShimPath: ['bin', 'webstorm.exe'],
+    appInformationExtractor: keys => {
+      let displayName = ''
+      let publisher = ''
+      let installLocation = ''
+
+      for (const item of keys) {
+        // NOTE:
+        // Webstorm adds the current release number to the end of the Display Name, below checks for "WebStorm"
+        if (
+          item.name === 'DisplayName' &&
+          item.type === RegistryValueType.REG_SZ &&
+          item.data.startsWith('WebStorm ')
+        ) {
+          displayName = 'WebStorm'
+        } else if (
+          item.name === 'Publisher' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          publisher = item.data
+        } else if (
+          item.name === 'InstallLocation' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          installLocation = item.data
+        }
+      }
+
+      return { displayName, publisher, installLocation }
+    },
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.',
+  },
+  {
+    name: ExternalEditor.Phpstorm,
+    registryKeys: [
+      // PhpStorm 2019.2
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.2',
+      },
+      // PhpStorm 2019.2.4
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.2.4',
+      },
+      // PhpStorm 2019.3
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.3',
+      },
+      // PhpStorm 2020.1
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2020.1',
+      },
+    ],
+    executableShimPath: ['bin', 'phpstorm.exe'],
+    appInformationExtractor: keys => {
+      let displayName = ''
+      let publisher = ''
+      let installLocation = ''
+
+      for (const item of keys) {
+        // NOTE:
+        // Webstorm adds the current release number to the end of the Display Name, below checks for "PhpStorm"
+        if (
+          item.name === 'DisplayName' &&
+          item.type === RegistryValueType.REG_SZ &&
+          item.data.startsWith('PhpStorm ')
+        ) {
+          displayName = 'PhpStorm'
+        } else if (
+          item.name === 'Publisher' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          publisher = item.data
+        } else if (
+          item.name === 'InstallLocation' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          installLocation = item.data
+        }
+      }
+
+      return { displayName, publisher, installLocation }
+    },
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('PhpStorm') && publisher === 'JetBrains s.r.o.',
+  },
+  {
+    name: ExternalEditor.NotepadPlusPlus,
+    registryKeys: [
+      // 64-bit version of Notepad++
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Notepad++',
+      },
+      // 32-bit version of Notepad++
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Notepad++',
+      },
+    ],
+    executableShimPath: [],
+    appInformationExtractor: keys => {
+      const displayName = getKeyOrEmpty(keys, 'DisplayName')
+      const publisher = getKeyOrEmpty(keys, 'Publisher')
+      const installLocation = getKeyOrEmpty(keys, 'DisplayIcon')
+
+      return { displayName, publisher, installLocation }
+    },
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('Notepad++') && publisher === 'Notepad++ Team',
+  },
+  {
+    name: ExternalEditor.Rider,
+    registryKeys: [
+      // Rider 2019.3.4
+      {
+        key: HKEY.HKEY_LOCAL_MACHINE,
+        subKey:
+          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\JetBrains Rider 2019.3.4',
+      },
+    ],
+    executableShimPath: ['bin', 'rider64.exe'],
+    appInformationExtractor: keys => {
+      let displayName = ''
+      let publisher = ''
+      let installLocation = ''
+
+      for (const item of keys) {
+        // NOTE:
+        // JetBrains Rider adds the current release number to the end of the Display Name, below checks for "JetBrains Rider"
+        if (
+          item.name === 'DisplayName' &&
+          item.type === RegistryValueType.REG_SZ &&
+          item.data.startsWith('JetBrains Rider ')
+        ) {
+          displayName = 'JetBrains Rider'
+        } else if (
+          item.name === 'Publisher' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          publisher = item.data
+        } else if (
+          item.name === 'InstallLocation' &&
+          item.type === RegistryValueType.REG_SZ
+        ) {
+          installLocation = item.data
+        }
+      }
+
+      return { displayName, publisher, installLocation }
+    },
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('JetBrains Rider') &&
+      publisher === 'JetBrains s.r.o.',
+  },
+]
+
+export function parse(label: string): ExternalEditor | null {
+  return parseEnumValue(ExternalEditor, label) ?? null
 }
 
 function getKeyOrEmpty(
@@ -471,202 +593,18 @@ function getKeyOrEmpty(
   return entry && entry.type === RegistryValueType.REG_SZ ? entry.data : ''
 }
 
-/**
- * Map the registry information to a list of known installer fields.
- *
- * @param editor The external editor being resolved
- * @param keys The collection of registry key-value pairs
- */
-function extractApplicationInformation(
-  editor: ExternalEditor,
-  keys: ReadonlyArray<RegistryValue>
-): { displayName: string; publisher: string; installLocation: string } {
-  if (
-    editor === ExternalEditor.Atom ||
-    editor === ExternalEditor.AtomBeta ||
-    editor === ExternalEditor.AtomNightly
-  ) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  if (
-    editor === ExternalEditor.VSCode ||
-    editor === ExternalEditor.VSCodeInsiders
-  ) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.VSCodium) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.SublimeText) {
-    let displayName = ''
-    let publisher = ''
-    let installLocation = ''
-
-    for (const item of keys) {
-      // NOTE:
-      // Sublime Text appends the build number to the DisplayName value, so for
-      // forward-compatibility let's do a simple check for the identifier
-      if (
-        item.name === 'DisplayName' &&
-        item.type === RegistryValueType.REG_SZ &&
-        item.data.startsWith('Sublime Text')
-      ) {
-        displayName = 'Sublime Text'
-      } else if (
-        item.name === 'Publisher' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        publisher = item.data
-      } else if (
-        item.name === 'InstallLocation' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        installLocation = item.data
-      }
-    }
-
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.CFBuilder) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.Typora) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.SlickEdit) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.Webstorm) {
-    let displayName = ''
-    let publisher = ''
-    let installLocation = ''
-
-    for (const item of keys) {
-      // NOTE:
-      // Webstorm adds the current release number to the end of the Display Name, below checks for "WebStorm"
-      if (
-        item.name === 'DisplayName' &&
-        item.type === RegistryValueType.REG_SZ &&
-        item.data.startsWith('WebStorm ')
-      ) {
-        displayName = 'WebStorm'
-      } else if (
-        item.name === 'Publisher' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        publisher = item.data
-      } else if (
-        item.name === 'InstallLocation' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        installLocation = item.data
-      }
-    }
-
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.Phpstorm) {
-    let displayName = ''
-    let publisher = ''
-    let installLocation = ''
-
-    for (const item of keys) {
-      // NOTE:
-      // Webstorm adds the current release number to the end of the Display Name, below checks for "PhpStorm"
-      if (
-        item.name === 'DisplayName' &&
-        item.type === RegistryValueType.REG_SZ &&
-        item.data.startsWith('PhpStorm ')
-      ) {
-        displayName = 'PhpStorm'
-      } else if (
-        item.name === 'Publisher' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        publisher = item.data
-      } else if (
-        item.name === 'InstallLocation' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        installLocation = item.data
-      }
-    }
-
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.NotepadPlusPlus) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'DisplayIcon')
-
-    return { displayName, publisher, installLocation }
-  }
-
-  if (editor === ExternalEditor.Rider) {
-    let displayName = ''
-    let publisher = ''
-    let installLocation = ''
-
-    for (const item of keys) {
-      // NOTE:
-      // JetBrains Rider adds the current release number to the end of the Display Name, below checks for "JetBrains Rider"
-      if (
-        item.name === 'DisplayName' &&
-        item.type === RegistryValueType.REG_SZ &&
-        item.data.startsWith('JetBrains Rider ')
-      ) {
-        displayName = 'JetBrains Rider'
-      } else if (
-        item.name === 'Publisher' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        publisher = item.data
-      } else if (
-        item.name === 'InstallLocation' &&
-        item.type === RegistryValueType.REG_SZ
-      ) {
-        installLocation = item.data
-      }
-    }
-
-    return { displayName, publisher, installLocation }
-  }
-
-  return assertNever(editor, `Unknown external editor: ${editor}`)
+const defaultAppInformationExtractor: AppInformationExtractor = keys => {
+  const displayName = getKeyOrEmpty(keys, 'DisplayName')
+  const publisher = getKeyOrEmpty(keys, 'Publisher')
+  const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
+  return { displayName, publisher, installLocation }
 }
 
-async function findApplication(editor: ExternalEditor): Promise<string | null> {
-  const registryKeys = getRegistryKeys(editor)
-
+async function findApplication(
+  editor: IWindowsExternalEditor
+): Promise<string | null> {
   let keys: ReadonlyArray<RegistryValue> = []
-  for (const { key, subKey } of registryKeys) {
+  for (const { key, subKey } of editor.registryKeys) {
     keys = enumerateValues(key, subKey)
     if (keys.length > 0) {
       break
@@ -677,23 +615,26 @@ async function findApplication(editor: ExternalEditor): Promise<string | null> {
     return null
   }
 
-  const {
-    displayName,
-    publisher,
-    installLocation,
-  } = extractApplicationInformation(editor, keys)
+  const appInformationExtractor =
+    editor.appInformationExtractor ?? defaultAppInformationExtractor
 
-  if (!isExpectedInstallation(editor, displayName, publisher)) {
+  const { displayName, publisher, installLocation } = appInformationExtractor(
+    keys
+  )
+
+  if (!editor.expectedInstallationChecker(displayName, publisher)) {
     log.debug(
-      `Registry entry for ${editor} did not match expected publisher settings`
+      `Registry entry for ${editor.name} did not match expected publisher settings`
     )
     return null
   }
 
-  const path = getExecutableShim(editor, installLocation)
+  const path = Path.join(installLocation, ...editor.executableShimPath)
   const exists = await pathExists(path)
   if (!exists) {
-    log.debug(`Command line interface for ${editor} not found at '${path}'`)
+    log.debug(
+      `Command line interface for ${editor.name} not found at '${path}'`
+    )
     return null
   }
 
@@ -709,143 +650,24 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<ExternalEditor>> = []
 
-  const [
-    atomPath,
-    atomBetaPath,
-    atomNightlyPath,
-    codePath,
-    codeInsidersPath,
-    codiumPath,
-    sublimePath,
-    cfBuilderPath,
-    typoraPath,
-    slickeditPath,
-    webstormPath,
-    phpstormPath,
-    notepadPlusPlusPath,
-    riderPath,
-  ] = await Promise.all([
-    findApplication(ExternalEditor.Atom),
-    findApplication(ExternalEditor.AtomBeta),
-    findApplication(ExternalEditor.AtomNightly),
-    findApplication(ExternalEditor.VSCode),
-    findApplication(ExternalEditor.VSCodeInsiders),
-    findApplication(ExternalEditor.VSCodium),
-    findApplication(ExternalEditor.SublimeText),
-    findApplication(ExternalEditor.CFBuilder),
-    findApplication(ExternalEditor.Typora),
-    findApplication(ExternalEditor.SlickEdit),
-    findApplication(ExternalEditor.Webstorm),
-    findApplication(ExternalEditor.Phpstorm),
-    findApplication(ExternalEditor.NotepadPlusPlus),
-    findApplication(ExternalEditor.Rider),
-  ])
+  const editorPaths = await Promise.all(
+    editors.map(editor =>
+      findApplication(editor).then(path => {
+        return { editor, path }
+      })
+    )
+  )
 
-  if (atomPath) {
-    results.push({
-      editor: ExternalEditor.Atom,
-      path: atomPath,
-      usesShell: true,
-    })
-  }
+  for (const editorPath of editorPaths) {
+    const { editor, path } = editorPath
 
-  if (atomBetaPath) {
-    results.push({
-      editor: ExternalEditor.AtomBeta,
-      path: atomBetaPath,
-      usesShell: true,
-    })
-  }
-
-  if (atomNightlyPath) {
-    results.push({
-      editor: ExternalEditor.AtomNightly,
-      path: atomNightlyPath,
-      usesShell: true,
-    })
-  }
-
-  if (codePath) {
-    results.push({
-      editor: ExternalEditor.VSCode,
-      path: codePath,
-      usesShell: true,
-    })
-  }
-
-  if (codeInsidersPath) {
-    results.push({
-      editor: ExternalEditor.VSCodeInsiders,
-      path: codeInsidersPath,
-      usesShell: true,
-    })
-  }
-
-  if (codiumPath) {
-    results.push({
-      editor: ExternalEditor.VSCodium,
-      path: codiumPath,
-      usesShell: true,
-    })
-  }
-
-  if (sublimePath) {
-    results.push({
-      editor: ExternalEditor.SublimeText,
-      path: sublimePath,
-      usesShell: false,
-    })
-  }
-
-  if (cfBuilderPath) {
-    results.push({
-      editor: ExternalEditor.CFBuilder,
-      path: cfBuilderPath,
-      usesShell: false,
-    })
-  }
-
-  if (typoraPath) {
-    results.push({
-      editor: ExternalEditor.Typora,
-      path: typoraPath,
-      usesShell: false,
-    })
-  }
-
-  if (slickeditPath) {
-    results.push({
-      editor: ExternalEditor.SlickEdit,
-      path: slickeditPath,
-    })
-  }
-
-  if (webstormPath) {
-    results.push({
-      editor: ExternalEditor.Webstorm,
-      path: webstormPath,
-    })
-  }
-
-  if (phpstormPath) {
-    results.push({
-      editor: ExternalEditor.Phpstorm,
-      path: phpstormPath,
-    })
-  }
-
-  if (notepadPlusPlusPath) {
-    results.push({
-      editor: ExternalEditor.NotepadPlusPlus,
-      path: notepadPlusPlusPath,
-    })
-  }
-
-  if (riderPath) {
-    results.push({
-      editor: ExternalEditor.Rider,
-      path: riderPath,
-    })
+    if (path) {
+      results.push({
+        editor: editor.name,
+        path: path,
+        usesShell: editor.usesShell ?? false,
+      })
+    }
   }
 
   return results

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -9,6 +9,7 @@ import {
 
 import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
+
 interface IWindowsAppInformation {
   displayName: string
   publisher: string
@@ -24,7 +25,9 @@ type ExpectedInstallationChecker = (
   publisher: string
 ) => boolean
 
+/** Represents an external editor on Windows */
 interface IWindowsExternalEditor {
+  /** Name of the editor. It will be used both as identifier and user-facing. */
   readonly name: string
 
   /**
@@ -35,28 +38,40 @@ interface IWindowsExternalEditor {
    */
   readonly registryKeys: ReadonlyArray<{ key: HKEY; subKey: string }>
 
+  /**
+   * List of path components from the editor's instalation folder to the
+   * executable shim.
+   **/
   readonly executableShimPath: ReadonlyArray<string>
 
+  /**
+   * Whether the or not the provided executable for the editor needs to be run
+   * inside of a shell.
+   */
   readonly usesShell?: boolean
 
   /**
    * Function that maps the registry information to a list of known installer
-   * fields.
+   * fields (display name, publisher and installation path).
    *
    * Receives the collection of registry key-value pairs for the app.
    */
   readonly appInformationExtractor?: AppInformationExtractor
 
   /**
-   * Confirm the found installation matches the expected identifier details
+   * Function to check if the found installation matches the expected identifier
+   * details.
    *
-   * @param editor The external editor
    * @param displayName The display name as listed in the registry
    * @param publisher The publisher who created the installer
    */
   readonly expectedInstallationChecker: ExpectedInstallationChecker
 }
 
+/**
+ * This list contains all the external editors supported on Windows. Add a new
+ * entry here to add support for your favorite editor.
+ **/
 const editors: IWindowsExternalEditor[] = [
   {
     name: 'Atom',

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -56,6 +56,26 @@ interface IWindowsExternalEditor {
   readonly expectedInstallationChecker: ExpectedInstallationChecker
 }
 
+const registryKey = (key: HKEY, ...subKeys: string[]) => ({
+  key,
+  subKey: Path.win32.join(...subKeys),
+})
+
+const uninstallSubKey =
+  'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
+
+const wow64UninstallSubKey =
+  'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
+
+const CurrentUserUninstallKey = (subKey: string) =>
+  registryKey(HKEY.HKEY_CURRENT_USER, uninstallSubKey, subKey)
+
+const LocalMachineUninstallKey = (subKey: string) =>
+  registryKey(HKEY.HKEY_LOCAL_MACHINE, uninstallSubKey, subKey)
+
+const Wow64LocalMachineUninstallKey = (subKey: string) =>
+  registryKey(HKEY.HKEY_LOCAL_MACHINE, wow64UninstallSubKey, subKey)
+
 /**
  * This list contains all the external editors supported on Windows. Add a new
  * entry here to add support for your favorite editor.
@@ -63,38 +83,21 @@ interface IWindowsExternalEditor {
 const editors: IWindowsExternalEditor[] = [
   {
     name: 'Atom',
-    registryKeys: [
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey: 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom',
-      },
-    ],
+    registryKeys: [CurrentUserUninstallKey('atom')],
     executableShimPath: ['bin', 'atom.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'Atom' && publisher === 'GitHub Inc.',
   },
   {
     name: 'Atom Beta',
-    registryKeys: [
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-beta',
-      },
-    ],
+    registryKeys: [CurrentUserUninstallKey('atom-beta')],
     executableShimPath: ['bin', 'atom-beta.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'Atom Beta' && publisher === 'GitHub Inc.',
   },
   {
     name: 'Atom Nightly',
-    registryKeys: [
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-nightly',
-      },
-    ],
+    registryKeys: [CurrentUserUninstallKey('atom-nightly')],
     executableShimPath: ['bin', 'atom-nightly.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'Atom Nightly' && publisher === 'GitHub Inc.',
@@ -103,29 +106,15 @@ const editors: IWindowsExternalEditor[] = [
     name: 'Visual Studio Code',
     registryKeys: [
       // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1',
-      },
+      CurrentUserUninstallKey('{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1'),
       // 32-bit version of VSCode (user)
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D628A17A-9713-46BF-8D57-E671B46A741E}_is1',
-      },
+      CurrentUserUninstallKey('{D628A17A-9713-46BF-8D57-E671B46A741E}_is1'),
       // 64-bit version of VSCode (system) - was default before user scope installation
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1',
-      },
+      LocalMachineUninstallKey('{EA457B21-F73E-494C-ACAB-524FDE069978}_is1'),
       // 32-bit version of VSCode (system)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1',
-      },
+      Wow64LocalMachineUninstallKey(
+        '{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1'
+      ),
     ],
     executableShimPath: ['bin', 'code.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -136,29 +125,15 @@ const editors: IWindowsExternalEditor[] = [
     name: 'Visual Studio Code (Insiders)',
     registryKeys: [
       // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1',
-      },
+      CurrentUserUninstallKey('{217B4C08-948D-4276-BFBB-BEE930AE5A2C}_is1'),
       // 32-bit version of VSCode (user)
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{26F4A15E-E392-4887-8C09-7BC55712FD5B}_is1',
-      },
+      CurrentUserUninstallKey('{26F4A15E-E392-4887-8C09-7BC55712FD5B}_is1'),
       // 64-bit version of VSCode (system) - was default before user scope installation
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1',
-      },
+      LocalMachineUninstallKey('{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1'),
       // 32-bit version of VSCode (system)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C26E74D1-022E-4238-8B9D-1E7564A36CC9}_is1',
-      },
+      Wow64LocalMachineUninstallKey(
+        '{C26E74D1-022E-4238-8B9D-1E7564A36CC9}_is1'
+      ),
     ],
     executableShimPath: ['bin', 'code-insiders.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -169,29 +144,15 @@ const editors: IWindowsExternalEditor[] = [
     name: 'Visual Studio Codium',
     registryKeys: [
       // 64-bit version of VSCodium (user)
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{2E1F05D1-C245-4562-81EE-28188DB6FD17}_is1',
-      },
+      CurrentUserUninstallKey('{2E1F05D1-C245-4562-81EE-28188DB6FD17}_is1'),
       // 32-bit version of VSCodium (user)
-      {
-        key: HKEY.HKEY_CURRENT_USER,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C6065F05-9603-4FC4-8101-B9781A25D88E}}_is1',
-      },
+      CurrentUserUninstallKey('{C6065F05-9603-4FC4-8101-B9781A25D88E}}_is1'),
       // 64-bit version of VSCodium (system)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}_is1',
-      },
+      LocalMachineUninstallKey('{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}_is1'),
       // 32-bit version of VSCodium (system)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{E34003BB-9E10-4501-8C11-BE3FAA83F23F}_is1',
-      },
+      Wow64LocalMachineUninstallKey(
+        '{E34003BB-9E10-4501-8C11-BE3FAA83F23F}_is1'
+      ),
     ],
     executableShimPath: ['bin', 'codium.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -200,13 +161,7 @@ const editors: IWindowsExternalEditor[] = [
   },
   {
     name: 'Sublime Text',
-    registryKeys: [
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Sublime Text 3_is1',
-      },
-    ],
+    registryKeys: [LocalMachineUninstallKey('Sublime Text 3_is1')],
     executableShimPath: ['subl.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Sublime Text') &&
@@ -216,17 +171,9 @@ const editors: IWindowsExternalEditor[] = [
     name: 'ColdFusion Builder',
     registryKeys: [
       // 64-bit version of ColdFusionBuilder3
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Adobe ColdFusion Builder 3_is1',
-      },
+      LocalMachineUninstallKey('Adobe ColdFusion Builder 3_is1'),
       // 64-bit version of ColdFusionBuilder2016
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Adobe ColdFusion Builder 2016',
-      },
+      LocalMachineUninstallKey('Adobe ColdFusion Builder 2016'),
     ],
     executableShimPath: ['CFBuilder.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -238,17 +185,11 @@ const editors: IWindowsExternalEditor[] = [
     name: 'Typora',
     registryKeys: [
       // 64-bit version of Typora
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
-      },
+      LocalMachineUninstallKey('{37771A20-7167-44C0-B322-FD3E54C56156}_is1'),
       // 32-bit version of Typora
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{37771A20-7167-44C0-B322-FD3E54C56156}_is1',
-      },
+      Wow64LocalMachineUninstallKey(
+        '{37771A20-7167-44C0-B322-FD3E54C56156}_is1'
+      ),
     ],
     executableShimPath: ['typora.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -258,71 +199,27 @@ const editors: IWindowsExternalEditor[] = [
     name: 'SlickEdit',
     registryKeys: [
       // 64-bit version of SlickEdit Pro 2018
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18406187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{18406187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 32-bit version of SlickEdit Pro 2018
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18006187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      Wow64LocalMachineUninstallKey('{18006187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Standard 2018
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18606187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{18606187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 32-bit version of SlickEdit Standard 2018
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{18206187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      Wow64LocalMachineUninstallKey('{18206187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Pro 2017
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15406187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{15406187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 32-bit version of SlickEdit Pro 2017
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{15006187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      Wow64LocalMachineUninstallKey('{15006187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Pro 2016 (21.0.1)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10C06187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{10C06187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Pro 2016 (21.0.0)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{10406187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{10406187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Pro 2015 (20.0.3)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0DC06187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{0DC06187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Pro 2015 (20.0.2)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0D406187-F49E-4822-CAF2-1D25C0C83BA2}',
-      },
+      LocalMachineUninstallKey('{0D406187-F49E-4822-CAF2-1D25C0C83BA2}'),
       // 64-bit version of SlickEdit Pro 2014 (19.0.2)
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}',
-      },
+      LocalMachineUninstallKey('{7CC0E567-ACD6-41E8-95DA-154CEEDB0A18}'),
     ],
     executableShimPath: ['win', 'vs.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -332,35 +229,15 @@ const editors: IWindowsExternalEditor[] = [
     name: 'JetBrains Webstorm',
     registryKeys: [
       // Webstorm 2018.3
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2018.3',
-      },
+      Wow64LocalMachineUninstallKey('WebStorm 2018.3'),
       // Webstorm 2019.2
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.2',
-      },
+      Wow64LocalMachineUninstallKey('WebStorm 2019.2'),
       // Webstorm 2019.2.4
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.2.4',
-      },
+      Wow64LocalMachineUninstallKey('WebStorm 2019.2.4'),
       // Webstorm 2019.3
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2019.3',
-      },
+      Wow64LocalMachineUninstallKey('WebStorm 2019.3'),
       // Webstorm 2020.1
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\WebStorm 2020.1',
-      },
+      Wow64LocalMachineUninstallKey('WebStorm 2020.1'),
     ],
     executableShimPath: ['bin', 'webstorm.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -370,29 +247,13 @@ const editors: IWindowsExternalEditor[] = [
     name: 'JetBrains Phpstorm',
     registryKeys: [
       // PhpStorm 2019.2
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.2',
-      },
+      Wow64LocalMachineUninstallKey('PhpStorm 2019.2'),
       // PhpStorm 2019.2.4
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.2.4',
-      },
+      Wow64LocalMachineUninstallKey('PhpStorm 2019.2.4'),
       // PhpStorm 2019.3
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2019.3',
-      },
+      Wow64LocalMachineUninstallKey('PhpStorm 2019.3'),
       // PhpStorm 2020.1
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PhpStorm 2020.1',
-      },
+      Wow64LocalMachineUninstallKey('PhpStorm 2020.1'),
     ],
     executableShimPath: ['bin', 'phpstorm.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
@@ -402,17 +263,9 @@ const editors: IWindowsExternalEditor[] = [
     name: 'Notepad++',
     registryKeys: [
       // 64-bit version of Notepad++
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Notepad++',
-      },
+      LocalMachineUninstallKey('Notepad++'),
       // 32-bit version of Notepad++
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Notepad++',
-      },
+      Wow64LocalMachineUninstallKey('Notepad++'),
     ],
     executableShimPath: [],
     installLocationRegistryKey: 'DisplayIcon',
@@ -423,11 +276,7 @@ const editors: IWindowsExternalEditor[] = [
     name: 'JetBrains Rider',
     registryKeys: [
       // Rider 2019.3.4
-      {
-        key: HKEY.HKEY_LOCAL_MACHINE,
-        subKey:
-          'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\JetBrains Rider 2019.3.4',
-      },
+      Wow64LocalMachineUninstallKey('JetBrains Rider 2019.3.4'),
     ],
     executableShimPath: ['bin', 'rider64.exe'],
     expectedInstallationChecker: (displayName, publisher) =>

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -177,8 +177,7 @@ const editors: IWindowsExternalEditor[] = [
     ],
     executableShimPath: ['CFBuilder.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
-      (displayName === 'Adobe ColdFusion Builder 3' ||
-        displayName === 'Adobe ColdFusion Builder 2016') &&
+      displayName.startsWith('Adobe ColdFusion Builder') &&
       publisher === 'Adobe Systems Incorporated',
   },
   {
@@ -316,7 +315,7 @@ async function findApplication(editor: IWindowsExternalEditor) {
     const { displayName, publisher, installLocation } = getAppInfo(editor, keys)
 
     if (!editor.expectedInstallationChecker(displayName, publisher)) {
-      log.debug(`Unexpectted registry entries for ${editor.name}`)
+      log.debug(`Unexpected registry entries for ${editor.name}`)
       continue
     }
 

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -9,26 +9,6 @@ import {
 
 import { pathExists } from 'fs-extra'
 import { IFoundEditor } from './found-editor'
-
-import { parseEnumValue } from '../enum'
-
-export enum ExternalEditor {
-  Atom = 'Atom',
-  AtomBeta = 'Atom Beta',
-  AtomNightly = 'Atom Nightly',
-  VSCode = 'Visual Studio Code',
-  VSCodeInsiders = 'Visual Studio Code (Insiders)',
-  VSCodium = 'Visual Studio Codium',
-  SublimeText = 'Sublime Text',
-  CFBuilder = 'ColdFusion Builder',
-  Typora = 'Typora',
-  SlickEdit = 'SlickEdit',
-  Webstorm = 'JetBrains Webstorm',
-  Phpstorm = 'JetBrains Phpstorm',
-  NotepadPlusPlus = 'Notepad++',
-  Rider = 'JetBrains Rider',
-}
-
 interface IWindowsAppInformation {
   displayName: string
   publisher: string
@@ -45,7 +25,7 @@ type ExpectedInstallationChecker = (
 ) => boolean
 
 interface IWindowsExternalEditor {
-  readonly name: ExternalEditor
+  readonly name: string
 
   /**
    * Set of registry keys associated with the installed application.
@@ -79,7 +59,7 @@ interface IWindowsExternalEditor {
 
 const editors: IWindowsExternalEditor[] = [
   {
-    name: ExternalEditor.Atom,
+    name: 'Atom',
     registryKeys: [
       {
         key: HKEY.HKEY_CURRENT_USER,
@@ -92,7 +72,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName === 'Atom' && publisher === 'GitHub Inc.',
   },
   {
-    name: ExternalEditor.AtomBeta,
+    name: 'Atom Beta',
     registryKeys: [
       {
         key: HKEY.HKEY_CURRENT_USER,
@@ -106,7 +86,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName === 'Atom Beta' && publisher === 'GitHub Inc.',
   },
   {
-    name: ExternalEditor.AtomNightly,
+    name: 'Atom Nightly',
     registryKeys: [
       {
         key: HKEY.HKEY_CURRENT_USER,
@@ -120,7 +100,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName === 'Atom Nightly' && publisher === 'GitHub Inc.',
   },
   {
-    name: ExternalEditor.VSCode,
+    name: 'Visual Studio Code',
     registryKeys: [
       // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
       {
@@ -154,7 +134,7 @@ const editors: IWindowsExternalEditor[] = [
       publisher === 'Microsoft Corporation',
   },
   {
-    name: ExternalEditor.VSCodeInsiders,
+    name: 'Visual Studio Code (Insiders)',
     registryKeys: [
       // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
       {
@@ -188,7 +168,7 @@ const editors: IWindowsExternalEditor[] = [
       publisher === 'Microsoft Corporation',
   },
   {
-    name: ExternalEditor.VSCodium,
+    name: 'Visual Studio Codium',
     registryKeys: [
       // 64-bit version of VSCodium (user)
       {
@@ -222,7 +202,7 @@ const editors: IWindowsExternalEditor[] = [
       publisher === 'Microsoft Corporation',
   },
   {
-    name: ExternalEditor.SublimeText,
+    name: 'Sublime Text',
     registryKeys: [
       {
         key: HKEY.HKEY_LOCAL_MACHINE,
@@ -265,7 +245,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName === 'Sublime Text' && publisher === 'Sublime HQ Pty Ltd',
   },
   {
-    name: ExternalEditor.CFBuilder,
+    name: 'ColdFusion Builder',
     registryKeys: [
       // 64-bit version of ColdFusionBuilder3
       {
@@ -287,7 +267,7 @@ const editors: IWindowsExternalEditor[] = [
       publisher === 'Adobe Systems Incorporated',
   },
   {
-    name: ExternalEditor.Typora,
+    name: 'Typora',
     registryKeys: [
       // 64-bit version of Typora
       {
@@ -307,7 +287,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName.startsWith('Typora') && publisher === 'typora.io',
   },
   {
-    name: ExternalEditor.SlickEdit,
+    name: 'SlickEdit',
     registryKeys: [
       // 64-bit version of SlickEdit Pro 2018
       {
@@ -381,7 +361,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName.startsWith('SlickEdit') && publisher === 'SlickEdit Inc.',
   },
   {
-    name: ExternalEditor.Webstorm,
+    name: 'JetBrains Webstorm',
     registryKeys: [
       // Webstorm 2018.3
       {
@@ -448,7 +428,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.',
   },
   {
-    name: ExternalEditor.Phpstorm,
+    name: 'JetBrains Phpstorm',
     registryKeys: [
       // PhpStorm 2019.2
       {
@@ -509,7 +489,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName.startsWith('PhpStorm') && publisher === 'JetBrains s.r.o.',
   },
   {
-    name: ExternalEditor.NotepadPlusPlus,
+    name: 'Notepad++',
     registryKeys: [
       // 64-bit version of Notepad++
       {
@@ -536,7 +516,7 @@ const editors: IWindowsExternalEditor[] = [
       displayName.startsWith('Notepad++') && publisher === 'Notepad++ Team',
   },
   {
-    name: ExternalEditor.Rider,
+    name: 'JetBrains Rider',
     registryKeys: [
       // Rider 2019.3.4
       {
@@ -580,10 +560,6 @@ const editors: IWindowsExternalEditor[] = [
       publisher === 'JetBrains s.r.o.',
   },
 ]
-
-export function parse(label: string): ExternalEditor | null {
-  return parseEnumValue(ExternalEditor, label) ?? null
-}
 
 function getKeyOrEmpty(
   keys: ReadonlyArray<RegistryValue>,
@@ -646,9 +622,9 @@ async function findApplication(
  * applications and their location on disk for Desktop to launch.
  */
 export async function getAvailableEditors(): Promise<
-  ReadonlyArray<IFoundEditor<ExternalEditor>>
+  ReadonlyArray<IFoundEditor<string>>
 > {
-  const results: Array<IFoundEditor<ExternalEditor>> = []
+  const results: Array<IFoundEditor<string>> = []
 
   const editorPaths = await Promise.all(
     editors.map(editor =>

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -45,12 +45,6 @@ interface IWindowsExternalEditor {
   readonly executableShimPath: ReadonlyArray<string>
 
   /**
-   * Whether the or not the provided executable for the editor needs to be run
-   * inside of a shell.
-   */
-  readonly usesShell?: boolean
-
-  /**
    * Function that maps the registry information to a list of known installer
    * fields (display name, publisher and installation path).
    *
@@ -84,8 +78,7 @@ const editors: IWindowsExternalEditor[] = [
         subKey: 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom',
       },
     ],
-    executableShimPath: ['bin', 'atom.cmd'], // remember, CMD must 'usesShell'
-    usesShell: true,
+    executableShimPath: ['bin', 'atom.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'Atom' && publisher === 'GitHub Inc.',
   },
@@ -98,8 +91,7 @@ const editors: IWindowsExternalEditor[] = [
           'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\atom-beta',
       },
     ],
-    executableShimPath: ['bin', 'atom-beta.cmd'], // remember, CMD must 'usesShell'
-    usesShell: true,
+    executableShimPath: ['bin', 'atom-beta.cmd'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'Atom Beta' && publisher === 'GitHub Inc.',
   },
@@ -113,7 +105,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'atom-nightly.cmd'],
-    usesShell: true,
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'Atom Nightly' && publisher === 'GitHub Inc.',
   },
@@ -146,7 +137,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'code.cmd'],
-    usesShell: true,
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Microsoft Visual Studio Code') &&
       publisher === 'Microsoft Corporation',
@@ -180,7 +170,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'code-insiders.cmd'],
-    usesShell: true,
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Microsoft Visual Studio Code Insiders') &&
       publisher === 'Microsoft Corporation',
@@ -214,7 +203,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'codium.cmd'],
-    usesShell: true,
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('VSCodium') &&
       publisher === 'Microsoft Corporation',
@@ -229,38 +217,9 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['subl.exe'],
-    getAppInfo: keys => {
-      let displayName = ''
-      let publisher = ''
-      let installLocation = ''
-
-      for (const item of keys) {
-        // NOTE:
-        // Sublime Text appends the build number to the DisplayName value, so for
-        // forward-compatibility let's do a simple check for the identifier
-        if (
-          item.name === 'DisplayName' &&
-          item.type === RegistryValueType.REG_SZ &&
-          item.data.startsWith('Sublime Text')
-        ) {
-          displayName = 'Sublime Text'
-        } else if (
-          item.name === 'Publisher' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          publisher = item.data
-        } else if (
-          item.name === 'InstallLocation' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          installLocation = item.data
-        }
-      }
-
-      return { displayName, publisher, installLocation }
-    },
     expectedInstallationChecker: (displayName, publisher) =>
-      displayName === 'Sublime Text' && publisher === 'Sublime HQ Pty Ltd',
+      displayName.startsWith('Sublime Text') &&
+      publisher === 'Sublime HQ Pty Ltd',
   },
   {
     name: 'ColdFusion Builder',
@@ -413,35 +372,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'webstorm.exe'],
-    getAppInfo: keys => {
-      let displayName = ''
-      let publisher = ''
-      let installLocation = ''
-
-      for (const item of keys) {
-        // NOTE:
-        // Webstorm adds the current release number to the end of the Display Name, below checks for "WebStorm"
-        if (
-          item.name === 'DisplayName' &&
-          item.type === RegistryValueType.REG_SZ &&
-          item.data.startsWith('WebStorm ')
-        ) {
-          displayName = 'WebStorm'
-        } else if (
-          item.name === 'Publisher' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          publisher = item.data
-        } else if (
-          item.name === 'InstallLocation' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          installLocation = item.data
-        }
-      }
-
-      return { displayName, publisher, installLocation }
-    },
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('WebStorm') && publisher === 'JetBrains s.r.o.',
   },
@@ -474,35 +404,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'phpstorm.exe'],
-    getAppInfo: keys => {
-      let displayName = ''
-      let publisher = ''
-      let installLocation = ''
-
-      for (const item of keys) {
-        // NOTE:
-        // Webstorm adds the current release number to the end of the Display Name, below checks for "PhpStorm"
-        if (
-          item.name === 'DisplayName' &&
-          item.type === RegistryValueType.REG_SZ &&
-          item.data.startsWith('PhpStorm ')
-        ) {
-          displayName = 'PhpStorm'
-        } else if (
-          item.name === 'Publisher' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          publisher = item.data
-        } else if (
-          item.name === 'InstallLocation' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          installLocation = item.data
-        }
-      }
-
-      return { displayName, publisher, installLocation }
-    },
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('PhpStorm') && publisher === 'JetBrains s.r.o.',
   },
@@ -524,11 +425,10 @@ const editors: IWindowsExternalEditor[] = [
     ],
     executableShimPath: [],
     getAppInfo: keys => {
-      const displayName = getKeyOrEmpty(keys, 'DisplayName')
-      const publisher = getKeyOrEmpty(keys, 'Publisher')
-      const installLocation = getKeyOrEmpty(keys, 'DisplayIcon')
-
-      return { displayName, publisher, installLocation }
+      return {
+        ...getFallbackAppInfo(keys),
+        installLocation: getKeyOrEmpty(keys, 'DisplayIcon'),
+      }
     },
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Notepad++') && publisher === 'Notepad++ Team',
@@ -544,35 +444,6 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'rider64.exe'],
-    getAppInfo: keys => {
-      let displayName = ''
-      let publisher = ''
-      let installLocation = ''
-
-      for (const item of keys) {
-        // NOTE:
-        // JetBrains Rider adds the current release number to the end of the Display Name, below checks for "JetBrains Rider"
-        if (
-          item.name === 'DisplayName' &&
-          item.type === RegistryValueType.REG_SZ &&
-          item.data.startsWith('JetBrains Rider ')
-        ) {
-          displayName = 'JetBrains Rider'
-        } else if (
-          item.name === 'Publisher' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          publisher = item.data
-        } else if (
-          item.name === 'InstallLocation' &&
-          item.type === RegistryValueType.REG_SZ
-        ) {
-          installLocation = item.data
-        }
-      }
-
-      return { displayName, publisher, installLocation }
-    },
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('JetBrains Rider') &&
       publisher === 'JetBrains s.r.o.',
@@ -643,22 +514,14 @@ export async function getAvailableEditors(): Promise<
 > {
   const results: Array<IFoundEditor<string>> = []
 
-  const editorPaths = await Promise.all(
-    editors.map(editor =>
-      findApplication(editor).then(path => {
-        return { editor, path }
-      })
-    )
-  )
-
-  for (const editorPath of editorPaths) {
-    const { editor, path } = editorPath
+  for (const editor of editors) {
+    const path = await findApplication(editor)
 
     if (path) {
       results.push({
         editor: editor.name,
-        path: path,
-        usesShell: editor.usesShell ?? false,
+        path,
+        usesShell: path.endsWith('.cmd'),
       })
     }
   }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -16,7 +16,7 @@ interface IWindowsAppInformation {
   installLocation: string
 }
 
-type AppInformationExtractor = (
+type AppInfoExtractor = (
   keys: ReadonlyArray<RegistryValue>
 ) => IWindowsAppInformation
 
@@ -39,7 +39,7 @@ interface IWindowsExternalEditor {
   readonly registryKeys: ReadonlyArray<{ key: HKEY; subKey: string }>
 
   /**
-   * List of path components from the editor's instalation folder to the
+   * List of path components from the editor's installation folder to the
    * executable shim.
    **/
   readonly executableShimPath: ReadonlyArray<string>
@@ -59,7 +59,7 @@ interface IWindowsExternalEditor {
    * Optional. If not provided, those three pieces of info will be obtained from
    * the 'DisplayName', 'Publisher' and 'InstallLocation' keys, respectively.
    */
-  readonly appInformationExtractor?: AppInformationExtractor
+  readonly getAppInfo?: AppInfoExtractor
 
   /**
    * Function to check if the found installation matches the expected identifier
@@ -229,7 +229,7 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['subl.exe'],
-    appInformationExtractor: keys => {
+    getAppInfo: keys => {
       let displayName = ''
       let publisher = ''
       let installLocation = ''
@@ -413,7 +413,7 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'webstorm.exe'],
-    appInformationExtractor: keys => {
+    getAppInfo: keys => {
       let displayName = ''
       let publisher = ''
       let installLocation = ''
@@ -474,7 +474,7 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'phpstorm.exe'],
-    appInformationExtractor: keys => {
+    getAppInfo: keys => {
       let displayName = ''
       let publisher = ''
       let installLocation = ''
@@ -523,7 +523,7 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: [],
-    appInformationExtractor: keys => {
+    getAppInfo: keys => {
       const displayName = getKeyOrEmpty(keys, 'DisplayName')
       const publisher = getKeyOrEmpty(keys, 'Publisher')
       const installLocation = getKeyOrEmpty(keys, 'DisplayIcon')
@@ -544,7 +544,7 @@ const editors: IWindowsExternalEditor[] = [
       },
     ],
     executableShimPath: ['bin', 'rider64.exe'],
-    appInformationExtractor: keys => {
+    getAppInfo: keys => {
       let displayName = ''
       let publisher = ''
       let installLocation = ''
@@ -587,7 +587,7 @@ function getKeyOrEmpty(
   return entry && entry.type === RegistryValueType.REG_SZ ? entry.data : ''
 }
 
-const defaultAppInformationExtractor: AppInformationExtractor = keys => {
+const getFallbackAppInfo: AppInfoExtractor = keys => {
   const displayName = getKeyOrEmpty(keys, 'DisplayName')
   const publisher = getKeyOrEmpty(keys, 'Publisher')
   const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
@@ -609,8 +609,7 @@ async function findApplication(
     return null
   }
 
-  const appInformationExtractor =
-    editor.appInformationExtractor ?? defaultAppInformationExtractor
+  const appInformationExtractor = editor.getAppInfo ?? getFallbackAppInfo
 
   const { displayName, publisher, installLocation } = appInformationExtractor(
     keys

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -55,6 +55,9 @@ interface IWindowsExternalEditor {
    * fields (display name, publisher and installation path).
    *
    * Receives the collection of registry key-value pairs for the app.
+   *
+   * Optional. If not provided, those three pieces of info will be obtained from
+   * the 'DisplayName', 'Publisher' and 'InstallLocation' keys, respectively.
    */
   readonly appInformationExtractor?: AppInformationExtractor
 

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -227,15 +227,10 @@ const editors: IWindowsExternalEditor[] = [
   {
     name: 'JetBrains Webstorm',
     registryKeys: [
-      // Webstorm 2018.3
       Wow64LocalMachineUninstallKey('WebStorm 2018.3'),
-      // Webstorm 2019.2
       Wow64LocalMachineUninstallKey('WebStorm 2019.2'),
-      // Webstorm 2019.2.4
       Wow64LocalMachineUninstallKey('WebStorm 2019.2.4'),
-      // Webstorm 2019.3
       Wow64LocalMachineUninstallKey('WebStorm 2019.3'),
-      // Webstorm 2020.1
       Wow64LocalMachineUninstallKey('WebStorm 2020.1'),
     ],
     executableShimPath: ['bin', 'webstorm.exe'],
@@ -245,13 +240,9 @@ const editors: IWindowsExternalEditor[] = [
   {
     name: 'JetBrains Phpstorm',
     registryKeys: [
-      // PhpStorm 2019.2
       Wow64LocalMachineUninstallKey('PhpStorm 2019.2'),
-      // PhpStorm 2019.2.4
       Wow64LocalMachineUninstallKey('PhpStorm 2019.2.4'),
-      // PhpStorm 2019.3
       Wow64LocalMachineUninstallKey('PhpStorm 2019.3'),
-      // PhpStorm 2020.1
       Wow64LocalMachineUninstallKey('PhpStorm 2020.1'),
     ],
     executableShimPath: ['bin', 'phpstorm.exe'],
@@ -273,10 +264,7 @@ const editors: IWindowsExternalEditor[] = [
   },
   {
     name: 'JetBrains Rider',
-    registryKeys: [
-      // Rider 2019.3.4
-      Wow64LocalMachineUninstallKey('JetBrains Rider 2019.3.4'),
-    ],
+    registryKeys: [Wow64LocalMachineUninstallKey('JetBrains Rider 2019.3.4')],
     executableShimPath: ['bin', 'rider64.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('JetBrains Rider') &&

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -107,11 +107,9 @@ import {
   ChangesWorkingDirectorySelection,
 } from '../app-state'
 import {
-  ExternalEditor,
   findEditorOrDefault,
   getAvailableEditors,
   launchExternalEditor,
-  parse,
 } from '../editors'
 import { assertNever, fatalError } from '../fatal-error'
 
@@ -388,9 +386,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private uncommittedChangesStrategy = defaultUncommittedChangesStrategy
 
-  private selectedExternalEditor: ExternalEditor | null = null
+  private selectedExternalEditor: string | null = null
 
-  private resolvedExternalEditor: ExternalEditor | null = null
+  private resolvedExternalEditor: string | null = null
 
   /** The user's preferred shell. */
   private selectedShell = DefaultShell
@@ -1711,7 +1709,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private updateSelectedExternalEditor(
-    selectedEditor: ExternalEditor | null
+    selectedEditor: string | null
   ): Promise<void> {
     this.selectedExternalEditor = selectedEditor
 
@@ -1720,16 +1718,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._resolveCurrentEditor()
   }
 
-  private async lookupSelectedExternalEditor(): Promise<ExternalEditor | null> {
+  private async lookupSelectedExternalEditor(): Promise<string | null> {
     const editors = (await getAvailableEditors()).map(found => found.editor)
 
-    const externalEditorValue = localStorage.getItem(externalEditorKey)
-    if (externalEditorValue) {
-      const value = parse(externalEditorValue)
-      // ensure editor is still installed
-      if (value && editors.includes(value)) {
-        return value
-      }
+    const value = localStorage.getItem(externalEditorKey)
+    // ensure editor is still installed
+    if (value && editors.includes(value)) {
+      return value
     }
 
     if (editors.length) {
@@ -4492,7 +4487,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
-  public _setExternalEditor(selectedEditor: ExternalEditor) {
+  public _setExternalEditor(selectedEditor: string) {
     const promise = this.updateSelectedExternalEditor(selectedEditor)
     localStorage.setItem(externalEditorKey, selectedEditor)
     this.emitUpdate()

--- a/app/src/lib/stores/helpers/tutorial-assessor.ts
+++ b/app/src/lib/stores/helpers/tutorial-assessor.ts
@@ -1,7 +1,6 @@
 import { IRepositoryState } from '../../app-state'
 import { TutorialStep } from '../../../models/tutorial-step'
 import { TipState } from '../../../models/tip'
-import { ExternalEditor } from '../../editors'
 import { setBoolean, getBoolean } from '../../local-storage'
 
 const skipInstallEditorKey = 'tutorial-install-editor-skipped'
@@ -32,7 +31,7 @@ export class OnboardingTutorialAssessor {
 
   public constructor(
     /** Method to call when we need to get the current editor */
-    private getResolvedExternalEditor: () => ExternalEditor | null
+    private getResolvedExternalEditor: () => string | null
   ) {}
 
   /** Determines what step the user needs to complete next in the Onboarding Tutorial */

--- a/app/src/models/menu-labels.ts
+++ b/app/src/models/menu-labels.ts
@@ -1,5 +1,4 @@
 import { Shell } from '../lib/shells'
-import { ExternalEditor } from '../lib/editors'
 
 export type MenuLabelsEvent = {
   /**
@@ -16,7 +15,7 @@ export type MenuLabelsEvent = {
    * Specify `null` to indicate that it is not known currently, which will
    * default to a placeholder based on the current platform.
    */
-  readonly selectedExternalEditor: ExternalEditor | null
+  readonly selectedExternalEditor: string | null
 
   /**
    * Has the use enabled "Show confirmation dialog before force pushing"?

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -16,7 +16,6 @@ import {
   isMergeConflictState,
   RebaseConflictState,
 } from '../../lib/app-state'
-import { ExternalEditor } from '../../lib/editors'
 import { assertNever, fatalError } from '../../lib/fatal-error'
 import {
   setGenericPassword,
@@ -1749,7 +1748,7 @@ export class Dispatcher {
   /**
    * Sets the user's preference for an external program to open repositories in.
    */
-  public setExternalEditor(editor: ExternalEditor): Promise<void> {
+  public setExternalEditor(editor: string): Promise<void> {
     return this.appStore._setExternalEditor(editor)
   }
 

--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -3,20 +3,19 @@ import { DialogContent } from '../dialog'
 import { LinkButton } from '../lib/link-button'
 import { Row } from '../../ui/lib/row'
 import { Select } from '../lib/select'
-import { ExternalEditor, parse as parseEditor } from '../../lib/editors'
 import { Shell, parse as parseShell } from '../../lib/shells'
 
 interface IIntegrationsPreferencesProps {
-  readonly availableEditors: ReadonlyArray<ExternalEditor>
-  readonly selectedExternalEditor: ExternalEditor | null
+  readonly availableEditors: ReadonlyArray<string>
+  readonly selectedExternalEditor: string | null
   readonly availableShells: ReadonlyArray<Shell>
   readonly selectedShell: Shell
-  readonly onSelectedEditorChanged: (editor: ExternalEditor) => void
+  readonly onSelectedEditorChanged: (editor: string) => void
   readonly onSelectedShellChanged: (shell: Shell) => void
 }
 
 interface IIntegrationsPreferencesState {
-  readonly selectedExternalEditor: ExternalEditor | null
+  readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
 }
 
@@ -67,7 +66,7 @@ export class Integrations extends React.Component<
   private onSelectedEditorChanged = (
     event: React.FormEvent<HTMLSelectElement>
   ) => {
-    const value = parseEditor(event.currentTarget.value)
+    const value = event.currentTarget.value
     if (value) {
       this.setState({ selectedExternalEditor: value })
       this.props.onSelectedEditorChanged(value)

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Account } from '../../models/account'
 import { PreferencesTab } from '../../models/preferences'
-import { ExternalEditor } from '../../lib/editors'
 import { Dispatcher } from '../dispatcher'
 import { TabBar, TabBarType } from '../tab-bar'
 import { Accounts } from './accounts'
@@ -48,7 +47,7 @@ interface IPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
-  readonly selectedExternalEditor: ExternalEditor | null
+  readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
   readonly automaticallySwitchTheme: boolean
@@ -69,8 +68,8 @@ interface IPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmForcePush: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
-  readonly availableEditors: ReadonlyArray<ExternalEditor>
-  readonly selectedExternalEditor: ExternalEditor | null
+  readonly availableEditors: ReadonlyArray<string>
+  readonly selectedExternalEditor: string | null
   readonly availableShells: ReadonlyArray<Shell>
   readonly selectedShell: Shell
   /**
@@ -395,7 +394,7 @@ export class Preferences extends React.Component<
     this.setState({ defaultBranch })
   }
 
-  private onSelectedEditorChanged = (editor: ExternalEditor) => {
+  private onSelectedEditorChanged = (editor: string) => {
     this.setState({ selectedExternalEditor: editor })
   }
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -26,7 +26,6 @@ import { StashDiffViewer } from './stashing'
 import { StashedChangesLoadStates } from '../models/stash-entry'
 import { TutorialPanel, TutorialWelcome, TutorialDone } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
-import { ExternalEditor } from '../lib/editors'
 import { openFile } from './lib/open-file'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
 
@@ -67,7 +66,7 @@ interface IRepositoryViewProps {
   readonly externalEditorLabel?: string
 
   /** A cached entry representing an external editor found on the user's machine */
-  readonly resolvedExternalEditor: ExternalEditor | null
+  readonly resolvedExternalEditor: string | null
 
   /**
    * Callback to open a selected file using the configured external editor

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -11,7 +11,6 @@ import {
   orderedTutorialSteps,
 } from '../../models/tutorial-step'
 import { encodePathAsUrl } from '../../lib/path'
-import { ExternalEditor } from '../../lib/editors'
 import { PopupType } from '../../models/popup'
 import { PreferencesTab } from '../../models/preferences'
 import { Ref } from '../lib/ref'
@@ -28,7 +27,7 @@ interface ITutorialPanelProps {
   /** name of the configured external editor
    * (`undefined` if none is configured.)
    */
-  readonly resolvedExternalEditor: ExternalEditor | null
+  readonly resolvedExternalEditor: string | null
   readonly currentTutorialStep: ValidTutorialStep
   readonly onExitTutorial: () => void
 }

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -25,7 +25,7 @@ The source for the editor integration on Windows is found in
 These editors are currently supported:
 
  - [Atom](https://atom.io/) - stable, Beta and Nightly
- - [Visual Studio Code](https://code.visualstudio.com/)
+ - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
  - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)
  - [ColdFusion Builder](https://www.adobe.com/products/coldfusion-builder.html)
@@ -36,36 +36,30 @@ These editors are currently supported:
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
  - [Notepad++](https://notepad-plus-plus.org/)
 
-These are defined in an enum at the top of the file:
+These are defined in a list at the top of the file:
 
 ```ts
-export enum ExternalEditor {
-  Atom = 'Atom',
-  AtomBeta = 'Atom Beta',
-  AtomNightly = 'Atom Nightly',
-  VSCode = 'Visual Studio Code',
-  VSCodeInsiders = 'Visual Studio Code (Insiders)',
-  VSCodium = 'Visual Studio Codium',
-  SublimeText = 'Sublime Text',
-  CFBuilder = 'ColdFusion Builder',
-  Typora = 'Typora',
-  SlickEdit = 'SlickEdit',
-  Webstorm = 'JetBrains Webstorm',
-  Phpstorm = 'JetBrains Phpstorm',
-  NotepadPlusPlus = 'Notepad++',
-  Rider = 'JetBrains Rider',
-}
+/**
+ * This list contains all the external editors supported on Windows. Add a new
+ * entry here to add support for your favorite editor.
+ **/
+const editors: IWindowsExternalEditor[] = [
+...
+]
 ```
 
-If you want to add another editor, add a new key to the `ExternalEditor`
-enum with a friendly name for the value. This will trigger a number of compiler
-errors, which are places in the module you need to add code.
+If you want to add another editor, you just need to add a new entry to this
+list. The compiler will help you with the info needed about the new editor.
+
+The `name` attribute will be shown in the list of supported editors inside the
+app, but will also be treated as the identifier of the editor, so it must be
+unique.
 
 The steps for resolving each editor can be found in `findApplication()` and in
 pseudocode looks like this:
 
 ```ts
-async function findApplication(editor: ExternalEditor): Promise<string | null> {
+async function findApplication(editor: IWindowsExternalEditor): Promise<string | null> {
   // find install location in registry
   // validate installation
   // find executable to launch
@@ -79,44 +73,27 @@ entries to the registry to help the OS with cleaning up later, if the user
 wishes to uninstall. These entries are used by GitHub Desktop to identify
 relevant programs and where they can be located.
 
-The registry locations for each editor are listed in `getRegistryKeys()`.
-Some editors support multiple install locations, but are structurally the
-same (for example 64-bit or 32-bit application, or stable and developer
+The registry locations for each editor are listed in the `registryKeys`
+property. Some editors support multiple install locations, but are structurally 
+the same (for example 64-bit or 32-bit application, or stable and developer
 channels).
 
 ```ts
-function getRegistryKeys(editor: ExternalEditor): ReadonlyArray<string> {
-  switch (editor) {
-    ...
-    case ExternalEditor.VisualStudioCode:
-      return [
-        // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1',
-        },
-        // 32-bit version of VSCode (user)
-        {
-          key: HKEY.HKEY_CURRENT_USER,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{D628A17A-9713-46BF-8D57-E671B46A741E}_is1',
-        },
-        // 64-bit version of VSCode (system) - was default before user scope installation
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1',
-        },
-        // 32-bit version of VSCode (system)
-        {
-          key: HKEY.HKEY_LOCAL_MACHINE,
-          subKey:
-            'SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1',
-        },
-      ]
-    ...
-  }
+{
+  name: 'Visual Studio Code',
+  registryKeys: [
+    // 64-bit version of VSCode (user) - provided by default in 64-bit Windows
+    CurrentUserUninstallKey('{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1'),
+    // 32-bit version of VSCode (user)
+    CurrentUserUninstallKey('{D628A17A-9713-46BF-8D57-E671B46A741E}_is1'),
+    // 64-bit version of VSCode (system) - was default before user scope installation
+    LocalMachineUninstallKey('{EA457B21-F73E-494C-ACAB-524FDE069978}_is1'),
+    // 32-bit version of VSCode (system)
+    Wow64LocalMachineUninstallKey(
+      '{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1'
+    ),
+  ],
+  ...
 }
 ```
 
@@ -136,6 +113,15 @@ If you're not sure how your editor is installed, check one of these locations:
 Your editor is probably hiding behind a GUID in one of these locations - this
 is the key that Desktop needs to read the registry and find the installation for your editor.
 
+As seen in the example above, you can use the following helper functions to
+enumerate the uninstall keys:
+ - `LocalMachineUninstallKey` for keys in 
+ `HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall`
+ - `Wow64LocalMachineUninstallKey` for keys in
+ `HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall`
+ - `CurrentUserUninstallKey` for keys in
+ `HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall`
+
 ### Step 2: Validate The Installation
 
 As part of installing to the registry, a program will insert a
@@ -144,30 +130,20 @@ application it expects, and identify where the install location of the
 application.
 
 There's two steps to this process. The first step is reading the registry, and
-you can see this code in `extractApplicationInformation()`:
+you can see this code in `getAppInfo()`:
 
 ```ts
-function extractApplicationInformation(
-  editor: ExternalEditor,
-  keys: ReadonlyArray<IRegistryEntry>
-): { displayName: string; publisher: string; installLocation: string } {
-  let displayName = ''
-  let publisher = ''
-  let installLocation = ''
-
-  ...
-
-  if (
-    editor === ExternalEditor.VisualStudioCode ||
-    editor === ExternalEditor.VisualStudioCodeInsiders
-  ) {
-    const displayName = getKeyOrEmpty(keys, 'DisplayName')
-    const publisher = getKeyOrEmpty(keys, 'Publisher')
-    const installLocation = getKeyOrEmpty(keys, 'InstallLocation')
-    return { displayName, publisher, installLocation }
-  }
-
-  ...
+function getAppInfo(
+  editor: IWindowsExternalEditor,
+  keys: ReadonlyArray<RegistryValue>
+): IWindowsAppInformation {
+  const displayName = getKeyOrEmpty(keys, 'DisplayName')
+  const publisher = getKeyOrEmpty(keys, 'Publisher')
+  const installLocation = getKeyOrEmpty(
+    keys,
+    editor.installLocationRegistryKey ?? 'InstallLocation'
+  )
+  return { displayName, publisher, installLocation }
 }
 ```
 
@@ -180,25 +156,23 @@ Desktop needs enough information to validate the installation - usually
 something related to the name of the program, and the identity of the
 publisher - along with the install location on disk.
 
-The second step is to validate the installation, and this is done in
-`isExpectedInstallation()`:
+The app will look for the app name in the `DisplayName` registry key, the
+publisher in the `Publisher` registry key, and the install location in the
+`InstallLocation` registry key. However, this last one can be overridden by
+setting a different registry key in the `installLocationRegistryKey` attribute
+of your new editor entry in the `editors` list.
+
+The second step is to validate the installation, and this is done in the
+`expectedInstallationChecker` functions defined for each editor entry:
 
 ```ts
-function isExpectedInstallation(
-  editor: ExternalEditor,
-  displayName: string,
-  publisher: string
-): boolean {
-  switch (editor) {
-    ...
-    case ExternalEditor.VisualStudioCode:
-      return (
-        displayName.startsWith('Microsoft Visual Studio Code') &&
-        publisher === 'Microsoft Corporation'
-      )
-    ...
-  }
-}
+{
+  name: 'Visual Studio Code',
+  ...
+  expectedInstallationChecker: (displayName, publisher) =>
+    displayName.startsWith('Microsoft Visual Studio Code') &&
+    publisher === 'Microsoft Corporation',
+},
 ```
 
 ### Step 3: Determine the program to launch
@@ -210,45 +184,15 @@ executable directly. Whatever options there are, this should be a known
 location with an interface that doesn't change between updates.
 
 ```ts
-function getExecutableShim(
-  editor: ExternalEditor,
-  installLocation: string
-): string {
-  switch (editor) {
-    ...
-    case ExternalEditor.VisualStudioCode:
-      return Path.join(installLocation, 'bin', 'code.cmd')
-    ...
-  }
-}
+{
+  name: 'Visual Studio Code',
+  ...
+  executableShimPath: ['bin', 'code.cmd'],
+},
 ```
 
 Desktop will confirm this file exists on disk before launching - if it's
 missing or lost it won't let you launch the external editor.
-
-If the external editor utilizes a CMD.EXE shell script to launch, Desktop
-needs to know this in order to properly launch the CMD.EXE shell.  This is
-done by setting the property `usesShell: true` in `getAvailableEditors`.
-
-```ts
-export async function getAvailableEditors(): Promise<
-  ReadonlyArray<IFoundEditor<ExternalEditor>>
-> {
-  ...
-
-  if (codePath) {
-    results.push({
-      editor: ExternalEditor.VisualStudioCode,
-      path: codePath,
-      usesShell: true,
-    })
-  }
-
-  ...
-
-  return results
-}
-```
 
 ## macOS
 
@@ -279,47 +223,31 @@ These editors are currently supported:
  - [JetBrains GoLand](https://www.jetbrains.com/go/)
  - [Android Studio](https://developer.android.com/studio)
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
+ - [Nova](https://nova.app/)
 
-These are defined in an enum at the top of the file:
-
-```ts
-export enum ExternalEditor {
-  Atom = 'Atom',
-  MacVim = 'MacVim',
-  VSCode = 'Visual Studio Code',
-  VSCodeInsiders = 'Visual Studio Code (Insiders)',
-  VSCodium = 'VSCodium',
-  SublimeText = 'Sublime Text',
-  BBEdit = 'BBEdit',
-  PhpStorm = 'PhpStorm',
-  RubyMine = 'RubyMine',
-  TextMate = 'TextMate',
-  Brackets = 'Brackets',
-  WebStorm = 'WebStorm',
-  Typora = 'Typora',
-  CodeRunner = 'CodeRunner',
-  SlickEdit = 'SlickEdit',
-  IntelliJ = 'IntelliJ',
-  Xcode = 'Xcode',
-  GoLand = 'GoLand',
-}
-```
-
-If you want to add another editor, add a new key to the `ExternalEditor`
-enum with a friendly name for the value. This will trigger a number of compiler
-errors, which are places in the module you need to add code.
-
-The steps for resolving each editor can be found in `findApplication()` and in
-pseudocode looks like this:
+These are defined in a list at the top of the file:
 
 ```ts
-async function findApplication(editor: ExternalEditor): Promise<string | null> {
-  // find path to installation
-  // find executable to launch
-}
+/**
+ * This list contains all the external editors supported on macOS. Add a new
+ * entry here to add support for your favorite editor.
+ **/
+const editors: IDarwinExternalEditor[] = [
+...
+]
 ```
 
-### Step 1: Find installation path
+If you want to add another editor, you just need to add a new entry to this
+list. The compiler will help you with the info needed about the new editor.
+
+The `name` attribute will be shown in the list of supported editors inside the
+app, but will also be treated as the identifier of the editor, so it must be
+unique.
+
+The function that resolves each editor is `findApplication()`, which only looks
+for the path to the installation and verifies it exists.
+
+### Find bundle identifier
 
 macOS programs are packaged as application bundles, and applications can
 read information from the OS to see if they are present.
@@ -328,51 +256,22 @@ The `CFBundleIdentifier` value in the plist is what applications use to
 uniquely identify themselves, for example `com.github.GitHubClient` is the
 identifier for GitHub Desktop.
 
-The `getBundleIdentifier()` method is the lookup method for this value:
+With this bundle identifier, the app can obtain the install location of the app.
+
+The `bundleIdentifiers` attribute lists all the bundle identifiers that can
+refer to the editor:
 
 ```ts
-function getBundleIdentifier(editor: ExternalEditor): string {
-  switch (editor) {
-    ...
-    case ExternalEditor.VisualStudioCode:
-      return ['com.microsoft.VSCode']
-    ...
-  }
-}
+{
+  name: 'Visual Studio Code',
+  bundleIdentifiers: ['com.microsoft.VSCode'],
+},
 ```
 
 AppKit provides an [`API`](https://developer.apple.com/documentation/appkit/nsworkspace/1533086-absolutepathforappbundlewithiden?language=objc)
 for searching for an application bundle. If it finds an application bundle,
 it will return the path to the application on disk. Otherwise it will raise an
 exception.
-
-### Step 2: Find executable to launch
-
-With that information, Desktop can resolve the executable and confirm it exists
-on disk before launching.
-
-This is done in the `getExecutableShim()` method:
-
-```ts
-function getExecutableShim(
-  editor: ExternalEditor,
-  installPath: string
-): string {
-  switch (editor) {
-    ...
-    case ExternalEditor.VisualStudioCode:
-      return Path.join(
-        installPath,
-        'Contents',
-        'Resources',
-        'app',
-        'bin',
-        'code'
-      )
-    ...
-  }
-}
-```
 
 ## Linux
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -126,10 +126,10 @@ enumerate the uninstall keys:
 
 As part of installing to the registry, a program will insert a
 number of key-value pairs - Desktop will enumerate these to ensure it's the
-application it expects, and identify where the install location of the
+application it expects, and identify the install location of the
 application.
 
-There's two steps to this process. The first step is reading the registry, and
+There are two steps to this process. The first step is reading the registry, and
 you can see this code in `getAppInfo()`:
 
 ```ts
@@ -256,7 +256,8 @@ The `CFBundleIdentifier` value in the plist is what applications use to
 uniquely identify themselves, for example `com.github.GitHubClient` is the
 identifier for GitHub Desktop.
 
-With this bundle identifier, the app can obtain the install location of the app.
+With this bundle identifier, the GitHub Desktop can obtain the install location
+of the app.
 
 The `bundleIdentifiers` attribute lists all the bundle identifiers that can
 refer to the editor:
@@ -274,7 +275,6 @@ it will return the path to the application on disk. Otherwise it will raise an
 exception.
 
 ## Linux
-
 
 The source for the editor integration on Linux is found in
 [`app/src/lib/editors/linux.ts`](https://github.com/desktop/desktop/blob/development/app/src/lib/editors/linux.ts).

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -288,67 +288,33 @@ These editors are currently supported:
  - [Typora](https://typora.io/)
  - [SlickEdit](https://www.slickedit.com)
 
-These are defined in an enum at the top of the file:
+These are defined in a list at the top of the file:
 
 ```ts
-export enum ExternalEditor {
-  Atom = 'Atom',
-  VSCode = 'Visual Studio Code',
-  VSCodeInsiders = 'Visual Studio Code (Insiders)',
-  VSCodium = 'VSCodium',
-  SublimeText = 'Sublime Text',
-  Typora = 'Typora',
-  SlickEdit = 'SlickEdit',
-}
+/**
+ * This list contains all the external editors supported on Linux. Add a new
+ * entry here to add support for your favorite editor.
+ **/
+const editors: ILinuxExternalEditor[] = [
+...
+]
 ```
 
-If you want to add another editor, add a new key to the `ExternalEditor`
-enum with a friendly name for the value. This will trigger a compiler
-error, and you need to add code to `getEditorPath()` to get the source
-building again.
+If you want to add another editor, you just need to add a new entry to this
+list. The compiler will help you with the info needed about the new editor.
 
-### Step 1: Find executable path
+The `name` attribute will be shown in the list of supported editors inside the
+app, but will also be treated as the identifier of the editor, so it must be
+unique.
 
-The `getEditorPath()` maps the editor enum to an expected path to the
-editor executable. Add a new `case` statement for your editor.
+### Find executable path
 
-```ts
-case ExternalEditor.VisualStudioCode:
-  return getPathIfAvailable('/usr/bin/code')
-```
-### Step 2: Lookup executable
-
-Once you've done that, add code to `getAvailableEditors()` so that it checks
-for your new editor, following the existing patterns.
+The `paths` attribute must contain a list of paths where executables for the
+editor might be found.
 
 ```ts
-export async function getAvailableEditors(): Promise<
-  ReadonlyArray<IFoundEditor<ExternalEditor>>
-> {
-  const results: Array<IFoundEditor<ExternalEditor>> = []
-
-  const [
-    atomPath,
-    codePath,
-    codeInsidersPath,
-    sublimePath,
-    typoraPath,
-    slickeditPath,
-  ] = await Promise.all([
-    getEditorPath(ExternalEditor.Atom),
-    getEditorPath(ExternalEditor.VisualStudioCode),
-    getEditorPath(ExternalEditor.VisualStudioCodeInsiders),
-    getEditorPath(ExternalEditor.SublimeText),
-    getEditorPath(ExternalEditor.Typora),
-    getEditorPath(ExternalEditor.SlickEdit),
-  ])
-
-  ...
-
-  if (codePath) {
-    results.push({ editor: ExternalEditor.VisualStudioCode, path: codePath })
-  }
-
-  ...
-}
+{
+  name: 'Visual Studio Code',
+  paths: ['/usr/bin/code'],
+},
 ```


### PR DESCRIPTION
Closes #5409

## Description

The changes in this PR are an attempt to simplify the code that integrates the app with external editors. Main changes:
- Gather all the info relative to external editors into entries of an array. This should make it easier and clearer adding support for new editors, since now all that info and logic won't be scattered.
- Removed the `ExternalEditor` enum and use a string instead. Several reasons for this:
  1. No code was leveraging the advantages of `ExternalEditor` as an enum, other than in `editors/darwin.ts`, `editors/win32.ts` and `editors/linux.ts`. Everywhere else its value was passed around, and finally stored/read as a string in/from the app settings.
  1. There weren't references to specific values of the enum outside of the mentioned files.
  1. With the new list of editors, keeping the enum around was just redundant. In the end, only editors inside the list AND detected in the user's machine will be available and used (🐛s aside).
- macOS editors are now opened using `open`, which only needs us to provide the bundle identifier of the editor, so we don't need to keep hardcoding paths to specific executables inside the editors' bundle.

Remaining work in this PR:
- ~~Make the same changes in the `editors/linux.ts` file.~~
- ~~Update the `docs/technical/editor-integration.md` document to reflect these new changes.~~
- ~~Other cleanup!~~

## Release notes

Notes: no-notes
