### PR TITLE
Describe how to find the bundle identifier for a macOS application

### DIFF
--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -328,6 +328,9 @@ The `CFBundleIdentifier` value in the plist is what applications use to
 uniquely identify themselves, for example `com.github.GitHubClient` is the
 identifier for GitHub Desktop.
 
+To find the bundle identifier for an application, using `PhpStorm` as an example, 
+run `defaults read /Applications/PhpStorm.app/Contents/Info CFBundleIdentifier`.
+
 The `getBundleIdentifier()` method is the lookup method for this value:
 
 ```ts


### PR DESCRIPTION
Add an example to the editor integration docs of how to read `CFBundleIdentifier` from a macOS application bundle.

Alternatives include `osascript -e 'id of app "PhpStorm"'` and `mdls -name kMDItemCFBundleIdentifier -r /Applications/PhpStorm.app`, but reading the data from the bundle directly seems the most straightforward.