### PR TITLE
Add beta release notes to area of README where we suggest downloading it 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ beta channel to get access to early builds of Desktop:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
+ 
+The release notes for the latest beta versions are available [here](https://desktop.github.com/release-notes/?env=beta).
 
 ### Community Releases
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11444

## Description

This adds a link to the download portion of the README so folks are able to see what has shipped in recent beta releases.
