### PR TITLE
Refactor delete branch methods

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -65,6 +65,7 @@ export async function deleteLocalBranch(
 
 /**
  * Deletes a remote branch
+ *
  * @param remoteName - the name of the remote to delete the branch from
  * @param remoteBranchName - the name of the branch on the remote
  * @param branchTipSha - the branch's sha is logged for reference, more useful

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -68,15 +68,12 @@ export async function deleteLocalBranch(
  *
  * @param remoteName - the name of the remote to delete the branch from
  * @param remoteBranchName - the name of the branch on the remote
- * @param branchTipSha - the branch's sha is logged for reference, more useful
- * for a remote only branch if the user wants to undo this delete.
  */
 export async function deleteRemoteBranch(
   repository: Repository,
   account: IGitAccount | null,
   remoteName: string,
-  remoteBranchName: string,
-  branchTipSha: string
+  remoteBranchName: string
 ): Promise<true> {
   const networkArguments = await gitNetworkArguments(repository, account)
   const remoteUrl =
@@ -96,10 +93,6 @@ export async function deleteRemoteBranch(
     env: await envForRemoteOperation(account, remoteUrl),
     expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
   })
-
-  if (branchTipSha !== undefined) {
-    log.info(`Deleted branch ${remoteBranchName} (was ${branchTipSha})`)
-  }
 
   // It's possible that the delete failed because the ref has already
   // been deleted on the remote. If we identify that specific

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -103,7 +103,7 @@ export async function deleteRemoteBranch(
 
   // It's possible that the delete failed because the ref has already
   // been deleted on the remote. If we identify that specific
-  // error we can safely remote our remote ref which is what would
+  // error we can safely remove our remote ref which is what would
   // happen if the push didn't fail.
   if (result.gitError === DugiteError.BranchDeletionFailed) {
     const ref = `refs/remotes/${remoteName}/${remoteBranchName}`

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -1,6 +1,6 @@
 import { git, gitNetworkArguments } from './core'
 import { Repository } from '../../models/repository'
-import { Branch, BranchType } from '../../models/branch'
+import { Branch } from '../../models/branch'
 import { IGitAccount } from '../../models/git-account'
 import { formatAsLocalRef } from './refs'
 import { deleteRef } from './update-ref'
@@ -53,8 +53,7 @@ export async function renameBranch(
 }
 
 /**
- * Delete the branch locally, see `deleteBranch` if you're looking to delete the
- * branch from the remote as well.
+ * Delete the branch locally.
  */
 export async function deleteLocalBranch(
   repository: Repository,
@@ -65,54 +64,49 @@ export async function deleteLocalBranch(
 }
 
 /**
- * Delete the branch. If the branch has a remote branch and `includeRemote` is true, it too will be
- * deleted. Silently deletes local branch if remote one is already deleted.
+ * Deletes a remote branch
+ * @param remoteName - the name of the remote to delete the branch from
+ * @param remoteBranchName - the name of the branch on the remote
+ * @param branchTipSha - the branch's sha is logged for reference, more useful
+ * for a remote only branch if the user wants to undo this delete.
  */
-export async function deleteBranch(
+export async function deleteRemoteBranch(
   repository: Repository,
-  branch: Branch,
   account: IGitAccount | null,
-  includeRemote: boolean
+  remoteName: string,
+  remoteBranchName: string,
+  branchTipSha: string
 ): Promise<true> {
-  if (branch.type === BranchType.Local) {
-    await deleteLocalBranch(repository, branch.name)
+  const networkArguments = await gitNetworkArguments(repository, account)
+  const remoteUrl =
+    (await getRemoteURL(repository, remoteName).catch(err => {
+      // If we can't get the URL then it's very unlikely Git will be able to
+      // either and the push will fail. The URL is only used to resolve the
+      // proxy though so it's not critical.
+      log.error(`Could not resolve remote url for remote ${remoteName}`, err)
+      return null
+    })) || getFallbackUrlForProxyResolve(account, repository)
+
+  const args = [...networkArguments, 'push', remoteName, `:${remoteBranchName}`]
+
+  // If the user is not authenticated, the push is going to fail
+  // Let this propagate and leave it to the caller to handle
+  const result = await git(args, repository.path, 'deleteRemoteBranch', {
+    env: await envForRemoteOperation(account, remoteUrl),
+    expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
+  })
+
+  if (branchTipSha !== undefined) {
+    log.info(`Deleted branch ${remoteBranchName} (was ${branchTipSha})`)
   }
 
-  const remoteName = branch.upstreamRemoteName
-
-  if (includeRemote && remoteName) {
-    const networkArguments = await gitNetworkArguments(repository, account)
-    const remoteUrl =
-      (await getRemoteURL(repository, remoteName).catch(err => {
-        // If we can't get the URL then it's very unlikely Git will be able to
-        // either and the push will fail. The URL is only used to resolve the
-        // proxy though so it's not critical.
-        log.error(`Could not resolve remote url for remote ${remoteName}`, err)
-        return null
-      })) || getFallbackUrlForProxyResolve(account, repository)
-
-    const args = [
-      ...networkArguments,
-      'push',
-      remoteName,
-      `:${branch.nameWithoutRemote}`,
-    ]
-
-    // If the user is not authenticated, the push is going to fail
-    // Let this propagate and leave it to the caller to handle
-    const result = await git(args, repository.path, 'deleteRemoteBranch', {
-      env: await envForRemoteOperation(account, remoteUrl),
-      expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
-    })
-
-    // It's possible that the delete failed because the ref has already
-    // been deleted on the remote. If we identify that specific
-    // error we can safely remote our remote ref which is what would
-    // happen if the push didn't fail.
-    if (result.gitError === DugiteError.BranchDeletionFailed) {
-      const ref = `refs/remotes/${remoteName}/${branch.nameWithoutRemote}`
-      await deleteRef(repository, ref)
-    }
+  // It's possible that the delete failed because the ref has already
+  // been deleted on the remote. If we identify that specific
+  // error we can safely remote our remote ref which is what would
+  // happen if the push didn't fail.
+  if (result.gitError === DugiteError.BranchDeletionFailed) {
+    const ref = `refs/remotes/${remoteName}/${remoteBranchName}`
+    await deleteRef(repository, ref)
   }
 
   return true

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3354,7 +3354,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const branchToCheckout = this.getBranchToCheckoutAfterDelete(branch, r)
       const gitStore = this.gitStoreCache.get(r)
 
-      if (branchToCheckout != null) {
+      if (branchToCheckout !== null) {
         await gitStore.performFailableOperation(() =>
           checkoutBranch(r, account, branchToCheckout)
         )

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3360,12 +3360,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
         )
       }
 
-      await gitStore.performFailableOperation(async () => {
+      await gitStore.performFailableOperation(() => {
         if (branch.type === BranchType.Remote) {
-          // Note: deleting a remote branch implementation not needed.
-          return
+          // Note: deleting a remote branch implementation not needed, yet.
+          return Promise.resolve(true)
         }
-        this.deleteLocalBranchAndUpstreamBranch(
+        return this.deleteLocalBranchAndUpstreamBranch(
           repository,
           branch,
           account,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3360,6 +3360,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
           return Promise.resolve()
         })
 
+        // We log the remote branch's sha so that the user can recover it.
+        log.info(
+          `Deleted branch ${branch.upstreamWithoutRemote} (was ${branch.tip.sha})`
+        )
+
         return this._refreshRepository(r)
       }
 
@@ -3407,8 +3412,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         account,
         branch.upstreamRemoteName,
-        branch.upstreamWithoutRemote,
-        branch.tip.sha
+        branch.upstreamWithoutRemote
       )
     }
     return

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3414,7 +3414,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
     // if current branch is not the branch being deleted, no need to switch
     // branches
-    if (currentBranch != null && branchToDelete.name !== currentBranch.name) {
+    if (currentBranch !== null && branchToDelete.name !== currentBranch.name) {
       return null
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3378,7 +3378,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /**
-   * Deletes the local branch. If the branch `includeRemote` is true, the
+   * Deletes the local branch. If the parameter `includeRemote` is true, the
    * upstream branch will be deleted also.
    */
   private async deleteLocalBranchAndUpstreamBranch(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3353,7 +3353,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.withAuthenticatingUser(repository, async (r, account) => {
       const gitStore = this.gitStoreCache.get(r)
 
-      // If soley a remote branch, there is no need to checkout a branch.
+      // If solely a remote branch, there is no need to checkout a branch.
       if (branch.type === BranchType.Remote) {
         await gitStore.performFailableOperation(() => {
           // Note: deleting a remote branch implementation not needed, yet.
@@ -3399,12 +3399,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     branch: Branch,
     account: IGitAccount | null,
-    includeRemote?: boolean
+    includeUpstream?: boolean
   ): Promise<void> {
     await deleteLocalBranch(repository, branch.name)
 
     if (
-      includeRemote === true &&
+      includeUpstream === true &&
       branch.upstreamRemoteName !== null &&
       branch.upstreamWithoutRemote !== null
     ) {

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -225,18 +225,11 @@ describe('git/branch', () => {
       expect(localBranch.upstreamRemoteName).not.toBeNull()
       expect(localBranch.upstreamWithoutRemote).not.toBeNull()
 
-      if (
-        localBranch.upstreamRemoteName === null ||
-        localBranch.upstreamWithoutRemote === null
-      ) {
-        return
-      }
-
       await deleteRemoteBranch(
         mockLocal,
         null,
-        localBranch.upstreamRemoteName,
-        localBranch.upstreamWithoutRemote
+        localBranch.upstreamRemoteName!,
+        localBranch.upstreamWithoutRemote!
       )
 
       expect(await getBranches(mockLocal, localRef)).toBeArrayOfSize(1)
@@ -274,18 +267,11 @@ describe('git/branch', () => {
       expect(localBranch.upstreamRemoteName).not.toBeNull()
       expect(localBranch.upstreamWithoutRemote).not.toBeNull()
 
-      if (
-        localBranch.upstreamRemoteName === null ||
-        localBranch.upstreamWithoutRemote === null
-      ) {
-        return
-      }
-
       await deleteRemoteBranch(
         mockLocal,
         null,
-        localBranch.upstreamRemoteName,
-        localBranch.upstreamWithoutRemote
+        localBranch.upstreamRemoteName!,
+        localBranch.upstreamWithoutRemote!
       )
 
       expect(await getBranches(mockLocal, remoteRef)).toBeArrayOfSize(0)

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -17,10 +17,11 @@ import { GitProcess } from 'dugite'
 import {
   getBranchesPointedAt,
   createBranch,
-  deleteBranch,
   getBranches,
   git,
   checkoutBranch,
+  deleteLocalBranch,
+  deleteRemoteBranch,
 } from '../../../src/lib/git'
 import { StatsStore, StatsDatabase } from '../../../src/lib/stats'
 import { UiActivityMonitor } from '../../../src/ui/lib/ui-activity-monitor'
@@ -167,7 +168,7 @@ describe('git/branch', () => {
     })
   })
 
-  describe('deleteBranch', () => {
+  describe('deleteLocalBranch', () => {
     let repository: Repository
 
     beforeEach(async () => {
@@ -186,74 +187,111 @@ describe('git/branch', () => {
       expect(branch).not.toBeNull()
       expect(await getBranches(repository, ref)).toBeArrayOfSize(1)
 
-      await deleteBranch(repository, branch!, null, false)
+      await deleteLocalBranch(repository, branch.name)
 
       expect(await getBranches(repository, ref)).toBeArrayOfSize(0)
     })
+  })
 
-    it('deletes remote branches', async () => {
+  describe('deleteRemoteBranch', () => {
+    let mockRemote: Repository
+
+    beforeEach(async () => {
+      const path = await setupFixtureRepository('test-repo')
+      mockRemote = new Repository(path, -1, null, false)
+    })
+
+    it('delete a local branches upstream branch', async () => {
       const name = 'test-branch'
-      const branch = await createBranch(repository, name, null)
+      const branch = await createBranch(mockRemote, name, null)
       const localRef = `refs/heads/${name}`
 
       expect(branch).not.toBeNull()
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(1)
 
-      const fork = await setupLocalForkOfRepository(repository)
+      const mockLocal = await setupLocalForkOfRepository(mockRemote)
 
       const remoteRef = `refs/remotes/origin/${name}`
-      const [remoteBranch] = await getBranches(fork, remoteRef)
+      const [remoteBranch] = await getBranches(mockLocal, remoteRef)
       expect(remoteBranch).not.toBeUndefined()
 
-      await checkoutBranch(fork, null, remoteBranch)
-      await git(['checkout', '-'], fork.path, 'checkoutPrevious')
+      await checkoutBranch(mockLocal, null, remoteBranch)
+      await git(['checkout', '-'], mockLocal.path, 'checkoutPrevious')
 
-      expect(await getBranches(fork, localRef)).toBeArrayOfSize(1)
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(1)
+      expect(await getBranches(mockLocal, localRef)).toBeArrayOfSize(1)
+      expect(await getBranches(mockRemote, localRef)).toBeArrayOfSize(1)
 
-      const [localBranch] = await getBranches(fork, localRef)
+      const [localBranch] = await getBranches(mockLocal, localRef)
       expect(localBranch).not.toBeUndefined()
+      expect(localBranch.upstreamRemoteName).not.toBeNull()
+      expect(localBranch.upstreamWithoutRemote).not.toBeNull()
 
-      await deleteBranch(fork, localBranch, null, true)
+      if (
+        localBranch.upstreamRemoteName === null ||
+        localBranch.upstreamWithoutRemote === null
+      ) {
+        return
+      }
 
-      expect(await getBranches(fork, localRef)).toBeArrayOfSize(0)
-      expect(await getBranches(fork, remoteRef)).toBeArrayOfSize(0)
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(0)
+      await deleteRemoteBranch(
+        mockLocal,
+        null,
+        localBranch.upstreamRemoteName,
+        localBranch.upstreamWithoutRemote,
+        localBranch.tip.sha
+      )
+
+      expect(await getBranches(mockLocal, localRef)).toBeArrayOfSize(1)
+      expect(await getBranches(mockLocal, remoteRef)).toBeArrayOfSize(0)
+      expect(await getBranches(mockRemote, localRef)).toBeArrayOfSize(0)
     })
 
     it('handles attempted delete of removed remote branch', async () => {
       const name = 'test-branch'
-      const branch = await createBranch(repository, name, null)
+      const branch = await createBranch(mockRemote, name, null)
       const localRef = `refs/heads/${name}`
 
       expect(branch).not.toBeNull()
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(1)
+      expect(await getBranches(mockRemote, localRef)).toBeArrayOfSize(1)
 
-      const fork = await setupLocalForkOfRepository(repository)
+      const mockLocal = await setupLocalForkOfRepository(mockRemote)
 
       const remoteRef = `refs/remotes/origin/${name}`
-      const [remoteBranch] = await getBranches(fork, remoteRef)
+      const [remoteBranch] = await getBranches(mockLocal, remoteRef)
       expect(remoteBranch).not.toBeUndefined()
 
-      await checkoutBranch(fork, null, remoteBranch)
-      await git(['checkout', '-'], fork.path, 'checkoutPrevious')
+      await checkoutBranch(mockLocal, null, remoteBranch)
+      await git(['checkout', '-'], mockLocal.path, 'checkoutPrevious')
 
-      expect(await getBranches(fork, localRef)).toBeArrayOfSize(1)
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(1)
+      expect(await getBranches(mockLocal, localRef)).toBeArrayOfSize(1)
+      expect(await getBranches(mockRemote, localRef)).toBeArrayOfSize(1)
 
-      const [upstreamBranch] = await getBranches(repository, localRef)
+      const [upstreamBranch] = await getBranches(mockRemote, localRef)
       expect(upstreamBranch).not.toBeUndefined()
-      await deleteBranch(repository, upstreamBranch, null, true)
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(0)
+      await deleteLocalBranch(mockRemote, upstreamBranch.name)
+      expect(await getBranches(mockRemote, localRef)).toBeArrayOfSize(0)
 
-      const [localBranch] = await getBranches(fork, localRef)
+      const [localBranch] = await getBranches(mockLocal, localRef)
       expect(localBranch).not.toBeUndefined()
+      expect(localBranch.upstreamRemoteName).not.toBeNull()
+      expect(localBranch.upstreamWithoutRemote).not.toBeNull()
 
-      await deleteBranch(fork, localBranch, null, true)
+      if (
+        localBranch.upstreamRemoteName === null ||
+        localBranch.upstreamWithoutRemote === null
+      ) {
+        return
+      }
 
-      expect(await getBranches(fork, localRef)).toBeArrayOfSize(0)
-      expect(await getBranches(fork, remoteRef)).toBeArrayOfSize(0)
-      expect(await getBranches(repository, localRef)).toBeArrayOfSize(0)
+      await deleteRemoteBranch(
+        mockLocal,
+        null,
+        localBranch.upstreamRemoteName,
+        localBranch.upstreamWithoutRemote,
+        localBranch.tip.sha
+      )
+
+      expect(await getBranches(mockLocal, remoteRef)).toBeArrayOfSize(0)
+      expect(await getBranches(mockRemote, localRef)).toBeArrayOfSize(0)
     })
   })
 })

--- a/app/test/unit/git/branch-test.ts
+++ b/app/test/unit/git/branch-test.ts
@@ -236,8 +236,7 @@ describe('git/branch', () => {
         mockLocal,
         null,
         localBranch.upstreamRemoteName,
-        localBranch.upstreamWithoutRemote,
-        localBranch.tip.sha
+        localBranch.upstreamWithoutRemote
       )
 
       expect(await getBranches(mockLocal, localRef)).toBeArrayOfSize(1)
@@ -286,8 +285,7 @@ describe('git/branch', () => {
         mockLocal,
         null,
         localBranch.upstreamRemoteName,
-        localBranch.upstreamWithoutRemote,
-        localBranch.tip.sha
+        localBranch.upstreamWithoutRemote
       )
 
       expect(await getBranches(mockLocal, remoteRef)).toBeArrayOfSize(0)


### PR DESCRIPTION
## Description

Based on discussions on PR https://github.com/desktop/desktop/pull/11434 about adding delete context menus to branches. We want to refactor the delete branch methods in branches to be more singular in responsibility to hopefully improve readability and clarify the intent of the code. This also creates a clearer separation from UI layer (handling user actions such as "I also want to delete the remote branch.") and the more api type layer handling commands such as `deleteLocalBranch` and `deleteRemoteBranch`.

- Removing `deleteBranch` from `branch.ts` as it was too broad of scope in deleting local and remote branches as well as deciding between those.
- Add `deleteRemoteBranch` to `branch.ts` to handle deleting remote branches.
- Refactor `app-store.ts` to handle the `includeRemote` logic from the user interface and choose when to use `deleteLocalBranch` and `deleteRemoteBranch`.
- During refactor, I changed the reference for getting the branch name when deleting remotely to use `upstreamWithoutRemote` as opposed to `nameWithoutRemote`

I confirmed what @niik pointed out -> that for that last bullet point (prior to this fix) that if I 

1. Created a branch `testA`, pushed it to remote, deleted it locally (`testA` only exists remotely)
![image](https://user-images.githubusercontent.com/75402236/106300470-8b479100-6224-11eb-814c-4d223a46b8e5.png)
2. Created a branch `testB`, pushed it to remote, renamed it locally to `testA`
![image](https://user-images.githubusercontent.com/75402236/106300596-b16d3100-6224-11eb-92b0-202afc4b7bd3.png)
![image](https://user-images.githubusercontent.com/75402236/106300852-f5f8cc80-6224-11eb-8f35-7ba561056b42.png)
3. Deleted `testA` and checked to include also delete it remotely.
![image](https://user-images.githubusercontent.com/75402236/106300904-090b9c80-6225-11eb-81d3-3ac70bd22b1a.png)
4. Wallah! I now deleted remote `origin/testA` and am left with `origin/testB`
![image](https://user-images.githubusercontent.com/75402236/106301331-964ef100-6225-11eb-996d-7e96a3caf08a.png)

Albeit that the above scenario is unlikely... it is a one variable name change to delete the actual upstream or tracking branch to what the user selected... which "should" be what the user intends... and not using this as a round about way of deleting a remote branch without checking it out :D


Notes: no-notes
