### PR TITLE
Rely on Git's init.defaultBranch config

### DIFF
--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -124,23 +124,6 @@ export async function checkoutPaths(
 }
 
 /**
- * Create and checkout the given branch.
- *
- * @param repository The repository.
- * @param branchName The branch to create and checkout.
- */
-export async function createAndCheckoutBranch(
-  repository: Repository,
-  branchName: string
-): Promise<void> {
-  await git(
-    ['checkout', '-b', branchName],
-    repository.path,
-    'createAndCheckoutBranch'
-  )
-}
-
-/**
  * Check out either stage #2 (ours) or #3 (theirs) for a conflicted
  * file.
  */

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -3,6 +3,7 @@ import { ICloneProgress } from '../../models/progress'
 import { CloneOptions } from '../../models/clone-options'
 import { CloneProgressParser, executionOptionsWithProgress } from '../progress'
 import { envForRemoteOperation } from './environment'
+import { getDefaultBranch } from '../helpers/default-branch'
 
 /**
  * Clones a repository from a given url into to the specified path.
@@ -34,7 +35,15 @@ export async function clone(
 
   const env = await envForRemoteOperation(options.account, url)
 
-  const args = [...networkArguments, 'clone', '--recursive']
+  const defaultBranch = options.defaultBranch ?? (await getDefaultBranch())
+
+  const args = [
+    ...networkArguments,
+    '-c',
+    `init.defaultBranch=${defaultBranch}`,
+    'clone',
+    '--recursive',
+  ]
 
   let opts: IGitExecutionOptions = { env }
 

--- a/app/src/lib/git/init.ts
+++ b/app/src/lib/git/init.ts
@@ -1,6 +1,11 @@
+import { getDefaultBranch } from '../helpers/default-branch'
 import { git } from './core'
 
 /** Init a new git repository in the given path. */
 export async function initGitRepository(path: string): Promise<void> {
-  await git(['init'], path, 'initGitRepository')
+  await git(
+    ['-c', `init.defaultBranch=${await getDefaultBranch()}`, 'init'],
+    path,
+    'initGitRepository'
+  )
 }

--- a/app/src/lib/helpers/default-branch.ts
+++ b/app/src/lib/helpers/default-branch.ts
@@ -43,5 +43,5 @@ export async function getDefaultBranch(): Promise<string> {
  * @param branchName The default branch name to use.
  */
 export async function setDefaultBranch(branchName: string) {
-  return setGlobalConfigValue('init.defaultBranch', branchName)
+  return setGlobalConfigValue(DefaultBranchSettingName, branchName)
 }

--- a/app/src/lib/helpers/default-branch.ts
+++ b/app/src/lib/helpers/default-branch.ts
@@ -2,16 +2,10 @@ import { getGlobalConfigValue, setGlobalConfigValue } from '../git'
 import { enableDefaultBranchSetting } from '../feature-flag'
 
 /**
- * The default branch name that Desktop's embedded version of Git
- * will use when initializing a new repository.
- */
-export const DefaultBranchInGit = 'master'
-
-/**
  * The default branch name that GitHub Desktop will use when
  * initializing a new repository.
  */
-export const DefaultBranchInDesktop = 'main'
+const DefaultBranchInDesktop = 'main'
 
 /**
  * The name of the Git configuration variable which holds what

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3875,7 +3875,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _clone(
     url: string,
     path: string,
-    options?: { branch?: string }
+    options?: { branch?: string; defaultBranch?: string }
   ): {
     promise: Promise<boolean>
     repository: CloningRepository

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -12,10 +12,7 @@ import { git } from '../../git'
 import { friendlyEndpointName } from '../../friendly-endpoint-name'
 import { IRemote } from '../../../models/remote'
 import { envForRemoteOperation } from '../../git/environment'
-import {
-  DefaultBranchInGit,
-  DefaultBranchInDesktop,
-} from '../../helpers/default-branch'
+import { getDefaultBranch } from '../../helpers/default-branch'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InitialReadmeContents =
@@ -118,15 +115,16 @@ export async function createTutorialRepository(
   }
 
   const repo = await createAPIRepository(account, name)
-  const branch = repo.default_branch ?? DefaultBranchInDesktop
+  const branch = repo.default_branch ?? (await getDefaultBranch())
   progressCb('Initializing local repository', 0.2)
 
   await ensureDir(path)
-  await git(['init'], path, 'tutorial:init')
 
-  if (branch !== DefaultBranchInGit) {
-    await git(['checkout', '-b', branch], path, 'tutorial:rename-branch')
-  }
+  await git(
+    ['-c', `init.defaultBranch=${branch}`, 'init'],
+    path,
+    'tutorial:init'
+  )
 
   await writeFile(Path.join(path, 'README.md'), InitialReadmeContents)
 

--- a/app/src/models/clone-options.ts
+++ b/app/src/models/clone-options.ts
@@ -6,4 +6,6 @@ export type CloneOptions = {
   readonly account: IGitAccount | null
   /** The branch to checkout after the clone has completed. */
   readonly branch?: string
+  /** The default branch name in case we're cloning an empty repository. */
+  readonly defaultBranch?: string
 }

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -10,7 +10,6 @@ import {
   getStatus,
   getAuthorIdentity,
   isGitRepository,
-  createAndCheckoutBranch,
 } from '../../lib/git'
 import { sanitizedRepositoryName } from './sanitized-repository-name'
 import { TextBox } from '../lib/text-box'

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -31,10 +31,6 @@ import { PopupType } from '../../models/popup'
 import { Ref } from '../lib/ref'
 import { enableReadmeOverwriteWarning } from '../../lib/feature-flag'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import {
-  getDefaultBranch,
-  DefaultBranchInGit,
-} from '../../lib/helpers/default-branch'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -244,25 +240,6 @@ export class CreateRepository extends React.Component<
     }
 
     const repository = repositories[0]
-
-    const defaultBranch = await getDefaultBranch()
-
-    if (defaultBranch !== DefaultBranchInGit) {
-      try {
-        // Manually checkout to the configured default branch.
-        // TODO (git@2.28): Remove this code when upgrading to git v2.28
-        // since this will be natively implemented.
-        await createAndCheckoutBranch(repository, defaultBranch)
-      } catch (e) {
-        // When we cannot checkout the default branch just log the error,
-        // since we don't want to stop the repository creation (since we're
-        // in the middle of the creation process).
-        log.error(
-          `createRepository: unable to create default branch "${defaultBranch}"`,
-          e
-        )
-      }
-    }
 
     if (this.state.createWithReadme) {
       try {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -646,7 +646,7 @@ export class Dispatcher {
   public async clone(
     url: string,
     path: string,
-    options?: { branch?: string }
+    options?: { branch?: string; defaultBranch?: string }
   ): Promise<Repository | null> {
     return this.appStore._completeOpenInDesktop(async () => {
       const { promise, repository } = this.appStore._clone(url, path, options)


### PR DESCRIPTION
Closes #11447 

## Description

While clearing out TODOs ahead of my parental leave I saw that I had made a note to rip out some workarounds we put in place while we waited for Git 2.28+. Since we shipped 2.29 in #11469 

⚠️ I didn't test this before pushing and I obviously can't take any ownership of it so please review thoroughly and make any necessary changes ⚠️ 