### PR TITLE
Add ref to branch

### DIFF
--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -95,7 +95,13 @@ export async function getBranches(
     }
 
     branches.push(
-      new Branch(name, upstream.length > 0 ? upstream : null, branchTip, type)
+      new Branch(
+        name,
+        upstream.length > 0 ? upstream : null,
+        branchTip,
+        type,
+        ref
+      )
     )
   }
 

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1111,7 +1111,7 @@ export class GitStore extends BaseStore {
           status.currentUpstreamBranch || null,
           branchTipCommit,
           BranchType.Local,
-          ''
+          `refs/heads/${currentBranch}`
         )
         this._tip = { kind: TipState.Valid, branch }
       } else if (currentTip) {

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1110,7 +1110,8 @@ export class GitStore extends BaseStore {
           currentBranch,
           status.currentUpstreamBranch || null,
           branchTipCommit,
-          BranchType.Local
+          BranchType.Local,
+          ''
         )
         this._tip = { kind: TipState.Valid, branch }
       } else if (currentTip) {

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -45,7 +45,7 @@ export class Branch {
    * @param upstream The remote-prefixed upstream name. E.g., `origin/main`.
    * @param tip Basic information (sha and author) of the latest commit on the branch.
    * @param type The type of branch, e.g., local or remote.
-   * @param ref The connical ref of the branch
+   * @param ref The canonical ref of the branch
    */
   public constructor(
     public readonly name: string,

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -77,7 +77,7 @@ export class Branch {
     }
 
     const pieces = this.ref.match(/^refs\/remotes\/(.*?)\/.*/)
-    if (!pieces || pieces.length < 2) {
+    if (!pieces || pieces.length === 2) {
       // This shouldn't happen, the remote ref should always be prefixed
       // with refs/remotes
       throw new Error(`Remote branch ref has unexpected format: ${this.ref}`)

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -45,12 +45,14 @@ export class Branch {
    * @param upstream The remote-prefixed upstream name. E.g., `origin/main`.
    * @param tip Basic information (sha and author) of the latest commit on the branch.
    * @param type The type of branch, e.g., local or remote.
+   * @param ref The connical ref of the branch
    */
   public constructor(
     public readonly name: string,
     public readonly upstream: string | null,
     public readonly tip: IBranchTip,
-    public readonly type: BranchType
+    public readonly type: BranchType,
+    public readonly ref: string
   ) {}
 
   /** The name of the upstream's remote. */

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -70,6 +70,20 @@ export class Branch {
     return pieces[1]
   }
 
+  /** The name of remote for a remote branch. If local, will return null. */
+  public get remoteName(): string | null {
+    if (this.type === BranchType.Local) {
+      return null
+    }
+    const remoteRefPrefix = 'refs/remotes/'
+    const remoteBranchName = this.ref.replace(remoteRefPrefix, '')
+    const pieces = remoteBranchName.match(/(.*?)\/.*/)
+    if (!pieces || pieces.length < 2) {
+      return null
+    }
+    return pieces[1]
+  }
+
   /**
    * The name of the branch's upstream without the remote prefix.
    */

--- a/app/src/models/branch.ts
+++ b/app/src/models/branch.ts
@@ -75,11 +75,12 @@ export class Branch {
     if (this.type === BranchType.Local) {
       return null
     }
-    const remoteRefPrefix = 'refs/remotes/'
-    const remoteBranchName = this.ref.replace(remoteRefPrefix, '')
-    const pieces = remoteBranchName.match(/(.*?)\/.*/)
+
+    const pieces = this.ref.match(/^refs\/remotes\/(.*?)\/.*/)
     if (!pieces || pieces.length < 2) {
-      return null
+      // This shouldn't happen, the remote ref should always be prefixed
+      // with refs/remotes
+      throw new Error(`Remote branch ref has unexpected format: ${this.ref}`)
     }
     return pieces[1]
   }

--- a/app/test/unit/create-branch-test.ts
+++ b/app/test/unit/create-branch-test.ts
@@ -30,6 +30,7 @@ const defaultBranch: Branch = {
   nameWithoutRemote: 'my-default-branch',
   isDesktopForkRemoteBranch: false,
   ref: '',
+  remoteName: '',
 }
 
 const upstreamDefaultBranch = null
@@ -44,6 +45,7 @@ const someOtherBranch: Branch = {
   nameWithoutRemote: 'some-other-branch',
   isDesktopForkRemoteBranch: false,
   ref: '',
+  remoteName: '',
 }
 
 describe('create-branch/getStartPoint', () => {

--- a/app/test/unit/create-branch-test.ts
+++ b/app/test/unit/create-branch-test.ts
@@ -29,6 +29,7 @@ const defaultBranch: Branch = {
   upstreamWithoutRemote: null,
   nameWithoutRemote: 'my-default-branch',
   isDesktopForkRemoteBranch: false,
+  ref: '',
 }
 
 const upstreamDefaultBranch = null
@@ -42,6 +43,7 @@ const someOtherBranch: Branch = {
   upstreamWithoutRemote: null,
   nameWithoutRemote: 'some-other-branch',
   isDesktopForkRemoteBranch: false,
+  ref: '',
 }
 
 describe('create-branch/getStartPoint', () => {

--- a/app/test/unit/find-forked-remotes-to-prune-test.ts
+++ b/app/test/unit/find-forked-remotes-to-prune-test.ts
@@ -42,7 +42,7 @@ function createSampleBranch(name: string, upstream: string | null) {
     author,
   }
 
-  return new Branch(name, upstream, branchTip, BranchType.Local)
+  return new Branch(name, upstream, branchTip, BranchType.Local, '')
 }
 
 describe('findForkedRemotesToPrune', () => {

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -44,6 +44,7 @@ describe('git/checkout', () => {
       },
       upstreamRemoteName: null,
       isDesktopForkRemoteBranch: false,
+      ref: '',
     }
 
     let errorRaised = false

--- a/app/test/unit/git/checkout-test.ts
+++ b/app/test/unit/git/checkout-test.ts
@@ -45,6 +45,7 @@ describe('git/checkout', () => {
       upstreamRemoteName: null,
       isDesktopForkRemoteBranch: false,
       ref: '',
+      remoteName: '',
     }
 
     let errorRaised = false

--- a/app/test/unit/group-branches-test.ts
+++ b/app/test/unit/group-branches-test.ts
@@ -10,16 +10,29 @@ describe('Branches grouping', () => {
     author,
   }
 
-  const currentBranch = new Branch('master', null, branchTip, BranchType.Local)
-  const defaultBranch = new Branch('master', null, branchTip, BranchType.Local)
+  const currentBranch = new Branch(
+    'master',
+    null,
+    branchTip,
+    BranchType.Local,
+    ''
+  )
+  const defaultBranch = new Branch(
+    'master',
+    null,
+    branchTip,
+    BranchType.Local,
+    ''
+  )
   const recentBranches = [
-    new Branch('some-recent-branch', null, branchTip, BranchType.Local),
+    new Branch('some-recent-branch', null, branchTip, BranchType.Local, ''),
   ]
   const otherBranch = new Branch(
     'other-branch',
     null,
     branchTip,
-    BranchType.Local
+    BranchType.Local,
+    ''
   )
 
   const allBranches = [currentBranch, ...recentBranches, otherBranch]


### PR DESCRIPTION
## Description

Add `ref` to the `branch` class to allow us to more accurately obtain a remote branch's remote. 

From @niik on PR https://github.com/desktop/desktop/pull/11434
> I don't think we can assume that the name of a remote branch will always start with the remote name. `name` is derived from `%(refname:short)` which attempts to give you the shortest possible **non-ambiguous** name. As a convoluted example if you've got a remote branch `refs/remotes/origin/foo` and a local branch called `origin/foo` the remote branch name would be `remotes/origin/foo` as that's the shortest non-ambiguous name.

Notes: no-notes