### PR TITLE
Release 2.6.3-beta2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.6.3-beta1",
+  "version": "2.6.3-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,8 +1,6 @@
 {
   "releases": {
-    "2.6.3-beta2": [
-      "[Improved] Update app icon for macOS Big Sur - #10855"
-    ],
+    "2.6.3-beta2": ["[Improved] Update app icon for macOS Big Sur - #10855"],
     "2.6.3-beta1": [
       "[Fixed] Fast-forward all possible branches except the current branch when fetching - #11387",
       "[Improved] Enable spellcheck on commit summary and description - #1597",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "2.6.3-beta2": [
+      "[Improved] Update app icon - #10855 #7536"
+    ],
     "2.6.3-beta1": [
       "[Fixed] Fast-forward all possible branches except the current branch when fetching - #11387",
       "[Improved] Enable spellcheck on commit summary and description - #1597",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.6.3-beta2": [
-      "[Improved] Update app icon for macOS Big Sur - #10855
+      "[Improved] Update app icon for macOS Big Sur - #10855"
     ],
     "2.6.3-beta1": [
       "[Fixed] Fast-forward all possible branches except the current branch when fetching - #11387",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.6.3-beta2": [
-      "[Improved] Update app icon - #10855 #7536"
+      "[Improved] Update app icon for macOS Big Sur - #10855
     ],
     "2.6.3-beta1": [
       "[Fixed] Fast-forward all possible branches except the current branch when fetching - #11387",


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Looking for the PR for the upcoming first beta of the v2.6.3 series? Well you've just found it, congratulations! :tada:

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated