### PR TITLE
Launch external editors as detached processes

### DIFF
--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, SpawnOptions } from 'child_process'
 import { pathExists } from 'fs-extra'
 import { ExternalEditorError, FoundEditor } from './shared'
 
@@ -21,13 +21,21 @@ export async function launchExternalEditor(
       { openPreferences: true }
     )
   }
+
+  const opts: SpawnOptions = {
+    // Make sure the editor processes are detached from the Desktop app.
+    // Otherwise, some editors (like Notepad++) will be killed when the
+    // Desktop app is closed.
+    detached: true,
+  }
+
   if (editor.usesShell) {
-    spawn(`"${editorPath}"`, [`"${fullPath}"`], { shell: true })
+    spawn(`"${editorPath}"`, [`"${fullPath}"`], { ...opts, shell: true })
   } else if (__DARWIN__) {
     // In macOS we can use `open`, which will open the right executable file
     // for us, we only need the path to the editor .app folder.
-    spawn('open', ['-a', editorPath, fullPath])
+    spawn('open', ['-a', editorPath, fullPath], opts)
   } else {
-    spawn(editorPath, [fullPath])
+    spawn(editorPath, [fullPath], opts)
   }
 }


### PR DESCRIPTION
Closes #11518

## Description

We weren't launching the external editors as detached processes, which was ok for most editors but caused that some (like Notepad++) were killed when GitHub Desktop was closed.

Just setting [`detached` to `true` in the `spawn` call](https://nodejs.org/api/child_process.html#child_process_options_detached) made the trick.

## Release notes

Notes: [Fixed] Notepad++ is not closed anymore with GitHub Desktop.
