### PR TITLE
Bump dugite to v1.97.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "deep-equal": "^1.0.1",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.96.0",
+    "dugite": "^1.97.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -355,10 +355,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.96.0:
-  version "1.96.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.96.0.tgz#3990a2f2adb344fd09c1bf96faa1ae63bfd8d0a4"
-  integrity sha512-J+cDoQFi1t5emi40TOqHhJ1pWBMRvzg8tHcpFVISiG19NVoM89xGWCDvH4IG0R49n6DFTDJyCSgqZGWL/p81eg==
+dugite@^1.97.0:
+  version "1.97.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.97.0.tgz#9d244637571917b98eb95c22e30b9f3e26304738"
+  integrity sha512-/5vUKYGFADT7rdYuBCzGx70wptQMtaGtSkfop7LFUjNS7+nt2ugLXafLBzzoEKzgdnZRQamsTauCBD0PAkyeGg==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"


### PR DESCRIPTION
Closes #11516 

## Description

dugite v1.97.0 includes a git for macOS built with the Mojave SDK: desktop/dugite-native#350

## Release notes

Notes: [Fixed] Remote git operations (like cloning a repo) won't fail on old macOS versions.
