### PR TITLE
Refactor getCommitsInRange to more generically accept a range parameter

### DIFF
--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -119,13 +119,25 @@ export async function getBranchAheadBehind(
  * Returns `null` when the rebase is not possible to perform, because of a
  * missing commit ID
  */
-export async function getCommitsInRange(
+export async function getCommitsBetweenCommits(
   repository: Repository,
   baseBranchSha: string,
   targetBranchSha: string
 ): Promise<ReadonlyArray<CommitOneLine> | null> {
   const range = revRange(baseBranchSha, targetBranchSha)
 
+  return getCommitsInRange(repository, range)
+}
+
+/**
+ * Get a list of commits inside the provided range.
+ *
+ * Returns `null` when it is not possible to perform because of a bad range.
+ */
+export async function getCommitsInRange(
+  repository: Repository,
+  range: string
+): Promise<ReadonlyArray<CommitOneLine> | null> {
   const args = [
     'rev-list',
     range,
@@ -144,12 +156,6 @@ export async function getCommitsInRange(
   const result = await git(args, repository.path, 'getCommitsInRange', options)
 
   if (result.gitError === GitError.BadRevision) {
-    // BadRevision can be raised here if git rev-list is unable to resolve a ref
-    // to a commit ID, so we need to signal to the caller that this rebase is
-    // not possible to perform
-    log.warn(
-      'Unable to rebase these branches because one or both of the refs do not exist in the repository'
-    )
     return null
   }
 

--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -112,6 +112,7 @@ export async function getBranchAheadBehind(
 /**
  * Get a list of commits from the target branch that do not exist on the base
  * branch, ordered how they will be applied to the base branch.
+ * Therefore, this will not include the baseBranchSha commit.
  *
  * This emulates how `git rebase` initially determines what will be applied to
  * the repository.

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -25,7 +25,7 @@ import {
   isGitRepository,
   RebaseResult,
   PushOptions,
-  getCommitsInRange,
+  getCommitsBetweenCommits,
   getBranches,
 } from '../../lib/git'
 import { isGitOnPath } from '../../lib/is-git-on-path'
@@ -381,7 +381,7 @@ export class Dispatcher {
     }
 
     // and the remote branch has commits that don't exist on the base branch
-    const remoteCommits = await getCommitsInRange(
+    const remoteCommits = await getCommitsBetweenCommits(
       repository,
       baseBranch.tip.sha,
       targetBranch.upstream

--- a/app/src/ui/rebase/choose-branch.tsx
+++ b/app/src/ui/rebase/choose-branch.tsx
@@ -7,7 +7,7 @@ import { ComputedAction } from '../../models/computed-action'
 
 import { IMatches } from '../../lib/fuzzy-find'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
-import { getCommitsInRange, getMergeBase } from '../../lib/git'
+import { getCommitsBetweenCommits, getMergeBase } from '../../lib/git'
 
 import { ActionStatusIcon } from '../lib/action-status-icon'
 
@@ -126,7 +126,7 @@ export class ChooseBranchDialog extends React.Component<
     })
 
     const { commits, base } = await promiseWithMinimumTimeout(async () => {
-      const commits = await getCommitsInRange(
+      const commits = await getCommitsBetweenCommits(
         repository,
         baseBranch.tip.sha,
         targetBranch.tip.sha


### PR DESCRIPTION
Part of work on #1685
## Description
Refactor getCommitsInRange to accept a revisionRange as the parameter instead of two commits so I can send an inclusive range in for cherry picking.

## Release notes
Notes: no-notes
