### PR TITLE
Improve onboarding to suggest emails from the user account

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -17,6 +17,9 @@ import {
   parseConfigLockFilePathFromError,
 } from '../../lib/git'
 import { ConfigLockFileExists } from './config-lock-file-exists'
+import { RadioButton } from './radio-button'
+import { Select } from './select'
+import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
 
 interface IConfigureGitUserProps {
   /** The logged-in accounts. */
@@ -33,8 +36,13 @@ interface IConfigureGitUserState {
   readonly globalUserName: string | null
   readonly globalUserEmail: string | null
 
-  readonly name: string
-  readonly email: string
+  readonly manualName: string
+  readonly manualEmail: string
+
+  readonly gitHubName: string
+  readonly gitHubEmail: string
+
+  readonly useGitHubAuthorInfo: boolean
 
   /**
    * If unable to save Git configuration values (name, email)
@@ -57,19 +65,30 @@ export class ConfigureGitUser extends React.Component<
 > {
   private readonly globalUsernamePromise = getGlobalConfigValue('user.name')
   private readonly globalEmailPromise = getGlobalConfigValue('user.email')
+  private loadInitialDataPromise: Promise<void> | null = null
 
   public constructor(props: IConfigureGitUserProps) {
     super(props)
 
+    const account = this.account
+
     this.state = {
       globalUserName: null,
       globalUserEmail: null,
-      name: '',
-      email: '',
+      manualName: '',
+      manualEmail: '',
+      useGitHubAuthorInfo: this.account !== null,
+      gitHubName: account?.name || account?.login || '',
+      gitHubEmail:
+        this.account !== null ? lookupPreferredEmail(this.account) : '',
     }
   }
 
   public async componentDidMount() {
+    this.loadInitialDataPromise = this.loadInitialData()
+  }
+
+  private async loadInitialData() {
     // Capture the current accounts prop because we'll be
     // doing a bunch of asynchronous stuff and we can't
     // rely on this.props.account to tell us what that prop
@@ -85,12 +104,14 @@ export class ConfigureGitUser extends React.Component<
       prevState => ({
         globalUserName,
         globalUserEmail,
-        name:
-          prevState.name.length === 0 ? globalUserName || '' : prevState.name,
-        email:
-          prevState.email.length === 0
+        manualName:
+          prevState.manualName.length === 0
+            ? globalUserName || ''
+            : prevState.manualName,
+        manualEmail:
+          prevState.manualEmail.length === 0
             ? globalUserEmail || ''
-            : prevState.email,
+            : prevState.manualEmail,
       }),
       () => {
         // Chances are low that we actually have an account at mount-time
@@ -106,12 +127,21 @@ export class ConfigureGitUser extends React.Component<
     )
   }
 
-  public componentDidUpdate(prevProps: IConfigureGitUserProps) {
+  public async componentDidUpdate(prevProps: IConfigureGitUserProps) {
     if (
+      this.loadInitialDataPromise !== null &&
       this.props.accounts !== prevProps.accounts &&
       this.props.accounts.length > 0
     ) {
       if (this.props.accounts[0] !== prevProps.accounts[0]) {
+        // Wait for the initial data load to finish before updating the state
+        // with the new account info.
+        // The problem is we might get the account info before we retrieved the
+        // global user name and email in `loadInitialData` and updated the state
+        // with them, so `componentDidUpdate` would get called and override
+        // whatever the user had in the global git config with the account info.
+        await this.loadInitialDataPromise
+
         const account = this.props.accounts[0]
         this.setDefaultValuesFromAccount(account)
       }
@@ -119,15 +149,30 @@ export class ConfigureGitUser extends React.Component<
   }
 
   private setDefaultValuesFromAccount(account: Account) {
-    if (this.state.name.length === 0) {
+    const preferredEmail = lookupPreferredEmail(account)
+    this.setState({
+      useGitHubAuthorInfo: true,
+      gitHubName: account.name || account.login,
+      gitHubEmail: preferredEmail,
+    })
+
+    if (this.state.manualName.length === 0) {
       this.setState({
-        name: account.name || account.login,
+        manualName: account.name || account.login,
       })
     }
 
-    if (this.state.email.length === 0) {
-      this.setState({ email: lookupPreferredEmail(account) })
+    if (this.state.manualEmail.length === 0) {
+      this.setState({ manualEmail: preferredEmail })
     }
+  }
+
+  private get account(): Account | null {
+    if (this.props.accounts.length === 0) {
+      return null
+    }
+
+    return this.props.accounts[0]
   }
 
   private dateWithMinuteOffset(date: Date, minuteOffset: number): Date {
@@ -137,30 +182,6 @@ export class ConfigureGitUser extends React.Component<
   }
 
   public render() {
-    const now = new Date()
-
-    // NB: We're using the name as the commit SHA:
-    //  1. `Commit` is referentially transparent wrt the SHA. So in order to get
-    //     it to update when we name changes, we need to change the SHA.
-    //  2. We don't display the SHA so the user won't ever know our secret.
-    const author = new CommitIdentity(
-      this.state.name,
-      this.state.email,
-      this.dateWithMinuteOffset(now, -30)
-    )
-    const dummyCommit = new Commit(
-      this.state.name,
-      this.state.name.slice(0, 7),
-      'Fix all the things',
-      '',
-      author,
-      author,
-      [],
-      [],
-      []
-    )
-    const emoji = new Map()
-
     const error =
       this.state.existingLockFilePath !== undefined ? (
         <ConfigLockFileExists
@@ -172,43 +193,164 @@ export class ConfigureGitUser extends React.Component<
 
     return (
       <div id="configure-git-user">
+        {this.renderAuthorOptions()}
+
         {error}
 
-        <Form className="sign-in-form" onSubmit={this.save}>
-          <TextBox
-            label="Name"
-            placeholder="Your Name"
-            value={this.state.name}
-            onValueChanged={this.onNameChange}
-          />
+        {this.state.useGitHubAuthorInfo
+          ? this.renderGitHubInfo()
+          : this.renderGitConfigForm()}
 
-          <TextBox
-            type="email"
-            label="Email"
-            placeholder="your-email@example.com"
-            value={this.state.email}
-            onValueChanged={this.onEmailChange}
-          />
-
-          <Row>
-            <Button type="submit">{this.props.saveLabel || 'Save'}</Button>
-            {this.props.children}
-          </Row>
-        </Form>
-
-        <div id="commit-list" className="commit-list-example">
-          <div className="header">Example commit</div>
-
-          <CommitListItem
-            commit={dummyCommit}
-            emoji={emoji}
-            gitHubRepository={null}
-            isLocal={false}
-            showUnpushedIndicator={false}
-          />
-        </div>
+        {this.renderExampleCommit()}
       </div>
     )
+  }
+
+  private renderExampleCommit() {
+    const now = new Date()
+
+    let name = this.state.manualName
+    let email = this.state.manualEmail
+
+    if (this.state.useGitHubAuthorInfo) {
+      name = this.state.gitHubName
+      email = this.state.gitHubEmail
+    }
+
+    // NB: We're using the name as the commit SHA:
+    //  1. `Commit` is referentially transparent wrt the SHA. So in order to get
+    //     it to update when we name changes, we need to change the SHA.
+    //  2. We don't display the SHA so the user won't ever know our secret.
+    const author = new CommitIdentity(
+      name,
+      email,
+      this.dateWithMinuteOffset(now, -30)
+    )
+    const dummyCommit = new Commit(
+      name,
+      name.slice(0, 7),
+      'Fix all the things',
+      '',
+      author,
+      author,
+      [],
+      [],
+      []
+    )
+    const emoji = new Map()
+
+    return (
+      <div id="commit-list" className="commit-list-example">
+        <div className="header">Example commit</div>
+
+        <CommitListItem
+          commit={dummyCommit}
+          emoji={emoji}
+          gitHubRepository={null}
+          isLocal={false}
+          showUnpushedIndicator={false}
+        />
+      </div>
+    )
+  }
+
+  private renderAuthorOptions() {
+    if (this.props.accounts.length === 0) {
+      return
+    }
+
+    return (
+      <div>
+        <RadioButton
+          label="Use my GitHub account name and email address"
+          checked={this.state.useGitHubAuthorInfo}
+          onSelected={this.onUseGitHubInfoSelected}
+          value="github-account"
+        />
+        <RadioButton
+          label="Configure manually"
+          checked={!this.state.useGitHubAuthorInfo}
+          onSelected={this.onUseGitConfigInfoSelected}
+          value="git-config"
+        />
+      </div>
+    )
+  }
+
+  private renderGitHubInfo() {
+    if (this.account === null) {
+      return
+    }
+
+    return (
+      <Form className="sign-in-form" onSubmit={this.save}>
+        <TextBox
+          label="Name"
+          placeholder="Your Name"
+          value={this.state.gitHubName}
+          disabled={true}
+        />
+
+        <Select
+          label="Email"
+          value={this.state.gitHubEmail}
+          onChange={this.onSelectedGitHubEmailChange}
+        >
+          {this.account.emails.map(e => (
+            <option key={e.email} value={e.email}>
+              {e.email}
+            </option>
+          ))}
+        </Select>
+
+        <Row>
+          <Button type="submit">{this.props.saveLabel || 'Save'}</Button>
+          {this.props.children}
+        </Row>
+      </Form>
+    )
+  }
+
+  private renderGitConfigForm() {
+    return (
+      <Form className="sign-in-form" onSubmit={this.save}>
+        <TextBox
+          label="Name"
+          placeholder="Your Name"
+          value={this.state.manualName}
+          onValueChanged={this.onNameChange}
+        />
+
+        <TextBox
+          type="email"
+          label="Email"
+          placeholder="your-email@example.com"
+          value={this.state.manualEmail}
+          onValueChanged={this.onEmailChange}
+        />
+
+        {this.account !== null && (
+          <GitEmailNotFoundWarning
+            accounts={[this.account]}
+            email={this.state.manualEmail}
+          />
+        )}
+
+        <Row>
+          <Button type="submit">{this.props.saveLabel || 'Save'}</Button>
+          {this.props.children}
+        </Row>
+      </Form>
+    )
+  }
+
+  private onSelectedGitHubEmailChange = (
+    event: React.FormEvent<HTMLSelectElement>
+  ) => {
+    const email = event.currentTarget.value
+    if (email) {
+      this.setState({ gitHubEmail: email })
+    }
   }
 
   private onLockFileDeleted = () => {
@@ -220,16 +362,35 @@ export class ConfigureGitUser extends React.Component<
     this.setState({ existingLockFilePath: undefined })
   }
 
+  private onUseGitHubInfoSelected = () => {
+    this.setState({ useGitHubAuthorInfo: true })
+  }
+
+  private onUseGitConfigInfoSelected = () => {
+    this.setState({ useGitHubAuthorInfo: false })
+  }
+
   private onNameChange = (name: string) => {
-    this.setState({ name })
+    this.setState({ manualName: name })
   }
 
   private onEmailChange = (email: string) => {
-    this.setState({ email })
+    this.setState({ manualEmail: email })
   }
 
   private save = async () => {
-    const { name, email, globalUserName, globalUserEmail } = this.state
+    const {
+      manualName,
+      manualEmail,
+      globalUserName,
+      globalUserEmail,
+      useGitHubAuthorInfo,
+      gitHubName,
+      gitHubEmail,
+    } = this.state
+
+    const name = useGitHubAuthorInfo ? gitHubName : manualName
+    const email = useGitHubAuthorInfo ? gitHubEmail : manualEmail
 
     try {
       if (name.length > 0 && name !== globalUserName) {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -20,6 +20,7 @@ import { ConfigLockFileExists } from './config-lock-file-exists'
 import { RadioButton } from './radio-button'
 import { Select } from './select'
 import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
+import { getDotComAPIEndpoint } from '../../lib/api'
 
 interface IConfigureGitUserProps {
   /** The logged-in accounts. */
@@ -255,14 +256,19 @@ export class ConfigureGitUser extends React.Component<
   }
 
   private renderAuthorOptions() {
-    if (this.props.accounts.length === 0) {
+    const account = this.account
+
+    if (account === null) {
       return
     }
+
+    const accountTypeSuffix =
+      account.endpoint === getDotComAPIEndpoint() ? '' : ' Enterprise'
 
     return (
       <div>
         <RadioButton
-          label="Use my GitHub account name and email address"
+          label={`Use my GitHub${accountTypeSuffix} account name and email address`}
           checked={this.state.useGitHubAuthorInfo}
           onSelected={this.onUseGitHubInfoSelected}
           value="github-account"

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { Account } from '../../models/account'
+import { LinkButton } from './link-button'
+import { getDotComAPIEndpoint } from '../../lib/api'
+
+interface IGitEmailNotFoundWarningProps {
+  /** The account the commit should be attributed to. */
+  readonly accounts: ReadonlyArray<Account>
+
+  /** The email address used in the commit author info. */
+  readonly email: string
+}
+
+/**
+ * A component which just displays a warning to the user if their git config
+ * email doesn't match any of the emails in their GitHub (Enterprise) account.
+ */
+export class GitEmailNotFoundWarning extends React.Component<
+  IGitEmailNotFoundWarningProps
+> {
+  private get accountEmails(): ReadonlyArray<string> {
+    // Merge email addresses from all accounts into an array
+    return this.props.accounts.reduce<ReadonlyArray<string>>(
+      (previousValue, currentValue) => {
+        return previousValue.concat(currentValue.emails.map(e => e.email))
+      },
+      []
+    )
+  }
+
+  public render() {
+    if (this.accountEmails.includes(this.props.email)) {
+      return null
+    }
+
+    return this.props.accounts.length === 1
+      ? this.renderForSingleAccount(this.props.accounts[0])
+      : this.renderForMultipleAccounts()
+  }
+
+  private renderForSingleAccount(account: Account) {
+    const accountType =
+      account.endpoint === getDotComAPIEndpoint()
+        ? 'GitHub'
+        : 'GitHub Enterprise'
+
+    return (
+      <div>
+        ⚠️ This email address doesn't match your {accountType} account, so your
+        commits will be wrongly attributed.{' '}
+        <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
+          Learn more.
+        </LinkButton>
+      </div>
+    )
+  }
+
+  private renderForMultipleAccounts() {
+    return (
+      <div>
+        ⚠️ This email address doesn't match either of your GitHub.com nor GitHub
+        Enterprise accounts, so your commits will be wrongly attributed.{' '}
+        <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
+          Learn more.
+        </LinkButton>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -33,21 +33,10 @@ export class GitEmailNotFoundWarning extends React.Component<
       return null
     }
 
-    return this.props.accounts.length === 1
-      ? this.renderForSingleAccount(this.props.accounts[0])
-      : this.renderForMultipleAccounts()
-  }
-
-  private renderForSingleAccount(account: Account) {
-    const accountType =
-      account.endpoint === getDotComAPIEndpoint()
-        ? 'GitHub'
-        : 'GitHub Enterprise'
-
     return (
       <div>
-        ⚠️ This email address doesn't match your {accountType} account, so your
-        commits will be wrongly attributed.{' '}
+        ⚠️ This email address doesn't match {this.getAccountTypeDescription()},
+        so your commits will be wrongly attributed.{' '}
         <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
           Learn more.
         </LinkButton>
@@ -55,15 +44,16 @@ export class GitEmailNotFoundWarning extends React.Component<
     )
   }
 
-  private renderForMultipleAccounts() {
-    return (
-      <div>
-        ⚠️ This email address doesn't match either of your GitHub.com nor GitHub
-        Enterprise accounts, so your commits will be wrongly attributed.{' '}
-        <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
-          Learn more.
-        </LinkButton>
-      </div>
-    )
+  private getAccountTypeDescription() {
+    if (this.props.accounts.length === 1) {
+      const accountType =
+        this.props.accounts[0].endpoint === getDotComAPIEndpoint()
+          ? 'GitHub'
+          : 'GitHub Enterprise'
+
+      return `your ${accountType} account`
+    }
+
+    return 'either of your GitHub.com nor GitHub Enterprise accounts'
   }
 }


### PR DESCRIPTION
## Description

This PR is part of #610 work. It introduces a few changes in the onboarding flow, in the "Configure Git" screen, to help the user choosing an email address that will get their commits properly attributed.

Additionally, I fixed a race condition that would replace the user's global git config with the name and email from the GitHub account under some circumstances.

There is only one known issue with these changes: a visual glitch that makes the email dropdown look a bit smaller than the textbox. I haven't seen this effect in other places of the app, but I'll investigate it separately and fix it in a different PR.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/107627570-c6ec4d00-6c5f-11eb-88d5-da49ddcb2e0f.png)

![image](https://user-images.githubusercontent.com/1083228/107627642-e2575800-6c5f-11eb-933d-8c9f7311ce93.png)

![image](https://user-images.githubusercontent.com/1083228/107627725-fe5af980-6c5f-11eb-8ff2-476339ba91ba.png)

## Release notes

Notes: [Improved] Suggest email addresses from the GitHub account and warn about misattributed commits during the onboarding
