### PR TITLE
In Preferences -> Git, allow using emails from the signed in accounts

### DIFF
--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -59,17 +59,6 @@ export class GitConfigUserForm extends React.Component<
   }
 
   public render() {
-    const dotComEmails =
-      this.props.dotComAccount?.emails.map(e => e.email) ?? []
-    const enterpriseEmails =
-      this.props.enterpriseAccount?.emails.map(e => e.email) ?? []
-
-    const shouldShowAccountType =
-      this.props.dotComAccount !== null && this.props.enterpriseAccount !== null
-
-    const dotComSuffix = shouldShowAccountType ? '(GitHub.com)' : ''
-    const enterpriseSuffix = shouldShowAccountType ? '(GitHub Enterprise)' : ''
-
     return (
       <div>
         <Row>
@@ -79,44 +68,78 @@ export class GitConfigUserForm extends React.Component<
             onValueChanged={this.props.onNameChanged}
           />
         </Row>
-        <Row>
-          <Select
-            label="Email"
-            value={
-              this.state.emailIsOther ? OtherEmailSelectValue : this.props.email
-            }
-            onChange={this.onEmailSelectChange}
-          >
-            {dotComEmails.map(e => (
-              <option key={e} value={e}>
-                {e} {dotComSuffix}
-              </option>
-            ))}
-            {enterpriseEmails.map(e => (
-              <option key={e} value={e}>
-                {e} {enterpriseSuffix}
-              </option>
-            ))}
-            <option key={OtherEmailSelectValue} value={OtherEmailSelectValue}>
-              {OtherEmailSelectValue}
-            </option>
-          </Select>
-        </Row>
-        {this.state.emailIsOther && (
-          <Row>
-            <TextBox
-              ref={this.emailInputRef}
-              type="email"
-              value={this.props.email}
-              onValueChanged={this.props.onEmailChanged}
-            />
-          </Row>
-        )}
+        {this.renderEmailDropdown()}
+        {this.renderEmailTextBox()}
         <GitEmailNotFoundWarning
           accounts={this.accounts}
           email={this.props.email}
         />
       </div>
+    )
+  }
+
+  private renderEmailDropdown() {
+    if (this.accountEmails.length === 0) {
+      return null
+    }
+
+    const dotComEmails =
+      this.props.dotComAccount?.emails.map(e => e.email) ?? []
+    const enterpriseEmails =
+      this.props.enterpriseAccount?.emails.map(e => e.email) ?? []
+
+    // When the user signed in both accounts, show a suffix to differentiate
+    // the origin of each email address
+    const shouldShowAccountType =
+      this.props.dotComAccount !== null && this.props.enterpriseAccount !== null
+
+    const dotComSuffix = shouldShowAccountType ? '(GitHub.com)' : ''
+    const enterpriseSuffix = shouldShowAccountType ? '(GitHub Enterprise)' : ''
+
+    return (
+      <Row>
+        <Select
+          label="Email"
+          value={
+            this.state.emailIsOther ? OtherEmailSelectValue : this.props.email
+          }
+          onChange={this.onEmailSelectChange}
+        >
+          {dotComEmails.map(e => (
+            <option key={e} value={e}>
+              {e} {dotComSuffix}
+            </option>
+          ))}
+          {enterpriseEmails.map(e => (
+            <option key={e} value={e}>
+              {e} {enterpriseSuffix}
+            </option>
+          ))}
+          <option key={OtherEmailSelectValue} value={OtherEmailSelectValue}>
+            {OtherEmailSelectValue}
+          </option>
+        </Select>
+      </Row>
+    )
+  }
+
+  private renderEmailTextBox() {
+    if (this.state.emailIsOther === false && this.accountEmails.length > 0) {
+      return null
+    }
+
+    const label = this.state.emailIsOther ? undefined : 'Email'
+
+    return (
+      <Row>
+        <TextBox
+          ref={this.emailInputRef}
+          label={label}
+          type="email"
+          value={this.props.email}
+          onValueChanged={this.props.onEmailChanged}
+        />
+      </Row>
     )
   }
 

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -1,0 +1,157 @@
+import * as React from 'react'
+import { TextBox } from './text-box'
+import { Row } from './row'
+import { Account } from '../../models/account'
+import { Select } from './select'
+import { GitEmailNotFoundWarning } from './git-email-not-found-warning'
+
+const OtherEmailSelectValue = 'Other'
+
+interface IGitConfigUserFormProps {
+  readonly name: string
+  readonly email: string
+
+  readonly dotComAccount: Account | null
+  readonly enterpriseAccount: Account | null
+
+  readonly onNameChanged: (name: string) => void
+  readonly onEmailChanged: (email: string) => void
+}
+
+interface IGitConfigUserFormState {
+  /**
+   * True if the selected email in the dropdown is not one of the suggestions.
+   * It's used to display the "Other" text box that allows the user to
+   * enter a custom email address.
+   */
+  readonly emailIsOther: boolean
+}
+
+export class GitConfigUserForm extends React.Component<
+  IGitConfigUserFormProps,
+  IGitConfigUserFormState
+> {
+  private emailInputRef = React.createRef<TextBox>()
+
+  public constructor(props: IGitConfigUserFormProps) {
+    super(props)
+
+    this.state = {
+      emailIsOther: !this.accountEmails.includes(this.props.email),
+    }
+  }
+
+  public componentDidUpdate(
+    prevProps: IGitConfigUserFormProps,
+    prevState: IGitConfigUserFormState
+  ) {
+    // Focus the text input that allows the user to enter a custom
+    // email address when the user selects "Other".
+    if (
+      this.state.emailIsOther !== prevState.emailIsOther &&
+      this.state.emailIsOther === true &&
+      this.emailInputRef.current !== null
+    ) {
+      const emailInput = this.emailInputRef.current
+      emailInput.focus()
+      emailInput.selectAll()
+    }
+  }
+
+  public render() {
+    const dotComEmails =
+      this.props.dotComAccount?.emails.map(e => e.email) ?? []
+    const enterpriseEmails =
+      this.props.enterpriseAccount?.emails.map(e => e.email) ?? []
+
+    const shouldShowAccountType =
+      this.props.dotComAccount !== null && this.props.enterpriseAccount !== null
+
+    const dotComSuffix = shouldShowAccountType ? '(GitHub.com)' : ''
+    const enterpriseSuffix = shouldShowAccountType ? '(GitHub Enterprise)' : ''
+
+    return (
+      <div>
+        <Row>
+          <TextBox
+            label="Name"
+            value={this.props.name}
+            onValueChanged={this.props.onNameChanged}
+          />
+        </Row>
+        <Row>
+          <Select
+            label="Email"
+            value={
+              this.state.emailIsOther ? OtherEmailSelectValue : this.props.email
+            }
+            onChange={this.onEmailSelectChange}
+          >
+            {dotComEmails.map(e => (
+              <option key={e} value={e}>
+                {e} {dotComSuffix}
+              </option>
+            ))}
+            {enterpriseEmails.map(e => (
+              <option key={e} value={e}>
+                {e} {enterpriseSuffix}
+              </option>
+            ))}
+            <option key={OtherEmailSelectValue} value={OtherEmailSelectValue}>
+              {OtherEmailSelectValue}
+            </option>
+          </Select>
+        </Row>
+        {this.state.emailIsOther && (
+          <Row>
+            <TextBox
+              ref={this.emailInputRef}
+              type="email"
+              value={this.props.email}
+              onValueChanged={this.props.onEmailChanged}
+            />
+          </Row>
+        )}
+        <GitEmailNotFoundWarning
+          accounts={this.accounts}
+          email={this.props.email}
+        />
+      </div>
+    )
+  }
+
+  private get accounts(): ReadonlyArray<Account> {
+    const accounts = []
+
+    if (this.props.dotComAccount) {
+      accounts.push(this.props.dotComAccount)
+    }
+
+    if (this.props.enterpriseAccount) {
+      accounts.push(this.props.enterpriseAccount)
+    }
+
+    return accounts
+  }
+
+  private get accountEmails(): ReadonlyArray<string> {
+    // Merge email addresses from all accounts into an array
+    return this.accounts.reduce<ReadonlyArray<string>>(
+      (previousValue, currentValue) => {
+        return previousValue.concat(currentValue.emails.map(e => e.email))
+      },
+      []
+    )
+  }
+
+  private onEmailSelectChange = (event: React.FormEvent<HTMLSelectElement>) => {
+    const value = event.currentTarget.value
+    this.setState({
+      emailIsOther: value === OtherEmailSelectValue,
+    })
+
+    if (value !== OtherEmailSelectValue) {
+      this.props.onEmailChanged?.(value)
+    }
+  }
+}

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -136,6 +136,9 @@ export class GitConfigUserForm extends React.Component<
       return null
     }
 
+    // Only show the "Email" label above the textbox when the textbox is
+    // presented independently, without the email dropdown, not when presented
+    // as a consequence of the option "Other" selected in the dropdown.
     const label = this.state.emailIsOther ? undefined : 'Email'
 
     return (
@@ -181,6 +184,8 @@ export class GitConfigUserForm extends React.Component<
       emailIsOther: value === OtherEmailSelectValue,
     })
 
+    // If the dropdown selection is "Other", the email address itself didn't
+    // change, technically, so no need to emit an update notification.
     if (value !== OtherEmailSelectValue) {
       this.props.onEmailChanged?.(value)
     }

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -27,6 +27,14 @@ interface IGitConfigUserFormState {
   readonly emailIsOther: boolean
 }
 
+/**
+ * Form with a name and email address used to present and change the user's info
+ * via git config.
+ *
+ * It'll offer the email addresses from the user's accounts (if any), and an
+ * option to enter a custom email address. In this case, it will also warn the
+ * user when this custom email address could result in misattributed commits.
+ */
 export class GitConfigUserForm extends React.Component<
   IGitConfigUserFormProps,
   IGitConfigUserFormState

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -29,7 +29,10 @@ export class GitEmailNotFoundWarning extends React.Component<
   }
 
   public render() {
-    if (this.accountEmails.includes(this.props.email)) {
+    if (
+      this.props.accounts.length === 0 ||
+      this.accountEmails.includes(this.props.email)
+    ) {
       return null
     }
 

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react'
-import { TextBox } from '../lib/text-box'
-import { Row } from '../lib/row'
 import { DialogContent } from '../dialog'
 import { SuggestedBranchNames } from '../../lib/helpers/default-branch'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
 import { Ref } from '../lib/ref'
 import { RadioButton } from '../lib/radio-button'
 import { enableDefaultBranchSetting } from '../../lib/feature-flag'
+import { Account } from '../../models/account'
+import { GitConfigUserForm } from '../lib/git-config-user-form'
 
 interface IGitProps {
   readonly name: string
   readonly email: string
   readonly defaultBranch: string
+
+  readonly dotComAccount: Account | null
+  readonly enterpriseAccount: Account | null
 
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
@@ -59,24 +62,22 @@ export class Git extends React.Component<IGitProps, IGitState> {
   public render() {
     return (
       <DialogContent>
-        <Row>
-          <TextBox
-            label="Name"
-            value={this.props.name}
-            onValueChanged={this.props.onNameChanged}
-          />
-        </Row>
-        <Row>
-          <TextBox
-            type="email"
-            label="Email"
-            value={this.props.email}
-            onValueChanged={this.props.onEmailChanged}
-          />
-        </Row>
-
+        {this.renderGitConfigAuthorInfo()}
         {this.renderDefaultBranchSetting()}
       </DialogContent>
+    )
+  }
+
+  private renderGitConfigAuthorInfo() {
+    return (
+      <GitConfigUserForm
+        email={this.props.email}
+        name={this.props.name}
+        enterpriseAccount={this.props.enterpriseAccount}
+        dotComAccount={this.props.dotComAccount}
+        onEmailChanged={this.props.onEmailChanged}
+        onNameChanged={this.props.onNameChanged}
+      />
     )
   }
 

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -282,6 +282,8 @@ export class Preferences extends React.Component<
               name={this.state.committerName}
               email={this.state.committerEmail}
               defaultBranch={this.state.defaultBranch}
+              dotComAccount={this.props.dotComAccount}
+              enterpriseAccount={this.props.enterpriseAccount}
               onNameChanged={this.onCommitterNameChanged}
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}

--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -1,4 +1,8 @@
 #welcome {
+  // Override the height of some components to make them bigger
+  --text-field-height: 29px;
+  --button-height: var(--text-field-height);
+
   align-items: stretch;
   justify-content: center;
   flex-direction: row;
@@ -62,13 +66,19 @@
   }
 
   input,
-  button {
+  button,
+  select {
     font-size: var(--font-size-md);
-    height: auto;
   }
 
   input {
     padding: var(--spacing-half);
+  }
+
+  select {
+    // We need to tweak the horizontal padding a bit here to fit correctly with
+    // the bigger size
+    padding: 0 1px;
   }
 
   button {


### PR DESCRIPTION
## Description

The work in this PR is also part of #610. In this case, showing a dropdown to users in Preferences -> Git to suggest using one of the email addresses from their account(s), also giving them the ability to select a custom email address.

In case of using a custom email address, a warning will be displayed if the provided address doesn't match any of the account email addresses, which could lead to misattributed commits.

As a bonus, it also fixes a small visual glitch mentioned in #11561 🎉 

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/107666674-0ed69880-6c8f-11eb-89a0-027767b1bd00.png)
![image](https://user-images.githubusercontent.com/1083228/107666709-172ed380-6c8f-11eb-8d01-5b46dcb0091e.png)
![image](https://user-images.githubusercontent.com/1083228/107666766-27df4980-6c8f-11eb-8832-6905c525aca8.png)

## Release notes

Notes: [Improved] Suggest email addresses from the GitHub account and warn about misattributed commits from Preferences
