### PR TITLE
Fix welcome screen on Windows

### DIFF
--- a/app/styles/ui/_welcome.scss
+++ b/app/styles/ui/_welcome.scss
@@ -1,7 +1,8 @@
 #welcome {
-  // Override the height of some components to make them bigger
-  --text-field-height: 29px;
-  --button-height: var(--text-field-height);
+  // Override the height of some components to make them bigger. The new height
+  // is platform specific and defined as --welcome-item-height
+  --text-field-height: var(--welcome-item-height);
+  --button-height: var(--welcome-item-height);
 
   align-items: stretch;
   justify-content: center;
@@ -246,4 +247,16 @@
 .forgot-password-link {
   align-self: center;
   margin-left: var(--spacing);
+}
+
+@include win32-context {
+  #welcome {
+    --welcome-item-height: 31.5px;
+  }
+}
+
+@include darwin-context {
+  #welcome {
+    --welcome-item-height: 29px;
+  }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -997,9 +997,9 @@ nice-try@^1.0.4:
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-abi@^2.7.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
-  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
+  integrity sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==
   dependencies:
     semver "^5.4.1"
 


### PR DESCRIPTION
## Description

While testing #11564 on Windows, I noticed something slightly odd: the text in buttons and textboxes in the Welcome screen weren't properly aligned. It was a regression introduced in #11561 where a fixed hardcoded height was set for those elements.

The problem is the specific height chosen, 29px, was only a good fit for macOS but not for Windows, which needs 31.5px.

This PR also bumps `node-abi`, since it includes a few fixes trying to build the app after an Electron/node upgrade. The original issue doesn't affect clean environments (hence why we were able to build the Windows app from CI).

## Release notes

Notes: no-notes
