### PR TITLE
Extract popover to a reusable component

### DIFF
--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -3,7 +3,7 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { RadioButton } from '../lib/radio-button'
 import { getBoolean, setBoolean } from '../../lib/local-storage'
-import { Popover } from '../lib/popover'
+import { Popover, PopoverCaretPosition } from '../lib/popover'
 
 interface IDiffOptionsProps {
   readonly hideWhitespaceChanges?: boolean
@@ -96,7 +96,10 @@ export class DiffOptions extends React.Component<
 
   private renderPopover() {
     return (
-      <Popover onClickOutside={this.closePopover}>
+      <Popover
+        caretPosition={PopoverCaretPosition.TopRight}
+        onClickOutside={this.closePopover}
+      >
         {this.renderHideWhitespaceChanges()}
         {this.renderShowSideBySide()}
       </Popover>

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import FocusTrap from 'focus-trap-react'
+import { Options as FocusTrapOptions } from 'focus-trap'
+
+interface IPopoverProps {
+  readonly onClickOutside: () => void
+}
+
+export class Popover extends React.Component<IPopoverProps> {
+  private focusTrapOptions: FocusTrapOptions
+  private divRef = React.createRef<HTMLDivElement>()
+
+  public constructor(props: IPopoverProps) {
+    super(props)
+
+    this.focusTrapOptions = {
+      allowOutsideClick: true,
+      escapeDeactivates: true,
+      onDeactivate: this.props.onClickOutside,
+    }
+  }
+
+  public componentDidMount() {
+    document.addEventListener('mousedown', this.onDocumentMouseDown)
+  }
+
+  public componentWillUnmount() {
+    document.removeEventListener('mousedown', this.onDocumentMouseDown)
+  }
+
+  private onDocumentMouseDown = (event: MouseEvent) => {
+    const { current: ref } = this.divRef
+    const { target } = event
+
+    if (
+      ref !== null &&
+      ref.parentElement !== null &&
+      target instanceof Node &&
+      !ref.parentElement.contains(target)
+    ) {
+      this.props.onClickOutside()
+    }
+  }
+
+  public render() {
+    return (
+      <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
+        <div className="popover-component" ref={this.divRef}>
+          {this.props.children}
+        </div>
+      </FocusTrap>
+    )
+  }
+}

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -25,7 +25,7 @@ interface IPopoverProps {
 
 export class Popover extends React.Component<IPopoverProps> {
   private focusTrapOptions: FocusTrapOptions
-  private divRef = React.createRef<HTMLDivElement>()
+  private containerDivRef = React.createRef<HTMLDivElement>()
 
   public constructor(props: IPopoverProps) {
     super(props)
@@ -46,7 +46,7 @@ export class Popover extends React.Component<IPopoverProps> {
   }
 
   private onDocumentMouseDown = (event: MouseEvent) => {
-    const { current: ref } = this.divRef
+    const { current: ref } = this.containerDivRef
     const { target } = event
 
     if (
@@ -64,7 +64,7 @@ export class Popover extends React.Component<IPopoverProps> {
 
     return (
       <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
-        <div className={classNames.join(' ')} ref={this.divRef}>
+        <div className={classNames.join(' ')} ref={this.containerDivRef}>
           {this.props.children}
         </div>
       </FocusTrap>

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -8,6 +8,11 @@ import { Options as FocusTrapOptions } from 'focus-trap'
  * - The second one is the alignment of the caret within that edge.
  *
  * Example: TopRight means the caret will be in the top edge, on its right side.
+ *
+ * **Note:** If new positions are added to this enum, the value given to them
+ * is prepended with `popover-caret-` to create a class name which defines, in
+ * `app/styles/ui/_popover.scss`, where the caret is located for that specific
+ * position.
  **/
 export enum PopoverCaretPosition {
   TopRight = 'top-right',

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -2,8 +2,20 @@ import * as React from 'react'
 import FocusTrap from 'focus-trap-react'
 import { Options as FocusTrapOptions } from 'focus-trap'
 
+/**
+ * Position of the caret relative to the pop up. It's composed by 2 dimensions:
+ * - The first one is the edge on which the caret will rest.
+ * - The second one is the alignment of the caret within that edge.
+ *
+ * Example: TopRight means the caret will be in the top edge, on its right side.
+ **/
+export enum PopoverCaretPosition {
+  TopRight = 'top-right',
+  LeftTop = 'left-top',
+}
 interface IPopoverProps {
   readonly onClickOutside: () => void
+  readonly caretPosition: PopoverCaretPosition
 }
 
 export class Popover extends React.Component<IPopoverProps> {
@@ -43,12 +55,18 @@ export class Popover extends React.Component<IPopoverProps> {
   }
 
   public render() {
+    const classNames = ['popover-component', this.getClassNameForCaret()]
+
     return (
       <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
-        <div className="popover-component" ref={this.divRef}>
+        <div className={classNames.join(' ')} ref={this.divRef}>
           {this.props.children}
         </div>
       </FocusTrap>
     )
+  }
+
+  private getClassNameForCaret() {
+    return `popover-caret-${this.props.caretPosition}`
   }
 }

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -82,3 +82,4 @@
 @import 'ui/local-changes-overwritten';
 @import 'ui/side-by-side-diff';
 @import 'ui/diff-options';
+@import 'ui/popover';

--- a/app/styles/ui/_diff-options.scss
+++ b/app/styles/ui/_diff-options.scss
@@ -57,48 +57,12 @@
     flex-direction: row;
   }
 
-  .popover {
-    font-size: var(--font-size);
-    font-family: var(--font-family-sans-serif);
-
+  .popover-component {
     position: absolute;
     left: 28px;
     margin-left: -250px;
     top: 27px;
-    z-index: var(--foldout-z-index);
 
-    background: var(--background-color);
-    color: var(--text-color);
-    border-radius: var(--border-radius);
-    border: var(--base-border);
-
-    padding: var(--spacing-double);
     width: 250px;
-
-    box-shadow: var(--base-box-shadow);
-
-    // Carets
-    &::before,
-    &::after {
-      position: absolute;
-      right: 20px;
-      display: inline-block;
-      content: '';
-      pointer-events: none;
-    }
-
-    &::before {
-      top: -16px;
-      margin-right: -9px;
-      border: 8px solid transparent;
-      border-bottom-color: var(--box-border-color);
-    }
-
-    &::after {
-      top: -14px;
-      margin-right: -8px;
-      border: 7px solid transparent;
-      border-bottom-color: var(--background-color);
-    }
   }
 }

--- a/app/styles/ui/_popover.scss
+++ b/app/styles/ui/_popover.scss
@@ -12,8 +12,10 @@
   padding: var(--spacing-double);
 
   box-shadow: var(--base-box-shadow);
+}
 
-  // Carets
+// Carets
+.popover-component.popover-caret-top-right {
   &::before,
   &::after {
     position: absolute;
@@ -35,5 +37,30 @@
     margin-right: -8px;
     border: 7px solid transparent;
     border-bottom-color: var(--background-color);
+  }
+}
+
+.popover-component.popover-caret-left-top {
+  &::before,
+  &::after {
+    position: absolute;
+    top: 20px;
+    display: inline-block;
+    content: '';
+    pointer-events: none;
+  }
+
+  &::before {
+    left: -16px;
+    margin-top: -9px;
+    border: 8px solid transparent;
+    border-right-color: var(--box-border-color);
+  }
+
+  &::after {
+    left: -14px;
+    margin-top: -8px;
+    border: 7px solid transparent;
+    border-right-color: var(--background-color);
   }
 }

--- a/app/styles/ui/_popover.scss
+++ b/app/styles/ui/_popover.scss
@@ -1,0 +1,39 @@
+.popover-component {
+  font-size: var(--font-size);
+  font-family: var(--font-family-sans-serif);
+
+  z-index: var(--foldout-z-index);
+
+  background: var(--background-color);
+  color: var(--text-color);
+  border-radius: var(--border-radius);
+  border: var(--base-border);
+
+  padding: var(--spacing-double);
+
+  box-shadow: var(--base-box-shadow);
+
+  // Carets
+  &::before,
+  &::after {
+    position: absolute;
+    right: 20px;
+    display: inline-block;
+    content: '';
+    pointer-events: none;
+  }
+
+  &::before {
+    top: -16px;
+    margin-right: -9px;
+    border: 8px solid transparent;
+    border-bottom-color: var(--box-border-color);
+  }
+
+  &::after {
+    top: -14px;
+    margin-right: -8px;
+    border: 7px solid transparent;
+    border-bottom-color: var(--background-color);
+  }
+}


### PR DESCRIPTION
## Description

This PR is part of #610 work. It extracts the popover we have for the diff options into a reusable component. It'll be used to warn users about the possibility of misattributed commits in a future PR.

In order to make that work easier, it also adds the possibility to position the popover caret in different positions (the 2 we need, so far 🤣 ).

The only thing this refactor might regress is the diff options popover in both History and Changes views. It should behave the same way when clicking inside, outside, on the ⚙️  button, etc.

## Release notes

Notes: no-notes
