### PR TITLE
Don't maximize the window when the Dock icon is clicked

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -211,6 +211,9 @@ export class AppWindow {
   public show() {
     this.window.show()
     if (this.shouldMaximizeOnShow) {
+      // Only maximize the window the first time it's shown, not every time.
+      // Otherwise, it causes the problem described in desktop/desktop#11590
+      this.shouldMaximizeOnShow = false
       this.window.maximize()
     }
   }


### PR DESCRIPTION
Closes #11590 

## Description

After the changes in #11162, the windows would always be maximized every time the app is shown, if it was maximized in the previous run. That includes when, on macOS, the user clicks on the app icon in the Dock.

With this PR, that will only happen the first time the window is shown.

## Release notes

Notes: [Fixed] The app is not maximized on macOS every time the user clicks on the app's icon in the Dock
