### PR TITLE
Bump desktop-trampoline to v0.9.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.2",
+    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.3",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.98.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -311,9 +311,9 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-trampoline@desktop/desktop-trampoline#v0.9.2:
-  version "0.9.2"
-  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/c77487f6456c3798ba764bec84931173c085a27f"
+desktop-trampoline@desktop/desktop-trampoline#v0.9.3:
+  version "0.9.3"
+  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/31bc7170f634aae182de9eb54a01aa04dc124297"
 
 detect-libc@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Description

Includes a fix for a buffer overflow error.

## Release notes

Notes: no-notes
