### PR TITLE
Release 2.6.4-beta2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.6.4-beta1",
+  "version": "2.6.4-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.2",
+    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.3",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.98.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -311,9 +311,9 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-trampoline@desktop/desktop-trampoline#v0.9.2:
-  version "0.9.2"
-  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/c77487f6456c3798ba764bec84931173c085a27f"
+desktop-trampoline@desktop/desktop-trampoline#v0.9.3:
+  version "0.9.3"
+  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/31bc7170f634aae182de9eb54a01aa04dc124297"
 
 detect-libc@^1.0.3:
   version "1.0.3"

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,11 @@
 {
   "releases": {
+    "2.6.4-beta2": [
+      "[Fixed] Allow users to modify git config on a per repository basis - #9449. Thanks @say25!",
+      "[Fixed] The app is not maximized on macOS every time the user clicks on the app's icon in the Dock - #11590",
+      "[Improved] Suggest emails from GitHub accounts and warn about misattributed commits in the commit message area - #11591",
+      "[Improved] Remote Git operations are now faster and less prone to errors on Windows - #11510"
+    ],
     "2.6.4-beta1": [
       "[Added] Add branch context menu with rename and delete to branch dropdown list - #5803 #10432",
       "[Fixed] Always respect the default branch name chosen by the user - #11447",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming second beta of the v2.6.4 series? Well you've just found it, congratulations! :tada:

**Note:** it includes also the commits in #11615, but those can be evaluated separately.

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated