### PR TITLE
Focus co-author input after clicking on "Add co-authors"

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -121,6 +121,8 @@ export class CommitMessage extends React.Component<
   private descriptionTextArea: HTMLTextAreaElement | null = null
   private descriptionTextAreaScrollDebounceId: number | null = null
 
+  private coAuthorInputRef = React.createRef<AuthorInput>()
+
   public constructor(props: ICommitMessageProps) {
     super(props)
     const { commitMessage } = this.props
@@ -180,6 +182,14 @@ export class CommitMessage extends React.Component<
 
     if (this.props.focusCommitMessage) {
       this.focusSummary()
+    } else if (
+      prevProps.showCoAuthoredBy === false &&
+      this.isCoAuthorInputVisible &&
+      // The co-author input could be also shown when switching between repos,
+      // but in that case we don't want to give the focus to the input.
+      prevProps.repository.id === this.props.repository.id
+    ) {
+      this.coAuthorInputRef.current?.focus()
     }
   }
 
@@ -344,6 +354,7 @@ export class CommitMessage extends React.Component<
 
     return (
       <AuthorInput
+        ref={this.coAuthorInputRef}
         onAuthorsUpdated={this.onCoAuthorsUpdated}
         authors={this.props.coAuthors}
         autoCompleteProvider={autocompletionProvider}

--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -467,6 +467,10 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
     this.state = {}
   }
 
+  public focus() {
+    this.editor?.focus()
+  }
+
   public componentWillUnmount() {
     // Sometimes the completion box seems to fail to register
     // the blur event and close. It's hard to reproduce so


### PR DESCRIPTION
## Description

This was something that bothered me, whenever I wanted to add someone as a co-author I not only had to click on the "Add Co-Author" button, but also on the textbox itself. Well, not anymore!

### Screenshots

https://user-images.githubusercontent.com/1083228/108361456-5f765600-71a7-11eb-977c-f36abcdba2ae.mov

## Release notes

Notes: [Improved] Clicking on "Add Co-Author" moves the focus to the co-authors text field
