### PR TITLE
Add .avif image support

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -87,7 +87,7 @@ const imageFileExtensions = new Set([
   '.ico',
   '.webp',
   '.bmp',
-  '.avif'
+  '.avif',
 ])
 
 /**

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -87,6 +87,7 @@ const imageFileExtensions = new Set([
   '.ico',
   '.webp',
   '.bmp',
+  '.avif'
 ])
 
 /**
@@ -298,6 +299,9 @@ function getMediaType(extension: string) {
   }
   if (extension === '.bmp') {
     return 'image/bmp'
+  }
+  if (extension === '.avif') {
+    return 'image/avif'
   }
 
   // fallback value as per the spec


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/10577

I tried to create a test for the `getBlobImage` function but I noticed that I would need a fixture with an avif image, and I was in doubt if putting a new image in the` repo-with-image-changes` folder and fixing the tests was a good solution.

### Screenshots
![Screen Shot 2021-02-19 at 11 55 55](https://user-images.githubusercontent.com/11650374/108520451-74d3a900-72a9-11eb-9023-7c82787a309a.png)

## Release notes
Notes: 
