### PR TITLE
Cherry picking Continue After Conflicts

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -277,7 +277,7 @@ export async function getCherryPickSnapshot(
   }
 
   const count = commits.length - remainingShas.length
-  const commitSummaryIndex = (count > 0 ? count : 1) - 1
+  const commitSummaryIndex = count > 0 ? count - 1 : 0
   return {
     progress: {
       kind: 'cherryPick',
@@ -316,13 +316,13 @@ export async function continueCherryPick(
   // apply conflict resolutions
   for (const [path, resolution] of manualResolutions) {
     const file = files.find(f => f.path === path)
-    if (file !== undefined) {
-      await stageManualConflictResolution(repository, file, resolution)
-    } else {
+    if (file === undefined) {
       log.error(
         `[continueCherryPick] couldn't find file ${path} even though there's a manual resolution for it`
       )
+      continue
     }
+    await stageManualConflictResolution(repository, file, resolution)
   }
 
   const otherFiles = trackedFiles.filter(f => !manualResolutions.has(f.path))

--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -55,7 +55,13 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
   }
 
   private onContinueCherryPick = (step: ShowConflictsStep) => {
-    // TODO: dispatch to continue the cherry pick
+    const { dispatcher, repository, workingDirectory, commits } = this.props
+    dispatcher.continueCherryPick(
+      repository,
+      workingDirectory.files,
+      step.conflictState,
+      commits.length
+    )
   }
 
   private onAbortCherryPick = (step: ShowConflictsStep) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -16,6 +16,7 @@ import {
   RebaseConflictState,
   isRebaseConflictState,
   isCherryPickConflictState,
+  CherryPickConflictState,
 } from '../../lib/app-state'
 import { assertNever, fatalError } from '../../lib/fatal-error'
 import {
@@ -2640,6 +2641,31 @@ export class Dispatcher {
       kind: CherryPickStepKind.ShowProgress,
     })
     await sleep(500)
+  }
+  /**
+   * Continue with the cherryPick after the user has resolved all conflicts with
+   * tracked files in the working directory.
+   */
+  public async continueCherryPick(
+    repository: Repository,
+    files: ReadonlyArray<WorkingDirectoryFileChange>,
+    conflictsState: CherryPickConflictState,
+    commitsCount: number
+  ): Promise<void> {
+    await this.switchCherryPickingFlowToShowProgress(repository)
+
+    const result = await this.appStore._continueCherryPick(
+      repository,
+      files,
+      conflictsState.manualResolutions
+    )
+
+    this.processCherryPickResult(
+      repository,
+      result,
+      conflictsState.targetBranchName,
+      commitsCount
+    )
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2528,15 +2528,7 @@ export class Dispatcher {
     commits: ReadonlyArray<CommitOneLine>
   ): Promise<void> {
     this.appStore._initializeCherryPickProgress(repository, commits)
-
-    this.setCherryPickFlowStep(repository, {
-      kind: CherryPickStepKind.ShowProgress,
-    })
-
-    // This timeout is intended to defer cherry picking from running immediately
-    // to better show that cherry picking is progressing rather than suddenly
-    // appearing and disappearing again.
-    await sleep(500)
+    this.switchCherryPickingFlowToShowProgress(repository)
     this.cherryPick(repository, targetBranch, commits)
   }
 
@@ -2652,5 +2644,17 @@ export class Dispatcher {
    */
   public setCherryPickConflictsResolved(repository: Repository) {
     return this.appStore._setCherryPickConflictsResolved(repository)
+  }
+
+  /**
+   * Moves cherry pick flow step to progress and defers to allow user to
+   * see the cherry picking progress dialog instead of suddenly appearing
+   * and disappearing again.
+   */
+  private async switchCherryPickingFlowToShowProgress(repository: Repository) {
+    this.setCherryPickFlowStep(repository, {
+      kind: CherryPickStepKind.ShowProgress,
+    })
+    await sleep(500)
   }
 }


### PR DESCRIPTION
Part of work on #1685

## Description

Added to continue cherry pick logic to allow for manual resolutions as well as handling the scenario of if a user resolves all conflicts by selecting the current's branches resolution resulting in an empty commit.

User can now cherry pick a commit resulting in conflicts, resolve conflicts, and continue the cherry pick for a successful cherry pick. 

![continueCherryPick](https://user-images.githubusercontent.com/75402236/108886045-8208d480-75d6-11eb-8bbe-aac5c2b7e1df.gif)

## Release notes
Notes: no-notes
