### PR TITLE
Thank you

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -277,7 +277,7 @@ export interface IAppState {
    * String of the form [version-number, user-login, user-login, user-login].
    * This will be reset for each new version.
    */
-  readonly versionAndUserOfLastThankYou: ReadonlyArray<string>
+  readonly versionAndUsersOfLastThankYou: ReadonlyArray<string>
 }
 
 export enum FoldoutType {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -269,6 +269,15 @@ export interface IAppState {
    * Whether or not the user has been introduced to the cherry pick feature
    */
   readonly hasShownCherryPickIntro: boolean
+
+  /**
+   * Record of what logged in users have been checked to see if thank you is in
+   * order for external contributions in latest release.
+   *
+   * String of the form [version-number, user-login, user-login, user-login].
+   * This will be reset for each new version.
+   */
+  readonly versionAndUserOfLastThankYou: ReadonlyArray<string>
 }
 
 export enum FoldoutType {

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -66,6 +66,7 @@ export function getReleaseSummary(
   )
   const bugfixes = entries.filter(e => e.kind === 'fixed')
   const other = entries.filter(e => e.kind === 'removed' || e.kind === 'other')
+  const thankYous = entries.filter(e => e.message.includes(' Thanks @'))
 
   const datePublished = moment(latestRelease.pub_date).format('MMMM Do YYYY')
 
@@ -77,6 +78,7 @@ export function getReleaseSummary(
     enhancements,
     bugfixes,
     other,
+    thankYous,
   }
 }
 

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -1,4 +1,3 @@
-import { String } from 'aws-sdk/clients/cloudsearchdomain'
 import moment from 'moment'
 
 import {

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -85,7 +85,10 @@ export function getReleaseSummary(
 async function getChangeLog(): Promise<ReadonlyArray<ReleaseMetadata>> {
   const changelog =
     'https://central.github.com/deployments/desktop/desktop/changelog.json'
-  const query = __RELEASE_CHANNEL__ === 'beta' ? '?env=beta' : ''
+  const query =
+    __RELEASE_CHANNEL__ === 'beta' || __RELEASE_CHANNEL__ === 'development'
+      ? '?env=beta'
+      : ''
 
   const response = await fetch(`${changelog}${query}`)
   if (response.ok) {
@@ -105,12 +108,10 @@ export async function generateReleaseSummary(): Promise<ReleaseSummary> {
 export async function getThankYouByUser(): Promise<
   Map<string, ReadonlyArray<ReleaseNote>>
 > {
-  let releaseMetaData = await getChangeLog()
-  if (__RELEASE_CHANNEL__ === 'beta' || __RELEASE_CHANNEL__ === 'development') {
-    releaseMetaData = [...releaseMetaData, ...(await getChangeLog(''))]
-  }
+  const releaseMetaData = await getChangeLog()
   const summaries = releaseMetaData.map(getReleaseSummary)
   const thankYousByUser = new Map<string, Array<ReleaseNote>>()
+
   summaries.forEach(s => {
     if (s.thankYous.length === 0) {
       return
@@ -122,6 +123,7 @@ export async function getThankYouByUser(): Promise<
       if (match === null) {
         return
       }
+
       const userHandle = match[0].slice(10, -1)
       let usersThanksYous = thankYousByUser.get(userHandle)
       if (usersThanksYous === undefined) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -342,7 +342,7 @@ const InitialRepositoryIndicatorTimeout = 2 * 60 * 1000
 const MaxInvalidFoldersToDisplay = 3
 
 const hasShownCherryPickIntroKey = 'has-shown-cherry-pick-intro'
-const versionAndUserOfLastThankYouKey = 'version-and-user-of-last-thank-you'
+const versionAndUsersOfLastThankYouKey = 'version-and-users-of-last-thank-you'
 
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
@@ -452,7 +452,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private hasShownCherryPickIntro: boolean = false
 
   private currentDragElement: DragElement | null = null
-  private versionAndUserOfLastThankYou: ReadonlyArray<string> = []
+  private versionAndUsersOfLastThankYou: ReadonlyArray<string> = []
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -805,7 +805,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitSpellcheckEnabled: this.commitSpellcheckEnabled,
       hasShownCherryPickIntro: this.hasShownCherryPickIntro,
       currentDragElement: this.currentDragElement,
-      versionAndUserOfLastThankYou: this.versionAndUserOfLastThankYou,
+      versionAndUsersOfLastThankYou: this.versionAndUsersOfLastThankYou,
     }
   }
 
@@ -1777,8 +1777,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
 
     this.hasShownCherryPickIntro = getBoolean(hasShownCherryPickIntroKey, false)
-    this.versionAndUserOfLastThankYou = getStringArray(
-      versionAndUserOfLastThankYouKey
+    this.versionAndUsersOfLastThankYou = getStringArray(
+      versionAndUsersOfLastThankYouKey
     )
 
     this.emitUpdateNow()
@@ -6232,28 +6232,29 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<IAheadBehind | null> {
     return getBranchAheadBehind(repository, branch)
   }
-  public _setVersionAndUserOfLastThankYou(
-    versionAndUserOfLastThankYou: ReadonlyArray<string>
+
+  public _setVersionAndUsersOfLastThankYou(
+    versionAndUsersOfLastThankYou: ReadonlyArray<string>
   ) {
     // don't update if both empty (equal)
     // don't update if same length and same version (assumption
     // is that update will be either adding a user or updating version)
     if (
-      (this.versionAndUserOfLastThankYou.length === 0 &&
-        versionAndUserOfLastThankYou.length === 0) ||
-      (this.versionAndUserOfLastThankYou.length ===
-        versionAndUserOfLastThankYou.length &&
-        this.versionAndUserOfLastThankYou[0] ===
-          versionAndUserOfLastThankYou[0])
+      (this.versionAndUsersOfLastThankYou.length === 0 &&
+        versionAndUsersOfLastThankYou.length === 0) ||
+      (this.versionAndUsersOfLastThankYou.length ===
+        versionAndUsersOfLastThankYou.length &&
+        this.versionAndUsersOfLastThankYou[0] ===
+          versionAndUsersOfLastThankYou[0])
     ) {
       return
     }
 
     setStringArray(
-      versionAndUserOfLastThankYouKey,
-      versionAndUserOfLastThankYou
+      versionAndUsersOfLastThankYouKey,
+      versionAndUsersOfLastThankYou
     )
-    this.versionAndUserOfLastThankYou = versionAndUserOfLastThankYou
+    this.versionAndUsersOfLastThankYou = versionAndUsersOfLastThankYou
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -209,6 +209,8 @@ import {
   getNumberArray,
   setNumberArray,
   getEnum,
+  getStringArray,
+  setStringArray,
 } from '../local-storage'
 import { ExternalEditorError, suggestedExternalEditor } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -340,6 +342,7 @@ const InitialRepositoryIndicatorTimeout = 2 * 60 * 1000
 const MaxInvalidFoldersToDisplay = 3
 
 const hasShownCherryPickIntroKey = 'has-shown-cherry-pick-intro'
+const versionAndUserOfLastThankYouKey = 'version-and-user-of-last-thank-you'
 
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
@@ -449,6 +452,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private hasShownCherryPickIntro: boolean = false
 
   private currentDragElement: DragElement | null = null
+  private versionAndUserOfLastThankYou: ReadonlyArray<string> = []
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -801,6 +805,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitSpellcheckEnabled: this.commitSpellcheckEnabled,
       hasShownCherryPickIntro: this.hasShownCherryPickIntro,
       currentDragElement: this.currentDragElement,
+      versionAndUserOfLastThankYou: this.versionAndUserOfLastThankYou,
     }
   }
 
@@ -1772,6 +1777,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
 
     this.hasShownCherryPickIntro = getBoolean(hasShownCherryPickIntroKey, false)
+    this.versionAndUserOfLastThankYou = getStringArray(
+      versionAndUserOfLastThankYouKey
+    )
 
     this.emitUpdateNow()
 
@@ -6223,6 +6231,31 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: Branch
   ): Promise<IAheadBehind | null> {
     return getBranchAheadBehind(repository, branch)
+  }
+  public _setVersionAndUserOfLastThankYou(
+    versionAndUserOfLastThankYou: ReadonlyArray<string>
+  ) {
+    // don't update if both empty (equal)
+    // don't update if same length and same version (assumption
+    // is that update will be either adding a user or updating version)
+    if (
+      (this.versionAndUserOfLastThankYou.length === 0 &&
+        versionAndUserOfLastThankYou.length === 0) ||
+      (this.versionAndUserOfLastThankYou.length ===
+        versionAndUserOfLastThankYou.length &&
+        this.versionAndUserOfLastThankYou[0] ===
+          versionAndUserOfLastThankYou[0])
+    ) {
+      return
+    }
+
+    setStringArray(
+      versionAndUserOfLastThankYouKey,
+      versionAndUserOfLastThankYou
+    )
+    this.versionAndUserOfLastThankYou = versionAndUserOfLastThankYou
+
+    this.emitUpdate()
   }
 }
 

--- a/app/src/lib/thank-you.ts
+++ b/app/src/lib/thank-you.ts
@@ -1,0 +1,38 @@
+import { Dispatcher } from '../ui/dispatcher'
+
+/**
+ * Compares locally stored version and user of last thank you to currently
+ * login in user and version
+ */
+export function hasUserAlreadyBeenCheckedOrThanked(
+  lastThankYou: ReadonlyArray<string>,
+  dotComLogin: string,
+  currentVersion: string
+): boolean {
+  if (lastThankYou.length === 0) {
+    return false
+  }
+
+  const lastVersion = lastThankYou[0]
+  const checkedUsers = lastThankYou.slice(1)
+
+  return checkedUsers.includes(dotComLogin) && lastVersion === currentVersion
+}
+
+/** Updates the local storage of version and users that have been checked for
+ * external contributions. We do this regardless of contributions so that
+ * we don't keep pinging for release notes. */
+export function updateLastThankYou(
+  dispatcher: Dispatcher,
+  lastThankYou: ReadonlyArray<string>,
+  dotComLogin: string,
+  currentVersion: string
+): void {
+  const lastVersion = lastThankYou[0]
+  // If new version, clear out last version users.
+  const checkedUsers =
+    lastVersion !== currentVersion ? [] : lastThankYou.slice(1)
+  checkedUsers.push(dotComLogin)
+  const updatedLastThankYou = [currentVersion, ...checkedUsers]
+  dispatcher.setVersionAndUsersOfLastThankYou(updatedLastThankYou)
+}

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -43,4 +43,14 @@ export class Account {
       this.name
     )
   }
+
+  /**
+   * Get a name to display
+   *
+   * This will by default return the 'name' as it is the friendly name.
+   * However, if not defined, we return the login
+   */
+  public get friendlyName(): string {
+    return this.name !== '' ? this.name : this.login
+  }
 }

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -9,6 +9,7 @@ export enum BannerType {
   SuccessfulCherryPick = 'SuccessfulCherryPick',
   CherryPickConflictsFound = 'CherryPickConflictsFound',
   CherryPickUndone = 'CherryPickUndone',
+  OpenThankYouCard = 'OpenThankYouCard',
 }
 
 export type Banner =
@@ -69,4 +70,9 @@ export type Banner =
       readonly targetBranchName: string
       /** number of commits cherry picked */
       readonly countCherryPicked: number
+    }
+  | {
+      readonly type: BannerType.OpenThankYouCard
+      readonly onOpenCard: () => void
+      readonly onThrewCardAway: () => void
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -281,7 +281,7 @@ export type Popup =
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
   | {
       type: PopupType.ThankYou
-      userReleaseNotes: ReleaseNote[]
+      userContributions: ReleaseNote[]
       friendlyName: string
-      version: string
+      latestVersion: string
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -5,7 +5,7 @@ import {
 } from './repository'
 import { PullRequest } from './pull-request'
 import { Branch } from './branch'
-import { ReleaseSummary } from './release-notes'
+import { ReleaseNote, ReleaseSummary } from './release-notes'
 import { IRemote } from './remote'
 import { RetryAction } from './retry-actions'
 import { WorkingDirectoryFileChange } from './status'
@@ -70,6 +70,7 @@ export enum PopupType {
   CherryPick,
   MoveToApplicationsFolder,
   ChangeRepositoryAlias,
+  ThankYou,
 }
 
 export type Popup =
@@ -278,3 +279,9 @@ export type Popup =
     }
   | { type: PopupType.MoveToApplicationsFolder }
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
+  | {
+      type: PopupType.ThankYou
+      userReleaseNotes: ReleaseNote[]
+      friendlyName: string
+      version: string
+    }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -281,7 +281,7 @@ export type Popup =
   | { type: PopupType.ChangeRepositoryAlias; repository: Repository }
   | {
       type: PopupType.ThankYou
-      userContributions: ReleaseNote[]
+      userContributions: ReadonlyArray<ReleaseNote>
       friendlyName: string
       latestVersion: string
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -123,7 +123,10 @@ export type Popup =
       initialName?: string
     }
   | { type: PopupType.SignIn }
-  | { type: PopupType.About }
+  | {
+      type: PopupType.About
+      userContributions: ReadonlyArray<ReleaseNote> | null
+    }
   | { type: PopupType.InstallGit; path: string }
   | { type: PopupType.PublishRepository; repository: Repository }
   | { type: PopupType.Acknowledgements }
@@ -283,5 +286,5 @@ export type Popup =
       type: PopupType.ThankYou
       userContributions: ReadonlyArray<ReleaseNote>
       friendlyName: string
-      latestVersion: string
+      latestVersion: string | null
     }

--- a/app/src/models/release-notes.ts
+++ b/app/src/models/release-notes.ts
@@ -26,4 +26,5 @@ export type ReleaseSummary = {
   readonly enhancements: ReadonlyArray<ReleaseNote>
   readonly bugfixes: ReadonlyArray<ReleaseNote>
   readonly other: ReadonlyArray<ReleaseNote>
+  readonly thankYous: ReadonlyArray<ReleaseNote>
 }

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -16,6 +16,7 @@ import { RelativeTime } from '../relative-time'
 import { assertNever } from '../../lib/fatal-error'
 import { ReleaseNotesUri } from '../lib/releases'
 import { encodePathAsUrl } from '../../lib/path'
+import { ReleaseNote } from '../../models/release-notes'
 
 const logoPath = __DARWIN__
   ? 'static/logo-64x64@2x.png'
@@ -46,6 +47,14 @@ interface IAboutProps {
 
   /** A function to call when the user wants to see Terms and Conditions. */
   readonly onShowTermsAndConditions: () => void
+
+  /** An array of release notes specific to the logged in dotcom user. */
+  readonly userContributions: ReadonlyArray<ReleaseNote> | null
+
+  /** Function to open user thank you */
+  readonly onOpenThankYouCard: (
+    userContributions: ReadonlyArray<ReleaseNote>
+  ) => void
 }
 
 interface IAboutState {
@@ -231,6 +240,27 @@ export class About extends React.Component<IAboutProps, IAboutState> {
     return null
   }
 
+  private onOpenThankYouCard = () => {
+    const { onOpenThankYouCard, userContributions } = this.props
+    if (userContributions === null) {
+      return
+    }
+    onOpenThankYouCard(userContributions)
+  }
+
+  private renderThankYou() {
+    if (this.props.userContributions === null) {
+      return null
+    }
+
+    return (
+      <p>
+        You contributed!{' '}
+        <LinkButton onClick={this.onOpenThankYouCard}>Open Card</LinkButton>
+      </p>
+    )
+  }
+
   public render() {
     const name = this.props.applicationName
     const version = this.props.applicationVersion
@@ -273,6 +303,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
           </p>
           {this.renderUpdateDetails()}
           {this.renderUpdateButton()}
+          {this.renderThankYou()}
         </DialogContent>
         <DefaultDialogFooter />
       </Dialog>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -102,7 +102,7 @@ import {
   initializeRebaseFlowForConflictedRepository,
   isCurrentBranchForcePush,
 } from '../lib/rebase'
-import { BannerType } from '../models/banner'
+import { Banner, BannerType } from '../models/banner'
 import { StashAndSwitchBranch } from './stash-changes/stash-and-switch-branch-dialog'
 import { OverwriteStash } from './stash-changes/overwrite-stashed-changes-dialog'
 import { ConfirmDiscardStashDialog } from './stashing/confirm-discard-stash'
@@ -2991,9 +2991,6 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    // Regardless of contributions, so we don't keep retrieving release notes.
-    updateLastThankYou(this.props.dispatcher, lastThankYou, login, getVersion())
-
     const { thankYous, latestVersion } = await generateReleaseSummary()
     const userContributions = thankYous.filter(ty => ty.message.includes(login))
 
@@ -3001,12 +2998,27 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    this.props.dispatcher.showPopup({
-      type: PopupType.ThankYou,
-      userContributions,
-      friendlyName,
-      latestVersion,
-    })
+    const banner: Banner = {
+      type: BannerType.OpenThankYouCard,
+      onOpenCard: () => {
+        this.props.dispatcher.showPopup({
+          type: PopupType.ThankYou,
+          userContributions,
+          friendlyName,
+          latestVersion,
+        })
+      },
+      onThrewCardAway: () => {
+        // This way banner will remain to they throw it away.
+        updateLastThankYou(
+          this.props.dispatcher,
+          lastThankYou,
+          login,
+          getVersion()
+        )
+      },
+    }
+    this.props.dispatcher.setBanner(banner)
   }
 }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2997,7 +2997,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    let { login } = dotComAccount
+    const { login } = dotComAccount
     if (hasUserAlreadyBeenCheckedOrThanked(lastThankYou, login, getVersion())) {
       return
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -779,7 +779,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     let userContributions = null
     if (dotComAccount !== null) {
       const tysByUsers = await getThankYouByUser()
-      let { login } = dotComAccount
+      const { login } = dotComAccount
       userContributions = tysByUsers.get(login) || null
     }
     this.props.dispatcher.showPopup({
@@ -2997,7 +2997,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    const { login } = dotComAccount
+    let { login } = dotComAccount
     if (hasUserAlreadyBeenCheckedOrThanked(lastThankYou, login, getVersion())) {
       return
     }
@@ -3035,7 +3035,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       // The user is not signed in or is a GHE user who should not have any.
       return
     }
-    let { friendlyName } = dotComAccount
+    const { friendlyName } = dotComAccount
 
     this.props.dispatcher.showPopup({
       type: PopupType.ThankYou,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2988,7 +2988,6 @@ export class App extends React.Component<IAppProps, IAppState> {
    * be able to be detected.
    */
   private async checkIfThankYouIsInOrder(): Promise<void> {
-    const { versionAndUsersOfLastThankYou: lastThankYou } = this.state
     // There should only be one dotcom account possible at a time.
     const dotComAccount = this.getDotComAccount()
 
@@ -2997,6 +2996,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
+    const { versionAndUsersOfLastThankYou: lastThankYou } = this.state
     const { login } = dotComAccount
     if (hasUserAlreadyBeenCheckedOrThanked(lastThankYou, login, getVersion())) {
       return

--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import { LinkButton } from '../lib/link-button'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { Banner } from './banner'
+
+interface IOpenThankYouCardProps {
+  readonly onDismissed: () => void
+  readonly onOpenCard: () => void
+  readonly onThrewCardAway: () => void
+}
+
+/**
+ * A component which tells the user that there is a thank you card for them.
+ */
+export class OpenThankYouCard extends React.Component<
+  IOpenThankYouCardProps,
+  {}
+> {
+  public render() {
+    return (
+      <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
+        <Octicon className="smiley-icon" symbol={OcticonSymbol.smiley} />
+
+        <span onSubmit={this.props.onOpenCard}>
+          The Desktop team would like to thank you for your recent
+          contributions.{' '}
+          <LinkButton onClick={this.props.onOpenCard}>
+            Open Your Card
+          </LinkButton>{' '}
+          or{' '}
+          <LinkButton onClick={this.onThrewCardAway}>Throw It Away</LinkButton>.
+        </span>
+      </Banner>
+    )
+  }
+
+  private onThrewCardAway(): void {
+    this.props.onDismissed()
+    this.props.onThrewCardAway()
+  }
+}

--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -34,7 +34,7 @@ export class OpenThankYouCard extends React.Component<
     )
   }
 
-  private onThrewCardAway(): void {
+  private onThrewCardAway = () => {
     this.props.onDismissed()
     this.props.onThrewCardAway()
   }

--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -28,7 +28,8 @@ export class OpenThankYouCard extends React.Component<
             Open Your Card
           </LinkButton>{' '}
           or{' '}
-          <LinkButton onClick={this.onThrewCardAway}>Throw It Away</LinkButton>.
+          <LinkButton onClick={this.onThrewCardAway}>Throw It Away</LinkButton>.{' '}
+          Psst.. check out the About modal.
         </span>
       </Banner>
     )

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -14,6 +14,7 @@ import { BranchAlreadyUpToDate } from './branch-already-up-to-date-banner'
 import { SuccessfulCherryPick } from './successful-cherry-pick'
 import { CherryPickConflictsBanner } from './cherry-pick-conflicts-banner'
 import { CherryPickUndone } from './cherry-pick-undone'
+import { OpenThankYouCard } from './open-thank-you-card'
 
 export function renderBanner(
   banner: Banner,
@@ -94,6 +95,15 @@ export function renderBanner(
           targetBranchName={banner.targetBranchName}
           countCherryPicked={banner.countCherryPicked}
           onDismissed={onDismissed}
+        />
+      )
+    case BannerType.OpenThankYouCard:
+      return (
+        <OpenThankYouCard
+          key="open-thank-you-card"
+          onDismissed={onDismissed}
+          onOpenCard={banner.onOpenCard}
+          onThrewCardAway={banner.onThrewCardAway}
         />
       )
     default:

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3066,4 +3066,11 @@ export class Dispatcher {
   ): Promise<IAheadBehind | null> {
     return this.appStore._getBranchAheadBehind(repository, branch)
   }
+
+  /** Set whether thanks you is in order for external contributions */
+  public setVersionAndUserOfLastThankYou(
+    versionAndUserOfLastThankYou: ReadonlyArray<string>
+  ) {
+    this.appStore._setVersionAndUserOfLastThankYou(versionAndUserOfLastThankYou)
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3068,9 +3068,11 @@ export class Dispatcher {
   }
 
   /** Set whether thanks you is in order for external contributions */
-  public setVersionAndUserOfLastThankYou(
-    versionAndUserOfLastThankYou: ReadonlyArray<string>
+  public setVersionAndUsersOfLastThankYou(
+    versionAndUsersOfLastThankYou: ReadonlyArray<string>
   ) {
-    this.appStore._setVersionAndUserOfLastThankYou(versionAndUserOfLastThankYou)
+    this.appStore._setVersionAndUsersOfLastThankYou(
+      versionAndUsersOfLastThankYou
+    )
   }
 }

--- a/app/src/ui/thank-you/index.ts
+++ b/app/src/ui/thank-you/index.ts
@@ -1,0 +1,1 @@
+export * from './thank-you'

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -125,8 +125,9 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
           <div className="container">
             <div className="thank-you-note">
               Thank you for all your hard work on GitHub Desktop version{' '}
-              {this.props.latestVersion}. You contributed:
+              {this.props.latestVersion}.
             </div>
+            <div className="contributions-heading">You contributed:</div>
             <div className="contributions">
               {this.renderList(this.props.userContributions)}
             </div>

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -38,9 +38,9 @@ const ReleaseNoteHeaderRightUri = encodePathAsUrl(
 interface IThankYouProps {
   readonly onDismissed: () => void
   readonly emoji: Map<string, string>
-  readonly userReleaseNotes: ReleaseNote[]
+  readonly userContributions: ReleaseNote[]
   readonly friendlyName: string
-  readonly version: string
+  readonly latestVersion: string
 }
 
 export class ThankYou extends React.Component<IThankYouProps, {}> {
@@ -125,10 +125,10 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
           <div className="container">
             <div className="thank-you-note">
               Thank you for all your hard work on GitHub Desktop version{' '}
-              {this.props.version}. You contributed:
+              {this.props.latestVersion}. You contributed:
             </div>
             <div className="contributions">
-              {this.renderList(this.props.userReleaseNotes)}
+              {this.renderList(this.props.userContributions)}
             </div>
             <div
               className="confetti-container"

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -38,7 +38,7 @@ const ReleaseNoteHeaderRightUri = encodePathAsUrl(
 interface IThankYouProps {
   readonly onDismissed: () => void
   readonly emoji: Map<string, string>
-  readonly userContributions: ReleaseNote[]
+  readonly userContributions: ReadonlyArray<ReleaseNote>
   readonly friendlyName: string
   readonly latestVersion: string
 }

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react'
+
+import { encodePathAsUrl } from '../../lib/path'
+
+import { ReleaseNote } from '../../models/release-notes'
+
+import { Dialog, DialogContent } from '../dialog'
+
+import { RichText } from '../lib/rich-text'
+import { Repository } from '../../models/repository'
+import { getDotComAPIEndpoint } from '../../lib/api'
+import { GitHubRepository } from '../../models/github-repository'
+import { Owner } from '../../models/owner'
+
+// HACK: This is needed because the `Rich`Text` component
+// needs to know what repo to link issues against.
+// Since release notes are Desktop specific, we can't
+// rely on the repo info we keep in state, so we've
+// stubbed out this repo
+const desktopOwner = new Owner('desktop', getDotComAPIEndpoint(), -1)
+const desktopUrl = 'https://github.com/desktop/desktop'
+const desktopRepository = new Repository(
+  '',
+  -1,
+  new GitHubRepository('desktop', desktopOwner, -1, false, desktopUrl),
+  true
+)
+
+const ReleaseNoteHeaderLeftUri = encodePathAsUrl(
+  __dirname,
+  'static/release-note-header-left.svg'
+)
+const ReleaseNoteHeaderRightUri = encodePathAsUrl(
+  __dirname,
+  'static/release-note-header-right.svg'
+)
+
+interface IThankYouProps {
+  readonly onDismissed: () => void
+  readonly emoji: Map<string, string>
+  readonly userReleaseNotes: ReleaseNote[]
+  readonly friendlyName: string
+  readonly version: string
+}
+
+export class ThankYou extends React.Component<IThankYouProps, {}> {
+  private renderList(
+    releaseEntries: ReadonlyArray<ReleaseNote>
+  ): JSX.Element | null {
+    if (releaseEntries.length === 0) {
+      return null
+    }
+
+    const options = new Array<JSX.Element>()
+
+    for (const [i, entry] of releaseEntries.entries()) {
+      options.push(
+        <li key={i}>
+          <RichText
+            text={entry.message}
+            emoji={this.props.emoji}
+            renderUrlsAsLinks={true}
+            repository={desktopRepository}
+          />
+        </li>
+      )
+    }
+
+    return (
+      <div className="section">
+        <ul className="entries">{options}</ul>
+      </div>
+    )
+  }
+
+  private renderConfetti(): JSX.Element | null {
+    const confetti = new Array<JSX.Element>()
+
+    const howMuchConfetti = 1500
+    for (let i = 0; i < howMuchConfetti; i++) {
+      confetti.push(<div key={i} className="confetti"></div>)
+    }
+
+    return <>{confetti}</>
+  }
+
+  public render() {
+    const dialogHeader = (
+      <div className="release-notes-header">
+        <div className="header-graphics">
+          <img
+            className="release-note-graphic-left"
+            src={ReleaseNoteHeaderLeftUri}
+          />
+          <div className="img-space"></div>
+          <img
+            className="release-note-graphic-right"
+            src={ReleaseNoteHeaderRightUri}
+          />
+        </div>
+        <div className="title">
+          <div className="thank-you">
+            Thank you {this.props.friendlyName}!{' '}
+            <RichText
+              text={':tada:'}
+              emoji={this.props.emoji}
+              renderUrlsAsLinks={true}
+              repository={desktopRepository}
+            />
+          </div>
+          <div className="thank-you-note">
+            The Desktop team wants to thank you personally.
+          </div>
+        </div>
+      </div>
+    )
+
+    return (
+      <Dialog
+        id="thank-you-notes"
+        onDismissed={this.props.onDismissed}
+        title={dialogHeader}
+      >
+        <DialogContent>
+          <div className="container">
+            <div className="thank-you-note">
+              Thank you for all your hard work on GitHub Desktop version{' '}
+              {this.props.version}. You contributed:
+            </div>
+            <div className="contributions">
+              {this.renderList(this.props.userReleaseNotes)}
+            </div>
+            <div
+              className="confetti-container"
+              onClick={this.props.onDismissed}
+            >
+              {this.renderConfetti()}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -40,7 +40,7 @@ interface IThankYouProps {
   readonly emoji: Map<string, string>
   readonly userContributions: ReadonlyArray<ReleaseNote>
   readonly friendlyName: string
-  readonly latestVersion: string
+  readonly latestVersion: string | null
 }
 
 export class ThankYou extends React.Component<IThankYouProps, {}> {
@@ -115,6 +115,18 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
       </div>
     )
 
+    const thankYou = 'Thank you for all your hard work on GitHub Desktop'
+    let thankYouNote
+    if (this.props.latestVersion === null) {
+      thankYouNote = <>{thankYou}</>
+    } else {
+      thankYouNote = (
+        <>
+          {thankYou} version {this.props.latestVersion}
+        </>
+      )
+    }
+
     return (
       <Dialog
         id="thank-you-notes"
@@ -123,10 +135,7 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
       >
         <DialogContent>
           <div className="container">
-            <div className="thank-you-note">
-              Thank you for all your hard work on GitHub Desktop version{' '}
-              {this.props.latestVersion}.
-            </div>
+            <div className="thank-you-note">{thankYouNote}.</div>
             <div className="contributions-heading">You contributed:</div>
             <div className="contributions">
               {this.renderList(this.props.userContributions)}

--- a/app/styles/ui/_banners.scss
+++ b/app/styles/ui/_banners.scss
@@ -1,6 +1,7 @@
 @import 'banners/successful';
 @import 'banners/conflicts';
 @import 'banners/update-available';
+@import 'banners/open_thank_you_card';
 
 .banner {
   $banner-height: 30px;

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -15,6 +15,7 @@
 @import 'dialogs/create-fork';
 @import 'dialogs/fork-settings';
 @import 'dialogs/cherry-pick';
+@import 'dialogs/thank-you';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to

--- a/app/styles/ui/banners/_open_thank_you_card.scss
+++ b/app/styles/ui/banners/_open_thank_you_card.scss
@@ -1,0 +1,5 @@
+#open-thank-you-card {
+  .smiley-icon {
+    margin-right: var(--spacing);
+  }
+}

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -1,0 +1,131 @@
+@import '../../../styles/variables';
+
+#thank-you-notes {
+  max-height: 450px;
+
+  .dialog-content {
+    // we'll own the layout inside here
+    padding: 0;
+  }
+
+  .dialog-header {
+    height: 100px;
+    position: relative;
+
+    .release-notes-header {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      padding: 0 var(--spacing-double);
+    }
+
+    .header-graphics {
+      display: flex;
+
+      .img-space {
+        flex-grow: 2;
+        display: flex;
+      }
+    }
+
+    .release-note-graphic-left {
+      margin-right: 20px;
+    }
+
+    .release-note-graphic-right {
+      margin-left: 20px;
+    }
+
+    .title {
+      text-align: center;
+      position: absolute;
+      width: 100%;
+      top: 0;
+      left: 0;
+      padding-top: 6%;
+
+      .thank-you-note {
+        font-size: var(--font-size-md);
+        font-weight: normal;
+      }
+
+      .thank-you {
+        font-size: var(--font-size-md);
+        font-weight: var(--font-weight-semibold);
+        div {
+          display: inline;
+        }
+      }
+    }
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      padding-left: 0;
+    }
+  }
+
+  a.close {
+    align-self: flex-start;
+    z-index: 1;
+  }
+
+  .container {
+    width: 600px;
+    max-height: 200px;
+    padding-left: var(--spacing-quint);
+    padding-right: var(--spacing-quint);
+    padding-top: var(--spacing-triple);
+    padding-bottom: var(--spacing-triple);
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    .thank-you-note {
+      font-weight: var(--font-weight-semibold);
+      padding-bottom: var(--spacing-triple);
+    }
+  }
+
+  .confetti-container {
+    position: absolute;
+    width: 110vw;
+    height: 110vh;
+    top: -50vh;
+    left: -33vw;
+  }
+  .confetti {
+    position: absolute;
+  }
+
+  $colors: (#d13447, #ffbf00, #263672);
+
+  @for $i from 0 through 1500 {
+    $w: random(8);
+    $l: random(100);
+    .confetti:nth-child(#{$i}) {
+      width: #{$w}px;
+      height: #{$w * 0.4}px;
+      background-color: nth($colors, random(3));
+      top: -10%;
+      left: unquote($l + '%');
+      opacity: random() + 0.5;
+      transform: rotate(#{random() * 360}deg);
+      animation-name: drop-#{$i};
+      animation-duration: unquote(5 + random() + 's');
+      animation-delay: unquote('-' + random() + 's');
+      animation-iteration-count: 1;
+    }
+
+    @keyframes drop-#{$i} {
+      100% {
+        top: 110%;
+        left: unquote($l + random(15) + '%');
+      }
+    }
+  }
+}

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -77,9 +77,8 @@
 
   .container {
     width: 600px;
-    max-height: 200px;
-    padding-left: var(--spacing-quint);
-    padding-right: var(--spacing-quint);
+    padding-left: 80px;
+    padding-right: 80px;
     padding-top: var(--spacing-triple);
     padding-bottom: var(--spacing-triple);
     overflow-x: hidden;
@@ -88,6 +87,14 @@
     .thank-you-note {
       font-weight: var(--font-weight-semibold);
       padding-bottom: var(--spacing-triple);
+    }
+
+    .contributions-heading {
+      font-weight: var(--font-weight-semibold);
+    }
+
+    .contributions {
+      max-height: 150px;
     }
   }
 
@@ -102,26 +109,27 @@
     position: absolute;
   }
 
-  $colors: (#d13447, #ffbf00, #263672);
+  $colors: (#e7001b, #ffe600, #0ebd25, #0f2679, #e21bd2);
 
   @for $i from 0 through 1500 {
     $w: random(8);
     $l: random(100);
+
     .confetti:nth-child(#{$i}) {
       width: #{$w}px;
       height: #{$w * 0.4}px;
-      background-color: nth($colors, random(3));
+      background-color: nth($colors, random(5));
       top: -10%;
       left: unquote($l + '%');
       opacity: random() + 0.5;
       transform: rotate(#{random() * 360}deg);
-      animation-name: drop-#{$i};
+      animation-name: falling-#{$i};
       animation-duration: unquote(5 + random() + 's');
       animation-delay: unquote('-' + random() + 's');
       animation-iteration-count: 1;
     }
 
-    @keyframes drop-#{$i} {
+    @keyframes falling-#{$i} {
       100% {
         top: 110%;
         left: unquote($l + random(15) + '%');

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -104,7 +104,19 @@
     height: 110vh;
     top: -50vh;
     left: -33vw;
+    animation: remove-confetti-container 0s ease-in 4s forwards;
+    animation-iteration-count: 1;
+    animation-fill-mode: forwards;
   }
+
+  @keyframes remove-confetti-container {
+    to {
+      width: 0;
+      height: 0;
+      overflow: hidden;
+    }
+  }
+
   .confetti {
     position: absolute;
   }


### PR DESCRIPTION
From 02/25/2021 Hackathon... 

## Description

Thank you to external contributors on opening of app after update. A banner will display asking them if they would like to open their card (or throw it away). This only displays if the logged in dot com user's login handle is in the "Thanks {handle}! section of a release note (thus effectively excluding internal contributors). It also only does this one time anytime a version changes. 

Intentionally neglected scenario:
- If user is logged in as GHE user, this check is skipped because they "shouldn't" be contributing to Desktop via a GHE account. If this were the case, it would be a wrongly attributed contribution and just like any contribution wrongly attributed would not be able to me compared against the currently logged in dot com user.

### Screenshots

(Hard coded different user for demo purposes)

https://user-images.githubusercontent.com/75402236/109297102-76e4bd00-77ff-11eb-99a6-1cd08fb2e488.mp4


## Release notes

Notes: Adds thank you card that thanks logged in user for their contributions on version change.
