### PR TITLE
Support deploying arm64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
       - name: Publish production app
         run: yarn run publish
         env:
+          npm_config_arch: ${{ matrix.arch }}
           DESKTOPBOT_TOKEN: ${{ secrets.DESKTOPBOT_TOKEN }}
           WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ uses [React](https://reactjs.org/).
 Download the official installer for your operating system:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
- - [macOS (M1 Chip)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
+ - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
  - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
 
@@ -28,7 +28,7 @@ Want to test out new features and get fixes before everyone else? Install the
 beta channel to get access to early builds of Desktop:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
- - [macOS (M1 Chip)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
+ - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
  
 The release notes for the latest beta versions are available [here](https://desktop.github.com/release-notes/?env=beta).

--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ from disk onto the application to get started.
 Want to test out new features and get fixes before everyone else? Install the
 beta channel to get access to early builds of Desktop:
 
+#### x64 builds
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
+
+#### arm64 builds
+ - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
+ - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64?env=beta)
  
 The release notes for the latest beta versions are available [here](https://desktop.github.com/release-notes/?env=beta).
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ uses [React](https://reactjs.org/).
 Download the official installer for your operating system:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
+ - [macOS (M1 Chip)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
  - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
 
@@ -26,13 +27,9 @@ from disk onto the application to get started.
 Want to test out new features and get fixes before everyone else? Install the
 beta channel to get access to early builds of Desktop:
 
-#### x64 builds
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
+ - [macOS (M1 Chip)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
-
-#### arm64 builds
- - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
- - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64?env=beta)
  
 The release notes for the latest beta versions are available [here](https://desktop.github.com/release-notes/?env=beta).
 

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -165,3 +165,8 @@ export function enableCherryPicking(): boolean {
 export function enableTextDiffExpansion(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should we allow apps running from Rosetta to auto-update to ARM64 builds? */
+export function enableUpdateFromRosettaToARM64(): boolean {
+  return false
+}

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -35,7 +35,7 @@ export function getExecutableName() {
 }
 
 export function getOSXZipName() {
-  return `${productName}.zip`
+  return `${productName}-${getArchitecture()}.zip`
 }
 
 export function getOSXZipPath() {
@@ -44,7 +44,7 @@ export function getOSXZipPath() {
 
 export function getWindowsInstallerName() {
   const productName = getExecutableName()
-  return `${productName}Setup.msi`
+  return `${productName}Setup-${getArchitecture()}.msi`
 }
 
 export function getWindowsInstallerPath() {
@@ -53,7 +53,7 @@ export function getWindowsInstallerPath() {
 
 export function getWindowsStandaloneName() {
   const productName = getExecutableName()
-  return `${productName}Setup.exe`
+  return `${productName}Setup-${getArchitecture()}.exe`
 }
 
 export function getWindowsStandalonePath() {
@@ -61,7 +61,7 @@ export function getWindowsStandalonePath() {
 }
 
 export function getWindowsFullNugetPackageName() {
-  return `${getWindowsIdentifierName()}-${version}-full.nupkg`
+  return `${getWindowsIdentifierName()}-${version}-${getArchitecture()}-full.nupkg`
 }
 
 export function getWindowsFullNugetPackagePath() {
@@ -74,7 +74,7 @@ export function getWindowsFullNugetPackagePath() {
 }
 
 export function getWindowsDeltaNugetPackageName() {
-  return `${getWindowsIdentifierName()}-${version}-delta.nupkg`
+  return `${getWindowsIdentifierName()}-${version}-${getArchitecture()}-delta.nupkg`
 }
 
 export function getWindowsDeltaNugetPackagePath() {

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -60,8 +60,11 @@ export function getWindowsStandalonePath() {
   return Path.join(getDistPath(), '..', 'installer', getWindowsStandaloneName())
 }
 
-export function getWindowsFullNugetPackageName() {
-  return `${getWindowsIdentifierName()}-${version}-${getArchitecture()}-full.nupkg`
+export function getWindowsFullNugetPackageName(
+  includeArchitecture: boolean = false
+) {
+  const architectureInfix = includeArchitecture ? `-${getArchitecture()}` : ''
+  return `${getWindowsIdentifierName()}-${version}${architectureInfix}-full.nupkg`
 }
 
 export function getWindowsFullNugetPackagePath() {
@@ -73,8 +76,11 @@ export function getWindowsFullNugetPackagePath() {
   )
 }
 
-export function getWindowsDeltaNugetPackageName() {
-  return `${getWindowsIdentifierName()}-${version}-${getArchitecture()}-delta.nupkg`
+export function getWindowsDeltaNugetPackageName(
+  includeArchitecture: boolean = false
+) {
+  const architectureInfix = includeArchitecture ? `-${getArchitecture()}` : ''
+  return `${getWindowsIdentifierName()}-${version}${architectureInfix}-delta.nupkg`
 }
 
 export function getWindowsDeltaNugetPackagePath() {

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -147,9 +147,12 @@ export function getArchitecture(): 'arm64' | 'x64' {
     return 'arm64'
   }
 
-  if (remote.app.runningUnderRosettaTranslation === true) {
-    return 'arm64'
-  }
+  // TODO: temporarily disable this to prevent upgrades from macOS users of the
+  // x64 version under Rosetta to the arm64 binary. This should be enabled again
+  // once we're confident about the arm64 build.
+  // if (remote.app.runningUnderRosettaTranslation === true) {
+  //   return 'arm64'
+  // }
 
   // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2
   // More info: https://www.rudyhuyn.com/blog/2017/12/13/how-to-detect-that-your-x86-application-runs-on-windows-on-arm/

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -1,6 +1,5 @@
 import * as Path from 'path'
 import * as Fs from 'fs'
-import * as os from 'os'
 
 import { getProductName, getVersion } from '../app/package-info'
 import { getReleaseBranchName } from './build-platforms'

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -3,7 +3,6 @@ import * as Fs from 'fs'
 
 import { getProductName, getVersion } from '../app/package-info'
 import { getReleaseBranchName } from './build-platforms'
-import { remote } from 'electron'
 
 const productName = getProductName()
 const version = getVersion()

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -152,13 +152,6 @@ export function getArchitecture(): 'arm64' | 'x64' {
     return 'arm64'
   }
 
-  // TODO: temporarily disable this to prevent upgrades from macOS users of the
-  // x64 version under Rosetta to the arm64 binary. This should be enabled again
-  // once we're confident about the arm64 build.
-  // if (remote.app.runningUnderRosettaTranslation === true) {
-  //   return 'arm64'
-  // }
-
   // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2
   // More info: https://www.rudyhuyn.com/blog/2017/12/13/how-to-detect-that-your-x86-application-runs-on-windows-on-arm/
   // Right now (March 3, 2021) is not very important because support for x64

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -116,7 +116,7 @@ function upload(assetName: string, assetPath: string) {
   const s3 = new AWS.S3(s3Info)
 
   const bucket = process.env.S3_BUCKET || ''
-  const key = `releases/${packageInfo.getVersion()}-${sha}/${distInfo.getArchitecture()}/${assetName.replace(
+  const key = `releases/${packageInfo.getVersion()}-${sha}/${assetName.replace(
     / /g,
     ''
   )}`

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -166,7 +166,10 @@ function getContext() {
   )
 }
 
-function updateDeploy(artifacts: ReadonlyArray<IUploadResult>, secret: string) {
+function updateDeploy(
+  artifacts: ReadonlyArray<IUploadResult>,
+  secret: string
+): Promise<void> {
   const { rendererSize, mainSize } = distInfo.getBundleSizes()
   const body = {
     context: getContext(),

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -74,6 +74,8 @@ function uploadOSXAssets() {
 }
 
 function uploadWindowsAssets() {
+  // For the nuget packages, include the architecture infix in the asset name
+  // when they're uploaded.
   const uploads = [
     upload(
       distInfo.getWindowsInstallerName(),
@@ -84,7 +86,7 @@ function uploadWindowsAssets() {
       distInfo.getWindowsStandalonePath()
     ),
     upload(
-      distInfo.getWindowsFullNugetPackageName(),
+      distInfo.getWindowsFullNugetPackageName(true),
       distInfo.getWindowsFullNugetPackagePath()
     ),
   ]
@@ -92,7 +94,7 @@ function uploadWindowsAssets() {
   if (distInfo.shouldMakeDelta()) {
     uploads.push(
       upload(
-        distInfo.getWindowsDeltaNugetPackageName(),
+        distInfo.getWindowsDeltaNugetPackageName(true),
         distInfo.getWindowsDeltaNugetPackagePath()
       )
     )

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -116,7 +116,7 @@ function upload(assetName: string, assetPath: string) {
   const s3 = new AWS.S3(s3Info)
 
   const bucket = process.env.S3_BUCKET || ''
-  const key = `releases/${packageInfo.getVersion()}-${sha}/${assetName.replace(
+  const key = `releases/${packageInfo.getVersion()}-${sha}/${distInfo.getArchitecture()}/${assetName.replace(
     / /g,
     ''
   )}`
@@ -160,10 +160,16 @@ function createSignature(body: any, secret: string) {
   return `sha1=${hmac.digest('hex')}`
 }
 
+function getContext() {
+  return (
+    process.platform + (distInfo.getArchitecture() === 'arm64' ? '-arm64' : '')
+  )
+}
+
 function updateDeploy(artifacts: ReadonlyArray<IUploadResult>, secret: string) {
   const { rendererSize, mainSize } = distInfo.getBundleSizes()
   const body = {
-    context: process.platform,
+    context: getContext(),
     branch_name: platforms.getReleaseBranchName(),
     artifacts,
     stats: {


### PR DESCRIPTION
## Description

This PR prepares our build scripts to deploy arm64 binaries to Central. Depends on github/central#500

Changes:
- Add the new builds to the README file. macOS only for now.
- Add new checks for the current architecture, trying to guess the best build we should try to update to (e.g. if we're running the macOS on Rosetta, we know we should try to update to the arm64 binary).
- New S3 keys to create a subfolder for each architecture.
- Take into account the new contexts created (`darwin-arm64` and `win32-arm64`).

## Release notes

Notes: no-notes
