### PR TITLE
Add support for RStudio Editor on MacOS

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -64,6 +64,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['com.jetbrains.RubyMine'],
   },
   {
+    name: 'RStudio',
+    bundleIdentifiers: ['org.rstudio.RStudio'],
+  },
+  {
     name: 'TextMate',
     bundleIdentifiers: ['com.macromates.TextMate'],
   },

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -210,6 +210,7 @@ These editors are currently supported:
  - [JetBrains PhpStorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains PyCharm](https://www.jetbrains.com/pycharm/)
  - [JetBrains RubyMine](https://www.jetbrains.com/rubymine/)
+ - [RStudio](https://rstudio.com/)
  - [TextMate](https://macromates.com)
  - [Brackets](http://brackets.io/)
      - To use Brackets the Command Line shortcut must be installed.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Part of https://github.com/desktop/desktop/issues/11386

## Description

Added support for RStudio Editor on MacOS

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Support RStudio Editor on MacOS
