### PR TITLE
Handle socket errors coming from the TCP trampoline client

### DIFF
--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -66,7 +66,7 @@ export class TrampolineServer {
       this.server.listen(0, '127.0.0.1', async () => {
         // Replace the error handler
         this.server.removeAllListeners('error')
-        this.server.on('error', error => this.onError(error))
+        this.server.on('error', this.onError)
 
         resolve()
       })
@@ -125,6 +125,8 @@ export class TrampolineServer {
     socket.pipe(split2(/\0/)).on('data', data => {
       this.onDataReceived(socket, parser, data)
     })
+
+    socket.on('error', this.onError)
   }
 
   private onDataReceived(
@@ -177,7 +179,7 @@ export class TrampolineServer {
     }
   }
 
-  private onError(error: Error) {
+  private onError = (error: Error) => {
     sendNonFatalException('trampolineServer', error)
     this.close()
   }


### PR DESCRIPTION
## Description

Aside from errors coming from the trampoline server (already being handled), in certain situations there might be errors coming from the socket itself for every specific connection. Those weren't handled and caused the app to crash when the [trampoline client](https://github.com/desktop/desktop-trampoline) failed in certain ways.

This PR doesn't address the reasons why the [trampoline client](https://github.com/desktop/desktop-trampoline) would do that, which will be investigated separately.

## Release notes

Notes: [Fixed] Crash sometimes when performing remote Git operations.
