### PR TITLE
Make commit attribution check case-insensitive

### DIFF
--- a/app/src/lib/is-account-email.ts
+++ b/app/src/lib/is-account-email.ts
@@ -1,0 +1,21 @@
+/**
+ * Checks if a given email address is included (case-insensitively) among the
+ * email addresses belonging to one or more accounts.
+ *
+ * Note: this check must be used only to decide whether or not when to warn the
+ *       user about the chance of getting misattributed commits, but not to
+ *       override a different but equivalent email address that the user entered
+ *       on purpose. For example, the user's account might have an address like
+ *       My.Email@domain.com, but they'd rather use my.email@domain in their git
+ *       commits.
+ *
+ * @param accountEmails Email addresses belonging to user accounts.
+ * @param email         Email address to validate.
+ */
+export function isAccountEmail(
+  accountEmails: ReadonlyArray<string>,
+  email: string
+) {
+  const lowercaseAccountEmails = accountEmails.map(email => email.toLowerCase())
+  return lowercaseAccountEmails.includes(email.toLowerCase())
+}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -34,6 +34,7 @@ import { lookupPreferredEmail } from '../../lib/email'
 import { setGlobalConfigValue } from '../../lib/git/config'
 import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
+import { isAccountEmail } from '../../lib/is-account-email'
 
 const addAuthorIcon = new OcticonSymbol(
   18,
@@ -293,7 +294,7 @@ export class CommitMessage extends React.Component<
     const warningBadgeVisible =
       email !== undefined &&
       repositoryAccount !== null &&
-      accountEmails.includes(email) === false
+      isAccountEmail(accountEmails, email) === false
 
     return (
       <CommitMessageAvatar

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -55,10 +55,17 @@ export class GitConfigUserForm extends React.Component<
     prevProps: IGitConfigUserFormProps,
     prevState: IGitConfigUserFormState
   ) {
+    const isEmailInputFocused =
+      this.emailInputRef.current !== null &&
+      this.emailInputRef.current.isFocused
+
     // If the email coming from the props has changed, it means a new config
     // was loaded into the form. In that case, make sure to only select the
-    // option "Other" if strictly needed.
-    if (prevProps.email !== this.props.email) {
+    // option "Other" if strictly needed, and select one of the account emails
+    // otherwise.
+    // If the "Other email" input field is currently focused, we won't hide it
+    // from the user, to prevent annoying UI glitches.
+    if (prevProps.email !== this.props.email && !isEmailInputFocused) {
       this.setState({
         emailIsOther: !this.accountEmails.includes(this.props.email),
       })

--- a/app/src/ui/lib/git-email-not-found-warning.tsx
+++ b/app/src/ui/lib/git-email-not-found-warning.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Account } from '../../models/account'
 import { LinkButton } from './link-button'
 import { getDotComAPIEndpoint } from '../../lib/api'
+import { isAccountEmail } from '../../lib/is-account-email'
 
 interface IGitEmailNotFoundWarningProps {
   /** The account the commit should be attributed to. */
@@ -31,7 +32,7 @@ export class GitEmailNotFoundWarning extends React.Component<
   public render() {
     if (
       this.props.accounts.length === 0 ||
-      this.accountEmails.includes(this.props.email)
+      isAccountEmail(this.accountEmails, this.props.email)
     ) {
       return null
     }

--- a/app/src/ui/lib/text-box.tsx
+++ b/app/src/ui/lib/text-box.tsx
@@ -143,6 +143,15 @@ export class TextBox extends React.Component<ITextBoxProps, ITextBoxState> {
     }
   }
 
+  /** Determines if the contained text input element is currently focused. */
+  public get isFocused() {
+    return (
+      this.inputElement !== null &&
+      document.activeElement !== null &&
+      this.inputElement === document.activeElement
+    )
+  }
+
   /**
    * Programmatically moves keyboard focus to the inner text input element if it can be focused
    * (i.e. if it's not disabled explicitly or implicitly through for example a fieldset).


### PR DESCRIPTION
Closes #11691

## Description

This PR makes a change in the way we check if the user's current email in git config is one of the emails registered in their account.

More specifically, this PR makes that check case insensitive. However, it's important to note that this case insensitive check is done only when deciding if the user should be warned about the possibility of unattributed commits, and not in other circumstances.

Thanks to this, if the user had `My.Email@domain.com` registered in their account, they could still choose to use `my.email@domain.com` (all lowercase) without (1) being overridden by `My.Email@domain.com` and (2) without being warned about getting misattributed commits.

Aside from that, this PR also fixes an annoying UI glitch that could happen when the user, while typing a custom email address, if at some point that email address turned into one of the account emails, the textfield would just disappear:


https://user-images.githubusercontent.com/1083228/110106378-e6cbe800-7da9-11eb-9620-93aa133f73ea.mov

### Screenshots

https://user-images.githubusercontent.com/1083228/110106716-4d510600-7daa-11eb-8e42-aed4e600aeba.mov

## Release notes

Notes: [Fixed] Commit attribution warning is not shown for emails with different capitalization.
