### PR TITLE
Cherry Picking Graceful Fail

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -281,6 +281,7 @@ import {
   CherryPickResult,
   continueCherryPick,
   getCherryPickSnapshot,
+  isCherryPickHeadFound,
 } from '../git/cherry-pick'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
@@ -5960,6 +5961,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commits: snapshot?.commits,
       sourceBranch: null,
     })
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _clearCherryPickingHead(repository: Repository): Promise<void> {
+    if (!isCherryPickHeadFound(repository)) {
+      return
+    }
+
+    const gitStore = this.gitStoreCache.get(repository)
+    await gitStore.performFailableOperation(() => abortCherryPick(repository))
   }
 }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2700,9 +2700,9 @@ export class Dispatcher {
         this.startConflictCherryPickFlow(repository)
         break
       default:
-        // If we get to an unknown error state, we want to abort any ongoing
-        // cherry pick. If the user closes error dialog and tries to
-        // cherry pick again, it will fail due to ongoing cherry pick.
+        // If the user closes error dialog and tries to cherry pick again, it
+        // will fail again due to ongoing cherry pick. Thus, if we get to an
+        // unhandled error state, we want to abort any ongoing cherry pick.
         this.appStore._clearCherryPickingHead(repository)
         this.appStore._endCherryPickFlow(repository)
         throw Error(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2700,6 +2700,10 @@ export class Dispatcher {
         this.startConflictCherryPickFlow(repository)
         break
       default:
+        // If we get to an unknown error state, we want to abort any ongoing
+        // cherry pick. If the user closes error dialog and tries to
+        // cherry pick again, it will fail due to ongoing cherry pick.
+        this.appStore._clearCherryPickingHead(repository)
         this.appStore._endCherryPickFlow(repository)
         throw Error(
           `Unable to perform cherry pick operation.


### PR DESCRIPTION
Part of #1685

## Description

Adds logic to abort any ongoing cherry pick in the event of an unhandled failure. (hopefully there won't be any.. but in case) If user reaches a failure resulting in a generic error dialog, trying to cherry pick after closing it will just result in more errors due to attempting to cherry pick with a ongoing cherry pick. This will clear this bad state.. so maybe they can try cherry picking another way..

## Release notes
Notes: no-notes
