### PR TITLE
Cherry Picking Undo Cherry Picked Commits

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -755,6 +755,13 @@ export interface ICherryPickState {
    * cherry pick.
    */
   readonly userHasResolvedConflicts: boolean
+
+  /**
+   * The sha of the target branch tip before cherry pick initiated.
+   *
+   * This will be set to null if no cherry pick has been initiated.
+   */
+  readonly targetBranchUndoSha: string | null
 }
 
 /**

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -289,6 +289,7 @@ export async function getCherryPickSnapshot(
     },
     remainingCommits: commits.slice(count, commits.length),
     commits,
+    targetBranchUndoSha: firstSha,
   }
 }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5924,10 +5924,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const { progress } = snapshot
+    const { progress, targetBranchUndoSha } = snapshot
 
     this.repositoryStateCache.updateCherryPickState(repository, () => ({
       progress,
+      targetBranchUndoSha,
     }))
   }
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -186,6 +186,7 @@ function getInitialRepositoryState(): IRepositoryState {
       step: null,
       progress: null,
       userHasResolvedConflicts: false,
+      targetBranchUndoSha: null,
     },
   }
 }

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -52,6 +52,8 @@ export type Banner =
       readonly targetBranchName: string
       /** number of commits cherry picked */
       readonly countCherryPicked: number
+      /** callback to run when user clicks undo link in banner */
+      readonly onUndoCherryPick: () => void
     }
   | {
       readonly type: BannerType.CherryPickConflictsFound

--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -11,6 +11,8 @@ export interface ICherryPickSnapshot {
   readonly commits: ReadonlyArray<CommitOneLine>
   /** The progress of the operation */
   readonly progress: ICherryPickProgress
+  /** The sha of the target branch tip before cherry pick initiated. */
+  readonly targetBranchUndoSha: string
 }
 
 /** Union type representing the possible states of the cherry pick flow */

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -74,6 +74,7 @@ export function renderBanner(
           targetBranchName={banner.targetBranchName}
           countCherryPicked={banner.countCherryPicked}
           onDismissed={onDismissed}
+          onUndoCherryPick={banner.onUndoCherryPick}
         />
       )
     case BannerType.CherryPickConflictsFound:

--- a/app/src/ui/banners/successful-cherry-pick.tsx
+++ b/app/src/ui/banners/successful-cherry-pick.tsx
@@ -1,32 +1,45 @@
 import * as React from 'react'
+import { LinkButton } from '../lib/link-button'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Banner } from './banner'
 
-export function SuccessfulCherryPick({
-  targetBranchName,
-  countCherryPicked,
-  onDismissed,
-}: {
+interface ISuccessfulCherryPickBannerProps {
   readonly targetBranchName: string
   readonly countCherryPicked: number
   readonly onDismissed: () => void
-}) {
-  const pluralized = countCherryPicked === 1 ? 'commit' : 'commits'
-  return (
-    <Banner
-      id="successful-cherry-pick"
-      timeout={7500}
-      onDismissed={onDismissed}
-    >
-      <div className="green-circle">
-        <Octicon className="check-icon" symbol={OcticonSymbol.check} />
-      </div>
-      <div className="banner-message">
-        <span>
-          Successfully copied {countCherryPicked} {pluralized} to{' '}
-          <strong>{targetBranchName}</strong>.
-        </span>
-      </div>
-    </Banner>
-  )
+  readonly onUndoCherryPick: () => void
+}
+
+export class SuccessfulCherryPick extends React.Component<
+  ISuccessfulCherryPickBannerProps,
+  {}
+> {
+  private undo = () => {
+    this.props.onDismissed()
+    this.props.onUndoCherryPick()
+  }
+
+  public render() {
+    const { countCherryPicked, onDismissed, targetBranchName } = this.props
+
+    const pluralized = countCherryPicked === 1 ? 'commit' : 'commits'
+    return (
+      <Banner
+        id="successful-cherry-pick"
+        timeout={7500}
+        onDismissed={onDismissed}
+      >
+        <div className="green-circle">
+          <Octicon className="check-icon" symbol={OcticonSymbol.check} />
+        </div>
+        <div className="banner-message">
+          <span>
+            Successfully copied {countCherryPicked} {pluralized} to{' '}
+            <strong>{targetBranchName}</strong>.{' '}
+            <LinkButton onClick={this.undo}>Undo</LinkButton>
+          </span>
+        </div>
+      </Banner>
+    )
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2537,9 +2537,8 @@ export class Dispatcher {
     repository: Repository,
     targetBranch: Branch
   ) {
-    const stateBefore = this.repositoryStateManager.get(repository)
-    const beforeSha = getTipSha(stateBefore.branchesState.tip)
-
+    const beforeSha = targetBranch.tip.sha
+    this.appStore._setCherryPickTargetBranchUndoSha(repository, beforeSha)
     log.info(
       `[cherryPick] starting cherry pick for ${targetBranch.name} at ${beforeSha}`
     )
@@ -2608,6 +2607,9 @@ export class Dispatcher {
       type: BannerType.SuccessfulCherryPick,
       targetBranchName,
       countCherryPicked,
+      onUndoCherryPick: () => {
+        this.undoCherryPick(repository)
+      },
     }
     this.setBanner(banner)
 
@@ -2759,5 +2761,13 @@ export class Dispatcher {
     })
 
     this.startCherryPick(repository, targetBranch, commits)
+  }
+
+  /**
+   * This method will perform a hard reset back to the tip of the target branch
+   * before the cherry pick happened.
+   */
+  private async undoCherryPick(repository: Repository): Promise<void> {
+    await this.appStore._undoCherryPick(repository)
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2608,7 +2608,7 @@ export class Dispatcher {
       targetBranchName,
       countCherryPicked,
       onUndoCherryPick: () => {
-        this.undoCherryPick(repository)
+        this.undoCherryPick(repository, targetBranchName)
       },
     }
     this.setBanner(banner)
@@ -2767,7 +2767,10 @@ export class Dispatcher {
    * This method will perform a hard reset back to the tip of the target branch
    * before the cherry pick happened.
    */
-  private async undoCherryPick(repository: Repository): Promise<void> {
-    await this.appStore._undoCherryPick(repository)
+  private async undoCherryPick(
+    repository: Repository,
+    targetBranchName: string
+  ): Promise<void> {
+    await this.appStore._undoCherryPick(repository, targetBranchName)
   }
 }


### PR DESCRIPTION
Part of #1685

## Description

Allows a user to undo the cherry picked commits.  

Note: We may expand upon this to revert back to the source branch of the cherry pick. But this part is needed either way.

### Screenshots

https://user-images.githubusercontent.com/75402236/110150535-5f807380-7dad-11eb-96c5-df3a4f5e9352.mp4


## Release notes
Notes: no-notes
