### PR TITLE
Cherry Picking allow redundant and empty commits

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -161,8 +161,12 @@ export async function cherryPick(
     )
   }
 
+  // --keep-redundant-commits follows pattern of making sure someone cherry
+  // picked commit summaries appear in target branch history even tho they may
+  // be empty. This flag also results in the ability to cherry pick empty
+  // commits (thus, --allow-empty is not required.)
   const result = await git(
-    ['cherry-pick', revisionRange],
+    ['cherry-pick', revisionRange, '--keep-redundant-commits'],
     repository.path,
     'cherry pick',
     baseOptions
@@ -390,8 +394,12 @@ export async function continueCherryPick(
     return parseCherryPickResult(result)
   }
 
+  // --keep-redundant-commits follows pattern of making sure someone cherry
+  // picked commit summaries appear in target branch history even tho they may
+  // be empty. This flag also results in the ability to cherry pick empty
+  // commits (thus, --allow-empty is not required.)
   const result = await git(
-    ['cherry-pick', '--continue'],
+    ['cherry-pick', '--continue', '--keep-redundant-commits'],
     repository.path,
     'continueCherryPick',
     options

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -96,6 +96,76 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
+  it('successfully cherry picks a redundant commit', async () => {
+    result = await cherryPick(repository, featureBranch.tip.sha)
+
+    const commits = await getCommits(repository, targetBranch.ref, 5)
+    expect(commits.length).toBe(2)
+    expect(result).toBe(CherryPickResult.CompletedWithoutError)
+
+    result = await cherryPick(repository, featureBranch.tip.sha)
+
+    const commitsAfterRedundant = await getCommits(
+      repository,
+      targetBranch.ref,
+      5
+    )
+    expect(commitsAfterRedundant.length).toBe(3)
+    expect(result).toBe(CherryPickResult.CompletedWithoutError)
+  })
+
+  it('successfully cherry picks an empty commit', async () => {
+    // add empty commit to feature branch
+    await switchTo(repository, featureBranchName)
+    await GitProcess.exec(
+      ['commit', '--allow-empty', '-m', 'Empty Commit'],
+      repository.path
+    )
+
+    featureBranch = await getBranchOrError(repository, featureBranchName)
+    await switchTo(repository, targetBranchName)
+
+    result = await cherryPick(repository, featureBranch.tip.sha)
+
+    const commits = await getCommits(repository, targetBranch.ref, 5)
+    expect(commits.length).toBe(2)
+    expect(result).toBe(CherryPickResult.CompletedWithoutError)
+  })
+
+  it('successfully cherry picks an empty commit inside a range', async () => {
+    const firstCommitSha = featureBranch.tip.sha
+
+    // add empty commit to feature branch
+    await switchTo(repository, featureBranchName)
+    await GitProcess.exec(
+      ['commit', '--allow-empty', '-m', 'Empty Commit'],
+      repository.path
+    )
+
+    // add another commit so empty commit will be inside a range
+    const featureBranchCommitTwo = {
+      commitMessage: 'Cherry Picked Feature! Number Two',
+      entries: [
+        {
+          path: 'THING_TWO.md',
+          contents: '# HELLO WORLD! \nTHINGS GO HERE\n',
+        },
+      ],
+    }
+    await makeCommit(repository, featureBranchCommitTwo)
+
+    featureBranch = await getBranchOrError(repository, featureBranchName)
+    await switchTo(repository, targetBranchName)
+
+    // cherry picking 3 (on added in setup, empty, featureBranchCommitTwo)
+    const commitRange = revRangeInclusive(firstCommitSha, featureBranch.tip.sha)
+    result = await cherryPick(repository, commitRange)
+
+    const commits = await getCommits(repository, targetBranch.ref, 5)
+    expect(commits.length).toBe(4) // original commit + 4 cherry picked
+    expect(result).toBe(CherryPickResult.CompletedWithoutError)
+  })
+
   it('successfully cherry picked multiple commits without conflicts', async () => {
     // keep reference to the first commit in cherry pick range
     const firstCommitSha = featureBranch.tip.sha
@@ -178,76 +248,6 @@ describe('git/cherry-pick', () => {
       expect(error.toString()).toContain(
         'is a merge but no -m option was given'
       )
-    }
-    expect(result).toBe(null)
-  })
-
-  it('fails to cherry pick an empty commit', async () => {
-    // add empty commit to feature branch
-    await switchTo(repository, featureBranchName)
-    await GitProcess.exec(
-      ['commit', '--allow-empty', '-m', 'Empty Commit'],
-      repository.path
-    )
-
-    featureBranch = await getBranchOrError(repository, featureBranchName)
-    await switchTo(repository, targetBranchName)
-
-    result = null
-    try {
-      result = await cherryPick(repository, featureBranch.tip.sha)
-    } catch (error) {
-      expect(error.toString()).toContain('There are no changes to commit')
-    }
-    expect(result).toBe(null)
-  })
-
-  it('fails to cherry pick an empty commit inside a range', async () => {
-    const firstCommitSha = featureBranch.tip.sha
-
-    // add empty commit to feature branch
-    await switchTo(repository, featureBranchName)
-    await GitProcess.exec(
-      ['commit', '--allow-empty', '-m', 'Empty Commit'],
-      repository.path
-    )
-
-    // add another commit so empty commit will be inside a range
-    const featureBranchCommitTwo = {
-      commitMessage: 'Cherry Picked Feature! Number Two',
-      entries: [
-        {
-          path: 'THING_TWO.md',
-          contents: '# HELLO WORLD! \nTHINGS GO HERE\n',
-        },
-      ],
-    }
-    await makeCommit(repository, featureBranchCommitTwo)
-
-    featureBranch = await getBranchOrError(repository, featureBranchName)
-    await switchTo(repository, targetBranchName)
-
-    try {
-      const commitRange = revRangeInclusive(
-        firstCommitSha,
-        featureBranch.tip.sha
-      )
-      result = await cherryPick(repository, commitRange)
-    } catch (error) {
-      expect(error.toString()).toContain('There are no changes to commit')
-    }
-    expect(result).toBe(null)
-  })
-
-  it('fails to cherry pick a redundant commit', async () => {
-    result = await cherryPick(repository, featureBranch.tip.sha)
-    expect(result).toBe(CherryPickResult.CompletedWithoutError)
-
-    result = null
-    try {
-      result = await cherryPick(repository, featureBranch.tip.sha)
-    } catch (error) {
-      expect(error.toString()).toContain('There are no changes to commit')
     }
     expect(result).toBe(null)
   })


### PR DESCRIPTION
Part of #1685

## Description

Allows user to cherry pick redundant or empty commits. This will result in a commit added to the target branches history that is empty but has the same summary of the cherry picked commit. 

Some discussion about this took place. Decision was we wouldn't want to stop user flow for these scenarios.
Especially in the case of a user selecting 5 commits and one in the middle was redundant/empty.

However, it does open the user up to make "weird" empty commits as many times as they would like.
May warrant further discussion. (Alternative in the same vein of not stopping flow that wasn't discussed is "skipping" these commits)

## Release notes
Notes: no-notes
