### PR TITLE
Cherry picking abort confirmation

### DIFF
--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -109,7 +109,7 @@ export type CommitsChosenStep = {
   commits: ReadonlyArray<CommitOneLine>
 }
 
-/** Shape of data to use when confirming user should abort rebase */
+/** Shape of data to use when confirming user should abort cherry pick */
 export type ConfirmAbortStep = {
   readonly kind: CherryPickStepKind.ConfirmAbort
   readonly conflictState: CherryPickConflictState

--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -20,6 +20,7 @@ export type CherryPickFlowStep =
   | ShowConflictsStep
   | CommitsChosenStep
   | HideConflictsStep
+  | ConfirmAbortStep
 
 export const enum CherryPickStepKind {
   /**
@@ -57,6 +58,7 @@ export const enum CherryPickStepKind {
    * the view will switch back to `ShowProgress`.
    */
   ShowConflicts = 'ShowConflicts',
+
   /**
    * The user may wish to leave the conflict dialog and view the files in
    * the Changes tab to get a better context. In this situation, the application
@@ -64,6 +66,13 @@ export const enum CherryPickStepKind {
    * conflicted list.
    */
   HideConflicts = 'HideConflicts',
+
+  /**
+   * If the user attempts to abort the in-progress cherry pick and the user has
+   * resolved conflicts, the application should ask the user to confirm that
+   * they wish to abort.
+   */
+  ConfirmAbort = 'ConfirmAbort',
 }
 
 /** Shape of data needed to choose the base branch for a cherry pick  */
@@ -98,4 +107,10 @@ export type HideConflictsStep = {
 export type CommitsChosenStep = {
   readonly kind: CherryPickStepKind.CommitsChosen
   commits: ReadonlyArray<CommitOneLine>
+}
+
+/** Shape of data to use when confirming user should abort rebase */
+export type ConfirmAbortStep = {
+  readonly kind: CherryPickStepKind.ConfirmAbort
+  readonly conflictState: CherryPickConflictState
 }

--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -204,10 +204,13 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
         const {
           commits: { length: commitCount },
         } = this.props
+        const sourceBranchName =
+          this.props.sourceBranch !== null ? this.props.sourceBranch.name : null
         return (
           <ConfirmCherryPickAbortDialog
             step={step}
             commitCount={commitCount}
+            sourceBranchName={sourceBranchName}
             onReturnToConflicts={this.moveToShowConflictedFileState}
             onConfirmAbort={this.abortCherryPick}
           />

--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -5,6 +5,7 @@ import { Branch } from '../../models/branch'
 import {
   CherryPickFlowStep,
   CherryPickStepKind,
+  ConfirmAbortStep,
   ShowConflictsStep,
 } from '../../models/cherry-pick'
 import { ICherryPickProgress } from '../../models/progress'
@@ -16,6 +17,8 @@ import { CherryPickProgressDialog } from './cherry-pick-progress-dialog'
 import { CommitOneLine } from '../../models/commit'
 import { CherryPickConflictsDialog } from './cherry-pick-conflicts-dialog'
 import { WorkingDirectoryStatus } from '../../models/status'
+import { getResolvedFiles } from '../../lib/status'
+import { ConfirmCherryPickAbortDialog } from './confirm-cherry-pick-abort-dialog'
 
 interface ICherryPickFlowProps {
   readonly repository: Repository
@@ -81,8 +84,34 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
   }
 
   private onAbortCherryPick = (step: ShowConflictsStep) => {
+    const {
+      dispatcher,
+      repository,
+      workingDirectory,
+      userHasResolvedConflicts,
+    } = this.props
+    const { conflictState } = step
+    const { manualResolutions } = conflictState
+    const { length: countResolvedConflicts } = getResolvedFiles(
+      workingDirectory,
+      manualResolutions
+    )
+
+    if (userHasResolvedConflicts || countResolvedConflicts > 0) {
+      dispatcher.setCherryPickFlowStep(repository, {
+        kind: CherryPickStepKind.ConfirmAbort,
+        conflictState,
+      })
+      return
+    }
+
+    this.abortCherryPick()
+  }
+
+  private abortCherryPick = async () => {
     const { dispatcher, repository, sourceBranch } = this.props
-    dispatcher.abortCherryPick(repository, sourceBranch)
+
+    await dispatcher.abortCherryPick(repository, sourceBranch)
     dispatcher.closePopup()
   }
 
@@ -94,6 +123,15 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
       sourceBranch,
       commits
     )
+  }
+
+  private moveToShowConflictedFileState = (step: ConfirmAbortStep) => {
+    const { conflictState } = step
+    const { dispatcher, repository } = this.props
+    dispatcher.setCherryPickFlowStep(repository, {
+      kind: CherryPickStepKind.ShowConflicts,
+      conflictState,
+    })
   }
 
   public render() {
@@ -160,6 +198,18 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
             resolvedExternalEditor={resolvedExternalEditor}
             openRepositoryInShell={openRepositoryInShell}
             sourceBranchName={sourceBranch !== null ? sourceBranch.name : null}
+          />
+        )
+      case CherryPickStepKind.ConfirmAbort:
+        const {
+          commits: { length: commitCount },
+        } = this.props
+        return (
+          <ConfirmCherryPickAbortDialog
+            step={step}
+            commitCount={commitCount}
+            onReturnToConflicts={this.moveToShowConflictedFileState}
+            onConfirmAbort={this.abortCherryPick}
           />
         )
       case CherryPickStepKind.CommitsChosen:

--- a/app/src/ui/cherry-pick/confirm-cherry-pick-abort-dialog.tsx
+++ b/app/src/ui/cherry-pick/confirm-cherry-pick-abort-dialog.tsx
@@ -8,6 +8,7 @@ import { ConfirmAbortStep } from '../../models/cherry-pick'
 interface IConfirmCherryPickAbortDialogProps {
   readonly step: ConfirmAbortStep
   readonly commitCount: number
+  readonly sourceBranchName: string | null
 
   readonly onReturnToConflicts: (step: ConfirmAbortStep) => void
   readonly onConfirmAbort: () => Promise<void>
@@ -45,7 +46,7 @@ export class ConfirmCherryPickAbortDialog extends React.Component<
   }
 
   private renderTextContent() {
-    const { commitCount, step } = this.props
+    const { commitCount, step, sourceBranchName } = this.props
     const { targetBranchName } = step.conflictState
 
     const pluralize = commitCount > 1 ? 'commits' : 'commit'
@@ -57,13 +58,23 @@ export class ConfirmCherryPickAbortDialog extends React.Component<
       </p>
     )
 
+    let returnTo = null
+    if (sourceBranchName !== null) {
+      returnTo = (
+        <>
+          {' and you will be taken back to '}
+          <Ref>{sourceBranchName}</Ref>
+        </>
+      )
+    }
+
     return (
       <div className="column-left">
         {confirm}
         <p>
-          Aborting this cherry pick will take you back to the original branch
-          you started on and the conflicts you have already resolved will be
-          discarded.
+          {'The conflicts you have already resolved will be discarded'}
+          {returnTo}
+          {'.'}
         </p>
       </div>
     )

--- a/app/src/ui/cherry-pick/confirm-cherry-pick-abort-dialog.tsx
+++ b/app/src/ui/cherry-pick/confirm-cherry-pick-abort-dialog.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Ref } from '../lib/ref'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { ConfirmAbortStep } from '../../models/cherry-pick'
+
+interface IConfirmCherryPickAbortDialogProps {
+  readonly step: ConfirmAbortStep
+  readonly commitCount: number
+
+  readonly onReturnToConflicts: (step: ConfirmAbortStep) => void
+  readonly onConfirmAbort: () => Promise<void>
+}
+
+interface IConfirmCherryPickAbortDialogState {
+  readonly isAborting: boolean
+}
+
+export class ConfirmCherryPickAbortDialog extends React.Component<
+  IConfirmCherryPickAbortDialogProps,
+  IConfirmCherryPickAbortDialogState
+> {
+  public constructor(props: IConfirmCherryPickAbortDialogProps) {
+    super(props)
+    this.state = {
+      isAborting: false,
+    }
+  }
+
+  private onSubmit = async () => {
+    this.setState({
+      isAborting: true,
+    })
+
+    await this.props.onConfirmAbort()
+
+    this.setState({
+      isAborting: false,
+    })
+  }
+
+  private onCancel = async () => {
+    await this.props.onReturnToConflicts(this.props.step)
+  }
+
+  private renderTextContent() {
+    const { commitCount, step } = this.props
+    const { targetBranchName } = step.conflictState
+
+    const pluralize = commitCount > 1 ? 'commits' : 'commit'
+    const confirm = (
+      <p>
+        {`Are you sure you want to abort cherry picking ${commitCount} ${pluralize}`}
+        {' onto '}
+        <Ref>{targetBranchName}</Ref>?
+      </p>
+    )
+
+    return (
+      <div className="column-left">
+        {confirm}
+        <p>
+          Aborting this cherry pick will take you back to the original branch
+          you started on and the conflicts you have already resolved will be
+          discarded.
+        </p>
+      </div>
+    )
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="abort-merge-warning"
+        title={
+          __DARWIN__ ? 'Confirm Abort Cherry Pick' : 'Confirm abort cherry pick'
+        }
+        onDismissed={this.onCancel}
+        onSubmit={this.onSubmit}
+        disabled={this.state.isAborting}
+        type="warning"
+      >
+        <DialogContent>{this.renderTextContent()}</DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={
+              __DARWIN__ ? 'Abort Cherry Pick' : 'Abort cherry pick'
+            }
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}


### PR DESCRIPTION
Part of #1685 

## Description

If a user has started resolving conflicts during a cherry pick, we want to confirm they want to abort and discard those changes.

### Screenshots

https://user-images.githubusercontent.com/75402236/110321586-e321a680-7fdf-11eb-96e2-78c452c895dc.mp4



## Release notes

Notes: no-notes
