### PR TITLE
Add cherry picking stats

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -355,6 +355,18 @@ export interface IDailyMeasures {
 
   /** Number of times the user has encountered an unhandled rejection */
   readonly unhandledRejectionCount: number
+
+  /** The number of times a successful cherry pick occurs */
+  readonly cherryPickSuccessfulCount: number
+
+  /** The number of times a cherry pick is initiated through drag and drop */
+  readonly cherryPickViaDragAndDropCount: number
+
+  /** The number of times a cherry pick is initiated through the context menu */
+  readonly cherryPickViaContextMenuCount: number
+
+  /** The number of times a cherry pick drag was started and canceled */
+  readonly cherryPickDragStartedAndCanceledCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -367,6 +367,18 @@ export interface IDailyMeasures {
 
   /** The number of times a cherry pick drag was started and canceled */
   readonly cherryPickDragStartedAndCanceledCount: number
+
+  /** The number of times conflicts encountered during a cherry pick  */
+  readonly cherryPickConflictsEncounteredCount: number
+
+  /** The number of times cherry pick ended successfully after conflicts  */
+  readonly cherryPickSuccessfulWithConflictsCount: number
+
+  /** The number of times cherry pick of multiple commits initiated  */
+  readonly cherryPickMultipleCommitsCount: number
+
+  /** The number of times a cherry pick was undone  */
+  readonly cherryPickUndoneCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -140,6 +140,10 @@ const DefaultDailyMeasures: IDailyMeasures = {
   diffOptionsViewedCount: 0,
   repositoryViewChangeCount: 0,
   unhandledRejectionCount: 0,
+  cherryPickSuccessfulCount: 0,
+  cherryPickViaDragAndDropCount: 0,
+  cherryPickViaContextMenuCount: 0,
+  cherryPickDragStartedAndCanceledCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1384,6 +1388,31 @@ export class StatsStore implements IStatsStore {
   public recordUnhandledRejection() {
     return this.updateDailyMeasures(m => ({
       unhandledRejectionCount: m.unhandledRejectionCount + 1,
+    }))
+  }
+
+  public recordCherryPickSuccessful(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickSuccessfulCount: m.cherryPickSuccessfulCount + 1,
+    }))
+  }
+
+  public recordCherryPickViaDragAndDrop(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickViaDragAndDropCount: m.cherryPickViaDragAndDropCount + 1,
+    }))
+  }
+
+  public recordCherryPickViaContextMenu(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickViaContextMenuCount: m.cherryPickViaContextMenuCount + 1,
+    }))
+  }
+
+  public recordCherryPickDragStartedAndCanceled(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickDragStartedAndCanceledCount:
+        m.cherryPickDragStartedAndCanceledCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -144,6 +144,10 @@ const DefaultDailyMeasures: IDailyMeasures = {
   cherryPickViaDragAndDropCount: 0,
   cherryPickViaContextMenuCount: 0,
   cherryPickDragStartedAndCanceledCount: 0,
+  cherryPickConflictsEncounteredCount: 0,
+  cherryPickSuccessfulWithConflictsCount: 0,
+  cherryPickMultipleCommitsCount: 0,
+  cherryPickUndoneCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1413,6 +1417,32 @@ export class StatsStore implements IStatsStore {
     return this.updateDailyMeasures(m => ({
       cherryPickDragStartedAndCanceledCount:
         m.cherryPickDragStartedAndCanceledCount + 1,
+    }))
+  }
+
+  public recordCherryPickConflictsEncountered(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickConflictsEncounteredCount:
+        m.cherryPickConflictsEncounteredCount + 1,
+    }))
+  }
+
+  public recordCherryPickSuccessfulWithConflicts(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickSuccessfulWithConflictsCount:
+        m.cherryPickSuccessfulWithConflictsCount + 1,
+    }))
+  }
+
+  public recordCherryPickMultipleCommits(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickMultipleCommitsCount: m.cherryPickMultipleCommitsCount + 1,
+    }))
+  }
+
+  public recordCherryPickUndone(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      cherryPickUndoneCount: m.cherryPickUndoneCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5955,7 +5955,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await gitStore.performFailableOperation(() => abortCherryPick(repository))
 
-    this.checkoutBranchIfNotNull(repository, sourceBranch)
+    await this.checkoutBranchIfNotNull(repository, sourceBranch)
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
@@ -6091,7 +6091,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
     await gitStore.performFailableOperation(() => abortCherryPick(repository))
 
-    this.checkoutBranchIfNotNull(repository, sourceBranch)
+    await this.checkoutBranchIfNotNull(repository, sourceBranch)
 
     return this._refreshRepository(repository)
   }
@@ -6125,11 +6125,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
       reset(repository, GitResetMode.Hard, targetBranchUndoSha)
     )
 
-    if(result !== true) {
+    if (result !== true) {
       return false
     }
 
-    this.checkoutBranchIfNotNull(repository, sourceBranch)
+    await this.checkoutBranchIfNotNull(repository, sourceBranch)
 
     const banner: Banner = {
       type: BannerType.CherryPickUndone,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2779,6 +2779,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.props.dispatcher.setCherryPickFlowStep(repository, initialStep)
+    this.props.dispatcher.recordCherryPickViaContextMenu()
 
     this.showPopup({
       type: PopupType.CherryPick,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2626,6 +2626,8 @@ export class Dispatcher {
 
     this.appStore._endCherryPickFlow(repository)
 
+    this.statsStore.recordCherryPickSuccessful()
+
     await this.refreshRepository(repository)
   }
 
@@ -2780,6 +2782,7 @@ export class Dispatcher {
       sourceBranch,
     })
 
+    this.statsStore.recordCherryPickViaDragAndDrop()
     this.startCherryPick(repository, targetBranch, commits, sourceBranch)
   }
 
@@ -2804,5 +2807,20 @@ export class Dispatcher {
       sourceBranch,
       commitsCount
     )
+  }
+
+  /** Method to record cherry pick initiated via the context menu. */
+  public recordCherryPickViaContextMenu() {
+    this.statsStore.recordCherryPickViaDragAndDrop()
+  }
+
+  /** Method to record cherry pick started via drag and drop and canceled. */
+  public recordCherryPickDragStartedAndCanceled() {
+    this.statsStore.recordCherryPickDragStartedAndCanceled()
+  }
+
+  /** Method to reset cherry picking state. */
+  public endCherryPickFlow(repository: Repository) {
+    this.appStore._endCherryPickFlow(repository)
   }
 }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -7,7 +7,6 @@ import {
   ICompareBranch,
   ComparisonMode,
   IDisplayHistory,
-  FoldoutType,
 } from '../../lib/app-state'
 import { CommitList } from './commit-list'
 import { Repository } from '../../models/repository'
@@ -45,6 +44,7 @@ interface ICompareSidebarProps {
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ) => void
+  readonly onDragCommitEnd: () => void
   readonly compareListScrollTop?: number
   readonly localTags: Map<string, string> | null
   readonly tagsToPush: ReadonlyArray<string> | null
@@ -243,7 +243,7 @@ export class CompareSidebar extends React.Component<
         compareListScrollTop={this.props.compareListScrollTop}
         tagsToPush={this.props.tagsToPush}
         onDragCommitStart={this.onDragCommitStart}
-        onDragCommitEnd={this.onDragCommitEnd}
+        onDragCommitEnd={this.props.onDragCommitEnd}
         hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
         onDismissCherryPickIntro={this.onDismissCherryPickIntro}
       />
@@ -536,16 +536,6 @@ export class CompareSidebar extends React.Component<
       kind: CherryPickStepKind.CommitsChosen,
       commits,
     })
-  }
-
-  /**
-   * This method is a generic event handler for when a commit has ended being
-   * dragged.
-   *
-   * Currently only used for cherry picking, but this could be more generic.
-   */
-  private onDragCommitEnd = () => {
-    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
   }
 }
 

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -559,6 +559,8 @@ export class RepositoryView extends React.Component<
   private onDragCommitEnd = async () => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
 
+    // On drag end fires before the drop event, we need to wait here and see if
+    // the drop event results in a change of cherry picking state.
     await sleep(10)
     const { cherryPickState } = this.props.state
     if (

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -14,6 +14,7 @@ import {
   IRepositoryState,
   RepositorySectionTab,
   ChangesSelectionKind,
+  FoldoutType,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
 import { IssuesStore, GitHubUserStore } from '../lib/stores'
@@ -28,6 +29,8 @@ import { TutorialPanel, TutorialWelcome, TutorialDone } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { openFile } from './lib/open-file'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
+import { sleep } from '../lib/promise'
+import { CherryPickStepKind } from '../models/cherry-pick'
 
 /** The widest the sidebar can be with the minimum window size. */
 const MaxSidebarWidth = 495
@@ -247,6 +250,7 @@ export class RepositoryView extends React.Component<
         tagsToPush={this.props.state.tagsToPush}
         aheadBehindStore={this.props.aheadBehindStore}
         hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
+        onDragCommitEnd={this.onDragCommitEnd}
       />
     )
   }
@@ -542,5 +546,26 @@ export class RepositoryView extends React.Component<
       )
     }
     return null
+  }
+
+  /**
+   * This method is a generic event handler for when a commit has ended being
+   * dragged.
+   *
+   * Currently only used for cherry picking, but this could be more generic.
+   */
+  private onDragCommitEnd = async () => {
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+
+    await sleep(10)
+    const { cherryPickState } = this.props.state
+    if (
+      cherryPickState !== null &&
+      cherryPickState.step !== null &&
+      cherryPickState.step.kind === CherryPickStepKind.CommitsChosen
+    ) {
+      this.props.dispatcher.endCherryPickFlow(this.props.repository)
+      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
+    }
   }
 }


### PR DESCRIPTION
Part of #1685

## Description
Adding stats to track cherry picking.

Questions attempting to shed light on:
1. What % of users cherry pick successfully?
2. What % of users use drag and drop?
3. What % of users use context menu?
4. What % of users start a drag and drop cherry pick but cancel it?
5. What % of users enter into conflicts and succeed after?
6. What % of users undo a cherry pick?
7. What % of users cherry pick multiple commits?

Notes:
1. Test our hypothesis that this is a desired feature.

2/3 - Test our hypothesis that users will prefer the drag/drop UI.

4. We are concerned users could start dragging and not know where to drag the commits. This will track if a user starts to drag and releases without starting a cherry pick. (This could indicate erroneous drags as well as not sure where to land drags).

5. Are conflicts common/are we providing a clear path to resolution?
6. Is undo a used pattern in this situation?
7. Multiple commits selection is not readily apparent - do we need more info on it?


## Release notes

Notes: no-notes
