### PR TITLE
Bump dugite from 1.98.0 to  1.100.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.3",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.98.0",
+    "dugite": "^1.100.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -409,6 +409,11 @@ function getDescriptionForError(error: DugiteError): string | null {
     case DugiteError.MergeWithLocalChanges:
     case DugiteError.RebaseWithLocalChanges:
       return null
+    case DugiteError.MergeCommitNoMainlineOption:
+      // Note: This has been made specific to cherry pick, but this error can
+      // appear for revert; however, our revert logic provides the -m option
+      // and avoids this error.
+      return 'You cannot cherry pick merge commits from GitHub Desktop. You can cherry pick merge commits from the terminal using the -m flag. Please select non-merge commits and try again.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -247,9 +247,7 @@ describe('git/cherry-pick', () => {
     try {
       result = await cherryPick(repository, featureBranch.tip.sha)
     } catch (error) {
-      expect(error.toString()).toContain(
-        'is a merge but no -m option was given'
-      )
+      expect(error.toString()).toContain('Error: Unknown error: 53')
     }
     expect(result).toBe(null)
   })

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -247,7 +247,9 @@ describe('git/cherry-pick', () => {
     try {
       result = await cherryPick(repository, featureBranch.tip.sha)
     } catch (error) {
-      expect(error.toString()).toContain('Error: Unknown error: 53')
+      expect(error.toString()).toContain(
+        'GitError: You cannot cherry pick merge commits from GitHub Desktop.'
+      )
     }
     expect(result).toBe(null)
   })

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -364,10 +364,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.98.0:
-  version "1.98.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.98.0.tgz#26983df758a000dea8879b364e1596c08104f809"
-  integrity sha512-wI9cW41rVqyB8yQnaP2LP7P5eAUzz4vEMX0rPXDXRJ4pDGMoxkVcTjzWZ9ojdOIw2uF8OibplEHCIZ3FADIy/Q==
+dugite@^1.100.0:
+  version "1.100.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.100.0.tgz#4e531a00945e7eb8ab14aa253d351f6689d4038e"
+  integrity sha512-WEoeDJ1wzC9tbULzmEw/cqpilL9ExoulVGepc7nlRkZNmsEnKbLRZW+Ims/uyrV02NA00LetkP/CsEpilNeq1A==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"


### PR DESCRIPTION
## Description

Dugite 1.100.0 - Updates git to 2.29.3 from 
Dugite 1.99.0 - Adds git error for merge commit (add for cherry pick handling)

## Release notes
Notes: no-notes
