### PR TITLE
Refresh after successful checkout during cherry pick

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5863,6 +5863,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return result
     }
 
+    await this._refreshRepository(repository)
+
     const progressCallback = (progress: ICherryPickProgress) => {
       this.repositoryStateCache.updateCherryPickState(repository, () => ({
         progress,


### PR DESCRIPTION
Part of #1685

## Description

Refresh repository so that history shown during conflict matches checked out branch.

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/110720149-1a5ca700-81dc-11eb-9e47-ee759a507bf6.png)

## Release notes

Notes: no-notes
