### PR TITLE
Prevent initiating cherry pick on checked out branch

### DIFF
--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -95,9 +95,9 @@ export class BranchListItem extends React.Component<
   }
 
   private onDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    const { onDropOntoBranch, name } = this.props
+    const { onDropOntoBranch, name, isCurrentBranch } = this.props
 
-    if (onDropOntoBranch !== undefined) {
+    if (onDropOntoBranch !== undefined && !isCurrentBranch) {
       onDropOntoBranch(name)
     }
   }


### PR DESCRIPTION
Part of #1685

## Description
Prevent cherry picking from current checked out branch onto itself. (This will just result in an empty commit)

## Release notes
Notes: no-notes
