### PR TITLE
Track trampoline server/client errors separately, and improve error messaging

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.3",
+    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.4",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.100.0",

--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -66,7 +66,7 @@ export class TrampolineServer {
       this.server.listen(0, '127.0.0.1', async () => {
         // Replace the error handler
         this.server.removeAllListeners('error')
-        this.server.on('error', this.onError)
+        this.server.on('error', this.onServerError)
 
         resolve()
       })
@@ -126,7 +126,7 @@ export class TrampolineServer {
       this.onDataReceived(socket, parser, data)
     })
 
-    socket.on('error', this.onError)
+    socket.on('error', this.onClientError)
   }
 
   private onDataReceived(
@@ -179,9 +179,13 @@ export class TrampolineServer {
     }
   }
 
-  private onError = (error: Error) => {
+  private onServerError = (error: Error) => {
     sendNonFatalException('trampolineServer', error)
     this.close()
+  }
+
+  private onClientError = (error: Error) => {
+    sendNonFatalException('trampolineClient', error)
   }
 }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -311,9 +311,9 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-trampoline@desktop/desktop-trampoline#v0.9.3:
-  version "0.9.3"
-  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/31bc7170f634aae182de9eb54a01aa04dc124297"
+desktop-trampoline@desktop/desktop-trampoline#v0.9.4:
+  version "0.9.4"
+  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/7eabea0f1a3f8432307719a1bd16d1ffde2bf6f6"
 
 detect-libc@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Closes #11696 
Closes #11701 

## Description

This PR bumps the desktop-trampoline to improve logging and error messaging thanks to desktop/desktop-trampoline#5

It also fixes a bug where the app closed the trampoline server when one of the clients has an error (which is what happened to #11696)

I could find and fix this issue thanks to @sky93 who has helped me A LOT to understand the problem!! ❤️ 🙇‍♂️ 

## Release notes

Notes: [Fixed] Remote Git operations failed in some circumstances.
