### PR TITLE
Option to hide "Recent" repositories in the repository list

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -219,6 +219,9 @@ export interface IAppState {
   /** Whether we should automatically change the currently selected appearance (aka theme) */
   readonly automaticallySwitchTheme: boolean
 
+  /** Whether we should hide the recent section in repositories list */
+  readonly hideRecentRepositories: boolean
+
   /**
    * A map keyed on a user account (GitHub.com or GitHub Enterprise)
    * containing an object with repositories that the authenticated

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -342,6 +342,9 @@ const MaxInvalidFoldersToDisplay = 3
 
 const hasShownCherryPickIntroKey = 'has-shown-cherry-pick-intro'
 
+const hideRecentRepositoriesKey = 'hide-recent-repositories'
+const hideRecentRepositoriesDefault = false
+
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
@@ -433,6 +436,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.Light
   private automaticallySwitchTheme = false
+
+  private hideRecentRepositories = false
 
   private hasUserViewedStash = false
 
@@ -788,6 +793,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedBranchesTab: this.selectedBranchesTab,
       selectedTheme: this.selectedTheme,
       automaticallySwitchTheme: this.automaticallySwitchTheme,
+      hideRecentRepositories: this.hideRecentRepositories,
       apiRepositories: this.apiRepositoriesStore.getState(),
       optOutOfUsageTracking: this.statsStore.getOptOut(),
       currentOnboardingTutorialStep: this.currentOnboardingTutorialStep,
@@ -1751,6 +1757,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.emitUpdate()
       }
     })
+
+    this.hideRecentRepositories = getBoolean(
+      hideRecentRepositoriesKey,
+      hideRecentRepositoriesDefault
+    )
 
     this.hasShownCherryPickIntro = getBoolean(hasShownCherryPickIntroKey, false)
 
@@ -5497,6 +5508,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setAutomaticallySwitchTheme(automaticallySwitchTheme: boolean) {
     setAutoSwitchPersistedTheme(automaticallySwitchTheme)
     this.automaticallySwitchTheme = automaticallySwitchTheme
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  /**
+   * Set the hide recent repositories flag
+   */
+  public _setHideRecentRepositories(hideRecentRepositories: boolean) {
+    this.hideRecentRepositories = hideRecentRepositories
+    setBoolean(hideRecentRepositoriesKey, hideRecentRepositories)
     this.emitUpdate()
 
     return Promise.resolve()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1395,6 +1395,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
             automaticallySwitchTheme={this.state.automaticallySwitchTheme}
+            hideRecentRepositories={this.state.hideRecentRepositories}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
           />
         )
@@ -2266,6 +2267,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         externalEditorLabel={externalEditorLabel}
         shellLabel={shellLabel}
         dispatcher={this.props.dispatcher}
+        hideRecentRepositories={this.state.hideRecentRepositories}
       />
     )
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2225,6 +2225,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set the hide recent repositories flag
+   */
+  public onHideRecentRepositoriesChanged(value: boolean) {
+    return this.appStore._setHideRecentRepositories(value)
+  }
+
+  /**
    * Increments either the `repoWithIndicatorClicked` or
    * the `repoWithoutIndicatorClicked` metric
    */

--- a/app/src/ui/preferences/appearance.tsx
+++ b/app/src/ui/preferences/appearance.tsx
@@ -13,7 +13,9 @@ interface IAppearanceProps {
   readonly selectedTheme: ApplicationTheme
   readonly onSelectedThemeChanged: (theme: ApplicationTheme) => void
   readonly automaticallySwitchTheme: boolean
+  readonly hideRecentRepositories: boolean
   readonly onAutomaticallySwitchThemeChanged: (checked: boolean) => void
+  readonly onHideRecentRepositoriesChanged: (checked: boolean) => void
 }
 
 const themes: ReadonlyArray<ISegmentedItem<ApplicationTheme>> = [
@@ -49,11 +51,21 @@ export class Appearance extends React.Component<IAppearanceProps, {}> {
     this.props.onAutomaticallySwitchThemeChanged(value)
   }
 
+  private onHideRecentRepositoriesChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+    this.props.onHideRecentRepositoriesChanged(value)
+  }
+
   public render() {
     return (
       <DialogContent>
-        {this.renderThemeOptions()}
-        {this.renderAutoSwitcherOption()}
+        <h2>Theme</h2>
+          {this.renderThemeOptions()}
+          {this.renderAutoSwitcherOption()}
+        <h2>Interface</h2>
+        {this.renderhideRecentRepositoriesOption()}
       </DialogContent>
     )
   }
@@ -85,6 +97,22 @@ export class Appearance extends React.Component<IAppearanceProps, {}> {
               : CheckboxValue.Off
           }
           onChange={this.onAutomaticallySwitchThemeChanged}
+        />
+      </Row>
+    )
+  }
+
+  public renderhideRecentRepositoriesOption() {
+    return (
+      <Row>
+        <Checkbox
+          label="Hide recently accessed repositories."
+          value={
+              this.props.hideRecentRepositories
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+          onChange={this.onHideRecentRepositoriesChanged}
         />
       </Row>
     )

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -56,6 +56,7 @@ interface IPreferencesProps {
   readonly selectedShell: Shell
   readonly selectedTheme: ApplicationTheme
   readonly automaticallySwitchTheme: boolean
+  readonly hideRecentRepositories: boolean
   readonly repositoryIndicatorsEnabled: boolean
 }
 
@@ -302,9 +303,13 @@ export class Preferences extends React.Component<
           <Appearance
             selectedTheme={this.props.selectedTheme}
             onSelectedThemeChanged={this.onSelectedThemeChanged}
+            hideRecentRepositories={this.props.hideRecentRepositories}
             automaticallySwitchTheme={this.props.automaticallySwitchTheme}
             onAutomaticallySwitchThemeChanged={
               this.onAutomaticallySwitchThemeChanged
+            }
+            onHideRecentRepositoriesChanged={
+              this.onHideRecentRepositoriesChanged
             }
           />
         )
@@ -419,6 +424,12 @@ export class Preferences extends React.Component<
     this.props.dispatcher.onAutomaticallySwitchThemeChanged(
       automaticallySwitchTheme
     )
+  }
+
+  private onHideRecentRepositoriesChanged = (
+    value: boolean
+  ) => {
+    this.props.dispatcher.onHideRecentRepositoriesChanged(value)
   }
 
   private renderFooter() {

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -67,6 +67,9 @@ interface IRepositoriesListProps {
   readonly filterText: string
 
   readonly dispatcher: Dispatcher
+
+  /** Flag to hide recent repositories */
+  readonly hideRecentRepositories: boolean
 }
 
 const RowHeight = 29
@@ -190,7 +193,7 @@ export class RepositoriesList extends React.Component<
     )
 
     const groups =
-      this.props.repositories.length > recentRepositoriesThreshold
+      this.props.repositories.length > recentRepositoriesThreshold && this.props.hideRecentRepositories === false
         ? [
             makeRecentRepositoriesGroup(
               this.props.recentRepositories,


### PR DESCRIPTION
Closes https://github.com/desktop/desktop/issues/11598

## Description

- Add an option to Hide the recent section in the repository list
- The option is added under "Appearance"

### Screenshots
![gitdesktop_recent_gif](https://user-images.githubusercontent.com/35450302/111067722-7f214580-84eb-11eb-9f57-c583c56e96d9.gif)

## Release notes

Notes:
Option to hide "Recent" section under repositories