### PR TITLE
Cherry picking mutliple commits text in branch dialog and [New] callout for history tab

### DIFF
--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -65,7 +65,9 @@ interface ICherryPickFlowProps {
 /** A component for initiating and performing a cherry pick. */
 export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
   private onFlowEnded = () => {
-    this.props.onDismissed()
+    const { onDismissed, dispatcher, repository } = this.props
+    onDismissed()
+    dispatcher.endCherryPickFlow(repository)
   }
 
   private onCherryPick = (targetBranch: Branch) => {
@@ -161,6 +163,7 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
             currentBranch={currentBranch}
             onCherryPick={this.onCherryPick}
             onDismissed={this.onFlowEnded}
+            commitCount={this.props.commits.length}
           />
         )
       }
@@ -197,7 +200,7 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
             step={step}
             userHasResolvedConflicts={userHasResolvedConflicts}
             workingDirectory={workingDirectory}
-            onDismissed={this.onFlowEnded}
+            onDismissed={this.props.onDismissed}
             onContinueCherryPick={this.onContinueCherryPick}
             onAbortCherryPick={this.onAbortCherryPick}
             showCherryPickConflictsBanner={this.showCherryPickConflictsBanner}

--- a/app/src/ui/cherry-pick/choose-target-branch.tsx
+++ b/app/src/ui/cherry-pick/choose-target-branch.tsx
@@ -32,6 +32,11 @@ interface IChooseTargetBranchDialogProps {
   readonly recentBranches: ReadonlyArray<Branch>
 
   /**
+   * Number of commits to cherry pick
+   */
+  readonly commitCount: number
+
+  /**
    * A function that's called when the user selects a branch and hits start
    * cherry pick
    */
@@ -107,7 +112,8 @@ export class ChooseTargetBranchDialog extends React.Component<
   }
 
   private renderOkButtonText() {
-    const okButtonText = 'Cherry pick commit'
+    const pluralize = this.props.commitCount > 1 ? 'commits' : 'commit'
+    const okButtonText = `Cherry pick ${this.props.commitCount} ${pluralize}`
 
     const { selectedBranch } = this.state
     if (selectedBranch !== null) {
@@ -126,13 +132,18 @@ export class ChooseTargetBranchDialog extends React.Component<
       ? 'You are not able to cherry pick from and to the same branch'
       : undefined
 
+    const pluralize = this.props.commitCount > 1 ? 'commits' : 'commit'
     return (
       <Dialog
         id="cherry-pick"
         onDismissed={this.props.onDismissed}
         onSubmit={this.startCherryPick}
         dismissable={true}
-        title={<strong>Cherry pick commit to a branch</strong>}
+        title={
+          <strong>
+            Cherry pick {this.props.commitCount} {pluralize} to a branch
+          </strong>
+        }
       >
         <DialogContent>
           <BranchList

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -153,10 +153,17 @@ export class RepositoryView extends React.Component<
         </span>
 
         <div className="with-indicator">
-          <span>History</span>
+          <span>History {this.renderNewCallToActionBubble()}</span>
         </div>
       </TabBar>
     )
+  }
+
+  private renderNewCallToActionBubble(): JSX.Element | null {
+    if (this.props.hasShownCherryPickIntro) {
+      return null
+    }
+    return <span className="call-to-action-bubble">New</span>
   }
 
   private renderChangesSidebar(): JSX.Element {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -160,7 +160,9 @@ export class RepositoryView extends React.Component<
   }
 
   private renderNewCallToActionBubble(): JSX.Element | null {
-    if (this.props.hasShownCherryPickIntro) {
+    const { hasShownCherryPickIntro, state } = this.props
+    const { compareState } = state
+    if (hasShownCherryPickIntro || compareState.commitSHAs.length === 0) {
       return null
     }
     return <span className="call-to-action-bubble">New</span>

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -79,6 +79,17 @@
     &.focus-ring {
       outline-offset: -4px;
     }
+
+    .call-to-action-bubble {
+      font-weight: var(--font-weight-semibold);
+      display: inline-block;
+      font-size: var(--font-size-xs);
+      border: 1px solid var(--call-to-action-bubble-border-color);
+      color: var(--call-to-action-bubble-color);
+      padding: 1px 5px;
+      border-radius: var(--border-radius);
+      margin-left: var(--spacing-third);
+    }
   }
 
   &.switch &-item {


### PR DESCRIPTION
Part of #1685

## Description

When multiple commits selected via context menu, have branch dialog indicate that multiple commits are selected.
(Also noticed a bug that if you opened branch modal and then dismissed, cherry pick state wasn't cleared)

When user has not been introduced to cherry picking yet, have [New] call out on history tab. It is removed once user hits got it on cherry pick intro pop over.

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/111143711-82084e80-855c-11eb-92b5-d94c9e95937b.png)

![image](https://user-images.githubusercontent.com/75402236/111143654-70bf4200-855c-11eb-9f25-51f42a61ac4a.png)

## Release notes

Notes: no-notes
