### PR TITLE
Add support for RStudio for Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -270,6 +270,14 @@ const editors: IWindowsExternalEditor[] = [
       displayName.startsWith('JetBrains Rider') &&
       publisher === 'JetBrains s.r.o.',
   },
+  {
+    name: 'RStudio',
+    registryKeys: [Wow64LocalMachineUninstallKey('RStudio')],
+    executableShimPath: [],
+    installLocationRegistryKey: 'DisplayIcon',
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName === 'RStudio' && publisher === 'RStudio',
+  },
 ]
 
 function getKeyOrEmpty(

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -35,6 +35,7 @@ These editors are currently supported:
  - [JetBrains Phpstorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
  - [Notepad++](https://notepad-plus-plus.org/)
+ - [RStudio](https://rstudio.com/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
Closes #11386 

## Description

This PR adds support for RStudio on Windows.

## Release notes

Notes: [Added] Add support for RStudio as external editor
