### PR TITLE
Fix race condition writing/reading git config

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -135,7 +135,7 @@ export async function setConfigValue(
     HOME: string
   }
 ): Promise<void> {
-  setConfigValueInPath(name, value, repository.path, env)
+  await setConfigValueInPath(name, value, repository.path, env)
 }
 
 /** Set the global config value by name. */
@@ -146,7 +146,7 @@ export async function setGlobalConfigValue(
     HOME: string
   }
 ): Promise<void> {
-  setConfigValueInPath(name, value, null, env)
+  await setConfigValueInPath(name, value, null, env)
 }
 
 /**
@@ -186,7 +186,7 @@ export async function removeConfigValue(
     HOME: string
   }
 ): Promise<void> {
-  removeConfigValueInPath(name, repository.path, env)
+  await removeConfigValueInPath(name, repository.path, env)
 }
 
 /** Remove the global config value by name. */
@@ -196,7 +196,7 @@ export async function removeGlobalConfigValue(
     HOME: string
   }
 ): Promise<void> {
-  removeConfigValueInPath(name, null, env)
+  await removeConfigValueInPath(name, null, env)
 }
 
 /**


### PR DESCRIPTION
## Description

Recently I noticed we got more CI builds failing randomly. After a closer inspection, seems like some of the changes in #11595 introduced race conditions by not waiting for some async functions to complete (or by not returning their promise).

This race condition affects places where a config value is set/removed, and then read immediately after (like we do in `config-test.ts`).

The only areas I see could be affected by something like that are the recently added improvements to fix misattributed commits. More specifically when the git config email is changed from anywhere inside the app, and then the UI is immediately refreshed to reflect the change in the avatar of the committer.

## Release notes

Notes: no-notes
