### PR TITLE
15 secs for cherry pick success banner time

### DIFF
--- a/app/src/ui/banners/successful-cherry-pick.tsx
+++ b/app/src/ui/banners/successful-cherry-pick.tsx
@@ -26,7 +26,7 @@ export class SuccessfulCherryPick extends React.Component<
     return (
       <Banner
         id="successful-cherry-pick"
-        timeout={7500}
+        timeout={15000}
         onDismissed={onDismissed}
       >
         <div className="green-circle">


### PR DESCRIPTION
Part of #1685

## Description

Doubling cherry pick success banner time to give user time to see undo option.

### Screenshots

https://user-images.githubusercontent.com/75402236/111515043-b92b5b00-8728-11eb-9a11-34b941fff686.mp4

## Release notes
Notes: Increase amount of time user sees cherry pick success banner
