### PR TITLE
Cherry picking overlay drag prompt

### DIFF
--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -28,6 +28,16 @@ export class DragAndDropManager {
   public onLeaveDropTarget(fn: () => void): Disposable {
     return this.emitter.on('leave-drop-target', fn)
   }
+
+  public emitEnterDropZone(dropZoneDescription: string) {
+    this.emitter.emit('enter-drop-zone', dropZoneDescription)
+  }
+
+  public onEnterDropZone(
+    fn: (dropZoneDescription: string) => void
+  ): Disposable {
+    return this.emitter.on('enter-drop-zone', fn)
+  }
 }
 
 export const dragAndDropManager = new DragAndDropManager()

--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -29,11 +29,11 @@ export class DragAndDropManager {
     return this.emitter.on('leave-drop-target', fn)
   }
 
-  public emitEnterDropZone(dropZoneDescription: string) {
+  public emitEnterDragZone(dropZoneDescription: string) {
     this.emitter.emit('enter-drop-zone', dropZoneDescription)
   }
 
-  public onEnterDropZone(
+  public onEnterDragZone(
     fn: (dropZoneDescription: string) => void
   ): Disposable {
     return this.emitter.on('enter-drop-zone', fn)

--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -29,3 +29,5 @@ export class DragAndDropManager {
     return this.emitter.on('leave-drop-target', fn)
   }
 }
+
+export const dragAndDropManager = new DragAndDropManager()

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2210,7 +2210,6 @@ export class App extends React.Component<IAppProps, IAppState> {
             commit={commit}
             selectedCommits={selectedCommits}
             emoji={emoji}
-            dragAndDropManager={dragAndDropManager}
           />
         )
       default:

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -134,7 +134,7 @@ import { WorkingDirectoryStatus } from '../models/status'
 import { DragElementType } from '../models/drag-element'
 import { CherryPickCommit } from './drag-elements/cherry-pick-commit'
 import classNames from 'classnames'
-import { DragAndDropManager } from '../lib/drag-and-drop-manager'
+import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -191,8 +191,6 @@ export class App extends React.Component<IAppProps, IAppState> {
   private get isShowingModal() {
     return this.state.currentPopup !== null || this.state.errors.length > 0
   }
-
-  private dragAndDropManager: DragAndDropManager = new DragAndDropManager()
 
   /**
    * Returns a memoized instance of onPopupDismissed() bound to the
@@ -2212,7 +2210,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             commit={commit}
             selectedCommits={selectedCommits}
             emoji={emoji}
-            dragAndDropManager={this.dragAndDropManager}
+            dragAndDropManager={dragAndDropManager}
           />
         )
       default:
@@ -2921,7 +2919,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    * assumptions to just update the currentDragElement.
    */
   private onDragEnterBranch = (branchName: string): void => {
-    this.dragAndDropManager.emitEnterDropTarget(branchName)
+    dragAndDropManager.emitEnterDropTarget(branchName)
   }
 
   /**
@@ -2932,7 +2930,7 @@ export class App extends React.Component<IAppProps, IAppState> {
    * assumptions to just update the currentDragElement.
    */
   private onDragLeaveBranch = (): void => {
-    this.dragAndDropManager.emitLeaveDropTarget()
+    dragAndDropManager.emitLeaveDropTarget()
   }
 }
 

--- a/app/src/ui/drag-elements/cherry-pick-commit.tsx
+++ b/app/src/ui/drag-elements/cherry-pick-commit.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import * as React from 'react'
-import { DragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { Commit } from '../../models/commit'
 import { GitHubRepository } from '../../models/github-repository'
 import { CommitListItem } from '../history/commit-list-item'
@@ -11,7 +11,6 @@ interface ICherryPickCommitProps {
   readonly selectedCommits: ReadonlyArray<Commit>
   readonly gitHubRepository: GitHubRepository | null
   readonly emoji: Map<string, string>
-  readonly dragAndDropManager: DragAndDropManager
 }
 
 interface ICherryPickCommitState {
@@ -28,11 +27,11 @@ export class CherryPickCommit extends React.Component<
       branchName: null,
     }
 
-    this.props.dragAndDropManager.onEnterDropTarget(targetDescription => {
+    dragAndDropManager.onEnterDropTarget(targetDescription => {
       this.setState({ branchName: targetDescription })
     })
 
-    this.props.dragAndDropManager.onLeaveDropTarget(() => {
+    dragAndDropManager.onLeaveDropTarget(() => {
       this.setState({ branchName: null })
     })
   }

--- a/app/src/ui/drag-overlay.tsx
+++ b/app/src/ui/drag-overlay.tsx
@@ -2,8 +2,10 @@ import * as React from 'react'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { PopoverCaretPosition } from './lib/popover'
 
+// time till we prompt the user about where to drag in seconds
+const dragPromptWaitTime = 2500
 interface IDragOverlayProps {
-  readonly dropZoneDescription: string
+  readonly dragZoneDescription: string
 }
 
 interface IDragOverlayState {
@@ -31,8 +33,8 @@ export class DragOverlay extends React.Component<
   }
 
   /** If drop zone is entered, hide drag prompts */
-  private dropZoneEntered = (dropZoneDescription: string) => {
-    if (this.props.dropZoneDescription === dropZoneDescription) {
+  private dragZoneEntered = (dropZoneDescription: string) => {
+    if (this.props.dragZoneDescription === dropZoneDescription) {
       this.clearDragPromptTimeOut()
       this.setState({ showDragPrompt: false })
     }
@@ -42,8 +44,8 @@ export class DragOverlay extends React.Component<
     // sets timer to wait before prompting the user on where it drag
     this.timeoutId = window.setTimeout(() => {
       this.setState({ showDragPrompt: true })
-    }, 2500)
-    dragAndDropManager.onEnterDropZone(this.dropZoneEntered)
+    }, dragPromptWaitTime)
+    dragAndDropManager.onEnterDragZone(this.dragZoneEntered)
   }
 
   public componentWillUnmount = () => {
@@ -56,7 +58,7 @@ export class DragOverlay extends React.Component<
     }
 
     // This acts more as a tool tip as we don't want to use the focus trap as in
-    // the Popover component. However, we wanted to use the styles from popover.
+    // the Popover component. However, we wanted to use its styles.
     const className = `popover-component popover-caret-${PopoverCaretPosition.TopLeft}`
     return (
       <div className={className}>

--- a/app/src/ui/drag-overlay.tsx
+++ b/app/src/ui/drag-overlay.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import { dragAndDropManager } from '../lib/drag-and-drop-manager'
+import { PopoverCaretPosition } from './lib/popover'
+
+interface IDragOverlayProps {
+  readonly dropZoneDescription: string
+}
+
+interface IDragOverlayState {
+  readonly showDragPrompt: boolean
+}
+
+export class DragOverlay extends React.Component<
+  IDragOverlayProps,
+  IDragOverlayState
+> {
+  private timeoutId: number | null = null
+
+  public constructor(props: IDragOverlayProps) {
+    super(props)
+
+    this.state = {
+      showDragPrompt: false,
+    }
+  }
+
+  private clearDragPromptTimeOut = () => {
+    if (this.timeoutId !== null) {
+      window.clearTimeout(this.timeoutId)
+    }
+  }
+
+  /** If drop zone is entered, hide drag prompts */
+  private dropZoneEntered = (dropZoneDescription: string) => {
+    if (this.props.dropZoneDescription === dropZoneDescription) {
+      this.clearDragPromptTimeOut()
+      this.setState({ showDragPrompt: false })
+    }
+  }
+
+  public componentWillMount = () => {
+    // sets timer to wait before prompting the user on where it drag
+    this.timeoutId = window.setTimeout(() => {
+      this.setState({ showDragPrompt: true })
+    }, 2500)
+    dragAndDropManager.onEnterDropZone(this.dropZoneEntered)
+  }
+
+  public componentWillUnmount = () => {
+    this.clearDragPromptTimeOut()
+  }
+
+  private renderDragPrompt() {
+    if (!this.state.showDragPrompt) {
+      return null
+    }
+
+    // This acts more as a tool tip as we don't want to use the focus trap as in
+    // the Popover component. However, we wanted to use the styles from popover.
+    const className = `popover-component popover-caret-${PopoverCaretPosition.TopLeft}`
+    return (
+      <div className={className}>
+        Drag the commits to a branch in the branch menu to cherry pick them.
+      </div>
+    )
+  }
+
+  public render() {
+    return <div id="drag-overlay">{this.renderDragPrompt()}</div>
+  }
+}

--- a/app/src/ui/drag-overlay.tsx
+++ b/app/src/ui/drag-overlay.tsx
@@ -52,7 +52,7 @@ export class DragOverlay extends React.Component<
     this.clearDragPromptTimeOut()
   }
 
-  private renderDragPrompt() {
+  private renderDragPrompt(): JSX.Element | null {
     if (!this.state.showDragPrompt) {
       return null
     }
@@ -62,7 +62,7 @@ export class DragOverlay extends React.Component<
     const className = `popover-component popover-caret-${PopoverCaretPosition.TopLeft}`
     return (
       <div className={className}>
-        Drag the commits to a branch in the branch menu to cherry pick them.
+        Drag to a branch in the branch menu to copy your commits
       </div>
     )
   }

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -276,7 +276,7 @@ export class SelectedCommit extends React.Component<
       return null
     }
 
-    return <DragOverlay dropZoneDescription="branch-button" />
+    return <DragOverlay dragZoneDescription="branch-button" />
   }
 
   private renderMultipleCommitsSelected(): JSX.Element {

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -28,6 +28,7 @@ import { showContextualMenu } from '../main-process-proxy'
 import { CommitSummary } from './commit-summary'
 import { FileList } from './file-list'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
+import { DragOverlay } from '../drag-overlay'
 
 interface ISelectedCommitProps {
   readonly repository: Repository
@@ -70,6 +71,9 @@ interface ISelectedCommitProps {
 
   /** Whether multiple commits are selected. */
   readonly areMultipleCommitsSelected: boolean
+
+  /** Whether or not to show the drag overlay */
+  readonly showDragOverlay: boolean
 }
 
 interface ISelectedCommitState {
@@ -240,7 +244,7 @@ export class SelectedCommit extends React.Component<
     const commit = this.props.selectedCommit
 
     if (this.props.areMultipleCommitsSelected) {
-      return <MultipleCommitsSelected />
+      return this.renderMultipleCommitsSelected()
     }
 
     if (commit == null) {
@@ -262,6 +266,40 @@ export class SelectedCommit extends React.Component<
           </Resizable>
           {this.renderDiff()}
         </div>
+        {this.renderDragOverlay()}
+      </div>
+    )
+  }
+
+  private renderDragOverlay(): JSX.Element | null {
+    if (!this.props.showDragOverlay) {
+      return null
+    }
+
+    return <DragOverlay dropZoneDescription="branch-button" />
+  }
+
+  private renderMultipleCommitsSelected(): JSX.Element {
+    const BlankSlateImage = encodePathAsUrl(
+      __dirname,
+      'static/empty-no-commit.svg'
+    )
+
+    return (
+      <div id="multiple-commits-selected" className="blankslate">
+        <div className="panel blankslate">
+          <img src={BlankSlateImage} className="blankslate-image" />
+          <div>
+            <p>Unable to display diff when multiple commits are selected.</p>
+            <div>You can:</div>
+            <ul>
+              <li>Select a single commit to view a diff.</li>
+              <li>Drag the commits to the branch menu to cherry pick them.</li>
+              <li>Right click on multiple commits to see options.</li>
+            </ul>
+          </div>
+        </div>
+        {this.renderDragOverlay()}
       </div>
     )
   }
@@ -328,28 +366,6 @@ function NoCommitSelected() {
     <div className="panel blankslate">
       <img src={BlankSlateImage} className="blankslate-image" />
       No commit selected
-    </div>
-  )
-}
-
-function MultipleCommitsSelected() {
-  const BlankSlateImage = encodePathAsUrl(
-    __dirname,
-    'static/empty-no-commit.svg'
-  )
-
-  return (
-    <div id="multiple-commits-selected" className="panel blankslate">
-      <img src={BlankSlateImage} className="blankslate-image" />
-      <div>
-        <p>Unable to display diff when multiple commits are selected.</p>
-        <div>You can:</div>
-        <ul>
-          <li>Select a single commit to view a diff.</li>
-          <li>Drag the commits to the branch menu to cherry pick them.</li>
-          <li>Right click on multiple commits to see options.</li>
-        </ul>
-      </div>
     </div>
   )
 }

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -16,6 +16,7 @@ import { Options as FocusTrapOptions } from 'focus-trap'
  **/
 export enum PopoverCaretPosition {
   TopRight = 'top-right',
+  TopLeft = 'top-left',
   LeftTop = 'left-top',
   LeftBottom = 'left-bottom',
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -29,6 +29,7 @@ import { TutorialPanel, TutorialWelcome, TutorialDone } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { openFile } from './lib/open-file'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
+import { CherryPickStepKind } from '../models/cherry-pick'
 
 /** The widest the sidebar can be with the minimum window size. */
 const MaxSidebarWidth = 495
@@ -342,7 +343,7 @@ export class RepositoryView extends React.Component<
   }
 
   private renderContentForHistory(): JSX.Element {
-    const { commitSelection } = this.props.state
+    const { commitSelection, cherryPickState } = this.props.state
 
     const sha =
       commitSelection.shas.length === 1 ? commitSelection.shas[0] : null
@@ -351,6 +352,11 @@ export class RepositoryView extends React.Component<
       sha != null ? this.props.state.commitLookup.get(sha) || null : null
 
     const { changedFiles, file, diff } = commitSelection
+
+    const { step } = cherryPickState
+
+    const showDragOverlay =
+      step !== null && step.kind === CherryPickStepKind.CommitsChosen
 
     return (
       <SelectedCommit
@@ -371,6 +377,7 @@ export class RepositoryView extends React.Component<
         onChangeImageDiffType={this.onChangeImageDiffType}
         onDiffOptionsOpened={this.onDiffOptionsOpened}
         areMultipleCommitsSelected={commitSelection.shas.length > 1}
+        showDragOverlay={showDragOverlay}
       />
     )
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -215,7 +215,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       cherryPickState.step !== null &&
       cherryPickState.step.kind === CherryPickStepKind.CommitsChosen
     ) {
-      dragAndDropManager.emitEnterDropZone('branch-button')
+      dragAndDropManager.emitEnterDragZone('branch-button')
       this.props.dispatcher.showFoldout({ type: FoldoutType.Branch })
     }
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -15,6 +15,7 @@ import { BranchesTab } from '../../models/branches-tab'
 import { PullRequest } from '../../models/pull-request'
 import classNames from 'classnames'
 import { CherryPickStepKind } from '../../models/cherry-pick'
+import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 
 interface IBranchDropdownProps {
   readonly dispatcher: Dispatcher
@@ -214,6 +215,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
       cherryPickState.step !== null &&
       cherryPickState.step.kind === CherryPickStepKind.CommitsChosen
     ) {
+      dragAndDropManager.emitEnterDropZone('branch-button')
       this.props.dispatcher.showFoldout({ type: FoldoutType.Branch })
     }
   }

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -85,3 +85,4 @@
 @import 'ui/commit-message-avatar';
 @import 'ui/popover';
 @import 'ui/drag-elements';
+@import 'ui/drag-overlay';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -292,6 +292,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --popup-overlay-z-index: calc(var(--popup-z-index) - 1);
   --foldout-z-index: calc(var(--popup-z-index) - 2);
   --nudge-arrow-z-index: calc(var(--popup-z-index) - 3);
+  --drag-overlay-z-index: calc(var(--popup-z-index) - 3);
   /**
    * This is 7 to make sure it appears on top code mirror
    * but behind popups, overlays, and foldouts

--- a/app/styles/ui/_drag-overlay.scss
+++ b/app/styles/ui/_drag-overlay.scss
@@ -5,6 +5,7 @@
   height: 100%;
   width: 100%;
   cursor: not-allowed;
+  z-index: var(--drag-overlay-z-index);
 
   .popover-component {
     width: fit-content;

--- a/app/styles/ui/_drag-overlay.scss
+++ b/app/styles/ui/_drag-overlay.scss
@@ -1,0 +1,15 @@
+#drag-overlay {
+  position: absolute;
+  top: 72px;
+  background: var(--overlay-background-color);
+  height: 100%;
+  width: 100%;
+  cursor: not-allowed;
+
+  .popover-component {
+    width: fit-content;
+    left: 70px;
+    position: relative;
+    top: 8px;
+  }
+}

--- a/app/styles/ui/_drag-overlay.scss
+++ b/app/styles/ui/_drag-overlay.scss
@@ -8,9 +8,10 @@
   z-index: var(--drag-overlay-z-index);
 
   .popover-component {
-    width: fit-content;
+    width: 300px;
     left: 70px;
     position: relative;
-    top: 8px;
+    top: 10px;
+    padding: var(--spacing);
   }
 }

--- a/app/styles/ui/_popover.scss
+++ b/app/styles/ui/_popover.scss
@@ -40,6 +40,31 @@
   }
 }
 
+.popover-component.popover-caret-top-left {
+  &::before,
+  &::after {
+    position: absolute;
+    left: 20px;
+    display: inline-block;
+    content: '';
+    pointer-events: none;
+  }
+
+  &::before {
+    top: -16px;
+    margin-right: -9px;
+    border: 8px solid transparent;
+    border-bottom-color: var(--box-border-color);
+  }
+
+  &::after {
+    top: -14px;
+    margin-right: -8px;
+    border: 7px solid transparent;
+    border-bottom-color: var(--background-color);
+  }
+}
+
 .popover-component.popover-caret-left-top {
   &::before,
   &::after {

--- a/app/styles/ui/history/_multiple_commits_selected.scss
+++ b/app/styles/ui/history/_multiple_commits_selected.scss
@@ -1,6 +1,5 @@
 #multiple-commits-selected {
   padding: 0;
-  text-align: left;
   display: block;
   ul {
     margin-top: 0px;
@@ -8,5 +7,6 @@
 
   .panel {
     height: 100%;
+    text-align: left;
   }
 }

--- a/app/styles/ui/history/_multiple_commits_selected.scss
+++ b/app/styles/ui/history/_multiple_commits_selected.scss
@@ -1,6 +1,12 @@
 #multiple-commits-selected {
+  padding: 0;
   text-align: left;
+  display: block;
   ul {
     margin-top: 0px;
+  }
+
+  .panel {
+    height: 100%;
   }
 }


### PR DESCRIPTION
Part of #1685 

## Description

Improves discoverability of cherry pick drag target of branch menu by having an overlay of the main content area. Also, after 2.5 seconds of not dragging to the target gives a tool tip type prompt.

### Screenshots
EDIT: The text-align left to center regression that can be seen in multiple selection has been fixed since this video.

EDIT: updated tool tip look since video.
![image](https://user-images.githubusercontent.com/75402236/111821502-1e15bb00-88b9-11eb-82e8-685c91cbfada.png)

https://user-images.githubusercontent.com/75402236/111718562-853b5d00-8830-11eb-931f-10bcab0d5823.mp4

## Release notes
Notes: Improve discoverability of cherry pick drag target of branch menu.
