### PR TITLE
Cherry Picking - Allow switching tab in branch menu during drag

### DIFF
--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -9,9 +9,13 @@ import { Disposable, Emitter } from 'event-kit'
  * drag event.
  */
 export class DragAndDropManager {
-  public isDragInProgress: boolean = false
+  private _isDragInProgress: boolean = false
 
   protected readonly emitter = new Emitter()
+
+  public get isDragInProgress(): boolean {
+    return this._isDragInProgress
+  }
 
   public emitEnterDropTarget(targetDescription: string) {
     this.emitter.emit('enter-drop-target', targetDescription)
@@ -32,11 +36,11 @@ export class DragAndDropManager {
   }
 
   public dragStarted(): void {
-    this.isDragInProgress = true
+    this._isDragInProgress = true
   }
 
   public dragEnded() {
-    this.isDragInProgress = false
+    this._isDragInProgress = false
   }
 
   public emitEnterDragZone(dropZoneDescription: string) {

--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -9,6 +9,8 @@ import { Disposable, Emitter } from 'event-kit'
  * drag event.
  */
 export class DragAndDropManager {
+  public isDragInProgress: boolean = false
+
   protected readonly emitter = new Emitter()
 
   public emitEnterDropTarget(targetDescription: string) {
@@ -28,4 +30,14 @@ export class DragAndDropManager {
   public onLeaveDropTarget(fn: () => void): Disposable {
     return this.emitter.on('leave-drop-target', fn)
   }
+
+  public dragStarted(): void {
+    this.isDragInProgress = true
+  }
+
+  public dragEnded() {
+    this.isDragInProgress = false
+  }
 }
+
+export const dragAndDropManager = new DragAndDropManager()

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -147,6 +147,7 @@ export class BranchesContainer extends React.Component<
       <TabBar
         onTabClicked={this.onTabClicked}
         selectedIndex={this.props.selectedTab}
+        allowDragOverSwitching={true}
       >
         <span>Branches</span>
         <span className="pull-request-tab">

--- a/app/src/ui/lib/draggable.tsx
+++ b/app/src/ui/lib/draggable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 
 interface IDraggableProps {
   /**
@@ -86,6 +87,7 @@ export class Draggable extends React.Component<IDraggableProps> {
     if (!this.dragStarted) {
       this.props.onRenderDragElement()
       this.props.onDragStart()
+      dragAndDropManager.dragStarted()
       this.dragStarted = true
     }
 
@@ -110,6 +112,7 @@ export class Draggable extends React.Component<IDraggableProps> {
     document.onmouseup = null
     this.props.onRemoveDragElement()
     this.props.onDragEnd(this.isLastElemBelowDropTarget())
+    dragAndDropManager.dragEnded()
   }
 
   /**

--- a/app/src/ui/tab-bar.tsx
+++ b/app/src/ui/tab-bar.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 
 /** Time to wait for drag element hover before switching tabs */
-const dragTabSwitchWaitTime = 1500
+const dragTabSwitchWaitTime = 500
 
 /** The tab bar type. */
 export enum TabBarType {


### PR DESCRIPTION
Part of #1685

## Description

During usability testing, we caught a scenario where if a user was just on the pr tab in the branch menu and then dragged up to open the branch menu, it would be on the pr tab. There was nowhere for the user to drop the commits on. 

This allows for the user to be able to switch to the branches tab by hovering over the tab selector for ~1.5s.~ 500ms.

### Screenshots

 500ms

https://user-images.githubusercontent.com/75402236/111973375-cce21300-8ad4-11eb-9e0c-c4b56da49057.mp4


## Release notes
Notes: [Fixed] Prevent user from being trapped on PR tab during cherry picking drag.
