### PR TITLE
cherry pick -> cherry-pick

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -79,7 +79,7 @@ class GitCherryPickParser {
 
     return {
       kind: 'cherryPick',
-      title: `Cherry picking commit ${this.count} of ${this.commits.length} commits`,
+      title: `Cherry-picking commit ${this.count} of ${this.commits.length} commits`,
       value: round(this.count / this.commits.length, 2),
       cherryPickCommitCount: this.count,
       totalCommitCount: this.commits.length,
@@ -150,7 +150,7 @@ export async function cherryPick(
       // revision range, so we need to signal to the caller that this cherry
       // pick is not possible to perform
       log.warn(
-        `Unable to cherry pick these branches
+        `Unable to cherry-pick these branches
         because one or both of the refs do not exist in the repository`
       )
       return CherryPickResult.UnableToStart
@@ -170,7 +170,7 @@ export async function cherryPick(
   const result = await git(
     ['cherry-pick', revisionRange, '--keep-redundant-commits'],
     repository.path,
-    'cherry pick',
+    'cherry-pick',
     baseOptions
   )
 
@@ -287,7 +287,7 @@ export async function getCherryPickSnapshot(
   return {
     progress: {
       kind: 'cherryPick',
-      title: `Cherry picking commit ${count} of ${commits.length} commits`,
+      title: `Cherry-picking commit ${count} of ${commits.length} commits`,
       value: round(count / commits.length, 2),
       cherryPickCommitCount: count,
       totalCommitCount: commits.length,
@@ -365,7 +365,7 @@ export async function continueCherryPick(
     const snapshot = await getCherryPickSnapshot(repository)
     if (snapshot === null) {
       log.warn(
-        `[continueCherryPick] unable to get cherry pick status, skipping other steps`
+        `[continueCherryPick] unable to get cherry-pick status, skipping other steps`
       )
       return CherryPickResult.UnableToStart
     }
@@ -382,7 +382,7 @@ export async function continueCherryPick(
 
   if (trackedFilesAfter.length === 0) {
     log.warn(
-      `[cherryPick] no tracked changes to commit, continuing cherry pick but skipping this commit`
+      `[cherryPick] no tracked changes to commit, continuing cherry-pick but skipping this commit`
     )
 
     // This commits the empty commit so that the cherry picked commit still
@@ -432,7 +432,7 @@ export async function isCherryPickHeadFound(
   } catch (err) {
     log.warn(
       `[cherryPick] a problem was encountered reading .git/CHERRY_PICK_HEAD,
-       so it is unsafe to continue cherry picking`,
+       so it is unsafe to continue cherry-picking`,
       err
     )
     return false

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -413,7 +413,7 @@ function getDescriptionForError(error: DugiteError): string | null {
       // Note: This has been made specific to cherry pick, but this error can
       // appear for revert; however, our revert logic provides the -m option
       // and avoids this error.
-      return 'You cannot cherry pick merge commits from GitHub Desktop. You can cherry pick merge commits from the terminal using the -m flag. Please select non-merge commits and try again.'
+      return 'You cannot cherry-pick merge commits from GitHub Desktop. You can cherry-pick merge commits from the terminal using the -m flag. Please select non-merge commits and try again.'
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5792,7 +5792,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (commits.length === 0) {
       // This shouldn't happen... but in case throw error.
       throw new Error(
-        'Unable to initialize cherry pick progress. No commits provided.'
+        'Unable to initialize cherry-pick progress. No commits provided.'
       )
     }
 
@@ -5800,7 +5800,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return {
         progress: {
           kind: 'cherryPick',
-          title: `Cherry picking commit 1 of ${commits.length} commits`,
+          title: `Cherry-picking commit 1 of ${commits.length} commits`,
           value: 0,
           cherryPickCommitCount: 1,
           totalCommitCount: commits.length,
@@ -5820,7 +5820,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     sourceBranch: Branch | null
   ): Promise<CherryPickResult> {
     if (commits.length === 0) {
-      log.warn('[_cherryPick] - Unable to cherry pick. No commits provided.')
+      log.warn('[_cherryPick] - Unable to cherry-pick. No commits provided.')
       return CherryPickResult.UnableToStart
     }
     let result: CherryPickResult | null | undefined
@@ -6043,7 +6043,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     if (snapshot === null) {
       log.warn(
-        `[showCherryPickConflictsDialog] unable to get cherry pick status from git, unable to continue`
+        `[showCherryPickConflictsDialog] unable to get cherry-pick status from git, unable to continue`
       )
       return
     }
@@ -6091,7 +6091,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { tip } = branchesState
     if (tip.kind !== TipState.Valid || tip.branch.name !== targetBranchName) {
       log.warn(
-        '[undoCherryPick] - Could not undo cherry pick.  User no longer on target branch.'
+        '[undoCherryPick] - Could not undo cherry-pick.  User no longer on target branch.'
       )
       return false
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2015,7 +2015,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         ) {
           log.warn(
             `[App] Invalid state encountered:
-            cherry pick flow should not be active when step is null,
+            cherry-pick flow should not be active when step is null,
             the selected app state is not a repository state,
             or cannot obtain the working directory.`
           )
@@ -2820,7 +2820,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       currentBranch = tip.branch
     } else {
       throw new Error(
-        'Tip is not in a valid state, which is required to start the cherry pick flow'
+        'Tip is not in a valid state, which is required to start the cherry-pick flow'
       )
     }
 
@@ -2880,7 +2880,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           !isCherryPickConflictState(conflictState)
         ) {
           log.debug(
-            `[App.onShowCherryPickConflictsBanner] no cherry pick conflict state found, ignoring...`
+            `[App.onShowCherryPickConflictsBanner] no cherry-pick conflict state found, ignoring...`
           )
           return
         }

--- a/app/src/ui/banners/cherry-pick-conflicts-banner.tsx
+++ b/app/src/ui/banners/cherry-pick-conflicts-banner.tsx
@@ -37,7 +37,7 @@ export class CherryPickConflictsBanner extends React.Component<
         <Octicon className="alert-icon" symbol={OcticonSymbol.alert} />
         <div className="banner-message">
           <span>
-            Resolve conflicts to continue cherry picking onto{' '}
+            Resolve conflicts to continue cherry-picking onto{' '}
             <strong>{this.props.targetBranchName}</strong>.
           </span>
           <LinkButton onClick={this.openDialog}>View conflicts</LinkButton>

--- a/app/src/ui/banners/cherry-pick-undone.tsx
+++ b/app/src/ui/banners/cherry-pick-undone.tsx
@@ -22,7 +22,7 @@ export class CherryPickUndone extends React.Component<
         </div>
         <div className="banner-message">
           <span>
-            Cherry pick undone. Successfully removed the {countCherryPicked}
+            Cherry-pick undone. Successfully removed the {countCherryPicked}
             {' copied '}
             {pluralized} from <strong>{targetBranchName}</strong>.
           </span>

--- a/app/src/ui/cherry-pick/cherry-pick-conflicts-dialog.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-conflicts-dialog.tsx
@@ -185,14 +185,14 @@ export class CherryPickConflictsDialog extends React.Component<
         ? 'Resolve all conflicts before continuing'
         : undefined
 
-    const ok = __DARWIN__ ? 'Continue Cherry Pick' : 'Continue cherry pick'
-    const cancel = __DARWIN__ ? 'Abort Cherry Pick' : 'Abort cherry pick'
+    const ok = __DARWIN__ ? 'Continue Cherry-pick' : 'Continue cherry-pick'
+    const cancel = __DARWIN__ ? 'Abort Cherry-pick' : 'Abort cherry-pick'
 
     return (
       <Dialog
         id="cherry-pick-conflicts-list"
         onDismissed={this.onDismissed}
-        title="Resolve conflicts before cherry picking"
+        title="Resolve conflicts before cherry-picking"
         onSubmit={this.onSubmit}
       >
         <DialogContent>

--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -170,7 +170,7 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
       case CherryPickStepKind.ShowProgress:
         if (this.props.progress === null) {
           log.error(
-            `[CherryPickFlow] cherry pick progress should not be null
+            `[CherryPickFlow] cherry-pick progress should not be null
             when showing progress. Skipping rendering..`
           )
           return null
@@ -230,7 +230,7 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
         // no ui for this part of flow
         return null
       default:
-        return assertNever(step, 'Unknown cherry pick step found')
+        return assertNever(step, 'Unknown cherry-pick step found')
     }
   }
 }

--- a/app/src/ui/cherry-pick/cherry-pick-progress-dialog.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-progress-dialog.tsx
@@ -30,7 +30,7 @@ export class CherryPickProgressDialog extends React.Component<
         dismissable={false}
         onDismissed={this.onDismissed}
         id="cherry-pick-progress"
-        title="Cherry pick in progress"
+        title="Cherry-pick in progress"
       >
         <DialogContent>
           <div>

--- a/app/src/ui/cherry-pick/choose-target-branch.tsx
+++ b/app/src/ui/cherry-pick/choose-target-branch.tsx
@@ -113,7 +113,7 @@ export class ChooseTargetBranchDialog extends React.Component<
 
   private renderOkButtonText() {
     const pluralize = this.props.commitCount > 1 ? 'commits' : 'commit'
-    const okButtonText = `Cherry pick ${this.props.commitCount} ${pluralize}`
+    const okButtonText = `Cherry-pick ${this.props.commitCount} ${pluralize}`
 
     const { selectedBranch } = this.state
     if (selectedBranch !== null) {
@@ -129,7 +129,7 @@ export class ChooseTargetBranchDialog extends React.Component<
 
   public render() {
     const tooltip = this.selectedBranchIsCurrentBranch()
-      ? 'You are not able to cherry pick from and to the same branch'
+      ? 'You are not able to cherry-pick from and to the same branch'
       : undefined
 
     const pluralize = this.props.commitCount > 1 ? 'commits' : 'commit'
@@ -141,7 +141,7 @@ export class ChooseTargetBranchDialog extends React.Component<
         dismissable={true}
         title={
           <strong>
-            Cherry pick {this.props.commitCount} {pluralize} to a branch
+            Cherry-pick {this.props.commitCount} {pluralize} to a branch
           </strong>
         }
       >

--- a/app/src/ui/cherry-pick/confirm-cherry-pick-abort-dialog.tsx
+++ b/app/src/ui/cherry-pick/confirm-cherry-pick-abort-dialog.tsx
@@ -52,7 +52,7 @@ export class ConfirmCherryPickAbortDialog extends React.Component<
     const pluralize = commitCount > 1 ? 'commits' : 'commit'
     const confirm = (
       <p>
-        {`Are you sure you want to abort cherry picking ${commitCount} ${pluralize}`}
+        {`Are you sure you want to abort cherry-picking ${commitCount} ${pluralize}`}
         {' onto '}
         <Ref>{targetBranchName}</Ref>?
       </p>
@@ -85,7 +85,7 @@ export class ConfirmCherryPickAbortDialog extends React.Component<
       <Dialog
         id="abort-merge-warning"
         title={
-          __DARWIN__ ? 'Confirm Abort Cherry Pick' : 'Confirm abort cherry pick'
+          __DARWIN__ ? 'Confirm Abort Cherry-pick' : 'Confirm abort cherry-pick'
         }
         onDismissed={this.onCancel}
         onSubmit={this.onSubmit}
@@ -97,7 +97,7 @@ export class ConfirmCherryPickAbortDialog extends React.Component<
           <OkCancelButtonGroup
             destructive={true}
             okButtonText={
-              __DARWIN__ ? 'Abort Cherry Pick' : 'Abort cherry pick'
+              __DARWIN__ ? 'Abort Cherry-pick' : 'Abort cherry-pick'
             }
           />
         </DialogFooter>

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2539,10 +2539,10 @@ export class Dispatcher {
     const beforeSha = targetBranch.tip.sha
     this.appStore._setCherryPickTargetBranchUndoSha(repository, beforeSha)
     log.info(
-      `[cherryPick] starting cherry pick for ${targetBranch.name} at ${beforeSha}`
+      `[cherryPick] starting cherry-pick for ${targetBranch.name} at ${beforeSha}`
     )
     log.info(
-      `[cherryPick] to restore the previous state if this completed cherry pick is unsatisfactory:`
+      `[cherryPick] to restore the previous state if this completed cherry-pick is unsatisfactory:`
     )
     log.info(`[cherryPick] - git checkout ${targetBranch.name}`)
     log.info(`[cherryPick] - git reset ${beforeSha} --hard`)
@@ -2588,7 +2588,7 @@ export class Dispatcher {
     const { conflictState } = stateAfter.changesState
     if (conflictState === null || !isCherryPickConflictState(conflictState)) {
       log.warn(
-        '[cherryPick] - conflict state was null or not in a cherry pick conflict state - unable to continue'
+        '[cherryPick] - conflict state was null or not in a cherry-pick conflict state - unable to continue'
       )
       return
     }
@@ -2774,7 +2774,7 @@ export class Dispatcher {
       cherryPickState.step.kind !== CherryPickStepKind.CommitsChosen
     ) {
       log.warn(
-        '[cherryPick] Invalid Cherry Picking State: Could not determine selected commits.'
+        '[cherryPick] Invalid Cherry-picking State: Could not determine selected commits.'
       )
       return
     }
@@ -2782,7 +2782,7 @@ export class Dispatcher {
     const { tip } = branchesState
     if (tip.kind !== TipState.Valid) {
       throw new Error(
-        'Tip is not in a valid state, which is required to start the cherry pick flow.'
+        'Tip is not in a valid state, which is required to start the cherry-pick flow.'
       )
     }
     const sourceBranch = tip.branch

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -228,7 +228,7 @@ export class CommitListItem extends React.PureComponent<
 
     if (enableCherryPicking()) {
       items.push({
-        label: __DARWIN__ ? 'Cherry Pick Commit…' : 'Cherry pick commit…',
+        label: __DARWIN__ ? 'Cherry-pick Commit…' : 'Cherry-pick commit…',
         action: this.onCherryPick,
         enabled: this.canCherryPick(),
       })
@@ -257,8 +257,8 @@ export class CommitListItem extends React.PureComponent<
     if (enableCherryPicking()) {
       items.push({
         label: __DARWIN__
-          ? `Cherry Pick ${count} Commits…`
-          : `Cherry pick ${count} commits…`,
+          ? `Cherry-pick ${count} Commits…`
+          : `Cherry-pick ${count} commits…`,
         action: this.onCherryPick,
         enabled: this.canCherryPick(),
       })

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -346,7 +346,7 @@ function MultipleCommitsSelected() {
         <div>You can:</div>
         <ul>
           <li>Select a single commit to view a diff.</li>
-          <li>Drag the commits to the branch menu to cherry pick them.</li>
+          <li>Drag the commits to the branch menu to cherry-pick them.</li>
           <li>Right click on multiple commits to see options.</li>
         </ul>
       </div>

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -171,7 +171,7 @@ export class LocalChangesOverwrittenDialog extends React.Component<
       case RetryActionType.Push:
         return 'push'
       case RetryActionType.CherryPick:
-        return 'cherry pick'
+        return 'cherry-pick'
       default:
         assertNever(
           this.props.retryAction,

--- a/app/test/helpers/repository-builder-cherry-pick-test.ts
+++ b/app/test/helpers/repository-builder-cherry-pick-test.ts
@@ -30,7 +30,7 @@ export async function createRepository(
 
   await switchTo(repository, featureBranchName)
   const featureBranchCommit = {
-    commitMessage: 'Cherry Picked Feature!',
+    commitMessage: 'Cherry-picked Feature!',
     entries: [
       {
         path: 'THING.md',

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -54,7 +54,7 @@ describe('git/cherry-pick', () => {
     result = null
   })
 
-  it('successfully cherry picked one commit without conflicts', async () => {
+  it('successfully cherry-picked one commit without conflicts', async () => {
     result = await cherryPick(repository, featureBranch.tip.sha)
     const cherryPickedCommit = await getCommit(
       repository,
@@ -67,7 +67,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('successfully cherry picked a commit with empty message', async () => {
+  it('successfully cherry-picked a commit with empty message', async () => {
     // add a commit with no message
     await switchTo(repository, featureBranchName)
     const filePath = Path.join(repository.path, 'EMPTY_MESSAGE.md')
@@ -96,7 +96,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('successfully cherry picks a redundant commit', async () => {
+  it('successfully cherry-picks a redundant commit', async () => {
     result = await cherryPick(repository, featureBranch.tip.sha)
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
@@ -114,7 +114,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('successfully cherry picks an empty commit', async () => {
+  it('successfully cherry-picks an empty commit', async () => {
     // add empty commit to feature branch
     await switchTo(repository, featureBranchName)
     await GitProcess.exec(
@@ -132,7 +132,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('successfully cherry picks an empty commit inside a range', async () => {
+  it('successfully cherry-picks an empty commit inside a range', async () => {
     const firstCommitSha = featureBranch.tip.sha
 
     // add empty commit to feature branch
@@ -144,7 +144,7 @@ describe('git/cherry-pick', () => {
 
     // add another commit so empty commit will be inside a range
     const featureBranchCommitTwo = {
-      commitMessage: 'Cherry Picked Feature! Number Two',
+      commitMessage: 'Cherry-picked Feature! Number Two',
       entries: [
         {
           path: 'THING_TWO.md',
@@ -166,7 +166,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('successfully cherry picked multiple commits without conflicts', async () => {
+  it('successfully cherry-picked multiple commits without conflicts', async () => {
     // keep reference to the first commit in cherry pick range
     const firstCommitSha = featureBranch.tip.sha
 
@@ -179,12 +179,12 @@ describe('git/cherry-pick', () => {
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
     expect(commits.length).toBe(5)
-    expect(commits[1].summary).toBe('Cherry Picked Feature! Number Three')
-    expect(commits[2].summary).toBe('Cherry Picked Feature! Number Two')
+    expect(commits[1].summary).toBe('Cherry-picked Feature! Number Three')
+    expect(commits[2].summary).toBe('Cherry-picked Feature! Number Two')
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('fails to cherry pick an invalid revision range', async () => {
+  it('fails to cherry-pick an invalid revision range', async () => {
     result = null
     try {
       result = await cherryPick(repository, 'no such revision')
@@ -194,7 +194,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(null)
   })
 
-  it('fails to cherry pick when working tree is not clean', async () => {
+  it('fails to cherry-pick when working tree is not clean', async () => {
     await FSE.writeFile(
       Path.join(repository.path, 'THING.md'),
       '# HELLO WORLD! \nTHINGS GO HERE\nFEATURE BRANCH UNDERWAY\n'
@@ -216,7 +216,7 @@ describe('git/cherry-pick', () => {
     expect(result).toBe(null)
   })
 
-  it('fails to cherry pick a merge commit', async () => {
+  it('fails to cherry-pick a merge commit', async () => {
     //create new branch off of default to merge into feature branch
     await switchTo(repository, 'main')
     const mergeBranchName = 'branch-to-merge'
@@ -248,13 +248,13 @@ describe('git/cherry-pick', () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
     } catch (error) {
       expect(error.toString()).toContain(
-        'GitError: You cannot cherry pick merge commits from GitHub Desktop.'
+        'GitError: You cannot cherry-pick merge commits from GitHub Desktop.'
       )
     }
     expect(result).toBe(null)
   })
 
-  describe('cherry picking with conflicts', () => {
+  describe('cherry-picking with conflicts', () => {
     beforeEach(async () => {
       // In the 'git/cherry-pick' `beforeEach`, we call `createRepository` which
       // adds a commit to the feature branch with a file called THING.md. In
@@ -272,7 +272,7 @@ describe('git/cherry-pick', () => {
       await makeCommit(repository, conflictingCommit)
     })
 
-    it('successfully detects cherry pick with conflicts', async () => {
+    it('successfully detects cherry-pick with conflicts', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -283,7 +283,7 @@ describe('git/cherry-pick', () => {
       expect(conflictedFiles).toHaveLength(1)
     })
 
-    it('successfully continues cherry picking with conflicts after resolving them by overwriting', async () => {
+    it('successfully continues cherry-picking with conflicts after resolving them by overwriting', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -316,7 +316,7 @@ describe('git/cherry-pick', () => {
       expect(result).toBe(CherryPickResult.CompletedWithoutError)
     })
 
-    it('successfully continues cherry picking with conflicts after resolving them manually', async () => {
+    it('successfully continues cherry-picking with conflicts after resolving them manually', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -344,7 +344,7 @@ describe('git/cherry-pick', () => {
       expect(result).toBe(CherryPickResult.CompletedWithoutError)
     })
 
-    it('successfully continues cherry picking with conflicts after resolving them manually and no changes to commit', async () => {
+    it('successfully continues cherry-picking with conflicts after resolving them manually and no changes to commit', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -372,7 +372,7 @@ describe('git/cherry-pick', () => {
       expect(result).toBe(CherryPickResult.CompletedWithoutError)
     })
 
-    it('successfully detects cherry picking with outstanding files not staged', async () => {
+    it('successfully detects cherry-picking with outstanding files not staged', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -386,7 +386,7 @@ describe('git/cherry-pick', () => {
       expect(conflictedFiles).toHaveLength(1)
     })
 
-    it('successfully continues cherry picking with additional changes to untracked files', async () => {
+    it('successfully continues cherry-picking with additional changes to untracked files', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -417,7 +417,7 @@ describe('git/cherry-pick', () => {
       expect(status.workingDirectory.files[0].path).toBe('UNTRACKED_FILE.md')
     })
 
-    it('successfully aborts cherry pick after conflict', async () => {
+    it('successfully aborts cherry-pick after conflict', async () => {
       result = await cherryPick(repository, featureBranch.tip.sha)
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
@@ -433,7 +433,7 @@ describe('git/cherry-pick', () => {
     })
   })
 
-  describe('cherry picking progress', () => {
+  describe('cherry-picking progress', () => {
     let progress = new Array<ICherryPickProgress>()
     beforeEach(() => {
       progress = []
@@ -452,13 +452,13 @@ describe('git/cherry-pick', () => {
         progress.push(p)
       )
 
-      // commit summary set up in before each is "Cherry Picked Feature"
+      // commit summary set up in before each is "Cherry-picked Feature"
       expect(progress).toEqual([
         {
-          currentCommitSummary: 'Cherry Picked Feature!',
+          currentCommitSummary: 'Cherry-picked Feature!',
           kind: 'cherryPick',
           cherryPickCommitCount: 1,
-          title: 'Cherry picking commit 1 of 1 commits',
+          title: 'Cherry-picking commit 1 of 1 commits',
           totalCommitCount: 1,
           value: 1,
         },
@@ -528,15 +528,15 @@ describe('git/cherry-pick', () => {
       expect(result).toBe(CherryPickResult.CompletedWithoutError)
       // After 3rd commit resolved, 3rd and 4th were cherry picked
       expect(progress).toHaveLength(4)
-      expect(progress[0].currentCommitSummary).toEqual('Cherry Picked Feature!')
+      expect(progress[0].currentCommitSummary).toEqual('Cherry-picked Feature!')
       expect(progress[1].currentCommitSummary).toEqual(
-        'Cherry Picked Feature! Number Two'
+        'Cherry-picked Feature! Number Two'
       )
       expect(progress[2].currentCommitSummary).toEqual(
-        'Cherry Picked Feature! Number Three'
+        'Cherry-picked Feature! Number Three'
       )
       expect(progress[3].currentCommitSummary).toEqual(
-        'Cherry Picked Feature! Number Four'
+        'Cherry-picked Feature! Number Four'
       )
     })
   })
@@ -546,7 +546,7 @@ async function addThreeMoreCommitsOntoFeatureBranch(repository: Repository) {
   await switchTo(repository, featureBranchName)
 
   const featureBranchCommitTwo = {
-    commitMessage: 'Cherry Picked Feature! Number Two',
+    commitMessage: 'Cherry-picked Feature! Number Two',
     entries: [
       {
         path: 'THING_TWO.md',
@@ -557,7 +557,7 @@ async function addThreeMoreCommitsOntoFeatureBranch(repository: Repository) {
   await makeCommit(repository, featureBranchCommitTwo)
 
   const featureBranchCommitThree = {
-    commitMessage: 'Cherry Picked Feature! Number Three',
+    commitMessage: 'Cherry-picked Feature! Number Three',
     entries: [
       {
         path: 'THING_THREE.md',
@@ -568,7 +568,7 @@ async function addThreeMoreCommitsOntoFeatureBranch(repository: Repository) {
   await makeCommit(repository, featureBranchCommitThree)
 
   const featureBranchCommitFour = {
-    commitMessage: 'Cherry Picked Feature! Number Four',
+    commitMessage: 'Cherry-picked Feature! Number Four',
     entries: [
       {
         path: 'THING_FOUR.md',

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -6,9 +6,9 @@ The following are the larger areas of upcoming work the GitHub Desktop team inte
 
 - Warn and provide a way to ensure your commits will be attributed to you: [#610](https://github.com/desktop/desktop/issues/610)
 
-#### Cherry picking commits from one branch to another
+#### Cherry-picking commits from one branch to another
 
-- Cherry pick commits with a context menu and interactively: [#1685](https://github.com/desktop/desktop/issues/1685)
+- Cherry-pick commits with a context menu and interactively: [#1685](https://github.com/desktop/desktop/issues/1685)
 
 ## Shipped in previous releases
 


### PR DESCRIPTION
This changes "cherry pick" to "cherry-pick" to conform more closely with the actual Git command and most documentation. It's a bit less friendly but I think makes it clearer.
