### PR TITLE
Suggest macOS users to move the app to `/Applications` to prevent issues

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -68,6 +68,7 @@ export enum PopupType {
   ChooseForkSettings,
   ConfirmDiscardSelection,
   CherryPick,
+  MoveToApplicationsFolder,
 }
 
 export type Popup =
@@ -274,3 +275,4 @@ export type Popup =
       commits: ReadonlyArray<CommitOneLine>
       sourceBranch: Branch | null
     }
+  | { type: PopupType.MoveToApplicationsFolder }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -134,6 +134,7 @@ import { DragElementType } from '../models/drag-element'
 import { CherryPickCommit } from './drag-elements/cherry-pick-commit'
 import classNames from 'classnames'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
+import { MoveToApplicationsFolder } from './move-to-applications-folder'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -308,6 +309,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     log.info(`launching: ${getVersion()} (${getOS()})`)
     log.info(`execPath: '${process.execPath}'`)
+
+    if (__DEV__ === false && remote.app.isInApplicationsFolder?.() === false) {
+      this.showPopup({ type: PopupType.MoveToApplicationsFolder })
+    }
   }
 
   private onMenuEvent(name: MenuEvent): any {
@@ -2031,6 +2036,14 @@ export class App extends React.Component<IAppProps, IAppState> {
             onShowCherryPickConflictsBanner={
               this.onShowCherryPickConflictsBanner
             }
+          />
+        )
+      }
+      case PopupType.MoveToApplicationsFolder: {
+        return (
+          <MoveToApplicationsFolder
+            dispatcher={this.props.dispatcher}
+            onDismissed={onPopupDismissedFn}
           />
         )
       }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -310,6 +310,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     log.info(`launching: ${getVersion()} (${getOS()})`)
     log.info(`execPath: '${process.execPath}'`)
 
+    // Only show the popup in beta/production releases
     if (__DEV__ === false && remote.app.isInApplicationsFolder?.() === false) {
       this.showPopup({ type: PopupType.MoveToApplicationsFolder })
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -310,7 +310,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     log.info(`launching: ${getVersion()} (${getOS()})`)
     log.info(`execPath: '${process.execPath}'`)
 
-    // Only show the popup in beta/production releases
+    // Only show the popup in beta/production releases and mac machines
     if (__DEV__ === false && remote.app.isInApplicationsFolder?.() === false) {
       this.showPopup({ type: PopupType.MoveToApplicationsFolder })
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1302,6 +1302,10 @@ export class Dispatcher {
     return this.appStore.setStatsOptOut(optOut, userViewedPrompt)
   }
 
+  public moveToApplicationsFolder() {
+    remote.app.moveToApplicationsFolder?.()
+  }
+
   /**
    * Clear any in-flight sign in state and return to the
    * initial (no sign-in) state.

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  OkCancelButtonGroup,
+} from './dialog'
+import { Dispatcher } from './dispatcher'
+
+interface IMoveToApplicationsFolderProps {
+  readonly dispatcher: Dispatcher
+
+  /**
+   * Callback to use when the dialog gets closed.
+   */
+  readonly onDismissed: () => void
+}
+
+export class MoveToApplicationsFolder extends React.Component<
+  IMoveToApplicationsFolderProps
+> {
+  public render() {
+    return (
+      <Dialog
+        title="Move GitHub Desktop to the Applications folder?"
+        id="move-to-applications-folder"
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+        type="warning"
+      >
+        <DialogContent>
+          <p>
+            It seems you're not running GitHub Desktop from the Applications
+            folder of your machine. That could cause some problems, for example
+            not being able to sign in.
+            <br />
+            Do you want to move GitHub Desktop to the Applications folder now?
+          </p>
+        </DialogContent>
+        {this.renderFooter()}
+      </Dialog>
+    )
+  }
+
+  private renderFooter() {
+    return (
+      <DialogFooter>
+        <OkCancelButtonGroup
+          okButtonText={'Move'}
+          okButtonTitle="This will move GitHub Desktop to the Applications folder in your machine."
+          cancelButtonText="Cancel"
+        />
+      </DialogFooter>
+    )
+  }
+
+  private onSubmit = async () => {
+    try {
+      this.props.dispatcher.moveToApplicationsFolder()
+    } catch (error) {
+      sendNonFatalException('moveApplication', error)
+    }
+
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -31,11 +31,13 @@ export class MoveToApplicationsFolder extends React.Component<
       >
         <DialogContent>
           <p>
-            It seems you're not running GitHub Desktop from the Applications
-            folder of your machine. That could cause some problems, for example
-            not being able to sign in.
+            We've detected that you're not running GitHub Desktop from the
+            Applications folder of your machine. This could cause problems with
+            the app, including impacting your ability to sign in.
+            <br />
             <br />
             Do you want to move GitHub Desktop to the Applications folder now?
+            This will also restart the app.
           </p>
         </DialogContent>
         {this.renderFooter()}
@@ -47,8 +49,8 @@ export class MoveToApplicationsFolder extends React.Component<
     return (
       <DialogFooter>
         <OkCancelButtonGroup
-          okButtonText={'Move'}
-          okButtonTitle="This will move GitHub Desktop to the Applications folder in your machine."
+          okButtonText={'Move and Restart'}
+          okButtonTitle="This will move GitHub Desktop to the Applications folder in your machine and restart the app."
           cancelButtonText="Cancel"
         />
       </DialogFooter>


### PR DESCRIPTION
## Description

We've noticed ~20% of our macOS users are launching the app from a path different than `/Applications`, and we believe that is causing issues when they try to sign in, where the browser is unable to call the app back with the user's token.

In order to prevent that, this PR uses [some Electron APIs](https://www.electronjs.org/docs/api/app#appmovetoapplicationsfolderoptions-macos) to detect this scenario and even move the app from wherever it is to the `/Application` folder, immediately restarting the app from its new location.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/112030851-f9307a80-8b3a-11eb-8d04-d6ae148e3926.png)

## Release notes

Notes: [Improved] Suggest macOS users to move the app to the Applications folder to prevent issues signing in
