### PR TITLE
Fix bug getting commit summary info in rebase

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -234,7 +234,7 @@ export async function getRebaseSnapshot(
     const hasValidCommit =
       commits.length > 0 &&
       nextCommitIndex >= 0 &&
-      nextCommitIndex <= commits.length
+      nextCommitIndex < commits.length
 
     const currentCommitSummary = hasValidCommit
       ? commits[nextCommitIndex].summary


### PR DESCRIPTION
## Description

I found that sometimes a rebase might involve more steps/commands than the number of commits we wanted to rebase. The app already handles those by not showing the commit summary in the "extra" steps/commands. It's not accurate, but it's simple and works well enough.

When that happens, if the app tries to grab a snapshot of the rebase progress from the `.git/rebase-merge` folder, part of the logic tries to grab the summary of the commit using the index of the current step/command to access the array of commits.

However, the check for the array boundaries was wrong, which breaks the UI-side of the rebase flow in these scenarios.

## Release notes

Notes: [Fixed] Don't fail during a complex rebase operation
