### PR TITLE
Bump dugite to 1.102.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.4",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.100.0",
+    "dugite": "^1.102.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -408,6 +408,8 @@ function getDescriptionForError(error: DugiteError): string | null {
       return 'A tag with that name already exists'
     case DugiteError.MergeWithLocalChanges:
     case DugiteError.RebaseWithLocalChanges:
+    case DugiteError.GPGFailedToSignData:
+    case DugiteError.ConflictModifyDeletedInBranch:
       return null
     case DugiteError.MergeCommitNoMainlineOption:
       // Note: This has been made specific to cherry pick, but this error can

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -364,10 +364,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.100.0:
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.100.0.tgz#4e531a00945e7eb8ab14aa253d351f6689d4038e"
-  integrity sha512-WEoeDJ1wzC9tbULzmEw/cqpilL9ExoulVGepc7nlRkZNmsEnKbLRZW+Ims/uyrV02NA00LetkP/CsEpilNeq1A==
+dugite@^1.102.0:
+  version "1.102.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.102.0.tgz#15fde8ec6726f03dabcee06e7e5ee5492bf9bf74"
+  integrity sha512-z3eqQd0sCAt/6HgEDFDKw/VFp9LJG5v7MpR0wQAZh4Y/vz/pt5rdjJozVGVX9kGP3sHbIVz251Ooi8lrLupUeQ==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"


### PR DESCRIPTION
## Description

Bump dugite to 1.102.0 so we will have access to new git error for cherry picking work.

## Release notes
Notes: no-notes
