### PR TITLE
Cherry-picking non existant file error

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.4",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
-    "dugite": "^1.100.0",
+    "dugite": "^1.102.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -190,6 +190,7 @@ function parseCherryPickResult(result: IGitResult): CherryPickResult {
   }
 
   switch (result.gitError) {
+    case GitError.ConflictModifyDeletedInBranch:
     case GitError.MergeConflicts:
       return CherryPickResult.ConflictsEncountered
     case GitError.UnresolvedConflicts:

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -408,6 +408,8 @@ function getDescriptionForError(error: DugiteError): string | null {
       return 'A tag with that name already exists'
     case DugiteError.MergeWithLocalChanges:
     case DugiteError.RebaseWithLocalChanges:
+    case DugiteError.GPGFailedToSignData:
+    case DugiteError.ConflictModifyDeletedInBranch:
       return null
     case DugiteError.MergeCommitNoMainlineOption:
       // Note: This has been made specific to cherry pick, but this error can

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -173,6 +173,7 @@ function parseUntrackedEntry(field: string): IStatusEntry {
  * Map the raw status text from Git to a structure we can work with in the app.
  */
 export function mapStatus(status: string): FileEntry {
+  console.log(status)
   if (status === '??') {
     return {
       kind: 'untracked',

--- a/app/src/ui/cherry-pick/cherry-pick-conflicts-dialog.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-conflicts-dialog.tsx
@@ -128,7 +128,7 @@ export class CherryPickConflictsDialog extends React.Component<
 
     const {
       manualResolutions,
-      targetBranchName: theirBranch,
+      targetBranchName: ourBranch,
     } = step.conflictState
 
     return (
@@ -143,9 +143,9 @@ export class CherryPickConflictsDialog extends React.Component<
                 repository,
                 dispatcher,
                 manualResolution: manualResolutions.get(f.path),
-                theirBranch,
-                ourBranch:
+                theirBranch:
                   sourceBranchName !== null ? sourceBranchName : undefined,
+                ourBranch,
               })
             : null
         )}

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -5,6 +5,7 @@ import {
   ConflictedFileStatus,
   ConflictsWithMarkers,
   ManualConflict,
+  GitStatusEntry,
 } from '../../../models/status'
 import { join } from 'path'
 import { Repository } from '../../../models/repository'
@@ -163,11 +164,16 @@ const renderManualConflictedFile: React.FunctionComponent<{
     props.theirBranch
   )
 
+  const conflictTypeString =
+    props.status.entry.us === GitStatusEntry.Deleted
+      ? 'File does not exist in target branch.'
+      : manualConflictString
+
   const content = (
     <>
       <div className="column-left">
         <PathText path={props.path} />
-        <div className="file-conflicts-status">{manualConflictString}</div>
+        <div className="file-conflicts-status">{conflictTypeString}</div>
       </div>
       <div className="action-buttons">
         <Button

--- a/app/src/ui/lib/parse-conflict-modify-delete-files.ts
+++ b/app/src/ui/lib/parse-conflict-modify-delete-files.ts
@@ -1,0 +1,46 @@
+/** Parse CONFLICT (modify/delete) errors to get the files that caused the error
+ *
+ * Example Error:
+ * CONFLICT (modify/delete): app/src/ui/lib/draggable.tsx deleted in HEAD and modified in 0f777848d (Allow switching tab in branch menu during drag). Version 0f777848d (Allow switching tab in branch menu during drag) of app/src/ui/lib/draggable.tsx left in tree.
+ * Auto-merging app/src/ui/branches/branches-container.tsx
+ * CONFLICT (modify/delete): app/src/lib/drag-and-drop-manager.ts deleted in HEAD and modified in 0f777848d (Allow switching tab in branch menu during drag). Version 0f777848d (Allow switching tab in branch menu during drag) of app/src/lib/drag-and-drop-manager.ts left in tree.
+ */
+
+export function parseConflictModifyDeleteFiles(
+  stdOut: string
+): ReadonlyArray<string> {
+  const files = new Array<string>()
+  const lines = stdOut.split('\n')
+
+  for (const line of lines) {
+    if (!line.startsWith('CONFLICT')) {
+      continue
+    }
+
+    const splitOnSpace = line.split(' ')
+    if (splitOnSpace.length >= 3) {
+      files.push(splitOnSpace[2].trim())
+    }
+  }
+
+  return files
+}
+
+/**
+ * Parse CONFLICT (modify/delete) errors to get commit summary of the commit
+ * that caused the error
+ */
+export function parseConflictModifyDeleteCommitSummary(stdOut: string): string {
+  const versionRegex = /Version\s.*\((.*)\)/
+  const versionMatches = stdOut.match(versionRegex)
+  if (versionMatches === null) {
+    return ''
+  }
+
+  const commitSummaryRegex = /\((.*)\)/
+  const summaryMatches = versionMatches[0].match(commitSummaryRegex)
+  if (summaryMatches === null) {
+    return ''
+  }
+  return summaryMatches[0].slice(1, -1)
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -364,10 +364,10 @@ double-ended-queue@^2.1.0-0:
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
-dugite@^1.100.0:
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.100.0.tgz#4e531a00945e7eb8ab14aa253d351f6689d4038e"
-  integrity sha512-WEoeDJ1wzC9tbULzmEw/cqpilL9ExoulVGepc7nlRkZNmsEnKbLRZW+Ims/uyrV02NA00LetkP/CsEpilNeq1A==
+dugite@^1.102.0:
+  version "1.102.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.102.0.tgz#15fde8ec6726f03dabcee06e7e5ee5492bf9bf74"
+  integrity sha512-z3eqQd0sCAt/6HgEDFDKw/VFp9LJG5v7MpR0wQAZh4Y/vz/pt5rdjJozVGVX9kGP3sHbIVz251Ooi8lrLupUeQ==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"


### PR DESCRIPTION

## Description

Parse and reformat conflict (rename/modify) error to a friendly message. This error occurs if a user attempts to cherry-pick a commit with modifications to files that do not exist on the target branch.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![image](https://user-images.githubusercontent.com/75402236/112397401-61689300-8cd8-11eb-80d5-95c1d663e8e5.png)


## Release notes
Notes: [Improved] Provide a friendly error when user cherry-picks modifications to files non-existent target branch.
