### PR TITLE
Cherry picking non existant file conflict

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -183,6 +183,7 @@ function parseCherryPickResult(result: IGitResult): CherryPickResult {
   }
 
   switch (result.gitError) {
+    case GitError.ConflictModifyDeletedInBranch:
     case GitError.MergeConflicts:
       return CherryPickResult.ConflictsEncountered
     case GitError.UnresolvedConflicts:

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -133,7 +133,10 @@ export async function cherryPick(
   progressCallback?: (progress: ICherryPickProgress) => void
 ): Promise<CherryPickResult> {
   let baseOptions: IGitExecutionOptions = {
-    expectedErrors: new Set([GitError.MergeConflicts]),
+    expectedErrors: new Set([
+      GitError.MergeConflicts,
+      GitError.ConflictModifyDeletedInBranch,
+    ]),
   }
 
   if (progressCallback !== undefined) {
@@ -354,6 +357,7 @@ export async function continueCherryPick(
   let options: IGitExecutionOptions = {
     expectedErrors: new Set([
       GitError.MergeConflicts,
+      GitError.ConflictModifyDeletedInBranch,
       GitError.UnresolvedConflicts,
     ]),
     env: {

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -173,7 +173,6 @@ function parseUntrackedEntry(field: string): IStatusEntry {
  * Map the raw status text from Git to a structure we can work with in the app.
  */
 export function mapStatus(status: string): FileEntry {
-  console.log(status)
   if (status === '??') {
     return {
       kind: 'untracked',

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -173,6 +173,7 @@ function parseUntrackedEntry(field: string): IStatusEntry {
  * Map the raw status text from Git to a structure we can work with in the app.
  */
 export function mapStatus(status: string): FileEntry {
+  console.log(status)
   if (status === '??') {
     return {
       kind: 'untracked',

--- a/app/src/lib/status.ts
+++ b/app/src/lib/status.ts
@@ -127,7 +127,8 @@ export function getLabelForManualResolutionOption(
     case GitStatusEntry.UpdatedButUnmerged:
       return `Use the modified file${suffix}`
     case GitStatusEntry.Deleted:
-      return `Use the deleted file${suffix}`
+      const deleteSuffix = branch ? ` on ${branch}` : ''
+      return `Do not include this file${deleteSuffix}`
     default:
       return assertNever(entry, 'Unknown status entry to format')
   }

--- a/app/src/ui/cherry-pick/cherry-pick-conflicts-dialog.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-conflicts-dialog.tsx
@@ -128,7 +128,7 @@ export class CherryPickConflictsDialog extends React.Component<
 
     const {
       manualResolutions,
-      targetBranchName: theirBranch,
+      targetBranchName: ourBranch,
     } = step.conflictState
 
     return (
@@ -143,9 +143,9 @@ export class CherryPickConflictsDialog extends React.Component<
                 repository,
                 dispatcher,
                 manualResolution: manualResolutions.get(f.path),
-                theirBranch,
-                ourBranch:
+                theirBranch:
                   sourceBranchName !== null ? sourceBranchName : undefined,
+                ourBranch,
               })
             : null
         )}

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -165,7 +165,8 @@ const renderManualConflictedFile: React.FunctionComponent<{
   )
 
   const conflictTypeString =
-    props.status.entry.us === GitStatusEntry.Deleted
+    props.status.entry.us === GitStatusEntry.Deleted ||
+    props.status.entry.them === GitStatusEntry.Deleted
       ? 'File does not exist in target branch.'
       : manualConflictString
 

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -5,6 +5,7 @@ import {
   ConflictedFileStatus,
   ConflictsWithMarkers,
   ManualConflict,
+  GitStatusEntry,
 } from '../../../models/status'
 import { join } from 'path'
 import { Repository } from '../../../models/repository'
@@ -163,11 +164,16 @@ const renderManualConflictedFile: React.FunctionComponent<{
     props.theirBranch
   )
 
+  const conflictTypeString =
+    props.status.entry.us === GitStatusEntry.Deleted
+      ? 'File does not exist in target branch.'
+      : manualConflictString
+
   const content = (
     <>
       <div className="column-left">
         <PathText path={props.path} />
-        <div className="file-conflicts-status">{manualConflictString}</div>
+        <div className="file-conflicts-status">{conflictTypeString}</div>
       </div>
       <div className="action-buttons">
         <Button

--- a/app/src/ui/lib/conflicts/unmerged-file.tsx
+++ b/app/src/ui/lib/conflicts/unmerged-file.tsx
@@ -163,12 +163,22 @@ const renderManualConflictedFile: React.FunctionComponent<{
     props.ourBranch,
     props.theirBranch
   )
+  const { ourBranch, theirBranch } = props
+  const { entry } = props.status
 
-  const conflictTypeString =
-    props.status.entry.us === GitStatusEntry.Deleted ||
-    props.status.entry.them === GitStatusEntry.Deleted
-      ? 'File does not exist in target branch.'
-      : manualConflictString
+  let conflictTypeString = manualConflictString
+
+  if ([entry.us, entry.them].includes(GitStatusEntry.Deleted)) {
+    let targetBranch = 'target branch'
+    if (entry.us === GitStatusEntry.Deleted && ourBranch !== undefined) {
+      targetBranch = ourBranch
+    }
+
+    if (entry.them === GitStatusEntry.Deleted && theirBranch !== undefined) {
+      targetBranch = theirBranch
+    }
+    conflictTypeString = `File does not exist on ${targetBranch}.`
+  }
 
   const content = (
     <>


### PR DESCRIPTION
Part of #1685

## Description

Make it so when user encounters conflict error when modifying a file that doesn't exist on the target branch, we give the user the option to either add the modified file or not include the file.

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/112550539-e82f7580-8d95-11eb-9d01-2c05cce87a4d.png)

## Release notes
Notes: [Improved] Show conflict dialog when user cherry-picks modifications to files non-existent target branch.
