### PR TITLE
Cherry-picking use main-line 1 for merge commits

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -167,9 +167,14 @@ export async function cherryPick(
   }
 
   // --keep-redundant-commits follows pattern of making sure someone cherry
-  // picked commit summaries appear in target branch history even tho they may
-  // be empty. This flag also results in the ability to cherry pick empty
-  // commits (thus, --allow-empty is not required.)
+  //  picked commit summaries appear in target branch history even tho they may
+  //  be empty. This flag also results in the ability to cherry pick empty
+  //  commits (thus, --allow-empty is not required.)
+  //
+  // -m 1 makes it so a merge commit always takes the first parent's history
+  //  (the branch you are cherry-picking from) for the commit. It also means
+  //  there could be multiple empty commits. I.E. If user does a range that
+  //  includes commits from that merge.
   const result = await git(
     ['cherry-pick', revisionRange, '--keep-redundant-commits', '-m 1'],
     repository.path,
@@ -403,9 +408,14 @@ export async function continueCherryPick(
   }
 
   // --keep-redundant-commits follows pattern of making sure someone cherry
-  // picked commit summaries appear in target branch history even tho they may
-  // be empty. This flag also results in the ability to cherry pick empty
-  // commits (thus, --allow-empty is not required.)
+  //  picked commit summaries appear in target branch history even tho they may
+  //  be empty. This flag also results in the ability to cherry pick empty
+  //  commits (thus, --allow-empty is not required.)
+  //
+  // -m 1 makes it so a merge commit always takes the first parent's history
+  //  (the branch you are cherry-picking from) for the commit. It also means
+  //  there could be multiple empty commits. I.E. If user does a range that
+  //  includes commits from that merge.
   const result = await git(
     ['cherry-pick', '--continue', '--keep-redundant-commits', '-m 1'],
     repository.path,

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -411,13 +411,8 @@ export async function continueCherryPick(
   //  picked commit summaries appear in target branch history even tho they may
   //  be empty. This flag also results in the ability to cherry pick empty
   //  commits (thus, --allow-empty is not required.)
-  //
-  // -m 1 makes it so a merge commit always takes the first parent's history
-  //  (the branch you are cherry-picking from) for the commit. It also means
-  //  there could be multiple empty commits. I.E. If user does a range that
-  //  includes commits from that merge.
   const result = await git(
-    ['cherry-pick', '--continue', '--keep-redundant-commits', '-m 1'],
+    ['cherry-pick', '--continue', '--keep-redundant-commits'],
     repository.path,
     'continueCherryPick',
     options

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -171,7 +171,7 @@ export async function cherryPick(
   // be empty. This flag also results in the ability to cherry pick empty
   // commits (thus, --allow-empty is not required.)
   const result = await git(
-    ['cherry-pick', revisionRange, '--keep-redundant-commits'],
+    ['cherry-pick', revisionRange, '--keep-redundant-commits', '-m 1'],
     repository.path,
     'cherry-pick',
     baseOptions
@@ -407,7 +407,7 @@ export async function continueCherryPick(
   // be empty. This flag also results in the ability to cherry pick empty
   // commits (thus, --allow-empty is not required.)
   const result = await git(
-    ['cherry-pick', '--continue', '--keep-redundant-commits'],
+    ['cherry-pick', '--continue', '--keep-redundant-commits', '-m 1'],
     repository.path,
     'continueCherryPick',
     options

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -410,12 +410,8 @@ function getDescriptionForError(error: DugiteError): string | null {
     case DugiteError.RebaseWithLocalChanges:
     case DugiteError.GPGFailedToSignData:
     case DugiteError.ConflictModifyDeletedInBranch:
-      return null
     case DugiteError.MergeCommitNoMainlineOption:
-      // Note: This has been made specific to cherry pick, but this error can
-      // appear for revert; however, our revert logic provides the -m option
-      // and avoids this error.
-      return 'You cannot cherry-pick merge commits from GitHub Desktop. You can cherry-pick merge commits from the terminal using the -m flag. Please select non-merge commits and try again.'
+      return null
     default:
       return assertNever(error, `Unknown error: ${error}`)
   }


### PR DESCRIPTION
Part of #1685 

## Description
Merge commits do not always show their history inline on the branch. Thus, in order to cherry-pick something that was merged in and history not shown. User must cherry-pick a merge commit to get those changes. If the commits were in the branches history, the merge commit just becomes an empty commit following the pattern of conflicts or redundant commits. This also means, that if a user has to cherry-pick multiple things that were merged, they can do them all at the the same time instead of selecting only non-merge commits.

### Screenshots
![cherry-pick-merge-commits](https://user-images.githubusercontent.com/75402236/112680576-ed4afe00-8e43-11eb-9313-8efe8089a12c.gif)


## Release notes
Notes: [Add] User can cherry-pick merge commits
