### PR TITLE
Diff expansion, part II: add gutter markers

### DIFF
--- a/app/src/ui/diff/diff-explorer.ts
+++ b/app/src/ui/diff/diff-explorer.ts
@@ -23,6 +23,11 @@ interface IDiffRange {
   readonly type: DiffRangeType | null
 }
 
+interface IDiffLineInfo {
+  readonly line: DiffLine
+  readonly hunk: DiffHunk
+}
+
 /**
  * Locate the diff hunk for the given (absolute) line number in the diff.
  */
@@ -37,18 +42,38 @@ export function diffHunkForIndex(
 }
 
 /**
+ * Locate the diff line and hunk for the given (absolute) line number in the diff.
+ */
+export function diffLineInfoForIndex(
+  hunks: ReadonlyArray<DiffHunk>,
+  index: number
+): IDiffLineInfo | null {
+  const hunk = diffHunkForIndex(hunks, index)
+  if (!hunk) {
+    return null
+  }
+
+  const line = hunk.lines[index - hunk.unifiedDiffStart]
+  if (!line) {
+    return null
+  }
+
+  return { hunk, line }
+}
+
+/**
  * Locate the diff line for the given (absolute) line number in the diff.
  */
 export function diffLineForIndex(
   hunks: ReadonlyArray<DiffHunk>,
   index: number
 ): DiffLine | null {
-  const hunk = diffHunkForIndex(hunks, index)
-  if (!hunk) {
+  const diffLineInfo = diffLineInfoForIndex(hunks, index)
+  if (diffLineInfo === null) {
     return null
   }
 
-  return hunk.lines[index - hunk.unifiedDiffStart] || null
+  return diffLineInfo.line
 }
 
 /** Get the line number as represented in the diff text itself. */

--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -4,6 +4,7 @@ import { diffLineForIndex } from './diff-explorer'
 import { ITokens } from '../../lib/highlighter/types'
 
 import 'codemirror/mode/javascript/javascript'
+import { enableTextDiffExpansion } from '../../lib/feature-flag'
 
 export interface IDiffSyntaxModeOptions {
   /**
@@ -37,6 +38,7 @@ const TokenNames: { [key: string]: string | null } = {
 
 interface IState {
   diffLineIndex: number
+  previousHunkOldEndLine: number | null
 }
 
 function skipLine(stream: CodeMirror.StringStream, state: IState) {
@@ -106,7 +108,7 @@ export class DiffSyntaxMode {
   }
 
   public startState(): IState {
-    return { diffLineIndex: 0 }
+    return { diffLineIndex: 0, previousHunkOldEndLine: null }
   }
 
   // Should never happen except for blank diffs but
@@ -130,7 +132,43 @@ export class DiffSyntaxMode {
 
       const token = index ? TokenNames[index] : null
 
-      return token ? `line-${token} line-background-${token}` : null
+      if (token === null) {
+        return null
+      }
+
+      let result = `line-${token} line-background-${token}`
+
+      // If it's a hunk header line, we want to make a few extra checks
+      // depending on the distance to the previous hunk.
+      if (index === '@' && enableTextDiffExpansion()) {
+        // First we grab the numbers in the hunk header
+        const matches = stream.match(/\@ -(\d+),(\d+) \+\d+,\d+ \@\@/)
+        if (matches !== null) {
+          const oldStartLine = parseInt(matches[1])
+          const oldLineCount = parseInt(matches[2])
+
+          // If there is a hunk above and the distance with this one is bigger
+          // than the expansion "step", return an additional class name that
+          // will be used to make that line taller to fit the expansion buttons.
+          if (
+            state.previousHunkOldEndLine !== null &&
+            oldStartLine - state.previousHunkOldEndLine > 20
+          ) {
+            result += ` line-${token}-expandable-both`
+          }
+
+          // Finally we update the state with the index of the last line of the
+          // current hunk.
+          state.previousHunkOldEndLine = oldStartLine + oldLineCount
+        }
+
+        // Check again if we reached the EOL after matching the regex
+        if (stream.eol()) {
+          state.diffLineIndex++
+        }
+      }
+
+      return result
     }
 
     // This happens when the mode is running without tokens, in this

--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -5,6 +5,7 @@ import { ITokens } from '../../lib/highlighter/types'
 
 import 'codemirror/mode/javascript/javascript'
 import { enableTextDiffExpansion } from '../../lib/feature-flag'
+import { DiffExpansionStep } from './text-diff-expansion'
 
 export interface IDiffSyntaxModeOptions {
   /**
@@ -152,7 +153,7 @@ export class DiffSyntaxMode {
           // will be used to make that line taller to fit the expansion buttons.
           if (
             state.previousHunkOldEndLine !== null &&
-            oldStartLine - state.previousHunkOldEndLine > 20
+            oldStartLine - state.previousHunkOldEndLine > DiffExpansionStep
           ) {
             result += ` line-${token}-expandable-both`
           }

--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -7,7 +7,7 @@ import {
 } from '../../models/diff'
 
 /** How many new lines will be added to a diff hunk. */
-const DiffExpansionStep = 20
+export const DiffExpansionStep = 20
 
 /** Type of expansion: could be up or down. */
 export type ExpansionKind = 'up' | 'down'

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { OcticonSymbol } from './octicons.generated'
 import classNames from 'classnames'
 import { createUniqueId, releaseUniqueId } from '../lib/id-pool'
+import ReactDOM from 'react-dom'
 
 interface IOcticonProps {
   /**
@@ -75,4 +76,26 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
       </svg>
     )
   }
+}
+
+/**
+ * Create an Octicon element for the DOM, wrapped in a div element.
+ *
+ * @param symbol    OcticonSymbol to render in the element.
+ * @param className Optional class to add to the wrapper element.
+ * @param id        Optional identifier to set to the wrapper element.
+ */
+export function createOcticonElement(
+  symbol: OcticonSymbol,
+  className?: string,
+  id?: string
+) {
+  const wrapper = document.createElement('div')
+  wrapper.id = id ?? ''
+  if (className !== undefined) {
+    wrapper.classList.add(className)
+  }
+  const octicon = <Octicon symbol={symbol} />
+  ReactDOM.render(octicon, wrapper)
+  return wrapper
 }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -31,6 +31,16 @@
   pre.CodeMirror-line-like {
     padding: 2px 0 2px var(--spacing-half);
 
+    &.diff-hunk-expandable-both {
+      padding-top: 14px;
+      padding-bottom: 14px;
+    }
+
+    &.diff-hunk:not(.diff-hunk-expandable-both) {
+      padding-top: 5px;
+      padding-bottom: 5px;
+    }
+
     svg.no-newline {
       height: 8px;
       fill: var(--error-color);
@@ -113,9 +123,53 @@
     width: 20px;
     right: -8px;
     top: 0;
+  }
 
-    &.includeable {
-      cursor: pointer;
+  .hunk-expand-up-handle {
+    position: absolute;
+    height: 50%;
+    width: 100%;
+    right: 0;
+    bottom: 0;
+    text-align: center;
+  }
+
+  .hunk-expand-down-handle {
+    position: absolute;
+    height: 50%;
+    width: 100%;
+    right: 0;
+    top: 0;
+    text-align: center;
+  }
+
+  .hunk-expand-whole-handle {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    right: 0;
+    bottom: 0;
+    text-align: center;
+  }
+
+  &:not(.includeable) {
+    .hunk-handle {
+      display: none;
+    }
+  }
+
+  &.expandable-both,
+  &:not(.diff-hunk) {
+    .hunk-expand-whole-handle {
+      display: none;
+    }
+  }
+
+  &:not(.expandable-both),
+  &:not(.diff-hunk) {
+    .hunk-expand-up-handle,
+    .hunk-expand-down-handle {
+      display: none;
     }
   }
 
@@ -129,6 +183,56 @@
 
   &.diff-hunk {
     background: var(--diff-hunk-gutter-background-color);
+
+    .hunk-expand-up-handle,
+    .hunk-expand-down-handle,
+    .hunk-expand-whole-handle {
+      background: var(--diff-hunk-gutter-background-color);
+    }
+
+    .hunk-expand-icon {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &:not(.expandable-up) {
+      .hunk-expand-whole-handle #hunk-expand-up-icon {
+        display: none;
+      }
+    }
+
+    &:not(.expandable-down) {
+      .hunk-expand-whole-handle #hunk-expand-down-icon {
+        display: none;
+      }
+    }
+
+    &:not(.expandable-short) {
+      .hunk-expand-whole-handle #hunk-expand-short-icon {
+        display: none;
+      }
+    }
+
+    // Allow hover effect when it's expandable in any way
+    &.expandable-up,
+    &.expandable-down,
+    &.expandable-short,
+    &.expandable-both {
+      :hover {
+        cursor: pointer;
+
+        background: var(--diff-hover-background-color);
+        border-color: var(--diff-hover-border-color);
+        color: var(--diff-hover-text-color);
+
+        &:last-child {
+          border-color: var(--diff-hover-gutter-color);
+        }
+      }
+    }
   }
 
   .before {
@@ -248,6 +352,20 @@
 
     &:last-child {
       border-color: var(--diff-hunk-gutter-color);
+    }
+  }
+
+  &.expandable-up:hover,
+  &.expandable-down:hover,
+  &.expandable-short:hover {
+    cursor: pointer;
+
+    background: var(--diff-hover-background-color);
+    border-color: var(--diff-hover-border-color);
+    color: var(--diff-hover-text-color);
+
+    &:last-child {
+      border-color: var(--diff-hover-gutter-color);
     }
   }
 }


### PR DESCRIPTION
## Description

Another PR part of the text diff expansion feature. This one just adds the gutter markers that the user can click to expand the diff. In order to get lines that are taller when the diff can be expanded both up and down, it requires a small change in the code that parses the diff for highlighting purposes.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/113028164-3fb15500-918b-11eb-9d4a-a4903fbf3b07.png)

## Release notes

Notes: no-notes
