### PR TITLE
Diff expansion, part IV: fix selection on expanded diffs

### DIFF
--- a/app/src/ui/diff/diff-explorer.ts
+++ b/app/src/ui/diff/diff-explorer.ts
@@ -96,6 +96,52 @@ export function lineNumberForDiffLine(
 
 /**
  * For the given row in the diff, determine the range of elements that
+ * should be displayed as interactive, as a hunk is not granular enough.
+ * The values in the returned range are mapped to lines in the original diff,
+ * in case the current diff has been partially expanded.
+ */
+export function findInteractiveOriginalDiffRange(
+  hunks: ReadonlyArray<DiffHunk>,
+  index: number
+): IDiffRange | null {
+  const range = findInteractiveDiffRange(hunks, index)
+
+  if (range === null) {
+    return null
+  }
+
+  const from = getLineInOriginalDiff(hunks, range.from)
+  const to = getLineInOriginalDiff(hunks, range.to)
+
+  if (from === null || to === null) {
+    return null
+  }
+
+  return {
+    ...range,
+    from,
+    to,
+  }
+}
+
+/**
+ * Utility function to get the line number in the original line from a given
+ * line number in the current text diff (which might be expanded).
+ */
+export function getLineInOriginalDiff(
+  hunks: ReadonlyArray<DiffHunk>,
+  index: number
+) {
+  const diffLine = diffLineForIndex(hunks, index)
+  if (diffLine === null) {
+    return null
+  }
+
+  return diffLine.originalLineNumber
+}
+
+/**
+ * For the given row in the diff, determine the range of elements that
  * should be displayed as interactive, as a hunk is not granular enough
  */
 export function findInteractiveDiffRange(

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -28,7 +28,10 @@ import {
 } from 'react-virtualized'
 import { SideBySideDiffRow } from './side-by-side-diff-row'
 import memoize from 'memoize-one'
-import { findInteractiveDiffRange, DiffRangeType } from './diff-explorer'
+import {
+  findInteractiveOriginalDiffRange,
+  DiffRangeType,
+} from './diff-explorer'
 import {
   ChangedFile,
   DiffRow,
@@ -589,7 +592,7 @@ export class SideBySideDiff extends React.Component<
     const selection = this.getSelection()
 
     if (selection !== undefined) {
-      const range = findInteractiveDiffRange(diff.hunks, hunkStartLine)
+      const range = findInteractiveOriginalDiffRange(diff.hunks, hunkStartLine)
       if (range !== null) {
         const { from, to } = range
         const sel = selection.withRangeSelection(from, to - from + 1, select)
@@ -629,7 +632,7 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const range = findInteractiveDiffRange(diff.hunks, diffLineNumber)
+    const range = findInteractiveOriginalDiffRange(diff.hunks, diffLineNumber)
     if (range === null || range.type === null) {
       return
     }
@@ -656,7 +659,10 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const range = findInteractiveDiffRange(this.props.diff.hunks, hunkStartLine)
+    const range = findInteractiveOriginalDiffRange(
+      this.props.diff.hunks,
+      hunkStartLine
+    )
     if (range === null || range.type === null) {
       return
     }


### PR DESCRIPTION
## Description

This PR makes a few changes in the way the app handles line selection. Instead of just using the line number of the change in the current diff (which can be expanded), the app will track the line number in the original diff, and keep it during the multiple expansions of the diff.

## Release notes

Notes: no-notes
