### PR TITLE
Ability to change spell check language to English

### DIFF
--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -150,11 +150,11 @@ function getSpellCheckLanguageMenuItem(
     return null
   }
 
-  const currentLanguageCodes = session.getSpellCheckerLanguages()
+  const spellcheckLanguageCodes = session.getSpellCheckerLanguages()
 
   const languageCode =
-    currentLanguageCodes.includes(englishLanguageCode) &&
-    !currentLanguageCodes.includes(userLanguageCode)
+    spellcheckLanguageCodes.includes(englishLanguageCode) &&
+    !spellcheckLanguageCodes.includes(userLanguageCode)
       ? userLanguageCode
       : englishLanguageCode
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -146,15 +146,18 @@ function getSpellCheckLanguageMenuItem(
 ): IMenuItem | null {
   const userLanguageCode = remote.app.getLocale()
   const englishLanguageCode = 'en-US'
-  if (userLanguageCode === englishLanguageCode) {
+  const spellcheckLanguageCodes = session.getSpellCheckerLanguages()
+
+  if (
+    userLanguageCode === englishLanguageCode &&
+    spellcheckLanguageCodes.includes(englishLanguageCode)
+  ) {
     return null
   }
 
-  const currentLanguageCodes = session.getSpellCheckerLanguages()
-
   const languageCode =
-    currentLanguageCodes.includes(englishLanguageCode) &&
-    !currentLanguageCodes.includes(userLanguageCode)
+    spellcheckLanguageCodes.includes(englishLanguageCode) &&
+    !spellcheckLanguageCodes.includes(userLanguageCode)
       ? userLanguageCode
       : englishLanguageCode
 


### PR DESCRIPTION
Closes #11589 

## Description

Add option for a non-macOS users who's system language is not English to set the applications spell checker to English (and also toggle back to the system language).

Note: MacOS natively detects multiple languages and thus does not support manually setting the language.

### Screenshots

Windows with system language set to German.

https://user-images.githubusercontent.com/75402236/113306740-66c66e80-92d2-11eb-984d-e89e4b0657ec.mov

Windows with system language set to English (No need for options)
![Screen Shot 2021-04-01 at 9 59 39 AM](https://user-images.githubusercontent.com/75402236/113306789-75148a80-92d2-11eb-84ad-1cfe3041fa93.png)

MacOS
MacOS natively detects multiple languages. As seen in screen shot, it doesn't show English or German word as misspelled and the English is set as the system language. Thus, no need for another option.
![Screen Shot 2021-04-01 at 10 06 18 AM](https://user-images.githubusercontent.com/75402236/113307017-b147eb00-92d2-11eb-85a1-878d56436cb1.png)


## Release notes
Notes: [Improved] For non macOS users with system language of not English, user can toggle between English and system language.
