### PR TITLE
Fix cherry-pick not ended on drop to current branch

### DIFF
--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -98,10 +98,19 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
   }
 
   private onMouseUp = () => {
-    const { onDropOntoBranch, name, isCurrentBranch } = this.props
+    const {
+      onDropOntoBranch,
+      onDropOntoCurrentBranch,
+      name,
+      isCurrentBranch,
+    } = this.props
 
     if (onDropOntoBranch !== undefined && !isCurrentBranch) {
       onDropOntoBranch(name)
+    }
+
+    if (onDropOntoCurrentBranch !== undefined && isCurrentBranch) {
+      onDropOntoCurrentBranch()
     }
   }
 

--- a/app/styles/ui/_app.scss
+++ b/app/styles/ui/_app.scss
@@ -45,13 +45,15 @@
             cursor: default;
           }
 
-          .branches-list-item:hover {
-            --text-color: var(--box-selected-active-text-color);
-            --text-secondary-color: var(--box-selected-active-text-color);
+          .list-item:not(.selected) {
+            .branches-list-item:hover {
+              --text-color: var(--box-selected-active-text-color);
+              --text-secondary-color: var(--box-selected-active-text-color);
 
-            color: var(--text-color);
-            background-color: var(--box-selected-active-background-color);
-            cursor: copy;
+              color: var(--text-color);
+              background-color: var(--box-selected-active-background-color);
+              cursor: copy;
+            }
           }
         }
       }


### PR DESCRIPTION
Closes #11915

## Description

When user cherry-picks onto the current branch, it should do nothing - it is not a valid drop target. 

### Screenshots

https://user-images.githubusercontent.com/75402236/113318948-f6721a00-92de-11eb-8a49-ae46fa4a29d0.mov


## Release notes

Notes: [Fixed] Dropping cherry-pick on current branch ends cherry-picking drag.
