### PR TITLE
Delete Branch: Use ahead/behind to determine if branch exist on remote

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -15,7 +15,7 @@ import {
 import { Account } from '../../models/account'
 import { AppMenu, IMenu } from '../../models/app-menu'
 import { IAuthor } from '../../models/author'
-import { Branch, BranchType } from '../../models/branch'
+import { Branch, BranchType, IAheadBehind } from '../../models/branch'
 import { BranchesTab } from '../../models/branches-tab'
 import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloningRepository } from '../../models/cloning-repository'
@@ -157,6 +157,7 @@ import {
   revRangeInclusive,
   GitResetMode,
   reset,
+  getBranchAheadBehind,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -6159,6 +6160,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _setDragElement(dragElement: DragElement | null): Promise<void> {
     this.currentDragElement = dragElement
     this.emitUpdate()
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _getBranchAheadBehind(
+    repository: Repository,
+    branch: Branch
+  ): Promise<IAheadBehind | null> {
+    return getBranchAheadBehind(repository, branch)
   }
 }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -304,7 +304,7 @@ export class BranchesContainer extends React.Component<
     })
   }
 
-  private onDeleteBranch = (branchName: string) => {
+  private onDeleteBranch = async (branchName: string) => {
     const branch = this.getBranchWithName(branchName)
 
     if (branch === undefined) {
@@ -320,11 +320,15 @@ export class BranchesContainer extends React.Component<
       return
     }
 
+    const aheadBehind = await this.props.dispatcher.getBranchAheadBehind(
+      this.props.repository,
+      branch
+    )
     this.props.dispatcher.showPopup({
       type: PopupType.DeleteBranch,
       repository: this.props.repository,
       branch,
-      existsOnRemote: branch.upstreamRemoteName !== null,
+      existsOnRemote: aheadBehind !== null,
     })
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -56,7 +56,7 @@ import { initializeRebaseFlowForConflictedRepository } from '../../lib/rebase'
 import { Account } from '../../models/account'
 import { AppMenu, ExecutableMenuItem } from '../../models/app-menu'
 import { IAuthor } from '../../models/author'
-import { Branch } from '../../models/branch'
+import { Branch, IAheadBehind } from '../../models/branch'
 import { BranchesTab } from '../../models/branches-tab'
 import { CloneRepositoryTab } from '../../models/clone-repository-tab'
 import { CloningRepository } from '../../models/cloning-repository'
@@ -2965,5 +2965,13 @@ export class Dispatcher {
     branchCreated: boolean
   ): void {
     this.appStore._setCherryPickBranchCreated(repository, branchCreated)
+  }
+
+  /** Gets a branches ahead behind remote or null if doesn't exist on remote */
+  public async getBranchAheadBehind(
+    repository: Repository,
+    branch: Branch
+  ): Promise<IAheadBehind | null> {
+    return this.appStore._getBranchAheadBehind(repository, branch)
   }
 }


### PR DESCRIPTION
## Description

Delete branch from the context menu on branches dropdown did not correctly detect when a branch has been deleted remotely (after a fetch has occurred). This PR fixes that by getting the branches AheadBehind state.  (Note: Delete branch from the app level branches menu worked correctly)

Thank you @TaxiTweedy for pointing out the problem in this comment. 
https://github.com/desktop/desktop/issues/750#issuecomment-811748813

### Screenshots
https://user-images.githubusercontent.com/75402236/113414567-47d7e300-938b-11eb-824e-f38c27619548.mov

## Release notes
Notes: [Fixed] Delete branch on branches dropdown context menu incorrectly detected the branch as existing on the remote after being deleted remotely and fetch had occurred.
