### PR TITLE
Split Whitespace Settings

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -202,8 +202,11 @@ export interface IAppState {
   /** What type of visual diff mode we should use to compare images */
   readonly imageDiffType: ImageDiffType
 
-  /** Whether we should hide white space changes in diff */
-  readonly hideWhitespaceInDiff: boolean
+  /** Whether we should hide white space changes in changes diff */
+  readonly hideWhitespaceInChangesDiff: boolean
+
+  /** Whether we should hide white space changes in history diff */
+  readonly hideWhitespaceInHistoryDiff: boolean
 
   /** Whether we should show side by side diffs */
   readonly showSideBySideDiff: boolean

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -49,7 +49,7 @@ export function enableWSLDetection(): boolean {
 
 /** Should the app show hide whitespace in changes tab */
 export function enableHideWhitespaceInDiffOption(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }
 
 /** Should the app use the shiny new TCP-based trampoline? */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4663,14 +4663,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
-  public async _setHideWhitespaceInChangesDiff(
+  public _setHideWhitespaceInChangesDiff(
     hideWhitespaceInDiff: boolean,
     repository: Repository
   ): Promise<void> {
     setBoolean(hideWhitespaceInChangesDiffKey, hideWhitespaceInDiff)
     this.hideWhitespaceInChangesDiff = hideWhitespaceInDiff
 
-    await this.refreshChangesSection(repository, {
+    return this.refreshChangesSection(repository, {
       includingStatus: true,
       clearPartialState: true,
     })

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4670,12 +4670,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setBoolean(hideWhitespaceInChangesDiffKey, hideWhitespaceInDiff)
     this.hideWhitespaceInChangesDiff = hideWhitespaceInDiff
 
-    if (enableHideWhitespaceInDiffOption()) {
-      await this.refreshChangesSection(repository, {
-        includingStatus: true,
-        clearPartialState: true,
-      })
-    }
+    await this.refreshChangesSection(repository, {
+      includingStatus: true,
+      clearPartialState: true,
+    })
   }
 
   public async _setHideWhitespaceInHistoryDiff(
@@ -4685,13 +4683,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     setBoolean(hideWhitespaceInHistoryDiffKey, hideWhitespaceInDiff)
     this.hideWhitespaceInHistoryDiff = hideWhitespaceInDiff
-
-    if (enableHideWhitespaceInDiffOption()) {
-      await this.refreshChangesSection(repository, {
-        includingStatus: true,
-        clearPartialState: true,
-      })
-    }
 
     if (file === null) {
       return this.updateChangesWorkingDirectoryDiff(repository)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -316,8 +316,10 @@ const externalEditorKey: string = 'externalEditor'
 const imageDiffTypeDefault = ImageDiffType.TwoUp
 const imageDiffTypeKey = 'image-diff-type'
 
-const hideWhitespaceInDiffDefault = false
-const hideWhitespaceInDiffKey = 'hide-whitespace-in-diff'
+const hideWhitespaceInChangesDiffDefault = false
+const hideWhitespaceInChangesDiffKey = 'hide-whitespace-in-changes-diff'
+const hideWhitespaceInHistoryDiffDefault = false
+const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
 
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
@@ -402,7 +404,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
-  private hideWhitespaceInDiff: boolean = hideWhitespaceInDiffDefault
+  private hideWhitespaceInChangesDiff: boolean = hideWhitespaceInChangesDiffDefault
+  private hideWhitespaceInHistoryDiff: boolean = hideWhitespaceInHistoryDiffDefault
   /** Whether or not the spellchecker is enabled for commit summary and description */
   private commitSpellcheckEnabled: boolean = commitSpellcheckEnabledDefault
   private showSideBySideDiff: boolean = ShowSideBySideDiffDefault
@@ -779,7 +782,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
-      hideWhitespaceInDiff: this.hideWhitespaceInDiff,
+      hideWhitespaceInChangesDiff: this.hideWhitespaceInChangesDiff,
+      hideWhitespaceInHistoryDiff: this.hideWhitespaceInHistoryDiff,
       showSideBySideDiff: this.showSideBySideDiff,
       selectedShell: this.selectedShell,
       repositoryFilterText: this.repositoryFilterText,
@@ -1356,7 +1360,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       repository,
       file,
       shas[0],
-      this.hideWhitespaceInDiff
+      this.hideWhitespaceInHistoryDiff
     )
 
     const stateAfterLoad = this.repositoryStateCache.get(repository)
@@ -1728,7 +1732,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ? imageDiffTypeDefault
         : parseInt(imageDiffTypeValue)
 
-    this.hideWhitespaceInDiff = getBoolean(hideWhitespaceInDiffKey, false)
+    this.hideWhitespaceInChangesDiff = getBoolean(
+      hideWhitespaceInChangesDiffKey,
+      false
+    )
+    this.hideWhitespaceInHistoryDiff = getBoolean(
+      hideWhitespaceInHistoryDiffKey,
+      false
+    )
     this.commitSpellcheckEnabled = getBoolean(
       commitSpellcheckEnabledKey,
       commitSpellcheckEnabledDefault
@@ -2198,7 +2209,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const diff = await getWorkingDirectoryDiff(
       repository,
       selectedFileBeforeLoad,
-      enableHideWhitespaceInDiffOption() && this.hideWhitespaceInDiff
+      enableHideWhitespaceInDiffOption() && this.hideWhitespaceInChangesDiff
     )
 
     const stateAfterLoad = this.repositoryStateCache.get(repository)
@@ -4652,13 +4663,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
-  public async _setHideWhitespaceInDiff(
+  public async _setHideWhitespaceInChangesDiff(
+    hideWhitespaceInDiff: boolean,
+    repository: Repository
+  ): Promise<void> {
+    setBoolean(hideWhitespaceInChangesDiffKey, hideWhitespaceInDiff)
+    this.hideWhitespaceInChangesDiff = hideWhitespaceInDiff
+
+    if (enableHideWhitespaceInDiffOption()) {
+      await this.refreshChangesSection(repository, {
+        includingStatus: true,
+        clearPartialState: true,
+      })
+    }
+  }
+
+  public async _setHideWhitespaceInHistoryDiff(
     hideWhitespaceInDiff: boolean,
     repository: Repository,
     file: CommittedFileChange | null
   ): Promise<void> {
-    setBoolean(hideWhitespaceInDiffKey, hideWhitespaceInDiff)
-    this.hideWhitespaceInDiff = hideWhitespaceInDiff
+    setBoolean(hideWhitespaceInHistoryDiffKey, hideWhitespaceInDiff)
+    this.hideWhitespaceInHistoryDiff = hideWhitespaceInDiff
 
     if (enableHideWhitespaceInDiffOption()) {
       await this.refreshChangesSection(repository, {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4676,7 +4676,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
   }
 
-  public async _setHideWhitespaceInHistoryDiff(
+  public _setHideWhitespaceInHistoryDiff(
     hideWhitespaceInDiff: boolean,
     repository: Repository,
     file: CommittedFileChange | null

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2663,7 +2663,8 @@ export class App extends React.Component<IAppProps, IAppState> {
           gitHubUserStore={this.props.gitHubUserStore}
           onViewCommitOnGitHub={this.onViewCommitOnGitHub}
           imageDiffType={state.imageDiffType}
-          hideWhitespaceInDiff={state.hideWhitespaceInDiff}
+          hideWhitespaceInChangesDiff={state.hideWhitespaceInChangesDiff}
+          hideWhitespaceInHistoryDiff={state.hideWhitespaceInHistoryDiff}
           showSideBySideDiff={state.showSideBySideDiff}
           focusCommitMessage={state.focusCommitMessage}
           askForConfirmationOnDiscardChanges={

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -130,7 +130,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
   private onHideWhitespaceInDiffChanged = async (
     hideWhitespaceInDiff: boolean
   ) => {
-    await this.props.dispatcher.onHideWhitespaceInDiffChanged(
+    await this.props.dispatcher.onHideWhitespaceInChangesDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository
     )

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -130,7 +130,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
   private onHideWhitespaceInDiffChanged = async (
     hideWhitespaceInDiff: boolean
   ) => {
-    await this.props.dispatcher.onHideWhitespaceInChangesDiffChanged(
+    return this.props.dispatcher.onHideWhitespaceInChangesDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository
     )

--- a/app/src/ui/changes/changes.tsx
+++ b/app/src/ui/changes/changes.tsx
@@ -127,9 +127,7 @@ export class Changes extends React.Component<IChangesProps, {}> {
     this.props.dispatcher.onShowSideBySideDiffChanged(showSideBySideDiff)
   }
 
-  private onHideWhitespaceInDiffChanged = async (
-    hideWhitespaceInDiff: boolean
-  ) => {
+  private onHideWhitespaceInDiffChanged = (hideWhitespaceInDiff: boolean) => {
     return this.props.dispatcher.onHideWhitespaceInChangesDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository

--- a/app/src/ui/diff/diff-options.tsx
+++ b/app/src/ui/diff/diff-options.tsx
@@ -74,10 +74,12 @@ export class DiffOptions extends React.Component<
     })
   }
 
-  private onHideWhitespaceChangesChanged = async (
+  private onHideWhitespaceChangesChanged = (
     event: React.FormEvent<HTMLInputElement>
   ) => {
-    await this.props.onHideWhitespaceChangesChanged(event.currentTarget.checked)
+    return this.props.onHideWhitespaceChangesChanged(
+      event.currentTarget.checked
+    )
   }
 
   public render() {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1941,13 +1941,24 @@ export class Dispatcher {
     return this.appStore._changeImageDiffType(type)
   }
 
-  /** Change the hide whitespace in diff setting */
-  public onHideWhitespaceInDiffChanged(
+  /** Change the hide whitespace in changes diff setting */
+  public onHideWhitespaceInChangesDiffChanged(
+    hideWhitespaceInDiff: boolean,
+    repository: Repository
+  ): Promise<void> {
+    return this.appStore._setHideWhitespaceInChangesDiff(
+      hideWhitespaceInDiff,
+      repository
+    )
+  }
+
+  /** Change the hide whitespace in history diff setting */
+  public onHideWhitespaceInHistoryDiffChanged(
     hideWhitespaceInDiff: boolean,
     repository: Repository,
     file: CommittedFileChange | null = null
   ): Promise<void> {
-    return this.appStore._setHideWhitespaceInDiff(
+    return this.appStore._setHideWhitespaceInHistoryDiff(
       hideWhitespaceInDiff,
       repository,
       file

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -161,7 +161,7 @@ export class CommitSummary extends React.Component<
     event: React.FormEvent<HTMLInputElement>
   ) => {
     const value = event.currentTarget.checked
-    await this.props.onHideWhitespaceInDiffChanged(value)
+    return this.props.onHideWhitespaceInDiffChanged(value)
   }
 
   private onResized = () => {

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -157,7 +157,7 @@ export class CommitSummary extends React.Component<
     }
   }
 
-  private onHideWhitespaceInDiffChanged = async (
+  private onHideWhitespaceInDiffChanged = (
     event: React.FormEvent<HTMLInputElement>
   ) => {
     const value = event.currentTarget.checked

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -193,7 +193,7 @@ export class SelectedCommit extends React.Component<
   private onHideWhitespaceInDiffChanged = async (
     hideWhitespaceInDiff: boolean
   ) => {
-    await this.props.dispatcher.onHideWhitespaceInDiffChanged(
+    await this.props.dispatcher.onHideWhitespaceInHistoryDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository,
       this.props.selectedFile as CommittedFileChange

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -190,10 +190,8 @@ export class SelectedCommit extends React.Component<
     }
   }
 
-  private onHideWhitespaceInDiffChanged = async (
-    hideWhitespaceInDiff: boolean
-  ) => {
-    await this.props.dispatcher.onHideWhitespaceInHistoryDiffChanged(
+  private onHideWhitespaceInDiffChanged = (hideWhitespaceInDiff: boolean) => {
+    return this.props.dispatcher.onHideWhitespaceInHistoryDiffChanged(
       hideWhitespaceInDiff,
       this.props.repository,
       this.props.selectedFile as CommittedFileChange

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -46,7 +46,8 @@ interface IRepositoryViewProps {
   readonly gitHubUserStore: GitHubUserStore
   readonly onViewCommitOnGitHub: (SHA: string) => void
   readonly imageDiffType: ImageDiffType
-  readonly hideWhitespaceInDiff: boolean
+  readonly hideWhitespaceInChangesDiff: boolean
+  readonly hideWhitespaceInHistoryDiff: boolean
   readonly showSideBySideDiff: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly focusCommitMessage: boolean
@@ -371,7 +372,7 @@ export class RepositoryView extends React.Component<
         selectedDiffType={this.props.imageDiffType}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
-        hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
+        hideWhitespaceInDiff={this.props.hideWhitespaceInHistoryDiff}
         showSideBySideDiff={this.props.showSideBySideDiff}
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}
@@ -449,7 +450,7 @@ export class RepositoryView extends React.Component<
           diff={diff}
           isCommitting={this.props.state.isCommitting}
           imageDiffType={this.props.imageDiffType}
-          hideWhitespaceInDiff={this.props.hideWhitespaceInDiff}
+          hideWhitespaceInDiff={this.props.hideWhitespaceInChangesDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
           onOpenBinaryFile={this.onOpenBinaryFile}
           onChangeImageDiffType={this.onChangeImageDiffType}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Follow up from #6818

## Description

- Decouples the hide whitespace changes in Changes and History Tabs

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: No notes (covered in #6818)
