### PR TITLE
Diff expansion, part VI: refactor split diff to use data from state instead of props

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -70,7 +70,7 @@ interface ISideBySideDiffProps {
   /** The file whose diff should be displayed. */
   readonly file: ChangedFile
 
-  /** The diff that should be rendered */
+  /** The initial diff */
   readonly diff: ITextDiff
 
   /**
@@ -101,6 +101,9 @@ interface ISideBySideDiffProps {
 }
 
 interface ISideBySideDiffState {
+  /** The diff that should be rendered */
+  readonly diff: ITextDiff
+
   /**
    * The list of syntax highlighting tokens corresponding to
    * the previous contents of the file.
@@ -174,6 +177,7 @@ export class SideBySideDiff extends React.Component<
     super(props)
 
     this.state = {
+      diff: props.diff,
       isSearching: false,
       selectedSearchResult: undefined,
     }
@@ -195,15 +199,24 @@ export class SideBySideDiff extends React.Component<
     document.removeEventListener('find-text', this.showSearch)
   }
 
-  public componentDidUpdate(prevProps: ISideBySideDiffProps) {
-    if (!highlightParametersEqual(this.props, prevProps)) {
+  public componentDidUpdate(
+    prevProps: ISideBySideDiffProps,
+    prevState: ISideBySideDiffState
+  ) {
+    if (
+      !highlightParametersEqual(this.props, prevProps, this.state, prevState)
+    ) {
       this.initDiffSyntaxMode()
       this.clearListRowsHeightCache()
+    }
+
+    if (this.props.diff.text !== prevProps.diff.text) {
+      this.setState({ diff: this.props.diff })
     }
   }
 
   public render() {
-    const rows = getDiffRows(this.props.diff, this.props.showSideBySideDiff)
+    const rows = getDiffRows(this.state.diff, this.props.showSideBySideDiff)
     const containerClassName = classNames('side-by-side-diff-container', {
       'unified-diff': !this.props.showSideBySideDiff,
       [`selecting-${this.state.selectingTextInRow}`]:
@@ -253,7 +266,7 @@ export class SideBySideDiff extends React.Component<
   }
 
   private renderRow = ({ index, parent, style, key }: ListRowProps) => {
-    const rows = getDiffRows(this.props.diff, this.props.showSideBySideDiff)
+    const rows = getDiffRows(this.state.diff, this.props.showSideBySideDiff)
     const row = rows[index]
 
     if (row === undefined) {
@@ -303,25 +316,41 @@ export class SideBySideDiff extends React.Component<
   }
 
   private async initDiffSyntaxMode() {
-    const { file, diff, repository } = this.props
+    const { file, repository } = this.props
+    const { diff } = this.state
 
-    // Store the current props to that we can see if anything
+    // Store the current props and state to that we can see if anything
     // changes from underneath us as we're making asynchronous
     // operations that makes our data stale or useless.
     const propsSnapshot = this.props
+    const stateSnapshot = this.state
 
     const lineFilters = getLineFilters(diff.hunks)
     const tabSize = 4
 
     const contents = await getFileContents(repository, file, lineFilters)
 
-    if (!highlightParametersEqual(this.props, propsSnapshot)) {
+    if (
+      !highlightParametersEqual(
+        this.props,
+        propsSnapshot,
+        this.state,
+        stateSnapshot
+      )
+    ) {
       return
     }
 
     const tokens = await highlightContents(contents, tabSize, lineFilters)
 
-    if (!highlightParametersEqual(this.props, propsSnapshot)) {
+    if (
+      !highlightParametersEqual(
+        this.props,
+        propsSnapshot,
+        this.state,
+        stateSnapshot
+      )
+    ) {
       return
     }
 
@@ -471,7 +500,7 @@ export class SideBySideDiff extends React.Component<
     rowNumber: number,
     column: DiffColumn
   ): number | null {
-    const rows = getDiffRows(this.props.diff, this.props.showSideBySideDiff)
+    const rows = getDiffRows(this.state.diff, this.props.showSideBySideDiff)
     const row = rows[rowNumber]
 
     if (row === undefined) {
@@ -588,7 +617,7 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const { diff } = this.props
+    const { diff } = this.state
     const selection = this.getSelection()
 
     if (selection !== undefined) {
@@ -623,7 +652,9 @@ export class SideBySideDiff extends React.Component<
    * @param diffLineNumber the line number the diff where the user clicked
    */
   private onContextMenuLine = (diffLineNumber: number) => {
-    const { file, diff } = this.props
+    const { file } = this.props
+    const { diff } = this.state
+
     if (!canSelect(file)) {
       return
     }
@@ -660,7 +691,7 @@ export class SideBySideDiff extends React.Component<
     }
 
     const range = findInteractiveOriginalDiffRange(
-      this.props.diff.hunks,
+      this.state.diff.hunks,
       hunkStartLine
     )
     if (range === null || range.type === null) {
@@ -709,6 +740,8 @@ export class SideBySideDiff extends React.Component<
       .withSelectNone()
       .withRangeSelection(startLine, endLine - startLine + 1, true)
 
+    // Pass the original diff (from props) instead of the (potentially)
+    // expanded one.
     this.props.onDiscardChanges(this.props.diff, newSelection)
   }
 
@@ -735,7 +768,8 @@ export class SideBySideDiff extends React.Component<
 
   private onSearch = (searchQuery: string, direction: 'next' | 'previous') => {
     let { selectedSearchResult, searchResults: searchResults } = this.state
-    const { diff, showSideBySideDiff } = this.props
+    const { showSideBySideDiff } = this.props
+    const { diff } = this.state
 
     // If the query is unchanged and we've got tokens we'll continue, else we'll restart
     if (searchQuery === this.state.searchQuery && searchResults !== undefined) {
@@ -791,13 +825,15 @@ export class SideBySideDiff extends React.Component<
  */
 function highlightParametersEqual(
   newProps: ISideBySideDiffProps,
-  prevProps: ISideBySideDiffProps
+  prevProps: ISideBySideDiffProps,
+  newState: ISideBySideDiffState,
+  prevState: ISideBySideDiffState
 ) {
   return (
-    newProps === prevProps ||
-    (newProps.file.id === prevProps.file.id &&
-      newProps.diff.text === prevProps.diff.text &&
-      newProps.showSideBySideDiff === prevProps.showSideBySideDiff)
+    (newProps === prevProps ||
+      (newProps.file.id === prevProps.file.id &&
+        newProps.showSideBySideDiff === prevProps.showSideBySideDiff)) &&
+    newState.diff.text === prevState.diff.text
   )
 }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -319,7 +319,7 @@ export class SideBySideDiff extends React.Component<
     const { file, repository } = this.props
     const { diff } = this.state
 
-    // Store the current props and state to that we can see if anything
+    // Store the current props and state so that we can see if anything
     // changes from underneath us as we're making asynchronous
     // operations that makes our data stale or useless.
     const propsSnapshot = this.props


### PR DESCRIPTION
## Description

The changes in this PR are quite simple, they just refactor the side-by-side diff view to grab the diff data from the state instead of doing so from its props. Thanks to this change, it can (in upcoming PRs) modify the diff by expanding it.

## Release notes

Notes: no-notes
