### PR TITLE
Diff expansion, part VII: add dummy hunk to allow expanding diffs from the bottom in split view

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -47,6 +47,8 @@ import { showContextualMenu } from '../main-process-proxy'
 import { getTokens } from './diff-syntax-mode'
 import { DiffSearchInput } from './diff-search-input'
 import { escapeRegExp } from '../../lib/helpers/regex'
+import { enableTextDiffExpansion } from '../../lib/feature-flag'
+import { getTextDiffWithBottomDummyHunk } from './text-diff-expansion'
 
 const DefaultRowHeight = 20
 const MaxLineLengthToCalculateDiff = 240
@@ -354,7 +356,19 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
+    const newContentLines = contents.newContents.split('\n')
+    const oldContentLines = contents.oldContents.split('\n')
+    const currentDiff = this.state.diff
+    const newDiff = enableTextDiffExpansion()
+      ? getTextDiffWithBottomDummyHunk(
+          currentDiff,
+          currentDiff.hunks,
+          oldContentLines.length,
+          newContentLines.length
+        )
+      : null
     this.setState({
+      diff: newDiff ?? currentDiff,
       beforeTokens: tokens.oldTokens,
       afterTokens: tokens.newTokens,
     })


### PR DESCRIPTION
## Description

This change adds the dummy hunk at the bottom of the diff so that it can be expanded there in split view.

I noticed that we display `@ @@` instead of `@@ @@`. That's a bug existing in prod that will be fixed in an upcoming PR.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/113584015-a969ad00-962a-11eb-9443-1359ac379f9a.png)

## Release notes

Notes: no-notes
