### PR TITLE
Diff expansion, part VIII: render hunk expansion handlers in split view

### DIFF
--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -185,6 +185,9 @@ interface IDiffRowHunk {
 
   /** How the hunk can be expanded. */
   readonly expansionType: DiffHunkExpansionType
+
+  /** Index of the hunk in the diff. */
+  readonly hunkIndex: number
 }
 
 export type DiffRow =

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -9,9 +9,11 @@ import {
 } from './diff-helpers'
 import { ILineTokens } from '../../lib/highlighter/types'
 import classNames from 'classnames'
-import { Octicon } from '../octicons'
+import { Octicon, OcticonSymbol } from '../octicons'
 import { narrowNoNewlineSymbol } from './text-diff'
 import { shallowEquals, structuralEquals } from '../../lib/equality'
+import { DiffHunkExpansionType } from '../../models/diff'
+import { ExpansionKind } from './text-diff-expansion'
 
 interface ISideBySideDiffRowProps {
   /**
@@ -72,6 +74,8 @@ interface ISideBySideDiffRowProps {
    */
   readonly onMouseLeaveHunk: (hunkStartLine: number) => void
 
+  readonly onExpandHunk: (hunkIndex: number, kind: ExpansionKind) => void
+
   /**
    * Called when the user clicks on the hunk handle. Called with the start
    * line of the hunk and a flag indicating whether to select or unselect
@@ -107,13 +111,19 @@ export class SideBySideDiffRow extends React.Component<
     const { row, showSideBySideDiff } = this.props
 
     switch (row.type) {
-      case DiffRowType.Hunk:
+      case DiffRowType.Hunk: {
+        const className = ['row', 'hunk-info']
+        if (row.expansionType === DiffHunkExpansionType.Both) {
+          className.push('expandable-both')
+        }
+
         return (
-          <div className="row hunk-info">
-            {this.renderLineNumber()}
+          <div className={classNames(className)}>
+            {this.renderHunkHeaderGutter(row.hunkIndex, row.expansionType)}
             {this.renderContentFromString(row.content)}
           </div>
         )
+      }
       case DiffRowType.Context:
         const { beforeLineNumber, afterLineNumber } = row
         if (!showSideBySideDiff) {
@@ -256,6 +266,86 @@ export class SideBySideDiffRow extends React.Component<
         )}
       </div>
     )
+  }
+
+  private getHunkExpansionElementInfo(
+    hunkIndex: number,
+    expansionType: DiffHunkExpansionType
+  ) {
+    switch (expansionType) {
+      // This can only be the first hunk
+      case DiffHunkExpansionType.Up:
+        return {
+          icon: OcticonSymbol.foldUp,
+          title: 'Expand Up',
+          handler: this.onExpandHunk(hunkIndex, 'up'),
+        }
+      // This can only be the last dummy hunk. In this case, we expand the
+      // second to last hunk down.
+      case DiffHunkExpansionType.Down:
+        return {
+          icon: OcticonSymbol.foldDown,
+          title: 'Expand Down',
+          handler: this.onExpandHunk(hunkIndex - 1, 'down'),
+        }
+      case DiffHunkExpansionType.Short:
+        return {
+          icon: OcticonSymbol.fold,
+          title: 'Expand All',
+          handler: this.onExpandHunk(hunkIndex, 'up'),
+        }
+    }
+
+    throw new Error(`Unexpected expansion type ${expansionType}`)
+  }
+
+  private renderHunkExpansionHandle(
+    hunkIndex: number,
+    expansionType: DiffHunkExpansionType
+  ) {
+    if (expansionType === DiffHunkExpansionType.None) {
+      return (
+        <div className="hunk-expansion-handle">
+          <span></span>
+        </div>
+      )
+    }
+
+    const elementInfo = this.getHunkExpansionElementInfo(
+      hunkIndex,
+      expansionType
+    )
+
+    return (
+      <div
+        className="hunk-expansion-handle selectable"
+        title={elementInfo.title}
+        onClick={elementInfo.handler}
+      >
+        <span>
+          <Octicon symbol={elementInfo.icon} />
+        </span>
+      </div>
+    )
+  }
+
+  private renderHunkHeaderGutter(
+    hunkIndex: number,
+    expansionType: DiffHunkExpansionType
+  ) {
+    if (expansionType === DiffHunkExpansionType.Both) {
+      return (
+        <div>
+          {this.renderHunkExpansionHandle(
+            hunkIndex,
+            DiffHunkExpansionType.Down
+          )}
+          {this.renderHunkExpansionHandle(hunkIndex, DiffHunkExpansionType.Up)}
+        </div>
+      )
+    }
+
+    return this.renderHunkExpansionHandle(hunkIndex, expansionType)
   }
 
   private renderHunkHandle() {
@@ -405,6 +495,10 @@ export class SideBySideDiffRow extends React.Component<
     if ('hunkStartLine' in this.props.row) {
       this.props.onMouseLeaveHunk(this.props.row.hunkStartLine)
     }
+  }
+
+  private onExpandHunk = (hunkIndex: number, kind: ExpansionKind) => () => {
+    this.props.onExpandHunk(hunkIndex, kind)
   }
 
   private onClickHunk = () => {

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -93,6 +93,37 @@
     }
   }
 
+  .row .hunk-expansion-handle {
+    width: var(--width-line-number);
+    flex-shrink: 0;
+    background: var(--diff-hunk-background-color);
+    color: var(--diff-hunk-text-color);
+    display: flex;
+    box-sizing: content-box;
+
+    span {
+      width: 100%;
+      height: 100%;
+      padding: 0 var(--spacing-half);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px 0;
+    }
+
+    &.selectable {
+      * {
+        cursor: pointer;
+      }
+
+      &:hover {
+        background: var(--diff-hover-background-color);
+        border-color: var(--diff-hover-border-color);
+        color: var(--diff-hover-text-color);
+      }
+    }
+  }
+
   .hunk-handle {
     position: absolute;
     height: 100%;
@@ -180,6 +211,7 @@
     &.hunk-info {
       background: var(--diff-hunk-background-color);
       color: var(--diff-hunk-text-color);
+      align-items: center;
 
       div,
       span {


### PR DESCRIPTION
## Description

These changes just add the hunk expansion handlers to the split view. It also fixes the bug I mentioned in the previous PR about a character being deleted in the hunk headers.

### Screenshots

https://user-images.githubusercontent.com/1083228/113584619-6956fa00-962b-11eb-9919-40bbc3c079c3.mov

## Release notes

Notes: no-notes
