### PR TITLE
Diff expansion, part X: fix selection of expanded diffs in split view

### DIFF
--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -46,11 +46,10 @@ export interface IDiffRowData {
   readonly lineNumber: number
 
   /**
-   * The line number on the diff.
-   * This is used for discarding lines
-   * and for partial committing lines.
+   * The line number on the original diff (without expansion).
+   * This is used for discarding lines and for partial committing lines.
    */
-  readonly diffLineNumber: number
+  readonly diffLineNumber: number | null
 
   /**
    * Flag to display that this diff line lacks a new line.

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -517,7 +517,7 @@ export class SideBySideDiffRow extends React.Component<
 
   private onContextMenuLineNumber = (evt: React.MouseEvent) => {
     const data = this.getDiffData(evt.currentTarget)
-    if (data !== null) {
+    if (data !== null && data.diffLineNumber !== null) {
       this.props.onContextMenuLine(data.diffLineNumber)
     }
   }

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -480,13 +480,15 @@ export class SideBySideDiff extends React.Component<
     return {
       ...data,
       tokens: finalTokens,
-      isSelected: isInSelection(
-        data.diffLineNumber,
-        row,
-        column,
-        this.getSelection(),
-        this.state.temporarySelection
-      ),
+      isSelected:
+        data.diffLineNumber !== null &&
+        isInSelection(
+          data.diffLineNumber,
+          row,
+          column,
+          this.getSelection(),
+          this.state.temporarySelection
+        ),
     }
   }
 
@@ -1127,7 +1129,7 @@ function getDataFromLine(
   return {
     content: line.content,
     lineNumber,
-    diffLineNumber,
+    diffLineNumber: line.originalLineNumber,
     noNewLineIndicator: line.noTrailingNewLine,
     tokens,
   }


### PR DESCRIPTION
## Description

This PR fixes the selection of changes from a expanded diff in split view. Basically, instead of using the line number in the expanded diff, it uses the line number in the original diff (which all added/deleted lines should have).

## Release notes

Notes: no-notes
