### PR TITLE
Use a save dialog instead of an open dialog when choosing where to clone a repo

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -165,3 +165,8 @@ export function enableCherryPicking(): boolean {
 export function enableTextDiffExpansion(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should we allow using the save dialog when choosing where to clone a repo */
+export function enableSaveDialogOnCloneRepository(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -503,27 +503,24 @@ export class CloneRepository extends React.Component<
   }
 
   private onChooseDirectory = async () => {
+    const tabState = this.getSelectedTabState()
     const window = remote.getCurrentWindow()
-    const { filePaths } = await remote.dialog.showOpenDialog(window, {
-      properties: ['createDirectory', 'openDirectory'],
+
+    const { canceled, filePath } = await remote.dialog.showSaveDialog(window, {
+      buttonLabel: 'Select',
+      nameFieldLabel: 'Clone As:',
+      showsTagField: false,
+      defaultPath: tabState.path,
+      properties: ['createDirectory'],
     })
 
-    if (filePaths.length === 0) {
+    if (canceled || filePath == null) {
       return
     }
 
-    const tabState = this.getSelectedTabState()
-    const lastParsedIdentifier = tabState.lastParsedIdentifier
-    const directory = lastParsedIdentifier
-      ? Path.join(filePaths[0], lastParsedIdentifier.name)
-      : filePaths[0]
+    this.setSelectedTabState({ path: filePath, error: null }, this.validatePath)
 
-    this.setSelectedTabState(
-      { path: directory, error: null },
-      this.validatePath
-    )
-
-    return directory
+    return filePath
   }
 
   private updateUrl = async (url: string) => {

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -567,6 +567,13 @@ export class CloneRepository extends React.Component<
         )
       }
     } catch (error) {
+      if (error.code === 'ENOTDIR') {
+        // path refers to a file or other file system entry
+        return new Error(
+          'There is already a file with this name. Git can only clone to a folder.'
+        )
+      }
+
       if (error.code === 'ENOENT') {
         // Folder does not exist
         return null


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes [N/A]

## Description

Since cloning a repo creates a directory, display a save dialog instead of an open dialog when picking a location to clone to.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="1072" alt="Screenshot_2021-04-05 17 25 02" src="https://user-images.githubusercontent.com/25517624/113629077-dec6c880-9633-11eb-9691-68589013b89c.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Improves the dialog box shown when picking a location to clone a repository to
