### PR TITLE
Fix some issues expanding diffs

### DIFF
--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -49,12 +49,17 @@ function mergeDiffHunks(hunk1: DiffHunk, hunk2: DiffHunk): DiffHunk {
     false
   )
 
+  const newHunkLines = [
+    newFirstHunkLine,
+    ...allHunk1LinesButFirst,
+    ...allHunk2LinesButFirst,
+  ]
+
   return new DiffHunk(
     newHunkHeader,
-    [newFirstHunkLine, ...allHunk1LinesButFirst, ...allHunk2LinesButFirst],
+    newHunkLines,
     hunk1.unifiedDiffStart,
-    // This -1 represents the header line of the second hunk that we removed
-    hunk2.unifiedDiffEnd - 1,
+    hunk1.unifiedDiffStart + newHunkLines.length,
     // The expansion type of the resulting hunk will match the expansion type
     // of the first hunk:
     // - If the first hunk can be expanded up, it means it's the very first


### PR DESCRIPTION
## Description

This PR fixes two issues:
1. Right now the app is avoiding to load and highlight the old/new file contents when there are only added lines or only removed lines, but not both kinds of lines. However, for diff expansion we need to at least **load** both file contents, and keep the new file contents around for expansion.
2. When 2 hunks are merged expanding down, the "adjacent" hunk is not updated so its `unifiedDiffEnd` was wrong, and we were using it for the new merged hunk 😓  Here we change the logic to one that should always work.

## Release notes

Notes: no-notes
