### PR TITLE
Allow expanding whole files in diff views

### DIFF
--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -5,7 +5,7 @@ import { ITokens } from '../../lib/highlighter/types'
 
 import 'codemirror/mode/javascript/javascript'
 import { enableTextDiffExpansion } from '../../lib/feature-flag'
-import { DiffExpansionStep } from './text-diff-expansion'
+import { DefaultDiffExpansionStep } from './text-diff-expansion'
 
 export interface IDiffSyntaxModeOptions {
   /**
@@ -153,7 +153,8 @@ export class DiffSyntaxMode {
           // will be used to make that line taller to fit the expansion buttons.
           if (
             state.previousHunkOldEndLine !== null &&
-            oldStartLine - state.previousHunkOldEndLine > DiffExpansionStep
+            oldStartLine - state.previousHunkOldEndLine >
+              DefaultDiffExpansionStep
           ) {
             result += ` line-${token}-expandable-both`
           }

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -99,6 +99,11 @@ interface ISideBySideDiffRowProps {
   readonly onContextMenuHunk: (hunkStartLine: number) => void
 
   /**
+   * Called when the user right-clicks a hunk expansion handle.
+   */
+  readonly onContextMenuExpandHunk: () => void
+
+  /**
    * Called when the user right-clicks text on the diff.
    */
   readonly onContextMenuText: () => void
@@ -305,7 +310,10 @@ export class SideBySideDiffRow extends React.Component<
   ) {
     if (expansionType === DiffHunkExpansionType.None) {
       return (
-        <div className="hunk-expansion-handle">
+        <div
+          className="hunk-expansion-handle"
+          onContextMenu={this.props.onContextMenuExpandHunk}
+        >
           <span></span>
         </div>
       )
@@ -321,6 +329,7 @@ export class SideBySideDiffRow extends React.Component<
         className="hunk-expansion-handle selectable"
         title={elementInfo.title}
         onClick={elementInfo.handler}
+        onContextMenu={this.props.onContextMenuExpandHunk}
       >
         <span>
           <Octicon symbol={elementInfo.icon} />

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -13,7 +13,7 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { narrowNoNewlineSymbol } from './text-diff'
 import { shallowEquals, structuralEquals } from '../../lib/equality'
 import { DiffHunkExpansionType } from '../../models/diff'
-import { ExpansionKind } from './text-diff-expansion'
+import { DiffExpansionKind } from './text-diff-expansion'
 
 interface ISideBySideDiffRowProps {
   /**
@@ -74,7 +74,7 @@ interface ISideBySideDiffRowProps {
    */
   readonly onMouseLeaveHunk: (hunkStartLine: number) => void
 
-  readonly onExpandHunk: (hunkIndex: number, kind: ExpansionKind) => void
+  readonly onExpandHunk: (hunkIndex: number, kind: DiffExpansionKind) => void
 
   /**
    * Called when the user clicks on the hunk handle. Called with the start
@@ -497,7 +497,7 @@ export class SideBySideDiffRow extends React.Component<
     }
   }
 
-  private onExpandHunk = (hunkIndex: number, kind: ExpansionKind) => () => {
+  private onExpandHunk = (hunkIndex: number, kind: DiffExpansionKind) => () => {
     this.props.onExpandHunk(hunkIndex, kind)
   }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -372,8 +372,11 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const newContentLines = contents.newContents.split('\n')
-    const oldContentLines = contents.oldContents.split('\n')
+    const newContentLines =
+      contents.newContents === null ? [] : contents.newContents.split('\n')
+    const oldContentLines =
+      contents.oldContents === null ? [] : contents.oldContents.split('\n')
+
     const currentDiff = this.state.diff
     const newDiff = enableTextDiffExpansion()
       ? getTextDiffWithBottomDummyHunk(

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -50,7 +50,7 @@ import { escapeRegExp } from '../../lib/helpers/regex'
 import { enableTextDiffExpansion } from '../../lib/feature-flag'
 import {
   expandTextDiffHunk,
-  ExpansionKind,
+  DiffExpansionKind,
   getTextDiffWithBottomDummyHunk,
 } from './text-diff-expansion'
 
@@ -636,7 +636,7 @@ export class SideBySideDiff extends React.Component<
     this.setState({ hoveredHunk: undefined })
   }
 
-  private onExpandHunk = (hunkIndex: number, kind: ExpansionKind) => {
+  private onExpandHunk = (hunkIndex: number, kind: DiffExpansionKind) => {
     const { diff } = this.state
 
     if (hunkIndex === -1 || hunkIndex >= diff.hunks.length) {
@@ -850,7 +850,7 @@ export class SideBySideDiff extends React.Component<
   }
 
   /** Expand a selected hunk. */
-  private expandHunk(hunk: DiffHunk, kind: ExpansionKind) {
+  private expandHunk(hunk: DiffHunk, kind: DiffExpansionKind) {
     const { diff } = this.state
 
     if (this.newContentLines === null || this.newContentLines.length === 0) {

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -6,6 +6,7 @@ import {
   DiffHunk,
   DiffLine,
   DiffSelection,
+  DiffHunkExpansionType,
 } from '../../models/diff'
 import {
   getLineFilters,
@@ -731,10 +732,16 @@ export class SideBySideDiff extends React.Component<
       return null
     }
 
+    const diff = this.state.diff
+
     return this.diffToRestore === null
       ? {
           label: __DARWIN__ ? 'Expand Whole File' : 'Expand whole file',
           action: this.onExpandWholeFile,
+          // If there is only one hunk that can't be expanded, disable this item
+          enabled:
+            diff.hunks.length !== 1 ||
+            diff.hunks[0].expansionType !== DiffHunkExpansionType.None,
         }
       : {
           label: __DARWIN__

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -225,6 +225,7 @@ export class SideBySideDiff extends React.Component<
     }
 
     if (this.props.diff.text !== prevProps.diff.text) {
+      this.diffToRestore = null
       this.setState({ diff: this.props.diff })
     }
   }

--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -134,7 +134,12 @@ export function expandWholeTextDiff(
 
   // The logic is to keep expanding the first hunk until it's the only one.
   // First expand the first hunk up, and then down as many times as possible.
-  while (result.hunks.length > 1) {
+  // If there is only one hunk, just expand it once up.
+  while (
+    result.hunks.length > 1 ||
+    (result.hunks.length === 1 &&
+      result.hunks[0].expansionType === DiffHunkExpansionType.Up)
+  ) {
     const firstHunk = result.hunks[0]
 
     const partialResult = expandTextDiffHunk(

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1393,6 +1393,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     }
 
     if (this.props.diff.text !== prevProps.diff.text) {
+      this.diffToRestore = null
       this.setState({ diff: this.props.diff })
     }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -679,10 +679,16 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       return null
     }
 
+    const diff = this.state.diff
+
     return this.diffToRestore === null
       ? {
           label: __DARWIN__ ? 'Expand Whole File' : 'Expand whole file',
           action: this.onExpandWholeFile,
+          // If there is only one hunk that can't be expanded, disable this item
+          enabled:
+            diff.hunks.length !== 1 ||
+            diff.hunks[0].expansionType !== DiffHunkExpansionType.None,
         }
       : {
           label: __DARWIN__

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -50,8 +50,9 @@ import {
 import { canSelect } from './diff-helpers'
 import {
   expandTextDiffHunk,
-  ExpansionKind,
+  DiffExpansionKind,
   getTextDiffWithBottomDummyHunk,
+  expandWholeTextDiff,
 } from './text-diff-expansion'
 import { createOcticonElement } from '../octicons/octicon'
 
@@ -341,6 +342,9 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   /** The content lines of the "new" file */
   private newContentLines: ReadonlyArray<string> | null = null
 
+  /** Diff to restore when "Collapse all expanded lines" option is used */
+  private diffToRestore: ITextDiff | null = null
+
   /** Whether a particular range should be highlighted due to hover */
   private hunkHighlightRange: ISelection | null = null
 
@@ -609,15 +613,13 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   }
 
   /** Expand a selected hunk. */
-  private expandHunk(hunk: DiffHunk, kind: ExpansionKind) {
-    const diff = this.state.diff
-
+  private expandHunk(hunk: DiffHunk, kind: DiffExpansionKind) {
     if (this.newContentLines === null || this.newContentLines.length === 0) {
       return
     }
 
     const updatedDiff = expandTextDiffHunk(
-      diff,
+      this.state.diff,
       hunk,
       kind,
       this.newContentLines
@@ -653,12 +655,41 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       },
     ]
 
+    const expandMenuItem = this.buildExpandMenuItem(event)
+    if (expandMenuItem !== null) {
+      items.push({ type: 'separator' }, expandMenuItem)
+    }
+
     const discardMenuItems = this.buildDiscardMenuItems(instance, event)
     if (discardMenuItems !== null) {
       items.push({ type: 'separator' }, ...discardMenuItems)
     }
 
     showContextualMenu(items)
+  }
+
+  private buildExpandMenuItem(event: Event): IMenuItem | null {
+    if (!enableTextDiffExpansion()) {
+      return null
+    }
+
+    if (!(event instanceof MouseEvent)) {
+      // We can only infer which line was clicked when the context menu is opened
+      // via a mouse event.
+      return null
+    }
+
+    return this.diffToRestore === null
+      ? {
+          label: __DARWIN__ ? 'Expand Whole File' : 'Expand whole file',
+          action: this.onExpandWholeFile,
+        }
+      : {
+          label: __DARWIN__
+            ? 'Collapse Expanded Lines'
+            : 'Collapse expanded lines',
+          action: this.onCollapseExpandedLines,
+        }
   }
 
   private buildDiscardMenuItems(
@@ -751,6 +782,41 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     // Pass the original diff (from props) instead of the (potentially)
     // expanded one.
     this.props.onDiscardChanges(this.props.diff, selection)
+  }
+
+  private onExpandWholeFile = () => {
+    if (this.newContentLines === null || this.newContentLines.length === 0) {
+      return
+    }
+
+    const updatedDiff = expandWholeTextDiff(
+      this.state.diff,
+      this.newContentLines
+    )
+
+    if (updatedDiff === undefined) {
+      return
+    }
+
+    this.diffToRestore = this.state.diff
+
+    this.setState({
+      diff: updatedDiff,
+    })
+    this.updateViewport()
+  }
+
+  private onCollapseExpandedLines = () => {
+    if (this.diffToRestore === null) {
+      return
+    }
+
+    this.setState({
+      diff: this.diffToRestore,
+    })
+    this.updateViewport()
+
+    this.diffToRestore = null
   }
 
   private getDiscardLabel(rangeType: DiffRangeType, numLines: number): string {
@@ -1118,7 +1184,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   private onHunkExpandHalfHandleMouseDown = (
     hunks: ReadonlyArray<DiffHunk>,
     hunk: DiffHunk,
-    kind: ExpansionKind,
+    kind: DiffExpansionKind,
     ev: MouseEvent
   ) => {
     if (!this.codeMirror) {

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -415,8 +415,10 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       return
     }
 
-    const newContentLines = contents.newContents.split('\n')
-    const oldContentLines = contents.oldContents.split('\n')
+    const newContentLines =
+      contents.newContents === null ? [] : contents.newContents.split('\n')
+    const oldContentLines =
+      contents.oldContents === null ? [] : contents.oldContents.split('\n')
 
     const currentDiff = this.state.diff
     const newDiff = enableTextDiffExpansion()


### PR DESCRIPTION
## Description

This PR adds the ability to expand diffs completely, and then collapse them back to their previous state. All this from the context menu.

### Screenshots

https://user-images.githubusercontent.com/1083228/113877074-a1d80e80-97b8-11eb-9d58-2a939cf3b450.mov

## Release notes

Notes: no-notes
