### PR TITLE
Fix spacing of release notes

### DIFF
--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -88,6 +88,7 @@
       flex: 1 1 275px;
       max-width: 75%;
       margin: 0 calc(var(--spacing) * 1.5);
+      height: 100%;
 
       .section {
         margin: var(--spacing-double) 0;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes [N/A]

## Description

- Fix spacing at bottom of release notes

### Screenshots

Before/after (when scrolled to the bottom):
<img width="259" alt="Screenshot_2021-04-07 12 06 26" src="https://user-images.githubusercontent.com/25517624/113898561-fc15a700-9799-11eb-809b-618eeaa80562.png">
<img width="263" alt="Screenshot_2021-04-07 12 08 14" src="https://user-images.githubusercontent.com/25517624/113898568-fd46d400-9799-11eb-8033-3723ed9547e7.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
