### PR TITLE
Cherry picking snapshot bug

### DIFF
--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -83,7 +83,7 @@ class GitCherryPickParser {
       kind: 'cherryPick',
       title: `Cherry-picking commit ${this.count} of ${this.commits.length} commits`,
       value: round(this.count / this.commits.length, 2),
-      cherryPickCommitCount: this.count,
+      position: this.count,
       totalCommitCount: this.commits.length,
       currentCommitSummary: this.commits[this.count - 1]?.summary ?? '',
     }
@@ -319,21 +319,21 @@ export async function getCherryPickSnapshot(
   }
 
   const commits = [...commitsCherryPicked, ...remainingCommits]
-  const count = commitsCherryPicked.length + 1
+  const position = commitsCherryPicked.length + 1
 
   return {
     progress: {
       kind: 'cherryPick',
-      title: `Cherry-picking commit ${count} of ${commits.length} commits`,
-      value: round(count / commits.length, 2),
-      cherryPickCommitCount: count,
+      title: `Cherry-picking commit ${position} of ${commits.length} commits`,
+      value: round(position / commits.length, 2),
+      position,
       totalCommitCount: commits.length,
       currentCommitSummary: remainingCommits[0].summary ?? '',
     },
     remainingCommits,
     commits,
     targetBranchUndoSha: headSha,
-    countCherryPicked: commitsCherryPicked.length,
+    cherryPickedCount: commitsCherryPicked.length,
   }
 }
 
@@ -413,7 +413,7 @@ export async function continueCherryPick(
       options,
       snapshot.commits,
       progressCallback,
-      snapshot.countCherryPicked
+      snapshot.cherryPickedCount
     )
   }
 

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -320,8 +320,9 @@ export async function getCherryPickSnapshot(
   }
 
   const commits = [...commitsCherryPicked, ...remainingCommits]
+  const { length } = commitsCherryPicked
+  const count = length > 0 ? length : length + 1
 
-  const count = commitsCherryPicked.length + 1
   return {
     progress: {
       kind: 'cherryPick',
@@ -329,7 +330,10 @@ export async function getCherryPickSnapshot(
       value: round(count / commits.length, 2),
       cherryPickCommitCount: count,
       totalCommitCount: commits.length,
-      currentCommitSummary: remainingCommits[0].summary ?? '',
+      currentCommitSummary:
+        length > 0
+          ? commitsCherryPicked[length - 1].summary
+          : remainingCommits[0].summary,
     },
     remainingCommits: commits.slice(count, commits.length),
     commits,

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -237,8 +237,8 @@ export async function getCherryPickSnapshot(
   // branch before the cherry-pick operation occurred.
   let headSha: string = ''
 
-  // Each line of .git/sequencer/todo holds a sha of a commits to lined up to be
-  // cherry-picked. These sha are in historical order starting oldest commit as
+  // Each line of .git/sequencer/todo holds a sha of a commit lined up to be
+  // cherry-picked. These shas are in historical order starting oldest commit as
   // the first line and newest as the last line.
   const remainingCommits: CommitOneLine[] = []
 
@@ -319,13 +319,6 @@ export async function getCherryPickSnapshot(
   }
 
   const commits = [...commitsCherryPicked, ...remainingCommits]
-
-  if (commits === null) {
-    // This should only be possible with corrupt sequencer files resulting in a
-    // bad revision range.
-    return null
-  }
-
   const count = commitsCherryPicked.length + 1
 
   return {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5847,7 +5847,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           kind: 'cherryPick',
           title: `Cherry-picking commit 1 of ${commits.length} commits`,
           value: 0,
-          cherryPickCommitCount: 1,
+          position: 1,
           totalCommitCount: commits.length,
           currentCommitSummary: commits[commits.length - 1].summary,
         },

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -5849,7 +5849,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
           value: 0,
           cherryPickCommitCount: 1,
           totalCommitCount: commits.length,
-          currentCommitSummary: commits[0].summary,
+          currentCommitSummary: commits[commits.length - 1].summary,
         },
       }
     })

--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -15,6 +15,8 @@ export interface ICherryPickSnapshot {
   readonly progress: ICherryPickProgress
   /** The sha of the target branch tip before cherry pick initiated. */
   readonly targetBranchUndoSha: string
+  /** The number of commits already cherry-picked */
+  readonly countCherryPicked: number
 }
 
 /** Union type representing the possible states of the cherry pick flow */

--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -16,7 +16,7 @@ export interface ICherryPickSnapshot {
   /** The sha of the target branch tip before cherry pick initiated. */
   readonly targetBranchUndoSha: string
   /** The number of commits already cherry-picked */
-  readonly countCherryPicked: number
+  readonly cherryPickedCount: number
 }
 
 /** Union type representing the possible states of the cherry pick flow */

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -115,8 +115,9 @@ export interface ICherryPickProgress extends IProgress {
   readonly kind: 'cherryPick'
   /** The summary of the commit applied to the base branch */
   readonly currentCommitSummary: string
-  /** The number of commits currently cherry picked onto the base branch */
-  readonly cherryPickCommitCount: number
+  /** The number to signify which commit in a selection is being cherry-picked
+   **/
+  readonly position: number
   /** The total number of commits to cherry pick on top of the current branch */
   readonly totalCommitCount: number
 }

--- a/app/src/ui/cherry-pick/cherry-pick-progress-dialog.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-progress-dialog.tsx
@@ -19,7 +19,7 @@ export class CherryPickProgressDialog extends React.Component<
 
   public render() {
     const {
-      cherryPickCommitCount,
+      position,
       totalCommitCount,
       value,
       currentCommitSummary,
@@ -42,7 +42,7 @@ export class CherryPickProgressDialog extends React.Component<
               </div>
               <div className="summary">
                 <div className="message">
-                  Commit {cherryPickCommitCount} of {totalCommitCount}
+                  Commit {position} of {totalCommitCount}
                 </div>
                 <div className="detail">
                   <RichText

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -567,8 +567,12 @@ describe('git/cherry-pick', () => {
       // resolution.
       expect(progress).toHaveLength(2)
 
+      // snapshot prepares the progress for the commit after what has
+      // already happened.
       const snapshot = await getCherryPickSnapshot(repository)
-      expect(snapshot?.progress).toEqual(progress[1])
+      expect(snapshot?.progress.cherryPickCommitCount).toEqual(
+        progress[1].cherryPickCommitCount + 1
+      )
 
       // resolve conflicts and continue
       const statusAfterConflictedCherryPick = await getStatusOrThrow(repository)

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -512,7 +512,7 @@ describe('git/cherry-pick', () => {
         {
           currentCommitSummary: 'Cherry-picked Feature!',
           kind: 'cherryPick',
-          cherryPickCommitCount: 1,
+          position: 1,
           title: 'Cherry-picking commit 1 of 1 commits',
           totalCommitCount: 1,
           value: 1,
@@ -570,9 +570,7 @@ describe('git/cherry-pick', () => {
       // snapshot prepares the progress for the commit after what has
       // already happened.
       const snapshot = await getCherryPickSnapshot(repository)
-      expect(snapshot?.progress.cherryPickCommitCount).toEqual(
-        progress[1].cherryPickCommitCount + 1
-      )
+      expect(snapshot?.progress.position).toEqual(progress[1].position + 1)
 
       // resolve conflicts and continue
       const statusAfterConflictedCherryPick = await getStatusOrThrow(repository)


### PR DESCRIPTION
## Description

The cherry-picking snapshot/progress did not always accurately reflect the operation during cherry-picks of multiple commits - most noticeable against an old branch and when a user restarted the app during a the cherry-pick.


For those of you who would like to take a trip down mind blown lane after the fact (seems less mind blowing now)...

The goal of cherry-picking snapshot is to be able to provide data for the progress dialog , the success banner, and obtain the sha to which we would reset the target branch too on undo. The information we need to parse from the sequencer is the count of all commits for the operation, how many have been cherry-picked, and the summaries of commits remaining to be cherry-picked. It is used in two places:  on continue and on opening the app during an ongoing cherry-pick. Both of these instances result in a pause in the progress and discontinuity in user interaction (meaning we can just keep the information in state and we need to parse it). Also, based on which one of those, we use different info from it.. thus something that appears to work for one doesn't mean it works for the other or all cases (why this bug is not readily apparent).

On first attempt, I erroneously thought that the commit sha stored in `abort-safety` was the commit you would reset to on abort. (This appears to work in basic scenarios) That is not the case, it is simply the sha of the last commit on the target branch. During a cherry-pick this starts off as the target branch head and then is updated each time a cherry-picked commit is committed. 

Fortunately, I found that the sha stored in `head` is the head of the target branch before the cherry-pick operation and does not change. This is what we want to abort too or undo too. 

Of note: The `todo` file was correctly understood in that it lists all the remaining shas left to cherry-pick in the operation with the next in line being the first line in the file. 

Thus, first major change is switching to that understanding. 

With that .. we now know that doing a `rev-list` (`getCommitInRange`) from the `abort-safety` to last todo sha made no sense to obtain all the commits for the operation as the `abort-safety` was changing with each commit. Just on that our total count would get smaller with each continued cherry-pick.

But to really throw us for a loop... If those to commit sha's are very different in terms of files changed and time in relation to the branch being cherry-picked onto. The `rev-list` may collect a bunch of commits that make all the changes to the files modified in the commit sha's given make sense. Therefore, cherry-picking from a relatively new branch to an old branch would have lots of file changes (and lots of commits in relation to those file changes) to make the changes in the referenced commit make sense on the target branch. Thus, during `rev-list` during cherry-picking in reference to sha's not yet cherry-picked sometimes resulted in a very wrong total commits count.
.... This is my understanding from toying messing with it (maybe there is a more technical understanding of this out there)...

I realized.. the reason I was using `rev-list` was to get all the commits for the operation and get the summaries for the remaining commits. In other words, get (1) the commits already cherry-picked (for total count) and (2) the commits remaining to be cherry-picked (for summaries). (2) I already had in the `todo` file - it provides the shas and summarys of all the remaining commits to be cherry-picked. I just need to update my parser to get the summary along with the shas. Yay! 

Now, I was left with getting the already cherry-picked commits. This I can use `rev-list` for from the target branch's `head` to the latest cherry-picked commit aka sha in `abort-safety`. From my understanding, this should always be accurate because we just committed these commits so there is no worry of comparison against an old branch/timeline.


### Screenshots
After fix:

https://user-images.githubusercontent.com/75402236/114029753-d8109f00-9847-11eb-9540-7bc6a62ec42d.mov

Before fix (in case you are curious... no 819 commits were not copied 😸 )

https://user-images.githubusercontent.com/75402236/114029615-af88a500-9847-11eb-9d0b-4d01b4ecaff3.mov

## Release notes
Notes: [Fixed] Cherry-pick progress no longer shows wrong number of commits in some circumstances.
