### PR TITLE
Remove macOS arm64 link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Want to test out new features and get fixes before everyone else? Install the
 beta channel to get access to early builds of Desktop:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
- - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
  - [Windows (ARM64)](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64?env=beta)
  


### PR DESCRIPTION
This PR removes the macOS arm64 link from the README in prep for our next beta release, since it's not yet working. More discussion in 
https://github.com/desktop/desktop/pull/9691#issuecomment-815955303