### PR TITLE
Temporary fix for keytar on Apple Silicon

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@dennisameling/keytar-temp": "^7.6.99-gh-desktop",
     "app-path": "^3.2.0",
     "byline": "^5.0.0",
     "chalk": "^2.3.0",
@@ -38,7 +39,6 @@
     "fs-admin": "^0.15.0",
     "fs-extra": "^9.0.1",
     "fuzzaldrin-plus": "^0.6.0",
-    "keytar": "^7.2.0",
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",
     "moment": "^2.24.0",

--- a/app/src/lib/stores/token-store.ts
+++ b/app/src/lib/stores/token-store.ts
@@ -1,4 +1,4 @@
-import * as keytar from 'keytar'
+import * as keytar from '@dennisameling/keytar-temp'
 
 function setItem(key: string, login: string, value: string) {
   return keytar.setPassword(key, login, value)

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -16,6 +16,14 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@dennisameling/keytar-temp@^7.6.99-gh-desktop":
+  version "7.6.99-gh-desktop"
+  resolved "https://registry.yarnpkg.com/@dennisameling/keytar-temp/-/keytar-temp-7.6.99-gh-desktop.tgz#b06bbd3cf30a69aadfb7da17291ceca589824f2c"
+  integrity sha512-Zh8A3xGe6YgjafKZpePNUl3yuRlucbsTbZ4djnGtrbjPSDvMixu4EgSupDe+Xz8LzbL8CEy8kiTvqQ2WnbWQSg==
+  dependencies:
+    node-addon-api "^3.0.0"
+    prebuild-install "^6.0.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -814,14 +822,6 @@ keyboardevents-areequal@^0.2.1:
   resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
   integrity sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==
 
-keytar@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.2.0.tgz#4db2bec4f9700743ffd9eda22eebb658965c8440"
-  integrity sha512-ECSaWvoLKI5SI0pGpZQeUV1/lpBYfkaxvoSp3zkiPOz05VavwSfLi8DdEaa9N2ekQZv3Chy+o7aP6n9mairBgw==
-  dependencies:
-    node-addon-api "^3.0.0"
-    prebuild-install "^6.0.0"
-
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -1000,6 +1000,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-abi@^2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.21.0.tgz#c2dc9ebad6f4f53d6ea9b531e7b8faad81041d48"
+  integrity sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==
+  dependencies:
+    semver "^5.4.1"
+
 node-abi@^2.7.0:
   version "2.19.3"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.3.tgz#252f5dcab12dad1b5503b2d27eddd4733930282d"
@@ -1008,9 +1015,9 @@ node-abi@^2.7.0:
     semver "^5.4.1"
 
 node-addon-api@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.2.tgz#04bc7b83fd845ba785bb6eae25bc857e1ef75681"
-  integrity sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
+  integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -1166,9 +1173,9 @@ prebuild-install@5.3.5, prebuild-install@^5.3.5:
     which-pm-runs "^1.0.0"
 
 prebuild-install@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.0.0.tgz#669022bcde57c710a869e39c5ca6bf9cd207f316"
-  integrity sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.1.tgz#6754fa6c0d55eced7f9e14408ff9e4cba6f097b4"
+  integrity sha512-M+cKwofFlHa5VpTWub7GLg5RLcunYIcLqtY5pKcls/u7xaAb8FrXZ520qY8rkpYy5xw90tYCyMO0MP5ggzR3Sw==
   dependencies:
     detect-libc "^1.0.3"
     expand-template "^2.0.3"
@@ -1176,7 +1183,7 @@ prebuild-install@^6.0.0:
     minimist "^1.2.3"
     mkdirp-classic "^0.5.3"
     napi-build-utils "^1.0.1"
-    node-abi "^2.7.0"
+    node-abi "^2.21.0"
     noop-logger "^0.1.1"
     npmlog "^4.0.1"
     pump "^3.0.0"
@@ -1184,7 +1191,6 @@ prebuild-install@^6.0.0:
     simple-get "^3.0.3"
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
 
 prepend-http@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Related to https://github.com/desktop/desktop/pull/9691#issuecomment-815999757

There are issues with Electron arm64 builds on Apple Silicon when using keytar. Related issue: https://github.com/atom/node-keytar/issues/346.

Keytar will (likely quite soon) switch to N-API prebuilds which eliminates the needs for them to publish prebuilds for every Node + Electron version (currently at 92 (!) prebuilds https://github.com/atom/node-keytar/releases/tag/v7.6.0), see https://github.com/atom/node-keytar/pull/331. I've created a temporary Keytar release based on that PR: https://www.npmjs.com/package/@dennisameling/keytar-temp

The alternatives to merging this PR are:
- Waiting for the upstream PR to be merged (switch to N-API) https://github.com/atom/node-keytar/pull/331
- Upgrading to Electron 12 (which for some weird reason doesn't have this issue, see https://github.com/atom/node-keytar/pull/376)

A release for testing on Apple Silicon can be found here: https://github.com/dennisameling/desktop/releases/tag/2.7.3-test