### PR TITLE
Fix off-by-one error merging diff hunks

### DIFF
--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -59,7 +59,7 @@ function mergeDiffHunks(hunk1: DiffHunk, hunk2: DiffHunk): DiffHunk {
     newHunkHeader,
     newHunkLines,
     hunk1.unifiedDiffStart,
-    hunk1.unifiedDiffStart + newHunkLines.length,
+    hunk1.unifiedDiffStart + newHunkLines.length - 1,
     // The expansion type of the resulting hunk will match the expansion type
     // of the first hunk:
     // - If the first hunk can be expanded up, it means it's the very first


### PR DESCRIPTION
## Description

Because of how Codemirror works, I have only seen the consequences of this bug in the unified diff 🤦‍♂️ 

The problem was we calculated the new end line of a new merged hunk with a +1. For example, if a hunk starts at 0 and has 47 lines… its end line should be 46, not 47.

## Release notes

Notes: no-notes
