### PR TITLE
Cherry-picking refactor to use commit list instead of range for multiple commits

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -154,7 +154,6 @@ import {
   deleteLocalBranch,
   deleteRemoteBranch,
   fastForwardBranches,
-  revRangeInclusive,
   GitResetMode,
   reset,
   getBranchAheadBehind,
@@ -5876,17 +5875,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       this.emitUpdate()
     }
 
-    let revisionRange: string
-    if (commits.length === 1) {
-      revisionRange = commits[0].sha
-    } else {
-      const earliestCommit = commits[commits.length - 1]
-      revisionRange = revRangeInclusive(earliestCommit.sha, commits[0].sha)
-    }
-
     const gitStore = this.gitStoreCache.get(repository)
     const result = await gitStore.performFailableOperation(() =>
-      cherryPick(repository, revisionRange, progressCallback)
+      cherryPick(repository, commits, progressCallback)
     )
 
     return result || CherryPickResult.Error

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -199,7 +199,11 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     // .slice is exclusive of last range end, thus + 1
     const rangeStart = start < end ? start : end
     const rangeEnd = start < end ? end + 1 : start + 1
-    const commitSHARange = this.props.commitSHAs.slice(rangeStart, rangeEnd)
+    // We reverse because we want the commits to be in ascending order.
+    // First commit in history -> first on array
+    const commitSHARange = this.props.commitSHAs
+      .slice(rangeStart, rangeEnd)
+      .reverse()
     const selectedCommits = this.lookupCommits(commitSHARange)
     this.props.onCommitsSelected(selectedCommits)
   }

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -4,6 +4,7 @@ import * as Path from 'path'
 import {
   getCommit,
   getCommits,
+  getCommitsInRange,
   merge,
   MergeResult,
   revRangeInclusive,
@@ -55,7 +56,8 @@ describe('git/cherry-pick', () => {
   })
 
   it('successfully cherry-picked one commit without conflicts', async () => {
-    result = await cherryPick(repository, featureBranch.tip.sha)
+    const featureTip = await getCommitOneLine(repository, featureBranch.tip.sha)
+    result = await cherryPick(repository, [featureTip])
     const cherryPickedCommit = await getCommit(
       repository,
       featureBranch.tip.sha
@@ -88,7 +90,8 @@ describe('git/cherry-pick', () => {
     )
     expect(emptyMessageCommit?.summary).toBe('')
 
-    result = await cherryPick(repository, featureBranch.tip.sha)
+    const featureTip = await getCommitOneLine(repository, featureBranch.tip.sha)
+    result = await cherryPick(repository, [featureTip])
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
     expect(commits.length).toBe(2)
@@ -97,13 +100,15 @@ describe('git/cherry-pick', () => {
   })
 
   it('successfully cherry-picks a redundant commit', async () => {
-    result = await cherryPick(repository, featureBranch.tip.sha)
+    let featureTip = await getCommitOneLine(repository, featureBranch.tip.sha)
+    result = await cherryPick(repository, [featureTip])
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
     expect(commits.length).toBe(2)
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
 
-    result = await cherryPick(repository, featureBranch.tip.sha)
+    featureTip = await getCommitOneLine(repository, featureBranch.tip.sha)
+    result = await cherryPick(repository, [featureTip])
 
     const commitsAfterRedundant = await getCommits(
       repository,
@@ -125,7 +130,8 @@ describe('git/cherry-pick', () => {
     featureBranch = await getBranchOrError(repository, featureBranchName)
     await switchTo(repository, targetBranchName)
 
-    result = await cherryPick(repository, featureBranch.tip.sha)
+    const featureTip = await getCommitOneLine(repository, featureBranch.tip.sha)
+    result = await cherryPick(repository, [featureTip])
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
     expect(commits.length).toBe(2)
@@ -159,7 +165,8 @@ describe('git/cherry-pick', () => {
 
     // cherry picking 3 (on added in setup, empty, featureBranchCommitTwo)
     const commitRange = revRangeInclusive(firstCommitSha, featureBranch.tip.sha)
-    result = await cherryPick(repository, commitRange)
+    const commitsInRange = await getCommitsInRange(repository, commitRange)
+    result = await cherryPick(repository, commitsInRange!)
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
     expect(commits.length).toBe(4) // original commit + 4 cherry picked
@@ -175,23 +182,18 @@ describe('git/cherry-pick', () => {
     await switchTo(repository, targetBranchName)
 
     const commitRange = revRangeInclusive(firstCommitSha, featureBranch.tip.sha)
-    result = await cherryPick(repository, commitRange)
+    const commitsInRange = await getCommitsInRange(repository, commitRange)
+    result = await cherryPick(repository, commitsInRange!)
 
     const commits = await getCommits(repository, targetBranch.ref, 5)
     expect(commits.length).toBe(5)
     expect(commits[1].summary).toBe('Cherry-picked Feature! Number Three')
     expect(commits[2].summary).toBe('Cherry-picked Feature! Number Two')
-    expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
-  it('fails to cherry-pick an invalid revision range', async () => {
-    result = null
-    try {
-      result = await cherryPick(repository, 'no such revision')
-    } catch (error) {
-      expect(error.toString()).toContain('Bad revision')
-    }
-    expect(result).toBe(null)
+  it('fails to cherry-pick array of no commits', async () => {
+    result = await cherryPick(repository, [])
+    expect(result).toBe(CherryPickResult.UnableToStart)
   })
 
   it('fails to cherry-pick when working tree is not clean', async () => {
@@ -207,7 +209,11 @@ describe('git/cherry-pick', () => {
     // No need to add dugite errors to handle it.
     result = null
     try {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
     } catch (error) {
       expect(error.toString()).toContain(
         'The following untracked working tree files would be overwritten by merge'
@@ -243,7 +249,8 @@ describe('git/cherry-pick', () => {
     featureBranch = await getBranchOrError(repository, featureBranchName)
     await switchTo(repository, targetBranchName)
 
-    result = await cherryPick(repository, featureBranch.tip.sha)
+    const featureTip = await getCommitOneLine(repository, featureBranch.tip.sha)
+    result = await cherryPick(repository, [featureTip])
     expect(result).toBe(CherryPickResult.CompletedWithoutError)
   })
 
@@ -292,7 +299,8 @@ describe('git/cherry-pick', () => {
     await switchTo(repository, targetBranchName)
 
     const commitRange = revRangeInclusive(firstSha, featureBranch.tip.sha)
-    result = await cherryPick(repository, commitRange)
+    const commitsInRange = await getCommitsInRange(repository, commitRange)
+    result = await cherryPick(repository, commitsInRange!)
     expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
     // resolve conflicts by writing files to disk
@@ -328,7 +336,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully detects cherry-pick with conflicts', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       const status = await getStatusOrThrow(repository)
@@ -339,7 +351,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully continues cherry-picking with conflicts after resolving them by overwriting', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       const statusAfterCherryPick = await getStatusOrThrow(repository)
@@ -372,7 +388,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully continues cherry-picking with conflicts after resolving them manually', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       const statusAfterCherryPick = await getStatusOrThrow(repository)
@@ -400,7 +420,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully continues cherry-picking with conflicts after resolving them manually and no changes to commit', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       const statusAfterCherryPick = await getStatusOrThrow(repository)
@@ -428,7 +452,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully detects cherry-picking with outstanding files not staged', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       result = await continueCherryPick(repository, [])
@@ -442,7 +470,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully continues cherry-picking with additional changes to untracked files', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       // resolve conflicts by writing files to disk
@@ -473,7 +505,11 @@ describe('git/cherry-pick', () => {
     })
 
     it('successfully aborts cherry-pick after conflict', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
+      )
+      result = await cherryPick(repository, [featureTip])
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
 
       // files from cherry pick exist in conflicted state
@@ -494,23 +530,23 @@ describe('git/cherry-pick', () => {
       progress = []
     })
 
-    it('errors when given invalid revision range', async () => {
+    it('errors when given no commits', async () => {
       const progress = new Array<ICherryPickProgress>()
-      result = await cherryPick(repository, 'INVALID REF', p =>
-        progress.push(p)
-      )
+      result = await cherryPick(repository, [], p => progress.push(p))
       expect(result).toBe(CherryPickResult.UnableToStart)
     })
 
     it('successfully parses progress for a single commit', async () => {
-      result = await cherryPick(repository, featureBranch.tip.sha, p =>
-        progress.push(p)
+      const featureTip = await getCommitOneLine(
+        repository,
+        featureBranch.tip.sha
       )
+      result = await cherryPick(repository, [featureTip], p => progress.push(p))
 
       // commit summary set up in before each is "Cherry-picked Feature"
       expect(progress).toEqual([
         {
-          currentCommitSummary: 'Cherry-picked Feature!',
+          currentCommitSummary: featureTip.summary,
           kind: 'cherryPick',
           position: 1,
           title: 'Cherry-picking commit 1 of 1 commits',
@@ -531,7 +567,10 @@ describe('git/cherry-pick', () => {
         firstCommitSha,
         featureBranch.tip.sha
       )
-      result = await cherryPick(repository, commitRange, p => progress.push(p))
+      const commitsInRange = await getCommitsInRange(repository, commitRange)
+      result = await cherryPick(repository, commitsInRange!, p =>
+        progress.push(p)
+      )
 
       expect(result).toBe(CherryPickResult.CompletedWithoutError)
       expect(progress).toHaveLength(4)
@@ -561,7 +600,10 @@ describe('git/cherry-pick', () => {
         firstCommitSha,
         featureBranch.tip.sha
       )
-      result = await cherryPick(repository, commitRange, p => progress.push(p))
+      const commitsInRange = await getCommitsInRange(repository, commitRange)
+      result = await cherryPick(repository, commitsInRange!, p =>
+        progress.push(p)
+      )
       expect(result).toBe(CherryPickResult.ConflictsEncountered)
       // First commit and second cherry picked and rest are waiting on conflict
       // resolution.
@@ -598,6 +640,11 @@ describe('git/cherry-pick', () => {
     })
   })
 })
+
+async function getCommitOneLine(repository: Repository, commitSha: string) {
+  const { sha, summary } = (await getCommit(repository, commitSha))!
+  return { sha, summary }
+}
 
 async function addThreeMoreCommitsOntoFeatureBranch(repository: Repository) {
   await switchTo(repository, featureBranchName)

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -530,12 +530,6 @@ describe('git/cherry-pick', () => {
       progress = []
     })
 
-    it('errors when given no commits', async () => {
-      const progress = new Array<ICherryPickProgress>()
-      result = await cherryPick(repository, [], p => progress.push(p))
-      expect(result).toBe(CherryPickResult.UnableToStart)
-    })
-
     it('successfully parses progress for a single commit', async () => {
       const featureTip = await getCommitOneLine(
         repository,


### PR DESCRIPTION
## Description

We found there were certain scenarios in which using the rev range argument `sha1^..sha4` did git math in a way that may not be expected by the user and resulted in cherry-picking more or less commits then shown in their selection.

This PR refactors cherry-picking to use each sha of the commits in the user's selection as arguments (`sha1 sha2 sha3 sha4`). This forces the cherry-pick to evaluate them individually and does not go and find more related commits/changes.

### Screenshots
Prior to this change -> the following cherry-pick would exclude the middle commit. As it was doing git math across sha1 and sha3 with respect to new target branch (which was 4 month old). sha1 and sha3 were not related to changes in sha2.. so git math said it didn't matter for the target branch/rev range. 😛 

https://user-images.githubusercontent.com/75402236/114194505-93573780-991d-11eb-8611-2a584faa2487.mov

## Release notes

Notes: no-notes
