### PR TITLE
Allow creating an alias for repositories

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -44,6 +44,7 @@ export interface IDatabaseRepository {
   readonly id?: number
   readonly gitHubRepositoryID: number | null
   readonly path: string
+  readonly alias: string | null
   readonly missing: boolean
 
   /** The last time the stash entries were checked for the repository */

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -175,3 +175,8 @@ export function enableUpdateFromRosettaToARM64(): boolean {
 export function enableSaveDialogOnCloneRepository(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we allow setting repository aliases? */
+export function enableRepositoryAliases(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1451,6 +1451,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     previousRepositoryId: number | null,
     currentRepositoryId: number
   ) {
+    // No need to update the recent repositories if the selected repository is
+    // the same as the old one (this could happen when the alias of the selected
+    // repository is changed).
+    if (previousRepositoryId === currentRepositoryId) {
+      return
+    }
+
     const recentRepositories = getNumberArray(RecentRepositoriesKey).filter(
       el => el !== currentRepositoryId && el !== previousRepositoryId
     )
@@ -3411,7 +3418,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _changeRepositoryAlias(
     repository: Repository,
-    newAlias: string
+    newAlias: string | null
   ): Promise<void> {
     return this.repositoriesStore.updateRepositoryAlias(repository, newAlias)
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3409,6 +3409,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _changeRepositoryAlias(
+    repository: Repository,
+    newAlias: string
+  ): Promise<void> {
+    return this.repositoriesStore.updateRepositoryAlias(repository, newAlias)
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _renameBranch(
     repository: Repository,
     branch: Branch,

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -278,7 +278,7 @@ export class RepositoriesStore extends TypedBaseStore<
    */
   public async updateRepositoryAlias(
     repository: Repository,
-    alias: string
+    alias: string | null
   ): Promise<void> {
     await this.db.repositories.update(repository.id, { alias })
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -132,6 +132,7 @@ export class RepositoriesStore extends TypedBaseStore<
         ? await this.findGitHubRepositoryByID(repo.gitHubRepositoryID)
         : await Promise.resolve(null), // Dexie gets confused if we return null
       repo.missing,
+      repo.alias,
       repo.workflowPreferences,
       repo.isTutorialRepository
     )
@@ -194,6 +195,7 @@ export class RepositoriesStore extends TypedBaseStore<
         return await this.db.repositories.put({
           ...(existingRepo?.id !== undefined && { id: existingRepo.id }),
           path,
+          alias: null,
           gitHubRepositoryID: ghRepo.dbID,
           missing: false,
           lastStashCheckDate: null,
@@ -228,6 +230,7 @@ export class RepositoriesStore extends TypedBaseStore<
           gitHubRepositoryID: null,
           missing: false,
           lastStashCheckDate: null,
+          alias: null,
         }
         const id = await this.db.repositories.add(dbRepo)
         return this.toRepository({ id, ...dbRepo })
@@ -261,9 +264,25 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.id,
       repository.gitHubRepository,
       missing,
+      repository.alias,
       repository.workflowPreferences,
       repository.isTutorialRepository
     )
+  }
+
+  /**
+   * Update the alias for the specified repository.
+   *
+   * @param repository  The repository to update.
+   * @param alias       The new alias to use.
+   */
+  public async updateRepositoryAlias(
+    repository: Repository,
+    alias: string
+  ): Promise<void> {
+    await this.db.repositories.update(repository.id, { alias })
+
+    this.emitUpdatedRepositories()
   }
 
   /**
@@ -295,6 +314,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repository.id,
       repository.gitHubRepository,
       false,
+      repository.alias,
       repository.workflowPreferences,
       repository.isTutorialRepository
     )
@@ -421,6 +441,7 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.id,
       ghRepo,
       repo.missing,
+      repo.alias,
       repo.workflowPreferences,
       repo.isTutorialRepository
     )

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -22,6 +22,7 @@ import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { clearTagsToPush } from './helpers/tags-to-push-storage'
 import { IMatchedGitHubRepository } from '../repository-matching'
 import { shallowEquals } from '../equality'
+import { enableRepositoryAliases } from '../feature-flag'
 
 /** The store for local repositories. */
 export class RepositoriesStore extends TypedBaseStore<
@@ -132,7 +133,7 @@ export class RepositoriesStore extends TypedBaseStore<
         ? await this.findGitHubRepositoryByID(repo.gitHubRepositoryID)
         : await Promise.resolve(null), // Dexie gets confused if we return null
       repo.missing,
-      repo.alias,
+      enableRepositoryAliases() ? repo.alias : null,
       repo.workflowPreferences,
       repo.isTutorialRepository
     )

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -69,6 +69,7 @@ export enum PopupType {
   ConfirmDiscardSelection,
   CherryPick,
   MoveToApplicationsFolder,
+  ChangeRepositoryAlias,
 }
 
 export type Popup =
@@ -276,3 +277,4 @@ export type Popup =
       sourceBranch: Branch | null
     }
   | { type: PopupType.MoveToApplicationsFolder }
+  | { type: PopupType.ChangeRepositoryAlias; repository: Repository }

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -68,6 +68,7 @@ export class Repository {
       this.id,
       gitHubRepository?.hash,
       this.missing,
+      this.alias,
       this.workflowPreferences.forkContributionTarget,
       this.isTutorialRepository
     )

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -51,6 +51,7 @@ export class Repository {
     public readonly id: number,
     public readonly gitHubRepository: GitHubRepository | null,
     public readonly missing: boolean,
+    public readonly alias: string | null = null,
     public readonly workflowPreferences: WorkflowPreferences = {},
     /**
      * True if the repository is a tutorial repository created as part of the

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -135,6 +135,7 @@ import { CherryPickCommit } from './drag-elements/cherry-pick-commit'
 import classNames from 'classnames'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { MoveToApplicationsFolder } from './move-to-applications-folder'
+import { ChangeRepositoryAlias } from './change-repository-alias/change-repository-alias-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2044,6 +2045,15 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <MoveToApplicationsFolder
             dispatcher={this.props.dispatcher}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.ChangeRepositoryAlias: {
+        return (
+          <ChangeRepositoryAlias
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2377,8 +2377,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     let icon: OcticonSymbol
     let title: string
     if (repository) {
+      const alias = repository instanceof Repository ? repository.alias : null
       icon = iconForRepository(repository)
-      title = repository.name
+      title = alias ?? repository.name
     } else if (this.state.repositories.length > 0) {
       icon = OcticonSymbol.repo
       title = __DARWIN__ ? 'Select a Repository' : 'Select a repository'

--- a/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
+++ b/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+
+import { Dispatcher } from '../dispatcher'
+import { Repository } from '../../models/repository'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { TextBox } from '../lib/text-box'
+
+interface IChangeRepositoryAliasProps {
+  readonly dispatcher: Dispatcher
+  readonly onDismissed: () => void
+  readonly repository: Repository
+}
+
+interface IChangeRepositoryAliasState {
+  readonly newAlias: string
+}
+
+export class ChangeRepositoryAlias extends React.Component<
+  IChangeRepositoryAliasProps,
+  IChangeRepositoryAliasState
+> {
+  public constructor(props: IChangeRepositoryAliasProps) {
+    super(props)
+
+    this.state = { newAlias: props.repository.alias ?? props.repository.name }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="rename-branch"
+        title={
+          __DARWIN__ ? 'Change Repository Alias' : 'Change repository alias'
+        }
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.changeAlias}
+      >
+        <DialogContent>
+          <TextBox
+            label="Name"
+            value={this.state.newAlias}
+            onValueChanged={this.onNameChanged}
+          />
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? `Change Alias` : `Change alias`}
+            okButtonDisabled={this.state.newAlias.length === 0}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onNameChanged = (newAlias: string) => {
+    this.setState({ newAlias })
+  }
+
+  private changeAlias = () => {
+    this.props.dispatcher.changeRepositoryAlias(
+      this.props.repository,
+      this.state.newAlias
+    )
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
+++ b/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { Dispatcher } from '../dispatcher'
-import { Repository } from '../../models/repository'
+import { nameOf, Repository } from '../../models/repository'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { TextBox } from '../lib/text-box'
@@ -27,11 +27,12 @@ export class ChangeRepositoryAlias extends React.Component<
   }
 
   public render() {
-    const verb = this.props.repository.alias === null ? 'Create' : 'Change'
+    const repository = this.props.repository
+    const verb = repository.alias === null ? 'Create' : 'Change'
 
     return (
       <Dialog
-        id="rename-branch"
+        id="change-repository-alias"
         title={
           __DARWIN__ ? `${verb} Repository Alias` : `${verb} repository alias`
         }
@@ -39,11 +40,18 @@ export class ChangeRepositoryAlias extends React.Component<
         onSubmit={this.changeAlias}
       >
         <DialogContent>
-          <TextBox
-            label="Name"
-            value={this.state.newAlias}
-            onValueChanged={this.onNameChanged}
-          />
+          <p>Choose a new alias for the repository "{nameOf(repository)}". </p>
+          <p>
+            <TextBox
+              value={this.state.newAlias}
+              onValueChanged={this.onNameChanged}
+            />
+          </p>
+          {repository.gitHubRepository !== null && (
+            <p className="description">
+              This will not affect the original repository name on GitHub.
+            </p>
+          )}
         </DialogContent>
 
         <DialogFooter>

--- a/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
+++ b/app/src/ui/change-repository-alias/change-repository-alias-dialog.tsx
@@ -27,11 +27,13 @@ export class ChangeRepositoryAlias extends React.Component<
   }
 
   public render() {
+    const verb = this.props.repository.alias === null ? 'Create' : 'Change'
+
     return (
       <Dialog
         id="rename-branch"
         title={
-          __DARWIN__ ? 'Change Repository Alias' : 'Change repository alias'
+          __DARWIN__ ? `${verb} Repository Alias` : `${verb} repository alias`
         }
         onDismissed={this.props.onDismissed}
         onSubmit={this.changeAlias}
@@ -46,7 +48,7 @@ export class ChangeRepositoryAlias extends React.Component<
 
         <DialogFooter>
           <OkCancelButtonGroup
-            okButtonText={__DARWIN__ ? `Change Alias` : `Change alias`}
+            okButtonText={__DARWIN__ ? `${verb} Alias` : `${verb} alias`}
             okButtonDisabled={this.state.newAlias.length === 0}
           />
         </DialogFooter>

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -698,7 +698,7 @@ export class Dispatcher {
   /** Changes the repository alias to a new name. */
   public changeRepositoryAlias(
     repository: Repository,
-    newAlias: string
+    newAlias: string | null
   ): Promise<void> {
     return this.appStore._changeRepositoryAlias(repository, newAlias)
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -695,6 +695,14 @@ export class Dispatcher {
     })
   }
 
+  /** Changes the repository alias to a new name. */
+  public changeRepositoryAlias(
+    repository: Repository,
+    newAlias: string
+  ): Promise<void> {
+    return this.appStore._changeRepositoryAlias(repository, newAlias)
+  }
+
   /** Rename the branch to a new name. */
   public renameBranch(
     repository: Repository,

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -89,13 +89,7 @@ export function groupRepositories(
       const { aheadBehind, changedFilesCount } =
         localRepositoryStateLookup.get(r.id) || fallbackValue
       const repositoryText =
-        r instanceof Repository
-          ? [
-              r.name,
-              nameOf(r), // Add the alias if it exists
-              ...(r.alias !== null ? [r.alias] : []),
-            ]
-          : [r.name]
+        r instanceof Repository ? [r.alias ?? r.name, nameOf(r)] : [r.name]
 
       return {
         text: repositoryText,
@@ -155,12 +149,7 @@ export function makeRecentRepositoriesGroup(
       localRepositoryStateLookup.get(id) || fallbackValue
     const repositoryText =
       repository instanceof Repository
-        ? [
-            repository.name,
-            nameOf(repository),
-            // Add the alias if it exists
-            ...(repository.alias !== null ? [repository.alias] : []),
-          ]
+        ? [repository.alias ?? repository.name, nameOf(repository)]
         : [repository.name]
     const nameCount = names.get(repository.name) || 0
     items.push({

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -89,7 +89,13 @@ export function groupRepositories(
       const { aheadBehind, changedFilesCount } =
         localRepositoryStateLookup.get(r.id) || fallbackValue
       const repositoryText =
-        r instanceof Repository ? [r.name, nameOf(r)] : [r.name]
+        r instanceof Repository
+          ? [
+              r.name,
+              nameOf(r), // Add the alias if it exists
+              ...(r.alias !== null ? [r.alias] : []),
+            ]
+          : [r.name]
 
       return {
         text: repositoryText,
@@ -149,7 +155,12 @@ export function makeRecentRepositoriesGroup(
       localRepositoryStateLookup.get(id) || fallbackValue
     const repositoryText =
       repository instanceof Repository
-        ? [repository.name, nameOf(repository)]
+        ? [
+            repository.name,
+            nameOf(repository),
+            // Add the alias if it exists
+            ...(repository.alias !== null ? [repository.alias] : []),
+          ]
         : [repository.name]
     const nameCount = names.get(repository.name) || 0
     items.push({

--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -132,8 +132,10 @@ export function makeRecentRepositoriesGroup(
   for (const id of recentRepositories) {
     const repository = repositories.find(r => r.id === id)
     if (repository !== undefined) {
-      const existingCount = names.get(repository.name) || 0
-      names.set(repository.name, existingCount + 1)
+      const alias = repository instanceof Repository ? repository.alias : null
+      const name = alias ?? repository.name
+      const existingCount = names.get(name) || 0
+      names.set(name, existingCount + 1)
     }
   }
 
@@ -147,11 +149,13 @@ export function makeRecentRepositoriesGroup(
 
     const { aheadBehind, changedFilesCount } =
       localRepositoryStateLookup.get(id) || fallbackValue
+    const repositoryAlias =
+      repository instanceof Repository ? repository.alias : null
     const repositoryText =
       repository instanceof Repository
-        ? [repository.alias ?? repository.name, nameOf(repository)]
+        ? [repositoryAlias ?? repository.name, nameOf(repository)]
         : [repository.name]
-    const nameCount = names.get(repository.name) || 0
+    const nameCount = names.get(repositoryAlias ?? repository.name) || 0
     items.push({
       text: repositoryText,
       id: id.toString(),

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -139,6 +139,7 @@ export class RepositoriesList extends React.Component<
         onOpenInShell={this.props.onOpenInShell}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onChangeRepositoryAlias={this.onChangeRepositoryAlias}
+        onRemoveRepositoryAlias={this.onRemoveRepositoryAlias}
         externalEditorLabel={this.props.externalEditorLabel}
         shellLabel={this.props.shellLabel}
         matches={matches}
@@ -327,5 +328,9 @@ export class RepositoriesList extends React.Component<
       type: PopupType.ChangeRepositoryAlias,
       repository,
     })
+  }
+
+  private onRemoveRepositoryAlias = (repository: Repository) => {
+    this.props.dispatcher.changeRepositoryAlias(repository, null)
   }
 }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -11,7 +11,7 @@ import {
 } from './group-repositories'
 import { FilterList, IFilterListGroup } from '../lib/filter-list'
 import { IMatches } from '../../lib/fuzzy-find'
-import { ILocalRepositoryState } from '../../models/repository'
+import { ILocalRepositoryState, Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Button } from '../lib/button'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -138,6 +138,7 @@ export class RepositoriesList extends React.Component<
         onShowRepository={this.props.onShowRepository}
         onOpenInShell={this.props.onOpenInShell}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
+        onChangeRepositoryAlias={this.onChangeRepositoryAlias}
         externalEditorLabel={this.props.externalEditorLabel}
         shellLabel={this.props.shellLabel}
         matches={matches}
@@ -319,5 +320,12 @@ export class RepositoriesList extends React.Component<
 
   private onCreateNewRepository = () => {
     this.props.dispatcher.showPopup({ type: PopupType.CreateRepository })
+  }
+
+  private onChangeRepositoryAlias = (repository: Repository) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.ChangeRepositoryAlias,
+      repository,
+    })
   }
 }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -68,13 +68,13 @@ export class RepositoryListItem extends React.Component<
       ? gitHubRepo.fullName + '\n' + gitHubRepo.htmlURL + '\n' + path
       : path
 
-    let prefix: string | null = null
-    if (this.props.needsDisambiguation && gitHubRepo) {
-      prefix = `${gitHubRepo.owner.login}/`
-    }
-
     const alias: string | null =
       repository instanceof Repository ? repository.alias : null
+
+    let prefix: string | null = null
+    if (this.props.needsDisambiguation && gitHubRepo && alias === null) {
+      prefix = `${gitHubRepo.owner.login}/`
+    }
 
     return (
       <div
@@ -87,43 +87,19 @@ export class RepositoryListItem extends React.Component<
           symbol={iconForRepository(repository)}
         />
 
-        {this.renderRepositoryTitle(repository, alias, prefix)}
+        <div className="name">
+          {prefix ? <span className="prefix">{prefix}</span> : null}
+          <HighlightText
+            text={alias ?? repository.name}
+            highlight={this.props.matches.title}
+          />
+        </div>
 
         {repository instanceof Repository &&
           renderRepoIndicators({
             aheadBehind: this.props.aheadBehind,
             hasChanges: hasChanges,
           })}
-      </div>
-    )
-  }
-
-  private renderRepositoryTitle(
-    repository: Repositoryish,
-    alias: string | null,
-    prefix: string | null
-  ) {
-    if (alias !== null) {
-      return (
-        <div className="alias">
-          <HighlightText text={alias} highlight={this.props.matches.title} />
-          <span className="originalName">
-            {prefix ? <span className="prefix">{prefix}</span> : null}
-            <HighlightText
-              text={repository.name}
-              highlight={this.props.matches.title}
-            />
-          </span>
-        </div>
-      )
-    }
-    return (
-      <div className="name">
-        {prefix ? <span className="prefix">{prefix}</span> : null}
-        <HighlightText
-          text={repository.name}
-          highlight={this.props.matches.title}
-        />
       </div>
     )
   }
@@ -179,8 +155,10 @@ export class RepositoryListItem extends React.Component<
     // If this is not a cloning repository, insert at the beginning an item to
     // change the repository alias.
     if (this.props.repository instanceof Repository) {
+      const verb = this.props.repository.alias == null ? 'Create' : 'Change'
+
       items.splice(0, 0, {
-        label: __DARWIN__ ? 'Change Alias' : 'Change alias…',
+        label: __DARWIN__ ? `${verb} Alias` : `${verb} alias`,
         action: this.changeAlias,
       })
     }

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -11,6 +11,7 @@ import {
   RevealInFileManagerLabel,
   DefaultEditorLabel,
 } from '../lib/context-menu'
+import { enableRepositoryAliases } from '../../lib/feature-flag'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -162,7 +163,7 @@ export class RepositoryListItem extends React.Component<
   private buildAliasMenuItems(): ReadonlyArray<IMenuItem> {
     const repository = this.props.repository
 
-    if (!(repository instanceof Repository)) {
+    if (!(repository instanceof Repository) || !enableRepositoryAliases()) {
       return []
     }
 

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -375,7 +375,8 @@ dialog {
     width: 400px;
   }
 
-  &#confirm-remove-repository {
+  &#confirm-remove-repository,
+  &#change-repository-alias {
     width: 450px;
 
     .description {

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -45,29 +45,11 @@
       width: 16px;
     }
 
-    .name,
-    .alias {
+    .name {
       // Long repository names truncate and ellipse
       @include ellipsis;
 
       .prefix {
-        color: var(--text-secondary-color);
-      }
-
-      &.alias {
-        display: flex;
-        // flex: auto;
-        width: 100%;
-        justify-content: space-between;
-        // flex-direction: row;
-        // flex-grow: 1;
-      }
-
-      // :not(.originalName) {
-      //   flex-grow: 1;
-      // }
-
-      .originalName {
         color: var(--text-secondary-color);
       }
 

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -45,11 +45,29 @@
       width: 16px;
     }
 
-    .name {
+    .name,
+    .alias {
       // Long repository names truncate and ellipse
       @include ellipsis;
 
       .prefix {
+        color: var(--text-secondary-color);
+      }
+
+      &.alias {
+        display: flex;
+        // flex: auto;
+        width: 100%;
+        justify-content: space-between;
+        // flex-direction: row;
+        // flex-grow: 1;
+      }
+
+      // :not(.originalName) {
+      //   flex-grow: 1;
+      // }
+
+      .originalName {
         color: var(--text-secondary-color);
       }
 


### PR DESCRIPTION
This is part of #7856

## Description

This PR adds initial support to create alias for repositories:
- New context menu actions to create, change or remove the alias of a repository from the repository list. Any character is valid.
- Filtering repositories now takes the alias into account.
- The original repository name is still visible by hovering over it, in the tooltip.

### Screenshots

https://user-images.githubusercontent.com/1083228/114741641-40c9b100-9d4b-11eb-8b83-a43270e293b3.mov

## Release notes

Notes: [New] Add an alias to your repos and name them however you want!
