### PR TITLE
Allow users to skip moving the app to /Applications

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -172,6 +172,9 @@ export interface IAppState {
   /** Whether we should show the update banner */
   readonly isUpdateAvailableBannerVisible: boolean
 
+  /** Whether we should ask the user to move the app to /Applications */
+  readonly askToMoveToApplicationsFolderSetting: boolean
+
   /** Whether we should show a confirmation dialog */
   readonly askForConfirmationOnRepositoryRemoval: boolean
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -302,9 +302,11 @@ const commitSummaryWidthConfigKey: string = 'commit-summary-width'
 const defaultStashedFilesWidth: number = 250
 const stashedFilesWidthConfigKey: string = 'stashed-files-width'
 
+const askToMoveToApplicationsFolderDefault: boolean = true
 const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
+const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmForcePushKey: string = 'confirmForcePush'
@@ -400,6 +402,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false
 
+  private askToMoveToApplicationsFolderSetting: boolean = askToMoveToApplicationsFolderDefault
   private askForConfirmationOnRepositoryRemoval: boolean = confirmRepoRemovalDefault
   private confirmDiscardChanges: boolean = confirmDiscardChangesDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
@@ -775,6 +778,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
       highlightAccessKeys: this.highlightAccessKeys,
       isUpdateAvailableBannerVisible: this.isUpdateAvailableBannerVisible,
       currentBanner: this.currentBanner,
+      askToMoveToApplicationsFolderSetting: this
+        .askToMoveToApplicationsFolderSetting,
       askForConfirmationOnRepositoryRemoval: this
         .askForConfirmationOnRepositoryRemoval,
       askForConfirmationOnDiscardChanges: this.confirmDiscardChanges,
@@ -1703,6 +1708,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.stashedFilesWidth = getNumber(
       stashedFilesWidthConfigKey,
       defaultStashedFilesWidth
+    )
+
+    this.askToMoveToApplicationsFolderSetting = getBoolean(
+      askToMoveToApplicationsFolderKey,
+      askToMoveToApplicationsFolderDefault
     )
 
     this.askForConfirmationOnRepositoryRemoval = getBoolean(
@@ -4605,6 +4615,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     await this.statsStore.setOptOut(optOut, userViewedPrompt)
 
     this.emitUpdate()
+  }
+
+  public _setAskToMoveToApplicationsFolderSetting(
+    value: boolean
+  ): Promise<void> {
+    this.askToMoveToApplicationsFolderSetting = value
+
+    setBoolean(askToMoveToApplicationsFolderKey, value)
+    this.emitUpdate()
+
+    return Promise.resolve()
   }
 
   public _setConfirmRepositoryRemovalSetting(

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -312,7 +312,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     log.info(`execPath: '${process.execPath}'`)
 
     // Only show the popup in beta/production releases and mac machines
-    if (__DEV__ === false && remote.app.isInApplicationsFolder?.() === false) {
+    if (
+      __DEV__ === false &&
+      this.state.askToMoveToApplicationsFolderSetting &&
+      remote.app.isInApplicationsFolder?.() === false
+    ) {
       this.showPopup({ type: PopupType.MoveToApplicationsFolder })
     }
   }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1761,6 +1761,15 @@ export class Dispatcher {
   }
 
   /**
+   * Sets the user's preference so that moving the app to /Applications is not asked
+   */
+  public setAskToMoveToApplicationsFolderSetting(
+    value: boolean
+  ): Promise<void> {
+    return this.appStore._setAskToMoveToApplicationsFolderSetting(value)
+  }
+
+  /**
    * Sets the user's preference so that confirmation to remove repo is not asked
    */
   public setConfirmRepoRemovalSetting(value: boolean): Promise<void> {

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -7,6 +7,7 @@ import {
   OkCancelButtonGroup,
 } from './dialog'
 import { Dispatcher } from './dispatcher'
+import { Checkbox, CheckboxValue } from './lib/checkbox'
 
 interface IMoveToApplicationsFolderProps {
   readonly dispatcher: Dispatcher
@@ -17,14 +18,27 @@ interface IMoveToApplicationsFolderProps {
   readonly onDismissed: () => void
 }
 
+interface IMoveToApplicationsFolderState {
+  readonly askToMoveToApplicationsFolder: boolean
+}
+
 export class MoveToApplicationsFolder extends React.Component<
-  IMoveToApplicationsFolderProps
+  IMoveToApplicationsFolderProps,
+  IMoveToApplicationsFolderState
 > {
+  public constructor(props: IMoveToApplicationsFolderProps) {
+    super(props)
+    this.state = {
+      askToMoveToApplicationsFolder: true,
+    }
+  }
+
   public render() {
     return (
       <Dialog
         title="Move GitHub Desktop to the Applications folder?"
         id="move-to-applications-folder"
+        dismissable={false}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onSubmit}
         type="warning"
@@ -39,6 +53,17 @@ export class MoveToApplicationsFolder extends React.Component<
             Do you want to move GitHub Desktop to the Applications folder now?
             This will also restart the app.
           </p>
+          <div>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.askToMoveToApplicationsFolder
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onAskToMoveToApplicationsFolderChanged}
+            />
+          </div>
         </DialogContent>
         {this.renderFooter()}
       </Dialog>
@@ -51,9 +76,25 @@ export class MoveToApplicationsFolder extends React.Component<
         <OkCancelButtonGroup
           okButtonText={'Move and Restart'}
           okButtonTitle="This will move GitHub Desktop to the Applications folder in your machine and restart the app."
-          cancelButtonText="Cancel"
+          cancelButtonText={__DARWIN__ ? 'Not Now' : 'Not now'}
+          onCancelButtonClick={this.onNotNow}
         />
       </DialogFooter>
+    )
+  }
+
+  private onAskToMoveToApplicationsFolderChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ askToMoveToApplicationsFolder: value })
+  }
+
+  private onNotNow = () => {
+    this.props.onDismissed()
+    this.props.dispatcher.setAskToMoveToApplicationsFolderSetting(
+      this.state.askToMoveToApplicationsFolder
     )
   }
 

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -74,9 +74,9 @@ export class MoveToApplicationsFolder extends React.Component<
     return (
       <DialogFooter>
         <OkCancelButtonGroup
-          okButtonText={'Move and Restart'}
+          okButtonText="Move and Restart"
           okButtonTitle="This will move GitHub Desktop to the Applications folder in your machine and restart the app."
-          cancelButtonText={__DARWIN__ ? 'Not Now' : 'Not now'}
+          cancelButtonText="Not Now"
           onCancelButtonClick={this.onNotNow}
         />
       </DialogFooter>


### PR DESCRIPTION
Closes #11998

## Description

This PR adds a checkbox to our "Move to `/Applications`" dialog so that users who can't move the app are not nagged anymore by the dialog. It also changes the title of the `Cancel` button to `Not Now`, for clarity, and makes the dialog non dismissable.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/114855598-6fe13080-9de6-11eb-9ab3-240a73f18822.png)

## Release notes

Notes: no-notes
