### PR TITLE
Fix branch tooltip 

### DIFF
--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -134,7 +134,6 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseUp={this.onMouseUp}
-        title={name}
       >
         <Octicon className="icon" symbol={icon} />
         <div className="name" title={name}>

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -134,6 +134,7 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseUp={this.onMouseUp}
+        title={name}
       >
         <Octicon className="icon" symbol={icon} />
         <div className="name" title={name}>

--- a/app/src/ui/drag-elements/cherry-pick-commit.tsx
+++ b/app/src/ui/drag-elements/cherry-pick-commit.tsx
@@ -42,15 +42,21 @@ export class CherryPickCommit extends React.Component<
    */
   private renderDragCopyLabel(count: number) {
     const { branchName } = this.state
-    if (branchName === null || __DARWIN__) {
+    if (branchName === null) {
       return
     }
+
+    const copyToPlus = __DARWIN__ ? null : (
+      <Octicon symbol={OcticonSymbol.plus} />
+    )
 
     return (
       <div className="copy-message-label">
         <div>
-          <Octicon symbol={OcticonSymbol.plus} />
-          Copy to <span className="branch-name">{branchName}</span>
+          {copyToPlus}
+          <span>
+            Copy to <span className="branch-name">{branchName}</span>
+          </span>
         </div>
       </div>
     )

--- a/app/src/ui/drag-elements/cherry-pick-commit.tsx
+++ b/app/src/ui/drag-elements/cherry-pick-commit.tsx
@@ -40,6 +40,9 @@ export class CherryPickCommit extends React.Component<
 
   private setBranchName(branchName: string) {
     if (__DARWIN__) {
+      // For macOs, we styled the copy to message to look like a native tool tip
+      // that appears when hovering over a element with the title attribute. We
+      // also are implementing this timeout to have similar hover-to-see feel.
       this.setState({ branchName: null })
 
       if (this.timeoutId !== null) {

--- a/app/src/ui/drag-elements/cherry-pick-commit.tsx
+++ b/app/src/ui/drag-elements/cherry-pick-commit.tsx
@@ -21,19 +21,38 @@ export class CherryPickCommit extends React.Component<
   ICherryPickCommitProps,
   ICherryPickCommitState
 > {
+  private timeoutId: number | null = null
+
   public constructor(props: ICherryPickCommitProps) {
     super(props)
     this.state = {
       branchName: null,
     }
 
-    dragAndDropManager.onEnterDropTarget(targetDescription => {
-      this.setState({ branchName: targetDescription })
+    dragAndDropManager.onEnterDropTarget(branchName => {
+      this.setBranchName(branchName)
     })
 
     dragAndDropManager.onLeaveDropTarget(() => {
       this.setState({ branchName: null })
     })
+  }
+
+  private setBranchName(branchName: string) {
+    if (__DARWIN__) {
+      this.setState({ branchName: null })
+
+      if (this.timeoutId !== null) {
+        window.clearTimeout(this.timeoutId)
+      }
+
+      this.timeoutId = window.setTimeout(
+        () => this.setState({ branchName }),
+        1500
+      )
+    } else {
+      this.setState({ branchName })
+    }
   }
 
   /**

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -447,6 +447,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --call-to-action-bubble-border-color: #{$green};
   --call-to-action-bubble-color: #{$green};
+
+  --title-tool-tip-background-color: rgb(236, 236, 236);
+  --title-tool-tip-shadow: 1px 2px 5px 0px rgb(125, 125, 125, 0.5);
 }
 
 ::backdrop {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -344,6 +344,9 @@ body.theme-dark {
 
   --call-to-action-bubble-background-color: #{$blue};
   --call-to-action-bubble-color: #{$white};
+
+  --title-tool-tip-background-color: rgb(56, 58, 62);
+  --title-tool-tip-shadow: none;
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/_app.scss
+++ b/app/styles/ui/_app.scss
@@ -45,6 +45,12 @@
             cursor: default;
           }
 
+          .branches-list-item {
+            div {
+              pointer-events: none;
+            }
+          }
+
           .list-item:not(.selected) {
             .branches-list-item:hover,
             .pull-request-item:hover {

--- a/app/styles/ui/_branches.scss
+++ b/app/styles/ui/_branches.scss
@@ -18,10 +18,6 @@
   .branches-list-item {
     height: 100%;
 
-    div {
-      pointer-events: none;
-    }
-
     &.new-branch-drop {
       margin-top: var(--spacing-half);
       height: 30px;

--- a/app/styles/ui/drag-elements/_cherry-pick-commit.scss
+++ b/app/styles/ui/drag-elements/_cherry-pick-commit.scss
@@ -55,6 +55,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      white-space: nowrap;
     }
   }
 

--- a/app/styles/ui/drag-elements/_cherry-pick-commit.scss
+++ b/app/styles/ui/drag-elements/_cherry-pick-commit.scss
@@ -16,9 +16,11 @@
     flex-direction: row;
     align-items: center;
     background-color: var(--background-color);
+    overflow: hidden;
 
     .commit {
       border-bottom: none;
+      max-width: 300px;
     }
 
     .count {
@@ -47,10 +49,22 @@
     border: 1px solid var(--box-border-color);
     color: var(--link-button-color);
     padding: var(--spacing-third) var(--spacing-half);
+
+    @include darwin {
+      padding: 1px var(--spacing-third);
+      font-size: 11px;
+      bottom: -25px;
+      color: var(--text-color);
+      background-color: var(--title-tool-tip-background-color);
+      border-radius: 1px;
+      box-shadow: var(--title-tool-tip-shadow);
+    }
+
     .branch-name {
       color: var(--text-color);
       margin-left: var(--spacing-third);
     }
+
     div {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Closes #12008

## Description

Add tooltip back when hovering over branch name in the branch-dropdown.

Also add "Copy to branch name" to macOS cherry-pick operation since tool tip is disabled during cherry-picking due to cursor conflicts.

### Screenshots
** UPDATE from other macOS video -> copy to message to feel like a tool tip on mac **

https://user-images.githubusercontent.com/75402236/115758347-04124100-a36d-11eb-8bd5-9dd9cf87c8f4.mov


MacOS

https://user-images.githubusercontent.com/75402236/115245676-3153ba80-a0f3-11eb-81c2-66da83bfb3d7.mov

Windows

https://user-images.githubusercontent.com/75402236/115246601-087ff500-a0f4-11eb-8746-2c208e129abc.mov



## Release notes

Notes: [Fixed] Show tooltip with full branch name in branch dropdown.
