### PR TITLE
Use italics for aliases in the repository list

### DIFF
--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -12,6 +12,7 @@ import {
   DefaultEditorLabel,
 } from '../lib/context-menu'
 import { enableRepositoryAliases } from '../../lib/feature-flag'
+import classNames from 'classnames'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -80,6 +81,10 @@ export class RepositoryListItem extends React.Component<
       prefix = `${gitHubRepo.owner.login}/`
     }
 
+    const classNameList = classNames('name', {
+      alias: alias !== null,
+    })
+
     return (
       <div
         onContextMenu={this.onContextMenu}
@@ -91,7 +96,7 @@ export class RepositoryListItem extends React.Component<
           symbol={iconForRepository(repository)}
         />
 
-        <div className="name">
+        <div className={classNames(classNameList)}>
           {prefix ? <span className="prefix">{prefix}</span> : null}
           <HighlightText
             text={alias ?? repository.name}

--- a/app/styles/ui/_repository-list.scss
+++ b/app/styles/ui/_repository-list.scss
@@ -62,6 +62,10 @@
       }
     }
 
+    .alias {
+      font-style: italic;
+    }
+
     .repo-indicators {
       margin-left: auto;
       display: flex;


### PR DESCRIPTION
## Description

This PR changes the style of aliases in the repository list, to show up in italics.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/115383945-b6fc6680-a1d6-11eb-9d8f-05882367c56d.png)

## Release notes

Notes: no-notes
