### PR TITLE
Add the repo alias to its tooltip

### DIFF
--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -68,12 +68,18 @@ export class RepositoryListItem extends React.Component<
       repository instanceof Repository ? repository.gitHubRepository : null
     const hasChanges = this.props.changedFilesCount > 0
 
-    const repoTooltip = gitHubRepo
-      ? gitHubRepo.fullName + '\n' + gitHubRepo.htmlURL + '\n' + path
-      : path
-
     const alias: string | null =
       repository instanceof Repository ? repository.alias : null
+
+    const repoTooltipComponents = gitHubRepo
+      ? [gitHubRepo.fullName, gitHubRepo.htmlURL, path]
+      : [path]
+
+    if (alias !== null) {
+      repoTooltipComponents.unshift(alias)
+    }
+
+    const repoTooltip = repoTooltipComponents.join('\n')
 
     let prefix: string | null = null
     if (this.props.needsDisambiguation && gitHubRepo) {


### PR DESCRIPTION
## Description

This PR adds the repository alias to the tooltip in the repository list, in order to address https://github.com/desktop/desktop/pull/12000#pullrequestreview-636014092

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/115384764-b0baba00-a1d7-11eb-8148-6e0480d5aace.png)

## Release notes

Notes: no-notes
