### PR TITLE
Cherry-pick multiple non sequential commits

### DIFF
--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -194,7 +194,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     // cherry-picking results. If user wants to use cherry-picking for
     // reordering, they will need to do multiple cherry-picks.
     // Goal: first commit in history -> first on array
-    const sorted = rows.map(r => r).sort((a, b) => b - a)
+    const sorted = [...rows].sort((a, b) => b - a)
 
     const selectedShas = sorted.map(r => this.props.commitSHAs[r])
     const selectedCommits = this.lookupCommits(selectedShas)

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -3,7 +3,7 @@ import memoize from 'memoize-one'
 import { GitHubRepository } from '../../models/github-repository'
 import { Commit, CommitOneLine } from '../../models/commit'
 import { CommitListItem } from './commit-list-item'
-import { List, SelectionSource } from '../lib/list'
+import { List } from '../lib/list'
 import { arrayEquals } from '../../lib/equality'
 import { Popover, PopoverCaretPosition } from '../lib/popover'
 import { Button } from '../lib/button'
@@ -188,22 +188,16 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     return undefined
   }
 
-  private onSelectedRangeChanged = (
-    start: number,
-    end: number,
-    source: SelectionSource
-  ) => {
-    // if user selects a range top down, start < end.
-    // if user selects a range down to up, start > end and need to be inverted.
-    // .slice is exclusive of last range end, thus + 1
-    const rangeStart = start < end ? start : end
-    const rangeEnd = start < end ? end + 1 : start + 1
-    // We reverse because we want the commits to be in ascending order.
-    // First commit in history -> first on array
-    const commitSHARange = this.props.commitSHAs
-      .slice(rangeStart, rangeEnd)
-      .reverse()
-    const selectedCommits = this.lookupCommits(commitSHARange)
+  private onSelectionChanged = (rows: ReadonlyArray<number>) => {
+    // Multi select can give something like 1, 5, 3 depending on order that user
+    // selects. We want to ensure they are in chronological order for best
+    // cherry-picking results. If user wants to use cherry-picking for
+    // reordering, they will need to do multiple cherry-picks.
+    // Goal: first commit in history -> first on array
+    const sorted = rows.map(r => r).sort((a, b) => (a - b) * -1)
+
+    const selectedShas = sorted.map(r => this.props.commitSHAs[r])
+    const selectedCommits = this.lookupCommits(selectedShas)
     this.props.onCommitsSelected(selectedCommits)
   }
 
@@ -299,9 +293,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           rowHeight={RowHeight}
           selectedRows={this.props.selectedSHAs.map(sha => this.rowForSHA(sha))}
           rowRenderer={this.renderCommit}
-          onSelectedRangeChanged={this.onSelectedRangeChanged}
+          onSelectionChanged={this.onSelectionChanged}
           onSelectedRowChanged={this.onSelectedRowChanged}
-          selectionMode="range"
+          selectionMode="multi"
           onScroll={this.onScroll}
           invalidationProps={{
             commits: this.props.commitSHAs,

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -194,7 +194,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     // cherry-picking results. If user wants to use cherry-picking for
     // reordering, they will need to do multiple cherry-picks.
     // Goal: first commit in history -> first on array
-    const sorted = rows.map(r => r).sort((a, b) => (a - b) * -1)
+    const sorted = rows.map(r => r).sort((a, b) => b - a)
 
     const selectedShas = sorted.map(r => this.props.commitSHAs[r])
     const selectedCommits = this.lookupCommits(selectedShas)

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -1067,14 +1067,15 @@ export class List extends React.Component<IListProps, IListState> {
           })
         }
       } else if (
-        this.props.selectionMode === 'range' &&
+        (this.props.selectionMode === 'range' ||
+          this.props.selectionMode === 'multi') &&
         this.props.selectedRows.length > 1 &&
         this.props.selectedRows.includes(row)
       ) {
-        // Do nothing. Multiple rows are already selected for a range. We assume
-        // the user is pressing down on multiple and may desire to start
-        // dragging. We will invoke the single selection `onRowMouseUp` if they
-        // let go here and no special keys are being pressed.
+        // Do nothing. Multiple rows are already selected. We assume the user is
+        // pressing down on multiple and may desire to start dragging. We will
+        // invoke the single selection `onRowMouseUp` if they let go here and no
+        // special keys are being pressed.
       } else if (
         this.props.selectedRows.length !== 1 ||
         (this.props.selectedRows.length === 1 &&
@@ -1111,12 +1112,13 @@ export class List extends React.Component<IListProps, IListState> {
       !multiSelectKey &&
       this.props.selectedRows.length > 1 &&
       this.props.selectedRows.includes(row) &&
-      this.props.selectionMode === 'range'
+      (this.props.selectionMode === 'range' ||
+        this.props.selectionMode === 'multi')
     ) {
-      // No special keys are depressed and multiple rows were selected in a
-      // range. The onRowMouseDown event was ignored for this scenario because
-      // the user may desire to started dragging multiple. However, if they let
-      // go, we want a new single selection to occur.
+      // No special keys are depressed and multiple rows were selected. The
+      // onRowMouseDown event was ignored for this scenario because the user may
+      // desire to started dragging multiple. However, if they let go, we want a
+      // new single selection to occur.
       this.selectSingleRowAfterMouseEvent(row, event)
     }
   }


### PR DESCRIPTION
Closes #12030

## Description

Allow cherry-picking multiple non sequential commits. 

A workflow decision made in this PR is that if a user selects commits in the order of 1, 5, 3. This will cherry pick in the order of 5,  3, 1 (5 being the oldest in history). This is generally cherry-picking best practice as it prevents accidentally cherry-picking a commit without changes/files needed in a previous commit.  If a user is attempting to use cherry-picking to reorder commits, they will have to explicitly do so with multiple cherry-pick operations.

### Screenshots

Below demos non sequential commits as well as shows some regression testing (range selection, up/down/paging, and single commit). Ensuring chronological ordering despite non chronological selection was also tested.

https://user-images.githubusercontent.com/75402236/115442450-05fac980-a1e0-11eb-8ec8-c383f35b1094.mov

## Release notes

Notes: [Improved] Cherry-pick multiple non-sequential commits at one time.
