### PR TITLE
#11375 : on clone show full message + on hover show full message

### DIFF
--- a/app/src/ui/cloning-repository.tsx
+++ b/app/src/ui/cloning-repository.tsx
@@ -27,7 +27,9 @@ export class CloningRepositoryView extends React.Component<
           <div className="title">Cloning {this.props.repository.name}</div>
         </div>
         <progress value={progressValue} />
-        <div className="details">{this.props.progress.description}</div>
+        <div title={this.props.progress.description} className="details">
+          {this.props.progress.description}
+        </div>
       </UiView>
     )
   }

--- a/app/styles/ui/_cloning-repository-view.scss
+++ b/app/styles/ui/_cloning-repository-view.scss
@@ -66,12 +66,13 @@
     overflow: hidden;
   }
 
-  /* Limit the progress text to one line. Without
-   * this the entire container will jump around in
-   * y-pos due to the change in height */
   .details {
     max-width: 100%;
-    @include ellipsis;
+    height: 30vh;
+    margin-bottom: 20vh;
+    overflow-wrap: anywhere;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   progress {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #11375

## Description

on clone show full message + on hover show full message


### Screenshots

Here is a snap showing full text and on hover show text : 

![Screenshot from 2021-04-21 23-31-34](https://user-images.githubusercontent.com/29339330/115596341-d0e29a00-a2f9-11eb-8648-53b6116b2bd1.png)


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 

### Additional Info : 
#11424 
