### PR TITLE
Add the architecture as path component of the updates URL

### DIFF
--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -171,7 +171,10 @@ class UpdateStore {
       remote.app.runningUnderRosettaTranslation === true
     ) {
       const url = new URL(updatesURL)
-      url.searchParams.set('architecture', 'arm64')
+      url.pathname = url.pathname.replace(
+        /\/desktop\/desktop\/(x64\/)?latest/,
+        '/desktop/desktop/arm64/latest'
+      )
       updatesURL = url.toString()
     }
 

--- a/script/dist-info.ts
+++ b/script/dist-info.ts
@@ -162,7 +162,12 @@ export function getArchitecture(): 'arm64' | 'x64' {
 }
 
 export function getUpdatesURL() {
-  return `https://central.github.com/api/deployments/desktop/desktop/latest?version=${version}&env=${getChannel()}&architecture=${getArchitecture()}`
+  // It is also possible to use a `x64/` path, but for now we'll leave the
+  // original URL without architecture in it (which will still work for
+  // compatibility reasons) in case anything goes wrong until we have everything
+  // sorted out.
+  const architecturePath = getArchitecture() === 'arm64' ? 'arm64/' : ''
+  return `https://central.github.com/api/deployments/desktop/desktop/${architecturePath}latest?version=${version}&env=${getChannel()}`
 }
 
 export function shouldMakeDelta() {


### PR DESCRIPTION
## Description

As part of the work to support arm64 I learned a bit about how Squirrel.Windows works and what it expects. So far we tried:
1. Using query parameters to indicate the architecture of the updates we want: this query parameter is only sent when Squirrel.Windows hits the `/RELEASES` endpoint, but not when it's gonna download the nupkg file with the update.
2. Adding an architecture suffix to the nupkg files listed in the `/RELEASES` endpoint, so we know which build to provide: this doesn't work because for some reason Squirrel.Windows is getting confused with versions and it just doesn't update.

In this PR we try a third approach which consists on changing the base path of all endpoints used by Squirrel (for Mac and Windows), including the architecture as a path component. Thanks to that we will know the architecture in both the `/RELEASES` and nupkg endpoints, without the need of adding any kind of suffix to the nupkg files.

## Release notes

Notes: no-notes
