### PR TITLE
Update build timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       # Needed for macOS arm64 until hosted macos-11.0 runners become available
       SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk


### PR DESCRIPTION
## Description

Beta release is failing - maybe a time out problem. Extending timeout from 45 to 60 minutes

## Release notes

Notes: no-notes
