### PR TITLE
made gitignore textarea resizeable

### DIFF
--- a/app/src/ui/repository-settings/git-ignore.tsx
+++ b/app/src/ui/repository-settings/git-ignore.tsx
@@ -28,7 +28,7 @@ export class GitIgnore extends React.Component<IGitIgnoreProps, {}> {
           placeholder="Ignored files"
           value={this.props.text || ''}
           onValueChanged={this.props.onIgnoreTextChanged}
-          rows={6}
+          rows={15}
         />
       </DialogContent>
     )

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -13,6 +13,7 @@
   font-family: var(--font-family-sans-serif);
   height: var(--text-field-height);
   padding: 0 var(--spacing-half);
+  resize: none;
 
   &:focus {
     @include textboxish-focus-styles;

--- a/app/styles/ui/_text-area.scss
+++ b/app/styles/ui/_text-area.scss
@@ -10,7 +10,10 @@
     @include textboxish-disabled;
 
     height: auto;
-    resize: none;
+    resize: both;
+    overflow: scroll;
+    max-width: 370px;
+    max-height: 80%;
     min-height: 100px;
   }
 }


### PR DESCRIPTION
<!--
Issue #11715 
-->

Closes #11715 

## Description
Changed the text area to show 15 lines with capability to resize the window.

### Screenshots

![image](https://user-images.githubusercontent.com/67401131/116013683-769a4f80-a5ff-11eb-8be0-f026718b2039.png)
![image](https://user-images.githubusercontent.com/67401131/116013688-8023b780-a5ff-11eb-9292-61e0241f9453.png)



## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
