### PR TITLE
Enable repository aliases feature flag

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -88,5 +88,5 @@ export function enableSaveDialogOnCloneRepository(): boolean {
 
 /** Should we allow setting repository aliases? */
 export function enableRepositoryAliases(): boolean {
-  return enableBetaFeatures()
+  return true
 }


### PR DESCRIPTION
Closes #7856

## Release notes

Notes: [New] Create aliases for repositories you want to be displayed differently in the repository list
