### PR TITLE
Initial squash git logic

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -64,7 +64,7 @@ function mapStatus(
 export async function getCommits(
   repository: Repository,
   revisionRange: string,
-  limit: number,
+  limit?: number,
   additionalArgs: ReadonlyArray<string> = []
 ): Promise<ReadonlyArray<Commit>> {
   const { formatArgs, parse } = createLogParser({
@@ -82,22 +82,22 @@ export async function getCommits(
     refs: '%D',
   })
 
-  const result = await git(
-    [
-      'log',
-      revisionRange,
-      `--date=raw`,
-      `--max-count=${limit}`,
-      ...formatArgs,
-      '--no-show-signature',
-      '--no-color',
-      ...additionalArgs,
-      '--',
-    ],
-    repository.path,
-    'getCommits',
-    { successExitCodes: new Set([0, 128]) }
+  const args = ['log', revisionRange, `--date=raw`]
+
+  if (limit !== undefined) {
+    args.push(`--max-count=${limit}`)
+  }
+
+  args.push(
+    ...formatArgs,
+    '--no-show-signature',
+    '--no-color',
+    ...additionalArgs,
+    '--'
   )
+  const result = await git(args, repository.path, 'getCommits', {
+    successExitCodes: new Set([0, 128]),
+  })
 
   // if the repository has an unborn HEAD, return an empty history of commits
   if (result.exitCode === 128) {

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -32,6 +32,7 @@ import { stageFiles } from './update-index'
 import { getStatus } from './status'
 import { getCommitsBetweenCommits } from './rev-list'
 import { Branch } from '../../models/branch'
+import { getCommits } from './log'
 
 /** The app-specific results from attempting to rebase a repository */
 export enum RebaseResult {
@@ -519,6 +520,67 @@ export async function continueRebase(
     ['rebase', '--continue'],
     repository.path,
     'continueRebase',
+    options
+  )
+
+  return parseRebaseResult(result)
+}
+
+/**
+ * Method for initiating interactive rebase in the app.
+ *
+ * In order to modify the interactive todo list during interactive rebase, we
+ * create a temporary todo list of our own. Pass that file's path into our
+ * interactive rebase and using the sequence.editor to cat replace the
+ * interactive todo list with the contents of our generated one.
+ *
+ * @param pathOfGeneratedTodo path to generated todo list for interactive rebase
+ * @param lastRetainedCommitRef the commit before the earliest commit to be changed during the interactive rebase
+ * @param action a description of the action to be displayed in the progress dialog - i.e. Squash, Amend, etc..
+ */
+export async function rebaseInteractive(
+  repository: Repository,
+  pathOfGeneratedTodo: string,
+  lastRetainedCommitRef: string,
+  action: string = 'interactive rebase',
+  gitEditor: string = ':',
+  progressCallback?: (progress: IRebaseProgress) => void
+): Promise<RebaseResult> {
+  const baseOptions: IGitExecutionOptions = {
+    expectedErrors: new Set([GitError.RebaseConflicts]),
+    env: {
+      GIT_EDITOR: gitEditor,
+    },
+  }
+
+  let options = baseOptions
+
+  if (progressCallback !== undefined) {
+    const commits = await getCommits(repository, lastRetainedCommitRef)
+
+    if (commits === null) {
+      log.warn(`Unable to interactively rebase if no commits in revision`)
+      return RebaseResult.Error
+    }
+
+    // TODO: pass in a rebase action for parser - Rebase, Squash, etc..
+    options = configureOptionsForRebase(baseOptions, {
+      commits,
+      progressCallback,
+    })
+  }
+
+  const result = await git(
+    [
+      '-c',
+      // This replaces interactive todo with contents of file at pathOfGeneratedTodo
+      `sequence.editor=cat "${pathOfGeneratedTodo}" >`,
+      'rebase',
+      '-i',
+      lastRetainedCommitRef,
+    ],
+    repository.path,
+    action,
     options
   )
 

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -9,11 +9,10 @@ import { rebaseInteractive, RebaseResult } from './rebase'
  * Squashes provided commits by calling interactive rebase
  *
  * @param toSquash - commits to squash onto another commit
- * @param squashOnto  - commit to squash the `squash` commits onto
- * @param previousCommit -  sha of commit before all commits in squash operation
+ * @param squashOnto  - commit to squash the `toSquash` commits onto
+ * @param lastRetainedCommitRef -  sha of commit before all commits in squash operation
  * @param commitSummary - summary of new commit made by squash
  * @param commitDescription - description of new commit made by squash
- * @returns - true if successful, false if failed
  */
 export async function squash(
   repository: Repository,

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -1,0 +1,87 @@
+import * as Path from 'path'
+import * as FSE from 'fs-extra'
+import { getCommits, git, IGitExecutionOptions } from '.'
+import { CommitOneLine } from '../../models/commit'
+import { Repository } from '../../models/repository'
+
+/**
+ * Initiates an interactive rebase and squashes provided commits
+ *
+ * @param squash - commits to squash onto another commit
+ * @param squashOnto  - commit to squash the `squash` commits onto
+ * @param previousCommit -  sha of commit before all commits in squash operation
+ * @param commitSummary - summary of new commit made by squash
+ * @param commitDescription - description of new commit made by squash
+ * @returns - true if successful, false if failed
+ */
+export async function squash(
+  repository: Repository,
+  squash: ReadonlyArray<CommitOneLine>,
+  squashOnto: CommitOneLine,
+  logIndex: number,
+  commitSummary: string,
+  commitDescription: string
+): Promise<ReadonlyArray<string>> {
+  const options: IGitExecutionOptions = {
+    env: {
+      // if we don't provide editor, we can't detect git errors
+      // GIT_EDITOR: ':',
+    },
+  }
+
+  // get commits from log to cherry pick
+  /*
+  const commits = await getCommits(
+    repository,
+    'HEAD~' + logIndex + 1,
+    logIndex + 1
+  )
+  */
+
+  //return commits.map(c => c.shortSha)
+
+  // current branch name
+  //  const currentBranch = git current branch...
+
+  // Create a temporary branch from the head before the earliest squash commit
+  // - const tempBranch = git checkout head~x -b temp branch... pick a branch name that doesn't exist..
+
+  // loop through log
+  //  if commit === SquashOnto
+  //    - cherry pick -n squash onto
+  //    - loop through ToSquash -> cherry pick -n (may have conflicts/Progress?)
+  //    - commit -m commitsummary and commitDescription
+  //  if commit in squashOnto
+  //    - continue loop
+  //  else
+  //    - cherry pick regular
+  // This loop process could be aborted at anytime.. if so delete temp branch, check out current branch
+
+  // check out current branch
+  // git hard reset --> HEAD~logIndex+1
+  // git rebase tempBranch ... this should not have conflicts since the branches base history should be the same..
+
+  // Start interactive rebase
+  await git(
+    [
+      'rebase',
+      '-c',
+      '"sequence.editor=sed -i /123456/d"',
+      '-i',
+      'HEAD~'logIndex+1,
+    ],
+    repository.path,
+    'squash',
+    options
+  )
+
+  return []
+
+  // parse todo
+
+  // build new todo
+
+  // save todo
+
+  //return true
+}

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -23,6 +23,7 @@ export async function squash(
   commitDescription: string
 ): Promise<RebaseResult> {
   let messagePath, todoPath
+  let result: RebaseResult
 
   try {
     const commits = await getCommits(
@@ -62,7 +63,7 @@ export async function squash(
         : commitSummary
     await FSE.writeFile(messagePath, message)
 
-    const result = await rebaseInteractive(
+    result = await rebaseInteractive(
       repository,
       todoPath,
       lastRetainedCommitRef,
@@ -70,8 +71,9 @@ export async function squash(
       `cat "${messagePath}" >`
       // TODO: add progress
     )
-    return result
   } catch (e) {
+    return RebaseResult.Error
+  } finally {
     if (todoPath !== undefined) {
       FSE.remove(todoPath)
     }
@@ -81,5 +83,5 @@ export async function squash(
     }
   }
 
-  return RebaseResult.Error
+  return result
 }

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -1,6 +1,6 @@
 import * as FSE from 'fs-extra'
 import { getCommits, revRange } from '.'
-import { Commit, CommitOneLine } from '../../models/commit'
+import { CommitOneLine } from '../../models/commit'
 import { Repository } from '../../models/repository'
 import { getTempFilePath } from '../file-system'
 import { rebaseInteractive, RebaseResult } from './rebase'
@@ -22,48 +22,64 @@ export async function squash(
   commitSummary: string,
   commitDescription: string
 ): Promise<RebaseResult> {
-  const commits: Commit[] = [
-    ...(await getCommits(repository, revRange(lastRetainedCommitRef, 'HEAD'))),
-  ]
+  let messagePath, todoPath
 
-  let todoOutput = ''
-  commits.forEach(c => {
-    if (toSquash.map(sq => sq.sha).includes(c.sha)) {
-      return
+  try {
+    const commits = await getCommits(
+      repository,
+      revRange(lastRetainedCommitRef, 'HEAD')
+    )
+
+    todoPath = await getTempFilePath('squashTodo')
+
+    // need to traverse in reverse so we do oldest to newest (replay commits)
+    for (let i = commits.length - 1; i >= 0; i--) {
+      // Ignore commits to squash because those are written right next to the target commit
+      if (toSquash.map(sq => sq.sha).includes(commits[i].sha)) {
+        continue
+      }
+
+      await FSE.appendFile(
+        todoPath,
+        `pick ${commits[i].sha} ${commits[i].summary}\n`
+      )
+
+      // If it's the target commit, write a `squash` line for every commit to squash
+      if (commits[i].sha === squashOnto.sha) {
+        for (let j = 0; j < toSquash.length; j++) {
+          await FSE.appendFile(
+            todoPath,
+            `squash ${toSquash[j].sha} ${toSquash[j].summary}\n`
+          )
+        }
+      }
     }
 
-    if (c.sha === squashOnto.sha) {
-      todoOutput += `pick ${c.sha} ${c.summary}\n`
-      toSquash.forEach(async sq => {
-        todoOutput += `squash ${sq.sha} ${sq.summary}\n`
-      })
-      return
+    messagePath = await getTempFilePath('squashCommitMessage')
+    const message =
+      commitDescription !== ''
+        ? `${commitSummary}\n\n${commitDescription}`
+        : commitSummary
+    await FSE.writeFile(messagePath, message)
+
+    const result = await rebaseInteractive(
+      repository,
+      todoPath,
+      lastRetainedCommitRef,
+      'squash',
+      `cat "${messagePath}" >`
+      // TODO: add progress
+    )
+    return result
+  } catch (e) {
+    if (todoPath !== undefined) {
+      FSE.remove(todoPath)
     }
 
-    todoOutput += `pick ${c.sha} ${c.summary}\n`
-  })
+    if (messagePath !== undefined) {
+      FSE.remove(messagePath)
+    }
+  }
 
-  const todoPath = await getTempFilePath('squashTodo')
-  await FSE.writeFile(todoPath, todoOutput)
-
-  const messagePath = await getTempFilePath('squashCommitMessage')
-  const message =
-    commitDescription !== ''
-      ? `${commitSummary}\n\n${commitDescription}`
-      : commitSummary
-  await FSE.writeFile(messagePath, message)
-
-  const result = await rebaseInteractive(
-    repository,
-    todoPath,
-    lastRetainedCommitRef,
-    'squash',
-    `cat "${messagePath}" >`
-    // TODO: add progress
-  )
-
-  FSE.remove(todoPath)
-  FSE.remove(messagePath)
-
-  return result
+  return RebaseResult.Error
 }

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -1,0 +1,70 @@
+import * as Path from 'path'
+import * as FSE from 'fs-extra'
+import { getCommit, getCommits, git } from '../../../src/lib/git'
+import { CommitOneLine } from '../../../src/models/commit'
+import { Repository } from '../../../src/models/repository'
+import { setupEmptyRepositoryDefaultMain } from '../../helpers/repositories'
+import { makeCommit } from '../../helpers/repository-scaffolding'
+
+describe('git/cherry-pick', () => {
+  let repository: Repository
+  let initialCommit: CommitOneLine
+
+  beforeEach(async () => {
+    repository = await setupEmptyRepositoryDefaultMain()
+    initialCommit = await makeSquashCommit(repository, 'initialize')
+  })
+
+  it('squashes one commit onto the next (non-conflicting)', async () => {
+    const firstCommit = await makeSquashCommit(repository, 'first')
+    const firstShortSha = firstCommit.sha.slice(0, 7)
+    const secondCommit = await makeSquashCommit(repository, 'second')
+    const secondShortSha = secondCommit.sha.slice(0, 7)
+    const thirdCommit = await makeSquashCommit(repository, 'third')
+    const thirdShortSha = thirdCommit.sha.slice(0, 7)
+
+    const path = Path.join(repository.path, 'test')
+    await FSE.writeFile(
+      Path.join(repository.path, 'test'),
+      `pick ${firstShortSha} 1\nsquash ${secondShortSha} 2\nsquash ${thirdShortSha} 3\n`
+    )
+
+    await git(
+      [
+        '-c',
+        `sequence.editor=cat "${path}" >`,
+        'rebase',
+        '-i',
+        initialCommit.sha,
+      ],
+      repository.path,
+      'squash',
+      {
+        env: {
+          GIT_EDITOR: ':',
+        },
+      }
+    )
+
+    const log = await getCommits(repository, 'HEAD', 5)
+    expect(log.length).toBe(2)
+  })
+})
+
+async function makeSquashCommit(
+  repository: Repository,
+  desc: string
+): Promise<CommitOneLine> {
+  const commitTree = {
+    commitMessage: desc,
+    entries: [
+      {
+        path: desc + '.md',
+        contents: '# ' + desc + ' \n',
+      },
+    ],
+  }
+  await makeCommit(repository, commitTree)
+
+  return (await getCommit(repository, 'HEAD'))!
+}


### PR DESCRIPTION
## Description

First bit of logic for squashing:
- adds interactive rebasing building upon existing rebase methods/data structures
- adds method for squashing utilizing introduced interactive rebase
- one unit test - POC
   - next PR to expand unit tests to include multiple, non-sequential/reorder, and conflict unit tests
- Also modified log to allow for no limit on getCommits as we don't know how far back in history someone might try to squash

## Release notes

Notes: no-notes
