### PR TITLE
Fix crash reporting errors

### DIFF
--- a/app/src/lib/get-architecture.ts
+++ b/app/src/lib/get-architecture.ts
@@ -1,4 +1,4 @@
-import { remote } from 'electron'
+import { App } from 'electron'
 
 export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
 
@@ -8,13 +8,13 @@ export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
  * arm64 devices with the ability to emulate x64 binaries (like macOS using
  * Rosetta).
  */
-export function getArchitecture(): Architecture {
+export function getArchitecture(app: App): Architecture {
   // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2
   // More info: https://www.rudyhuyn.com/blog/2017/12/13/how-to-detect-that-your-x86-application-runs-on-windows-on-arm/
   // Right now (April 26, 2021) is not very important because support for x64
   // apps on an arm64 Windows is experimental. See:
   // https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/
-  if (remote.app.runningUnderRosettaTranslation === true) {
+  if (app.runningUnderRosettaTranslation === true) {
     return 'x64-emulated'
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -493,7 +493,7 @@ export class StatsStore implements IStatsStore {
       version: getVersion(),
       osVersion: getOS(),
       platform: process.platform,
-      architecture: getArchitecture(),
+      architecture: getArchitecture(remote.app),
       theme: getPersistedThemeName(),
       selectedTerminalEmulator,
       selectedTextEditor,

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -25,7 +25,7 @@ export async function reportError(
   }
 
   data.set('platform', process.platform)
-  data.set('architecture', getArchitecture())
+  data.set('architecture', getArchitecture(app))
   data.set('sha', __SHA__)
   data.set('version', app.getVersion())
 


### PR DESCRIPTION
## Description

Due to a recent change, the app is crashing when the app crashes and tries to report the crash. Yes.

The problem is `remote` is `undefined` in the main process, so calling `remote.app` would crash.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/116508575-f7886e00-a8c1-11eb-93ad-4d231d945aad.png)

## Release notes

Notes: [Fixed] The app will send error reports when it crashes
