### PR TITLE
Release 2.8.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/get-architecture.ts
+++ b/app/src/lib/get-architecture.ts
@@ -1,4 +1,4 @@
-import { remote } from 'electron'
+import { App } from 'electron'
 
 export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
 
@@ -8,13 +8,13 @@ export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
  * arm64 devices with the ability to emulate x64 binaries (like macOS using
  * Rosetta).
  */
-export function getArchitecture(): Architecture {
+export function getArchitecture(app: App): Architecture {
   // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2
   // More info: https://www.rudyhuyn.com/blog/2017/12/13/how-to-detect-that-your-x86-application-runs-on-windows-on-arm/
   // Right now (April 26, 2021) is not very important because support for x64
   // apps on an arm64 Windows is experimental. See:
   // https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/
-  if (remote.app.runningUnderRosettaTranslation === true) {
+  if (app.runningUnderRosettaTranslation === true) {
     return 'x64-emulated'
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -493,7 +493,7 @@ export class StatsStore implements IStatsStore {
       version: getVersion(),
       osVersion: getOS(),
       platform: process.platform,
-      architecture: getArchitecture(),
+      architecture: getArchitecture(remote.app),
       theme: getPersistedThemeName(),
       selectedTerminalEmulator,
       selectedTextEditor,

--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -25,7 +25,7 @@ export async function reportError(
   }
 
   data.set('platform', process.platform)
-  data.set('architecture', getArchitecture())
+  data.set('architecture', getArchitecture(app))
   data.set('sha', __SHA__)
   data.set('version', app.getVersion())
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "2.8.1": [
+      "[Fixed] The app will send error reports when it crashes - #12089"
+    ],
     "2.8.0": [
       "[New] Expand diffs to view more context around your changes - #7014",
       "[New] Create aliases for repositories you want to be displayed differently in the repository list - #7856",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming v2.8.1 production release? Well you've just found it, congratulations! :tada:

This is based on the 2.8.0 release (tag [release-2.8.0](https://github.com/desktop/desktop/releases/tag/release-2.8.0)) and includes:
- Fix for crash reporting crashes #12089 
- Fix for crash showing crash to users #12104 
- Disable partial commits while hiding whitespace changes #12129

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release 😂  **LOL** 🤣  ALL LOOKS GOOD, KTHXBAI
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated