### PR TITLE
Enable `remote` for the crash window

### DIFF
--- a/app/src/main-process/crash-window.ts
+++ b/app/src/main-process/crash-window.ts
@@ -38,6 +38,7 @@ export class CrashWindow {
         disableBlinkFeatures: 'Auxclick',
         nodeIntegration: true,
         spellcheck: false,
+        enableRemoteModule: true,
       },
     }
 


### PR DESCRIPTION
## Description

This PR fixes a problem introduced when we upgraded from Electron v9 to v11: since that upgrade, a crash in the application would kill the main window but wouldn't show the alert dialog with the stack trace and other information. Instead, a crash would happen in the context of that alert dialog because `remote` there is `undefined`.

The problem was it's now a requirement to specify `enableRemoteModule: true` if you want `remote` to be available in the context of that new window.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/116711874-8e911b00-a9d3-11eb-93f6-f3b81fe87216.png)

## Release notes

Notes: no-notes
