### PR TITLE
Thank you Part 3 - Parse thank you release notes separately

### DIFF
--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -66,6 +66,7 @@ export function getReleaseSummary(
   )
   const bugfixes = entries.filter(e => e.kind === 'fixed')
   const other = entries.filter(e => e.kind === 'removed' || e.kind === 'other')
+  const thankYous = entries.filter(e => e.message.includes(' Thanks @'))
 
   const datePublished = moment(latestRelease.pub_date).format('MMMM Do YYYY')
 
@@ -77,6 +78,7 @@ export function getReleaseSummary(
     enhancements,
     bugfixes,
     other,
+    thankYous,
   }
 }
 

--- a/app/src/models/release-notes.ts
+++ b/app/src/models/release-notes.ts
@@ -26,4 +26,5 @@ export type ReleaseSummary = {
   readonly enhancements: ReadonlyArray<ReleaseNote>
   readonly bugfixes: ReadonlyArray<ReleaseNote>
   readonly other: ReadonlyArray<ReleaseNote>
+  readonly thankYous: ReadonlyArray<ReleaseNote>
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -463,6 +463,12 @@ export class App extends React.Component<IAppProps, IAppState> {
               message: 'In other news...',
             },
           ],
+          thankYous: [
+            {
+              kind: 'other',
+              message: 'In other news... . Thanks @some-body-to-thank!',
+            },
+          ],
         },
       })
     }


### PR DESCRIPTION
## Description

Logic to start parsing the thank you notes as their own category/type.

The logic just says that the release note must contain ' Thanks @'. Therefore, we are open to a false-positive if we ever write a release note with ' Thanks @' inside of it. But, seeing as we input the release notes, that is an unlikely scenario. Also, in that unlikely scenario there would also have to be the logged in user's handle in the release note for it to trigger the thank you logic. And, even in that case, it wouldn't the end of the world to accidenlty thank that user.. seeing as we put the word "Thanks" and their handle the same message. 😛 

This PR is also independent of part 1 and 2.

## Release notes
Notes: no-notes
