### PR TITLE
Thank you Part 4 - Logic for storing when we have thanked a user

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -269,6 +269,15 @@ export interface IAppState {
    * Whether or not the user has been introduced to the cherry pick feature
    */
   readonly hasShownCherryPickIntro: boolean
+
+  /**
+   * Record of what logged in users have been checked to see if thank you is in
+   * order for external contributions in latest release.
+   *
+   * String of the form [version-number, user-login, user-login, user-login].
+   * This will be reset for each new version.
+   */
+  readonly versionAndUsersOfLastThankYou: ReadonlyArray<string>
 }
 
 export enum FoldoutType {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -40,6 +40,7 @@ import { TutorialStep } from '../models/tutorial-step'
 import { UncommittedChangesStrategy } from '../models/uncommitted-changes-strategy'
 import { CherryPickFlowStep } from '../models/cherry-pick'
 import { DragElement } from '../models/drag-element'
+import { ILastThankYou } from '../models/last-thank-you'
 
 export enum SelectionType {
   Repository,
@@ -273,11 +274,8 @@ export interface IAppState {
   /**
    * Record of what logged in users have been checked to see if thank you is in
    * order for external contributions in latest release.
-   *
-   * String of the form [version-number, user-login, user-login, user-login].
-   * This will be reset for each new version.
    */
-  readonly versionAndUsersOfLastThankYou: ReadonlyArray<string>
+  readonly lastThankYou: ILastThankYou | undefined
 }
 
 export enum FoldoutType {

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -177,3 +177,36 @@ export function getEnum<T extends string>(
   const storedValue = localStorage.getItem(key)
   return storedValue === null ? undefined : parseEnumValue(enumObj, storedValue)
 }
+
+/**
+ * Retrieve an object of type T's value from a given local
+ * storage entry, if found. If not found, return undefined.
+ *
+ * @param key local storage entry to read
+ */
+export function getObject<T>(key: string): T | undefined {
+  const rawData = localStorage.getItem(key)
+
+  if (rawData === null) {
+    return
+  }
+
+  try {
+    return JSON.parse(rawData)
+  } catch (e) {
+    // If corrupted and can't be parsed, we return undefined.
+    return
+  }
+}
+
+/**
+ * Set the provided key in local storage to an object, or update the
+ * existing value if a key is already defined.
+ *
+ * @param key local storage entry to update
+ * @param value the object to set
+ */
+export function setObject(key: string, value: object) {
+  const rawData = JSON.stringify(value)
+  localStorage.setItem(key, rawData)
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -209,6 +209,8 @@ import {
   getNumberArray,
   setNumberArray,
   getEnum,
+  getStringArray,
+  setStringArray,
 } from '../local-storage'
 import { ExternalEditorError, suggestedExternalEditor } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -340,6 +342,7 @@ const InitialRepositoryIndicatorTimeout = 2 * 60 * 1000
 const MaxInvalidFoldersToDisplay = 3
 
 const hasShownCherryPickIntroKey = 'has-shown-cherry-pick-intro'
+const versionAndUsersOfLastThankYouKey = 'version-and-users-of-last-thank-you'
 
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
@@ -449,6 +452,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private hasShownCherryPickIntro: boolean = false
 
   private currentDragElement: DragElement | null = null
+  private versionAndUsersOfLastThankYou: ReadonlyArray<string> = []
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -801,6 +805,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       commitSpellcheckEnabled: this.commitSpellcheckEnabled,
       hasShownCherryPickIntro: this.hasShownCherryPickIntro,
       currentDragElement: this.currentDragElement,
+      versionAndUsersOfLastThankYou: this.versionAndUsersOfLastThankYou,
     }
   }
 
@@ -1772,6 +1777,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     })
 
     this.hasShownCherryPickIntro = getBoolean(hasShownCherryPickIntroKey, false)
+    this.versionAndUsersOfLastThankYou = getStringArray(
+      versionAndUsersOfLastThankYouKey
+    )
 
     this.emitUpdateNow()
 
@@ -6223,6 +6231,32 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: Branch
   ): Promise<IAheadBehind | null> {
     return getBranchAheadBehind(repository, branch)
+  }
+
+  public _setVersionAndUsersOfLastThankYou(
+    versionAndUsersOfLastThankYou: ReadonlyArray<string>
+  ) {
+    // don't update if both empty (equal)
+    // don't update if same length and same version (assumption
+    // is that update will be either adding a user or updating version)
+    if (
+      (this.versionAndUsersOfLastThankYou.length === 0 &&
+        versionAndUsersOfLastThankYou.length === 0) ||
+      (this.versionAndUsersOfLastThankYou.length ===
+        versionAndUsersOfLastThankYou.length &&
+        this.versionAndUsersOfLastThankYou[0] ===
+          versionAndUsersOfLastThankYou[0])
+    ) {
+      return
+    }
+
+    setStringArray(
+      versionAndUsersOfLastThankYouKey,
+      versionAndUsersOfLastThankYou
+    )
+    this.versionAndUsersOfLastThankYou = versionAndUsersOfLastThankYou
+
+    this.emitUpdate()
   }
 }
 

--- a/app/src/models/last-thank-you.ts
+++ b/app/src/models/last-thank-you.ts
@@ -1,0 +1,4 @@
+export interface ILastThankYou {
+  version: string
+  checkedUsers: ReadonlyArray<string>
+}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3066,4 +3066,13 @@ export class Dispatcher {
   ): Promise<IAheadBehind | null> {
     return this.appStore._getBranchAheadBehind(repository, branch)
   }
+
+  /** Set whether thanks you is in order for external contributions */
+  public setVersionAndUsersOfLastThankYou(
+    versionAndUsersOfLastThankYou: ReadonlyArray<string>
+  ) {
+    this.appStore._setVersionAndUsersOfLastThankYou(
+      versionAndUsersOfLastThankYou
+    )
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -108,6 +108,7 @@ import { CherryPickResult } from '../../lib/git/cherry-pick'
 import { sleep } from '../../lib/promise'
 import { DragElement } from '../../models/drag-element'
 import { findDefaultUpstreamBranch } from '../../lib/branch'
+import { ILastThankYou } from '../../models/last-thank-you'
 
 /**
  * An error handler function.
@@ -3067,12 +3068,8 @@ export class Dispatcher {
     return this.appStore._getBranchAheadBehind(repository, branch)
   }
 
-  /** Set whether thanks you is in order for external contributions */
-  public setVersionAndUsersOfLastThankYou(
-    versionAndUsersOfLastThankYou: ReadonlyArray<string>
-  ) {
-    this.appStore._setVersionAndUsersOfLastThankYou(
-      versionAndUsersOfLastThankYou
-    )
+  /** Set whether thank you is in order for external contributions */
+  public setLastThankYou(lastThankYou: ILastThankYou) {
+    this.appStore._setLastThankYou(lastThankYou)
   }
 }


### PR DESCRIPTION
## Description

This is the app state and local storage logic for remembering when we have thanked a user and they have thrown away their card. 

Caveats.. If a user jumps between versions, they can get thanked multiple times. That would mean install version x and then installing version y that is older and in both version x and version y the user had a contribution. I am comfortable with assuming that is a rare/non-existent scenario and worst case is they just get thanked again (which is just a banner they don't have to open the card). 

Also, this one is not dependent on part 1, 2, 3, 4. 

## Release notes
Notes: no-notes
