### PR TITLE
Fix hover highlighting for expansion handlers

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -330,7 +330,7 @@ export class SideBySideDiffRow extends React.Component<
 
     return (
       <div
-        className="hunk-expansion-handle selectable"
+        className="hunk-expansion-handle selectable hoverable"
         title={elementInfo.title}
         onClick={elementInfo.handler}
         onContextMenu={this.props.onContextMenuExpandHunk}


### PR DESCRIPTION
## Description

Due to a regression introduced in #12129, the expansion handlers wouldn't highlight anymore on hovering. A new "hoverable" class was introduced, but these handlers didn't have it.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/117108753-ed63e500-ad83-11eb-9038-4f277db52d1c.png)

## Release notes

Notes: no-notes
