### PR TITLE
Show the build architecture in the About dialog

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -39,6 +39,11 @@ interface IAboutProps {
    */
   readonly applicationVersion: string
 
+  /**
+   * The currently installed (and running) architecture of the app.
+   */
+  readonly applicationArchitecture: string
+
   /** A function to call to kick off an update check. */
   readonly onCheckForUpdates: () => void
 
@@ -258,8 +263,10 @@ export class About extends React.Component<IAboutProps, IAboutState> {
           </Row>
           <h2>{name}</h2>
           <p className="no-padding">
-            <span className="selectable-text">{versionText}</span> (
-            {releaseNotesLink})
+            <span className="selectable-text">
+              {versionText} ({this.props.applicationArchitecture})
+            </span>{' '}
+            ({releaseNotesLink})
           </p>
           <p className="no-padding">
             <LinkButton onClick={this.props.onShowTermsAndConditions}>

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1545,6 +1545,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             onDismissed={onPopupDismissedFn}
             applicationName={getName()}
             applicationVersion={version}
+            applicationArchitecture={process.arch}
             onCheckForUpdates={this.onCheckForUpdates}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}


### PR DESCRIPTION
## Description

This PR adds the architecture of the running build to the About dialog.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/117113227-77af4780-ad8a-11eb-97e1-713da9bb2d4b.png) ![image](https://user-images.githubusercontent.com/1083228/117113991-8b0ee280-ad8b-11eb-9155-87bdb29a071c.png)

## Release notes

Notes: no-notes
