### PR TITLE
Allow users to stash existing changes before undoing a commit

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -10,7 +10,7 @@ import { IRemote } from './remote'
 import { RetryAction } from './retry-actions'
 import { WorkingDirectoryFileChange } from './status'
 import { PreferencesTab } from './preferences'
-import { CommitOneLine, ICommitContext } from './commit'
+import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { IStashEntry } from './stash-entry'
 import { Account } from '../models/account'
 import { Progress } from './progress'
@@ -75,6 +75,7 @@ export enum PopupType {
   ThankYou,
   CommitMessage,
   MultiCommitOperation,
+  ConfirmStashBeforeUndo,
 }
 
 export type Popup =
@@ -304,4 +305,10 @@ export type Popup =
   | {
       type: PopupType.MultiCommitOperation
       repository: Repository
+    }
+  | {
+      type: PopupType.ConfirmStashBeforeUndo
+      repository: Repository
+      commit: Commit
+      overwrite: boolean
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -156,6 +156,7 @@ import { DefaultCommitMessage } from '../models/commit-message'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { MultiCommitOperation } from './multi-commit-operation/multi-commit-operation'
+import { StashBeforeUndo } from './undo/stash-before-undo'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2222,6 +2223,19 @@ export class App extends React.Component<IAppProps, IAppState> {
             openFileInExternalEditor={this.openFileInExternalEditor}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
+          />
+        )
+      }
+      case PopupType.ConfirmStashBeforeUndo: {
+        const { repository, commit, overwrite } = popup
+        return (
+          <StashBeforeUndo
+            key="stash-before-undo"
+            dispatcher={this.props.dispatcher}
+            repository={repository}
+            commit={commit}
+            overwrite={overwrite}
+            onDismissed={onPopupDismissedFn}
           />
         )
       }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -766,6 +766,14 @@ export class Dispatcher {
     return this.appStore._undoCommit(repository, commit)
   }
 
+  /** Undo the given commit. */
+  public stashAndUndoCommit(
+    repository: Repository,
+    commit: Commit
+  ): Promise<void> {
+    return this.appStore._stashAndUndoCommit(repository, commit)
+  }
+
   /** Revert the commit with the given SHA */
   public revertCommit(repository: Repository, commit: Commit): Promise<void> {
     return this.appStore._revertCommit(repository, commit)

--- a/app/src/ui/undo/stash-before-undo.tsx
+++ b/app/src/ui/undo/stash-before-undo.tsx
@@ -4,7 +4,6 @@ import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { Octicon, OcticonSymbol } from '../octicons'
 import { Commit } from '../../models/commit'
 
 interface IStashBeforeUndoProps {
@@ -60,9 +59,8 @@ export class StashBeforeUndo extends React.Component<
           </Row>
           {this.props.overwrite && (
             <Row>
-              <Octicon symbol={OcticonSymbol.alert} /> You also have stashed
-              changes on this branch. If you continue, your current stash will
-              be overwritten by creating a new stash
+              You also have stashed changes on this branch. If you continue,
+              your current stash will be overwritten by creating a new stash
             </Row>
           )}
         </DialogContent>

--- a/app/src/ui/undo/stash-before-undo.tsx
+++ b/app/src/ui/undo/stash-before-undo.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { Commit } from '../../models/commit'
+
+interface IStashBeforeUndoProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly commit: Commit
+  readonly overwrite: boolean
+  readonly onDismissed: () => void
+}
+
+interface IStashBeforeUndoState {
+  readonly isLoading: boolean
+}
+
+/**
+ * Dialog that alerts user that there are uncommitted changes in the working
+ * directory where they are gonna be undoing a commit.
+ */
+export class StashBeforeUndo extends React.Component<
+  IStashBeforeUndoProps,
+  IStashBeforeUndoState
+> {
+  public constructor(props: IStashBeforeUndoProps) {
+    super(props)
+    this.state = { isLoading: false }
+  }
+
+  public render() {
+    const title = __DARWIN__ ? 'Undo Commit' : 'Undo commit'
+    const okButtonTitle = this.props.overwrite
+      ? __DARWIN__
+        ? 'Overwrite and Undo'
+        : 'Overwrite and undo'
+      : __DARWIN__
+      ? 'Stash and Undo'
+      : 'Stash and undo'
+
+    return (
+      <Dialog
+        id="stash-before-undo"
+        type="warning"
+        title={title}
+        loading={this.state.isLoading}
+        disabled={this.state.isLoading}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            You have changes on this branch. Undoing the commit might lose some
+            of these changes. Do you want to stash your changes and undo the
+            commit?
+          </Row>
+          {this.props.overwrite && (
+            <Row>
+              <Octicon symbol={OcticonSymbol.alert} /> You also have stashed
+              changes on this branch. If you continue, your current stash will
+              be overwritten by creating a new stash
+            </Row>
+          )}
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={okButtonTitle}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onSubmit = async () => {
+    const { dispatcher, repository, commit, onDismissed } = this.props
+    this.setState({ isLoading: true })
+
+    try {
+      await dispatcher.stashAndUndoCommit(repository, commit)
+    } finally {
+      this.setState({ isLoading: false })
+    }
+
+    onDismissed()
+  }
+}


### PR DESCRIPTION
## Description

If changes in the working directory overlap changes in a commit the user is going to undo, Desktop will allow the user to stash those changes before undoing the commit.

If the user already has stashed changes, Desktop will warn the user that those stashed changes will be replaced (and therefore lost).

I'd love to hear your feedback about the wording inside those confirmation dialogs.

### Screenshots

https://user-images.githubusercontent.com/1083228/117131839-4773a300-ada2-11eb-9b92-25a952baf177.mov

With no stashed changes:
![image](https://user-images.githubusercontent.com/1083228/117131920-66723500-ada2-11eb-8dfa-f3b371cc0c5e.png)

With other stashed changes already:
![image](https://user-images.githubusercontent.com/1083228/117131897-5e19fa00-ada2-11eb-8480-c446d7853967.png)

## Release notes

Notes: [Improved] Current changes will be stashed before undoing a commit in case of conflicts
