### PR TITLE
Get all previous releases to retroactively thank contributors

### DIFF
--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -88,18 +88,14 @@ export async function getChangeLog(
 ): Promise<ReadonlyArray<ReleaseMetadata>> {
   const changelog =
     'https://central.github.com/deployments/desktop/desktop/changelog.json'
-  const params = []
+  const params = new URLSearchParams()
   if (__RELEASE_CHANNEL__ === 'beta') {
-    params.push('env=beta')
+    params.append('env', 'beta')
   }
   if (limit !== undefined) {
-    params.push(`limit=${limit}`)
+    params.append('limit', limit.toString())
   }
-  let query = ''
-  params.forEach(param => {
-    const prefix = query === '' ? '?' : '&'
-    query += `${prefix}${param}`
-  })
+  const query = params.toString() !== '' ? `?${params.toString()}` : ''
 
   const response = await fetch(`${changelog}${query}`)
   if (response.ok) {

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -86,18 +86,19 @@ export function getReleaseSummary(
 export async function getChangeLog(
   limit?: number
 ): Promise<ReadonlyArray<ReleaseMetadata>> {
-  const changelog =
+  const changelogURL = new URL(
     'https://central.github.com/deployments/desktop/desktop/changelog.json'
-  const params = new URLSearchParams()
-  if (__RELEASE_CHANNEL__ === 'beta') {
-    params.append('env', 'beta')
-  }
-  if (limit !== undefined) {
-    params.append('limit', limit.toString())
-  }
-  const query = params.toString() !== '' ? `?${params.toString()}` : ''
+  )
 
-  const response = await fetch(`${changelog}${query}`)
+  if (__RELEASE_CHANNEL__ === 'beta') {
+    changelogURL.searchParams.set('env', 'beta')
+  }
+
+  if (limit !== undefined) {
+    changelogURL.searchParams.set('limit', limit.toString())
+  }
+
+  const response = await fetch(changelogURL.toString())
   if (response.ok) {
     const releases: ReadonlyArray<ReleaseMetadata> = await response.json()
     return releases

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -83,10 +83,23 @@ export function getReleaseSummary(
   }
 }
 
-export async function getChangeLog(): Promise<ReadonlyArray<ReleaseMetadata>> {
+export async function getChangeLog(
+  limit?: number
+): Promise<ReadonlyArray<ReleaseMetadata>> {
   const changelog =
     'https://central.github.com/deployments/desktop/desktop/changelog.json'
-  const query = __RELEASE_CHANNEL__ === 'beta' ? '?env=beta' : ''
+  const params = []
+  if (__RELEASE_CHANNEL__ === 'beta') {
+    params.push('env=beta')
+  }
+  if (limit !== undefined) {
+    params.push(`limit=${limit}`)
+  }
+  let query = ''
+  params.forEach(param => {
+    const prefix = query === '' ? '?' : '&'
+    query += `${prefix}${param}`
+  })
 
   const response = await fetch(`${changelog}${query}`)
   if (response.ok) {

--- a/app/src/lib/thank-you.ts
+++ b/app/src/lib/thank-you.ts
@@ -47,7 +47,9 @@ export function updateLastThankYou(
 export async function getThankYouByUser(
   isOnlyLastRelease: boolean
 ): Promise<Map<string, ReadonlyArray<ReleaseNote>>> {
-  let releaseMetaData = await getChangeLog()
+  // 250 is more than total number beta release to date (5/5/2021) and the
+  // purpose of getting more is to retroactively thank contributors to date.
+  let releaseMetaData = await getChangeLog(250)
   if (isOnlyLastRelease) {
     releaseMetaData = releaseMetaData.slice(0, 1)
   }

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -96,6 +96,10 @@
     .contributions {
       max-height: 150px;
     }
+
+    .section {
+      padding-bottom: var(--spacing-triple);
+    }
   }
 
   .confetti-container {


### PR DESCRIPTION
## Description

Make use of modified change log call to get more than 10 previous release when retroactively thanking past contributors.

### Screenshots
Check out all those PRs @say25!!!

https://user-images.githubusercontent.com/75402236/117182141-fbc1f900-ada3-11eb-8e91-c5e2137a7456.mov


## Release notes
Notes: no-notes
