### PR TITLE
Minor changes to thank you card

### DIFF
--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -21,8 +21,7 @@ export class OpenThankYouCard extends React.Component<
     return (
       <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
         <span onSubmit={this.props.onOpenCard}>
-          The Desktop team would like to thank you for your
-          contributions.{' '}
+          The Desktop team would like to thank you for your contributions.{' '}
           <LinkButton onClick={this.props.onOpenCard}>
             Open Your Card
           </LinkButton>{' '}

--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -21,7 +21,7 @@ export class OpenThankYouCard extends React.Component<
     return (
       <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
         <span onSubmit={this.props.onOpenCard}>
-          The Desktop team would like to thank you for your recent
+          The Desktop team would like to thank you for your
           contributions.{' '}
           <LinkButton onClick={this.props.onOpenCard}>
             Open Your Card

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -104,7 +104,7 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
       >
         <DialogContent>
           <div className="container">
-            <div className="thank-you-note">{thankYouNote}.</div>
+            <div className="thank-you-note">{thankYouNote}</div>
             <div className="contributions-heading">You contributed:</div>
             <div className="contributions">
               {this.renderList(this.props.userContributions)}

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -80,9 +80,6 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
               renderUrlsAsLinks={true}
             />
           </div>
-          <div className="thank-you-note">
-            The Desktop team wants to thank you personally.
-          </div>
         </div>
       </div>
     )

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -84,7 +84,7 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
       </div>
     )
 
-    const thankYou = 'Thank you for all your hard work on GitHub Desktop'
+    const thankYou = "Thanks so much for all your hard work on GitHub Desktop. We're so grateful for you helping to make the app better for everyone!"
     let thankYouNote
     if (this.props.latestVersion === null) {
       thankYouNote = <>{thankYou}</>

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -84,17 +84,16 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
       </div>
     )
 
-    const thankYou = "Thanks so much for all your hard work on GitHub Desktop. We're so grateful for you helping to make the app better for everyone!"
-    let thankYouNote
-    if (this.props.latestVersion === null) {
-      thankYouNote = <>{thankYou}</>
-    } else {
-      thankYouNote = (
-        <>
-          {thankYou} version {this.props.latestVersion}
-        </>
-      )
-    }
+    const version =
+      this.props.latestVersion !== null
+        ? ` version ${this.props.latestVersion}`
+        : ''
+    const thankYouNote = (
+      <>
+        Thanks so much for all your hard work on GitHub Desktop{version}. We're
+        so grateful for you helping to make the app better for everyone!
+      </>
+    )
 
     return (
       <Dialog

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -85,13 +85,12 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
     )
 
     const version =
-      this.props.latestVersion !== null
-        ? ` version ${this.props.latestVersion}`
-        : ''
+      this.props.latestVersion !== null ? ` ${this.props.latestVersion}` : ''
     const thankYouNote = (
       <>
         Thanks so much for all your hard work on GitHub Desktop{version}. We're
-        so grateful for you helping to make the app better for everyone!
+        so grateful for your willingness to contribute and make the app better
+        for everyone!
       </>
     )
 
@@ -114,6 +113,7 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
             >
               {this.renderConfetti()}
             </div>
+            <div className="footer"></div>
           </div>
         </DialogContent>
       </Dialog>

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -7,6 +7,7 @@
   .dialog-content {
     // we'll own the layout inside here
     padding: 0;
+    overflow: hidden;
   }
 
   .dialog-header {
@@ -79,12 +80,25 @@
 
   .container {
     width: 600px;
-    padding-left: 80px;
-    padding-right: 80px;
+    padding-left: 72px;
+    padding-right: 72px;
     padding-top: var(--spacing-triple);
     padding-bottom: var(--spacing-triple);
     overflow-x: hidden;
     overflow-y: auto;
+
+    .footer {
+      position: fixed;
+      height: var(--spacing-triple);
+      width: 95%;
+      bottom: 0;
+      left: 0;
+      background-color: var(--background-color);
+    }
+
+    .section {
+      padding-bottom: var(--spacing-triple);
+    }
 
     .thank-you-note {
       padding-bottom: var(--spacing-triple);

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -9,7 +9,7 @@
   }
 
   .dialog-header {
-    height: 100px;
+    height: 88px;
     position: relative;
 
     .release-notes-header {

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -2,6 +2,7 @@
 
 #thank-you-notes {
   max-height: 450px;
+  padding-top: var(--spacing-half);
 
   .dialog-content {
     // we'll own the layout inside here
@@ -73,6 +74,7 @@
   a.close {
     align-self: flex-start;
     z-index: 1;
+    margin-top: calc(var(--spacing) * -1);
   }
 
   .container {

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -85,7 +85,6 @@
     overflow-y: auto;
 
     .thank-you-note {
-      font-weight: var(--font-weight-semibold);
       padding-bottom: var(--spacing-triple);
     }
 


### PR DESCRIPTION
This just slightly changes the wording of the thank you card.

1. I removed "recent" from the banner text that lets people know they have a card available since we're also sending cards for retroactive contributions.
2. I updated the layout and verbiage slightly on the card itself. Here's how it looks with this PR.

After:
<img width="919" alt="Screen Shot 2021-05-05 at 12 50 13 PM" src="https://user-images.githubusercontent.com/5091167/117194104-ec8d7c00-ada0-11eb-9109-6071580a283a.png">

Before:
<img width="767" alt="Screen Shot 2021-05-05 at 12 55 43 PM" src="https://user-images.githubusercontent.com/5091167/117194334-370ef880-ada1-11eb-99ef-18b3dc94768a.png">

NOTE: I didn't have time to tackle the differentiation for the description when the Desktop version number is included. @tidy-dev Would you mind taking a crack at that? I'll add a self-review note where I'm referring to.



