### PR TITLE
FIx overflow behavior for tab-containers and select components

### DIFF
--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -48,10 +48,6 @@
     color: var(--text-secondary-color);
   }
 
-  .select-component {
-    overflow: hidden;
-  }
-
   .popover-component {
     // This allows for using <Rows> to structure content within dialog content.
     // All Rows that are direct descendants of dialog content except for the

--- a/app/styles/ui/_select.scss
+++ b/app/styles/ui/_select.scss
@@ -21,5 +21,6 @@
 
     // Don't include the default padding from textboxish, it's too much
     padding: 0;
+    width: 100%;
   }
 }

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -3,6 +3,10 @@
   flex-direction: row;
   height: var(--tab-bar-height);
 
+  .tab-container {
+    overflow: hidden;
+  }
+
   &.vertical {
     flex-direction: column;
     align-items: stretch;

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -3,10 +3,6 @@
   flex-direction: row;
   height: var(--tab-bar-height);
 
-  .tab-container {
-    overflow: hidden;
-  }
-
   &.vertical {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Description

This PR makes a few changes in the (global) style of `Select` components and tab containers.

The original problem was that very long items inside of a `Select` component would cause the tab container to grow beyond its boundaries:

![image](https://user-images.githubusercontent.com/1083228/117279613-2b373b00-ae62-11eb-87cf-a59ee52f730f.png)

Making sure the `select` element doesn't exceed the boundaries of its `Select` parent component, and that `tab-container` elements don't allow overflow, fixed this issue.

These changes fix the mentioned issue in:
- The Git config subscreen in the `Preferences` dialog (the one from the screenshot above)
- The Git config subscreen in the `Repository Settings` dialog
- The warning for misattributed commits (which was fixed in a different way)

Other sections that could've regressed (but didn't see anything in my testing):
- Any view where `tab-container` is used. So far that's only the `Preferences` and `Repository Settings` dialogs.
- Any view where a `Select` component is used:
	- New repo dialog
	- Publish repo dialog
	- Git config screen in Welcome flow
	- `Integrations` screen (external editor and shell)

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/117279782-591c7f80-ae62-11eb-9d38-10e3573992df.png)

![image](https://user-images.githubusercontent.com/1083228/117280259-b4e70880-ae62-11eb-962c-1e39c927fd7e.png)

![image](https://user-images.githubusercontent.com/1083228/117280405-dba53f00-ae62-11eb-966d-e4bc35bed9f8.png)

## Release notes

Notes: [Fixed] Long emails are truncated in the Git config
