### PR TITLE
Better text token parsing of new line

### DIFF
--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -180,7 +180,7 @@ export class Tokenizer {
     // to ensure this isn't part of an email address, peek at the previous
     // character - if something is found and it's not whitespace, bail out
     const lastItem = this.getLastProcessedChar()
-    if (lastItem && lastItem !== ' ') {
+    if (lastItem && !/\s/.test(lastItem)) {
       return null
     }
 
@@ -212,7 +212,7 @@ export class Tokenizer {
     // to ensure this isn't just the part of some word - if something is
     // found and it's not whitespace, bail out
     const lastItem = this.getLastProcessedChar()
-    if (lastItem && lastItem !== ' ') {
+    if (lastItem && !/\s/.test(lastItem)) {
       return null
     }
 

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -279,6 +279,12 @@ export class Tokenizer {
             this.scanForHyperlink(text, i)
           )
           break
+        
+        case '\n':
+          this.append(element)
+          this.append(' ')
+          i++
+          break
 
         default:
           this.append(element)
@@ -319,6 +325,12 @@ export class Tokenizer {
           i = this.inspectAndMove(element, i, () =>
             this.scanForHyperlink(text, i, repository)
           )
+          break
+        
+        case '\n':
+          this.append(element)
+          this.append(' ')
+          i++
           break
 
         default:

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -280,12 +280,6 @@ export class Tokenizer {
           )
           break
 
-        case '\n':
-          this.append(element)
-          this.append(' ')
-          i++
-          break
-
         default:
           this.append(element)
           i++
@@ -325,12 +319,6 @@ export class Tokenizer {
           i = this.inspectAndMove(element, i, () =>
             this.scanForHyperlink(text, i, repository)
           )
-          break
-
-        case '\n':
-          this.append(element)
-          this.append(' ')
-          i++
           break
 
         default:

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -279,7 +279,7 @@ export class Tokenizer {
             this.scanForHyperlink(text, i)
           )
           break
-        
+
         case '\n':
           this.append(element)
           this.append(' ')
@@ -326,7 +326,7 @@ export class Tokenizer {
             this.scanForHyperlink(text, i, repository)
           )
           break
-        
+
         case '\n':
           this.append(element)
           this.append(' ')

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -381,18 +381,18 @@ This fixes https://github.com/shiftkey/some-repo/issues/1034
 Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
 
       const expectedBefore = `Note: we keep a "denylist" of authentication methods for which we do
-not want to enable http.emptyAuth automatically. An allowlist would be
-nicer, but less robust, as we want to support linking to several cURL
-versions and the list of authentication methods (as well as their names)
-changed over time.
-
-[jes: actually added the "auto" handling, excluded Digest, too]
-
-This fixes `
+ not want to enable http.emptyAuth automatically. An allowlist would be
+ nicer, but less robust, as we want to support linking to several cURL
+ versions and the list of authentication methods (as well as their names)
+ changed over time.
+ 
+ [jes: actually added the "auto" handling, excluded Digest, too]
+ 
+ This fixes `
 
       const expectedAfter = `
-
-Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
+ 
+ Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
 
       const tokenizer = new Tokenizer(emoji, repository)
       const results = tokenizer.tokenize(text)

--- a/app/test/unit/text-token-parser-test.ts
+++ b/app/test/unit/text-token-parser-test.ts
@@ -381,18 +381,18 @@ This fixes https://github.com/shiftkey/some-repo/issues/1034
 Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
 
       const expectedBefore = `Note: we keep a "denylist" of authentication methods for which we do
- not want to enable http.emptyAuth automatically. An allowlist would be
- nicer, but less robust, as we want to support linking to several cURL
- versions and the list of authentication methods (as well as their names)
- changed over time.
- 
- [jes: actually added the "auto" handling, excluded Digest, too]
- 
- This fixes `
+not want to enable http.emptyAuth automatically. An allowlist would be
+nicer, but less robust, as we want to support linking to several cURL
+versions and the list of authentication methods (as well as their names)
+changed over time.
+
+[jes: actually added the "auto" handling, excluded Digest, too]
+
+This fixes `
 
       const expectedAfter = `
- 
- Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>`
 
       const tokenizer = new Tokenizer(emoji, repository)
       const results = tokenizer.tokenize(text)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #12105

### Description

- If the new line starts with a link or a mention, the text token parser can't recognize them as such.

### Screenshots

## Before
![before](https://user-images.githubusercontent.com/9341546/117539461-6dec4500-b013-11eb-83ac-c5ab7a3d1743.gif)

## After
![after](https://user-images.githubusercontent.com/9341546/117539525-bd327580-b013-11eb-8abf-8f2f3af57da7.gif)

## Tokenization result BEFORE changes
![image](https://user-images.githubusercontent.com/9341546/117540410-f240c700-b017-11eb-8ecb-9e715259dd63.png)

## Tokenization result AFTER changes
![image](https://user-images.githubusercontent.com/9341546/117540342-92e2b700-b017-11eb-8d2a-f415cbeb947a.png)



