### PR TITLE
Squashing: Dispatcher and app store stub out

### DIFF
--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -45,7 +45,11 @@ export async function squash(
     // need to traverse in reverse so we do oldest to newest (replay commits)
     for (let i = commits.length - 1; i >= 0; i--) {
       // Ignore commits to squash because those are written right next to the target commit
-      if (toSquash.map(sq => sq.sha).includes(commits[i].sha)) {
+      if (
+        toSquash.map(sq => sq.sha).includes(commits[i].sha) &&
+        // unless it is the squashOnto commit (this happens when squashing via the context menu)
+        commits[i].sha !== squashOnto.sha
+      ) {
         continue
       }
 

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -29,7 +29,8 @@ export async function squash(
       throw new Error('[squash] No commits provided to squash.')
     }
 
-    if (toSquash.find(c => c.sha === squashOnto.sha) !== undefined) {
+    const toSquashShas = new Set(toSquash.map(c => c.sha))
+    if (toSquashShas.has(squashOnto.sha)) {
       throw new Error(
         '[squash] The commits to squash cannot contain the commit to squash onto.'
       )
@@ -49,7 +50,7 @@ export async function squash(
     todoPath = await getTempFilePath('squashTodo')
     let foundSquashOntoCommitInLog = false
     // need to traverse in reverse so we do oldest to newest (replay commits)
-    const toSquashShas = new Set(toSquash.map(c => c.sha))
+
     for (let i = commits.length - 1; i >= 0; i--) {
       // Ignore commits toSquash because those are written right after the squashOnto commit
       if (toSquashShas.has(commits[i].sha)) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3073,7 +3073,14 @@ export class Dispatcher {
     this.appStore._setLastThankYou(lastThankYou)
   }
 
-  /** Starts a cherry pick of the given commits onto the target branch */
+  /**
+   * Starts a squash
+   *
+   * @param toSquash - commits to squash onto another commit
+   * @param squashOnto  - commit to squash the `toSquash` commits onto
+   * @param lastRetainedCommitRef - commit ref of commit before commits in squash
+   * @param commitContext - to build the commit message from
+   */
   public async squash(
     repository: Repository,
     toSquash: ReadonlyArray<Commit>,
@@ -3154,8 +3161,8 @@ export class Dispatcher {
   }
 
   /**
-   * Obtains the current app conflict state and switches cherry pick flow to
-   * show conflicts step
+   * Obtains the current app conflict state and switches squash flow to show
+   * conflicts step
    */
   private startConflictSquashFlow(repository: Repository): void {
     const stateAfter = this.repositoryStateManager.get(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3072,4 +3072,119 @@ export class Dispatcher {
   public setLastThankYou(lastThankYou: ILastThankYou) {
     this.appStore._setLastThankYou(lastThankYou)
   }
+
+  /** Starts a cherry pick of the given commits onto the target branch */
+  public async squash(
+    repository: Repository,
+    toSquash: ReadonlyArray<Commit>,
+    squashOnto: Commit,
+    lastRetainedCommitRef: string,
+    commitContext: ICommitContext
+  ): Promise<void> {
+    // TODO: initialize squash flow for progress dialog
+    // TODO: set undo sha in state (combine with initialize?)
+    // TODO: handle uncommitted changes
+
+    const result = await this.appStore._squash(
+      repository,
+      toSquash,
+      squashOnto,
+      lastRetainedCommitRef,
+      commitContext
+    )
+
+    this.logHowToRevertSquash(repository)
+
+    this.processSquashRebaseResult(repository, result, toSquash)
+  }
+
+  private logHowToRevertSquash(repository: Repository): void {
+    const stateBefore = this.repositoryStateManager.get(repository)
+    const { tip } = stateBefore.branchesState
+    const beforeSha = getTipSha(tip)
+
+    if (tip.kind !== TipState.Valid) {
+      log.info(
+        `[squash] - could not determine branch for ${beforeSha}. No revert instructions provided.`
+      )
+      return
+    }
+
+    log.info(`[squash] starting rebase for ${tip.branch.name} at ${beforeSha}`)
+    log.info(
+      `[squash] to restore the previous state if this completed rebase is unsatisfactory:`
+    )
+    log.info(`[squash] - git checkout ${tip.branch.name}`)
+    log.info(`[squash] - git reset ${beforeSha} --hard`)
+  }
+
+  /**
+   * Processes the squash result
+   *  1. Completes the squash with banner if successful.
+   *  2. Moves squash flow to conflicts handler.
+   *  3. Handles errors.
+   */
+  private async processSquashRebaseResult(
+    repository: Repository,
+    cherryPickResult: RebaseResult,
+    toSquash: ReadonlyArray<CommitOneLine>
+  ): Promise<void> {
+    // This will update the conflict state of the app. This is needed to start
+    // conflict flow if squash results in conflict.
+    const status = await this.appStore._loadStatus(repository)
+    switch (cherryPickResult) {
+      case RebaseResult.CompletedWithoutError:
+        if (status !== null && status.currentTip !== undefined) {
+          // This sets the history to the current tip
+          // TODO: Look at history back to last retained commit and search for
+          // squashed commit based on new commit message ... if there is more
+          // than one, just take the most recent. (not likely?)
+          await this.changeCommitSelection(repository, [status.currentTip])
+        }
+
+        await this.completeSquash(repository, toSquash.length)
+        break
+      case RebaseResult.ConflictsEncountered:
+        this.startConflictSquashFlow(repository)
+        break
+      default:
+        // TODO: clear state
+        this.appStore._closePopup()
+    }
+  }
+
+  /**
+   * Obtains the current app conflict state and switches cherry pick flow to
+   * show conflicts step
+   */
+  private startConflictSquashFlow(repository: Repository): void {
+    const stateAfter = this.repositoryStateManager.get(repository)
+    const { conflictState } = stateAfter.changesState
+    if (conflictState === null || !isRebaseConflictState(conflictState)) {
+      log.error(
+        '[squash] - conflict state was null or not in a rebase conflict state - unable to continue'
+      )
+
+      // TODO: clear state
+      return
+    }
+    // TODO: switch state to show conflict dialog
+    // TODO: record conflict encountered during squash
+  }
+
+  /**
+   * Wrap squash actions
+   * - closes popups
+   * - refreshes repo (so changes appear in history)
+   * TODO: Displays success banner
+   * TODO: state resetting
+   * TODO: record successful squash stats
+   */
+  private async completeSquash(
+    repository: Repository,
+    countSquashed: number
+  ): Promise<void> {
+    this.closePopup()
+    await this.refreshRepository(repository)
+  }
 }

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -53,7 +53,7 @@ describe('git/cherry-pick', () => {
     expect(squashedFilePaths).toContain('second.md')
   })
 
-  it('squashes one commit onto the next (non-conflicting, squashOnto in toSquash array)', async () => {
+  it('returns error when squashOnto is in the toSquash array', async () => {
     const firstCommit = await makeSquashCommit(repository, 'first')
     const secondCommit = await makeSquashCommit(repository, 'second')
 
@@ -65,19 +65,7 @@ describe('git/cherry-pick', () => {
       'Test Summary\n\nTest Body'
     )
 
-    expect(result).toBe(RebaseResult.CompletedWithoutError)
-
-    const log = await getCommits(repository, 'HEAD', 5)
-    const squashed = log[0]
-    expect(squashed.summary).toBe('Test Summary')
-    expect(squashed.body).toBe('Test Body\n')
-    expect(log.length).toBe(2)
-
-    // verify squashed commit contains changes from squashed commits
-    const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.map(f => f.path).join(' ')
-    expect(squashedFilePaths).toContain('first.md')
-    expect(squashedFilePaths).toContain('second.md')
+    expect(result).toBe(RebaseResult.Error)
   })
 
   it('squashes multiple commit onto one (non-conflicting)', async () => {


### PR DESCRIPTION
## Description

Adds app store and dispatcher methods for squashing. A lot of stubbing out to build upon in rest of PR's. With this you could, squash non-conflicting squashes once wired to the UI. Conflicts are currently unhandled - just a stub method.

Upcoming PRs:
1. Wire up context menu to the dispatcher/app store methods/feature flag
2. Add a success banner
3. Add undo cause it's handy for testing :D
4. Wire up drag/drop UI
5. Conflict resolution part 1: hopefully make a reusable component... maybe refactor current implementations (merge, rebase, cherry-picking)
6.  Progress dialog.. reusable component again maybe
7. Uncommitted changes
8. Close/reopen app during conflict
9. Stats

## Release notes
Notes: no-notes
