### PR TITLE
Squashing: Update squash logic to respect log history in order to reduce conflicts

### DIFF
--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -6,7 +6,20 @@ import { getTempFilePath } from '../file-system'
 import { rebaseInteractive, RebaseResult } from './rebase'
 
 /**
- * Squashes provided commits by calling interactive rebase
+ * Squashes provided commits by calling interactive rebase.
+ *
+ * Goal is to replay the commits in order from oldest to newest to reduce
+ * conflicts with toSquash commits placed in the log at the location of the
+ * squashOnto commit.
+ *
+ * Example: A user's history from oldest to newest is A, B, C, D, E and they
+ * want to squash A and E (toSquash) onto C. Our goal:  B, A-C-E, D. Thus,
+ * maintaining that A came before C and E came after C, placed in history at the
+ * the squashOnto of C.
+ *
+ * Also means if the last 2 commits in history are A, B, whether user squashes A
+ * onto B or B onto A. It will always perform based on log history, thus, B onto
+ * A.
  *
  * @param toSquash - commits to squash onto another commit and does not contain the squashOnto commit
  * @param squashOnto  - commit to squash the `toSquash` commits onto
@@ -49,28 +62,70 @@ export async function squash(
 
     todoPath = await getTempFilePath('squashTodo')
     let foundSquashOntoCommitInLog = false
-    // need to traverse in reverse so we do oldest to newest (replay commits)
-
+    const toReplayAtSquash = []
+    const toReplayAfterSquash = []
+    // Traversed in reverse so we do oldest to newest (replay commits)
     for (let i = commits.length - 1; i >= 0; i--) {
-      // Ignore commits toSquash because those are written right after the squashOnto commit
       if (toSquashShas.has(commits[i].sha)) {
+        // If it is a toSquash commit and we have not found the squashOnto
+        // commit yet we want to keep track of them in the order of the log.
+        // Thus, we use a new `toReplayAtSquash` array and not trust that what
+        // was sent is in the order of the log.
+        if (foundSquashOntoCommitInLog) {
+          await FSE.appendFile(
+            todoPath,
+            `squash ${commits[i].sha} ${commits[i].summary}\n`
+          )
+        } else {
+          // However, if we have found the squashOnto commit, we can go ahead
+          // and squash them (as we will hold any picks till after)
+          toReplayAtSquash.push(commits[i])
+        }
+
         continue
       }
 
+      // If it's the squashOnto commit, replay to the toSquash in the order they
+      // appeared on the log to reduce potential conflicts.
+      if (commits[i].sha === squashOnto.sha) {
+        foundSquashOntoCommitInLog = true
+        toReplayAtSquash.push(commits[i])
+
+        for (let j = 0; j < toReplayAtSquash.length; j++) {
+          const action = j === 0 ? 'pick' : 'squash'
+          await FSE.appendFile(
+            todoPath,
+            `${action} ${toReplayAtSquash[j].sha} ${toReplayAtSquash[j].summary}\n`
+          )
+        }
+
+        continue
+      }
+
+      // We can't just replay a pick in case there is a commit from the toSquash
+      // commits further up in history that need to be replayed with the
+      // squashes. Thus, we will keep track of these and replay after traversing
+      // the remainder of the log.
+      if (foundSquashOntoCommitInLog) {
+        toReplayAfterSquash.push(commits[i])
+        continue
+      }
+
+      // If it is not one toSquash nor the squashOnto and have not found the
+      // squashOnto commit, we simply record it is an unchanged pick (before the
+      // squash)
       await FSE.appendFile(
         todoPath,
         `pick ${commits[i].sha} ${commits[i].summary}\n`
       )
+    }
 
-      // If it's the squashOnto commit, write a `squash` line for every commit to squash
-      if (commits[i].sha === squashOnto.sha) {
-        foundSquashOntoCommitInLog = true
-        for (let j = 0; j < toSquash.length; j++) {
-          await FSE.appendFile(
-            todoPath,
-            `squash ${toSquash[j].sha} ${toSquash[j].summary}\n`
-          )
-        }
+    if (toReplayAfterSquash.length > 0) {
+      for (let i = 0; i < toReplayAfterSquash.length; i++) {
+        await FSE.appendFile(
+          todoPath,
+          `pick ${toReplayAfterSquash[i].sha} ${toReplayAfterSquash[i].summary}\n`
+        )
       }
     }
 

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -118,7 +118,7 @@ describe('git/cherry-pick', () => {
     // Thus, reordering to 'second', 'first - third - fifth', 'fourth'
     const result = await squash(
       repository,
-      [firstCommit, fifthCommit],
+      [fifthCommit, firstCommit], // provided in opposite log order
       thirdCommit,
       initialCommit.sha,
       ''

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -99,7 +99,7 @@ describe('git/cherry-pick', () => {
     expect(squashedFilePaths).toContain('fourth.md')
   })
 
-  fit('squashes multiple commit non-sequential commits (reorders, non-conflicting)', async () => {
+  it('squashes multiple commit non-sequential commits (reorders, non-conflicting)', async () => {
     const firstCommit = await makeSquashCommit(repository, 'first')
     await makeSquashCommit(repository, 'second')
     const thirdCommit = await makeSquashCommit(repository, 'third')


### PR DESCRIPTION
## Description

Updated to squash commits in the order that they appear on the log. 

This may feel trivial at first glance, but given that a user adds a line to to the bottom of a file in commit A and then adds another line to the bottom in commit B. If the user drags A onto B indicating they want to squash A onto B. The original logic would reorder to B than A and squash resulting in a conflict as would now modify the last line of the file with B's changes which would now be the same line as in A.  However, had the user dragged B onto A, it would have maintained the order of A to B and no conflicts would arise. We are assuming that the user's goal was just to merge A and B and did not want any reordering to happen, they logically just want them to be one commit where 2 lines were added. Thus, this update will always maintain squashing commits order in respect to their history on the log.

Note: Reordering will still happen in the scenario a user has commits A, B, and C and the drag A onto C. This will respect the users choice of direction so it will be come B, A-C as opposed to if they dragged C onto A which will become A-C, B. But the order of A and C to each other will still be maintained based on history to reduce conflicts. 

## Release notes
Notes: no-notes
