### PR TITLE
Add detection for x64 emulation on Windows ARM

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.7",
+    "detect-arm64-translation": "https://github.com/desktop/node-detect-arm64-translation#v1.0.4",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.103.0",

--- a/app/src/lib/get-architecture.ts
+++ b/app/src/lib/get-architecture.ts
@@ -1,4 +1,5 @@
 import { App } from 'electron'
+import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
 
@@ -9,12 +10,10 @@ export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
  * Rosetta).
  */
 export function getArchitecture(app: App): Architecture {
-  // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2
-  // More info: https://www.rudyhuyn.com/blog/2017/12/13/how-to-detect-that-your-x86-application-runs-on-windows-on-arm/
-  // Right now (April 26, 2021) is not very important because support for x64
-  // apps on an arm64 Windows is experimental. See:
-  // https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/
-  if (app.runningUnderRosettaTranslation === true) {
+  if (
+    app.runningUnderRosettaTranslation === true ||
+    isRunningUnderARM64Translation() === true
+  ) {
     return 'x64-emulated'
   }
 

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -15,6 +15,7 @@ import { ReleaseSummary } from '../../models/release-notes'
 import { generateReleaseSummary } from '../../lib/release-notes'
 import { setNumber, getNumber } from '../../lib/local-storage'
 import { enableUpdateFromRosettaToARM64 } from '../../lib/feature-flag'
+import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 /** The states the auto updater can be in. */
 export enum UpdateStatus {
@@ -168,7 +169,8 @@ class UpdateStore {
     // the arm64 binary.
     if (
       enableUpdateFromRosettaToARM64() &&
-      remote.app.runningUnderRosettaTranslation === true
+      (remote.app.runningUnderRosettaTranslation === true ||
+        isRunningUnderARM64Translation() === true)
     ) {
       const url = new URL(updatesURL)
       url.pathname = url.pathname.replace(

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -318,6 +318,13 @@ desktop-trampoline@desktop/desktop-trampoline#v0.9.7:
     node-addon-api "^3.1.0"
     prebuild-install "^6.0.0"
 
+"detect-arm64-translation@https://github.com/desktop/node-detect-arm64-translation#v1.0.4":
+  version "1.0.3"
+  resolved "https://github.com/desktop/node-detect-arm64-translation#d03110738f94fa684fc20cdfa412e83cd7984c89"
+  dependencies:
+    node-addon-api "^3.1.0"
+    prebuild-install "^5.3.5"
+
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"


### PR DESCRIPTION
## Description

This PR adds a [new module](https://github.com/desktop/node-detect-arm64-translation) that tells us if an x64 build is being emulated on an ARM64 device. With it, we will get metrics of how many users are nowadays running (and crashing) the app on Windows ARM, and will allow them, eventually, to automagically switch to arm64 updates :_D

We'll get rid of this module once Electron implements the same functionality (I intend to submit a PR Soon™ 🤞 ).

## Release notes

Notes: no-notes
