### PR TITLE
Added an option to also change the name in the misattributed commit dialog

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -12,13 +12,13 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 interface ICommitMessageAvatarState {
   readonly isPopoverOpen: boolean
 
-  readonly updateGitUsername: boolean;
+  readonly updateGitUsername: boolean
 
   /** Currently selected account email address. */
   readonly accountEmail: string
 
   /** Currently selected account name. */
-  readonly accountName: string;
+  readonly accountName: string
 }
 
 interface ICommitMessageAvatarProps {
@@ -56,7 +56,10 @@ interface ICommitMessageAvatarProps {
   /** Preferred name of the user's account. */
   readonly preferredAccountName: string
 
-  readonly onUpdate: (email: string | undefined, userName: string | undefined) => void
+  readonly onUpdate: (
+    email: string | undefined,
+    userName: string | undefined
+  ) => void
 
   readonly onOpenRepositorySettings: () => void
 }
@@ -76,7 +79,7 @@ export class CommitMessageAvatar extends React.Component<
       isPopoverOpen: false,
       updateGitUsername: false,
       accountEmail: this.props.preferredAccountEmail,
-      accountName: this.props.preferredAccountName
+      accountName: this.props.preferredAccountName,
     }
   }
 
@@ -172,11 +175,14 @@ export class CommitMessageAvatar extends React.Component<
           </div>
         </Row>
         <Row>
-          <Checkbox 
-            value={this.state.updateGitUsername ? CheckboxValue.On : CheckboxValue.Off} 
+          <Checkbox
+            value={
+              this.state.updateGitUsername
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
             onChange={this.onShouldUpdateGitUsernameChange}
-          >
-          </Checkbox>
+          />
           <div>
             Also update the global Git username ({this.props.userName}) to
           </div>
@@ -198,11 +204,7 @@ export class CommitMessageAvatar extends React.Component<
           <Button onClick={this.onIgnoreClick} tooltip="Ignore" type="button">
             Ignore
           </Button>
-          <Button
-            onClick={this.onUpdateClick}
-            tooltip="Update"
-            type="submit"
-          >
+          <Button onClick={this.onUpdateClick} tooltip="Update" type="submit">
             Update
           </Button>
         </Row>
@@ -231,12 +233,11 @@ export class CommitMessageAvatar extends React.Component<
         ? this.state.accountEmail
         : undefined
 
-    const newName =
-      this.state.updateGitUsername
-        ? this.state.accountName
-        : undefined
+    const newName = this.state.updateGitUsername
+      ? this.state.accountName
+      : undefined
 
-    if(newMail !== undefined || newName !== undefined) {
+    if (newMail !== undefined || newName !== undefined) {
       this.props.onUpdate(newMail, newName)
     }
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -294,6 +294,15 @@ export class CommitMessage extends React.Component<
     const accountEmails = repositoryAccount?.emails.map(e => e.email) ?? []
     const email = commitAuthor?.email
 
+    const accountNames = new Set<string>();
+    if(repositoryAccount !== null && repositoryAccount !== undefined) {
+      if(repositoryAccount.name !== '') {
+        accountNames.add(repositoryAccount.name)
+      }
+      
+      accountNames.add(repositoryAccount.login)
+    }
+
     const warningBadgeVisible =
       email !== undefined &&
       repositoryAccount !== null &&
@@ -305,6 +314,7 @@ export class CommitMessage extends React.Component<
         user={avatarUser}
         title={avatarTitle}
         email={commitAuthor?.email}
+        userName={commitAuthor?.name}
         isEnterpriseAccount={
           repositoryAccount?.endpoint !== getDotComAPIEndpoint()
         }
@@ -315,14 +325,27 @@ export class CommitMessage extends React.Component<
             ? lookupPreferredEmail(repositoryAccount)
             : ''
         }
-        onUpdateEmail={this.onUpdateUserEmail}
+        accountNames={accountNames}
+        preferredAccountName={
+          repositoryAccount !== null && repositoryAccount !== undefined
+            ? repositoryAccount.friendlyName
+            : ''
+        }
+        onUpdate={this.onUpdate}
         onOpenRepositorySettings={this.onOpenRepositorySettings}
       />
     )
   }
 
-  private onUpdateUserEmail = async (email: string) => {
-    await setGlobalConfigValue('user.email', email)
+  private onUpdate = async (email: string | undefined, userName: string | undefined) => {
+    if(email !== undefined) {
+      await setGlobalConfigValue('user.email', email)
+    }
+
+    if(userName !== undefined) {
+      await setGlobalConfigValue('user.name', userName)
+    }
+
     this.props.dispatcher.refreshAuthor(this.props.repository)
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -294,12 +294,12 @@ export class CommitMessage extends React.Component<
     const accountEmails = repositoryAccount?.emails.map(e => e.email) ?? []
     const email = commitAuthor?.email
 
-    const accountNames = new Set<string>();
-    if(repositoryAccount !== null && repositoryAccount !== undefined) {
-      if(repositoryAccount.name !== '') {
+    const accountNames = new Set<string>()
+    if (repositoryAccount !== null && repositoryAccount !== undefined) {
+      if (repositoryAccount.name !== '') {
         accountNames.add(repositoryAccount.name)
       }
-      
+
       accountNames.add(repositoryAccount.login)
     }
 
@@ -337,12 +337,15 @@ export class CommitMessage extends React.Component<
     )
   }
 
-  private onUpdate = async (email: string | undefined, userName: string | undefined) => {
-    if(email !== undefined) {
+  private onUpdate = async (
+    email: string | undefined,
+    userName: string | undefined
+  ) => {
+    if (email !== undefined) {
       await setGlobalConfigValue('user.email', email)
     }
 
-    if(userName !== undefined) {
+    if (userName !== undefined) {
       await setGlobalConfigValue('user.name', userName)
     }
 


### PR DESCRIPTION
Closes #11760 

## Description
- Added an option to also change the name (Git username) in the misattributed commit dialog
- Added a checkbox that can be enabled to change the git username
- Added a select (only enabled when the above checkbox is) that contains the gh-users display/friendly name (if set) and the user/display name
- Modified the Update-Button and method

### Screenshots & Demo
Demo:
![UserNameOptionInCommitMisattributedDemo](https://user-images.githubusercontent.com/40789489/118168538-3ec93f80-b428-11eb-9a61-3162e25895de.gif)


General view:
![general](https://user-images.githubusercontent.com/40789489/118167368-e6de0900-b426-11eb-9867-fd4d7445d32f.png)

View with extended combobox/select:
![extended combobox](https://user-images.githubusercontent.com/40789489/118167388-ed6c8080-b426-11eb-99d3-79141772ccaa.png)


## Release notes
Notes: Added an option to also change the Git username in the misattributed commit dialog
