### PR TITLE
Made misattributed warning badge more noticeable

### DIFF
--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -13,7 +13,8 @@
     border: #d1d5da 1px solid;
 
     > svg {
-      height: 10px;
+      color: #ff4500;
+      height: 12px;
       // With width=100%, the icon will be centered horizontally
       width: 100%;
     }


### PR DESCRIPTION
Closes #12210

## Description
- Proposal for #12210 
- makes the warning icon a bit bigger and gives it a more noticeable color

### Screenshots
light mode:
![grafik](https://user-images.githubusercontent.com/40789489/118171617-b64c9e00-b42b-11eb-92d2-7076df6c44e9.png)

dark mode:
![grafik](https://user-images.githubusercontent.com/40789489/118171635-ba78bb80-b42b-11eb-9b8c-7e3fdd4360b7.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
