### PR TITLE
Squash by context menu

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -95,3 +95,8 @@ export function enableRepositoryAliases(): boolean {
 export function enableBranchFromCommit(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we allow squashing? */
+export function enableSquashing(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -63,7 +63,7 @@ function mapStatus(
  */
 export async function getCommits(
   repository: Repository,
-  revisionRange: string,
+  revisionRange?: string,
   limit?: number,
   additionalArgs: ReadonlyArray<string> = []
 ): Promise<ReadonlyArray<Commit>> {
@@ -82,7 +82,13 @@ export async function getCommits(
     refs: '%D',
   })
 
-  const args = ['log', revisionRange, `--date=raw`]
+  const args = ['log']
+
+  if (revisionRange !== undefined) {
+    args.push(revisionRange)
+  }
+
+  args.push('--date=raw')
 
   if (limit !== undefined) {
     args.push(`--max-count=${limit}`)

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -23,7 +23,8 @@ import { rebaseInteractive, RebaseResult } from './rebase'
  *
  * @param toSquash - commits to squash onto another commit and does not contain the squashOnto commit
  * @param squashOnto  - commit to squash the `toSquash` commits onto
- * @param lastRetainedCommitRef - sha of commit before commits in squash
+ * @param lastRetainedCommitRef - sha of commit before commits in squash or null
+ * if commit to be squash is the root (first in history) of the branch
  * @param commitMessage - the first line of the string provided will be the
  * summary and rest the body (similar to commit implementation)
  */
@@ -31,7 +32,7 @@ export async function squash(
   repository: Repository,
   toSquash: ReadonlyArray<CommitOneLine>,
   squashOnto: CommitOneLine,
-  lastRetainedCommitRef: string,
+  lastRetainedCommitRef: string | null,
   commitMessage: string
 ): Promise<RebaseResult> {
   let messagePath, todoPath
@@ -51,7 +52,7 @@ export async function squash(
 
     const commits = await getCommits(
       repository,
-      lastRetainedCommitRef === '--root'
+      lastRetainedCommitRef === null
         ? undefined
         : revRange(lastRetainedCommitRef, 'HEAD')
     )

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -51,7 +51,9 @@ export async function squash(
 
     const commits = await getCommits(
       repository,
-      revRange(lastRetainedCommitRef, 'HEAD')
+      lastRetainedCommitRef === '--root'
+        ? undefined
+        : revRange(lastRetainedCommitRef, 'HEAD')
     )
 
     if (commits.length === 0) {

--- a/app/src/lib/squash/squashed-commit-description.ts
+++ b/app/src/lib/squash/squashed-commit-description.ts
@@ -1,0 +1,17 @@
+import { Commit } from '../../models/commit'
+
+export function getSquashedCommitDescription(
+  commits: ReadonlyArray<Commit>,
+  squashOnto: Commit
+): string {
+  const commitMessages = commits.map(
+    c => `${c.summary.trim()}\n\n${c.bodyNoCoAuthors.trim()}`
+  )
+
+  const descriptions = [
+    squashOnto.bodyNoCoAuthors.trim(),
+    ...commitMessages,
+  ].filter(d => d.trim() !== '')
+
+  return descriptions.join('\n\n')
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6259,7 +6259,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     toSquash: ReadonlyArray<CommitOneLine>,
     squashOnto: CommitOneLine,
-    lastRetainedCommitRef: string,
+    lastRetainedCommitRef: string | null,
     commitContext: ICommitContext
   ): Promise<RebaseResult> {
     if (toSquash.length === 0) {

--- a/app/src/lib/unique-coauthors-as-authors.ts
+++ b/app/src/lib/unique-coauthors-as-authors.ts
@@ -1,0 +1,18 @@
+import _ from 'lodash'
+import { IAuthor } from '../models/author'
+import { Commit } from '../models/commit'
+import { GitAuthor } from '../models/git-author'
+
+export function getUniqueCoauthorsAsAuthors(
+  commits: ReadonlyArray<Commit>
+): ReadonlyArray<IAuthor> {
+  const allCommitsCoAuthors: GitAuthor[] = _.flatten(
+    commits.map(c => c.coAuthors)
+  )
+
+  const uniqueCoAuthors = _.uniqBy(allCommitsCoAuthors, a => a.email && a.name)
+
+  return uniqueCoAuthors.map(ca => {
+    return { name: ca.name, email: ca.email, username: null }
+  })
+}

--- a/app/src/lib/unique-coauthors-as-authors.ts
+++ b/app/src/lib/unique-coauthors-as-authors.ts
@@ -10,7 +10,10 @@ export function getUniqueCoauthorsAsAuthors(
     commits.map(c => c.coAuthors)
   )
 
-  const uniqueCoAuthors = _.uniqBy(allCommitsCoAuthors, a => a.email && a.name)
+  const uniqueCoAuthors = _.uniqWith(
+    allCommitsCoAuthors,
+    (a, b) => a.email === b.email && a.name === b.name
+  )
 
   return uniqueCoAuthors.map(ca => {
     return { name: ca.name, email: ca.email, username: null }

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -37,6 +37,19 @@ function extractCoAuthors(trailers: ReadonlyArray<ITrailer>) {
   return coAuthors
 }
 
+function trimCoAuthorsTrailers(
+  trailers: ReadonlyArray<ITrailer>,
+  body: string
+) {
+  let trimmedCoAuthors = body
+
+  trailers.filter(isCoAuthoredByTrailer).forEach(({ token, value }) => {
+    trimmedCoAuthors = trimmedCoAuthors.replace(`${token}: ${value}`, '')
+  })
+
+  return trimmedCoAuthors
+}
+
 /**
  * A minimal shape of data to represent a commit, for situations where the
  * application does not require the full commit metadata.
@@ -58,6 +71,11 @@ export class Commit {
    * trailers.
    */
   public readonly coAuthors: ReadonlyArray<GitAuthor>
+
+  /**
+   * The commit body after removing coauthors
+   */
+  public readonly bodyNoCoAuthors: string
 
   /**
    * A value indicating whether the author and the committer
@@ -95,5 +113,7 @@ export class Commit {
     this.authoredByCommitter =
       this.author.name === this.committer.name &&
       this.author.email === this.committer.email
+
+    this.bodyNoCoAuthors = trimCoAuthorsTrailers(trailers, body)
   }
 }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -682,6 +682,8 @@ export class ChangesList extends React.Component<
         showNoWriteAccess={fileCount > 0 && !hasWritePermissionForRepository}
         shouldNudge={this.props.shouldNudgeToCommit}
         commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
+        persistCoAuthors={true}
+        persistCommitMessage={true}
       />
     )
   }

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -107,6 +107,8 @@ export class CommitMessageDialog extends React.Component<
             showBranchProtected={this.props.showBranchProtected}
             showNoWriteAccess={this.props.showNoWriteAccess}
             commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
+            persistCoAuthors={false}
+            persistCommitMessage={false}
             onCreateCommit={this.props.onSubmitCommitMessage}
           />
         </DialogContent>

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3078,14 +3078,16 @@ export class Dispatcher {
    *
    * @param toSquash - commits to squash onto another commit
    * @param squashOnto  - commit to squash the `toSquash` commits onto
-   * @param lastRetainedCommitRef - commit ref of commit before commits in squash
+   * @param lastRetainedCommitRef - commit ref of commit before commits in
+   * squash or null if a commit to squash is root (first in history) of the
+   * branch
    * @param commitContext - to build the commit message from
    */
   public async squash(
     repository: Repository,
     toSquash: ReadonlyArray<Commit>,
     squashOnto: Commit,
-    lastRetainedCommitRef: string,
+    lastRetainedCommitRef: string | null,
     commitContext: ICommitContext
   ): Promise<void> {
     // TODO: initialize squash flow for progress dialog

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -12,7 +12,7 @@ import { AvatarStack } from '../lib/avatar-stack'
 import { IMenuItem } from '../../lib/menu-item'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Draggable } from '../lib/draggable'
-import { enableBranchFromCommit } from '../../lib/feature-flag'
+import { enableBranchFromCommit, enableSquashing } from '../../lib/feature-flag'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -275,12 +275,14 @@ export class CommitListItem extends React.PureComponent<
       enabled: this.canCherryPick(),
     })
 
-    items.push({
-      label: __DARWIN__
-        ? `Squash ${count} Commits…`
-        : `Squash ${count} commits…`,
-      action: this.onSquash,
-    })
+    if (enableSquashing()) {
+      items.push({
+        label: __DARWIN__
+          ? `Squash ${count} Commits…`
+          : `Squash ${count} commits…`,
+        action: this.onSquash,
+      })
+    }
 
     return items
   }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -30,6 +30,10 @@ interface ICommitProps {
   readonly onDragEnd?: (clearCherryPickingState: boolean) => void
   readonly onRenderCherryPickCommitDragElement?: (commit: Commit) => void
   readonly onRemoveCherryPickDragElement?: () => void
+  readonly onSquash?: (
+    toSquash: ReadonlyArray<Commit>,
+    squashOnto: Commit
+  ) => void
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
   readonly unpushedTags?: ReadonlyArray<string>
@@ -163,6 +167,12 @@ export class CommitListItem extends React.PureComponent<
     }
   }
 
+  private onSquash = () => {
+    if (this.props.onSquash !== undefined) {
+      this.props.onSquash(this.props.selectedCommits, this.props.commit)
+    }
+  }
+
   private onContextMenu = (event: React.MouseEvent<any>) => {
     event.preventDefault()
 
@@ -263,6 +273,13 @@ export class CommitListItem extends React.PureComponent<
         : `Cherry-pick ${count} commits…`,
       action: this.onCherryPick,
       enabled: this.canCherryPick(),
+    })
+
+    items.push({
+      label: __DARWIN__
+        ? `Squash ${count} Commits…`
+        : `Squash ${count} commits…`,
+      action: this.onSquash,
     })
 
     return items

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -60,6 +60,13 @@ interface ICommitListProps {
   /** Callback to fire to cherry picking the commit  */
   readonly onCherryPick: (commits: ReadonlyArray<CommitOneLine>) => void
 
+  /** Callback to fire to squashing commits  */
+  readonly onSquash: (
+    toSquash: ReadonlyArray<Commit>,
+    squashOnto: Commit,
+    lastRetainedCommitRef: string
+  ) => void
+
   /** Callback to fire to when has started being dragged  */
   readonly onDragCommitStart: (commits: ReadonlyArray<CommitOneLine>) => void
 
@@ -155,6 +162,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onCreateTag={this.props.onCreateTag}
         onDeleteTag={this.props.onDeleteTag}
         onCherryPick={this.props.onCherryPick}
+        onSquash={this.onSquash}
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
@@ -169,6 +177,19 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         }
       />
     )
+  }
+
+  private onSquash = (toSquash: ReadonlyArray<Commit>, squashOnto: Commit) => {
+    const indexes = [...toSquash, squashOnto].map(v =>
+      this.props.commitSHAs.findIndex(sha => sha === v.sha)
+    )
+    const maxIndex = Math.max(...indexes)
+    const lastIndex = this.props.commitSHAs.length - 1
+    /* If the commit is the first commit in the branch, you cannot reference it
+    using the sha, you must use the --root flag */
+    const lastRetainedCommitRef =
+      maxIndex === lastIndex ? '--root' : `${this.props.commitSHAs[maxIndex]}^`
+    this.props.onSquash(toSquash, squashOnto, lastRetainedCommitRef)
   }
 
   private onRenderCherryPickCommitDragElement = (commit: Commit) => {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -64,7 +64,7 @@ interface ICommitListProps {
   readonly onSquash: (
     toSquash: ReadonlyArray<Commit>,
     squashOnto: Commit,
-    lastRetainedCommitRef: string
+    lastRetainedCommitRef: string | null
   ) => void
 
   /** Callback to fire to when has started being dragged  */
@@ -186,9 +186,9 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const maxIndex = Math.max(...indexes)
     const lastIndex = this.props.commitSHAs.length - 1
     /* If the commit is the first commit in the branch, you cannot reference it
-    using the sha, you must use the --root flag */
+    using the sha */
     const lastRetainedCommitRef =
-      maxIndex === lastIndex ? '--root' : `${this.props.commitSHAs[maxIndex]}^`
+      maxIndex !== lastIndex ? `${this.props.commitSHAs[maxIndex]}^` : null
     this.props.onSquash(toSquash, squashOnto, lastRetainedCommitRef)
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -567,7 +567,7 @@ export class CompareSidebar extends React.Component<
   private onSquash = (
     toSquash: ReadonlyArray<Commit>,
     squashOnto: Commit,
-    lastRetainedCommitRef: string
+    lastRetainedCommitRef: string | null
   ) => {
     const toSquashSansSquashOnto = toSquash.filter(
       c => c.sha !== squashOnto.sha

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Commit, CommitOneLine } from '../../models/commit'
+import { Commit, CommitOneLine, ICommitContext } from '../../models/commit'
 import {
   HistoryTabMode,
   ICompareState,
@@ -28,7 +28,8 @@ import { AheadBehindStore } from '../../lib/stores/ahead-behind-store'
 import { CherryPickStepKind } from '../../models/cherry-pick'
 import { DragElementType } from '../../models/drag-element'
 import { PopupType } from '../../models/popup'
-
+import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-authors'
+import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 interface ICompareSidebarProps {
   readonly repository: Repository
   readonly isLocalRepository: boolean
@@ -242,6 +243,7 @@ export class CompareSidebar extends React.Component<
         onCreateTag={this.onCreateTag}
         onDeleteTag={this.onDeleteTag}
         onCherryPick={this.onCherryPick}
+        onSquash={this.onSquash}
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
@@ -560,6 +562,47 @@ export class CompareSidebar extends React.Component<
 
   private onCherryPick = (commits: ReadonlyArray<CommitOneLine>) => {
     this.props.onCherryPick(this.props.repository, commits)
+  }
+
+  private onSquash = (
+    toSquash: ReadonlyArray<Commit>,
+    squashOnto: Commit,
+    lastRetainedCommitRef: string
+  ) => {
+    const toSquashSansSquashOnto = toSquash.filter(
+      c => c.sha !== squashOnto.sha
+    )
+    const allCommitsInSquash = [...toSquashSansSquashOnto, squashOnto]
+    const coAuthors = getUniqueCoauthorsAsAuthors(allCommitsInSquash)
+
+    const squashedDescription = getSquashedCommitDescription(
+      toSquashSansSquashOnto,
+      squashOnto
+    )
+
+    this.props.dispatcher.showPopup({
+      type: PopupType.CommitMessage,
+      repository: this.props.repository,
+      coAuthors,
+      showCoAuthoredBy: coAuthors.length > 0,
+      commitMessage: {
+        summary: squashOnto.summary,
+        description: squashedDescription,
+      },
+      dialogTitle: `Squash ${allCommitsInSquash.length} Commits`,
+      dialogButtonText: `Squash ${allCommitsInSquash.length} Commits`,
+      prepopulateCommitSummary: true,
+      onSubmitCommitMessage: async (context: ICommitContext) => {
+        this.props.dispatcher.squash(
+          this.props.repository,
+          toSquashSansSquashOnto,
+          squashOnto,
+          lastRetainedCommitRef,
+          context
+        )
+        return true
+      },
+    })
   }
 
   /**

--- a/app/test/unit/squashed-commit-description-test.ts
+++ b/app/test/unit/squashed-commit-description-test.ts
@@ -1,0 +1,73 @@
+import { ITrailer } from '../../src/lib/git'
+import { Commit } from '../../src/models/commit'
+import { CommitIdentity } from '../../src/models/commit-identity'
+import { getSquashedCommitDescription } from '../../src/lib/squash/squashed-commit-description'
+
+describe('getSquashedCommitDescription', () => {
+  const mockCoAuthorTrailers = [
+    { token: 'Co-Authored-By', value: 'test <test>' },
+  ]
+  it('builds squashed commit descriptions - no coauthors provided', async () => {
+    const commits: Commit[] = [
+      buildTestCommit('summary1', 'desc1', []),
+      buildTestCommit('summary2', 'desc2', []),
+    ]
+
+    const squashOnto = buildTestCommit('ontoSummary', 'ontoDesc', [])
+
+    const desc = getSquashedCommitDescription(commits, squashOnto)
+    expect(desc).toBe('ontoDesc\n\nsummary1\n\ndesc1\n\nsummary2\n\ndesc2')
+  })
+
+  it('builds squashed commit descriptions that do not include coauthors', async () => {
+    const commits: Commit[] = [
+      buildTestCommit('summary1', 'desc1', mockCoAuthorTrailers),
+      buildTestCommit('summary2', 'desc2', mockCoAuthorTrailers),
+    ]
+
+    const squashOnto = buildTestCommit(
+      'ontoSummary',
+      'ontoDesc',
+      mockCoAuthorTrailers
+    )
+
+    const desc = getSquashedCommitDescription(commits, squashOnto)
+    expect(desc).toBe('ontoDesc\n\nsummary1\n\ndesc1\n\nsummary2\n\ndesc2')
+  })
+
+  it('builds squashed commit descriptions with whitespace trimmed', async () => {
+    const commits: Commit[] = [
+      buildTestCommit('summary1    ', 'desc1   ', mockCoAuthorTrailers),
+      buildTestCommit('summary2\n', 'desc2\n', mockCoAuthorTrailers),
+    ]
+
+    const squashOnto = buildTestCommit(
+      'ontoSummary',
+      'ontoDesc  \n',
+      mockCoAuthorTrailers
+    )
+
+    const desc = getSquashedCommitDescription(commits, squashOnto)
+    expect(desc).toBe('ontoDesc\n\nsummary1\n\ndesc1\n\nsummary2\n\ndesc2')
+  })
+})
+
+function buildTestCommit(
+  summary: string,
+  body: string,
+  trailers: ReadonlyArray<ITrailer>
+): Commit {
+  const author = new CommitIdentity('test', 'test', new Date())
+
+  return new Commit(
+    'test',
+    'test',
+    summary,
+    body,
+    author,
+    author,
+    [],
+    trailers,
+    []
+  )
+}

--- a/app/test/unit/unique-coauthors-as-authors-test.ts
+++ b/app/test/unit/unique-coauthors-as-authors-test.ts
@@ -1,0 +1,94 @@
+import { ITrailer } from '../../src/lib/git'
+import { getUniqueCoauthorsAsAuthors } from '../../src/lib/unique-coauthors-as-authors'
+import { Commit } from '../../src/models/commit'
+import { CommitIdentity } from '../../src/models/commit-identity'
+
+describe('getUniqueCoauthorsAsAuthors', () => {
+  it('can returns empty array for no coauthors', async () => {
+    const trailers: ReadonlyArray<ITrailer> = [
+      { token: 'Signed-Off-By', value: 'test <test@github.com>' },
+    ]
+
+    const commits: Commit[] = [
+      buildTestCommit(trailers),
+      buildTestCommit([]),
+      buildTestCommit(trailers),
+    ]
+
+    const coAuthors = getUniqueCoauthorsAsAuthors(commits)
+    expect(coAuthors).toBeArrayOfSize(0)
+  })
+
+  it('gets coauthor from commit with coauthor', async () => {
+    const email = 'tidy-dev@github.com'
+    const name = 'tidy-dev'
+    const trailers = [buildTestCoAuthorTrailer(email, name)]
+    const commits: Commit[] = [buildTestCommit(trailers)]
+
+    const coAuthors = getUniqueCoauthorsAsAuthors(commits)
+    expect(coAuthors).toBeArrayOfSize(1)
+    const coAuthor = coAuthors[0]
+    expect(coAuthor.email).toBe(email)
+    expect(coAuthor.name).toBe(name)
+  })
+
+  it('does not return duplicate authors', async () => {
+    const email = 'tidy-dev@github.com'
+    const name = 'tidy-dev'
+    const trailers = [buildTestCoAuthorTrailer(email, name)]
+
+    const commits: Commit[] = [
+      buildTestCommit(trailers),
+      buildTestCommit(trailers),
+      buildTestCommit(trailers),
+    ]
+
+    const coAuthors = getUniqueCoauthorsAsAuthors(commits)
+    expect(coAuthors).toBeArrayOfSize(1)
+    const coAuthor = coAuthors[0]
+    expect(coAuthor.email).toBe(email)
+    expect(coAuthor.name).toBe(name)
+  })
+
+  it('can get multiple coauthors on multiple commits', async () => {
+    const first_email = 'tidy-dev@github.com'
+    const first_name = 'tidy-dev'
+    const firstTrailers = [buildTestCoAuthorTrailer(first_email, first_name)]
+
+    const second_email = 'sergiou87@github.com'
+    const second_name = 'Sergio'
+    const secondTrailers = [buildTestCoAuthorTrailer(second_email, second_name)]
+
+    const commits: Commit[] = [
+      buildTestCommit(firstTrailers),
+      buildTestCommit([]),
+      buildTestCommit(secondTrailers),
+    ]
+
+    const coAuthors = getUniqueCoauthorsAsAuthors(commits)
+    expect(coAuthors).toBeArrayOfSize(2)
+    const coAuthorEmails = coAuthors.map(c => c.email)
+    expect(coAuthorEmails).toContain(first_email)
+    expect(coAuthorEmails).toContain(second_email)
+  })
+})
+
+function buildTestCommit(trailers: ReadonlyArray<ITrailer>): Commit {
+  const author = new CommitIdentity('test', 'test', new Date())
+
+  return new Commit(
+    'test',
+    'test',
+    'test',
+    'test',
+    author,
+    author,
+    [],
+    trailers,
+    []
+  )
+}
+
+function buildTestCoAuthorTrailer(email: string, name: string) {
+  return { token: 'Co-Authored-By', value: `${name} <${email}>` }
+}

--- a/app/test/unit/unique-coauthors-as-authors-test.ts
+++ b/app/test/unit/unique-coauthors-as-authors-test.ts
@@ -50,6 +50,39 @@ describe('getUniqueCoauthorsAsAuthors', () => {
     expect(coAuthor.name).toBe(name)
   })
 
+  it('does not return duplicate authors when name is different and email is the same', async () => {
+    const email = 'tidy-dev@github.com'
+    const name = 'tidy-dev'
+    const trailers = [buildTestCoAuthorTrailer(email, name)]
+    const trailersDiffName = [buildTestCoAuthorTrailer(email, name + 'hello')]
+
+    const commits: Commit[] = [
+      buildTestCommit(trailers),
+      buildTestCommit(trailers),
+      buildTestCommit(trailersDiffName),
+    ]
+
+    const coAuthors = getUniqueCoauthorsAsAuthors(commits)
+    expect(coAuthors).toBeArrayOfSize(2)
+  })
+
+  it('does not return duplicate authors when email is different and name is the same', async () => {
+    const email = 'tidy-dev@github.com'
+    const otherEmail = 'sergiou87@github.com'
+    const name = 'tidy-dev'
+    const trailers = [buildTestCoAuthorTrailer(email, name)]
+    const trailersDiffEmail = [buildTestCoAuthorTrailer(otherEmail, name)]
+
+    const commits: Commit[] = [
+      buildTestCommit(trailers),
+      buildTestCommit(trailers),
+      buildTestCommit(trailersDiffEmail),
+    ]
+
+    const coAuthors = getUniqueCoauthorsAsAuthors(commits)
+    expect(coAuthors).toBeArrayOfSize(2)
+  })
+
   it('can get multiple coauthors on multiple commits', async () => {
     const first_email = 'tidy-dev@github.com'
     const first_name = 'tidy-dev'


### PR DESCRIPTION
## Description

- Add squashing via the context menu which is feature-flagged to development.
- Makes persisting the coauthor and commit message to the changes state in the commit-message optional. Otherwise if you squash something and then navigate to changes tab, the commit message input is updated to what was done in the dialog.
- Added ability to get the commit's body without coauthor trailers so they are not duplicated during squashing and commit description is less cluttered.
- Also handled the scenario where user squashes the root commit of a branch which cannot be rebased using traditional commit ref syntax of `sha^` or `HEAD~n`.  In doing so, I needed to make the getCommits method flexible enough to not specify a rev-range (get all commits in the branches history). 


### Screenshots
https://user-images.githubusercontent.com/75402236/118318043-d4b3a780-b4c6-11eb-944f-aa1022399f80.mov

## Release notes
Notes: no-notes



