### PR TITLE
Squashing successful banner

### DIFF
--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -10,6 +10,7 @@ export enum BannerType {
   CherryPickConflictsFound = 'CherryPickConflictsFound',
   CherryPickUndone = 'CherryPickUndone',
   OpenThankYouCard = 'OpenThankYouCard',
+  SuccessfulSquash = 'SuccessfulSquash',
 }
 
 export type Banner =
@@ -76,4 +77,13 @@ export type Banner =
       readonly emoji: Map<string, string>
       readonly onOpenCard: () => void
       readonly onThrowCardAway: () => void
+    }
+  | {
+      readonly type: BannerType.SuccessfulSquash
+      /** number of commits squashed */
+      readonly count: number
+      /**  name of branch commits are squashed on*/
+      readonly branchName: string
+      /** callback to run when user clicks undo link in banner */
+      readonly onUndo: () => void
     }

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -82,8 +82,6 @@ export type Banner =
       readonly type: BannerType.SuccessfulSquash
       /** number of commits squashed */
       readonly count: number
-      /**  name of branch commits are squashed on*/
-      readonly branchName: string
       /** callback to run when user clicks undo link in banner */
       readonly onUndo: () => void
     }

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -112,7 +112,6 @@ export function renderBanner(
       return (
         <SuccessfulSquash
           key="successful-squash"
-          branchName={banner.branchName}
           count={banner.count}
           onDismissed={onDismissed}
           onUndo={banner.onUndo}

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -15,6 +15,7 @@ import { SuccessfulCherryPick } from './successful-cherry-pick'
 import { CherryPickConflictsBanner } from './cherry-pick-conflicts-banner'
 import { CherryPickUndone } from './cherry-pick-undone'
 import { OpenThankYouCard } from './open-thank-you-card'
+import { SuccessfulSquash } from './successful-squash'
 
 export function renderBanner(
   banner: Banner,
@@ -105,6 +106,16 @@ export function renderBanner(
           onDismissed={onDismissed}
           onOpenCard={banner.onOpenCard}
           onThrowCardAway={banner.onThrowCardAway}
+        />
+      )
+    case BannerType.SuccessfulSquash:
+      return (
+        <SuccessfulSquash
+          key="successful-squash"
+          branchName={banner.branchName}
+          count={banner.count}
+          onDismissed={onDismissed}
+          onUndo={banner.onUndo}
         />
       )
     default:

--- a/app/src/ui/banners/success-banner.tsx
+++ b/app/src/ui/banners/success-banner.tsx
@@ -30,7 +30,7 @@ export class SuccessBanner extends React.Component<ISuccessBannerProps, {}> {
   public render() {
     return (
       <Banner
-        id="successful-cherry-pick"
+        id="successful"
         timeout={this.props.timeout}
         onDismissed={this.props.onDismissed}
       >
@@ -38,10 +38,8 @@ export class SuccessBanner extends React.Component<ISuccessBannerProps, {}> {
           <Octicon className="check-icon" symbol={OcticonSymbol.check} />
         </div>
         <div className="banner-message">
-          <span>
-            {this.props.children}
-            {this.renderUndo()}
-          </span>
+          <span className="success-contents">{this.props.children}</span>
+          {this.renderUndo()}
         </div>
       </Banner>
     )

--- a/app/src/ui/banners/success-banner.tsx
+++ b/app/src/ui/banners/success-banner.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { LinkButton } from '../lib/link-button'
+import { Octicon, OcticonSymbol } from '../octicons'
+import { Banner } from './banner'
+
+interface ISuccessBannerProps {
+  readonly timeout: number
+  readonly onDismissed: () => void
+  readonly onUndo?: () => void
+}
+
+export class SuccessBanner extends React.Component<ISuccessBannerProps, {}> {
+  private undo = () => {
+    this.props.onDismissed()
+
+    if (this.props.onUndo === undefined) {
+      return
+    }
+
+    this.props.onUndo()
+  }
+
+  private renderUndo = () => {
+    if (this.props.onUndo === undefined) {
+      return
+    }
+    return <LinkButton onClick={this.undo}>Undo</LinkButton>
+  }
+
+  public render() {
+    return (
+      <Banner
+        id="successful-cherry-pick"
+        timeout={this.props.timeout}
+        onDismissed={this.props.onDismissed}
+      >
+        <div className="green-circle">
+          <Octicon className="check-icon" symbol={OcticonSymbol.check} />
+        </div>
+        <div className="banner-message">
+          <span>
+            {this.props.children}
+            {this.renderUndo()}
+          </span>
+        </div>
+      </Banner>
+    )
+  }
+}

--- a/app/src/ui/banners/successful-cherry-pick.tsx
+++ b/app/src/ui/banners/successful-cherry-pick.tsx
@@ -30,7 +30,7 @@ export class SuccessfulCherryPick extends React.Component<
       >
         <span>
           Successfully copied {countCherryPicked} {pluralized} to{' '}
-          <strong>{targetBranchName}</strong>.{' '}
+          <strong>{targetBranchName}</strong>.
         </span>
       </SuccessBanner>
     )

--- a/app/src/ui/banners/successful-cherry-pick.tsx
+++ b/app/src/ui/banners/successful-cherry-pick.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-import { LinkButton } from '../lib/link-button'
-import { Octicon, OcticonSymbol } from '../octicons'
-import { Banner } from './banner'
+import { SuccessBanner } from './success-banner'
 
 interface ISuccessfulCherryPickBannerProps {
   readonly targetBranchName: string
@@ -14,32 +12,27 @@ export class SuccessfulCherryPick extends React.Component<
   ISuccessfulCherryPickBannerProps,
   {}
 > {
-  private undo = () => {
-    this.props.onDismissed()
-    this.props.onUndoCherryPick()
-  }
-
   public render() {
-    const { countCherryPicked, onDismissed, targetBranchName } = this.props
+    const {
+      countCherryPicked,
+      onDismissed,
+      onUndoCherryPick,
+      targetBranchName,
+    } = this.props
 
     const pluralized = countCherryPicked === 1 ? 'commit' : 'commits'
+
     return (
-      <Banner
-        id="successful-cherry-pick"
+      <SuccessBanner
         timeout={15000}
         onDismissed={onDismissed}
+        onUndo={onUndoCherryPick}
       >
-        <div className="green-circle">
-          <Octicon className="check-icon" symbol={OcticonSymbol.check} />
-        </div>
-        <div className="banner-message">
-          <span>
-            Successfully copied {countCherryPicked} {pluralized} to{' '}
-            <strong>{targetBranchName}</strong>.{' '}
-            <LinkButton onClick={this.undo}>Undo</LinkButton>
-          </span>
-        </div>
-      </Banner>
+        <span>
+          Successfully copied {countCherryPicked} {pluralized} to{' '}
+          <strong>{targetBranchName}</strong>.{' '}
+        </span>
+      </SuccessBanner>
     )
   }
 }

--- a/app/src/ui/banners/successful-merge.tsx
+++ b/app/src/ui/banners/successful-merge.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Octicon, OcticonSymbol } from '../octicons'
-import { Banner } from './banner'
+import { SuccessBanner } from './success-banner'
 
 export function SuccessfulMerge({
   ourBranch,
@@ -27,11 +26,8 @@ export function SuccessfulMerge({
     )
 
   return (
-    <Banner id="successful-merge" timeout={5000} onDismissed={onDismissed}>
-      <div className="green-circle">
-        <Octicon className="check-icon" symbol={OcticonSymbol.check} />
-      </div>
+    <SuccessBanner timeout={5000} onDismissed={onDismissed}>
       <div className="banner-message">{message}</div>
-    </Banner>
+    </SuccessBanner>
   )
 }

--- a/app/src/ui/banners/successful-rebase.tsx
+++ b/app/src/ui/banners/successful-rebase.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Octicon, OcticonSymbol } from '../octicons'
-import { Banner } from './banner'
+import { SuccessBanner } from './success-banner'
 
 export function SuccessfulRebase({
   baseBranch,
@@ -27,11 +26,8 @@ export function SuccessfulRebase({
     )
 
   return (
-    <Banner id="successful-rebase" timeout={5000} onDismissed={onDismissed}>
-      <div className="green-circle">
-        <Octicon className="check-icon" symbol={OcticonSymbol.check} />
-      </div>
+    <SuccessBanner timeout={5000} onDismissed={onDismissed}>
       <div className="banner-message">{message}</div>
-    </Banner>
+    </SuccessBanner>
   )
 }

--- a/app/src/ui/banners/successful-squash.tsx
+++ b/app/src/ui/banners/successful-squash.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { SuccessBanner } from './success-banner'
+
+interface ISuccessfulSquashedBannerProps {
+  readonly branchName: string
+  readonly count: number
+  readonly onDismissed: () => void
+  readonly onUndo: () => void
+}
+
+export class SuccessfulSquash extends React.Component<
+  ISuccessfulSquashedBannerProps,
+  {}
+> {
+  public render() {
+    const { count, branchName, onDismissed, onUndo } = this.props
+
+    const pluralized = count === 1 ? 'commit' : 'commits'
+
+    return (
+      <SuccessBanner timeout={15000} onDismissed={onDismissed} onUndo={onUndo}>
+        <span>
+          Successfully squashed {count} {pluralized} on{' '}
+          <strong>{branchName}</strong>.{' '}
+        </span>
+      </SuccessBanner>
+    )
+  }
+}

--- a/app/src/ui/banners/successful-squash.tsx
+++ b/app/src/ui/banners/successful-squash.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { SuccessBanner } from './success-banner'
 
 interface ISuccessfulSquashedBannerProps {
-  readonly branchName: string
   readonly count: number
   readonly onDismissed: () => void
   readonly onUndo: () => void
@@ -13,15 +12,14 @@ export class SuccessfulSquash extends React.Component<
   {}
 > {
   public render() {
-    const { count, branchName, onDismissed, onUndo } = this.props
+    const { count, onDismissed, onUndo } = this.props
 
     const pluralized = count === 1 ? 'commit' : 'commits'
 
     return (
       <SuccessBanner timeout={15000} onDismissed={onDismissed} onUndo={onUndo}>
         <span>
-          Successfully squashed {count} {pluralized} on{' '}
-          <strong>{branchName}</strong>.{' '}
+          Successfully squashed {count} {pluralized}.
         </span>
       </SuccessBanner>
     )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3149,7 +3149,7 @@ export class Dispatcher {
           await this.changeCommitSelection(repository, [status.currentTip])
         }
 
-        await this.completeSquash(repository, toSquash.length)
+        await this.completeSquash(repository, toSquash.length + 1)
         break
       case RebaseResult.ConflictsEncountered:
         this.startConflictSquashFlow(repository)
@@ -3189,9 +3189,19 @@ export class Dispatcher {
    */
   private async completeSquash(
     repository: Repository,
-    countSquashed: number
+    count: number
   ): Promise<void> {
     this.closePopup()
+
+    const banner: Banner = {
+      type: BannerType.SuccessfulSquash,
+      count,
+      onUndo: () => {
+        // TODO: call undo squash
+      },
+    }
+    this.setBanner(banner)
+
     await this.refreshRepository(repository)
   }
 }

--- a/app/styles/ui/banners/_successful.scss
+++ b/app/styles/ui/banners/_successful.scss
@@ -1,7 +1,5 @@
 #cherry-pick-undone,
-#successful-cherry-pick,
-#successful-rebase,
-#successful-merge {
+#successful {
   .banner-message {
     span {
       max-width: 100%;
@@ -27,5 +25,9 @@
     display: flex;
     flex-shrink: 0;
     flex-grow: 0;
+  }
+
+  .success-contents {
+    padding-right: var(--spacing-half);
   }
 }


### PR DESCRIPTION
## Description

Add squash success banner and refactor some repetitive component logic into one component.

Note: You can't test/see this without #12217 merged

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/118319698-21987d80-b4c9-11eb-8cd6-b924e7ded4c3.png)


## Release notes

Notes: no-notes
