### PR TITLE
Refactor storing drag data into drag and drop manager

### DIFF
--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -1,4 +1,5 @@
 import { Disposable, Emitter } from 'event-kit'
+import { DragData, DragType } from '../models/drag-drop'
 
 /**
  * The drag and drop manager is implemented to manage drag and drop events
@@ -10,6 +11,7 @@ import { Disposable, Emitter } from 'event-kit'
  */
 export class DragAndDropManager {
   private _isDragInProgress: boolean = false
+  private _dragData: DragData | null = null
 
   protected readonly emitter = new Emitter()
 
@@ -51,6 +53,22 @@ export class DragAndDropManager {
     fn: (dropZoneDescription: string) => void
   ): Disposable {
     return this.emitter.on('enter-drop-zone', fn)
+  }
+
+  public setDragData(dragData: DragData | null): void {
+    this._dragData = dragData
+  }
+
+  public get dragData(): DragData | null {
+    return this._dragData
+  }
+
+  public isDragOfTypeInProgress(type: DragType) {
+    return this._isDragInProgress && this.isDragOfType(type)
+  }
+
+  public isDragOfType(type: DragType) {
+    return this._dragData !== null && this._dragData.type === type
   }
 }
 

--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -24,21 +24,11 @@ export type CherryPickFlowStep =
   | ChooseTargetBranchesStep
   | ShowProgressStep
   | ShowConflictsStep
-  | CommitsChosenStep
   | HideConflictsStep
   | ConfirmAbortStep
   | CreateBranchStep
 
 export const enum CherryPickStepKind {
-  /**
-   * An initial state of a cherry pick.
-   *
-   * This is where the user has started dragging a commit or set of commits but
-   * has not yet dropped them on a branch or an area to launch to choose branch
-   * dialog.
-   */
-  CommitsChosen = 'CommitsChosen',
-
   /**
    * An initial state of a cherry pick.
    *
@@ -111,15 +101,6 @@ export type ShowConflictsStep = {
 /** Shape of data to track when user hides conflicts dialog */
 export type HideConflictsStep = {
   readonly kind: CherryPickStepKind.HideConflicts
-}
-
-/**
- * Shape of data for when a user has chosen commits to cherry pick but not yet
- * selected a target branch.
- */
-export type CommitsChosenStep = {
-  readonly kind: CherryPickStepKind.CommitsChosen
-  commits: ReadonlyArray<CommitOneLine>
 }
 
 /** Shape of data to use when confirming user should abort cherry pick */

--- a/app/src/models/drag-drop.ts
+++ b/app/src/models/drag-drop.ts
@@ -2,20 +2,25 @@ import { Commit } from './commit'
 import { GitHubRepository } from './github-repository'
 
 /**
- * This is a type is used in conjunction with the drag and drop manager to to
+ * This is a type is used in conjunction with the drag and drop manager to
  * store and specify the types of data that are being dragged
  *
  * Thus, using a `|` here would allow us to specify multiple types of data that
  * can be dragged.
  */
-export type DragData = ReadonlyArray<Commit>
+export type DragData = CommitDragData
 
-export enum DragElementType {
+export type CommitDragData = {
+  type: DragType.Commit
+  commits: ReadonlyArray<Commit>
+}
+
+export enum DragType {
   Commit,
 }
 
 export type DragElement = {
-  type: DragElementType.Commit
+  type: DragType.Commit
   commit: Commit
   selectedCommits: ReadonlyArray<Commit>
   gitHubRepository: GitHubRepository | null

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2336,10 +2336,10 @@ export class App extends React.Component<IAppProps, IAppState> {
 
   private getDesktopAppContentsClassNames = (): string => {
     const { currentDragElement } = this.state
-    const isCherryPickCommitBeingDragged =
+    const isCommitBeingDragged =
       currentDragElement !== null && currentDragElement.type === DragType.Commit
     return classNames({
-      'commit-being-dragged': isCherryPickCommitBeingDragged,
+      'commit-being-dragged': isCommitBeingDragged,
     })
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -145,7 +145,7 @@ import {
 import { ReleaseNote } from '../models/release-notes'
 import { CommitMessageDialog } from './commit-message/commit-message-dialog'
 import { buildAutocompletionProviders } from './autocompletion'
-import { DragElementType } from '../models/drag-drop'
+import { DragType } from '../models/drag-drop'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2284,7 +2284,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const { gitHubRepository, commit, selectedCommits } = currentDragElement
     switch (currentDragElement.type) {
-      case DragElementType.Commit:
+      case DragType.Commit:
         return (
           <CommitDragElement
             gitHubRepository={gitHubRepository}
@@ -2337,8 +2337,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   private getDesktopAppContentsClassNames = (): string => {
     const { currentDragElement } = this.state
     const isCherryPickCommitBeingDragged =
-      currentDragElement !== null &&
-      currentDragElement.type === DragElementType.Commit
+      currentDragElement !== null && currentDragElement.type === DragType.Commit
     return classNames({
       'commit-being-dragged': isCherryPickCommitBeingDragged,
     })

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -10,6 +10,7 @@ import { showContextualMenu } from '../main-process-proxy'
 import { IMenuItem } from '../../lib/menu-item'
 import { String } from 'aws-sdk/clients/apigateway'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { DragType } from '../../models/drag-drop'
 
 interface IBranchListItemProps {
   /** The name of the branch */
@@ -36,9 +37,6 @@ interface IBranchListItemProps {
 
   /** When a drag element has landed on the current branch */
   readonly onDropOntoCurrentBranch?: () => void
-
-  /** Whether something is being dragged */
-  readonly isSomethingBeingDragged?: boolean
 }
 
 /** The branch component. */
@@ -85,13 +83,13 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
   }
 
   private onMouseEnter = () => {
-    if (this.props.isSomethingBeingDragged) {
+    if (dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
       dragAndDropManager.emitEnterDropTarget(this.props.name)
     }
   }
 
   private onMouseLeave = () => {
-    if (this.props.isSomethingBeingDragged) {
+    if (dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
       dragAndDropManager.emitLeaveDropTarget()
     }
   }

--- a/app/src/ui/branches/branch-renderer.tsx
+++ b/app/src/ui/branches/branch-renderer.tsx
@@ -13,8 +13,7 @@ export function renderDefaultBranch(
   onRenameBranch?: (branchName: string) => void,
   onDeleteBranch?: (branchName: string) => void,
   onDropOntoBranch?: (branchName: string) => void,
-  onDropOntoCurrentBranch?: () => void,
-  isSomethingBeingDragged?: boolean
+  onDropOntoCurrentBranch?: () => void
 ): JSX.Element {
   const branch = item.branch
   const commit = branch.tip
@@ -30,7 +29,6 @@ export function renderDefaultBranch(
       onDeleteBranch={onDeleteBranch}
       onDropOntoBranch={onDropOntoBranch}
       onDropOntoCurrentBranch={onDropOntoCurrentBranch}
-      isSomethingBeingDragged={isSomethingBeingDragged}
     />
   )
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -26,6 +26,7 @@ import { renderDefaultBranch } from './branch-renderer'
 import { IMatches } from '../../lib/fuzzy-find'
 import { startTimer } from '../lib/timing'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { DragType } from '../../models/drag-drop'
 
 interface IBranchesContainerProps {
   readonly dispatcher: Dispatcher
@@ -42,12 +43,6 @@ interface IBranchesContainerProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
-
-  /** When a drag element has landed on the current branch */
-  readonly onDropOntoCurrentBranch?: () => void
-
-  /** Whether a cherry pick is in progress */
-  readonly isCherryPickInProgress?: boolean
 }
 
 interface IBranchesContainerState {
@@ -161,8 +156,7 @@ export class BranchesContainer extends React.Component<
       this.onRenameBranch,
       this.onDeleteBranch,
       this.onDropOntoBranch,
-      this.props.onDropOntoCurrentBranch,
-      this.props.isCherryPickInProgress
+      this.onDropOntoCurrentBranch
     )
   }
 
@@ -188,10 +182,9 @@ export class BranchesContainer extends React.Component<
             canCreateNewBranch={true}
             onCreateNewBranch={this.onCreateBranchWithName}
             renderBranch={this.renderBranch}
-            hideFilterRow={
-              this.props.isCherryPickInProgress &&
-              dragAndDropManager.isDragInProgress
-            }
+            hideFilterRow={dragAndDropManager.isDragOfTypeInProgress(
+              DragType.Commit
+            )}
             renderPreList={this.renderPreList}
           />
         )
@@ -205,10 +198,7 @@ export class BranchesContainer extends React.Component<
   }
 
   private renderPreList = () => {
-    if (
-      !this.props.isCherryPickInProgress ||
-      !dragAndDropManager.isDragInProgress
-    ) {
+    if (!dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
       return null
     }
 
@@ -229,15 +219,23 @@ export class BranchesContainer extends React.Component<
     )
   }
 
-  private onMouseUpNewBranchDrop = () => {
-    if (!this.props.isCherryPickInProgress) {
+  private onMouseUpNewBranchDrop = async () => {
+    const { dragData } = dragAndDropManager
+    if (dragData === null || dragData.type !== DragType.Commit) {
       return
     }
 
-    this.props.dispatcher.setCherryPickCreateBranchFlowStep(
+    await this.props.dispatcher.setCherryPickCreateBranchFlowStep(
       this.props.repository,
       ''
     )
+
+    this.props.dispatcher.showPopup({
+      type: PopupType.CherryPick,
+      repository: this.props.repository,
+      commits: dragData.commits,
+      sourceBranch: this.props.currentBranch,
+    })
   }
 
   private onMouseEnterNewBranchDrop = () => {
@@ -273,7 +271,6 @@ export class BranchesContainer extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={repository}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
-        isCherryPickInProgress={this.props.isCherryPickInProgress}
       />
     )
   }
@@ -397,11 +394,18 @@ export class BranchesContainer extends React.Component<
       return
     }
 
-    if (this.props.isCherryPickInProgress) {
+    if (dragAndDropManager.isDragOfType(DragType.Commit)) {
       this.props.dispatcher.startCherryPickWithBranch(
         this.props.repository,
         branch
       )
+    }
+  }
+
+  private onDropOntoCurrentBranch = () => {
+    if (dragAndDropManager.isDragOfType(DragType.Commit)) {
+      this.props.dispatcher.endCherryPickFlow(this.props.repository)
+      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
     }
   }
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -404,7 +404,6 @@ export class BranchesContainer extends React.Component<
 
   private onDropOntoCurrentBranch = () => {
     if (dragAndDropManager.isDragOfType(DragType.Commit)) {
-      this.props.dispatcher.endCherryPickFlow(this.props.repository)
       this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
     }
   }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -19,6 +19,8 @@ import { Button } from '../lib/button'
 import { Octicon, syncClockwise } from '../octicons'
 import { FoldoutType } from '../../lib/app-state'
 import { startTimer } from '../lib/timing'
+import { DragType } from '../../models/drag-drop'
+import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 
 interface IPullRequestListItem extends IFilterListItem {
   readonly id: string
@@ -63,9 +65,6 @@ interface IPullRequestListProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
-
-  /** Whether a cherry pick is in progress */
-  readonly isCherryPickInProgress?: boolean
 }
 
 interface IPullRequestListState {
@@ -180,14 +179,13 @@ export class PullRequestList extends React.Component<
 
   private onDropOntoPullRequest = (prNumber: number) => {
     const {
-      isCherryPickInProgress,
       repository,
       selectedPullRequest,
       dispatcher,
       pullRequests,
     } = this.props
 
-    if (!isCherryPickInProgress) {
+    if (!dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
       return
     }
 

--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -293,7 +293,6 @@ export class CherryPickFlow extends React.Component<ICherryPickFlowProps> {
             headerText={headerText}
           />
         )
-      case CherryPickStepKind.CommitsChosen:
       case CherryPickStepKind.HideConflicts:
         // no ui for this part of flow
         return null

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -72,11 +72,6 @@ export class CommitListItem extends React.PureComponent<
     }
   }
 
-    ) {
-      onSquash(selectedCommits, commit)
-    }
-  }
-
   public render() {
     const { commit } = this.props
     const {
@@ -90,15 +85,11 @@ export class CommitListItem extends React.PureComponent<
         isEnabled={isDraggable}
         onDragStart={this.onDragStart}
         onDragEnd={this.onDragEnd}
-        onRenderDragElement={this.onRenderCherryPickCommitDragElement}
+        onRenderDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.onRemoveDragElement}
         dropTargetSelectors={['.branches-list-item', '.pull-request-item']}
       >
-        <div
-          className="commit"
-          onContextMenu={this.onContextMenu}
-          onMouseUp={this.onMouseUp}
-        >
+        <div className="commit" onContextMenu={this.onContextMenu}>
           <div className="info">
             <RichText
               className="summary"

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -68,9 +68,6 @@ interface ICommitListProps {
   ) => void
 
   /** Callback to fire to when has started being dragged  */
-  readonly onDragCommitStart: (commits: ReadonlyArray<CommitOneLine>) => void
-
-  /** Callback to fire to when has started being dragged  */
   readonly onDragCommitEnd: (clearCherryPickingState: boolean) => void
   /**
    * Optional callback that fires on page scroll in order to allow passing
@@ -96,14 +93,14 @@ interface ICommitListProps {
   /** Whether a cherry pick is progress */
   readonly isCherryPickInProgress: boolean
 
-  /** Callback to render cherry pick commit drag element */
-  readonly onRenderCherryPickCommitDragElement: (
+  /** Callback to render commit drag element */
+  readonly onRenderCommitDragElement: (
     commit: Commit,
     selectedCommits: ReadonlyArray<Commit>
   ) => void
 
-  /** Callback to remove cherry pick commit drag element */
-  readonly onRemoveCherryPickCommitDragElement: () => void
+  /** Callback to remove commit drag element */
+  readonly onRemoveCommitDragElement: () => void
 }
 
 /** A component which displays the list of commits. */
@@ -166,15 +163,10 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
-        onDragStart={this.props.onDragCommitStart}
         onDragEnd={this.props.onDragCommitEnd}
         isCherryPickInProgress={this.props.isCherryPickInProgress}
-        onRenderCherryPickCommitDragElement={
-          this.onRenderCherryPickCommitDragElement
-        }
-        onRemoveCherryPickDragElement={
-          this.props.onRemoveCherryPickCommitDragElement
-        }
+        onRenderCommitDragElement={this.onRenderCommitDragElement}
+        onRemoveDragElement={this.props.onRemoveCommitDragElement}
       />
     )
   }
@@ -192,8 +184,8 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     this.props.onSquash(toSquash, squashOnto, lastRetainedCommitRef)
   }
 
-  private onRenderCherryPickCommitDragElement = (commit: Commit) => {
-    this.props.onRenderCherryPickCommitDragElement(
+  private onRenderCommitDragElement = (commit: Commit) => {
+    this.props.onRenderCommitDragElement(
       commit,
       this.lookupCommits(this.props.selectedSHAs)
     )

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -25,8 +25,7 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { Ref } from '../lib/ref'
 import { MergeCallToActionWithConflicts } from './merge-call-to-action-with-conflicts'
 import { AheadBehindStore } from '../../lib/stores/ahead-behind-store'
-import { CherryPickStepKind } from '../../models/cherry-pick'
-import { DragElementType } from '../../models/drag-drop'
+import { DragType } from '../../models/drag-drop'
 import { PopupType } from '../../models/popup'
 import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-authors'
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
@@ -248,34 +247,29 @@ export class CompareSidebar extends React.Component<
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
         tagsToPush={this.props.tagsToPush}
-        onDragCommitStart={this.onDragCommitStart}
         onDragCommitEnd={this.props.onDragCommitEnd}
         hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
         onDismissCherryPickIntro={this.onDismissCherryPickIntro}
         isCherryPickInProgress={this.props.isCherryPickInProgress}
-        onRenderCherryPickCommitDragElement={
-          this.onRenderCherryPickCommitDragElement
-        }
-        onRemoveCherryPickCommitDragElement={
-          this.onRemoveCherryPickCommitDragElement
-        }
+        onRenderCommitDragElement={this.onRenderCommitDragElement}
+        onRemoveCommitDragElement={this.onRemoveCommitDragElement}
       />
     )
   }
 
-  private onRenderCherryPickCommitDragElement = (
+  private onRenderCommitDragElement = (
     commit: Commit,
     selectedCommits: ReadonlyArray<Commit>
   ) => {
     this.props.dispatcher.setDragElement({
-      type: DragElementType.Commit,
+      type: DragType.Commit,
       commit,
       selectedCommits,
       gitHubRepository: this.props.repository.gitHubRepository,
     })
   }
 
-  private onRemoveCherryPickCommitDragElement = () => {
+  private onRemoveCommitDragElement = () => {
     this.props.dispatcher.clearDragElement()
   }
 
@@ -572,6 +566,7 @@ export class CompareSidebar extends React.Component<
     const toSquashSansSquashOnto = toSquash.filter(
       c => c.sha !== squashOnto.sha
     )
+
     const allCommitsInSquash = [...toSquashSansSquashOnto, squashOnto]
     const coAuthors = getUniqueCoauthorsAsAuthors(allCommitsInSquash)
 
@@ -602,19 +597,6 @@ export class CompareSidebar extends React.Component<
         )
         return true
       },
-    })
-  }
-
-  /**
-   * This method is a generic event handler for when a commit has started being
-   * dragged.
-   *
-   * Currently only used for cherry picking, but this could be more generic.
-   */
-  private onDragCommitStart = (commits: ReadonlyArray<CommitOneLine>) => {
-    this.props.dispatcher.setCherryPickFlowStep(this.props.repository, {
-      kind: CherryPickStepKind.CommitsChosen,
-      commits,
     })
   }
 }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -29,7 +29,8 @@ import { TutorialPanel, TutorialWelcome, TutorialDone } from './tutorial'
 import { TutorialStep, isValidTutorialStep } from '../models/tutorial-step'
 import { openFile } from './lib/open-file'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
-import { CherryPickStepKind } from '../models/cherry-pick'
+import { dragAndDropManager } from '../lib/drag-and-drop-manager'
+import { DragType } from '../models/drag-drop'
 
 /** The widest the sidebar can be with the minimum window size. */
 const MaxSidebarWidth = 495
@@ -344,7 +345,7 @@ export class RepositoryView extends React.Component<
   }
 
   private renderContentForHistory(): JSX.Element {
-    const { commitSelection, cherryPickState } = this.props.state
+    const { commitSelection } = this.props.state
 
     const sha =
       commitSelection.shas.length === 1 ? commitSelection.shas[0] : null
@@ -354,10 +355,9 @@ export class RepositoryView extends React.Component<
 
     const { changedFiles, file, diff } = commitSelection
 
-    const { step } = cherryPickState
-
-    const showDragOverlay =
-      step !== null && step.kind === CherryPickStepKind.CommitsChosen
+    const showDragOverlay = dragAndDropManager.isDragOfTypeInProgress(
+      DragType.Commit
+    )
 
     return (
       <SelectedCommit

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -14,8 +14,8 @@ import { assertNever } from '../../lib/fatal-error'
 import { BranchesTab } from '../../models/branches-tab'
 import { PullRequest } from '../../models/pull-request'
 import classNames from 'classnames'
-import { CherryPickStepKind } from '../../models/cherry-pick'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { DragType } from '../../models/drag-drop'
 
 interface IBranchDropdownProps {
   readonly dispatcher: Dispatcher
@@ -76,19 +76,8 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
         pullRequests={this.props.pullRequests}
         currentPullRequest={this.props.currentPullRequest}
         isLoadingPullRequests={this.props.isLoadingPullRequests}
-        onDropOntoCurrentBranch={this.onDropOntoCurrentBranch}
-        isCherryPickInProgress={repositoryState.cherryPickState.step !== null}
       />
     )
-  }
-
-  private onDropOntoCurrentBranch = () => {
-    const { repositoryState, repository } = this.props
-    const { cherryPickState } = repositoryState
-    if (cherryPickState !== null && cherryPickState.step !== null) {
-      this.props.dispatcher.endCherryPickFlow(repository)
-      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
-    }
   }
 
   private onDropDownStateChanged = (state: DropdownState) => {
@@ -199,14 +188,7 @@ export class BranchDropdown extends React.Component<IBranchDropdownProps> {
    * that we can open the branch menu when dragging a commit over it.
    */
   private onMouseEnter = (): void => {
-    // If the cherry picking state is initiated with commits chosen, we assume
-    // the user is dragging commits. Therefore, we should open the branch
-    // menu.
-    const { cherryPickState } = this.props.repositoryState
-    if (
-      cherryPickState.step !== null &&
-      cherryPickState.step.kind === CherryPickStepKind.CommitsChosen
-    ) {
+    if (dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
       dragAndDropManager.emitEnterDragZone('branch-button')
       this.props.dispatcher.showFoldout({ type: FoldoutType.Branch })
     }


### PR DESCRIPTION
## Description

Moving the tracking of data associated with a current drag into the drag and drop manager and using the drag and drop manager solely for determining when a drag is taking place as opposed to a cherry-pick state variable.

### Screenshots
Notes: no-notes
