### PR TITLE
Reusable conflicts dialog for multi commit operations - merging, rebasing, cherry-picking, etc..

### DIFF
--- a/app/src/ui/multi-commit-operation/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/conflicts-dialog.tsx
@@ -39,12 +39,12 @@ interface IConflictsDialogProps {
     repository: Repository,
     workingDirectory: WorkingDirectoryStatus,
     ourBranch: string,
-    theirBranch: string
-  ) => void
+    theirBranch?: string
+  ) => Promise<void>
   readonly onAbort: (
     workingDirectory: WorkingDirectoryStatus,
     manualResolutions: Map<string, ManualConflictResolution>
-  ) => void
+  ) => Promise<void>
   readonly onDismissed: () => void
   readonly openFileInExternalEditor: (path: string) => void
   readonly openRepositoryInShell: (repository: Repository) => void
@@ -116,7 +116,13 @@ export class ConflictsDialog extends React.Component<
       onDismissed,
     } = this.props
 
-    onSubmit(dispatcher, repository, workingDirectory, ourBranch, theirBranch)
+    await onSubmit(
+      dispatcher,
+      repository,
+      workingDirectory,
+      ourBranch,
+      theirBranch
+    )
     onDismissed()
   }
 
@@ -128,7 +134,7 @@ export class ConflictsDialog extends React.Component<
 
     const { workingDirectory, manualResolutions } = this.props
     this.setState({ isAborting: true })
-    this.props.onAbort(workingDirectory, manualResolutions)
+    await this.props.onAbort(workingDirectory, manualResolutions)
     this.setState({ isAborting: false })
     this.props.onDismissed()
   }

--- a/app/src/ui/multi-commit-operation/conflicts-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/conflicts-dialog.tsx
@@ -1,0 +1,229 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dispatcher } from '../dispatcher'
+import { Repository } from '../../models/repository'
+import {
+  WorkingDirectoryStatus,
+  WorkingDirectoryFileChange,
+} from '../../models/status'
+import {
+  isConflictedFile,
+  getResolvedFiles,
+  getConflictedFiles,
+  getUnmergedFiles,
+} from '../../lib/status'
+import {
+  renderUnmergedFile,
+  renderUnmergedFilesSummary,
+  renderShellLink,
+  renderAllResolved,
+} from '../lib/conflicts'
+import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IConflictsDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly workingDirectory: WorkingDirectoryStatus
+  readonly userHasResolvedConflicts?: boolean
+  readonly resolvedExternalEditor: string | null
+  readonly ourBranch: string
+  /* `undefined` when we didn't know the branch at the beginning of this flow */
+  readonly theirBranch?: string
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+  readonly headerTitle: string
+  readonly submitButton: string
+  readonly abortButton: string
+  readonly onSubmit: (
+    dispatcher: Dispatcher,
+    repository: Repository,
+    workingDirectory: WorkingDirectoryStatus,
+    ourBranch: string,
+    theirBranch: string
+  ) => void
+  readonly onAbort: (
+    workingDirectory: WorkingDirectoryStatus,
+    manualResolutions: Map<string, ManualConflictResolution>
+  ) => void
+  readonly onDismissed: () => void
+  readonly openFileInExternalEditor: (path: string) => void
+  readonly openRepositoryInShell: (repository: Repository) => void
+  readonly someConflictsHaveBeenResolved: () => void
+}
+
+interface IConflictsDialogState {
+  readonly isCommitting: boolean
+  readonly isAborting: boolean
+}
+
+/**
+ * Modal to tell the user their encountered conflicts
+ * - To be used generically with conflicts encountered by numerous operations
+ *   such as merging, rebasing, cherry-picking, squashing, reordering, etc.
+ */
+export class ConflictsDialog extends React.Component<
+  IConflictsDialogProps,
+  IConflictsDialogState
+> {
+  public constructor(props: IConflictsDialogProps) {
+    super(props)
+    this.state = {
+      isCommitting: false,
+      isAborting: false,
+    }
+  }
+
+  /**
+   *  Provides us ability to track if user has resolved at least one conflict in
+   *  this operation
+   */
+  public componentWillUnmount() {
+    const {
+      workingDirectory,
+      userHasResolvedConflicts,
+      manualResolutions,
+      someConflictsHaveBeenResolved,
+    } = this.props
+
+    // skip this work once we know conflicts have been resolved
+    if (userHasResolvedConflicts) {
+      return
+    }
+
+    const resolvedConflicts = getResolvedFiles(
+      workingDirectory,
+      manualResolutions
+    )
+
+    if (resolvedConflicts.length > 0) {
+      someConflictsHaveBeenResolved()
+    }
+  }
+
+  /**
+   *  Invokes submit callback and dismisses modal
+   */
+  private onSubmit = async () => {
+    this.setState({ isCommitting: true })
+
+    const {
+      dispatcher,
+      repository,
+      workingDirectory,
+      ourBranch,
+      theirBranch,
+      onSubmit,
+      onDismissed,
+    } = this.props
+
+    onSubmit(dispatcher, repository, workingDirectory, ourBranch, theirBranch)
+    onDismissed()
+  }
+
+  /**
+   *  Invokes abort callback and dismisses modal
+   */
+  private onAbort = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+
+    const { workingDirectory, manualResolutions } = this.props
+    this.setState({ isAborting: true })
+    this.props.onAbort(workingDirectory, manualResolutions)
+    this.setState({ isAborting: false })
+    this.props.onDismissed()
+  }
+
+  private openThisRepositoryInShell = () =>
+    this.props.openRepositoryInShell(this.props.repository)
+
+  /**
+   *  Renders the list of conflicts in the dialog
+   */
+  private renderUnmergedFiles(
+    files: ReadonlyArray<WorkingDirectoryFileChange>
+  ) {
+    return (
+      <ul className="unmerged-file-statuses">
+        {files.map(f =>
+          isConflictedFile(f.status)
+            ? renderUnmergedFile({
+                path: f.path,
+                status: f.status,
+                resolvedExternalEditor: this.props.resolvedExternalEditor,
+                openFileInExternalEditor: this.props.openFileInExternalEditor,
+                repository: this.props.repository,
+                dispatcher: this.props.dispatcher,
+                manualResolution: this.props.manualResolutions.get(f.path),
+                ourBranch: this.props.ourBranch,
+                theirBranch: this.props.theirBranch,
+              })
+            : null
+        )}
+      </ul>
+    )
+  }
+
+  private renderContent(
+    unmergedFiles: ReadonlyArray<WorkingDirectoryFileChange>,
+    conflictedFilesCount: number
+  ): JSX.Element {
+    if (unmergedFiles.length === 0) {
+      return renderAllResolved()
+    }
+
+    return (
+      <>
+        {renderUnmergedFilesSummary(conflictedFilesCount)}
+        {this.renderUnmergedFiles(unmergedFiles)}
+        {renderShellLink(this.openThisRepositoryInShell)}
+      </>
+    )
+  }
+
+  public render() {
+    const {
+      workingDirectory,
+      manualResolutions,
+      headerTitle,
+      submitButton,
+      abortButton,
+    } = this.props
+
+    const unmergedFiles = getUnmergedFiles(this.props.workingDirectory)
+    const conflictedFiles = getConflictedFiles(
+      workingDirectory,
+      manualResolutions
+    )
+
+    const tooltipString =
+      conflictedFiles.length > 0
+        ? 'Resolve all changes before continuing'
+        : undefined
+
+    return (
+      <Dialog
+        id="conflicts-dialog"
+        dismissable={!this.state.isCommitting}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onSubmit}
+        title={headerTitle}
+        loading={this.state.isCommitting}
+        disabled={this.state.isCommitting}
+      >
+        <DialogContent>
+          {this.renderContent(unmergedFiles, conflictedFiles.length)}
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={submitButton}
+            okButtonDisabled={conflictedFiles.length > 0}
+            okButtonTitle={tooltipString}
+            cancelButtonText={abortButton}
+            onCancelButtonClick={this.onAbort}
+            cancelButtonDisabled={this.state.isAborting}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/styles/ui/dialogs/_merge-conflicts.scss
+++ b/app/styles/ui/dialogs/_merge-conflicts.scss
@@ -1,5 +1,6 @@
 @import '../../mixins';
 
+dialog#conflicts-dialog,
 dialog#merge-conflicts-list,
 dialog#cherry-pick-conflicts-list,
 dialog#rebase-conflicts-list {


### PR DESCRIPTION
## Description

This is simply the creation of a conflict modal that has all the shared parts of the three existing conflict modals.
To be followed with a PR for refactoring merging, rebasing, and cherry-picking to use it (which may result in tweaking it.. particularly I think the callbacks may need parameter adjustments).

A first step in creating Multi Commit Operation components/models to reduce a lot of redundant code.

## Release notes
Notes: no-notes
