### PR TITLE
Squash drag ux improvement

### DIFF
--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -1,5 +1,5 @@
 import { Disposable, Emitter } from 'event-kit'
-import { DragData, DragType } from '../models/drag-drop'
+import { DragData, DragType, DropTarget } from '../models/drag-drop'
 
 /**
  * The drag and drop manager is implemented to manage drag and drop events
@@ -19,17 +19,15 @@ export class DragAndDropManager {
     return this._isDragInProgress
   }
 
-  public emitEnterDropTarget(targetDescription: string) {
-    this.emitter.emit('enter-drop-target', targetDescription)
+  public emitEnterDropTarget(target: DropTarget) {
+    this.emitter.emit('enter-drop-target', target)
   }
 
   public emitLeaveDropTarget() {
     this.emitter.emit('leave-drop-target', {})
   }
 
-  public onEnterDropTarget(
-    fn: (targetDescription: string) => void
-  ): Disposable {
+  public onEnterDropTarget(fn: (target: DropTarget) => void): Disposable {
     return this.emitter.on('enter-drop-target', fn)
   }
 

--- a/app/src/models/drag-drop.ts
+++ b/app/src/models/drag-drop.ts
@@ -25,3 +25,23 @@ export type DragElement = {
   selectedCommits: ReadonlyArray<Commit>
   gitHubRepository: GitHubRepository | null
 }
+
+export enum DropTargetType {
+  Branch,
+  Commit,
+}
+
+export type BranchTarget = {
+  type: DropTargetType.Branch
+  branchName: string
+}
+
+export type CommitTarget = {
+  type: DropTargetType.Commit
+}
+
+/**
+ * This is a type is used in conjunction with the drag and drop manager to
+ * pass information about a drop target.
+ */
+export type DropTarget = BranchTarget | CommitTarget

--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -10,7 +10,7 @@ import { showContextualMenu } from '../main-process-proxy'
 import { IMenuItem } from '../../lib/menu-item'
 import { String } from 'aws-sdk/clients/apigateway'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
-import { DragType } from '../../models/drag-drop'
+import { DragType, DropTargetType } from '../../models/drag-drop'
 
 interface IBranchListItemProps {
   /** The name of the branch */
@@ -84,7 +84,10 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
 
   private onMouseEnter = () => {
     if (dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
-      dragAndDropManager.emitEnterDropTarget(this.props.name)
+      dragAndDropManager.emitEnterDropTarget({
+        type: DropTargetType.Branch,
+        branchName: this.props.name,
+      })
     }
   }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -26,7 +26,7 @@ import { renderDefaultBranch } from './branch-renderer'
 import { IMatches } from '../../lib/fuzzy-find'
 import { startTimer } from '../lib/timing'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
-import { DragType } from '../../models/drag-drop'
+import { DragType, DropTargetType } from '../../models/drag-drop'
 
 interface IBranchesContainerProps {
   readonly dispatcher: Dispatcher
@@ -241,7 +241,10 @@ export class BranchesContainer extends React.Component<
   private onMouseEnterNewBranchDrop = () => {
     // This is just used for displaying on windows drag ghost.
     // Thus, it doesn't have to be an actual branch name.
-    dragAndDropManager.emitEnterDropTarget('a new branch')
+    dragAndDropManager.emitEnterDropTarget({
+      type: DropTargetType.Branch,
+      branchName: 'a new branch',
+    })
   }
 
   private onMouseLeaveNewBranchDrop = () => {

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -8,6 +8,7 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { GitHubRepository } from '../../models/github-repository'
 import { Dispatcher } from '../dispatcher'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { DropTargetType } from '../../models/drag-drop'
 
 export interface IPullRequestListItemProps {
   /** The title. */
@@ -63,7 +64,10 @@ export class PullRequestListItem extends React.Component<
 
   private onMouseEnter = () => {
     if (dragAndDropManager.isDragInProgress) {
-      dragAndDropManager.emitEnterDragZone(this.props.title)
+      dragAndDropManager.emitEnterDropTarget({
+        type: DropTargetType.Branch,
+        branchName: this.props.title,
+      })
     }
   }
 

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -85,7 +85,7 @@ export class CommitMessageDialog extends React.Component<
   public render() {
     return (
       <Dialog
-        id="commit-message"
+        id="commit-message-dialog"
         title={this.props.dialogTitle}
         onDismissed={this.props.onDismissed}
       >

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -95,9 +95,11 @@ export class CommitDragElement extends React.Component<
         )
         break
       case DropTargetType.Commit:
+        // Selected commits (being dragged) + the one commit it is squashed (dropped) on.
+        const commitsBeingSquashedCount = this.props.selectedCommits.length + 1
         toolTipContents = (
           <>
-            <span>Squash {this.props.selectedCommits.length + 1} commits</span>
+            <span>Squash {commitsBeingSquashedCount} commits</span>
           </>
         )
         break

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -1,7 +1,9 @@
 import classNames from 'classnames'
 import * as React from 'react'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { assertNever } from '../../lib/fatal-error'
 import { Commit } from '../../models/commit'
+import { DropTarget, DropTargetType } from '../../models/drag-drop'
 import { GitHubRepository } from '../../models/github-repository'
 import { CommitListItem } from '../history/commit-list-item'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -14,7 +16,8 @@ interface ICommitDragElementProps {
 }
 
 interface ICommitDragElementState {
-  readonly branchName: string | null
+  readonly showTooltip: boolean
+  readonly currentDropTarget: DropTarget | null
 }
 
 export class CommitDragElement extends React.Component<
@@ -26,60 +29,90 @@ export class CommitDragElement extends React.Component<
   public constructor(props: ICommitDragElementProps) {
     super(props)
     this.state = {
-      branchName: null,
+      showTooltip: false,
+      currentDropTarget: null,
     }
 
-    dragAndDropManager.onEnterDropTarget(branchName => {
-      this.setBranchName(branchName)
+    dragAndDropManager.onEnterDropTarget(dropTarget => {
+      this.setState({ currentDropTarget: dropTarget })
+      switch (dropTarget.type) {
+        case DropTargetType.Branch:
+          this.setToolTipTimer(1500)
+          break
+        case DropTargetType.Commit:
+          this.setState({ showTooltip: true })
+          break
+        default:
+          assertNever(dropTarget, `Unknown drop target type: ${dropTarget}`)
+      }
     })
 
     dragAndDropManager.onLeaveDropTarget(() => {
-      this.setState({ branchName: null })
+      this.setState({ currentDropTarget: null, showTooltip: false })
     })
   }
 
-  private setBranchName(branchName: string) {
+  private setToolTipTimer(time: number) {
     if (__DARWIN__) {
       // For macOs, we styled the copy to message to look like a native tool tip
       // that appears when hovering over a element with the title attribute. We
       // also are implementing this timeout to have similar hover-to-see feel.
-      this.setState({ branchName: null })
+      this.setState({ showTooltip: false })
 
       if (this.timeoutId !== null) {
         window.clearTimeout(this.timeoutId)
       }
 
       this.timeoutId = window.setTimeout(
-        () => this.setState({ branchName }),
-        1500
+        () => this.setState({ showTooltip: true }),
+        time
       )
     } else {
-      this.setState({ branchName })
+      this.setState({ showTooltip: true })
     }
   }
 
-  /**
-   * The "copy to" label is a windows convention we are implementing to provide
-   * a more intuitive ux for windows users.
-   */
-  private renderDragCopyLabel(count: number) {
-    const { branchName } = this.state
-    if (branchName === null) {
+  private renderDragToolTip() {
+    const { showTooltip, currentDropTarget } = this.state
+    if (!showTooltip || currentDropTarget === null) {
       return
     }
 
-    const copyToPlus = __DARWIN__ ? null : (
-      <Octicon symbol={OcticonSymbol.plus} />
-    )
+    let toolTipContents
+    switch (currentDropTarget.type) {
+      case DropTargetType.Branch:
+        const copyToPlus = __DARWIN__ ? null : (
+          <Octicon symbol={OcticonSymbol.plus} />
+        )
+        toolTipContents = (
+          <>
+            {copyToPlus}
+            <span>
+              Copy to{' '}
+              <span className="branch-name">
+                {currentDropTarget.branchName}
+              </span>
+            </span>
+          </>
+        )
+        break
+      case DropTargetType.Commit:
+        toolTipContents = (
+          <>
+            <span>Squash {this.props.selectedCommits.length + 1} commits</span>
+          </>
+        )
+        break
+      default:
+        assertNever(
+          currentDropTarget,
+          `Unknown drop target type: ${currentDropTarget}`
+        )
+    }
 
     return (
-      <div className="copy-message-label">
-        <div>
-          {copyToPlus}
-          <span>
-            Copy to <span className="branch-name">{branchName}</span>
-          </span>
-        </div>
+      <div className="tool-tip-contents">
+        <div>{toolTipContents}</div>
       </div>
     )
   }
@@ -90,7 +123,7 @@ export class CommitDragElement extends React.Component<
 
     const className = classNames({ 'multiple-selected': count > 1 })
     return (
-      <div id="cherry-pick-commit-drag-element" className={className}>
+      <div id="commit-drag-element" className={className}>
         <div className="commit-box">
           <div className="count">{count}</div>
           <CommitListItem
@@ -102,7 +135,7 @@ export class CommitDragElement extends React.Component<
             showUnpushedIndicator={false}
           />
         </div>
-        {this.renderDragCopyLabel(count)}
+        {this.renderDragToolTip()}
       </div>
     )
   }

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -37,10 +37,8 @@ export class CommitDragElement extends React.Component<
       this.setState({ currentDropTarget: dropTarget })
       switch (dropTarget.type) {
         case DropTargetType.Branch:
-          this.setToolTipTimer(1500)
-          break
         case DropTargetType.Commit:
-          this.setState({ showTooltip: true })
+          this.setToolTipTimer(1500)
           break
         default:
           assertNever(dropTarget, `Unknown drop target type: ${dropTarget}`)

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -82,13 +82,15 @@ export class CommitDragElement extends React.Component<
     switch (currentDropTarget.type) {
       case DropTargetType.Branch:
         const copyToPlus = __DARWIN__ ? null : (
-          <Octicon symbol={OcticonSymbol.plus} />
+          <Octicon className="copy-to-icon" symbol={OcticonSymbol.plus} />
         )
         toolTipContents = (
           <>
             {copyToPlus}
             <span>
+              <span className="copy-to">
               Copy to{' '}
+              </span>
               <span className="branch-name">
                 {currentDropTarget.branchName}
               </span>

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -86,9 +86,7 @@ export class CommitDragElement extends React.Component<
           <>
             {copyToPlus}
             <span>
-              <span className="copy-to">
-              Copy to{' '}
-              </span>
+              <span className="copy-to">Copy to </span>
               <span className="branch-name">
                 {currentDropTarget.branchName}
               </span>

--- a/app/styles/ui/_app.scss
+++ b/app/styles/ui/_app.scss
@@ -95,6 +95,12 @@
             color: var(--text-color);
             background-color: var(--box-selected-active-background-color);
           }
+
+          .commit {
+            div {
+              pointer-events: none;
+            }
+          }
         }
       }
     }

--- a/app/styles/ui/_drag-elements.scss
+++ b/app/styles/ui/_drag-elements.scss
@@ -1,4 +1,4 @@
-@import 'drag-elements/cherry-pick-commit';
+@import 'drag-elements/commit-drag-element';
 
 #dragElement {
   position: absolute;

--- a/app/styles/ui/dialogs/_commit-message.scss
+++ b/app/styles/ui/dialogs/_commit-message.scss
@@ -1,9 +1,8 @@
-dialog#commit-message {
+dialog#commit-message-dialog {
   .dialog-content {
     padding: 0;
   }
-
-  .dialog-header {
-    padding: var(--spacing);
+  #commit-message {
+    background-color: inherit;
   }
 }

--- a/app/styles/ui/drag-elements/_cherry-pick-commit.scss
+++ b/app/styles/ui/drag-elements/_cherry-pick-commit.scss
@@ -47,7 +47,7 @@
     left: 0px;
     background-color: var(--background-color);
     border: 1px solid var(--box-border-color);
-    color: var(--link-button-color);
+    color: var(--text-color);
     padding: var(--spacing-third) var(--spacing-half);
 
     @include darwin {
@@ -61,8 +61,12 @@
     }
 
     .branch-name {
-      color: var(--text-color);
       margin-left: var(--spacing-third);
+    }
+
+    .copy-to,
+    .copy-to-icon {
+      color: var(--link-button-color);
     }
 
     div {

--- a/app/styles/ui/drag-elements/_cherry-pick-commit.scss
+++ b/app/styles/ui/drag-elements/_cherry-pick-commit.scss
@@ -1,4 +1,4 @@
-#cherry-pick-commit-drag-element {
+#commit-drag-element {
   display: block;
   position: absolute;
   height: 50px;
@@ -41,7 +41,7 @@
     }
   }
 
-  .copy-message-label {
+  .tool-tip-contents {
     position: absolute;
     bottom: -35px;
     left: 0px;

--- a/app/styles/ui/drag-elements/_commit-drag-element.scss
+++ b/app/styles/ui/drag-elements/_commit-drag-element.scss
@@ -54,7 +54,6 @@
       padding: 1px var(--spacing-third);
       font-size: 11px;
       bottom: -25px;
-      color: var(--text-color);
       background-color: var(--title-tool-tip-background-color);
       border-radius: 1px;
       box-shadow: var(--title-tool-tip-shadow);
@@ -64,9 +63,11 @@
       margin-left: var(--spacing-third);
     }
 
-    .copy-to,
-    .copy-to-icon {
-      color: var(--link-button-color);
+    @include win32 {
+      .copy-to,
+      .copy-to-icon {
+        color: var(--link-button-color);
+      }
     }
 
     div {

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -75,7 +75,7 @@
   }
 }
 
-#cherry-pick-commit-drag-element .commit,
+#commit-drag-element .commit,
 #commit-list .commit {
   display: flex;
   flex-direction: row;
@@ -158,7 +158,7 @@
     }
   }
 
-  .copy-message-label {
+  .tool-tip-contents {
     display: none;
   }
 }


### PR DESCRIPTION
## Description

Some UX/UI improvements for squashing UI.
- Add "Squash x commits" tooltip following cherry-picking delay design
- Disable other commit title tooltips during drag
- Make squash dialog consistent with other dialogs

### Screenshots

https://user-images.githubusercontent.com/75402236/118866148-b6c3b980-b8af-11eb-83b8-de0091bfa9a2.mov

## Release notes

Notes: no-notes
