### PR TITLE
Fix off-by-one issue expanding whole files

### DIFF
--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -232,7 +232,7 @@ export function expandTextDiffHunk(
       // which is effectively taking all the undiscovered file contents and
       // would prevent us from expanding down the diff.
       if (isAdjacentDummyHunk === false) {
-        const downLimit = adjacentHunk.header.newStartLine - 1
+        const downLimit = adjacentHunk.header.newStartLine
         to = Math.min(to, downLimit)
         shouldMergeWithAdjacent = to === downLimit
       }

--- a/app/test/unit/text-diff-expansion-test.ts
+++ b/app/test/unit/text-diff-expansion-test.ts
@@ -5,6 +5,7 @@ import { GitProcess } from 'dugite'
 import { DiffParser } from '../../src/lib/diff-parser'
 import {
   expandTextDiffHunk,
+  expandWholeTextDiff,
   getTextDiffWithBottomDummyHunk,
 } from '../../src/ui/diff/text-diff-expansion'
 import { ITextDiff, DiffType } from '../../src/models/diff/diff-data'
@@ -165,7 +166,7 @@ describe('text-diff-expansion', () => {
   })
 
   it('merges hunks when the gap between them is shorter than the expansion size', async () => {
-    const { textDiff, newContentLines } = await prepareDiff(100, [10, 20])
+    const { textDiff, newContentLines } = await prepareDiff(100, [20, 10])
     const expandedDiff = expandTextDiffHunk(
       textDiff,
       textDiff.hunks[0],
@@ -184,8 +185,43 @@ describe('text-diff-expansion', () => {
 
     const firstHunk = expandedDiff!.hunks[0]
     expect(firstHunk.header.oldStartLine).toBe(8)
-    expect(firstHunk.header.oldLineCount).toBe(14)
+    expect(firstHunk.header.oldLineCount).toBe(16)
     expect(firstHunk.header.newStartLine).toBe(8)
-    expect(firstHunk.header.newLineCount).toBe(16)
+    expect(firstHunk.header.newLineCount).toBe(18)
+  })
+
+  it('expands the whole file', async () => {
+    const { textDiff, newContentLines } = await prepareDiff(35, [
+      20,
+      17,
+      8,
+      7,
+      6,
+    ])
+
+    const expandedDiff = expandWholeTextDiff(textDiff, newContentLines)
+    expect(expandedDiff!.hunks).toHaveLength(1)
+
+    const firstHunk = expandedDiff!.hunks[0]
+    expect(firstHunk.lines).toHaveLength(40 + 1) // +1 for the header
+
+    let expectedNewLine = 1
+    let expectedOldLine = 1
+
+    // Make sure line numbers are consecutive as expected
+    for (const line of firstHunk.lines) {
+      if (line.type === DiffLineType.Add) {
+        expect(line.newLineNumber).toBe(expectedNewLine)
+        expectedNewLine++
+      } else if (line.type === DiffLineType.Delete) {
+        expect(line.oldLineNumber).toBe(expectedOldLine)
+        expectedOldLine++
+      } else if (line.type === DiffLineType.Context) {
+        expect(line.newLineNumber).toBe(expectedNewLine)
+        expectedNewLine++
+        expect(line.oldLineNumber).toBe(expectedOldLine)
+        expectedOldLine++
+      }
+    }
   })
 })


### PR DESCRIPTION
Closes #12237 

## Description

The problem was an off-by-one error (classic) that only happened when a hunk is merged with the adjacent when it's expanded **down**. That doesn't happen when the user manually expands individual hunks, because when the gap between hunks is too short and will result in both hunks to be merged, the hunk below is expanded **up** with its adjacent above 🤯 

However, when a whole file is expanded, the algorithm just expands the first hunk first up and then down as many times as needed.

## Release notes

Notes: [Fixed] Expanding files doesn't show duplicated lines anymore
