### PR TITLE
Release 2.8.2-beta2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.8.2-beta1",
+  "version": "2.8.2-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.7",
+    "detect-arm64-translation": "https://github.com/desktop/node-detect-arm64-translation#v1.0.4",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.103.0",

--- a/app/src/lib/get-architecture.ts
+++ b/app/src/lib/get-architecture.ts
@@ -1,4 +1,5 @@
 import { App } from 'electron'
+import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
 
@@ -9,12 +10,10 @@ export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
  * Rosetta).
  */
 export function getArchitecture(app: App): Architecture {
-  // TODO: Check if it's x64 running on an arm64 Windows with IsWow64Process2
-  // More info: https://www.rudyhuyn.com/blog/2017/12/13/how-to-detect-that-your-x86-application-runs-on-windows-on-arm/
-  // Right now (April 26, 2021) is not very important because support for x64
-  // apps on an arm64 Windows is experimental. See:
-  // https://blogs.windows.com/windows-insider/2020/12/10/introducing-x64-emulation-in-preview-for-windows-10-on-arm-pcs-to-the-windows-insider-program/
-  if (app.runningUnderRosettaTranslation === true) {
+  if (
+    app.runningUnderRosettaTranslation === true ||
+    isRunningUnderARM64Translation() === true
+  ) {
     return 'x64-emulated'
   }
 

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -83,12 +83,22 @@ export function getReleaseSummary(
   }
 }
 
-export async function getChangeLog(): Promise<ReadonlyArray<ReleaseMetadata>> {
-  const changelog =
+export async function getChangeLog(
+  limit?: number
+): Promise<ReadonlyArray<ReleaseMetadata>> {
+  const changelogURL = new URL(
     'https://central.github.com/deployments/desktop/desktop/changelog.json'
-  const query = __RELEASE_CHANNEL__ === 'beta' ? '?env=beta' : ''
+  )
 
-  const response = await fetch(`${changelog}${query}`)
+  if (__RELEASE_CHANNEL__ === 'beta') {
+    changelogURL.searchParams.set('env', 'beta')
+  }
+
+  if (limit !== undefined) {
+    changelogURL.searchParams.set('limit', limit.toString())
+  }
+
+  const response = await fetch(changelogURL.toString())
   if (response.ok) {
     const releases: ReadonlyArray<ReleaseMetadata> = await response.json()
     return releases

--- a/app/src/lib/thank-you.ts
+++ b/app/src/lib/thank-you.ts
@@ -47,7 +47,9 @@ export function updateLastThankYou(
 export async function getThankYouByUser(
   isOnlyLastRelease: boolean
 ): Promise<Map<string, ReadonlyArray<ReleaseNote>>> {
-  let releaseMetaData = await getChangeLog()
+  // 250 is more than total number beta release to date (5/5/2021) and the
+  // purpose of getting more is to retroactively thank contributors to date.
+  let releaseMetaData = await getChangeLog(250)
   if (isOnlyLastRelease) {
     releaseMetaData = releaseMetaData.slice(0, 1)
   }

--- a/app/src/ui/banners/open-thank-you-card.tsx
+++ b/app/src/ui/banners/open-thank-you-card.tsx
@@ -21,8 +21,7 @@ export class OpenThankYouCard extends React.Component<
     return (
       <Banner id="open-thank-you-card" onDismissed={this.props.onDismissed}>
         <span onSubmit={this.props.onOpenCard}>
-          The Desktop team would like to thank you for your recent
-          contributions.{' '}
+          The Desktop team would like to thank you for your contributions.{' '}
           <LinkButton onClick={this.props.onOpenCard}>
             Open Your Card
           </LinkButton>{' '}

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -15,6 +15,7 @@ import { ReleaseSummary } from '../../models/release-notes'
 import { generateReleaseSummary } from '../../lib/release-notes'
 import { setNumber, getNumber } from '../../lib/local-storage'
 import { enableUpdateFromRosettaToARM64 } from '../../lib/feature-flag'
+import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 /** The states the auto updater can be in. */
 export enum UpdateStatus {
@@ -168,7 +169,8 @@ class UpdateStore {
     // the arm64 binary.
     if (
       enableUpdateFromRosettaToARM64() &&
-      remote.app.runningUnderRosettaTranslation === true
+      (remote.app.runningUnderRosettaTranslation === true ||
+        isRunningUnderARM64Translation() === true)
     ) {
       const url = new URL(updatesURL)
       url.pathname = url.pathname.replace(

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -80,24 +80,19 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
               renderUrlsAsLinks={true}
             />
           </div>
-          <div className="thank-you-note">
-            The Desktop team wants to thank you personally.
-          </div>
         </div>
       </div>
     )
 
-    const thankYou = 'Thank you for all your hard work on GitHub Desktop'
-    let thankYouNote
-    if (this.props.latestVersion === null) {
-      thankYouNote = <>{thankYou}</>
-    } else {
-      thankYouNote = (
-        <>
-          {thankYou} version {this.props.latestVersion}
-        </>
-      )
-    }
+    const version =
+      this.props.latestVersion !== null ? ` ${this.props.latestVersion}` : ''
+    const thankYouNote = (
+      <>
+        Thanks so much for all your hard work on GitHub Desktop{version}. We're
+        so grateful for your willingness to contribute and make the app better
+        for everyone!
+      </>
+    )
 
     return (
       <Dialog
@@ -107,7 +102,7 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
       >
         <DialogContent>
           <div className="container">
-            <div className="thank-you-note">{thankYouNote}.</div>
+            <div className="thank-you-note">{thankYouNote}</div>
             <div className="contributions-heading">You contributed:</div>
             <div className="contributions">
               {this.renderList(this.props.userContributions)}
@@ -118,6 +113,7 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
             >
               {this.renderConfetti()}
             </div>
+            <div className="footer"></div>
           </div>
         </DialogContent>
       </Dialog>

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -2,14 +2,16 @@
 
 #thank-you-notes {
   max-height: 450px;
+  padding-top: var(--spacing-half);
 
   .dialog-content {
     // we'll own the layout inside here
     padding: 0;
+    overflow: hidden;
   }
 
   .dialog-header {
-    height: 100px;
+    height: 88px;
     position: relative;
 
     .release-notes-header {
@@ -73,19 +75,32 @@
   a.close {
     align-self: flex-start;
     z-index: 1;
+    margin-top: calc(var(--spacing) * -1);
   }
 
   .container {
     width: 600px;
-    padding-left: 80px;
-    padding-right: 80px;
+    padding-left: 72px;
+    padding-right: 72px;
     padding-top: var(--spacing-triple);
     padding-bottom: var(--spacing-triple);
     overflow-x: hidden;
     overflow-y: auto;
 
+    .footer {
+      position: fixed;
+      height: var(--spacing-triple);
+      width: 95%;
+      bottom: 0;
+      left: 0;
+      background-color: var(--background-color);
+    }
+
+    .section {
+      padding-bottom: var(--spacing-triple);
+    }
+
     .thank-you-note {
-      font-weight: var(--font-weight-semibold);
       padding-bottom: var(--spacing-triple);
     }
 

--- a/app/styles/ui/dialogs/_thank-you.scss
+++ b/app/styles/ui/dialogs/_thank-you.scss
@@ -111,6 +111,10 @@
     .contributions {
       max-height: 150px;
     }
+
+    .section {
+      padding-bottom: var(--spacing-triple);
+    }
   }
 
   .confetti-container {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -318,6 +318,13 @@ desktop-trampoline@desktop/desktop-trampoline#v0.9.7:
     node-addon-api "^3.1.0"
     prebuild-install "^6.0.0"
 
+"detect-arm64-translation@https://github.com/desktop/node-detect-arm64-translation#v1.0.4":
+  version "1.0.3"
+  resolved "https://github.com/desktop/node-detect-arm64-translation#d03110738f94fa684fc20cdfa412e83cd7984c89"
+  dependencies:
+    node-addon-api "^3.1.0"
+    prebuild-install "^5.3.5"
+
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,8 @@
 {
   "releases": {
+    "2.8.2-beta2": [
+      "[Fixed] Lists of commits, repositories or changes don't disappear after switching between apps"
+    ],
     "2.8.2-beta1": [
       "[Added] Thank external contributors for their work - #12137",
       "[Fixed] Disable partial change selection in split view while whitespace changes are hidden - #12129",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,8 @@
 {
   "releases": {
     "2.8.2-beta2": [
-      "[Fixed] Lists of commits, repositories or changes don't disappear after switching between apps"
+      "[Fixed] Lists of commits, repositories or changes don't disappear after switching between apps",
+      "[Improved] Thank you note language improved and retrieves all past release notes to retroactively thank all contributors"
     ],
     "2.8.2-beta1": [
       "[Added] Thank external contributors for their work - #12137",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "^11.4.4",
+    "electron": "^11.1.1",
     "electron-builder": "^22.7.0",
     "electron-packager": "^15.1.0",
     "electron-winstaller": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4141,10 +4141,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@^11.4.4:
-  version "11.4.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.4.tgz#d6c046dedd9e22df5f6408841c3f8ae1a1d59414"
-  integrity sha512-m52nF85VADCmL9DpzJfgmkvc9fNiGZPYwptv/4fTYrYhAMiO+hmClGMXncCoSAzoULQjl+f+0b9CY4yd6nRFlQ==
+electron@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.1.1.tgz#188f036f8282798398dca9513e9bb3b10213e3aa"
+  integrity sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming second beta of the v2.8.2 series? Well you've just found it, congratulations!

This is basically the same as 2.8.2-beta1, but Electron has been reverted to v11.1.1 after finding [an issue where lists get emptied randomly after switching between apps](https://github.com/electron/electron/issues/29261) 😱 

It also includes:
- Ability to detect x64 emulated builds running on Windows ARM #12207 
- Several improvements to the Thank You card #12153 #12148

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated