### PR TITLE
Add a reusable confirm abort dialog

### DIFF
--- a/app/src/ui/multi-commit-operation/confirm-abort-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/confirm-abort-dialog.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+interface IConfirmAbortDialogProps {
+  readonly operation: string
+
+  readonly onReturnToConflicts: () => void
+  readonly onConfirmAbort: () => Promise<void>
+}
+
+interface IConfirmAbortDialogState {
+  readonly isAborting: boolean
+}
+
+export class ConfirmAbortDialog extends React.Component<
+  IConfirmAbortDialogProps,
+  IConfirmAbortDialogState
+> {
+  public constructor(props: IConfirmAbortDialogProps) {
+    super(props)
+    this.state = {
+      isAborting: false,
+    }
+  }
+
+  private onSubmit = async () => {
+    this.setState({
+      isAborting: true,
+    })
+
+    await this.props.onConfirmAbort()
+
+    this.setState({
+      isAborting: false,
+    })
+  }
+
+  private onCancel = async () => {
+    await this.props.onReturnToConflicts()
+  }
+
+  public render() {
+    const { operation } = this.props
+    return (
+      <Dialog
+        id="abort-warning"
+        title={
+          __DARWIN__
+            ? `Confirm Abort ${operation}`
+            : `Confirm abort ${operation.toLowerCase()}`
+        }
+        onDismissed={this.onCancel}
+        onSubmit={this.onSubmit}
+        disabled={this.state.isAborting}
+        type="warning"
+      >
+        <DialogContent>
+          <div className="column-left">
+            <p>Are you sure you want to abort {operation.toLowerCase()}?</p>
+            <p>
+              This will take you back to the original branch state and the
+              conflicts you have already resolved will be discarded.
+            </p>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            destructive={true}
+            okButtonText={
+              __DARWIN__
+                ? `Abort ${operation}`
+                : `Abort ${operation.toLowerCase()}`
+            }
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/multi-commit-operation/confirm-abort-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/confirm-abort-dialog.tsx
@@ -3,6 +3,14 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 interface IConfirmAbortDialogProps {
+  /**
+   * This is expected to be capitalized for correct output on windows and macOs.
+   *
+   * Examples:
+   *  - Rebase
+   *  - Cherry-pick
+   *  - Squash
+   */
   readonly operation: string
   readonly onReturnToConflicts: () => void
   readonly onConfirmAbort: () => Promise<void>

--- a/app/src/ui/multi-commit-operation/confirm-abort-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/confirm-abort-dialog.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
-
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
 interface IConfirmAbortDialogProps {
   readonly operation: string
-
   readonly onReturnToConflicts: () => void
   readonly onConfirmAbort: () => Promise<void>
 }
@@ -37,7 +36,7 @@ export class ConfirmAbortDialog extends React.Component<
   }
 
   private onCancel = async () => {
-    await this.props.onReturnToConflicts()
+    return this.props.onReturnToConflicts()
   }
 
   public render() {
@@ -57,7 +56,9 @@ export class ConfirmAbortDialog extends React.Component<
       >
         <DialogContent>
           <div className="column-left">
-            <p>Are you sure you want to abort {operation.toLowerCase()}?</p>
+            <p>
+              Are you sure you want to abort this {operation.toLowerCase()}?
+            </p>
             <p>
               This will take you back to the original branch state and the
               conflicts you have already resolved will be discarded.

--- a/app/styles/ui/dialogs/_abort-merge.scss
+++ b/app/styles/ui/dialogs/_abort-merge.scss
@@ -1,5 +1,6 @@
 @import '../../mixins';
 
+dialog#abort-warning,
 dialog#abort-merge-warning {
   width: 450px;
 


### PR DESCRIPTION
## Description

Adds a reusable confirm abort dialog to use with multi commit operation flow.

## Release notes

Notes: no-notes
