### PR TITLE
Track stats when users undo a commit

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -41,6 +41,9 @@ export interface IDailyMeasures {
   /** The number of commits created with one or more co-authors. */
   readonly coAuthoredCommits: number
 
+  /** The number of commits undone by the user. */
+  readonly commitsUndone: number
+
   /** The number of times a branch is compared to an arbitrary branch */
   readonly branchComparisons: number
 

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -41,8 +41,11 @@ export interface IDailyMeasures {
   /** The number of commits created with one or more co-authors. */
   readonly coAuthoredCommits: number
 
-  /** The number of commits undone by the user. */
-  readonly commitsUndone: number
+  /** The number of commits undone by the user with a dirty working directory. */
+  readonly commitsUndoneWithChanges: number
+
+  /** The number of commits undone by the user with a clean working directory. */
+  readonly commitsUndoneWithoutChanges: number
 
   /** The number of times a branch is compared to an arbitrary branch */
   readonly branchComparisons: number

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -62,6 +62,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   partialCommits: 0,
   openShellCount: 0,
   coAuthoredCommits: 0,
+  commitsUndone: 0,
   branchComparisons: 0,
   defaultBranchComparisons: 0,
   mergesInitiatedFromComparison: 0,
@@ -652,6 +653,13 @@ export class StatsStore implements IStatsStore {
   public recordCoAuthoredCommit(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       coAuthoredCommits: m.coAuthoredCommits + 1,
+    }))
+  }
+
+  /** Record that a commit was undone. */
+  public recordCommitUndone(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      commitsUndone: m.commitsUndone + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -62,7 +62,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   partialCommits: 0,
   openShellCount: 0,
   coAuthoredCommits: 0,
-  commitsUndone: 0,
+  commitsUndoneWithChanges: 0,
+  commitsUndoneWithoutChanges: 0,
   branchComparisons: 0,
   defaultBranchComparisons: 0,
   mergesInitiatedFromComparison: 0,
@@ -656,10 +657,19 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  /** Record that a commit was undone. */
-  public recordCommitUndone(): Promise<void> {
+  /**
+   * Record that a commit was undone.
+   *
+   * @param cleanWorkingDirectory Whether the working directory is clean.
+   */
+  public recordCommitUndone(cleanWorkingDirectory: boolean): Promise<void> {
+    if (cleanWorkingDirectory) {
+      return this.updateDailyMeasures(m => ({
+        commitsUndoneWithoutChanges: m.commitsUndoneWithoutChanges + 1,
+      }))
+    }
     return this.updateDailyMeasures(m => ({
-      commitsUndone: m.commitsUndone + 1,
+      commitsUndoneWithChanges: m.commitsUndoneWithChanges + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4088,6 +4088,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await gitStore.undoCommit(commit)
 
+    this.statsStore.recordCommitUndone()
+
     const { commitSelection } = this.repositoryStateCache.get(repository)
 
     if (

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4086,9 +4086,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 
+    const currentState = this.repositoryStateCache.get(repository)
+    const { changesState } = currentState
+    const isWorkingDirectoryClean =
+      changesState.workingDirectory.files.length === 0
+
     await gitStore.undoCommit(commit)
 
-    this.statsStore.recordCommitUndone()
+    this.statsStore.recordCommitUndone(isWorkingDirectoryClean)
 
     const { commitSelection } = this.repositoryStateCache.get(repository)
 


### PR DESCRIPTION
## Description

This PR starts tracking stats when users undo commits. It directly records when the user clicks on the `Undo` button and the commit is effectively undone.

Is there any other metric that could help us understand better how users use `Undo`? For example:
- Whether or not they undid a commit while having changes in the working directory.
- If there were changes… whether or not they conflicted with the changes in the commit.
- ???

## Release notes

Notes: no-notes
