### PR TITLE
Create resusable warn force push-dialog

### DIFF
--- a/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { Dispatcher } from '../dispatcher'
+import { DialogFooter, DialogContent, Dialog } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IWarnForcePushProps {
+  /**
+   * This is expected to be capitalized for correct output on windows and macOs.
+   *
+   * Examples:
+   *  - Rebase
+   *  - Squash
+   *  - Reorder
+   */
+  readonly operation: string
+  readonly dispatcher: Dispatcher
+  readonly askForConfirmationOnForcePush: boolean
+  readonly onBegin: () => void
+  readonly onDismissed: () => void
+}
+
+interface IWarnForcePushState {
+  readonly askForConfirmationOnForcePush: boolean
+}
+
+export class WarnForcePushDialog extends React.Component<
+  IWarnForcePushProps,
+  IWarnForcePushState
+> {
+  public constructor(props: IWarnForcePushProps) {
+    super(props)
+
+    this.state = {
+      askForConfirmationOnForcePush: props.askForConfirmationOnForcePush,
+    }
+  }
+
+  public render() {
+    const { operation, onDismissed } = this.props
+
+    const title = __DARWIN__
+      ? `${operation} Will Require Force Push`
+      : `${operation} will require force push'`
+
+    return (
+      <Dialog
+        title={title}
+        onDismissed={this.props.onDismissed}
+        onSubmit={this.onBegin}
+        dismissable={false}
+        type="warning"
+      >
+        <DialogContent>
+          <p>Are you sure you want to {operation}?</p>
+          <p>
+            At the end of the {operation.toLowerCase()} flow, GitHub Desktop
+            will enable you to force push the branch to update the upstream
+            branch. Force pushing will alter the history on the remote and
+            potentially cause problems for others collaborating on this branch.
+          </p>
+          <div>
+            <Checkbox
+              label="Do not show this message again"
+              value={
+                this.state.askForConfirmationOnForcePush
+                  ? CheckboxValue.Off
+                  : CheckboxValue.On
+              }
+              onChange={this.onAskForConfirmationOnForcePushChanged}
+            />
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={
+              __DARWIN__ ? `Begin ${operation}` : `Begin ${operation}`
+            }
+            onCancelButtonClick={this.props.onDismissed}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onAskForConfirmationOnForcePushChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = !event.currentTarget.checked
+
+    this.setState({ askForConfirmationOnForcePush: value })
+  }
+
+  private onBegin = async () => {
+    this.props.dispatcher.setConfirmForcePushSetting(
+      this.state.askForConfirmationOnForcePush
+    )
+
+    this.props.onBegin()
+  }
+}

--- a/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
@@ -73,9 +73,9 @@ export class WarnForcePushDialog extends React.Component<
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
-            okButtonText={
-              __DARWIN__ ? `Begin ${operation}` : `Begin ${operation}`
-            }
+            okButtonText={`Begin ${
+              __DARWIN__ ? operation : operation.toLowerCase()
+            }`}
             onCancelButtonClick={this.props.onDismissed}
           />
         </DialogFooter>

--- a/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
@@ -46,7 +46,7 @@ export class WarnForcePushDialog extends React.Component<
     return (
       <Dialog
         title={title}
-        onDismissed={this.props.onDismissed}
+        onDismissed={onDismissed}
         onSubmit={this.onBegin}
         dismissable={false}
         type="warning"


### PR DESCRIPTION
## Description

Reusable warn force push-dialog for multi commit operations.

## Release notes

Notes: no-notes
