### PR TITLE
use app.hide() instead of Menu.sendActionToFirstResponder()

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -81,7 +81,7 @@ export class AppWindow {
       this.window.on('close', e => {
         if (!quitting) {
           e.preventDefault()
-          Menu.sendActionToFirstResponder('hide:')
+          app.hide()
         }
       })
     }


### PR DESCRIPTION
## Description

Uses `app.hide()` instead of `Menu.sendActionToFirstResponder()` which is cleaner

## Release notes

Notes: no-notes