### PR TITLE
Release 2.8.2-beta3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.8.2-beta2",
+  "version": "2.8.2-beta3",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -41,6 +41,12 @@ export interface IDailyMeasures {
   /** The number of commits created with one or more co-authors. */
   readonly coAuthoredCommits: number
 
+  /** The number of commits undone by the user with a dirty working directory. */
+  readonly commitsUndoneWithChanges: number
+
+  /** The number of commits undone by the user with a clean working directory. */
+  readonly commitsUndoneWithoutChanges: number
+
   /** The number of times a branch is compared to an arbitrary branch */
   readonly branchComparisons: number
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -62,6 +62,8 @@ const DefaultDailyMeasures: IDailyMeasures = {
   partialCommits: 0,
   openShellCount: 0,
   coAuthoredCommits: 0,
+  commitsUndoneWithChanges: 0,
+  commitsUndoneWithoutChanges: 0,
   branchComparisons: 0,
   defaultBranchComparisons: 0,
   mergesInitiatedFromComparison: 0,
@@ -652,6 +654,22 @@ export class StatsStore implements IStatsStore {
   public recordCoAuthoredCommit(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       coAuthoredCommits: m.coAuthoredCommits + 1,
+    }))
+  }
+
+  /**
+   * Record that a commit was undone.
+   *
+   * @param cleanWorkingDirectory Whether the working directory is clean.
+   */
+  public recordCommitUndone(cleanWorkingDirectory: boolean): Promise<void> {
+    if (cleanWorkingDirectory) {
+      return this.updateDailyMeasures(m => ({
+        commitsUndoneWithoutChanges: m.commitsUndoneWithoutChanges + 1,
+      }))
+    }
+    return this.updateDailyMeasures(m => ({
+      commitsUndoneWithChanges: m.commitsUndoneWithChanges + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4084,7 +4084,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 
+    const currentState = this.repositoryStateCache.get(repository)
+    const { changesState } = currentState
+    const isWorkingDirectoryClean =
+      changesState.workingDirectory.files.length === 0
+
     await gitStore.undoCommit(commit)
+
+    this.statsStore.recordCommitUndone(isWorkingDirectoryClean)
 
     const { commitSelection } = this.repositoryStateCache.get(repository)
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,6 @@
 {
   "releases": {
+    "2.8.2-beta3": [],
     "2.8.2-beta2": [
       "[Fixed] Lists of commits, repositories or changes don't disappear after switching between apps",
       "[Improved] Thank you note language improved and retrieves all past release notes to retroactively thank all contributors"


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming third beta of the v2.8.2 series? Well you've just found it, congratulations!

This is basically the same as 2.8.2-beta2, but including some new metrics around undoing commits: #12258 

## Release checklist

- [x] ~~Check to see if there are any errors in Sentry that have only occurred since the last production release~~
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated