### PR TITLE
It isn't a drop if there is no drag in progress

### DIFF
--- a/app/src/ui/branches/branch-list-item.tsx
+++ b/app/src/ui/branches/branch-list-item.tsx
@@ -105,6 +105,10 @@ export class BranchListItem extends React.Component<IBranchListItemProps, {}> {
       isCurrentBranch,
     } = this.props
 
+    if (!dragAndDropManager.isDragOfTypeInProgress(DragType.Commit)) {
+      return
+    }
+
     if (onDropOntoBranch !== undefined && !isCurrentBranch) {
       onDropOntoBranch(name)
     }


### PR DESCRIPTION
## Description

@sergiou87 Found a regression in the drag/drop refactor logic that if you started a drag and dropped not on a branch. Then, went to go switch a branch. It would start a cherry-pick.

I missed a spot where it is need to check whether a drag is in progress before moving forward with onDrop logic. 

### Screenshots

https://user-images.githubusercontent.com/75402236/119333732-36f37180-bc58-11eb-9b4a-025d3cd0a4a6.mov


## Release notes

Notes: no-notes



