### PR TITLE
Refactor on drag end

### DIFF
--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -1,5 +1,10 @@
 import { Disposable, Emitter } from 'event-kit'
-import { DragData, DragType, DropTarget } from '../models/drag-drop'
+import {
+  DragData,
+  DragType,
+  DropTarget,
+  DropTargetSelector,
+} from '../models/drag-drop'
 
 /**
  * The drag and drop manager is implemented to manage drag and drop events
@@ -35,11 +40,18 @@ export class DragAndDropManager {
     return this.emitter.on('leave-drop-target', fn)
   }
 
+  public onDragEnded(
+    fn: (dropTargetSelector: DropTargetSelector | undefined) => void
+  ): Disposable {
+    return this.emitter.on('drag-ended', fn)
+  }
+
   public dragStarted(): void {
     this._isDragInProgress = true
   }
 
-  public dragEnded() {
+  public dragEnded(dropTargetSelector: DropTargetSelector | undefined) {
+    this.emitter.emit('drag-ended', dropTargetSelector)
     this._isDragInProgress = false
   }
 

--- a/app/src/models/drag-drop.ts
+++ b/app/src/models/drag-drop.ts
@@ -31,6 +31,12 @@ export enum DropTargetType {
   Commit,
 }
 
+export enum DropTargetSelector {
+  Branch = '.branches-list-item',
+  PullRequest = '.pull-request-item',
+  Commit = '.commit',
+}
+
 export type BranchTarget = {
   type: DropTargetType.Branch
   branchName: string

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -149,11 +149,12 @@ import {
 import { ReleaseNote } from '../models/release-notes'
 import { CommitMessageDialog } from './commit-message/commit-message-dialog'
 import { buildAutocompletionProviders } from './autocompletion'
-import { DragType } from '../models/drag-drop'
+import { DragType, DropTargetSelector } from '../models/drag-drop'
 import { enableSquashing } from '../lib/feature-flag'
 import { ConflictsDialog } from './multi-commit-operation/conflicts-dialog'
 import { DefaultCommitMessage } from '../models/commit-message'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
+import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -307,6 +308,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         })
       }
     )
+
+    dragAndDropManager.onDragEnded(this.onDragEnd)
   }
 
   public componentWillUnmount() {
@@ -3198,6 +3201,15 @@ export class App extends React.Component<IAppProps, IAppState> {
       )
       this.props.dispatcher.closePopup()
       this.props.dispatcher.recordGuidedConflictedMergeCompletion()
+    }
+  }
+
+  private onDragEnd = (dropTargetSelector: DropTargetSelector | undefined) => {
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    if (dropTargetSelector === undefined) {
+      // TODO: refactor to "DragStartedAndCanceled" as not specific to
+      // cherry-picking anymore
+      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
     }
   }
 }

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -14,7 +14,11 @@ import { Octicon, OcticonSymbol } from '../octicons'
 import { Draggable } from '../lib/draggable'
 import { enableBranchFromCommit, enableSquashing } from '../../lib/feature-flag'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
-import { DragType, DropTargetType } from '../../models/drag-drop'
+import {
+  DragType,
+  DropTargetSelector,
+  DropTargetType,
+} from '../../models/drag-drop'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -122,9 +126,9 @@ export class CommitListItem extends React.PureComponent<
         onRenderDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.onRemoveDragElement}
         dropTargetSelectors={[
-          '.branches-list-item',
-          '.pull-request-item',
-          '.commit',
+          DropTargetSelector.Branch,
+          DropTargetSelector.PullRequest,
+          DropTargetSelector.Commit,
         ]}
       >
         <div

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -32,7 +32,6 @@ interface ICommitProps {
   readonly onCreateTag?: (targetCommitSha: string) => void
   readonly onDeleteTag?: (tagName: string) => void
   readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
-  readonly onDragEnd?: (clearCherryPickingState: boolean) => void
   readonly onRenderCommitDragElement?: (commit: Commit) => void
   readonly onRemoveDragElement?: () => void
   readonly onSquash?: (
@@ -122,7 +121,6 @@ export class CommitListItem extends React.PureComponent<
       <Draggable
         isEnabled={isDraggable}
         onDragStart={this.onDragStart}
-        onDragEnd={this.onDragEnd}
         onRenderDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.onRemoveDragElement}
         dropTargetSelectors={[
@@ -391,12 +389,6 @@ export class CommitListItem extends React.PureComponent<
       type: DragType.Commit,
       commits: this.props.selectedCommits,
     })
-  }
-
-  private onDragEnd = (isOverDragTarget: boolean): void => {
-    if (this.props.onDragEnd !== undefined) {
-      this.props.onDragEnd(!isOverDragTarget)
-    }
   }
 
   private onRenderCommitDragElement = () => {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -67,8 +67,6 @@ interface ICommitListProps {
     lastRetainedCommitRef: string | null
   ) => void
 
-  /** Callback to fire to when has started being dragged  */
-  readonly onDragCommitEnd: (clearCherryPickingState: boolean) => void
   /**
    * Optional callback that fires on page scroll in order to allow passing
    * a new scrollTop value up to the parent component for storing.
@@ -163,7 +161,6 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
-        onDragEnd={this.props.onDragCommitEnd}
         isCherryPickInProgress={this.props.isCherryPickInProgress}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.props.onRemoveCommitDragElement}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -46,7 +46,6 @@ interface ICompareSidebarProps {
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ) => void
-  readonly onDragCommitEnd: (clearCherryPickingState: boolean) => void
   readonly compareListScrollTop?: number
   readonly localTags: Map<string, string> | null
   readonly tagsToPush: ReadonlyArray<string> | null
@@ -247,7 +246,6 @@ export class CompareSidebar extends React.Component<
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
         tagsToPush={this.props.tagsToPush}
-        onDragCommitEnd={this.props.onDragCommitEnd}
         hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
         onDismissCherryPickIntro={this.onDismissCherryPickIntro}
         isCherryPickInProgress={this.props.isCherryPickInProgress}

--- a/app/src/ui/lib/draggable.tsx
+++ b/app/src/ui/lib/draggable.tsx
@@ -152,9 +152,9 @@ export class Draggable extends React.Component<IDraggableProps> {
     mouseScroller.clearScrollTimer()
     this.props.onRemoveDragElement()
     if (this.props.onDragEnd !== undefined) {
-      this.props.onDragEnd(this.isLastElemBelowDropTarget())
+      this.props.onDragEnd(this.getLastElemBelowDropTarget())
     }
-    dragAndDropManager.dragEnded(this.isLastElemBelowDropTarget())
+    dragAndDropManager.dragEnded(this.getLastElemBelowDropTarget())
   }
 
   /**
@@ -162,7 +162,7 @@ export class Draggable extends React.Component<IDraggableProps> {
    * css selectors provided in dropTargetSelectors to determine if the drag
    * ended on target or not.
    */
-  private isLastElemBelowDropTarget = (): DropTargetSelector | undefined => {
+  private getLastElemBelowDropTarget = (): DropTargetSelector | undefined => {
     if (this.elemBelow === null) {
       return
     }

--- a/app/src/ui/lib/draggable.tsx
+++ b/app/src/ui/lib/draggable.tsx
@@ -15,10 +15,13 @@ interface IDraggableProps {
    * Callback for when the drag ends - user releases mouse (mouse up event) or
    * mouse goes out of screen
    *
-   * @param isOverDropTarget - whether the last element the mouse was over
-   * before the mouse up event matches one of the dropTargetSelectors provided
+   * @param dropTargetSelector - if the last element the mouse was over
+   * before the mouse up event matches one of the dropTargetSelectors provided,
+   * it is that selector enum
    */
-  readonly onDragEnd: (isOverDropTarget: boolean) => void
+  readonly onDragEnd?: (
+    dropTargetSelector: DropTargetSelector | undefined
+  ) => void
 
   /** Callback to render a drag element inside the #dragElement */
   readonly onRenderDragElement: () => void
@@ -148,8 +151,10 @@ export class Draggable extends React.Component<IDraggableProps> {
     document.removeEventListener('mousemove', this.onMouseMove)
     mouseScroller.clearScrollTimer()
     this.props.onRemoveDragElement()
-    this.props.onDragEnd(this.isLastElemBelowDropTarget())
-    dragAndDropManager.dragEnded()
+    if (this.props.onDragEnd !== undefined) {
+      this.props.onDragEnd(this.isLastElemBelowDropTarget())
+    }
+    dragAndDropManager.dragEnded(this.isLastElemBelowDropTarget())
   }
 
   /**
@@ -157,16 +162,14 @@ export class Draggable extends React.Component<IDraggableProps> {
    * css selectors provided in dropTargetSelectors to determine if the drag
    * ended on target or not.
    */
-  private isLastElemBelowDropTarget = (): boolean => {
+  private isLastElemBelowDropTarget = (): DropTargetSelector | undefined => {
     if (this.elemBelow === null) {
-      return false
+      return
     }
 
-    const foundDropTarget = this.props.dropTargetSelectors.find(dts => {
+    return this.props.dropTargetSelectors.find(dts => {
       return this.elemBelow !== null && this.elemBelow.closest(dts) !== null
     })
-
-    return foundDropTarget !== undefined
   }
 
   public render() {

--- a/app/src/ui/lib/draggable.tsx
+++ b/app/src/ui/lib/draggable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { mouseScroller } from '../../lib/mouse-scroller'
 import { sleep } from '../../lib/promise'
+import { DropTargetSelector } from '../../models/drag-drop'
 
 interface IDraggableProps {
   /**
@@ -29,7 +30,7 @@ interface IDraggableProps {
   readonly isEnabled: boolean
 
   /** An array of css selectors for elements that are valid drop targets. */
-  readonly dropTargetSelectors: ReadonlyArray<string>
+  readonly dropTargetSelectors: ReadonlyArray<DropTargetSelector>
 }
 
 export class Draggable extends React.Component<IDraggableProps> {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -14,7 +14,6 @@ import {
   IRepositoryState,
   RepositorySectionTab,
   ChangesSelectionKind,
-  FoldoutType,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
 import { IssuesStore, GitHubUserStore } from '../lib/stores'
@@ -260,7 +259,6 @@ export class RepositoryView extends React.Component<
         tagsToPush={this.props.state.tagsToPush}
         aheadBehindStore={this.props.aheadBehindStore}
         hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
-        onDragCommitEnd={this.onDragCommitEnd}
         isCherryPickInProgress={this.props.state.cherryPickState.step !== null}
       />
     )
@@ -564,26 +562,5 @@ export class RepositoryView extends React.Component<
       )
     }
     return null
-  }
-
-  /**
-   * This method is a generic event handler for when a commit has ended being
-   * dragged.
-   *
-   * Currently only used for cherry picking, but this could be more generic.
-   */
-  private onDragCommitEnd = async (clearCherryPickingState: boolean) => {
-    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
-
-    if (!clearCherryPickingState) {
-      return
-    }
-
-    const { state, repository } = this.props
-    const { cherryPickState } = state
-    if (cherryPickState !== null && cherryPickState.step !== null) {
-      this.props.dispatcher.endCherryPickFlow(repository)
-      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
-    }
   }
 }


### PR DESCRIPTION
## Description

Another drag and drop refactor that is inline with other drag/drop refactors. Since the app is no longer in a cherry-picking state during a drag, there is no need to bubble up the drag end event until we reach the repo state variable and since we are using event emitters for the other  "global" event anyways - it makes since as a emitter and not as a bubble up just to reach a dispatcher.

## Release notes
Notes: no-notes
