### PR TITLE
Release 2.8.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.8.2-beta3",
+  "version": "2.8.2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "2.8.2": [
+      "[New] Add support for macOS on Apple silicon devices - #9691. Thanks @dennisameling!",
+      "[Added] Thank external contributors for their work - #12137",
+      "[Fixed] Disable partial change selection in split view while whitespace changes are hidden - #12129"
+    ],
     "2.8.2-beta3": [],
     "2.8.2-beta2": [
       "[Fixed] Lists of commits, repositories or changes don't disappear after switching between apps",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming v2.8.2 production release? Well you've just found it, congratulations! :tada:

This is based on the 2.8.2-beta3 release (tag [release-2.8.2-beta3](https://github.com/desktop/desktop/releases/tag/release-2.8.2-beta3)).

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated