### PR TITLE
Adding Multi Commit Operation models

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -4,7 +4,7 @@ import { IDiff, ImageDiffType } from '../models/diff'
 import { Repository, ILocalRepositoryState } from '../models/repository'
 import { Branch, IAheadBehind } from '../models/branch'
 import { Tip } from '../models/tip'
-import { Commit, CommitOneLine } from '../models/commit'
+import { Commit, CommitOneLine, ICommitContext } from '../models/commit'
 import { CommittedFileChange, WorkingDirectoryStatus } from '../models/status'
 import { CloningRepository } from '../models/cloning-repository'
 import { IMenu } from '../models/app-menu'
@@ -21,6 +21,7 @@ import {
   ICheckoutProgress,
   ICloneProgress,
   ICherryPickProgress,
+  IMultiCommitOperationProgress,
 } from '../models/progress'
 import { Popup } from '../models/popup'
 
@@ -41,6 +42,10 @@ import { UncommittedChangesStrategy } from '../models/uncommitted-changes-strate
 import { CherryPickFlowStep } from '../models/cherry-pick'
 import { DragElement } from '../models/drag-drop'
 import { ILastThankYou } from '../models/last-thank-you'
+import {
+  MultiCommitOperationKind,
+  MultiCommitOperationStep,
+} from '../models/multi-commit-operation'
 
 export enum SelectionType {
   Repository,
@@ -466,6 +471,10 @@ export interface IRepositoryState {
 
   /** State associated with a squash operation */
   readonly squashState: ISquashState
+
+  /** State associated with a multi commit operation such as rebase,
+   * cherry-pick, squash, reorder... */
+  readonly multiCommitOperationState: IMultiCommitOperationState
 }
 
 export interface IBranchesState {
@@ -837,4 +846,113 @@ export function isCherryPickConflictState(
   conflictStatus: ConflictState
 ): conflictStatus is CherryPickConflictState {
   return conflictStatus.kind === 'cherryPick'
+}
+
+/**
+ * Tracks the state of the app during a multi commit operation such as rebase,
+ * cherry-picking, and interactive rebase (squashing, reordering).
+ *
+ * Depending on the operation or state of the operation, properties may be null.
+ */
+export interface IMultiCommitOperationState {
+  /**
+   * The current step of the operation the user is at.
+   * Examples: ChooseBranchStep, ChooseBranchStep, ShowConflictsStep, etc.
+   */
+  readonly step: MultiCommitOperationStep | null
+
+  /**
+   * The kind of operation it is.
+   * Examples: Rebase, Cherry-pick, Squash, etc.
+   */
+  readonly operationKind: MultiCommitOperationKind | null // rebase, cherry-pick, squash
+
+  /**
+   * The underlying parsed Git information associated with the progress of the
+   * current operation.
+   *
+   * Example: During cherry-picking, after each commit this progress will be
+   * updated to reflect the next commit in the list to cherry-pick.
+   */
+  readonly progress: IMultiCommitOperationProgress | null
+
+  /**
+   * Whether the user has done work to resolve any conflicts as part of this
+   * operation, and therefore, should be warned on aborting the operation.
+   */
+  readonly userHasResolvedConflicts: boolean
+
+  /**
+   * Array of commits used during the operation.
+   */
+  readonly commits: ReadonlyArray<Commit> | null
+
+  /**
+   * If operation specifies a commit that it takes place around
+   *
+   * Example: Squashing all the 'commits' array onto the 'targetCommit'
+   */
+  readonly targetCommit: Commit | null
+
+  /**
+   * If an operation needs can specify a commit message
+   *
+   * Example: Squashing - proving a new commit message/description
+   */
+  readonly commitContext: ICommitContext | null
+
+  /**
+   * For use with interaction rebase operations
+   */
+  readonly lastRetainedCommitRef: string | null
+
+  /**
+   * This is the commit ID of the HEAD of the in-flight operation used to compare
+   * the state of the after an operation to a previous state.
+   */
+  readonly currentTip: string | null
+
+  /**
+   * The commit id of the tip of the branch user is modifying in the operation.
+   *
+   * Uses:
+   *  - Cherry-picking = tip of target branch before cherry-pick, used to undo cherry-pick
+   *  - Rebasing = tip of current branch before rebase, used enable force pushing after rebase complete.
+   *  - Interactive Rebasing (Squash, Reorder) = tip of current branch, used for force pushing and undoing
+   */
+  readonly originalBranchTip: string | null
+
+  /**
+   * The branch that are the source of the commits for an operation
+   *
+   * Cherry-pick = the branch the user started on.
+   * Rebase = the branch the user picks in the choose branch dialog
+   * Squashing - not applicable
+   */
+  readonly sourceBranch: Branch | null
+
+  /**
+   * The branch that is being modified during the operation.
+   *
+   * - Cherry-pick = the branch chosen to copy commits to.
+   * - Rebase = the current branch the user is on.
+   */
+  readonly targetBranch: Branch | null
+
+  /**
+   * Whether a branch was created during operation.
+   *
+   * Example: can create a new branch to copy commits to during cherry-pick
+   */
+  readonly branchCreated: boolean
+}
+
+export type MultiCommitOperationConflictState = {
+  readonly kind: 'multiCommitOperation'
+
+  /**
+   * Manual resolutions chosen by the user for conflicted files to be applied
+   * before continuing the operation
+   */
+  readonly manualResolutions: Map<string, ManualConflictResolution>
 }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -205,5 +205,20 @@ function getInitialRepositoryState(): IRepositoryState {
       undoSha: null,
       squashBranchName: null,
     },
+    multiCommitOperationState: {
+      step: null,
+      operationKind: null,
+      progress: null,
+      userHasResolvedConflicts: false,
+      commits: null,
+      targetCommit: null,
+      commitContext: null,
+      lastRetainedCommitRef: null,
+      currentTip: null,
+      originalBranchTip: null,
+      sourceBranch: null,
+      targetBranch: null,
+      branchCreated: false,
+    },
   }
 }

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -1,0 +1,190 @@
+import { Branch } from './branch'
+import { CommitOneLine } from './commit'
+import { GitHubRepository } from './github-repository'
+import { ManualConflictResolution } from './manual-conflict-resolution'
+import { IDetachedHead, IUnbornRepository, IValidBranch } from './tip'
+
+/**
+ * Enum of types of multi commit operations
+ *
+ * Note: These are used to output the operation to the user
+ * and as such should be capitalized.
+ */
+export const enum MultiCommitOperationKind {
+  Rebase = 'Rebase',
+  CherryPick = 'Cherry-pick',
+  Squash = 'Squash',
+}
+
+/**
+ * Union type representing the possible states of an multi commit operation
+ * such as rebase, interactive rebase, cherry-pick.
+ */
+export type MultiCommitOperationStep =
+  | ChooseBranchStep
+  | WarnForcePushStep
+  | ShowProgressStep
+  | ShowConflictsStep
+  | HideConflictsStep
+  | ConfirmAbortStep
+  | CreateBranchStep
+
+/**
+ * Possible kinds of steps that may happen during a multi commit operation such
+ * as rebase, interactive rebase, cherry-pick.
+ */
+export const enum MultiCommitOperationStepKind {
+  /**
+   * The step that the user picks which other branch is involved in the
+   * operation asides from the currently checked out branch.
+   *
+   * Examples:
+   *  Rebase - what branch to rebase commits from
+   *  Cherry-pick - what branch to copy commits to.
+   */
+  ChooseBranch = 'ChooseBranch',
+
+  /**
+   * Step to show dialog warning user if operation will result in needing to
+   * force push.
+   */
+  WarnForcePush = 'WarnForcePush',
+
+  /**
+   * Step to show a dialog that shows the operation is progressing.
+   */
+  ShowProgress = 'ShowProgress',
+
+  /**
+   * The operation has encountered conflicts that need resolved. This will be
+   * shown as a list of files and the conflict state.
+   *
+   * Once the conflicts are resolved, the user can continue the operation.
+   */
+  ShowConflicts = 'ShowConflicts',
+
+  /**
+   * The user may wish to leave the conflict dialog and view the files in
+   * the Changes tab to get a better context. In this situation, the application
+   * will show a banner to indicate this context and help the user return to the
+   * conflicted list.
+   */
+  HideConflicts = 'HideConflicts',
+
+  /**
+   * If the user attempts to abort the in-progress operation and the user has
+   * resolved conflicts, the application should ask the user to confirm that
+   * they wish to abort.
+   */
+  ConfirmAbort = 'ConfirmAbort',
+
+  /**
+   * If the user invokes creating a new branch during the operation, display
+   * a new branch dialog to them.
+   *
+   * Example: Cherry-picking to a new branch.
+   */
+  CreateBranch = 'CreateBranch',
+}
+
+export type ChooseBranchStep = {
+  readonly kind: MultiCommitOperationStepKind.ChooseBranch
+  readonly defaultBranch: Branch | null
+  readonly currentBranch: Branch
+  readonly allBranches: ReadonlyArray<Branch>
+  readonly recentBranches: ReadonlyArray<Branch>
+  readonly initialBranch?: Branch
+}
+
+export type WarnForcePushStep = {
+  readonly kind: MultiCommitOperationStepKind.WarnForcePush
+  readonly baseBranch: Branch
+  readonly targetBranch: Branch
+  readonly commits: ReadonlyArray<CommitOneLine>
+}
+
+export type ShowProgressStep = {
+  readonly kind: MultiCommitOperationStepKind.ShowProgress
+}
+
+export type ShowConflictsStep = {
+  readonly kind: MultiCommitOperationStepKind.ShowConflicts
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+  /**
+   * Depending on the operation, this may be either source branch or the
+   * target branch.
+   *
+   * Also, we may not know what it is. This usually happens if Desktop is closed
+   * during an operation and the reopened and we lose some context that is
+   * stored in state.
+   */
+  readonly ourBranch?: string
+
+  /**
+   * Depending on the operation, this may be either source branch or the
+   * target branch
+   *
+   * Also, we may not know what it is. This usually happens if Desktop is closed
+   * during an operation and the reopened and we lose some context that is
+   * stored in state.
+   */
+  readonly theirBranch?: string
+}
+
+export type HideConflictsStep = {
+  readonly kind: MultiCommitOperationStepKind.HideConflicts
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+  /**
+   * Depending on the operation, this may be either source branch or the
+   * target branch.
+   *
+   * Also, we may not know what it is. This usually happens if Desktop is closed
+   * during an operation and the reopened and we lose some context that is
+   * stored in state.
+   */
+  readonly ourBranch?: string
+
+  /**
+   * Depending on the operation, this may be either source branch or the
+   * target branch
+   *
+   * Also, we may not know what it is. This usually happens if Desktop is closed
+   * during an operation and the reopened and we lose some context that is
+   * stored in state.
+   */
+  readonly theirBranch?: string
+}
+
+export type ConfirmAbortStep = {
+  readonly kind: MultiCommitOperationStepKind.ConfirmAbort
+  /**
+   * Depending on the operation, this may be either source branch or the
+   * target branch.
+   *
+   * Also, we may not know what it is. This usually happens if Desktop is closed
+   * during an operation and the reopened and we lose some context that is
+   * stored in state.
+   */
+  readonly ourBranch?: string
+
+  /**
+   * Depending on the operation, this may be either source branch or the
+   * target branch
+   *
+   * Also, we may not know what it is. This usually happens if Desktop is closed
+   * during an operation and the reopened and we lose some context that is
+   * stored in state.
+   */
+  readonly theirBranch?: string
+  readonly manualResolutions: Map<string, ManualConflictResolution>
+}
+
+export type CreateBranchStep = {
+  readonly kind: MultiCommitOperationStepKind.CreateBranch
+  allBranches: ReadonlyArray<Branch>
+  defaultBranch: Branch | null
+  upstreamDefaultBranch: Branch | null
+  upstreamGhRepo: GitHubRepository | null
+  tip: IUnbornRepository | IDetachedHead | IValidBranch
+  targetBranchName: string
+}


### PR DESCRIPTION
## Description

I created a `MultiCommitOperationState` that is a combination of the things tracked by Cherry-picking, Rebasing, and Interactive rebasing (Squashing, Reordering). I also briefly looked over merging to see if merging could be easily refactored to use this too and it looks pretty similar, but right now going to focus on rebasing (so interactive rebase will play nice) and then cherry-picking since it is already following the pattern. We will see if time permits to bring merge in so we have consistency through out these kind of operations.

Some considerations and things that may change as I continue to develop this. 
- I have thought of having an OperationDetails property that would be of type OperationDetail = CherryPickDetails | RebaseDetails | InteractiveRebaseDetails. Thus, allowing a little more flexibility and not such as flat architecture where we have properties for all operations whether they are needed or not. 
 - Examples: 
       -  Cherry-pick and Rebase need to track a sourceBranch and squashing does not.
       -  Squashing/Reordering tracks a targetCommit and lastRetainedRef and cherry-pick and rebase do not.

ConflictState - Currently Merge, Rebase, and CherryPick track different sets of things under the conflictState.. However many of those things are part of the whole operation such as `targetBranch`, `sourceBranch`, `originalBranchTip` (undo sha), etc. I moved to flatten these to `multiCommitOperationState` and only have purely conflict state related things there and I was left with `manualResolutions`, `ours`, `theirs` as `ours` and `theirs` are different depending on your operation and only used in the conflicts modal. I also flattened that in the steps.. but I am considering wrapping those back under the `MultiCommitOperationConflictState`.. The final landing of this is to be determined when I refactor rebase under the multi commit operation (meaning the update conflict state logic will need to be updated in the load status logic) to ensure I have everything needed for all the use cases. 

## Release notes

Notes: no-notes
