### PR TITLE
Multi commit operation state methods

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6367,18 +6367,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _endMultiCommitOperation(repository: Repository): void {
     this.repositoryStateCache.updateMultiCommitOperationState(
       repository,
-      () => ({
-        step: null,
-        operationKind: null,
-        progress: null,
-        userHasResolvedConflicts: false,
-        commits: null,
-        currentTip: null,
-        originalBranchTip: null,
-        sourceBranch: null,
-        targetBranch: null,
-        branchCreated: false,
-      })
+      null
     )
 
     this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6365,11 +6365,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _endMultiCommitOperation(repository: Repository): void {
-    this.repositoryStateCache.updateMultiCommitOperationState(
-      repository,
-      null
-    )
-
+    this.repositoryStateCache.clearMultiCommitOperationState(repository)
     this.emitUpdate()
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -288,7 +288,6 @@ import { getTipSha } from '../tip'
 import {
   MultiCommitOperationKind,
   MultiCommitOperationStep,
-  MultiCommitOperationStepKind,
 } from '../../models/multi-commit-operation'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -20,6 +20,7 @@ import {
   ChangesSelectionKind,
   ICherryPickState,
   ISquashState,
+  IMultiCommitOperationState,
 } from '../app-state'
 import { merge } from '../merge'
 import { DefaultCommitMessage } from '../../models/commit-message'
@@ -123,6 +124,24 @@ export class RepositoryStateCache {
       const { squashState } = state
       const newState = merge(squashState, fn(squashState))
       return { squashState: newState }
+    })
+  }
+
+  public updateMultiCommitOperationState<
+    K extends keyof IMultiCommitOperationState
+  >(
+    repository: Repository,
+    fn: (
+      state: IMultiCommitOperationState
+    ) => Pick<IMultiCommitOperationState, K>
+  ) {
+    this.update(repository, state => {
+      const { multiCommitOperationState } = state
+      const newState = merge(
+        multiCommitOperationState,
+        fn(multiCommitOperationState)
+      )
+      return { multiCommitOperationState: newState }
     })
   }
 }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -132,15 +132,15 @@ export class RepositoryStateCache {
   >(
     repository: Repository,
     fn: (
-      state: IMultiCommitOperationState
+      state: IMultiCommitOperationState | null
     ) => Pick<IMultiCommitOperationState, K>
   ) {
     this.update(repository, state => {
       const { multiCommitOperationState } = state
-      const newState = merge(
-        multiCommitOperationState,
-        fn(multiCommitOperationState)
-      )
+      const newState =
+        fn !== null
+          ? merge(multiCommitOperationState, fn(multiCommitOperationState))
+          : null
       return { multiCommitOperationState: newState }
     })
   }

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -132,16 +132,35 @@ export class RepositoryStateCache {
   >(
     repository: Repository,
     fn: (
-      state: IMultiCommitOperationState | null
+      state: IMultiCommitOperationState
     ) => Pick<IMultiCommitOperationState, K>
   ) {
     this.update(repository, state => {
       const { multiCommitOperationState } = state
-      const newState =
-        fn !== null
-          ? merge(multiCommitOperationState, fn(multiCommitOperationState))
-          : null
+      if (multiCommitOperationState === null) {
+        throw new Error('Cannot update a null state.')
+      }
+
+      const newState = merge(
+        multiCommitOperationState,
+        fn(multiCommitOperationState)
+      )
       return { multiCommitOperationState: newState }
+    })
+  }
+
+  public initializeMultiCommitOperationState(
+    repository: Repository,
+    multiCommitOperationState: IMultiCommitOperationState
+  ) {
+    this.update(repository, () => {
+      return { multiCommitOperationState }
+    })
+  }
+
+  public clearMultiCommitOperationState(repository: Repository) {
+    this.update(repository, () => {
+      return { multiCommitOperationState: null }
     })
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -110,6 +110,7 @@ import { DragElement, DragType } from '../../models/drag-drop'
 import { findDefaultUpstreamBranch } from '../../lib/branch'
 import { ILastThankYou } from '../../models/last-thank-you'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { MultiCommitOperationStep } from '../../models/multi-commit-operation'
 
 /**
  * An error handler function.
@@ -3210,5 +3211,4 @@ export class Dispatcher {
   public endMultiCommitOperation(repository: Repository) {
     this.appStore._endMultiCommitOperation(repository)
   }
-
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3194,4 +3194,21 @@ export class Dispatcher {
   ): Promise<boolean> {
     return this.appStore._undoSquash(repository, commitsCount)
   }
+
+  /**
+   * This method is to update the multi operation state to move it along in
+   * steps.
+   */
+  public setMultiCommitOperationStep(
+    repository: Repository,
+    step: MultiCommitOperationStep
+  ): Promise<void> {
+    return this.appStore._setMultiCommitOperationStep(repository, step)
+  }
+
+  /** Method to clear multi commit operation state. */
+  public endMultiCommitOperation(repository: Repository) {
+    this.appStore._endMultiCommitOperation(repository)
+  }
+
 }


### PR DESCRIPTION
## Description

Adding the multi commit operation state management methods. The initialize one may grow or split into more than one depending on the operation - currently just tested for squashing, but trying to keep it generalized.

## Release notes
Notes: no-notes
