### PR TITLE
Multi commit operation base class

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -44,7 +44,6 @@ import { DragElement } from '../models/drag-drop'
 import { ILastThankYou } from '../models/last-thank-you'
 import {
   MultiCommitOperationDetail,
-  MultiCommitOperationKind,
   MultiCommitOperationStep,
 } from '../models/multi-commit-operation'
 
@@ -859,12 +858,6 @@ export interface IMultiCommitOperationState {
    * Examples: ChooseBranchStep, ChooseBranchStep, ShowConflictsStep, etc.
    */
   readonly step: MultiCommitOperationStep
-
-  /**
-   * The kind of operation it is.
-   * Examples: Rebase, Cherry-pick, Squash, etc.
-   */
-  readonly operationKind: MultiCommitOperationKind // rebase, cherry-pick, squash
 
   /**
    * This hold properties specific to the operation.

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6376,25 +6376,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     targetBranch: Branch,
     commits: ReadonlyArray<Commit>
   ): void {
-    this.repositoryStateCache.updateMultiCommitOperationState(
-      repository,
-      () => ({
-        operationKind,
-        targetBranch,
-        currentTip: targetBranch.tip.sha,
-        originalBranchTip: targetBranch.tip.sha,
-        commits,
-        progress: {
-          kind: 'multiCommitOperation',
-          currentCommitSummary: commits[0].summary,
-          position: 1,
-          totalCommitCount: commits.length,
-          value: 0,
-          title: `${operationKind}: commit 1 of ${commits.length} commits`,
-        },
-      })
-    )
-
     this.emitUpdate()
   }
 }

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -2,7 +2,6 @@ import { MultiCommitOperationConflictState } from '../lib/app-state'
 import { Branch } from './branch'
 import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { GitHubRepository } from './github-repository'
-import { ManualConflictResolution } from './manual-conflict-resolution'
 import { IDetachedHead, IUnbornRepository, IValidBranch } from './tip'
 
 /**
@@ -110,26 +109,7 @@ export type ShowProgressStep = {
 
 export type ShowConflictsStep = {
   readonly kind: MultiCommitOperationStepKind.ShowConflicts
-  readonly manualResolutions: Map<string, ManualConflictResolution>
-  /**
-   * Depending on the operation, this may be either source branch or the
-   * target branch.
-   *
-   * Also, we may not know what it is. This usually happens if Desktop is closed
-   * during an operation and the reopened and we lose some context that is
-   * stored in state.
-   */
-  readonly ourBranch?: string
-
-  /**
-   * Depending on the operation, this may be either source branch or the
-   * target branch
-   *
-   * Also, we may not know what it is. This usually happens if Desktop is closed
-   * during an operation and the reopened and we lose some context that is
-   * stored in state.
-   */
-  readonly theirBranch?: string
+  readonly conflictState: MultiCommitOperationConflictState
 }
 
 export type HideConflictsStep = {
@@ -176,7 +156,7 @@ interface ISourceBranchDetails {
   readonly sourceBranch: ICommitContext
 }
 interface ISquashDetails extends IInteractiveRebaseDetails {
-  readonly operationKind: MultiCommitOperationKind.Squash
+  readonly kind: MultiCommitOperationKind.Squash
   /**
    * The commit context of the commit squashed.
    */
@@ -184,7 +164,7 @@ interface ISquashDetails extends IInteractiveRebaseDetails {
 }
 
 interface ICherryPickDetails extends ISourceBranchDetails {
-  readonly operationKind: MultiCommitOperationKind.CherryPick
+  readonly kind: MultiCommitOperationKind.CherryPick
   /**
    * Whether a branch was created during operation.
    *
@@ -194,7 +174,7 @@ interface ICherryPickDetails extends ISourceBranchDetails {
 }
 
 interface IRebaseDetails extends ISourceBranchDetails {
-  readonly operationKind: MultiCommitOperationKind.Rebase
+  readonly kind: MultiCommitOperationKind.Rebase
 }
 
 export type MultiCommitOperationDetail =

--- a/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
@@ -1,0 +1,243 @@
+import * as React from 'react'
+import { assertNever } from '../../lib/fatal-error'
+import { Repository } from '../../models/repository'
+import { WorkingDirectoryStatus } from '../../models/status'
+import { Dispatcher } from '../dispatcher'
+import { getResolvedFiles } from '../../lib/status'
+import { ConflictState, IMultiCommitOperationState } from '../../lib/app-state'
+import { Branch } from '../../models/branch'
+import { MultiCommitOperationStepKind } from '../../models/multi-commit-operation'
+import { ConflictsDialog } from './conflicts-dialog'
+import { ConfirmAbortDialog } from './confirm-abort-dialog'
+import { ProgressDialog } from './progress-dialog'
+import { WarnForcePushDialog } from './warn-force-push-dialog'
+
+export interface IMultiCommitOperationProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+
+  /** The current state of the multi commit operation */
+  readonly state: IMultiCommitOperationState
+
+  /** The current state of conflicts in the app */
+  readonly conflictState: ConflictState | null
+
+  /** The emoji map for showing commit emoji's */
+  readonly emoji: Map<string, string>
+
+  /** The current state of the working directory */
+  readonly workingDirectory: WorkingDirectoryStatus
+
+  /** Whether user should be warned about force pushing */
+  readonly askForConfirmationOnForcePush: boolean
+
+  /**
+   * Callbacks for the conflict selection components to let the user jump out
+   * to their preferred editor.
+   */
+  readonly openFileInExternalEditor: (path: string) => void
+  readonly resolvedExternalEditor: string | null
+  readonly openRepositoryInShell: (repository: Repository) => void
+}
+
+/** A component for initiating and performing a rebase of the current branch. */
+export abstract class MultiCommitOperation extends React.Component<
+  IMultiCommitOperationProps
+> {
+  abstract onBeginOperation = () => {}
+
+  abstract onChooseBranch = (targetBranch: Branch) => {}
+
+  abstract onContinueAfterConflicts = async (): Promise<void> => {}
+
+  abstract onAbort = async (): Promise<void> => {}
+
+  abstract onConflictsDialogDismissed = () => {}
+
+  abstract renderChooseBranch = (): JSX.Element | null => {
+    return null
+  }
+
+  abstract renderCreateBranch = (): JSX.Element | null => {
+    return null
+  }
+
+  protected onFlowEnded = () => {
+    this.props.dispatcher.closePopup()
+    this.props.dispatcher.endMultiCommitOperation(this.props.repository)
+  }
+
+  /**
+   * Method to call anytime we do state type checking that should pass but is
+   * needed for typing purposes. Thus it should never happen, so throw error if
+   * does.
+   */
+  protected endFlowInvalidState(): void {
+    const { step, operationDetail } = this.props.state
+    throw new Error(
+      `[${operationDetail.kind}] - Invalid state - ${operationDetail.kind} ended during ${step}.`
+    )
+  }
+
+  protected onInvokeConflictsDialogDismissed = (operationPrefix: string) => {
+    const { repository, dispatcher, state } = this.props
+    const { targetBranch, step } = state
+
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { conflictState } = step
+    dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.HideConflicts,
+      conflictState,
+    })
+
+    const operationDescription = (
+      <>
+        {operationPrefix} <strong>{targetBranch.name}</strong>
+      </>
+    )
+    return dispatcher.onConflictsFoundBanner(
+      repository,
+      operationDescription,
+      conflictState
+    )
+  }
+
+  private onConfirmingAbort = async (): Promise<void> => {
+    const { repository, dispatcher, workingDirectory, state } = this.props
+    const { userHasResolvedConflicts, step } = state
+
+    if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { conflictState } = step
+    const resolvedConflicts = getResolvedFiles(
+      workingDirectory,
+      conflictState.manualResolutions
+    )
+
+    if (userHasResolvedConflicts || resolvedConflicts.length > 0) {
+      dispatcher.setMultiCommitOperationStep(repository, {
+        kind: MultiCommitOperationStepKind.ConfirmAbort,
+        conflictState,
+      })
+      return
+    }
+
+    return this.onAbort()
+  }
+
+  private moveToConflictState = () => {
+    const { dispatcher, repository, state } = this.props
+    const { step } = state
+    if (step.kind !== MultiCommitOperationStepKind.ConfirmAbort) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { conflictState } = step
+    return dispatcher.setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowConflicts,
+      conflictState,
+    })
+  }
+
+  private setConflictsHaveBeenResolved = () => {
+    this.props.dispatcher.setConflictsResolved(this.props.repository)
+  }
+
+  public render() {
+    const { state } = this.props
+    const { step } = state
+
+    switch (step.kind) {
+      case MultiCommitOperationStepKind.ChooseBranch: {
+        return this.renderChooseBranch()
+      }
+      case MultiCommitOperationStepKind.ShowProgress:
+        const { emoji } = this.props
+        return (
+          <ProgressDialog
+            progress={state.progress}
+            emoji={emoji}
+            operation={state.operationDetail.kind}
+          />
+        )
+      case MultiCommitOperationStepKind.ShowConflicts: {
+        const {
+          repository,
+          resolvedExternalEditor,
+          openFileInExternalEditor,
+          openRepositoryInShell,
+          dispatcher,
+          workingDirectory,
+          state,
+        } = this.props
+
+        const { userHasResolvedConflicts, operationDetail } = state
+        const { manualResolutions, ourBranch, theirBranch } = step.conflictState
+
+        const operation = __DARWIN__
+          ? operationDetail.kind
+          : operationDetail.kind.toLowerCase()
+        const submit = `Continue ${operation}`
+        const abort = `Abort ${operation}`
+
+        return (
+          <ConflictsDialog
+            dispatcher={dispatcher}
+            repository={repository}
+            workingDirectory={workingDirectory}
+            userHasResolvedConflicts={userHasResolvedConflicts}
+            resolvedExternalEditor={resolvedExternalEditor}
+            ourBranch={ourBranch}
+            theirBranch={theirBranch}
+            manualResolutions={manualResolutions}
+            headerTitle={`Resolve conflicts before ${operationDetail.kind}`}
+            submitButton={submit}
+            abortButton={abort}
+            onSubmit={this.onContinueAfterConflicts}
+            onAbort={this.onConfirmingAbort}
+            onDismissed={this.onConflictsDialogDismissed}
+            openFileInExternalEditor={openFileInExternalEditor}
+            openRepositoryInShell={openRepositoryInShell}
+            someConflictsHaveBeenResolved={this.setConflictsHaveBeenResolved}
+          />
+        )
+      }
+      case MultiCommitOperationStepKind.ConfirmAbort:
+        return (
+          <ConfirmAbortDialog
+            operation={this.props.state.operationDetail.kind}
+            onConfirmAbort={this.onAbort}
+            onReturnToConflicts={this.moveToConflictState}
+          />
+        )
+      case MultiCommitOperationStepKind.WarnForcePush:
+        const { dispatcher, askForConfirmationOnForcePush } = this.props
+        return (
+          <WarnForcePushDialog
+            operation={state.operationDetail.kind}
+            dispatcher={dispatcher}
+            askForConfirmationOnForcePush={askForConfirmationOnForcePush}
+            onBegin={this.onBeginOperation}
+            onDismissed={this.onFlowEnded}
+          />
+        )
+      case MultiCommitOperationStepKind.CreateBranch:
+        return this.renderCreateBranch()
+      case MultiCommitOperationStepKind.HideConflicts:
+        return null
+      default:
+        return assertNever(
+          step,
+          `Unknown multi commit operation step found: ${step}`
+        )
+    }
+  }
+}


### PR DESCRIPTION
## Description

This class is an abstract class that any operation we add can extend so any operation can use this shared logic but can also have logic specific to that operation. 

Note: Dispatcher method for showing conflict dialog banner will be further updated in later PR's. More a less a partial place holder for this class.

## Release notes
Notes: no-notes
