### PR TITLE
Refactor Rebase progress to generic to allow squash to use rebase progress parser

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -34,7 +34,6 @@ import { ApplicableTheme, ApplicationTheme } from '../ui/lib/application-theme'
 import { IAccountRepositories } from './stores/api-repositories-store'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { Banner } from '../models/banner'
-import { GitRebaseProgress } from '../models/rebase'
 import { RebaseFlowStep } from '../models/rebase-flow-step'
 import { IStashEntry } from '../models/stash-entry'
 import { TutorialStep } from '../models/tutorial-step'
@@ -549,7 +548,7 @@ export interface IRebaseState {
    * This will be set to `null` when no base branch has been selected to
    * initiate the rebase.
    */
-  readonly progress: GitRebaseProgress | null
+  readonly progress: IMultiCommitOperationProgress | null
 
   /**
    * The known range of commits that will be applied to the repository

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -82,7 +82,6 @@ class GitCherryPickParser {
 
     return {
       kind: 'cherryPick',
-      title: `Cherry-picking commit ${this.count} of ${this.commits.length} commits`,
       value: round(this.count / this.commits.length, 2),
       position: this.count,
       totalCommitCount: this.commits.length,
@@ -320,7 +319,6 @@ export async function getCherryPickSnapshot(
     return {
       progress: {
         kind: 'cherryPick',
-        title: `Cherry-picking commit 1 of 1 commits`,
         value: 1,
         position: 1,
         totalCommitCount: 1,
@@ -353,7 +351,6 @@ export async function getCherryPickSnapshot(
   return {
     progress: {
       kind: 'cherryPick',
-      title: `Cherry-picking commit ${position} of ${commits.length} commits`,
       value: round(position / commits.length, 2),
       position,
       totalCommitCount: commits.length,

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -1,6 +1,8 @@
 import * as FSE from 'fs-extra'
 import { getCommits, revRange } from '.'
 import { CommitOneLine } from '../../models/commit'
+import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
+import { IMultiCommitOperationProgress } from '../../models/progress'
 import { Repository } from '../../models/repository'
 import { getTempFilePath } from '../file-system'
 import { rebaseInteractive, RebaseResult } from './rebase'
@@ -33,7 +35,8 @@ export async function squash(
   toSquash: ReadonlyArray<CommitOneLine>,
   squashOnto: CommitOneLine,
   lastRetainedCommitRef: string | null,
-  commitMessage: string
+  commitMessage: string,
+  progressCallback?: (progress: IMultiCommitOperationProgress) => void
 ): Promise<RebaseResult> {
   let messagePath, todoPath
   let result: RebaseResult
@@ -149,9 +152,10 @@ export async function squash(
       repository,
       todoPath,
       lastRetainedCommitRef,
-      'squash',
-      gitEditor
-      // TODO: add progress
+      MultiCommitOperationKind.Squash,
+      gitEditor,
+      progressCallback,
+      commits
     )
   } catch (e) {
     log.error(e)

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -16,7 +16,7 @@ interface IProgress {
    * events. For more detailed information about the progress see
    * the description field
    */
-  readonly title: string
+  readonly title?: string
 
   /**
    * An informative text for user consumption. In the case of git progress this
@@ -99,17 +99,6 @@ export interface IRevertProgress extends IProgress {
   kind: 'revert'
 }
 
-/** An object describing the progress of a rebase operation */
-export interface IRebaseProgress extends IProgress {
-  readonly kind: 'rebase'
-  /** The summary of the commit applied to the base branch */
-  readonly currentCommitSummary: string
-  /** The number of commits currently rebased onto the base branch */
-  readonly rebasedCommitCount: number
-  /** The total number of commits to rebase on top of the current branch */
-  readonly totalCommitCount: number
-}
-
 /** An object describing the progress of a cherry pick operation */
 export interface ICherryPickProgress extends IProgress {
   readonly kind: 'cherryPick'
@@ -139,6 +128,5 @@ export type Progress =
   | IPullProgress
   | IPushProgress
   | IRevertProgress
-  | IRebaseProgress
   | ICherryPickProgress
   | IMultiCommitOperationProgress

--- a/app/src/models/rebase.ts
+++ b/app/src/models/rebase.ts
@@ -1,4 +1,4 @@
-import { IRebaseProgress } from './progress'
+import { IMultiCommitOperationProgress } from './progress'
 import { ComputedAction } from './computed-action'
 import { CommitOneLine } from './commit'
 
@@ -27,7 +27,7 @@ export type RebaseInternalState = {
 export type RebaseProgressOptions = {
   commits: ReadonlyArray<CommitOneLine>
   /** The callback to fire when rebase progress is reported */
-  progressCallback: (progress: IRebaseProgress) => void
+  progressCallback: (progress: IMultiCommitOperationProgress) => void
 }
 
 export type CleanRebase = {
@@ -53,22 +53,10 @@ export type RebasePreview =
   | RebaseNotSupported
   | RebaseLoading
 
-/** Represents the progress of a Git rebase operation to be shown to the user */
-export type GitRebaseProgress = {
-  /** A numeric value between 0 and 1 representing the percent completed */
-  readonly value: number
-  /** The current number of commits rebased as part of this operation */
-  readonly rebasedCommitCount: number
-  /** The commit summary associated with the current commit (if found) */
-  readonly currentCommitSummary: string | null
-  /** The count of known commits that will be rebased onto the base branch */
-  readonly totalCommitCount: number
-}
-
 /** Represents a snapshot of the rebase state from the Git repository  */
 export type GitRebaseSnapshot = {
   /** The sequence of commits that are used in the rebase */
   readonly commits: ReadonlyArray<CommitOneLine>
   /** The progress of the operation */
-  readonly progress: GitRebaseProgress
+  readonly progress: IMultiCommitOperationProgress
 }

--- a/app/src/ui/rebase/progress-dialog.tsx
+++ b/app/src/ui/rebase/progress-dialog.tsx
@@ -6,11 +6,11 @@ import { RichText } from '../lib/rich-text'
 
 import { Dialog, DialogContent } from '../dialog'
 import { Octicon, OcticonSymbol } from '../octicons'
-import { GitRebaseProgress } from '../../models/rebase'
+import { IMultiCommitOperationProgress } from '../../models/progress'
 
 interface IRebaseProgressDialogProps {
   /** Progress information about the current rebase */
-  readonly progress: GitRebaseProgress
+  readonly progress: IMultiCommitOperationProgress
 
   readonly emoji: Map<string, string>
 }
@@ -24,14 +24,14 @@ export class RebaseProgressDialog extends React.Component<
 
   public render() {
     const {
-      rebasedCommitCount,
+      position,
       totalCommitCount,
       value,
       currentCommitSummary,
     } = this.props.progress
 
     // ensure progress always starts from 1
-    const count = rebasedCommitCount <= 1 ? 1 : rebasedCommitCount
+    const count = position <= 1 ? 1 : position
 
     const progressValue = formatRebaseValue(value)
     return (

--- a/app/src/ui/rebase/rebase-flow.tsx
+++ b/app/src/ui/rebase/rebase-flow.tsx
@@ -8,7 +8,6 @@ import {
   RebaseFlowStep,
   ConfirmAbortStep,
 } from '../../models/rebase-flow-step'
-import { GitRebaseProgress } from '../../models/rebase'
 import { WorkingDirectoryStatus } from '../../models/status'
 
 import { Dispatcher } from '../dispatcher'
@@ -19,6 +18,7 @@ import { ConfirmAbortDialog } from './confirm-abort-dialog'
 import { getResolvedFiles } from '../../lib/status'
 import { WarnForcePushDialog } from './warn-force-push-dialog'
 import { ConflictsDialog } from '../multi-commit-operation/conflicts-dialog'
+import { IMultiCommitOperationProgress } from '../../models/progress'
 
 interface IRebaseFlowProps {
   readonly repository: Repository
@@ -35,7 +35,7 @@ interface IRebaseFlowProps {
   readonly step: RebaseFlowStep
 
   /** Git progress information about the current rebase */
-  readonly progress: GitRebaseProgress | null
+  readonly progress: IMultiCommitOperationProgress | null
 
   /**
    * Track whether the user has done work to resolve conflicts as part of this

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -543,7 +543,6 @@ describe('git/cherry-pick', () => {
           currentCommitSummary: featureTip.summary,
           kind: 'cherryPick',
           position: 1,
-          title: 'Cherry-picking commit 1 of 1 commits',
           totalCommitCount: 1,
           value: 1,
         },

--- a/app/test/unit/git/rebase/progress-test.ts
+++ b/app/test/unit/git/rebase/progress-test.ts
@@ -14,7 +14,7 @@ import { getStatusOrThrow } from '../../../helpers/status'
 import { GitRebaseSnapshot } from '../../../../src/models/rebase'
 import { setupEmptyDirectory } from '../../../helpers/repositories'
 import { getBranchOrError } from '../../../helpers/git'
-import { IRebaseProgress } from '../../../../src/models/progress'
+import { IMultiCommitOperationProgress } from '../../../../src/models/progress'
 import { isConflictedFile } from '../../../../src/lib/status'
 import { ManualConflictResolution } from '../../../../src/models/manual-conflict-resolution'
 import { Repository } from '../../../../src/models/repository'
@@ -37,7 +37,7 @@ describe('git/rebase', () => {
     let result: RebaseResult
     let snapshot: GitRebaseSnapshot | null
     let status: IStatusResult
-    let progress = new Array<IRebaseProgress>()
+    let progress = new Array<IMultiCommitOperationProgress>()
 
     beforeEach(async () => {
       repository = await createShortRebaseTest(
@@ -52,7 +52,7 @@ describe('git/rebase', () => {
 
       const baseBranch = await getBranchOrError(repository, baseBranchName)
 
-      progress = new Array<IRebaseProgress>()
+      progress = new Array<IMultiCommitOperationProgress>()
       result = await rebase(repository, baseBranch, featureBranch, p =>
         progress.push(p)
       )
@@ -70,9 +70,8 @@ describe('git/rebase', () => {
       expect(progress).toEqual([
         {
           currentCommitSummary: 'Feature Branch!',
-          kind: 'rebase',
-          rebasedCommitCount: 1,
-          title: 'Rebasing commit 1 of 1 commits',
+          kind: 'multiCommitOperation',
+          position: 1,
           totalCommitCount: 1,
           value: 1,
         },
@@ -85,7 +84,7 @@ describe('git/rebase', () => {
       expect(s.commits.length).toEqual(1)
       expect(s.commits[0].summary).toEqual('Feature Branch!')
 
-      expect(s.progress.rebasedCommitCount).toEqual(1)
+      expect(s.progress.position).toEqual(1)
       expect(s.progress.totalCommitCount).toEqual(1)
       expect(s.progress.currentCommitSummary).toEqual('Feature Branch!')
       expect(s.progress.value).toEqual(1)
@@ -101,7 +100,7 @@ describe('git/rebase', () => {
     let result: RebaseResult
     let snapshot: GitRebaseSnapshot | null
     let status: IStatusResult
-    let progress = new Array<IRebaseProgress>()
+    let progress = new Array<IMultiCommitOperationProgress>()
 
     beforeEach(async () => {
       repository = await createLongRebaseTest(baseBranchName, featureBranchName)
@@ -113,7 +112,7 @@ describe('git/rebase', () => {
 
       const baseBranch = await getBranchOrError(repository, baseBranchName)
 
-      progress = new Array<IRebaseProgress>()
+      progress = new Array<IMultiCommitOperationProgress>()
       result = await rebase(repository, baseBranch, featureBranch, p =>
         progress.push(p)
       )
@@ -131,9 +130,8 @@ describe('git/rebase', () => {
       expect(progress).toEqual([
         {
           currentCommitSummary: 'Feature Branch First Commit!',
-          kind: 'rebase',
-          rebasedCommitCount: 1,
-          title: 'Rebasing commit 1 of 10 commits',
+          kind: 'multiCommitOperation',
+          position: 1,
           totalCommitCount: 10,
           value: 0.1,
         },
@@ -142,7 +140,7 @@ describe('git/rebase', () => {
 
     it('reports progress after resolving conflicts', async () => {
       const strategy = ManualConflictResolution.theirs
-      const progressCb = (p: IRebaseProgress) => progress.push(p)
+      const progressCb = (p: IMultiCommitOperationProgress) => progress.push(p)
 
       while (result === RebaseResult.ConflictsEncountered) {
         result = await resolveAndContinue(repository!, strategy, progressCb)
@@ -151,9 +149,8 @@ describe('git/rebase', () => {
       expect(progress.length).toEqual(10)
       expect(progress[9]).toEqual({
         currentCommitSummary: 'Feature Branch Tenth Commit!',
-        kind: 'rebase',
-        rebasedCommitCount: 10,
-        title: 'Rebasing commit 10 of 10 commits',
+        kind: 'multiCommitOperation',
+        position: 10,
         totalCommitCount: 10,
         value: 1,
       })
@@ -165,7 +162,7 @@ describe('git/rebase', () => {
       expect(s.commits.length).toEqual(10)
       expect(s.commits[0].summary).toEqual('Feature Branch First Commit!')
 
-      expect(s.progress.rebasedCommitCount).toEqual(1)
+      expect(s.progress.position).toEqual(1)
       expect(s.progress.totalCommitCount).toEqual(10)
       expect(s.progress.currentCommitSummary).toEqual(
         'Feature Branch First Commit!'
@@ -182,7 +179,7 @@ describe('git/rebase', () => {
 async function resolveAndContinue(
   repository: Repository,
   strategy: ManualConflictResolution,
-  progressCb: (progress: IRebaseProgress) => void
+  progressCb: (progress: IMultiCommitOperationProgress) => void
 ) {
   const status = await getStatus(repository)
   const files = status?.workingDirectory.files ?? []


### PR DESCRIPTION
## Description

This makes rebase use the new `IMultiCommitOperationProgress` anywhere it used `IRebaseProgress` or `GitRebaseProgress` which all have the same properties just that `rebasedCount` becomes `position`. Also make the `title` property optional for the `IProgress` since it was not actually used for  Rebase, Cherry-pick, nor the new Multi Commit Operation models.

This makes it so that squash can just use the rebase progress parser in the interactive rebase to process progress.

## Release notes

Notes: no-notes
