### PR TITLE
Add Sublime Text 4 to editor list

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -172,8 +172,16 @@ const editors: IWindowsExternalEditor[] = [
       publisher === 'Microsoft Corporation',
   },
   {
-    name: 'Sublime Text',
+    name: 'Sublime Text 3',
     registryKeys: [LocalMachineUninstallKey('Sublime Text 3_is1')],
+    executableShimPath: ['subl.exe'],
+    expectedInstallationChecker: (displayName, publisher) =>
+      displayName.startsWith('Sublime Text 3') &&
+      publisher === 'Sublime HQ Pty Ltd',
+  },
+  {
+    name: 'Sublime Text',
+    registryKeys: [LocalMachineUninstallKey('Sublime Text_is1')],
     executableShimPath: ['subl.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Sublime Text') &&


### PR DESCRIPTION
Add Sublime Text 4 as separate version due to changes in registry between ST3 and ST4, and edit old "Sublime Text" name to "Sublime Text 3" to differentiate them in Desktop. No need for version number for ST4 as the program has changed their naming convention regarding registry.

Problem discussed in:
https://github.com/desktop/desktop/issues/12124
https://github.community/t/no-external-editors-found-install-vs-code/181626

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #12124

## Description

-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
