### PR TITLE
Squash with progress/conflict dialogs and force push

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -561,7 +561,6 @@ export async function rebaseInteractive(
       return RebaseResult.Error
     }
 
-    // TODO: pass in a rebase action for parser - Rebase, Squash, etc..
     options = configureOptionsForRebase(baseOptions, {
       commits,
       progressCallback,

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -1,6 +1,6 @@
 import * as FSE from 'fs-extra'
 import { getCommits, revRange } from '.'
-import { CommitOneLine } from '../../models/commit'
+import { Commit } from '../../models/commit'
 import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
 import { IMultiCommitOperationProgress } from '../../models/progress'
 import { Repository } from '../../models/repository'
@@ -32,8 +32,8 @@ import { rebaseInteractive, RebaseResult } from './rebase'
  */
 export async function squash(
   repository: Repository,
-  toSquash: ReadonlyArray<CommitOneLine>,
-  squashOnto: CommitOneLine,
+  toSquash: ReadonlyArray<Commit>,
+  squashOnto: Commit,
   lastRetainedCommitRef: string | null,
   commitMessage: string,
   progressCallback?: (progress: IMultiCommitOperationProgress) => void
@@ -155,7 +155,7 @@ export async function squash(
       MultiCommitOperationKind.Squash,
       gitEditor,
       progressCallback,
-      commits
+      [...toSquash, squashOnto]
     )
   } catch (e) {
     log.error(e)

--- a/app/src/ui/multi-commit-operation/squash.tsx
+++ b/app/src/ui/multi-commit-operation/squash.tsx
@@ -63,7 +63,8 @@ export abstract class Squash extends BaseMultiCommitOperation {
     return dispatcher.processSquashRebaseResult(
       repository,
       rebaseResult,
-      commits
+      commits,
+      targetBranch.name
     )
   }
 

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -8,7 +8,7 @@ import {
   getRebaseInternalState,
   RebaseResult,
 } from '../../../src/lib/git'
-import { CommitOneLine } from '../../../src/models/commit'
+import { Commit } from '../../../src/models/commit'
 import { Repository } from '../../../src/models/repository'
 import { setupEmptyRepositoryDefaultMain } from '../../helpers/repositories'
 import { makeCommit } from '../../helpers/repository-scaffolding'
@@ -19,7 +19,7 @@ import { getTempFilePath } from '../../../src/lib/file-system'
 
 describe('git/cherry-pick', () => {
   let repository: Repository
-  let initialCommit: CommitOneLine
+  let initialCommit: Commit
 
   beforeEach(async () => {
     repository = await setupEmptyRepositoryDefaultMain()
@@ -308,10 +308,11 @@ describe('git/cherry-pick', () => {
     await makeSquashCommit(repository, 'first')
     const secondCommit = await makeSquashCommit(repository, 'second')
 
+    const badCommit = { ...secondCommit, sha: 'INVALID', summary: 'INVALID' }
     const result = await squash(
       repository,
       [secondCommit],
-      { sha: 'INVALID', summary: 'INVALID' },
+      badCommit,
       initialCommit.sha,
       'Test Summary\n\nTest Body'
     )
@@ -350,7 +351,7 @@ async function makeSquashCommit(
   repository: Repository,
   desc: string,
   file?: string
-): Promise<CommitOneLine> {
+): Promise<Commit> {
   file = file || desc
   const commitTree = {
     commitMessage: desc,


### PR DESCRIPTION
## Description
YAY! Get to use all that refactoring for something! Squashing has a complete flow through progress and conflicts management.

One unhappy feels: I am using the rebase progress parser since squash is a rebase.. however the rebase is actually aware of all the commits up to the one before the rebase action. Thus as can be seen in the video, even tho I am only squashing 2 commits... the rebase progress parser gets a total of all 5 that it has to reorder/pick back on to the branch during the operation.

Also there is an additional progress updater that is not implemented at this point... but really am unsure if we will ever get a similar feel to rebase/cherry-pick that is doing a one at time action easy to follow where this is a change of 5 into 3 action.

But there are higher priority things to focus on at the moment such as:
- Handling when changes exist
- Handling merge commits
- Disabling squashing in compare view where it doesn't make sense
- Implementing squash merge.
- Metric tracking

After that stuff will circle back to cosmetic feels/behind the scenes refactors. 

### Screenshots
https://user-images.githubusercontent.com/75402236/119686374-44edf180-be14-11eb-9897-ff595dad3156.mov

## Release notes
Notes: no-notes
