### PR TITLE
Add Fluent Terminal to Windows Shells

### DIFF
--- a/app/src/lib/shells/win32.ts
+++ b/app/src/lib/shells/win32.ts
@@ -18,6 +18,7 @@ export enum Shell {
   Cygwin = 'Cygwin',
   WSL = 'WSL',
   WindowTerminal = 'Windows Terminal',
+  FluentTerminal = 'Fluent Terminal',
   Alacritty = 'Alacritty',
 }
 
@@ -102,6 +103,14 @@ export async function getAvailableShells(): Promise<
     shells.push({
       shell: Shell.WindowTerminal,
       path: windowsTerminal,
+    })
+  }
+
+  const fluentTerminal = await findFluentTerminal()
+  if (fluentTerminal != null) {
+    shells.push({
+      shell: Shell.FluentTerminal,
+      path: fluentTerminal,
     })
   }
   return shells
@@ -361,6 +370,26 @@ async function findWindowsTerminal(): Promise<string | null> {
   return null
 }
 
+async function findFluentTerminal(): Promise<string | null> {
+  // Fluent Terminal has a link at
+  // C:\Users\<User>\AppData\Local\Microsoft\WindowsApps\flute.exe
+  const localAppData = process.env.LocalAppData
+  if (localAppData != null) {
+    const fluentTerminalpath = Path.join(
+      localAppData,
+      '\\Microsoft\\WindowsApps\\flute.exe'
+    )
+    if (await pathExists(fluentTerminalpath)) {
+      return fluentTerminalpath
+    } else {
+      log.debug(
+        `[Fluent Terminal] flute.exe doest not exist at '${fluentTerminalpath}'`
+      )
+    }
+  }
+  return null
+}
+
 export function launch(
   foundShell: IFoundShell<Shell>,
   path: string
@@ -437,6 +466,10 @@ export function launch(
       const windowsTerminalPath = `"${foundShell.path}"`
       log.info(`launching ${shell} at path: ${windowsTerminalPath}`)
       return spawn(windowsTerminalPath, ['-d .'], { shell: true, cwd: path })
+    case Shell.FluentTerminal:
+      const fluentTerminalPath = `"${foundShell.path}"`
+      log.info(`launching ${shell} at path: ${fluentTerminalPath}`)
+      return spawn(fluentTerminalPath, ['new'], { shell: true, cwd: path })
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -32,6 +32,7 @@ These shells are currently supported:
  - [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) (beta)
  - [Windows Terminal](https://github.com/microsoft/terminal)
  - [Alacritty](https://github.com/alacritty/alacritty)
+ - [Fluent Terminal](https://github.com/felixse/FluentTerminal)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
## Description

This PR adds [Fluent Terminal](https://github.com/felixse/FluentTerminal) to list of supported Windows shells.

### Screenshots

![](https://i.imgur.com/8yh2ovY.png)

![](https://i.imgur.com/kc3p642.png)

## Release notes

Notes: Add Fluent Terminal to list of Windows shells
