### PR TITLE
Add Links to Official Apple Silicon Installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Download the official installer for your operating system:
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
  - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
- - [Windows (ARM64)](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64)
  - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
 
 You can install this alongside your existing GitHub Desktop for Mac or GitHub

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ uses [React](https://reactjs.org/).
 
 Download the official installer for your operating system:
 
- - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
+ - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin) 
+ - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
+ - [Windows (ARM64)](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64)
  - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
 
 You can install this alongside your existing GitHub Desktop for Mac or GitHub

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ uses [React](https://reactjs.org/).
 
 Download the official installer for your operating system:
 
- - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin) 
+ - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
  - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
  - [Windows (ARM64)](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]

## Description

- Now that there are production version of the Apple Silicon Builds, we should link to them from the README
- In other news, I don't think these links exist on https://desktop.github.com/ yet and maybe they should?

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
