### PR TITLE
Reload HTTP fetch cache when cloning

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -633,7 +633,10 @@ export class API {
     name: string,
     protocol: GitProtocol | undefined
   ): Promise<IAPIRepositoryCloneInfo | null> {
-    const response = await this.request('GET', `repos/${owner}/${name}`)
+    const response = await this.requestReloadCache(
+      'GET',
+      `repos/${owner}/${name}`
+    )
 
     if (response.status === HttpStatusCode.NotFound) {
       return null
@@ -1025,6 +1028,25 @@ export class API {
     customHeaders?: Object
   ): Promise<Response> {
     return request(this.endpoint, this.token, method, path, body, customHeaders)
+  }
+
+  /** Make an authenticated request to the client's endpoint with its token but
+   * skip checking cache while also updating cache. */
+  private requestReloadCache(
+    method: HTTPMethod,
+    path: string,
+    body?: Object,
+    customHeaders?: Object
+  ): Promise<Response> {
+    return request(
+      this.endpoint,
+      this.token,
+      method,
+      path,
+      body,
+      customHeaders,
+      true
+    )
   }
 
   /**

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -109,6 +109,9 @@ export function getAbsoluteUrl(endpoint: string, path: string): string {
  * @param path          - The path, including any query string parameters.
  * @param jsonBody      - The JSON body to send.
  * @param customHeaders - Any optional additional headers to send.
+ * @param reloadCache   - sets cache option to reload — The browser fetches
+ * the resource from the remote server without first looking in the cache, but
+ * then will update the cache with the downloaded resource.
  */
 export function request(
   endpoint: string,
@@ -116,7 +119,8 @@ export function request(
   method: HTTPMethod,
   path: string,
   jsonBody?: Object,
-  customHeaders?: Object
+  customHeaders?: Object,
+  reloadCache: boolean = false
 ): Promise<Response> {
   const url = getAbsoluteUrl(endpoint, path)
 
@@ -135,10 +139,14 @@ export function request(
     ...customHeaders,
   }
 
-  const options = {
+  const options: RequestInit = {
     headers,
     method,
     body: JSON.stringify(jsonBody),
+  }
+
+  if (reloadCache) {
+    options.cache = 'reload' as RequestCache
   }
 
   return fetch(url, options)


### PR DESCRIPTION
Closes #3855

## Description

During cloning , we make an http request ending in `repos/${owner}/${name}` (which is just getting the details of the repo).

For example, If I clone my repo called `awesome-repo`. It would be `baseurl/repos/tidy-dev/awesome-repo`.  

[By default, on this request](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache):
```
default — The browser looks for a matching request in its HTTP cache.
If there is a match and it is fresh, it will be returned from the cache.
If there is a match but it is stale, the browser will make a conditional request to the remote server. If the server indicates that the resource has not changed, it will be returned from the cache. Otherwise the resource will be downloaded from the server and the cache will be updated.
If there is no match, the browser will make a normal request, and will update the cache with the downloaded resource.
```
The reason this probably stays "fresh" is because we use that same call many other places like when fetching.

Thus, if I have an already cloned repo of `awesome-repo` that means I have a cache for it. If I change it's name to `not-so-awesome-repo` and recreate a new repo called `awesome-repo`. When desktop tries to clone it and hits that same `baseurl/repos/tidy-dev/awesome-repo`, it gets the details or ID for the old `awesome-repo` which is now the `not-so-awesome-repo`. 

Solution: Whenever we clone, we do not check the cache. This is intuitive anyways because cloning usually is our first contact with a repo and we wouldn't generally have a cache for it.

Notes on previous PRs that we thought might have fixed this.
There are two portions to this issue:

1. If I rename a repository `awesome-repo` to `not-so-awesome-repo` on github.com, I want that rename reflected in Desktop. This is what #8132 does - during a repository refresh cycle it detects the a change in the cloneURL when it is renamed and correctly updates the name of repository locally. 

2. More of a bug, if after I do step 1, I make a new repo called `awesome-repo` (the old name) and clone it. I want it to be named and update `awesome-repo` but it was named and updating to `not-so-awesome-repo`.  This may not have updated the name to `'not-so-awesome-repo` when this issue was originally entered as I would expect the updated name only happens because of #8132, however bug of it pointing to `not-so-awesome-repo` may have still existed because the cache that made it so the id we retrieved for 'awesome-repo' was still now the id of `not-so-awesome-repo`.

There is reference to this being closed by #9138 in [this comment.](https://github.com/desktop/desktop/issues/3855#issuecomment-599661854) Looking at the code.. I am not sure how this one did impact this.. but maybe there is more I don't understand. Only thing I suspect is that because step 1 changed the nature/timing/repro steps of this bug that it may have appeared to be gone. 

Other thing to be aware of that I don't think we can mitigate without some kind of .com webhook to make the rename detection more immediate is if a user does 1 and 2 in quick succession not allowing desktop to detect the rename of the original repo. The cache will now be updated with 2's details and so the first instance of the repo in Desktop will now effectively be a duplicate of the new one in step two with the old name. If a user does this, the solution would be to just clone the renamed one.

### Screenshots
This screen share shows the behavior off if I wait for the app to detect the rename (which takes a little bit as it is just waiting on a periodic cycle behind the scenes). 

https://user-images.githubusercontent.com/75402236/119874655-da13e780-bef3-11eb-9044-4209a7a240ad.mov

This screen share highlights that is in fact pointing to and updating the new repo.

https://user-images.githubusercontent.com/75402236/119876045-74c0f600-bef5-11eb-84b2-b4ee68e2205f.mov


## Release notes
Notes: [Fixed] Rename a repo and then create and clone a repo with that repo's previous name now points to a new repo not the renamed one.
