### PR TITLE
Fix drag & drop warnings

### DIFF
--- a/app/src/ui/drag-overlay.tsx
+++ b/app/src/ui/drag-overlay.tsx
@@ -1,3 +1,4 @@
+import { Disposable } from 'event-kit'
 import * as React from 'react'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { PopoverCaretPosition } from './lib/popover'
@@ -17,6 +18,7 @@ export class DragOverlay extends React.Component<
   IDragOverlayState
 > {
   private timeoutId: number | null = null
+  private onEnterDragZoneDisposable: Disposable | null = null
 
   public constructor(props: IDragOverlayProps) {
     super(props)
@@ -45,11 +47,18 @@ export class DragOverlay extends React.Component<
     this.timeoutId = window.setTimeout(() => {
       this.setState({ showDragPrompt: true })
     }, dragPromptWaitTime)
-    dragAndDropManager.onEnterDragZone(this.dragZoneEntered)
+    this.onEnterDragZoneDisposable = dragAndDropManager.onEnterDragZone(
+      this.dragZoneEntered
+    )
   }
 
   public componentWillUnmount = () => {
     this.clearDragPromptTimeOut()
+
+    if (this.onEnterDragZoneDisposable !== null) {
+      this.onEnterDragZoneDisposable.dispose()
+      this.onEnterDragZoneDisposable = null
+    }
   }
 
   private renderDragPrompt(): JSX.Element | null {


### PR DESCRIPTION
## Description

Some of the drag & drop events we're observing in the `CommitDragElement` and `DragOverlay` were being triggered after the component is unmounted, causing a warning because we tried to change the component's state.
This PR makes sure we unobserve them after the component is unmounted, hopefully being also a good citizen.

## Release notes

Notes: no-notes
