### PR TITLE
Remove extra space in drag & drop tooltips

### DIFF
--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -86,7 +86,7 @@ export class CommitDragElement extends React.Component<
           <>
             {copyToPlus}
             <span>
-              <span className="copy-to">Copy to </span>
+              <span className="copy-to">Copy to</span>
               <span className="branch-name">
                 {currentDropTarget.branchName}
               </span>


### PR DESCRIPTION
### Screenshots

![image](https://user-images.githubusercontent.com/1083228/120220338-e02ffe00-c23c-11eb-9097-e24ff0b5d55b.png)

## Release notes

Notes: [Fixed] Remove extra space from drag & drop tooltips
