### PR TITLE
Throw error if merge commit exists in squash

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -15,6 +15,7 @@ import {
 } from './interpret-trailers'
 import { getCaptures } from '../helpers/regex'
 import { createLogParser } from './git-delimiter-parser'
+import { revRange } from '.'
 
 /**
  * Map the raw status text from Git to an app-friendly value
@@ -207,4 +208,22 @@ export async function getCommit(
   }
 
   return commits[0]
+}
+
+/**
+ * Determine if merge commits exist in history after given commit
+ * If no commitRef is null, goes back to HEAD of branch.
+ */
+export async function doMergeCommitsExistAfterCommit(
+  repository: Repository,
+  commitRef: string | null
+): Promise<boolean> {
+  const commitRevRange =
+    commitRef === null ? undefined : revRange(commitRef, 'HEAD')
+
+  const mergeCommits = await getCommits(repository, commitRevRange, undefined, [
+    '--merges',
+  ])
+
+  return mergeCommits.length > 0
 }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -582,7 +582,7 @@ export class CompareSidebar extends React.Component<
     ) {
       defaultErrorHandler(
         new Error(
-          `Squashing replays all commits up to the last one required for the quash. A merge commit cannot exists among those commits.`
+          `Squashing replays all commits up to the last one required for the squash. A merge commit cannot exists among those commits.`
         ),
         this.props.dispatcher
       )

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -582,7 +582,7 @@ export class CompareSidebar extends React.Component<
     ) {
       defaultErrorHandler(
         new Error(
-          `Squashing replays all commits up to the last one required for the squash. A merge commit cannot exists among those commits.`
+          `Unable to squash. Squashing replays all commits up to the last one required for the squash. A merge commit cannot exist among those commits.`
         ),
         this.props.dispatcher
       )

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -582,7 +582,7 @@ export class CompareSidebar extends React.Component<
     ) {
       defaultErrorHandler(
         new Error(
-          `Cannot Squash: merge commit found. Squashing is an interactive rebase replaying all commits up to the last one required for the squash.`
+          `Squashing replays all commits up to the last one required for the quash. A merge commit cannot exists among those commits.`
         ),
         this.props.dispatcher
       )


### PR DESCRIPTION
## Description

Throws an error before starting squash if squash would fail due to merge commits being in the interactive rebase history.

Some context:
An interactive rebase by default will rewrite history keeping the commits merged in and drop the actual merge commit. We felt this would feel strange if a user dragged a commit onto another commit (whether either of those commits had to do with the merge) and the merge commit just disappearing from their history. Also if a user chose to actually squash a merge commit that had say 3 commits in the history associated with it, all 4 (3 + merge) of those commits would disappear as they would be squashed. Thus, we chose to error in this scenario and not allow users to do this as we are assuming it to be an uncommon/edge case that would require more explanation to the user that a drag/drop could not provide.

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/120363340-0b1c5f80-c2da-11eb-91e4-aa20ae116e99.png)
Notes: no-notes
