### PR TITLE
Enable cross auto-update to arm64 on macOS production builds

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -71,8 +71,15 @@ export function enableTextDiffExpansion(): boolean {
   return true
 }
 
-/** Should we allow apps running from Rosetta to auto-update to ARM64 builds? */
-export function enableUpdateFromRosettaToARM64(): boolean {
+/**
+ * Should we allow x64 apps running under ARM translation to auto-update to
+ * ARM64 builds?
+ */
+export function enableUpdateFromEmulatedX64ToARM64(): boolean {
+  if (__DARWIN__) {
+    return true
+  }
+
   return enableBetaFeatures()
 }
 

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -14,7 +14,7 @@ import { parseError } from '../../lib/squirrel-error-parser'
 import { ReleaseSummary } from '../../models/release-notes'
 import { generateReleaseSummary } from '../../lib/release-notes'
 import { setNumber, getNumber } from '../../lib/local-storage'
-import { enableUpdateFromRosettaToARM64 } from '../../lib/feature-flag'
+import { enableUpdateFromEmulatedX64ToARM64 } from '../../lib/feature-flag'
 import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 /** The states the auto updater can be in. */
@@ -168,7 +168,7 @@ class UpdateStore {
     // on an arm64 machine), we need to tweak the update URL here to point at
     // the arm64 binary.
     if (
-      enableUpdateFromRosettaToARM64() &&
+      enableUpdateFromEmulatedX64ToARM64() &&
       (remote.app.runningUnderRosettaTranslation === true ||
         isRunningUnderARM64Translation() === true)
     ) {


### PR DESCRIPTION
## Description

The feature flag will be `true` only on macOS, meaning Windows builds will still not auto-update to arm64 in production.

## Release notes

Notes: no-notes
