### PR TITLE
Don't allow squashing when comparing a branch to another

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -42,6 +42,7 @@ interface ICommitProps {
   readonly unpushedIndicatorTitle?: string
   readonly unpushedTags?: ReadonlyArray<string>
   readonly isCherryPickInProgress?: boolean
+  readonly disableSquashing?: boolean
 }
 
 interface ICommitListItemState {
@@ -76,9 +77,10 @@ export class CommitListItem extends React.PureComponent<
   }
 
   private onMouseUp = () => {
-    const { onSquash, selectedCommits, commit } = this.props
+    const { onSquash, selectedCommits, commit, disableSquashing } = this.props
     if (
       enableSquashing() &&
+      disableSquashing !== true &&
       dragAndDropManager.isDragOfTypeInProgress(DragType.Commit) &&
       onSquash !== undefined &&
       // don't squash if dragging one commit and dropping onto itself
@@ -89,10 +91,11 @@ export class CommitListItem extends React.PureComponent<
   }
 
   private onMouseEnter = () => {
-    const { selectedCommits, commit } = this.props
+    const { selectedCommits, commit, disableSquashing } = this.props
     const isSelected =
       selectedCommits.find(c => c.sha === commit.sha) !== undefined
     if (
+      disableSquashing !== true &&
       dragAndDropManager.isDragOfTypeInProgress(DragType.Commit) &&
       enableSquashing() &&
       !isSelected

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -99,6 +99,9 @@ interface ICommitListProps {
 
   /** Callback to remove commit drag element */
   readonly onRemoveCommitDragElement: () => void
+
+  /** Whether squashing should be enabled on the commit list */
+  readonly disableSquashing?: boolean
 }
 
 /** A component which displays the list of commits. */
@@ -164,6 +167,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         isCherryPickInProgress={this.props.isCherryPickInProgress}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.props.onRemoveCommitDragElement}
+        disableSquashing={this.props.disableSquashing}
       />
     )
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -251,6 +251,7 @@ export class CompareSidebar extends React.Component<
         isCherryPickInProgress={this.props.isCherryPickInProgress}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveCommitDragElement={this.onRemoveCommitDragElement}
+        disableSquashing={formState.kind === HistoryTabMode.Compare}
       />
     )
   }

--- a/app/styles/ui/_app.scss
+++ b/app/styles/ui/_app.scss
@@ -86,19 +86,28 @@
     // 'squashing-enabled' class is due to feature flagging. If feature flag is
     // removed, we could move .list-item block up under the #commit-list above
     &.squashing-enabled {
-      #commit-list {
-        .list-item:not(.selected) {
-          .commit:hover {
-            --text-color: var(--box-selected-active-text-color);
-            --text-secondary-color: var(--box-selected-active-text-color);
+      // When NOT comparing a branch, the #commit-list is a direct child of
+      // .compare-commit-list which is a direct child of #compare-view and we
+      // only want this highlighting to take effect when not comparing branches.
+      // Note: there is another .compare-commit-list higher up when comparing so
+      // the direct child selector is important.
+      #compare-view {
+        > .compare-commit-list {
+          > #commit-list {
+            .list-item:not(.selected) {
+              .commit:hover {
+                --text-color: var(--box-selected-active-text-color);
+                --text-secondary-color: var(--box-selected-active-text-color);
 
-            color: var(--text-color);
-            background-color: var(--box-selected-active-background-color);
-          }
+                color: var(--text-color);
+                background-color: var(--box-selected-active-background-color);
+              }
 
-          .commit {
-            div {
-              pointer-events: none;
+              .commit {
+                div {
+                  pointer-events: none;
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Description

When comparing a branch to another squashing doesn't make sense because what is in the commit list is not a logical history in respect to the checked out branch anymore. Thus, this PR disables squashing during branch comparison in the history tab.

### Screenshots

https://user-images.githubusercontent.com/75402236/120370119-2c814980-c2e2-11eb-9c24-5fdcd11bfbc7.mov


## Release notes
Notes: no-notes
