### PR TITLE
Add stash for local changes on squash

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6390,7 +6390,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const {
       branchesState,
       squashState: { undoSha, squashBranchName },
+      changesState: { workingDirectory },
     } = this.repositoryStateCache.get(repository)
+
+    if (workingDirectory.files.length > 0) {
+      log.error(
+        '[undoSquash] - Could not undo squash. This would delete the local changes that exist on the branch.'
+      )
+      return false
+    }
+
     const { tip } = branchesState
     if (tip.kind !== TipState.Valid || tip.branch.name !== squashBranchName) {
       log.error(

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -1,7 +1,7 @@
 import { Repository } from './repository'
 import { CloneOptions } from './clone-options'
 import { Branch } from './branch'
-import { CommitOneLine } from './commit'
+import { Commit, CommitOneLine, ICommitContext } from './commit'
 
 /** The types of actions that can be retried. */
 export enum RetryActionType {
@@ -14,6 +14,7 @@ export enum RetryActionType {
   Rebase,
   CherryPick,
   CreateBranchForCherryPick,
+  Squash,
 }
 
 /** The retriable actions and their associated data. */
@@ -60,4 +61,12 @@ export type RetryAction =
       noTrackOption: boolean
       commits: ReadonlyArray<CommitOneLine>
       sourceBranch: Branch | null
+    }
+  | {
+      type: RetryActionType.Squash
+      repository: Repository
+      toSquash: ReadonlyArray<Commit>
+      squashOnto: Commit
+      lastRetainedCommitRef: string | null
+      commitContext: ICommitContext
     }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1947,6 +1947,14 @@ export class Dispatcher {
           retryAction.commits,
           retryAction.sourceBranch
         )
+      case RetryActionType.Squash:
+        return this.squash(
+          retryAction.repository,
+          retryAction.toSquash,
+          retryAction.squashOnto,
+          retryAction.lastRetainedCommitRef,
+          retryAction.commitContext
+        )
       default:
         return assertNever(retryAction, `Unknown retry action: ${retryAction}`)
     }
@@ -3082,7 +3090,18 @@ export class Dispatcher {
     lastRetainedCommitRef: string | null,
     commitContext: ICommitContext
   ): Promise<void> {
-    // TODO: handle uncommitted changes
+    const retry: RetryAction = {
+      type: RetryActionType.Squash,
+      repository,
+      toSquash,
+      squashOnto,
+      lastRetainedCommitRef,
+      commitContext,
+    }
+
+    if (this.appStore._checkForUncommittedChanges(repository, retry)) {
+      return
+    }
 
     const stateBefore = this.repositoryStateManager.get(repository)
     const { tip } = stateBefore.branchesState

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -173,6 +173,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
       case RetryActionType.CherryPick:
       case RetryActionType.CreateBranchForCherryPick:
         return 'cherry-pick'
+      case RetryActionType.Squash:
+        return 'squash'
       default:
         assertNever(
           this.props.retryAction,


### PR DESCRIPTION
## Description

When user has local changes, require them to stash to continue. 

Notes: I had originally thought about doing this on behalf of the user. But changed my mind because it breaks our apps convention  compared to other similar functionality (merge, rebase, cherry-pick). Also, squashing can result in conflicts which when resolved result in conflicts with the stash; therefore, I think it would feel more logical to the user to handle these conflicts as separate actions of "conflicts while squashing" and "conflicts that are preset because of popping stash".

### Screenshots
https://user-images.githubusercontent.com/75402236/120373433-589ec980-c2e6-11eb-87fc-2e61ed34d3a5.mov

## Release notes
Notes: no-notes
