### PR TITLE
Enable squashing for beta

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -100,5 +100,5 @@ export function enableBranchFromCommit(): boolean {
 
 /** Should we allow squashing? */
 export function enableSquashing(): boolean {
-  return enableDevelopmentFeatures()
+  return enableBetaFeatures()
 }


### PR DESCRIPTION
## Description

Enables squashing for beta. 

Preferably wait till these are in as these represent "broken" paths with squashing:
(of course as long as these are in before beta is released, this going in last isn't particularly important :P) 
 - #12335 
 - #12334
 - #12331 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes
Notes: [New] Squash commits on the history tab!
