### PR TITLE
Show warning before undoing commit if it conflicts changes in working directory

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4139,11 +4139,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
       changesState.workingDirectory.files.length === 0
 
     // Warn the user if there are changes in the working directory
-    if (showConfirmationDialog && !isWorkingDirectoryClean) {
+    if (
+      showConfirmationDialog &&
+      (!isWorkingDirectoryClean || commit.isMergeCommit)
+    ) {
       return this._showPopup({
         type: PopupType.WarnLocalChangesBeforeUndo,
         repository,
         commit,
+        isWorkingDirectoryClean,
       })
     }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4135,29 +4135,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const gitStore = this.gitStoreCache.get(repository)
     const repositoryState = this.repositoryStateCache.get(repository)
     const { changesState } = repositoryState
-
-    if (showConfirmationDialog) {
-      // Compare file paths in working directory and in the commit that will be undone
-      const workingDirectoryFiles = changesState.workingDirectory.files.map(
-        f => f.path
-      )
-      const commitFiles = (await getChangedFiles(repository, commit.sha)).map(
-        f => f.path
-      )
-
-      // Warn the user if there is any overlap between commit files and working
-      // directory files
-      if (workingDirectoryFiles.some(f => commitFiles.includes(f))) {
-        return this._showPopup({
-          type: PopupType.WarnLocalChangesBeforeUndo,
-          repository,
-          commit,
-        })
-      }
-    }
-
     const isWorkingDirectoryClean =
       changesState.workingDirectory.files.length === 0
+
+    // Warn the user if there are changes in the working directory
+    if (showConfirmationDialog && !isWorkingDirectoryClean) {
+      return this._showPopup({
+        type: PopupType.WarnLocalChangesBeforeUndo,
+        repository,
+        commit,
+      })
+    }
 
     await gitStore.undoCommit(commit)
 

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -84,6 +84,11 @@ export class Commit {
   public readonly authoredByCommitter: boolean
 
   /**
+   * Whether or not the commit is a merge commit (i.e. has at least 2 parents)
+   */
+  public readonly isMergeCommit: boolean
+
+  /**
    * @param sha The commit's SHA.
    * @param shortSha The commit's shortSHA.
    * @param summary The first line of the commit message.
@@ -115,5 +120,7 @@ export class Commit {
       this.author.email === this.committer.email
 
     this.bodyNoCoAuthors = trimCoAuthorsTrailers(trailers, body)
+
+    this.isMergeCommit = parentSHAs.length > 1
   }
 }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -310,4 +310,5 @@ export type Popup =
       type: PopupType.WarnLocalChangesBeforeUndo
       repository: Repository
       commit: Commit
+      isWorkingDirectoryClean: boolean
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -10,7 +10,7 @@ import { IRemote } from './remote'
 import { RetryAction } from './retry-actions'
 import { WorkingDirectoryFileChange } from './status'
 import { PreferencesTab } from './preferences'
-import { CommitOneLine, ICommitContext } from './commit'
+import { Commit, CommitOneLine, ICommitContext } from './commit'
 import { IStashEntry } from './stash-entry'
 import { Account } from '../models/account'
 import { Progress } from './progress'
@@ -75,6 +75,7 @@ export enum PopupType {
   ThankYou,
   CommitMessage,
   MultiCommitOperation,
+  WarnLocalChangesBeforeUndo,
 }
 
 export type Popup =
@@ -304,4 +305,9 @@ export type Popup =
   | {
       type: PopupType.MultiCommitOperation
       repository: Repository
+    }
+  | {
+      type: PopupType.WarnLocalChangesBeforeUndo
+      repository: Repository
+      commit: Commit
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2227,13 +2227,14 @@ export class App extends React.Component<IAppProps, IAppState> {
         )
       }
       case PopupType.WarnLocalChangesBeforeUndo: {
-        const { repository, commit } = popup
+        const { repository, commit, isWorkingDirectoryClean } = popup
         return (
           <WarnLocalChangesBeforeUndo
             key="warn-local-changes-before-undo"
             dispatcher={this.props.dispatcher}
             repository={repository}
             commit={commit}
+            isWorkingDirectoryClean={isWorkingDirectoryClean}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -156,6 +156,7 @@ import { DefaultCommitMessage } from '../models/commit-message'
 import { ManualConflictResolution } from '../models/manual-conflict-resolution'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { MultiCommitOperation } from './multi-commit-operation/multi-commit-operation'
+import { WarnLocalChangesBeforeUndo } from './undo/warn-local-changes-before-undo'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2222,6 +2223,18 @@ export class App extends React.Component<IAppProps, IAppState> {
             openFileInExternalEditor={this.openFileInExternalEditor}
             resolvedExternalEditor={this.state.resolvedExternalEditor}
             openRepositoryInShell={this.openCurrentRepositoryInShell}
+          />
+        )
+      }
+      case PopupType.WarnLocalChangesBeforeUndo: {
+        const { repository, commit } = popup
+        return (
+          <WarnLocalChangesBeforeUndo
+            key="warn-local-changes-before-undo"
+            dispatcher={this.props.dispatcher}
+            repository={repository}
+            commit={commit}
+            onDismissed={onPopupDismissedFn}
           />
         )
       }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -762,8 +762,12 @@ export class Dispatcher {
   }
 
   /** Undo the given commit. */
-  public undoCommit(repository: Repository, commit: Commit): Promise<void> {
-    return this.appStore._undoCommit(repository, commit)
+  public undoCommit(
+    repository: Repository,
+    commit: Commit,
+    showConfirmationDialog: boolean = true
+  ): Promise<void> {
+    return this.appStore._undoCommit(repository, commit, showConfirmationDialog)
   }
 
   /** Revert the commit with the given SHA */

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -65,7 +65,7 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
           some of these changes being lost.
           <br />
           <br />
-          Besides, undoing a merge commit will apply the changes from the merge
+          Also, undoing a merge commit will apply the changes from the merge
           into your working directory, and committing again will create an
           entirely new commit. This means you will lose the merge commit and, as
           a result, commits from the merged branch could disappear from this
@@ -78,12 +78,13 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
     } else if (this.props.commit.isMergeCommit) {
       return (
         <>
-          You are about to undo a merge commit. Undoing a merge commit will
-          apply the changes from the merge into your working directory, and
-          committing again will create an entirely new commit. This means you
-          will lose the merge commit and, as a result, commits from the merged
-          branch could disappear from this branch. Do you want to continue
-          anyway?
+          Undoing a merge commit will apply the changes from the merge into your
+          working directory, and committing again will create an entirely new
+          commit. This means you will lose the merge commit and, as a result,
+          commits from the merged branch could disappear from this branch.
+          <br />
+          <br />
+          Do you want to continue anyway?
         </>
       )
     } else {

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Commit } from '../../models/commit'
+
+interface IWarnLocalChangesBeforeUndoProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly commit: Commit
+  readonly onDismissed: () => void
+}
+
+interface IWarnLocalChangesBeforeUndoState {
+  readonly isLoading: boolean
+}
+
+/**
+ * Dialog that alerts user that there are uncommitted changes in the working
+ * directory where they are gonna be undoing a commit.
+ */
+export class WarnLocalChangesBeforeUndo extends React.Component<
+  IWarnLocalChangesBeforeUndoProps,
+  IWarnLocalChangesBeforeUndoState
+> {
+  public constructor(props: IWarnLocalChangesBeforeUndoProps) {
+    super(props)
+    this.state = { isLoading: false }
+  }
+
+  public render() {
+    const title = __DARWIN__ ? 'Undo Commit' : 'Undo commit'
+
+    return (
+      <Dialog
+        id="warn-local-changes-before-undo"
+        type="warning"
+        title={title}
+        loading={this.state.isLoading}
+        disabled={this.state.isLoading}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            You have changes on this branch. Undoing the commit might lose some
+            of these changes. Do you want to continue anyway?
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup destructive={true} okButtonText="Continue" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onSubmit = async () => {
+    const { dispatcher, repository, commit, onDismissed } = this.props
+    this.setState({ isLoading: true })
+
+    try {
+      await dispatcher.undoCommit(repository, commit, false)
+    } finally {
+      this.setState({ isLoading: false })
+    }
+
+    onDismissed()
+  }
+}

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -45,8 +45,8 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
       >
         <DialogContent>
           <Row>
-            You have changes on this branch. Undoing the commit might lose some
-            of these changes. Do you want to continue anyway?
+            You have changes in progress. Undoing the commit might result in
+            some of these changes being lost. Do you want to continue anyway?
           </Row>
         </DialogContent>
         <DialogFooter>

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -10,6 +10,7 @@ interface IWarnLocalChangesBeforeUndoProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly commit: Commit
+  readonly isWorkingDirectoryClean: boolean
   readonly onDismissed: () => void
 }
 
@@ -44,16 +45,29 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>
-          <Row>
-            You have changes in progress. Undoing the commit might result in
-            some of these changes being lost. Do you want to continue anyway?
-          </Row>
+          <Row>{this.getWarningText()}</Row>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup destructive={true} okButtonText="Continue" />
         </DialogFooter>
       </Dialog>
     )
+  }
+
+  private getWarningText() {
+    if (
+      this.props.commit.isMergeCommit &&
+      !this.props.isWorkingDirectoryClean
+    ) {
+      return `You have changes in progress. Undoing the merge commit might
+      result in some of these changes being lost. Do you want to continue anyway?`
+    } else if (this.props.commit.isMergeCommit) {
+      return `You are about to undo a merge commit. Undoing a merge commit might
+      result in a confusing set of changes. Do you want to continue anyway?`
+    } else {
+      return `You have changes in progress. Undoing the commit might result in
+      some of these changes being lost. Do you want to continue anyway?`
+    }
   }
 
   private onSubmit = async () => {

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -65,11 +65,7 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
           some of these changes being lost.
           <br />
           <br />
-          Also, undoing a merge commit will apply the changes from the merge
-          into your working directory, and committing again will create an
-          entirely new commit. This means you will lose the merge commit and, as
-          a result, commits from the merged branch could disappear from this
-          branch.
+          {this.getMergeCommitUndoWarningText()}
           <br />
           <br />
           Do you want to continue anyway?
@@ -78,10 +74,7 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
     } else if (this.props.commit.isMergeCommit) {
       return (
         <>
-          Undoing a merge commit will apply the changes from the merge into your
-          working directory, and committing again will create an entirely new
-          commit. This means you will lose the merge commit and, as a result,
-          commits from the merged branch could disappear from this branch.
+          {this.getMergeCommitUndoWarningText()}
           <br />
           <br />
           Do you want to continue anyway?
@@ -95,6 +88,13 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
         </>
       )
     }
+  }
+
+  private getMergeCommitUndoWarningText() {
+    return `Undoing a merge commit will apply the changes from the merge into
+    your working directory, and committing again will create an entirely new
+    commit. This means you will lose the merge commit and, as a result, commits
+    from the merged branch could disappear from this branch.`
   }
 
   private onSubmit = async () => {

--- a/app/src/ui/undo/warn-local-changes-before-undo.tsx
+++ b/app/src/ui/undo/warn-local-changes-before-undo.tsx
@@ -59,14 +59,40 @@ export class WarnLocalChangesBeforeUndo extends React.Component<
       this.props.commit.isMergeCommit &&
       !this.props.isWorkingDirectoryClean
     ) {
-      return `You have changes in progress. Undoing the merge commit might
-      result in some of these changes being lost. Do you want to continue anyway?`
+      return (
+        <>
+          You have changes in progress. Undoing the merge commit might result in
+          some of these changes being lost.
+          <br />
+          <br />
+          Besides, undoing a merge commit will apply the changes from the merge
+          into your working directory, and committing again will create an
+          entirely new commit. This means you will lose the merge commit and, as
+          a result, commits from the merged branch could disappear from this
+          branch.
+          <br />
+          <br />
+          Do you want to continue anyway?
+        </>
+      )
     } else if (this.props.commit.isMergeCommit) {
-      return `You are about to undo a merge commit. Undoing a merge commit might
-      result in a confusing set of changes. Do you want to continue anyway?`
+      return (
+        <>
+          You are about to undo a merge commit. Undoing a merge commit will
+          apply the changes from the merge into your working directory, and
+          committing again will create an entirely new commit. This means you
+          will lose the merge commit and, as a result, commits from the merged
+          branch could disappear from this branch. Do you want to continue
+          anyway?
+        </>
+      )
     } else {
-      return `You have changes in progress. Undoing the commit might result in
-      some of these changes being lost. Do you want to continue anyway?`
+      return (
+        <>
+          You have changes in progress. Undoing the commit might result in some
+          of these changes being lost. Do you want to continue anyway?
+        </>
+      )
     }
   }
 

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -168,7 +168,7 @@ describe('AppStore', () => {
       let state = getAppState(appStore)
       expect(state.localCommitSHAs).toHaveLength(1)
 
-      await appStore._undoCommit(repository, firstCommit!)
+      await appStore._undoCommit(repository, firstCommit!, false)
 
       state = getAppState(appStore)
       expect(state.localCommitSHAs).toHaveLength(0)


### PR DESCRIPTION
Closes #4596
Closes #9286
Closes #5874
Closes #6043

## Description

This PR checks if there are changes in the working directory that could be overwritten by the changes in the commit to be undone. Basically, the warning is shown only if any of the files changed in the working directory was changed in the commit to undo.

### Screenshots

https://user-images.githubusercontent.com/1083228/120466412-5482b280-c39f-11eb-81f0-253594e7527d.mov

## Release notes

Notes: [Improved] Warn users before undoing commits when changes can be lost in the process
