### PR TITLE
Add "Undo Commit" action to the context menu

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4155,15 +4155,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.statsStore.recordCommitUndone(isWorkingDirectoryClean)
 
-    const { commitSelection } = this.repositoryStateCache.get(repository)
-
-    if (
-      commitSelection.shas.length > 0 &&
-      commitSelection.shas.find(sha => sha === commit.sha) !== undefined
-    ) {
-      this.clearSelectedCommit(repository)
-    }
-
     return this._refreshRepository(repository)
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4151,6 +4151,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       })
     }
 
+    // Make sure we show the changes after undoing the commit
+    await this._changeRepositorySection(
+      repository,
+      RepositorySectionTab.Changes
+    )
+
     await gitStore.undoCommit(commit)
 
     this.statsStore.recordCommitUndone(isWorkingDirectoryClean)

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -158,6 +158,7 @@ export class CommitDragElement extends React.Component<
             commit={commit}
             selectedCommits={selectedCommits}
             emoji={emoji}
+            canBeUndone={false}
             isLocal={false}
             showUnpushedIndicator={false}
           />

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -252,7 +252,7 @@ export class CommitListItem extends React.PureComponent<
 
     if (this.props.canBeUndone) {
       items.push({
-        label: __DARWIN__ ? 'Undo Commit' : 'Undo commit',
+        label: __DARWIN__ ? 'Undo Commit…' : 'Undo commit…',
         action: () => {
           if (this.props.onUndoCommit) {
             this.props.onUndoCommit(this.props.commit)

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -26,6 +26,8 @@ interface ICommitProps {
   readonly selectedCommits: ReadonlyArray<Commit>
   readonly emoji: Map<string, string>
   readonly isLocal: boolean
+  readonly canBeUndone: boolean
+  readonly onUndoCommit?: (commit: Commit) => void
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
   readonly onCreateBranch?: (commit: CommitOneLine) => void
@@ -246,19 +248,31 @@ export class CommitListItem extends React.PureComponent<
       viewOnGitHubLabel = 'View on GitHub Enterprise'
     }
 
-    const items: IMenuItem[] = [
-      {
-        label: __DARWIN__
-          ? 'Revert Changes in Commit'
-          : 'Revert changes in commit',
+    const items: IMenuItem[] = []
+
+    if (this.props.canBeUndone) {
+      items.push({
+        label: __DARWIN__ ? 'Undo Commit' : 'Undo commit',
         action: () => {
-          if (this.props.onRevertCommit) {
-            this.props.onRevertCommit(this.props.commit)
+          if (this.props.onUndoCommit) {
+            this.props.onUndoCommit(this.props.commit)
           }
         },
-        enabled: this.props.onRevertCommit !== undefined,
+        enabled: this.props.onUndoCommit !== undefined,
+      })
+    }
+
+    items.push({
+      label: __DARWIN__
+        ? 'Revert Changes in Commit'
+        : 'Revert changes in commit',
+      action: () => {
+        if (this.props.onRevertCommit) {
+          this.props.onRevertCommit(this.props.commit)
+        }
       },
-    ]
+      enabled: this.props.onRevertCommit !== undefined,
+    })
 
     if (enableBranchFromCommit()) {
       items.push({

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -24,6 +24,9 @@ interface ICommitListProps {
   /** The SHAs of the selected commits */
   readonly selectedSHAs: ReadonlyArray<string>
 
+  /** Whether or not commits in this list can be undone. */
+  readonly canUndoCommits: boolean
+
   /** The emoji lookup to render images inline */
   readonly emoji: Map<string, string>
 
@@ -38,6 +41,9 @@ interface ICommitListProps {
 
   /** Callback that fires when a scroll event has occurred */
   readonly onScroll: (start: number, end: number) => void
+
+  /** Callback to fire to undo a given commit in the current repository */
+  readonly onUndoCommit: ((commit: Commit) => void) | undefined
 
   /** Callback to fire to revert a given commit in the current repository */
   readonly onRevertCommit: ((commit: Commit) => void) | undefined
@@ -148,6 +154,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         key={commit.sha}
         gitHubRepository={this.props.gitHubRepository}
         isLocal={isLocal}
+        canBeUndone={this.props.canUndoCommits && isLocal && row === 0}
         showUnpushedIndicator={showUnpushedIndicator}
         unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
           isLocal,
@@ -161,6 +168,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onDeleteTag={this.props.onDeleteTag}
         onCherryPick={this.props.onCherryPick}
         onSquash={this.onSquash}
+        onUndoCommit={this.props.onUndoCommit}
         onRevertCommit={this.props.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -40,7 +40,6 @@ interface ICompareSidebarProps {
   readonly dispatcher: Dispatcher
   readonly currentBranch: Branch | null
   readonly selectedCommitShas: ReadonlyArray<string>
-  readonly onUndoCommit: (commit: Commit) => void
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
@@ -233,7 +232,7 @@ export class CompareSidebar extends React.Component<
         canUndoCommits={formState.kind === HistoryTabMode.History}
         emoji={this.props.emoji}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
-        onUndoCommit={this.props.onUndoCommit}
+        onUndoCommit={this.onUndoCommit}
         onRevertCommit={
           ableToRevertCommit(this.props.compareState.formState)
             ? this.props.onRevertCommit
@@ -541,6 +540,10 @@ export class CompareSidebar extends React.Component<
       targetCommitSha,
       this.props.localTags
     )
+  }
+
+  private onUndoCommit = (commit: Commit) => {
+    this.props.dispatcher.undoCommit(this.props.repository, commit)
   }
 
   private onCreateBranch = (commit: CommitOneLine) => {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -40,6 +40,7 @@ interface ICompareSidebarProps {
   readonly dispatcher: Dispatcher
   readonly currentBranch: Branch | null
   readonly selectedCommitShas: ReadonlyArray<string>
+  readonly onUndoCommit: (commit: Commit) => void
   readonly onRevertCommit: (commit: Commit) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
@@ -229,8 +230,10 @@ export class CompareSidebar extends React.Component<
         commitSHAs={commitSHAs}
         selectedSHAs={this.props.selectedCommitShas}
         localCommitSHAs={this.props.localCommitSHAs}
+        canUndoCommits={formState.kind === HistoryTabMode.History}
         emoji={this.props.emoji}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+        onUndoCommit={this.props.onUndoCommit}
         onRevertCommit={
           ableToRevertCommit(this.props.compareState.formState)
             ? this.props.onRevertCommit

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -248,6 +248,7 @@ export class ConfigureGitUser extends React.Component<
           commit={dummyCommit}
           emoji={emoji}
           gitHubRepository={null}
+          canBeUndone={false}
           isLocal={false}
           showUnpushedIndicator={false}
           selectedCommits={[dummyCommit]}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -251,7 +251,6 @@ export class RepositoryView extends React.Component<
         localCommitSHAs={this.props.state.localCommitSHAs}
         localTags={this.props.state.localTags}
         dispatcher={this.props.dispatcher}
-        onUndoCommit={this.onUndoCommit}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onCompareListScrolled={this.onCompareListScrolled}
@@ -489,10 +488,6 @@ export class RepositoryView extends React.Component<
         {this.maybeRenderTutorialPanel()}
       </UiView>
     )
-  }
-
-  private onUndoCommit = (commit: Commit) => {
-    this.props.dispatcher.undoCommit(this.props.repository, commit)
   }
 
   private onRevertCommit = (commit: Commit) => {

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -251,6 +251,7 @@ export class RepositoryView extends React.Component<
         localCommitSHAs={this.props.state.localCommitSHAs}
         localTags={this.props.state.localTags}
         dispatcher={this.props.dispatcher}
+        onUndoCommit={this.onUndoCommit}
         onRevertCommit={this.onRevertCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onCompareListScrolled={this.onCompareListScrolled}
@@ -488,6 +489,10 @@ export class RepositoryView extends React.Component<
         {this.maybeRenderTutorialPanel()}
       </UiView>
     )
+  }
+
+  private onUndoCommit = (commit: Commit) => {
+    this.props.dispatcher.undoCommit(this.props.repository, commit)
   }
 
   private onRevertCommit = (commit: Commit) => {


### PR DESCRIPTION
## Description

Depends on #12341 

Adds an `Undo Commit` in the context menu of the commit list, for individual commits.

### Screenshots

https://user-images.githubusercontent.com/1083228/120476668-230fe400-c3ab-11eb-8e00-f8db8f3124d5.mov

## Release notes

Notes: [Improved] Allow to undo the latest commit from the context menu in the History tab
