### PR TITLE
Allow amending the last commit

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -435,6 +435,9 @@ export interface IRepositoryState {
   /** Is a commit in progress? */
   readonly isCommitting: boolean
 
+  /** Is an amend in progress? */
+  readonly isAmending: boolean
+
   /** The date the repository was last fetched. */
   readonly lastFetched: Date | null
 

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -102,3 +102,8 @@ export function enableBranchFromCommit(): boolean {
 export function enableSquashing(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we allow amending commits? */
+export function enableAmendingCommits(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -14,7 +14,8 @@ import { stageManualConflictResolution } from './stage'
 export async function createCommit(
   repository: Repository,
   message: string,
-  files: ReadonlyArray<WorkingDirectoryFileChange>
+  files: ReadonlyArray<WorkingDirectoryFileChange>,
+  amend: boolean = false
 ): Promise<string> {
   // Clear the staging area, our diffs reflect the difference between the
   // working directory and the last commit (if any) so our commits should
@@ -23,8 +24,14 @@ export async function createCommit(
 
   await stageFiles(repository, files)
 
+  const args = ['-F', '-']
+
+  if (amend) {
+    args.push('--amend')
+  }
+
   const result = await git(
-    ['commit', '-F', '-'],
+    ['commit', ...args],
     repository.path,
     'createCommit',
     {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3166,8 +3166,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: Branch,
     explicitStrategy?: UncommittedChangesStrategy
   ): Promise<Repository> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     const repositoryState = this.repositoryStateCache.get(repository)
     const { changesState, branchesState } = repositoryState
     const { currentBranchProtected, stashEntry } = changesState
@@ -3522,8 +3520,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     includeUpstream?: boolean,
     toCheckout?: Branch | null
   ): Promise<void> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     return this.withAuthenticatingUser(repository, async (r, account) => {
       const gitStore = this.gitStoreCache.get(r)
 
@@ -3655,8 +3651,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     account: IGitAccount | null,
     options?: PushOptions
   ): Promise<void> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     const state = this.repositoryStateCache.get(repository)
     const { remote } = state
     if (remote === null) {
@@ -3892,8 +3886,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     account: IGitAccount | null
   ): Promise<void> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     return this.withPushPullFetch(repository, async () => {
       const gitStore = this.gitStoreCache.get(repository)
       const remote = gitStore.currentRemote
@@ -4151,21 +4143,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
-  private async stopAmendingRepositoryIfNeeded(repository: Repository) {
-    const repositoryState = await this.repositoryStateCache.get(repository)
-
-    if (repositoryState.isAmending) {
-      this._setAmendingRepository(repository, false)
-    }
-  }
-
   public async _undoCommit(
     repository: Repository,
     commit: Commit,
     showConfirmationDialog: boolean
   ): Promise<void> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     const gitStore = this.gitStoreCache.get(repository)
     const repositoryState = this.repositoryStateCache.get(repository)
     const { changesState } = repositoryState
@@ -4425,8 +4407,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: string,
     mergeStatus: MergeTreeResult | null
   ): Promise<void> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     const gitStore = this.gitStoreCache.get(repository)
 
     if (mergeStatus !== null) {
@@ -4553,8 +4533,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     baseBranch: Branch,
     targetBranch: Branch
   ): Promise<RebaseResult> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     const progressCallback = (progress: IMultiCommitOperationProgress) => {
       this.repositoryStateCache.updateRebaseState(repository, () => ({
         progress,
@@ -5243,8 +5221,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     commit: Commit
   ): Promise<void> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     return this.withAuthenticatingUser(repository, async (repo, account) => {
       const gitStore = this.gitStoreCache.get(repo)
 
@@ -6034,8 +6010,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ): Promise<CherryPickResult> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     if (commits.length === 0) {
       log.error('[_cherryPick] - Unable to cherry-pick. No commits provided.')
       return CherryPickResult.UnableToStart
@@ -6396,8 +6370,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     lastRetainedCommitRef: string | null,
     commitContext: ICommitContext
   ): Promise<RebaseResult> {
-    await this.stopAmendingRepositoryIfNeeded(repository)
-
     if (toSquash.length === 0) {
       log.error('[_squash] - Unable to squash. No commits provided.')
       return RebaseResult.Error

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -3166,6 +3166,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: Branch,
     explicitStrategy?: UncommittedChangesStrategy
   ): Promise<Repository> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     const repositoryState = this.repositoryStateCache.get(repository)
     const { changesState, branchesState } = repositoryState
     const { currentBranchProtected, stashEntry } = changesState
@@ -3520,6 +3522,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     includeUpstream?: boolean,
     toCheckout?: Branch | null
   ): Promise<void> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     return this.withAuthenticatingUser(repository, async (r, account) => {
       const gitStore = this.gitStoreCache.get(r)
 
@@ -3651,6 +3655,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     account: IGitAccount | null,
     options?: PushOptions
   ): Promise<void> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     const state = this.repositoryStateCache.get(repository)
     const { remote } = state
     if (remote === null) {
@@ -3886,6 +3892,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     account: IGitAccount | null
   ): Promise<void> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     return this.withPushPullFetch(repository, async () => {
       const gitStore = this.gitStoreCache.get(repository)
       const remote = gitStore.currentRemote
@@ -4143,11 +4151,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
   }
 
+  private async stopAmendingRepositoryIfNeeded(repository: Repository) {
+    const repositoryState = await this.repositoryStateCache.get(repository)
+
+    if (repositoryState.isAmending) {
+      this._setAmendingRepository(repository, false)
+    }
+  }
+
   public async _undoCommit(
     repository: Repository,
     commit: Commit,
     showConfirmationDialog: boolean
   ): Promise<void> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     const gitStore = this.gitStoreCache.get(repository)
     const repositoryState = this.repositoryStateCache.get(repository)
     const { changesState } = repositoryState
@@ -4407,6 +4425,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     branch: string,
     mergeStatus: MergeTreeResult | null
   ): Promise<void> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     const gitStore = this.gitStoreCache.get(repository)
 
     if (mergeStatus !== null) {
@@ -4533,6 +4553,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     baseBranch: Branch,
     targetBranch: Branch
   ): Promise<RebaseResult> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     const progressCallback = (progress: IMultiCommitOperationProgress) => {
       this.repositoryStateCache.updateRebaseState(repository, () => ({
         progress,
@@ -5221,6 +5243,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     commit: Commit
   ): Promise<void> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     return this.withAuthenticatingUser(repository, async (repo, account) => {
       const gitStore = this.gitStoreCache.get(repo)
 
@@ -6010,6 +6034,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ): Promise<CherryPickResult> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     if (commits.length === 0) {
       log.error('[_cherryPick] - Unable to cherry-pick. No commits provided.')
       return CherryPickResult.UnableToStart
@@ -6370,6 +6396,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     lastRetainedCommitRef: string | null,
     commitContext: ICommitContext
   ): Promise<RebaseResult> {
+    await this.stopAmendingRepositoryIfNeeded(repository)
+
     if (toSquash.length === 0) {
       log.error('[_squash] - Unable to squash. No commits provided.')
       return RebaseResult.Error

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -228,6 +228,7 @@ function getInitialRepositoryState(): IRepositoryState {
     remote: null,
     isPushPullFetchInProgress: false,
     isCommitting: false,
+    isAmending: false,
     lastFetched: null,
     checkoutProgress: null,
     pushPullFetchProgress: null,

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -13,6 +13,10 @@ export interface ICommitContext {
    */
   readonly description: string | null
   /**
+   * Whether or not it should amend the last commit (optional, default: false)
+   */
+  readonly amend?: boolean
+  /**
    * An optional array of commit trailers (for example Co-Authored-By trailers) which will be appended to the commit message in accordance with the Git trailer configuration.
    */
   readonly trailers?: ReadonlyArray<ITrailer>

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -31,7 +31,7 @@ import { showContextualMenu } from '../main-process-proxy'
 import { arrayEquals } from '../../lib/equality'
 import { clipboard } from 'electron'
 import { basename } from 'path'
-import { ICommitContext } from '../../models/commit'
+import { Commit, ICommitContext } from '../../models/commit'
 import { RebaseConflictState, ConflictState } from '../../lib/app-state'
 import { ContinueRebase } from './continue-rebase'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -100,6 +100,7 @@ interface IChangesListProps {
   readonly repository: Repository
   readonly repositoryAccount: Account | null
   readonly workingDirectory: WorkingDirectoryStatus
+  readonly mostRecentLocalCommit: Commit | null
   /**
    * An object containing the conflicts in the working directory.
    * When null it means that there are no conflicts.
@@ -139,6 +140,7 @@ interface IChangesListProps {
   readonly dispatcher: Dispatcher
   readonly availableWidth: number
   readonly isCommitting: boolean
+  readonly isAmending: boolean
   readonly currentBranchProtected: boolean
 
   /**
@@ -610,6 +612,7 @@ export class ChangesList extends React.Component<
       repositoryAccount,
       dispatcher,
       isCommitting,
+      isAmending,
       currentBranchProtected,
     } = this.props
 
@@ -670,6 +673,7 @@ export class ChangesList extends React.Component<
         focusCommitMessage={this.props.focusCommitMessage}
         autocompletionProviders={this.props.autocompletionProviders}
         isCommitting={isCommitting}
+        commitToAmend={isAmending ? this.props.mostRecentLocalCommit : null}
         showCoAuthoredBy={this.props.showCoAuthoredBy}
         coAuthors={this.props.coAuthors}
         placeholder={this.getPlaceholderMessage(

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -608,8 +608,7 @@ export class CommitMessage extends React.Component<
     if (commitToAmend !== null) {
       return (
         <CommitWarning icon={CommitWarningIcon.Information}>
-          Your changes will modify your{' '}
-          <strong>most recent commit</strong>.{' '}
+          Your changes will modify your <strong>most recent commit</strong>.{' '}
           <LinkButton onClick={this.onStopAmending}>Stop amending</LinkButton>{' '}
           to make these changes as a new commit.
         </CommitWarning>

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -22,10 +22,7 @@ import { IAuthor } from '../../models/author'
 import { IMenuItem } from '../../lib/menu-item'
 import { Commit, ICommitContext } from '../../models/commit'
 import { startTimer } from '../lib/timing'
-import {
-  PermissionsCommitWarning,
-  PermissionsCommitWarningIcon,
-} from './permissions-commit-warning'
+import { CommitWarning, CommitWarningIcon } from './commit-warning'
 import { LinkButton } from '../lib/link-button'
 import { FoldoutType } from '../../lib/app-state'
 import { IAvatarUser, getAvatarUserFromAuthor } from '../../models/avatar'
@@ -610,22 +607,20 @@ export class CommitMessage extends React.Component<
 
     if (commitToAmend !== null) {
       return (
-        <PermissionsCommitWarning
-          icon={PermissionsCommitWarningIcon.Information}
-        >
+        <CommitWarning icon={CommitWarningIcon.Information}>
           Your changes will be applied to your{' '}
           <strong>most recent commit</strong>.{' '}
           <LinkButton onClick={this.onStopAmending}>Stop amending</LinkButton>{' '}
           to go back to normal.
-        </PermissionsCommitWarning>
+        </CommitWarning>
       )
     } else if (showNoWriteAccess) {
       return (
-        <PermissionsCommitWarning icon={PermissionsCommitWarningIcon.Warning}>
+        <CommitWarning icon={CommitWarningIcon.Warning}>
           You don't have write access to <strong>{repository.name}</strong>.
           Want to{' '}
           <LinkButton onClick={this.onMakeFork}>create a fork</LinkButton>?
-        </PermissionsCommitWarning>
+        </CommitWarning>
       )
     } else if (showBranchProtected) {
       if (branch === null) {
@@ -637,11 +632,11 @@ export class CommitMessage extends React.Component<
       }
 
       return (
-        <PermissionsCommitWarning icon={PermissionsCommitWarningIcon.Warning}>
+        <CommitWarning icon={CommitWarningIcon.Warning}>
           <strong>{branch}</strong> is a protected branch. Want to{' '}
           <LinkButton onClick={this.onSwitchBranch}>switch branches</LinkButton>
           ?
-        </PermissionsCommitWarning>
+        </CommitWarning>
       )
     } else {
       return null

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -685,31 +685,37 @@ export class CommitMessage extends React.Component<
     const loading = isCommitting === true ? <Loading /> : undefined
 
     const isAmending = this.props.commitToAmend !== null
-    const commitVerb = isAmending
-      ? loading
-        ? 'Amending'
-        : 'Amend'
-      : loading
-      ? 'Committing'
-      : 'Commit'
+
+    const amendVerb = loading ? 'Amending' : 'Amend'
+    const commitVerb = loading ? 'Committing' : 'Commit'
+
+    const amendTitle = `${amendVerb} last commit`
     const commitTitle =
       branchName !== null ? `${commitVerb} to ${branchName}` : commitVerb
-    const defaultContents = isAmending ? (
-      <>{commitVerb} last commit</>
-    ) : branchName !== null ? (
-      <>
-        {commitVerb} to <strong>{branchName}</strong>
-      </>
-    ) : (
-      commitVerb
-    )
+
+    const defaultCommitContents =
+      branchName !== null ? (
+        <>
+          {commitVerb} to <strong>{branchName}</strong>
+        </>
+      ) : (
+        commitVerb
+      )
+
+    const defaultAmendContents = <>{amendVerb} last commit</>
+
+    const defaultContents = isAmending
+      ? defaultAmendContents
+      : defaultCommitContents
 
     const commitButton = commitButtonText ? commitButtonText : defaultContents
 
     return (
       <>
         {loading}
-        <span title={commitTitle}>{commitButton}</span>
+        <span title={isAmending ? amendTitle : commitTitle}>
+          {commitButton}
+        </span>
       </>
     )
   }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -608,10 +608,10 @@ export class CommitMessage extends React.Component<
     if (commitToAmend !== null) {
       return (
         <CommitWarning icon={CommitWarningIcon.Information}>
-          Your changes will be applied to your{' '}
+          Your changes will modify your{' '}
           <strong>most recent commit</strong>.{' '}
           <LinkButton onClick={this.onStopAmending}>Stop amending</LinkButton>{' '}
-          to go back to normal.
+          to make these changes as a new commit.
         </CommitWarning>
       )
     } else if (showNoWriteAccess) {

--- a/app/src/ui/changes/commit-warning.tsx
+++ b/app/src/ui/changes/commit-warning.tsx
@@ -2,21 +2,21 @@ import * as React from 'react'
 import { assertNever } from '../../lib/fatal-error'
 import { Octicon, OcticonSymbol } from '../octicons'
 
-export enum PermissionsCommitWarningIcon {
+export enum CommitWarningIcon {
   Warning,
   Information,
 }
 
-const renderIcon = (icon: PermissionsCommitWarningIcon) => {
+const renderIcon = (icon: CommitWarningIcon) => {
   let className = ''
   let symbol = OcticonSymbol.alert
 
   switch (icon) {
-    case PermissionsCommitWarningIcon.Warning:
+    case CommitWarningIcon.Warning:
       className = 'warning-icon'
       symbol = OcticonSymbol.alert
       break
-    case PermissionsCommitWarningIcon.Information:
+    case CommitWarningIcon.Information:
       className = 'information-icon'
       symbol = OcticonSymbol.info
       break
@@ -29,11 +29,11 @@ const renderIcon = (icon: PermissionsCommitWarningIcon) => {
 
 /** A warning displayed above the commit button
  */
-export const PermissionsCommitWarning: React.FunctionComponent<{
-  readonly icon: PermissionsCommitWarningIcon
+export const CommitWarning: React.FunctionComponent<{
+  readonly icon: CommitWarningIcon
 }> = props => {
   return (
-    <div id="permissions-commit-warning" onContextMenu={ignoreContextMenu}>
+    <div id="commit-warning" onContextMenu={ignoreContextMenu}>
       <div className="warning-icon-container">{renderIcon(props.icon)}</div>
       <div className="warning-message">{props.children}</div>
     </div>

--- a/app/src/ui/changes/permissions-commit-warning.tsx
+++ b/app/src/ui/changes/permissions-commit-warning.tsx
@@ -1,14 +1,40 @@
 import * as React from 'react'
+import { assertNever } from '../../lib/fatal-error'
 import { Octicon, OcticonSymbol } from '../octicons'
+
+export enum PermissionsCommitWarningIcon {
+  Warning,
+  Information,
+}
+
+const renderIcon = (icon: PermissionsCommitWarningIcon) => {
+  let className = ''
+  let symbol = OcticonSymbol.alert
+
+  switch (icon) {
+    case PermissionsCommitWarningIcon.Warning:
+      className = 'warning-icon'
+      symbol = OcticonSymbol.alert
+      break
+    case PermissionsCommitWarningIcon.Information:
+      className = 'information-icon'
+      symbol = OcticonSymbol.info
+      break
+    default:
+      assertNever(icon, `Unexpected icon value ${icon}`)
+  }
+
+  return <Octicon className={className} symbol={symbol} />
+}
 
 /** A warning displayed above the commit button
  */
-export const PermissionsCommitWarning: React.FunctionComponent = props => {
+export const PermissionsCommitWarning: React.FunctionComponent<{
+  readonly icon: PermissionsCommitWarningIcon
+}> = props => {
   return (
     <div id="permissions-commit-warning" onContextMenu={ignoreContextMenu}>
-      <div className="warning-icon-container">
-        <Octicon className="warning-icon" symbol={OcticonSymbol.alert} />
-      </div>
+      <div className="warning-icon-container">{renderIcon(props.icon)}</div>
       <div className="warning-message">{props.children}</div>
     </div>
   )

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -49,6 +49,7 @@ interface IChangesSidebarProps {
   readonly issuesStore: IssuesStore
   readonly availableWidth: number
   readonly isCommitting: boolean
+  readonly isAmending: boolean
   readonly isPushPullFetchInProgress: boolean
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
@@ -299,7 +300,8 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
 
     // We don't allow undoing commits that have tags associated to them, since then
     // the commit won't be completely deleted because the tag will still point to it.
-    if (commit && commit.tags.length === 0) {
+    // Also, don't allow undoing commits while the user is amending the last one.
+    if (commit && commit.tags.length === 0 && !this.props.isAmending) {
       child = (
         <CSSTransition
           classNames="undo"
@@ -366,6 +368,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           repositoryAccount={repositoryAccount}
           workingDirectory={workingDirectory}
           conflictState={conflictState}
+          mostRecentLocalCommit={this.props.mostRecentLocalCommit}
           rebaseConflictState={rebaseConflictState}
           selectedFileIDs={selectedFileIDs}
           onFileSelectionChanged={this.onFileSelectionChanged}
@@ -387,6 +390,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           availableWidth={this.props.availableWidth}
           onIgnore={this.onIgnore}
           isCommitting={this.props.isCommitting}
+          isAmending={this.props.isAmending}
           showCoAuthoredBy={showCoAuthoredBy}
           coAuthors={coAuthors}
           externalEditorLabel={this.props.externalEditorLabel}

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -94,6 +94,7 @@ export class CommitMessageDialog extends React.Component<
             branch={this.props.branch}
             commitAuthor={this.props.commitAuthor}
             commitButtonText={this.props.dialogButtonText}
+            commitToAmend={null}
             repository={this.props.repository}
             dispatcher={this.props.dispatcher}
             commitMessage={this.props.commitMessage}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -761,6 +761,16 @@ export class Dispatcher {
     )
   }
 
+  /** Switch between amending the most recent commit and not. */
+  public async setAmendingRepository(
+    repository: Repository,
+    amending: boolean
+  ) {
+    await this.changeRepositorySection(repository, RepositorySectionTab.Changes)
+
+    this.appStore._setAmendingRepository(repository, amending)
+  }
+
   /** Undo the given commit. */
   public undoCommit(
     repository: Repository,

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -159,6 +159,7 @@ export class CommitDragElement extends React.Component<
             selectedCommits={selectedCommits}
             emoji={emoji}
             canBeUndone={false}
+            canBeAmended={false}
             isLocal={false}
             showUnpushedIndicator={false}
           />

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -27,12 +27,14 @@ interface ICommitProps {
   readonly emoji: Map<string, string>
   readonly isLocal: boolean
   readonly canBeUndone: boolean
+  readonly canBeAmended: boolean
   readonly onUndoCommit?: (commit: Commit) => void
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
   readonly onCreateBranch?: (commit: CommitOneLine) => void
   readonly onCreateTag?: (targetCommitSha: string) => void
   readonly onDeleteTag?: (tagName: string) => void
+  readonly onAmendCommit?: () => void
   readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
   readonly onRenderCommitDragElement?: (commit: Commit) => void
   readonly onRemoveDragElement?: () => void
@@ -196,6 +198,12 @@ export class CommitListItem extends React.PureComponent<
     )
   }
 
+  private onAmendCommit = () => {
+    if (this.props.onAmendCommit !== undefined) {
+      this.props.onAmendCommit()
+    }
+  }
+
   private onCopySHA = () => {
     clipboard.writeText(this.props.commit.sha)
   }
@@ -249,6 +257,14 @@ export class CommitListItem extends React.PureComponent<
     }
 
     const items: IMenuItem[] = []
+
+    if (this.props.canBeAmended) {
+      items.push({
+        label: __DARWIN__ ? 'Amend Commit…' : 'Amend commit…',
+        enabled: this.props.isLocal,
+        action: this.onAmendCommit,
+      })
+    }
 
     if (this.props.canBeUndone) {
       items.push({

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -12,7 +12,11 @@ import { AvatarStack } from '../lib/avatar-stack'
 import { IMenuItem } from '../../lib/menu-item'
 import { Octicon, OcticonSymbol } from '../octicons'
 import { Draggable } from '../lib/draggable'
-import { enableBranchFromCommit, enableSquashing } from '../../lib/feature-flag'
+import {
+  enableAmendingCommits,
+  enableBranchFromCommit,
+  enableSquashing,
+} from '../../lib/feature-flag'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import {
   DragType,
@@ -258,7 +262,7 @@ export class CommitListItem extends React.PureComponent<
 
     const items: IMenuItem[] = []
 
-    if (this.props.canBeAmended) {
+    if (this.props.canBeAmended && enableAmendingCommits()) {
       items.push({
         label: __DARWIN__ ? 'Amend Commit…' : 'Amend commit…',
         enabled: this.props.isLocal,

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -27,6 +27,9 @@ interface ICommitListProps {
   /** Whether or not commits in this list can be undone. */
   readonly canUndoCommits: boolean
 
+  /** Whether or not commits in this list can be amended. */
+  readonly canAmendCommits: boolean
+
   /** The emoji lookup to render images inline */
   readonly emoji: Map<string, string>
 
@@ -47,6 +50,8 @@ interface ICommitListProps {
 
   /** Callback to fire to revert a given commit in the current repository */
   readonly onRevertCommit: ((commit: Commit) => void) | undefined
+
+  readonly onAmendCommit?: () => void
 
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
@@ -155,6 +160,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         gitHubRepository={this.props.gitHubRepository}
         isLocal={isLocal}
         canBeUndone={this.props.canUndoCommits && isLocal && row === 0}
+        canBeAmended={this.props.canAmendCommits && isLocal && row === 0}
         showUnpushedIndicator={showUnpushedIndicator}
         unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
           isLocal,
@@ -170,6 +176,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onSquash={this.onSquash}
         onUndoCommit={this.props.onUndoCommit}
         onRevertCommit={this.props.onRevertCommit}
+        onAmendCommit={this.props.onAmendCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
         isCherryPickInProgress={this.props.isCherryPickInProgress}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -42,6 +42,7 @@ interface ICompareSidebarProps {
   readonly selectedCommitShas: ReadonlyArray<string>
   readonly onUndoCommit: (commit: Commit) => void
   readonly onRevertCommit: (commit: Commit) => void
+  readonly onAmendCommit: () => void
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
   readonly onCherryPick: (
@@ -231,6 +232,7 @@ export class CompareSidebar extends React.Component<
         selectedSHAs={this.props.selectedCommitShas}
         localCommitSHAs={this.props.localCommitSHAs}
         canUndoCommits={formState.kind === HistoryTabMode.History}
+        canAmendCommits={formState.kind === HistoryTabMode.History}
         emoji={this.props.emoji}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onUndoCommit={this.props.onUndoCommit}
@@ -239,6 +241,7 @@ export class CompareSidebar extends React.Component<
             ? this.props.onRevertCommit
             : undefined
         }
+        onAmendCommit={this.props.onAmendCommit}
         onCommitsSelected={this.onCommitsSelected}
         onScroll={this.onScroll}
         onCreateBranch={this.onCreateBranch}

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -249,6 +249,7 @@ export class ConfigureGitUser extends React.Component<
           emoji={emoji}
           gitHubRepository={null}
           canBeUndone={false}
+          canBeAmended={false}
           isLocal={false}
           showUnpushedIndicator={false}
           selectedCommits={[dummyCommit]}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -211,6 +211,7 @@ export class RepositoryView extends React.Component<
         availableWidth={availableWidth}
         gitHubUserStore={this.props.gitHubUserStore}
         isCommitting={this.props.state.isCommitting}
+        isAmending={this.props.state.isAmending}
         isPushPullFetchInProgress={this.props.state.isPushPullFetchInProgress}
         focusCommitMessage={this.props.focusCommitMessage}
         askForConfirmationOnDiscardChanges={

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -253,6 +253,7 @@ export class RepositoryView extends React.Component<
         dispatcher={this.props.dispatcher}
         onUndoCommit={this.onUndoCommit}
         onRevertCommit={this.onRevertCommit}
+        onAmendCommit={this.onAmendCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onCompareListScrolled={this.onCompareListScrolled}
         onCherryPick={this.props.onCherryPick}
@@ -497,6 +498,10 @@ export class RepositoryView extends React.Component<
 
   private onRevertCommit = (commit: Commit) => {
     this.props.dispatcher.revertCommit(this.props.repository, commit)
+  }
+
+  private onAmendCommit = () => {
+    this.props.dispatcher.setAmendingRepository(this.props.repository, true)
   }
 
   public componentDidMount() {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -418,6 +418,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   /** Dialog */
   --dialog-warning-color: #{$yellow-600};
+  --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red};
 
   /** Inline paths and code */

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -324,6 +324,7 @@ body.theme-dark {
 
   /** Dialog */
   --dialog-warning-color: #{$yellow-600};
+  --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red-600};
 
   /** Inline paths and code */

--- a/app/styles/ui/_changes.scss
+++ b/app/styles/ui/_changes.scss
@@ -5,4 +5,4 @@
 @import 'changes/changes-view';
 @import 'changes/no-changes';
 @import 'changes/oversized-files-warning';
-@import 'changes/permissions-commit-warning';
+@import 'changes/commit-warning';

--- a/app/styles/ui/changes/_commit-warning.scss
+++ b/app/styles/ui/changes/_commit-warning.scss
@@ -1,6 +1,6 @@
 @import '../../mixins';
 
-#permissions-commit-warning {
+#commit-warning {
   border-top: 1px solid var(--box-border-color);
   flex-direction: column;
   flex-shrink: 0;

--- a/app/styles/ui/changes/_permissions-commit-warning.scss
+++ b/app/styles/ui/changes/_permissions-commit-warning.scss
@@ -26,8 +26,13 @@
     position: relative;
     text-align: center;
 
-    .warning-icon {
+    .warning-icon,
+    .information-icon {
       color: var(--dialog-warning-color);
+
+      &.information-icon {
+        color: var(--dialog-information-color);
+      }
 
       background: var(--box-alt-background-color);
       border-width: 0 var(--spacing-half);


### PR DESCRIPTION
Closes #1644 

## Description

This PR introduces the ability to amend the last commit in your branch (if it's not pushed) by right-clicking it in the `History` tab and selecting the new `Amend Commit…` action.

This will switch Desktop to a "amending" state, where all selected changes and the new summary and description will be applied to the last commit.

### Screenshots

https://user-images.githubusercontent.com/1083228/120630029-b2c69880-c466-11eb-9c48-dafc769459d0.mov

## Release notes

Notes: [New] Amend the last local commit in your branch
