### PR TITLE
Fix Coauthor Regression

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -242,7 +242,11 @@ export class CommitMessage extends React.Component<
       return []
     }
 
-    return this.state.coAuthors.map(a => ({
+    const coAuthors = this.props.persistCoAuthors
+      ? this.props.coAuthors
+      : this.state.coAuthors
+
+    return coAuthors.map(a => ({
       token: 'Co-Authored-By',
       value: `${a.name} <${a.email}>`,
     }))

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -242,6 +242,12 @@ export class CommitMessage extends React.Component<
       return []
     }
 
+    /**
+     * When we persist coauthors in the app's changes state or outside this
+     * component, they will be sent in via the props. When we do not want to
+     * persist (like when used in modal), we will be storing and using from the
+     * component's state.
+     */
     const coAuthors = this.props.persistCoAuthors
       ? this.props.coAuthors
       : this.state.coAuthors


### PR DESCRIPTION
## Description

This fixes the coauthor trailer not being added consistently when coauthor added to a commit. 

Thanks again @cheshire137 for being an awesome desktop user and pointing this beta regression out! 🙇 

### Screenshots
This screenshot shows that the coauthor applies as expected and doesn't apply when removed (no weird state persisting/non persisting issues) as well as shows that coauthors used in squashing modal do not persist to main commit area (the reason the modification that introduced the bug was put in place)

https://user-images.githubusercontent.com/75402236/120655082-49d42600-c450-11eb-88d5-be6f70c32970.mov

## Release notes
Notes: [Fixed] Coauthor trailer was not added when coauthor added to a commit (beta bug only). 
