### PR TITLE
Fix coauthor styling in commit message dialog

### DIFF
--- a/app/src/ui/lib/author-input.tsx
+++ b/app/src/ui/lib/author-input.tsx
@@ -722,6 +722,7 @@ export class AuthorInput extends React.Component<IAuthorInputProps, {}> {
         closeOnUnfocus: true,
         closeCharacters: /\s/,
         hint: this.onAutocompleteUser,
+        container: host,
       },
     }
 

--- a/app/styles/ui/_autocompletion.scss
+++ b/app/styles/ui/_autocompletion.scss
@@ -172,3 +172,14 @@
     }
   }
 }
+
+.author-input-component {
+  ul.CodeMirror-hints {
+    margin-top: var(--spacing-double);
+    padding: 0;
+    li {
+      margin-bottom: auto;
+      padding-left: var(--spacing);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Noticed the auto complete for coauthors in the dialog was not showing up right:
![Screen Shot 2021-06-03 at 11 06 42 AM](https://user-images.githubusercontent.com/75402236/120668780-ca991f00-c45c-11eb-8d59-9073bafa5069.png)

As you might gather, this PR fixes it.

### Screenshots
Screenshot shows in dialog and shows in regular commit area to show no regression.

https://user-images.githubusercontent.com/75402236/120668900-ee5c6500-c45c-11eb-9f12-7cca0f3b0790.mov

## Release notes
Notes: no-notes
