### PR TITLE
Initial drag&drop support to insert items into a list

### DIFF
--- a/app/src/models/drag-drop.ts
+++ b/app/src/models/drag-drop.ts
@@ -29,12 +29,14 @@ export type DragElement = {
 export enum DropTargetType {
   Branch,
   Commit,
+  ListInsertionPoint,
 }
 
 export enum DropTargetSelector {
   Branch = '.branches-list-item',
   PullRequest = '.pull-request-item',
   Commit = '.commit',
+  ListInsertionPoint = '.list-insertion-point',
 }
 
 export type BranchTarget = {
@@ -46,8 +48,14 @@ export type CommitTarget = {
   type: DropTargetType.Commit
 }
 
+export type ListInsertionPointTarget = {
+  type: DropTargetType.ListInsertionPoint
+  data: DragData
+  index: number
+}
+
 /**
  * This is a type is used in conjunction with the drag and drop manager to
  * pass information about a drop target.
  */
-export type DropTarget = BranchTarget | CommitTarget
+export type DropTarget = BranchTarget | CommitTarget | ListInsertionPointTarget

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { assertNever } from '../../lib/fatal-error'
 import { Commit } from '../../models/commit'
-import { DropTarget, DropTargetType } from '../../models/drag-drop'
+import { DragType, DropTarget, DropTargetType } from '../../models/drag-drop'
 import { GitHubRepository } from '../../models/github-repository'
 import { CommitListItem } from '../history/commit-list-item'
 import { Octicon, OcticonSymbol } from '../octicons'
@@ -94,6 +94,24 @@ export class CommitDragElement extends React.Component<
           </>
         )
         break
+      case DropTargetType.ListInsertionPoint:
+        if (currentDropTarget.data.type !== DragType.Commit) {
+          toolTipContents = (
+            <>
+              <span>'Insert here'</span>
+            </>
+          )
+          break
+        }
+
+        const pluralized =
+          currentDropTarget.data.commits.length === 1 ? 'commit' : 'commits'
+        toolTipContents = (
+          <>
+            <span>{`Move ${pluralized} here`}</span>
+          </>
+        )
+        break
       default:
         assertNever(
           currentDropTarget,
@@ -115,6 +133,7 @@ export class CommitDragElement extends React.Component<
         switch (dropTarget.type) {
           case DropTargetType.Branch:
           case DropTargetType.Commit:
+          case DropTargetType.ListInsertionPoint:
             this.setToolTipTimer(1500)
             break
           default:

--- a/app/src/ui/lib/list/list-item-insertion-overlay.tsx
+++ b/app/src/ui/lib/list/list-item-insertion-overlay.tsx
@@ -1,0 +1,141 @@
+import classNames from 'classnames'
+import * as React from 'react'
+import { dragAndDropManager } from '../../../lib/drag-and-drop-manager'
+import { DragData, DragType, DropTargetType } from '../../../models/drag-drop'
+
+enum InsertionFeedbackType {
+  None,
+  Top,
+  Bottom,
+}
+
+interface IListItemInsertionOverlayProps {
+  readonly onDropDataInsertion?: (
+    insertionIndex: number,
+    data: DragData
+  ) => void
+
+  readonly itemIndex: number
+  readonly dragType: DragType
+}
+
+interface IListItemInsertionOverlayState {
+  readonly feedbackType: InsertionFeedbackType
+}
+
+/** A component which displays a single commit in a commit list. */
+export class ListItemInsertionOverlay extends React.PureComponent<
+  IListItemInsertionOverlayProps,
+  IListItemInsertionOverlayState
+> {
+  public constructor(props: IListItemInsertionOverlayProps) {
+    super(props)
+
+    this.state = {
+      feedbackType: InsertionFeedbackType.None,
+    }
+  }
+
+  public renderInsertionIndicator(feedbackType: InsertionFeedbackType) {
+    const isTop = feedbackType === InsertionFeedbackType.Top
+
+    const classes = classNames('list-item-insertion-indicator', {
+      top: isTop,
+      bottom: !isTop,
+    })
+
+    return (
+      <>
+        <div className={`${classes} darwin-circle`} />
+        <div className={`${classes} darwin-line`} />
+      </>
+    )
+  }
+
+  public render() {
+    return (
+      <div className="list-item-insertion-overlay">
+        <div
+          className="list-insertion-point top"
+          onMouseEnter={this.getOnInsertionAreaMouseEnter(
+            InsertionFeedbackType.Top
+          )}
+          onMouseLeave={this.onInsertionAreaMouseLeave}
+          onMouseUp={this.onInsertionAreaMouseUp}
+        />
+        {this.state.feedbackType === InsertionFeedbackType.Top &&
+          this.renderInsertionIndicator(InsertionFeedbackType.Top)}
+        {this.props.children}
+        {this.state.feedbackType === InsertionFeedbackType.Bottom &&
+          this.renderInsertionIndicator(InsertionFeedbackType.Bottom)}
+        <div
+          className="list-insertion-point bottom"
+          onMouseEnter={this.getOnInsertionAreaMouseEnter(
+            InsertionFeedbackType.Bottom
+          )}
+          onMouseLeave={this.onInsertionAreaMouseLeave}
+          onMouseUp={this.onInsertionAreaMouseUp}
+        />
+      </div>
+    )
+  }
+
+  private isDragInProgress() {
+    return dragAndDropManager.isDragOfTypeInProgress(this.props.dragType)
+  }
+
+  private getOnInsertionAreaMouseEnter(feedbackType: InsertionFeedbackType) {
+    return (event: React.MouseEvent) => {
+      this.switchToInsertionFeedbackType(feedbackType)
+    }
+  }
+
+  private onInsertionAreaMouseLeave = (event: React.MouseEvent) => {
+    this.switchToInsertionFeedbackType(InsertionFeedbackType.None)
+  }
+
+  private switchToInsertionFeedbackType(feedbackType: InsertionFeedbackType) {
+    if (
+      feedbackType !== InsertionFeedbackType.None &&
+      !this.isDragInProgress()
+    ) {
+      return
+    }
+
+    this.setState({ feedbackType })
+
+    if (feedbackType === InsertionFeedbackType.None) {
+      dragAndDropManager.emitLeaveDropTarget()
+    } else if (
+      this.isDragInProgress() &&
+      dragAndDropManager.dragData !== null
+    ) {
+      dragAndDropManager.emitEnterDropTarget({
+        type: DropTargetType.ListInsertionPoint,
+        data: dragAndDropManager.dragData,
+        index: this.props.itemIndex,
+      })
+    }
+  }
+
+  private onInsertionAreaMouseUp = () => {
+    if (
+      !this.isDragInProgress() ||
+      this.state.feedbackType === InsertionFeedbackType.None ||
+      dragAndDropManager.dragData === null
+    ) {
+      return
+    }
+
+    if (this.props.onDropDataInsertion !== undefined) {
+      let index = this.props.itemIndex
+
+      if (this.state.feedbackType === InsertionFeedbackType.Bottom) {
+        index++
+      }
+      this.props.onDropDataInsertion(index, dragAndDropManager.dragData)
+    }
+
+    this.switchToInsertionFeedbackType(InsertionFeedbackType.None)
+  }
+}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -15,6 +15,8 @@ import {
 } from './selection'
 import { createUniqueId, releaseUniqueId } from '../../lib/id-pool'
 import { range } from '../../../lib/range'
+import { ListItemInsertionOverlay } from './list-item-insertion-overlay'
+import { DragData, DragType } from '../../../models/drag-drop'
 
 /**
  * Describe the first argument given to the cellRenderer,
@@ -174,6 +176,15 @@ interface IListProps {
   readonly onRowMouseDown?: (row: number, event: React.MouseEvent<any>) => void
 
   /**
+   * A handler called whenever the user drops items on the list to be inserted.
+   *
+   * @param row - The index of the row where the user intends to insert the new
+   *              items.
+   * @param data -  The data dropped by the user.
+   */
+  readonly onDropDataInsertion?: (row: number, data: DragData) => void
+
+  /**
    * An optional handler called to determine whether a given row is
    * selectable or not. Reasons for why a row might not be selectable
    * includes it being a group header or the item being disabled.
@@ -196,6 +207,9 @@ interface IListProps {
 
   /** Whether or not selection should follow pointer device */
   readonly selectOnHover?: boolean
+
+  /** Type of elements that can be inserted in the list via drag & drop. Optional. */
+  readonly insertionDragType?: DragType
 
   /**
    * Whether or not to explicitly move focus to a row if it was selected
@@ -796,7 +810,20 @@ export class List extends React.Component<IListProps, IListState> {
     // We only need to keep a reference to the focused element
     const ref = focused ? this.onFocusedItemRef : undefined
 
-    const element = this.props.rowRenderer(params.rowIndex)
+    const row = this.props.rowRenderer(rowIndex)
+
+    const element =
+      this.props.insertionDragType !== undefined ? (
+        <ListItemInsertionOverlay
+          onDropDataInsertion={this.props.onDropDataInsertion}
+          itemIndex={rowIndex}
+          dragType={this.props.insertionDragType}
+        >
+          {row}
+        </ListItemInsertionOverlay>
+      ) : (
+        row
+      )
 
     const id = this.state.rowIdPrefix
       ? `${this.state.rowIdPrefix}-${rowIndex}`

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -9,6 +9,7 @@
 @import 'ui/file-list';
 @import 'ui/octicons';
 @import 'ui/list';
+@import 'ui/list-item-insertion-overlay';
 @import 'ui/repository-list';
 @import 'ui/changes';
 @import 'ui/cloning-repository-view';

--- a/app/styles/ui/_list-item-insertion-overlay.scss
+++ b/app/styles/ui/_list-item-insertion-overlay.scss
@@ -1,0 +1,58 @@
+.list-item-insertion-overlay {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.list-insertion-point {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 15px;
+
+  &.top {
+    top: 0;
+  }
+
+  &.bottom {
+    bottom: 0;
+  }
+}
+
+.list-item-insertion-indicator {
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+
+  &.darwin-line {
+    left: 10px;
+    right: 0;
+    height: 2px;
+    background-color: var(--focus-color);
+
+    &.top {
+      top: -1px;
+    }
+    &.bottom {
+      bottom: -1px;
+    }
+  }
+
+  &.darwin-circle {
+    left: 0;
+    width: 10px;
+    height: 10px;
+    border-color: var(--focus-color);
+    border-radius: 50%;
+    border-style: solid;
+    border-width: 2px;
+
+    &.top {
+      top: -5px;
+    }
+    &.bottom {
+      bottom: -5px;
+    }
+  }
+}


### PR DESCRIPTION
Part of #12299 

## Description

This PR adds an overlay used to enable dropping items between rows of a list, which we will leverage in an upcoming PR to reorder commits in the `History` tab. In this PR, however, it's not possible to do so yet.

A few architecture details:

- When a list has this drag&drop "reordering" / "insertion" capability enabled, it will wrap every row with a `ListItemInsertionOverlay` component.
- This new component has:
	- Two drop areas/targets where items can be dropped.
	- Indicators for those two areas to give feedback to the user when they can drop the items.

It still requires some UX love for those indicators on both macOS and specially Windows, but that's for a future PR.

### Screenshots

This video shows the feature but it can't be seen in this branch yet.

https://user-images.githubusercontent.com/1083228/120681432-a9a3ee80-c49b-11eb-93f2-db4b281a3a48.mov

## Release notes

Notes: no-notes
