### PR TITLE
Drag & drop commits inside of the History tab

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -102,3 +102,8 @@ export function enableBranchFromCommit(): boolean {
 export function enableSquashing(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we allow reordering commits? */
+export function enableCommitReordering(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3073,6 +3073,15 @@ export class Dispatcher {
     this.appStore._setLastThankYou(lastThankYou)
   }
 
+  public async reorderCommits(
+    repository: Repository,
+    commitsToReorder: ReadonlyArray<Commit>,
+    beforeCommit: Commit | null,
+    lastRetainedCommitRef: string | null
+  ) {
+    // TODO: Implement!!
+  }
+
   /**
    * Starts a squash
    *

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -130,6 +130,7 @@ export class CommitListItem extends React.PureComponent<
           DropTargetSelector.Branch,
           DropTargetSelector.PullRequest,
           DropTargetSelector.Commit,
+          DropTargetSelector.ListInsertionPoint,
         ]}
       >
         <div

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -8,6 +8,7 @@ import { arrayEquals } from '../../lib/equality'
 import { Popover, PopoverCaretPosition } from '../lib/popover'
 import { Button } from '../lib/button'
 import { encodePathAsUrl } from '../../lib/path'
+import { DragData, DragType } from '../../models/drag-drop'
 
 const RowHeight = 50
 
@@ -57,6 +58,20 @@ interface ICommitListProps {
   /** Callback to fire to delete an unpushed tag */
   readonly onDeleteTag: (tagName: string) => void
 
+  /**
+   * A handler called whenever the user drops commits on the list to be inserted.
+   *
+   * @param baseCommit - The commit before the selected commits will be inserted.
+   *                     This will be null when commits must be inserted at the
+   *                     end of the list.
+   * @param commitsToInsert -  The commits dropped by the user.
+   */
+  readonly onDropCommitInsertion?: (
+    baseCommit: Commit | null,
+    commitsToInsert: ReadonlyArray<Commit>,
+    lastRetainedCommitRef: string | null
+  ) => void
+
   /** Callback to fire to cherry picking the commit  */
   readonly onCherryPick: (commits: ReadonlyArray<CommitOneLine>) => void
 
@@ -81,6 +96,9 @@ interface ICommitListProps {
 
   /* Tags that haven't been pushed yet. This is used to show the unpushed indicator */
   readonly tagsToPush: ReadonlyArray<string> | null
+
+  /** Whether or not commits in this list can be reordered. */
+  readonly reorderingEnabled: boolean
 
   /* Whether or not the user has been introduced to cherry picking feature */
   readonly hasShownCherryPickIntro: boolean
@@ -172,17 +190,25 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     )
   }
 
-  private onSquash = (toSquash: ReadonlyArray<Commit>, squashOnto: Commit) => {
-    const indexes = [...toSquash, squashOnto].map(v =>
-      this.props.commitSHAs.findIndex(sha => sha === v.sha)
-    )
+  private getLastRetainedCommitRef(indexes: ReadonlyArray<number>) {
     const maxIndex = Math.max(...indexes)
     const lastIndex = this.props.commitSHAs.length - 1
     /* If the commit is the first commit in the branch, you cannot reference it
     using the sha */
     const lastRetainedCommitRef =
       maxIndex !== lastIndex ? `${this.props.commitSHAs[maxIndex]}^` : null
-    this.props.onSquash(toSquash, squashOnto, lastRetainedCommitRef)
+    return lastRetainedCommitRef
+  }
+
+  private onSquash = (toSquash: ReadonlyArray<Commit>, squashOnto: Commit) => {
+    const indexes = [...toSquash, squashOnto].map(v =>
+      this.props.commitSHAs.findIndex(sha => sha === v.sha)
+    )
+    this.props.onSquash(
+      toSquash,
+      squashOnto,
+      this.getLastRetainedCommitRef(indexes)
+    )
   }
 
   private onRenderCommitDragElement = (commit: Commit) => {
@@ -314,10 +340,14 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
           rowHeight={RowHeight}
           selectedRows={this.props.selectedSHAs.map(sha => this.rowForSHA(sha))}
           rowRenderer={this.renderCommit}
+          onDropDataInsertion={this.onDropDataInsertion}
           onSelectionChanged={this.onSelectionChanged}
           onSelectedRowChanged={this.onSelectedRowChanged}
           selectionMode="multi"
           onScroll={this.onScroll}
+          insertionDragType={
+            this.props.reorderingEnabled ? DragType.Commit : undefined
+          }
           invalidationProps={{
             commits: this.props.commitSHAs,
             localCommitSHAs: this.props.localCommitSHAs,
@@ -328,6 +358,29 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         />
         {this.renderCherryPickIntroPopover()}
       </div>
+    )
+  }
+
+  private onDropDataInsertion = (row: number, data: DragData) => {
+    if (
+      this.props.onDropCommitInsertion === undefined ||
+      data.type !== DragType.Commit
+    ) {
+      return
+    }
+
+    const baseCommitSHA =
+      row < this.props.commitSHAs.length ? this.props.commitSHAs[row] : null
+    const baseCommit =
+      baseCommitSHA !== null ? this.props.commitLookup.get(baseCommitSHA) : null
+    const indexes = [...data.commits, baseCommit]
+      .filter((v): v is Commit => v !== null && v !== undefined)
+      .map(v => this.props.commitSHAs.findIndex(sha => sha === v.sha))
+
+    this.props.onDropCommitInsertion(
+      baseCommit ?? null,
+      data.commits,
+      this.getLastRetainedCommitRef(indexes)
     )
   }
 }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -30,6 +30,7 @@ import { PopupType } from '../../models/popup'
 import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-authors'
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
+import { enableCommitReordering } from '../../lib/feature-flag'
 interface ICompareSidebarProps {
   readonly repository: Repository
   readonly isLocalRepository: boolean
@@ -230,6 +231,9 @@ export class CompareSidebar extends React.Component<
         selectedSHAs={this.props.selectedCommitShas}
         localCommitSHAs={this.props.localCommitSHAs}
         emoji={this.props.emoji}
+        reorderingEnabled={
+          enableCommitReordering() && formState.kind === HistoryTabMode.History
+        }
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onRevertCommit={
           ableToRevertCommit(this.props.compareState.formState)
@@ -242,6 +246,7 @@ export class CompareSidebar extends React.Component<
         onCreateTag={this.onCreateTag}
         onDeleteTag={this.onDeleteTag}
         onCherryPick={this.onCherryPick}
+        onDropCommitInsertion={this.onDropCommitInsertion}
         onSquash={this.onSquash}
         emptyListMessage={emptyListMessage}
         onCompareListScrolled={this.props.onCompareListScrolled}
@@ -254,6 +259,19 @@ export class CompareSidebar extends React.Component<
         onRemoveCommitDragElement={this.onRemoveCommitDragElement}
         disableSquashing={formState.kind === HistoryTabMode.Compare}
       />
+    )
+  }
+
+  private onDropCommitInsertion = (
+    baseCommit: Commit | null,
+    commitsToInsert: ReadonlyArray<Commit>,
+    lastRetainedCommitRef: string | null
+  ) => {
+    this.props.dispatcher.reorderCommits(
+      this.props.repository,
+      commitsToInsert,
+      baseCommit,
+      lastRetainedCommitRef
     )
   }
 


### PR DESCRIPTION
Part of #12299

(Blocked by #12358)

## Description

This PR wires the work from #12358 with the code needed to reorder commits, leaving a placeholder for the endpoint in the `Dispatcher`.

### Screenshots

https://user-images.githubusercontent.com/1083228/120681432-a9a3ee80-c49b-11eb-93f2-db4b281a3a48.mov

## Release notes

Notes: no-notes
