### PR TITLE
Open in [Editor] will be enabled on bat/cmd/sh/exe extensions

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -507,8 +507,7 @@ export class ChangesList extends React.Component<
         })
       })
 
-    const enabled = isSafeExtension && status.kind !== AppFileStatusKind.Deleted
-
+    const enabled = status.kind !== AppFileStatusKind.Deleted
     items.push(
       { type: 'separator' },
       this.getCopyPathMenuItem(file),
@@ -517,7 +516,7 @@ export class ChangesList extends React.Component<
       {
         label: OpenWithDefaultProgramLabel,
         action: () => this.props.onOpenItem(path),
-        enabled,
+        enabled: enabled && isSafeExtension,
       }
     )
 
@@ -540,7 +539,7 @@ export class ChangesList extends React.Component<
       })
     }
 
-    const enabled = isSafeExtension && status.kind !== AppFileStatusKind.Deleted
+    const enabled = status.kind !== AppFileStatusKind.Deleted
 
     items.push(
       this.getCopyPathMenuItem(file),
@@ -549,7 +548,7 @@ export class ChangesList extends React.Component<
       {
         label: OpenWithDefaultProgramLabel,
         action: () => this.props.onOpenItem(path),
-        enabled,
+        enabled: enabled && isSafeExtension,
       }
     )
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -344,7 +344,7 @@ export class SelectedCommit extends React.Component<
       {
         label: openInExternalEditor,
         action: () => this.props.onOpenInExternalEditor(fullPath),
-        enabled: isSafeExtension && fileExistsOnDisk,
+        enabled: fileExistsOnDisk,
       },
       {
         label: OpenWithDefaultProgramLabel,


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #6361

## Description

- Removed the restriction for bat/cmd/sh/exe for "Open in [editor]", however the "Open in default program" flow is disabled as it will run the file.

### Screenshots
![image](https://user-images.githubusercontent.com/29285479/120933598-7f546a00-c703-11eb-9fd7-274b13eca409.png)

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
