### PR TITLE
Modifying merge conflict detection/handling to support --squash

### DIFF
--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -147,5 +147,18 @@ export async function abortMerge(repository: Repository): Promise<void> {
  */
 export async function isMergeHeadSet(repository: Repository): Promise<boolean> {
   const path = Path.join(repository.path, '.git', 'MERGE_HEAD')
-  return FSE.pathExists(path)
+  return await FSE.pathExists(path)
+}
+
+/**
+ * Check the `.git/SQUASH_MSG` file exists in a repository
+ * This would indicate we did a merge --squash and have not committed.. indicating
+ * we have detected a conflict.
+ *
+ * Note: If we abort the merge, this doesn't get cleared automatically which
+ * could lead to this being erroneously available in a non merge --squashing scenario.
+ */
+export async function isSquashMsgSet(repository: Repository): Promise<boolean> {
+  const path = Path.join(repository.path, '.git', 'SQUASH_MSG')
+  return await FSE.pathExists(path)
 }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -23,7 +23,7 @@ import { DiffSelectionType, DiffSelection } from '../../models/diff'
 import { Repository } from '../../models/repository'
 import { IAheadBehind } from '../../models/branch'
 import { fatalError } from '../../lib/fatal-error'
-import { isMergeHeadSet } from './merge'
+import { isMergeHeadSet, isSquashMsgSet } from './merge'
 import { getBinaryPaths } from './diff'
 import { getRebaseInternalState } from './rebase'
 import { RebaseInternalState } from '../../models/rebase'
@@ -58,6 +58,9 @@ export interface IStatusResult {
 
   /** true if repository is in a conflicted state */
   readonly mergeHeadFound: boolean
+
+  /** true merge --squash operation started */
+  readonly squashMsgFound: boolean
 
   /** details about the rebase operation, if found */
   readonly rebaseInternalState: RebaseInternalState | null
@@ -235,6 +238,8 @@ export async function getStatus(
 
   const isCherryPickingHeadFound = await isCherryPickHeadFound(repository)
 
+  const squashMsgFound = await isSquashMsgSet(repository)
+
   return {
     currentBranch,
     currentTip,
@@ -245,6 +250,7 @@ export async function getStatus(
     rebaseInternalState,
     workingDirectory,
     isCherryPickingHeadFound,
+    squashMsgFound,
   }
 }
 

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -70,6 +70,9 @@ export interface IStatusResult {
 
   /** the absolute path to the repository's working directory */
   readonly workingDirectory: WorkingDirectoryStatus
+
+  /** whether conflicting files present on repository */
+  readonly doConflictedFilesExist: boolean
 }
 
 interface IStatusHeadersData {
@@ -251,6 +254,7 @@ export async function getStatus(
     workingDirectory,
     isCherryPickingHeadFound,
     squashMsgFound,
+    doConflictedFilesExist: conflictedFilesInIndex,
   }
 }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2196,13 +2196,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const possibleTheirsBranches = await getBranchesPointedAt(
+    let possibleTheirsBranches = await getBranchesPointedAt(
       repository,
       'MERGE_HEAD'
     )
     // null means we encountered an error
     if (possibleTheirsBranches === null) {
-      return
+      possibleTheirsBranches = []
+      // return
     }
     const theirBranch =
       possibleTheirsBranches.length === 1

--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -1,7 +1,6 @@
 import {
   WorkingDirectoryStatus,
   WorkingDirectoryFileChange,
-  isConflictedFileStatus,
 } from '../../../models/status'
 import { IStatusResult } from '../../git'
 import {
@@ -121,15 +120,14 @@ export function updateChangedFiles(
  */
 function getConflictState(
   status: IStatusResult,
-  manualResolutions: Map<string, ManualConflictResolution>,
-  files: ReadonlyArray<WorkingDirectoryFileChange>
+  manualResolutions: Map<string, ManualConflictResolution>
 ): ConflictState | null {
   // If there are no conflicts found in working directory, conflict state should
   // be null this is important when checking for a conflict after a --squash
   // merge which will not have a MERGE_HEAD but would have SQUASH_MSG which also
   // can be present when no conflicts. You shouldn't be able to have
   // any form of the other conflicts without conflicted files anyways.
-  if (!files.some(f => isConflictedFileStatus(f.status))) {
+  if (!status.doConflictedFilesExist) {
     return null
   }
 
@@ -281,11 +279,7 @@ export function updateConflictState(
       ? prevConflictState.manualResolutions
       : new Map<string, ManualConflictResolution>()
 
-  const newConflictState = getConflictState(
-    status,
-    manualResolutions,
-    state.workingDirectory.files
-  )
+  const newConflictState = getConflictState(status, manualResolutions)
 
   if (prevConflictState == null && newConflictState == null) {
     return null

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -31,6 +31,7 @@ export function createStatus<K extends keyof IStatusResult>(
   const baseStatus: IStatusResult = {
     exists: true,
     mergeHeadFound: false,
+    squashMsgFound: false,
     rebaseInternalState: null,
     isCherryPickingHeadFound: false,
     workingDirectory: WorkingDirectoryStatus.fromFiles([]),

--- a/app/test/helpers/changes-state-helper.ts
+++ b/app/test/helpers/changes-state-helper.ts
@@ -35,6 +35,7 @@ export function createStatus<K extends keyof IStatusResult>(
     rebaseInternalState: null,
     isCherryPickingHeadFound: false,
     workingDirectory: WorkingDirectoryStatus.fromFiles([]),
+    doConflictedFilesExist: false,
   }
 
   return merge(baseStatus, pick)

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -5,6 +5,14 @@ import {
 } from '../../../helpers/changes-state-helper'
 import { ManualConflictResolution } from '../../../../src/models/manual-conflict-resolution'
 import { IStatsStore } from '../../../../src/lib/stats'
+import {
+  AppFileStatusKind,
+  GitStatusEntry,
+  UnmergedEntrySummary,
+  WorkingDirectoryFileChange,
+  WorkingDirectoryStatus,
+} from '../../../../src/models/status'
+import { DiffSelection, DiffSelectionType } from '../../../../src/models/diff'
 
 describe('updateConflictState', () => {
   let statsStore: IStatsStore
@@ -44,6 +52,7 @@ describe('updateConflictState', () => {
           currentTip: 'old-sha',
           manualResolutions,
         },
+        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         mergeHeadFound: true,
@@ -80,9 +89,10 @@ describe('updateConflictState', () => {
       expect(conflictState).toBeNull()
     })
 
-    it('returns a value when status has MERGE_HEAD set', () => {
+    it('returns a value when status has MERGE_HEAD set and in conflicted state', () => {
       const prevState = createState({
         conflictState: null,
+        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         mergeHeadFound: true,
@@ -108,6 +118,7 @@ describe('updateConflictState', () => {
           currentTip: 'old-sha',
           manualResolutions: new Map<string, ManualConflictResolution>(),
         },
+        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         mergeHeadFound: true,
@@ -178,9 +189,10 @@ describe('updateConflictState', () => {
       expect(conflictState).toBeNull()
     })
 
-    it('returns a value when status has REBASE_HEAD set', () => {
+    it('returns a value when status has REBASE_HEAD set and conflict present', () => {
       const prevState = createState({
         conflictState: null,
+        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         rebaseInternalState: {
@@ -214,6 +226,7 @@ describe('updateConflictState', () => {
           baseBranchTip: 'another-sha',
           originalBranchTip: 'some-other-sha',
         },
+        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         rebaseInternalState: {
@@ -247,6 +260,7 @@ describe('updateConflictState', () => {
           baseBranchTip: 'another-sha',
           originalBranchTip: 'old-sha',
         },
+        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         rebaseInternalState: {
@@ -309,3 +323,23 @@ describe('updateConflictState', () => {
     })
   })
 })
+
+function getWorkingDirectoryWithConflictedFile(): WorkingDirectoryStatus {
+  const files: ReadonlyArray<WorkingDirectoryFileChange> = [
+    new WorkingDirectoryFileChange(
+      'test',
+      {
+        kind: AppFileStatusKind.Conflicted,
+        entry: {
+          kind: 'conflicted',
+          action: UnmergedEntrySummary.BothAdded,
+          us: GitStatusEntry.Added,
+          them: GitStatusEntry.Added,
+        },
+        conflictMarkerCount: 1,
+      },
+      DiffSelection.fromInitialSelection(DiffSelectionType.All)
+    ),
+  ]
+  return WorkingDirectoryStatus.fromFiles(files)
+}

--- a/app/test/unit/stores/updates/update-conflict-state-test.ts
+++ b/app/test/unit/stores/updates/update-conflict-state-test.ts
@@ -5,14 +5,6 @@ import {
 } from '../../../helpers/changes-state-helper'
 import { ManualConflictResolution } from '../../../../src/models/manual-conflict-resolution'
 import { IStatsStore } from '../../../../src/lib/stats'
-import {
-  AppFileStatusKind,
-  GitStatusEntry,
-  UnmergedEntrySummary,
-  WorkingDirectoryFileChange,
-  WorkingDirectoryStatus,
-} from '../../../../src/models/status'
-import { DiffSelection, DiffSelectionType } from '../../../../src/models/diff'
 
 describe('updateConflictState', () => {
   let statsStore: IStatsStore
@@ -52,12 +44,12 @@ describe('updateConflictState', () => {
           currentTip: 'old-sha',
           manualResolutions,
         },
-        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         mergeHeadFound: true,
         currentBranch: 'master',
         currentTip: 'first-sha',
+        doConflictedFilesExist: true,
       })
 
       const conflictState = updateConflictState(prevState, status, statsStore)
@@ -92,12 +84,12 @@ describe('updateConflictState', () => {
     it('returns a value when status has MERGE_HEAD set and in conflicted state', () => {
       const prevState = createState({
         conflictState: null,
-        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         mergeHeadFound: true,
         currentBranch: 'master',
         currentTip: 'first-sha',
+        doConflictedFilesExist: true,
       })
 
       const conflictState = updateConflictState(prevState, status, statsStore)
@@ -118,12 +110,12 @@ describe('updateConflictState', () => {
           currentTip: 'old-sha',
           manualResolutions: new Map<string, ManualConflictResolution>(),
         },
-        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         mergeHeadFound: true,
         currentBranch: 'master',
         currentTip: 'first-sha',
+        doConflictedFilesExist: true,
       })
 
       updateConflictState(prevState, status, statsStore)
@@ -192,7 +184,6 @@ describe('updateConflictState', () => {
     it('returns a value when status has REBASE_HEAD set and conflict present', () => {
       const prevState = createState({
         conflictState: null,
-        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         rebaseInternalState: {
@@ -202,6 +193,7 @@ describe('updateConflictState', () => {
         },
         currentBranch: 'master',
         currentTip: 'first-sha',
+        doConflictedFilesExist: true,
       })
 
       const conflictState = updateConflictState(prevState, status, statsStore)
@@ -226,7 +218,6 @@ describe('updateConflictState', () => {
           baseBranchTip: 'another-sha',
           originalBranchTip: 'some-other-sha',
         },
-        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         rebaseInternalState: {
@@ -236,6 +227,7 @@ describe('updateConflictState', () => {
         },
         currentBranch: 'master',
         currentTip: 'first-sha',
+        doConflictedFilesExist: true,
       })
 
       const conflictState = updateConflictState(prevState, status, statsStore)
@@ -260,7 +252,6 @@ describe('updateConflictState', () => {
           baseBranchTip: 'another-sha',
           originalBranchTip: 'old-sha',
         },
-        workingDirectory: getWorkingDirectoryWithConflictedFile(),
       })
       const status = createStatus({
         rebaseInternalState: {
@@ -269,6 +260,7 @@ describe('updateConflictState', () => {
           baseBranchTip: 'an-even-older-sha',
         },
         currentTip: 'current-sha',
+        doConflictedFilesExist: true,
       })
 
       updateConflictState(prevState, status, statsStore)
@@ -323,23 +315,3 @@ describe('updateConflictState', () => {
     })
   })
 })
-
-function getWorkingDirectoryWithConflictedFile(): WorkingDirectoryStatus {
-  const files: ReadonlyArray<WorkingDirectoryFileChange> = [
-    new WorkingDirectoryFileChange(
-      'test',
-      {
-        kind: AppFileStatusKind.Conflicted,
-        entry: {
-          kind: 'conflicted',
-          action: UnmergedEntrySummary.BothAdded,
-          us: GitStatusEntry.Added,
-          them: GitStatusEntry.Added,
-        },
-        conflictMarkerCount: 1,
-      },
-      DiffSelection.fromInitialSelection(DiffSelectionType.All)
-    ),
-  ]
-  return WorkingDirectoryStatus.fromFiles(files)
-}


### PR DESCRIPTION
## Description

There is a pretty fundamental change to getting the conflict state that is saying that there must be conflicted files or it just returns null. Before, it only checked against there being a merge head, rebase git files, or cherry picking head and it would return a conflict state whether there was conflicts or not (because if those are present it means the operation has stopped which occurs during conflicts). Fairly sure you should have always have conflicted files to have a conflicted state, and was required to add check for it to detect conflict state for merge --squash because if conflicts occur after a merge --squash there is no longer a merge head and only thing available to indicate there was a merge is the SQUASH_MSG file. Thus, I use that to set a Merge conflict state. However, if you were to discard the changes (with desktop or not) that are in conflict, SQUASH_MSG will remain and I so I need to check for conflicted files to actually put it in conflict state.  

TLDR; This change requires regression testing conflicts during merging, rebasing, and cherry-picks and I did not see a change in behavior after adding the additional constraint (which should be true for them) to the logic setting the conflict state.

## Release notes

Notes: no-notes
