### PR TITLE
Wire modal UI entry to squash and merge option

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -103,6 +103,11 @@ export function enableSquashing(): boolean {
   return enableBetaFeatures()
 }
 
+/** Should we allow squash-merging? */
+export function enableSquashMerging(): boolean {
+  return enableBetaFeatures()
+}
+
 /** Should we allow amending commits? */
 export function enableAmendingCommits(): boolean {
   return enableBetaFeatures()

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../dropdown-select-button'
 import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
 import { assertNever } from '../../../lib/fatal-error'
+import { enableSquashMerging } from '../../../lib/feature-flag'
 
 interface IBaseChooseBranchDialogProps {
   readonly dispatcher: Dispatcher
@@ -186,29 +187,32 @@ export abstract class BaseChooseBranchDialog extends React.Component<
   }
 
   private getMergeOptions = (): IDropdownSelectButtonOption[] => {
-    return [
+    const mergeOptions = [
       {
         label: 'Create a merge commit',
         description:
           'The commits from the selected branch will be added to the current branch via a merge commit.',
         value: MultiCommitOperationKind.Merge,
       },
-      /*
-      {
+    ]
+    if (enableSquashMerging()) {
+      mergeOptions.push({
         label: 'Squash and merge',
         description:
           'The commits in the selected branch will be combined into one commit in the current branch.',
         value: MultiCommitOperationKind.Squash,
-      },
-      /* TODO: Add in when refactor rebase to multi commit operation
-      {
+      })
+    }
+
+    /* TODO: Add in when refactor rebase to multi commit operation
+      mergeOptions.push({
         label: 'Rebase and merge',
         description:
           'The commits from the selected branch will be rebased and added to the current branch.',
         value: MultiCommitOperationKind.Rebase,
-      },
+      })
       */
-    ]
+    return mergeOptions
   }
 
   private renderStatusPreview() {

--- a/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/merge-choose-branch-dialog.tsx
@@ -21,15 +21,17 @@ export class MergeChooseBranchDialog extends BaseChooseBranchDialog {
       return
     }
 
-    const branch = this.state.selectedBranch
-    if (!branch) {
+    const { selectedBranch } = this.state
+    const { operation, dispatcher, repository } = this.props
+    if (!selectedBranch) {
       return
     }
 
-    this.props.dispatcher.mergeBranch(
-      this.props.repository,
-      branch.name,
-      this.mergeStatus
+    dispatcher.mergeBranch(
+      repository,
+      selectedBranch.name,
+      this.mergeStatus,
+      operation === MultiCommitOperationKind.Squash
     )
     this.props.onDismissed()
   }


### PR DESCRIPTION
## Description
Wire up UI to modal.

TBD/Later PR: 
- When merge conflict resolves to empty commit, it errors as we don't usually allow empty commits in desktop (except in cherry-picking and regular merge commits)... we could allow empty or do a success banner of "Already up to date". 
- Abort merge currently errors as it is not actually a merge anymore.. later PR will add a check to clear working directory/squash_msg if multi commit state = merge/isSquash.

### Screenshots
https://user-images.githubusercontent.com/75402236/120945330-9d6f9980-c706-11eb-982c-36aac7957657.mov

## Release notes
Notes: Squash merging enabled!
