### PR TITLE
Enable flow to reorder commits

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -471,8 +471,8 @@ export interface IRepositoryState {
   /** State associated with a cherry pick being performed */
   readonly cherryPickState: ICherryPickState
 
-  /** State associated with a squash operation */
-  readonly squashState: ISquashState
+  /** Undo state associated with a multi commit operation operation */
+  readonly multiCommitOperationUndoState: IMultiCommitOperationUndoState
 
   /** State associated with a multi commit operation such as rebase,
    * cherry-pick, squash, reorder... */
@@ -808,21 +808,24 @@ export interface ICherryPickState {
   readonly branchCreated: boolean
 }
 
-/** State associated with a cherry pick being performed on a repository */
-export interface ISquashState {
+/**
+ * Undo state associated with a multi commit operation being performed on a
+ * repository.
+ */
+export interface IMultiCommitOperationUndoState {
   /**
-   * The sha of the tip before squash was initiated.
+   * The sha of the tip before operation was initiated.
    *
-   * This will be set to null if no squash has been initiated.
+   * This will be set to null if no multi commit operation has been initiated.
    */
   readonly undoSha: string | null
 
   /**
-   * The name of the branch the squash operation applied to
+   * The name of the branch the operation applied to
    *
-   * This will be set to null if no squash has been initiated.
+   * This will be set to null if no multi-commit operation has been initiated.
    */
-  readonly squashBranchName: string | null
+  readonly branchName: string | null
 }
 
 /**

--- a/app/src/lib/git/reorder.ts
+++ b/app/src/lib/git/reorder.ts
@@ -86,7 +86,7 @@ export async function reorder(
       // appeared on the log to reduce potential conflicts.
       if (beforeCommit !== null && commit.sha === beforeCommit.sha) {
         foundBaseCommitInLog = true
-        toReplayBeforeBaseCommit.unshift(commit)
+        toReplayAfterReorder.push(commit)
 
         for (let j = 0; j < toReplayBeforeBaseCommit.length; j++) {
           await FSE.appendFile(

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -19,7 +19,7 @@ import {
   IRebaseState,
   ChangesSelectionKind,
   ICherryPickState,
-  ISquashState,
+  IMultiCommitOperationUndoState,
   IMultiCommitOperationState,
 } from '../app-state'
 import { merge } from '../merge'
@@ -133,14 +133,21 @@ export class RepositoryStateCache {
     })
   }
 
-  public updateSquashState<K extends keyof ISquashState>(
+  public updateMultiCommitOperationUndoState<
+    K extends keyof IMultiCommitOperationUndoState
+  >(
     repository: Repository,
-    fn: (state: ISquashState) => Pick<ISquashState, K>
+    fn: (
+      state: IMultiCommitOperationUndoState
+    ) => Pick<IMultiCommitOperationUndoState, K>
   ) {
     this.update(repository, state => {
-      const { squashState } = state
-      const newState = merge(squashState, fn(squashState))
-      return { squashState: newState }
+      const { multiCommitOperationUndoState } = state
+      const newState = merge(
+        multiCommitOperationUndoState,
+        fn(multiCommitOperationUndoState)
+      )
+      return { multiCommitOperationUndoState: newState }
     })
   }
 
@@ -257,9 +264,9 @@ function getInitialRepositoryState(): IRepositoryState {
       targetBranchUndoSha: null,
       branchCreated: false,
     },
-    squashState: {
+    multiCommitOperationUndoState: {
       undoSha: null,
-      squashBranchName: null,
+      branchName: null,
     },
     multiCommitOperationState: null,
   }

--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -10,8 +10,10 @@ export enum BannerType {
   CherryPickConflictsFound = 'CherryPickConflictsFound',
   CherryPickUndone = 'CherryPickUndone',
   SquashUndone = 'SquashUndone',
+  ReorderUndone = 'ReorderUndone',
   OpenThankYouCard = 'OpenThankYouCard',
   SuccessfulSquash = 'SuccessfulSquash',
+  SuccessfulReorder = 'SuccessfulReorder',
   ConflictsFound = 'ConflictsFound',
 }
 
@@ -90,6 +92,18 @@ export type Banner =
   | {
       readonly type: BannerType.SquashUndone
       /** number of commits squashed */
+      readonly commitsCount: number
+    }
+  | {
+      readonly type: BannerType.SuccessfulReorder
+      /** number of commits reordered */
+      readonly count: number
+      /** callback to run when user clicks undo link in banner */
+      readonly onUndo: () => void
+    }
+  | {
+      readonly type: BannerType.ReorderUndone
+      /** number of commits reordered */
       readonly commitsCount: number
     }
   | {

--- a/app/src/models/retry-actions.ts
+++ b/app/src/models/retry-actions.ts
@@ -15,6 +15,7 @@ export enum RetryActionType {
   CherryPick,
   CreateBranchForCherryPick,
   Squash,
+  Reorder,
 }
 
 /** The retriable actions and their associated data. */
@@ -69,4 +70,11 @@ export type RetryAction =
       squashOnto: Commit
       lastRetainedCommitRef: string | null
       commitContext: ICommitContext
+    }
+  | {
+      type: RetryActionType.Reorder
+      repository: Repository
+      commitsToReorder: ReadonlyArray<Commit>
+      beforeCommit: Commit | null
+      lastRetainedCommitRef: string | null
     }

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -119,13 +119,37 @@ export function renderBanner(
           onUndo={banner.onUndo}
         />
       )
-    case BannerType.SquashUndone:
+    case BannerType.SquashUndone: {
       const pluralized = banner.commitsCount === 1 ? 'commit' : 'commits'
       return (
         <SuccessBanner timeout={5000} onDismissed={onDismissed}>
           Squash of {banner.commitsCount} {pluralized} undone.
         </SuccessBanner>
       )
+    }
+    case BannerType.SuccessfulReorder: {
+      const pluralized = banner.count === 1 ? 'commit' : 'commits'
+
+      return (
+        <SuccessBanner
+          timeout={15000}
+          onDismissed={onDismissed}
+          onUndo={banner.onUndo}
+        >
+          <span>
+            Successfully reordered {banner.count} {pluralized}.
+          </span>
+        </SuccessBanner>
+      )
+    }
+    case BannerType.ReorderUndone: {
+      const pluralized = banner.commitsCount === 1 ? 'commit' : 'commits'
+      return (
+        <SuccessBanner timeout={5000} onDismissed={onDismissed}>
+          Reorder of {banner.commitsCount} {pluralized} undone.
+        </SuccessBanner>
+      )
+    }
     case BannerType.ConflictsFound:
       return (
         <ConflictsFoundBanner

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3388,11 +3388,9 @@ export class Dispatcher {
       case MultiCommitOperationKind.Rebase:
       case MultiCommitOperationKind.CherryPick:
       case MultiCommitOperationKind.Merge:
-        throw new Error(
-          `Unexpected multi commit operation kind to undo ${kind}`
-        )
+        throw new Error(`Unexpected multi commit operation kind ${kind}`)
       default:
-        assertNever(kind, `Unsupported multi operation kind to undo ${kind}`)
+        assertNever(kind, `Unsupported multi operation kind ${kind}`)
     }
 
     const banner: Banner = {

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -384,8 +384,21 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       return
     }
 
+    // The base commit index will be in row - 1, because row is the position
+    // where the new item should be inserted, and commits have a reverse order
+    // (newer commits are in lower row values) in the list.
+    const baseCommitIndex = row === 0 ? null : row - 1
+
+    if (
+      this.props.commitSHAs.length === 0 ||
+      (baseCommitIndex !== null &&
+        baseCommitIndex > this.props.commitSHAs.length)
+    ) {
+      return
+    }
+
     const baseCommitSHA =
-      row < this.props.commitSHAs.length ? this.props.commitSHAs[row] : null
+      baseCommitIndex === null ? null : this.props.commitSHAs[baseCommitIndex]
     const baseCommit =
       baseCommitSHA !== null ? this.props.commitLookup.get(baseCommitSHA) : null
     const indexes = [...data.commits, baseCommit]

--- a/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
+++ b/app/src/ui/local-changes-overwritten/local-changes-overwritten-dialog.tsx
@@ -175,6 +175,8 @@ export class LocalChangesOverwrittenDialog extends React.Component<
         return 'cherry-pick'
       case RetryActionType.Squash:
         return 'squash'
+      case RetryActionType.Reorder:
+        return 'reorder'
       default:
         assertNever(
           this.props.retryAction,

--- a/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/multi-commit-operation.tsx
@@ -4,6 +4,7 @@ import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
 import { Squash } from './squash'
 import { IMultiCommitOperationProps } from './base-multi-commit-operation'
 import { Merge } from './merge'
+import { Reorder } from './reorder'
 
 /** A component for managing the views of a multi commit operation. */
 export class MultiCommitOperation extends React.Component<
@@ -51,7 +52,22 @@ export class MultiCommitOperation extends React.Component<
           />
         )
       case MultiCommitOperationKind.Reorder:
-        return null
+        return (
+          <Reorder
+            repository={this.props.repository}
+            dispatcher={this.props.dispatcher}
+            state={this.props.state}
+            conflictState={this.props.conflictState}
+            emoji={this.props.emoji}
+            workingDirectory={this.props.workingDirectory}
+            askForConfirmationOnForcePush={
+              this.props.askForConfirmationOnForcePush
+            }
+            openFileInExternalEditor={this.props.openFileInExternalEditor}
+            resolvedExternalEditor={this.props.resolvedExternalEditor}
+            openRepositoryInShell={this.props.openRepositoryInShell}
+          />
+        )
       default:
         return assertNever(
           kind,

--- a/app/src/ui/multi-commit-operation/reorder.tsx
+++ b/app/src/ui/multi-commit-operation/reorder.tsx
@@ -1,0 +1,75 @@
+import { RebaseConflictState } from '../../lib/app-state'
+import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
+import { BaseMultiCommitOperation } from './base-multi-commit-operation'
+
+export abstract class Reorder extends BaseMultiCommitOperation {
+  protected onBeginOperation = () => {
+    const { repository, dispatcher, state } = this.props
+    const { commits, operationDetail } = state
+
+    if (operationDetail.kind !== MultiCommitOperationKind.Reorder) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    const { beforeCommit, lastRetainedCommitRef } = operationDetail
+
+    return dispatcher.reorderCommits(
+      repository,
+      commits,
+      beforeCommit,
+      lastRetainedCommitRef
+    )
+  }
+
+  protected onContinueAfterConflicts = async (): Promise<void> => {
+    const {
+      repository,
+      dispatcher,
+      workingDirectory,
+      state,
+      conflictState,
+    } = this.props
+    const { commits, currentTip, targetBranch, originalBranchTip } = state
+
+    if (conflictState === null) {
+      this.endFlowInvalidState()
+      return
+    }
+
+    await dispatcher.switchMultiCommitOperationToShowProgress(repository)
+
+    const rebaseConflictState: RebaseConflictState = {
+      kind: 'rebase',
+      currentTip,
+      targetBranch: targetBranch.name,
+      baseBranch: undefined,
+      originalBranchTip,
+      baseBranchTip: currentTip,
+      manualResolutions: conflictState.manualResolutions,
+    }
+
+    const rebaseResult = await dispatcher.continueRebase(
+      repository,
+      workingDirectory,
+      rebaseConflictState
+    )
+
+    return dispatcher.processReorderRebaseResult(
+      repository,
+      rebaseResult,
+      commits,
+      targetBranch.name
+    )
+  }
+
+  protected onAbort = async (): Promise<void> => {
+    const { repository, dispatcher } = this.props
+    this.onFlowEnded()
+    return dispatcher.abortRebase(repository)
+  }
+
+  protected onConflictsDialogDismissed = () => {
+    this.onInvokeConflictsDialogDismissed('reordering commits on')
+  }
+}

--- a/app/src/ui/multi-commit-operation/reorder.tsx
+++ b/app/src/ui/multi-commit-operation/reorder.tsx
@@ -55,10 +55,11 @@ export abstract class Reorder extends BaseMultiCommitOperation {
       rebaseConflictState
     )
 
-    return dispatcher.processReorderRebaseResult(
+    return dispatcher.processMultiCommitOperationRebaseResult(
+      MultiCommitOperationKind.Reorder,
       repository,
       rebaseResult,
-      commits,
+      commits.length,
       targetBranch.name
     )
   }

--- a/app/src/ui/multi-commit-operation/squash.tsx
+++ b/app/src/ui/multi-commit-operation/squash.tsx
@@ -60,10 +60,11 @@ export abstract class Squash extends BaseMultiCommitOperation {
       rebaseConflictState
     )
 
-    return dispatcher.processSquashRebaseResult(
+    return dispatcher.processMultiCommitOperationRebaseResult(
+      MultiCommitOperationKind.Squash,
       repository,
       rebaseResult,
-      commits,
+      commits.length + 1,
       targetBranch.name
     )
   }

--- a/app/test/unit/git/reorder-test.ts
+++ b/app/test/unit/git/reorder-test.ts
@@ -44,17 +44,17 @@ describe('git/reorder', () => {
     expect(log[1].summary).toBe('second')
     expect(log[0].summary).toBe('first')
   })
-  /*
+
   it('moves first and fourth commits after the second one respecting their order in the log', async () => {
     const firstCommit = await makeSampleCommit(repository, 'first')
-    const secondCommit = await makeSampleCommit(repository, 'second')
-    await makeSampleCommit(repository, 'third')
+    await makeSampleCommit(repository, 'second')
+    const thirdCommit = await makeSampleCommit(repository, 'third')
     const fourthCommit = await makeSampleCommit(repository, 'fourth')
 
     const result = await reorder(
       repository,
       [fourthCommit, firstCommit], // provided in opposite log order
-      secondCommit,
+      thirdCommit,
       initialCommit.sha
     )
 
@@ -72,7 +72,7 @@ describe('git/reorder', () => {
       'initialize',
     ])
   })
-*/
+
   it('moves first commit after the last one', async () => {
     const firstCommit = await makeSampleCommit(repository, 'first')
     await makeSampleCommit(repository, 'second')

--- a/app/test/unit/git/reorder-test.ts
+++ b/app/test/unit/git/reorder-test.ts
@@ -25,14 +25,14 @@ describe('git/reorder', () => {
     initialCommit = await makeSampleCommit(repository, 'initialize')
   })
 
-  it('moves first commit after the second one', async () => {
+  it('moves second commit before the first one', async () => {
     const firstCommit = await makeSampleCommit(repository, 'first')
     const secondCommit = await makeSampleCommit(repository, 'second')
 
     const result = await reorder(
       repository,
-      [firstCommit],
-      secondCommit,
+      [secondCommit],
+      firstCommit,
       initialCommit.sha
     )
 
@@ -44,7 +44,7 @@ describe('git/reorder', () => {
     expect(log[1].summary).toBe('second')
     expect(log[0].summary).toBe('first')
   })
-
+  /*
   it('moves first and fourth commits after the second one respecting their order in the log', async () => {
     const firstCommit = await makeSampleCommit(repository, 'first')
     const secondCommit = await makeSampleCommit(repository, 'second')
@@ -72,7 +72,7 @@ describe('git/reorder', () => {
       'initialize',
     ])
   })
-
+*/
   it('moves first commit after the last one', async () => {
     const firstCommit = await makeSampleCommit(repository, 'first')
     await makeSampleCommit(repository, 'second')
@@ -111,25 +111,25 @@ describe('git/reorder', () => {
     expect(log.length).toBe(3)
 
     const summaries = log.map(c => c.summary)
-    expect(summaries).toStrictEqual(['second', 'first', 'initialize'])
+    expect(summaries).toStrictEqual(['second', 'initialize', 'first'])
   })
 
   it('handles reordering a conflicting commit', async () => {
-    const firstCommit = await makeSampleCommit(repository, 'first')
+    await makeSampleCommit(repository, 'first')
 
     // make a commit with a commit message 'second' and adding file 'second.md'
-    await makeSampleCommit(repository, 'second')
+    const secondCommit = await makeSampleCommit(repository, 'second')
 
     // make a third commit modifying 'second.md' from secondCommit
     const thirdCommit = await makeSampleCommit(repository, 'third', 'second')
 
-    // move third commit after first commit
+    // move third commit before second commit
     // Will cause a conflict due to modifications to 'second.md'  - a file that
     // does not exist in the first commit.
     const result = await reorder(
       repository,
       [thirdCommit],
-      firstCommit,
+      secondCommit,
       initialCommit.sha
     )
 


### PR DESCRIPTION
Closes #12299 

## Description

This PR enables the flow to reorder commits, handling conflicts and undo. I refactored a few things around undoing squash commits, just to be able to reuse that code for reordering.

However, there are other functions that seemed less easy to reuse, so for now I duplicated them and we'll look for opportunities to refactor later (I'm open to suggestions of course! 😄 )

### Screenshots

https://user-images.githubusercontent.com/1083228/120996944-13b3e080-c787-11eb-9f6e-03f13a503e31.mov

## Release notes

Notes: [New] Reorder commits from the History tab
