### PR TITLE
Fix for dragging commits clicking from anywhere in them

### DIFF
--- a/app/src/lib/drag-and-drop-manager.ts
+++ b/app/src/lib/drag-and-drop-manager.ts
@@ -40,6 +40,10 @@ export class DragAndDropManager {
     return this.emitter.on('leave-drop-target', fn)
   }
 
+  public onDragStarted(fn: () => void): Disposable {
+    return this.emitter.on('drag-started', fn)
+  }
+
   public onDragEnded(
     fn: (dropTargetSelector: DropTargetSelector | undefined) => void
   ): Disposable {
@@ -48,11 +52,12 @@ export class DragAndDropManager {
 
   public dragStarted(): void {
     this._isDragInProgress = true
+    this.emitter.emit('drag-started', {})
   }
 
   public dragEnded(dropTargetSelector: DropTargetSelector | undefined) {
-    this.emitter.emit('drag-ended', dropTargetSelector)
     this._isDragInProgress = false
+    this.emitter.emit('drag-ended', dropTargetSelector)
   }
 
   public emitEnterDragZone(dropZoneDescription: string) {


### PR DESCRIPTION
## Description

After my work in #12364 I noticed that you cannot start dragging commits from anywhere in the list items anymore, there are some areas that don't seem clickable.

The reason was the new "insertion overlay" was being rendered when the user is not dragging, and the areas where you can drop the commits to reorder them have pointer events disabled.

This PR observes when the app starts dragging and starts rendering those areas only when needed.

### Screenshots

https://user-images.githubusercontent.com/1083228/121003260-a0619d00-c78d-11eb-9b36-76b77b1b92cf.mov

## Release notes

Notes: no-notes
