### PR TITLE
Don't allow reordering commits when merge commits are involved

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -267,12 +267,27 @@ export class CompareSidebar extends React.Component<
     )
   }
 
-  private onDropCommitInsertion = (
+  private onDropCommitInsertion = async (
     baseCommit: Commit | null,
     commitsToInsert: ReadonlyArray<Commit>,
     lastRetainedCommitRef: string | null
   ) => {
-    this.props.dispatcher.reorderCommits(
+    if (
+      await doMergeCommitsExistAfterCommit(
+        this.props.repository,
+        lastRetainedCommitRef
+      )
+    ) {
+      defaultErrorHandler(
+        new Error(
+          `Unable to reorder. Reordering replays all commits up to the last one required for the reorder. A merge commit cannot exist among those commits.`
+        ),
+        this.props.dispatcher
+      )
+      return
+    }
+
+    return this.props.dispatcher.reorderCommits(
       this.props.repository,
       commitsToInsert,
       baseCommit,


### PR DESCRIPTION
## Description

Just like what we do with squash since #12331, we'll throw an error if we try to reorder commits when merge commits are in the history.

### Screenshots

https://user-images.githubusercontent.com/1083228/121008915-cdb14980-c793-11eb-9702-aa13c9d9c6a8.mov

## Release notes

Notes: no-notes
