### PR TITLE
Abort squash merge

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1961,7 +1961,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.updateMultiCommitOperationConflictsIfFound(repository)
 
     if (this.selectedRepository === repository) {
-      this._triggerConflictsFlow(repository)
+      this._triggerConflictsFlow(repository, status)
     }
 
     this.emitUpdate()
@@ -2071,7 +2071,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
   }
 
-  private async _triggerConflictsFlow(repository: Repository) {
+  private async _triggerConflictsFlow(
+    repository: Repository,
+    status: IStatusResult
+  ) {
     const state = this.repositoryStateCache.get(repository)
     const {
       changesState: { conflictState },
@@ -2089,7 +2092,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
         repository,
         conflictState,
         multiCommitOperationState,
-        branchesState.tip
+        branchesState.tip,
+        status.squashMsgFound
       )
     } else if (isRebaseConflictState(conflictState)) {
       // TODO: This will likely get refactored to a showConflictsDialog method
@@ -2162,14 +2166,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     conflictState: MergeConflictState,
     multiCommitOperationState: IMultiCommitOperationState | null,
-    tip: Tip
+    tip: Tip,
+    isSquash: boolean
   ) {
     if (multiCommitOperationState === null && tip.kind === TipState.Valid) {
       this._initializeMultiCommitOperation(
         repository,
         {
           kind: MultiCommitOperationKind.Merge,
-          isSquash: false,
+          isSquash,
           sourceBranch: null,
         },
         tip.branch,
@@ -4637,6 +4642,44 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public async _abortMerge(repository: Repository): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
     return await gitStore.performFailableOperation(() => abortMerge(repository))
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _abortSquashMerge(repository: Repository): Promise<void> {
+    const gitStore = this.gitStoreCache.get(repository)
+    const {
+      branchesState,
+      changesState: { workingDirectory },
+    } = this.repositoryStateCache.get(repository)
+
+    const commitResult = await this._finishConflictedMerge(
+      repository,
+      workingDirectory,
+      new Map<string, ManualConflictResolution>()
+    )
+
+    // By committing, we clear out the SQUASH_MSG (and anything else git would
+    // choose to store for the --squash merge operation)
+    if (commitResult === undefined) {
+      log.error(
+        `[_abortSquashMerge] - Could not abort squash merge - commiting squash msg failed`
+      )
+      return
+    }
+
+    // Since we have not reloaded the status, this tip is the tip before the
+    // squash commit above.
+    const { tip } = branchesState
+    if (tip.kind !== TipState.Valid) {
+      log.error(
+        `[_abortSquashMerge] - Could not abort squash merge - tip was invalid`
+      )
+      return
+    }
+
+    await gitStore.performFailableOperation(() =>
+      reset(repository, GitResetMode.Hard, tip.branch.tip.sha)
+    )
   }
 
   /** This shouldn't be called directly. See `Dispatcher`.

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1223,6 +1223,12 @@ export class Dispatcher {
     await this.appStore._loadStatus(repository)
   }
 
+  /** aborts an in-flight merge and refreshes the repository's status */
+  public async abortSquashMerge(repository: Repository) {
+    await this.appStore._abortSquashMerge(repository)
+    return this.appStore._refreshRepository(repository)
+  }
+
   /**
    * commits an in-flight merge and shows a banner if successful
    *

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -47,8 +47,18 @@ export abstract class Merge extends BaseMultiCommitOperation {
   }
 
   protected onAbort = async (): Promise<void> => {
-    const { repository, dispatcher } = this.props
+    const {
+      repository,
+      dispatcher,
+      state: { operationDetail },
+    } = this.props
     this.onFlowEnded()
+    if (
+      operationDetail.kind === MultiCommitOperationKind.Merge &&
+      operationDetail.isSquash
+    ) {
+      return dispatcher.abortSquashMerge(repository)
+    }
     return dispatcher.abortMerge(repository)
   }
 


### PR DESCRIPTION
## Description

Ability to abort a squash merge. This is different then aborting a regular merge because the merge head is no longer set at the point of conflicts.

### Screenshots
https://user-images.githubusercontent.com/75402236/121027598-186f9900-c775-11eb-8545-0323b57bd0b6.mov

## Release notes

Notes: no-notes
