### PR TITLE
Reset to commit

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -117,3 +117,8 @@ export function enableAmendingCommits(): boolean {
 export function enableCommitReordering(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should we allow resetting to a previous commit? */
+export function enableResetToCommit(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4232,6 +4232,45 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._refreshRepository(repository)
   }
 
+  public async _resetToCommit(
+    repository: Repository,
+    commit: Commit,
+    showConfirmationDialog: boolean
+  ): Promise<void> {
+    const gitStore = this.gitStoreCache.get(repository)
+    // const repositoryState = this.repositoryStateCache.get(repository)
+    // const { changesState } = repositoryState
+    // const isWorkingDirectoryClean =
+    //   changesState.workingDirectory.files.length === 0
+
+    // Warn the user if there are changes in the working directory
+    // if (
+    //   showConfirmationDialog &&
+    //   (!isWorkingDirectoryClean || commit.isMergeCommit)
+    // ) {
+    //   return this._showPopup({
+    //     type: PopupType.WarnLocalChangesBeforeUndo,
+    //     repository,
+    //     commit,
+    //     isWorkingDirectoryClean,
+    //   })
+    // }
+
+    // Make sure we show the changes after undoing the commit
+    await this._changeRepositorySection(
+      repository,
+      RepositorySectionTab.Changes
+    )
+
+    await gitStore.performFailableOperation(() =>
+      reset(repository, GitResetMode.Mixed, commit.sha)
+    )
+
+    // this.statsStore.recordCommitUndone(isWorkingDirectoryClean)
+
+    return this._refreshRepository(repository)
+  }
+
   /**
    * Fetch a specific refspec for the repository.
    *

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4238,25 +4238,21 @@ export class AppStore extends TypedBaseStore<IAppState> {
     showConfirmationDialog: boolean
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
-    // const repositoryState = this.repositoryStateCache.get(repository)
-    // const { changesState } = repositoryState
-    // const isWorkingDirectoryClean =
-    //   changesState.workingDirectory.files.length === 0
+    const repositoryState = this.repositoryStateCache.get(repository)
+    const { changesState } = repositoryState
+    const isWorkingDirectoryClean =
+      changesState.workingDirectory.files.length === 0
 
     // Warn the user if there are changes in the working directory
-    // if (
-    //   showConfirmationDialog &&
-    //   (!isWorkingDirectoryClean || commit.isMergeCommit)
-    // ) {
-    //   return this._showPopup({
-    //     type: PopupType.WarnLocalChangesBeforeUndo,
-    //     repository,
-    //     commit,
-    //     isWorkingDirectoryClean,
-    //   })
-    // }
+    if (showConfirmationDialog && !isWorkingDirectoryClean) {
+      return this._showPopup({
+        type: PopupType.WarningBeforeReset,
+        repository,
+        commit,
+      })
+    }
 
-    // Make sure we show the changes after undoing the commit
+    // Make sure we show the changes after resetting to the commit
     await this._changeRepositorySection(
       repository,
       RepositorySectionTab.Changes

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -73,6 +73,7 @@ export enum PopupType {
   CommitMessage,
   MultiCommitOperation,
   WarnLocalChangesBeforeUndo,
+  WarningBeforeReset,
 }
 
 export type Popup =
@@ -291,4 +292,9 @@ export type Popup =
       repository: Repository
       commit: Commit
       isWorkingDirectoryClean: boolean
+    }
+  | {
+      type: PopupType.WarningBeforeReset
+      repository: Repository
+      commit: Commit
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -147,6 +147,7 @@ import { enableSquashing } from '../lib/feature-flag'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { MultiCommitOperation } from './multi-commit-operation/multi-commit-operation'
 import { WarnLocalChangesBeforeUndo } from './undo/warn-local-changes-before-undo'
+import { WarningBeforeReset } from './reset/warning-before-reset'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2103,6 +2104,18 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={repository}
             commit={commit}
             isWorkingDirectoryClean={isWorkingDirectoryClean}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.WarningBeforeReset: {
+        const { repository, commit } = popup
+        return (
+          <WarningBeforeReset
+            key="warning-before-reset"
+            dispatcher={this.props.dispatcher}
+            repository={repository}
+            commit={commit}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -781,6 +781,19 @@ export class Dispatcher {
     return this.appStore._undoCommit(repository, commit, showConfirmationDialog)
   }
 
+  /** Reset to a given commit. */
+  public resetToCommit(
+    repository: Repository,
+    commit: Commit,
+    showConfirmationDialog: boolean = true
+  ): Promise<void> {
+    return this.appStore._resetToCommit(
+      repository,
+      commit,
+      showConfirmationDialog
+    )
+  }
+
   /** Revert the commit with the given SHA */
   public revertCommit(repository: Repository, commit: Commit): Promise<void> {
     return this.appStore._revertCommit(repository, commit)

--- a/app/src/ui/drag-elements/commit-drag-element.tsx
+++ b/app/src/ui/drag-elements/commit-drag-element.tsx
@@ -179,6 +179,7 @@ export class CommitDragElement extends React.Component<
             emoji={emoji}
             canBeUndone={false}
             canBeAmended={false}
+            canBeResetTo={false}
             isLocal={false}
             showUnpushedIndicator={false}
           />

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -311,6 +311,8 @@ export class CommitListItem extends React.PureComponent<
       enabled: this.props.onRevertCommit !== undefined,
     })
 
+    items.push({ type: 'separator' })
+
     if (enableBranchFromCommit()) {
       items.push({
         label: __DARWIN__

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -15,6 +15,7 @@ import { Draggable } from '../lib/draggable'
 import {
   enableAmendingCommits,
   enableBranchFromCommit,
+  enableResetToCommit,
   enableSquashing,
 } from '../../lib/feature-flag'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
@@ -285,16 +286,18 @@ export class CommitListItem extends React.PureComponent<
       })
     }
 
-    items.push({
-      label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
-      action: () => {
-        if (this.props.onResetToCommit) {
-          this.props.onResetToCommit(this.props.commit)
-        }
-      },
-      enabled:
-        this.props.canBeResetTo && this.props.onResetToCommit !== undefined,
-    })
+    if (enableResetToCommit()) {
+      items.push({
+        label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
+        action: () => {
+          if (this.props.onResetToCommit) {
+            this.props.onResetToCommit(this.props.commit)
+          }
+        },
+        enabled:
+          this.props.canBeResetTo && this.props.onResetToCommit !== undefined,
+      })
+    }
 
     items.push({
       label: __DARWIN__

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -32,6 +32,8 @@ interface ICommitProps {
   readonly isLocal: boolean
   readonly canBeUndone: boolean
   readonly canBeAmended: boolean
+  readonly canBeResetTo: boolean
+  readonly onResetToCommit?: (commit: Commit) => void
   readonly onUndoCommit?: (commit: Commit) => void
   readonly onRevertCommit?: (commit: Commit) => void
   readonly onViewCommitOnGitHub?: (sha: string) => void
@@ -280,6 +282,18 @@ export class CommitListItem extends React.PureComponent<
           }
         },
         enabled: this.props.onUndoCommit !== undefined,
+      })
+    }
+
+    if (this.props.canBeResetTo) {
+      items.push({
+        label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
+        action: () => {
+          if (this.props.onResetToCommit) {
+            this.props.onResetToCommit(this.props.commit)
+          }
+        },
+        enabled: this.props.onResetToCommit !== undefined,
       })
     }
 

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -285,17 +285,16 @@ export class CommitListItem extends React.PureComponent<
       })
     }
 
-    if (this.props.canBeResetTo) {
-      items.push({
-        label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
-        action: () => {
-          if (this.props.onResetToCommit) {
-            this.props.onResetToCommit(this.props.commit)
-          }
-        },
-        enabled: this.props.onResetToCommit !== undefined,
-      })
-    }
+    items.push({
+      label: __DARWIN__ ? 'Reset to Commit…' : 'Reset to commit…',
+      action: () => {
+        if (this.props.onResetToCommit) {
+          this.props.onResetToCommit(this.props.commit)
+        }
+      },
+      enabled:
+        this.props.canBeResetTo && this.props.onResetToCommit !== undefined,
+    })
 
     items.push({
       label: __DARWIN__

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -31,6 +31,9 @@ interface ICommitListProps {
   /** Whether or not commits in this list can be amended. */
   readonly canAmendCommits: boolean
 
+  /** Whether or the user can reset to commits in this list. */
+  readonly canResetToCommits: boolean
+
   /** The emoji lookup to render images inline */
   readonly emoji: Map<string, string>
 
@@ -48,6 +51,9 @@ interface ICommitListProps {
 
   /** Callback to fire to undo a given commit in the current repository */
   readonly onUndoCommit: ((commit: Commit) => void) | undefined
+
+  /** Callback to fire to reset to a given commit in the current repository */
+  readonly onResetToCommit: (commit: Commit) => void
 
   /** Callback to fire to revert a given commit in the current repository */
   readonly onRevertCommit: ((commit: Commit) => void) | undefined
@@ -172,6 +178,12 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       (isLocal || unpushedTags.length > 0) &&
       this.props.isLocalRepository === false
 
+    // The user can reset to any commit up to the first non-local one (included).
+    // They cannot reset to the most recent commit... because they're already
+    // in it.
+    const isResettableCommit =
+      row > 0 && row <= this.props.localCommitSHAs.length
+
     return (
       <CommitListItem
         key={commit.sha}
@@ -179,6 +191,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         isLocal={isLocal}
         canBeUndone={this.props.canUndoCommits && isLocal && row === 0}
         canBeAmended={this.props.canAmendCommits && isLocal && row === 0}
+        canBeResetTo={this.props.canResetToCommits && isResettableCommit}
         showUnpushedIndicator={showUnpushedIndicator}
         unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(
           isLocal,
@@ -192,6 +205,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onDeleteTag={this.props.onDeleteTag}
         onCherryPick={this.props.onCherryPick}
         onSquash={this.onSquash}
+        onResetToCommit={this.props.onResetToCommit}
         onUndoCommit={this.props.onUndoCommit}
         onRevertCommit={this.props.onRevertCommit}
         onAmendCommit={this.props.onAmendCommit}

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -231,6 +231,7 @@ export class CompareSidebar extends React.Component<
         commitSHAs={commitSHAs}
         selectedSHAs={this.props.selectedCommitShas}
         localCommitSHAs={this.props.localCommitSHAs}
+        canResetToCommits={formState.kind === HistoryTabMode.History}
         canUndoCommits={formState.kind === HistoryTabMode.History}
         canAmendCommits={formState.kind === HistoryTabMode.History}
         emoji={this.props.emoji}
@@ -239,6 +240,7 @@ export class CompareSidebar extends React.Component<
         }
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         onUndoCommit={this.onUndoCommit}
+        onResetToCommit={this.onResetToCommit}
         onRevertCommit={
           ableToRevertCommit(this.props.compareState.formState)
             ? this.props.onRevertCommit
@@ -580,6 +582,10 @@ export class CompareSidebar extends React.Component<
 
   private onUndoCommit = (commit: Commit) => {
     this.props.dispatcher.undoCommit(this.props.repository, commit)
+  }
+
+  private onResetToCommit = (commit: Commit) => {
+    this.props.dispatcher.resetToCommit(this.props.repository, commit)
   }
 
   private onCreateBranch = (commit: CommitOneLine) => {

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -250,6 +250,7 @@ export class ConfigureGitUser extends React.Component<
           gitHubRepository={null}
           canBeUndone={false}
           canBeAmended={false}
+          canBeResetTo={false}
           isLocal={false}
           showUnpushedIndicator={false}
           selectedCommits={[dummyCommit]}

--- a/app/src/ui/reset/warning-before-reset.tsx
+++ b/app/src/ui/reset/warning-before-reset.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Repository } from '../../models/repository'
+import { Dispatcher } from '../dispatcher'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Commit } from '../../models/commit'
+
+interface IWarningBeforeResetProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: Repository
+  readonly commit: Commit
+  readonly onDismissed: () => void
+}
+
+interface IWarningBeforeResetState {
+  readonly isLoading: boolean
+}
+
+/**
+ * Dialog that alerts user that there are uncommitted changes in the working
+ * directory where they are gonna be resetting to a previous commit.
+ */
+export class WarningBeforeReset extends React.Component<
+  IWarningBeforeResetProps,
+  IWarningBeforeResetState
+> {
+  public constructor(props: IWarningBeforeResetProps) {
+    super(props)
+    this.state = { isLoading: false }
+  }
+
+  public render() {
+    const title = __DARWIN__ ? 'Reset to Commit' : 'Reset to commit'
+
+    return (
+      <Dialog
+        id="warning-before-reset"
+        type="warning"
+        title={title}
+        loading={this.state.isLoading}
+        disabled={this.state.isLoading}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            You have changes in progress. Resetting to a previous commit might
+            result in some of these changes being lost. Do you want to continue
+            anyway?
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup destructive={true} okButtonText="Continue" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onSubmit = async () => {
+    const { dispatcher, repository, commit, onDismissed } = this.props
+    this.setState({ isLoading: true })
+
+    try {
+      await dispatcher.resetToCommit(repository, commit, false)
+    } finally {
+      this.setState({ isLoading: false })
+    }
+
+    onDismissed()
+  }
+}


### PR DESCRIPTION
Closes TBD

## Description

Initial work to reset HEAD to a previous commit, up to the first non-local commit. When you use it, it resets the HEAD of the repo to the commit you selected, keeping all the changes in the working dir and in the commits in between. As a consequence, undoing the last commit is equivalent to resetting to the second to last commit, with the only difference that undoing the commit also keeps the commit summary and description.
You can see how you can reset up to the first non-local commit (which would, effectively, “undo” all local commits at once).

I'll add metrics in a new PR.

### Screenshots

https://user-images.githubusercontent.com/1083228/121159693-b170e380-c84b-11eb-9c9a-f6f69897649a.mov

## Release notes

Notes: [New] Reset to a previous commit
