### PR TITLE
Drop empty root commit after an interactive rebase

### DIFF
--- a/app/src/ui/multi-commit-operation/reorder.tsx
+++ b/app/src/ui/multi-commit-operation/reorder.tsx
@@ -30,7 +30,18 @@ export abstract class Reorder extends BaseMultiCommitOperation {
       state,
       conflictState,
     } = this.props
-    const { commits, currentTip, targetBranch, originalBranchTip } = state
+    const {
+      commits,
+      currentTip,
+      targetBranch,
+      originalBranchTip,
+      operationDetail,
+    } = state
+
+    if (operationDetail.kind !== MultiCommitOperationKind.Reorder) {
+      this.endFlowInvalidState()
+      return
+    }
 
     if (conflictState === null) {
       this.endFlowInvalidState()
@@ -60,7 +71,8 @@ export abstract class Reorder extends BaseMultiCommitOperation {
       repository,
       rebaseResult,
       commits.length,
-      targetBranch.name
+      targetBranch.name,
+      operationDetail.lastRetainedCommitRef === null
     )
   }
 

--- a/app/src/ui/multi-commit-operation/squash.tsx
+++ b/app/src/ui/multi-commit-operation/squash.tsx
@@ -35,7 +35,18 @@ export abstract class Squash extends BaseMultiCommitOperation {
       state,
       conflictState,
     } = this.props
-    const { commits, currentTip, targetBranch, originalBranchTip } = state
+    const {
+      commits,
+      currentTip,
+      targetBranch,
+      originalBranchTip,
+      operationDetail,
+    } = state
+
+    if (operationDetail.kind !== MultiCommitOperationKind.Squash) {
+      this.endFlowInvalidState()
+      return
+    }
 
     if (conflictState === null) {
       this.endFlowInvalidState()
@@ -65,7 +76,8 @@ export abstract class Squash extends BaseMultiCommitOperation {
       repository,
       rebaseResult,
       commits.length + 1,
-      targetBranch.name
+      targetBranch.name,
+      operationDetail.lastRetainedCommitRef === null
     )
   }
 


### PR DESCRIPTION
## Description

Something I noticed while working on reordering is that if you move a commit to the beginning of the branch, and that operation causes conflicts, git creates a completely empty commit. I haven’t seen a way to prevent this or to set a message for it… and right now the app doesn’t render it nicely :cry: The app is expecting that commits always have a summary/description.

This branch cleans that commit after the reorder/squash operation is completed.

However…
1. The empty commit is still visible while the user deals with the conflicts.
2. If, for whatever reason, we wrongly decide the root commit is empty and we drop it… it might cause user data loss.

So, personally, I prefer to make sure we render those empty commits properly and avoid destructive operations as much as possible.

### Screenshots

https://user-images.githubusercontent.com/1083228/121057854-02d39100-c7c0-11eb-8679-333effd57e3b.mov

## Release notes

Notes: no-notes
