### PR TITLE
Add force-push warning to reorder and squash operations

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -389,10 +389,11 @@ export class Dispatcher {
   }
 
   /**
-   * Check for remote commits that could affect an interactive rebase operation.
+   * Check for remote commits that could affect an rebase operation.
    *
-   * @param targetBranch    The branch where the interactive rebase takes place.
+   * @param targetBranch    The branch where the rebase takes place.
    * @param oldestCommitRef Ref of the oldest commit involved in the interactive
+   *                        rebase, or tip of the base branch in a regular
    *                        rebase. If it's null, the root of the branch will be
    *                        considered.
    */
@@ -416,8 +417,8 @@ export class Dispatcher {
     }
 
     // At this point, the target branch has an upstream. Therefore, if the
-    // interactive rebase goes up to the root commit of the branch, remote
-    // commits that will require a force push after the rebase do exist.
+    // rebase goes up to the root commit of the branch, remote commits that will
+    // require a force push after the rebase do exist.
     if (oldestCommitRef === null) {
       return true
     }

--- a/app/src/ui/multi-commit-operation/reorder.tsx
+++ b/app/src/ui/multi-commit-operation/reorder.tsx
@@ -18,7 +18,8 @@ export abstract class Reorder extends BaseMultiCommitOperation {
       repository,
       commits,
       beforeCommit,
-      lastRetainedCommitRef
+      lastRetainedCommitRef,
+      true
     )
   }
 

--- a/app/src/ui/multi-commit-operation/squash.tsx
+++ b/app/src/ui/multi-commit-operation/squash.tsx
@@ -23,7 +23,8 @@ export abstract class Squash extends BaseMultiCommitOperation {
       commits,
       targetCommit,
       lastRetainedCommitRef,
-      commitContext
+      commitContext,
+      true
     )
   }
 

--- a/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/warn-force-push-dialog.tsx
@@ -52,7 +52,7 @@ export class WarnForcePushDialog extends React.Component<
         type="warning"
       >
         <DialogContent>
-          <p>Are you sure you want to {operation}?</p>
+          <p>Are you sure you want to {operation.toLowerCase()}?</p>
           <p>
             At the end of the {operation.toLowerCase()} flow, GitHub Desktop
             will enable you to force push the branch to update the upstream


### PR DESCRIPTION
## Description

This PR adds the new dialog to warn the user when a squash or reorder operation will require force-pushing the current branch.

The way it detects this situation is by looking for commits in common between the remote and the "last retained commit ref" (meaning, the oldest commit involved in the rebase operation). If there are commits in common, it means the user will require a force-push after the interactive rebase.

### Screenshots

https://user-images.githubusercontent.com/1083228/121173465-2565b880-c859-11eb-9320-d54d899e822d.mov

## Release notes

Notes: no-notes
