### PR TITLE
Squash and squash merge metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -371,8 +371,8 @@ export interface IDailyMeasures {
   /** The number of times a cherry pick is initiated through the context menu */
   readonly cherryPickViaContextMenuCount: number
 
-  /** The number of times a cherry pick drag was started and canceled */
-  readonly cherryPickDragStartedAndCanceledCount: number
+  /** The number of times a drag operation was started and canceled */
+  readonly dragStartedAndCanceledCount: number
 
   /** The number of times conflicts encountered during a cherry pick  */
   readonly cherryPickConflictsEncounteredCount: number

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -445,6 +445,9 @@ export interface IDailyMeasures {
 
   /** The number of times a successful squash merge occurs */
   readonly squashMergeSuccessfulCount: number
+
+  /** The number of times a squash merge is initiated */
+  readonly squashMergeInvokedCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -415,6 +415,36 @@ export interface IDailyMeasures {
 
   /** The number of times a reorder was undone  */
   readonly reorderUndoneCount: number
+
+  /** The number of times conflicts encountered during a squash */
+  readonly squashConflictsEncounteredCount: number
+
+  /** The number of times squash of multiple commits invoked  */
+  readonly squashMultipleCommitsInvokedCount: number
+
+  /** The number of times a successful squash occurs */
+  readonly squashSuccessfulCount: number
+
+  /** The number of times squash ended successfully after conflicts  */
+  readonly squashSuccessfulWithConflictsCount: number
+
+  /** The number of times a squash is initiated through the context menu */
+  readonly squashViaContextMenuInvokedCount: number
+
+  /** The number of times a squash is initiated through drag and drop */
+  readonly squashViaDragAndDropInvokedCount: number
+
+  /** The number of times a squash was undone  */
+  readonly squashUndoneCount: number
+
+  /** The number of times the `Branch -> Squash and Merge Into Current Branch` menu item is used */
+  readonly squashMergeIntoCurrentBranchMenuCount: number
+
+  /** The number of times squash merge ended successfully after conflicts  */
+  readonly squashMergeSuccessfulWithConflictsCount: number
+
+  /** The number of times a successful squash merge occurs */
+  readonly squashMergeSuccessfulCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -161,6 +161,16 @@ const DefaultDailyMeasures: IDailyMeasures = {
   reorderSuccessfulWithConflictsCount: 0,
   reorderMultipleCommitsCount: 0,
   reorderUndoneCount: 0,
+  squashConflictsEncounteredCount: 0,
+  squashMultipleCommitsInvokedCount: 0,
+  squashSuccessfulCount: 0,
+  squashSuccessfulWithConflictsCount: 0,
+  squashViaContextMenuInvokedCount: 0,
+  squashViaDragAndDropInvokedCount: 0,
+  squashUndoneCount: 0,
+  squashMergeIntoCurrentBranchMenuCount: 0,
+  squashMergeSuccessfulWithConflictsCount: 0,
+  squashMergeSuccessfulCount: 0,
 }
 
 interface IOnboardingStats {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -172,6 +172,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   squashMergeIntoCurrentBranchMenuCount: 0,
   squashMergeSuccessfulWithConflictsCount: 0,
   squashMergeSuccessfulCount: 0,
+  squashMergeInvokedCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1676,6 +1677,12 @@ export class StatsStore implements IStatsStore {
   public recordSquashMergeSuccessful(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       squashMergeSuccessfulCount: m.squashMergeSuccessfulCount + 1,
+    }))
+  }
+
+  public recordSquashMergeInvokedCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      squashMergeInvokedCount: m.squashMergeInvokedCount + 1,
     }))
   }
 

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1593,7 +1593,7 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  public recordOperationConflictsEncounteredCount(
+  public async recordOperationConflictsEncounteredCount(
     kind: MultiCommitOperationKind
   ): Promise<void> {
     switch (kind) {
@@ -1604,15 +1604,16 @@ export class StatsStore implements IStatsStore {
       case MultiCommitOperationKind.CherryPick:
       case MultiCommitOperationKind.Rebase:
       case MultiCommitOperationKind.Merge:
-        throw new Error(
+        log.error(
           `[recordOperationConflictsEncounteredCount] - Operation not supported: ${kind}`
         )
+        return
       default:
         return assertNever(kind, `Unknown operation kind of ${kind}.`)
     }
   }
 
-  public recordOperationSuccessful(
+  public async recordOperationSuccessful(
     kind: MultiCommitOperationKind
   ): Promise<void> {
     switch (kind) {
@@ -1623,15 +1624,16 @@ export class StatsStore implements IStatsStore {
       case MultiCommitOperationKind.CherryPick:
       case MultiCommitOperationKind.Rebase:
       case MultiCommitOperationKind.Merge:
-        throw new Error(
+        log.error(
           `[recordOperationSuccessful] - Operation not supported: ${kind}`
         )
+        return
       default:
         return assertNever(kind, `Unknown operation kind of ${kind}.`)
     }
   }
 
-  public recordOperationSuccessfulWithConflicts(
+  public async recordOperationSuccessfulWithConflicts(
     kind: MultiCommitOperationKind
   ): Promise<void> {
     switch (kind) {
@@ -1642,15 +1644,18 @@ export class StatsStore implements IStatsStore {
       case MultiCommitOperationKind.CherryPick:
       case MultiCommitOperationKind.Rebase:
       case MultiCommitOperationKind.Merge:
-        throw new Error(
+        log.error(
           `[recordOperationSuccessfulWithConflicts] - Operation not supported: ${kind}`
         )
+        return
       default:
         return assertNever(kind, `Unknown operation kind of ${kind}.`)
     }
   }
 
-  public recordOperationUndone(kind: MultiCommitOperationKind): Promise<void> {
+  public async recordOperationUndone(
+    kind: MultiCommitOperationKind
+  ): Promise<void> {
     switch (kind) {
       case MultiCommitOperationKind.Squash:
         return this.recordSquashUndone()
@@ -1659,9 +1664,8 @@ export class StatsStore implements IStatsStore {
       case MultiCommitOperationKind.CherryPick:
       case MultiCommitOperationKind.Rebase:
       case MultiCommitOperationKind.Merge:
-        throw new Error(
-          `[recordOperationUndone] - Operation not supported: ${kind}`
-        )
+        log.error(`[recordOperationUndone] - Operation not supported: ${kind}`)
+        return
       default:
         return assertNever(kind, `Unknown operation kind of ${kind}.`)
     }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -146,7 +146,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   cherryPickSuccessfulCount: 0,
   cherryPickViaDragAndDropCount: 0,
   cherryPickViaContextMenuCount: 0,
-  cherryPickDragStartedAndCanceledCount: 0,
+  dragStartedAndCanceledCount: 0,
   cherryPickConflictsEncounteredCount: 0,
   cherryPickSuccessfulWithConflictsCount: 0,
   cherryPickMultipleCommitsCount: 0,
@@ -1455,10 +1455,9 @@ export class StatsStore implements IStatsStore {
     }))
   }
 
-  public recordCherryPickDragStartedAndCanceled(): Promise<void> {
+  public recordDragStartedAndCanceled(): Promise<void> {
     return this.updateDailyMeasures(m => ({
-      cherryPickDragStartedAndCanceledCount:
-        m.cherryPickDragStartedAndCanceledCount + 1,
+      dragStartedAndCanceledCount: m.dragStartedAndCanceledCount + 1,
     }))
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4474,6 +4474,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const gitStore = this.gitStoreCache.get(repository)
 
+    if (isSquash) {
+      this.statsStore.recordSquashMergeInvokedCount()
+    }
+
     if (mergeStatus !== null) {
       if (mergeStatus.kind === ComputedAction.Clean) {
         this.statsStore.recordMergeHintSuccessAndUserProceeded()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4493,6 +4493,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ourBranch: tip.branch.name,
         theirBranch: branch,
       })
+      if (isSquash) {
+        // This code will only run when there are no conflicts.
+        // Thus recordSquashMergeSuccessful is done here and when merge finishes
+        // successfully after conflicts in `dispatcher.finishConflictedMerge`.
+        this.statsStore.recordSquashMergeSuccessful()
+      }
     } else if (
       mergeResult === MergeResult.AlreadyUpToDate &&
       tip.kind === TipState.Valid

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -3051,9 +3051,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   private onDragEnd = (dropTargetSelector: DropTargetSelector | undefined) => {
     this.props.dispatcher.closeFoldout(FoldoutType.Branch)
     if (dropTargetSelector === undefined) {
-      // TODO: refactor to "DragStartedAndCanceled" as not specific to
-      // cherry-picking anymore
-      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
+      this.props.dispatcher.recordDragStartedAndCanceled()
     }
   }
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -386,6 +386,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         this.props.dispatcher.recordMenuInitiatedMerge()
         return this.mergeBranch()
       case 'squash-and-merge-branch':
+        this.props.dispatcher.recordMenuInitiatedMerge(true)
         return this.mergeBranch(true)
       case 'rebase-branch':
         this.props.dispatcher.recordMenuInitiatedRebase()

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -404,7 +404,7 @@ export class BranchesContainer extends React.Component<
 
   private onDropOntoCurrentBranch = () => {
     if (dragAndDropManager.isDragOfType(DragType.Commit)) {
-      this.props.dispatcher.recordCherryPickDragStartedAndCanceled()
+      this.props.dispatcher.recordDragStartedAndCanceled()
     }
   }
 }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -196,7 +196,7 @@ export class PullRequestList extends React.Component<
       prNumber === selectedPullRequest.pullRequestNumber
     ) {
       dispatcher.endCherryPickFlow(repository)
-      dispatcher.recordCherryPickDragStartedAndCanceled()
+      dispatcher.recordDragStartedAndCanceled()
       return
     }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3034,9 +3034,9 @@ export class Dispatcher {
     this.statsStore.recordCherryPickViaContextMenu()
   }
 
-  /** Method to record cherry pick started via drag and drop and canceled. */
-  public recordCherryPickDragStartedAndCanceled() {
-    this.statsStore.recordCherryPickDragStartedAndCanceled()
+  /** Method to record an operation started via drag and drop and canceled. */
+  public recordDragStartedAndCanceled() {
+    this.statsStore.recordDragStartedAndCanceled()
   }
 
   /** Method to reset cherry picking state. */

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -44,7 +44,8 @@ interface ICommitProps {
   readonly onRemoveDragElement?: () => void
   readonly onSquash?: (
     toSquash: ReadonlyArray<Commit>,
-    squashOnto: Commit
+    squashOnto: Commit,
+    isInvokedByContextMenu: boolean
   ) => void
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
@@ -94,7 +95,7 @@ export class CommitListItem extends React.PureComponent<
       // don't squash if dragging one commit and dropping onto itself
       selectedCommits.filter(c => c.sha !== commit.sha).length > 0
     ) {
-      onSquash(selectedCommits, commit)
+      onSquash(selectedCommits, commit, false)
     }
   }
 
@@ -233,7 +234,7 @@ export class CommitListItem extends React.PureComponent<
 
   private onSquash = () => {
     if (this.props.onSquash !== undefined) {
-      this.props.onSquash(this.props.selectedCommits, this.props.commit)
+      this.props.onSquash(this.props.selectedCommits, this.props.commit, true)
     }
   }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -90,7 +90,8 @@ interface ICommitListProps {
   readonly onSquash: (
     toSquash: ReadonlyArray<Commit>,
     squashOnto: Commit,
-    lastRetainedCommitRef: string | null
+    lastRetainedCommitRef: string | null,
+    isInvokedByContextMenu: boolean
   ) => void
 
   /**
@@ -215,14 +216,19 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     return lastRetainedCommitRef
   }
 
-  private onSquash = (toSquash: ReadonlyArray<Commit>, squashOnto: Commit) => {
+  private onSquash = (
+    toSquash: ReadonlyArray<Commit>,
+    squashOnto: Commit,
+    isInvokedByContextMenu: boolean
+  ) => {
     const indexes = [...toSquash, squashOnto].map(v =>
       this.props.commitSHAs.findIndex(sha => sha === v.sha)
     )
     this.props.onSquash(
       toSquash,
       squashOnto,
-      this.getLastRetainedCommitRef(indexes)
+      this.getLastRetainedCommitRef(indexes),
+      isInvokedByContextMenu
     )
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -603,7 +603,8 @@ export class CompareSidebar extends React.Component<
   private onSquash = async (
     toSquash: ReadonlyArray<Commit>,
     squashOnto: Commit,
-    lastRetainedCommitRef: string | null
+    lastRetainedCommitRef: string | null,
+    isInvokedByContextMenu: boolean
   ) => {
     const toSquashSansSquashOnto = toSquash.filter(
       c => c.sha !== squashOnto.sha
@@ -631,6 +632,8 @@ export class CompareSidebar extends React.Component<
       )
       return
     }
+
+    this.props.dispatcher.recordSquashInvoked(isInvokedByContextMenu)
 
     this.props.dispatcher.showPopup({
       type: PopupType.CommitMessage,


### PR DESCRIPTION
## Description

This PR starts tracking for metrics around squashing commits and squash merging. Squashing follows similar pattern to cherry-picking, rebasing, and reordering.  Squash-merging I did not recreate all the merge tracking metrics as they looked to be monitoring the merge conflicts dialog process pretty tightly.  That information I do not think is needed at a squash merging granular level.

Squashing Commits:
- squashConflictsEncounteredCount
- squashMultipleCommitsInvokedCount
- squashSuccessfulCount
- squashSuccessfulWithConflictsCount
- squashViaContextMenuInvokedCount:
- squashViaDragAndDropInvokedCount
- squashUndoneCount

Merge Squashing:
- squashMergeInvokedCount
- squashMergeIntoCurrentBranchMenuCount
   - useful to see if users will invoke squash merge via branch menu or via merge dialog select dropdown button
- squashMergeSuccessfulCount
- squashMergeSuccessfulWithConflictsCount

Also refactors 
`cherryPickDragStartedAndCanceledCount` to  `dragStartedAndCanceledCount`

## Release notes
Notes: no-notes
