### PR TITLE
Track metrics around resetting to a specific commit

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -448,6 +448,9 @@ export interface IDailyMeasures {
 
   /** The number of times a squash merge is initiated */
   readonly squashMergeInvokedCount: number
+
+  /** The number of times the user reset to a previous commit. */
+  readonly resetToCommitCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -173,6 +173,7 @@ const DefaultDailyMeasures: IDailyMeasures = {
   squashMergeSuccessfulWithConflictsCount: 0,
   squashMergeSuccessfulCount: 0,
   squashMergeInvokedCount: 0,
+  resetToCommitCount: 0,
 }
 
 interface IOnboardingStats {
@@ -717,6 +718,13 @@ export class StatsStore implements IStatsStore {
     return this.updateDailyMeasures(m => ({
       amendCommitSuccessfulWithoutFileChangesCount:
         m.amendCommitSuccessfulWithoutFileChangesCount + 1,
+    }))
+  }
+
+  /** Record that the user reset to a previous commit */
+  public recordResetToCommitCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      resetToCommitCount: m.resetToCommitCount + 1,
     }))
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -825,6 +825,7 @@ export class Dispatcher {
     commit: Commit,
     showConfirmationDialog: boolean = true
   ): Promise<void> {
+    this.statsStore.recordResetToCommitCount()
     return this.appStore._resetToCommit(
       repository,
       commit,


### PR DESCRIPTION
## Description

This PR adds tracking for how many times users reset to a specific commit.

## Release notes

Notes: no-notes
