### PR TITLE
Make squash-merge and rebase options available in comparison view

### DIFF
--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -31,6 +31,12 @@ interface IDropdownSelectButtonProps {
   readonly onSelectChange?: (
     selectedOption: IDropdownSelectButtonOption
   ) => void
+
+  /** Callback for when button is selected option button is clicked */
+  readonly onSubmit?: (
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedOption: IDropdownSelectButtonOption
+  ) => void
 }
 
 interface IDropdownSelectButtonState {
@@ -162,6 +168,15 @@ export class DropdownSelectButton extends React.Component<
     )
   }
 
+  private onSubmit = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (
+      this.props.onSubmit !== undefined &&
+      this.state.selectedOption !== null
+    ) {
+      this.props.onSubmit(event, this.state.selectedOption)
+    }
+  }
+
   public render() {
     const { options, disabled } = this.props
     const {
@@ -191,6 +206,7 @@ export class DropdownSelectButton extends React.Component<
           type="submit"
           tooltip={this.props.tooltip}
           onButtonRef={this.onInvokeButtonRef}
+          onClick={this.onSubmit}
         >
           {selectedOption.label}
         </Button>

--- a/app/src/ui/dropdown-select-button.tsx
+++ b/app/src/ui/dropdown-select-button.tsx
@@ -175,14 +175,16 @@ export class DropdownSelectButton extends React.Component<
 
     const openClass =
       optionsPositionBottom !== undefined ? 'open-top' : 'open-bottom'
-    const classes = classNames(
+    const containerClasses = classNames(
       'dropdown-select-button',
       showButtonOptions ? openClass : null
     )
+
+    const dropdownClasses = classNames('dropdown-button', { disabled })
     // The button is type of submit so that it will trigger a form's onSubmit
     // method.
     return (
-      <div className={classes}>
+      <div className={containerClasses}>
         <Button
           className="invoke-button"
           disabled={disabled}
@@ -193,8 +195,7 @@ export class DropdownSelectButton extends React.Component<
           {selectedOption.label}
         </Button>
         <Button
-          disabled={disabled}
-          className="dropdown-button"
+          className={dropdownClasses}
           onClick={this.openSplitButtonDropdown}
           type="button"
         >

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -4,10 +4,16 @@ import { HistoryTabMode } from '../../lib/app-state'
 import { Repository } from '../../models/repository'
 import { Branch } from '../../models/branch'
 import { Dispatcher } from '../dispatcher'
-import { Button } from '../lib/button'
 import { ActionStatusIcon } from '../lib/action-status-icon'
 import { MergeTreeResult } from '../../models/merge'
 import { ComputedAction } from '../../models/computed-action'
+import {
+  DropdownSelectButton,
+  IDropdownSelectButtonOption,
+} from '../dropdown-select-button'
+import { getMergeOptions, updateRebasePreview } from '../lib/update-branch'
+import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
+import { RebasePreview } from '../../models/rebase'
 
 interface IMergeCallToActionWithConflictsProps {
   readonly repository: Repository
@@ -18,74 +24,204 @@ interface IMergeCallToActionWithConflictsProps {
   readonly commitsBehind: number
 }
 
+interface IMergeCallToActionWithConflictsState {
+  readonly selectedOperation: MultiCommitOperationKind
+  readonly rebasePreview: RebasePreview | null
+}
+
 export class MergeCallToActionWithConflicts extends React.Component<
   IMergeCallToActionWithConflictsProps,
-  {}
+  IMergeCallToActionWithConflictsState
 > {
-  public render() {
-    const { commitsBehind } = this.props
+  /**
+   * This is obtained by either the merge status or the rebase preview. Depending
+   * on which option is selected in the dropdown.
+   */
+  private get computedAction(): ComputedAction | null {
+    if (this.state.selectedOperation === MultiCommitOperationKind.Rebase) {
+      return this.state.rebasePreview !== null
+        ? this.state.rebasePreview.kind
+        : null
+    }
+    return this.props.mergeStatus !== null ? this.props.mergeStatus.kind : null
+  }
 
-    const cannotMergeBranch =
+  /**
+   * This is obtained by either the merge status or the rebase preview. Depending
+   * on which option is selected in the dropdown.
+   */
+  private get commitCount(): number {
+    const { selectedOperation, rebasePreview } = this.state
+    if (selectedOperation === MultiCommitOperationKind.Rebase) {
+      return rebasePreview !== null &&
+        rebasePreview.kind === ComputedAction.Clean
+        ? rebasePreview.commits.length
+        : 0
+    }
+
+    return this.props.commitsBehind
+  }
+
+  public constructor(props: IMergeCallToActionWithConflictsProps) {
+    super(props)
+
+    this.state = {
+      selectedOperation: MultiCommitOperationKind.Merge,
+      rebasePreview: null,
+    }
+  }
+
+  private isUpdateBranchDisabled(): boolean {
+    if (this.commitCount <= 0) {
+      return true
+    }
+
+    const { selectedOperation, rebasePreview } = this.state
+    if (selectedOperation === MultiCommitOperationKind.Rebase) {
+      return (
+        rebasePreview === null || rebasePreview.kind !== ComputedAction.Clean
+      )
+    }
+
+    return (
       this.props.mergeStatus != null &&
       this.props.mergeStatus.kind === ComputedAction.Invalid
+    )
+  }
 
-    const disabled = commitsBehind <= 0 || cannotMergeBranch
+  private updateRebasePreview = async (baseBranch: Branch) => {
+    const { currentBranch: targetBranch, repository } = this.props
+    updateRebasePreview(baseBranch, targetBranch, repository, rebasePreview => {
+      this.setState({ rebasePreview })
+    })
+  }
 
-    const mergeDetails = commitsBehind > 0 ? this.renderMergeStatus() : null
+  private onOperationChange = (option: IDropdownSelectButtonOption) => {
+    const value = option.value as MultiCommitOperationKind
+    this.setState({ selectedOperation: value })
+    if (value === MultiCommitOperationKind.Rebase) {
+      this.updateRebasePreview(this.props.comparisonBranch)
+    }
+  }
+
+  private onOperationInvoked = async (
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedOption: IDropdownSelectButtonOption
+  ) => {
+    event.preventDefault()
+
+    const { dispatcher, repository } = this.props
+
+    await this.dispatchOperation(
+      selectedOption.value as MultiCommitOperationKind
+    )
+
+    dispatcher.executeCompare(repository, {
+      kind: HistoryTabMode.History,
+    })
+
+    dispatcher.updateCompareForm(repository, {
+      showBranchList: false,
+      filterText: '',
+    })
+  }
+
+  private async dispatchOperation(
+    operation: MultiCommitOperationKind
+  ): Promise<void> {
+    const {
+      dispatcher,
+      currentBranch,
+      comparisonBranch,
+      repository,
+      mergeStatus,
+    } = this.props
+
+    if (operation === MultiCommitOperationKind.Rebase) {
+      const commits =
+        this.state.rebasePreview !== null &&
+        this.state.rebasePreview.kind === ComputedAction.Clean
+          ? this.state.rebasePreview.commits
+          : []
+      return dispatcher.startRebase(
+        repository,
+        comparisonBranch,
+        currentBranch,
+        commits
+      )
+    }
+
+    dispatcher.initializeMultiCommitOperation(
+      repository,
+      {
+        kind: MultiCommitOperationKind.Merge,
+        isSquash: operation === MultiCommitOperationKind.Squash,
+        sourceBranch: comparisonBranch,
+      },
+      currentBranch,
+      []
+    )
+    dispatcher.recordCompareInitiatedMerge()
+
+    return dispatcher.mergeBranch(repository, comparisonBranch, mergeStatus)
+  }
+
+  public render() {
+    const disabled = this.isUpdateBranchDisabled()
+    const mergeDetails = this.commitCount > 0 ? this.renderMergeStatus() : null
 
     return (
       <div className="merge-cta">
         {mergeDetails}
 
-        <Button type="submit" disabled={disabled} onClick={this.onMergeClicked}>
-          Merge into <strong>{this.props.currentBranch.name}</strong>
-        </Button>
+        <DropdownSelectButton
+          selectedValue={this.state.selectedOperation}
+          options={getMergeOptions()}
+          disabled={disabled}
+          onSelectChange={this.onOperationChange}
+          onSubmit={this.onOperationInvoked}
+        />
       </div>
     )
   }
 
   private renderMergeStatus() {
+    if (this.computedAction === null) {
+      return null
+    }
+
     return (
       <div className="merge-status-component">
         <ActionStatusIcon
-          status={this.props.mergeStatus}
+          status={{ kind: this.computedAction }}
           classNamePrefix="merge-status"
         />
 
-        {this.renderMergeDetails(
-          this.props.currentBranch,
-          this.props.comparisonBranch,
-          this.props.mergeStatus,
-          this.props.commitsBehind
-        )}
+        {this.renderStatusDetails()}
       </div>
     )
   }
 
-  private renderMergeDetails(
-    currentBranch: Branch,
-    comparisonBranch: Branch,
-    mergeStatus: MergeTreeResult | null,
-    behindCount: number
-  ) {
-    if (mergeStatus === null) {
+  private renderStatusDetails() {
+    const { currentBranch, comparisonBranch, mergeStatus } = this.props
+    const { selectedOperation } = this.state
+    if (this.computedAction === null) {
       return null
     }
+    switch (this.computedAction) {
+      case ComputedAction.Loading:
+        return this.renderLoadingMessage()
+      case ComputedAction.Clean:
+        return this.renderCleanMessage(currentBranch, comparisonBranch)
+      case ComputedAction.Invalid:
+        return this.renderInvalidMessage()
+    }
 
-    if (mergeStatus.kind === ComputedAction.Loading) {
-      return this.renderLoadingMergeMessage()
-    }
-    if (mergeStatus.kind === ComputedAction.Clean) {
-      return this.renderCleanMergeMessage(
-        currentBranch,
-        comparisonBranch,
-        behindCount
-      )
-    }
-    if (mergeStatus.kind === ComputedAction.Invalid) {
-      return this.renderInvalidMergeMessage()
-    }
-    if (mergeStatus.kind === ComputedAction.Conflicts) {
+    if (
+      selectedOperation !== MultiCommitOperationKind.Rebase &&
+      mergeStatus !== null &&
+      mergeStatus.kind === ComputedAction.Conflicts
+    ) {
       return this.renderConflictedMergeMessage(
         currentBranch,
         comparisonBranch,
@@ -95,37 +231,51 @@ export class MergeCallToActionWithConflicts extends React.Component<
     return null
   }
 
-  private renderLoadingMergeMessage() {
+  private renderLoadingMessage() {
     return (
       <div className="merge-message merge-message-loading">
-        Checking for ability to merge automatically...
+        Checking for ability to {this.state.selectedOperation.toLowerCase()}{' '}
+        automatically...
       </div>
     )
   }
 
-  private renderCleanMergeMessage(
-    currentBranch: Branch,
-    branch: Branch,
-    count: number
-  ) {
-    if (count > 0) {
-      const pluralized = count === 1 ? 'commit' : 'commits'
-      return (
-        <div className="merge-message">
-          This will merge
-          <strong>{` ${count} ${pluralized}`}</strong>
-          {` from `}
-          <strong>{branch.name}</strong>
-          {` into `}
-          <strong>{currentBranch.name}</strong>
-        </div>
-      )
-    } else {
+  private renderCleanMessage(currentBranch: Branch, branch: Branch) {
+    if (this.commitCount <= 0) {
       return null
     }
+
+    const pluralized = this.commitCount === 1 ? 'commit' : 'commits'
+
+    if (this.state.selectedOperation === MultiCommitOperationKind.Rebase) {
+      return (
+        <>
+          This will update <strong>{currentBranch.name}</strong>
+          {` by applying its `}
+          <strong>{` ${this.commitCount} ${pluralized}`}</strong>
+          {` on top of `}
+          <strong>{branch.name}</strong>
+        </>
+      )
+    }
+
+    return (
+      <div className="merge-message">
+        This will merge
+        <strong>{` ${this.commitCount} ${pluralized}`}</strong>
+        {` from `}
+        <strong>{branch.name}</strong>
+        {` into `}
+        <strong>{currentBranch.name}</strong>
+      </div>
+    )
   }
 
-  private renderInvalidMergeMessage() {
+  private renderInvalidMessage() {
+    if (this.state.selectedOperation === MultiCommitOperationKind.Rebase) {
+      return <>Unable to start rebase. Check you have chosen a valid branch.</>
+    }
+
     return (
       <div className="merge-message">
         Unable to merge unrelated histories in this repository
@@ -149,32 +299,5 @@ export class MergeCallToActionWithConflicts extends React.Component<
         <strong>{currentBranch.name}</strong>
       </div>
     )
-  }
-
-  private onMergeClicked = async () => {
-    const { comparisonBranch, repository, mergeStatus } = this.props
-
-    this.props.dispatcher.recordCompareInitiatedMerge()
-
-    this.props.dispatcher.initializeMergeOperation(
-      repository,
-      false,
-      comparisonBranch
-    )
-
-    await this.props.dispatcher.mergeBranch(
-      repository,
-      comparisonBranch,
-      mergeStatus
-    )
-
-    this.props.dispatcher.executeCompare(repository, {
-      kind: HistoryTabMode.History,
-    })
-
-    this.props.dispatcher.updateCompareForm(repository, {
-      showBranchList: false,
-      filterText: '',
-    })
   }
 }

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -241,7 +241,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
     return (
       <div className="merge-message merge-message-loading">
         Checking for ability to {this.state.selectedOperation.toLowerCase()}{' '}
-        automatically...
+        automatically…
       </div>
     )
   }

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -258,7 +258,7 @@ export class MergeCallToActionWithConflicts extends React.Component<
         <div className="merge-message">
           This will update <strong>{currentBranch.name}</strong>
           {` by applying its `}
-          <strong>{` ${this.commitCount} ${pluralized}`}</strong>
+          <strong>{`${this.commitCount} ${pluralized}`}</strong>
           {` on top of `}
           <strong>{branch.name}</strong>
         </div>

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -249,13 +249,13 @@ export class MergeCallToActionWithConflicts extends React.Component<
 
     if (this.state.selectedOperation === MultiCommitOperationKind.Rebase) {
       return (
-        <>
+        <div className="merge-message">
           This will update <strong>{currentBranch.name}</strong>
           {` by applying its `}
           <strong>{` ${this.commitCount} ${pluralized}`}</strong>
           {` on top of `}
           <strong>{branch.name}</strong>
-        </>
+        </div>
       )
     }
 
@@ -273,7 +273,11 @@ export class MergeCallToActionWithConflicts extends React.Component<
 
   private renderInvalidMessage() {
     if (this.state.selectedOperation === MultiCommitOperationKind.Rebase) {
-      return <>Unable to start rebase. Check you have chosen a valid branch.</>
+      return (
+        <div className="merge-message">
+          Unable to start rebase. Check you have chosen a valid branch.
+        </div>
+      )
     }
 
     return (

--- a/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
+++ b/app/src/ui/history/merge-call-to-action-with-conflicts.tsx
@@ -151,11 +151,12 @@ export class MergeCallToActionWithConflicts extends React.Component<
       )
     }
 
+    const isSquash = operation === MultiCommitOperationKind.Squash
     dispatcher.initializeMultiCommitOperation(
       repository,
       {
         kind: MultiCommitOperationKind.Merge,
-        isSquash: operation === MultiCommitOperationKind.Squash,
+        isSquash,
         sourceBranch: comparisonBranch,
       },
       currentBranch,
@@ -163,7 +164,12 @@ export class MergeCallToActionWithConflicts extends React.Component<
     )
     dispatcher.recordCompareInitiatedMerge()
 
-    return dispatcher.mergeBranch(repository, comparisonBranch, mergeStatus)
+    return dispatcher.mergeBranch(
+      repository,
+      comparisonBranch,
+      mergeStatus,
+      isSquash
+    )
   }
 
   public render() {

--- a/app/src/ui/lib/update-branch.ts
+++ b/app/src/ui/lib/update-branch.ts
@@ -1,0 +1,92 @@
+import { enableSquashMerging } from '../../lib/feature-flag'
+import { getCommitsBetweenCommits, getMergeBase } from '../../lib/git'
+import { promiseWithMinimumTimeout } from '../../lib/promise'
+import { Branch } from '../../models/branch'
+import { ComputedAction } from '../../models/computed-action'
+import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
+import { RebasePreview } from '../../models/rebase'
+import { Repository } from '../../models/repository'
+import { IDropdownSelectButtonOption } from '../dropdown-select-button'
+
+export function getMergeOptions(): ReadonlyArray<IDropdownSelectButtonOption> {
+  const mergeOptions = [
+    {
+      label: 'Create a merge commit',
+      description:
+        'The commits from the selected branch will be added to the current branch via a merge commit.',
+      value: MultiCommitOperationKind.Merge,
+    },
+  ]
+  if (enableSquashMerging()) {
+    mergeOptions.push({
+      label: 'Squash and merge',
+      description:
+        'The commits in the selected branch will be combined into one commit in the current branch.',
+      value: MultiCommitOperationKind.Squash,
+    })
+  }
+  mergeOptions.push({
+    label: 'Rebase',
+    description:
+      'The commits from the selected branch will be rebased and added to the current branch.',
+    value: MultiCommitOperationKind.Rebase,
+  })
+  return mergeOptions
+}
+
+export async function updateRebasePreview(
+  baseBranch: Branch,
+  targetBranch: Branch,
+  repository: Repository,
+  onUpdate: (rebasePreview: RebasePreview | null) => void
+) {
+  const computingRebaseForBranch = baseBranch.name
+
+  onUpdate({
+    kind: ComputedAction.Loading,
+  })
+
+  const { commits, base } = await promiseWithMinimumTimeout(async () => {
+    const commits = await getCommitsBetweenCommits(
+      repository,
+      baseBranch.tip.sha,
+      targetBranch.tip.sha
+    )
+
+    const base = await getMergeBase(
+      repository,
+      baseBranch.tip.sha,
+      targetBranch.tip.sha
+    )
+
+    return { commits, base }
+  }, 500)
+
+  // if the branch being track has changed since we started this work, abandon
+  // any further state updates (this function is re-entrant if the user is
+  // using the keyboard to quickly switch branches)
+  if (computingRebaseForBranch !== baseBranch.name) {
+    onUpdate(null)
+    return
+  }
+
+  // if we are unable to find any commits to rebase, indicate that we're
+  // unable to proceed with the rebase
+  if (commits === null) {
+    onUpdate({
+      kind: ComputedAction.Invalid,
+    })
+    return
+  }
+
+  // the target branch is a direct descendant of the base branch
+  // which means the target branch is already up to date and the commits
+  // do not need to be applied
+  const isDirectDescendant = base === baseBranch.tip.sha
+  const commitsOrIgnore = isDirectDescendant ? [] : commits
+
+  onUpdate({
+    kind: ComputedAction.Clean,
+    commits: commitsOrIgnore,
+  })
+}

--- a/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/choose-branch/base-choose-branch-dialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../dropdown-select-button'
 import { MultiCommitOperationKind } from '../../../models/multi-commit-operation'
 import { assertNever } from '../../../lib/fatal-error'
-import { enableSquashMerging } from '../../../lib/feature-flag'
+import { getMergeOptions } from '../../lib/update-branch'
 
 interface IBaseChooseBranchDialogProps {
   readonly dispatcher: Dispatcher
@@ -192,32 +192,6 @@ export abstract class BaseChooseBranchDialog extends React.Component<
     }
   }
 
-  private getMergeOptions = (): IDropdownSelectButtonOption[] => {
-    const mergeOptions = [
-      {
-        label: 'Create a merge commit',
-        description:
-          'The commits from the selected branch will be added to the current branch via a merge commit.',
-        value: MultiCommitOperationKind.Merge,
-      },
-    ]
-    if (enableSquashMerging()) {
-      mergeOptions.push({
-        label: 'Squash and merge',
-        description:
-          'The commits in the selected branch will be combined into one commit in the current branch.',
-        value: MultiCommitOperationKind.Squash,
-      })
-    }
-    mergeOptions.push({
-      label: 'Rebase',
-      description:
-        'The commits from the selected branch will be rebased and added to the current branch.',
-      value: MultiCommitOperationKind.Rebase,
-    })
-    return mergeOptions
-  }
-
   private renderStatusPreview() {
     const { currentBranch } = this.props
     const { selectedBranch, statusPreview: preview } = this.state
@@ -275,7 +249,7 @@ export abstract class BaseChooseBranchDialog extends React.Component<
           {this.renderStatusPreview()}
           <DropdownSelectButton
             selectedValue={operation}
-            options={this.getMergeOptions()}
+            options={getMergeOptions()}
             disabled={!this.canStart()}
             tooltip={this.getSubmitButtonToolTip()}
             onSelectChange={this.onOperationChange}

--- a/app/styles/ui/_dropdown-select-button.scss
+++ b/app/styles/ui/_dropdown-select-button.scss
@@ -66,6 +66,10 @@
       border-color: var(--button-background);
       background-color: var(--button-hover-background);
     }
+
+    &.disabled {
+      opacity: 0.6;
+    }
   }
 
   .dropdown-select-button-options {

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -69,6 +69,9 @@
     flex-direction: column;
     font-size: var(--font-size-sm);
     padding: var(--spacing);
+    .merge-status-component {
+      text-align: center;
+    }
   }
 
   .no-branches {

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -68,7 +68,6 @@
     display: flex;
     flex-direction: column;
     font-size: var(--font-size-sm);
-    text-align: center;
     padding: var(--spacing);
   }
 


### PR DESCRIPTION
## Description

Make squash-merge and rebase options available in comparison view

Fun note.. this logically makes sense but when I first did it confused me.. If you regular merge or rebase the comparison view will now show no commits Behind. However if you squash merge, it will still show the same number behind because it doesn't get those commits in its history (it just gets the changes).

### Screenshots

https://user-images.githubusercontent.com/75402236/121361436-4a166a80-c903-11eb-8df7-6493f80b6fc4.mov


## Release notes

Notes: no-notes
