### PR TITLE
Create intros for the new drag&drop features :tada:

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -45,6 +45,7 @@ import {
   MultiCommitOperationDetail,
   MultiCommitOperationStep,
 } from '../models/multi-commit-operation'
+import { DragAndDropIntroType } from '../ui/history/drag-and-drop-intro'
 
 export enum SelectionType {
   Repository,
@@ -271,9 +272,9 @@ export interface IAppState {
   readonly commitSpellcheckEnabled: boolean
 
   /**
-   * Whether or not the user has been introduced to the cherry pick feature
+   * List of drag & drop intro types that have been shown to the user.
    */
-  readonly hasShownCherryPickIntro: boolean
+  readonly dragAndDropIntroTypesShown: ReadonlySet<DragAndDropIntroType>
 
   /**
    * Record of what logged in users have been checked to see if thank you is in

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2747,7 +2747,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           aheadBehindStore={this.props.aheadBehindStore}
           commitSpellcheckEnabled={this.state.commitSpellcheckEnabled}
           onCherryPick={this.startCherryPickWithoutBranch}
-          hasShownCherryPickIntro={this.state.hasShownCherryPickIntro}
+          dragAndDropIntroTypesShown={this.state.dragAndDropIntroTypesShown}
         />
       )
     } else if (selectedState.type === SelectionType.CloningRepository) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -120,6 +120,7 @@ import {
   MultiCommitOperationStep,
   MultiCommitOperationStepKind,
 } from '../../models/multi-commit-operation'
+import { DragAndDropIntroType } from '../history/drag-and-drop-intro'
 
 /**
  * An error handler function.
@@ -2696,7 +2697,7 @@ export class Dispatcher {
     sourceBranch: Branch | null
   ): Promise<void> {
     this.initializeCherryPickFlow(repository, commits)
-    this.dismissCherryPickIntro()
+    this.markDragAndDropIntroAsSeen(DragAndDropIntroType.CherryPick)
 
     const retry: RetryAction = {
       type: RetryActionType.CherryPick,
@@ -3058,9 +3059,9 @@ export class Dispatcher {
     return this.appStore._setCherryPickProgressFromState(repository)
   }
 
-  /** Method to dismiss cherry pick intro */
-  public dismissCherryPickIntro(): void {
-    this.appStore._dismissCherryPickIntro()
+  /** Method to mark a drag & drop intro as seen */
+  public markDragAndDropIntroAsSeen(intro: DragAndDropIntroType): void {
+    this.appStore._markDragAndDropIntroAsSeen(intro)
   }
 
   /**
@@ -3188,6 +3189,8 @@ export class Dispatcher {
       return
     }
 
+    this.markDragAndDropIntroAsSeen(DragAndDropIntroType.Reorder)
+
     const stateBefore = this.repositoryStateManager.get(repository)
     const { tip } = stateBefore.branchesState
 
@@ -3291,6 +3294,8 @@ export class Dispatcher {
     if (this.appStore._checkForUncommittedChanges(repository, retry)) {
       return
     }
+
+    this.markDragAndDropIntroAsSeen(DragAndDropIntroType.Squash)
 
     const stateBefore = this.repositoryStateManager.get(repository)
     const { tip } = stateBefore.branchesState

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -9,6 +9,11 @@ import { Popover, PopoverCaretPosition } from '../lib/popover'
 import { Button } from '../lib/button'
 import { encodePathAsUrl } from '../../lib/path'
 import { DragData, DragType } from '../../models/drag-drop'
+import {
+  AvailableDragAndDropIntroKeys,
+  AvailableDragAndDropIntros,
+  DragAndDropIntroType,
+} from './drag-and-drop-intro'
 
 const RowHeight = 50
 
@@ -118,11 +123,11 @@ interface ICommitListProps {
   /** Whether or not commits in this list can be reordered. */
   readonly reorderingEnabled: boolean
 
-  /* Whether or not the user has been introduced to cherry picking feature */
-  readonly hasShownCherryPickIntro: boolean
+  /* Types of drag and drop intros already seen by the user */
+  readonly dragAndDropIntroTypesShown: ReadonlySet<DragAndDropIntroType>
 
-  /** Callback to fire when cherry pick intro popover has been dismissed */
-  readonly onDismissCherryPickIntro: () => void
+  /** Callback to fire when a drag & drop intro popover has been seen */
+  readonly onDragAndDropIntroSeen: (intro: DragAndDropIntroType) => void
 
   /** Whether a cherry pick is progress */
   readonly isCherryPickInProgress: boolean
@@ -140,9 +145,30 @@ interface ICommitListProps {
   readonly disableSquashing?: boolean
 }
 
+interface ICommitListState {
+  /** Remaining drag and drop intros to show in the popover. */
+  readonly remainingDragAndDropIntros: ReadonlyArray<DragAndDropIntroType>
+}
+
 /** A component which displays the list of commits. */
-export class CommitList extends React.Component<ICommitListProps, {}> {
+export class CommitList extends React.Component<
+  ICommitListProps,
+  ICommitListState
+> {
   private commitsHash = memoize(makeCommitsHash, arrayEquals)
+
+  public constructor(props: ICommitListProps) {
+    super(props)
+
+    const remainingDragAndDropIntros = AvailableDragAndDropIntroKeys.filter(
+      intro => !props.dragAndDropIntroTypesShown.has(intro)
+    )
+
+    this.state = {
+      remainingDragAndDropIntros,
+    }
+  }
+
   private getVisibleCommits(): ReadonlyArray<Commit> {
     const commits = new Array<Commit>()
     for (const sha of this.props.commitSHAs) {
@@ -332,7 +358,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
   }
 
   private renderCherryPickIntroPopover() {
-    if (this.props.hasShownCherryPickIntro) {
+    if (this.state.remainingDragAndDropIntros.length === 0) {
       return null
     }
 
@@ -341,24 +367,43 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
       'static/cherry-pick-intro.png'
     )
 
+    const nextButtonTitle =
+      this.state.remainingDragAndDropIntros.length > 1 ? 'Next' : 'Got it'
+
+    const introType = this.state.remainingDragAndDropIntros[0]
+    const intro = AvailableDragAndDropIntros[introType]
+
     return (
       <Popover caretPosition={PopoverCaretPosition.LeftTop}>
         <img src={cherryPickIntro} className="cherry-pick-intro" />
         <h3>
-          Drag and drop to cherry pick!
+          {intro.title}
           <span className="call-to-action-bubble">New</span>
         </h3>
-        <p>
-          Copy commits to another branch by dragging and dropping them onto a
-          branch in the branch menu, or by right clicking on a commit.
-        </p>
+        <p>{intro.body}</p>
         <div>
-          <Button onClick={this.props.onDismissCherryPickIntro} type="submit">
-            Got it
+          <Button onClick={this.onNextDragAndDropIntro} type="submit">
+            {nextButtonTitle}
           </Button>
         </div>
       </Popover>
     )
+  }
+
+  private onNextDragAndDropIntro = () => {
+    if (this.state.remainingDragAndDropIntros.length === 0) {
+      return
+    }
+
+    const intro = this.state.remainingDragAndDropIntros[0]
+
+    this.setState({
+      remainingDragAndDropIntros: this.state.remainingDragAndDropIntros.slice(
+        1
+      ),
+    })
+
+    this.props.onDragAndDropIntroSeen(intro)
   }
 
   public render() {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -31,6 +31,7 @@ import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-autho
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
 import { enableCommitReordering } from '../../lib/feature-flag'
+import { DragAndDropIntroType } from './drag-and-drop-intro'
 interface ICompareSidebarProps {
   readonly repository: Repository
   readonly isLocalRepository: boolean
@@ -53,7 +54,7 @@ interface ICompareSidebarProps {
   readonly localTags: Map<string, string> | null
   readonly tagsToPush: ReadonlyArray<string> | null
   readonly aheadBehindStore: AheadBehindStore
-  readonly hasShownCherryPickIntro: boolean
+  readonly dragAndDropIntroTypesShown: ReadonlySet<DragAndDropIntroType>
   readonly isCherryPickInProgress: boolean
 }
 
@@ -259,8 +260,8 @@ export class CompareSidebar extends React.Component<
         onCompareListScrolled={this.props.onCompareListScrolled}
         compareListScrollTop={this.props.compareListScrollTop}
         tagsToPush={this.props.tagsToPush}
-        hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
-        onDismissCherryPickIntro={this.onDismissCherryPickIntro}
+        dragAndDropIntroTypesShown={this.props.dragAndDropIntroTypesShown}
+        onDragAndDropIntroSeen={this.onDragAndDropIntroSeen}
         isCherryPickInProgress={this.props.isCherryPickInProgress}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveCommitDragElement={this.onRemoveCommitDragElement}
@@ -313,8 +314,8 @@ export class CompareSidebar extends React.Component<
     this.props.dispatcher.clearDragElement()
   }
 
-  private onDismissCherryPickIntro = () => {
-    this.props.dispatcher.dismissCherryPickIntro()
+  private onDragAndDropIntroSeen = (intro: DragAndDropIntroType) => {
+    this.props.dispatcher.markDragAndDropIntroAsSeen(intro)
   }
 
   private renderActiveTab(view: ICompareBranch) {

--- a/app/src/ui/history/drag-and-drop-intro.ts
+++ b/app/src/ui/history/drag-and-drop-intro.ts
@@ -22,17 +22,17 @@ export const AvailableDragAndDropIntros: Record<
   DragAndDropIntro
 > = {
   [DragAndDropIntroType.CherryPick]: {
-    title: 'Cherry-pick!',
+    title: 'Drag and drop to cherry-pick!',
     body:
       'Copy commits to another branch by dragging and dropping them onto a branch in the branch menu, or by right clicking on a commit.',
   },
   [DragAndDropIntroType.Squash]: {
-    title: 'Squash!',
+    title: 'Drag and drop to squash!',
     body:
       'Squash commits by dragging and dropping them onto another commit, or by right clicking on multiple commits.',
   },
   [DragAndDropIntroType.Reorder]: {
-    title: 'Reorder!',
+    title: 'Drag and drop to reorder!',
     body:
       'Reorder commits to tidy up your history by dragging and dropping them to a different position.',
   },

--- a/app/src/ui/history/drag-and-drop-intro.ts
+++ b/app/src/ui/history/drag-and-drop-intro.ts
@@ -1,0 +1,39 @@
+/** Type of the drag and drop intro popover. Each value represents a feature. */
+export enum DragAndDropIntroType {
+  CherryPick = 'cherry-pick',
+  Squash = 'squash',
+  Reorder = 'reorder',
+}
+
+/** Structure to describe the drag and drop intro popover. */
+export type DragAndDropIntro = {
+  readonly title: string
+  readonly body: string
+}
+
+/** List of all available drag and drop intro types. */
+export const AvailableDragAndDropIntroKeys = Object.values(
+  DragAndDropIntroType
+) as ReadonlyArray<DragAndDropIntroType>
+
+/** Map with all available drag and drop intros. */
+export const AvailableDragAndDropIntros: Record<
+  DragAndDropIntroType,
+  DragAndDropIntro
+> = {
+  [DragAndDropIntroType.CherryPick]: {
+    title: 'Cherry-pick!',
+    body:
+      'Copy commits to another branch by dragging and dropping them onto a branch in the branch menu, or by right clicking on a commit.',
+  },
+  [DragAndDropIntroType.Squash]: {
+    title: 'Squash!',
+    body:
+      'Squash commits by dragging and dropping them onto another commit, or by right clicking on multiple commits.',
+  },
+  [DragAndDropIntroType.Reorder]: {
+    title: 'Reorder!',
+    body:
+      'Reorder commits to tidy up your history by dragging and dropping them to a different position.',
+  },
+}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -30,6 +30,10 @@ import { openFile } from './lib/open-file'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
 import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { DragType } from '../models/drag-drop'
+import {
+  DragAndDropIntroType,
+  AvailableDragAndDropIntroKeys,
+} from './history/drag-and-drop-intro'
 
 /** The widest the sidebar can be with the minimum window size. */
 const MaxSidebarWidth = 495
@@ -92,8 +96,9 @@ interface IRepositoryViewProps {
     repository: Repository,
     commits: ReadonlyArray<CommitOneLine>
   ) => void
-  /* Whether or not the user has been introduced to cherry picking feature */
-  readonly hasShownCherryPickIntro: boolean
+
+  /* Types of drag and drop intros already seen by the user */
+  readonly dragAndDropIntroTypesShown: ReadonlySet<DragAndDropIntroType>
 }
 
 interface IRepositoryViewState {
@@ -162,9 +167,12 @@ export class RepositoryView extends React.Component<
   }
 
   private renderNewCallToActionBubble(): JSX.Element | null {
-    const { hasShownCherryPickIntro, state } = this.props
+    const { dragAndDropIntroTypesShown, state } = this.props
     const { compareState } = state
-    if (hasShownCherryPickIntro || compareState.commitSHAs.length === 0) {
+    const hasSeenAllDragAndDropIntros =
+      dragAndDropIntroTypesShown.size >= AvailableDragAndDropIntroKeys.length
+
+    if (hasSeenAllDragAndDropIntros || compareState.commitSHAs.length === 0) {
       return null
     }
     return <span className="call-to-action-bubble">New</span>
@@ -260,7 +268,7 @@ export class RepositoryView extends React.Component<
         compareListScrollTop={scrollTop}
         tagsToPush={this.props.state.tagsToPush}
         aheadBehindStore={this.props.aheadBehindStore}
-        hasShownCherryPickIntro={this.props.hasShownCherryPickIntro}
+        dragAndDropIntroTypesShown={this.props.dragAndDropIntroTypesShown}
         isCherryPickInProgress={this.props.state.cherryPickState.step !== null}
       />
     )

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -169,8 +169,10 @@ export class RepositoryView extends React.Component<
   private renderNewCallToActionBubble(): JSX.Element | null {
     const { dragAndDropIntroTypesShown, state } = this.props
     const { compareState } = state
-    const hasSeenAllDragAndDropIntros =
-      dragAndDropIntroTypesShown.size >= AvailableDragAndDropIntroKeys.length
+    const remainingDragAndDropIntros = AvailableDragAndDropIntroKeys.filter(
+      intro => !dragAndDropIntroTypesShown.has(intro)
+    )
+    const hasSeenAllDragAndDropIntros = remainingDragAndDropIntros.length === 0
 
     if (hasSeenAllDragAndDropIntros || compareState.commitSHAs.length === 0) {
       return null


### PR DESCRIPTION
## Description

This PR does a small refactor over the existing cherry-picking intro to make it a bit more generic. The old flag to check if the user saw the cherry-picking intro is converted into the new way of indicating that.

Instead of filling our storage with booleans, I added an array of features for which the user already saw the intro. The rest of drag&drop features not in that array will be "queued" in the popover.

### Screenshots

https://user-images.githubusercontent.com/1083228/121392438-b028df00-c94f-11eb-93bb-d618c992909a.mov

## Release notes

Notes: no-notes
