### PR TITLE
Add formatter function for commit descriptions

### DIFF
--- a/app/src/lib/format-commit-message.ts
+++ b/app/src/lib/format-commit-message.ts
@@ -21,6 +21,13 @@ export async function formatCommitMessage(
 ) {
   const { summary, description, trailers } = context
 
+  // Apply word wrap and limit the lines of the description
+  // to 72 characters
+  const formattedDescription = description?.replace(
+    /(?![^\n]{1,72}$)([^\n]{1,72})\s/g,
+    '$1\n'
+  )
+
   // Git always trim whitespace at the end of commit messages
   // so we concatenate the summary with the description, ensuring
   // that they're separated by two newlines. If we don't have a
@@ -28,7 +35,10 @@ export async function formatCommitMessage(
   // all get trimmed away and replaced with a single newline (since
   // all commit messages needs to end with a newline for git
   // interpret-trailers to work)
-  const message = `${summary}\n\n${description || ''}\n`.replace(/\s+$/, '\n')
+  const message = `${summary}\n\n${formattedDescription || ''}\n`.replace(
+    /\s+$/,
+    '\n'
+  )
 
   return trailers !== undefined && trailers.length > 0
     ? mergeTrailers(repository, message, trailers)

--- a/app/test/unit/format-commit-message-test.ts
+++ b/app/test/unit/format-commit-message-test.ts
@@ -34,6 +34,19 @@ describe('formatCommitMessage', () => {
     ).toBe('foo\n\nbar\n')
   })
 
+  it('formats descriptions with a maximum line length of 72 characters', async () => {
+    const repo = await setupEmptyRepository()
+    expect(
+      await formatCommitMessage(repo, {
+        summary: 'foo',
+        description:
+          'Lorem ipsum dolor sit amet.\n\nConsetetur\nsadipscing\n elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.',
+      })
+    ).toBe(
+      'foo\n\nLorem ipsum dolor sit amet.\n\nConsetetur\nsadipscing\n elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna\naliquyam erat, sed diam voluptua.\n'
+    )
+  })
+
   it('appends trailers to a summary-only message', async () => {
     const repo = await setupEmptyRepository()
     const trailers = [


### PR DESCRIPTION
## Description

This PR adds a formatter regex that wraps commit descriptions word-wise at the 72 character limit. This way you can simply enter a description and don't have to worry about line lengths to avoid a long one-liner description.

It addresses (in part) issue #62. 

### Screenshots

#### Before

Description is on one line

![grafik](https://user-images.githubusercontent.com/12641361/122052055-8d7e4680-cde5-11eb-80c0-089599a238a1.png)

#### After

Description is split across multiple lines

![grafik](https://user-images.githubusercontent.com/12641361/122051758-3f694300-cde5-11eb-8a4e-0b0d4934fa45.png)

## Release notes

Notes: Add word-wise wrap to commit descriptions
