### PR TITLE
Add support for Sublime Text 4 on Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -173,7 +173,12 @@ const editors: IWindowsExternalEditor[] = [
   },
   {
     name: 'Sublime Text',
-    registryKeys: [LocalMachineUninstallKey('Sublime Text 3_is1')],
+    registryKeys: [
+      // Sublime Text 4 (and newer?)
+      LocalMachineUninstallKey('Sublime Text_is1'),
+      // Sublime Text 3
+      LocalMachineUninstallKey('Sublime Text 3_is1'),
+    ],
     executableShimPath: ['subl.exe'],
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Sublime Text') &&


### PR DESCRIPTION
Closes #12124

## Description

This PR adds the new uninstall key needed for Sublime Text 4 on Windows. It supersedes #12297 and #12179 just to make sure it gets merged in time for the upcoming release, sorry about that 😅  And thank you both @tsvetilian-ty and @ooksanen for your contributions 🙏 🙇‍♂️ 

## Release notes

Notes: [Added] Add support for Sublime Text 4 on Windows
