### PR TITLE
Clear merge operations state after successful merge so rebases can start

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4587,6 +4587,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         // successfully after conflicts in `dispatcher.finishConflictedMerge`.
         this.statsStore.recordSquashMergeSuccessful()
       }
+      this._endMultiCommitOperation(repository)
     } else if (
       mergeResult === MergeResult.AlreadyUpToDate &&
       tip.kind === TipState.Valid
@@ -4596,6 +4597,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
         ourBranch: tip.branch.name,
         theirBranch: sourceBranch.name,
       })
+      this._endMultiCommitOperation(repository)
     }
 
     return this._refreshRepository(repository)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3361,7 +3361,7 @@ export class Dispatcher {
       tip
     )
 
-    this.processMultiCommitOperationRebaseResult(
+    return this.processMultiCommitOperationRebaseResult(
       MultiCommitOperationKind.Squash,
       repository,
       result,


### PR DESCRIPTION
## Description

This PR fixes a regression in the upcoming release, where completing a merge wouldn't clear the state of the app, so new operations like a rebase wouldn't start.

### Screenshots

Before the fix:

https://user-images.githubusercontent.com/1083228/121554281-50473c80-ca12-11eb-9a52-0d6a2c81d0d4.mov

After the fix: In the video, you can see how after a successful merge with `development`, if I try to start a rebase, the dialog pops up as expected. In the latest beta, that doesn't happen and the app grays out all options in the Branch menu, making it impossible to proceed with any other operation.

https://user-images.githubusercontent.com/1083228/121554497-82589e80-ca12-11eb-949e-5b85d1d44ed9.mov

## Release notes

Notes: no-notes
