### PR TITLE
Fix unhandled error when conflicts are detected

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6789,10 +6789,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (multiCommitOperationState === null) {
       const gitStore = this.gitStoreCache.get(repository)
 
-      const sourceBranch = gitStore.allBranches.find(
-        branch => branch.name === theirBranch
-      )
-
       const targetBranch = gitStore.allBranches.find(
         branch => branch.name === currentBranch
       )
@@ -6800,6 +6796,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       if (targetBranch === undefined) {
         return
       }
+
+      const sourceBranch = gitStore.allBranches.find(
+        branch => branch.name === theirBranch
+      )
 
       this._initializeMultiCommitOperation(
         repository,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6777,6 +6777,36 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** This shouldn't be called directly. See `Dispatcher`. */
+  public async _handleConflictsDetectedOnError(
+    repository: Repository,
+    currentBranch: string,
+    theirBranch: string
+  ): Promise<void> {
+    const { multiCommitOperationState } = this.repositoryStateCache.get(
+      repository
+    )
+
+    if (multiCommitOperationState === null) {
+      return
+    }
+
+    this._setMultiCommitOperationStep(repository, {
+      kind: MultiCommitOperationStepKind.ShowConflicts,
+      conflictState: {
+        kind: 'multiCommitOperation',
+        manualResolutions: new Map<string, ManualConflictResolution>(),
+        ourBranch: currentBranch,
+        theirBranch,
+      },
+    })
+
+    return this._showPopup({
+      type: PopupType.MultiCommitOperation,
+      repository,
+    })
+  }
+
+  /** This shouldn't be called directly. See `Dispatcher`. */
   public async _setMultiCommitOperationStep(
     repository: Repository,
     step: MultiCommitOperationStep

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6787,7 +6787,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
     )
 
     if (multiCommitOperationState === null) {
-      return
+      const gitStore = this.gitStoreCache.get(repository)
+
+      const sourceBranch = gitStore.allBranches.find(
+        branch => branch.name === theirBranch
+      )
+
+      const targetBranch = gitStore.allBranches.find(
+        branch => branch.name === currentBranch
+      )
+
+      if (targetBranch === undefined) {
+        return
+      }
+
+      this._initializeMultiCommitOperation(
+        repository,
+        {
+          kind: MultiCommitOperationKind.Merge,
+          isSquash: false,
+          sourceBranch: sourceBranch ?? null,
+        },
+        targetBranch,
+        []
+      )
     }
 
     this._setMultiCommitOperationStep(repository, {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3573,6 +3573,18 @@ export class Dispatcher {
     return result
   }
 
+  public handleConflictsDetectedOnError(
+    repository: Repository,
+    currentBranch: string,
+    theirBranch: string
+  ) {
+    return this.appStore._handleConflictsDetectedOnError(
+      repository,
+      currentBranch,
+      theirBranch
+    )
+  }
+
   /**
    * This method is to update the multi operation state to move it along in
    * steps.

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -20,8 +20,6 @@ import { getDotComAPIEndpoint } from '../../lib/api'
 import { hasWritePermission } from '../../models/github-repository'
 import { RetryActionType } from '../../models/retry-actions'
 import { parseFilesToBeOverwritten } from '../lib/parse-files-to-be-overwritten'
-import { MultiCommitOperationStepKind } from '../../models/multi-commit-operation'
-import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 
 /** An error which also has a code property. */
 interface IErrorWithCode extends Error {
@@ -316,20 +314,11 @@ export async function mergeConflictHandler(
 
   const { currentBranch, theirBranch } = gitContext
 
-  dispatcher.setMultiCommitOperationStep(repository, {
-    kind: MultiCommitOperationStepKind.ShowConflicts,
-    conflictState: {
-      kind: 'multiCommitOperation',
-      manualResolutions: new Map<string, ManualConflictResolution>(),
-      ourBranch: currentBranch,
-      theirBranch,
-    },
-  })
-
-  dispatcher.showPopup({
-    type: PopupType.MultiCommitOperation,
+  dispatcher.handleConflictsDetectedOnError(
     repository,
-  })
+    currentBranch,
+    theirBranch
+  )
 
   return null
 }


### PR DESCRIPTION
## Description

This PR addresses instances of a new error that happens when merge conflicts are detected out of a "multi-commit operation" (like pulling from a diverged branch). The fix consists on initializing a Merge multi-commit operation before setting the `ShowConflicts` step if no "multi commit operation" was initialized before.

## Release notes

Notes: no-notes
