### PR TITLE
 Add Amend button next to Undo for the last unpushed commit

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -303,7 +303,7 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  */
 const RecentRepositoriesLength = 3
 
-const defaultSidebarWidth: number = 250
+const defaultSidebarWidth: number = 275
 const sidebarWidthConfigKey: string = 'sidebar-width'
 
 const defaultCommitSummaryWidth: number = 250

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -14,7 +14,7 @@ import { Dispatcher } from '../dispatcher'
 import { IssuesStore, GitHubUserStore } from '../../lib/stores'
 import { CommitIdentity } from '../../models/commit-identity'
 import { Commit, ICommitContext } from '../../models/commit'
-import { UndoCommit } from './undo-commit'
+import { UndoCommit } from './undo-amend-commit'
 import {
   buildAutocompletionProviders,
   IAutocompletionProvider,
@@ -294,6 +294,10 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     }
   }
 
+  private onAmend = () => {
+    this.props.dispatcher.setAmendingRepository(this.props.repository, true)
+  }
+
   private renderMostRecentLocalCommit() {
     const commit = this.props.mostRecentLocalCommit
     let child: JSX.Element | null = null
@@ -312,6 +316,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
             isPushPullFetchInProgress={this.props.isPushPullFetchInProgress}
             commit={commit}
             onUndo={this.onUndo}
+            onAmend={this.onAmend}
             emoji={this.props.emoji}
             isCommitting={this.props.isCommitting}
           />

--- a/app/src/ui/changes/undo-amend-commit.tsx
+++ b/app/src/ui/changes/undo-amend-commit.tsx
@@ -9,6 +9,9 @@ interface IUndoCommitProps {
   /** The function to call when the Undo button is clicked. */
   readonly onUndo: () => void
 
+  /** The function to call when the Amend button is clicked. */
+  readonly onAmend: () => void
+
   /** The commit to undo. */
   readonly commit: Commit
 
@@ -28,12 +31,12 @@ export class UndoCommit extends React.Component<IUndoCommitProps, {}> {
     const disabled =
       this.props.isPushPullFetchInProgress || this.props.isCommitting
     const title = disabled
-      ? 'Undo is disabled while the repository is being updated'
+      ? 'Undo and amend are disabled while the repository is being updated'
       : undefined
 
     const authorDate = this.props.commit.author.date
     return (
-      <div id="undo-commit" role="group" aria-label="Undo commit">
+      <div id="undo-amend-commit" role="group" aria-label="Undo or amend commit">
         <div className="commit-info">
           <div className="ago">
             Committed <RelativeTime date={authorDate} />
@@ -46,6 +49,9 @@ export class UndoCommit extends React.Component<IUndoCommitProps, {}> {
           />
         </div>
         <div className="actions" title={title}>
+          <Button size="small" disabled={disabled} onClick={this.props.onAmend}>
+            Amend
+          </Button>
           <Button size="small" disabled={disabled} onClick={this.props.onUndo}>
             Undo
           </Button>

--- a/app/styles/ui/_changes.scss
+++ b/app/styles/ui/_changes.scss
@@ -1,7 +1,7 @@
 @import 'changes/commit-message';
 @import 'changes/continue-rebase';
 @import 'changes/changes-list';
-@import 'changes/undo-commit';
+@import 'changes/undo-amend-commit';
 @import 'changes/changes-view';
 @import 'changes/no-changes';
 @import 'changes/oversized-files-warning';

--- a/app/styles/ui/changes/_undo-amend-commit.scss
+++ b/app/styles/ui/changes/_undo-amend-commit.scss
@@ -1,4 +1,4 @@
-#undo-commit {
+#undo-amend-commit {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -26,10 +26,12 @@
   }
 
   // We're creating this wrapper to be able to set the padding. If we had
-  // padding on #undo-commit, the enter/leave animate wouldn't animate the
+  // padding on #undo-amend-commit, the enter/leave animate wouldn't animate the
   // amount of the padding.
   .actions {
     padding: var(--spacing);
+    display: flex;
+    gap: var(--spacing-half);
 
     // In order to not add to the margin already in commit-info.
     padding-left: 0;


### PR DESCRIPTION
This provides an enhancement to #12353 and adds an even more convenient UX solving #1644.

## Description

This is a feature I've been missing for quite some time.
I was happy to see #12353 going live, but it's not quite as handy as I'd like – the convenience of Undo in the sidebar is specifically the reason why I've been using that button _a lot_. But, fortunately now with Amend being easy to dispatch, it was pleasant to implement a useful Amend button right next to Undo, making amending a breeze.

Also increased `defaultSidebarWidth` a bit from 250 to 275, so that there's still comfortable room the for commit message (and time).

### Screenshots

![Amend](https://user-images.githubusercontent.com/4550621/122289930-88a7b880-cef3-11eb-8d6e-50e8ae43f0e8.png)

## Release notes

Notes: [New] Amend the last local commit handily from the staging area
