### PR TITLE
Alert when commit summary exceeds cutoff limit

### DIFF
--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -7,7 +7,8 @@ import {
 } from './text-token-parser'
 import { assertNever } from './fatal-error'
 
-const MaxSummaryLength = 72
+export const IdealSummaryLength = 50
+export const MaxSummaryLength = 72
 
 /**
  * A method used to wrap long commit summaries and put any overflow

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -7,7 +7,6 @@ import {
 } from './text-token-parser'
 import { assertNever } from './fatal-error'
 
-export const IdealSummaryLength = 50
 export const MaxSummaryLength = 72
 
 /**

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -313,36 +313,46 @@ export abstract class AutocompletingTextInput<
         focusable={false}
       >
         <h3>{this.props.warningMessage!.title}</h3>
-        <Row><div>{this.props.warningMessage!.description}</div></Row>
+        <Row>
+          <div>{this.props.warningMessage!.description}</div>
+        </Row>
       </Popover>
     )
   }
 
   private renderWarningBadge() {
     return (
-      <div className="warning-badge" onMouseEnter={this.onWarningBadgeMouseEnter} onMouseLeave={this.onWarningBadgeMouseLeave}>
+      <div
+        className="warning-badge"
+        onMouseEnter={this.onWarningBadgeMouseEnter}
+        onMouseLeave={this.onWarningBadgeMouseLeave}
+      >
         <Octicon symbol={OcticonSymbol.alert} />
         {this.state.isPopoverOpen && this.renderPopover()}
       </div>
     )
   }
 
-  private onWarningBadgeMouseEnter = (event: React.MouseEvent<HTMLDivElement>) => {
+  private onWarningBadgeMouseEnter = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
     event.preventDefault()
     this.openPopover()
   }
 
-  private onWarningBadgeMouseLeave = (event: React.MouseEvent<HTMLDivElement>) => {
+  private onWarningBadgeMouseLeave = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
     event.preventDefault()
     this.closePopover()
   }
 
   private openPopover() {
-    this.setState(prevState => ({...prevState, isPopoverOpen: true}))
+    this.setState(prevState => ({ ...prevState, isPopoverOpen: true }))
   }
 
   private closePopover() {
-    this.setState(prevState => ({...prevState, isPopoverOpen: false}))
+    this.setState(prevState => ({ ...prevState, isPopoverOpen: false }))
   }
 
   private onBlur = (e: React.FocusEvent<ElementType>) => {

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -35,6 +35,10 @@ import { setGlobalConfigValue } from '../../lib/git/config'
 import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { isAccountEmail } from '../../lib/is-account-email'
+import {
+  IdealSummaryLength,
+  MaxSummaryLength,
+} from '../../lib/wrap-rich-text-commit-message'
 
 const addAuthorIcon = new OcticonSymbol(
   18,
@@ -731,6 +735,8 @@ export class CommitMessage extends React.Component<
 
     const summaryInputClassName = classNames('summary-field', 'nudge-arrow', {
       'nudge-arrow-left': this.props.shouldNudge === true,
+      'near-limit': this.state.summary.length > IdealSummaryLength,
+      'over-limit': this.state.summary.length > MaxSummaryLength,
     })
 
     return (

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -43,11 +43,11 @@ const addAuthorIcon = new OcticonSymbol(
   18,
   13,
   'M14 6V4.25a.75.75 0 0 1 1.5 0V6h1.75a.75.75 0 1 1 0 1.5H15.5v1.75a.75.75 0 0 ' +
-    '1-1.5 0V7.5h-1.75a.75.75 0 1 1 0-1.5H14zM8.5 4a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 ' +
-    '0zm.063 3.064a3.995 3.995 0 0 0 1.2-4.429A3.996 3.996 0 0 0 8.298.725a4.01 4.01 0 0 ' +
-    '0-6.064 1.91 3.987 3.987 0 0 0 1.2 4.43A5.988 5.988 0 0 0 0 12.2a.748.748 0 0 0 ' +
-    '.716.766.751.751 0 0 0 .784-.697 4.49 4.49 0 0 1 1.39-3.04 4.51 4.51 0 0 1 6.218 ' +
-    '0 4.49 4.49 0 0 1 1.39 3.04.748.748 0 0 0 .786.73.75.75 0 0 0 .714-.8 5.989 5.989 0 0 0-3.435-5.136z'
+  '1-1.5 0V7.5h-1.75a.75.75 0 1 1 0-1.5H14zM8.5 4a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 ' +
+  '0zm.063 3.064a3.995 3.995 0 0 0 1.2-4.429A3.996 3.996 0 0 0 8.298.725a4.01 4.01 0 0 ' +
+  '0-6.064 1.91 3.987 3.987 0 0 0 1.2 4.43A5.988 5.988 0 0 0 0 12.2a.748.748 0 0 0 ' +
+  '.716.766.751.751 0 0 0 .784-.697 4.49 4.49 0 0 1 1.39-3.04 4.51 4.51 0 0 1 6.218 ' +
+  '0 4.49 4.49 0 0 1 1.39 3.04.748.748 0 0 0 .786.73.75.75 0 0 0 .714-.8 5.989 5.989 0 0 0-3.435-5.136z'
 )
 
 interface ICommitMessageProps {
@@ -761,7 +761,7 @@ export class CommitMessage extends React.Component<
             onContextMenu={this.onAutocompletingInputContextMenu}
             disabled={this.props.isCommitting === true}
             spellcheck={this.props.commitSpellcheckEnabled}
-            warningMessage={charactersOverLimit > 0 ? { title:'This commit summary is too long',description: <>The summary is limited to {MaxSummaryLength} characters, which you've exceeded. <strong>{charactersOverLimit} {charactersOverLimit === 1 ? 'character':'characters'}</strong> going over the limit will be cut off.</> }: undefined}
+            warningMessage={charactersOverLimit > 0 ? { title: 'This commit summary is very long', description: <>The summary is limited to {MaxSummaryLength} characters, which you've exceeded. <strong>{charactersOverLimit} {charactersOverLimit === 1 ? 'character' : 'characters'}</strong> going over the limit will be moved into the commit description.</> } : undefined}
           />
         </div>
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -36,7 +36,6 @@ import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { isAccountEmail } from '../../lib/is-account-email'
 import {
-  IdealSummaryLength,
   MaxSummaryLength,
 } from '../../lib/wrap-rich-text-commit-message'
 
@@ -354,7 +353,7 @@ export class CommitMessage extends React.Component<
     const accountEmails = repositoryAccount?.emails.map(e => e.email) ?? []
     const email = commitAuthor?.email
 
-    const warningBadgeVisible =
+    let warningBadgeVisible =
       email !== undefined &&
       repositoryAccount !== null &&
       repositoryAccount !== undefined &&
@@ -734,10 +733,10 @@ export class CommitMessage extends React.Component<
     })
 
     const summaryInputClassName = classNames('summary-field', 'nudge-arrow', {
-      'nudge-arrow-left': this.props.shouldNudge === true,
-      'near-limit': this.state.summary.length > IdealSummaryLength,
-      'over-limit': this.state.summary.length > MaxSummaryLength,
+      'nudge-arrow-left': this.props.shouldNudge === true
     })
+
+    const charactersOverLimit = this.state.summary.length - MaxSummaryLength
 
     return (
       <div
@@ -762,6 +761,7 @@ export class CommitMessage extends React.Component<
             onContextMenu={this.onAutocompletingInputContextMenu}
             disabled={this.props.isCommitting === true}
             spellcheck={this.props.commitSpellcheckEnabled}
+            warningMessage={charactersOverLimit > 0 ? { title:'This commit summary is too long',description: <>The summary is limited to {MaxSummaryLength} characters, which you've exceeded. <strong>{charactersOverLimit} {charactersOverLimit === 1 ? 'character':'characters'}</strong> going over the limit will be cut off.</> }: undefined}
           />
         </div>
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -35,19 +35,17 @@ import { setGlobalConfigValue } from '../../lib/git/config'
 import { PopupType } from '../../models/popup'
 import { RepositorySettingsTab } from '../repository-settings/repository-settings'
 import { isAccountEmail } from '../../lib/is-account-email'
-import {
-  MaxSummaryLength,
-} from '../../lib/wrap-rich-text-commit-message'
+import { MaxSummaryLength } from '../../lib/wrap-rich-text-commit-message'
 
 const addAuthorIcon = new OcticonSymbol(
   18,
   13,
   'M14 6V4.25a.75.75 0 0 1 1.5 0V6h1.75a.75.75 0 1 1 0 1.5H15.5v1.75a.75.75 0 0 ' +
-  '1-1.5 0V7.5h-1.75a.75.75 0 1 1 0-1.5H14zM8.5 4a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 ' +
-  '0zm.063 3.064a3.995 3.995 0 0 0 1.2-4.429A3.996 3.996 0 0 0 8.298.725a4.01 4.01 0 0 ' +
-  '0-6.064 1.91 3.987 3.987 0 0 0 1.2 4.43A5.988 5.988 0 0 0 0 12.2a.748.748 0 0 0 ' +
-  '.716.766.751.751 0 0 0 .784-.697 4.49 4.49 0 0 1 1.39-3.04 4.51 4.51 0 0 1 6.218 ' +
-  '0 4.49 4.49 0 0 1 1.39 3.04.748.748 0 0 0 .786.73.75.75 0 0 0 .714-.8 5.989 5.989 0 0 0-3.435-5.136z'
+    '1-1.5 0V7.5h-1.75a.75.75 0 1 1 0-1.5H14zM8.5 4a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 ' +
+    '0zm.063 3.064a3.995 3.995 0 0 0 1.2-4.429A3.996 3.996 0 0 0 8.298.725a4.01 4.01 0 0 ' +
+    '0-6.064 1.91 3.987 3.987 0 0 0 1.2 4.43A5.988 5.988 0 0 0 0 12.2a.748.748 0 0 0 ' +
+    '.716.766.751.751 0 0 0 .784-.697 4.49 4.49 0 0 1 1.39-3.04 4.51 4.51 0 0 1 6.218 ' +
+    '0 4.49 4.49 0 0 1 1.39 3.04.748.748 0 0 0 .786.73.75.75 0 0 0 .714-.8 5.989 5.989 0 0 0-3.435-5.136z'
 )
 
 interface ICommitMessageProps {
@@ -733,7 +731,7 @@ export class CommitMessage extends React.Component<
     })
 
     const summaryInputClassName = classNames('summary-field', 'nudge-arrow', {
-      'nudge-arrow-left': this.props.shouldNudge === true
+      'nudge-arrow-left': this.props.shouldNudge === true,
     })
 
     const charactersOverLimit = this.state.summary.length - MaxSummaryLength
@@ -761,7 +759,27 @@ export class CommitMessage extends React.Component<
             onContextMenu={this.onAutocompletingInputContextMenu}
             disabled={this.props.isCommitting === true}
             spellcheck={this.props.commitSpellcheckEnabled}
-            warningMessage={charactersOverLimit > 0 ? { title: 'This commit summary is very long', description: <>The summary is limited to {MaxSummaryLength} characters, which you've exceeded. <strong>{charactersOverLimit} {charactersOverLimit === 1 ? 'character' : 'characters'}</strong> going over the limit will be moved into the commit description.</> } : undefined}
+            warningMessage={
+              charactersOverLimit > 0
+                ? {
+                    title: 'This commit summary is very long',
+                    description: (
+                      <>
+                        The summary is limited to {MaxSummaryLength} characters,
+                        which you've exceeded.{' '}
+                        <strong>
+                          {charactersOverLimit}{' '}
+                          {charactersOverLimit === 1
+                            ? 'character'
+                            : 'characters'}
+                        </strong>{' '}
+                        going over the limit will be moved into the commit
+                        description.
+                      </>
+                    ),
+                  }
+                : undefined
+            }
           />
         </div>
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -353,7 +353,7 @@ export class CommitMessage extends React.Component<
     const accountEmails = repositoryAccount?.emails.map(e => e.email) ?? []
     const email = commitAuthor?.email
 
-    let warningBadgeVisible =
+    const warningBadgeVisible =
       email !== undefined &&
       repositoryAccount !== null &&
       repositoryAccount !== undefined &&

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -67,7 +67,10 @@ export class Popover extends React.Component<IPopoverProps> {
     const classNames = ['popover-component', this.getClassNameForCaret()]
 
     return (
-      <FocusTrap active={this.props.focusable ?? true} focusTrapOptions={this.focusTrapOptions}>
+      <FocusTrap
+        active={this.props.focusable ?? true}
+        focusTrapOptions={this.focusTrapOptions}
+      >
         <div className={classNames.join(' ')} ref={this.containerDivRef}>
           {this.props.children}
         </div>

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -23,6 +23,7 @@ export enum PopoverCaretPosition {
 interface IPopoverProps {
   readonly onClickOutside?: () => void
   readonly caretPosition: PopoverCaretPosition
+  readonly focusable?: boolean
 }
 
 export class Popover extends React.Component<IPopoverProps> {
@@ -66,7 +67,7 @@ export class Popover extends React.Component<IPopoverProps> {
     const classNames = ['popover-component', this.getClassNameForCaret()]
 
     return (
-      <FocusTrap active={true} focusTrapOptions={this.focusTrapOptions}>
+      <FocusTrap active={this.props.focusable ?? true} focusTrapOptions={this.focusTrapOptions}>
         <div className={classNames.join(' ')} ref={this.containerDivRef}>
           {this.props.children}
         </div>

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -324,8 +324,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    */
   --text-field-height: 25px;
   --text-field-focus-shadow-color: #{rgba($blue, 0.25)};
-  --text-field-focus-shadow-color-modified: #{rgba($yellow-700, 0.25)};
-  --text-field-focus-shadow-color-deleted: #{rgba($red, 0.25)};
+  --text-field-focus-shadow-color-warning: #{rgba($yellow-600, 0.25)};
 
   /**
    * Blankslate actions, see `BlankslateAction` component.

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -324,6 +324,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    */
   --text-field-height: 25px;
   --text-field-focus-shadow-color: #{rgba($blue, 0.25)};
+  --text-field-focus-shadow-color-modified: #{rgba($yellow-700, 0.25)};
+  --text-field-focus-shadow-color-deleted: #{rgba($red, 0.25)};
 
   /**
    * Blankslate actions, see `BlankslateAction` component.

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -23,10 +23,10 @@
   }
 }
 
-@mixin textboxish-focus-styles {
+@mixin textboxish-focus-styles($border-color: var(--focus-color), $box-shadow-color: var(--text-field-focus-shadow-color)) {
   outline: none;
-  border-color: var(--focus-color);
-  box-shadow: 0 0 0 1px var(--text-field-focus-shadow-color);
+  border-color: $border-color;
+  box-shadow: 0 0 0 1px $box-shadow-color;
 }
 
 @mixin textboxish-disabled-styles {

--- a/app/styles/mixins/_textboxish.scss
+++ b/app/styles/mixins/_textboxish.scss
@@ -21,6 +21,14 @@
   &::-webkit-input-placeholder {
     color: var(--box-placeholder-color);
   }
+
+  &.warning {
+    border-color: var(--dialog-warning-color);
+
+    &:focus {
+      @include textboxish-focus-styles(var(--dialog-warning-color), var(--text-field-focus-shadow-color-warning));
+    }
+  }
 }
 
 @mixin textboxish-focus-styles($border-color: var(--focus-color), $box-shadow-color: var(--text-field-focus-shadow-color)) {

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -68,7 +68,7 @@
       // With width=100%, the icon will be centered horizontally
       width: 100%;
     }
-    
+
     .popover-component {
       position: absolute;
       left: 24px;

--- a/app/styles/ui/_text-box.scss
+++ b/app/styles/ui/_text-box.scss
@@ -1,6 +1,7 @@
 @import '../mixins';
 
 .text-box-component {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -49,6 +50,30 @@
       // https://github.com/primer/octicons/blob/4661c1e0aa30c7d252318d2b003af782a6891089/icons/x-16.svg#L1
       -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>');
       -webkit-mask-repeat: no-repeat;
+    }
+  }
+
+  .warning-badge {
+    background-color: #f6f8fa;
+    width: 18px;
+    height: 18px;
+    position: absolute;
+    top: -6px;
+    right: -7px;
+    border-radius: 9px;
+    border: #d1d5da 1px solid;
+
+    > svg {
+      height: 10px;
+      // With width=100%, the icon will be centered horizontally
+      width: 100%;
+    }
+    
+    .popover-component {
+      position: absolute;
+      left: 24px;
+      bottom: -12px;
+      width: 300px;
     }
   }
 }

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -22,20 +22,6 @@
       input {
         width: 100%;
       }
-
-      &.near-limit input {
-        border-color: var(--color-modified);
-        &:focus {
-          @include textboxish-focus-styles(var(--color-modified), var(--text-field-focus-shadow-color-modified));
-        }
-      }
-
-      &.over-limit input {
-        border-color: var(--color-deleted);
-        &:focus {
-          @include textboxish-focus-styles(var(--color-deleted), var(--text-field-focus-shadow-color-deleted));
-        }
-      }
     }
 
     .avatar {

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -22,6 +22,20 @@
       input {
         width: 100%;
       }
+
+      &.near-limit input {
+        border-color: var(--color-modified);
+        &:focus {
+          @include textboxish-focus-styles(var(--color-modified), var(--text-field-focus-shadow-color-modified));
+        }
+      }
+
+      &.over-limit input {
+        border-color: var(--color-deleted);
+        &:focus {
+          @include textboxish-focus-styles(var(--color-deleted), var(--text-field-focus-shadow-color-deleted));
+        }
+      }
     }
 
     .avatar {


### PR DESCRIPTION
Closes #2055.

## Description

This adds visual feedback regarding commit summary length, using the textbox's border:
- When ideal length (50 characters or less), the textbox is blue as usual. All is well.
- When a bit longer, but still below or at cutoff length (72 characters or less), the textbox is calmly yellow. This is still an okay length, though getting near the limit.
- When above cutoff length (72 characters or more), the textbox is alarmingly red. Since GitHub Desktop will messily cut the message off right at the 72 character mark, the user should be very deliberate about exceeding this.

### Screenshots

![Commit summary length feedback in action](https://user-images.githubusercontent.com/4550621/122298559-3a97b280-cefd-11eb-8de7-c06a193eac42.gif)

## Release notes

Notes: [New] Visual feedback on commit summary length
