### PR TITLE
Render empty commits properly

### DIFF
--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -24,6 +24,7 @@ import {
   DropTargetSelector,
   DropTargetType,
 } from '../../models/drag-drop'
+import classNames from 'classnames'
 
 interface ICommitProps {
   readonly gitHubRepository: GitHubRepository | null
@@ -131,6 +132,14 @@ export class CommitListItem extends React.PureComponent<
     } = commit
 
     const isDraggable = this.canCherryPick()
+    const hasEmptySummary = commit.summary.length === 0
+    const commitSummary = hasEmptySummary
+      ? 'Empty commit message'
+      : commit.summary
+
+    const summaryClassNames = classNames('summary', {
+      'empty-summary': hasEmptySummary,
+    })
 
     return (
       <Draggable
@@ -153,16 +162,12 @@ export class CommitListItem extends React.PureComponent<
           onMouseUp={this.onMouseUp}
         >
           <div className="info">
-            {commit.summary.length > 0 ? (
-              <RichText
-                className="summary"
-                emoji={this.props.emoji}
-                text={commit.summary}
-                renderUrlsAsLinks={false}
-              />
-            ) : (
-              <div className="summary empty-summary">Empty commit message</div>
-            )}
+            <RichText
+              className={summaryClassNames}
+              emoji={this.props.emoji}
+              text={commitSummary}
+              renderUrlsAsLinks={false}
+            />
             <div className="description">
               <AvatarStack users={this.state.avatarUsers} />
               <div className="byline">

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -153,12 +153,16 @@ export class CommitListItem extends React.PureComponent<
           onMouseUp={this.onMouseUp}
         >
           <div className="info">
-            <RichText
-              className="summary"
-              emoji={this.props.emoji}
-              text={commit.summary}
-              renderUrlsAsLinks={false}
-            />
+            {commit.summary.length > 0 ? (
+              <RichText
+                className="summary"
+                emoji={this.props.emoji}
+                text={commit.summary}
+                renderUrlsAsLinks={false}
+              />
+            ) : (
+              <div className="summary empty-summary">Empty commit message</div>
+            )}
             <div className="description">
               <AvatarStack users={this.state.avatarUsers} />
               <div className="byline">

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -304,12 +304,18 @@ export class CommitSummary extends React.Component<
     return (
       <div id="commit-summary" className={className}>
         <div className="commit-summary-header">
-          <RichText
-            className="commit-summary-title"
-            emoji={this.props.emoji}
-            repository={this.props.repository}
-            text={this.state.summary}
-          />
+          {this.state.summary.length > 0 ? (
+            <RichText
+              className="commit-summary-title"
+              emoji={this.props.emoji}
+              repository={this.props.repository}
+              text={this.state.summary}
+            />
+          ) : (
+            <div className="commit-summary-title empty-summary">
+              Empty commit message
+            </div>
+          )}
 
           <ul className="commit-summary-meta">
             <li

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -301,21 +301,24 @@ export class CommitSummary extends React.Component<
       'hide-description-border': this.props.hideDescriptionBorder,
     })
 
+    const hasEmptySummary = this.state.summary.length === 0
+    const commitSummary = hasEmptySummary
+      ? 'Empty commit message'
+      : this.state.summary
+
+    const summaryClassNames = classNames('commit-summary-title', {
+      'empty-summary': hasEmptySummary,
+    })
+
     return (
       <div id="commit-summary" className={className}>
         <div className="commit-summary-header">
-          {this.state.summary.length > 0 ? (
-            <RichText
-              className="commit-summary-title"
-              emoji={this.props.emoji}
-              repository={this.props.repository}
-              text={this.state.summary}
-            />
-          ) : (
-            <div className="commit-summary-title empty-summary">
-              Empty commit message
-            </div>
-          )}
+          <RichText
+            className={summaryClassNames}
+            emoji={this.props.emoji}
+            repository={this.props.repository}
+            text={commitSummary}
+          />
 
           <ul className="commit-summary-meta">
             <li

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -104,6 +104,10 @@
 
     .summary {
       font-weight: var(--font-weight-semibold);
+
+      &.empty-summary {
+        color: var(--text-secondary-color);
+      }
     }
 
     .summary,

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -79,6 +79,10 @@
     line-height: 16px;
     padding: var(--spacing);
     word-wrap: break-word;
+
+    &.empty-summary {
+      color: var(--text-secondary-color);
+    }
   }
 
   &-description-container {


### PR DESCRIPTION
## Description

We found that under some circumstances, git will create empty commits that don't render properly in our app (see #12394 for more context). This PR adds a fake `Empty commit message` message to those commits.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/122552536-b5181d80-d036-11eb-8577-5cf13d8434f7.png)

![image](https://user-images.githubusercontent.com/1083228/122552549-b8130e00-d036-11eb-88ec-68b7a6ca185a.png)

## Release notes

Notes: no-notes
