### PR TITLE
Improve time committing

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2638,11 +2638,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
           }
         })
 
-        await this._refreshRepository(repository)
         await this.refreshChangesSection(repository, {
           includingStatus: true,
           clearPartialState: true,
         })
+
+        // Do not await for refreshing the repository, otherwise this will block
+        // the commit button unnecessarily for a long time in big repos.
+        this._refreshRepository(repository)
       }
 
       return result !== undefined


### PR DESCRIPTION
## Description

This PR tries to address an issue where committing _seems_ to take too long, specially in large repos.

The problem is the commit time is short, but right after it we're doing some work to prepare the UI for that new commit. During that time, the commit button is disabled and shows a "loading" indicator.

This work consists of: 1) update the list of changes and 2) refreshing the whole repository.

We think (1) is essential to complete before we let the user make another commit, otherwise the changes list might show stuff that has been committed already.

(2) however might be necessary, but there is no need to block the user until that's finished. This PR keeps triggering that repository status update but makes it asynchronous. Thanks to that we've seen improvements of up to 50%.

## Release notes

Notes: [Improved] Reduced time needed to make a commit
