### PR TITLE
Improve auth error and prompt: suggest using PAT instead of password

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -302,7 +302,8 @@ function getDescriptionForError(error: DugiteError): string | null {
 - You may need to log out and log back in to refresh your token.
 - You do not have permission to access this repository.
 - The repository is archived on GitHub. Check the repository settings to confirm you are still permitted to push commits.
-- If you use SSH authentication, check that your key is added to the ssh-agent and associated with your account.`
+- If you use SSH authentication, check that your key is added to the ssh-agent and associated with your account.
+- If you used username / password authentication, you might need to use a Personal Access Token instead of your account password. Check the documentation of your repository hosting service.`
   }
 
   switch (error) {

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -78,13 +78,13 @@ export class GenericGitAuthentication extends React.Component<
 
           <Row>
             <div>
-              Depending on your repository's hosting service, you might
-              need to use a Personal Access Token (PAT) as your password.
-              Take a look at the{' '}
+              Depending on your repository's hosting service, you might need to
+              use a Personal Access Token (PAT) as your password. Learn more
+              about creating a PAT in our{' '}
               <LinkButton uri="https://github.com/desktop/desktop/tree/development/docs/integrations">
-                integration instructions
-              </LinkButton>{' '}
-              for different hosting services to learn how to create a PAT.
+                integration docs
+              </LinkButton>
+              .
             </div>
           </Row>
         </DialogContent>

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -78,8 +78,8 @@ export class GenericGitAuthentication extends React.Component<
 
           <Row>
             <div>
-              Depending on the hosting service of your repository, you might
-              need to use a Personal Access Token (PAT) instead of a password.
+              Depending on your repository's hosting service, you might
+              need to use a Personal Access Token (PAT) as your password.
               Take a look at the{' '}
               <LinkButton uri="https://github.com/desktop/desktop/tree/development/docs/integrations">
                 integration instructions

--- a/app/src/ui/generic-git-auth/generic-git-auth.tsx
+++ b/app/src/ui/generic-git-auth/generic-git-auth.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { RetryAction } from '../../models/retry-actions'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Ref } from '../lib/ref'
+import { LinkButton } from '../lib/link-button'
 
 interface IGenericGitAuthenticationProps {
   /** The hostname with which the user tried to authenticate. */
@@ -73,6 +74,18 @@ export class GenericGitAuthentication extends React.Component<
               value={this.state.password}
               onValueChanged={this.onPasswordChange}
             />
+          </Row>
+
+          <Row>
+            <div>
+              Depending on the hosting service of your repository, you might
+              need to use a Personal Access Token (PAT) instead of a password.
+              Take a look at the{' '}
+              <LinkButton uri="https://github.com/desktop/desktop/tree/development/docs/integrations">
+                integration instructions
+              </LinkButton>{' '}
+              for different hosting services to learn how to create a PAT.
+            </div>
           </Row>
         </DialogContent>
 


### PR DESCRIPTION
Closes #12323

## Description

This PR makes some changes to indicate the user they might need to use a Personal Access Token instead of a password to access their git repository. These changes are located in:
- The prompt for username and password in non-GitHub repositories. This includes a link to https://github.com/desktop/desktop/tree/development/docs/integrations
- The error alert when the authentication fails during a git operation.

As always, I'm more than open to verbiage suggestions 😄 

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/123830973-1fb53d00-d904-11eb-9593-81299cb206f2.png)

![image](https://user-images.githubusercontent.com/1083228/123831047-3360a380-d904-11eb-9393-2aaaaaf2fb86.png)

## Release notes

Notes: no-notes
