### PR TITLE
Use "Recycle Bin" name only on Windows

### DIFF
--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -13,7 +13,7 @@ export const RevealInFileManagerLabel = __DARWIN__
   ? 'Show in Explorer'
   : 'Show in your File Manager'
 
-export const TrashNameLabel = __DARWIN__ ? 'Trash' : 'Recycle Bin'
+export const TrashNameLabel = __WIN32__ ? 'Recycle Bin' : 'Trash'
 
 export const OpenWithDefaultProgramLabel = __DARWIN__
   ? 'Open with Default Program'


### PR DESCRIPTION
## Description

This PR was originally submitted to `shiftkey/desktop` by @hydrogen-mvm  in https://github.com/shiftkey/desktop/pull/388 as the "Recycle Bin" terminology isn't really a thing in Linux window managers. 

### Screenshots

This is visible from the _Discard Changes_ dialog on all platforms.

![](https://user-images.githubusercontent.com/359239/124006494-ba6b5580-d9b0-11eb-9693-7e202a20432b.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
