### PR TITLE
Show co-author textfield after undoing a commit if needed

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -222,6 +222,11 @@ export class CommitMessage extends React.Component<
       })
     }
 
+    // If the need to show co-authors from the props changed, update the state.
+    if (prevProps.showCoAuthoredBy !== this.props.showCoAuthoredBy) {
+      this.setState({ showCoAuthoredBy: this.props.showCoAuthoredBy })
+    }
+
     if (this.props.focusCommitMessage) {
       this.focusSummary()
     } else if (


### PR DESCRIPTION
Closes #12537

## Description

Before this PR, when a commit with coauthors was undone, the state of the app was updated to show those coauthors in the commit message area.

However, the current state of the `CommitMessage` component would prevail over this change in the props.

This PR looks for changes in the `props` flag to show/hide the co-authors textfield, and updates the state if needed.

### Screenshots

https://user-images.githubusercontent.com/1083228/124122551-7fcbf080-da76-11eb-8e12-d9b2cb2350ce.mov

## Release notes

Notes: [Fixed] Show co-authors from undone commits
