### PR TITLE
Fix commits missing in History tab

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -66,6 +66,7 @@ export async function getCommits(
   repository: Repository,
   revisionRange?: string,
   limit?: number,
+  skip?: number,
   additionalArgs: ReadonlyArray<string> = []
 ): Promise<ReadonlyArray<Commit>> {
   const { formatArgs, parse } = createLogParser({
@@ -93,6 +94,10 @@ export async function getCommits(
 
   if (limit !== undefined) {
     args.push(`--max-count=${limit}`)
+  }
+
+  if (skip !== undefined) {
+    args.push(`--skip=${skip}`)
   }
 
   args.push(
@@ -221,9 +226,13 @@ export async function doMergeCommitsExistAfterCommit(
   const commitRevRange =
     commitRef === null ? undefined : revRange(commitRef, 'HEAD')
 
-  const mergeCommits = await getCommits(repository, commitRevRange, undefined, [
-    '--merges',
-  ])
+  const mergeCommits = await getCommits(
+    repository,
+    commitRevRange,
+    undefined,
+    undefined,
+    ['--merges']
+  )
 
   return mergeCommits.length > 0
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1124,7 +1124,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
 
       // load initial group of commits for current branch
-      const commits = await gitStore.loadCommitBatch('HEAD')
+      const commits = await gitStore.loadCommitBatch('HEAD', 0)
 
       if (commits === null) {
         return
@@ -1275,9 +1275,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { formState } = state.compareState
     if (formState.kind === HistoryTabMode.History) {
       const commits = state.compareState.commitSHAs
-      const lastCommitSha = commits[commits.length - 1]
+      const firstCommitSha = commits[0]
 
-      const newCommits = await gitStore.loadCommitBatch(`${lastCommitSha}^`)
+      const newCommits = await gitStore.loadCommitBatch(
+        firstCommitSha,
+        commits.length
+      )
       if (newCommits == null) {
         return
       }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1275,12 +1275,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const { formState } = state.compareState
     if (formState.kind === HistoryTabMode.History) {
       const commits = state.compareState.commitSHAs
-      const firstCommitSha = commits[0]
 
-      const newCommits = await gitStore.loadCommitBatch(
-        firstCommitSha,
-        commits.length
-      )
+      const newCommits = await gitStore.loadCommitBatch('HEAD', commits.length)
       if (newCommits == null) {
         return
       }

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -616,7 +616,7 @@ export class GitStore extends BaseStore {
       )
     } else {
       localCommits = await this.performFailableOperation(() =>
-        getCommits(this.repository, 'HEAD', CommitBatchSize, [
+        getCommits(this.repository, 'HEAD', CommitBatchSize, undefined, [
           '--not',
           '--remotes',
         ])

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -202,12 +202,12 @@ export class GitStore extends BaseStore {
   }
 
   /** Load a batch of commits from the repository, using a given commitish object as the starting point */
-  public async loadCommitBatch(commitish: string) {
+  public async loadCommitBatch(commitish: string, skip: number) {
     if (this.requestsInFight.has(LoadingHistoryRequestKey)) {
       return null
     }
 
-    const requestKey = `history/compare/${commitish}`
+    const requestKey = `history/compare/${commitish}/skip/${skip}`
     if (this.requestsInFight.has(requestKey)) {
       return null
     }
@@ -215,7 +215,7 @@ export class GitStore extends BaseStore {
     this.requestsInFight.add(requestKey)
 
     const commits = await this.performFailableOperation(() =>
-      getCommits(this.repository, commitish, CommitBatchSize)
+      getCommits(this.repository, commitish, CommitBatchSize, skip)
     )
 
     this.requestsInFight.delete(requestKey)

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -201,37 +201,6 @@ export class GitStore extends BaseStore {
     this.emitUpdate()
   }
 
-  /** Load the next batch of history, starting from the last loaded commit. */
-  public async loadNextHistoryBatch() {
-    if (this.requestsInFight.has(LoadingHistoryRequestKey)) {
-      return
-    }
-
-    if (!this.history.length) {
-      return
-    }
-
-    const lastSHA = this.history[this.history.length - 1]
-    const requestKey = `history/${lastSHA}`
-    if (this.requestsInFight.has(requestKey)) {
-      return
-    }
-
-    this.requestsInFight.add(requestKey)
-
-    const commits = await this.performFailableOperation(() =>
-      getCommits(this.repository, `${lastSHA}^`, CommitBatchSize)
-    )
-    if (!commits) {
-      return
-    }
-
-    this._history = this._history.concat(commits.map(c => c.sha))
-    this.storeCommits(commits)
-    this.requestsInFight.delete(requestKey)
-    this.emitUpdate()
-  }
-
   /** Load a batch of commits from the repository, using a given commitish object as the starting point */
   public async loadCommitBatch(commitish: string) {
     if (this.requestsInFight.has(LoadingHistoryRequestKey)) {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -498,7 +498,7 @@ export class CompareSidebar extends React.Component<
     if (commits.length - end <= CloseToBottomThreshold) {
       if (this.loadingMoreCommitsPromise != null) {
         // as this callback fires for any scroll event we need to guard
-        // against re-entrant calls to loadNextHistoryBatch
+        // against re-entrant calls to loadCommitBatch
         return
       }
 

--- a/app/test/unit/git-store-test.ts
+++ b/app/test/unit/git-store-test.ts
@@ -39,7 +39,7 @@ describe('GitStore', () => {
       const repo = new Repository(path, -1, null, false)
       const gitStore = new GitStore(repo, shell, statsStore)
 
-      const commits = await gitStore.loadCommitBatch('HEAD')
+      const commits = await gitStore.loadCommitBatch('HEAD', 0)
 
       expect(commits).not.toBeNull()
       expect(commits).toHaveLength(100)


### PR DESCRIPTION
Closes #12506
Closes #3704

## Description

I think https://github.com/desktop/desktop/issues/12506#issuecomment-872409814 gives good context about the reason behind this bug. Luckily, `git` has a `--skip` parameter, so with the changes in this PR, when we need to load a new page of commits, we'll run `git log` from `HEAD` and skip the X first commits.

In order to test this, you can create a repository with two branches alternating commits between two branches and finally merging them, using this script:

```bash
mkdir test-repo
cd test-repo
git init

git checkout -b main
echo "initial file" > 0
git add 0
git commit -m "initial commit"

git checkout -b sub

for F in {1..300}; do
  echo "hello $F" > $F

  # if F is even, then commit from main
  if [ $((F%2)) -eq 0 ]; then
    git checkout main
    git add $F
    git commit -m "commit $F"
  else
    # if F is odd, then commit from sub
    git checkout sub
    git add $F
    git commit -m "commit $F"
  fi
done

git checkout main
git merge sub
```

### Screenshots

Without the fix, after the second page is loaded, you only see commits from one of the branches (either odd or even numbers in the test repo):

https://user-images.githubusercontent.com/1083228/124259683-14922500-db2f-11eb-8c6f-fbe3f09b473a.mov

With the fix, you always see both odd and even numbers:

https://user-images.githubusercontent.com/1083228/124259807-39869800-db2f-11eb-8d0f-db8eac823eef.mov

## Release notes

Notes: [Fixed] History tab shows all commits as the user scrolls down
