### PR TITLE
Check invalidated tokens and suggest to sign in again

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1048,7 +1048,6 @@ export class API {
       reloadCache?: boolean
     } = {}
   ): Promise<Response> {
-    return request(
     const response = await request(
       this.endpoint,
       this.token,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -525,6 +525,28 @@ export class AppStore extends TypedBaseStore<IAppState> {
         this.repositoryIndicatorUpdater.start()
       }
     }, InitialRepositoryIndicatorTimeout)
+
+    API.onTokenInvalidated(this.onTokenInvalidated)
+  }
+
+  private onTokenInvalidated = (endpoint: string) => {
+    const account = getAccountForEndpoint(this.accounts, endpoint)
+
+    if (account === null) {
+      return
+    }
+
+    // If the token was invalidated for an account, sign out from that account
+    this._removeAccount(account)
+
+    const isEnterpriseAccount = account.endpoint !== getDotComAPIEndpoint()
+    const accountTypeSuffix = isEnterpriseAccount ? ' Enterprise' : ''
+
+    const error = new Error(
+      `The token for your GitHub${accountTypeSuffix} account was invalidated. Please, sign in again`
+    )
+
+    this._pushError(error)
   }
 
   /** Figure out what step of the tutorial the user needs to do next */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -539,14 +539,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // If the token was invalidated for an account, sign out from that account
     this._removeAccount(account)
 
-    const isEnterpriseAccount = account.endpoint !== getDotComAPIEndpoint()
-    const accountTypeSuffix = isEnterpriseAccount ? ' Enterprise' : ''
-
-    const error = new Error(
-      `The token for your GitHub${accountTypeSuffix} account was invalidated. Please, sign in again`
-    )
-
-    this._pushError(error)
+    this._showPopup({
+      type: PopupType.InvalidatedToken,
+      account,
+    })
   }
 
   /** Figure out what step of the tutorial the user needs to do next */

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -536,6 +536,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    // If there is a currently open popup, don't do anything here. Since the
+    // app can only show one popup at a time, we don't want to close the current
+    // one in favor of the error we're about to show.
+    if (this.currentPopup !== null) {
+      return
+    }
+
     // If the token was invalidated for an account, sign out from that account
     this._removeAccount(account)
 

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -74,6 +74,7 @@ export enum PopupType {
   MultiCommitOperation,
   WarnLocalChangesBeforeUndo,
   WarningBeforeReset,
+  InvalidatedToken,
 }
 
 export type Popup =
@@ -297,4 +298,8 @@ export type Popup =
       type: PopupType.WarningBeforeReset
       repository: Repository
       commit: Commit
+    }
+  | {
+      type: PopupType.InvalidatedToken
+      account: Account
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -147,6 +147,7 @@ import { dragAndDropManager } from '../lib/drag-and-drop-manager'
 import { MultiCommitOperation } from './multi-commit-operation/multi-commit-operation'
 import { WarnLocalChangesBeforeUndo } from './undo/warn-local-changes-before-undo'
 import { WarningBeforeReset } from './reset/warning-before-reset'
+import { InvalidatedToken } from './invalidated-token/invalidated-token'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2111,6 +2112,16 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             repository={repository}
             commit={commit}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.InvalidatedToken: {
+        return (
+          <InvalidatedToken
+            key="invalidated-token"
+            dispatcher={this.props.dispatcher}
+            account={popup.account}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1524,9 +1524,15 @@ export class Dispatcher {
   /**
    * Launch a sign in dialog for authenticating a user with
    * a GitHub Enterprise instance.
+   * Optionally, you can provide an endpoint URL.
    */
-  public async showEnterpriseSignInDialog(): Promise<void> {
+  public async showEnterpriseSignInDialog(endpoint?: string): Promise<void> {
     await this.appStore._beginEnterpriseSignIn()
+
+    if (endpoint !== undefined) {
+      await this.appStore._setSignInEndpoint(endpoint)
+    }
+
     await this.appStore._showPopup({ type: PopupType.SignIn })
   }
 

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Dispatcher } from '../dispatcher'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { Account } from '../../models/account'
+import { getDotComAPIEndpoint } from '../../lib/api'
+
+interface IInvalidatedTokenResetProps {
+  readonly dispatcher: Dispatcher
+  readonly account: Account
+  readonly onDismissed: () => void
+}
+
+/**
+ * Dialog that alerts user that there are uncommitted changes in the working
+ * directory where they are gonna be resetting to a previous commit.
+ */
+export class InvalidatedToken extends React.Component<
+  IInvalidatedTokenResetProps
+> {
+  public render() {
+    const accountTypeSuffix = this.isEnterpriseAccount ? ' Enterprise' : ''
+
+    return (
+      <Dialog
+        id="invalidated-token"
+        type="warning"
+        title="Warning"
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            Your account token has been invalidated and you have been signed out
+            from your GitHub{accountTypeSuffix} account. Do you want to sign in
+            again?
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup okButtonText="Yes" cancelButtonText="No" />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private get isEnterpriseAccount() {
+    return this.props.account.endpoint !== getDotComAPIEndpoint()
+  }
+
+  private onSubmit = () => {
+    const { dispatcher, onDismissed } = this.props
+
+    onDismissed()
+
+    if (this.isEnterpriseAccount) {
+      dispatcher.showEnterpriseSignInDialog(this.props.account.endpoint)
+    } else {
+      dispatcher.showDotComSignInDialog()
+    }
+  }
+}

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -13,8 +13,8 @@ interface IInvalidatedTokenResetProps {
 }
 
 /**
- * Dialog that alerts user that there are uncommitted changes in the working
- * directory where they are gonna be resetting to a previous commit.
+ * Dialog that alerts user that their GitHub (Enterprise) account token is not
+ * valid and they need to sign in again.
  */
 export class InvalidatedToken extends React.Component<
   IInvalidatedTokenResetProps


### PR DESCRIPTION
## Description

With the changes in this PR, the app will now check for 401 errors coming from API requests. If those happen, the app will immediately sign out the user and warn them about this, while suggesting them to sign in again.

If they decided to sign in again, they'll be led directly to the sign in flow of the specific account whose token was invalidated (i.e. if the dotcom account was invalidated, they'll sign in that account directly, if the GHE account was invalidated, the account's endpoint will be used to sign in again in that GHE account).

### Screenshots

https://user-images.githubusercontent.com/1083228/124268896-74da9400-db3a-11eb-92eb-42b853ef1ef2.mov

## Release notes

Notes: [Improved] Detect when tokens are invalidated and suggest users to sign in again
