### PR TITLE
Allow double-clicking vertical segmented controls to submit their form

### DIFF
--- a/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/segmented-item.tsx
@@ -35,6 +35,12 @@ interface ISegmentedItemProps<T> {
    * a pointer device.
    */
   readonly onClick: (value: T) => void
+
+  /**
+   * A function that's called when a user double-clicks on the item
+   * using a pointer device.
+   */
+  readonly onDoubleClick: (value: T) => void
 }
 
 export class SegmentedItem<T> extends React.Component<
@@ -43,6 +49,10 @@ export class SegmentedItem<T> extends React.Component<
 > {
   private onClick = () => {
     this.props.onClick(this.props.value)
+  }
+
+  private onDoubleClick = () => {
+    this.props.onDoubleClick(this.props.value)
   }
 
   public render() {
@@ -57,6 +67,7 @@ export class SegmentedItem<T> extends React.Component<
       <li
         className={className}
         onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
         role="radio"
         id={this.props.id}
         aria-checked={isSelected ? 'true' : 'false'}

--- a/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
+++ b/app/src/ui/lib/vertical-segmented-control/vertical-segmented-control.tsx
@@ -116,10 +116,25 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
     }
   }
 
+  private submitForm() {
+    const form = this.formRef
+    if (form) {
+      // NB: In order to play nicely with React's custom event dispatching,
+      // we dispatch an event instead of calling `submit` directly on the
+      // form.
+      form.dispatchEvent(new Event('submit'))
+    }
+  }
+
   private onItemClick = (key: T) => {
     if (key !== this.props.selectedKey) {
       this.props.onSelectionChanged(key)
     }
+  }
+
+  private onItemDoubleClick = (key: T) => {
+    this.onItemClick(key)
+    this.submitForm()
   }
 
   private getListItemId(index: number) {
@@ -136,6 +151,7 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
         isSelected={item.key === this.props.selectedKey}
         value={item.key}
         onClick={this.onItemClick}
+        onDoubleClick={this.onItemDoubleClick}
       />
     )
   }
@@ -154,13 +170,7 @@ export class VerticalSegmentedControl<T extends Key> extends React.Component<
       }
       event.preventDefault()
     } else if (event.key === 'Enter') {
-      const form = this.formRef
-      if (form) {
-        // NB: In order to play nicely with React's custom event dispatching,
-        // we dispatch an event instead of calling `submit` directly on the
-        // form.
-        form.dispatchEvent(new Event('submit'))
-      }
+      this.submitForm()
     }
   }
 


### PR DESCRIPTION
Closes #12522

## Description

Double-clicking a vertical segmented control option now selects that option and tries to submit the form the control is contained in, just like hitting enter did in the past.

### Screenshots

<img src="https://user-images.githubusercontent.com/25517624/124361234-05c57400-dbfc-11eb-84f6-8600c318774e.gif" width="400">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: New: Double-click an option when switching branches to quickly confirm how you want changed files to be handled
