### PR TITLE
Fixed collapsing circle in progress dialog

### DIFF
--- a/app/styles/ui/dialogs/_progress-dialog.scss
+++ b/app/styles/ui/dialogs/_progress-dialog.scss
@@ -31,6 +31,7 @@ dialog#multi-commit-progress {
       height: 22px;
       width: 22px;
       display: flex;
+      flex: 0 0 auto;
       justify-content: center;
       align-items: center;
     }


### PR DESCRIPTION
Closes #12594

## Description
- Fixes the collapsing green circle by setting ``flex: 0 0 auto``
- This causes the circle to neither shrink nor grow and therefore keeps the set height and width.

### Screenshots

![grafik](https://user-images.githubusercontent.com/40789489/125205049-9c3f0880-e280-11eb-9d7c-425625216afd.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
