### PR TITLE
Bump Electron to v11.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "=11.1.1",
+    "electron": "=11.2.0",
     "electron-builder": "^22.7.0",
     "electron-packager": "^15.1.0",
     "electron-winstaller": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4136,10 +4136,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@=11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.1.1.tgz#188f036f8282798398dca9513e9bb3b10213e3aa"
-  integrity sha512-tlbex3xosJgfileN6BAQRotevPRXB/wQIq48QeQ08tUJJrXwE72c8smsM/hbHx5eDgnbfJ2G3a60PmRjHU2NhA==
+electron@=11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.2.0.tgz#f8577ea4c9ba94068850256145be26b0b89a5dd7"
+  integrity sha512-weszOPAJPoPu6ozL7vR9enXmaDSqH+KE9iZODfbGdnFgtVfVdfyedjlvEGIUJkLMPXM1y/QWwCl2dINzr0Jq5Q==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
## Description

This fixes an issue were the Chrome dev tools wouldn't show local variables while paused in a breakpoint.

⚠️ **IMPORTANT:** this needs extensive testing in beta during a reasonably long time, it's possible we can also reproduce [the issue of empty lists](https://github.com/electron/electron/issues/29261) with this version too ⚠️

If that happens, just going back to 11.1.1 should be enough to fix it.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1083228/126974686-19f8884c-dd8a-4a76-9aef-4d903f55a8a4.png)

After:
![image](https://user-images.githubusercontent.com/1083228/126974567-855bb86a-8f11-4979-96d9-6059387f213a.png)

## Release notes

Notes: no-notes
