### PR TITLE
Fix misattributed commit warning in dark mode

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -176,6 +176,13 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --co-author-tag-border-color: #{$blue-200};
 
   /**
+   * Author input (co-authors)
+   */
+  --commit-warning-badge-background-color: #{$gray-000};
+  --commit-warning-badge-border-color: #{$gray-300};
+  --commit-warning-badge-icon-color: #{$gray-900};
+
+  /**
    * The height of the title bar area on Win32 platforms
    * If changed, update titleBarHeight in 'app/src/ui/dialog/dialog.tsx'
   */

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -3,16 +3,17 @@
   position: relative;
 
   .warning-badge {
-    background-color: #f6f8fa;
+    background-color: var(--commit-warning-badge-background-color);
+    border: var(--commit-warning-badge-border-color) 1px solid;
     width: 18px;
     height: 18px;
     position: absolute;
     margin-top: -6px;
     margin-left: -7px;
     border-radius: 9px;
-    border: #d1d5da 1px solid;
 
     > svg {
+      color: var(--commit-warning-badge-icon-color);
       height: 10px;
       // With width=100%, the icon will be centered horizontally
       width: 100%;


### PR DESCRIPTION
Closes #12210

## Description

The icon used in the badge uses `--text-color` which varies with the color theme. This PR fixes the color for the badge.

I also took the chance to remove some hardcoded colors I added when I first implemented this badge 😅 

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1083228/127021697-81183938-6785-4268-9ead-ebbadb099b77.png)

After:
![image](https://user-images.githubusercontent.com/1083228/127021724-6ba5b1fc-d0ef-473d-8cf6-5cc46aaa0813.png)

## Release notes

Notes: [Fixed] Warning for misattributed commits is clearly visible in dark theme
