### PR TITLE
Show number of lines changed in a commit

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -574,7 +574,7 @@ export interface ICommitSelection {
   /** The commits currently selected in the app */
   readonly shas: ReadonlyArray<string>
 
-  /** The list of files associated with the current commit */
+  /** The changeset data associated with the selected commit */
   readonly changesetData: IChangesetData
 
   /** The selected file inside the selected commit */

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -46,6 +46,7 @@ import {
   MultiCommitOperationStep,
 } from '../models/multi-commit-operation'
 import { DragAndDropIntroType } from '../ui/history/drag-and-drop-intro'
+import { IChangesetData } from './git'
 
 export enum SelectionType {
   Repository,
@@ -574,7 +575,7 @@ export interface ICommitSelection {
   readonly shas: ReadonlyArray<string>
 
   /** The list of files associated with the current commit */
-  readonly changedFiles: ReadonlyArray<CommittedFileChange>
+  readonly changesetData: IChangesetData
 
   /** The selected file inside the selected commit */
   readonly file: CommittedFileChange | null

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -122,3 +122,8 @@ export function enableCommitReordering(): boolean {
 export function enableResetToCommit(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should we show line changes (added/deleted) in commits? */
+export function enableLineChangesInCommit(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1355,7 +1355,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       file: firstFileOrDefault,
-      changesetData: changesetData,
+      changesetData,
       diff: null,
     }))
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1326,10 +1326,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const gitStore = this.gitStoreCache.get(repository)
-    const changedFiles = await gitStore.performFailableOperation(() =>
+    const changesetData = await gitStore.performFailableOperation(() =>
       getChangedFiles(repository, currentSHAs[0])
     )
-    if (!changedFiles) {
+    if (!changesetData) {
       return
     }
 
@@ -1349,13 +1349,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const noFileSelected = commitSelection.file === null
 
     const firstFileOrDefault =
-      noFileSelected && changedFiles.files.length
-        ? changedFiles.files[0]
+      noFileSelected && changesetData.files.length
+        ? changesetData.files[0]
         : commitSelection.file
 
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       file: firstFileOrDefault,
-      changesetData: changedFiles,
+      changesetData: changesetData,
       diff: null,
     }))
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1015,7 +1015,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       shas: [],
       file: null,
-      changedFiles: [],
+      changesetData: { files: [], linesAdded: 0, linesDeleted: 0 },
       diff: null,
     }))
   }
@@ -1037,7 +1037,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       shas,
       file: null,
-      changedFiles: [],
+      changesetData: { files: [], linesAdded: 0, linesDeleted: 0 },
       diff: null,
     }))
 
@@ -1349,13 +1349,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const noFileSelected = commitSelection.file === null
 
     const firstFileOrDefault =
-      noFileSelected && changedFiles.length
-        ? changedFiles[0]
+      noFileSelected && changedFiles.files.length
+        ? changedFiles.files[0]
         : commitSelection.file
 
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       file: firstFileOrDefault,
-      changedFiles,
+      changesetData: changedFiles,
       diff: null,
     }))
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -3,7 +3,6 @@ import { Commit } from '../../models/commit'
 import { PullRequest } from '../../models/pull-request'
 import { Repository } from '../../models/repository'
 import {
-  CommittedFileChange,
   WorkingDirectoryFileChange,
   WorkingDirectoryStatus,
 } from '../../models/status'
@@ -195,7 +194,7 @@ function getInitialRepositoryState(): IRepositoryState {
     commitSelection: {
       shas: [],
       file: null,
-      changedFiles: new Array<CommittedFileChange>(),
+      changesetData: { files: [], linesAdded: 0, linesDeleted: 0 },
       diff: null,
     },
     changesState: {

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -399,18 +399,12 @@ export class CommitSummary extends React.Component<
           className="commit-summary-meta-item without-truncation lines-added"
           title={linesAddedTitle}
         >
-          {/* <span aria-hidden="true">
-            <Octicon symbol={OcticonSymbol.plus} />
-          </span> */}
           +{linesAdded}
         </li>
         <li
           className="commit-summary-meta-item without-truncation lines-deleted"
           title={linesDeletedTitle}
         >
-          {/* <span aria-hidden="true">
-            <Octicon symbol={OcticonSymbol.dash} />
-          </span> */}
           -{linesDeleted}
         </li>
       </>

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import classNames from 'classnames'
 
-import { FileChange } from '../../models/status'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { RichText } from '../lib/rich-text'
@@ -14,11 +13,12 @@ import { Tokenizer, TokenResult } from '../../lib/text-token-parser'
 import { wrapRichTextCommitMessage } from '../../lib/wrap-rich-text-commit-message'
 import { DiffOptions } from '../diff/diff-options'
 import { RepositorySectionTab } from '../../lib/app-state'
+import { IChangesetData } from '../../lib/git'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
   readonly commit: Commit
-  readonly files: ReadonlyArray<FileChange>
+  readonly files: IChangesetData
   readonly emoji: Map<string, string>
 
   /**
@@ -290,7 +290,7 @@ export class CommitSummary extends React.Component<
   }
 
   public render() {
-    const fileCount = this.props.files.length
+    const fileCount = this.props.files.files.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
     const filesDescription = `${fileCount} changed ${filesPlural}`
     const shortSHA = this.props.commit.shortSha
@@ -353,6 +353,7 @@ export class CommitSummary extends React.Component<
 
               {filesDescription}
             </li>
+            {this.renderLinesChanged()}
             {this.renderTags()}
 
             <li
@@ -377,6 +378,42 @@ export class CommitSummary extends React.Component<
 
         {this.renderDescription()}
       </div>
+    )
+  }
+
+  private renderLinesChanged() {
+    const linesAdded = this.props.files.linesAdded
+    const linesDeleted = this.props.files.linesDeleted
+    if (linesAdded + linesDeleted === 0) {
+      return null
+    }
+
+    const linesAddedPlural = linesAdded === 1 ? 'line' : 'lines'
+    const linesDeletedPlural = linesDeleted === 1 ? 'line' : 'lines'
+    const linesAddedTitle = `${linesAdded} ${linesAddedPlural} added`
+    const linesDeletedTitle = `${linesDeleted} ${linesDeletedPlural} deleted`
+
+    return (
+      <>
+        <li
+          className="commit-summary-meta-item without-truncation lines-added"
+          title={linesAddedTitle}
+        >
+          {/* <span aria-hidden="true">
+            <Octicon symbol={OcticonSymbol.plus} />
+          </span> */}
+          +{linesAdded}
+        </li>
+        <li
+          className="commit-summary-meta-item without-truncation lines-deleted"
+          title={linesDeletedTitle}
+        >
+          {/* <span aria-hidden="true">
+            <Octicon symbol={OcticonSymbol.dash} />
+          </span> */}
+          -{linesDeleted}
+        </li>
+      </>
     )
   }
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -18,7 +18,7 @@ import { IChangesetData } from '../../lib/git'
 interface ICommitSummaryProps {
   readonly repository: Repository
   readonly commit: Commit
-  readonly files: IChangesetData
+  readonly changesetData: IChangesetData
   readonly emoji: Map<string, string>
 
   /**
@@ -290,7 +290,7 @@ export class CommitSummary extends React.Component<
   }
 
   public render() {
-    const fileCount = this.props.files.files.length
+    const fileCount = this.props.changesetData.files.length
     const filesPlural = fileCount === 1 ? 'file' : 'files'
     const filesDescription = `${fileCount} changed ${filesPlural}`
     const shortSHA = this.props.commit.shortSha
@@ -382,8 +382,8 @@ export class CommitSummary extends React.Component<
   }
 
   private renderLinesChanged() {
-    const linesAdded = this.props.files.linesAdded
-    const linesDeleted = this.props.files.linesDeleted
+    const linesAdded = this.props.changesetData.linesAdded
+    const linesDeleted = this.props.changesetData.linesDeleted
     if (linesAdded + linesDeleted === 0) {
       return null
     }

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -161,7 +161,7 @@ export class SelectedCommit extends React.Component<
     return (
       <CommitSummary
         commit={commit}
-        files={this.props.changesetData}
+        changesetData={this.props.changesetData}
         emoji={this.props.emoji}
         repository={this.props.repository}
         onExpandChanged={this.onExpandChanged}

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -28,13 +28,14 @@ import { showContextualMenu } from '../main-process-proxy'
 import { CommitSummary } from './commit-summary'
 import { FileList } from './file-list'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
+import { IChangesetData } from '../../lib/git'
 
 interface ISelectedCommitProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly emoji: Map<string, string>
   readonly selectedCommit: Commit | null
-  readonly changedFiles: ReadonlyArray<CommittedFileChange>
+  readonly changesetData: IChangesetData
   readonly selectedFile: CommittedFileChange | null
   readonly currentDiff: IDiff | null
   readonly commitSummaryWidth: number
@@ -132,7 +133,7 @@ export class SelectedCommit extends React.Component<
     if (file == null) {
       // don't show both 'empty' messages
       const message =
-        this.props.changedFiles.length === 0 ? '' : 'No file selected'
+        this.props.changesetData.files.length === 0 ? '' : 'No file selected'
 
       return (
         <div className="panel blankslate" id="diff">
@@ -160,7 +161,7 @@ export class SelectedCommit extends React.Component<
     return (
       <CommitSummary
         commit={commit}
-        files={this.props.changedFiles}
+        files={this.props.changesetData}
         emoji={this.props.emoji}
         repository={this.props.repository}
         onExpandChanged={this.onExpandChanged}
@@ -210,7 +211,7 @@ export class SelectedCommit extends React.Component<
   }
 
   private renderFileList() {
-    const files = this.props.changedFiles
+    const files = this.props.changesetData.files
     if (files.length === 0) {
       return <div className="fill-window">No files in commit</div>
     }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -377,7 +377,7 @@ export class RepositoryView extends React.Component<
     const selectedCommit =
       sha != null ? this.props.state.commitLookup.get(sha) || null : null
 
-    const { changedFiles, file, diff } = commitSelection
+    const { changesetData: changedFiles, file, diff } = commitSelection
 
     const showDragOverlay = dragAndDropManager.isDragOfTypeInProgress(
       DragType.Commit
@@ -388,7 +388,7 @@ export class RepositoryView extends React.Component<
         repository={this.props.repository}
         dispatcher={this.props.dispatcher}
         selectedCommit={selectedCommit}
-        changedFiles={changedFiles}
+        changesetData={changedFiles}
         selectedFile={file}
         currentDiff={diff}
         emoji={this.props.emoji}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -377,7 +377,7 @@ export class RepositoryView extends React.Component<
     const selectedCommit =
       sha != null ? this.props.state.commitLookup.get(sha) || null : null
 
-    const { changesetData: changedFiles, file, diff } = commitSelection
+    const { changesetData, file, diff } = commitSelection
 
     const showDragOverlay = dragAndDropManager.isDragOfTypeInProgress(
       DragType.Commit
@@ -388,7 +388,7 @@ export class RepositoryView extends React.Component<
         repository={this.props.repository}
         dispatcher={this.props.dispatcher}
         selectedCommit={selectedCommit}
-        changesetData={changedFiles}
+        changesetData={changesetData}
         selectedFile={file}
         currentDiff={diff}
         emoji={this.props.emoji}

--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -71,6 +71,14 @@
   &-title,
   &-meta {
     padding: var(--spacing);
+
+    .lines-added {
+      color: var(--color-new);
+    }
+
+    .lines-deleted {
+      color: var(--color-deleted);
+    }
   }
 
   &-title {

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -187,9 +187,9 @@ describe('git/commit', () => {
       expect(newTip.shortSha).toEqual(sha)
 
       // verify that the contents of this new commit are just the new file
-      const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.files.length).toEqual(1)
-      expect(changedFiles.files[0].path).toEqual(newFileName)
+      const changesetData = await getChangedFiles(repository, newTip.sha)
+      expect(changesetData.files.length).toEqual(1)
+      expect(changesetData.files[0].path).toEqual(newFileName)
 
       // verify that changes remain for this new file
       const status = await getStatusOrThrow(repository)
@@ -239,9 +239,9 @@ describe('git/commit', () => {
       expect(newTip.summary).toEqual('title')
 
       // verify that the contents of this new commit are just the modified file
-      const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.files.length).toEqual(1)
-      expect(changedFiles.files[0].path).toEqual(modifiedFile)
+      const changesetData = await getChangedFiles(repository, newTip.sha)
+      expect(changesetData.files.length).toEqual(1)
+      expect(changesetData.files[0].path).toEqual(modifiedFile)
 
       // verify that changes remain for this modified file
       const status = await getStatusOrThrow(repository)
@@ -294,9 +294,9 @@ describe('git/commit', () => {
       expect(newTip.shortSha).toEqual(sha)
 
       // verify that the contents of this new commit are just the modified file
-      const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.files.length).toEqual(1)
-      expect(changedFiles.files[0].path).toEqual(fileName)
+      const changesetData = await getChangedFiles(repository, newTip.sha)
+      expect(changesetData.files.length).toEqual(1)
+      expect(changesetData.files[0].path).toEqual(fileName)
     })
 
     it('can commit multiple hunks from modified file', async () => {
@@ -340,9 +340,9 @@ describe('git/commit', () => {
       expect(newTip.shortSha).toEqual(sha)
 
       // verify that the contents of this new commit are just the modified file
-      const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.files.length).toEqual(1)
-      expect(changedFiles.files[0].path).toEqual(modifiedFile)
+      const changesetData = await getChangedFiles(repository, newTip.sha)
+      expect(changesetData.files.length).toEqual(1)
+      expect(changesetData.files[0].path).toEqual(modifiedFile)
 
       // verify that changes remain for this modified file
       const status = await getStatusOrThrow(repository)
@@ -382,9 +382,9 @@ describe('git/commit', () => {
       expect(newTip.sha.substring(0, 7)).toEqual(sha)
 
       // verify that the contents of this new commit are just the new file
-      const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.files.length).toEqual(1)
-      expect(changedFiles.files[0].path).toEqual(deletedFile)
+      const changesetData = await getChangedFiles(repository, newTip.sha)
+      expect(changesetData.files.length).toEqual(1)
+      expect(changesetData.files[0].path).toEqual(deletedFile)
 
       // verify that changes remain for this new file
       const status = await getStatusOrThrow(repository)
@@ -838,10 +838,12 @@ describe('git/commit', () => {
       expect(beforeCommit.currentTip).not.toBe(afterCommit.currentTip)
 
       // Verify the file was delete in repo
-      const changedFiles = await getChangedFiles(repo, afterCommit.currentTip!)
-      expect(changedFiles.files.length).toBe(2)
-      expect(changedFiles.files[0].status.kind).toBe(AppFileStatusKind.Modified)
-      expect(changedFiles.files[1].status.kind).toBe(AppFileStatusKind.Deleted)
+      const changesetData = await getChangedFiles(repo, afterCommit.currentTip!)
+      expect(changesetData.files.length).toBe(2)
+      expect(changesetData.files[0].status.kind).toBe(
+        AppFileStatusKind.Modified
+      )
+      expect(changesetData.files[1].status.kind).toBe(AppFileStatusKind.Deleted)
     })
   })
 })

--- a/app/test/unit/git/commit-test.ts
+++ b/app/test/unit/git/commit-test.ts
@@ -188,8 +188,8 @@ describe('git/commit', () => {
 
       // verify that the contents of this new commit are just the new file
       const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.length).toEqual(1)
-      expect(changedFiles[0].path).toEqual(newFileName)
+      expect(changedFiles.files.length).toEqual(1)
+      expect(changedFiles.files[0].path).toEqual(newFileName)
 
       // verify that changes remain for this new file
       const status = await getStatusOrThrow(repository)
@@ -240,8 +240,8 @@ describe('git/commit', () => {
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.length).toEqual(1)
-      expect(changedFiles[0].path).toEqual(modifiedFile)
+      expect(changedFiles.files.length).toEqual(1)
+      expect(changedFiles.files[0].path).toEqual(modifiedFile)
 
       // verify that changes remain for this modified file
       const status = await getStatusOrThrow(repository)
@@ -295,8 +295,8 @@ describe('git/commit', () => {
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.length).toEqual(1)
-      expect(changedFiles[0].path).toEqual(fileName)
+      expect(changedFiles.files.length).toEqual(1)
+      expect(changedFiles.files[0].path).toEqual(fileName)
     })
 
     it('can commit multiple hunks from modified file', async () => {
@@ -341,8 +341,8 @@ describe('git/commit', () => {
 
       // verify that the contents of this new commit are just the modified file
       const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.length).toEqual(1)
-      expect(changedFiles[0].path).toEqual(modifiedFile)
+      expect(changedFiles.files.length).toEqual(1)
+      expect(changedFiles.files[0].path).toEqual(modifiedFile)
 
       // verify that changes remain for this modified file
       const status = await getStatusOrThrow(repository)
@@ -383,8 +383,8 @@ describe('git/commit', () => {
 
       // verify that the contents of this new commit are just the new file
       const changedFiles = await getChangedFiles(repository, newTip.sha)
-      expect(changedFiles.length).toEqual(1)
-      expect(changedFiles[0].path).toEqual(deletedFile)
+      expect(changedFiles.files.length).toEqual(1)
+      expect(changedFiles.files[0].path).toEqual(deletedFile)
 
       // verify that changes remain for this new file
       const status = await getStatusOrThrow(repository)
@@ -839,9 +839,9 @@ describe('git/commit', () => {
 
       // Verify the file was delete in repo
       const changedFiles = await getChangedFiles(repo, afterCommit.currentTip!)
-      expect(changedFiles.length).toBe(2)
-      expect(changedFiles[0].status.kind).toBe(AppFileStatusKind.Modified)
-      expect(changedFiles[1].status.kind).toBe(AppFileStatusKind.Deleted)
+      expect(changedFiles.files.length).toBe(2)
+      expect(changedFiles.files[0].status.kind).toBe(AppFileStatusKind.Modified)
+      expect(changedFiles.files[1].status.kind).toBe(AppFileStatusKind.Deleted)
     })
   })
 })

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -61,13 +61,13 @@ describe('git/log', () => {
 
   describe('getChangedFiles', () => {
     it('loads the files changed in the commit', async () => {
-      const changedFiles = await getChangedFiles(
+      const changesetData = await getChangedFiles(
         repository,
         '7cd6640e5b6ca8dbfd0b33d0281ebe702127079c'
       )
-      expect(changedFiles.files).toHaveLength(1)
-      expect(changedFiles.files[0].path).toBe('README.md')
-      expect(changedFiles.files[0].status.kind).toBe(AppFileStatusKind.New)
+      expect(changesetData.files).toHaveLength(1)
+      expect(changesetData.files[0].path).toBe('README.md')
+      expect(changesetData.files[0].status.kind).toBe(AppFileStatusKind.New)
     })
 
     it('detects renames', async () => {
@@ -104,27 +104,29 @@ describe('git/log', () => {
       // ensure the test repository is configured to detect copies
       await setupLocalConfig(repository, [['diff.renames', 'copies']])
 
-      const changedFiles = await getChangedFiles(repository, 'a500bf415')
-      expect(changedFiles.files).toHaveLength(2)
+      const changesetData = await getChangedFiles(repository, 'a500bf415')
+      expect(changesetData.files).toHaveLength(2)
 
-      expect(changedFiles.files[0].path).toBe('duplicate-with-edits.md')
-      expect(changedFiles.files[0].status).toEqual({
+      expect(changesetData.files[0].path).toBe('duplicate-with-edits.md')
+      expect(changesetData.files[0].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
       })
 
-      expect(changedFiles.files[1].path).toBe('duplicate.md')
-      expect(changedFiles.files[1].status).toEqual({
+      expect(changesetData.files[1].path).toBe('duplicate.md')
+      expect(changesetData.files[1].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
       })
     })
 
     it('handles commit when HEAD exists on disk', async () => {
-      const changedFiles = await getChangedFiles(repository, 'HEAD')
-      expect(changedFiles.files).toHaveLength(1)
-      expect(changedFiles.files[0].path).toBe('README.md')
-      expect(changedFiles.files[0].status.kind).toBe(AppFileStatusKind.Modified)
+      const changesetData = await getChangedFiles(repository, 'HEAD')
+      expect(changesetData.files).toHaveLength(1)
+      expect(changesetData.files[0].path).toBe('README.md')
+      expect(changesetData.files[0].status.kind).toBe(
+        AppFileStatusKind.Modified
+      )
     })
   })
 })

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -61,13 +61,13 @@ describe('git/log', () => {
 
   describe('getChangedFiles', () => {
     it('loads the files changed in the commit', async () => {
-      const files = await getChangedFiles(
+      const changedFiles = await getChangedFiles(
         repository,
         '7cd6640e5b6ca8dbfd0b33d0281ebe702127079c'
       )
-      expect(files).toHaveLength(1)
-      expect(files[0].path).toBe('README.md')
-      expect(files[0].status.kind).toBe(AppFileStatusKind.New)
+      expect(changedFiles.files).toHaveLength(1)
+      expect(changedFiles.files[0].path).toBe('README.md')
+      expect(changedFiles.files[0].status.kind).toBe(AppFileStatusKind.New)
     })
 
     it('detects renames', async () => {
@@ -77,19 +77,19 @@ describe('git/log', () => {
       repository = new Repository(testRepoPath, -1, null, false)
 
       const first = await getChangedFiles(repository, '55bdecb')
-      expect(first).toHaveLength(1)
+      expect(first.files).toHaveLength(1)
 
-      expect(first[0].path).toBe('NEWER.md')
-      expect(first[0].status).toEqual({
+      expect(first.files[0].path).toBe('NEWER.md')
+      expect(first.files[0].status).toEqual({
         kind: AppFileStatusKind.Renamed,
         oldPath: 'NEW.md',
       })
 
       const second = await getChangedFiles(repository, 'c898ca8')
-      expect(second).toHaveLength(1)
+      expect(second.files).toHaveLength(1)
 
-      expect(second[0].path).toBe('NEW.md')
-      expect(second[0].status).toEqual({
+      expect(second.files[0].path).toBe('NEW.md')
+      expect(second.files[0].status).toEqual({
         kind: AppFileStatusKind.Renamed,
         oldPath: 'OLD.md',
       })
@@ -104,27 +104,27 @@ describe('git/log', () => {
       // ensure the test repository is configured to detect copies
       await setupLocalConfig(repository, [['diff.renames', 'copies']])
 
-      const files = await getChangedFiles(repository, 'a500bf415')
-      expect(files).toHaveLength(2)
+      const changedFiles = await getChangedFiles(repository, 'a500bf415')
+      expect(changedFiles.files).toHaveLength(2)
 
-      expect(files[0].path).toBe('duplicate-with-edits.md')
-      expect(files[0].status).toEqual({
+      expect(changedFiles.files[0].path).toBe('duplicate-with-edits.md')
+      expect(changedFiles.files[0].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
       })
 
-      expect(files[1].path).toBe('duplicate.md')
-      expect(files[1].status).toEqual({
+      expect(changedFiles.files[1].path).toBe('duplicate.md')
+      expect(changedFiles.files[1].status).toEqual({
         kind: AppFileStatusKind.Copied,
         oldPath: 'initial.md',
       })
     })
 
     it('handles commit when HEAD exists on disk', async () => {
-      const files = await getChangedFiles(repository, 'HEAD')
-      expect(files).toHaveLength(1)
-      expect(files[0].path).toBe('README.md')
-      expect(files[0].status.kind).toBe(AppFileStatusKind.Modified)
+      const changedFiles = await getChangedFiles(repository, 'HEAD')
+      expect(changedFiles.files).toHaveLength(1)
+      expect(changedFiles.files[0].path).toBe('README.md')
+      expect(changedFiles.files[0].status.kind).toBe(AppFileStatusKind.Modified)
     })
   })
 })

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -290,10 +290,9 @@ describe('git/rebase', () => {
 
       status = await getStatusOrThrow(repository)
 
-      filesInRebasedCommit = await getChangedFiles(
-        repository,
-        status.currentTip!
-      )
+      const changedFiles = await getChangedFiles(repository, status.currentTip!)
+
+      filesInRebasedCommit = changedFiles.files
     })
 
     it('returns success', () => {

--- a/app/test/unit/git/rebase/detect-conflict-test.ts
+++ b/app/test/unit/git/rebase/detect-conflict-test.ts
@@ -290,9 +290,12 @@ describe('git/rebase', () => {
 
       status = await getStatusOrThrow(repository)
 
-      const changedFiles = await getChangedFiles(repository, status.currentTip!)
+      const changesetData = await getChangedFiles(
+        repository,
+        status.currentTip!
+      )
 
-      filesInRebasedCommit = changedFiles.files
+      filesInRebasedCommit = changesetData.files
     })
 
     it('returns success', () => {

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -47,8 +47,13 @@ describe('git/cherry-pick', () => {
     expect(log.length).toBe(2)
 
     // verify squashed commit contains changes from squashed commits
-    const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
+    const squashedChangesetData = await getChangedFiles(
+      repository,
+      squashed.sha
+    )
+    const squashedFilePaths = squashedChangesetData.files
+      .map(f => f.path)
+      .join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
   })
@@ -91,8 +96,13 @@ describe('git/cherry-pick', () => {
     expect(log.length).toBe(2)
 
     // verify squashed commit contains changes from squashed commits
-    const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
+    const squashedChangesetData = await getChangedFiles(
+      repository,
+      squashed.sha
+    )
+    const squashedFilePaths = squashedChangesetData.files
+      .map(f => f.path)
+      .join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
     expect(squashedFilePaths).toContain('third.md')
@@ -123,8 +133,13 @@ describe('git/cherry-pick', () => {
     expect(log.length).toBe(1)
 
     // verify squashed commit contains changes from squashed commits
-    const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
+    const squashedChangesetData = await getChangedFiles(
+      repository,
+      squashed.sha
+    )
+    const squashedFilePaths = squashedChangesetData.files
+      .map(f => f.path)
+      .join(' ')
     expect(squashedFilePaths).toContain('initialize')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
@@ -169,8 +184,13 @@ describe('git/cherry-pick', () => {
     expect(log.length).toBe(4)
 
     // verify squashed commit contains changes from squashed commits
-    const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
+    const squashedChangesetData = await getChangedFiles(
+      repository,
+      squashed.sha
+    )
+    const squashedFilePaths = squashedChangesetData.files
+      .map(f => f.path)
+      .join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('third.md')
     expect(squashedFilePaths).toContain('fifth.md')
@@ -257,8 +277,13 @@ describe('git/cherry-pick', () => {
     expect(squashed.body).toBe('Test Body\n')
 
     // verify squashed commit contains changes from squashed commits
-    const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
+    const squashedChangesetData = await getChangedFiles(
+      repository,
+      squashed.sha
+    )
+    const squashedFilePaths = squashedChangesetData.files
+      .map(f => f.path)
+      .join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
   })

--- a/app/test/unit/git/squash-test.ts
+++ b/app/test/unit/git/squash-test.ts
@@ -48,7 +48,7 @@ describe('git/cherry-pick', () => {
 
     // verify squashed commit contains changes from squashed commits
     const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.map(f => f.path).join(' ')
+    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
   })
@@ -92,7 +92,7 @@ describe('git/cherry-pick', () => {
 
     // verify squashed commit contains changes from squashed commits
     const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.map(f => f.path).join(' ')
+    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
     expect(squashedFilePaths).toContain('third.md')
@@ -124,7 +124,7 @@ describe('git/cherry-pick', () => {
 
     // verify squashed commit contains changes from squashed commits
     const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.map(f => f.path).join(' ')
+    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
     expect(squashedFilePaths).toContain('initialize')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
@@ -170,7 +170,7 @@ describe('git/cherry-pick', () => {
 
     // verify squashed commit contains changes from squashed commits
     const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.map(f => f.path).join(' ')
+    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('third.md')
     expect(squashedFilePaths).toContain('fifth.md')
@@ -258,7 +258,7 @@ describe('git/cherry-pick', () => {
 
     // verify squashed commit contains changes from squashed commits
     const squashedFiles = await getChangedFiles(repository, squashed.sha)
-    const squashedFilePaths = squashedFiles.map(f => f.path).join(' ')
+    const squashedFilePaths = squashedFiles.files.map(f => f.path).join(' ')
     expect(squashedFilePaths).toContain('first.md')
     expect(squashedFilePaths).toContain('second.md')
   })


### PR DESCRIPTION
Closes #11656

## Description

This PR adds the number of lines added/removed in a commit. This is only shown if there are line changes of any kind. If all files in a commit are binary files, those counters won't be shown at all.

I hid this behind a feature flag, in case having the extra `git log` causes any harm anywhere I haven't seen.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/128003774-a1918c25-88fd-407f-8d8c-9367aadb13c2.png)

## Release notes

Notes: [Added] See how many lines were added or deleted in a commit.
