### PR TITLE
Allow users to use Windows' OpenSSH binaries when available

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -197,6 +197,9 @@ export interface IAppState {
   /** The external editor to use when opening repositories */
   readonly selectedExternalEditor: string | null
 
+  /** Whether or not the app should use Windows' OpenSSH client */
+  readonly useWindowsOpenSSH: boolean
+
   /** The current setting for whether the user has disable usage reports */
   readonly optOutOfUsageTracking: boolean
   /**

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -127,3 +127,8 @@ export function enableResetToCommit(): boolean {
 export function enableLineChangesInCommit(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we allow using Windows' OpenSSH? */
+export function enableWindowsOpenSSH(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -18,6 +18,7 @@ import { isErrnoException } from '../errno-exception'
 import { ChildProcess } from 'child_process'
 import { Readable } from 'stream'
 import split2 from 'split2'
+import { getSSHArguments } from '../ssh/ssh'
 
 /**
  * An extension of the execution options in dugite that
@@ -131,7 +132,8 @@ export async function git(
   name: string,
   options?: IGitExecutionOptions
 ): Promise<IGitResult> {
-  args = [...getSSHArguments(), ...args]
+  const sshArguments = await getSSHArguments()
+  args = [...sshArguments, ...args]
 
   const defaultOptions: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
@@ -475,19 +477,6 @@ export async function gitNetworkArguments(
 
   // opt in for v2 of the Git Wire protocol for GitHub repositories
   return [...baseArgs, '-c', 'protocol.version=2']
-}
-
-/**
- * Returns the git arguments related to SSH depending on the current context
- * (OS and user settings).
- */
-export function getSSHArguments() {
-  if (!__WIN32__) {
-    return []
-  }
-
-  // Replace git sshCommand with Windows' OpenSSH executable path
-  return ['-c', 'core.sshCommand="C:\\Windows\\System32\\OpenSSH\\ssh.exe"']
 }
 
 /**

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -138,11 +138,13 @@ export async function git(
     expectedErrors: new Set(),
   }
 
+  const sshEnvironment = await getSSHEnvironment()
+
   let combinedOutput = ''
   const opts = {
     ...defaultOptions,
     ...options,
-    env: merge(options?.env, getSSHEnvironment()),
+    env: merge(options?.env, sshEnvironment),
   }
 
   opts.processCallback = (process: ChildProcess) => {

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -18,7 +18,8 @@ import { isErrnoException } from '../errno-exception'
 import { ChildProcess } from 'child_process'
 import { Readable } from 'stream'
 import split2 from 'split2'
-import { getSSHArguments } from '../ssh/ssh'
+import { getSSHEnvironment } from '../ssh/ssh'
+import { merge } from '../merge'
 
 /**
  * An extension of the execution options in dugite that
@@ -132,16 +133,17 @@ export async function git(
   name: string,
   options?: IGitExecutionOptions
 ): Promise<IGitResult> {
-  const sshArguments = await getSSHArguments()
-  args = [...sshArguments, ...args]
-
   const defaultOptions: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
     expectedErrors: new Set(),
   }
 
   let combinedOutput = ''
-  const opts = { ...defaultOptions, ...options }
+  const opts = {
+    ...defaultOptions,
+    ...options,
+    env: merge(options?.env, getSSHEnvironment()),
+  }
 
   opts.processCallback = (process: ChildProcess) => {
     options?.processCallback?.(process)

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -131,6 +131,8 @@ export async function git(
   name: string,
   options?: IGitExecutionOptions
 ): Promise<IGitResult> {
+  args = [...getSSHArguments(), ...args]
+
   const defaultOptions: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
     expectedErrors: new Set(),
@@ -473,6 +475,19 @@ export async function gitNetworkArguments(
 
   // opt in for v2 of the Git Wire protocol for GitHub repositories
   return [...baseArgs, '-c', 'protocol.version=2']
+}
+
+/**
+ * Returns the git arguments related to SSH depending on the current context
+ * (OS and user settings).
+ */
+export function getSSHArguments() {
+  if (!__WIN32__) {
+    return []
+  }
+
+  // Replace git sshCommand with Windows' OpenSSH executable path
+  return ['-c', 'core.sshCommand="C:\\Windows\\System32\\OpenSSH\\ssh.exe"']
 }
 
 /**

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -1,7 +1,7 @@
 import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
 import { isErrnoException } from '../errno-exception'
-import { getSSHArguments } from './core'
+import { getSSHArguments } from '../ssh/ssh'
 
 type ProcessOutput = {
   /** The contents of stdout received from the spawned process */
@@ -25,14 +25,15 @@ type ProcessOutput = {
  *                         will be killed silently and the truncated output is
  *                         returned.
  */
-export function spawnAndComplete(
+export async function spawnAndComplete(
   args: string[],
   path: string,
   name: string,
   successExitCodes?: Set<number>,
   stdOutMaxLength?: number
 ): Promise<ProcessOutput> {
-  args = [...getSSHArguments(), ...args]
+  const sshArguments = await getSSHArguments()
+  args = [...sshArguments, ...args]
 
   const commandName = `${name}: git ${args.join(' ')}`
   return GitPerf.measure(

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -1,6 +1,7 @@
 import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
 import { isErrnoException } from '../errno-exception'
+import { getSSHArguments } from './core'
 
 type ProcessOutput = {
   /** The contents of stdout received from the spawned process */
@@ -31,6 +32,8 @@ export function spawnAndComplete(
   successExitCodes?: Set<number>,
   stdOutMaxLength?: number
 ): Promise<ProcessOutput> {
+  args = [...getSSHArguments(), ...args]
+
   const commandName = `${name}: git ${args.join(' ')}`
   return GitPerf.measure(
     commandName,

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -1,7 +1,7 @@
 import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
 import { isErrnoException } from '../errno-exception'
-import { getSSHArguments } from '../ssh/ssh'
+import { getSSHEnvironment } from '../ssh/ssh'
 
 type ProcessOutput = {
   /** The contents of stdout received from the spawned process */
@@ -32,15 +32,14 @@ export async function spawnAndComplete(
   successExitCodes?: Set<number>,
   stdOutMaxLength?: number
 ): Promise<ProcessOutput> {
-  const sshArguments = await getSSHArguments()
-  args = [...sshArguments, ...args]
-
   const commandName = `${name}: git ${args.join(' ')}`
   return GitPerf.measure(
     commandName,
     () =>
       new Promise<ProcessOutput>((resolve, reject) => {
-        const process = GitProcess.spawn(args, path)
+        const process = GitProcess.spawn(args, path, {
+          env: getSSHEnvironment(),
+        })
 
         process.on('error', err => {
           // If this is an exception thrown by Node.js while attempting to

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -36,9 +36,9 @@ export async function spawnAndComplete(
   return GitPerf.measure(
     commandName,
     () =>
-      new Promise<ProcessOutput>((resolve, reject) => {
+      new Promise<ProcessOutput>(async (resolve, reject) => {
         const process = GitProcess.spawn(args, path, {
-          env: getSSHEnvironment(),
+          env: await getSSHEnvironment(),
         })
 
         process.on('error', err => {

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -1,0 +1,28 @@
+import * as fse from 'fs-extra'
+import memoizeOne from 'memoize-one'
+
+const WindowsOpenSSHPath = 'C:\\Windows\\System32\\OpenSSH\\ssh.exe'
+
+export const isWindowsSSHAvailable = memoizeOne(
+  async (): Promise<boolean> => {
+    if (!__WIN32__) {
+      return false
+    }
+
+    return await fse.pathExists(WindowsOpenSSHPath)
+  }
+)
+
+/**
+ * Returns the git arguments related to SSH depending on the current context
+ * (OS and user settings).
+ */
+export async function getSSHArguments() {
+  const useWindowsSSH = await isWindowsSSHAvailable()
+  if (!useWindowsSSH) {
+    return []
+  }
+
+  // Replace git sshCommand with Windows' OpenSSH executable path
+  return ['-c', `core.sshCommand="${WindowsOpenSSHPath}"`]
+}

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -35,15 +35,17 @@ function isWindowsOpenSSHUseEnabled() {
 }
 
 /**
- * Returns the git arguments related to SSH depending on the current context
- * (OS and user settings).
+ * Returns the git environment variables related to SSH depending on the current
+ * context (OS and user settings).
  */
-export async function getSSHArguments() {
+export async function getSSHEnvironment() {
   const canUseWindowsSSH = await isWindowsOpenSSHAvailable()
   if (!canUseWindowsSSH || !isWindowsOpenSSHUseEnabled()) {
-    return []
+    return {}
   }
 
-  // Replace git sshCommand with Windows' OpenSSH executable path
-  return ['-c', `core.sshCommand="${WindowsOpenSSHPath}"`]
+  // Replace git ssh command with Windows' OpenSSH executable path
+  return {
+    GIT_SSH_COMMAND: WindowsOpenSSHPath,
+  }
 }

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -3,7 +3,7 @@ import memoizeOne from 'memoize-one'
 import { enableWindowsOpenSSH } from '../feature-flag'
 import { getBoolean } from '../local-storage'
 
-const WindowsOpenSSHPath = 'C:\\Windows\\System32\\OpenSSH\\ssh.exe'
+const WindowsOpenSSHPath = 'C:/Windows/System32/OpenSSH/ssh.exe'
 
 export const UseWindowsOpenSSHKey: string = 'useWindowsOpenSSH'
 

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -1,5 +1,6 @@
 import * as fse from 'fs-extra'
 import memoizeOne from 'memoize-one'
+import { enableWindowsOpenSSH } from '../feature-flag'
 import { getBoolean } from '../local-storage'
 
 const WindowsOpenSSHPath = 'C:\\Windows\\System32\\OpenSSH\\ssh.exe'
@@ -8,7 +9,7 @@ export const UseWindowsOpenSSHKey: string = 'useWindowsOpenSSH'
 
 export const isWindowsOpenSSHAvailable = memoizeOne(
   async (): Promise<boolean> => {
-    if (!__WIN32__) {
+    if (!__WIN32__ || !enableWindowsOpenSSH()) {
       return false
     }
 

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -13,6 +13,12 @@ export const isWindowsOpenSSHAvailable = memoizeOne(
       return false
     }
 
+    // FIXME: for now, seems like we can't use Windows' OpenSSH binary on Windows
+    // for ARM.
+    if (process.arch === 'arm64') {
+      return false
+    }
+
     return await fse.pathExists(WindowsOpenSSHPath)
   }
 )

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -23,13 +23,24 @@ export const isWindowsOpenSSHAvailable = memoizeOne(
   }
 )
 
+// HACK: The purpose of this function is to wrap `getBoolean` inside a try/catch
+// block, because for some reason, accessing localStorage from tests sometimes
+// fails.
+function isWindowsOpenSSHUseEnabled() {
+  try {
+    return getBoolean(UseWindowsOpenSSHKey, false)
+  } catch (e) {
+    return false
+  }
+}
+
 /**
  * Returns the git arguments related to SSH depending on the current context
  * (OS and user settings).
  */
 export async function getSSHArguments() {
   const canUseWindowsSSH = await isWindowsOpenSSHAvailable()
-  if (!canUseWindowsSSH || !getBoolean(UseWindowsOpenSSHKey, false)) {
+  if (!canUseWindowsSSH || !isWindowsOpenSSHUseEnabled()) {
     return []
   }
 

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -1,9 +1,12 @@
 import * as fse from 'fs-extra'
 import memoizeOne from 'memoize-one'
+import { getBoolean } from '../local-storage'
 
 const WindowsOpenSSHPath = 'C:\\Windows\\System32\\OpenSSH\\ssh.exe'
 
-export const isWindowsSSHAvailable = memoizeOne(
+export const UseWindowsOpenSSHKey: string = 'useWindowsOpenSSH'
+
+export const isWindowsOpenSSHAvailable = memoizeOne(
   async (): Promise<boolean> => {
     if (!__WIN32__) {
       return false
@@ -18,8 +21,8 @@ export const isWindowsSSHAvailable = memoizeOne(
  * (OS and user settings).
  */
 export async function getSSHArguments() {
-  const useWindowsSSH = await isWindowsSSHAvailable()
-  if (!useWindowsSSH) {
+  const canUseWindowsSSH = await isWindowsOpenSSHAvailable()
+  if (!canUseWindowsSSH || !getBoolean(UseWindowsOpenSSHKey, false)) {
     return []
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -336,6 +336,8 @@ const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
 
+const useWindowsOpenSSHKey: string = 'useWindowsOpenSSH'
+
 const shellKey = 'shell'
 
 const repositoryIndicatorsEnabledKey = 'enable-repository-indicators'
@@ -450,6 +452,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private selectedTheme = ApplicationTheme.System
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
 
+  private useWindowsOpenSSH: boolean = false
+
   private hasUserViewedStash = false
 
   private repositoryIndicatorsEnabled: boolean
@@ -483,6 +487,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     super()
 
     this.showWelcomeFlow = !hasShownWelcomeFlow()
+
+    // If the user never selected whether to use Windows OpenSSH or not, use it
+    // by default if we have to show the welcome flow (i.e. if it's a new install)
+    if (__WIN32__ && getBoolean(useWindowsOpenSSHKey) === undefined) {
+      this.useWindowsOpenSSH = this.showWelcomeFlow
+    }
 
     this.gitStoreCache = new GitStoreCache(
       shell,
@@ -838,6 +848,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       selectedTheme: this.selectedTheme,
       currentTheme: this.currentTheme,
       apiRepositories: this.apiRepositoriesStore.getState(),
+      useWindowsOpenSSH: this.useWindowsOpenSSH,
       optOutOfUsageTracking: this.statsStore.getOptOut(),
       currentOnboardingTutorialStep: this.currentOnboardingTutorialStep,
       repositoryIndicatorsEnabled: this.repositoryIndicatorsEnabled,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -491,7 +491,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // If the user never selected whether to use Windows OpenSSH or not, use it
     // by default if we have to show the welcome flow (i.e. if it's a new install)
     if (__WIN32__ && getBoolean(useWindowsOpenSSHKey) === undefined) {
-      this.useWindowsOpenSSH = this.showWelcomeFlow
+      this._setUseWindowsOpenSSH(this.showWelcomeFlow)
     }
 
     this.gitStoreCache = new GitStoreCache(
@@ -3088,6 +3088,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     setBoolean(commitSpellcheckEnabledKey, commitSpellcheckEnabled)
     this.commitSpellcheckEnabled = commitSpellcheckEnabled
+
+    this.emitUpdate()
+  }
+
+  public _setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
+    setBoolean(useWindowsOpenSSHKey, useWindowsOpenSSH)
+    this.useWindowsOpenSSH = useWindowsOpenSSH
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -293,6 +293,7 @@ import {
 } from '../../models/multi-commit-operation'
 import { reorder } from '../git/reorder'
 import { DragAndDropIntroType } from '../../ui/history/drag-and-drop-intro'
+import { UseWindowsOpenSSHKey } from '../ssh/ssh'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -335,8 +336,6 @@ const hideWhitespaceInHistoryDiffKey = 'hide-whitespace-in-diff'
 
 const commitSpellcheckEnabledDefault = true
 const commitSpellcheckEnabledKey = 'commit-spellcheck-enabled'
-
-const useWindowsOpenSSHKey: string = 'useWindowsOpenSSH'
 
 const shellKey = 'shell'
 
@@ -490,7 +489,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     // If the user never selected whether to use Windows OpenSSH or not, use it
     // by default if we have to show the welcome flow (i.e. if it's a new install)
-    if (__WIN32__ && getBoolean(useWindowsOpenSSHKey) === undefined) {
+    if (__WIN32__ && getBoolean(UseWindowsOpenSSHKey) === undefined) {
       this._setUseWindowsOpenSSH(this.showWelcomeFlow)
     }
 
@@ -3093,7 +3092,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public _setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
-    setBoolean(useWindowsOpenSSHKey, useWindowsOpenSSH)
+    setBoolean(UseWindowsOpenSSHKey, useWindowsOpenSSH)
     this.useWindowsOpenSSH = useWindowsOpenSSH
 
     this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -487,10 +487,16 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.showWelcomeFlow = !hasShownWelcomeFlow()
 
-    // If the user never selected whether to use Windows OpenSSH or not, use it
-    // by default if we have to show the welcome flow (i.e. if it's a new install)
-    if (__WIN32__ && getBoolean(UseWindowsOpenSSHKey) === undefined) {
-      this._setUseWindowsOpenSSH(this.showWelcomeFlow)
+    if (__WIN32__) {
+      const useWindowsOpenSSH = getBoolean(UseWindowsOpenSSHKey)
+
+      // If the user never selected whether to use Windows OpenSSH or not, use it
+      // by default if we have to show the welcome flow (i.e. if it's a new install)
+      if (useWindowsOpenSSH === undefined) {
+        this._setUseWindowsOpenSSH(this.showWelcomeFlow)
+      } else {
+        this.useWindowsOpenSSH = useWindowsOpenSSH
+      }
     }
 
     this.gitStoreCache = new GitStoreCache(

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1413,6 +1413,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmForcePush={this.state.askForConfirmationOnForcePush}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
+            useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             enterpriseAccount={this.getEnterpriseAccount()}
             repository={repository}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2658,6 +2658,10 @@ export class Dispatcher {
     this.appStore._setCommitSpellcheckEnabled(commitSpellcheckEnabled)
   }
 
+  public setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
+    this.appStore._setUseWindowsOpenSSH(useWindowsOpenSSH)
+  }
+
   public recordDiffOptionsViewed() {
     return this.statsStore.recordDiffOptionsViewed()
   }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -5,6 +5,7 @@ import { LinkButton } from '../lib/link-button'
 import { SamplesURL } from '../../lib/stats'
 import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-strategy'
 import { RadioButton } from '../lib/radio-button'
+import { isWindowsSSHAvailable } from '../../lib/ssh/ssh'
 
 interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
@@ -20,6 +21,7 @@ interface IAdvancedPreferencesProps {
 interface IAdvancedPreferencesState {
   readonly optOutOfUsageTracking: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
+  readonly canUseWindowsSSH: boolean
 }
 
 export class Advanced extends React.Component<
@@ -32,7 +34,16 @@ export class Advanced extends React.Component<
     this.state = {
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
+      canUseWindowsSSH: false,
     }
+  }
+
+  public componentDidMount() {
+    this.checkSSHAvailability()
+  }
+
+  private async checkSSHAvailability() {
+    this.setState({ canUseWindowsSSH: await isWindowsSSHAvailable() })
   }
 
   private onReportingOptOutChanged = (
@@ -118,6 +129,7 @@ export class Advanced extends React.Component<
             list. Disabling this may improve performance with many repositories.
           </p>
         </div>
+        {this.renderSSHSettings()}
         <div className="advanced-section">
           <h2>Usage</h2>
           <Checkbox
@@ -131,6 +143,27 @@ export class Advanced extends React.Component<
           />
         </div>
       </DialogContent>
+    )
+  }
+
+  private renderSSHSettings() {
+    if (!this.state.canUseWindowsSSH) {
+      return null
+    }
+
+    return (
+      <div className="advanced-section">
+        <h2>SSH</h2>
+        <Checkbox
+          label="Use system OpenSSH (recommended)"
+          value={
+            this.state.optOutOfUsageTracking
+              ? CheckboxValue.Off
+              : CheckboxValue.On
+          }
+          onChange={this.onReportingOptOutChanged}
+        />
+      </div>
     )
   }
 }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -8,9 +8,11 @@ import { RadioButton } from '../lib/radio-button'
 import { isWindowsSSHAvailable } from '../../lib/ssh/ssh'
 
 interface IAdvancedPreferencesProps {
+  readonly useWindowsOpenSSH: boolean
   readonly optOutOfUsageTracking: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly repositoryIndicatorsEnabled: boolean
+  readonly onUseWindowsOpenSSHChanged: (checked: boolean) => void
   readonly onOptOutofReportingChanged: (checked: boolean) => void
   readonly onUncommittedChangesStrategyChanged: (
     value: UncommittedChangesStrategy
@@ -66,6 +68,12 @@ export class Advanced extends React.Component<
     event: React.FormEvent<HTMLInputElement>
   ) => {
     this.props.onRepositoryIndicatorsEnabledChanged(event.currentTarget.checked)
+  }
+
+  private onUseWindowsOpenSSHChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onUseWindowsOpenSSHChanged(event.currentTarget.checked)
   }
 
   private reportDesktopUsageLabel() {
@@ -157,11 +165,9 @@ export class Advanced extends React.Component<
         <Checkbox
           label="Use system OpenSSH (recommended)"
           value={
-            this.state.optOutOfUsageTracking
-              ? CheckboxValue.Off
-              : CheckboxValue.On
+            this.props.useWindowsOpenSSH ? CheckboxValue.On : CheckboxValue.Off
           }
-          onChange={this.onReportingOptOutChanged}
+          onChange={this.onUseWindowsOpenSSHChanged}
         />
       </div>
     )

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -5,7 +5,7 @@ import { LinkButton } from '../lib/link-button'
 import { SamplesURL } from '../../lib/stats'
 import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-strategy'
 import { RadioButton } from '../lib/radio-button'
-import { isWindowsSSHAvailable } from '../../lib/ssh/ssh'
+import { isWindowsOpenSSHAvailable } from '../../lib/ssh/ssh'
 
 interface IAdvancedPreferencesProps {
   readonly useWindowsOpenSSH: boolean
@@ -45,7 +45,7 @@ export class Advanced extends React.Component<
   }
 
   private async checkSSHAvailability() {
-    this.setState({ canUseWindowsSSH: await isWindowsSSHAvailable() })
+    this.setState({ canUseWindowsSSH: await isWindowsOpenSSHAvailable() })
   }
 
   private onReportingOptOutChanged = (

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -11,7 +11,7 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly repositoryIndicatorsEnabled: boolean
-  readonly onOptOutofReportingchanged: (checked: boolean) => void
+  readonly onOptOutofReportingChanged: (checked: boolean) => void
   readonly onUncommittedChangesStrategyChanged: (
     value: UncommittedChangesStrategy
   ) => void
@@ -52,7 +52,7 @@ export class Advanced extends React.Component<
     const value = !event.currentTarget.checked
 
     this.setState({ optOutOfUsageTracking: value })
-    this.props.onOptOutofReportingchanged(value)
+    this.props.onOptOutofReportingChanged(value)
   }
 
   private onUncommittedChangesStrategyChanged = (

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -326,7 +326,7 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
-            onOptOutofReportingchanged={this.onOptOutofReportingChanged}
+            onOptOutofReportingChanged={this.onOptOutofReportingChanged}
             onUncommittedChangesStrategyChanged={
               this.onUncommittedChangesStrategyChanged
             }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -47,6 +47,7 @@ interface IPreferencesProps {
   readonly enterpriseAccount: Account | null
   readonly repository: Repository | null
   readonly onDismissed: () => void
+  readonly useWindowsOpenSSH: boolean
   readonly optOutOfUsageTracking: boolean
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
@@ -68,6 +69,7 @@ interface IPreferencesState {
   readonly initialCommitterEmail: string | null
   readonly initialDefaultBranch: string | null
   readonly disallowedCharactersMessage: string | null
+  readonly useWindowsOpenSSH: boolean
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
@@ -106,6 +108,7 @@ export class Preferences extends React.Component<
       initialDefaultBranch: null,
       disallowedCharactersMessage: null,
       availableEditors: [],
+      useWindowsOpenSSH: false,
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
@@ -158,6 +161,7 @@ export class Preferences extends React.Component<
       initialCommitterName,
       initialCommitterEmail,
       initialDefaultBranch,
+      useWindowsOpenSSH: this.props.useWindowsOpenSSH,
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
@@ -323,9 +327,11 @@ export class Preferences extends React.Component<
       case PreferencesTab.Advanced: {
         View = (
           <Advanced
+            useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
+            onUseWindowsOpenSSHChanged={this.onUseWindowsOpenSSHChanged}
             onOptOutofReportingChanged={this.onOptOutofReportingChanged}
             onUncommittedChangesStrategyChanged={
               this.onUncommittedChangesStrategyChanged
@@ -356,6 +362,10 @@ export class Preferences extends React.Component<
 
   private onLockFileDeleteError = (e: Error) => {
     this.props.dispatcher.postError(e)
+  }
+
+  private onUseWindowsOpenSSHChanged = (useWindowsOpenSSH: boolean) => {
+    this.setState({ useWindowsOpenSSH })
   }
 
   private onOptOutofReportingChanged = (value: boolean) => {
@@ -492,6 +502,8 @@ export class Preferences extends React.Component<
       this.props.dispatcher.postError(e)
       return
     }
+
+    this.props.dispatcher.setUseWindowsOpenSSH(this.state.useWindowsOpenSSH)
 
     await this.props.dispatcher.setStatsOptOut(
       this.state.optOutOfUsageTracking,


### PR DESCRIPTION
Closes #5641

## Description

This PR introduces a new setting for users on Windows versions 10.0.17134 and newer, where there is a system OpenSSH available. New Windows installs will have this setting enabled by default, while existing installs will have this setting disabled in order to persist the existing behavior and avoid causing issues to users that already have everything set up and running.

Regarding the implementation, it just adds the `-c core.sshCommand="C:\\Windows\\System32\\OpenSSH\\ssh.exe"` parameter to all git calls.
I haven't managed to make this works on Windows 11 for ARM, it's like Desktop doesn't see that `ssh.exe`. I still have to test this on Windows 11 for x64 to see if it works there or if it's a Windows 11 issue.

**EDIT:** I just tested it and it doesn't work on ARM, but it does work on Windows 11 for x64 🎉 

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/128366520-fc280188-6795-4017-9261-ca1e0c7ea986.png)

## Release notes

Notes: [Improved] Windows users can now rely on the system OpenSSH for their git repositories.
