### PR TITLE
1. Use MultiCommitOperationProgress for cherry-picking

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -20,7 +20,6 @@ import {
   Progress,
   ICheckoutProgress,
   ICloneProgress,
-  ICherryPickProgress,
   IMultiCommitOperationProgress,
 } from '../models/progress'
 import { Popup } from '../models/popup'
@@ -789,7 +788,7 @@ export interface ICherryPickState {
    * This will be set to `null` when no target branch has been selected to
    * initiate the rebase.
    */
-  readonly progress: ICherryPickProgress | null
+  readonly progress: IMultiCommitOperationProgress | null
 
   /**
    * Whether the user has done work to resolve any conflicts as part of this

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -59,7 +59,6 @@ import {
   ICheckoutProgress,
   IFetchProgress,
   IRevertProgress,
-  ICherryPickProgress,
   IMultiCommitOperationProgress,
 } from '../../models/progress'
 import { Popup, PopupType } from '../../models/popup'
@@ -6219,7 +6218,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateCherryPickState(repository, () => {
       return {
         progress: {
-          kind: 'cherryPick',
+          kind: 'multiCommitOperation',
           value: 0,
           position: 1,
           totalCommitCount: commits.length,
@@ -6243,7 +6242,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     await this._refreshRepository(repository)
 
-    const progressCallback = (progress: ICherryPickProgress) => {
+    const progressCallback = (progress: IMultiCommitOperationProgress) => {
       this.repositoryStateCache.updateCherryPickState(repository, () => ({
         progress,
       }))
@@ -6383,7 +6382,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     manualResolutions: ReadonlyMap<string, ManualConflictResolution>
   ): Promise<CherryPickResult> {
-    const progressCallback = (progress: ICherryPickProgress) => {
+    const progressCallback = (progress: IMultiCommitOperationProgress) => {
       this.repositoryStateCache.updateCherryPickState(repository, () => ({
         progress,
       }))

--- a/app/src/models/cherry-pick.ts
+++ b/app/src/models/cherry-pick.ts
@@ -2,7 +2,7 @@ import { CherryPickConflictState } from '../lib/app-state'
 import { Branch } from './branch'
 import { CommitOneLine } from './commit'
 import { GitHubRepository } from './github-repository'
-import { ICherryPickProgress } from './progress'
+import { IMultiCommitOperationProgress } from './progress'
 import { IDetachedHead, IUnbornRepository, IValidBranch } from './tip'
 
 /** Represents a snapshot of the cherry pick state from the Git repository  */
@@ -12,7 +12,7 @@ export interface ICherryPickSnapshot {
   /** The sequence of commits being cherry picked */
   readonly commits: ReadonlyArray<CommitOneLine>
   /** The progress of the operation */
-  readonly progress: ICherryPickProgress
+  readonly progress: IMultiCommitOperationProgress
   /** The sha of the target branch tip before cherry pick initiated. */
   readonly targetBranchUndoSha: string
   /** The number of commits already cherry-picked */

--- a/app/src/models/progress.ts
+++ b/app/src/models/progress.ts
@@ -99,18 +99,6 @@ export interface IRevertProgress extends IProgress {
   kind: 'revert'
 }
 
-/** An object describing the progress of a cherry pick operation */
-export interface ICherryPickProgress extends IProgress {
-  readonly kind: 'cherryPick'
-  /** The summary of the commit applied to the base branch */
-  readonly currentCommitSummary: string
-  /** The number to signify which commit in a selection is being cherry-picked
-   **/
-  readonly position: number
-  /** The total number of commits to cherry pick on top of the current branch */
-  readonly totalCommitCount: number
-}
-
 export interface IMultiCommitOperationProgress extends IProgress {
   readonly kind: 'multiCommitOperation'
   /** The summary of the commit applied */
@@ -128,5 +116,4 @@ export type Progress =
   | IPullProgress
   | IPushProgress
   | IRevertProgress
-  | ICherryPickProgress
   | IMultiCommitOperationProgress

--- a/app/src/ui/cherry-pick/cherry-pick-flow.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-flow.tsx
@@ -7,7 +7,6 @@ import {
   CherryPickStepKind,
   ConfirmAbortStep,
 } from '../../models/cherry-pick'
-import { ICherryPickProgress } from '../../models/progress'
 
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
@@ -19,13 +18,14 @@ import { getResolvedFiles } from '../../lib/status'
 import { ConfirmCherryPickAbortDialog } from './confirm-cherry-pick-abort-dialog'
 import { CreateBranch } from '../create-branch'
 import { ConflictsDialog } from '../multi-commit-operation/conflicts-dialog'
+import { IMultiCommitOperationProgress } from '../../models/progress'
 
 interface ICherryPickFlowProps {
   readonly repository: Repository
   readonly dispatcher: Dispatcher
   readonly step: CherryPickFlowStep
   readonly commits: ReadonlyArray<CommitOneLine>
-  readonly progress: ICherryPickProgress | null
+  readonly progress: IMultiCommitOperationProgress | null
   readonly emoji: Map<string, string>
 
   /**

--- a/app/src/ui/cherry-pick/cherry-pick-progress-dialog.tsx
+++ b/app/src/ui/cherry-pick/cherry-pick-progress-dialog.tsx
@@ -3,11 +3,11 @@ import { RichText } from '../lib/rich-text'
 import { Dialog, DialogContent } from '../dialog'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
-import { ICherryPickProgress } from '../../models/progress'
+import { IMultiCommitOperationProgress } from '../../models/progress'
 
 interface ICherryPickProgressDialogProps {
   /** Progress information about the current cherry pick */
-  readonly progress: ICherryPickProgress
+  readonly progress: IMultiCommitOperationProgress
 
   readonly emoji: Map<string, string>
 }

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -19,7 +19,7 @@ import {
 import { isConflictedFile } from '../../../src/lib/status'
 import { Branch } from '../../../src/models/branch'
 import { ManualConflictResolution } from '../../../src/models/manual-conflict-resolution'
-import { ICherryPickProgress } from '../../../src/models/progress'
+import { IMultiCommitOperationProgress } from '../../../src/models/progress'
 import { Repository } from '../../../src/models/repository'
 import { AppFileStatusKind } from '../../../src/models/status'
 import { getBranchOrError } from '../../helpers/git'
@@ -525,7 +525,7 @@ describe('git/cherry-pick', () => {
   })
 
   describe('cherry-picking progress', () => {
-    let progress = new Array<ICherryPickProgress>()
+    let progress = new Array<IMultiCommitOperationProgress>()
     beforeEach(() => {
       progress = []
     })

--- a/app/test/unit/git/cherry-pick-test.ts
+++ b/app/test/unit/git/cherry-pick-test.ts
@@ -541,7 +541,7 @@ describe('git/cherry-pick', () => {
       expect(progress).toEqual([
         {
           currentCommitSummary: featureTip.summary,
-          kind: 'cherryPick',
+          kind: 'multiCommitOperation',
           position: 1,
           totalCommitCount: 1,
           value: 1,


### PR DESCRIPTION
## Description
Updates cherry-picking to use multi commit operation progress object.

## Release notes

Notes: no-notes
