### PR TITLE
3. Refactor state management variables for cherry picking

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -881,10 +881,11 @@ export interface IMultiCommitOperationState {
    *
    * Uses:
    *  - Cherry-picking = tip of target branch before cherry-pick, used to undo cherry-pick
+   *        - This maybe null if app opens mid cherry-pick
    *  - Rebasing = tip of current branch before rebase, used enable force pushing after rebase complete.
    *  - Interactive Rebasing (Squash, Reorder) = tip of current branch, used for force pushing and undoing
    */
-  readonly originalBranchTip: string
+  readonly originalBranchTip: string | null
 
   /**
    * The branch that is being modified during the operation.

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -877,17 +877,6 @@ export interface IMultiCommitOperationState {
   readonly userHasResolvedConflicts: boolean
 
   /**
-   * Array of commits used during the operation.
-   */
-  readonly commits: ReadonlyArray<Commit>
-
-  /**
-   * This is the commit sha of the HEAD of the in-flight operation used to compare
-   * the state of the after an operation to a previous state.
-   */
-  readonly currentTip: string
-
-  /**
    * The commit id of the tip of the branch user is modifying in the operation.
    *
    * Uses:
@@ -900,11 +889,11 @@ export interface IMultiCommitOperationState {
   /**
    * The branch that is being modified during the operation.
    *
-   * - Cherry-pick = the branch chosen to copy commits to.
+   * - Cherry-pick = the branch chosen to copy commits to; Maybe null when cherry-pick is in the choose branch step.
    * - Rebase = the current branch the user is on.
    * - Squash = the current branch the user is on.
    */
-  readonly targetBranch: Branch
+  readonly targetBranch: Branch | null
 }
 
 export type MultiCommitOperationConflictState = {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2089,7 +2089,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const { step } = multiCommitOperationState
+    const { step, operationDetail } = multiCommitOperationState
     if (step.kind !== MultiCommitOperationStepKind.ShowConflicts) {
       return
     }
@@ -2107,7 +2107,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       const { currentTip } = conflictState
       this.repositoryStateCache.updateMultiCommitOperationState(
         repository,
-        () => ({ currentTip })
+        () => ({ operationDetail: { ...operationDetail, currentTip } })
       )
     }
   }
@@ -6896,8 +6896,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
         value: 0,
       },
       userHasResolvedConflicts: false,
-      commits,
-      currentTip: targetBranch.tip.sha,
       originalBranchTip: targetBranch.tip.sha,
       targetBranch,
     })

--- a/app/src/models/multi-commit-operation.ts
+++ b/app/src/models/multi-commit-operation.ts
@@ -140,7 +140,19 @@ interface IInteractiveRebaseDetails {
    * interactive rebase or null if rebasing to the root.
    */
   readonly lastRetainedCommitRef: string | null
+
+  /**
+   * Array of commits used during the operation.
+   */
+  readonly commits: ReadonlyArray<Commit>
+
+  /**
+   * This is the commit sha of the HEAD of the in-flight operation used to compare
+   * the state of the after an operation to a previous state.
+   */
+  readonly currentTip: string
 }
+
 interface ISourceBranchDetails {
   /**
    * The branch that are the source of the commits for the operation.
@@ -150,6 +162,7 @@ interface ISourceBranchDetails {
    */
   readonly sourceBranch: Branch | null
 }
+
 interface ISquashDetails extends IInteractiveRebaseDetails {
   readonly kind: MultiCommitOperationKind.Squash
 
@@ -181,6 +194,11 @@ interface ICherryPickDetails extends ISourceBranchDetails {
    * Example: can create a new branch to copy commits to during cherry-pick
    */
   readonly branchCreated: boolean
+
+  /**
+   * Array of commits used during the operation.
+   */
+  readonly commits: ReadonlyArray<CommitOneLine>
 }
 
 interface IRebaseDetails extends ISourceBranchDetails {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3546,13 +3546,20 @@ export class Dispatcher {
 
     const {
       branchesState,
-      multiCommitOperationState,
+      multiCommitOperationState: mcos,
     } = this.repositoryStateManager.get(repository)
     const { tip } = branchesState
 
-    if (tip.kind === TipState.Valid && multiCommitOperationState !== null) {
-      const { originalBranchTip } = multiCommitOperationState
-      this.addRebasedBranchToForcePushList(repository, tip, originalBranchTip)
+    if (
+      tip.kind === TipState.Valid &&
+      mcos !== null &&
+      mcos.originalBranchTip !== null
+    ) {
+      this.addRebasedBranchToForcePushList(
+        repository,
+        tip,
+        mcos.originalBranchTip
+      )
     }
 
     this.statsStore.recordOperationSuccessful(kind)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3217,6 +3217,8 @@ export class Dispatcher {
         kind: MultiCommitOperationKind.Reorder,
         lastRetainedCommitRef,
         beforeCommit,
+        commits: commitsToReorder,
+        currentTip: tip.branch.tip.sha,
       },
       tip.branch,
       commitsToReorder
@@ -3322,6 +3324,8 @@ export class Dispatcher {
         lastRetainedCommitRef,
         commitContext,
         targetCommit: squashOnto,
+        commits: toSquash,
+        currentTip: tip.branch.tip.sha,
       },
       tip.branch,
       toSquash

--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -97,7 +97,8 @@ export abstract class BaseMultiCommitOperation extends React.Component<
 
     const operationDescription = (
       <>
-        {operationPrefix} <strong>{targetBranch.name}</strong>
+        {operationPrefix}{' '}
+        {targetBranch !== null ? <strong>{targetBranch.name}</strong> : null}
       </>
     )
     return dispatcher.onConflictsFoundBanner(

--- a/app/src/ui/multi-commit-operation/cherry-pick.tsx
+++ b/app/src/ui/multi-commit-operation/cherry-pick.tsx
@@ -11,7 +11,7 @@ export abstract class CherryPick extends BaseMultiCommitOperation {
       state,
       conflictState,
     } = this.props
-    const { commits, operationDetail, targetBranch } = state
+    const { operationDetail, targetBranch } = state
 
     if (
       conflictState === null ||
@@ -21,6 +21,8 @@ export abstract class CherryPick extends BaseMultiCommitOperation {
       this.endFlowInvalidState()
       return
     }
+
+    const { commits } = operationDetail
 
     await dispatcher.switchMultiCommitOperationToShowProgress(repository)
 

--- a/app/src/ui/multi-commit-operation/reorder.tsx
+++ b/app/src/ui/multi-commit-operation/reorder.tsx
@@ -5,14 +5,14 @@ import { BaseMultiCommitOperation } from './base-multi-commit-operation'
 export abstract class Reorder extends BaseMultiCommitOperation {
   protected onBeginOperation = () => {
     const { repository, dispatcher, state } = this.props
-    const { commits, operationDetail } = state
+    const { operationDetail } = state
 
     if (operationDetail.kind !== MultiCommitOperationKind.Reorder) {
       this.endFlowInvalidState()
       return
     }
 
-    const { beforeCommit, lastRetainedCommitRef } = operationDetail
+    const { commits, beforeCommit, lastRetainedCommitRef } = operationDetail
 
     return dispatcher.reorderCommits(
       repository,
@@ -31,12 +31,18 @@ export abstract class Reorder extends BaseMultiCommitOperation {
       state,
       conflictState,
     } = this.props
-    const { commits, currentTip, targetBranch, originalBranchTip } = state
+    const { operationDetail, targetBranch, originalBranchTip } = state
 
-    if (conflictState === null) {
+    if (
+      conflictState === null ||
+      targetBranch === null ||
+      operationDetail.kind !== MultiCommitOperationKind.Reorder
+    ) {
       this.endFlowInvalidState()
       return
     }
+
+    const { commits, currentTip } = operationDetail
 
     await dispatcher.switchMultiCommitOperationToShowProgress(repository)
 

--- a/app/src/ui/multi-commit-operation/reorder.tsx
+++ b/app/src/ui/multi-commit-operation/reorder.tsx
@@ -36,6 +36,7 @@ export abstract class Reorder extends BaseMultiCommitOperation {
     if (
       conflictState === null ||
       targetBranch === null ||
+      originalBranchTip === null ||
       operationDetail.kind !== MultiCommitOperationKind.Reorder
     ) {
       this.endFlowInvalidState()

--- a/app/src/ui/multi-commit-operation/squash.tsx
+++ b/app/src/ui/multi-commit-operation/squash.tsx
@@ -5,7 +5,7 @@ import { BaseMultiCommitOperation } from './base-multi-commit-operation'
 export abstract class Squash extends BaseMultiCommitOperation {
   protected onBeginOperation = () => {
     const { repository, dispatcher, state } = this.props
-    const { commits, operationDetail } = state
+    const { operationDetail } = state
 
     if (operationDetail.kind !== MultiCommitOperationKind.Squash) {
       this.endFlowInvalidState()
@@ -16,6 +16,7 @@ export abstract class Squash extends BaseMultiCommitOperation {
       targetCommit,
       lastRetainedCommitRef,
       commitContext,
+      commits,
     } = operationDetail
 
     return dispatcher.squash(
@@ -36,12 +37,18 @@ export abstract class Squash extends BaseMultiCommitOperation {
       state,
       conflictState,
     } = this.props
-    const { commits, currentTip, targetBranch, originalBranchTip } = state
+    const { operationDetail, targetBranch, originalBranchTip } = state
 
-    if (conflictState === null) {
+    if (
+      conflictState === null ||
+      targetBranch === null ||
+      operationDetail.kind !== MultiCommitOperationKind.Squash
+    ) {
       this.endFlowInvalidState()
       return
     }
+
+    const { commits, currentTip } = operationDetail
 
     await dispatcher.switchMultiCommitOperationToShowProgress(repository)
 

--- a/app/src/ui/multi-commit-operation/squash.tsx
+++ b/app/src/ui/multi-commit-operation/squash.tsx
@@ -42,6 +42,7 @@ export abstract class Squash extends BaseMultiCommitOperation {
     if (
       conflictState === null ||
       targetBranch === null ||
+      originalBranchTip === null ||
       operationDetail.kind !== MultiCommitOperationKind.Squash
     ) {
       this.endFlowInvalidState()


### PR DESCRIPTION
On top of PR #12746

## Description

Refactor multi commit operational state management variables for cherry-picking.
- cherry-picking uses commitOneLine not regular commits
- targetBranch will be null on choose branch dialog
- cherry-picking doesn't use the currentTip like rebase does

## Release notes

Notes: no-notes
