### PR TITLE
Add support for IntelliJ CE for Mac OS

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -101,6 +101,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['com.jetbrains.intellij'],
   },
   {
+    name: 'IntelliJ CE',
+    bundleIdentifiers: ['com.jetbrains.intellij.ce'],
+  },
+  {
     name: 'Xcode',
     bundleIdentifiers: ['com.apple.dt.Xcode'],
   },

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -101,7 +101,7 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['com.jetbrains.intellij'],
   },
   {
-    name: 'IntelliJ CE',
+    name: 'IntelliJ Community Edition',
     bundleIdentifiers: ['com.jetbrains.intellij.ce'],
   },
   {


### PR DESCRIPTION
Adds support for IntelliJ IDEA Community Edition as an external editor, for Mac OS specifically
Addresses #9453, and is related to #12566

## Description

- Added support for IntelliJ IDEA CE as an external editor on Mac OS

## Release notes

Notes: Added support for IntelliJ CE as external editors