### PR TITLE
Improve SSH support with passphrase and host prompts

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -132,3 +132,8 @@ export function enableLineChangesInCommit(): boolean {
 export function enableWindowsOpenSSH(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we use SSH askpass? */
+export function enableSSHAskPass(): boolean {
+  return __WIN32__ && enableBetaFeatures()
+}

--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -117,7 +117,7 @@ export async function getFileHash(
   path: string,
   type: 'sha1' | 'sha256'
 ): Promise<string> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     const hash = Crypto.createHash(type)
     hash.setEncoding('hex')
     const input = FSE.createReadStream(path)
@@ -125,6 +125,9 @@ export async function getFileHash(
     hash.on('finish', () => {
       resolve(hash.read() as string)
     })
+
+    input.on('error', reject)
+    hash.on('error', reject)
 
     input.pipe(hash)
   })

--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -4,6 +4,7 @@ import * as Path from 'path'
 import { Disposable } from 'event-kit'
 import { Tailer } from './tailer'
 import byline from 'byline'
+import * as Crypto from 'crypto'
 
 /**
  * Get a path to a temp file using the given name. Note that the file itself
@@ -109,5 +110,22 @@ export async function readPartialFile(
       })
       .on('error', reject)
       .on('end', () => resolve(Buffer.concat(chunks, total)))
+  })
+}
+
+export async function getFileHash(
+  path: string,
+  type: 'sha1' | 'sha256'
+): Promise<string> {
+  return new Promise(resolve => {
+    const hash = Crypto.createHash(type)
+    hash.setEncoding('hex')
+    const input = FSE.createReadStream(path)
+
+    hash.on('finish', () => {
+      resolve(hash.read() as string)
+    })
+
+    input.pipe(hash)
   })
 }

--- a/app/src/lib/git/authentication.ts
+++ b/app/src/lib/git/authentication.ts
@@ -8,13 +8,16 @@ import { TrampolineCommandIdentifier } from '../trampoline/trampoline-command'
 
 /** Get the environment for authenticating remote operations. */
 export function envForAuthentication(auth: IGitAccount | null): Object {
+  const askPassPath = enableDesktopTrampoline()
+    ? getDesktopTrampolinePath()
+    : getAskPassTrampolinePath()
+
   const env = {
     DESKTOP_PATH: process.execPath,
     DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
     DESKTOP_TRAMPOLINE_IDENTIFIER: TrampolineCommandIdentifier.AskPass,
-    GIT_ASKPASS: enableDesktopTrampoline()
-      ? getDesktopTrampolinePath()
-      : getAskPassTrampolinePath(),
+    GIT_ASKPASS: askPassPath,
+    SSH_ASKPASS: askPassPath,
     // supported since Git 2.3, this is used to ensure we never interactively prompt
     // for credentials - even as a fallback
     GIT_TERMINAL_PROMPT: '0',

--- a/app/src/lib/git/authentication.ts
+++ b/app/src/lib/git/authentication.ts
@@ -18,6 +18,7 @@ export function envForAuthentication(auth: IGitAccount | null): Object {
     DESKTOP_TRAMPOLINE_IDENTIFIER: TrampolineCommandIdentifier.AskPass,
     GIT_ASKPASS: askPassPath,
     SSH_ASKPASS: askPassPath,
+    DISPLAY: '.', // Needed to force ssh on macOS to use the ssh-askpass
     // supported since Git 2.3, this is used to ensure we never interactively prompt
     // for credentials - even as a fallback
     GIT_TERMINAL_PROMPT: '0',

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -60,8 +60,13 @@ async function getHashForSSHKey(keyPath: string) {
 
 /** Retrieves the passphrase for the SSH key in the given path. */
 export async function getSSHKeyPassphrase(keyPath: string) {
-  const fileHash = await getHashForSSHKey(keyPath)
-  return TokenStore.getItem(SSHKeyPassphraseTokenStoreKey, fileHash)
+  try {
+    const fileHash = await getHashForSSHKey(keyPath)
+    return TokenStore.getItem(SSHKeyPassphraseTokenStoreKey, fileHash)
+  } catch (e) {
+    log.error('Could not retrieve passphrase for SSH key:', e)
+    return null
+  }
 }
 
 /** Stores the passphrase for the SSH key in the given path. */
@@ -69,6 +74,14 @@ export async function storeSSHKeyPassphrase(
   keyPath: string,
   passphrase: string
 ) {
-  const fileHash = await getHashForSSHKey(keyPath)
-  return TokenStore.setItem(SSHKeyPassphraseTokenStoreKey, fileHash, passphrase)
+  try {
+    const fileHash = await getHashForSSHKey(keyPath)
+    await TokenStore.setItem(
+      SSHKeyPassphraseTokenStoreKey,
+      fileHash,
+      passphrase
+    )
+  } catch (e) {
+    log.error('Could not store passphrase for SSH key:', e)
+  }
 }

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -40,12 +40,16 @@ function isWindowsOpenSSHUseEnabled() {
  */
 export async function getSSHEnvironment() {
   const canUseWindowsSSH = await isWindowsOpenSSHAvailable()
-  if (!canUseWindowsSSH || !isWindowsOpenSSHUseEnabled()) {
+  if (canUseWindowsSSH && isWindowsOpenSSHUseEnabled()) {
     return {}
   }
 
-  // Replace git ssh command with Windows' OpenSSH executable path
-  return {
-    GIT_SSH_COMMAND: WindowsOpenSSHPath,
+  if (canUseWindowsSSH && getBoolean(UseWindowsOpenSSHKey, false)) {
+    // Replace git ssh command with Windows' OpenSSH executable path
+    return {
+      GIT_SSH_COMMAND: WindowsOpenSSHPath,
+    }
   }
+
+  return {}
 }

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -1,6 +1,6 @@
 import * as fse from 'fs-extra'
 import memoizeOne from 'memoize-one'
-import { enableWindowsOpenSSH } from '../feature-flag'
+import { enableSSHAskPass, enableWindowsOpenSSH } from '../feature-flag'
 import { getFileHash } from '../file-system'
 import { getBoolean } from '../local-storage'
 import { TokenStore } from '../stores'
@@ -43,10 +43,6 @@ function isWindowsOpenSSHUseEnabled() {
 export async function getSSHEnvironment() {
   const canUseWindowsSSH = await isWindowsOpenSSHAvailable()
   if (canUseWindowsSSH && isWindowsOpenSSHUseEnabled()) {
-    return {}
-  }
-
-  if (canUseWindowsSSH && getBoolean(UseWindowsOpenSSHKey, false)) {
     // Replace git ssh command with Windows' OpenSSH executable path
     return {
       GIT_SSH_COMMAND: WindowsOpenSSHPath,

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -1,6 +1,6 @@
 import * as fse from 'fs-extra'
 import memoizeOne from 'memoize-one'
-import { enableSSHAskPass, enableWindowsOpenSSH } from '../feature-flag'
+import { enableWindowsOpenSSH } from '../feature-flag'
 import { getFileHash } from '../file-system'
 import { getBoolean } from '../local-storage'
 import { TokenStore } from '../stores'

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -1,6 +1,7 @@
 import { getKeyForEndpoint } from '../auth'
 import { TokenStore } from '../stores'
 import { TrampolineCommandHandler } from './trampoline-command'
+import { trampolineUIHelper } from './trampoline-ui-helper'
 
 export const askpassTrampolineHandler: TrampolineCommandHandler = async command => {
   if (command.parameters.length !== 1) {
@@ -8,8 +9,10 @@ export const askpassTrampolineHandler: TrampolineCommandHandler = async command 
   }
 
   if (command.parameters[0].startsWith('The authenticity of host ')) {
-    // FIXME: actually ask the user what to do with the host
-    return 'yes'
+    const addHost = await trampolineUIHelper.promptAddingSSHHost(
+      command.parameters[0]
+    )
+    return addHost ? 'yes' : 'no'
   }
 
   const username = command.environmentVariables.get('DESKTOP_USERNAME')

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -7,6 +7,11 @@ export const askpassTrampolineHandler: TrampolineCommandHandler = async command 
     return undefined
   }
 
+  if (command.parameters[0].startsWith('The authenticity of host ')) {
+    // FIXME: actually ask the user what to do with the host
+    return 'yes'
+  }
+
   const username = command.environmentVariables.get('DESKTOP_USERNAME')
   if (username === undefined || username.length === 0) {
     return undefined

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -46,7 +46,16 @@ async function handleSSHKeyPassphrase(
     return undefined
   }
 
-  const keyPath = matches[1]
+  let keyPath = matches[1]
+
+  // The ssh bundled with Desktop on Windows, for some reason, provides Unix-like
+  // paths for the keys (e.g. /c/Users/.../id_rsa). We need to convert them to
+  // Windows-like paths (e.g. C:\Users\...\id_rsa).
+  if (__WIN32__ && /^\/\w\//.test(keyPath)) {
+    const driveLetter = keyPath[1]
+    keyPath = keyPath.slice(2)
+    keyPath = `${driveLetter}:${keyPath}`
+  }
 
   const storedPassphrase = await getSSHKeyPassphrase(keyPath)
   if (storedPassphrase !== null) {

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -6,19 +6,29 @@ import { trampolineUIHelper } from './trampoline-ui-helper'
 
 async function handleSSHHostAuthenticity(
   prompt: string
-): Promise<string | undefined> {
-  const promptRegex = /^The authenticity of host '([^']+)' can't be established.\nRSA key fingerprint is ([^.]+).\nAre you sure you want to continue connecting \(yes\/no\/\[fingerprint\]\)\? $/
+): Promise<'yes' | 'no' | undefined> {
+  const promptRegex = /^The authenticity of host '([^ ]+) \(([^\)]+)\)' can't be established.\nRSA key fingerprint is ([^.]+).\nAre you sure you want to continue connecting \(yes\/no\/\[fingerprint\]\)\? $/
 
   const matches = promptRegex.exec(prompt)
-  if (matches === null || matches.length < 3) {
+  if (matches === null || matches.length < 4) {
     return undefined
   }
 
   const host = matches[1]
-  const fingerprint = matches[2]
+  const ip = matches[2]
+  const fingerprint = matches[3]
+
+  // We'll accept github.com as valid host automatically
+  if (
+    host === 'github.com' &&
+    fingerprint === 'SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8'
+  ) {
+    return 'yes'
+  }
 
   const addHost = await trampolineUIHelper.promptAddingSSHHost(
     host,
+    ip,
     fingerprint
   )
   return addHost ? 'yes' : 'no'

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -18,7 +18,9 @@ async function handleSSHHostAuthenticity(
   const ip = matches[2]
   const fingerprint = matches[3]
 
-  // We'll accept github.com as valid host automatically
+  // We'll accept github.com as valid host automatically. GitHub's public key
+  // fingerprint can be obtained from
+  // https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
   if (
     host === 'github.com' &&
     fingerprint === 'SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8'

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -1,4 +1,5 @@
 import { getKeyForEndpoint } from '../auth'
+import { getSSHKeyPassphrase } from '../ssh/ssh'
 import { TokenStore } from '../stores'
 import { TrampolineCommandHandler } from './trampoline-command'
 import { trampolineUIHelper } from './trampoline-ui-helper'
@@ -34,6 +35,12 @@ async function handleSSHKeyPassphrase(
   }
 
   const keyPath = matches[1]
+
+  const storedPassphrase = await getSSHKeyPassphrase(keyPath)
+  if (storedPassphrase !== null) {
+    return storedPassphrase
+  }
+
   const passphrase = await trampolineUIHelper.promptSSHKeyPassphrase(keyPath)
 
   return passphrase ?? ''

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -9,11 +9,15 @@ class TrampolineUIHelper {
     this.dispatcher = dispatcher
   }
 
-  public promptAddingSSHHost(message: string): Promise<boolean> {
+  public promptAddingSSHHost(
+    host: string,
+    fingerprint: string
+  ): Promise<boolean> {
     return new Promise(resolve => {
       this.dispatcher.showPopup({
         type: PopupType.AddSSHHost,
-        message,
+        host,
+        fingerprint,
         onSubmit: resolve,
       })
     })

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -1,0 +1,29 @@
+import { Dispatcher } from '../../ui/dispatcher'
+
+enum AddSSHHostPreference {
+  YES = 'yes',
+  NO = 'no',
+  PERMANENT = 'permanent',
+}
+
+class TrampolineUIHelper {
+  // The dispatcher must be set before this helper can do anything
+  private dispatcher!: Dispatcher
+
+  public setDispatcher(dispatcher: Dispatcher) {
+    this.dispatcher = dispatcher
+  }
+
+  public promptAddingSSHHost(message: string): Promise<AddSSHHostPreference> {
+    return new Promise((resolve, reject) => {
+      this.dispatcher.showPopup({
+        type: 'input',
+        title: 'Add SSH Host',
+        message,
+        input: '',
+      })
+    })
+  }
+}
+
+export const trampolineUIHelper = new TrampolineUIHelper()

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -1,10 +1,5 @@
+import { PopupType } from '../../models/popup'
 import { Dispatcher } from '../../ui/dispatcher'
-
-enum AddSSHHostPreference {
-  YES = 'yes',
-  NO = 'no',
-  PERMANENT = 'permanent',
-}
 
 class TrampolineUIHelper {
   // The dispatcher must be set before this helper can do anything
@@ -14,13 +9,12 @@ class TrampolineUIHelper {
     this.dispatcher = dispatcher
   }
 
-  public promptAddingSSHHost(message: string): Promise<AddSSHHostPreference> {
-    return new Promise((resolve, reject) => {
+  public promptAddingSSHHost(message: string): Promise<boolean> {
+    return new Promise(resolve => {
       this.dispatcher.showPopup({
-        type: 'input',
-        title: 'Add SSH Host',
+        type: PopupType.AddSSHHost,
         message,
-        input: '',
+        onSubmit: resolve,
       })
     })
   }

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -20,7 +20,7 @@ class TrampolineUIHelper {
         host,
         ip,
         fingerprint,
-        onSubmit: resolve,
+        onSubmit: addHost => resolve(addHost),
       })
     })
   }
@@ -30,7 +30,7 @@ class TrampolineUIHelper {
       this.dispatcher.showPopup({
         type: PopupType.SSHKeyPassphrase,
         keyPath,
-        onSubmit: resolve,
+        onSubmit: passphrase => resolve(passphrase),
       })
     })
   }

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -22,6 +22,16 @@ class TrampolineUIHelper {
       })
     })
   }
+
+  public promptSSHKeyPassphrase(keyPath: string): Promise<string | undefined> {
+    return new Promise(resolve => {
+      this.dispatcher.showPopup({
+        type: PopupType.SSHKeyPassphrase,
+        keyPath,
+        onSubmit: resolve,
+      })
+    })
+  }
 }
 
 export const trampolineUIHelper = new TrampolineUIHelper()

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -11,12 +11,14 @@ class TrampolineUIHelper {
 
   public promptAddingSSHHost(
     host: string,
+    ip: string,
     fingerprint: string
   ): Promise<boolean> {
     return new Promise(resolve => {
       this.dispatcher.showPopup({
         type: PopupType.AddSSHHost,
         host,
+        ip,
         fingerprint,
         onSubmit: resolve,
       })

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -301,6 +301,7 @@ export type Popup =
   | {
       type: PopupType.AddSSHHost
       host: string
+      ip: string
       fingerprint: string
       onSubmit: (addHost: boolean) => void
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -74,6 +74,7 @@ export enum PopupType {
   WarnLocalChangesBeforeUndo,
   WarningBeforeReset,
   InvalidatedToken,
+  AddSSHHost,
 }
 
 export type Popup =
@@ -295,4 +296,9 @@ export type Popup =
   | {
       type: PopupType.InvalidatedToken
       account: Account
+    }
+  | {
+      type: PopupType.AddSSHHost
+      message: string
+      onSubmit: (addHost: boolean) => void
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -75,6 +75,7 @@ export enum PopupType {
   WarningBeforeReset,
   InvalidatedToken,
   AddSSHHost,
+  SSHKeyPassphrase,
 }
 
 export type Popup =
@@ -302,4 +303,9 @@ export type Popup =
       host: string
       fingerprint: string
       onSubmit: (addHost: boolean) => void
+    }
+  | {
+      type: PopupType.SSHKeyPassphrase
+      keyPath: string
+      onSubmit: (passphrase: string | undefined) => void
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -299,6 +299,7 @@ export type Popup =
     }
   | {
       type: PopupType.AddSSHHost
-      message: string
+      host: string
+      fingerprint: string
       onSubmit: (addHost: boolean) => void
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -147,6 +147,7 @@ import {
   MultiCommitOperationStepKind,
 } from '../models/multi-commit-operation'
 import { AddSSHHost } from './ssh/add-ssh-host'
+import { SSHKeyPassphrase } from './ssh/ssh-key-passphrase'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2091,6 +2092,16 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="add-ssh-host"
             host={popup.host}
             fingerprint={popup.fingerprint}
+            onSubmit={popup.onSubmit}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.SSHKeyPassphrase: {
+        return (
+          <SSHKeyPassphrase
+            key="ssh-key-passphrase"
+            keyPath={popup.keyPath}
             onSubmit={popup.onSubmit}
             onDismissed={onPopupDismissedFn}
           />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2089,7 +2089,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return (
           <AddSSHHost
             key="add-ssh-host"
-            message={popup.message}
+            host={popup.host}
+            fingerprint={popup.fingerprint}
             onSubmit={popup.onSubmit}
             onDismissed={onPopupDismissedFn}
           />

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -146,6 +146,7 @@ import {
   MultiCommitOperationKind,
   MultiCommitOperationStepKind,
 } from '../models/multi-commit-operation'
+import { AddSSHHost } from './ssh/add-ssh-host'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2080,6 +2081,16 @@ export class App extends React.Component<IAppProps, IAppState> {
             key="invalidated-token"
             dispatcher={this.props.dispatcher}
             account={popup.account}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.AddSSHHost: {
+        return (
+          <AddSSHHost
+            key="add-ssh-host"
+            message={popup.message}
+            onSubmit={popup.onSubmit}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2091,6 +2091,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <AddSSHHost
             key="add-ssh-host"
             host={popup.host}
+            ip={popup.ip}
             fingerprint={popup.fingerprint}
             onSubmit={popup.onSubmit}
             onDismissed={onPopupDismissedFn}

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -82,6 +82,7 @@ import {
   ApplicationTheme,
   supportsSystemThemeChanges,
 } from './lib/application-theme'
+import { trampolineUIHelper } from '../lib/trampoline/trampoline-ui-helper'
 
 if (__DEV__) {
   installDevGlobals()
@@ -300,6 +301,9 @@ dispatcher.registerErrorHandler(refusedWorkflowUpdate)
 document.body.classList.add(`platform-${process.platform}`)
 
 dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
+
+// The trampoline UI helper needs a reference to the dispatcher before it's used
+trampolineUIHelper.setDispatcher(dispatcher)
 
 ipcRenderer.on('focus', () => {
   const { selectedState } = appStore.getState()

--- a/app/src/ui/invalidated-token/invalidated-token.tsx
+++ b/app/src/ui/invalidated-token/invalidated-token.tsx
@@ -6,7 +6,7 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Account } from '../../models/account'
 import { getDotComAPIEndpoint } from '../../lib/api'
 
-interface IInvalidatedTokenResetProps {
+interface IInvalidatedTokenProps {
   readonly dispatcher: Dispatcher
   readonly account: Account
   readonly onDismissed: () => void
@@ -16,9 +16,7 @@ interface IInvalidatedTokenResetProps {
  * Dialog that alerts user that their GitHub (Enterprise) account token is not
  * valid and they need to sign in again.
  */
-export class InvalidatedToken extends React.Component<
-  IInvalidatedTokenResetProps
-> {
+export class InvalidatedToken extends React.Component<IInvalidatedTokenProps> {
   public render() {
     const accountTypeSuffix = this.isEnterpriseAccount ? ' Enterprise' : ''
 

--- a/app/src/ui/ssh/add-ssh-host.tsx
+++ b/app/src/ui/ssh/add-ssh-host.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IAddSSHHostProps {
+  readonly message: string
+  readonly onSubmit: (addHost: boolean) => void
+  readonly onDismissed: () => void
+}
+
+/**
+ * Dialog prompts the user to add a new SSH host as known.
+ */
+export class AddSSHHost extends React.Component<IAddSSHHostProps> {
+  public render() {
+    return (
+      <Dialog
+        id="add-ssh-host"
+        type="normal"
+        title="SSH Host"
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>{this.props.message}</Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText="Yes"
+            cancelButtonText="No"
+            onCancelButtonClick={this.onCancel}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private submit(addHost: boolean) {
+    const { onSubmit, onDismissed } = this.props
+
+    onSubmit(addHost)
+    onDismissed()
+  }
+
+  private onSubmit = () => {
+    this.submit(true)
+  }
+
+  private onCancel = () => {
+    this.submit(false)
+  }
+}

--- a/app/src/ui/ssh/add-ssh-host.tsx
+++ b/app/src/ui/ssh/add-ssh-host.tsx
@@ -4,7 +4,8 @@ import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 interface IAddSSHHostProps {
-  readonly message: string
+  readonly host: string
+  readonly fingerprint: string
   readonly onSubmit: (addHost: boolean) => void
   readonly onDismissed: () => void
 }
@@ -23,7 +24,12 @@ export class AddSSHHost extends React.Component<IAddSSHHostProps> {
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>
-          <Row>{this.props.message}</Row>
+          <Row>
+            The authenticity of host '{this.props.host}' can't be established.
+            RSA key fingerprint is {this.props.fingerprint}.
+            <br />
+            Are you sure you want to continue connecting?
+          </Row>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup

--- a/app/src/ui/ssh/add-ssh-host.tsx
+++ b/app/src/ui/ssh/add-ssh-host.tsx
@@ -20,6 +20,7 @@ export class AddSSHHost extends React.Component<IAddSSHHostProps> {
         id="add-ssh-host"
         type="normal"
         title="SSH Host"
+        dismissable={false}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >

--- a/app/src/ui/ssh/add-ssh-host.tsx
+++ b/app/src/ui/ssh/add-ssh-host.tsx
@@ -5,6 +5,7 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 interface IAddSSHHostProps {
   readonly host: string
+  readonly ip: string
   readonly fingerprint: string
   readonly onSubmit: (addHost: boolean) => void
   readonly onDismissed: () => void
@@ -26,8 +27,8 @@ export class AddSSHHost extends React.Component<IAddSSHHostProps> {
       >
         <DialogContent>
           <Row>
-            The authenticity of host '{this.props.host}' can't be established.
-            RSA key fingerprint is {this.props.fingerprint}.
+            The authenticity of host '{this.props.host} ({this.props.ip})' can't
+            be established. RSA key fingerprint is {this.props.fingerprint}.
             <br />
             Are you sure you want to continue connecting?
           </Row>

--- a/app/src/ui/ssh/ssh-key-passphrase.tsx
+++ b/app/src/ui/ssh/ssh-key-passphrase.tsx
@@ -3,6 +3,8 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { TextBox } from '../lib/text-box'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { storeSSHKeyPassphrase } from '../../lib/ssh/ssh'
 
 interface ISSHKeyPassphraseProps {
   readonly keyPath: string
@@ -12,6 +14,7 @@ interface ISSHKeyPassphraseProps {
 
 interface ISSHKeyPassphraseState {
   readonly passphrase: string
+  readonly rememberPassphrase: boolean
 }
 
 /**
@@ -23,7 +26,7 @@ export class SSHKeyPassphrase extends React.Component<
 > {
   public constructor(props: ISSHKeyPassphraseProps) {
     super(props)
-    this.state = { passphrase: '' }
+    this.state = { passphrase: '', rememberPassphrase: false }
   }
 
   public render() {
@@ -45,6 +48,17 @@ export class SSHKeyPassphrase extends React.Component<
               onValueChanged={this.onValueChanged}
             />
           </Row>
+          <Row>
+            <Checkbox
+              label="Remember passphrase"
+              value={
+                this.state.rememberPassphrase
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onRememberPassphraseChanged}
+            />
+          </Row>
         </DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
@@ -54,6 +68,12 @@ export class SSHKeyPassphrase extends React.Component<
         </DialogFooter>
       </Dialog>
     )
+  }
+
+  private onRememberPassphraseChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({ rememberPassphrase: event.currentTarget.checked })
   }
 
   private onValueChanged = (value: string) => {
@@ -68,6 +88,9 @@ export class SSHKeyPassphrase extends React.Component<
   }
 
   private onSubmit = () => {
+    if (this.state.rememberPassphrase) {
+      storeSSHKeyPassphrase(this.props.keyPath, this.state.passphrase)
+    }
     this.submit(this.state.passphrase)
   }
 

--- a/app/src/ui/ssh/ssh-key-passphrase.tsx
+++ b/app/src/ui/ssh/ssh-key-passphrase.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { TextBox } from '../lib/text-box'
+
+interface ISSHKeyPassphraseProps {
+  readonly keyPath: string
+  readonly onSubmit: (passphrase: string | undefined) => void
+  readonly onDismissed: () => void
+}
+
+interface ISSHKeyPassphraseState {
+  readonly passphrase: string
+}
+
+/**
+ * Dialog prompts the user the passphrase of an SSH key.
+ */
+export class SSHKeyPassphrase extends React.Component<
+  ISSHKeyPassphraseProps,
+  ISSHKeyPassphraseState
+> {
+  public constructor(props: ISSHKeyPassphraseProps) {
+    super(props)
+    this.state = { passphrase: '' }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="ssh-key-passphrase"
+        type="normal"
+        title="SSH Key Passphrase"
+        dismissable={false}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            <TextBox
+              label={`Enter passphrase for key '${this.props.keyPath}':`}
+              value={this.state.passphrase}
+              type="password"
+              onValueChanged={this.onValueChanged}
+            />
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            onCancelButtonClick={this.onCancel}
+            okButtonDisabled={this.state.passphrase.length === 0}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onValueChanged = (value: string) => {
+    this.setState({ passphrase: value })
+  }
+
+  private submit(passphrase: string | undefined) {
+    const { onSubmit, onDismissed } = this.props
+
+    onSubmit(passphrase)
+    onDismissed()
+  }
+
+  private onSubmit = () => {
+    this.submit(this.state.passphrase)
+  }
+
+  private onCancel = () => {
+    this.submit(undefined)
+  }
+}


### PR DESCRIPTION
Closes #3457
Closes #8761

## Description

This PR sits on top of #12734 

The changes in this PR leverage the new TCP-based askpass trampoline from #11510, by providing that trampoline as the askpass program for SSH too.

That way, we can intercept when SSH prompts stuff to the user (like the SSH key passphrase or adding a host to the list of known hosts).

So far this is only available on Windows because macOS makes it a bit difficult to provide a custom SSH_ASKPASS program. That'll be tackled in a different PR.

### Screenshots

Note: the video is kind of a lie, since github.com is added as a host automatically. Users will be prompted about other hosts, though.

https://user-images.githubusercontent.com/1083228/129027589-def08dcc-e986-48aa-9c00-c15a2480848f.mov

## Release notes

Notes: [Fixed] Prompt SSH info to Windows users, like the key passphrase or adding a host to the list of known hosts