### PR TITLE
Refactor around trampoline environment variables

### DIFF
--- a/app/src/lib/git/authentication.ts
+++ b/app/src/lib/git/authentication.ts
@@ -1,45 +1,21 @@
-import * as Path from 'path'
-
 import { GitError as DugiteError } from 'dugite'
 import { IGitAccount } from '../../models/git-account'
-import { enableDesktopTrampoline, enableSSHAskPass } from '../feature-flag'
-import { getDesktopTrampolineFilename } from 'desktop-trampoline'
-import { TrampolineCommandIdentifier } from '../trampoline/trampoline-command'
 
 /** Get the environment for authenticating remote operations. */
 export function envForAuthentication(auth: IGitAccount | null): Object {
-  const askPassPath = enableDesktopTrampoline()
-    ? getDesktopTrampolinePath()
-    : getAskPassTrampolinePath()
-
   const env = {
-    DESKTOP_PATH: process.execPath,
-    DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
-    DESKTOP_TRAMPOLINE_IDENTIFIER: TrampolineCommandIdentifier.AskPass,
-    GIT_ASKPASS: askPassPath,
     // supported since Git 2.3, this is used to ensure we never interactively prompt
     // for credentials - even as a fallback
     GIT_TERMINAL_PROMPT: '0',
     GIT_TRACE: localStorage.getItem('git-trace') || '0',
   }
 
-  const sshEnv = !enableSSHAskPass()
-    ? {}
-    : {
-        SSH_ASKPASS: askPassPath,
-        DISPLAY: '.', // Needed to force ssh on macOS to use the ssh-askpass
-      }
-
   if (!auth) {
-    return {
-      ...env,
-      ...sshEnv,
-    }
+    return env
   }
 
   return {
     ...env,
-    ...sshEnv,
     DESKTOP_USERNAME: auth.login,
     DESKTOP_ENDPOINT: auth.endpoint,
   }
@@ -52,20 +28,3 @@ export const AuthenticationErrors: ReadonlySet<DugiteError> = new Set([
   DugiteError.HTTPSRepositoryNotFound,
   DugiteError.SSHRepositoryNotFound,
 ])
-
-function getDesktopTrampolinePath(): string {
-  return Path.resolve(
-    __dirname,
-    'desktop-trampoline',
-    getDesktopTrampolineFilename()
-  )
-}
-
-function getAskPassTrampolinePath(): string {
-  const extension = __WIN32__ ? 'bat' : 'sh'
-  return Path.resolve(__dirname, 'static', `ask-pass-trampoline.${extension}`)
-}
-
-function getAskPassScriptPath(): string {
-  return Path.resolve(__dirname, 'ask-pass.js')
-}

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -6,8 +6,10 @@ import { formatAsLocalRef } from './refs'
 import { deleteRef } from './update-ref'
 import { GitError as DugiteError } from 'dugite'
 import { getRemoteURL } from './remote'
-import { getFallbackUrlForProxyResolve } from './environment'
-import { withTrampolineEnvForRemoteOperation } from '../trampoline/trampoline-environment'
+import {
+  envForRemoteOperation,
+  getFallbackUrlForProxyResolve,
+} from './environment'
 import { createForEachRefParser } from './git-delimiter-parser'
 
 /**
@@ -88,18 +90,10 @@ export async function deleteRemoteBranch(
 
   // If the user is not authenticated, the push is going to fail
   // Let this propagate and leave it to the caller to handle
-  const result = await withTrampolineEnvForRemoteOperation(
-    account,
-    remoteUrl,
-    env => {
-      return git(args, repository.path, 'deleteRemoteBranch', {
-        env,
-        expectedErrors: new Set<DugiteError>([
-          DugiteError.BranchDeletionFailed,
-        ]),
-      })
-    }
-  )
+  const result = await git(args, repository.path, 'deleteRemoteBranch', {
+    env: envForRemoteOperation(account, remoteUrl),
+    expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
+  })
 
   // It's possible that the delete failed because the ref has already
   // been deleted on the remote. If we identify that specific

--- a/app/src/lib/git/clone.ts
+++ b/app/src/lib/git/clone.ts
@@ -2,9 +2,8 @@ import { git, IGitExecutionOptions, gitNetworkArguments } from './core'
 import { ICloneProgress } from '../../models/progress'
 import { CloneOptions } from '../../models/clone-options'
 import { CloneProgressParser, executionOptionsWithProgress } from '../progress'
-import { withTrampolineEnvForRemoteOperation } from '../trampoline/trampoline-environment'
-import { merge } from '../merge'
 import { getDefaultBranch } from '../helpers/default-branch'
+import { envForRemoteOperation } from './environment'
 
 /**
  * Clones a repository from a given url into to the specified path.
@@ -34,6 +33,8 @@ export async function clone(
 ): Promise<void> {
   const networkArguments = await gitNetworkArguments(null, options.account)
 
+  const env = await envForRemoteOperation(options.account, url)
+
   const defaultBranch = options.defaultBranch ?? (await getDefaultBranch())
 
   const args = [
@@ -44,7 +45,7 @@ export async function clone(
     '--recursive',
   ]
 
-  let opts: IGitExecutionOptions = {}
+  let opts: IGitExecutionOptions = { env }
 
   if (progressCallback) {
     args.push('--progress')
@@ -74,10 +75,5 @@ export async function clone(
 
   args.push('--', url, path)
 
-  await withTrampolineEnvForRemoteOperation(options.account, url, env => {
-    return git(args, __dirname, 'clone', {
-      ...opts,
-      env: merge(opts.env, env),
-    })
-  })
+  await git(args, __dirname, 'clone', opts)
 }

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -6,8 +6,7 @@ import { FetchProgressParser, executionOptionsWithProgress } from '../progress'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 import { IRemote } from '../../models/remote'
 import { ITrackingBranch } from '../../models/branch'
-import { merge } from '../merge'
-import { withTrampolineEnvForRemoteOperation } from '../trampoline/trampoline-environment'
+import { envForRemoteOperation } from './environment'
 
 async function getFetchArgs(
   repository: Repository,
@@ -64,6 +63,7 @@ export async function fetch(
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
+    env: envForRemoteOperation(account, remote.url),
   }
 
   if (progressCallback) {
@@ -109,12 +109,7 @@ export async function fetch(
     progressCallback
   )
 
-  await withTrampolineEnvForRemoteOperation(account, remote.url, env => {
-    return git(args, repository.path, 'fetch', {
-      ...opts,
-      env: merge(opts.env, env),
-    })
-  })
+  await git(args, repository.path, 'fetch', opts)
 }
 
 /** Fetch a given refspec from the given remote. */
@@ -126,18 +121,14 @@ export async function fetchRefspec(
 ): Promise<void> {
   const options = {
     successExitCodes: new Set([0, 128]),
+    env: envForRemoteOperation(account, remote.url),
   }
 
   const networkArguments = await gitNetworkArguments(repository, account)
 
   const args = [...networkArguments, 'fetch', remote.name, refspec]
 
-  await withTrampolineEnvForRemoteOperation(account, remote.url, env => {
-    return git(args, repository.path, 'fetchRefspec', {
-      ...options,
-      env,
-    })
-  })
+  await git(args, repository.path, 'fetchRefspec', options)
 }
 
 export async function fastForwardBranches(

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -12,8 +12,7 @@ import { PullProgressParser, executionOptionsWithProgress } from '../progress'
 import { AuthenticationErrors } from './authentication'
 import { enableRecurseSubmodulesFlag } from '../feature-flag'
 import { IRemote } from '../../models/remote'
-import { merge } from '../merge'
-import { withTrampolineEnvForRemoteOperation } from '../trampoline/trampoline-environment'
+import { envForRemoteOperation } from './environment'
 
 async function getPullArgs(
   repository: Repository,
@@ -58,6 +57,7 @@ export async function pull(
   progressCallback?: (progress: IPullProgress) => void
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
+    env: await envForRemoteOperation(account, remote.url),
     expectedErrors: AuthenticationErrors,
   }
 
@@ -104,16 +104,7 @@ export async function pull(
     account,
     progressCallback
   )
-  const result = await withTrampolineEnvForRemoteOperation(
-    account,
-    remote.url,
-    env => {
-      return git(args, repository.path, 'pull', {
-        ...opts,
-        env: merge(opts.env, env),
-      })
-    }
-  )
+  const result = await git(args, repository.path, 'pull', opts)
 
   if (result.gitErrorDescription) {
     throw new GitError(result, args)

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -12,8 +12,7 @@ import { IGitAccount } from '../../models/git-account'
 import { PushProgressParser, executionOptionsWithProgress } from '../progress'
 import { AuthenticationErrors } from './authentication'
 import { IRemote } from '../../models/remote'
-import { merge } from '../merge'
-import { withTrampolineEnvForRemoteOperation } from '../trampoline/trampoline-environment'
+import { envForRemoteOperation } from './environment'
 
 export type PushOptions = {
   /**
@@ -83,6 +82,7 @@ export async function push(
   expectedErrors.add(DugiteError.ProtectedBranchForcePush)
 
   let opts: IGitExecutionOptions = {
+    env: await envForRemoteOperation(account, remote.url),
     expectedErrors,
   }
 
@@ -120,16 +120,7 @@ export async function push(
     })
   }
 
-  const result = await withTrampolineEnvForRemoteOperation(
-    account,
-    remote.url,
-    env => {
-      return git(args, repository.path, 'push', {
-        ...opts,
-        env: merge(opts.env, env),
-      })
-    }
-  )
+  const result = await git(args, repository.path, 'push', opts)
 
   if (result.gitErrorDescription) {
     throw new GitError(result, args)

--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -2,7 +2,7 @@ import { git, gitNetworkArguments } from './core'
 import { Repository } from '../../models/repository'
 import { IGitAccount } from '../../models/git-account'
 import { IRemote } from '../../models/remote'
-import { withTrampolineEnvForRemoteOperation } from '../trampoline/trampoline-environment'
+import { envForRemoteOperation } from './environment'
 
 /**
  * Create a new tag on the given target commit.
@@ -103,16 +103,10 @@ export async function fetchTagsToPush(
     '--porcelain',
   ]
 
-  const result = await withTrampolineEnvForRemoteOperation(
-    account,
-    remote.url,
-    env => {
-      return git(args, repository.path, 'fetchTagsToPush', {
-        env,
-        successExitCodes: new Set([0, 1, 128]),
-      })
-    }
-  )
+  const result = await git(args, repository.path, 'fetchTagsToPush', {
+    env: await envForRemoteOperation(account, remote.url),
+    successExitCodes: new Set([0, 1, 128]),
+  })
 
   if (result.exitCode !== 0 && result.exitCode !== 1) {
     // Only when the exit code of git is 0 or 1, its stdout is parseable.

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -60,7 +60,8 @@ export async function getSSHEnvironment() {
   return baseEnv
 }
 
-const SSHKeyPassphraseTokenStoreKey = 'GitHub-Desktop-SSHKeyPassphrases'
+const appName = __DEV__ ? 'GitHub Desktop Dev' : 'GitHub'
+const SSHKeyPassphraseTokenStoreKey = `${appName} - SSH key passphrases`
 
 async function getHashForSSHKey(keyPath: string) {
   return getFileHash(keyPath, 'sha256')

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -11,9 +11,8 @@ import {
 import { git } from '../../git'
 import { friendlyEndpointName } from '../../friendly-endpoint-name'
 import { IRemote } from '../../../models/remote'
-import { merge } from '../../merge'
-import { withTrampolineEnvForRemoteOperation } from '../../trampoline/trampoline-environment'
 import { getDefaultBranch } from '../../helpers/default-branch'
+import { envForRemoteOperation } from '../../git/environment'
 
 const nl = __WIN32__ ? '\r\n' : '\n'
 const InitialReadmeContents =
@@ -72,7 +71,9 @@ async function pushRepo(
   progressCb(pushTitle, 0)
 
   const pushOpts = await executionOptionsWithProgress(
-    {},
+    {
+      env: await envForRemoteOperation(account, remote.url),
+    },
     new PushProgressParser(),
     progress => {
       if (progress.kind === 'progress') {
@@ -82,13 +83,7 @@ async function pushRepo(
   )
 
   const args = ['push', '-u', remote.name, remoteBranchName]
-
-  await withTrampolineEnvForRemoteOperation(account, remote.url, env => {
-    return git(args, path, 'tutorial:push', {
-      ...pushOpts,
-      env: merge(pushOpts.env, env),
-    })
-  })
+  await git(args, path, 'tutorial:push', pushOpts)
 }
 
 /**

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -1,40 +1,54 @@
-import { IGitAccount } from '../../models/git-account'
-import { envForRemoteOperation } from '../git/environment'
 import { trampolineServer } from './trampoline-server'
 import { withTrampolineToken } from './trampoline-tokens'
+import * as Path from 'path'
+import { enableDesktopTrampoline } from '../feature-flag'
+import { getDesktopTrampolineFilename } from 'desktop-trampoline'
+import { TrampolineCommandIdentifier } from '../trampoline/trampoline-command'
 
 /**
  * Allows invoking a function with a set of environment variables to use when
- * invoking a Git subcommand that needs to communicate with a remote (i.e.
- * fetch, clone, push, pull, ls-remote, etc etc) and with a token to use in the
+ * invoking a Git subcommand that needs to use the trampoline (mainly git
+ * operations requiring an askpass script) and with a token to use in the
  * trampoline server.
  *
- * For more info about the specific environment variables used in the remote
- * git operation, please see `envForRemoteOperation`.
- *
- * @param account   The authentication information (if available) to provide
- *                  to Git for use when connecting to the remote
- * @param remoteUrl The primary remote URL for this operation. Note that Git
- *                  might connect to other remotes in order to fulfill the
- *                  operation. As an example, a clone of
- *                  https://github.com/desktop/desktop could contain a submodule
- *                  pointing to another host entirely. Used to resolve which
- *                  proxy (if any) should be used for the operation.
  * @param fn        Function to invoke with all the necessary environment
  *                  variables.
  */
-export async function withTrampolineEnvForRemoteOperation<T>(
-  account: IGitAccount | null,
-  remoteUrl: string,
+export async function withTrampolineEnv<T>(
   fn: (env: Object) => Promise<T>
 ): Promise<T> {
-  const env = await envForRemoteOperation(account, remoteUrl)
+  const askPassPath = enableDesktopTrampoline()
+    ? getDesktopTrampolinePath()
+    : getAskPassTrampolinePath()
 
   return withTrampolineToken(async token =>
     fn({
-      ...env,
       DESKTOP_PORT: await trampolineServer.getPort(),
       DESKTOP_TRAMPOLINE_TOKEN: token,
+      GIT_ASKPASS: askPassPath,
+      DESKTOP_TRAMPOLINE_IDENTIFIER: TrampolineCommandIdentifier.AskPass,
+
+      // Env variables specific to the old askpass trampoline
+      DESKTOP_PATH: process.execPath,
+      DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
     })
   )
+}
+
+/** Returns the path of the desktop-trampoline binary. */
+export function getDesktopTrampolinePath(): string {
+  return Path.resolve(
+    __dirname,
+    'desktop-trampoline',
+    getDesktopTrampolineFilename()
+  )
+}
+
+function getAskPassTrampolinePath(): string {
+  const extension = __WIN32__ ? 'bat' : 'sh'
+  return Path.resolve(__dirname, 'static', `ask-pass-trampoline.${extension}`)
+}
+
+function getAskPassScriptPath(): string {
+  return Path.resolve(__dirname, 'ask-pass.js')
 }


### PR DESCRIPTION
## Description

This PR sits on top of #12756 

While working on #12756, I noticed how there are some scenarios where the ASKPASS env variables weren't set. We were only setting those for specific `git` commands, but some others could need it too.

This PR moves all the logic around setting those env variables to a more reasonable place, and then those are set for every git command. That meant I had to revert some of the changes from #11510.

I recommend reviewing this PR hiding the whitespace changes.

As a bonus, I also renamed the token storage key we use to persist SSH key passphrases to something less cryptic, as we have in https://github.com/desktop/desktop/blob/7665cf24c50e287493f52395fce6955fb8f38c56/app/src/lib/auth.ts#L9-L14

## Release notes

Notes: no-notes
