### PR TITLE
Enable SSH improvements on macOS

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.7",
+    "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "detect-arm64-translation": "https://github.com/desktop/node-detect-arm64-translation#v1.0.4",
     "dexie": "^2.0.0",
     "double-ended-queue": "^2.1.0-0",

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -135,7 +135,8 @@ export function enableWindowsOpenSSH(): boolean {
 
 /** Should we use SSH askpass? */
 export function enableSSHAskPass(): boolean {
-  return __WIN32__ && enableBetaFeatures()
+  // TODO: enable in prod *ONLY for Windows*
+  return enableBetaFeatures()
 }
 
 /** Should we use the setImmediate alternative? */

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -135,7 +135,6 @@ export function enableWindowsOpenSSH(): boolean {
 
 /** Should we use SSH askpass? */
 export function enableSSHAskPass(): boolean {
-  // TODO: enable in prod *ONLY for Windows*
   return enableBetaFeatures()
 }
 

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -74,7 +74,7 @@ export async function getSSHEnvironment() {
   return baseEnv
 }
 
-const appName = __DEV__ ? 'GitHub Desktop Dev' : 'GitHub'
+const appName = __DEV__ ? 'GitHub Desktop Dev' : 'GitHub Desktop'
 const SSHKeyPassphraseTokenStoreKey = `${appName} - SSH key passphrases`
 
 async function getHashForSSHKey(keyPath: string) {

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -4,7 +4,10 @@ import { enableSSHAskPass, enableWindowsOpenSSH } from '../feature-flag'
 import { getFileHash } from '../file-system'
 import { getBoolean } from '../local-storage'
 import { TokenStore } from '../stores'
-import { getDesktopTrampolinePath } from '../trampoline/trampoline-environment'
+import {
+  getDesktopTrampolinePath,
+  getSSHWrapperPath,
+} from '../trampoline/trampoline-environment'
 
 const WindowsOpenSSHPath = 'C:/Windows/System32/OpenSSH/ssh.exe'
 
@@ -56,6 +59,15 @@ export async function getSSHEnvironment() {
     return {
       ...baseEnv,
       GIT_SSH_COMMAND: WindowsOpenSSHPath,
+    }
+  }
+
+  if (__DARWIN__ && enableSSHAskPass()) {
+    // Replace git ssh command with our wrapper
+    return {
+      ...baseEnv,
+      DISPLAY: '.', // Required for ssh to actually use SSH_ASKPASS
+      GIT_SSH_COMMAND: `"${getSSHWrapperPath()}"`,
     }
   }
 

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -62,11 +62,11 @@ export async function getSSHEnvironment() {
     }
   }
 
-  if (__DARWIN__ && enableSSHAskPass()) {
-    // Replace git ssh command with our wrapper
+  if (__DARWIN__ && __DEV__ && enableSSHAskPass()) {
+    // Replace git ssh command with our wrapper in dev builds, since they are
+    // launched from a command line.
     return {
       ...baseEnv,
-      DISPLAY: '.', // Required for ssh to actually use SSH_ASKPASS
       GIT_SSH_COMMAND: `"${getSSHWrapperPath()}"`,
     }
   }

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -52,3 +52,8 @@ function getAskPassTrampolinePath(): string {
 function getAskPassScriptPath(): string {
   return Path.resolve(__dirname, 'ask-pass.js')
 }
+
+/** Returns the path of the ssh-wrapper binary. */
+export function getSSHWrapperPath(): string {
+  return Path.resolve(__dirname, 'desktop-trampoline', 'ssh-wrapper')
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -311,9 +311,9 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-trampoline@desktop/desktop-trampoline#v0.9.7:
-  version "0.9.7"
-  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/38c590851f84e1dc856b6fd7e49920ef360c2ca0"
+desktop-trampoline@desktop/desktop-trampoline#v0.9.8:
+  version "0.9.8"
+  resolved "https://codeload.github.com/desktop/desktop-trampoline/tar.gz/cbd3dbb31d0d3ea9f325067f48bfbf60b6663a57"
   dependencies:
     node-addon-api "^3.1.0"
     prebuild-install "^6.0.0"

--- a/script/build.ts
+++ b/script/build.ts
@@ -344,6 +344,19 @@ function copyDependencies() {
     path.resolve(desktopTrampolineDir, desktopTrampolineFile)
   )
 
+  if (process.platform === 'darwin') {
+    console.log('  Copying ssh-wrapper')
+    const sshWrapperFile = 'ssh-wrapper'
+    fs.copySync(
+      path.resolve(
+        projectRoot,
+        'app/node_modules/desktop-trampoline/build/Release',
+        sshWrapperFile
+      ),
+      path.resolve(desktopTrampolineDir, sshWrapperFile)
+    )
+  }
+
   console.log('  Copying git environment…')
   const gitDir = path.resolve(outRoot, 'git')
   fs.removeSync(gitDir)

--- a/script/build.ts
+++ b/script/build.ts
@@ -344,7 +344,8 @@ function copyDependencies() {
     path.resolve(desktopTrampolineDir, desktopTrampolineFile)
   )
 
-  if (process.platform === 'darwin') {
+  // Dev builds for macOS require a SSH wrapper to use SSH_ASKPASS
+  if (process.platform === 'darwin' && isDevelopmentBuild) {
     console.log('  Copying ssh-wrapper')
     const sshWrapperFile = 'ssh-wrapper'
     fs.copySync(


### PR DESCRIPTION
## Description

This PR is a continuation of #12756 , where macOS support was left out since it required some additional work.

The important work to enable these improvements on macOS is in the desktop-trampoline package, more specifically in https://github.com/desktop/desktop-trampoline/pull/13

This PR just bumps `desktop-trampoline` to a version which includes the new `ssh-wrapper`, and makes sure the wrapper is copied in builds and git uses it on macOS.

### Screenshots

Note: the video is kind of a lie, since github.com is added as a host automatically. Users will be prompted about other hosts, though.

https://user-images.githubusercontent.com/1083228/129715245-47370730-8359-4273-b878-f26a14845c36.mov

## Release notes

Notes: [Fixed] Prompt SSH info to macOS users, like the key passphrase or adding a host to the list of known hosts
