### PR TITLE
Set DISPLAY env variable on Windows

### DIFF
--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -45,6 +45,8 @@ export async function getSSHEnvironment() {
   const baseEnv = enableSSHAskPass()
     ? {
         SSH_ASKPASS: getDesktopTrampolinePath(),
+        // DISPLAY needs to be set to _something_ so ssh actually uses SSH_ASKPASS
+        DISPLAY: '.',
       }
     : {}
 


### PR DESCRIPTION
## Description

This should force ssh to use `SSH_ASKPASS` on Windows too 😓 

## Release notes

Notes: no-notes
