### PR TITLE
Await for `envForRemoteOperation`

### DIFF
--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -91,7 +91,7 @@ export async function deleteRemoteBranch(
   // If the user is not authenticated, the push is going to fail
   // Let this propagate and leave it to the caller to handle
   const result = await git(args, repository.path, 'deleteRemoteBranch', {
-    env: envForRemoteOperation(account, remoteUrl),
+    env: await envForRemoteOperation(account, remoteUrl),
     expectedErrors: new Set<DugiteError>([DugiteError.BranchDeletionFailed]),
   })
 

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -63,7 +63,7 @@ export async function fetch(
 ): Promise<void> {
   let opts: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
-    env: envForRemoteOperation(account, remote.url),
+    env: await envForRemoteOperation(account, remote.url),
   }
 
   if (progressCallback) {
@@ -121,7 +121,7 @@ export async function fetchRefspec(
 ): Promise<void> {
   const options = {
     successExitCodes: new Set([0, 128]),
-    env: envForRemoteOperation(account, remote.url),
+    env: await envForRemoteOperation(account, remote.url),
   }
 
   const networkArguments = await gitNetworkArguments(repository, account)


### PR DESCRIPTION
Closes #12796

## Description

In the refactor of #12762 I forgot to add `await` to a few places where `envForRemoteOperation` is invoked, causing that instead of filling `env` with environment variables as expected, it would have an unresolved promise 🤦 

## Release notes

Notes: [Fixed] Fixed authentication errors in some Git operations
