### PR TITLE
SSH passphrase fixes and improvements

### DIFF
--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -1,7 +1,6 @@
 import { GitProcess } from 'dugite'
 import * as GitPerf from '../../ui/lib/git-perf'
 import { isErrnoException } from '../errno-exception'
-import { getSSHEnvironment } from '../ssh/ssh'
 import { withTrampolineEnv } from '../trampoline/trampoline-environment'
 
 type ProcessOutput = {
@@ -39,13 +38,7 @@ export async function spawnAndComplete(
       commandName,
       () =>
         new Promise<ProcessOutput>(async (resolve, reject) => {
-          const sshEnv = await getSSHEnvironment()
-          const process = GitProcess.spawn(args, path, {
-            env: {
-              ...env,
-              ...sshEnv,
-            },
-          })
+          const process = GitProcess.spawn(args, path, { env })
 
           process.on('error', err => {
             // If this is an exception thrown by Node.js while attempting to

--- a/app/src/lib/ssh/ssh-key-passphrase.ts
+++ b/app/src/lib/ssh/ssh-key-passphrase.ts
@@ -1,0 +1,78 @@
+import { getFileHash } from '../file-system'
+import { TokenStore } from '../stores'
+
+const appName = __DEV__ ? 'GitHub Desktop Dev' : 'GitHub Desktop'
+const SSHKeyPassphraseTokenStoreKey = `${appName} - SSH key passphrases`
+
+async function getHashForSSHKey(keyPath: string) {
+  return getFileHash(keyPath, 'sha256')
+}
+
+/** Retrieves the passphrase for the SSH key in the given path. */
+export async function getSSHKeyPassphrase(keyPath: string) {
+  try {
+    const fileHash = await getHashForSSHKey(keyPath)
+    return TokenStore.getItem(SSHKeyPassphraseTokenStoreKey, fileHash)
+  } catch (e) {
+    log.error('Could not retrieve passphrase for SSH key:', e)
+    return null
+  }
+}
+
+type SSHKeyPassphraseEntry = {
+  /** Hash of the SSH key file. */
+  keyHash: string
+
+  /** Passphrase for the SSH key. */
+  passphrase: string
+}
+
+/**
+ * This map contains the SSH key passphrases that are pending to be stored.
+ * What this means is that a git operation is currently in progress, and the
+ * user wanted to store the passphrase for the SSH key, however we don't want
+ * to store it until we know the git operation finished successfully.
+ */
+const SSHKeyPassphrasesToStore = new Map<string, SSHKeyPassphraseEntry>()
+
+/**
+ * Keeps the SSH key passphrase in memory to be stored later if the ongoing git
+ * operation succeeds.
+ *
+ * @param operationGUID A unique identifier for the ongoing git operation. In
+ *                      practice, it will always be the trampoline token for the
+ *                      ongoing git operation.
+ * @param keyPath       Path to the SSH key.
+ * @param passphrase    Passphrase for the SSH key.
+ */
+export async function keepSSHKeyPassphraseToStore(
+  operationGUID: string,
+  keyPath: string,
+  passphrase: string
+) {
+  try {
+    const keyHash = await getHashForSSHKey(keyPath)
+    SSHKeyPassphrasesToStore.set(operationGUID, { keyHash, passphrase })
+  } catch (e) {
+    log.error('Could not store passphrase for SSH key:', e)
+  }
+}
+
+/** Removes the SSH key passphrase from memory. */
+export function removePendingSSHKeyPassphraseToStore(operationGUID: string) {
+  SSHKeyPassphrasesToStore.delete(operationGUID)
+}
+
+/** Stores a pending SSH key passphrase if the operation succeeded. */
+export async function storePendingSSHKeyPassphrase(operationGUID: string) {
+  const entry = SSHKeyPassphrasesToStore.get(operationGUID)
+  if (entry === undefined) {
+    return
+  }
+
+  await TokenStore.setItem(
+    SSHKeyPassphraseTokenStoreKey,
+    entry.keyHash,
+    entry.passphrase
+  )
+}

--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -1,9 +1,7 @@
 import * as fse from 'fs-extra'
 import memoizeOne from 'memoize-one'
 import { enableSSHAskPass, enableWindowsOpenSSH } from '../feature-flag'
-import { getFileHash } from '../file-system'
 import { getBoolean } from '../local-storage'
-import { TokenStore } from '../stores'
 import {
   getDesktopTrampolinePath,
   getSSHWrapperPath,
@@ -72,39 +70,4 @@ export async function getSSHEnvironment() {
   }
 
   return baseEnv
-}
-
-const appName = __DEV__ ? 'GitHub Desktop Dev' : 'GitHub Desktop'
-const SSHKeyPassphraseTokenStoreKey = `${appName} - SSH key passphrases`
-
-async function getHashForSSHKey(keyPath: string) {
-  return getFileHash(keyPath, 'sha256')
-}
-
-/** Retrieves the passphrase for the SSH key in the given path. */
-export async function getSSHKeyPassphrase(keyPath: string) {
-  try {
-    const fileHash = await getHashForSSHKey(keyPath)
-    return TokenStore.getItem(SSHKeyPassphraseTokenStoreKey, fileHash)
-  } catch (e) {
-    log.error('Could not retrieve passphrase for SSH key:', e)
-    return null
-  }
-}
-
-/** Stores the passphrase for the SSH key in the given path. */
-export async function storeSSHKeyPassphrase(
-  keyPath: string,
-  passphrase: string
-) {
-  try {
-    const fileHash = await getHashForSSHKey(keyPath)
-    await TokenStore.setItem(
-      SSHKeyPassphraseTokenStoreKey,
-      fileHash,
-      passphrase
-    )
-  } catch (e) {
-    log.error('Could not store passphrase for SSH key:', e)
-  }
 }

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -62,7 +62,10 @@ async function handleSSHKeyPassphrase(
     return storedPassphrase
   }
 
-  const passphrase = await trampolineUIHelper.promptSSHKeyPassphrase(keyPath)
+  const {
+    passphrase,
+    storePassphrase,
+  } = await trampolineUIHelper.promptSSHKeyPassphrase(keyPath)
 
   return passphrase ?? ''
 }

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -1,5 +1,8 @@
 import { getKeyForEndpoint } from '../auth'
-import { getSSHKeyPassphrase } from '../ssh/ssh'
+import {
+  getSSHKeyPassphrase,
+  keepSSHKeyPassphraseToStore,
+} from '../ssh/ssh-key-passphrase'
 import { TokenStore } from '../stores'
 import { TrampolineCommandHandler } from './trampoline-command'
 import { trampolineUIHelper } from './trampoline-ui-helper'
@@ -37,6 +40,7 @@ async function handleSSHHostAuthenticity(
 }
 
 async function handleSSHKeyPassphrase(
+  operationGUID: string,
   prompt: string
 ): Promise<string | undefined> {
   const promptRegex = /^Enter passphrase for key '(.+)': $/
@@ -67,6 +71,10 @@ async function handleSSHKeyPassphrase(
     storePassphrase,
   } = await trampolineUIHelper.promptSSHKeyPassphrase(keyPath)
 
+  if (passphrase !== undefined && storePassphrase) {
+    keepSSHKeyPassphraseToStore(operationGUID, keyPath, passphrase)
+  }
+
   return passphrase ?? ''
 }
 
@@ -82,7 +90,7 @@ export const askpassTrampolineHandler: TrampolineCommandHandler = async command 
   }
 
   if (firstParameter.startsWith('Enter passphrase for key ')) {
-    return handleSSHKeyPassphrase(firstParameter)
+    return handleSSHKeyPassphrase(command.trampolineToken, firstParameter)
   }
 
   const username = command.environmentVariables.get('DESKTOP_USERNAME')

--- a/app/src/lib/trampoline/trampoline-command-parser.ts
+++ b/app/src/lib/trampoline/trampoline-command-parser.ts
@@ -126,8 +126,17 @@ export class TrampolineCommandParser {
       )
     }
 
+    const trampolineToken = this.environmentVariables.get(
+      'DESKTOP_TRAMPOLINE_TOKEN'
+    )
+
+    if (trampolineToken === undefined) {
+      throw new Error(`The trampoline token is missing`)
+    }
+
     return {
       identifier,
+      trampolineToken,
       parameters: this.parameters,
       environmentVariables: this.environmentVariables,
     }

--- a/app/src/lib/trampoline/trampoline-command.ts
+++ b/app/src/lib/trampoline/trampoline-command.ts
@@ -13,6 +13,12 @@ export interface ITrampolineCommand {
   readonly identifier: TrampolineCommandIdentifier
 
   /**
+   * Trampoline token sent with this command via the DESKTOP_TRAMPOLINE_TOKEN
+   * environment variable.
+   */
+  readonly trampolineToken: string
+
+  /**
    * Parameters of the command.
    *
    * This corresponds to the command line arguments (argv) except the name of

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -4,12 +4,19 @@ import * as Path from 'path'
 import { enableDesktopTrampoline } from '../feature-flag'
 import { getDesktopTrampolineFilename } from 'desktop-trampoline'
 import { TrampolineCommandIdentifier } from '../trampoline/trampoline-command'
+import { getSSHEnvironment } from '../ssh/ssh'
+import {
+  removePendingSSHKeyPassphraseToStore,
+  storePendingSSHKeyPassphrase,
+} from '../ssh/ssh-key-passphrase'
 
 /**
  * Allows invoking a function with a set of environment variables to use when
  * invoking a Git subcommand that needs to use the trampoline (mainly git
  * operations requiring an askpass script) and with a token to use in the
  * trampoline server.
+ * It will handle saving SSH key passphrases when needed if the git operation
+ * succeeds.
  *
  * @param fn        Function to invoke with all the necessary environment
  *                  variables.
@@ -21,18 +28,40 @@ export async function withTrampolineEnv<T>(
     ? getDesktopTrampolinePath()
     : getAskPassTrampolinePath()
 
-  return withTrampolineToken(async token =>
-    fn({
-      DESKTOP_PORT: await trampolineServer.getPort(),
-      DESKTOP_TRAMPOLINE_TOKEN: token,
-      GIT_ASKPASS: askPassPath,
-      DESKTOP_TRAMPOLINE_IDENTIFIER: TrampolineCommandIdentifier.AskPass,
+  const sshEnv = await getSSHEnvironment()
 
-      // Env variables specific to the old askpass trampoline
-      DESKTOP_PATH: process.execPath,
-      DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
-    })
-  )
+  return withTrampolineToken(async token => {
+    // The code below assumes a few things in order to manage SSH key passphrases
+    // correctly:
+    // 1. `withTrampolineEnv` is only used in the functions `git` (core.ts) and
+    //    `spawnAndComplete` (spawn.ts)
+    // 2. Those two functions always thrown an error when something went wrong,
+    //    and just return a result when everything went fine.
+    //
+    // With those two premises in mind, we can safely assume that right after
+    // `fn` has been invoked, we can store the SSH key passphrase for this git
+    // operation if there was one pending to be stored.
+    try {
+      const result = await fn({
+        DESKTOP_PORT: await trampolineServer.getPort(),
+        DESKTOP_TRAMPOLINE_TOKEN: token,
+        GIT_ASKPASS: askPassPath,
+        DESKTOP_TRAMPOLINE_IDENTIFIER: TrampolineCommandIdentifier.AskPass,
+
+        ...sshEnv,
+
+        // Env variables specific to the old askpass trampoline
+        DESKTOP_PATH: process.execPath,
+        DESKTOP_ASKPASS_SCRIPT: getAskPassScriptPath(),
+      })
+
+      await storePendingSSHKeyPassphrase(token)
+
+      return result
+    } finally {
+      removePendingSSHKeyPassphraseToStore(token)
+    }
+  })
 }
 
 /** Returns the path of the desktop-trampoline binary. */

--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -157,9 +157,7 @@ export class TrampolineServer {
   }
 
   private async processCommand(socket: Socket, command: ITrampolineCommand) {
-    const token = command.environmentVariables.get('DESKTOP_TRAMPOLINE_TOKEN')
-
-    if (token === undefined || !isValidTrampolineToken(token)) {
+    if (!isValidTrampolineToken(command.trampolineToken)) {
       throw new Error('Tried to use invalid trampoline token')
     }
 

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -1,6 +1,11 @@
 import { PopupType } from '../../models/popup'
 import { Dispatcher } from '../../ui/dispatcher'
 
+type PromptSSHKeyPassphraseResponse = {
+  readonly passphrase: string | undefined
+  readonly storePassphrase: boolean
+}
+
 class TrampolineUIHelper {
   // The dispatcher must be set before this helper can do anything
   private dispatcher!: Dispatcher
@@ -25,12 +30,15 @@ class TrampolineUIHelper {
     })
   }
 
-  public promptSSHKeyPassphrase(keyPath: string): Promise<string | undefined> {
+  public promptSSHKeyPassphrase(
+    keyPath: string
+  ): Promise<PromptSSHKeyPassphraseResponse> {
     return new Promise(resolve => {
       this.dispatcher.showPopup({
         type: PopupType.SSHKeyPassphrase,
         keyPath,
-        onSubmit: passphrase => resolve(passphrase),
+        onSubmit: (passphrase, storePassphrase) =>
+          resolve({ passphrase, storePassphrase }),
       })
     })
   }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -308,5 +308,8 @@ export type Popup =
   | {
       type: PopupType.SSHKeyPassphrase
       keyPath: string
-      onSubmit: (passphrase: string | undefined) => void
+      onSubmit: (
+        passphrase: string | undefined,
+        storePassphrase: boolean
+      ) => void
     }

--- a/app/src/ui/ssh/ssh-key-passphrase.tsx
+++ b/app/src/ui/ssh/ssh-key-passphrase.tsx
@@ -4,11 +4,13 @@ import { Row } from '../lib/row'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { TextBox } from '../lib/text-box'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
-import { storeSSHKeyPassphrase } from '../../lib/ssh/ssh'
 
 interface ISSHKeyPassphraseProps {
   readonly keyPath: string
-  readonly onSubmit: (passphrase: string | undefined) => void
+  readonly onSubmit: (
+    passphrase: string | undefined,
+    storePassphrase: boolean
+  ) => void
   readonly onDismissed: () => void
 }
 
@@ -80,21 +82,18 @@ export class SSHKeyPassphrase extends React.Component<
     this.setState({ passphrase: value })
   }
 
-  private submit(passphrase: string | undefined) {
+  private submit(passphrase: string | undefined, storePassphrase: boolean) {
     const { onSubmit, onDismissed } = this.props
 
-    onSubmit(passphrase)
+    onSubmit(passphrase, storePassphrase)
     onDismissed()
   }
 
   private onSubmit = () => {
-    if (this.state.rememberPassphrase) {
-      storeSSHKeyPassphrase(this.props.keyPath, this.state.passphrase)
-    }
-    this.submit(this.state.passphrase)
+    this.submit(this.state.passphrase, this.state.rememberPassphrase)
   }
 
   private onCancel = () => {
-    this.submit(undefined)
+    this.submit(undefined, false)
   }
 }


### PR DESCRIPTION
## Description

This PR addresses an issue discovered in https://github.com/desktop/desktop/issues/2579#issuecomment-900938792

It sits on top of #12782 so that I could test it properly, because doing so on Windows would be very painful for me 😆 

Basically, the problem with the implementation prior to this PR is that we were storing the SSH key passphrase immediately after the user entered it, regardless of whether the git operation succeeded or not. Because of that, if the user entered the wrong passphrase, that would be stored immediately and never asked again, resulting in a loop of despair where Desktop would automagically read the (bad) passphrase from the Keychain and giving it to git to just fail miserably.

This problem was a bit challenging to fix, because the code handling the prompt (`trampoline-askpass-handler.ts`) and the code handling the git operation (`core.ts` or `spawn.ts`) are mostly disconnected, and we must be sure to store password A for operation X only when operation X succeeds, but not for operations Y or Z.

In order to solve this, I've leveraged the use of unique tokens for the trampoline: for the time a git operation is running, we create a unique token that the trampoline will use to make it harder to exploit for malicious purposes. That token, effectively, identifies that specific git operation uniquely. Thanks to that, we can do this:
1. When we get the prompt from the trampoline askpass handler, prompt the user for their SSH key passphrase.
2. If the user checked the `Remember passphrase` checkbox, keep the passphrase they entered **in memory**, associated to the unique trampoline token (and the hash of the SSH key file, of course).
3. Pass the passphrase to git so it can continue the operation.
4. Once the git operation finished, look for the passphrase associated to its trampoline token and store it in the keychain / credential manager.
5. Remove the passphrase from memory.

The main caveat of this approach is that if the user enters the right passphrase but git fails for whatever other reason, the passphrase won't be remembered and the user will need to enter it in future attempts. An alternative would be not storing the passphrase **only** if the error returned by the git operation was an authentication error. However, in that case, if the password was wrong but the git operation failed in some other way before noticing that (hence not reporting an authentication failure), the bad password might be stored in the keychain and would be imposible to fix unless the user manually deleted the stored password.

### Screenshots

The video below shows how I:
1. Enter the wrong password 3 times with `Remember passphrase` unchecked. And, of course, it doesn't remember the passphrase ✅ 
1. Enter the wrong password 3 times with `Remember passphrase` checked. And it still doesn't remember the passphrase ✅ 
1. Enter the right password with `Remember passphrase` unchecked. And, of course, it doesn't remember the passphrase but the command works ✅  
1. Enter the right password with `Remember passphrase` checked. It does remember the passphrase and the command works ✅  
1. I fetch again and it just works because it remembered the password 🎉 

https://user-images.githubusercontent.com/1083228/129895330-2fea89c0-e0f6-4399-87a6-d0716eed5f27.mp4

## Release notes

Notes: [Fixed] Wrong SSH key passphrases are not stored.
