### PR TITLE
Fix `Undo` link not showing up for cherry-picks

### DIFF
--- a/app/src/models/banner.ts
+++ b/app/src/models/banner.ts
@@ -60,7 +60,7 @@ export type Banner =
       /** number of commits cherry picked */
       readonly count: number
       /** callback to run when user clicks undo link in banner */
-      readonly onUndoCherryPick: () => void
+      readonly onUndo: () => void
     }
   | {
       readonly type: BannerType.CherryPickConflictsFound

--- a/app/src/ui/banners/render-banner.tsx
+++ b/app/src/ui/banners/render-banner.tsx
@@ -79,7 +79,7 @@ export function renderBanner(
           targetBranchName={banner.targetBranchName}
           countCherryPicked={banner.count}
           onDismissed={onDismissed}
-          onUndoCherryPick={banner.onUndoCherryPick}
+          onUndo={banner.onUndo}
         />
       )
     case BannerType.CherryPickConflictsFound:

--- a/app/src/ui/banners/successful-cherry-pick.tsx
+++ b/app/src/ui/banners/successful-cherry-pick.tsx
@@ -5,7 +5,7 @@ interface ISuccessfulCherryPickBannerProps {
   readonly targetBranchName: string
   readonly countCherryPicked: number
   readonly onDismissed: () => void
-  readonly onUndoCherryPick: () => void
+  readonly onUndo: () => void
 }
 
 export class SuccessfulCherryPick extends React.Component<
@@ -16,18 +16,14 @@ export class SuccessfulCherryPick extends React.Component<
     const {
       countCherryPicked,
       onDismissed,
-      onUndoCherryPick,
+      onUndo,
       targetBranchName,
     } = this.props
 
     const pluralized = countCherryPicked === 1 ? 'commit' : 'commits'
 
     return (
-      <SuccessBanner
-        timeout={15000}
-        onDismissed={onDismissed}
-        onUndo={onUndoCherryPick}
-      >
+      <SuccessBanner timeout={15000} onDismissed={onDismissed} onUndo={onUndo}>
         <span>
           Successfully copied {countCherryPicked} {pluralized} to{' '}
           <strong>{targetBranchName}</strong>.


### PR DESCRIPTION
## Description

This PR fixes a regression where the `Undo` link wouldn't be available after a successful cherry-pick. The regression seems to be introduced in #12757 

## Release notes

Notes: no-notes
