### PR TITLE
Remove any to have better typing

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3513,7 +3513,7 @@ export class Dispatcher {
       targetBranch,
     } = mcos
 
-    const bannerBase: any = {
+    const bannerBase = {
       count,
       onUndo: () => {
         this.undoMultiCommitOperation(mcos, repository, count)


### PR DESCRIPTION
## Description

This removes the `any` keyword that caused a lack of type checking that could have prevented a type detectable regression in cherry-picking.

## Release notes
Notes: no-notes
