### PR TITLE
Setting for toggling "Recent" repositories in the repository switcher

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -237,6 +237,9 @@ export interface IAppState {
   /** The selected appearance (aka theme) preference */
   readonly selectedTheme: ApplicationTheme
 
+  /** Whether or not to show recent repositories */
+  readonly showRecentRepositories: boolean
+
   /** The currently applied appearance (aka theme) */
   readonly currentTheme: ApplicableTheme
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -299,6 +299,9 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
  */
 const RecentRepositoriesLength = 3
 
+const showRecentRepositoriesDefault = true;
+const showRecentRepositoriesKey = 'showRecentRepositories'
+
 const defaultSidebarWidth: number = 250
 const sidebarWidthConfigKey: string = 'sidebar-width'
 
@@ -444,6 +447,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private selectedBranchesTab = BranchesTab.Branches
   private selectedTheme = ApplicationTheme.System
+  private showRecentRepositories = showRecentRepositoriesDefault;
   private currentTheme: ApplicableTheme = ApplicationTheme.Light
 
   private useWindowsOpenSSH: boolean = false
@@ -856,6 +860,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       dragAndDropIntroTypesShown: this.dragAndDropIntroTypesShown,
       currentDragElement: this.currentDragElement,
       lastThankYou: this.lastThankYou,
+      showRecentRepositories: this.showRecentRepositories
     }
   }
 
@@ -1779,6 +1784,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.askForConfirmationOnForcePush = getBoolean(
       confirmForcePushKey,
       askForConfirmationOnForcePushDefault
+    )
+
+    this.showRecentRepositories = getBoolean(
+      showRecentRepositoriesKey,
+      showRecentRepositoriesDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -5867,6 +5877,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     return Promise.resolve()
+  }
+
+  /**
+   * Set whether or not to show recent repositories
+   */
+  public _setShowRecentRepositories(show: boolean) {
+    setBoolean(showRecentRepositoriesKey, show);
+    this.showRecentRepositories = show
+    this.emitUpdate()
   }
 
   public async _resolveCurrentEditor() {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2370,6 +2370,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         onOpenInExternalEditor={this.openInExternalEditor}
         externalEditorLabel={externalEditorLabel}
         shellLabel={shellLabel}
+        showRecentRepositories={this.state.showRecentRepositories}
         dispatcher={this.props.dispatcher}
       />
     )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2365,6 +2365,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set whether or not to show recent repositories
+   */
+  public setShowRecentRepositories(show: boolean) {
+    return this.appStore._setShowRecentRepositories(show)
+  }
+
+  /**
    * Increments either the `repoWithIndicatorClicked` or
    * the `repoWithoutIndicatorClicked` metric
    */

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -30,6 +30,7 @@ interface IRepositoriesListProps {
   readonly selectedRepository: Repositoryish | null
   readonly repositories: ReadonlyArray<Repositoryish>
   readonly recentRepositories: ReadonlyArray<number>
+  readonly showRecentRepositories: boolean
 
   /** A cache of the latest repository state values, keyed by the repository id */
   readonly localRepositoryStateLookup: ReadonlyMap<
@@ -193,7 +194,8 @@ export class RepositoriesList extends React.Component<
     )
 
     const groups =
-      this.props.repositories.length > recentRepositoriesThreshold
+      this.props.repositories.length > recentRepositoriesThreshold &&
+      this.props.showRecentRepositories
         ? [
             makeRecentRepositoriesGroup(
               this.props.recentRepositories,


### PR DESCRIPTION
Closes #11598

## Description

Adds an `AppState` setting to hide "recent" repositories from the repositories list. #9156 #11598 #12633 #12824

Per the closed pull request #11789 , the Options UI remains unchanged. This feature can only be implemented by opening the developer tools and setting the local storage manually. This unblocks power-users, allowing them to access or beta-run this feature, while not impacting existing target customers.

If this feature were ever to make it to the Options UI, the boilerplate with the AppState and Dispatcher are already present.

### Screenshots

No UI change; only dev tools change.

## Release notes

Notes: no-notes
