### PR TITLE
Fix (or vastly improve) performance issue /w dynamic gutter lines

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1016,10 +1016,15 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
 
     const gutterParentElement = cm.getGutterElement()
     const gutterElement = gutterParentElement.getElementsByClassName(
-      'diff-gutter'
+      diffGutterName
     )[0]
-    gutterElement.setAttribute('style', `width: ${diffSize * 2}px;`)
-    cm.refresh()
+
+    const newStyle = `width: ${diffSize * 2}px;`
+    const currentStyle = gutterElement.getAttribute('style')
+    if (newStyle !== currentStyle) {
+      gutterElement.setAttribute('style', newStyle)
+      cm.refresh()
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #12830

## Description

In 2.9.1, we released an improvement on the gutter diff displays that dynamically set the width of the line number gutters to prevent clipping - PR #12071.

Unfortunately, it was found to cause performance issues for large diffs. This PR aims to fix or vastly improve that performance issue by only applying the dynamic styles for the gutter lines when they change (not continuously as the user scrolls).

### Screenshots

## Release notes
Notes: [Fixed] Fix scrolling performance for large diffs.
