### PR TITLE
Releases 2.9.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1016,10 +1016,15 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
 
     const gutterParentElement = cm.getGutterElement()
     const gutterElement = gutterParentElement.getElementsByClassName(
-      'diff-gutter'
+      diffGutterName
     )[0]
-    gutterElement.setAttribute('style', `width: ${diffSize * 2}px;`)
-    cm.refresh()
+
+    const newStyle = `width: ${diffSize * 2}px;`
+    const currentStyle = gutterElement.getAttribute('style')
+    if (newStyle !== currentStyle) {
+      gutterElement.setAttribute('style', newStyle)
+      cm.refresh()
+    }
   }
 
   /**

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,6 @@
 {
   "releases": {
+    "2.9.2": ["[Fixed] Fix scrolling performance issue for large diffs."],
     "2.9.1": [
       "[Added] Add Fluent Terminal shell support - #12305. Thanks @Idered!",
       "[Added] Add support for IntelliJ CE for macOS - #12748. Thanks @T41US!",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming v2.9.2 production release? Well you've just found it, congratulations! :tada:

This is based on [release tag 2.9.1](https://github.com/desktop/desktop/releases/tag/release-2.9.1) and [one hotfix](https://github.com/desktop/desktop/pull/12834) for a performance issue introduced in 2.9.1 when scrolling large diffs.


## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
-- Nothing worth of mentioning
- [x] Verify that all feature flags are flipped appropriately
-- No feature flag changes.
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
-- No new metrics