### PR TITLE
Fix Notepad++ and RStudio integration on Windows

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -298,7 +298,7 @@ const editors: IWindowsExternalEditor[] = [
       // 32-bit version of Notepad++
       Wow64LocalMachineUninstallKey('Notepad++'),
     ],
-    executableShimPaths: [],
+    executableShimPaths: [[]],
     installLocationRegistryKey: 'DisplayIcon',
     expectedInstallationChecker: (displayName, publisher) =>
       displayName.startsWith('Notepad++') && publisher === 'Notepad++ Team',
@@ -314,7 +314,7 @@ const editors: IWindowsExternalEditor[] = [
   {
     name: 'RStudio',
     registryKeys: [Wow64LocalMachineUninstallKey('RStudio')],
-    executableShimPaths: [],
+    executableShimPaths: [[]],
     installLocationRegistryKey: 'DisplayIcon',
     expectedInstallationChecker: (displayName, publisher) =>
       displayName === 'RStudio' && publisher === 'RStudio',


### PR DESCRIPTION
Closes #12841

## Description

The regression was introduced in #12778, where the `executableShimPath` changed from a list of path components, to a list of lists of path components (meaning, there could be multiple executable paths to check): RStudio and Notepad++ don't need specific paths because for those we just check the `DisplayIcon` entry in the registry, and just specifying `[]` broke the logic we have for those, because that meant there weren't executable files for those editors. Instead, we needed to use `[[]]` (meaning, there is only 1 executable path which is whatever was in the `DisplayIcon`).

## Release notes

Notes: [Fixed] Fix integration of Notepad++ and RStudio on Windows
