### PR TITLE
Silently error when no conflicts present for dismissing conflict dialog

### DIFF
--- a/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
+++ b/app/src/ui/multi-commit-operation/base-multi-commit-operation.tsx
@@ -73,11 +73,15 @@ export abstract class BaseMultiCommitOperation extends React.Component<
    * needed for typing purposes. Thus it should never happen, so throw error if
    * does.
    */
-  protected endFlowInvalidState(): void {
+  protected endFlowInvalidState(isSilent: boolean = false): void {
     const { step, operationDetail } = this.props.state
-    throw new Error(
-      `[${operationDetail.kind}] - Invalid state - ${operationDetail.kind} ended during ${step.kind}.`
-    )
+    const errorMessage = `[${operationDetail.kind}] - Invalid state - ${operationDetail.kind} ended during ${step.kind}.`
+    if (isSilent) {
+      this.onFlowEnded()
+      log.error(errorMessage)
+      return
+    }
+    throw new Error(errorMessage)
   }
 
   protected onInvokeConflictsDialogDismissed = (operationPrefix: string) => {

--- a/app/src/ui/multi-commit-operation/merge.tsx
+++ b/app/src/ui/multi-commit-operation/merge.tsx
@@ -72,7 +72,7 @@ export abstract class Merge extends BaseMultiCommitOperation {
   protected onConflictsDialogDismissed = () => {
     const { dispatcher, workingDirectory, conflictState } = this.props
     if (conflictState === null || !isMergeConflictState(conflictState)) {
-      this.endFlowInvalidState()
+      this.endFlowInvalidState(true)
       return
     }
     dispatcher.recordMergeConflictsDialogDismissal()


### PR DESCRIPTION
## Description

After refactoring the merge operation to use our new `Multi-Commit-Operation logic`. We are seeing an error in sentry where somehow a user is dismissing the conflicts dialog when there is _not_ a conflict detected in the applications state. 

I am unable to reproduce this error, but my theory is the user starts a merge with conflicts inside of Desktop and then resolves the conflicts outside of Desktop. Thus, when they return to Desktop and attempts to dismiss the stale conflicts dialog, there is a race condition between Desktop detecting no conflict (and closing the dialog on its own) and the user dismissing it.

As we were not seeing this type of error before the refactor, the logic likely didn't error out but just assumed no conflicts - just moved on. Thus, this PR is doing the same thing. Instead of throwing an error (and crashing the app), we simply log the error and end the merge flow.

## Release notes
Notes: no-notes
