### PR TITLE
Tidy up log messages around scanning for installed editors

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -137,9 +137,11 @@ async function findApplication(
         return installPath
       }
 
-      log.debug(`App installation for ${editor} not found at '${installPath}'`)
+      log.debug(
+        `App installation for ${editor.name} not found at '${installPath}'`
+      )
     } catch (error) {
-      log.debug(`Unable to locate ${editor} installation`, error)
+      log.debug(`Unable to locate ${editor.name} installation`, error)
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Noticed these log messages in my console while debugging and they struck me as both unnecessary and uninformative

![image](https://user-images.githubusercontent.com/634063/131479013-801e668a-033c-45cd-84c1-62bde05d9356.png)

The `[Object object]` part here used to say which editor wasn't being found and the log messages were a lot less annoying when there were only a few editors.

Note that this only affects debug log messages (which aren't persisted to disk) and only on macOS.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
