### PR TITLE
Small fixes/improvements in diff expansion

### DIFF
--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -1,4 +1,4 @@
-import { DiffHunk, DiffLine } from '../../models/diff'
+import { DiffHunk, DiffLine, DiffLineType } from '../../models/diff'
 import * as CodeMirror from 'codemirror'
 import { diffLineForIndex } from './diff-explorer'
 import { ITokens } from '../../lib/highlighter/types'
@@ -30,7 +30,9 @@ export interface IDiffSyntaxModeSpec extends IDiffSyntaxModeOptions {
   readonly name: 'github-diff-syntax'
 }
 
-const TokenNames: { [key: string]: string | null } = {
+type DiffSyntaxToken = 'diff-add' | 'diff-delete' | 'diff-hunk' | 'diff-context'
+
+const TokenNames: { [key: string]: DiffSyntaxToken | null } = {
   '+': 'diff-add',
   '-': 'diff-delete',
   '@': 'diff-hunk',
@@ -46,6 +48,10 @@ function skipLine(stream: CodeMirror.StringStream, state: IState) {
   stream.skipToEnd()
   state.diffLineIndex++
   return null
+}
+
+function getBaseDiffLineStyle(token: DiffSyntaxToken) {
+  return `line-${token} line-background-${token}`
 }
 
 /**
@@ -112,10 +118,22 @@ export class DiffSyntaxMode {
     return { diffLineIndex: 0, previousHunkOldEndLine: null }
   }
 
-  // Should never happen except for blank diffs but
-  // let's play along
   public blankLine(state: IState) {
+    // A line might be empty in a non-blank diff for the only line of the
+    // dummy hunk we put at the bottom of the diff to allow users to expand
+    // the visible contents.
+    if (this.hunks !== undefined && this.hunks.length > 0) {
+      const diffLine = diffLineForIndex(this.hunks, state.diffLineIndex)
+
+      if (diffLine?.type === DiffLineType.Hunk) {
+        return getBaseDiffLineStyle('diff-hunk')
+      }
+    }
+
+    // Should never happen except for blank diffs but
+    // let's play along
     state.diffLineIndex++
+    return undefined
   }
 
   public token = (
@@ -131,13 +149,17 @@ export class DiffSyntaxMode {
         state.diffLineIndex++
       }
 
-      const token = index ? TokenNames[index] : null
+      if (index === null) {
+        return null
+      }
+
+      const token = TokenNames[index] ?? null
 
       if (token === null) {
         return null
       }
 
-      let result = `line-${token} line-background-${token}`
+      let result = getBaseDiffLineStyle(token)
 
       // If it's a hunk header line, we want to make a few extra checks
       // depending on the distance to the previous hunk.

--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -436,14 +436,8 @@ export function getTextDiffWithBottomDummyHunk(
     dummyNewStartLine,
     numberOfNewLines - dummyNewStartLine + 1
   )
-  const dummyLine = new DiffLine(
-    '@@ @@',
-    DiffLineType.Hunk,
-    null,
-    null,
-    null,
-    false
-  )
+  // Use an empty line for this dummy hunk to keep the diff clean
+  const dummyLine = new DiffLine('', DiffLineType.Hunk, null, null, null, false)
   const dummyHunk = new DiffHunk(
     dummyHeader,
     [dummyLine],

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1172,7 +1172,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
 
       hunkExpandWholeHandle.appendChild(
         createOcticonElement(
-          OcticonSymbol.fold,
+          OcticonSymbol.unfold,
           'hunk-expand-icon',
           'hunk-expand-short-icon'
         )

--- a/app/test/unit/text-diff-expansion-test.ts
+++ b/app/test/unit/text-diff-expansion-test.ts
@@ -83,7 +83,7 @@ describe('text-diff-expansion', () => {
 
     const firstLine = lastHunk.lines[0]
     expect(firstLine.type).toBe(DiffLineType.Hunk)
-    expect(firstLine.text).toBe('@@ @@')
+    expect(firstLine.text).toBe('')
     expect(firstLine.newLineNumber).toBe(null)
     expect(firstLine.oldLineNumber).toBe(null)
   })


### PR DESCRIPTION
## Description

This PR makes two changes in diff expansion to be consistent with dotcom's experience:
1. Use the right icon in short diff hunks.
2. Use empty lines for the dummy hunks at the bottom.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1083228/131665315-042655e2-22fc-43c8-bb8c-e12c6f243ec9.png)

After:
![image](https://user-images.githubusercontent.com/1083228/131665501-f0df2860-d5d0-44c3-b170-353e4af57ae4.png)

## Release notes

Notes: [Fixed] Use unfold icon for diff expansion
