### PR TITLE
Use same width for hunk expansion handles as we do for line numbers

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -323,6 +323,7 @@ export class SideBySideDiffRow extends React.Component<
         <div
           className="hunk-expansion-handle"
           onContextMenu={this.props.onContextMenuExpandHunk}
+          style={{ width: this.props.lineNumberWidth }}
         >
           <span></span>
         </div>
@@ -339,6 +340,7 @@ export class SideBySideDiffRow extends React.Component<
         className="hunk-expansion-handle selectable hoverable"
         title={elementInfo.title}
         onClick={elementInfo.handler}
+        style={{ width: this.props.lineNumberWidth }}
         onContextMenu={this.props.onContextMenuExpandHunk}
       >
         <span>


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Noticed that the diff expansion handle gutters didn't use the same size as line numbers in the unified diff view

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

### Before
![image](https://user-images.githubusercontent.com/634063/131694828-83bd6f7f-f1fd-434a-a5d6-59631bddca0e.png)

### After
![image](https://user-images.githubusercontent.com/634063/131694857-5ab0754c-2e3c-4b7b-aced-2d6bcf6cf320.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
