### PR TITLE
Don't update multi commit operation if it is already complete

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4644,6 +4644,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   /** This shouldn't be called directly. See `Dispatcher`. */
   public _setConflictsResolved(repository: Repository) {
+    const { multiCommitOperationState } = this.repositoryStateCache.get(
+      repository
+    )
+
+    // the operation has already completed.
+    if (multiCommitOperationState === null) {
+      return
+    }
+
     // an update is not emitted here because there is no need
     // to trigger a re-render at this point
 


### PR DESCRIPTION
## Description

Fixes bad regression in latest beta that happens during conflict handling of a multi commit operation. I believe this is actually a timing bug that was introduced because I found in the rebase factor where we were not using`await` on something that was causing a race condition. However, now it means that the bit of code that updates  the multi commit operation state on whether conflicts have been resolved or not that fires on the conflict dialog unmounting is happening after the multi commit operation state has already been cleared. Note, this wouldn't happen if a user has more than one conflict in an operation because it only sets this state if it has not already been set and only is a problem the last time the dialog closes.

## Release notes

Notes: [Fixed] App no longer crashes when resolving an multi-commit-operation with a single conflict.
