### PR TITLE
Diff expansion optimizations

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -459,15 +459,15 @@ for (const basenameMode of basenameModes) {
   }
 }
 
-function guessMimeType(contents: string) {
-  if (contents.startsWith('<?xml')) {
+function guessMimeType(contents: ReadonlyArray<string>) {
+  const firstLine = contents[0]
+
+  if (firstLine.startsWith('<?xml')) {
     return 'text/xml'
   }
 
-  if (contents.startsWith('#!')) {
-    const m = /^#!.*?(ts-node|node|bash|sh|python(?:[\d.]+)?)\r?\n/g.exec(
-      contents
-    )
+  if (firstLine.startsWith('#!')) {
+    const m = /^#!.*?(ts-node|node|bash|sh|python(?:[\d.]+)?)/g.exec(firstLine)
 
     if (m) {
       switch (m[1]) {
@@ -497,7 +497,7 @@ async function detectMode(
   const mimeType =
     extensionMIMEMap.get(request.extension.toLowerCase()) ||
     basenameMIMEMap.get(request.basename.toLowerCase()) ||
-    guessMimeType(request.contents)
+    guessMimeType(request.contentLines)
 
   if (!mimeType) {
     return null
@@ -576,7 +576,6 @@ onmessage = async (ev: MessageEvent) => {
   const request = ev.data as IHighlightRequest
 
   const tabSize = request.tabSize || 4
-  const contents = request.contents
   const addModeClass = request.addModeClass === true
 
   const mode = await detectMode(request)
@@ -595,7 +594,7 @@ onmessage = async (ev: MessageEvent) => {
   // line we need so that we can bail immediately when we've reached it.
   const maxLine = lineFilter ? Math.max(...lineFilter) : null
 
-  const lines = contents.split(/\r?\n/)
+  const lines = request.contentLines.concat()
   const state: any = mode.startState ? mode.startState() : null
 
   const tokens: ITokens = {}

--- a/app/src/lib/highlighter/types.ts
+++ b/app/src/lib/highlighter/types.ts
@@ -56,9 +56,9 @@ export interface IHighlightRequest {
   readonly extension: string
 
   /**
-   * The actual contents which is to be used for highlighting.
+   * The actual content lines which is to be used for highlighting.
    */
-  readonly contents: string
+  readonly contentLines: ReadonlyArray<string>
 
   /**
    * An optional filter of lines which needs to be tokenized.

--- a/app/src/lib/highlighter/worker.ts
+++ b/app/src/lib/highlighter/worker.ts
@@ -28,7 +28,7 @@ const workerUri = encodePathAsUrl(__dirname, 'highlighter.js')
  *                  modes we can significantly speed up the highlight process.
  */
 export function highlight(
-  contents: string,
+  contentLines: ReadonlyArray<string>,
   basename: string,
   extension: string,
   tabSize: number,
@@ -36,7 +36,7 @@ export function highlight(
 ): Promise<ITokens> {
   // Bail early if there's no content to highlight or if we don't
   // need any lines from this file.
-  if (!contents.length || !lines.length) {
+  if (!contentLines.length || !lines.length) {
     return Promise.resolve({})
   }
 
@@ -70,7 +70,7 @@ export function highlight(
     }
 
     const request: IHighlightRequest = {
-      contents,
+      contentLines,
       basename,
       extension,
       tabSize,

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -392,9 +392,9 @@ export class SideBySideDiff extends React.Component<
     }
 
     const newContentLines =
-      contents.newContents === null ? [] : contents.newContents.split('\n')
+      contents.newContents === null ? [] : contents.newContents
     const oldContentLines =
-      contents.oldContents === null ? [] : contents.oldContents.split('\n')
+      contents.oldContents === null ? [] : contents.oldContents
 
     const currentDiff = this.state.diff
     const shouldEnableDiffExpansion =

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -114,9 +114,28 @@ interface ISideBySideDiffProps {
   readonly showSideBySideDiff: boolean
 }
 
-interface ISideBySideDiffState {
+interface ISideBySideTextDiffDocumentContents {
+  /** The content lines of the "new" file */
+  readonly newContentLines: ReadonlyArray<string>
+
+  /** The content lines of the "old" file */
+  readonly oldContentLines: ReadonlyArray<string>
+
+  /** Whether or not the file can be expanded */
+  readonly canBeExpanded: boolean
+}
+
+interface ISideBySideTextDiffDocument {
   /** The diff that should be rendered */
   readonly diff: ITextDiff
+
+  /** Contents of the old and new files for this diff. */
+  readonly contents: ISideBySideTextDiffDocumentContents | null
+}
+
+interface ISideBySideDiffState {
+  /** Represents a diff and its associated files (old and new) */
+  readonly document: ISideBySideTextDiffDocument
 
   /**
    * The list of syntax highlighting tokens corresponding to
@@ -187,9 +206,6 @@ export class SideBySideDiff extends React.Component<
 > {
   private virtualListRef = React.createRef<List>()
 
-  /** The content lines of the "new" file */
-  private newContentLines: ReadonlyArray<string> | null = null
-
   /** Diff to restore when "Collapse all expanded lines" option is used */
   private diffToRestore: ITextDiff | null = null
 
@@ -197,7 +213,10 @@ export class SideBySideDiff extends React.Component<
     super(props)
 
     this.state = {
-      diff: props.diff,
+      document: {
+        diff: props.diff,
+        contents: null,
+      },
       isSearching: false,
       selectedSearchResult: undefined,
     }
@@ -232,15 +251,22 @@ export class SideBySideDiff extends React.Component<
 
     if (this.props.diff.text !== prevProps.diff.text) {
       this.diffToRestore = null
-      this.setState({ diff: this.props.diff })
+      this.setState({
+        document: {
+          diff: this.props.diff,
+          contents: null,
+        },
+      })
     }
   }
 
   public render() {
+    const { diff, contents } = this.state.document
+
     const rows = getDiffRows(
-      this.state.diff,
+      diff,
       this.props.showSideBySideDiff,
-      this.newContentLines !== null
+      contents !== null && contents.newContentLines.length > 0
     )
     const containerClassName = classNames('side-by-side-diff-container', {
       'unified-diff': !this.props.showSideBySideDiff,
@@ -291,10 +317,11 @@ export class SideBySideDiff extends React.Component<
   }
 
   private renderRow = ({ index, parent, style, key }: ListRowProps) => {
+    const { diff, contents } = this.state.document
     const rows = getDiffRows(
-      this.state.diff,
+      diff,
       this.props.showSideBySideDiff,
-      this.newContentLines !== null
+      contents !== null && contents.newContentLines.length > 0
     )
     const row = rows[index]
 
@@ -303,7 +330,7 @@ export class SideBySideDiff extends React.Component<
     }
 
     const lineNumberWidth = `${getLineWidthFromDigitCount(
-      getNumberOfDigits(this.state.diff.maxLineNumber)
+      getNumberOfDigits(diff.maxLineNumber)
     )}px`
 
     const rowWithTokens = this.createFullRow(row, index)
@@ -354,7 +381,7 @@ export class SideBySideDiff extends React.Component<
 
   private async initDiffSyntaxMode() {
     const { file, repository } = this.props
-    const { diff } = this.state
+    const { contents: currentContents, diff: currentDiff } = this.state.document
 
     // Store the current props and state so that we can see if anything
     // changes from underneath us as we're making asynchronous
@@ -362,10 +389,18 @@ export class SideBySideDiff extends React.Component<
     const propsSnapshot = this.props
     const stateSnapshot = this.state
 
-    const lineFilters = getLineFilters(diff.hunks)
+    const lineFilters = getLineFilters(currentDiff.hunks)
     const tabSize = 4
 
-    const contents = await getFileContents(repository, file, lineFilters)
+    const contents =
+      currentContents !== null
+        ? {
+            file,
+            newContents: currentContents.newContentLines,
+            oldContents: currentContents.oldContentLines,
+            canBeExpanded: currentContents.canBeExpanded,
+          }
+        : await getFileContents(repository, file, lineFilters)
 
     if (
       !highlightParametersEqual(
@@ -391,12 +426,9 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const newContentLines =
-      contents.newContents === null ? [] : contents.newContents
-    const oldContentLines =
-      contents.oldContents === null ? [] : contents.oldContents
+    const newContentLines = contents.newContents ?? []
+    const oldContentLines = contents.oldContents ?? []
 
-    const currentDiff = this.state.diff
     const shouldEnableDiffExpansion =
       enableTextDiffExpansion() && contents.canBeExpanded
     const newDiff = shouldEnableDiffExpansion
@@ -407,10 +439,16 @@ export class SideBySideDiff extends React.Component<
           newContentLines.length
         )
       : null
-    this.newContentLines = shouldEnableDiffExpansion ? newContentLines : null
 
     this.setState({
-      diff: newDiff ?? currentDiff,
+      document: {
+        diff: newDiff ?? currentDiff,
+        contents: {
+          newContentLines: shouldEnableDiffExpansion ? newContentLines : [],
+          oldContentLines: shouldEnableDiffExpansion ? oldContentLines : [],
+          canBeExpanded: contents.canBeExpanded,
+        },
+      },
       beforeTokens: tokens.oldTokens,
       afterTokens: tokens.newTokens,
     })
@@ -558,10 +596,11 @@ export class SideBySideDiff extends React.Component<
     rowNumber: number,
     column: DiffColumn
   ): number | null {
+    const { diff, contents } = this.state.document
     const rows = getDiffRows(
-      this.state.diff,
+      diff,
       this.props.showSideBySideDiff,
-      this.newContentLines !== null
+      contents !== null && contents.newContentLines.length > 0
     )
     const row = rows[rowNumber]
 
@@ -675,7 +714,7 @@ export class SideBySideDiff extends React.Component<
   }
 
   private onExpandHunk = (hunkIndex: number, kind: DiffExpansionKind) => {
-    const { diff } = this.state
+    const { diff } = this.state.document
 
     if (hunkIndex === -1 || hunkIndex >= diff.hunks.length) {
       return
@@ -689,7 +728,7 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    const { diff } = this.state
+    const { diff } = this.state.document
     const selection = this.getSelection()
 
     if (selection !== undefined) {
@@ -732,7 +771,7 @@ export class SideBySideDiff extends React.Component<
    */
   private onContextMenuLine = (diffLineNumber: number) => {
     const { file, hideWhitespaceInDiff } = this.props
-    const { diff } = this.state
+    const { diff } = this.state.document
 
     if (!canSelect(file)) {
       return
@@ -760,11 +799,14 @@ export class SideBySideDiff extends React.Component<
   }
 
   private buildExpandMenuItem(): IMenuItem | null {
-    if (!enableTextDiffExpansion() || this.newContentLines === null) {
+    const { diff, contents } = this.state.document
+    if (
+      !enableTextDiffExpansion() ||
+      contents === null ||
+      contents.newContentLines.length === 0
+    ) {
       return null
     }
-
-    const diff = this.state.diff
 
     return this.diffToRestore === null
       ? {
@@ -784,23 +826,25 @@ export class SideBySideDiff extends React.Component<
   }
 
   private onExpandWholeFile = () => {
-    if (this.newContentLines === null || this.newContentLines.length === 0) {
+    const { diff, contents } = this.state.document
+
+    if (contents === null || contents.newContentLines.length === 0) {
       return
     }
 
-    const updatedDiff = expandWholeTextDiff(
-      this.state.diff,
-      this.newContentLines
-    )
+    const updatedDiff = expandWholeTextDiff(diff, contents.newContentLines)
 
     if (updatedDiff === undefined) {
       return
     }
 
-    this.diffToRestore = this.state.diff
+    this.diffToRestore = diff
 
     this.setState({
-      diff: updatedDiff,
+      document: {
+        ...this.state.document,
+        diff: updatedDiff,
+      },
     })
   }
 
@@ -810,7 +854,10 @@ export class SideBySideDiff extends React.Component<
     }
 
     this.setState({
-      diff: this.diffToRestore,
+      document: {
+        ...this.state.document,
+        diff: this.diffToRestore,
+      },
     })
 
     this.diffToRestore = null
@@ -831,7 +878,7 @@ export class SideBySideDiff extends React.Component<
     }
 
     const range = findInteractiveOriginalDiffRange(
-      this.state.diff.hunks,
+      this.state.document.diff.hunks,
       hunkStartLine
     )
     if (range === null || range.type === null) {
@@ -918,7 +965,7 @@ export class SideBySideDiff extends React.Component<
   private onSearch = (searchQuery: string, direction: 'next' | 'previous') => {
     let { selectedSearchResult, searchResults: searchResults } = this.state
     const { showSideBySideDiff } = this.props
-    const { diff } = this.state
+    const { diff, contents } = this.state.document
 
     // If the query is unchanged and we've got tokens we'll continue, else we'll restart
     if (searchQuery === this.state.searchQuery && searchResults !== undefined) {
@@ -937,7 +984,7 @@ export class SideBySideDiff extends React.Component<
         diff,
         showSideBySideDiff,
         searchQuery,
-        this.newContentLines !== null
+        contents !== null && contents.newContentLines.length > 0
       )
       selectedSearchResult = 0
 
@@ -971,9 +1018,9 @@ export class SideBySideDiff extends React.Component<
 
   /** Expand a selected hunk. */
   private expandHunk(hunk: DiffHunk, kind: DiffExpansionKind) {
-    const { diff } = this.state
+    const { diff, contents } = this.state.document
 
-    if (this.newContentLines === null || this.newContentLines.length === 0) {
+    if (contents === null || contents.newContentLines.length === 0) {
       return
     }
 
@@ -981,7 +1028,7 @@ export class SideBySideDiff extends React.Component<
       diff,
       hunk,
       kind,
-      this.newContentLines
+      contents.newContentLines
     )
 
     if (updatedDiff === undefined) {
@@ -989,7 +1036,10 @@ export class SideBySideDiff extends React.Component<
     }
 
     this.setState({
-      diff: updatedDiff,
+      document: {
+        ...this.state.document,
+        diff: updatedDiff,
+      },
     })
   }
 }
@@ -1011,7 +1061,7 @@ function highlightParametersEqual(
     (newProps === prevProps ||
       (newProps.file.id === prevProps.file.id &&
         newProps.showSideBySideDiff === prevProps.showSideBySideDiff)) &&
-    newState.diff.text === prevState.diff.text
+    newState.document.diff.text === prevState.document.diff.text
   )
 }
 

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -36,8 +36,8 @@ interface ILineFilters {
 
 interface IFileContents {
   readonly file: ChangedFile
-  readonly oldContents: string | null
-  readonly newContents: string | null
+  readonly oldContents: ReadonlyArray<string> | null
+  readonly newContents: ReadonlyArray<string> | null
   readonly canBeExpanded: boolean
 }
 
@@ -135,8 +135,10 @@ export async function getFileContents(
 
   return {
     file,
-    oldContents: oldContents === null ? null : oldContents.toString('utf8'),
-    newContents: newContents === null ? null : newContents.toString('utf8'),
+    oldContents:
+      oldContents === null ? null : oldContents.toString('utf8').split(/\r?\n/),
+    newContents:
+      newContents === null ? null : newContents.toString('utf8').split(/\r?\n/),
     canBeExpanded:
       newContents !== null &&
       newContents.length <= MaxDiffExpansionNewContentLength,

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -34,10 +34,10 @@ interface ILineFilters {
   readonly newLineFilter: Array<number>
 }
 
-interface IFileContents {
+export interface IFileContents {
   readonly file: ChangedFile
-  readonly oldContents: ReadonlyArray<string> | null
-  readonly newContents: ReadonlyArray<string> | null
+  readonly oldContents: ReadonlyArray<string>
+  readonly newContents: ReadonlyArray<string>
   readonly canBeExpanded: boolean
 }
 
@@ -135,10 +135,8 @@ export async function getFileContents(
 
   return {
     file,
-    oldContents:
-      oldContents === null ? null : oldContents.toString('utf8').split(/\r?\n/),
-    newContents:
-      newContents === null ? null : newContents.toString('utf8').split(/\r?\n/),
+    oldContents: oldContents?.toString('utf8').split(/\r?\n/) ?? [],
+    newContents: newContents?.toString('utf8').split(/\r?\n/) ?? [],
     canBeExpanded:
       newContents !== null &&
       newContents.length <= MaxDiffExpansionNewContentLength,

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -418,9 +418,9 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     }
 
     const newContentLines =
-      contents.newContents === null ? [] : contents.newContents.split('\n')
+      contents.newContents === null ? [] : contents.newContents
     const oldContentLines =
-      contents.oldContents === null ? [] : contents.oldContents.split('\n')
+      contents.oldContents === null ? [] : contents.oldContents
 
     const currentDiff = this.state.diff
     const shouldEnableDiffExpansion =

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -445,10 +445,8 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       return
     }
 
-    const newContentLines =
-      contents.newContents === null ? [] : contents.newContents
-    const oldContentLines =
-      contents.oldContents === null ? [] : contents.oldContents
+    const newContentLines = contents.newContents ?? []
+    const oldContentLines = contents.oldContents ?? []
 
     const shouldEnableDiffExpansion =
       enableTextDiffExpansion() && contents.canBeExpanded


### PR DESCRIPTION
## Description

In a conversation with @niik, he pointed out that the app was loading the file contents several times since diff expansion was added. It was especially bad that the app read the files (old and new) twice in a row the first time a diff is displayed.

After discussing some alternatives, we decided to cache the file contents in memory, when the diff can be expanded. That will happen when the files, old and new, are smaller than 256KB. That means, we would only cache up to 0.5MB.

### Screenshots

Before:

https://user-images.githubusercontent.com/1083228/131876584-7a63f60f-fcc2-4d6b-b3b6-3c133cbae40a.mov

After:

https://user-images.githubusercontent.com/1083228/131873777-48fe982e-3bf6-4b1c-8a0b-afbd04a11dd8.mov

## Release notes

Notes: [Improved] Better performance displaying diffs
