### PR TITLE
Fix gaps in the commit message container revealing a different background

### DIFF
--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -59,6 +59,9 @@
   &.with-action-bar {
     .description-field textarea {
       min-height: 80px;
+
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
   }
 
@@ -108,7 +111,9 @@
     .action-bar {
       padding: var(--spacing-half);
       background: var(--box-background-color);
-      border-radius: var(--border-radius);
+
+      border-bottom-left-radius: var(--border-radius);
+      border-bottom-right-radius: var(--border-radius);
 
       // We're not faking being a textbox any more
       cursor: default;

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -33,8 +33,11 @@
   }
 
   &.with-co-authors .description-focus-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    .action-bar,
+    & {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 
   .co-authors-toggle {


### PR DESCRIPTION
Fixes #12900

### Screenshots

State | Before | After
--- | --- | ---
Initial | ![Commit message container with gaps][0] | ![Commit message container without gaps][1]
Selected | ![Selected commit message container with gaps][2] | ![Selected commit message container without gaps][3]

## Release notes

Notes:

- [Fixed] Cleaned up the gaps above the action bar in the commit message container

[0]: https://user-images.githubusercontent.com/24855774/132023581-97979a5f-5218-4fb6-9d1e-bbe68377979d.png
[1]: https://user-images.githubusercontent.com/24855774/132023432-a8f45c2f-5144-4a68-ae26-e5e3ff766517.png
[2]: https://user-images.githubusercontent.com/24855774/132023811-5200f782-9c1f-4626-9fa3-da266cbcd19d.png
[3]: https://user-images.githubusercontent.com/24855774/132023391-d2e6f8d2-54d0-4331-a862-85b666bbb9a1.png