### PR TITLE
Improve diff render and load

### DIFF
--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -119,12 +119,19 @@ export class DiffSyntaxMode {
   }
 
   public blankLine(state: IState) {
+    // If we run into a blank line and we don't have hunks yet, and given we
+    // should never get blank diffs, let's assume we're in the last line of a
+    // diff that was just loaded, but for which we haven't run the highlighter
+    // yet. If we don't do this, that last line will be formatted wrongly.
+    if (this.hunks === undefined) {
+      return getBaseDiffLineStyle('diff-hunk')
+    }
+
     // A line might be empty in a non-blank diff for the only line of the
     // dummy hunk we put at the bottom of the diff to allow users to expand
     // the visible contents.
-    if (this.hunks !== undefined && this.hunks.length > 0) {
+    if (this.hunks.length > 0) {
       const diffLine = diffLineForIndex(this.hunks, state.diffLineIndex)
-
       if (diffLine?.type === DiffLineType.Hunk) {
         return getBaseDiffLineStyle('diff-hunk')
       }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -33,6 +33,7 @@ import {
   enableHideWhitespaceInDiffOption,
   enableExperimentalDiffViewer,
 } from '../../lib/feature-flag'
+import { IFileContents } from './syntax-highlighting'
 
 // image used when no diff is displayed
 const NoDiffImage = encodePathAsUrl(__dirname, 'static/ufo-alert.svg')
@@ -58,6 +59,9 @@ interface IDiffProps {
 
   /** The diff that should be rendered */
   readonly diff: IDiff
+
+  /** Contents of the old and new files related to the current text diff. */
+  readonly fileContents: IFileContents | null
 
   /** The type of image diff to display. */
   readonly imageDiffType: ImageDiffType
@@ -276,6 +280,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
         onIncludeChanged={this.props.onIncludeChanged}
         onDiscardChanges={this.props.onDiscardChanges}
         diff={diff}
+        fileContents={this.props.fileContents}
         askForConfirmationOnDiscardChanges={
           this.props.askForConfirmationOnDiscardChanges
         }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -60,7 +60,10 @@ interface IDiffProps {
   /** The diff that should be rendered */
   readonly diff: IDiff
 
-  /** Contents of the old and new files related to the current text diff. */
+  /**
+   * Contents of the old and new files related to the current text diff. Only
+   * needed for diffs that can be expanded.
+   */
   readonly fileContents: IFileContents | null
 
   /** The type of image diff to display. */

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -260,6 +260,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
           repository={this.props.repository}
           file={this.props.file}
           diff={diff}
+          fileContents={this.props.fileContents}
           hideWhitespaceInDiff={hideWhitespaceInDiff}
           showSideBySideDiff={this.props.showSideBySideDiff}
           onIncludeChanged={this.props.onIncludeChanged}

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -61,8 +61,8 @@ interface IDiffProps {
   readonly diff: IDiff
 
   /**
-   * Contents of the old and new files related to the current text diff. Only
-   * needed for diffs that can be expanded.
+   * Contents of the old and new files related to the current text diff. Must
+   * be null for diffs that cannot be expanded.
    */
   readonly fileContents: IFileContents | null
 

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -61,8 +61,7 @@ interface IDiffProps {
   readonly diff: IDiff
 
   /**
-   * Contents of the old and new files related to the current text diff. Must
-   * be null for diffs that cannot be expanded.
+   * Contents of the old and new files related to the current text diff.
    */
   readonly fileContents: IFileContents | null
 

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -143,6 +143,11 @@ export class SeamlessDiffSwitcher extends React.Component<
       props.diff === null ||
       (props.diff.kind === DiffType.Text && fileContents === null)
     const beganOrFinishedLoadingDiff = isLoadingDiff !== state.isLoadingDiff
+    // If the props diff is not a Text diff, just pass it along to the state.
+    const diff =
+      props.diff !== null && props.diff.kind !== DiffType.Text
+        ? props.diff
+        : state.diff
 
     return {
       isLoadingDiff,
@@ -151,7 +156,7 @@ export class SeamlessDiffSwitcher extends React.Component<
       // can't say that it's slow in all other cases we leave the
       // isLoadingSlow state as-is
       ...(beganOrFinishedLoadingDiff ? { isLoadingSlow: false } : undefined),
-      diff: state.diff,
+      diff,
       fileContents,
     }
   }
@@ -254,7 +259,7 @@ export class SeamlessDiffSwitcher extends React.Component<
 
     this.loadingFile = null
 
-    this.setState({ diff: newDiff, fileContents })
+    this.setState({ diff: newDiff ?? diff, fileContents })
   }
 
   private onSlowLoadingTimeout = () => {

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -316,7 +316,9 @@ export class SeamlessDiffSwitcher extends React.Component<
             imageDiffType={imageDiffType}
             file={file}
             diff={diff}
-            fileContents={fileContents}
+            fileContents={
+              fileContents?.canBeExpanded === true ? fileContents : null
+            }
             readOnly={readOnly}
             hideWhitespaceInDiff={hideWhitespaceInDiff}
             showSideBySideDiff={showSideBySideDiff}

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -316,9 +316,7 @@ export class SeamlessDiffSwitcher extends React.Component<
             imageDiffType={imageDiffType}
             file={file}
             diff={diff}
-            fileContents={
-              fileContents?.canBeExpanded === true ? fileContents : null
-            }
+            fileContents={fileContents}
             readOnly={readOnly}
             hideWhitespaceInDiff={hideWhitespaceInDiff}
             showSideBySideDiff={showSideBySideDiff}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -84,8 +84,8 @@ interface ISideBySideDiffProps {
   readonly diff: ITextDiff
 
   /**
-   * Contents of the old and new files related to the current diff. Only needed
-   * for diffs that can be expanded.
+   * Contents of the old and new files related to the current text diff. Must
+   * be null for diffs that cannot be expanded.
    */
   readonly fileContents: IFileContents | null
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -50,7 +50,6 @@ import { showContextualMenu } from '../main-process-proxy'
 import { getTokens } from './diff-syntax-mode'
 import { DiffSearchInput } from './diff-search-input'
 import { escapeRegExp } from '../../lib/helpers/regex'
-import { enableTextDiffExpansion } from '../../lib/feature-flag'
 import {
   expandTextDiffHunk,
   DiffExpansionKind,
@@ -752,7 +751,6 @@ export class SideBySideDiff extends React.Component<
     const contents = this.props.fileContents
     const { diff } = this.state
     if (
-      !enableTextDiffExpansion() ||
       contents === null ||
       !contents.canBeExpanded ||
       contents.newContents.length === 0

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -238,16 +238,22 @@ export class SideBySideDiff extends React.Component<
     }
   }
 
-  public render() {
+  private canExpandDiff() {
     const contents = this.props.fileContents
+    return (
+      contents !== null &&
+      contents.canBeExpanded &&
+      contents.newContents.length > 0
+    )
+  }
+
+  public render() {
     const { diff } = this.state
 
     const rows = getDiffRows(
       diff,
       this.props.showSideBySideDiff,
-      contents !== null &&
-        contents.canBeExpanded &&
-        contents.newContents.length > 0
+      this.canExpandDiff()
     )
     const containerClassName = classNames('side-by-side-diff-container', {
       'unified-diff': !this.props.showSideBySideDiff,
@@ -298,14 +304,11 @@ export class SideBySideDiff extends React.Component<
   }
 
   private renderRow = ({ index, parent, style, key }: ListRowProps) => {
-    const contents = this.props.fileContents
     const { diff } = this.state
     const rows = getDiffRows(
       diff,
       this.props.showSideBySideDiff,
-      contents !== null &&
-        contents.canBeExpanded &&
-        contents.newContents.length > 0
+      this.canExpandDiff()
     )
     const row = rows[index]
 
@@ -542,14 +545,11 @@ export class SideBySideDiff extends React.Component<
     rowNumber: number,
     column: DiffColumn
   ): number | null {
-    const contents = this.props.fileContents
     const { diff } = this.state
     const rows = getDiffRows(
       diff,
       this.props.showSideBySideDiff,
-      contents !== null &&
-        contents.canBeExpanded &&
-        contents.newContents.length > 0
+      this.canExpandDiff()
     )
     const row = rows[rowNumber]
 
@@ -748,13 +748,8 @@ export class SideBySideDiff extends React.Component<
   }
 
   private buildExpandMenuItem(): IMenuItem | null {
-    const contents = this.props.fileContents
     const { diff } = this.state
-    if (
-      contents === null ||
-      !contents.canBeExpanded ||
-      contents.newContents.length === 0
-    ) {
+    if (!this.canExpandDiff()) {
       return null
     }
 
@@ -779,11 +774,7 @@ export class SideBySideDiff extends React.Component<
     const contents = this.props.fileContents
     const { diff } = this.state
 
-    if (
-      contents === null ||
-      !contents.canBeExpanded ||
-      contents.newContents.length === 0
-    ) {
+    if (contents === null || !this.canExpandDiff()) {
       return
     }
 
@@ -910,7 +901,6 @@ export class SideBySideDiff extends React.Component<
   private onSearch = (searchQuery: string, direction: 'next' | 'previous') => {
     let { selectedSearchResult, searchResults: searchResults } = this.state
     const { showSideBySideDiff } = this.props
-    const contents = this.props.fileContents
     const { diff } = this.state
 
     // If the query is unchanged and we've got tokens we'll continue, else we'll restart
@@ -930,9 +920,7 @@ export class SideBySideDiff extends React.Component<
         diff,
         showSideBySideDiff,
         searchQuery,
-        contents !== null &&
-          contents.canBeExpanded &&
-          contents.newContents.length > 0
+        this.canExpandDiff()
       )
       selectedSearchResult = 0
 
@@ -969,11 +957,7 @@ export class SideBySideDiff extends React.Component<
     const contents = this.props.fileContents
     const { diff } = this.state
 
-    if (
-      contents === null ||
-      !contents.canBeExpanded ||
-      contents.newContents.length === 0
-    ) {
+    if (contents === null || !this.canExpandDiff()) {
       return
     }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -787,9 +787,7 @@ export class SideBySideDiff extends React.Component<
 
     this.diffToRestore = diff
 
-    this.setState({
-      diff: updatedDiff,
-    })
+    this.setState({ diff: updatedDiff })
   }
 
   private onCollapseExpandedLines = () => {
@@ -797,9 +795,7 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    this.setState({
-      diff: this.diffToRestore,
-    })
+    this.setState({ diff: this.diffToRestore })
 
     this.diffToRestore = null
   }
@@ -978,9 +974,7 @@ export class SideBySideDiff extends React.Component<
       return
     }
 
-    this.setState({
-      diff: updatedDiff,
-    })
+    this.setState({ diff: updatedDiff })
   }
 }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -993,7 +993,8 @@ function highlightParametersEqual(
     (newProps === prevProps ||
       (newProps.file.id === prevProps.file.id &&
         newProps.showSideBySideDiff === prevProps.showSideBySideDiff)) &&
-    newState.diff.text === prevState.diff.text
+    newState.diff.text === prevState.diff.text &&
+    prevProps.fileContents?.file.id === newProps.fileContents?.file.id
   )
 }
 

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -83,7 +83,10 @@ interface ISideBySideDiffProps {
   /** The initial diff */
   readonly diff: ITextDiff
 
-  /** The contents of the old and new files related to the current diff. */
+  /**
+   * Contents of the old and new files related to the current diff. Only needed
+   * for diffs that can be expanded.
+   */
   readonly fileContents: IFileContents | null
 
   /**

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -84,8 +84,7 @@ interface ISideBySideDiffProps {
   readonly diff: ITextDiff
 
   /**
-   * Contents of the old and new files related to the current text diff. Must
-   * be null for diffs that cannot be expanded.
+   * Contents of the old and new files related to the current text diff.
    */
   readonly fileContents: IFileContents | null
 
@@ -247,7 +246,9 @@ export class SideBySideDiff extends React.Component<
     const rows = getDiffRows(
       diff,
       this.props.showSideBySideDiff,
-      contents !== null && contents.newContents.length > 0
+      contents !== null &&
+        contents.canBeExpanded &&
+        contents.newContents.length > 0
     )
     const containerClassName = classNames('side-by-side-diff-container', {
       'unified-diff': !this.props.showSideBySideDiff,
@@ -303,7 +304,9 @@ export class SideBySideDiff extends React.Component<
     const rows = getDiffRows(
       diff,
       this.props.showSideBySideDiff,
-      contents !== null && contents.newContents.length > 0
+      contents !== null &&
+        contents.canBeExpanded &&
+        contents.newContents.length > 0
     )
     const row = rows[index]
 
@@ -545,7 +548,9 @@ export class SideBySideDiff extends React.Component<
     const rows = getDiffRows(
       diff,
       this.props.showSideBySideDiff,
-      contents !== null && contents.newContents.length > 0
+      contents !== null &&
+        contents.canBeExpanded &&
+        contents.newContents.length > 0
     )
     const row = rows[rowNumber]
 
@@ -749,6 +754,7 @@ export class SideBySideDiff extends React.Component<
     if (
       !enableTextDiffExpansion() ||
       contents === null ||
+      !contents.canBeExpanded ||
       contents.newContents.length === 0
     ) {
       return null
@@ -775,7 +781,11 @@ export class SideBySideDiff extends React.Component<
     const contents = this.props.fileContents
     const { diff } = this.state
 
-    if (contents === null || contents.newContents.length === 0) {
+    if (
+      contents === null ||
+      !contents.canBeExpanded ||
+      contents.newContents.length === 0
+    ) {
       return
     }
 
@@ -922,7 +932,9 @@ export class SideBySideDiff extends React.Component<
         diff,
         showSideBySideDiff,
         searchQuery,
-        contents !== null && contents.newContents.length > 0
+        contents !== null &&
+          contents.canBeExpanded &&
+          contents.newContents.length > 0
       )
       selectedSearchResult = 0
 
@@ -959,7 +971,11 @@ export class SideBySideDiff extends React.Component<
     const contents = this.props.fileContents
     const { diff } = this.state
 
-    if (contents === null || contents.newContents.length === 0) {
+    if (
+      contents === null ||
+      !contents.canBeExpanded ||
+      contents.newContents.length === 0
+    ) {
       return
     }
 

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -138,6 +138,7 @@ export async function getFileContents(
     oldContents: oldContents?.toString('utf8').split(/\r?\n/) ?? [],
     newContents: newContents?.toString('utf8').split(/\r?\n/) ?? [],
     canBeExpanded:
+      enableTextDiffExpansion() &&
       newContents !== null &&
       newContents.length <= MaxDiffExpansionNewContentLength,
   }

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -41,7 +41,6 @@ import { clamp } from '../../lib/clamp'
 import { uuid } from '../../lib/uuid'
 import { showContextualMenu } from '../main-process-proxy'
 import { IMenuItem } from '../../lib/menu-item'
-import { enableTextDiffExpansion } from '../../lib/feature-flag'
 import {
   canSelect,
   getLineWidthFromDigitCount,
@@ -653,7 +652,6 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     const contents = this.props.fileContents
 
     if (
-      !enableTextDiffExpansion() ||
       contents === null ||
       !contents.canBeExpanded ||
       contents.newContents.length === 0
@@ -1038,7 +1036,6 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
 
     const contents = this.props.fileContents
     const shouldEnableDiffExpansion =
-      enableTextDiffExpansion() &&
       contents !== null &&
       contents.canBeExpanded &&
       contents.newContents.length > 0
@@ -1107,7 +1104,6 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     const contents = this.props.fileContents
 
     if (
-      enableTextDiffExpansion() &&
       contents !== null &&
       contents.canBeExpanded &&
       contents.newContents.length > 0

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -588,15 +588,20 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     return this.selection === null
   }
 
+  private canExpandDiff() {
+    const contents = this.props.fileContents
+    return (
+      contents !== null &&
+      contents.canBeExpanded &&
+      contents.newContents.length > 0
+    )
+  }
+
   /** Expand a selected hunk. */
   private expandHunk(hunk: DiffHunk, kind: DiffExpansionKind) {
     const contents = this.props.fileContents
 
-    if (
-      contents === null ||
-      !contents.canBeExpanded ||
-      contents.newContents.length === 0
-    ) {
+    if (contents === null || !this.canExpandDiff()) {
       return
     }
 
@@ -649,13 +654,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   }
 
   private buildExpandMenuItem(event: Event): IMenuItem | null {
-    const contents = this.props.fileContents
-
-    if (
-      contents === null ||
-      !contents.canBeExpanded ||
-      contents.newContents.length === 0
-    ) {
+    if (!this.canExpandDiff()) {
       return null
     }
 
@@ -773,11 +772,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   private onExpandWholeFile = () => {
     const contents = this.props.fileContents
 
-    if (
-      contents === null ||
-      !contents.canBeExpanded ||
-      contents.newContents.length === 0
-    ) {
+    if (contents === null || !this.canExpandDiff()) {
       return
     }
 
@@ -1034,11 +1029,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       diffLine.originalLineNumber !== null &&
       inSelection(this.hunkHighlightRange, diffLine.originalLineNumber)
 
-    const contents = this.props.fileContents
-    const shouldEnableDiffExpansion =
-      contents !== null &&
-      contents.canBeExpanded &&
-      contents.newContents.length > 0
+    const shouldEnableDiffExpansion = this.canExpandDiff()
 
     return {
       'diff-line-gutter': true,
@@ -1101,13 +1092,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     hunkHandle.classList.add('hunk-handle')
     marker.appendChild(hunkHandle)
 
-    const contents = this.props.fileContents
-
-    if (
-      contents !== null &&
-      contents.canBeExpanded &&
-      contents.newContents.length > 0
-    ) {
+    if (this.canExpandDiff()) {
       const hunkExpandUpHandle = document.createElement('div')
       hunkExpandUpHandle.classList.add('hunk-expand-up-handle')
       hunkExpandUpHandle.title = 'Expand Up'

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -84,7 +84,8 @@ function highlightParametersEqual(
 ) {
   return (
     (newProps === prevProps || newProps.file.id === prevProps.file.id) &&
-    newState.diff.text === prevState.diff.text
+    newState.diff.text === prevState.diff.text &&
+    prevProps.fileContents?.file.id === newProps.fileContents?.file.id
   )
 }
 

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -151,8 +151,7 @@ interface ITextDiffProps {
   /** The initial diff that should be rendered */
   readonly diff: ITextDiff
   /**
-   * Contents of the old and new files related to the current text diff. Must
-   * be null for diffs that cannot be expanded.
+   * Contents of the old and new files related to the current text diff.
    */
   readonly fileContents: IFileContents | null
   /** If true, no selections or discards can be done against this diff. */
@@ -594,7 +593,11 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   private expandHunk(hunk: DiffHunk, kind: DiffExpansionKind) {
     const contents = this.props.fileContents
 
-    if (contents === null || contents.newContents.length === 0) {
+    if (
+      contents === null ||
+      !contents.canBeExpanded ||
+      contents.newContents.length === 0
+    ) {
       return
     }
 
@@ -652,6 +655,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     if (
       !enableTextDiffExpansion() ||
       contents === null ||
+      !contents.canBeExpanded ||
       contents.newContents.length === 0
     ) {
       return null
@@ -771,7 +775,11 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   private onExpandWholeFile = () => {
     const contents = this.props.fileContents
 
-    if (contents === null || contents.newContents.length === 0) {
+    if (
+      contents === null ||
+      !contents.canBeExpanded ||
+      contents.newContents.length === 0
+    ) {
       return
     }
 
@@ -1032,6 +1040,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     const shouldEnableDiffExpansion =
       enableTextDiffExpansion() &&
       contents !== null &&
+      contents.canBeExpanded &&
       contents.newContents.length > 0
 
     return {
@@ -1100,6 +1109,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     if (
       enableTextDiffExpansion() &&
       contents !== null &&
+      contents.canBeExpanded &&
       contents.newContents.length > 0
     ) {
       const hunkExpandUpHandle = document.createElement('div')

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -609,9 +609,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       return
     }
 
-    this.setState({
-      diff: updatedDiff,
-    })
+    this.setState({ diff: updatedDiff })
     this.updateViewport()
   }
 
@@ -788,9 +786,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
 
     this.diffToRestore = this.state.diff
 
-    this.setState({
-      diff: updatedDiff,
-    })
+    this.setState({ diff: updatedDiff })
     this.updateViewport()
   }
 
@@ -799,9 +795,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       return
     }
 
-    this.setState({
-      diff: this.diffToRestore,
-    })
+    this.setState({ diff: this.diffToRestore })
     this.updateViewport()
 
     this.diffToRestore = null

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -151,8 +151,8 @@ interface ITextDiffProps {
   /** The initial diff that should be rendered */
   readonly diff: ITextDiff
   /**
-   * Contents of the old and new files related to the current diff. Only needed
-   * for diffs that can be expanded.
+   * Contents of the old and new files related to the current text diff. Must
+   * be null for diffs that cannot be expanded.
    */
   readonly fileContents: IFileContents | null
   /** If true, no selections or discards can be done against this diff. */

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -150,7 +150,10 @@ interface ITextDiffProps {
   readonly file: ChangedFile
   /** The initial diff that should be rendered */
   readonly diff: ITextDiff
-  /** The contents of the old and new files related to the current diff. */
+  /**
+   * Contents of the old and new files related to the current diff. Only needed
+   * for diffs that can be expanded.
+   */
   readonly fileContents: IFileContents | null
   /** If true, no selections or discards can be done against this diff. */
   readonly readOnly: boolean


### PR DESCRIPTION
## Description

This PR brings MOAR optimizations discussed with @niik. After #12893, we also wanted to get rid of some of the glitches that made the experience jarring, like lines changing height or the hunk at the bottom to expand the diff popping up a few milliseconds:

https://user-images.githubusercontent.com/1083228/132034431-cabef7a3-96a2-4599-870d-c5424a35cbe8.mov

The problem was that for diff expansion we needed to load the file contents before we know whether or not the file can be expanded (also from the bottom). Once we know, we can start showing the nice unfold icons, and for that we might need to tweak the height of the affected lines.

These contents were loaded a few milliseconds after the diff is rendered for the first time, so we've moved here that part to the `SeamlessDiffSwitcher`. That way, we can leverage its logic to show the old diff for as long as we need before both the diff and the file contents are available, replacing that old diff with a spinner if the load takes too long, and finally switching to the new diff once everything is ready for perfect first render 😍 

### Screenshots

This is how it looks on my machine when I switch quickly between files:

https://user-images.githubusercontent.com/1083228/132034982-4cef499a-9ea1-48fd-9bd5-b61e1078aab2.mov

And then if I simulate that loading the file contents takes longer, we show the loading feedback as expected…

https://user-images.githubusercontent.com/1083228/132035096-069bb742-c376-4e6c-ac4d-59dc2a907f35.mov

## Release notes

Notes: [Fixed] Fixed glitches when diffs are shown for the first time
