### PR TITLE
Update roadmap and contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,11 +33,7 @@ Please report unacceptable behavior to [opensource+desktop@github.com](mailto:op
 
 ### The Roadmap
 
-GitHub Desktop recently announced its
-[1.0 release](https://github.com/blog/2437-announcing-github-desktop-1-0) and
-are working towards deprecating the classic Mac and Windows applications.
-
-Beyond that, we are working on a roadmap you can read [here](https://github.com/desktop/desktop/blob/development/docs/process/roadmap.md).
+We are working on a roadmap you can read [here](https://github.com/desktop/desktop/blob/development/docs/process/roadmap.md).
 The immediate milestones are more detailed, and the latter milestones are more
 fuzzy and subject to change.
 

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -4,13 +4,17 @@ The following are the larger areas of upcoming work the GitHub Desktop team inte
 
 #### Native arm64 support for macOS and Windows
 
-- Provide support for arm64 Windows machines and Apple Silicon (M1) machines: [#9691](https://github.com/desktop/desktop/pull/9691)
-
-#### Expanding diffs
-
-- Allow users to expand diffs to get more context outside of the specific hunk where the change is: [#7014](https://github.com/desktop/desktop/issues/7014)
+- Provide support for arm64 Windows machines: [#9691](https://github.com/desktop/desktop/pull/9691)
 
 ## Shipped in previous releases
+
+#### Native support for Apple Silicon (M1)
+
+- Provide support for Apple Silicon (M1) machines: [#9691](https://github.com/desktop/desktop/pull/9691)
+
+#### Expanding diffs (2.8.0)
+
+- Allow users to expand diffs to get more context outside of the specific hunk where the change is: [#7014](https://github.com/desktop/desktop/issues/7014)
 
 #### Cherry-picking commits from one branch to another (2.7.1)
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]

## Description

- Updates to roadmap to mark diff expansion and M1 support as done.
- Removes mention of recently shipping 1.0 (that was almost 4 years ago 😱 )

## Release notes

Notes: no-notes
