### PR TITLE
Add unit tests for our SSH host prompt parser

### DIFF
--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -71,3 +71,19 @@ export async function getSSHEnvironment() {
 
   return baseEnv
 }
+
+export function parseAddSSHHostPrompt(prompt: string) {
+  const promptRegex = /^The authenticity of host '([^ ]+) \(([^\)]+)\)' can't be established.\n([^ ]+) key fingerprint is ([^.]+).\n(?:.*\n)*Are you sure you want to continue connecting \(yes\/no\/\[fingerprint\]\)\? $/
+
+  const matches = promptRegex.exec(prompt)
+  if (matches === null || matches.length < 5) {
+    return null
+  }
+
+  return {
+    host: matches[1],
+    ip: matches[2],
+    keyType: matches[3],
+    fingerprint: matches[4],
+  }
+}

--- a/app/test/unit/ssh-test.ts
+++ b/app/test/unit/ssh-test.ts
@@ -1,0 +1,36 @@
+import { parseAddSSHHostPrompt } from '../../src/lib/ssh/ssh'
+
+describe('SSH', () => {
+  describe('parsing SSH prompts', () => {
+    it('extracts info from github.com host key fingerprint', () => {
+      const prompt = `The authenticity of host 'github.com (140.82.121.3)' can't be established.
+RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `
+
+      const info = parseAddSSHHostPrompt(prompt)
+
+      expect(info).toEqual({
+        host: 'github.com',
+        ip: '140.82.121.3',
+        fingerprint: 'SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8',
+        keyType: 'RSA',
+      })
+    })
+
+    it('extracts info from fake host key fingerprint', () => {
+      const prompt = `The authenticity of host 'my-domain.com (1.2.3.4)' can't be established.
+FAKE-TYPE key fingerprint is ThisIsAFakeFingerprintForTestingPurposes.
+This key is not known by any other names.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `
+
+      const info = parseAddSSHHostPrompt(prompt)
+
+      expect(info).toEqual({
+        host: 'my-domain.com',
+        ip: '1.2.3.4',
+        fingerprint: 'ThisIsAFakeFingerprintForTestingPurposes',
+        keyType: 'FAKE-TYPE',
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description

After the work done in #12894 I think it'd be useful to keep around some test cases in case future versions of OpenSSH change this prompt, make sure we don't introduce regressions.

## Release notes

Notes: no-notes
