### PR TITLE
Improves added and deleted line borders for high contrast mode

### DIFF
--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -393,3 +393,30 @@ export function getNumberOfDigits(val: number): number {
  * GitHub.com's behavior.
  **/
 export const MaxIntraLineDiffStringLength = 1024
+
+/**
+ * Used to obtain classes applied to style the row if it is the first or last of
+ * a group of added, deleted, or modified rows in the unified diff.
+ **/
+export function getFirstAndLastClassesUnified(
+  tokenIndex: string,
+  prevTokenIndex: string | undefined,
+  nextTokenIndex: string | undefined
+): string[] {
+  const addDeleteTokens = ['+', '-']
+  if (!addDeleteTokens.includes(tokenIndex)) {
+    return []
+  }
+
+  const classNames = []
+
+  if (prevTokenIndex !== tokenIndex) {
+    classNames.push('is-first')
+  }
+
+  if (nextTokenIndex !== tokenIndex) {
+    classNames.push('is-last')
+  }
+
+  return classNames
+}

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -395,6 +395,39 @@ export function getNumberOfDigits(val: number): number {
 export const MaxIntraLineDiffStringLength = 1024
 
 /**
+ * Used to obtain classes applied to style the row as first or last of a group
+ * of added or deleted rows in the side-by-side diff.
+ **/
+export function getFirstAndLastClassesSideBySide(
+  row: SimplifiedDiffRow,
+  previousRow: SimplifiedDiffRow | undefined,
+  nextRow: SimplifiedDiffRow | undefined,
+  addedDeleted: DiffRowType
+): ReadonlyArray<string> {
+  const classes: Array<string> = []
+  const typesToCheck = [addedDeleted, DiffRowType.Modified]
+
+  // Is the row of the type we are checking? No. Then can't be first or last.
+  if (!typesToCheck.includes(row.type)) {
+    return []
+  }
+
+  // Is the previous row exist or is of the type we are checking?
+  // No. Then this row must be the first of this type.
+  if (previousRow === undefined || !typesToCheck.includes(previousRow.type)) {
+    classes.push('is-first')
+  }
+
+  // Is the next row exist or is of the type we are checking?
+  // No. Then this row must be last of this type.
+  if (nextRow === undefined || !typesToCheck.includes(nextRow.type)) {
+    classes.push('is-last')
+  }
+
+  return classes
+}
+
+/**
  * Used to obtain classes applied to style the row if it is the first or last of
  * a group of added, deleted, or modified rows in the unified diff.
  **/

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -402,7 +402,7 @@ export function getFirstAndLastClassesSideBySide(
   row: SimplifiedDiffRow,
   previousRow: SimplifiedDiffRow | undefined,
   nextRow: SimplifiedDiffRow | undefined,
-  addedOrDeleted: DiffRowType
+  addedOrDeleted: DiffRowType.Added | DiffRowType.Deleted
 ): ReadonlyArray<string> {
   const classes = new Array<string>()
   const typesToCheck = [addedOrDeleted, DiffRowType.Modified]

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -404,7 +404,7 @@ export function getFirstAndLastClassesSideBySide(
   nextRow: SimplifiedDiffRow | undefined,
   addedOrDeleted: DiffRowType
 ): ReadonlyArray<string> {
-  const classes: Array<string> = []
+  const classes = new Array<string>()
   const typesToCheck = [addedOrDeleted, DiffRowType.Modified]
 
   // Is the row of the type we are checking? No. Then can't be first or last.

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -437,10 +437,7 @@ export function getFirstAndLastClassesUnified(
   prevToken: DiffSyntaxToken | null,
   nextToken: DiffSyntaxToken | null
 ): string[] {
-  const addedOrDeletedTokens = [
-    DiffSyntaxToken.DiffAdded,
-    DiffSyntaxToken.DiffDeleted,
-  ]
+  const addedOrDeletedTokens = [DiffSyntaxToken.Add, DiffSyntaxToken.Delete]
   if (!addedOrDeletedTokens.includes(token)) {
     return []
   }

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../models/status'
 import { DiffHunk, DiffHunkExpansionType } from '../../models/diff/raw-diff'
 import { DiffLineType } from '../../models/diff'
+import { DiffSyntaxToken } from './diff-syntax-mode'
 
 /**
  * DiffRowType defines the different types of
@@ -432,22 +433,25 @@ export function getFirstAndLastClassesSideBySide(
  * a group of added, deleted, or modified rows in the unified diff.
  **/
 export function getFirstAndLastClassesUnified(
-  tokenIndex: string,
-  prevTokenIndex: string | undefined,
-  nextTokenIndex: string | undefined
+  token: DiffSyntaxToken,
+  prevToken: DiffSyntaxToken | null,
+  nextToken: DiffSyntaxToken | null
 ): string[] {
-  const addDeleteTokens = ['+', '-']
-  if (!addDeleteTokens.includes(tokenIndex)) {
+  const addedOrDeletedTokens = [
+    DiffSyntaxToken.DiffAdded,
+    DiffSyntaxToken.DiffDeleted,
+  ]
+  if (!addedOrDeletedTokens.includes(token)) {
     return []
   }
 
   const classNames = []
 
-  if (prevTokenIndex !== tokenIndex) {
+  if (prevToken !== token) {
     classNames.push('is-first')
   }
 
-  if (nextTokenIndex !== tokenIndex) {
+  if (nextToken !== token) {
     classNames.push('is-last')
   }
 

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -402,10 +402,10 @@ export function getFirstAndLastClassesSideBySide(
   row: SimplifiedDiffRow,
   previousRow: SimplifiedDiffRow | undefined,
   nextRow: SimplifiedDiffRow | undefined,
-  addedDeleted: DiffRowType
+  addedOrDeleted: DiffRowType
 ): ReadonlyArray<string> {
   const classes: Array<string> = []
-  const typesToCheck = [addedDeleted, DiffRowType.Modified]
+  const typesToCheck = [addedOrDeleted, DiffRowType.Modified]
 
   // Is the row of the type we are checking? No. Then can't be first or last.
   if (!typesToCheck.includes(row.type)) {

--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -434,8 +434,8 @@ export function getFirstAndLastClassesSideBySide(
  **/
 export function getFirstAndLastClassesUnified(
   token: DiffSyntaxToken,
-  prevToken: DiffSyntaxToken | null,
-  nextToken: DiffSyntaxToken | null
+  prevToken: DiffSyntaxToken | undefined,
+  nextToken: DiffSyntaxToken | undefined
 ): string[] {
   const addedOrDeletedTokens = [DiffSyntaxToken.Add, DiffSyntaxToken.Delete]
   if (!addedOrDeletedTokens.includes(token)) {

--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -181,7 +181,7 @@ export class DiffSyntaxMode {
 
       const nextLine = stream.lookAhead(1)
       const nextLineTokenIndex =
-        typeof nextLine === `string` ? nextLine[0] : undefined
+        typeof nextLine === 'string' ? nextLine[0] : undefined
       const lineBackgroundClassNames = getFirstAndLastClassesUnified(
         index,
         state.prevLineTokenIndex,

--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -38,7 +38,7 @@ export enum DiffSyntaxToken {
   Context = 'diff-context',
 }
 
-const TokenNames: { [key: string]: DiffSyntaxToken | null } = {
+const TokenNames: { [key: string]: DiffSyntaxToken | undefined } = {
   '+': DiffSyntaxToken.Add,
   '-': DiffSyntaxToken.Delete,
   '@': DiffSyntaxToken.Hunk,
@@ -48,7 +48,7 @@ const TokenNames: { [key: string]: DiffSyntaxToken | null } = {
 interface IState {
   diffLineIndex: number
   previousHunkOldEndLine: number | null
-  prevLineToken: DiffSyntaxToken | null
+  prevLineToken: DiffSyntaxToken | undefined
 }
 
 function skipLine(stream: CodeMirror.StringStream, state: IState) {
@@ -132,7 +132,7 @@ export class DiffSyntaxMode {
     return {
       diffLineIndex: 0,
       previousHunkOldEndLine: null,
-      prevLineToken: null,
+      prevLineToken: undefined,
     }
   }
 
@@ -178,15 +178,15 @@ export class DiffSyntaxMode {
         return null
       }
 
-      const token = TokenNames[tokenKey] ?? null
+      const token = TokenNames[tokenKey]
 
-      if (token === null) {
+      if (token === undefined) {
         return null
       }
 
       const nextLine = stream.lookAhead(1)
       const nextLineToken =
-        typeof nextLine === 'string' ? TokenNames[nextLine[0]] : null
+        typeof nextLine === 'string' ? TokenNames[nextLine[0]] : undefined
 
       const lineBackgroundClassNames = getFirstAndLastClassesUnified(
         token,

--- a/app/src/ui/diff/diff-syntax-mode.ts
+++ b/app/src/ui/diff/diff-syntax-mode.ts
@@ -32,17 +32,17 @@ export interface IDiffSyntaxModeSpec extends IDiffSyntaxModeOptions {
 }
 
 export enum DiffSyntaxToken {
-  DiffAdded = 'diff-add',
-  DiffDeleted = 'diff-deleted',
-  DiffHunk = 'diff-hunk',
-  DiffContext = 'diff-context',
+  Add = 'diff-add',
+  Delete = 'diff-delete',
+  Hunk = 'diff-hunk',
+  Context = 'diff-context',
 }
 
 const TokenNames: { [key: string]: DiffSyntaxToken | null } = {
-  '+': DiffSyntaxToken.DiffAdded,
-  '-': DiffSyntaxToken.DiffDeleted,
-  '@': DiffSyntaxToken.DiffHunk,
-  ' ': DiffSyntaxToken.DiffContext,
+  '+': DiffSyntaxToken.Add,
+  '-': DiffSyntaxToken.Delete,
+  '@': DiffSyntaxToken.Hunk,
+  ' ': DiffSyntaxToken.Context,
 }
 
 interface IState {
@@ -142,7 +142,7 @@ export class DiffSyntaxMode {
     // diff that was just loaded, but for which we haven't run the highlighter
     // yet. If we don't do this, that last line will be formatted wrongly.
     if (this.hunks === undefined) {
-      return getBaseDiffLineStyle(DiffSyntaxToken.DiffHunk)
+      return getBaseDiffLineStyle(DiffSyntaxToken.Hunk)
     }
 
     // A line might be empty in a non-blank diff for the only line of the
@@ -151,7 +151,7 @@ export class DiffSyntaxMode {
     if (this.hunks.length > 0) {
       const diffLine = diffLineForIndex(this.hunks, state.diffLineIndex)
       if (diffLine?.type === DiffLineType.Hunk) {
-        return getBaseDiffLineStyle(DiffSyntaxToken.DiffHunk)
+        return getBaseDiffLineStyle(DiffSyntaxToken.Hunk)
       }
     }
 
@@ -199,7 +199,7 @@ export class DiffSyntaxMode {
 
       // If it's a hunk header line, we want to make a few extra checks
       // depending on the distance to the previous hunk.
-      if (token === DiffSyntaxToken.DiffHunk && enableTextDiffExpansion()) {
+      if (token === DiffSyntaxToken.Hunk && enableTextDiffExpansion()) {
         // First we grab the numbers in the hunk header
         const matches = stream.match(/\@ -(\d+),(\d+) \+\d+,\d+ \@\@/)
         if (matches !== null) {

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -121,6 +121,16 @@ interface ISideBySideDiffRowProps {
    */
   readonly onContextMenuText: () => void
 
+  /**
+   * Array of classes applied to the after section of a row
+   */
+  readonly afterClassNames: ReadonlyArray<string>
+
+  /**
+   * Array of classes applied to the before section of a row
+   */
+  readonly beforeClassNames: ReadonlyArray<string>
+
   /** Called when the user changes the hide whitespace in diffs setting. */
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
 }
@@ -138,8 +148,15 @@ export class SideBySideDiffRow extends React.Component<
     this.state = { showWhitespaceHint: undefined }
   }
   public render() {
-    const { row, showSideBySideDiff } = this.props
+    const {
+      row,
+      showSideBySideDiff,
+      beforeClassNames,
+      afterClassNames,
+    } = this.props
 
+    const beforeClasses = classNames('before', ...beforeClassNames)
+    const afterClasses = classNames('after', ...afterClassNames)
     switch (row.type) {
       case DiffRowType.Hunk: {
         const className = ['row', 'hunk-info']
@@ -188,7 +205,7 @@ export class SideBySideDiffRow extends React.Component<
               className="row added"
               onMouseEnter={this.onMouseEnterLineNumber}
             >
-              <div className="after">
+              <div className={afterClasses}>
                 {this.renderLineNumbers([undefined, lineNumber], isSelected)}
                 {this.renderHunkHandle()}
                 {this.renderContent(row.data)}
@@ -200,12 +217,12 @@ export class SideBySideDiffRow extends React.Component<
 
         return (
           <div className="row added" onMouseEnter={this.onMouseEnterLineNumber}>
-            <div className="before">
+            <div className={beforeClasses}>
               {this.renderLineNumber()}
               {this.renderContentFromString('')}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
-            <div className="after">
+            <div className={afterClasses}>
               {this.renderLineNumber(lineNumber, isSelected)}
               {this.renderContent(row.data)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
@@ -222,7 +239,7 @@ export class SideBySideDiffRow extends React.Component<
               className="row deleted"
               onMouseEnter={this.onMouseEnterLineNumber}
             >
-              <div className="before">
+              <div className={beforeClasses}>
                 {this.renderLineNumbers([lineNumber, undefined], isSelected)}
                 {this.renderHunkHandle()}
                 {this.renderContent(row.data)}
@@ -237,12 +254,12 @@ export class SideBySideDiffRow extends React.Component<
             className="row deleted"
             onMouseEnter={this.onMouseEnterLineNumber}
           >
-            <div className="before">
+            <div className={beforeClasses}>
               {this.renderLineNumber(lineNumber, isSelected)}
               {this.renderContent(row.data)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
-            <div className="after">
+            <div className={afterClasses}>
               {this.renderLineNumber()}
               {this.renderContentFromString('')}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
@@ -255,12 +272,18 @@ export class SideBySideDiffRow extends React.Component<
         const { beforeData: before, afterData: after } = row
         return (
           <div className="row modified">
-            <div className="before" onMouseEnter={this.onMouseEnterLineNumber}>
+            <div
+              className={beforeClasses}
+              onMouseEnter={this.onMouseEnterLineNumber}
+            >
               {this.renderLineNumber(before.lineNumber, before.isSelected)}
               {this.renderContent(before)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
-            <div className="after" onMouseEnter={this.onMouseEnterLineNumber}>
+            <div
+              className={afterClasses}
+              onMouseEnter={this.onMouseEnterLineNumber}
+            >
               {this.renderLineNumber(after.lineNumber, after.isSelected)}
               {this.renderContent(after)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -46,6 +46,7 @@ import {
   getLineWidthFromDigitCount,
   getNumberOfDigits,
   MaxIntraLineDiffStringLength,
+  getFirstAndLastClassesSideBySide,
 } from './diff-helpers'
 import { showContextualMenu } from '../../lib/menu-item'
 import { getTokens } from './diff-syntax-mode'
@@ -323,11 +324,27 @@ export class SideBySideDiff extends React.Component<
       this.props.showSideBySideDiff,
       this.canExpandDiff()
     )
-    const row = rows[index]
 
+    const row = rows[index]
     if (row === undefined) {
       return null
     }
+
+    const prev = rows[index - 1]
+    const next = rows[index + 1]
+
+    const beforeClassNames = getFirstAndLastClassesSideBySide(
+      row,
+      prev,
+      next,
+      DiffRowType.Deleted
+    )
+    const afterClassNames = getFirstAndLastClassesSideBySide(
+      row,
+      prev,
+      next,
+      DiffRowType.Added
+    )
 
     const lineNumberWidth = getLineWidthFromDigitCount(
       getNumberOfDigits(diff.maxLineNumber)
@@ -368,6 +385,8 @@ export class SideBySideDiff extends React.Component<
             onHideWhitespaceInDiffChanged={
               this.props.onHideWhitespaceInDiffChanged
             }
+            beforeClassNames={beforeClassNames}
+            afterClassNames={afterClassNames}
           />
         </div>
       </CellMeasurer>

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -1150,17 +1150,17 @@ function getDiffRowsFromHunk(
 }
 
 function getModifiedRows(
-  addedDeletedLines: ReadonlyArray<ModifiedLine>,
+  addedOrDeletedLines: ReadonlyArray<ModifiedLine>,
   showSideBySideDiff: boolean
 ): ReadonlyArray<SimplifiedDiffRow> {
-  if (addedDeletedLines.length === 0) {
+  if (addedOrDeletedLines.length === 0) {
     return []
   }
-  const hunkStartLine = addedDeletedLines[0].diffLineNumber
+  const hunkStartLine = addedOrDeletedLines[0].diffLineNumber
   const addedLines = new Array<ModifiedLine>()
   const deletedLines = new Array<ModifiedLine>()
 
-  for (const line of addedDeletedLines) {
+  for (const line of addedOrDeletedLines) {
     if (line.line.type === DiffLineType.Add) {
       addedLines.push(line)
     } else if (line.line.type === DiffLineType.Delete) {

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -277,8 +277,18 @@
     background: var(--diff-add-background-color);
 
     @include high-contrast {
-      border: var(--hc-diff-add-border);
+      border-right: var(--hc-diff-add-border);
+      border-left: var(--hc-diff-add-border);
       margin-top: 1px;
+
+      &.is-first {
+        margin-top: 1px;
+        border-top: var(--hc-diff-add-border);
+      }
+
+      &.is-last {
+        border-bottom: var(--hc-diff-add-border);
+      }
     }
   }
 
@@ -286,7 +296,17 @@
     background: var(--diff-delete-background-color);
 
     @include high-contrast {
-      border: var(--hc-diff-delete-border);
+      border-right: var(--hc-diff-delete-border);
+      border-left: var(--hc-diff-delete-border);
+
+      &.is-first {
+        margin-top: 1px;
+        border-top: var(--hc-diff-delete-border);
+      }
+
+      &.is-last {
+        border-bottom: var(--hc-diff-delete-border);
+      }
     }
   }
 

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -182,10 +182,18 @@
   .before {
     color: var(--diff-delete-text-color);
     background: var(--diff-delete-background-color);
-    border-right: 1px solid var(--diff-border-color);
 
     @include high-contrast {
-      border: var(--hc-diff-delete-border);
+      border-right: var(--hc-diff-delete-border);
+      border-left: var(--hc-diff-delete-border);
+
+      &.is-first {
+        border-top: var(--hc-diff-delete-border);
+      }
+
+      &.is-last {
+        border-bottom: var(--hc-diff-delete-border);
+      }
     }
 
     .line-number {
@@ -206,7 +214,16 @@
     background: var(--diff-add-background-color);
 
     @include high-contrast {
-      border: var(--hc-diff-add-border);
+      border-left: var(--hc-diff-add-border);
+      border-right: var(--hc-diff-add-border);
+
+      &.is-first {
+        border-top: var(--hc-diff-add-border);
+      }
+
+      &.is-last {
+        border-bottom: var(--hc-diff-add-border);
+      }
     }
 
     .line-number {


### PR DESCRIPTION
## Description



Improves added and deleted line borders for high contrast mode. Previously high-contrast mode put a border around each line. Goal was to have borders around each group of deleted or added lines.

### Screenshots

Split:
![image](https://user-images.githubusercontent.com/75402236/132374372-e0433612-9e04-4bb2-8172-c57c3a5286d7.png)


Unified:
![image](https://user-images.githubusercontent.com/75402236/132374203-94828575-a1d1-4615-b204-37dccf6379e4.png)


## Release notes
Notes: [Improved] Use a border around groups of added and deleted lines in high-contrast mode
