### PR TITLE
Fix merge head check regression introduced with squash merge

### DIFF
--- a/app/src/lib/stores/updates/changes-state.ts
+++ b/app/src/lib/stores/updates/changes-state.ts
@@ -122,15 +122,6 @@ function getConflictState(
   status: IStatusResult,
   manualResolutions: Map<string, ManualConflictResolution>
 ): ConflictState | null {
-  // If there are no conflicts found in working directory, conflict state should
-  // be null this is important when checking for a conflict after a --squash
-  // merge which will not have a MERGE_HEAD but would have SQUASH_MSG which also
-  // can be present when no conflicts. You shouldn't be able to have
-  // any form of the other conflicts without conflicted files anyways.
-  if (!status.doConflictedFilesExist) {
-    return null
-  }
-
   if (status.rebaseInternalState !== null) {
     const { currentTip } = status
     if (currentTip == null) {
@@ -169,7 +160,12 @@ function getConflictState(
   if (
     currentBranch == null ||
     currentTip == null ||
-    (!mergeHeadFound && !squashMsgFound)
+    (!mergeHeadFound && !squashMsgFound) ||
+    // If there are no conflicts, we want to ignore the squash msg found.
+    // However, we do want to prompt the conflicts showing all resolved
+    // if a regular merge conflicts are all resolves so user can
+    // commit the merge commit.
+    (!mergeHeadFound && !status.doConflictedFilesExist)
   ) {
     return null
   }


### PR DESCRIPTION
Closes #12881

## Description
Adds back merge conflict type detection when merge conflicts have been resolved outside of Desktop. Programmatically this is when there are no conflicts but a merge head still exists indicating that a conflict did exist at some point and so a merge commit is now required.  

Side note: This regression was introduced with squash merging. In squash merging, we detect using the squash msg file, as opposed to merge head. However, we cannot commit an empty commit and therefore, we don't want to keep getting prompted for squash merge even tho there is a squash msg file after conflicts are resolved.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/132390705-c021e4e6-e23c-4c2e-89e0-e0be50362f2c.png)

## Release notes
Notes: [Fixed] Merge flow continues after merge conflicts are resolved with exterior conflict tool.
