### PR TITLE
Fix high-contrast border regression on list items

### DIFF
--- a/app/src/ui/lib/custom-theme.ts
+++ b/app/src/ui/lib/custom-theme.ts
@@ -36,6 +36,7 @@ export function buildCustomThemeStyles(customTheme: ICustomTheme): string {
   const highContrastSpecific = `
       --box-selected-active-border: 2px solid ${border};
       --list-item-hover-border: 2px solid ${border};
+      --list-item-hover-border-bottom: 2px solid ${border};
 
       --secondary-button-hover-border-width: 2px;
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -294,6 +294,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --list-item-hover-background-color: #{$gray-100};
   --list-item-hover-text-color: var(--text-color);
   --list-item-hover-border: none;
+  --list-item-hover-border-bottom: var(--base-border);
 
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;

--- a/app/styles/mixins/_list-item.scss
+++ b/app/styles/mixins/_list-item.scss
@@ -21,6 +21,9 @@
   &:not(.not-selectable):hover {
     background: var(--list-item-hover-background-color);
     color: var(--list-item-hover-text-color);
-    border: var(--list-item-hover-border);
+    border-bottom: var(--list-item-hover-border-bottom);
+    border-top: var(--list-item-hover-border);
+    border-left: var(--list-item-hover-border);
+    border-right: var(--list-item-hover-border);
   }
 }

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -217,6 +217,8 @@ body.theme-dark {
   --list-item-selected-active-badge-background-color: #{$white};
   --list-item-hover-background-color: #{$gray-800};
   --list-item-hover-text-color: var(--text-color);
+  --list-item-hover-border: none;
+  --list-item-hover-border-bottom: var(--base-border);
 
   /**
    * Toast notifications are shown temporarily for things like the zoom


### PR DESCRIPTION
## Description
List items have a bottom border and high-contrast css unintentionally removed that border on hover for non-high-contrast themes.

### Screenshots
Before:

https://user-images.githubusercontent.com/75402236/132564574-440aa981-a411-4b82-8313-dd1dfe78d1d7.mov

After:


https://user-images.githubusercontent.com/75402236/132564705-f412eb63-c91d-4674-842e-bcc2eeef560a.mov



## Release notes
Notes: [Fixed] Bottom border remains on hover of list items for non-high-contrast themes.
