### PR TITLE
Prevent styles from high-contrast theme from leaking

### DIFF
--- a/app/src/ui/app-theme.tsx
+++ b/app/src/ui/app-theme.tsx
@@ -58,7 +58,8 @@ export class AppTheme extends React.PureComponent<IAppThemeProps> {
 
     if (
       !body.classList.contains(newThemeClassName) ||
-      (body.classList.contains('theme-custom') && !this.props.useCustomTheme)
+      (body.classList.contains('theme-high-contrast') &&
+        !this.props.useCustomTheme)
     ) {
       this.clearThemes()
       body.classList.add(newThemeClassName)
@@ -79,8 +80,11 @@ export class AppTheme extends React.PureComponent<IAppThemeProps> {
     const { background } = customTheme
     const body = document.body
 
-    if (!body.classList.contains('theme-custom')) {
-      body.classList.add('theme-custom')
+    if (!body.classList.contains('theme-high-contrast')) {
+      // Currently our only custom theme is the high-contrast theme
+      // If we were to expand upon custom theming we would not
+      // want this so specific.
+      body.classList.add('theme-high-contrast')
       // This is important so that code diff syntax colors are legible if the
       // user customizes to a light vs dark background. Tho, the code diff does
       // still use the customizable text color for some of the syntax text so

--- a/app/src/ui/lib/custom-theme.ts
+++ b/app/src/ui/lib/custom-theme.ts
@@ -33,61 +33,13 @@ export function buildCustomThemeStyles(customTheme: ICustomTheme): string {
   const secondaryActiveColor = lightenDarkenHexColor(activeItem, 20)
   const secondaryBackgroundColor = lightenDarkenHexColor(background, 20)
 
-  const highContrastSpecific = `
-      --box-selected-active-border: 2px solid ${border};
-      --list-item-hover-border: 2px solid ${border};
-      --tab-bar-hover-border: 2px solid ${border} !important;
-      --tab-bar-item-border: 2px solid ${background};
-      --foldout-border: 1px solid ${border};
-      --horizontal-bar-active-color: ${activeItem};
-      --horizontal-bar-active-text-color: ${activeText};
-  `
-
   return `body.theme-high-contrast {
-    --background-color: ${background};
-    --box-background-color: ${background};
-    --box-alt-background-color: ${background};
-    --box-alt-text-color: ${activeText};
-
-    --diff-hunk-gutter-background-color: ${background};
-    --diff-text-color: ${text};
-    --diff-line-number-color: ${text};
-    --diff-gutter-background-color: ${background};
-    --diff-hunk-background-color: ${background};
-    --diff-empty-row-background-color: ${secondaryBackgroundColor};
-
-    --box-border-color: ${border};
-    --diff-border-color: ${border};
-
-    --box-selected-background-color: ${secondaryActiveColor};
-    --box-selected-text-color: ${activeText};
-
-    --box-selected-active-background-color: ${activeItem};
-    --box-selected-active-text-color: ${activeText};
-
-    --button-background: ${activeItem};
-    --button-text-color: ${activeText};
-    --secondary-button-background: ${background};
-    --secondary-button-text-color: ${text};
-    --button-hover-background: ${secondaryActiveColor};
-    --secondary-button-hover-background: ${secondaryBackgroundColor};
-    --app-menu-button-hover-background-color: ${secondaryBackgroundColor};
-    --toolbar-button-focus-background-color: ${secondaryBackgroundColor};
-    --toolbar-button-hover-background-color: ${secondaryBackgroundColor};
-    --toolbar-button-active-border-color: ${border};
-    --tab-bar-hover-background-color: ${secondaryBackgroundColor};
-
-    --text-color: ${text};
-    --text-secondary-color: ${text};
-    --toolbar-background-color: ${background};
-    --toolbar-button-secondary-color: ${text};
-
-    --list-item-hover-background-color: ${secondaryActiveColor};
-    --list-item-hover-text-color: ${activeText};
-
-    --box-placeholder-color: ${text};
-    --tab-bar-active-color: ${activeItem};
-
-    ${highContrastSpecific}
+    --hc-background-color: ${background};
+    --hc-secondary-background-color: ${secondaryBackgroundColor};
+    --hc-border-color: ${border};
+    --hc-text-color: ${text};
+    --hc-active-item-color: ${activeItem};
+    --hc-secondary-active-item-color: ${secondaryActiveColor};
+    --hc-active-text-color: ${activeText};
   }`
 }

--- a/app/src/ui/lib/custom-theme.ts
+++ b/app/src/ui/lib/custom-theme.ts
@@ -36,13 +36,6 @@ export function buildCustomThemeStyles(customTheme: ICustomTheme): string {
   const highContrastSpecific = `
       --box-selected-active-border: 2px solid ${border};
       --list-item-hover-border: 2px solid ${border};
-
-      --secondary-button-hover-border-width: 2px;
-
-      --tab-bar-box-shadow: none;
-
-      --diff-add-border: 1px solid green;
-      --diff-delete-border: 1px solid crimson;
       --tab-bar-hover-border: 2px solid ${border} !important;
       --tab-bar-item-border: 2px solid ${background};
       --foldout-border: 1px solid ${border};
@@ -50,7 +43,7 @@ export function buildCustomThemeStyles(customTheme: ICustomTheme): string {
       --horizontal-bar-active-text-color: ${activeText};
   `
 
-  return `body.theme-custom {
+  return `body.theme-high-contrast {
     --background-color: ${background};
     --box-background-color: ${background};
     --box-alt-background-color: ${background};

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -5,3 +5,4 @@
 @import 'mixins/checkboard-background';
 @import 'mixins/close-button';
 @import 'mixins/list-item';
+@import 'mixins/high-contrast';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -113,11 +113,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --box-border-accent-color: #{$blue};
 
   /**
-   * Background color for selected boxes without keyboard focus
-   */
-  --box-selected-background-color: #ebeef1;
-
-  /**
    * Text color for when a user hovers over a boxe with a
    * pointing device. Should not be used by boxes that doesn't
    * implement a hover state since this will conflict with
@@ -271,10 +266,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --tab-bar-active-color: #{$blue};
   --tab-bar-background-color: #{$white};
   --tab-bar-hover-background-color: #{$gray-100};
-  --tab-bar-box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
-  --tab-bar-hover-border: none;
-  --horizontal-bar-active-color: 'none';
-  --tab-bar-item-border: 'none';
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);
@@ -292,8 +283,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --list-item-selected-active-badge-color: #{$gray-900};
   --list-item-selected-active-badge-background-color: #{$white};
   --list-item-hover-background-color: #{$gray-100};
-  --list-item-hover-text-color: var(--text-color);
-  --list-item-hover-border: none;
 
   /** Win32 has custom scrol bars, see _scroll.scss */
   --win32-scroll-bar-size: 10px;
@@ -370,7 +359,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --diff-selected-text-color: var(--background-color);
 
   --diff-add-background-color: #{darken($green-000, 2%)};
-  --diff-add-border: 'none';
   --diff-add-border-color: #{$green-300};
   --diff-add-gutter-color: #{$green-300};
   --diff-add-gutter-background-color: #{darken($green-100, 3%)};
@@ -383,7 +371,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --diff-delete-gutter-background-color: #{$red-100};
   --diff-delete-inner-background-color: #fdb8c0;
   --diff-delete-text-color: var(--diff-text-color);
-  --diff-add-border: 'none';
 
   --diff-hunk-background-color: #{$blue-000};
   --diff-hunk-border-color: #{$blue-200};
@@ -471,8 +458,6 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --title-tool-tip-background-color: rgb(236, 236, 236);
   --title-tool-tip-shadow: 1px 2px 5px 0px rgb(125, 125, 125, 0.5);
-
-  --foldout-border: 'none';
 }
 
 ::backdrop {

--- a/app/styles/desktop.scss
+++ b/app/styles/desktop.scss
@@ -2,6 +2,7 @@
 
 @import 'variables';
 @import 'themes/dark';
+@import 'themes/high-contrast';
 
 @import 'mixins';
 

--- a/app/styles/mixins/_high-contrast.scss
+++ b/app/styles/mixins/_high-contrast.scss
@@ -1,0 +1,7 @@
+// A mixin which takes a content block that should only
+// be applied when we are using the high-contrast theme
+@mixin high-contrast {
+  body.theme-high-contrast & {
+    @content;
+  }
+}

--- a/app/styles/mixins/_list-item.scss
+++ b/app/styles/mixins/_list-item.scss
@@ -20,7 +20,9 @@
 
   &:not(.not-selectable):hover {
     background: var(--list-item-hover-background-color);
-    color: var(--list-item-hover-text-color);
-    border: var(--list-item-hover-border);
+    @include high-contrast {
+      color: var(--list-item-hover-text-color);
+      border: var(--list-item-hover-border);
+    }
   }
 }

--- a/app/styles/mixins/_list-item.scss
+++ b/app/styles/mixins/_list-item.scss
@@ -21,8 +21,8 @@
   &:not(.not-selectable):hover {
     background: var(--list-item-hover-background-color);
     @include high-contrast {
-      color: var(--list-item-hover-text-color);
-      border: var(--list-item-hover-border);
+      color: var(--hc-active-text-color);
+      border: var(--hc-hover-border);
     }
   }
 }

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -197,8 +197,6 @@ body.theme-dark {
   --tab-bar-active-color: #{$blue};
   --tab-bar-background-color: var(--box-background-color);
   --tab-bar-hover-background-color: #{$gray-800};
-  --horizontal-bar-active-color: 'none';
-  --tab-bar-item-border: 'none';
 
   /** Count bubble colors when used inside of a tab bar item */
   --tab-bar-count-color: var(--text-color);
@@ -216,7 +214,6 @@ body.theme-dark {
   --list-item-selected-active-badge-color: #{$gray-900};
   --list-item-selected-active-badge-background-color: #{$white};
   --list-item-hover-background-color: #{$gray-800};
-  --list-item-hover-text-color: var(--text-color);
 
   /**
    * Toast notifications are shown temporarily for things like the zoom
@@ -351,8 +348,6 @@ body.theme-dark {
 
   --title-tool-tip-background-color: rgb(56, 58, 62);
   --title-tool-tip-shadow: none;
-
-  --foldout-border: 'none';
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/themes/_high-contrast.scss
+++ b/app/styles/themes/_high-contrast.scss
@@ -16,7 +16,7 @@ body.theme-high-contrast {
   --text-secondary-color: var(--hc-text-color);
 
   //border
-  --hc-hover-border: 2px solid var(--hc-border-color) !important;
+  --hc-hover-border: 2px solid var(--hc-border-color);
 
   /// tab-bar
   --tab-bar-active-color: var(--hc-active-item-color);

--- a/app/styles/themes/_high-contrast.scss
+++ b/app/styles/themes/_high-contrast.scss
@@ -1,73 +1,68 @@
 body.theme-high-contrast {
   // A small set of colors used to flatten ux and improve contrast
-  --hc-background: #090c11;
-  --hc-secondary-background: #323946;
-  --hc-border: #7a828e;
-  --hc-text: #f0f3f6;
-  --hc-active-item: #9ea7b3;
-  --hc-secondary-active-item: #596069;
-  --hc-active-text: #090c11;
+  --hc-background-color: #090c11;
+  --hc-secondary-background-color: #323946;
+  --hc-border-color: #7a828e;
+  --hc-text-color: #f0f3f6;
+  --hc-active-item-color: #9ea7b3;
+  --hc-secondary-active-item-color: #596069;
+  --hc-active-text-color: #090c11;
+  --hc-diff-add-border-color: green;
+  --hc-diff-delete-border-color: crimson;
 
   // background/text
-  --background-color: var(--hc-background);
-  --text-color: var(--hc-text);
-  --text-secondary-color: var(--hc-text);
+  --background-color: var(--hc-background-color);
+  --text-color: var(--hc-text-color);
+  --text-secondary-color: var(--hc-text-color);
+
+  //border
+  --hc-hover-border: 2px solid var(--hc-border-color) !important;
 
   /// tab-bar
-  --tab-bar-hover-border: 2px solid var(--hc-border) !important;
-  --tab-bar-item-border: 2px solid var(--hc-background);
-  --tab-bar-box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
-  --tab-bar-hover-background-color: var(--hc-secondary-background);
-  --tab-bar-active-color: var(--hc-active-item);
-  --horizontal-bar-active-color: var(--hc-active-item);
-  --horizontal-bar-active-text-color: var(--hc-active-text);
+  --tab-bar-active-color: var(--hc-active-item-color);
+  --tab-bar-hover-background-color: var(--hc-secondary-background-color);
 
   // box
-  --box-selected-active-border: 2px solid var(--hc-border);
-  --box-background-color: var(--hc-background);
-  --box-alt-background-color: var(--hc-background);
-  --box-alt-text-color: var(--hc-active-text);
-  --box-border-color: var(--hc-border);
-  --box-selected-background-color: var(--hc-secondary-active-item);
-  --box-selected-text-color: var(--hc-active-text);
-  --box-selected-active-background-color: var(--hc-active-item);
-  --box-selected-active-text-color: var(--hc-active-text);
-  --box-placeholder-color: var(--hc-text);
+  --box-selected-active-border: var(--hc-hover-border);
+  --box-background-color: var(--hc-background-color);
+  --box-alt-background-color: var(--hc-background-color);
+  --box-border-color: var(--hc-border-color);
+  --box-selected-background-color: var(--hc-secondary-active-item-color);
+  --box-selected-text-color: var(--hc-active-text-color);
+  --box-selected-active-background-color: var(--hc-active-item-color);
+  --box-selected-active-text-color: var(--hc-active-text-color);
+  --box-placeholder-color: var(--hc-text-color);
 
   // button
-  --button-background: var(--hc-active-item);
-  --button-text-color: var(--hc-active-text);
-  --secondary-button-background: var(--hc-background);
-  --secondary-button-text-color: var(--hc-text);
-  --button-hover-background: var(--hc-secondary-active-item);
-  --secondary-button-hover-background: var(--hc-secondary-background);
-  --secondary-button-hover-border-width: 2px;
+  --button-background: var(--hc-active-item-color);
+  --button-text-color: var(--hc-active-text-color);
+  --secondary-button-background: var(--hc-background-color);
+  --secondary-button-text-color: var(--hc-text-color);
+  --button-hover-background: var(--hc-secondary-active-item-color);
+  --secondary-button-hover-background: var(--hc-secondary-background-color);
 
   // menu
-  --app-menu-button-hover-background-color: var(--hc-secondary-background);
-  --foldout-border: 1px solid var(--hc-border);
+  --app-menu-button-hover-background-color: var(--hc-secondary-background-color);
 
   // toolbar
-  --toolbar-button-focus-background-color: var(--hc-secondary-background);
-  --toolbar-button-hover-background-color: var(--hc-secondary-background);
-  --toolbar-button-active-border-color: var(--hc-border);
-  --toolbar-background-color: var(--hc-background);
-  --toolbar-button-secondary-color: var(--hc-text);
+  --toolbar-button-focus-background-color: var(--hc-secondary-background-color);
+  --toolbar-button-hover-background-color: var(--hc-secondary-background-color);
+  --toolbar-button-active-border-color: var(--hc-border-color);
+  --toolbar-background-color: var(--hc-background-color);
+  --toolbar-button-secondary-color: var(--hc-text-color);
 
   // list
-  --list-item-hover-background-color: var(--hc-secondary-active-item);
-  --list-item-hover-text-color: var(--hc-active-text);
-  --list-item-hover-border: 2px solid var(--hc-border);
-  --list-item-hover-text-color: var(--text-color);
+  --list-item-hover-background-color: var(--hc-secondary-active-item-color);
 
   // diff
-  --diff-add-border: 1px solid green;
-  --diff-delete-border: 1px solid crimson;
-  --diff-hunk-gutter-background-color: var(--hc-background);
-  --diff-text-color: var(--hc-text);
-  --diff-line-number-color: var(--hc-text);
-  --diff-gutter-background-color: var(--hc-background);
-  --diff-hunk-background-color: var(--hc-background);
-  --diff-empty-row-background-color: var(--hc-secondary-background);
-  --diff-border-color: var(--hc-border);
+  --hc-diff-add-border: 1px solid var(--hc-diff-add-border-color);
+  --hc-diff-delete-border: 1px solid var(--hc-diff-delete-border-color);
+
+  --diff-hunk-gutter-background-color: var(--hc-background-color);
+  --diff-text-color: var(--hc-text-color);
+  --diff-line-number-color: var(--hc-text-color);
+  --diff-gutter-background-color: var(--hc-background-color);
+  --diff-hunk-background-color: var(--hc-background-color);
+  --diff-empty-row-background-color: var(--hc-secondary-background-color);
+  --diff-border-color: var(--hc-border-color);
 }

--- a/app/styles/themes/_high-contrast.scss
+++ b/app/styles/themes/_high-contrast.scss
@@ -1,0 +1,73 @@
+body.theme-high-contrast {
+  // A small set of colors used to flatten ux and improve contrast
+  --hc-background: #090c11;
+  --hc-secondary-background: #323946;
+  --hc-border: #7a828e;
+  --hc-text: #f0f3f6;
+  --hc-active-item: #9ea7b3;
+  --hc-secondary-active-item: #596069;
+  --hc-active-text: #090c11;
+
+  // background/text
+  --background-color: var(--hc-background);
+  --text-color: var(--hc-text);
+  --text-secondary-color: var(--hc-text);
+
+  /// tab-bar
+  --tab-bar-hover-border: 2px solid var(--hc-border) !important;
+  --tab-bar-item-border: 2px solid var(--hc-background);
+  --tab-bar-box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
+  --tab-bar-hover-background-color: var(--hc-secondary-background);
+  --tab-bar-active-color: var(--hc-active-item);
+  --horizontal-bar-active-color: var(--hc-active-item);
+  --horizontal-bar-active-text-color: var(--hc-active-text);
+
+  // box
+  --box-selected-active-border: 2px solid var(--hc-border);
+  --box-background-color: var(--hc-background);
+  --box-alt-background-color: var(--hc-background);
+  --box-alt-text-color: var(--hc-active-text);
+  --box-border-color: var(--hc-border);
+  --box-selected-background-color: var(--hc-secondary-active-item);
+  --box-selected-text-color: var(--hc-active-text);
+  --box-selected-active-background-color: var(--hc-active-item);
+  --box-selected-active-text-color: var(--hc-active-text);
+  --box-placeholder-color: var(--hc-text);
+
+  // button
+  --button-background: var(--hc-active-item);
+  --button-text-color: var(--hc-active-text);
+  --secondary-button-background: var(--hc-background);
+  --secondary-button-text-color: var(--hc-text);
+  --button-hover-background: var(--hc-secondary-active-item);
+  --secondary-button-hover-background: var(--hc-secondary-background);
+  --secondary-button-hover-border-width: 2px;
+
+  // menu
+  --app-menu-button-hover-background-color: var(--hc-secondary-background);
+  --foldout-border: 1px solid var(--hc-border);
+
+  // toolbar
+  --toolbar-button-focus-background-color: var(--hc-secondary-background);
+  --toolbar-button-hover-background-color: var(--hc-secondary-background);
+  --toolbar-button-active-border-color: var(--hc-border);
+  --toolbar-background-color: var(--hc-background);
+  --toolbar-button-secondary-color: var(--hc-text);
+
+  // list
+  --list-item-hover-background-color: var(--hc-secondary-active-item);
+  --list-item-hover-text-color: var(--hc-active-text);
+  --list-item-hover-border: 2px solid var(--hc-border);
+  --list-item-hover-text-color: var(--text-color);
+
+  // diff
+  --diff-add-border: 1px solid green;
+  --diff-delete-border: 1px solid crimson;
+  --diff-hunk-gutter-background-color: var(--hc-background);
+  --diff-text-color: var(--hc-text);
+  --diff-line-number-color: var(--hc-text);
+  --diff-gutter-background-color: var(--hc-background);
+  --diff-hunk-background-color: var(--hc-background);
+  --diff-empty-row-background-color: var(--hc-secondary-background);
+  --diff-border-color: var(--hc-border);
+}

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -20,7 +20,7 @@
 
   &:not(:disabled):hover {
     @include high-contrast {
-      border-width: var(--secondary-button-hover-border-width);
+      border-width: 2px;
     }
 
     border-color: var(--secondary-button-focus-border-color);

--- a/app/styles/ui/_button.scss
+++ b/app/styles/ui/_button.scss
@@ -19,7 +19,10 @@
   border-radius: var(--button-border-radius);
 
   &:not(:disabled):hover {
-    border-width: var(--secondary-button-hover-border-width);
+    @include high-contrast {
+      border-width: var(--secondary-button-hover-border-width);
+    }
+
     border-color: var(--secondary-button-focus-border-color);
     background-color: var(--secondary-button-hover-background);
   }

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -271,7 +271,7 @@
     background: var(--diff-add-background-color);
 
     @include high-contrast {
-      border: var(--diff-add-border);
+      border: var(--hc-diff-add-border);
       margin-top: 1px;
     }
   }
@@ -280,7 +280,7 @@
     background: var(--diff-delete-background-color);
 
     @include high-contrast {
-      border: var(--diff-delete-border);
+      border: var(--hc-diff-delete-border);
     }
   }
 

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -269,13 +269,19 @@
 .CodeMirror-linebackground {
   &.diff-add {
     background: var(--diff-add-background-color);
-    border: var(--diff-add-border);
-    margin-top: 1px;
+
+    @include high-contrast {
+      border: var(--diff-add-border);
+      margin-top: 1px;
+    }
   }
 
   &.diff-delete {
     background: var(--diff-delete-background-color);
-    border: var(--diff-delete-border);
+
+    @include high-contrast {
+      border: var(--diff-delete-border);
+    }
   }
 
   &.diff-context {

--- a/app/styles/ui/_foldout.scss
+++ b/app/styles/ui/_foldout.scss
@@ -19,7 +19,10 @@
   .foldout {
     background: var(--background-color);
     color: var(--text-color);
-    border: var(--foldout-border);
-    overflow: hidden;
+
+    @include high-contrast {
+      border: var(--foldout-border);
+      overflow: hidden;
+    }
   }
 }

--- a/app/styles/ui/_foldout.scss
+++ b/app/styles/ui/_foldout.scss
@@ -21,7 +21,7 @@
     color: var(--text-color);
 
     @include high-contrast {
-      border: var(--foldout-border);
+      border: 1px solid var(--hc-border-color);
       overflow: hidden;
     }
   }

--- a/app/styles/ui/_list.scss
+++ b/app/styles/ui/_list.scss
@@ -70,7 +70,10 @@
 
     color: var(--text-color);
     background-color: var(--box-selected-active-background-color);
-    border: var(--box-selected-active-border);
+
+    @include high-contrast {
+      border: var(--box-selected-active-border);
+    }
   }
 }
 

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -174,7 +174,10 @@
     color: var(--diff-delete-text-color);
     background: var(--diff-delete-background-color);
     border-right: 1px solid var(--diff-border-color);
-    border: var(--diff-delete-border);
+
+    @include high-contrast {
+      border: var(--diff-delete-border);
+    }
 
     .line-number {
       background: var(--diff-delete-gutter-background-color);
@@ -192,7 +195,10 @@
   .after {
     color: var(--diff-add-text-color);
     background: var(--diff-add-background-color);
-    border: var(--diff-add-border);
+
+    @include high-contrast {
+      border: var(--diff-add-border);
+    }
 
     .line-number {
       background: var(--diff-add-gutter-background-color);
@@ -233,7 +239,10 @@
     &.added .before,
     &.deleted .after {
       background: var(--diff-empty-row-background-color);
-      border: none;
+
+      @include high-contrast {
+        border: none;
+      }
 
       .line-number {
         background: var(--diff-empty-row-gutter-background-color);
@@ -259,7 +268,10 @@
     &.context .after {
       background: var(--diff-background-color);
       color: var(--diff-text-color);
-      border: none;
+
+      @include high-contrast {
+        border: none;
+      }
 
       .line-number {
         background: var(--diff-gutter-background-color);

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -176,7 +176,7 @@
     border-right: 1px solid var(--diff-border-color);
 
     @include high-contrast {
-      border: var(--diff-delete-border);
+      border: var(--hc-diff-delete-border);
     }
 
     .line-number {
@@ -197,7 +197,7 @@
     background: var(--diff-add-background-color);
 
     @include high-contrast {
-      border: var(--diff-add-border);
+      border: var(--hc-diff-add-border);
     }
 
     .line-number {

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -13,7 +13,12 @@
 
   &-item {
     // Reset styles from global buttons
-    border: var(--tab-bar-item-border);
+    border: none;
+
+    @include high-contrast {
+      border: var(--tab-bar-item-border);
+    }
+
     box-shadow: none;
     color: var(--text-color);
     background: var(--background-color);
@@ -47,15 +52,22 @@
     // in so far that it doesn't have an active selection state, just a selected
     // one.
     &.selected {
-      box-shadow: var(--tab-bar-box-shadow);
-      background-color: var(--horizontal-bar-active-color);
-      color: var(--horizontal-bar-active-text-color);
+      box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
+
+      @include high-contrast {
+        box-shadow: var(--tab-bar-box-shadow);
+        background-color: var(--horizontal-bar-active-color);
+        color: var(--horizontal-bar-active-text-color);
+      }
     }
 
     &:hover {
       background: var(--tab-bar-hover-background-color);
-      border: var(--tab-bar-hover-border);
-      color: var(--text-color);
+
+      @include high-contrast {
+        border: var(--tab-bar-hover-border);
+        color: var(--text-color);
+      }
     }
 
     .with-indicator {
@@ -165,7 +177,10 @@
 
       &:hover {
         background: var(--tab-bar-hover-background-color);
-        border: var(--tab-bar-hover-border);
+
+        @include high-contrast {
+          border: var(--tab-bar-hover-border);
+        }
       }
     }
 

--- a/app/styles/ui/_tab-bar.scss
+++ b/app/styles/ui/_tab-bar.scss
@@ -16,7 +16,7 @@
     border: none;
 
     @include high-contrast {
-      border: var(--tab-bar-item-border);
+      border: 2px solid var(--hc-background-color);
     }
 
     box-shadow: none;
@@ -55,9 +55,9 @@
       box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
 
       @include high-contrast {
-        box-shadow: var(--tab-bar-box-shadow);
-        background-color: var(--horizontal-bar-active-color);
-        color: var(--horizontal-bar-active-text-color);
+        box-shadow: inset 0 -3px 0px var(--tab-bar-active-color);
+        background-color: var(--hc-active-item-color);
+        color: var(--hc-active-text-color);
       }
     }
 
@@ -65,7 +65,7 @@
       background: var(--tab-bar-hover-background-color);
 
       @include high-contrast {
-        border: var(--tab-bar-hover-border);
+        border: var(--hc-hover-border);
         color: var(--text-color);
       }
     }
@@ -179,7 +179,7 @@
         background: var(--tab-bar-hover-background-color);
 
         @include high-contrast {
-          border: var(--tab-bar-hover-border);
+          border: var(--hc-hover-border);
         }
       }
     }

--- a/app/styles/ui/history/_commit-list.scss
+++ b/app/styles/ui/history/_commit-list.scss
@@ -74,9 +74,11 @@
     }
   }
 
-  .list-item:hover {
-    .commit {
-      color: var(--text-color);
+  @include high-contrast {
+    .list-item:hover {
+      .commit {
+        color: var(--text-color);
+      }
     }
   }
 }

--- a/app/test/unit/custom-theme-test.ts
+++ b/app/test/unit/custom-theme-test.ts
@@ -6,10 +6,12 @@ import {
 
 describe('CustomTheme', () => {
   describe('buildCustomThemeStyles', () => {
-    it('sets the first line to body.theme-custom {', () => {
+    it('sets the first line to body.theme-high-contrast {', () => {
       const customTheme = CustomThemeDefaults[ApplicationTheme.HighContrast]
       const customThemeStyles = buildCustomThemeStyles(customTheme)
-      expect(customThemeStyles.split('\n')[0]).toBe('body.theme-custom {')
+      expect(customThemeStyles.split('\n')[0]).toBe(
+        'body.theme-high-contrast {'
+      )
     })
 
     it('sets the last line to }', () => {


### PR DESCRIPTION
## Description

There was some bleed from high-contrast border styles into non-high contrast themes. This moves high-contrast styles into their own css file and only applies them through use of a mixin instead of css variables. Making it so that when not on a high-contrast theme, there should be no new styles/variables applied.

### Screenshots

https://user-images.githubusercontent.com/75402236/133092469-7a8f73e5-8402-4417-a214-ed73a18c6f88.mov



## Release notes
Notes: [Fixed] High-contrast theme styles no longer bleed into regular themes.
