### PR TITLE
Add support for WezTerm on macOS

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -11,6 +11,7 @@ export enum Shell {
   PowerShellCore = 'PowerShell Core',
   Kitty = 'Kitty',
   Alacritty = 'Alacritty',
+  WezTerm = 'WezTerm',
 }
 
 export const Default = Shell.Terminal
@@ -33,6 +34,8 @@ function getBundleID(shell: Shell): string {
       return 'net.kovidgoyal.kitty'
     case Shell.Alacritty:
       return 'io.alacritty'
+    case Shell.WezTerm:
+      return 'com.github.wez.wezterm'
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -58,6 +61,7 @@ export async function getAvailableShells(): Promise<
     powerShellCorePath,
     kittyPath,
     alacrittyPath,
+    wezTermPath,
   ] = await Promise.all([
     getShellPath(Shell.Terminal),
     getShellPath(Shell.Hyper),
@@ -65,6 +69,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.PowerShellCore),
     getShellPath(Shell.Kitty),
     getShellPath(Shell.Alacritty),
+    getShellPath(Shell.WezTerm),
   ])
 
   const shells: Array<IFoundShell<Shell>> = []
@@ -94,6 +99,11 @@ export async function getAvailableShells(): Promise<
     shells.push({ shell: Shell.Alacritty, path: alacrittyExecutable })
   }
 
+  if (wezTermPath) {
+    const wezTermExecutable = `${wezTermPath}/Contents/MacOS/wezterm`
+    shells.push({ shell: Shell.WezTerm, path: wezTermExecutable })
+  }
+
   return shells
 }
 
@@ -115,6 +125,12 @@ export function launch(
     // It uses --working-directory command to start the shell
     // in the specified working directory.
     return spawn(foundShell.path, ['--working-directory', path])
+  } else if (foundShell.shell === Shell.WezTerm) {
+    // WezTerm, like Alacritty, "cannot open files in the 'folder' format."
+    //
+    // It uses the subcommand `start`, followed by the option `--cwd` to set
+    // the working directory, followed by the path.
+    return spawn(foundShell.path, ['start', '--cwd', path])
   } else {
     const bundleID = getBundleID(foundShell.shell)
     return spawn('open', ['-b', bundleID, path])

--- a/docs/technical/shell-integration.md
+++ b/docs/technical/shell-integration.md
@@ -149,6 +149,7 @@ These shells are currently supported:
  - [PowerShell Core](https://github.com/powershell/powershell/)
  - [Kitty](https://sw.kovidgoyal.net/kitty/)
  - [Alacritty](https://github.com/alacritty/alacritty)
+ - [WezTerm](https://github.com/wez/wezterm)
 
 These are defined in an enum at the top of the file:
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->



## Description

- This commit adds support for [WezTerm](https://github.com/wez/wezterm) to be selected as the default terminal emulator for GitHub Desktop on macOS.
- I followed the guidelines in [docs/technical/shell-integration.md](https://github.com/desktop/desktop/blob/development/docs/technical/shell-integration.md), and also referred to the (relatively) recent [PR that added support for Alacritty](https://github.com/desktop/desktop/pull/10243).
- I've verified, using the Node REPL on my own machine, the command for [launching WezTerm in a specific working directory](https://wezfurlong.org/wezterm/config/launch.html#specifying-the-current-working-directory). (It's not altogether different from what's required for Kitty or Alacritty.)



<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Adds support for WezTerm on macOS
