### PR TITLE
Reload diff when app regains focus

### DIFF
--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -120,6 +120,15 @@ function isSameFile(prevFile: ChangedFile, newFile: ChangedFile) {
   return prevFile === newFile || prevFile.id === newFile.id
 }
 
+function isSameDiff(prevDiff: IDiff, newDiff: IDiff) {
+  return (
+    prevDiff === newDiff ||
+    (isTextDiff(prevDiff) &&
+      isTextDiff(newDiff) &&
+      prevDiff.text === newDiff.text)
+  )
+}
+
 function isTextDiff(diff: IDiff): diff is ITextDiff | ILargeTextDiff {
   return diff.kind === DiffType.Text || diff.kind === DiffType.LargeText
 }

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -174,7 +174,7 @@ export class SeamlessDiffSwitcher extends React.Component<
   private slowLoadingTimeoutId: number | null = null
 
   /** File whose (old & new files) contents are being loaded. */
-  private loadingFile: ChangedFile | null = null
+  private loadingState: { file: ChangedFile; diff: IDiff } | null = null
 
   public constructor(props: ISeamlessDiffSwitcherProps) {
     super(props)
@@ -238,11 +238,15 @@ export class SeamlessDiffSwitcher extends React.Component<
       return
     }
 
-    if (this.loadingFile !== null && isSameFile(fileToLoad, this.loadingFile)) {
+    if (
+      this.loadingState !== null &&
+      isSameFile(this.loadingState.file, fileToLoad) &&
+      isSameDiff(this.loadingState.diff, diff)
+    ) {
       return
     }
 
-    this.loadingFile = fileToLoad
+    this.loadingState = { file: fileToLoad, diff }
 
     const lineFilters = getLineFilters(diff.hunks)
     const fileContents = await getFileContents(
@@ -250,6 +254,8 @@ export class SeamlessDiffSwitcher extends React.Component<
       this.props.file,
       lineFilters
     )
+
+    this.loadingState = null
 
     if (!isSameFile(fileToLoad, this.props.file)) {
       return
@@ -264,8 +270,6 @@ export class SeamlessDiffSwitcher extends React.Component<
             fileContents.newContents.length
           )
         : null
-
-    this.loadingFile = null
 
     this.setState({ diff: newDiff ?? diff, fileContents })
   }

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -220,10 +220,10 @@ export class SeamlessDiffSwitcher extends React.Component<
       }
     }
 
-    this.loadFileContentsIfNeeded()
+    this.loadFileContentsIfNeeded(prevProps.diff)
   }
 
-  private async loadFileContentsIfNeeded() {
+  private async loadFileContentsIfNeeded(prevDiff: IDiff | null) {
     const { diff, file: fileToLoad } = this.props
 
     if (diff === null || !isTextDiff(diff)) {
@@ -233,7 +233,9 @@ export class SeamlessDiffSwitcher extends React.Component<
     const currentFileContents = this.state.fileContents
     if (
       currentFileContents !== null &&
-      isSameFile(currentFileContents.file, fileToLoad)
+      isSameFile(currentFileContents.file, fileToLoad) &&
+      prevDiff !== null &&
+      isSameDiff(prevDiff, diff)
     ) {
       return
     }

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -257,7 +257,7 @@ export class SeamlessDiffSwitcher extends React.Component<
     const lineFilters = getLineFilters(diff.hunks)
     const fileContents = await getFileContents(
       this.props.repository,
-      this.props.file,
+      fileToLoad,
       lineFilters
     )
 

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -197,7 +197,7 @@ export class SeamlessDiffSwitcher extends React.Component<
     if (this.state.isLoadingDiff) {
       this.scheduleSlowLoadingTimeout()
     }
-    this.loadFileContentsIfNeeded()
+    this.loadFileContentsIfNeeded(null)
   }
 
   public componentWillUnmount() {

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -230,6 +230,8 @@ export class SeamlessDiffSwitcher extends React.Component<
       return
     }
 
+    // Have we already loaded file contents for this file and is the diff
+    // still the same, if so there's no need to do it again.
     const currentFileContents = this.state.fileContents
     if (
       currentFileContents !== null &&
@@ -240,6 +242,8 @@ export class SeamlessDiffSwitcher extends React.Component<
       return
     }
 
+    // Are we currently loading file contents for this file and is the diff
+    // still the same? If so we can wait for that to load
     if (
       this.loadingState !== null &&
       isSameFile(this.loadingState.file, fileToLoad) &&

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -263,6 +263,7 @@ export class SeamlessDiffSwitcher extends React.Component<
 
     this.loadingState = null
 
+    // Has the file changed while we've been reading it?
     if (!isSameFile(fileToLoad, this.props.file)) {
       return
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #12962

## Description

As noted in #12962 the otherwise wonderful changes we made in https://github.com/desktop/desktop/pull/12903 had the unintended side-effect of not reloading diffs when the application loses and then regains focus. This PR makes us consider changed between the previous and current diff (the diff between the diff and the diff or the diff diff if you will) as a condition for diff reload in the seamless diff switcher.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Refresh diffs when application receives focus
