### PR TITLE
Only consider invalid tokens when 401s come from GH(E)

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1058,7 +1058,13 @@ export class API {
       options.reloadCache
     )
 
-    if (response.status === 401) {
+    // Only consider invalid token when the status is 401 and the response has
+    // the X-GitHub-Request-Id header, meaning it comes from GH(E) and not from
+    // any kind of proxy/gateway. For more info see #12943
+    if (
+      response.status === 401 &&
+      response.headers.has('X-GitHub-Request-Id')
+    ) {
       API.emitTokenInvalidated(this.endpoint)
     }
 

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1061,9 +1061,12 @@ export class API {
     // Only consider invalid token when the status is 401 and the response has
     // the X-GitHub-Request-Id header, meaning it comes from GH(E) and not from
     // any kind of proxy/gateway. For more info see #12943
+    // We're also not considering a token has been invalidated when the reason
+    // behind a 401 is the fact that any kind of 2 factor auth is required.
     if (
       response.status === 401 &&
-      response.headers.has('X-GitHub-Request-Id')
+      response.headers.has('X-GitHub-Request-Id') &&
+      !response.headers.has('X-GitHub-OTP')
     ) {
       API.emitTokenInvalidated(this.endpoint)
     }


### PR DESCRIPTION
Closes #12943 

## Description

It seems company gateways/proxies might give a 401 error in certain circumstances when users attempt to access GHE instances (in the issue above, when the user tries to access GHE repos from out of the company VPN).

This PR adds an additional check to make sure the 401 we received comes from GH(E) by looking for the `X-GitHub-Request-Id` header, and only in that scenario the app will consider the token invalid.

## Release notes

Notes: [Fixed] Tokens are not considered invalid when accessing GitHub Enterprise from outside of the company's VPN
