### PR TITLE
Bump Electron to v11.5.0

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -145,7 +145,5 @@ export function enableSSHAskPass(): boolean {
 
 /** Should we use the setImmediate alternative? */
 export function enableSetAlmostImmediate(): boolean {
-  // We only noticed the problem with `setImmediate` on macOS, so no need to
-  // use this trick on Windows for now.
-  return __DARWIN__ && enableBetaFeatures()
+  return false
 }

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "=11.2.0",
+    "electron": "=11.5.0",
     "electron-builder": "^22.7.0",
     "electron-packager": "^15.1.0",
     "electron-winstaller": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,10 +4212,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@=11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.2.0.tgz#f8577ea4c9ba94068850256145be26b0b89a5dd7"
-  integrity sha512-weszOPAJPoPu6ozL7vR9enXmaDSqH+KE9iZODfbGdnFgtVfVdfyedjlvEGIUJkLMPXM1y/QWwCl2dINzr0Jq5Q==
+electron@=11.5.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.5.0.tgz#f1650543b9d8f2047d3807755bdb120153ed210f"
+  integrity sha512-WjNDd6lGpxyiNjE3LhnFCAk/D9GIj1rU3GSDealVShhkkkPR3Vh4q8ErXGDl1OAO/faomVa10KoFPUN/pLbNxg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
## Description

This PR upgrades Electron to the latest v11.x release and disables the workaround introduced in #12765 for the bug in electron/electron#29261

The reason is it's possible the aforementioned Electron bug might happen only after reloading the app from the Dev tools. If we confirm that's the case, we'll remove the whole changeset introduced in #12765 in a future PR.

## Release notes

Notes: no-notes
