### PR TITLE
Release 2.9.4-beta3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.4-beta2",
+  "version": "2.9.4-beta3",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "2.9.4-beta3": [
+      "[Fixed] Refresh diffs when application receives focus - #12962",
+      "[Fixed] Tokens are not considered invalid when accessing GitHub Enterprise from outside of the company's VPN - #12943",
+      "[Improved] Upgrade embedded Git to v2.32.0 on macOS, and to v2.32.0.windows.2 on Windows - #13000"
+    ],
     "2.9.4-beta2": [
       "[Added] Add support for WezTerm on macOS - #12957. Thanks @theodore-s-beers!",
       "[Fixed] Remove high-contrast specific hover effects from light and dark theme - #12952",

--- a/script/build.ts
+++ b/script/build.ts
@@ -40,6 +40,7 @@ import {
   getExecutableName,
   isPublishable,
   getIconFileName,
+  getDistArchitecture,
 } from './dist-info'
 import { isCircleCI, isGitHubActions } from './build-platforms'
 
@@ -376,9 +377,11 @@ function copyDependencies() {
       'Microsoft.Vsts.Authentication.dll',
       'git-askpass.exe',
       'git-credential-manager.exe',
+      'WebView2Loader.dll',
     ]
 
-    const gitCoreDir = path.join(gitDir, 'mingw64', 'libexec', 'git-core')
+    const mingwFolder = getDistArchitecture() === 'x64' ? 'mingw64' : 'mingw32'
+    const gitCoreDir = path.join(gitDir, mingwFolder, 'libexec', 'git-core')
 
     for (const file of files) {
       const filePath = path.join(gitCoreDir, file)


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming third beta of the v2.9.4 series? Well, you've just found it, congratulations!

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
--- Only change is the `setAlmostImmediate` feature flag, which has been completely disabled 🤞 
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
--- No new metrics