### PR TITLE
Fix missing initial syntax highlighting for simple unified diffs

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -623,6 +623,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
 
   private getAndStoreCodeMirrorInstance = (cmh: CodeMirrorHost | null) => {
     this.codeMirror = cmh === null ? null : cmh.getEditor()
+    this.initDiffSyntaxMode()
   }
 
   private onContextMenu = (instance: CodeMirror.Editor, event: Event) => {
@@ -1444,8 +1445,6 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   }
 
   public componentDidMount() {
-    this.initDiffSyntaxMode()
-
     // Listen for the custom event find-text (see app.tsx)
     // and trigger the search plugin if we see it.
     document.addEventListener('find-text', this.onFindText)

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1395,6 +1395,10 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       return
     }
 
+    if (!isSameFileContents(this.props.fileContents, prevProps.fileContents)) {
+      this.initDiffSyntaxMode()
+    }
+
     if (canSelect(this.props.file)) {
       if (
         !canSelect(prevProps.file) ||
@@ -1475,4 +1479,8 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
       />
     )
   }
+}
+
+function isSameFileContents(x: IFileContents | null, y: IFileContents | null) {
+  return x?.newContents === y?.newContents && x?.oldContents === y?.oldContents
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Spotted this while working on #12979. For non-expandable diffs 

### Steps to reproduce

1. Create a straightforward diff which will be the first selected in the repository, like a new file called `a.js` containing `function() {}`.
2. Reload or launch the app

Expected results
The file is syntax highlighted

Actual results
It's not because the file contents are loaded asynchronously by the `SeamlessDiffSwitcher` but there's not logic in `TextDiff` to update syntax highlighting when file contents change (in this case "change" means "are loaded").

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Syntax highlighting is once again applied when viewing a small change for the first time