### PR TITLE
Scroll diff to top if we switched to a new file

### DIFF
--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -236,6 +236,14 @@ export class SideBySideDiff extends React.Component<
         diff: this.props.diff,
       })
     }
+
+    // Scroll to top if we switched to a new file
+    if (
+      this.virtualListRef.current !== null &&
+      this.props.file.id !== prevProps.file.id
+    ) {
+      this.virtualListRef.current.scrollToPosition(0)
+    }
   }
 
   private canExpandDiff() {

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -1424,6 +1424,11 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
     if (snapshot !== null) {
       this.codeMirror.scrollTo(undefined, snapshot.top)
     }
+
+    // Scroll to top if we switched to a new file
+    if (this.props.file.id !== prevProps.file.id) {
+      this.codeMirror.scrollTo(undefined, 0)
+    }
   }
 
   public getSnapshotBeforeUpdate(


### PR DESCRIPTION
Closes #12980

## Description

This PR scrolls the diff to the top when switching between files. I tried to save the scroll position per file and restore it when needed, but it was a minefield, especially given we have 2 completely different implementations of the diff viewer. For example, not only it's resulting difficult to restore the scroll position after the cells have been resized and rendered, but there are also some situations (resizing and expanding diffs) where the stored position won't be useful.

Because of that, I decided to just fix the most annoying part for now 😅 

## Release notes

Notes: [Fixed] Diff are scrolled to the top when switching between files.
