### PR TITLE
add syntax mapping for HAML

### DIFF
--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -314,6 +314,12 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     },
   },
   {
+    install: () => import('codemirror/mode/haml/haml'),
+    mappings: {
+      '.haml': 'text/x-haml',
+    },
+  },
+  {
     install: () => import('codemirror/mode/sieve/sieve'),
     mappings: {
       '.sieve': 'application/sieve',

--- a/docs/technical/syntax-highlighting.md
+++ b/docs/technical/syntax-highlighting.md
@@ -8,7 +8,7 @@ We introduced syntax highlighted diffs in [#3101](https://github.com/desktop/des
 
 We currently support syntax highlighting for the following languages and file types.
 
-JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart and Docker.
+JavaScript, JSON, TypeScript, Coffeescript, HTML, Asp, JavaServer Pages, CSS, SCSS, LESS, VUE, Markdown, Yaml, XML, Diff, Objective-C, Scala, C#, Java, C, C++, Kotlin, Ocaml, F#, Swift, sh/bash, SQL, CYPHER, Go, Perl, PHP, Python, Ruby, Clojure, Rust, Elixir, Haxe, R, PowerShell, Visual Basic, Fortran, Lua, Crystal, Julia, sTex, SPARQL, Stylus, Soy, Smalltalk, Slim, HAML, Sieve, Scheme, ReStructuredText, RPM, Q, Puppet, Pug, Protobuf, Properties, Apache Pig, ASCII Armor (PGP), Oz, Pascal, Toml, Dart and Docker.
 
 This list was never meant to be exhaustive, we expect to add more languages going forward but this seemed like a good first step.
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13009

## Description

this PR just adds syntax mapping for [HAML](https://haml.info/)

## Release notes

Adding syntax mapping for [HAML](https://haml.info/)

Notes: you rock! 🙌 

**PS:** please tell [Brendan Forster](https://github.com/shiftkey/) that [his 🐧 Linux patches on GitHub Desktop are great](https://github.com/shiftkey/desktop#github-desktop---the-linux-fork) and that I hope that this will merged some day so that GitHub Desktop will have [official Linux support](https://github.com/desktop/desktop/issues/1525)