### PR TITLE
Filesize error improvement

### DIFF
--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -18,6 +18,7 @@ import { isErrnoException } from '../errno-exception'
 import { ChildProcess } from 'child_process'
 import { Readable } from 'stream'
 import split2 from 'split2'
+import { getFileFromExceedsError } from '../helpers/regex'
 import { merge } from '../merge'
 import { withTrampolineEnv } from '../trampoline/trampoline-environment'
 
@@ -239,6 +240,15 @@ export async function git(
     }
 
     log.error(errorMessage.join('\n'))
+
+    if (gitError === DugiteError.PushWithFileSizeExceedingLimit) {
+      const result = getFileFromExceedsError(errorMessage.join())
+      const files = result.join('\n')
+
+      if (files !== '') {
+        gitResult.gitErrorDescription += '\n\nFile causing error:\n\n' + files
+      }
+    }
 
     throw new GitError(gitResult, args)
   })

--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -51,3 +51,43 @@ export function getMatches(text: string, re: RegExp): Array<RegExpExecArray> {
 export function escapeRegExp(expression: string) {
   return expression.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
 }
+
+
+/*
+ * Looks for the phrases "remote: error File " and " is (file size I.E. 106.5 MB); this exceeds GitHub's file size limit of 100.00 MB"
+ * inside of a string containing errors and return an array of all the filenames and their sizes located between these two strings.
+ *
+ * example return [ "LargeFile.exe (150.00 MB)", "AlsoTooLargeOfAFile.txt (1.00 GB)" ]
+ */
+export function getFileFromExceedsError(error: string): string[] {
+  const endRegex = /(;\sthis\sexceeds\sGitHub's\sfile\ssize\slimit\sof\s100.00\sMB)/gm
+  const beginRegex = /(^remote:\serror:\sFile\s)/gm
+  const beginMatches = Array.from(error.matchAll(beginRegex))
+  const endMatches = Array.from(error.matchAll(endRegex))
+
+  // Something went wrong and we didn't find the same amount of endings as we did beginnings
+  // Just return an empty array as the output we'd give would look weird anyway
+  if (beginMatches.length !== endMatches.length) {
+    return []
+  }
+
+  const files: string[] = []
+
+  for (let index = 0; index < beginMatches.length; index++) {
+    const beginMatch = beginMatches[index]
+    const endMatch = endMatches[index]
+
+    if (beginMatch.index === undefined || endMatch.index === undefined) {
+      continue
+    }
+
+    const from = beginMatch.index + beginMatch[0].length
+    const to = endMatch.index
+    let file = error.slice(from, to)
+    file = file.replace('is ', '(')
+    file += ')'
+    files.push(file)
+  }
+
+  return files
+}

--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -52,7 +52,6 @@ export function escapeRegExp(expression: string) {
   return expression.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
 }
 
-
 /*
  * Looks for the phrases "remote: error File " and " is (file size I.E. 106.5 MB); this exceeds GitHub's file size limit of 100.00 MB"
  * inside of a string containing errors and return an array of all the filenames and their sizes located between these two strings.


### PR DESCRIPTION
Is a redo of #12540 since I ruined the git history.
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #10242 

## Description

- This will put the offending file name in the error message 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/41391321/134847583-8e44dff9-51c3-4807-b099-ee56e708ab49.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added offending file name to the file exceeds size limit error.
