### PR TITLE
add an option to select source branch after cherry-pick

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -289,6 +289,13 @@ export interface IAppState {
    * order for external contributions in latest release.
    */
   readonly lastThankYou: ILastThankYou | undefined
+
+  /**
+   * Indicate if, after a successful cherry-pick, desktop should restore
+   * source branch and commit selection instead of staying on the target 
+   * branch.
+   */
+  readonly cherryPickRestoreSource: boolean
 }
 
 export enum FoldoutType {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -347,6 +347,8 @@ const hasShownCherryPickIntroKey = 'has-shown-cherry-pick-intro'
 const dragAndDropIntroTypesShownKey = 'drag-and-drop-intro-types-shown'
 const lastThankYouKey = 'version-and-users-of-last-thank-you'
 const customThemeKey = 'custom-theme-key'
+const cherryPickRestoreSourceKey = 'cherry-pick-restore-source-branch'
+
 export class AppStore extends TypedBaseStore<IAppState> {
   private readonly gitStoreCache: GitStoreCache
 
@@ -448,6 +450,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private repositoryIndicatorsEnabled: boolean
 
+  private cherryPickRestoreSource: boolean = false
+
   /** Which step the user needs to complete next in the onboarding tutorial */
   private currentOnboardingTutorialStep = TutorialStep.NotApplicable
   private readonly tutorialAssessor: OnboardingTutorialAssessor
@@ -508,6 +512,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.tutorialAssessor = new OnboardingTutorialAssessor(
       this.getResolvedExternalEditor
     )
+
+    if (getBoolean(cherryPickRestoreSourceKey) === undefined) {
+      setBoolean(cherryPickRestoreSourceKey, false)
+    }
+    this.cherryPickRestoreSource =
+      getBoolean(cherryPickRestoreSourceKey) ?? true
 
     // We're considering flipping the default value and have new users
     // start off with repository indicators disabled. As such we'll start
@@ -853,6 +863,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       dragAndDropIntroTypesShown: this.dragAndDropIntroTypesShown,
       currentDragElement: this.currentDragElement,
       lastThankYou: this.lastThankYou,
+      cherryPickRestoreSource: this.cherryPickRestoreSource
     }
   }
 
@@ -3096,6 +3107,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setUseWindowsOpenSSH(useWindowsOpenSSH: boolean) {
     setBoolean(UseWindowsOpenSSHKey, useWindowsOpenSSH)
     this.useWindowsOpenSSH = useWindowsOpenSSH
+
+    this.emitUpdate()
+  }
+
+  public _setCherryPickRestoreSourceSetting(cherryPickRestoreSource: boolean) {
+    setBoolean(cherryPickRestoreSourceKey, cherryPickRestoreSource)
+    this.cherryPickRestoreSource = cherryPickRestoreSource
 
     this.emitUpdate()
   }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1416,6 +1416,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedShell={this.state.selectedShell}
             selectedTheme={this.state.selectedTheme}
             customTheme={this.state.customTheme}
+            cherryPickRestoreSource={this.state.cherryPickRestoreSource}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
           />
         )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2589,6 +2589,10 @@ export class Dispatcher {
     this.appStore._setUseWindowsOpenSSH(useWindowsOpenSSH)
   }
 
+  public setCherryPickRestoreSourceSetting(cherryPickRestoreSource: boolean) {
+    this.appStore._setCherryPickRestoreSourceSetting(cherryPickRestoreSource)
+  }
+
   public recordDiffOptionsViewed() {
     return this.statsStore.recordDiffOptionsViewed()
   }
@@ -2923,6 +2927,9 @@ export class Dispatcher {
 
     switch (cherryPickResult) {
       case CherryPickResult.CompletedWithoutError:
+        if (this.appStore.getState().cherryPickRestoreSource && sourceBranch) {
+          await this.checkoutBranch(repository, sourceBranch)
+        }
         await this.changeCommitSelection(repository, [commits[0].sha])
         await this.completeMultiCommitOperation(repository, commits.length)
         break

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2930,7 +2930,7 @@ export class Dispatcher {
         if (this.appStore.getState().cherryPickRestoreSource && sourceBranch) {
           await this.checkoutBranch(repository, sourceBranch)
         }
-        await this.changeCommitSelection(repository, [commits[0].sha])
+        await this.changeCommitSelection(repository, commits.map(commit => commit.sha))
         await this.completeMultiCommitOperation(repository, commits.length)
         break
       case CherryPickResult.ConflictsEncountered:

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -12,12 +12,15 @@ interface IAdvancedPreferencesProps {
   readonly optOutOfUsageTracking: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly repositoryIndicatorsEnabled: boolean
+  readonly cherryPickRestoreSource: boolean
+
   readonly onUseWindowsOpenSSHChanged: (checked: boolean) => void
   readonly onOptOutofReportingChanged: (checked: boolean) => void
   readonly onUncommittedChangesStrategyChanged: (
     value: UncommittedChangesStrategy
   ) => void
   readonly onRepositoryIndicatorsEnabledChanged: (enabled: boolean) => void
+  readonly onCherryPickResourceSourceChanged: (checked: boolean) => void
 }
 
 interface IAdvancedPreferencesState {
@@ -75,6 +78,12 @@ export class Advanced extends React.Component<
   ) => {
     this.props.onUseWindowsOpenSSHChanged(event.currentTarget.checked)
   }
+  
+  private onCherryPickResourceSourceChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.props.onCherryPickResourceSourceChanged(event.currentTarget.checked)
+  }
 
   private reportDesktopUsageLabel() {
     return (
@@ -119,6 +128,16 @@ export class Advanced extends React.Component<
             }
             label="Always stash and leave my changes on the current branch"
             onSelected={this.onUncommittedChangesStrategyChanged}
+          />
+        </div>
+        <div className="advanced-section">
+          <h2>Cherry picking</h2>
+          <Checkbox
+            label="Restore source branch and commit selection after cherry picking"
+            value={
+              this.props.cherryPickRestoreSource ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onCherryPickResourceSourceChanged}
           />
         </div>
         <div className="advanced-section">

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -59,6 +59,7 @@ interface IPreferencesProps {
   readonly selectedTheme: ApplicationTheme
   readonly customTheme?: ICustomTheme
   readonly repositoryIndicatorsEnabled: boolean
+  readonly cherryPickRestoreSource: boolean
 }
 
 interface IPreferencesState {
@@ -89,6 +90,7 @@ interface IPreferencesState {
    */
   readonly existingLockFilePath?: string
   readonly repositoryIndicatorsEnabled: boolean
+  readonly cherryPickRestoreSource: boolean
 }
 
 /** The app-level preferences component. */
@@ -119,6 +121,7 @@ export class Preferences extends React.Component<
       availableShells: [],
       selectedShell: this.props.selectedShell,
       repositoryIndicatorsEnabled: this.props.repositoryIndicatorsEnabled,
+      cherryPickRestoreSource: this.props.cherryPickRestoreSource,
     }
   }
 
@@ -170,6 +173,7 @@ export class Preferences extends React.Component<
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
+      cherryPickRestoreSource: this.props.cherryPickRestoreSource,
     })
   }
 
@@ -334,6 +338,7 @@ export class Preferences extends React.Component<
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
+            cherryPickRestoreSource={this.state.cherryPickRestoreSource}
             onUseWindowsOpenSSHChanged={this.onUseWindowsOpenSSHChanged}
             onOptOutofReportingChanged={this.onOptOutofReportingChanged}
             onUncommittedChangesStrategyChanged={
@@ -341,6 +346,9 @@ export class Preferences extends React.Component<
             }
             onRepositoryIndicatorsEnabledChanged={
               this.onRepositoryIndicatorsEnabledChanged
+            }
+            onCherryPickResourceSourceChanged={
+              this.onCherryPickResourceSourceChanged
             }
           />
         )
@@ -426,6 +434,12 @@ export class Preferences extends React.Component<
     this.props.dispatcher.setCustomTheme(theme)
   }
 
+  private onCherryPickResourceSourceChanged = (
+    cherryPickRestoreSource: boolean
+  ) => {
+    this.setState({ cherryPickRestoreSource })
+  }
+
   private renderFooter() {
     const hasDisabledError = this.state.disallowedCharactersMessage != null
 
@@ -509,6 +523,9 @@ export class Preferences extends React.Component<
       this.props.dispatcher.postError(e)
       return
     }
+    this.props.dispatcher.setCherryPickRestoreSourceSetting(
+      this.state.cherryPickRestoreSource
+    )
 
     this.props.dispatcher.setUseWindowsOpenSSH(this.state.useWindowsOpenSSH)
 


### PR DESCRIPTION

<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->
Closes #13031

## Description
* add an entry in parameters dialog, advanced tab, ' Restore source branch and commit selection after cherry picking', default to false.
* added a boolean key 'cherry-pick-restore-source-branch'
* modified code to select source branch after cherry picking if option enabled

### Screenshots


![desktop-cherry-pick](https://user-images.githubusercontent.com/1267483/135042114-4abd2887-3a34-4030-9720-4850e3c3da5a.gif)

## Release notes

* add an option to stay on source branch after cherry-picking.

Notes:

It seems like the function `dispatcher.changeCommitSelection` does not work correctly ( the commits seems to be selected, but the list view state is not correct, and the file list is empty. you have to select another commit and re-select the commit that was selected to update the list.
