### PR TITLE
Create tag improvements, part II

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -152,3 +152,8 @@ export function enableSetAlmostImmediate(): boolean {
 export function enableCICheckRuns(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should we show previous tags as suggestions? */
+export function enablePreviousTagSuggestions(): boolean {
+  return enableBetaFeatures()
+}

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import _ from 'lodash'
 
 import { Repository } from '../../models/repository'
 import { Dispatcher } from '../dispatcher'
@@ -52,7 +51,6 @@ export class CreateTag extends React.Component<
   public render() {
     const error = this.getCurrentError()
     const disabled = error !== null || this.state.tagName.length === 0
-    const lastThreeTags = _.takeRight(this.state.previousTags, 3)
 
     return (
       <Dialog
@@ -72,22 +70,7 @@ export class CreateTag extends React.Component<
             onValueChange={this.updateTagName}
           />
 
-          {this.state.previousTags !== null && (
-            <>
-              <p>Previous Tags</p>
-              {lastThreeTags.length === 0 ? (
-                <>
-                  <p>{`No matches found for '${this.state.tagName}'`}</p>
-                </>
-              ) : (
-                lastThreeTags.map((item: string, index: number) => (
-                  <>
-                    <Ref key={index}>{item}</Ref>{' '}
-                  </>
-                ))
-              )}
-            </>
-          )}
+          {this.renderPreviousTags()}
         </DialogContent>
 
         <DialogFooter>
@@ -97,6 +80,34 @@ export class CreateTag extends React.Component<
           />
         </DialogFooter>
       </Dialog>
+    )
+  }
+
+  private renderPreviousTags() {
+    const { localTags } = this.props
+    const { previousTags, tagName } = this.state
+
+    if (previousTags === null || localTags === null || localTags.size === 0) {
+      return null
+    }
+
+    const lastThreeTags = previousTags.slice(-3)
+
+    return (
+      <>
+        <p>Previous Tags</p>
+        {lastThreeTags.length === 0 ? (
+          <>
+            <p>{`No matches found for '${tagName}'`}</p>
+          </>
+        ) : (
+          lastThreeTags.map((item: string, index: number) => (
+            <>
+              <Ref key={index}>{item}</Ref>{' '}
+            </>
+          ))
+        )}
+      </>
     )
   }
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -8,6 +8,7 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { startTimer } from '../lib/timing'
 import { Ref } from '../lib/ref'
 import { RefNameTextBox } from '../lib/ref-name-text-box'
+import { enablePreviousTagSuggestions } from '../../lib/feature-flag'
 
 interface ICreateTagProps {
   readonly repository: Repository
@@ -84,6 +85,10 @@ export class CreateTag extends React.Component<
   }
 
   private renderPreviousTags() {
+    if (!enablePreviousTagSuggestions()) {
+      return null
+    }
+
     const { localTags } = this.props
     const { previousTags, tagName } = this.state
 

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -91,11 +91,12 @@ export class CreateTag extends React.Component<
       return null
     }
 
+    const title = __DARWIN__ ? 'Previous Tags' : 'Previous tags'
     const lastThreeTags = previousTags.slice(-3)
 
     return (
       <>
-        <p>Previous Tags</p>
+        <p>{title}</p>
         {lastThreeTags.length === 0 ? (
           <>
             <p>{`No matches found for '${tagName}'`}</p>

--- a/app/src/ui/create-tag/create-tag-dialog.tsx
+++ b/app/src/ui/create-tag/create-tag-dialog.tsx
@@ -103,14 +103,10 @@ export class CreateTag extends React.Component<
       <>
         <p>{title}</p>
         {lastThreeTags.length === 0 ? (
-          <>
-            <p>{`No matches found for '${tagName}'`}</p>
-          </>
+          <p>{`No matches found for '${tagName}'`}</p>
         ) : (
           lastThreeTags.map((item: string, index: number) => (
-            <>
-              <Ref key={index}>{item}</Ref>{' '}
-            </>
+            <Ref key={index}>{item}</Ref>
           ))
         )}
       </>

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -376,6 +376,11 @@ dialog {
   }
   &#create-tag {
     width: 400px;
+
+    // Spacing for list of previous tags
+    .ref-component {
+      margin-right: var(--spacing-half);
+    }
   }
 
   &#confirm-remove-repository,


### PR DESCRIPTION
## Description

This PR is a continuation of #12966 with the following changes:
- Don't show the `Previous Tags` section at all if the repo has no tags.
- Fix the `Previous Tags` title to be `Previous tags` on Windows.
- Use `.slice(-3)` instead of `_.takeRight(…)` as @say25 suggested (❤️ )
- Hide this new feature behind a feature flag, and enable it for beta.

## Release notes

Notes: no-notes
