### PR TITLE
Wrap long email addresses in the misattributed commit warning popover

### DIFF
--- a/app/src/ui/changes/commit-message-avatar.tsx
+++ b/app/src/ui/changes/commit-message-avatar.tsx
@@ -130,8 +130,9 @@ export class CommitMessageAvatar extends React.Component<
         <h3>This commit will be misattributed</h3>
         <Row>
           <div>
-            The email in your global Git config ({this.props.email}) doesn't
-            match your GitHub{accountTypeSuffix} account.{' '}
+            The email in your global Git config (
+            <span className="git-email">{this.props.email}</span>) doesn't match
+            your GitHub{accountTypeSuffix} account.{' '}
             <LinkButton uri="https://docs.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user">
               Learn more.
             </LinkButton>

--- a/app/styles/ui/_commit-message-avatar.scss
+++ b/app/styles/ui/_commit-message-avatar.scss
@@ -49,6 +49,10 @@
     color: var(--text-secondary-color);
   }
 
+  .git-email {
+    overflow-wrap: anywhere;
+  }
+
   .popover-component {
     // This allows for using <Rows> to structure content within dialog content.
     // All Rows that are direct descendants of dialog content except for the


### PR DESCRIPTION
## Description

This PR makes sure long email addresses are wrapped and don't overflow in the misattributed commit warning popover.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1083228/135257641-1984c3b1-7602-4d5f-97b9-1e7a5e61c35f.png)

After:
![image](https://user-images.githubusercontent.com/1083228/135257684-20de8ae2-55cf-42b6-816d-0464c649817a.png)

## Release notes

Notes: no-notes
