### PR TITLE
Fix SSH prompt parser for some variants

### DIFF
--- a/app/src/lib/ssh/ssh.ts
+++ b/app/src/lib/ssh/ssh.ts
@@ -73,7 +73,7 @@ export async function getSSHEnvironment() {
 }
 
 export function parseAddSSHHostPrompt(prompt: string) {
-  const promptRegex = /^The authenticity of host '([^ ]+) \(([^\)]+)\)' can't be established.\n([^ ]+) key fingerprint is ([^.]+).\n(?:.*\n)*Are you sure you want to continue connecting \(yes\/no\/\[fingerprint\]\)\? $/
+  const promptRegex = /^The authenticity of host '([^ ]+) \(([^\)]+)\)' can't be established[^.]*\.\n([^ ]+) key fingerprint is ([^.]+)\./
 
   const matches = promptRegex.exec(prompt)
   if (matches === null || matches.length < 5) {

--- a/app/test/unit/ssh-test.ts
+++ b/app/test/unit/ssh-test.ts
@@ -32,5 +32,37 @@ Are you sure you want to continue connecting (yes/no/[fingerprint])? `
         keyType: 'FAKE-TYPE',
       })
     })
+
+    it('extracts info from fake host key fingerprint when keys of different type are available', () => {
+      const prompt = `The authenticity of host 'my-domain.com (1.2.3.4)' can't be established
+but keys of different type are already known for this host.
+FAKE-TYPE key fingerprint is ThisIsAFakeFingerprintForTestingPurposes.
+Are you sure you want to continue connecting (yes/no/[fingerprint])? `
+
+      const info = parseAddSSHHostPrompt(prompt)
+
+      expect(info).toEqual({
+        host: 'my-domain.com',
+        ip: '1.2.3.4',
+        fingerprint: 'ThisIsAFakeFingerprintForTestingPurposes',
+        keyType: 'FAKE-TYPE',
+      })
+    })
+
+    it('extract info when [fingerprint] option is not present', () => {
+      const prompt = `The authenticity of host 'my-domain.com (1.2.3.4)' can't be established.
+FAKE-TYPE key fingerprint is ThisIsAFakeFingerprintForTestingPurposes.
+This key is not known by any other names.
+Are you sure you want to continue connecting (yes/no)? `
+
+      const info = parseAddSSHHostPrompt(prompt)
+
+      expect(info).toEqual({
+        host: 'my-domain.com',
+        ip: '1.2.3.4',
+        fingerprint: 'ThisIsAFakeFingerprintForTestingPurposes',
+        keyType: 'FAKE-TYPE',
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #13050

## Description

This PR relaxes the regex used to parse the SSH prompt for unknown host key fingerprints in order to support different prompt variants. According to https://github.com/openssh/openssh-portable/blob/53237ac789183946dac6dcb8838bc3b6b9b43be1/sshconnect.c#L1136the prompt might include certain info we didn't take into account, so this PR…
1. Stops parsing beyond the fingerprint
2. Ignores whatever is between `established` and the next `.`

## Release notes

Notes: no-notes
