### PR TITLE
Release 2.9.4-beta4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.4-beta3",
+  "version": "2.9.4-beta4",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -2,7 +2,7 @@
   "releases": {
     "2.9.4-beta4": [
       "[Added] Add syntax mapping for HAML - #13009. Thanks @alexanderadam!",
-      "[Fixed] Diff are scrolled to the top when switching between files - #12980",
+      "[Fixed] Diffs are scrolled to the top when switching between files - #12980",
       "[Fixed] Fix SSH prompt for unknown hosts in some scenarios - #13050",
       "[Fixed] Syntax highlighting is once again applied when viewing a small change for the first time - #13004",
       "[Fixed] Wrap long email addresses in the misattributed commit warning popover - #13044",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 {
   "releases": {
+    "2.9.4-beta4": [
+      "[Fixed] Add syntax mapping for HAML - #13009. Thanks @alexanderadam!",
+      "[Fixed] Diff are scrolled to the top when switching between files - #12980",
+      "[Fixed] Fix SSH prompt for unknown hosts in some scenarios - #13050",
+      "[Fixed] Syntax highlighting is once again applied when viewing a small change for the first time - #13004",
+      "[Fixed] Wrap long email addresses in the misattributed commit warning popover - #13044",
+      "[Improved] Added offending file name to the file exceeds size limit error - #10242. Thanks @ADustyOldMuffin!",
+      "[Improved] Show a message explaining why line selection is disabled when hiding whitespace - #12979",
+      "[Improved] Show previous similar tags in the tag creation dialog - #12509. Thanks @mahezsh!"
+    ],
     "2.9.4-beta3": [
       "[Fixed] Refresh diffs when application receives focus - #12962",
       "[Fixed] Tokens are not considered invalid when accessing GitHub Enterprise from outside of the company's VPN - #12943",

--- a/changelog.json
+++ b/changelog.json
@@ -4,9 +4,9 @@
       "[Added] Add syntax mapping for HAML - #13009. Thanks @alexanderadam!",
       "[Fixed] Diffs are scrolled to the top when switching between files - #12980",
       "[Fixed] Fix SSH prompt for unknown hosts in some scenarios - #13050",
-      "[Fixed] Syntax highlighting is once again applied when viewing a small change for the first time - #13004",
+      "[Fixed] Apply syntax highlighting when viewing a small change for the first time - #13004",
       "[Fixed] Wrap long email addresses in the misattributed commit warning popover - #13044",
-      "[Improved] Added offending file name to the file exceeds size limit error - #10242. Thanks @ADustyOldMuffin!",
+      "[Improved] Add offending file name to the file exceeds size limit error - #10242. Thanks @ADustyOldMuffin!",
       "[Improved] Show a message explaining why line selection is disabled when hiding whitespace - #12979",
       "[Improved] Show previous similar tags in the tag creation dialog - #12509. Thanks @mahezsh!"
     ],

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.9.4-beta4": [
-      "[Fixed] Add syntax mapping for HAML - #13009. Thanks @alexanderadam!",
+      "[Added] Add syntax mapping for HAML - #13009. Thanks @alexanderadam!",
       "[Fixed] Diff are scrolled to the top when switching between files - #12980",
       "[Fixed] Fix SSH prompt for unknown hosts in some scenarios - #13050",
       "[Fixed] Syntax highlighting is once again applied when viewing a small change for the first time - #13004",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming fourth beta of the v2.9.4 series? Well, you've just found it, congratulations!

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
--- `setAlmostImmediate` is still disabled, the new CI check runs are only enabled for dev and the tag creation improvements enabled for beta. All looking as expected!
![image](https://user-images.githubusercontent.com/1083228/135880479-3e55ddc4-1ea9-44fc-b366-f3b2fd114171.png)

- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
--- No new metrics