### PR TITLE
Moving the retrieval of actions workflows sooner for better performance

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1038,20 +1038,18 @@ export class API {
    * List workflow run jobs for a given workflow run
    */
   public async fetchWorkflowRunJobs(
-    workflowRun: IAPIWorkflowRun
+    jobs_url: string
   ): Promise<IAPIWorkflowJobs | null> {
     const customHeaders = {
       Accept: 'application/vnd.github.antiope-preview+json',
     }
-    const response = await this.request('GET', workflowRun.jobs_url, {
+    const response = await this.request('GET', jobs_url, {
       customHeaders,
     })
     try {
       return await parsedResponse<IAPIWorkflowJobs>(response)
     } catch (err) {
-      log.debug(
-        `Failed fetching workflow jobs for workflow run named: ${workflowRun.name}`
-      )
+      log.debug(`Failed fetching workflow jobs: ${jobs_url}`)
     }
     return null
   }

--- a/app/src/ui/branches/ci-check-list-item-logs.tsx
+++ b/app/src/ui/branches/ci-check-list-item-logs.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react'
+import {
+  getCheckDurationInSeconds,
+  IRefCheck,
+  IRefCheckOutput,
+  RefCheckOutputType,
+} from '../../lib/stores/commit-status-store'
+
+import { Octicon } from '../octicons'
+import { getClassNameForCheck, getSymbolForCheck } from './ci-status'
+import classNames from 'classnames'
+import { APICheckConclusion } from '../../lib/api'
+import { Button } from '../lib/button'
+import { encodePathAsUrl } from '../../lib/path'
+
+// TODO: Get empty graphic for logs?
+const BlankSlateImage = encodePathAsUrl(
+  __dirname,
+  'static/empty-no-pull-requests.svg'
+)
+
+interface ICICheckRunListItemLogsProps {
+  /** The check run to display **/
+  readonly checkRun: IRefCheck
+
+  /** Whether call for actions logs is pending */
+  readonly loadingLogs: boolean
+
+  /** Callback to opens check runs on GitHub */
+  readonly onViewOnGitHub: (checkRun: IRefCheck) => void
+}
+
+/** The CI check list item. */
+export class CICheckRunListItemLogs extends React.PureComponent<
+  ICICheckRunListItemLogsProps
+> {
+  private onViewOnGitHub = () => {
+    this.props.onViewOnGitHub(this.props.checkRun)
+  }
+
+  private isNoAdditionalInfoToDisplay(output: IRefCheckOutput): boolean {
+    return (
+      this.isNoOutputText(output) &&
+      (output.summary === undefined ||
+        output.summary === null ||
+        output.summary.trim() === '')
+    )
+  }
+
+  private isNoOutputText(output: IRefCheckOutput): boolean {
+    return (
+      output.type === RefCheckOutputType.Default &&
+      (output.text === null || output.text.trim() === '')
+    )
+  }
+
+  private renderActionsLogOutput = (output: IRefCheckOutput) => {
+    if (output.type === RefCheckOutputType.Default) {
+      return null
+    }
+
+    return output.steps.map((step, i) => {
+      const header = (
+        <div className="ci-check-run-log-step" key={i}>
+          <div className="ci-check-status-symbol">
+            <Octicon
+              className={classNames(
+                'ci-status',
+                `ci-status-${getClassNameForCheck(step)}`
+              )}
+              symbol={getSymbolForCheck(step)}
+              title={step.name}
+            />
+          </div>
+          <div className="ci-check-run-log-step-name">{step.name}</div>
+          <div>{getCheckDurationInSeconds(step)}s</div>
+        </div>
+      )
+
+      const log =
+        step.conclusion === APICheckConclusion.Failure ? step.log : null
+
+      return (
+        <>
+          {header}
+          {log}
+        </>
+      )
+    })
+  }
+
+  private renderNonActionsLogOutput = (output: IRefCheckOutput) => {
+    if (output.type === RefCheckOutputType.Actions || output.text === null) {
+      return null
+    }
+
+    // TODO: Html needs santized. Later PR
+    return <div dangerouslySetInnerHTML={{ __html: output.text }}></div>
+  }
+
+  private renderMetaOutput = (
+    output: IRefCheckOutput,
+    checkRunName: string
+  ) => {
+    const { title, summary } = output
+
+    // Don't display something empty or redundant
+    const displayTitle =
+      title !== null &&
+      title.trim() !== '' &&
+      title.trim().toLocaleLowerCase() !==
+        checkRunName.trim().toLocaleLowerCase()
+
+    const displaySummary =
+      summary !== null && summary !== undefined && summary.trim() !== ''
+
+    return (
+      <div>
+        {displayTitle ? <div>{title}</div> : null}
+        {displaySummary ? <pre>{summary}</pre> : null}
+      </div>
+    )
+  }
+
+  private renderEmptyLogOutput = () => {
+    return (
+      <div className="no-logs-to-display">
+        No additional information to display.
+      </div>
+    )
+  }
+
+  private renderLoadingLogs = () => {
+    return (
+      <div className="loading-logs">
+        <img src={BlankSlateImage} className="blankslate-image" />
+        <div className="title">Hang tight</div>
+        <div className="loading-blurb">Loading the logs as fast as I can!</div>
+      </div>
+    )
+  }
+
+  private renderViewOnGitHub = () => {
+    return (
+      <div className="view-on-github">
+        <Button onClick={this.onViewOnGitHub}>View on GitHub</Button>
+      </div>
+    )
+  }
+
+  private hasActionsWorkflowLogs = (): boolean => {
+    return this.props.checkRun.jobs_url !== undefined
+  }
+
+  public render() {
+    const {
+      loadingLogs,
+      checkRun: { output, name },
+    } = this.props
+
+    if (this.hasActionsWorkflowLogs() && loadingLogs) {
+      return this.renderLoadingLogs()
+    }
+
+    return (
+      <div className="ci-check-list-item-logs">
+        <div className="ci-check-list-item-logs-output">
+          {this.isNoAdditionalInfoToDisplay(output)
+            ? this.renderEmptyLogOutput()
+            : null}
+          {this.renderMetaOutput(output, name)}
+          {this.renderActionsLogOutput(output)}
+          {this.renderNonActionsLogOutput(output)}
+        </div>
+        {this.renderViewOnGitHub()}
+      </div>
+    )
+  }
+}

--- a/app/src/ui/branches/ci-check-list-item.tsx
+++ b/app/src/ui/branches/ci-check-list-item.tsx
@@ -1,23 +1,11 @@
 import * as React from 'react'
-import {
-  getCheckDurationInSeconds,
-  IRefCheck,
-  IRefCheckOutput,
-  RefCheckOutputType,
-} from '../../lib/stores/commit-status-store'
+import { IRefCheck } from '../../lib/stores/commit-status-store'
 
 import { Octicon } from '../octicons'
 import { getClassNameForCheck, getSymbolForCheck } from './ci-status'
 import classNames from 'classnames'
-import { APICheckConclusion } from '../../lib/api'
-import { Button } from '../lib/button'
-import { encodePathAsUrl } from '../../lib/path'
 
-// TODO: Get empty graphic for logs?
-const BlankSlateImage = encodePathAsUrl(
-  __dirname,
-  'static/empty-no-pull-requests.svg'
-)
+import { CICheckRunListItemLogs } from './ci-check-list-item-logs'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -48,143 +36,8 @@ export class CICheckRunListItem extends React.PureComponent<
     this.props.onViewOnGitHub(this.props.checkRun)
   }
 
-  private isNoAdditionalInfoToDisplay(output: IRefCheckOutput): boolean {
-    return (
-      this.isNoOutputText(output) &&
-      (output.summary === undefined ||
-        output.summary === null ||
-        output.summary.trim() === '')
-    )
-  }
-
-  private isNoOutputText(output: IRefCheckOutput): boolean {
-    return (
-      output.type === RefCheckOutputType.Default &&
-      (output.text === null || output.text.trim() === '')
-    )
-  }
-
-  private renderActionsLogOutput = (output: IRefCheckOutput) => {
-    if (output.type === RefCheckOutputType.Default) {
-      return null
-    }
-
-    return output.steps.map((step, i) => {
-      const header = (
-        <div className="ci-check-run-log-step" key={i}>
-          <div className="ci-check-status-symbol">
-            <Octicon
-              className={classNames(
-                'ci-status',
-                `ci-status-${getClassNameForCheck(step)}`
-              )}
-              symbol={getSymbolForCheck(step)}
-              title={step.name}
-            />
-          </div>
-          <div className="ci-check-run-log-step-name">{step.name}</div>
-          <div>{getCheckDurationInSeconds(step)}s</div>
-        </div>
-      )
-
-      const log =
-        step.conclusion === APICheckConclusion.Failure ? step.log : null
-
-      return (
-        <>
-          {header}
-          {log}
-        </>
-      )
-    })
-  }
-
-  private renderNonActionsLogOutput = (output: IRefCheckOutput) => {
-    if (output.type === RefCheckOutputType.Actions || output.text === null) {
-      return null
-    }
-
-    // TODO: Html needs santized. Later PR
-    return <div dangerouslySetInnerHTML={{ __html: output.text }}></div>
-  }
-
-  private renderMetaOutput = (
-    output: IRefCheckOutput,
-    checkRunName: string
-  ) => {
-    const { title, summary } = output
-
-    // Don't display something empty or redundant
-    const displayTitle =
-      title !== null &&
-      title.trim() !== '' &&
-      title.trim().toLocaleLowerCase() !==
-        checkRunName.trim().toLocaleLowerCase()
-
-    const displaySummary =
-      summary !== null && summary !== undefined && summary.trim() !== ''
-
-    return (
-      <div>
-        {displayTitle ? <div>{title}</div> : null}
-        {displaySummary ? <pre>{summary}</pre> : null}
-      </div>
-    )
-  }
-
-  private renderEmptyLogOutput = () => {
-    return (
-      <div className="no-logs-to-display">
-        No additional information to display.
-      </div>
-    )
-  }
-
-  private renderLoadingLogs = () => {
-    return (
-      <div className="loading-logs">
-        <img src={BlankSlateImage} className="blankslate-image" />
-        <div className="title">Hang tight</div>
-        <div className="loading-blurb">Loading the logs as fast as I can!</div>
-      </div>
-    )
-  }
-
-  private renderViewOnGitHub = () => {
-    return (
-      <div className="view-on-github">
-        <Button onClick={this.onViewOnGitHub}>View on GitHub</Button>
-      </div>
-    )
-  }
-
-  private renderLogs = () => {
-    const {
-      loadingLogs,
-      checkRun: { output, name },
-    } = this.props
-
-    if (loadingLogs && this.isNoOutputText(output)) {
-      return this.renderLoadingLogs()
-    }
-
-    return (
-      <div className="ci-check-list-item-logs">
-        <div className="ci-check-list-item-logs-output">
-          {this.isNoAdditionalInfoToDisplay(output)
-            ? this.renderEmptyLogOutput()
-            : null}
-          {this.renderMetaOutput(output, name)}
-          {this.renderActionsLogOutput(output)}
-          {this.renderNonActionsLogOutput(output)}
-        </div>
-        {this.renderViewOnGitHub()}
-      </div>
-    )
-  }
-
   public render() {
-    const { checkRun, showLogs } = this.props
+    const { checkRun, showLogs, loadingLogs } = this.props
 
     return (
       <>
@@ -210,7 +63,13 @@ export class CICheckRunListItem extends React.PureComponent<
             </div>
           </div>
         </div>
-        {showLogs ? this.renderLogs() : null}
+        {showLogs ? (
+          <CICheckRunListItemLogs
+            checkRun={checkRun}
+            loadingLogs={loadingLogs}
+            onViewOnGitHub={this.onViewOnGitHub}
+          />
+        ) : null}
       </>
     )
   }

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -20,9 +20,6 @@ interface ICICheckRunListProps {
   /** The GitHub repository to use when looking up commit status. */
   readonly repository: GitHubRepository
 
-  /** The current branch name. */
-  readonly branchName: string
-
   /** The pull request's number. */
   readonly prNumber: number
 }
@@ -111,7 +108,6 @@ export class CICheckRunList extends React.PureComponent<
         ? await this.props.dispatcher.getActionsWorkflowRunLogs(
             this.props.repository,
             this.getCommitRef(this.props.prNumber),
-            this.props.branchName,
             statusChecks
           )
         : statusChecks

--- a/app/src/ui/branches/ci-status.tsx
+++ b/app/src/ui/branches/ci-status.tsx
@@ -26,6 +26,12 @@ interface ICIStatusProps {
 
   /** A callback to bubble up whether there is a check displayed */
   readonly onCheckChange?: (check: ICombinedRefCheck | null) => void
+
+  /**
+   * The branch name of the commit ref. This can be optionally supplied when
+   * fetching actions workflow info is required for the status.
+   */
+  readonly branchName?: string
 }
 
 interface ICIStatusState {
@@ -57,7 +63,8 @@ export class CIStatus extends React.PureComponent<
     this.statusSubscription = this.props.dispatcher.subscribeToCommitStatus(
       this.props.repository,
       this.props.commitRef,
-      this.onStatus
+      this.onStatus,
+      this.props.branchName
     )
   }
 

--- a/app/src/ui/branches/pull-request-badge.tsx
+++ b/app/src/ui/branches/pull-request-badge.tsx
@@ -16,6 +16,9 @@ interface IPullRequestBadgeProps {
 
   /** The GitHub repository to use when looking up commit status. */
   readonly onBadgeClick: () => void
+
+  /** The current branch name. */
+  readonly branchName: string
 }
 
 interface IPullRequestBadgeState {
@@ -60,6 +63,7 @@ export class PullRequestBadge extends React.Component<
           dispatcher={this.props.dispatcher}
           repository={this.props.repository}
           onCheckChange={this.onCheckChange}
+          branchName={this.props.branchName}
         />
       </div>
     )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2411,8 +2411,13 @@ export class Dispatcher {
   public subscribeToCommitStatus(
     repository: GitHubRepository,
     ref: string,
-    callback: StatusCallBack
+    callback: StatusCallBack,
+    branchName?: string
   ): IDisposable {
+    if (branchName !== undefined) {
+      this.commitStatusStore.setCheckedOutRefAndBranchName(ref, branchName)
+    }
+
     return this.commitStatusStore.subscribe(repository, ref, callback)
   }
 
@@ -2422,13 +2427,11 @@ export class Dispatcher {
   public getActionsWorkflowRunLogs(
     repository: GitHubRepository,
     ref: string,
-    branchName: string,
     checkRuns: ReadonlyArray<IRefCheck>
   ): Promise<ReadonlyArray<IRefCheck>> {
     return this.commitStatusStore.getLatestPRWorkflowRunsLogsForCheckRun(
       repository,
       ref,
-      branchName,
       checkRuns
     )
   }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -254,10 +254,6 @@ export class BranchDropdown extends React.Component<
 
   private renderPopover() {
     const pr = this.props.currentPullRequest
-    const { tip } = this.props.repositoryState.branchesState
-    // It is ok if it doesn't exist, we just can't retrieve actions workflows
-    const currentBranchName = tip.kind === TipState.Valid ? tip.branch.name : ''
-
     if (pr === null) {
       return null
     }
@@ -273,7 +269,6 @@ export class BranchDropdown extends React.Component<
               prNumber={pr.pullRequestNumber}
               dispatcher={this.props.dispatcher}
               repository={pr.base.gitHubRepository}
-              branchName={currentBranchName}
             />
           </div>
         </Popover>
@@ -283,6 +278,9 @@ export class BranchDropdown extends React.Component<
 
   private renderPullRequestInfo() {
     const pr = this.props.currentPullRequest
+    const { tip } = this.props.repositoryState.branchesState
+    // It is ok if it doesn't exist, we just can't retrieve actions workflows
+    const currentBranchName = tip.kind === TipState.Valid ? tip.branch.name : ''
 
     if (pr === null) {
       return null
@@ -294,6 +292,7 @@ export class BranchDropdown extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}
         onBadgeClick={this.onBadgeClick}
+        branchName={currentBranchName}
       />
     )
   }


### PR DESCRIPTION
## Description
For logs output, there are 2 sources. The check runs call has an `output` property for non-actions check runners and if a check run is also an action's workflow. We must additionally call the jobs endpoint and the logs endpoint to obtain the logs. We already do the check run call for each PR so we can show the check runs overall status in the pull request dropdown list and in the pull request badge when a pull request branch is checked out. 

The only way to know if a check run has an action workflow is to retrieve the action workflows for a given branch (the pull request branch). Since we don't want to have the expense of this call for all pull requests when the user may not even care about most of the PR logs, my current implementation waits until the user clicks on the PR badge and then does the actions workflow retrieve for that pr branch and and if the check runs have actions workflows it subsequently does the jobs and logs retrieve... But, this means that check runs that don't have action workflows, show loading when we have retrieved all the actions workflows, jobs, and logs when we in reality already have their output.

In this PR, when we subscribe to the check runs in the PR Badge, I set a `checkedOutRef` property. Thus, when we loop through PRs to retrieve the check runs. I can go ahead and do the actions workflow call for the PR (and just get the logs_url and jobs_url) that is currently checked out. Technically this really is the last checked out PR because I do not bother to clear this when switching to a non-pr branch, but this could be added if we feel this call is two high a cost. 

Now, if you open the PR Badge, it will start retrieving the logs for each of the PR's with action workflow and go ahead and show the `output` for those that are not check-runs. Resulting in a smoother experience on the non-action check runs.

## Release notes
Notes: no-notes
