### PR TITLE
Update actions logs step/background styling to be congruent with dotcom

### DIFF
--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -610,7 +610,8 @@ async function parseJobStepLogs(
 
     const stepsWLogs = new Array<IAPIWorkflowJobStep>()
     for (const step of job.steps) {
-      const stepFileName = `${step.number}_${step.name}.txt`
+      const stepName = step.name.replace('/', '')
+      const stepFileName = `${step.number}_${stepName}.txt`
       const stepLogFile = jobFolder.file(stepFileName)
       if (stepLogFile === null) {
         stepsWLogs.push(step)

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -731,7 +731,7 @@ function getCheckRunShortDescription(
  * Attempts to get the duration of a check run in seconds.
  * If it fails, it returns 0
  */
-export function getCheckDurationInSeconds(
+function getCheckDurationInSeconds(
   checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
 ): number {
   try {
@@ -746,6 +746,23 @@ export function getCheckDurationInSeconds(
   } catch (e) {}
 
   return 0
+}
+
+export function getFormattedCheckRunDuration(
+  checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
+): string {
+  const duration = getCheckDurationInSeconds(checkRun)
+  if (duration < 60) {
+    return `${duration}s`
+  }
+
+  const minutes = Math.floor(duration / 60)
+  const seconds = duration - minutes * 60
+  if (seconds === 0) {
+    return `${minutes}m`
+  }
+
+  return `${minutes}m ${seconds}s`
 }
 
 /**

--- a/app/src/ui/branches/ci-check-run-action-logs.tsx
+++ b/app/src/ui/branches/ci-check-run-action-logs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {
-  getCheckDurationInSeconds,
+  getFormattedCheckRunDuration,
   IRefCheckOutput,
   RefCheckOutputType,
 } from '../../lib/stores/commit-status-store'
@@ -75,7 +75,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
             title={step.name}
           />
           <div className="ci-check-run-log-step-name">{step.name}</div>
-          <div>{getCheckDurationInSeconds(step)}s</div>
+          <div>{getFormattedCheckRunDuration(step)}</div>
         </div>
       )
 

--- a/app/src/ui/branches/ci-check-run-action-logs.tsx
+++ b/app/src/ui/branches/ci-check-run-action-logs.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import {
+  getCheckDurationInSeconds,
+  IRefCheckOutput,
+  RefCheckOutputType,
+} from '../../lib/stores/commit-status-store'
+
+import { Octicon } from '../octicons'
+import { getClassNameForLogStep, getSymbolForLogStep } from './ci-status'
+import classNames from 'classnames'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+
+interface ICICheckRunActionLogsProps {
+  /** The check run to display **/
+  readonly output: IRefCheckOutput
+
+  /** Whether call for actions logs is pending */
+  readonly loadingLogs: boolean
+}
+
+interface ICICheckRunActionLogsState {
+  readonly stepOpenState: Map<number, boolean>
+}
+
+export class CICheckRunActionLogs extends React.PureComponent<
+  ICICheckRunActionLogsProps,
+  ICICheckRunActionLogsState
+> {
+  public constructor(props: ICICheckRunActionLogsProps) {
+    super(props)
+    this.state = {
+      stepOpenState: new Map<number, boolean>(),
+    }
+  }
+
+  public toggleOpenState = (index: number) => {
+    return () => {
+      const { stepOpenState } = this.state
+      stepOpenState.set(index, !(stepOpenState.get(index) === true))
+      this.setState({ stepOpenState: new Map(stepOpenState) })
+    }
+  }
+
+  public render() {
+    const { output, loadingLogs } = this.props
+
+    if (loadingLogs) {
+      return <>Loading...</>
+    }
+
+    if (output.type !== RefCheckOutputType.Actions) {
+      // This shouldn't happen, should only be provided actions type
+      return <>Unable to load logs.</>
+    }
+
+    return output.steps.map((step, i) => {
+      const showLogs = this.state.stepOpenState.get(i) === true
+
+      const header = (
+        <div className="ci-check-run-log-step-header-container">
+          <Octicon
+            className="log-step-toggled-indicator"
+            symbol={
+              showLogs ? OcticonSymbol.chevronDown : OcticonSymbol.chevronRight
+            }
+            title={step.name}
+          />
+
+          <Octicon
+            className={classNames(
+              'log-step-status',
+              `ci-status-${getClassNameForLogStep(step)}`
+            )}
+            symbol={getSymbolForLogStep(step)}
+            title={step.name}
+          />
+          <div className="ci-check-run-log-step-name">{step.name}</div>
+          <div>{getCheckDurationInSeconds(step)}s</div>
+        </div>
+      )
+
+      const headerClassNames = classNames('ci-check-run-log-step-header', {
+        open: showLogs,
+      })
+      return (
+        <div
+          className="ci-check-run-log-step"
+          key={i}
+          onClick={this.toggleOpenState(i)}
+        >
+          <div className={headerClassNames}>{header}</div>
+          {showLogs ? (
+            <div className="ci-check-run-step-log-display">{step.log}</div>
+          ) : null}
+        </div>
+      )
+    })
+  }
+}

--- a/app/src/ui/branches/ci-status.tsx
+++ b/app/src/ui/branches/ci-status.tsx
@@ -154,6 +154,19 @@ export function getSymbolForCheck(
   return OcticonSymbol.dotFill
 }
 
+export function getSymbolForLogStep(
+  logStep: IAPIWorkflowJobStep
+): OcticonSymbolType {
+  switch (logStep.conclusion) {
+    case 'success':
+      return OcticonSymbol.checkCircleFill
+    case 'failure':
+      return OcticonSymbol.xCircleFill
+  }
+
+  return getSymbolForCheck(logStep)
+}
+
 export function getClassNameForCheck(
   check: ICombinedRefCheck | IRefCheck | IAPIWorkflowJobStep
 ): string {
@@ -173,6 +186,16 @@ export function getClassNameForCheck(
 
   // Pending
   return 'pending'
+}
+
+export function getClassNameForLogStep(logStep: IAPIWorkflowJobStep): string {
+  switch (logStep.conclusion) {
+    case 'failure':
+      return logStep.conclusion
+  }
+
+  // Pending
+  return ''
 }
 
 /**

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -458,6 +458,14 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --title-tool-tip-background-color: rgb(236, 236, 236);
   --title-tool-tip-shadow: 1px 2px 5px 0px rgb(125, 125, 125, 0.5);
+
+  // Actions check run variables
+  --check-run-bg-color: #24292f; // #010409
+  --check-run-border-color: hsl(210deg 18% 87%);
+  --check-run-text-primary-color: #f6f8fa; // #c9d1d9
+  --check-run-step-header-open-bg-color: #32383f; // #161b22
+  --check-run-header-label-text-color: #d0d7de; // #8b949e
+  --check-run-text-secondary-color: #8c959f; // #8b949e
 }
 
 ::backdrop {

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -348,6 +348,14 @@ body.theme-dark {
 
   --title-tool-tip-background-color: rgb(56, 58, 62);
   --title-tool-tip-shadow: none;
+
+  // Actions check run variables
+  --check-run-bg-color: #010409;
+  --check-run-border-color: hsl(210deg 18% 87%);
+  --check-run-text-primary-color: #c9d1d9;
+  --check-run-step-header-open-bg-color: #161b22;
+  --check-run-header-label-text-color: #8b949e;
+  --check-run-text-secondary-color: #8b949e;
 }
 
 // this emulates the cursor for the co-author input because it isn't exactly

--- a/app/styles/ui/_ci-check-list-item.scss
+++ b/app/styles/ui/_ci-check-list-item.scss
@@ -42,7 +42,7 @@
   }
 
   .ci-check-list-item-logs-output {
-    padding-top: var(--spacing);
+    padding: var(--spacing);
     max-height: 200px;
     overflow: auto;
     word-break: break-word;
@@ -55,17 +55,15 @@
   &.actions {
     color: var(--check-run-header-label-text-color);
     background-color: var(--check-run-bg-color);
-    border-color: var(--check-run-border-color) !important;
+    border-color: var(--check-run-border-color);
 
     .ci-check-run-log-step {
-      border-radius: 6px !important;
-      padding-left: 8px !important;
-      padding-right: 4px !important;
-
       .ci-check-run-log-step-header {
-        border-radius: 6px !important;
-        padding: 8px !important;
-        margin-bottom: 4px !important;
+        border-radius: 6px;
+        padding: 8px;
+        margin-bottom: var(--spacing-half);
+        margin-left: var(--spacing-half);
+        margin-right: var(--spacing-half);
         color: var(--check-run-text-secondary-color);
         overflow: hidden;
         text-overflow: ellipsis;

--- a/app/styles/ui/_ci-check-list-item.scss
+++ b/app/styles/ui/_ci-check-list-item.scss
@@ -34,7 +34,7 @@
 
 .ci-check-list-item-logs {
   .view-on-github {
-    padding: var(--spacing);
+    padding: var(--spacing-half);
 
     .button-component {
       width: 100%;
@@ -58,6 +58,10 @@
     border-color: var(--check-run-border-color);
 
     .ci-check-run-log-step {
+      div:first-child:hover {
+        background-color: var(--check-run-step-header-open-bg-color);
+      }
+
       .ci-check-run-log-step-header {
         border-radius: 6px;
         padding: 8px;
@@ -71,10 +75,6 @@
 
         &.open {
           color: var(--check-run-text-primary-color);
-        }
-
-        &.open,
-        :hover {
           background-color: var(--check-run-step-header-open-bg-color);
         }
 
@@ -94,9 +94,10 @@
       }
 
       .ci-check-run-step-log-display {
+        // TODO: Future PR for log parsing - use theme variables here (this is just copied from github.com inspector)
         word-wrap: break-word;
         font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace !important;
-        font-size: 12px !important;
+        font-size: var(--font-size-sm);
         padding-top: 4px !important;
         padding-bottom: 4px !important;
         margin-top: 8px !important;

--- a/app/styles/ui/_ci-check-list-item.scss
+++ b/app/styles/ui/_ci-check-list-item.scss
@@ -33,32 +33,6 @@
 }
 
 .ci-check-list-item-logs {
-  border-bottom: var(--base-border);
-  box-shadow: inset 0px 0px 3px -1px grey;
-
-  .ci-check-list-item-logs-output {
-    padding: var(--spacing);
-    font-size: var(--font-size-sm);
-    max-height: 200px;
-    overflow: auto;
-    word-break: break-word;
-
-    pre {
-      margin: 0;
-    }
-
-    .ci-check-run-log-step {
-      display: flex;
-      align-items: center;
-      .ci-check-status-symbol {
-        padding: var(--spacing-third);
-      }
-      .ci-check-run-log-step-name {
-        flex: 1;
-      }
-    }
-  }
-
   .view-on-github {
     padding: var(--spacing);
 
@@ -66,24 +40,71 @@
       width: 100%;
     }
   }
-}
 
-.loading-logs {
-  border-bottom: var(--base-border);
-  box-shadow: inset 0px 0px 3px -1px grey;
-  padding: var(--spacing);
-  text-align: center;
+  .ci-check-list-item-logs-output {
+    padding-top: var(--spacing);
+    max-height: 200px;
+    overflow: auto;
+    word-break: break-word;
 
-  .blankslate-image {
-    min-width: 350px;
+    pre {
+      margin: 0;
+    }
   }
 
-  .title {
-    font-weight: var(--font-weight-semibold);
-    margin-top: calc(var(--spacing) * -1);
-  }
+  &.actions {
+    color: var(--check-run-header-label-text-color);
+    background-color: var(--check-run-bg-color);
+    border-color: var(--check-run-border-color) !important;
 
-  .loading-blurb {
-    font-size: var(--font-size-sm);
+    .ci-check-run-log-step {
+      border-radius: 6px !important;
+      padding-left: 8px !important;
+      padding-right: 4px !important;
+
+      .ci-check-run-log-step-header {
+        border-radius: 6px !important;
+        padding: 8px !important;
+        margin-bottom: 4px !important;
+        color: var(--check-run-text-secondary-color);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+
+        &.open {
+          color: var(--check-run-text-primary-color);
+        }
+
+        &.open,
+        :hover {
+          background-color: var(--check-run-step-header-open-bg-color);
+        }
+
+        .ci-check-run-log-step-header-container {
+          display: flex;
+          align-items: center;
+
+          .ci-check-run-log-step-name {
+            flex: 1;
+          }
+
+          .log-step-toggled-indicator,
+          .log-step-status {
+            margin-right: var(--spacing);
+          }
+        }
+      }
+
+      .ci-check-run-step-log-display {
+        word-wrap: break-word;
+        font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace !important;
+        font-size: 12px !important;
+        padding-top: 4px !important;
+        padding-bottom: 4px !important;
+        margin-top: 8px !important;
+        margin-bottom: 8px !important;
+        margin-left: 8px !important;
+      }
+    }
   }
 }

--- a/app/styles/ui/_ci-check-list-item.scss
+++ b/app/styles/ui/_ci-check-list-item.scss
@@ -34,7 +34,7 @@
 
 .ci-check-list-item-logs {
   .view-on-github {
-    padding: var(--spacing-half);
+    padding: var(--spacing);
 
     .button-component {
       width: 100%;
@@ -42,7 +42,7 @@
   }
 
   .ci-check-list-item-logs-output {
-    padding: var(--spacing);
+    padding: var(--spacing-half);
     max-height: 200px;
     overflow: auto;
     word-break: break-word;


### PR DESCRIPTION
NOTE: This is built upon the code #13064  - that should be reviewed first.

## Description

- Moved action logs output display into it's own component.
- Updated UI elements/iconts/CSS to be congruent with dotcom's dark terminal like approach (whether app is in light or dark mode)
- Allow user to open any step log output
- Reverted to simple Loading... text for loading state.. Seems it might fit better for 

To be continued...
- Add add azure log format parser to the actual log output.
- Move the View on GitHub button to a popout icon in the corner.
- Resizable log area

Other thoughts...
- If a user clicks badge to see logs, then clicks off to close dropdown. Then, goes and opens it again.. it must retrieve the logs.. thus loading again. This would be very annoying if no changes have actually occurred on the PR. Thinking we could improve the experience by caching last retrieved logs and show those.. but also have a loading indication of some sort.
- Tho dotcom doesn't do this.. it almost feels like the check run titles themselves should be darker even in a light theme.. :/ As it is the contrast really pops.. to me it feels funny.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/136231411-d2bf178b-7b3a-45e7-baab-92c7beaa0586.png)

![image](https://user-images.githubusercontent.com/75402236/136232385-7c361601-755e-463a-bb40-101fae1c5a68.png)

## Release notes
Notes: no-notes
