### PR TITLE
Add checks summary header

### DIFF
--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -608,6 +608,32 @@ function apiStatusToRefCheck(apiStatus: IAPIRefStatusItem): IRefCheck {
   }
 }
 
+export function getCheckRunConclusionAdjective(
+  conclusion: APICheckConclusion | null
+): string {
+  if (conclusion === null) {
+    return 'In progress'
+  }
+
+  switch (conclusion) {
+    case APICheckConclusion.ActionRequired:
+      return 'Action required'
+    case APICheckConclusion.Canceled:
+      return 'Canceled'
+    case APICheckConclusion.TimedOut:
+      return 'Timed out'
+    case APICheckConclusion.Failure:
+      return 'Failed'
+    case APICheckConclusion.Neutral:
+      return 'Neutral'
+    case APICheckConclusion.Success:
+      return 'Successful'
+    case APICheckConclusion.Skipped:
+      return 'Skipped'
+    case APICheckConclusion.Stale:
+      return 'Marked as stale'
+  }
+}
 /**
  * Method to generate a user friendly short check run description such as
  * "Successful in xs", "In Progress", "Failed after 1m"
@@ -631,35 +657,21 @@ function getCheckRunShortDescription(
     return 'In progress'
   }
 
-  let adjective = ''
-  let preposition = 'after'
+  const adjective = getCheckRunConclusionAdjective(conclusion)
 
-  // Some of these such as 'Action required' or 'Skipped' don't make sense with
-  // time context so we just return them.
-  switch (conclusion) {
-    case APICheckConclusion.ActionRequired:
-      return 'Action required'
-    case APICheckConclusion.Canceled:
-      adjective = 'Canceled'
-      break
-    case APICheckConclusion.TimedOut:
-      adjective = 'Timed out'
-      break
-    case APICheckConclusion.Failure:
-      adjective = 'Failed'
-      break
-    case APICheckConclusion.Neutral:
-      adjective = 'Completed'
-      break
-    case APICheckConclusion.Success:
-      adjective = 'Successful'
-      preposition = 'in'
-      break
-    case APICheckConclusion.Skipped:
-      return 'Skipped'
-    case APICheckConclusion.Stale:
-      return 'Marked as stale'
+  // Some conclusions such as 'Action required' or 'Skipped' don't make sense
+  // with time context so we just return them.
+  if (
+    [
+      APICheckConclusion.ActionRequired,
+      APICheckConclusion.Skipped,
+      APICheckConclusion.Stale,
+    ].includes(conclusion)
+  ) {
+    return adjective
   }
+
+  const preposition = conclusion === APICheckConclusion.Success ? 'in' : 'after'
 
   if (durationSeconds !== undefined && durationSeconds > 0) {
     const duration =

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -265,9 +265,9 @@ export class CICheckRunList extends React.PureComponent<
         <div className="ci-check-run-list-header">
           <div className="ci-check-run-list-title-container">
             <div className="title">Checks Summary</div>
-            {this.renderRerunButton()}
+            <div className="check-run-list-summary">{checkRunSummary}</div>
           </div>
-          <div className="check-run-list-summary">{checkRunSummary}</div>
+          {this.renderRerunButton()}
         </div>
         {checkRuns.length !== 0 ? checkLists : 'Unable to load checks runs.'}
       </div>

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -173,16 +173,18 @@ export class CICheckRunList extends React.PureComponent<
 
     const summaryArray = []
     for (const [conclusion, count] of conclusionMap.entries()) {
-      summaryArray.push(`${count} ${conclusion}`)
+      summaryArray.push({ count, conclusion })
     }
 
     if (summaryArray.length > 1) {
-      return `${summaryArray.slice(0, -1).join(', ')}, and ${summaryArray.slice(
-        -1
-      )} checks`
+      const output = summaryArray.map(
+        ({ count, conclusion }) => `${count} ${conclusion}`
+      )
+      return `${output.slice(0, -1).join(', ')}, and ${output.slice(-1)} checks`
     }
 
-    return `${summaryArray[0]} check`
+    const pluralize = summaryArray[0].count > 1 ? 'checks' : 'check'
+    return `${summaryArray[0].count} ${summaryArray[0].conclusion} ${pluralize}`
   }
 
   private rerunJobs = () => {

--- a/app/styles/ui/_ci-check-list.scss
+++ b/app/styles/ui/_ci-check-list.scss
@@ -12,22 +12,54 @@
   max-height: 585px;
   overflow-y: auto;
   overflow-x: hidden;
-}
+  border-radius: var(--border-radius);
 
-.ci-check-app-header {
-  display: flex;
-  align-items: center;
-  border-bottom: var(--base-border);
-  padding: var(--spacing-half) var(--spacing);
-  background-color: var(--box-alt-background-color);
-  min-height: 35px;
-
-  .ci-check-app-name {
-    font-weight: var(--font-weight-semibold);
-    flex: 1;
+  .ci-check-run-list-header,
+  .ci-check-app-header {
+    background-color: var(--box-alt-background-color);
+    border-bottom: var(--base-border);
   }
 
-  .open-closed-icon {
-    margin-right: var(--spacing-half);
+  .ci-check-run-list-header {
+    font-size: var(--font-size-md);
+    padding: var(--spacing);
+    padding-top: var(--spacing-half);
+
+    .ci-check-run-list-title-container {
+      display: flex;
+      align-items: center;
+      .title {
+        font-weight: var(--font-weight-semibold);
+        flex: 1;
+      }
+    }
+
+    .check-run-list-summary {
+      color: var(--text-secondary-color);
+      font-weight: var(--text-secondary-color);
+      font-size: var(--font-size-sm);
+    }
+  }
+
+  .ci-check-app-list:last-child {
+    .ci-check-app-header {
+      border: none;
+    }
+  }
+
+  .ci-check-app-header {
+    display: flex;
+    align-items: center;
+    padding: var(--spacing-half) var(--spacing);
+    min-height: 35px;
+
+    .ci-check-app-name {
+      font-weight: var(--font-weight-semibold);
+      flex: 1;
+    }
+
+    .open-closed-icon {
+      margin-right: var(--spacing-half);
+    }
   }
 }

--- a/app/styles/ui/_ci-check-list.scss
+++ b/app/styles/ui/_ci-check-list.scss
@@ -21,23 +21,24 @@
   }
 
   .ci-check-run-list-header {
+    display: flex;
     font-size: var(--font-size-md);
     padding: var(--spacing);
     padding-top: var(--spacing-half);
+    padding-right: var(--spacing-half);
 
     .ci-check-run-list-title-container {
-      display: flex;
+      flex: 1;
       align-items: center;
       .title {
         font-weight: var(--font-weight-semibold);
-        flex: 1;
       }
-    }
 
-    .check-run-list-summary {
-      color: var(--text-secondary-color);
-      font-weight: var(--text-secondary-color);
-      font-size: var(--font-size-sm);
+      .check-run-list-summary {
+        color: var(--text-secondary-color);
+        font-weight: var(--text-secondary-color);
+        font-size: var(--font-size-sm);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Adds a header to the check runs so the rerun button has a home. Additionally provides an overall summary/meta data.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/136450529-edfe2bb4-0309-4099-95e5-62c46594eb68.png)

There are multiple conclusion types. Technically, the summary could get very lengthy.. tho probably very unlikely.:
```
if (conclusion === null) {
    return 'In progress'
  }

  switch (conclusion) {
    case APICheckConclusion.ActionRequired:
      return 'Action required'
    case APICheckConclusion.Canceled:
      return 'Canceled'
    case APICheckConclusion.TimedOut:
      return 'Timed out'
    case APICheckConclusion.Failure:
      return 'Failed'
    case APICheckConclusion.Neutral:
      return 'Neutral'
    case APICheckConclusion.Success:
      return 'Successful'
    case APICheckConclusion.Skipped:
      return 'Skipped'
    case APICheckConclusion.Stale:
      return 'Marked as stale'
  }
  ```
Here is what it would look like if there were multiple of conclusion types:
![image](https://user-images.githubusercontent.com/75402236/136450342-6e5274da-e280-4982-b256-e24251216885.png)

UPDATE:
![image](https://user-images.githubusercontent.com/75402236/136571412-b3a50f19-01f8-4e2d-ac60-ab5f1e26dfa6.png)

## Release notes
Notes: no-notes
