### PR TITLE
Branch name for actions workflow retrieve needs to be URI encoded

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1019,7 +1019,9 @@ export class API {
     name: string,
     branchName: string
   ): Promise<IAPIWorkflowRuns | null> {
-    const path = `repos/${owner}/${name}/actions/runs?event=pull_request&branch=${branchName}`
+    const path = `repos/${owner}/${name}/actions/runs?event=pull_request&branch=${encodeURIComponent(
+      branchName
+    )}`
     const customHeaders = {
       Accept: 'application/vnd.github.antiope-preview+json',
     }


### PR DESCRIPTION
## Description

@niik pointed out that branch names need to be encoded before we put them in a URL because they can have characters that break the URL. [More context here.](https://github.com/desktop/desktop/pull/9086) Thanks @niik!

## Release notes

Notes: no-notes
