### PR TITLE
Rerun button will rerequest all check suite's

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1082,6 +1082,29 @@ export class API {
   }
 
   /**
+   * Triggers GitHub to rerequest an existing check suite, without pushing new
+   * code to a repository.
+   */
+  public async rerequestCheckSuite(
+    owner: string,
+    name: string,
+    checkSuiteId: number
+  ): Promise<boolean> {
+    const path = `/repos/${owner}/${name}/check-suites/${checkSuiteId}/rerequest`
+    const response = await this.request('POST', path)
+
+    try {
+      return response.ok
+    } catch (_) {
+      log.debug(
+        `Failed retry check suite id ${checkSuiteId} (${owner}/${name})`
+      )
+    }
+
+    return false
+  }
+
+  /**
    * Get branch protection info to determine if a user can push to a given branch.
    *
    * Note: if request fails, the default returned value assumes full access for the user

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -14,6 +14,7 @@ import {
   IAPIWorkflowJobStep,
   IAPIWorkflowJob,
   IAPIWorkflowJobs,
+  getAccountForEndpoint,
 } from '../api'
 import { IDisposable, Disposable } from 'event-kit'
 import { setAlmostImmediate } from '../set-almost-immediate'
@@ -541,6 +542,20 @@ export class CommitStatusStore {
     }
 
     return Array.from(wrMap.values())
+  }
+
+  public async rerequestCheckSuite(
+    repository: GitHubRepository,
+    checkSuiteId: number
+  ): Promise<boolean> {
+    const { owner, name } = repository
+    const account = getAccountForEndpoint(this.accounts, repository.endpoint)
+    if (account === null) {
+      return false
+    }
+
+    const api = API.fromAccount(account)
+    return api.rerequestCheckSuite(owner.login, name, checkSuiteId)
   }
 }
 

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -148,7 +148,17 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   private rerunJobs = () => {
-    // TODO: Rerun jobs
+    // Get unique set of check suite ids
+    const checkSuiteIds = new Set<number | null>([
+      ...this.state.checkRuns.map(cr => cr.checkSuiteId),
+    ])
+
+    for (const id of checkSuiteIds) {
+      if (id === null) {
+        continue
+      }
+      this.props.dispatcher.rerequestCheckSuite(this.props.repository, id)
+    }
   }
 
   private onAppHeaderClick = (appName: string) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2434,6 +2434,17 @@ export class Dispatcher {
   }
 
   /**
+   * Triggers GitHub to rerequest an existing check suite, without pushing new
+   * code to a repository.
+   */
+  public rerequestCheckSuite(
+    repository: GitHubRepository,
+    checkSuiteId: number
+  ): Promise<boolean> {
+    return this.commitStatusStore.rerequestCheckSuite(repository, checkSuiteId)
+  }
+
+  /**
    * Creates a stash for the current branch. Note that this will
    * override any stash that already exists for the current branch.
    *


### PR DESCRIPTION
## Description

This adds the logic to trigger rerunning the check run suites on the rerun all jobs button. 

Currently only prod OAuth app id is allowed via checks api. Thus, to test this you must enable to the feature-flag and do a build:prod and run it from your dist folder.

@gimenete  Already has us a PR going to get the dev app id added so running build:prod is not a permanent thing.
https://github.com/github/github/pull/196291

Next up we need to retrieve the check runs immediately after to show they are pending.

ADDED:
Also note, currently this naively attempts to retry all check suites but some of them are not re-requestable and result in a 403 error. [Looking into a way to prevent trying to re-request those ones.
](https://github.com/github/c2c-actions-checks/issues/94#issuecomment-938797794)
## Release notes
Notes: no-notes
