### PR TITLE
Better performance for non actions output

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1040,20 +1040,18 @@ export class API {
    * List workflow run jobs for a given workflow run
    */
   public async fetchWorkflowRunJobs(
-    workflowRun: IAPIWorkflowRun
+    jobs_url: string
   ): Promise<IAPIWorkflowJobs | null> {
     const customHeaders = {
       Accept: 'application/vnd.github.antiope-preview+json',
     }
-    const response = await this.request('GET', workflowRun.jobs_url, {
+    const response = await this.request('GET', jobs_url, {
       customHeaders,
     })
     try {
       return await parsedResponse<IAPIWorkflowJobs>(response)
     } catch (err) {
-      log.debug(
-        `Failed fetching workflow jobs for workflow run named: ${workflowRun.name}`
-      )
+      log.debug(`Failed fetching workflow jobs: ${jobs_url}`)
     }
     return null
   }

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -371,13 +371,13 @@ interface IAPIWorkflowRuns {
 }
 // NB. Only partially mapped
 export interface IAPIWorkflowRun {
+  readonly id: number
   /**
    * The workflow_id is the id of the workflow not the individual run.
    **/
   readonly workflow_id: number
   readonly cancel_url: string
   readonly created_at: string
-  readonly jobs_url: string
   readonly logs_url: string
   readonly name: string
   readonly rerun_url: string
@@ -1040,18 +1040,23 @@ export class API {
    * List workflow run jobs for a given workflow run
    */
   public async fetchWorkflowRunJobs(
-    jobs_url: string
+    owner: string,
+    name: string,
+    workflowRunId: number
   ): Promise<IAPIWorkflowJobs | null> {
+    const path = `repos/${owner}/${name}/actions/runs/${workflowRunId}/jobs`
     const customHeaders = {
       Accept: 'application/vnd.github.antiope-preview+json',
     }
-    const response = await this.request('GET', jobs_url, {
+    const response = await this.request('GET', path, {
       customHeaders,
     })
     try {
       return await parsedResponse<IAPIWorkflowJobs>(response)
     } catch (err) {
-      log.debug(`Failed fetching workflow jobs: ${jobs_url}`)
+      log.debug(
+        `Failed fetching workflow jobs (${owner}/${name}) workflow run: ${workflowRunId}`
+      )
     }
     return null
   }

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -39,6 +39,8 @@ export interface IRefCheck {
   readonly checkSuiteId: number | null // API status don't have check suite id's
   readonly output: IRefCheckOutput
   readonly htmlUrl: string | null
+  readonly jobs_url?: string
+  readonly logs_url?: string
 }
 
 /**
@@ -421,10 +423,10 @@ export class CommitStatusStore {
   }
 
   /**
-   * Retrieve GitHub Actions workflows, jobs, and logs for the branch and apply
-   * logs to matching check run output.
+   * Retrieve GitHub Actions workflows and populates the job and log url if
+   * applicable to the checkruns
    */
-  public async getLatestPRWorkflowRunsLogsForCheckRun(
+  public async getCheckRunActionsJobsAndLogURLS(
     repository: GitHubRepository,
     ref: string,
     branchName: string,
@@ -454,11 +456,23 @@ export class CommitStatusStore {
       return checkRuns
     }
 
-    const logCache = new Map<number, JSZip>()
-    const jobsCache = new Map<number, IAPIWorkflowJobs>()
+    return this.getCheckRunWithActionsJobAndLogURLs(
+      checkRuns,
+      latestWorkflowRuns
+    )
+  }
+
+  private getCheckRunWithActionsJobAndLogURLs(
+    checkRuns: ReadonlyArray<IRefCheck>,
+    actionWorkflowRuns: ReadonlyArray<IAPIWorkflowRun>
+  ): ReadonlyArray<IRefCheck> {
+    if (actionWorkflowRuns.length === 0 || checkRuns.length === 0) {
+      return checkRuns
+    }
+
     const mappedCheckRuns = new Array<IRefCheck>()
     for (const cr of checkRuns) {
-      const matchingWR = latestWorkflowRuns.find(
+      const matchingWR = actionWorkflowRuns.find(
         wr => wr.check_suite_id === cr.checkSuiteId
       )
       if (matchingWR === undefined) {
@@ -466,11 +480,55 @@ export class CommitStatusStore {
         continue
       }
 
+      const { jobs_url, logs_url } = matchingWR
+      mappedCheckRuns.push({
+        ...cr,
+        jobs_url,
+        logs_url,
+      })
+    }
+
+    return mappedCheckRuns
+  }
+
+  /**
+   * Retrieve GitHub Actions job and logs for the check runs.
+   */
+  public async getLatestPRWorkflowRunsLogsForCheckRun(
+    repository: GitHubRepository,
+    ref: string,
+    checkRuns: ReadonlyArray<IRefCheck>
+  ): Promise<ReadonlyArray<IRefCheck>> {
+    const key = getCacheKeyForRepository(repository, ref)
+    const subscription = this.subscriptions.get(key)
+    if (subscription === undefined) {
+      return checkRuns
+    }
+
+    const account = this.accounts.find(
+      a => a.endpoint === subscription.endpoint
+    )
+
+    if (account === undefined) {
+      return checkRuns
+    }
+
+    const api = API.fromAccount(account)
+
+    const logCache = new Map<string, JSZip>()
+    const jobsCache = new Map<string, IAPIWorkflowJobs>()
+    const mappedCheckRuns = new Array<IRefCheck>()
+    for (const cr of checkRuns) {
+      if (cr.jobs_url === undefined || cr.logs_url === undefined) {
+        mappedCheckRuns.push(cr)
+        continue
+      }
+
       // Multiple check runs match a single workflow run.
       // We can prevent several job network calls by caching them.
       const workFlowRunJobs =
-        jobsCache.get(matchingWR.workflow_id) ??
-        (await api.fetchWorkflowRunJobs(matchingWR))
+        jobsCache.get(cr.jobs_url) ??
+        (await api.fetchWorkflowRunJobs(cr.jobs_url))
 
       // Here check run and jobs only share their names.
       // Thus, unfortunately cannot match on a numerical id.
@@ -483,14 +541,14 @@ export class CommitStatusStore {
       // One workflow can have the logs for multiple check runs.. no need to
       // keep retrieving it. So we are hashing it.
       const logZip =
-        logCache.get(matchingWR.workflow_id) ??
-        (await api.fetchWorkflowRunJobLogs(matchingWR.logs_url))
+        logCache.get(cr.logs_url) ??
+        (await api.fetchWorkflowRunJobLogs(cr.logs_url))
       if (logZip === null) {
         mappedCheckRuns.push(cr)
         continue
       }
 
-      logCache.set(matchingWR.workflow_id, logZip)
+      logCache.set(cr.logs_url, logZip)
 
       mappedCheckRuns.push({
         ...cr,

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -515,7 +515,7 @@ export class CommitStatusStore {
     const api = API.fromAccount(account)
 
     const logCache = new Map<string, JSZip>()
-    const jobsCache = new Map<number, IAPIWorkflowJobs>()
+    const jobsCache = new Map<number, IAPIWorkflowJobs | null>()
     const mappedCheckRuns = new Array<IRefCheck>()
     for (const cr of checkRuns) {
       if (cr.actionsWorkflowRunId === undefined || cr.logs_url === undefined) {
@@ -528,6 +528,7 @@ export class CommitStatusStore {
       const workFlowRunJobs =
         jobsCache.get(cr.actionsWorkflowRunId) ??
         (await api.fetchWorkflowRunJobs(owner, name, cr.actionsWorkflowRunId))
+      jobsCache.set(cr.actionsWorkflowRunId, workFlowRunJobs)
 
       // Here check run and jobs only share their names.
       // Thus, unfortunately cannot match on a numerical id.

--- a/app/src/ui/branches/ci-check-list-item.tsx
+++ b/app/src/ui/branches/ci-check-list-item.tsx
@@ -24,7 +24,10 @@ interface ICICheckRunListItemProps {
   readonly checkRun: IRefCheck
 
   /** Whether call for actions logs is pending */
-  readonly loadingLogs: boolean
+  readonly loadingActionLogs: boolean
+
+  /** Whether tcall for actions workflows is pending */
+  readonly loadingActionWorkflows: boolean
 
   /** Whether to show the logs for this check run */
   readonly showLogs: boolean
@@ -158,13 +161,21 @@ export class CICheckRunListItem extends React.PureComponent<
     )
   }
 
+  private hasActionsWorkflowLogs = (): boolean => {
+    return this.props.checkRun.jobs_url !== undefined
+  }
+
   private renderLogs = () => {
     const {
       loadingLogs,
+      loadingActionWorkflows,
       checkRun: { output, name },
     } = this.props
 
-    if (loadingLogs && this.isNoOutputText(output)) {
+    if (
+      loadingActionWorkflows ||
+      (this.hasActionsWorkflowLogs() && loadingLogs)
+    ) {
       return this.renderLoadingLogs()
     }
 

--- a/app/src/ui/branches/ci-check-list-item.tsx
+++ b/app/src/ui/branches/ci-check-list-item.tsx
@@ -167,14 +167,14 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderLogs = () => {
     const {
-      loadingLogs,
+      loadingActionLogs,
       loadingActionWorkflows,
       checkRun: { output, name },
     } = this.props
 
     if (
       loadingActionWorkflows ||
-      (this.hasActionsWorkflowLogs() && loadingLogs)
+      (this.hasActionsWorkflowLogs() && loadingActionLogs)
     ) {
       return this.renderLoadingLogs()
     }

--- a/app/src/ui/branches/ci-check-list-item.tsx
+++ b/app/src/ui/branches/ci-check-list-item.tsx
@@ -162,7 +162,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private hasActionsWorkflowLogs() {
-    return this.props.checkRun.jobs_url !== undefined
+    return this.props.checkRun.actionsWorkflowRunId !== undefined
   }
 
   private renderLogs = () => {

--- a/app/src/ui/branches/ci-check-list-item.tsx
+++ b/app/src/ui/branches/ci-check-list-item.tsx
@@ -161,7 +161,7 @@ export class CICheckRunListItem extends React.PureComponent<
     )
   }
 
-  private hasActionsWorkflowLogs = (): boolean => {
+  private hasActionsWorkflowLogs() {
     return this.props.checkRun.jobs_url !== undefined
   }
 

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -118,7 +118,12 @@ export class CICheckRunList extends React.PureComponent<
     }
 
     /*
-      Until we retrieve the actions 
+      Until we retrieve the actions workflows, we don't know if a check run has
+      action logs to output, thus, we want to show loading until then. However,
+      once the workflows have been retrieved and since the logs retrieval and
+      parsing can be noticeably time consuming. We go ahead and flip a flag so
+      that we know we can go ahead and display the checkrun `output` content if
+      a check run does not have action logs to retrieve/parse.
     */
     const checkRunsWithActionsUrls = await this.props.dispatcher.getCheckRunActionsJobsAndLogURLS(
       this.props.repository,
@@ -132,7 +137,6 @@ export class CICheckRunList extends React.PureComponent<
       loadingActionWorkflows: false,
     })
 
-    //
     const checkRuns = await this.props.dispatcher.getActionsWorkflowRunLogs(
       this.props.repository,
       this.getCommitRef(this.props.prNumber),

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -132,11 +132,14 @@ export class CICheckRunList extends React.PureComponent<
       statusChecks
     )
 
-  if (this.subscription === null) {
-    return
-  }
+    // When the component unmounts, this is set to null. This check will help us
+    // prevent using set state on an unmounted component it it is unmounted
+    // before above api returns.
+    if (this.statusSubscription === null) {
+      return
+    }
 
-  this.setState({
+    this.setState({
       checkRuns: checkRunsWithActionsUrls,
       loadingActionWorkflows: false,
     })
@@ -146,6 +149,13 @@ export class CICheckRunList extends React.PureComponent<
       this.getCommitRef(this.props.prNumber),
       checkRunsWithActionsUrls
     )
+
+    // When the component unmounts, this is set to null. This check will help us
+    // prevent using set state on an unmounted component it it is unmounted
+    // before above api returns.
+    if (this.statusSubscription === null) {
+      return
+    }
 
     this.setState({ checkRuns, loadingActionLogs: false })
   }

--- a/app/src/ui/branches/ci-check-run-list.tsx
+++ b/app/src/ui/branches/ci-check-run-list.tsx
@@ -132,7 +132,11 @@ export class CICheckRunList extends React.PureComponent<
       statusChecks
     )
 
-    this.setState({
+  if (this.subscription === null) {
+    return
+  }
+
+  this.setState({
       checkRuns: checkRunsWithActionsUrls,
       loadingActionWorkflows: false,
     })

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2422,10 +2422,25 @@ export class Dispatcher {
   public getActionsWorkflowRunLogs(
     repository: GitHubRepository,
     ref: string,
-    branchName: string,
     checkRuns: ReadonlyArray<IRefCheck>
   ): Promise<ReadonlyArray<IRefCheck>> {
     return this.commitStatusStore.getLatestPRWorkflowRunsLogsForCheckRun(
+      repository,
+      ref,
+      checkRuns
+    )
+  }
+
+  /**
+   * Populates Actions workflow log and job url's for provided checkruns if applicable
+   */
+  public getCheckRunActionsJobsAndLogURLS(
+    repository: GitHubRepository,
+    ref: string,
+    branchName: string,
+    checkRuns: ReadonlyArray<IRefCheck>
+  ): Promise<ReadonlyArray<IRefCheck>> {
+    return this.commitStatusStore.getCheckRunActionsJobsAndLogURLS(
       repository,
       ref,
       branchName,


### PR DESCRIPTION
## Description
Approach from #13064 was undesirable from a code maintenance/concept coupling stand point.

In this PR, I still wait until the user clicks the PR badge. However, instead of waiting for the actions workflow call, jobs call, and logs call/parsing to complete. I split it into two waitings. We have a boolean that is for loading only the actions workflow call where we can determine whether a check run has actions jobs/logs associated with it. Then, we have the original boolean for when the jobs/logs api call and parsing is complete.

The actions workflow call is very lightweight in comparison to the logs retrieval/parsing. Thus, even tho this approach is not as fast #13064 in terms of performance for non-actions, I only saw the loading image for a couple of seconds for non actions check runs when my network setting was for slow 3g ... when compared 20-30s for the action logs. On my regular settings, I was hard-pressed to ever see the loading image for them. Thus, I think this is just as useable a solution.

Side note: We hope to subscribe a websocket for action logs which would likely mean they would become individualized as opposed to currently waiting on all the logs for all the check runs - thus much faster.

### Screenshots

https://user-images.githubusercontent.com/75402236/136603603-e84b6329-6fed-4a88-8ffd-42d1c1089efb.mov

## Release notes
Notes: no-notes
