### PR TITLE
Make log file request without auth token

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -15,6 +15,7 @@ import username from 'username'
 import { GitProtocol } from './remote-parsing'
 import { Emitter } from 'event-kit'
 import JSZip from 'jszip'
+import { remote } from 'electron'
 
 const envEndpoint = process.env['DESKTOP_GITHUB_DOTCOM_API_ENDPOINT']
 const envHTMLURL = process.env['DESKTOP_GITHUB_DOTCOM_HTML_URL']
@@ -1064,12 +1065,51 @@ export class API {
    * If it fails to retrieve or parse the zip file, it will return null.
    */
   public async fetchWorkflowRunJobLogs(logsUrl: string): Promise<JSZip | null> {
-    const customHeaders = {
-      Accept: 'application/vnd.github.antiope-preview+json',
-    }
-    const response = await this.request('GET', logsUrl, {
-      customHeaders,
+    const zipURL: string | null = await new Promise(resolve => {
+      const customHeaders = {
+        Accept: 'application/vnd.github.antiope-preview+json',
+      }
+
+      remote.session.defaultSession.webRequest.onBeforeRedirect(details => {
+        if (
+          details.responseHeaders &&
+          details.responseHeaders.location.length > 0 &&
+          details.responseHeaders.location[0].startsWith(
+            'https://pipelines.actions.githubusercontent.com'
+          )
+        ) {
+          resolve(details.responseHeaders.location[0])
+        }
+
+        // This means if some other request happens at the same time
+        // that redirects.. we will lose this call to the logs.
+        // ... Considered a timer... but that feels hacky for an unlikely edge case..
+        resolve(null)
+      })
+
+      this.request('GET', logsUrl, {
+        customHeaders,
+      }).then(response => {
+        // Something other than redirect happend so resolve to null
+        // so that we are not waiting for onBeforeRedirect for forever...
+        if (response.type !== 'opaqueredirect') {
+          resolve(null)
+        }
+      })
     })
+
+    remote.session.defaultSession.webRequest.onBeforeRedirect(null)
+
+    if (zipURL === null) {
+      return null
+    }
+
+    const response = await request(
+      this.endpoint,
+      null, // Do not send token!
+      'GET',
+      zipURL
+    )
 
     try {
       const zipBlob = await response.blob()

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -143,6 +143,9 @@ export function request(
     headers,
     method,
     body: JSON.stringify(jsonBody),
+    // We do not want to automatically follow location header redirects as it
+    // will mean appending our auth token to an externally provided endpoint.
+    redirect: 'manual',
   }
 
   if (reloadCache) {


### PR DESCRIPTION
## Description

This PR:
1) Adds the redirect: 'manual' to all our http requests so that no-one in the future can unintentionally send an auth token to an external provided url via fetches default behavior to follow the location header with the initial requests headers. This setting cancels the redirect call. This means it will show in the network tab in red. 

_Another other option would be to set it to 'error' and add a parameter such as isRedirectManual. This would provided more explicit code for future devs and still disallow the default option of 'follow'_

2) Utilizes electron session's `webRequest.onBeforeRedirect` to grab the redirect url and then makes a request to it without providing the auth token.

## Release notes
Notes: no-notes
