### PR TITLE
Prevent cross-domain redirects from preserving auth headers

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -1,6 +1,6 @@
 import '../lib/logging/main/install'
 
-import { app, Menu, ipcMain, BrowserWindow, shell } from 'electron'
+import { app, Menu, ipcMain, BrowserWindow, shell, session } from 'electron'
 import * as Fs from 'fs'
 import * as URL from 'url'
 
@@ -28,6 +28,7 @@ import { ISerializableMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
 import { stat } from 'fs-extra'
 import { isApplicationBundle } from '../lib/is-application-bundle'
+import { installSameOriginFilter } from './same-origin-filter'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -433,6 +434,10 @@ app.on('ready', () => {
         Menu.setApplicationMenu(currentMenu)
         mainWindow.sendAppMenu()
       }
+
+      // Ensures auth-related headers won't traverse http redirects to hosts
+      // on different origins than the originating request.
+      installSameOriginFilter(session.defaultSession.webRequest)
     }
   )
 

--- a/app/src/main-process/same-origin-filter.ts
+++ b/app/src/main-process/same-origin-filter.ts
@@ -1,5 +1,36 @@
 import { WebRequest } from 'electron/main'
 
+/**
+ * Installs a web request filter to prevent cross domain leaks of auth headers
+ *
+ * GitHub Desktop uses the fetch[1] web API for all of our API requests. When fetch
+ * is used in a browser and it encounters an http redirect to another origin
+ * domain CORS policies will apply to prevent submission of credentials[2].
+ *
+ * In our case however there's no concept of same-origin (and even if there were
+ * it'd be problematic because we'd be making cross-origin request constantly to
+ * GitHub.com and GHE instances) so the `credentials: same-origin` setting won't
+ * help us.
+ *
+ * This is normally not a problem until http redirects get involved. When making
+ * an authenticated request to an API endpoint which in turn issues a redirect
+ * to another domain fetch will happily pass along our token to the second
+ * domain and there's no way for us to prevent that from happening[3] using
+ * the vanilla fetch API.
+ *
+ * That's the reason why this filter exists. It will look at all initiated
+ * requests and store their origin along with their request ID. The request id
+ * will be the same for any subsequent redirect requests but the urls will be
+ * changing. Upon each request we will check to see if we've seen the request
+ * id before and if so if the origin matches. If the origin doesn't match we'll
+ * strip some potentially dangerous headers from the redirect request.
+ *
+ * 1. https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+ * 2. https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+ * 3. https://github.com/whatwg/fetch/issues/763
+ *
+ * @param webRequest
+ */
 export function installSameOriginFilter(webRequest: WebRequest) {
   const requestOrigin = new Map<number, string>()
   const safeProtocols = new Set(['devtools:', 'file:', 'chrome-extension:'])

--- a/app/src/main-process/same-origin-filter.ts
+++ b/app/src/main-process/same-origin-filter.ts
@@ -32,6 +32,7 @@ import { WebRequest } from 'electron/main'
  * @param webRequest
  */
 export function installSameOriginFilter(webRequest: WebRequest) {
+  // A map between the request ID and the _initial_ request origin
   const requestOrigin = new Map<number, string>()
   const safeProtocols = new Set(['devtools:', 'file:', 'chrome-extension:'])
   const unsafeHeaders = new Set(['authentication', 'authorization', 'cookie'])

--- a/app/src/main-process/same-origin-filter.ts
+++ b/app/src/main-process/same-origin-filter.ts
@@ -59,11 +59,6 @@ export function installSameOriginFilter(webRequest: WebRequest) {
       return cb({ requestHeaders: details.requestHeaders })
     }
 
-    // From here on we consider this request unsafe, there's no point in
-    // restoring unsafe headers should the request end up being redirected
-    // back to the origin again so we can just drop it from the dictionary
-    requestOrigin.delete(details.id)
-
     const sanitizedHeaders: Record<string, string> = {}
 
     for (const [k, v] of Object.entries(details.requestHeaders)) {

--- a/app/src/main-process/same-origin-filter.ts
+++ b/app/src/main-process/same-origin-filter.ts
@@ -55,7 +55,7 @@ export function installSameOriginFilter(webRequest: WebRequest) {
     const initialOrigin = requestOrigin.get(details.id)
     const { origin } = new URL(details.url)
 
-    if (initialOrigin === origin) {
+    if (initialOrigin === undefined || initialOrigin === origin) {
       return cb({ requestHeaders: details.requestHeaders })
     }
 

--- a/app/src/main-process/same-origin-filter.ts
+++ b/app/src/main-process/same-origin-filter.ts
@@ -1,0 +1,53 @@
+import { WebRequest } from 'electron/main'
+
+export function installSameOriginFilter(webRequest: WebRequest) {
+  const requestOrigin = new Map<number, string>()
+  const safeProtocols = new Set(['devtools:', 'file:', 'chrome-extension:'])
+  const unsafeHeaders = new Set(['authentication', 'authorization', 'cookie'])
+
+  webRequest.onBeforeRequest((details, cb) => {
+    const { protocol, origin } = new URL(details.url)
+
+    // This is called once for the initial request and then once for each
+    // "subrequest" thereafter, i.e. a request to https://foo/bar which gets
+    // redirected to https://foo/baz will trigger this twice and we only
+    // care about capturing the initial request origin
+    if (!safeProtocols.has(protocol) && !requestOrigin.has(details.id)) {
+      requestOrigin.set(details.id, origin)
+    }
+
+    cb({})
+  })
+
+  webRequest.onBeforeSendHeaders((details, cb) => {
+    const initialOrigin = requestOrigin.get(details.id)
+
+    if (initialOrigin === undefined) {
+      return cb({ requestHeaders: details.requestHeaders })
+    }
+
+    const { origin } = new URL(details.url)
+
+    if (initialOrigin === origin) {
+      return cb({ requestHeaders: details.requestHeaders })
+    }
+
+    // From here on we consider this request unsafe, there's no point in
+    // restoring unsafe headers should the request end up being redirected
+    // back to the origin again so we can just drop it from the dictionary
+    requestOrigin.delete(details.id)
+
+    const sanitizedHeaders: Record<string, string> = {}
+
+    for (const [k, v] of Object.entries(details.requestHeaders)) {
+      if (!unsafeHeaders.has(k.toLowerCase())) {
+        sanitizedHeaders[k] = v
+      }
+    }
+
+    log.debug(`Sanitizing cross-origin redirect to ${origin}`)
+    return cb({ requestHeaders: sanitizedHeaders })
+  })
+
+  webRequest.onCompleted(details => requestOrigin.delete(details.id))
+}

--- a/app/src/main-process/same-origin-filter.ts
+++ b/app/src/main-process/same-origin-filter.ts
@@ -53,11 +53,6 @@ export function installSameOriginFilter(webRequest: WebRequest) {
 
   webRequest.onBeforeSendHeaders((details, cb) => {
     const initialOrigin = requestOrigin.get(details.id)
-
-    if (initialOrigin === undefined) {
-      return cb({ requestHeaders: details.requestHeaders })
-    }
-
     const { origin } = new URL(details.url)
 
     if (initialOrigin === origin) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Refs: #13106

## Description

GitHub Desktop uses the [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) web API for all of our API requests. When fetch is used in a browser and it encounters an http redirect to another origin domain CORS policies will apply to prevent submission of [credentials](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch).

In our case however there's no concept of same-origin (and even if there were it'd be problematic because we'd be making cross-origin request constantly to GitHub.com and GHE instances) so the `credentials: same-origin` setting won't help us.

This is normally not a problem until http redirects get involved. When making an authenticated request to an API endpoint which in turn issues a redirect to another domain fetch will happily pass along our token to the second
domain and there's no way for us to prevent that from [happening](https://github.com/whatwg/fetch/issues/763) using the vanilla fetch API.

In this PR I'm introducing a filter which attempts to identify any cross-origin redirect and sanitize potentially sensitive headers from the subsequent request.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
