### PR TITLE
Fix missing CSS variables

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -113,6 +113,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --box-border-accent-color: #{$blue};
 
   /**
+   * Background color for selected boxes without keyboard focus
+   */
+  --box-selected-background-color: #ebeef1;
+
+  /**
    * Text color for when a user hovers over a boxe with a
    * pointing device. Should not be used by boxes that doesn't
    * implement a hover state since this will conflict with

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -131,6 +131,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
    * implement a hover state since this will conflict with
    * selection and active selection
    */
+  --box-hover-background-color: #{$gray-100};
 
   /**
    * Text color for selected boxes without keyboard focus

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -98,6 +98,7 @@ body.theme-dark {
    * implement a hover state since this will conflict with
    * selection and active selection
    */
+  --box-hover-background-color: #{$gray-800};
 
   /**
    * Text color for selected boxes without keyboard focus


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

Noticed that the inactive selected state for list items has disappeared in the light theme.

This is how it looks

![image](https://user-images.githubusercontent.com/634063/137128026-2adead2a-994d-4f28-b45f-3e46de6afbcb.png)

And this is how it should look

![image](https://user-images.githubusercontent.com/634063/137128092-ba9180a1-27d6-4c11-b8df-bd2aa524a251.png)

This was accidentally removed and not caught in review in https://github.com/desktop/desktop/pull/12952

Additionally I noticed that the hover state for vertical segmented controls didn't work in either dark or light theme. That was accidentally removed by myself in https://github.com/desktop/desktop/commit/2476c49f8655ed7c5a9e07550eb62c21fb609432 and apparently hasn't worked since 2017(!)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes