### PR TITLE
Use custom tooltips for link buttons

### DIFF
--- a/app/src/ui/lib/link-button.tsx
+++ b/app/src/ui/lib/link-button.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { shell } from '../../lib/app-shell'
 import classNames from 'classnames'
+import { Tooltip } from './tooltip'
+import { createObservableRef } from './observable-ref'
 
 interface ILinkButtonProps {
   /** A URI to open on click. */
@@ -28,18 +30,22 @@ interface ILinkButtonProps {
  * Provide `children` elements for the title of the rendered hyperlink.
  */
 export class LinkButton extends React.Component<ILinkButtonProps, {}> {
+  private readonly anchorRef = createObservableRef<HTMLAnchorElement>()
+
   public render() {
     const href = this.props.uri || ''
     const className = classNames('link-button-component', this.props.className)
+    const { title } = this.props
 
     return (
       <a
+        ref={this.anchorRef}
         className={className}
         href={href}
         onClick={this.onClick}
-        title={this.props.title}
         tabIndex={this.props.tabIndex}
       >
+        {title && <Tooltip target={this.anchorRef}>{title}</Tooltip>}
         {this.props.children}
       </a>
     )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

I apparently missed implementing custom tooltips for link buttons in #13116.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
![image](https://user-images.githubusercontent.com/634063/138695012-5660e199-9efa-4906-901d-5a11d9b6db70.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
