### PR TITLE
Replace dialog animations with fade when user prefers reduced motion

### DIFF
--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -50,6 +50,22 @@ dialog {
   min-width: 400px;
   max-width: 600px;
 
+  // Substitute the appear/exit animations with a fade in fade out effect if the
+  // user prefers reduced motion.
+  //
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+  @media (prefers-reduced-motion) {
+    transition: opacity 100ms ease-in !important;
+    transform: none !important;
+
+    &.modal-enter {
+      opacity: 0 !important;
+    }
+    &.modal-enter-active {
+      opacity: 1 !important;
+    }
+  }
+
   // The modal class here is the transition name for the react css transition
   // group which allows us to apply an animation when the popup appears.
   &.modal {


### PR DESCRIPTION
Fixes #12976
Fixes #2768

## Description

Since we're now able to make use of the `prefers-reduced-motion` media query I took the opportunity to update the dialog animation based on it.

Note that the presence of `prefers-reduced-motion` does not imply blanket removal of animations but rather to avoid excessive motion. In the case of dialog appear/exit the scale transform is merely replaced with a fade in/out transition instead. In other places like the [whitespace hint popover](https://github.com/desktop/desktop/blob/e3e2a4dd087d152038474b1d5928fc817553a18c/app/styles/ui/_popover.scss#L55-L64) it makes more sense to remove the animation altogether.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 