### PR TITLE
Checks failed dialog

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -289,6 +289,11 @@ export interface IAppState {
    * order for external contributions in latest release.
    */
   readonly lastThankYou: ILastThankYou | undefined
+
+  /**
+   * Whether or not the CI status popover is visible.
+   */
+  readonly showCIStatusPopover: boolean
 }
 
 export enum FoldoutType {

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -12,6 +12,7 @@ import {
 import JSZip from 'jszip'
 import moment from 'moment'
 import { enableCICheckRunsLogs } from '../feature-flag'
+import { GitHubRepository } from '../../models/github-repository'
 
 /**
  * A Desktop-specific model closely related to a GitHub API Check Run.
@@ -561,4 +562,24 @@ export function getCheckRunDisplayName(
       ? 'Code scanning results' // seems this is hardcoded on dotcom too :/
       : undefined
   return wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
+}
+
+export function getCheckRunStepURL(
+  checkRun: IRefCheck,
+  step: IAPIWorkflowJobStep,
+  repository: GitHubRepository,
+  pullRequestNumber: number
+): string | null {
+  if (checkRun.htmlUrl === null && repository.htmlURL === null) {
+    // A check run may not have a url depending on how it is setup.
+    // However, the repository should have one; Thus, we shouldn't hit this
+    return null
+  }
+
+  const url =
+    checkRun.htmlUrl !== null
+      ? `${checkRun.htmlUrl}/#step:${step.number}:1`
+      : `${repository.htmlURL}/pull/${pullRequestNumber}`
+
+  return url
 }

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -564,6 +564,15 @@ export function getCheckRunDisplayName(
   return wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
 }
 
+/**
+ * Generates the URL pointing to the details of a given check run. If that check
+ * run has no specific URL, returns the URL of the associated pull request.
+ *
+ * @param checkRun Check run to generate the URL for
+ * @param step Check run step to generate the URL for
+ * @param repository Repository to which the check run belongs
+ * @param pullRequestNumber Number of PR associated with the check run
+ */
 export function getCheckRunStepURL(
   checkRun: IRefCheck,
   step: IAPIWorkflowJobStep,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -461,6 +461,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   private currentDragElement: DragElement | null = null
   private lastThankYou: ILastThankYou | undefined
+  private showCIStatusPopover: boolean = false
 
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
@@ -853,6 +854,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       dragAndDropIntroTypesShown: this.dragAndDropIntroTypesShown,
       currentDragElement: this.currentDragElement,
       lastThankYou: this.lastThankYou,
+      showCIStatusPopover: this.showCIStatusPopover,
     }
   }
 
@@ -6727,6 +6729,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
+    this.emitUpdate()
+  }
+
+  public _setShowCIStatusPopover(showCIStatusPopover: boolean) {
+    if (this.showCIStatusPopover !== showCIStatusPopover) {
+      this.showCIStatusPopover = showCIStatusPopover
+      this.emitUpdate()
+    }
+  }
+
+  public _toggleCIStatusPopover() {
+    this.showCIStatusPopover = !this.showCIStatusPopover
     this.emitUpdate()
   }
 }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -18,6 +18,7 @@ import { ITextDiff, DiffSelection } from './diff'
 import { RepositorySettingsTab } from '../ui/repository-settings/repository-settings'
 import { ICommitMessage } from './commit-message'
 import { IAuthor } from './author'
+import { IRefCheck } from '../lib/ci-checks/ci-checks'
 
 export enum PopupType {
   RenameBranch = 1,
@@ -75,6 +76,7 @@ export enum PopupType {
   InvalidatedToken,
   AddSSHHost,
   SSHKeyPassphrase,
+  PullRequestChecksFailed,
 }
 
 export type Popup =
@@ -308,4 +310,13 @@ export type Popup =
         passphrase: string | undefined,
         storePassphrase: boolean
       ) => void
+    }
+  | {
+      type: PopupType.PullRequestChecksFailed
+      repository: RepositoryWithGitHubRepository
+      pullRequest: PullRequest
+      needsSelectRepository: boolean
+      commitMessage: string
+      commitSha: string
+      checks: ReadonlyArray<IRefCheck>
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -142,6 +142,7 @@ import { AddSSHHost } from './ssh/add-ssh-host'
 import { SSHKeyPassphrase } from './ssh/ssh-key-passphrase'
 import { getMultiCommitOperationChooseBranchStep } from '../lib/multi-commit-operation'
 import { ConfirmForcePush } from './rebase/confirm-force-push'
+import { PullRequestChecksFailed } from './notifications/pull-request-checks-failed'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2048,6 +2049,23 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.PullRequestChecksFailed: {
+        return (
+          <PullRequestChecksFailed
+            key="pull-request-checks-failed"
+            dispatcher={this.props.dispatcher}
+            shouldChangeRepository={popup.needsSelectRepository}
+            repository={popup.repository}
+            pullRequest={popup.pullRequest}
+            commitMessage={popup.commitMessage}
+            commitSha={popup.commitSha}
+            checks={popup.checks}
+            accounts={this.state.accounts}
+            onSubmit={onPopupDismissedFn}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
     }
@@ -2514,6 +2532,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         shouldNudge={
           this.state.currentOnboardingTutorialStep === TutorialStep.CreateBranch
         }
+        showCIStatusPopover={this.state.showCIStatusPopover}
       />
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -28,6 +28,12 @@ interface ICICheckRunListItemProps {
   /** Whether or not to show the action workflow event in the title */
   readonly showEventInTitle: boolean
 
+  /** Whether the list item can be selected */
+  readonly selectable: boolean
+
+  /** Whether the list item is selected */
+  readonly selected: boolean
+
   /** Callback for when a check run is clicked */
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
@@ -35,7 +41,7 @@ interface ICICheckRunListItemProps {
   readonly onViewCheckExternally: (checkRun: IRefCheck) => void
 
   /** Callback to open a job steps link on dotcom*/
-  readonly onViewJobStep: (
+  readonly onViewJobStep?: (
     checkRun: IRefCheck,
     step: IAPIWorkflowJobStep
   ) => void
@@ -54,7 +60,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private onViewJobStep = (step: IAPIWorkflowJobStep) => {
-    this.props.onViewJobStep(this.props.checkRun, step)
+    this.props.onViewJobStep?.(this.props.checkRun, step)
   }
 
   private renderCheckStatusSymbol = (): JSX.Element => {
@@ -74,9 +80,9 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckJobStepToggle = (): JSX.Element | null => {
-    const { checkRun, isCheckRunExpanded } = this.props
+    const { checkRun, isCheckRunExpanded, selectable } = this.props
 
-    if (checkRun.actionJobSteps === undefined) {
+    if (checkRun.actionJobSteps === undefined || selectable) {
       return null
     }
 
@@ -119,7 +125,10 @@ export class CICheckRunListItem extends React.PureComponent<
     return (
       <>
         <div
-          className="ci-check-list-item list-item"
+          className={classNames('ci-check-list-item list-item', {
+            selected: this.props.selected,
+          })}
+          tabIndex={0}
           onClick={this.toggleCheckRunExpansion}
         >
           {this.renderCheckStatusSymbol()}

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -6,6 +6,7 @@ import {
   getCheckRunConclusionAdjective,
   ICombinedRefCheck,
   IRefCheck,
+  getCheckRunStepURL,
 } from '../../lib/ci-checks/ci-checks'
 import { Octicon, syncClockwise } from '../octicons'
 import { Button } from '../lib/button'
@@ -229,18 +230,13 @@ export class CICheckRunPopover extends React.PureComponent<
     checkRun: IRefCheck,
     step: IAPIWorkflowJobStep
   ): void => {
-    if (checkRun.htmlUrl === null && this.props.repository.htmlURL === null) {
-      // A check run may not have a url depending on how it is setup.
-      // However, the repository should have one; Thus, we shouldn't hit this
-      return
+    const { repository, prNumber, dispatcher } = this.props
+
+    const url = getCheckRunStepURL(checkRun, step, repository, prNumber)
+
+    if (url !== null) {
+      dispatcher.openInBrowser(url)
     }
-
-    const url =
-      checkRun.htmlUrl !== null
-        ? `${checkRun.htmlUrl}/#step:${step.number}:1`
-        : `${this.props.repository.htmlURL}/pull/${this.props.prNumber}`
-
-    this.props.dispatcher.openInBrowser(url)
   }
 
   private getCommitRef(prNumber: number): string {

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -276,17 +276,10 @@ export class CICheckRunPopover extends React.PureComponent<
   }
 
   private rerunJobs = () => {
-    // Get unique set of check suite ids
-    const checkSuiteIds = new Set<number | null>([
-      ...this.state.checkRuns.map(cr => cr.checkSuiteId),
-    ])
-
-    for (const id of checkSuiteIds) {
-      if (id === null) {
-        continue
-      }
-      this.props.dispatcher.rerequestCheckSuite(this.props.repository, id)
-    }
+    this.props.dispatcher.rerequestCheckSuites(
+      this.props.repository,
+      this.state.checkRuns
+    )
   }
 
   private getPopoverPositioningStyles = (): React.CSSProperties => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2448,7 +2448,7 @@ export class Dispatcher {
   }
 
   /**
-   * Triggers GitHub to rerequest an existing check suite, without pushing new
+   * Triggers GitHub to rerequest a list of check suites, without pushing new
    * code to a repository.
    */
   public async rerequestCheckSuites(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3705,4 +3705,12 @@ export class Dispatcher {
       currentBranch.tip.sha
     )
   }
+
+  public setShowCIStatusPopover(showCIStatusPopover: boolean) {
+    this.appStore._setShowCIStatusPopover(showCIStatusPopover)
+  }
+
+  public _toggleCIStatusPopover() {
+    this.appStore._toggleCIStatusPopover()
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2451,11 +2451,25 @@ export class Dispatcher {
    * Triggers GitHub to rerequest an existing check suite, without pushing new
    * code to a repository.
    */
-  public rerequestCheckSuite(
+  public async rerequestCheckSuites(
     repository: GitHubRepository,
-    checkSuiteId: number
-  ): Promise<boolean> {
-    return this.commitStatusStore.rerequestCheckSuite(repository, checkSuiteId)
+    checkRuns: ReadonlyArray<IRefCheck>
+  ): Promise<void> {
+    // Get unique set of check suite ids
+    const checkSuiteIds = new Set<number | null>([
+      ...checkRuns.map(cr => cr.checkSuiteId),
+    ])
+
+    const promises = new Array<Promise<boolean>>()
+
+    for (const id of checkSuiteIds) {
+      if (id === null) {
+        continue
+      }
+      promises.push(this.commitStatusStore.rerequestCheckSuite(repository, id))
+    }
+
+    await Promise.all(promises)
   }
 
   /**

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -54,7 +54,7 @@ export class PullRequestChecksFailed extends React.Component<
 
     const { checks } = this.props
 
-    const selectedCheck = checks.find(check => isFailure(check)) ?? checks[0]
+    const selectedCheck = checks.find(isFailure) ?? checks[0]
     this.state = {
       switchingToPullRequest: false,
       selectedCheckID: selectedCheck.id,

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -1,0 +1,301 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { PullRequest } from '../../models/pull-request'
+import { Dispatcher } from '../dispatcher'
+import { CICheckRunList } from '../check-runs/ci-check-run-list'
+import {
+  IRefCheck,
+  getLatestPRWorkflowRunsLogsForCheckRun,
+  getCheckRunActionsJobsAndLogURLS,
+  isFailure,
+} from '../../lib/ci-checks/ci-checks'
+import { CICheckRunLogs } from '../check-runs/ci-check-run-item-logs'
+import { Account } from '../../models/account'
+import { API, getHTMLURL } from '../../lib/api'
+import { Octicon, syncClockwise } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+import { Button } from '../lib/button'
+import { RepositoryWithGitHubRepository } from '../../models/repository'
+
+interface IPullRequestChecksFailedProps {
+  readonly dispatcher: Dispatcher
+  readonly shouldChangeRepository: boolean
+  readonly accounts: ReadonlyArray<Account>
+  readonly repository: RepositoryWithGitHubRepository
+  readonly pullRequest: PullRequest
+  readonly commitMessage: string
+  readonly commitSha: string
+  readonly checks: ReadonlyArray<IRefCheck>
+  readonly onSubmit: () => void
+  readonly onDismissed: () => void
+}
+
+interface IPullRequestChecksFailedState {
+  readonly switchingToPullRequest: boolean
+  readonly selectedCheckID: number
+  readonly checks: ReadonlyArray<IRefCheck>
+  readonly loadingActionWorkflows: boolean
+  readonly loadingActionLogs: boolean
+}
+
+/**
+ * Dialog to show the result of a CI check run.
+ */
+export class PullRequestChecksFailed extends React.Component<
+  IPullRequestChecksFailedProps,
+  IPullRequestChecksFailedState
+> {
+  private checkRunsLoadCancelled: boolean = false
+
+  public constructor(props: IPullRequestChecksFailedProps) {
+    super(props)
+
+    const { checks } = this.props
+
+    const selectedCheck = checks.find(check => isFailure(check)) ?? checks[0]
+    this.state = {
+      switchingToPullRequest: false,
+      selectedCheckID: selectedCheck.id,
+      checks,
+      loadingActionWorkflows: true,
+      loadingActionLogs: true,
+    }
+  }
+
+  public render() {
+    let okButtonTitle = __DARWIN__
+      ? 'Switch to Pull Request'
+      : 'Switch to pull request'
+
+    if (this.props.shouldChangeRepository) {
+      okButtonTitle = __DARWIN__
+        ? 'Switch to Repository and Pull Request'
+        : 'Switch to repository and pull request'
+    }
+
+    const { pullRequest, repository } = this.props
+
+    const dialogTitle = (
+      <span className="custom-title">
+        <Octicon
+          className={pullRequest.draft ? 'draft' : undefined}
+          symbol={OcticonSymbol.gitPullRequest}
+        />
+        <span className="pr-title">{pullRequest.title}</span>{' '}
+        <span className="pr-number">#{pullRequest.pullRequestNumber}</span>{' '}
+      </span>
+    )
+
+    const selectedCheck = this.state.checks.find(
+      check => check.id === this.state.selectedCheckID
+    )
+
+    const failedChecks = this.state.checks.filter(
+      check => check.conclusion === 'failure'
+    )
+    const pluralChecks = failedChecks.length > 1 ? 'checks' : 'check'
+    const pluralThem = failedChecks.length > 1 ? 'them' : 'it'
+
+    const loading =
+      this.state.loadingActionWorkflows ||
+      this.state.loadingActionLogs ||
+      this.state.switchingToPullRequest
+
+    const baseHref = getHTMLURL(repository.gitHubRepository.endpoint)
+
+    return (
+      <Dialog
+        id="pull-request-checks-failed"
+        type="normal"
+        title={dialogTitle}
+        dismissable={false}
+        onSubmit={this.props.onSubmit}
+        onDismissed={this.props.onDismissed}
+        loading={loading}
+      >
+        <DialogContent>
+          <Row>
+            <span className="summary">
+              {failedChecks.length} {pluralChecks} failed in your pull request.
+              Do you want to switch to that Pull Request now and start fixing{' '}
+              {pluralThem}?
+            </span>
+          </Row>
+          <Row>
+            <div className="ci-check-run-dialog-container">
+              <div className="ci-check-run-header">
+                <span className="message">
+                  {this.props.commitMessage.slice(0, 72)}
+                </span>
+                <span aria-hidden="true">
+                  <Octicon symbol={OcticonSymbol.gitCommit} />
+                </span>{' '}
+                <span className="sha">{this.props.commitSha.slice(0, 9)}</span>
+                {this.renderRerunButton()}
+              </div>
+              <div className="ci-check-run-content">
+                <CICheckRunList
+                  checkRuns={this.state.checks}
+                  loadingActionLogs={this.state.loadingActionLogs}
+                  loadingActionWorkflows={this.state.loadingActionWorkflows}
+                  showLogsInline={false}
+                  selectable={true}
+                  selectedCheckRun={selectedCheck}
+                  baseHref={baseHref}
+                  onViewOnGitHub={this.onViewOnGitHub}
+                  onCheckRunClick={this.onCheckRunClick}
+                />
+                {selectedCheck !== undefined && (
+                  <CICheckRunLogs
+                    checkRun={selectedCheck}
+                    loadingActionLogs={this.state.loadingActionLogs}
+                    loadingActionWorkflows={this.state.loadingActionWorkflows}
+                    baseHref={baseHref}
+                  />
+                )}
+              </div>
+            </div>
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            onCancelButtonClick={this.props.onDismissed}
+            cancelButtonText="Dismiss"
+            okButtonText={okButtonTitle}
+            onOkButtonClick={this.onSubmit}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  public componentDidMount() {
+    this.loadCheckRunLogs()
+  }
+
+  public componentWillUnmount() {
+    this.checkRunsLoadCancelled = true
+  }
+
+  private renderRerunButton = () => {
+    const { checks } = this.state
+    return (
+      <div className="ci-check-rerun">
+        <Button onClick={this.rerunJobs} disabled={checks.length === 0}>
+          <Octicon symbol={syncClockwise} /> Re-run jobs
+        </Button>
+      </div>
+    )
+  }
+
+  private rerunJobs = () => {
+    // Get unique set of check suite ids
+    const checkSuiteIds = new Set<number | null>([
+      ...this.state.checks.map(cr => cr.checkSuiteId),
+    ])
+
+    for (const id of checkSuiteIds) {
+      if (id === null) {
+        continue
+      }
+      this.props.dispatcher.rerequestCheckSuite(
+        this.props.repository.gitHubRepository,
+        id
+      )
+    }
+
+    this.props.onDismissed()
+  }
+
+  private async loadCheckRunLogs() {
+    const { pullRequest, repository } = this.props
+    const { gitHubRepository } = repository
+
+    const account = this.props.accounts.find(
+      a => a.endpoint === gitHubRepository.endpoint
+    )
+
+    if (account === undefined) {
+      this.setState({
+        loadingActionWorkflows: false,
+        loadingActionLogs: false,
+      })
+      return
+    }
+
+    const api = API.fromAccount(account)
+
+    /*
+      Until we retrieve the actions workflows, we don't know if a check run has
+      action logs to output, thus, we want to show loading until then. However,
+      once the workflows have been retrieved and since the logs retrieval and
+      parsing can be noticeably time consuming. We go ahead and flip a flag so
+      that we know we can go ahead and display the checkrun `output` content if
+      a check run does not have action logs to retrieve/parse.
+    */
+    const checkRunsWithActionsUrls = await getCheckRunActionsJobsAndLogURLS(
+      api,
+      gitHubRepository.owner.login,
+      gitHubRepository.name,
+      pullRequest.head.ref,
+      this.props.checks
+    )
+
+    if (this.checkRunsLoadCancelled) {
+      return
+    }
+
+    this.setState({
+      checks: checkRunsWithActionsUrls,
+      loadingActionWorkflows: false,
+    })
+
+    const checks = await getLatestPRWorkflowRunsLogsForCheckRun(
+      api,
+      gitHubRepository.owner.login,
+      gitHubRepository.name,
+      checkRunsWithActionsUrls
+    )
+
+    if (this.checkRunsLoadCancelled) {
+      return
+    }
+
+    this.setState({ checks, loadingActionLogs: false })
+  }
+
+  private onCheckRunClick = (checkRun: IRefCheck): void => {
+    this.setState({ selectedCheckID: checkRun.id })
+  }
+
+  private onViewOnGitHub = (checkRun: IRefCheck) => {
+    const { repository, pullRequest, dispatcher } = this.props
+
+    // Some checks do not provide htmlURLS like ones for the legacy status
+    // object as they do not have a view in the checks screen. In that case we
+    // will just open the PR and they can navigate from there... a little
+    // dissatisfying tho more of an edgecase anyways.
+    const url =
+      checkRun.htmlUrl ??
+      `${repository.gitHubRepository.htmlURL}/pull/${pullRequest.pullRequestNumber}`
+    if (url === null) {
+      // The repository should have a htmlURL.
+      return
+    }
+    dispatcher.openInBrowser(url)
+  }
+
+  private onSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    const { dispatcher, repository, pullRequest } = this.props
+
+    this.setState({ switchingToPullRequest: true })
+    await dispatcher.selectRepository(repository)
+    await dispatcher.checkoutPullRequest(repository, pullRequest)
+    this.setState({ switchingToPullRequest: false })
+
+    this.props.onDismissed()
+  }
+}

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -24,6 +24,10 @@ import { LinkButton } from '../lib/link-button'
 import { encodePathAsUrl } from '../../lib/path'
 
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
+const BlankSlateImage = encodePathAsUrl(
+  __dirname,
+  'static/empty-no-pull-requests.svg'
+)
 const MaxCommitMessageLength = 72
 
 interface IPullRequestChecksFailedProps {
@@ -190,26 +194,35 @@ export class PullRequestChecksFailed extends React.Component<
       return null
     }
 
-    if (this.loadingChecksInfo) {
-      // TODO: add nice loading indicator
-      return null
-    }
+    let stepsContent = null
 
-    const stepsContent =
-      selectedCheck.actionJobSteps === undefined ? (
-        this.renderEmptyLogOutput()
-      ) : (
+    if (this.loadingChecksInfo) {
+      stepsContent = this.renderCheckRunStepsLoading()
+    } else if (selectedCheck.actionJobSteps === undefined) {
+      stepsContent = this.renderEmptyLogOutput()
+    } else {
+      stepsContent = (
         <CICheckRunActionsJobStepList
           steps={selectedCheck.actionJobSteps}
           onViewJobStep={this.onViewJobStep}
         />
       )
+    }
 
     return (
       <div className="ci-check-run-job-steps-container">{stepsContent}</div>
     )
   }
 
+  private renderCheckRunStepsLoading(): JSX.Element {
+    return (
+      <div className="loading-check-runs">
+        <img src={BlankSlateImage} className="blankslate-image" />
+        <div className="title">Stand By</div>
+        <div className="call-to-action">Check run steps incoming!</div>
+      </div>
+    )
+  }
   private renderEmptyLogOutput() {
     return (
       <div className="no-steps-to-display">

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -266,22 +266,10 @@ export class PullRequestChecksFailed extends React.Component<
   }
 
   private rerunJobs = () => {
-    // Get unique set of check suite ids
-    const checkSuiteIds = new Set<number | null>([
-      ...this.state.checks.map(cr => cr.checkSuiteId),
-    ])
-
-    for (const id of checkSuiteIds) {
-      if (id === null) {
-        continue
-      }
-      this.props.dispatcher.rerequestCheckSuite(
-        this.props.repository.gitHubRepository,
-        id
-      )
-    }
-
-    this.props.onDismissed()
+    this.props.dispatcher.rerequestCheckSuites(
+      this.props.repository.gitHubRepository,
+      this.state.checks
+    )
   }
 
   private async loadCheckRunLogs() {

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -53,10 +53,10 @@ interface IBranchDropdownProps {
 
   /** Whether this component should show its onboarding tutorial nudge arrow */
   readonly shouldNudge: boolean
-}
 
+  readonly showCIStatusPopover: boolean
+}
 interface IBranchDropdownState {
-  readonly isPopoverOpen: boolean
   readonly badgeBottom: number
 }
 
@@ -70,7 +70,6 @@ export class BranchDropdown extends React.Component<
   public constructor(props: IBranchDropdownProps) {
     super(props)
     this.state = {
-      isPopoverOpen: false,
       badgeBottom: 0,
     }
   }
@@ -197,7 +196,7 @@ export class BranchDropdown extends React.Component<
         >
           {this.renderPullRequestInfo()}
         </ToolbarDropdown>
-        {this.state.isPopoverOpen && this.renderPopover()}
+        {this.props.showCIStatusPopover && this.renderPopover()}
       </>
     )
   }
@@ -216,7 +215,11 @@ export class BranchDropdown extends React.Component<
   }
 
   private onBadgeClick = () => {
-    if (this.state.isPopoverOpen) {
+    this.togglePopover()
+  }
+
+  private togglePopover() {
+    if (this.props.showCIStatusPopover) {
       this.closePopover()
     } else {
       this.props.dispatcher.closeFoldout(FoldoutType.Branch)
@@ -229,17 +232,12 @@ export class BranchDropdown extends React.Component<
   }
 
   private openPopover = () => {
-    this.setState(prevState => {
-      if (!prevState.isPopoverOpen) {
-        return { isPopoverOpen: true }
-      }
-      return null
-    })
+    this.props.dispatcher.setShowCIStatusPopover(true)
   }
 
   private closePopover = (event?: MouseEvent) => {
     if (event === undefined) {
-      this.setState({ isPopoverOpen: false })
+      this.props.dispatcher.setShowCIStatusPopover(false)
       return
     }
 
@@ -254,7 +252,7 @@ export class BranchDropdown extends React.Component<
       return
     }
 
-    this.setState({ isPopoverOpen: false })
+    this.props.dispatcher.setShowCIStatusPopover(false)
   }
 
   private renderPopover() {

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -93,4 +93,5 @@
 @import 'ui/check-runs/_ci-check-run-list';
 @import 'ui/check-runs/_ci-check-run-popover';
 @import 'ui/check-runs/ci-check-run-job-steps';
+@import 'ui/_pull-request-checks-failed';
 @import 'ui/_sandboxed-markdown';

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -32,6 +32,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --link-button-color: #{$blue};
   --link-button-hover-color: #{$blue-600};
+  --link-button-selected-hover-color: #{$blue-200};
 
   --secondary-button-background: #{$gray-000};
   --secondary-button-hover-background: #{$white};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -28,6 +28,7 @@ body.theme-dark {
 
   --link-button-color: #{lighten($blue-400, 3%)};
   --link-button-hover-color: #{$blue-400};
+  --link-button-selected-hover-color: #{$blue-300};
 
   --secondary-button-background: #{$gray-800};
   --secondary-button-hover-background: var(--secondary-button-background);

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -444,6 +444,11 @@ dialog {
     width: 400px;
   }
 
+  &#pull-request-checks-failed {
+    max-width: none;
+    width: 910px;
+  }
+
   &#workflow-push-rejected {
     .ref-component {
       display: inline-block;

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -1,0 +1,89 @@
+#pull-request-checks-failed {
+  .custom-title {
+    display: flex;
+    column-gap: 4px;
+    align-items: center;
+
+    .pr-number {
+      color: var(--text-secondary-color);
+    }
+
+    .octicon {
+      vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+      color: var(--pr-open-icon-color);
+
+      &.draft {
+        color: var(--pr-draft-icon-color);
+      }
+    }
+  }
+
+  .ci-check-run-dialog-container {
+    height: 300px;
+    width: 100%;
+    border-radius: var(--border-radius);
+    border: var(--base-border);
+    overflow-y: hidden;
+    overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .ci-check-run-header {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: var(--spacing);
+      border-bottom: var(--base-border);
+
+      .message {
+        margin-right: var(--spacing);
+        font-weight: bold;
+      }
+
+      .octicon {
+        margin-right: var(--spacing-third);
+        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+      }
+
+      .sha {
+        user-select: text;
+      }
+
+      .ci-check-rerun {
+        margin-left: auto;
+      }
+    }
+
+    .ci-check-run-content {
+      display: flex;
+      flex-direction: row;
+      align-items: stretch;
+      justify-content: stretch;
+      overflow-x: hidden;
+      overflow-y: hidden;
+      height: 100%;
+    }
+
+    .ci-check-run-list {
+      width: 30%;
+      border-radius: 0;
+    }
+    .ci-check-list-item-logs {
+      width: 70%;
+      box-shadow: none;
+      border: none;
+      border-left: var(--base-border);
+      border-right: none;
+    }
+    .ci-check-list-item-logs-output {
+      max-height: none;
+      height: 100%;
+    }
+    .loading-logs {
+      box-shadow: none;
+      border: none;
+      border-left: var(--base-border);
+      width: 70%;
+    }
+  }
+}

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -68,12 +68,42 @@
       width: 40%;
       border-radius: 0;
     }
-    .ci-check-run-job-steps-list {
+
+    .ci-check-run-job-steps-container {
       width: 60%;
-      box-shadow: none;
-      border: none;
-      border-left: var(--base-border);
-      border-right: none;
+      overflow-y: auto;
+
+      .ci-check-run-job-steps-list {
+        box-shadow: none;
+        border: none;
+        border-left: var(--base-border);
+        border-right: none;
+      }
+
+      .no-steps-to-display {
+        display: flex;
+        padding: var(--spacing);
+        align-items: center;
+        height: 100%;
+
+        .text {
+          flex: 1;
+          margin-right: var(--spacing);
+
+          div {
+            margin-top: var(--spacing);
+          }
+        }
+
+        .blankslate-image {
+          flex: 0;
+          height: 140px;
+          width: 146px;
+          min-width: 140px;
+          min-height: 146px;
+          align-self: flex-end;
+        }
+      }
     }
   }
 }

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -65,25 +65,15 @@
     }
 
     .ci-check-run-list {
-      width: 30%;
+      width: 40%;
       border-radius: 0;
     }
-    .ci-check-list-item-logs {
-      width: 70%;
+    .ci-check-run-job-steps-list {
+      width: 60%;
       box-shadow: none;
       border: none;
       border-left: var(--base-border);
       border-right: none;
-    }
-    .ci-check-list-item-logs-output {
-      max-height: none;
-      height: 100%;
-    }
-    .loading-logs {
-      box-shadow: none;
-      border: none;
-      border-left: var(--base-border);
-      width: 70%;
     }
   }
 }

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -104,6 +104,29 @@
           align-self: flex-end;
         }
       }
+
+      .loading-check-runs {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        padding: var(--spacing);
+        padding-bottom: var(--spacing-double);
+
+        .blankslate-image {
+          width: 100%;
+          min-width: auto;
+        }
+
+        .title {
+          font-weight: var(--font-weight-semibold);
+        }
+
+        .call-to-action {
+          font-size: var(--font-size-sm);
+        }
+      }
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -2,9 +2,16 @@
   display: flex;
   width: 100%;
   border-bottom: var(--base-border);
-  height: 100%;
+  height: auto;
 
-  .ci-check-name span {
+  &.selected .ci-check-name span {
+    &:hover {
+      color: var(--link-button-selected-hover-color);
+      cursor: pointer !important;
+    }
+  }
+
+  &:not(.selected) .ci-check-name span {
     &:hover {
       color: var(--link-button-color);
       cursor: pointer !important;


### PR DESCRIPTION
## Description

More work on "checks failed" notification: this PR has the new dialog that will be shown when a notification like that is received.

One change worth noting in this PR is that I made the state of showing or not the CI status popover part of the global app state. That will allow us to easily show/hide it when the user clicks on a notification, depending on whether or not the user is in the very same repository and PR referenced by the notification.

There is [a commit](https://github.com/desktop/desktop/commit/925355de177f136d17a767c6823988c7e1f95bcb) in this branch that must not be merged because it's here just for testing purposes: if you click on the CI badge in the branch dropdown button, the app will show the dialog for the current Pull Request.

### Screenshots

https://user-images.githubusercontent.com/1083228/142204248-04534d73-e8cd-4bf6-8158-11b2f296602b.mov

## Release notes

Notes: no-notes
