### PR TITLE
change wording for default branch name option

### DIFF
--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -104,7 +104,7 @@ export class Git extends React.Component<IGitProps, IGitState> {
 
     return (
       <div className="default-branch-component">
-        <h2>Default branch for new repositories</h2>
+        <h2>Default branch name for new repositories</h2>
 
         {SuggestedBranchNames.map((branchName: string) => (
           <RadioButton


### PR DESCRIPTION
This PR does not close any issues.

## Description

- This PR changes the wording for the default branch name option. There seemed to be some confusion in a (since deleted) comment on #9845 over what this setting meant, so this PR should make it clearer.

### Screenshots

![image](https://user-images.githubusercontent.com/42586271/139599702-300063a4-1fef-4bac-bf90-3f7884445df0.png)

## Release notes

Notes: no-notes? not sure
