### PR TITLE
Actions logs css improvements

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -94,7 +94,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
     let logGroup: ILogLineTemplateData[] = []
     for (let i = 0; i < logLinesData.length; i++) {
       const lineData = logLinesData[i]
-      const isNextLineDataInGroup = logLinesData[i + 1]?.inGroup
+      const isNextLineDataInGroup = logLinesData[i + 1]?.inGroup ?? false
 
       // We simply have a regular log line
       if (!lineData.isGroup && !lineData.inGroup) {
@@ -105,7 +105,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
       // Otherwise this line is part of a group
       logGroup.push(lineData)
 
-      // If the currently line is the last in the group, then we want to render
+      // If the current line is the last in the group, then we want to render
       // the group
       if (!isNextLineDataInGroup) {
         logLineJSX.push(this.renderLogLineGroup(logGroup, i))

--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -126,6 +126,30 @@ export class CICheckRunActionLogs extends React.PureComponent<
     })
 
     const cn = classNames('line', logGroupSummary.className)
+
+    // Naturally, the groups of lines will be aligned to edge of the line number
+    // of first line in the group. Like this:
+    //  1 some non grouped line
+    //  2 \/ First line of Group
+    //    3   next line
+    //    4   next line
+    //  5 some non grouped line
+    // We want all line numbers to be vertically aligned. This this:
+    //  1 some non grouped line
+    //  2 \/ First line of Group
+    //  3   next line
+    //  4   next line
+    //  5 some non grouped line
+    // To do this, we need to artificially move the left position of the group
+    // to line up with the non-grouped lines. (negative margin left) However,
+    // that makes the first line in the group or summary line overlap it's line
+    // number.
+    //  1 some non grouped line
+    //  \2/ First line of Group
+    //  3   next line
+    //  4   next lineß
+    //  5 some non grouped line
+    // Thus, we correct the style on the sumary line inversely.
     const groupStyle = { marginLeft: -1 * this.logLineNumberWidth }
     const summaryStyle = { marginLeft: 1 * this.logLineNumberWidth }
     return (

--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -126,11 +126,17 @@ export class CICheckRunActionLogs extends React.PureComponent<
     })
 
     const cn = classNames('line', logGroupSummary.className)
+    const groupStyle = { marginLeft: -1 * this.logLineNumberWidth }
+    const summaryStyle = { marginLeft: 1 * this.logLineNumberWidth }
     return (
       <div className={cn} key={index}>
         {this.renderLogLineNumber(logGroupSummary.lineNumber)}
-        <details className="log-group" open={logGroupSummary.groupExpanded}>
-          <summary>
+        <details
+          className="log-group"
+          open={logGroupSummary.groupExpanded}
+          style={groupStyle}
+        >
+          <summary style={summaryStyle}>
             {this.renderLogLineContentTemplate(logGroupSummary)}
           </summary>
           {logGroupBody}
@@ -145,10 +151,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
     isInGroup: boolean = false
   ): JSX.Element {
     const cn = classNames('line', lineData.className)
-    const style = isInGroup
-      ? // Meh... the +10 is due to the margin-left of the log group = var(--spacing).... if this changes oh no.. we broke - maybe can make this better in a future css improving pr.
-        { marginLeft: -1 * (this.logLineNumberWidth + 10) }
-      : undefined
+    const style = undefined
     return (
       <div className={cn} key={index} style={style}>
         {this.renderLogLineNumber(lineData.lineNumber)}
@@ -227,6 +230,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
   ): JSX.Element {
     const headerClassNames = classNames('ci-check-run-log-step-header', {
       open: showLogs,
+      skipped: isSkipped,
     })
 
     return (

--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -151,9 +151,8 @@ export class CICheckRunActionLogs extends React.PureComponent<
     isInGroup: boolean = false
   ): JSX.Element {
     const cn = classNames('line', lineData.className)
-    const style = undefined
     return (
-      <div className={cn} key={index} style={style}>
+      <div className={cn} key={index}>
         {this.renderLogLineNumber(lineData.lineNumber)}
         {this.renderLogLineContentTemplate(lineData)}
       </div>

--- a/app/styles/ui/check-runs/_ci-check-run-logs.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-logs.scss
@@ -85,6 +85,13 @@
 
           .line-content {
             margin-left: var(--spacing);
+
+            // 'word-break: normal' combined with 'overflow-wrap: anywhere' give
+            // us good line wrapping. It breaks long sections of joined
+            // characters such as a file path in an "anywhere" fashion so that
+            // we don't get overflowing lines yet also breaks sentence text in a
+            // "by words" fashion so as not to break in the middle of words.
+            // Similar to how the deprecated: word-break: break-word worked.
             word-break: normal;
             overflow-wrap: anywhere;
           }

--- a/app/styles/ui/check-runs/_ci-check-run-logs.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-logs.scss
@@ -23,13 +23,11 @@
     border-color: var(--check-run-border-color);
 
     .ci-check-run-log-step {
-      // TODO: Figure out why hover only does middle part and not padding when using classes
-      // Currently can't figure out how to not hover skipped steps. :/
-      div:first-child:hover {
-        background-color: var(--check-run-step-header-open-bg-color);
-      }
-
       .ci-check-run-log-step-header {
+        &:not(.skipped):hover {
+          background-color: var(--check-run-step-header-open-bg-color);
+        }
+
         border-radius: 6px;
         padding: 8px;
         margin-bottom: var(--spacing-half);

--- a/app/styles/ui/check-runs/_ci-check-run-logs.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-logs.scss
@@ -72,28 +72,34 @@
 
         .line {
           display: flex;
+          width: 100%;
 
           .line-number {
             overflow: hidden;
             text-overflow: ellipsis;
             text-align: right;
             display: inline-block;
+            flex-shrink: 0;
+            flex-grow: 0;
           }
 
           .line-content {
             margin-left: var(--spacing);
-            white-space: nowrap;
-            max-width: 90%;
+            word-break: normal;
+            overflow-wrap: anywhere;
           }
 
           &.log-line-group {
             details.log-group {
-              margin-left: var(--spacing);
+              width: 100%;
+
+              summary {
+                padding-left: var(--spacing);
+              }
 
               .line {
                 .line-content {
                   margin-left: var(--spacing-double);
-                  max-width: 88%;
                 }
               }
             }


### PR DESCRIPTION
## Description

Some CSS polish for the action logs parser.
- line numbers line up.
- lines break nicely to not force overflows
- skipped headers don't have hover styles
- log detail groups don't have hover styles

Bonus: a pr comment resolution about truthy/falsy from last pr.

### Screenshots


https://user-images.githubusercontent.com/75402236/139855363-d2991cbf-7cd5-4138-a0d4-7f5a4424b15a.mov


## Release notes
Notes: no-notes
