### PR TITLE
Make the check run "View on GitHub" button not so prominent. 

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -77,7 +77,6 @@ export class CICheckRunListItem extends React.PureComponent<
             baseHref={baseHref}
             loadingActionLogs={loadingActionLogs}
             loadingActionWorkflows={loadingActionLogs}
-            onViewOnGitHub={this.onViewOnGitHub}
             onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
           />
         ) : null}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -57,6 +57,14 @@ export class CICheckRunListItem extends React.PureComponent<
     this.props.onViewOnGitHub(this.props.checkRun)
   }
 
+  private onMouseOverLogs = () => {
+    this.setState({ isMouseOverLogs: true })
+  }
+
+  private onMouseLeaveLogs = () => {
+    this.setState({ isMouseOverLogs: false })
+  }
+
   public render() {
     const { checkRun, showLogs, loadingActionLogs, baseHref } = this.props
 
@@ -100,6 +108,8 @@ export class CICheckRunListItem extends React.PureComponent<
             baseHref={baseHref}
             loadingActionLogs={loadingActionLogs}
             loadingActionWorkflows={loadingActionLogs}
+            onMouseOver={this.onMouseOverLogs}
+            onMouseLeave={this.onMouseLeaveLogs}
             onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
           />
         ) : null}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -53,7 +53,8 @@ export class CICheckRunListItem extends React.PureComponent<
     this.props.onCheckRunClick(this.props.checkRun)
   }
 
-  private onViewOnGitHub = () => {
+  private onViewOnGitHub = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
     this.props.onViewOnGitHub(this.props.checkRun)
   }
 

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -4,6 +4,7 @@ import { Octicon } from '../octicons'
 import { getClassNameForCheck, getSymbolForCheck } from '../branches/ci-status'
 import classNames from 'classnames'
 import { CICheckRunLogs } from './ci-check-run-logs'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -32,10 +33,22 @@ interface ICICheckRunListItemProps {
   readonly onMarkdownLinkClicked: (url: string) => void
 }
 
+interface ICICheckRunListItemState {
+  readonly isMouseOverLogs: boolean
+}
+
 /** The CI check list item. */
 export class CICheckRunListItem extends React.PureComponent<
-  ICICheckRunListItemProps
+  ICICheckRunListItemProps,
+  ICICheckRunListItemState
 > {
+  public constructor(props: ICICheckRunListItemProps) {
+    super(props)
+    this.state = {
+      isMouseOverLogs: false,
+    }
+  }
+
   private onCheckRunClick = () => {
     this.props.onCheckRunClick(this.props.checkRun)
   }
@@ -63,12 +76,22 @@ export class CICheckRunListItem extends React.PureComponent<
               title={checkRun.description}
             />
           </div>
-
           <div className="ci-check-list-item-detail">
             <div className="ci-check-name">{checkRun.name}</div>
             <div className="ci-check-description" title={checkRun.description}>
               {checkRun.description}
             </div>
+          </div>
+          <div
+            className={classNames('view-on-github', {
+              show: this.state.isMouseOverLogs,
+            })}
+            onClick={this.onViewOnGitHub}
+          >
+            <Octicon
+              symbol={OcticonSymbol.linkExternal}
+              title="View on GitHub"
+            />
           </div>
         </div>
         {showLogs ? (

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -5,7 +5,6 @@ import {
   RefCheckOutputType,
 } from '../../lib/ci-checks/ci-checks'
 import classNames from 'classnames'
-import { Button } from '../lib/button'
 import { CICheckRunActionLogs } from './ci-check-run-actions-logs'
 import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
 
@@ -24,7 +23,6 @@ interface ICICheckRunLogsProps {
   readonly baseHref: string | null
 
   /** Callback to opens check runs on GitHub */
-  readonly onViewOnGitHub: (checkRun: IRefCheck) => void
 
   /** Callback to open URL's originating from markdown */
   readonly onMarkdownLinkClicked: (url: string) => void
@@ -32,9 +30,6 @@ interface ICICheckRunLogsProps {
 
 /** The CI check list item. */
 export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
-  private onViewOnGitHub = () => {
-    this.props.onViewOnGitHub(this.props.checkRun)
-  }
 
   private isNoAdditionalInfoToDisplay(output: IRefCheckOutput): boolean {
     return (
@@ -136,14 +131,6 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
     return <div className="no-logs-to-display">Loading…</div>
   }
 
-  private renderViewOnGitHub = () => {
-    return (
-      <div className="view-on-github">
-        <Button onClick={this.onViewOnGitHub}>View on GitHub</Button>
-      </div>
-    )
-  }
-
   private hasActionsWorkflowLogs() {
     return this.props.checkRun.actionsWorkflowRunId !== undefined
   }
@@ -177,7 +164,6 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
             : this.renderMetaOutput(output, name)}
           {logsOutput}
         </div>
-        {this.renderViewOnGitHub()}
       </div>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -23,6 +23,10 @@ interface ICICheckRunLogsProps {
   readonly baseHref: string | null
 
   /** Callback to opens check runs on GitHub */
+  readonly onMouseOver: (mouseEvent: React.MouseEvent<HTMLDivElement>) => void
+
+  /** Callback to opens check runs on GitHub */
+  readonly onMouseLeave: (mouseEvent: React.MouseEvent<HTMLDivElement>) => void
 
   /** Callback to open URL's originating from markdown */
   readonly onMarkdownLinkClicked: (url: string) => void
@@ -30,7 +34,6 @@ interface ICICheckRunLogsProps {
 
 /** The CI check list item. */
 export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
-
   private isNoAdditionalInfoToDisplay(output: IRefCheckOutput): boolean {
     return (
       this.isNoOutputText(output) &&
@@ -157,7 +160,11 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
     })
 
     return (
-      <div className={className}>
+      <div
+        className={className}
+        onMouseOver={this.props.onMouseOver}
+        onMouseLeave={this.props.onMouseLeave}
+      >
         <div className="ci-check-list-item-logs-output">
           {this.isNoAdditionalInfoToDisplay(output)
             ? this.renderEmptyLogOutput()

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -42,4 +42,8 @@
   .view-on-github.show {
     display: block;
   }
+  
+  .view-on-github:hover {
+    color: var(--text-primary-color);
+  }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -30,4 +30,16 @@
     width: 250px;
     height: 12px;
   }
+
+  .view-on-github {
+    display: none;
+    padding: var(--spacing);
+    padding-bottom: var(--spacing-half);
+    color: var(--text-secondary-color);
+  }
+
+  &:hover .view-on-github,
+  .view-on-github.show {
+    display: block;
+  }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -36,14 +36,14 @@
     padding: var(--spacing);
     padding-bottom: var(--spacing-half);
     color: var(--text-secondary-color);
+
+    .octicon:hover {
+      color: var(--text-color);
+    }
   }
 
   &:hover .view-on-github,
   .view-on-github.show {
     display: block;
-  }
-
-  .view-on-github:hover {
-    color: var(--text-primary-color);
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -42,7 +42,7 @@
   .view-on-github.show {
     display: block;
   }
-  
+
   .view-on-github:hover {
     color: var(--text-primary-color);
   }

--- a/app/styles/ui/check-runs/_ci-check-run-logs.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-logs.scss
@@ -1,25 +1,11 @@
 .ci-check-list-item-logs {
-  .view-on-github {
-    padding: var(--spacing);
-
-    .button-component {
-      width: 100%;
-    }
-  }
+  position: relative;
 
   .ci-check-list-item-logs-output {
-    padding: var(--spacing-half);
-    max-height: 200px;
-
-    .meta-output {
-      h4 {
-        padding: 0 var(--spacing-half);
-        margin-bottom: 0;
-      }
-    }
+    max-height: 250px;
 
     .sandboxed-markdown-iframe-container {
-      max-height: 150px;
+      max-height: 250px;
     }
   }
 


### PR DESCRIPTION
## Description

Made the "View on Github" button not so prominent - also increased log viewing max-height.

Thanks for the feedback @sergiou87 and @billygriffin about hover over to display.

### Screenshots

https://user-images.githubusercontent.com/75402236/140186329-db77102d-13b0-469f-8336-c5a0ca4f1a2e.mov

## Release notes

Notes: no-notes
