### PR TITLE
Support PyCharm as an external editor

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -346,9 +346,7 @@ const editors: WindowsExternalEditor[] = [
   },
   {
     name: 'JetBrains PyCharm',
-    registryKeys: registryKeysForJetBrainsIDE(
-      'PyCharm'
-    ),
+    registryKeys: registryKeysForJetBrainsIDE('PyCharm'),
     executableShimPaths: executableShimPathsForJetBrainsIDE('pycharm'),
     displayNamePrefix: 'PyCharm ',
     publisher: 'JetBrains s.r.o.',

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -344,6 +344,15 @@ const editors: WindowsExternalEditor[] = [
     displayNamePrefix: 'IntelliJ IDEA Community Edition ',
     publisher: 'JetBrains s.r.o.',
   },
+  {
+    name: 'JetBrains PyCharm',
+    registryKeys: registryKeysForJetBrainsIDE(
+      'PyCharm'
+    ),
+    executableShimPaths: executableShimPathsForJetBrainsIDE('pycharm'),
+    displayNamePrefix: 'PyCharm ',
+    publisher: 'JetBrains s.r.o.',
+  },
 ]
 
 function getKeyOrEmpty(


### PR DESCRIPTION
## Description

Adds support for JetBrains PyCharm as an external editor on Windows machines.

### Screenshots

![image](https://user-images.githubusercontent.com/11730266/140394862-0a40ea7d-a98b-44fc-b987-41c4c43ba24f.png)
![image](https://user-images.githubusercontent.com/11730266/140395070-eca01007-c0b3-4f57-88c2-c96048fe2d6a.png)

## Release notes

Notes:
The change uses the existing functionality for finding JetBrains products. I manually tested the change on my Windows machine and it worked well.