### PR TITLE
Open and scroll to first Error check run when opening a failed check run popover.

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -336,7 +336,7 @@ export function isIncomplete(check: IRefCheck) {
 }
 
 /** Whether the check has failed (failure or requires action) */
-export function isFailure(check: IRefCheck) {
+export function isFailure(check: IRefCheck | IAPIWorkflowJobStep) {
   if (check.status === 'completed') {
     switch (check.conclusion) {
       case 'failure':


### PR DESCRIPTION
## Description

To help get he user to the likely information they need, we will open the first app header that has a check run with an error and then open the first error check run and scroll to the first check run step with an error.

### Screenshots
https://user-images.githubusercontent.com/75402236/140426513-4d94eb39-f4a8-47a4-bfe3-96ce22203fb7.mov

## Release notes
Notes: no-notes
