### PR TITLE
Clip long check run names so we don't have wonkiness on hover.

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -5,6 +5,7 @@ import { getClassNameForCheck, getSymbolForCheck } from '../branches/ci-status'
 import classNames from 'classnames'
 import { CICheckRunLogs } from './ci-check-run-logs'
 import * as OcticonSymbol from '../octicons/octicons.generated'
+import { TooltippedContent } from '../lib/tooltipped-content'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -86,10 +87,16 @@ export class CICheckRunListItem extends React.PureComponent<
             />
           </div>
           <div className="ci-check-list-item-detail">
-            <div className="ci-check-name">{checkRun.name}</div>
-            <div className="ci-check-description" title={checkRun.description}>
-              {checkRun.description}
-            </div>
+            <TooltippedContent
+              className="ci-check-name"
+              tooltip={checkRun.name}
+              onlyWhenOverflowed={true}
+              tagName="div"
+            >
+              {checkRun.name}
+            </TooltippedContent>
+
+            <div className="ci-check-description">{checkRun.description}</div>
           </div>
           <div
             className={classNames('view-on-github', {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -12,7 +12,7 @@
   .ci-check-list-item-detail {
     flex: 1;
     margin: auto;
-    width: 80%;
+    overflow-x: hidden;
   }
 
   .ci-check-name {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -12,10 +12,14 @@
   .ci-check-list-item-detail {
     flex: 1;
     margin: auto;
+    width: 80%;
   }
 
   .ci-check-name {
     font-weight: var(--font-weight-semibold);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   .ci-check-description {
@@ -32,10 +36,14 @@
   }
 
   .view-on-github {
-    display: none;
-    padding: var(--spacing);
-    padding-bottom: var(--spacing-half);
+    margin: var(--spacing);
     color: var(--text-secondary-color);
+    min-height: var(--spacing);
+    min-width: var(--spacing-double);
+
+    .octicon {
+      display: none;
+    }
 
     .octicon:hover {
       color: var(--text-color);
@@ -44,6 +52,8 @@
 
   &:hover .view-on-github,
   .view-on-github.show {
-    display: block;
+    .octicon {
+      display: block;
+    }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -36,14 +36,10 @@
   }
 
   .view-on-github {
-    margin: var(--spacing);
+    display: none;
+    padding: var(--spacing);
+    padding-bottom: var(--spacing-half);
     color: var(--text-secondary-color);
-    min-height: var(--spacing);
-    min-width: var(--spacing-double);
-
-    .octicon {
-      display: none;
-    }
 
     .octicon:hover {
       color: var(--text-color);
@@ -52,8 +48,6 @@
 
   &:hover .view-on-github,
   .view-on-github.show {
-    .octicon {
-      display: block;
-    }
+    display: block;
   }
 }


### PR DESCRIPTION
## Description
Noticed that for long check run names.. we get some ugly movement/wrapping with new hover to View on Github.

### Screenshots
I found it via the last check run on Central repo (one in Other group).. didn't post screenshots since it is a private repo.

But, here is a forced finished result with text clipping. (Before, it would wrap to new line..)
![image](https://user-images.githubusercontent.com/75402236/140427036-2cab7642-8c34-4385-a65b-68a05e757c63.png)


## Release notes
Notes: no-notes
