### PR TITLE
Spinner loader on check run header selection (similar to dotcom loading)

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -27,9 +27,6 @@ const INDIVIDUAL_LOG_LINE_NUMBER_WIDTH_ALLOWED = 10
 interface ICICheckRunActionLogsProps {
   /** The check run to display **/
   readonly output: IRefCheckOutput
-
-  /** Whether call for actions logs is pending */
-  readonly loadingLogs: boolean
 }
 
 interface ICICheckRunActionLogsState {
@@ -335,11 +332,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
   }
 
   public render() {
-    const { output, loadingLogs } = this.props
-
-    if (loadingLogs) {
-      return <>Loading…</>
-    }
+    const { output } = this.props
 
     if (output.type !== RefCheckOutputType.Actions) {
       // This shouldn't happen, should only be provided actions type

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -122,7 +122,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   public render() {
-    const { checkRun, showLogs, loadingActionLogs, baseHref } = this.props
+    const { checkRun, showLogs, baseHref } = this.props
 
     return (
       <>
@@ -159,8 +159,6 @@ export class CICheckRunListItem extends React.PureComponent<
           <CICheckRunLogs
             checkRun={checkRun}
             baseHref={baseHref}
-            loadingActionLogs={loadingActionLogs}
-            loadingActionWorkflows={loadingActionLogs}
             onMouseOver={this.onMouseOverLogs}
             onMouseLeave={this.onMouseLeaveLogs}
             onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -67,6 +67,60 @@ export class CICheckRunListItem extends React.PureComponent<
     this.setState({ isMouseOverLogs: false })
   }
 
+  private isLoading = (): boolean => {
+    if (this.props.loadingActionLogs) {
+      return true
+    }
+
+    if (
+      this.props.loadingActionWorkflows &&
+      this.props.checkRun.actionsWorkflowRunId !== undefined
+    ) {
+      return true
+    }
+
+    return false
+  }
+
+  private renderCheckStatusSymbol = (): JSX.Element => {
+    const { checkRun, showLogs } = this.props
+
+    const stepLoader = (
+      <svg
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        className="spin"
+      >
+        <g strokeWidth="2">
+          <circle cx="8" cy="8" r="7" stroke="#959da5"></circle>
+          <path
+            d="m12.9497 3.05025c1.3128 1.31276 2.0503 3.09323 2.0503 4.94975 0 1.85651-.7375 3.637-2.0503 4.9497"
+            stroke="#fafbfc"
+          ></path>
+        </g>
+      </svg>
+    )
+
+    return (
+      <div className="ci-check-status-symbol">
+        {this.isLoading() && showLogs ? (
+          stepLoader
+        ) : (
+          <Octicon
+            className={classNames(
+              'ci-status',
+              `ci-status-${getClassNameForCheck(checkRun)}`
+            )}
+            symbol={getSymbolForCheck(checkRun)}
+            title={checkRun.description}
+          />
+        )}
+      </div>
+    )
+  }
+
   public render() {
     const { checkRun, showLogs, loadingActionLogs, baseHref } = this.props
 
@@ -76,16 +130,7 @@ export class CICheckRunListItem extends React.PureComponent<
           className="ci-check-list-item list-item"
           onClick={this.onCheckRunClick}
         >
-          <div className="ci-check-status-symbol">
-            <Octicon
-              className={classNames(
-                'ci-status',
-                `ci-status-${getClassNameForCheck(checkRun)}`
-              )}
-              symbol={getSymbolForCheck(checkRun)}
-              title={checkRun.description}
-            />
-          </div>
+          {this.renderCheckStatusSymbol()}
           <div className="ci-check-list-item-detail">
             <TooltippedContent
               className="ci-check-name"
@@ -110,7 +155,7 @@ export class CICheckRunListItem extends React.PureComponent<
             />
           </div>
         </div>
-        {showLogs ? (
+        {showLogs && !this.isLoading() ? (
           <CICheckRunLogs
             checkRun={checkRun}
             baseHref={baseHref}

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -12,12 +12,6 @@ interface ICICheckRunLogsProps {
   /** The check run to display **/
   readonly checkRun: IRefCheck
 
-  /** Whether call for actions logs is pending */
-  readonly loadingActionLogs: boolean
-
-  /** Whether tcall for actions workflows is pending */
-  readonly loadingActionWorkflows: boolean
-
   /** The base href used for relative links provided in check run markdown
    * output */
   readonly baseHref: string | null
@@ -102,27 +96,17 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
     )
   }
 
-  private renderLoadingLogs = () => {
-    return <div className="no-logs-to-display">Loading…</div>
-  }
-
   private hasActionsWorkflowLogs() {
     return this.props.checkRun.actionsWorkflowRunId !== undefined
   }
 
   public render() {
     const {
-      loadingActionWorkflows,
-      loadingActionLogs,
       checkRun: { output, name },
     } = this.props
 
-    if (loadingActionWorkflows) {
-      return this.renderLoadingLogs()
-    }
-
     const logsOutput = this.hasActionsWorkflowLogs() ? (
-      <CICheckRunActionLogs output={output} loadingLogs={loadingActionLogs} />
+      <CICheckRunActionLogs output={output} />
     ) : (
       this.renderNonActionsLogOutput(output, name)
     )


### PR DESCRIPTION
## Description

On dotcom, when a user clicks on an actions step workflow header, the user gets a spinner in place of the dropdown chevron until the logs can load. In Desktop, since our logs all are loaded at the check name level (one step higher in the grouping). I implemented a similar loader at that level instead, but the same spinner to mimic dotcom feel. Just like dotcom, you only see a spinner if you attempt to open one and the logs are being retrieved.

### Screenshots
When a failure exists, it is going to already be in a loading state as we want to open it as soon as it loads. On a success state, you won't see the spinner till you try to click on one that is loading... this way you don't see numerous loaders on the screen at once

https://user-images.githubusercontent.com/75402236/140754548-d18be9ba-567a-40eb-a1cc-58e8c51abeca.mov


## Release notes
Notes: no-notes
