### PR TITLE
Feature flag displaying ci check logs

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -11,6 +11,7 @@ import {
 } from '../api'
 import JSZip from 'jszip'
 import moment from 'moment'
+import { enableCICheckRunsLogs } from '../feature-flag'
 
 /**
  * A Desktop-specific model closely related to a GitHub API Check Run.
@@ -419,6 +420,20 @@ export async function getLatestPRWorkflowRunsLogsForCheckRun(
     const matchingJob = workFlowRunJobs?.jobs.find(j => j.name === cr.name)
     if (matchingJob === undefined) {
       mappedCheckRuns.push(cr)
+      continue
+    }
+
+    if (!enableCICheckRunsLogs()) {
+      mappedCheckRuns.push({
+        ...cr,
+        htmlUrl: matchingJob.html_url,
+        output: {
+          ...cr.output,
+          type: RefCheckOutputType.Actions,
+          steps: matchingJob.steps,
+        },
+      })
+
       continue
     }
 

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -153,6 +153,11 @@ export function enableCICheckRuns(): boolean {
   return enableDevelopmentFeatures()
 }
 
+/** Should ci check runs show logs? */
+export function enableCICheckRunsLogs(): boolean {
+  return false
+}
+
 /** Should we show previous tags as suggestions? */
 export function enablePreviousTagSuggestions(): boolean {
   return enableBetaFeatures()

--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -19,6 +19,7 @@ import {
   isFailure,
   RefCheckOutputType,
 } from '../../lib/ci-checks/ci-checks'
+import { enableCICheckRunsLogs } from '../../lib/feature-flag'
 
 const MIN_LOG_LINE_NUMBER_WIDTH = 25 // makes numbers line up with chevron
 const MAX_LOG_LINE_NUMBER_WIDTH = 100 // arbitrarily chosen
@@ -294,8 +295,8 @@ export class CICheckRunActionLogs extends React.PureComponent<
     index: number
   ): JSX.Element {
     const headerClassNames = classNames('ci-check-run-log-step-header', {
-      open: showLogs,
-      skipped: isSkipped,
+      open: showLogs && enableCICheckRunsLogs(),
+      skipped: isSkipped || !enableCICheckRunsLogs(),
     })
 
     return (
@@ -305,7 +306,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
         ref={this.onStepHeaderRef(index)}
       >
         <div className="ci-check-run-log-step-header-container">
-          {!isSkipped ? (
+          {!isSkipped && enableCICheckRunsLogs() ? (
             <Octicon
               className="log-step-toggled-indicator"
               symbol={

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -13,7 +13,6 @@ import { encodePathAsUrl } from '../../lib/path'
 
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 
-
 interface ICICheckRunLogsProps {
   /** The check run to display **/
   readonly checkRun: IRefCheck

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -7,6 +7,7 @@ import {
 import classNames from 'classnames'
 import { CICheckRunActionLogs } from './ci-check-run-actions-logs'
 import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
+import { enableCICheckRunsLogs } from '../../lib/feature-flag'
 
 interface ICICheckRunLogsProps {
   /** The check run to display **/
@@ -76,7 +77,7 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
     output: IRefCheckOutput,
     checkRunName: string
   ) => {
-    if (this.isOutputToDisplay(output)) {
+    if (this.isOutputToDisplay(output) || !enableCICheckRunsLogs()) {
       return this.renderEmptyLogOutput()
     }
 


### PR DESCRIPTION
## Description

Added an additional feature flag to remove displaying and retrieval of logs.

- Non-action will now expand to a "No additional info" (to be made better in another PR)
- Actions will now expand to view log steps. 
  - No longer have expansion chevrons
  - No longer have selection or hover styles.

### Screenshots

https://user-images.githubusercontent.com/75402236/140954934-29046305-3c03-4d7d-a7f7-e507373cf1e1.mov

## Release notes

Notes: no-notes
