### PR TITLE
No logs display for ci checks

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -317,7 +317,7 @@ export enum APICheckConclusion {
  */
 export interface IAPIRefStatusItem {
   readonly state: APIRefState
-  readonly target_url: string
+  readonly target_url: string | null
   readonly description: string
   readonly context: string
   readonly id: number

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -139,7 +139,7 @@ export function apiStatusToRefCheck(apiStatus: IAPIRefStatusItem): IRefCheck {
       title: null,
       text: null,
     },
-    htmlUrl: null,
+    htmlUrl: apiStatus.target_url,
   }
 }
 

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -27,8 +27,8 @@ interface ICICheckRunListItemProps {
   /** Callback for when a check run is clicked */
   readonly onCheckRunClick: (checkRun: IRefCheck) => void
 
-  /** Callback to opens check runs on GitHub */
-  readonly onViewOnGitHub: (checkRun: IRefCheck) => void
+  /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
+  readonly onViewCheckDetails: (checkRun: IRefCheck) => void
 
   /** Callback to open URL's originating from markdown */
   readonly onMarkdownLinkClicked: (url: string) => void
@@ -54,9 +54,9 @@ export class CICheckRunListItem extends React.PureComponent<
     this.props.onCheckRunClick(this.props.checkRun)
   }
 
-  private onViewOnGitHub = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation()
-    this.props.onViewOnGitHub(this.props.checkRun)
+  private onViewCheckDetails = (e?: React.MouseEvent<HTMLDivElement>) => {
+    e?.stopPropagation()
+    this.props.onViewCheckDetails(this.props.checkRun)
   }
 
   private onMouseOverLogs = () => {
@@ -147,7 +147,7 @@ export class CICheckRunListItem extends React.PureComponent<
             className={classNames('view-on-github', {
               show: this.state.isMouseOverLogs,
             })}
-            onClick={this.onViewOnGitHub}
+            onClick={this.onViewCheckDetails}
           >
             <Octicon
               symbol={OcticonSymbol.linkExternal}
@@ -162,6 +162,7 @@ export class CICheckRunListItem extends React.PureComponent<
             onMouseOver={this.onMouseOverLogs}
             onMouseLeave={this.onMouseLeaveLogs}
             onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
+            onViewCheckDetails={this.onViewCheckDetails}
           />
         ) : null}
       </>

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -19,8 +19,8 @@ interface ICICheckRunListProps {
    * output */
   readonly baseHref: string | null
 
-  /** Callback to opens check runs on GitHub */
-  readonly onViewOnGitHub: (checkRun: IRefCheck) => void
+  /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
+  readonly onViewCheckDetails: (checkRun: IRefCheck) => void
 
   /** Callback to open URL's originating from markdown */
   readonly onMarkdownLinkClicked: (url: string) => void
@@ -141,7 +141,7 @@ export class CICheckRunList extends React.PureComponent<
           loadingActionWorkflows={this.props.loadingActionWorkflows}
           showLogs={this.state.checkRunLogsShown === c.id.toString()}
           onCheckRunClick={this.onCheckRunClick}
-          onViewOnGitHub={this.props.onViewOnGitHub}
+          onViewCheckDetails={this.props.onViewCheckDetails}
           onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
         />
       )

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -28,6 +28,9 @@ interface ICICheckRunLogsProps {
 
   /** Callback to open URL's originating from markdown */
   readonly onMarkdownLinkClicked: (url: string) => void
+
+  /** Callback to open check run target url (maybe GitHub, maybe third party check run)*/
+  readonly onViewCheckDetails: () => void
 }
 
 /** The CI check list item. */
@@ -92,16 +95,16 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
     )
   }
 
-  private onViewPRGitHub = () => {}
-
   private renderEmptyLogOutput = () => {
     return (
       <div className="no-logs-to-display">
         <div className="text">
           There is no output data to display for this check.
           <div>
-            <LinkButton onClick={this.onViewPRGitHub}>
-              View this pull request on GitHub
+            <LinkButton onClick={this.props.onViewCheckDetails}>
+              {this.props.checkRun.htmlUrl !== null
+                ? 'View check details'
+                : 'View check pull request'}
             </LinkButton>
           </div>
         </div>

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -7,6 +7,10 @@ import {
 import classNames from 'classnames'
 import { CICheckRunActionLogs } from './ci-check-run-actions-logs'
 import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
+import { LinkButton } from '../lib/link-button'
+import { encodePathAsUrl } from '../../lib/path'
+
+const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 
 interface ICICheckRunLogsProps {
   /** The check run to display **/
@@ -94,10 +98,20 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
     )
   }
 
+  private onViewPRGitHub = () => {}
+
   private renderEmptyLogOutput = () => {
     return (
       <div className="no-logs-to-display">
-        No additional information to display.
+        <div className="text">
+          There is no output data to display for this check.
+          <div>
+            <LinkButton onClick={this.onViewPRGitHub}>
+              View this pull request on GitHub
+            </LinkButton>
+          </div>
+        </div>
+        <img src={PaperStackImage} className="blankslate-image" />
       </div>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -198,7 +198,7 @@ export class CICheckRunPopover extends React.PureComponent<
     this.setState({ checkRuns, loadingActionLogs: false })
   }
 
-  private viewCheckRunsOnGitHub = (checkRun: IRefCheck): void => {
+  private onViewCheckDetails = (checkRun: IRefCheck): void => {
     // Some checks do not provide htmlURLS like ones for the legacy status
     // object as they do not have a view in the checks screen. In that case we
     // will just open the PR and they can navigate from there... a little
@@ -304,7 +304,7 @@ export class CICheckRunPopover extends React.PureComponent<
             checkRuns={checkRuns}
             loadingActionLogs={loadingActionLogs}
             loadingActionWorkflows={loadingActionWorkflows}
-            onViewOnGitHub={this.viewCheckRunsOnGitHub}
+            onViewCheckDetails={this.onViewCheckDetails}
             onMarkdownLinkClicked={this.markDownLinkClicked}
           />
         </Popover>

--- a/app/styles/ui/check-runs/_ci-check-run-logs.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-logs.scss
@@ -116,3 +116,26 @@
     }
   }
 }
+
+.no-logs-to-display {
+  display: flex;
+  padding: var(--spacing);
+
+  .text {
+    flex: 1;
+    margin-right: var(--spacing);
+
+    div {
+      margin-top: var(--spacing);
+    }
+  }
+
+  .blankslate-image {
+    flex: 0;
+    height: 70px;
+    width: 73px;
+    min-width: 70px;
+    min-height: 73px;
+    align-self: flex-end;
+  }
+}


### PR DESCRIPTION
## Description
This may change depending on further feedback on what expanding check runs is going to look like... but I already had this going and want to get it in so we have something that looks more usable.

![image](https://user-images.githubusercontent.com/75402236/140975090-9b507f37-1488-414f-b432-92e5abd31ebb.png)

## Release notes

Notes: no-notes
