### PR TITLE
CI check run popover positioning

### DIFF
--- a/app/src/ui/branches/pull-request-badge.tsx
+++ b/app/src/ui/branches/pull-request-badge.tsx
@@ -16,6 +16,10 @@ interface IPullRequestBadgeProps {
 
   /** The GitHub repository to use when looking up commit status. */
   readonly onBadgeClick: () => void
+
+  /** When the bottom edge of the pull request badge position changes. For
+   * example, on a mac, this changes when the user maximizes Desktop. */
+  readonly onBadgeBottomPositionUpdate: (bottom: number) => void
 }
 
 interface IPullRequestBadgeState {
@@ -28,11 +32,31 @@ export class PullRequestBadge extends React.Component<
   IPullRequestBadgeProps,
   IPullRequestBadgeState
 > {
+  private badgeRef: HTMLDivElement | null = null
+  private badgeBoundingBottom: number = 0
+
   public constructor(props: IPullRequestBadgeProps) {
     super(props)
     this.state = {
       isStatusShowing: false,
     }
+  }
+
+  public componentDidUpdate() {
+    if (this.badgeRef === null) {
+      return
+    }
+
+    if (
+      this.badgeRef.getBoundingClientRect().bottom !== this.badgeBoundingBottom
+    ) {
+      this.badgeBoundingBottom = this.badgeRef.getBoundingClientRect().bottom
+      this.props.onBadgeBottomPositionUpdate(this.badgeBoundingBottom)
+    }
+  }
+
+  private onRef = (badgeRef: HTMLDivElement) => {
+    this.badgeRef = badgeRef
   }
 
   private onBadgeClick = (
@@ -53,7 +77,7 @@ export class PullRequestBadge extends React.Component<
   public render() {
     const ref = `refs/pull/${this.props.number}/head`
     return (
-      <div id="pr-badge" onClick={this.onBadgeClick}>
+      <div id="pr-badge" onClick={this.onBadgeClick} ref={this.onRef}>
         <span className="number">#{this.props.number}</span>
         <CIStatus
           commitRef={ref}

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -181,6 +181,6 @@ export class CICheckRunList extends React.PureComponent<
       </div>
     ))
 
-    return <div className="ci-check-run-list">{checkLists}</div>
+    return <>{checkLists}</>
   }
 }

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -26,6 +26,10 @@ interface ICICheckRunPopoverProps {
   /** The pull request's number. */
   readonly prNumber: number
 
+  /** The bottom of the pull request badge so we can position popover relative
+   * to it. */
+  readonly badgeBottom: number
+
   /** Callback for when popover closes */
   readonly closePopover: (event?: MouseEvent) => void
 }
@@ -267,6 +271,20 @@ export class CICheckRunPopover extends React.PureComponent<
     }
   }
 
+  private getPopoverPositioningStyles = (): React.CSSProperties => {
+    const top = this.props.badgeBottom + 10
+    return { top, maxHeight: `calc(100% - ${top + 10}px)` }
+  }
+
+  private getListHeightStyles = (): React.CSSProperties => {
+    const headerHeight = 55
+    return {
+      maxHeight: `${
+        window.innerHeight - (this.props.badgeBottom + headerHeight + 20)
+      }px`,
+    }
+  }
+
   private renderRerunButton = () => {
     const { checkRuns } = this.state
     return (
@@ -291,6 +309,7 @@ export class CICheckRunPopover extends React.PureComponent<
         <Popover
           caretPosition={PopoverCaretPosition.Top}
           onClickOutside={this.props.closePopover}
+          style={this.getPopoverPositioningStyles()}
         >
           <div className="ci-check-run-list-header">
             <div className="ci-check-run-list-title-container">
@@ -299,14 +318,16 @@ export class CICheckRunPopover extends React.PureComponent<
             </div>
             {this.renderRerunButton()}
           </div>
-          <CICheckRunList
-            baseHref={baseHref}
-            checkRuns={checkRuns}
-            loadingActionLogs={loadingActionLogs}
-            loadingActionWorkflows={loadingActionWorkflows}
-            onViewCheckDetails={this.onViewCheckDetails}
-            onMarkdownLinkClicked={this.markDownLinkClicked}
-          />
+          <div className="ci-check-run-list" style={this.getListHeightStyles()}>
+            <CICheckRunList
+              baseHref={baseHref}
+              checkRuns={checkRuns}
+              loadingActionLogs={loadingActionLogs}
+              loadingActionWorkflows={loadingActionWorkflows}
+              onViewCheckDetails={this.onViewCheckDetails}
+              onMarkdownLinkClicked={this.markDownLinkClicked}
+            />
+          </div>
         </Popover>
       </div>
     )

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -57,6 +57,7 @@ interface IBranchDropdownProps {
 
 interface IBranchDropdownState {
   readonly isPopoverOpen: boolean
+  readonly badgeBottom: number
 }
 
 /**
@@ -70,6 +71,7 @@ export class BranchDropdown extends React.Component<
     super(props)
     this.state = {
       isPopoverOpen: false,
+      badgeBottom: 0,
     }
   }
 
@@ -222,6 +224,10 @@ export class BranchDropdown extends React.Component<
     }
   }
 
+  private updateBadgeBottomPosition = (badgeBottom: number) => {
+    this.setState({ badgeBottom })
+  }
+
   private openPopover = () => {
     this.setState(prevState => {
       if (!prevState.isPopoverOpen) {
@@ -267,6 +273,7 @@ export class BranchDropdown extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}
         branchName={currentBranchName}
+        badgeBottom={this.state.badgeBottom}
         closePopover={this.closePopover}
       />
     )
@@ -285,6 +292,7 @@ export class BranchDropdown extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}
         onBadgeClick={this.onBadgeClick}
+        onBadgeBottomPositionUpdate={this.updateBadgeBottomPosition}
       />
     )
   }

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,5 +1,4 @@
 .ci-check-run-list {
-  max-height: 585px;
   overflow-y: auto;
   overflow-x: hidden;
   border-radius: var(--border-radius);

--- a/app/styles/ui/check-runs/_ci-check-run-popover.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-popover.scss
@@ -1,10 +1,10 @@
 .ci-check-list-popover {
   .popover-component {
-    position: relative;
+    position: absolute;
     padding: 0px;
     width: 375px;
-    top: 45px;
-    margin-left: -272px;
+    top: 60;
+    margin-left: -270px;
   }
 
   .ci-check-run-list-header {
@@ -15,6 +15,8 @@
     padding: var(--spacing);
     padding-top: var(--spacing-half);
     padding-right: var(--spacing-half);
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
 
     .ci-check-run-list-title-container {
       flex: 1;


### PR DESCRIPTION
## Description

1) Check run popover is now absolutely positioned so that it doesn't cause the Publish/Fetch button to move on open. Added logic to watch for change in position caused by mac full screen - same approach used for branch and repo dropdowns.

2) Check run popover will now expand to take up the whole height of the app when viewing a repo with numerous checks.

### Screenshots
(Shows that publish/fetch button isn't moved)
![image](https://user-images.githubusercontent.com/75402236/141108130-1ec0da0c-1385-4539-91d6-66434afa041d.png)

## Release notes

Notes: no-notes
