### PR TITLE
Flatten check run heirarchy

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -336,7 +336,6 @@ export interface IAPIRefCheckRun {
   readonly status: APICheckStatus
   readonly conclusion: APICheckConclusion | null
   readonly name: string
-  readonly output: IAPIRefCheckRunOutput
   readonly check_suite: IAPIRefCheckRunCheckSuite
   readonly app: IAPIRefCheckRunApp
   readonly completed_at: string

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -530,3 +530,18 @@ export function getFormattedCheckRunDuration(
     .duration(getCheckDurationInSeconds(checkRun), 'seconds')
     .format('d[d] h[h] m[m] s[s]', { largest: 4 })
 }
+
+/** Get check run display name
+ *
+ * Goal: Action Workflow Name / workflow run name
+ * If no workflow run name (non-actions check), then just return the name.
+ */
+export function getCheckRunDisplayName(checkRun: IRefCheck): string {
+  const wfName =
+    checkRun.actionsWorkflowName !== undefined
+      ? checkRun.actionsWorkflowName
+      : checkRun.appName === 'GitHub Code Scanning'
+      ? 'Code scanning results' // seems this is hardcoded on dotcom too :/
+      : undefined
+  return wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
+}

--- a/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-logs.tsx
@@ -15,9 +15,7 @@ import {
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import {
   getFormattedCheckRunDuration,
-  IRefCheckOutput,
   isFailure,
-  RefCheckOutputType,
 } from '../../lib/ci-checks/ci-checks'
 import { enableCICheckRunsLogs } from '../../lib/feature-flag'
 
@@ -26,8 +24,7 @@ const MAX_LOG_LINE_NUMBER_WIDTH = 100 // arbitrarily chosen
 const INDIVIDUAL_LOG_LINE_NUMBER_WIDTH_ALLOWED = 10
 
 interface ICICheckRunActionLogsProps {
-  /** The check run to display **/
-  readonly output: IRefCheckOutput
+  readonly actionSteps: ReadonlyArray<IAPIWorkflowJobStep>
 }
 
 interface ICICheckRunActionLogsState {
@@ -45,10 +42,7 @@ export class CICheckRunActionLogs extends React.PureComponent<
     super(props)
 
     const openSections = new Set<number>()
-    const firstFailedSectionIndex =
-      props.output.type === RefCheckOutputType.Actions
-        ? props.output.steps.findIndex(isFailure)
-        : -1
+    const firstFailedSectionIndex = this.props.actionSteps.findIndex(isFailure)
 
     openSections.add(firstFailedSectionIndex)
 
@@ -59,15 +53,8 @@ export class CICheckRunActionLogs extends React.PureComponent<
   }
 
   public componentDidUpdate(prevProps: ICICheckRunActionLogsProps) {
-    if (
-      prevProps.output.type === this.props.output.type ||
-      this.props.output.type !== RefCheckOutputType.Actions
-    ) {
-      return
-    }
-
     const openSections = new Set<number>()
-    const firstFailedSectionIndex = this.props.output.steps.findIndex(isFailure)
+    const firstFailedSectionIndex = this.props.actionSteps.findIndex(isFailure)
 
     openSections.add(firstFailedSectionIndex)
 
@@ -333,14 +320,9 @@ export class CICheckRunActionLogs extends React.PureComponent<
   }
 
   public render() {
-    const { output } = this.props
+    const { actionSteps } = this.props
 
-    if (output.type !== RefCheckOutputType.Actions) {
-      // This shouldn't happen, should only be provided actions type
-      return <>Unable to load logs.</>
-    }
-
-    return output.steps.map((step, i) => {
+    return actionSteps.map((step, i) => {
       const isSkipped = step.conclusion === 'skipped'
       const showLogs = this.state.openSections.has(i) && !isSkipped
 

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -124,6 +124,9 @@ export class CICheckRunListItem extends React.PureComponent<
   public render() {
     const { checkRun, showLogs, baseHref } = this.props
 
+    const name = checkRun.actionsWorkflowName
+      ? `${checkRun.actionsWorkflowName} / ${checkRun.name}`
+      : checkRun.name
     return (
       <>
         <div
@@ -134,11 +137,11 @@ export class CICheckRunListItem extends React.PureComponent<
           <div className="ci-check-list-item-detail">
             <TooltippedContent
               className="ci-check-name"
-              tooltip={checkRun.name}
+              tooltip={name}
               onlyWhenOverflowed={true}
               tagName="div"
             >
-              {checkRun.name}
+              {name}
             </TooltippedContent>
 
             <div className="ci-check-description">{checkRun.description}</div>
@@ -155,7 +158,9 @@ export class CICheckRunListItem extends React.PureComponent<
             />
           </div>
         </div>
-        {showLogs && !this.isLoading() ? (
+        {showLogs &&
+        !this.isLoading() &&
+        checkRun.actionJobSteps !== undefined ? (
           <CICheckRunLogs
             checkRun={checkRun}
             baseHref={baseHref}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import { IRefCheck } from '../../lib/ci-checks/ci-checks'
+import {
+  getCheckRunDisplayName,
+  IRefCheck,
+} from '../../lib/ci-checks/ci-checks'
 import { Octicon } from '../octicons'
 import { getClassNameForCheck, getSymbolForCheck } from '../branches/ci-status'
 import classNames from 'classnames'
@@ -124,14 +127,7 @@ export class CICheckRunListItem extends React.PureComponent<
   public render() {
     const { checkRun, showLogs, baseHref } = this.props
 
-    const wfName =
-      checkRun.actionsWorkflowName !== undefined
-        ? checkRun.actionsWorkflowName
-        : checkRun.appName === 'GitHub Code Scanning'
-        ? 'Code scanning results' // seems this is hardcoded on dotcom too :/
-        : undefined
-    const name =
-      wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
+    const name = getCheckRunDisplayName(checkRun)
     return (
       <>
         <div

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -124,9 +124,14 @@ export class CICheckRunListItem extends React.PureComponent<
   public render() {
     const { checkRun, showLogs, baseHref } = this.props
 
-    const name = checkRun.actionsWorkflowName
-      ? `${checkRun.actionsWorkflowName} / ${checkRun.name}`
-      : checkRun.name
+    const wfName =
+      checkRun.actionsWorkflowName !== undefined
+        ? checkRun.actionsWorkflowName
+        : checkRun.appName === 'GitHub Code Scanning'
+        ? 'Code scanning results' // seems this is hardcoded on dotcom too :/
+        : undefined
+    const name =
+      wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
     return (
       <>
         <div

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { IRefCheck, isFailure } from '../../lib/ci-checks/ci-checks'
+import {
+  getCheckRunDisplayName,
+  IRefCheck,
+  isFailure,
+} from '../../lib/ci-checks/ci-checks'
 import { CICheckRunListItem } from './ci-check-run-list-item'
 
 interface ICICheckRunListProps {
@@ -84,21 +88,25 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   private renderList = (): JSX.Element | null => {
-    const list = [...this.props.checkRuns].sort().map((c, i) => {
-      return (
-        <CICheckRunListItem
-          key={i}
-          checkRun={c}
-          baseHref={this.props.baseHref}
-          loadingActionLogs={this.props.loadingActionLogs}
-          loadingActionWorkflows={this.props.loadingActionWorkflows}
-          showLogs={this.state.checkRunExpanded === c.id.toString()}
-          onCheckRunClick={this.onCheckRunClick}
-          onViewCheckDetails={this.props.onViewCheckDetails}
-          onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
-        />
+    const list = [...this.props.checkRuns]
+      .sort((a, b) =>
+        getCheckRunDisplayName(a).localeCompare(getCheckRunDisplayName(b))
       )
-    })
+      .map((c, i) => {
+        return (
+          <CICheckRunListItem
+            key={i}
+            checkRun={c}
+            baseHref={this.props.baseHref}
+            loadingActionLogs={this.props.loadingActionLogs}
+            loadingActionWorkflows={this.props.loadingActionWorkflows}
+            showLogs={this.state.checkRunExpanded === c.id.toString()}
+            onCheckRunClick={this.onCheckRunClick}
+            onViewCheckDetails={this.props.onViewCheckDetails}
+            onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
+          />
+        )
+      })
 
     return <>{list}</>
   }

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react'
 import { IRefCheck, isFailure } from '../../lib/ci-checks/ci-checks'
-import { Octicon } from '../octicons'
-import _ from 'lodash'
 import { CICheckRunListItem } from './ci-check-run-list-item'
-import * as OcticonSymbol from '../octicons/octicons.generated'
 
 interface ICICheckRunListProps {
   /** List of check runs to display */
@@ -27,11 +24,8 @@ interface ICICheckRunListProps {
 }
 
 interface ICICheckRunListState {
-  readonly checkRunsShown: string | null
+  readonly checkRunExpanded: string | null
   readonly hasUserToggledCheckRun: boolean
-  readonly checkRunLogsShown: string | null
-  readonly checksByApp: _.Dictionary<IRefCheck[]>
-  readonly appNames: ReadonlyArray<string>
 }
 
 /** The CI Check list. */
@@ -46,12 +40,6 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   public componentDidUpdate(prevProps: ICICheckRunListProps) {
-    // Currently, this updates if we retreive from api, thus memory ref check is
-    // appropriate.
-    if (prevProps.checkRuns === this.props.checkRuns) {
-      return
-    }
-
     this.setState(
       this.setupStateAfterCheckRunPropChange(this.props, this.state)
     )
@@ -61,77 +49,42 @@ export class CICheckRunList extends React.PureComponent<
     props: ICICheckRunListProps,
     currentState: ICICheckRunListState | null
   ): ICICheckRunListState {
-    const checksByApp = _.groupBy(props.checkRuns, 'appName')
-    if (checksByApp[''] !== undefined) {
-      checksByApp['Other'] = checksByApp['']
-      delete checksByApp['']
-    }
-    const appNames = this.getSortedAppNames(checksByApp)
-
-    let checkRunLogsShown =
-      currentState !== null ? currentState.checkRunLogsShown : null
-    let checkRunsShown =
-      currentState !== null ? currentState.checkRunsShown : null
+    let checkRunExpanded =
+      currentState !== null ? currentState.checkRunExpanded : null
 
     if (currentState === null || !currentState.hasUserToggledCheckRun) {
-      // If there is a failure, we want the first app and first check run with a
-      // failure, to be opened so the user doesn't have to click through to find
-      // it.
-      const firstFailureAppName = appNames.find(an => {
-        checkRunLogsShown =
-          checksByApp[an].find(isFailure)?.id.toString() ?? null
-        return checkRunLogsShown !== null
-      })
-
-      // If there are no failures, just show the first app open. Let user pick
-      // which logs they would like look it. (checkRunLogsShown = null)
-      checkRunsShown =
-        firstFailureAppName !== undefined ? firstFailureAppName : appNames[0]
+      // If there is a failure, we want the first check run with a failure, to
+      // be opened so the user doesn't have to click through to find it.
+      // Otherwise, just open the first one. (Only actions type can be expanded.)
+      const firstFailure = props.checkRuns.find(
+        cr => isFailure(cr) && cr.actionJobSteps !== undefined
+      )
+      checkRunExpanded =
+        firstFailure !== undefined
+          ? firstFailure.id.toString()
+          : props.checkRuns[0].id.toString()
     }
 
     return {
-      checkRunsShown,
-      checkRunLogsShown,
-      checksByApp,
-      appNames,
+      checkRunExpanded,
       hasUserToggledCheckRun: currentState
         ? currentState.hasUserToggledCheckRun
         : false,
     }
   }
 
-  private getSortedAppNames(checksByApp: _.Dictionary<IRefCheck[]>): string[] {
-    return Object.keys(checksByApp)
-      .sort((a, b) => b.length - a.length)
-      .map(name => (name !== '' ? name : 'Other'))
-  }
-
   private onCheckRunClick = (checkRun: IRefCheck): void => {
     this.setState({
-      checkRunLogsShown:
-        this.state.checkRunLogsShown === checkRun.id.toString()
+      checkRunExpanded:
+        this.state.checkRunExpanded === checkRun.id.toString()
           ? null
           : checkRun.id.toString(),
       hasUserToggledCheckRun: true,
     })
   }
 
-  private onAppHeaderClick = (appName: string) => {
-    return () => {
-      this.setState({
-        checkRunsShown: this.state.checkRunsShown === appName ? '' : appName,
-        hasUserToggledCheckRun: true,
-      })
-    }
-  }
-
-  private renderList = (appName: string): JSX.Element | null => {
-    const { checkRunsShown, checksByApp } = this.state
-    if (checkRunsShown !== appName) {
-      return null
-    }
-
-    const list = checksByApp[appName].map((c, i) => {
+  private renderList = (): JSX.Element | null => {
+    const list = [...this.props.checkRuns].sort().map((c, i) => {
       return (
         <CICheckRunListItem
           key={i}
@@ -139,7 +92,7 @@ export class CICheckRunList extends React.PureComponent<
           baseHref={this.props.baseHref}
           loadingActionLogs={this.props.loadingActionLogs}
           loadingActionWorkflows={this.props.loadingActionWorkflows}
-          showLogs={this.state.checkRunLogsShown === c.id.toString()}
+          showLogs={this.state.checkRunExpanded === c.id.toString()}
           onCheckRunClick={this.onCheckRunClick}
           onViewCheckDetails={this.props.onViewCheckDetails}
           onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
@@ -150,37 +103,11 @@ export class CICheckRunList extends React.PureComponent<
     return <>{list}</>
   }
 
-  private renderCheckAppHeader = (appName: string): JSX.Element => {
-    const { checkRunsShown } = this.state
-
+  public render() {
     return (
-      <div
-        className="ci-check-app-header"
-        onClick={this.onAppHeaderClick(appName)}
-      >
-        <Octicon
-          className="open-closed-icon"
-          symbol={
-            checkRunsShown === appName
-              ? OcticonSymbol.chevronDown
-              : OcticonSymbol.chevronRight
-          }
-        />
-        <div className="ci-check-app-name">{appName}</div>
+      <div className="ci-check-run-list">
+        <div className="ci-check-app-list">{this.renderList()}</div>
       </div>
     )
-  }
-
-  public render() {
-    const { appNames } = this.state
-
-    const checkLists = appNames.map(appName => (
-      <div className="ci-check-app-list" key={appName}>
-        {this.renderCheckAppHeader(appName)}
-        {this.renderList(appName)}
-      </div>
-    ))
-
-    return <div className="ci-check-run-list">{checkLists}</div>
   }
 }

--- a/app/src/ui/check-runs/ci-check-run-logs.tsx
+++ b/app/src/ui/check-runs/ci-check-run-logs.tsx
@@ -1,17 +1,7 @@
 import * as React from 'react'
-import {
-  IRefCheck,
-  IRefCheckOutput,
-  RefCheckOutputType,
-} from '../../lib/ci-checks/ci-checks'
+import { IRefCheck } from '../../lib/ci-checks/ci-checks'
 import classNames from 'classnames'
 import { CICheckRunActionLogs } from './ci-check-run-actions-logs'
-import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
-import { enableCICheckRunsLogs } from '../../lib/feature-flag'
-import { LinkButton } from '../lib/link-button'
-import { encodePathAsUrl } from '../../lib/path'
-
-const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 
 interface ICICheckRunLogsProps {
   /** The check run to display **/
@@ -36,102 +26,16 @@ interface ICICheckRunLogsProps {
 
 /** The CI check list item. */
 export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
-  private isOutputToDisplay(output: IRefCheckOutput): boolean {
-    return (
-      output.type === RefCheckOutputType.Default &&
-      (output.text === null || output.text.trim() === '') &&
-      (output.summary === undefined ||
-        output.summary === null ||
-        output.summary.trim() === '')
-    )
-  }
-
-  private getNonActionsOutputMD(
-    output: IRefCheckOutput,
-    checkRunName: string
-  ): string | null {
-    const { title, summary } = output
-
-    const titleOutput =
-      title !== null &&
-      title.trim() !== '' &&
-      title.trim().toLocaleLowerCase() !==
-        checkRunName.trim().toLocaleLowerCase()
-        ? `### ${title.trim()}\n`
-        : ''
-
-    const summaryOutput =
-      summary !== null && summary !== undefined && summary.trim() !== ''
-        ? summary
-        : ''
-
-    const mainOutput =
-      output.type !== RefCheckOutputType.Actions && output.text !== null
-        ? output.text.trim()
-        : ''
-
-    const combinedOutput = titleOutput + summaryOutput + mainOutput
-    return combinedOutput === '' ? null : combinedOutput
-  }
-
-  private renderNonActionsLogOutput = (
-    output: IRefCheckOutput,
-    checkRunName: string
-  ) => {
-    if (this.isOutputToDisplay(output) || !enableCICheckRunsLogs()) {
-      return this.renderEmptyLogOutput()
-    }
-
-    const markdown = this.getNonActionsOutputMD(output, checkRunName)
-    if (output.type === RefCheckOutputType.Actions || markdown === null) {
-      return null
-    }
-
-    return (
-      <SandboxedMarkdown
-        markdown={markdown}
-        baseHref={this.props.baseHref}
-        onMarkdownLinkClicked={this.props.onMarkdownLinkClicked}
-      />
-    )
-  }
-
-  private renderEmptyLogOutput = () => {
-    return (
-      <div className="no-logs-to-display">
-        <div className="text">
-          There is no output data to display for this check.
-          <div>
-            <LinkButton onClick={this.props.onViewCheckDetails}>
-              {this.props.checkRun.htmlUrl !== null
-                ? 'View check details'
-                : 'View check pull request'}
-            </LinkButton>
-          </div>
-        </div>
-        <img src={PaperStackImage} className="blankslate-image" />
-      </div>
-    )
-  }
-
-  private hasActionsWorkflowLogs() {
-    return this.props.checkRun.actionsWorkflowRunId !== undefined
-  }
-
   public render() {
     const {
-      checkRun: { output, name },
+      checkRun: { actionJobSteps },
     } = this.props
 
-    const logsOutput = this.hasActionsWorkflowLogs() ? (
-      <CICheckRunActionLogs output={output} />
-    ) : (
-      this.renderNonActionsLogOutput(output, name)
-    )
+    if (actionJobSteps === undefined) {
+      return
+    }
 
-    const className = classNames('ci-check-list-item-logs', {
-      actions: this.hasActionsWorkflowLogs(),
-    })
+    const className = classNames('ci-check-list-item-logs', 'actions')
 
     return (
       <div
@@ -139,7 +43,9 @@ export class CICheckRunLogs extends React.PureComponent<ICICheckRunLogsProps> {
         onMouseOver={this.props.onMouseOver}
         onMouseLeave={this.props.onMouseLeave}
       >
-        <div className="ci-check-list-item-logs-output">{logsOutput}</div>
+        <div className="ci-check-list-item-logs-output">
+          <CICheckRunActionLogs actionSteps={actionJobSteps} />
+        </div>
       </div>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -299,14 +299,16 @@ export class CICheckRunPopover extends React.PureComponent<
             </div>
             {this.renderRerunButton()}
           </div>
-          <CICheckRunList
-            baseHref={baseHref}
-            checkRuns={checkRuns}
-            loadingActionLogs={loadingActionLogs}
-            loadingActionWorkflows={loadingActionWorkflows}
-            onViewCheckDetails={this.onViewCheckDetails}
-            onMarkdownLinkClicked={this.markDownLinkClicked}
-          />
+          {!loadingActionLogs ? (
+            <CICheckRunList
+              baseHref={baseHref}
+              checkRuns={checkRuns}
+              loadingActionLogs={loadingActionLogs}
+              loadingActionWorkflows={loadingActionWorkflows}
+              onViewCheckDetails={this.onViewCheckDetails}
+              onMarkdownLinkClicked={this.markDownLinkClicked}
+            />
+          ) : null}
         </Popover>
       </div>
     )

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -254,8 +254,18 @@ export class BranchDropdown extends React.Component<
   private renderPopover() {
     const pr = this.props.currentPullRequest
     const { tip } = this.props.repositoryState.branchesState
-    // It is ok if it doesn't exist, we just can't retrieve actions workflows
-    const currentBranchName = tip.kind === TipState.Valid ? tip.branch.name : ''
+    // This is used for retrieving the PR's action check runs (if exist). For
+    // forked repo PRs, we must use the upstreamWithoutRemote as we make are own
+    // temporary branch in Desktop for these that doesn't exist remotely (and
+    // thus doesn't exist in action's world). The upstreamWIthoutRemote will
+    // match a non forked PR. It _should_ only be null for a local branch..
+    // which _should_ not happen in this context. But, worst case, the user
+    // simply won't be able to retreive action steps and will get check run list
+    // items that are given for non-action checks.
+    const currentBranchName =
+      tip.kind === TipState.Valid
+        ? tip.branch.upstreamWithoutRemote ?? tip.branch.name
+        : ''
 
     if (pr === null) {
       return null


### PR DESCRIPTION
## Description

This PR flattens the check hierarchy and changes the naming scheme to have a more consistent feel to the merged check list on a PR conversation tab of dotcom.

Also while testing this, I realized that PRs from forked repos were not showing action steps when dotcom was.. and that was because I was using Desktop's local branch name which is a locally generated name in the case of forks. Thus, switched to use the upstream branch name.

Notes for future PRs:
1) Requires us to wait for first actions check run retrieve and therefore we will need to add a loading at the top level and I don't think spinner I had on other fits here.. leaning towards a similar loader as shown in PR list.

2) This required some removal of old log viewing code that was just feature flagged before, but it is not meant to exhaustively removal log logic (have another PR for that).

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/141208004-14cf7f85-3131-4398-8ec4-256d6e53d8c0.png)

## Release notes
Notes: no-notes
