### PR TITLE
Fix click area to select hunk on both sides of diff

### DIFF
--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -204,12 +204,12 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContentFromString('')}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
-            {this.renderHunkHandle()}
             <div className="after">
               {this.renderLineNumber(lineNumber, isSelected)}
               {this.renderContent(row.data)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
+            {this.renderHunkHandle()}
           </div>
         )
       }
@@ -241,12 +241,12 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(row.data)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
-            {this.renderHunkHandle()}
             <div className="after">
               {this.renderLineNumber()}
               {this.renderContentFromString('')}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
+            {this.renderHunkHandle()}
           </div>
         )
       }
@@ -259,12 +259,12 @@ export class SideBySideDiffRow extends React.Component<
               {this.renderContent(before)}
               {this.renderWhitespaceHintPopover(DiffColumn.Before)}
             </div>
-            {this.renderHunkHandle()}
             <div className="after" onMouseEnter={this.onMouseEnterLineNumber}>
               {this.renderLineNumber(after.lineNumber, after.isSelected)}
               {this.renderContent(after)}
               {this.renderWhitespaceHintPopover(DiffColumn.After)}
             </div>
+            {this.renderHunkHandle()}
           </div>
         )
       }

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -138,6 +138,7 @@
     width: 20px;
     left: calc(50% - 10px);
     top: 0;
+    z-index: 1;
 
     &.hoverable {
       cursor: pointer;

--- a/app/styles/ui/_side-by-side-diff.scss
+++ b/app/styles/ui/_side-by-side-diff.scss
@@ -138,7 +138,6 @@
     width: 20px;
     left: calc(50% - 10px);
     top: 0;
-    z-index: 1;
 
     &.hoverable {
       cursor: pointer;


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13325

## Description

Add a `z-index` to elements responsible for selecting a hunk on the both sides of a diff, so that the click area is above the row and not obstructed by its right-side part.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->
Restored click area:
![image](https://user-images.githubusercontent.com/33615628/141791882-b47f2cda-4d89-449e-ad5e-58040648941f.png)

### Gifs
Before: 
![w7EtEmWaCW](https://user-images.githubusercontent.com/33615628/141791717-db552345-b914-41ed-a8d8-96c9d1602340.gif)
After:
![tT91g5D0vv](https://user-images.githubusercontent.com/33615628/141791731-ac5c1214-0c42-48d4-a41e-4a1a2c913899.gif)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
