### PR TITLE
Revert split action list item - Use title as link

### DIFF
--- a/app/src/ui/changes/changed-file.tsx
+++ b/app/src/ui/changes/changed-file.tsx
@@ -5,6 +5,7 @@ import { Octicon, iconForStatus } from '../octicons'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { mapStatus } from '../../lib/status'
 import { WorkingDirectoryFileChange } from '../../models/status'
+import { TooltipDirection } from '../lib/tooltip'
 
 interface IChangedFileProps {
   readonly file: WorkingDirectoryFileChange
@@ -75,7 +76,7 @@ export class ChangedFile extends React.Component<IChangedFileProps, {}> {
           symbol={iconForStatus(status)}
           className={'status status-' + fileStatus.toLowerCase()}
           title={fileStatus}
-          tooltipDirection="e"
+          tooltipDirection={TooltipDirection.EAST}
         />
       </div>
     )

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -41,7 +41,7 @@ import classNames from 'classnames'
 import { hasWritePermission } from '../../models/github-repository'
 import { hasConflictedFiles } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
-import { Tooltip } from '../lib/tooltip'
+import { Tooltip, TooltipDirection } from '../lib/tooltip'
 
 const RowHeight = 29
 const StashIcon: OcticonSymbol.OcticonSymbolType = {
@@ -780,7 +780,7 @@ export class ChangesList extends React.Component<
           onContextMenu={this.onContextMenu}
           ref={this.headerRef}
         >
-          <Tooltip target={this.headerRef} direction="n">
+          <Tooltip target={this.headerRef} direction={TooltipDirection.NORTH}>
             {selectedChangesDescription}
           </Tooltip>
           <Checkbox

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -7,6 +7,8 @@ import {
 } from '../branches/ci-status'
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import { getFormattedCheckRunDuration } from '../../lib/ci-checks/ci-checks'
+import { TooltippedContent } from '../lib/tooltipped-content'
+import { TooltipDirectionDef } from '../lib/tooltip'
 
 interface ICICheckRunActionsJobStepListItemProps {
   readonly step: IAPIWorkflowJobStep
@@ -50,9 +52,15 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
             />
           </div>
 
-          <div className="job-step-name">
+          <TooltippedContent
+            className="job-step-name"
+            tooltip={step.name}
+            onlyWhenOverflowed={true}
+            tagName="div"
+            direction={TooltipDirectionDef.NORTH}
+          >
             <span onClick={this.onViewJobStepExternally}>{step.name}</span>
-          </div>
+          </TooltippedContent>
 
           <div className="job-step-duration">
             {getFormattedCheckRunDuration(step)}

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -8,20 +8,21 @@ import {
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import { getFormattedCheckRunDuration } from '../../lib/ci-checks/ci-checks'
 import { TooltippedContent } from '../lib/tooltipped-content'
+import * as OcticonSymbol from '../octicons/octicons.generated'
 
 interface ICICheckRunActionsJobStepListItemProps {
   readonly step: IAPIWorkflowJobStep
   readonly firstFailedStep: IAPIWorkflowJobStep | undefined
 
   /** Callback to open a job steps link on dotcom*/
-  readonly onViewJobStep: (step: IAPIWorkflowJobStep) => void
+  readonly onViewJobStepExternally: (step: IAPIWorkflowJobStep) => void
 }
 
 export class CICheckRunActionsJobStepListItem extends React.PureComponent<
   ICICheckRunActionsJobStepListItemProps
 > {
-  private onViewJobStep = () => {
-    this.props.onViewJobStep(this.props.step)
+  private onViewJobStepExternally = () => {
+    this.props.onViewJobStepExternally(this.props.step)
   }
 
   private onStepHeaderRef = (step: IAPIWorkflowJobStep) => {
@@ -36,19 +37,25 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
     }
   }
 
+  private renderLinkExternal = (): JSX.Element | null => {
+    return (
+      <TooltippedContent
+        className="view-externally"
+        tooltip="View on GitHub"
+        tagName="div"
+      >
+        <div onClick={this.onViewJobStepExternally}>
+          <Octicon symbol={OcticonSymbol.linkExternal} />
+        </div>
+      </TooltippedContent>
+    )
+  }
+
   public render() {
     const { step } = this.props
     return (
-      <TooltippedContent
-        className="ci-check-run-job-step"
-        tooltip="View online"
-        tagName="div"
-      >
-        <div
-          className="list-item"
-          onClick={this.onViewJobStep}
-          ref={this.onStepHeaderRef(step)}
-        >
+      <div className="ci-check-run-job-step">
+        <div className="list-item" ref={this.onStepHeaderRef(step)}>
           <div className="job-step-status-symbol">
             <Octicon
               className={classNames(
@@ -63,8 +70,9 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
           <div className="job-step-duration">
             {getFormattedCheckRunDuration(step)}
           </div>
+          {this.renderLinkExternal()}
         </div>
-      </TooltippedContent>
+      </div>
     )
   }
 }

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -8,7 +8,7 @@ import {
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import { getFormattedCheckRunDuration } from '../../lib/ci-checks/ci-checks'
 import { TooltippedContent } from '../lib/tooltipped-content'
-import { TooltipDirectionDef } from '../lib/tooltip'
+import { TooltipDirection } from '../lib/tooltip'
 
 interface ICICheckRunActionsJobStepListItemProps {
   readonly step: IAPIWorkflowJobStep
@@ -57,7 +57,7 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
             tooltip={step.name}
             onlyWhenOverflowed={true}
             tagName="div"
-            direction={TooltipDirectionDef.NORTH}
+            direction={TooltipDirection.NORTH}
           >
             <span onClick={this.onViewJobStepExternally}>{step.name}</span>
           </TooltippedContent>

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -7,8 +7,6 @@ import {
 } from '../branches/ci-status'
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import { getFormattedCheckRunDuration } from '../../lib/ci-checks/ci-checks'
-import { TooltippedContent } from '../lib/tooltipped-content'
-import * as OcticonSymbol from '../octicons/octicons.generated'
 
 interface ICICheckRunActionsJobStepListItemProps {
   readonly step: IAPIWorkflowJobStep
@@ -37,20 +35,6 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
     }
   }
 
-  private renderLinkExternal = (): JSX.Element | null => {
-    return (
-      <TooltippedContent
-        className="view-externally"
-        tooltip="View on GitHub"
-        tagName="div"
-      >
-        <div onClick={this.onViewJobStepExternally}>
-          <Octicon symbol={OcticonSymbol.linkExternal} />
-        </div>
-      </TooltippedContent>
-    )
-  }
-
   public render() {
     const { step } = this.props
     return (
@@ -66,11 +50,13 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
             />
           </div>
 
-          <div className="job-step-name">{step.name}</div>
+          <div className="job-step-name">
+            <span onClick={this.onViewJobStepExternally}>{step.name}</span>
+          </div>
+
           <div className="job-step-duration">
             {getFormattedCheckRunDuration(step)}
           </div>
-          {this.renderLinkExternal()}
         </div>
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-list.tsx
@@ -43,7 +43,7 @@ export class CICheckRunActionsJobStepList extends React.PureComponent<
           key={i}
           step={step}
           firstFailedStep={this.state.firstFailedStep}
-          onViewJobStep={this.props.onViewJobStep}
+          onViewJobStepExternally={this.props.onViewJobStep}
         />
       )
     })

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -45,8 +45,7 @@ export class CICheckRunListItem extends React.PureComponent<
     this.props.onCheckRunExpansionToggleClick(this.props.checkRun)
   }
 
-  private onViewCheckExternally = (e?: React.MouseEvent<HTMLDivElement>) => {
-    e?.stopPropagation()
+  private onViewCheckExternally = () => {
     this.props.onViewCheckExternally(this.props.checkRun)
   }
 
@@ -67,20 +66,6 @@ export class CICheckRunListItem extends React.PureComponent<
           symbol={getSymbolForCheck(checkRun)}
         />
       </div>
-    )
-  }
-
-  private renderLinkExternal = (): JSX.Element | null => {
-    return (
-      <TooltippedContent
-        className="view-externally"
-        tooltip="View online"
-        tagName="div"
-      >
-        <div onClick={this.onViewCheckExternally}>
-          <Octicon symbol={OcticonSymbol.linkExternal} />
-        </div>
-      </TooltippedContent>
     )
   }
 
@@ -115,7 +100,7 @@ export class CICheckRunListItem extends React.PureComponent<
           onlyWhenOverflowed={true}
           tagName="div"
         >
-          {name}
+          <span onClick={this.onViewCheckExternally}>{name}</span>
         </TooltippedContent>
 
         <div className="ci-check-description">{checkRun.description}</div>
@@ -129,12 +114,11 @@ export class CICheckRunListItem extends React.PureComponent<
     return (
       <>
         <div
-          className="ci-check-list-item"
+          className="ci-check-list-item list-item"
           onClick={this.toggleCheckRunExpansion}
         >
           {this.renderCheckStatusSymbol()}
           {this.renderCheckRunName()}
-          {this.renderLinkExternal()}
           {this.renderCheckJobStepToggle()}
         </div>
         {isCheckRunExpanded && checkRun.actionJobSteps !== undefined ? (

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -71,12 +71,6 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderLinkExternal = (): JSX.Element | null => {
-    const { checkRun } = this.props
-
-    if (checkRun.actionJobSteps === undefined) {
-      return null
-    }
-
     return (
       <TooltippedContent
         className="view-externally"
@@ -98,11 +92,7 @@ export class CICheckRunListItem extends React.PureComponent<
     }
 
     return (
-      <TooltippedContent
-        className="job-step-toggled-indicator"
-        tooltip="Show job steps"
-        tagName="div"
-      >
+      <div className="job-step-toggled-indicator">
         <Octicon
           symbol={
             isCheckRunExpanded
@@ -110,7 +100,7 @@ export class CICheckRunListItem extends React.PureComponent<
               : OcticonSymbol.chevronUp
           }
         />
-      </TooltippedContent>
+      </div>
     )
   }
 

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -10,6 +10,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { CICheckRunActionsJobStepList } from './ci-check-run-actions-job-step-list'
 import { IAPIWorkflowJobStep } from '../../lib/api'
+import { TooltipDirectionDef } from '../lib/tooltip'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -99,6 +100,7 @@ export class CICheckRunListItem extends React.PureComponent<
           tooltip={name}
           onlyWhenOverflowed={true}
           tagName="div"
+          direction={TooltipDirectionDef.NORTH}
         >
           <span onClick={this.onViewCheckExternally}>{name}</span>
         </TooltippedContent>

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -28,7 +28,7 @@ interface ICICheckRunListItemProps {
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
   /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
-  readonly onViewCheckDetails: (checkRun: IRefCheck) => void
+  readonly onViewCheckExternally: (checkRun: IRefCheck) => void
 
   /** Callback to open a job steps link on dotcom*/
   readonly onViewJobStep: (
@@ -41,13 +41,13 @@ interface ICICheckRunListItemProps {
 export class CICheckRunListItem extends React.PureComponent<
   ICICheckRunListItemProps
 > {
-  private onCheckRunClick = () => {
+  private toggleCheckRunExpansion = () => {
     this.props.onCheckRunExpansionToggleClick(this.props.checkRun)
   }
 
-  private onViewCheckDetails = (e?: React.MouseEvent<HTMLDivElement>) => {
+  private onViewCheckExternally = (e?: React.MouseEvent<HTMLDivElement>) => {
     e?.stopPropagation()
-    this.props.onViewCheckDetails(this.props.checkRun)
+    this.props.onViewCheckExternally(this.props.checkRun)
   }
 
   private onViewJobStep = (step: IAPIWorkflowJobStep) => {
@@ -70,7 +70,27 @@ export class CICheckRunListItem extends React.PureComponent<
     )
   }
 
-  private rendeCheckJobStepToggle = (): JSX.Element | null => {
+  private renderLinkExternal = (): JSX.Element | null => {
+    const { checkRun } = this.props
+
+    if (checkRun.actionJobSteps === undefined) {
+      return null
+    }
+
+    return (
+      <TooltippedContent
+        className="view-externally"
+        tooltip="View online"
+        tagName="div"
+      >
+        <div onClick={this.onViewCheckExternally}>
+          <Octicon symbol={OcticonSymbol.linkExternal} />
+        </div>
+      </TooltippedContent>
+    )
+  }
+
+  private renderCheckJobStepToggle = (): JSX.Element | null => {
     const { checkRun, isCheckRunExpanded } = this.props
 
     if (checkRun.actionJobSteps === undefined) {
@@ -83,15 +103,13 @@ export class CICheckRunListItem extends React.PureComponent<
         tooltip="Show job steps"
         tagName="div"
       >
-        <div onClick={this.onCheckRunClick}>
-          <Octicon
-            symbol={
-              isCheckRunExpanded
-                ? OcticonSymbol.chevronDown
-                : OcticonSymbol.chevronUp
-            }
-          />
-        </div>
+        <Octicon
+          symbol={
+            isCheckRunExpanded
+              ? OcticonSymbol.chevronDown
+              : OcticonSymbol.chevronUp
+          }
+        />
       </TooltippedContent>
     )
   }
@@ -100,10 +118,7 @@ export class CICheckRunListItem extends React.PureComponent<
     const { checkRun } = this.props
     const name = getCheckRunDisplayName(checkRun)
     return (
-      <div
-        className="ci-check-list-item-detail"
-        onClick={this.onViewCheckDetails}
-      >
+      <div className="ci-check-list-item-detail">
         <TooltippedContent
           className="ci-check-name"
           tooltip={name}
@@ -123,16 +138,14 @@ export class CICheckRunListItem extends React.PureComponent<
 
     return (
       <>
-        <div className="ci-check-list-item">
-          <TooltippedContent
-            className="check-run-details"
-            tooltip="View online"
-            tagName="div"
-          >
-            {this.renderCheckStatusSymbol()}
-            {this.renderCheckRunName()}
-          </TooltippedContent>
-          {this.rendeCheckJobStepToggle()}
+        <div
+          className="ci-check-list-item"
+          onClick={this.toggleCheckRunExpansion}
+        >
+          {this.renderCheckStatusSymbol()}
+          {this.renderCheckRunName()}
+          {this.renderLinkExternal()}
+          {this.renderCheckJobStepToggle()}
         </div>
         {isCheckRunExpanded && checkRun.actionJobSteps !== undefined ? (
           <CICheckRunActionsJobStepList

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -10,7 +10,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { CICheckRunActionsJobStepList } from './ci-check-run-actions-job-step-list'
 import { IAPIWorkflowJobStep } from '../../lib/api'
-import { TooltipDirectionDef } from '../lib/tooltip'
+import { TooltipDirection } from '../lib/tooltip'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -100,7 +100,7 @@ export class CICheckRunListItem extends React.PureComponent<
           tooltip={name}
           onlyWhenOverflowed={true}
           tagName="div"
-          direction={TooltipDirectionDef.NORTH}
+          direction={TooltipDirection.NORTH}
         >
           <span onClick={this.onViewCheckExternally}>{name}</span>
         </TooltippedContent>

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -101,7 +101,7 @@ export class CICheckRunList extends React.PureComponent<
             loadingActionWorkflows={this.props.loadingActionWorkflows}
             isCheckRunExpanded={this.state.checkRunExpanded === c.id.toString()}
             onCheckRunExpansionToggleClick={this.onCheckRunClick}
-            onViewCheckDetails={this.props.onViewCheckDetails}
+            onViewCheckExternally={this.props.onViewCheckDetails}
             onViewJobStep={this.props.onViewJobStep}
           />
         )

--- a/app/src/ui/diff/side-by-side-diff-row.tsx
+++ b/app/src/ui/diff/side-by-side-diff-row.tsx
@@ -18,6 +18,7 @@ import { DiffExpansionKind } from './text-diff-expansion'
 import { PopoverCaretPosition } from '../lib/popover'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { TooltippedContent } from '../lib/tooltipped-content'
+import { TooltipDirection } from '../lib/tooltip'
 
 interface ISideBySideDiffRowProps {
   /**
@@ -371,7 +372,10 @@ export class SideBySideDiffRow extends React.Component<
         style={{ width: this.props.lineNumberWidth }}
         onContextMenu={this.props.onContextMenuExpandHunk}
       >
-        <TooltippedContent direction="s" tooltip={elementInfo.title}>
+        <TooltippedContent
+          direction={TooltipDirection.SOUTH}
+          tooltip={elementInfo.title}
+        >
           <Octicon symbol={elementInfo.icon} />
         </TooltippedContent>
       </div>

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../lib/set-almost-immediate'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { clipboard } from 'electron'
+import { TooltipDirection } from '../lib/tooltip'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
@@ -350,7 +351,7 @@ export class CommitSummary extends React.Component<
                 tooltip={this.renderShaTooltip()}
                 tooltipClassName="sha-hint"
                 interactive={true}
-                direction="s"
+                direction={TooltipDirection.SOUTH}
               >
                 {shortSHA}
               </TooltippedContent>

--- a/app/src/ui/lib/avatar.tsx
+++ b/app/src/ui/lib/avatar.tsx
@@ -5,6 +5,7 @@ import { generateGravatarUrl } from '../../lib/gravatar'
 import { Octicon } from '../octicons'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { TooltippedContent } from './tooltipped-content'
+import { TooltipDirection } from './tooltip'
 
 interface IAvatarProps {
   /** The user whose avatar should be displayed. */
@@ -221,7 +222,7 @@ export class Avatar extends React.Component<IAvatarProps, IAvatarState> {
         className="avatar-container"
         tooltipClassName={this.props.title ? undefined : 'user-info'}
         tooltip={title}
-        direction="n"
+        direction={TooltipDirection.NORTH}
         tagName="div"
       >
         {img}

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import { Tooltip } from './tooltip'
+import { Tooltip, TooltipDirection } from './tooltip'
 import { createObservableRef } from './observable-ref'
 
 export interface IButtonProps {
@@ -123,7 +123,7 @@ export class Button extends React.Component<IButtonProps, {}> {
         {tooltip && (
           <Tooltip
             target={this.innerButtonRef}
-            direction="n"
+            direction={TooltipDirection.NORTH}
             // Show the tooltip immediately on hover if the button is disabled
             delay={disabled && tooltip ? 0 : undefined}
           >

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -7,6 +7,16 @@ import { assertNever } from '../../lib/fatal-error'
 import { rectEquals, rectContains } from './rect'
 
 export type TooltipDirection = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
+export enum TooltipDirectionDef {
+  NORTH = 'n',
+  NORTH_EAST = 'ne',
+  EAST = 'e',
+  SOUTH_EAST = 'se',
+  SOUTH = 's',
+  SOUTH_WEST = 'sw',
+  WEST = 'w',
+  NORTH_WEST = 'nw',
+}
 const DefaultTooltipDelay = 400
 const InteractiveTooltipHideDelay = 250
 

--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -6,8 +6,7 @@ import classNames from 'classnames'
 import { assertNever } from '../../lib/fatal-error'
 import { rectEquals, rectContains } from './rect'
 
-export type TooltipDirection = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
-export enum TooltipDirectionDef {
+export enum TooltipDirection {
   NORTH = 'n',
   NORTH_EAST = 'ne',
   EAST = 'e',
@@ -17,6 +16,7 @@ export enum TooltipDirectionDef {
   WEST = 'w',
   NORTH_WEST = 'nw',
 }
+
 const DefaultTooltipDelay = 400
 const InteractiveTooltipHideDelay = 250
 
@@ -399,7 +399,7 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
 
     const direction = visible
       ? getDirection(this.props.direction, targetRect, windowRect, tooltipRect)
-      : 's'
+      : TooltipDirection.SOUTH
 
     const style: React.CSSProperties = visible
       ? getTooltipPositionStyle(direction, targetRect, hostRect, tooltipRect)
@@ -465,14 +465,14 @@ function getDirection(
     rectContains(window, getTooltipRectRelativeTo(target, direction, tooltip))
 
   let candidates = new Set<TooltipDirection>([
-    'n',
-    'ne',
-    'nw',
-    's',
-    'se',
-    'sw',
-    'e',
-    'w',
+    TooltipDirection.NORTH,
+    TooltipDirection.NORTH_EAST,
+    TooltipDirection.NORTH_WEST,
+    TooltipDirection.SOUTH,
+    TooltipDirection.SOUTH_EAST,
+    TooltipDirection.SOUTH_WEST,
+    TooltipDirection.EAST,
+    TooltipDirection.WEST,
   ])
 
   // We'll attempt to honor the desired placement but if it won't fit we'll
@@ -483,17 +483,31 @@ function getDirection(
     }
 
     // Try to respect the desired direction by changing the order
-    if (direction.startsWith('s')) {
-      candidates = new Set(['s', 'se', 'sw', ...candidates])
-    } else if (direction.startsWith('n')) {
-      candidates = new Set(['n', 'ne', 'nw', ...candidates])
+    if (direction.startsWith(TooltipDirection.SOUTH)) {
+      candidates = new Set([
+        TooltipDirection.SOUTH,
+        TooltipDirection.SOUTH_EAST,
+        TooltipDirection.SOUTH_WEST,
+        ...candidates,
+      ])
+    } else if (direction.startsWith(TooltipDirection.NORTH)) {
+      candidates = new Set([
+        TooltipDirection.NORTH,
+        TooltipDirection.NORTH_EAST,
+        TooltipDirection.NORTH_WEST,
+        ...candidates,
+      ])
     }
 
     // We already know it won't fit
     candidates.delete(direction)
   } else {
     // Placement based on mouse position, prefer south east, north east
-    candidates = new Set(['se', 'ne', ...candidates])
+    candidates = new Set([
+      TooltipDirection.SOUTH_EAST,
+      TooltipDirection.NORTH_EAST,
+      ...candidates,
+    ])
   }
 
   for (const candidate of candidates) {
@@ -503,7 +517,7 @@ function getDirection(
   }
 
   // Fall back to south even though it doesn't fit
-  return 's'
+  return TooltipDirection.SOUTH
 }
 
 function getTooltipPositionStyle(
@@ -532,21 +546,21 @@ function getTooltipRectRelativeTo(
   const tip = new DOMRect(10, 0, 6, 6)
 
   switch (direction) {
-    case 'ne':
+    case TooltipDirection.NORTH_EAST:
       return new DOMRect(xMid - tip.x - tip.width, yTop - tip.height, w, h)
-    case 'n':
+    case TooltipDirection.NORTH:
       return new DOMRect(xMid - w / 2, yTop - tip.height, w, h)
-    case 'nw':
+    case TooltipDirection.NORTH_WEST:
       return new DOMRect(xMid - w + tip.right, yTop - tip.height, w, h)
-    case 'e':
+    case TooltipDirection.EAST:
       return new DOMRect(xRight + tip.width, yMid, w, h)
-    case 'se':
+    case TooltipDirection.SOUTH_EAST:
       return new DOMRect(xMid - tip.x - tip.width, yBotttom + tip.height, w, h)
-    case 's':
+    case TooltipDirection.SOUTH:
       return new DOMRect(xMid - w / 2, yBotttom + tip.height, w, h)
-    case 'sw':
+    case TooltipDirection.SOUTH_WEST:
       return new DOMRect(xMid - w + tip.right, yBotttom + tip.height, w, h)
-    case 'w':
+    case TooltipDirection.WEST:
       return new DOMRect(xLeft - w - tip.width, yMid, w, h)
     default:
       return assertNever(direction, `Unknown direction ${direction}`)

--- a/app/src/ui/octicons/octicon.tsx
+++ b/app/src/ui/octicons/octicon.tsx
@@ -51,7 +51,7 @@ export class Octicon extends React.Component<IOcticonProps, {}> {
 
     // Octicons are typically very small so having an explicit direction makes
     // more sense
-    const direction = tooltipDirection ?? 'n'
+    const direction = tooltipDirection ?? TooltipDirection.NORTH
 
     return (
       <svg

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -5,7 +5,7 @@ import { assertNever } from '../../lib/fatal-error'
 import { Button } from '../lib/button'
 import { clamp } from '../../lib/clamp'
 import { createObservableRef } from '../lib/observable-ref'
-import { Tooltip } from '../lib/tooltip'
+import { Tooltip, TooltipDirection } from '../lib/tooltip'
 
 /** The button style. */
 export enum ToolbarButtonStyle {
@@ -173,7 +173,7 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
         ref={this.wrapperRef}
       >
         {tooltip && (
-          <Tooltip target={this.wrapperRef} direction="s">
+          <Tooltip target={this.wrapperRef} direction={TooltipDirection.SOUTH}>
             {tooltip}
           </Tooltip>
         )}

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -6,6 +6,10 @@
     border-bottom: var(--base-border);
     background-color: var(--box-alt-background-color);
 
+    .job-step-duration {
+      color: var(--text-secondary-color);
+    }
+
     &:hover {
       /* 100% is baseline so 95% is 5% darker */
       filter: brightness(95%);
@@ -18,8 +22,8 @@
 
     .job-step-status-symbol,
     .job-step-duration {
-      padding: var(--spacing);
-      padding-top: 12px;
+      padding: var(--spacing-half) var(--spacing);
+      margin-top: 2px;
     }
 
     .job-step-name {

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -1,6 +1,5 @@
 .ci-check-run-job-steps-list {
   overflow-y: auto;
-  max-height: 250px;
   border-bottom: var(--base-border);
 
   .ci-check-run-job-step {

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -24,6 +24,9 @@
 
     .job-step-name {
       flex-grow: 1;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
     }
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -10,12 +10,9 @@
       /* 100% is baseline so 95% is 5% darker */
       filter: brightness(95%);
 
-      .job-step-duration {
-        display: none;
-      }
-
-      .view-externally {
-        display: block;
+      .job-step-name span {
+        color: var(--link-button-color);
+        cursor: pointer !important;
       }
     }
 

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -9,6 +9,14 @@
     &:hover {
       /* 100% is baseline so 95% is 5% darker */
       filter: brightness(95%);
+
+      .job-step-duration {
+        display: none;
+      }
+
+      .view-externally {
+        display: block;
+      }
     }
 
     .job-step-status-symbol,

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -13,8 +13,10 @@
     &:hover {
       /* 100% is baseline so 95% is 5% darker */
       filter: brightness(95%);
+    }
 
-      .job-step-name span {
+    .job-step-name span {
+      &:hover {
         color: var(--link-button-color);
         cursor: pointer !important;
       }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -5,8 +5,9 @@
   height: 100%;
 
   &:hover {
-    .view-externally {
-      display: block;
+    .ci-check-name span {
+      color: var(--link-button-color);
+      cursor: pointer !important;
     }
   }
 

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -4,26 +4,30 @@
   border-bottom: var(--base-border);
   height: 100%;
 
+  &:hover {
+    .view-externally {
+      display: block;
+    }
+  }
+
+  .view-externally {
+    display: none;
+    color: var(--text-secondary-color);
+
+    div {
+      margin-top: 2px;
+    }
+
+    &:hover {
+      color: var(--text-color);
+    }
+  }
+
   .ci-check-status-symbol,
-  .job-step-toggled-indicator div {
+  .view-externally,
+  .job-step-toggled-indicator {
     padding: var(--spacing);
     padding-top: 11px;
-  }
-
-  .check-run-details {
-    flex-grow: 1;
-    display: flex;
-    overflow: hidden;
-
-    &:hover {
-      background: var(--list-item-hover-background-color);
-    }
-  }
-
-  .job-step-toggled-indicator {
-    &:hover {
-      background: var(--list-item-hover-background-color);
-    }
   }
 
   .ci-check-list-item-detail {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -19,6 +19,7 @@
 
   .job-step-toggled-indicator {
     padding-left: 0px;
+    color: var(--text-secondary-color);
   }
 
   .ci-check-list-item-detail {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -10,24 +10,14 @@
     }
   }
 
-  .view-externally {
-    display: none;
-    color: var(--text-secondary-color);
-
-    div {
-      margin-top: 2px;
-    }
-
-    &:hover {
-      color: var(--text-color);
-    }
-  }
-
   .ci-check-status-symbol,
-  .view-externally,
   .job-step-toggled-indicator {
     padding: var(--spacing);
     padding-top: 11px;
+  }
+
+  .job-step-toggled-indicator {
+    padding-left: 0px;
   }
 
   .ci-check-list-item-detail {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -4,8 +4,8 @@
   border-bottom: var(--base-border);
   height: 100%;
 
-  &:hover {
-    .ci-check-name span {
+  .ci-check-name span {
+    &:hover {
       color: var(--link-button-color);
       cursor: pointer !important;
     }

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -2,4 +2,19 @@
   overflow-y: auto;
   overflow-x: hidden;
   border-radius: var(--border-radius);
+
+  .view-externally {
+    display: none;
+    color: var(--text-secondary-color);
+
+    div {
+      padding: var(--spacing);
+      padding-top: 12px;
+      padding-bottom: 8px;
+    }
+
+    &:hover {
+      color: var(--text-color);
+    }
+  }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -2,19 +2,4 @@
   overflow-y: auto;
   overflow-x: hidden;
   border-radius: var(--border-radius);
-
-  .view-externally {
-    display: none;
-    color: var(--text-secondary-color);
-
-    div {
-      padding: var(--spacing);
-      padding-top: 12px;
-      padding-bottom: 8px;
-    }
-
-    &:hover {
-      color: var(--text-color);
-    }
-  }
 }


### PR DESCRIPTION
 Based on #13317 

## Description

The click list item to view online did not quite fit the Desktop UI/felt a bit unexpected. Switched back to the list item expand/collapsing and hover of title appears as link with blue text.

Got more UI feedback for using links as opposed to link external icon on private issue since team sync.

### Screenshots

https://user-images.githubusercontent.com/75402236/141828886-1c6d1c1e-fb99-4ed0-b04f-5111877c6429.mov

## Release notes
Notes: no-notes
