### PR TITLE
Warn hidden bidi characters in diffs

### DIFF
--- a/app/src/lib/diff-parser.ts
+++ b/app/src/lib/diff-parser.ts
@@ -375,15 +375,13 @@ export class DiffParser {
       throw new Error('Malformed diff, empty hunk')
     }
 
-    const hunk = new DiffHunk(
+    return new DiffHunk(
       header,
       lines,
       linesConsumed,
       linesConsumed + lines.length - 1,
       getHunkHeaderExpansionType(hunkIndex, header, previousHunk)
     )
-
-    return hunk
   }
 
   /**

--- a/app/src/lib/diff-parser.ts
+++ b/app/src/lib/diff-parser.ts
@@ -22,6 +22,11 @@ import { getLargestLineNumber } from '../ui/diff/diff-helpers'
 // in which case s defaults to 1
 const diffHeaderRe = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/
 
+/**
+ * Regular expression matching invisible bidirectional Unicode characters that
+ * may be interpreted or compiled differently than what it appears. See more:
+ * https://github.co/hiddenchars
+ */
 export const HiddenBidiCharsRegex = /[\u202A-\u202E]|[\u2066-\u2069]/
 
 const DiffPrefixAdd = '+' as const

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -284,6 +284,7 @@ export async function convertDiff(
     hunks: diff.hunks,
     lineEndingsChange,
     maxLineNumber: diff.maxLineNumber,
+    hasHiddenBidiChars: diff.hasHiddenBidiChars,
   }
 }
 
@@ -387,6 +388,7 @@ function buildDiff(
       hunks: diff.hunks,
       lineEndingsChange,
       maxLineNumber: diff.maxLineNumber,
+      hasHiddenBidiChars: diff.hasHiddenBidiChars,
     }
 
     return Promise.resolve(largeTextDiff)

--- a/app/src/models/diff/diff-data.ts
+++ b/app/src/models/diff/diff-data.ts
@@ -55,6 +55,8 @@ interface ITextDiffData {
   readonly lineEndingsChange?: LineEndingsChange
   /** The largest line number in the diff  */
   readonly maxLineNumber: number
+  /** Whether or not the diff has invisible bidi characters */
+  readonly hasHiddenBidiChars: boolean
 }
 
 export interface ITextDiff extends ITextDiffData {

--- a/app/src/models/diff/raw-diff.ts
+++ b/app/src/models/diff/raw-diff.ts
@@ -98,4 +98,7 @@ export interface IRawDiff {
 
   /** The largest line number in the diff */
   readonly maxLineNumber: number
+
+  /** Whether or not the diff has invisible bidi characters */
+  readonly hasHiddenBidiChars: boolean
 }

--- a/app/src/ui/diff/hidden-bidi-chars-warning.tsx
+++ b/app/src/ui/diff/hidden-bidi-chars-warning.tsx
@@ -8,7 +8,7 @@ export class HiddenBidiCharsWarning extends React.Component {
     return (
       <div className="hidden-bidi-chars-warning">
         <Octicon symbol={OcticonSymbol.alert} />
-        This file contains bidirectional Unicode text that may be interpreted or
+        This diff contains bidirectional Unicode text that may be interpreted or
         compiled differently than what appears below. To review, open the file
         in an editor that reveals hidden Unicode characters.{' '}
         <LinkButton uri="https://github.co/hiddenchars">

--- a/app/src/ui/diff/hidden-bidi-chars-warning.tsx
+++ b/app/src/ui/diff/hidden-bidi-chars-warning.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+import { LinkButton } from '../lib/link-button'
+
+export class HiddenBidiCharsWarning extends React.Component {
+  public render() {
+    return (
+      <div className="hidden-bidi-chars-warning">
+        <Octicon symbol={OcticonSymbol.alert} />
+        This file contains bidirectional Unicode text that may be interpreted or
+        compiled differently than what appears below. To review, open the file
+        in an editor that reveals hidden Unicode characters.{' '}
+        <LinkButton uri="https://github.co/hiddenchars">
+          Learn more about bidirectional Unicode characters
+        </LinkButton>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -202,6 +202,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
       kind: DiffType.Text,
       lineEndingsChange: diff.lineEndingsChange,
       maxLineNumber: diff.maxLineNumber,
+      hasHiddenBidiChars: diff.hasHiddenBidiChars,
     }
 
     return this.renderTextDiff(textDiff)

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -23,9 +23,6 @@ import {
   IFileContents,
 } from './syntax-highlighting'
 import { getTextDiffWithBottomDummyHunk } from './text-diff-expansion'
-import { Octicon } from '../octicons'
-import * as OcticonSymbol from '../octicons/octicons.generated'
-import { LinkButton } from '../lib/link-button'
 
 /**
  * The time (in milliseconds) we allow when loading a diff before
@@ -336,20 +333,6 @@ export class SeamlessDiffSwitcher extends React.Component<
 
     return (
       <div className={className}>
-        {diff !== null &&
-        diff.kind === DiffType.Text &&
-        diff.hasHiddenBidiChars ? (
-          <div className="hidden-bidi-chars-warning">
-            <Octicon symbol={OcticonSymbol.alert} />
-            This file contains bidirectional Unicode text that may be
-            interpreted or compiled differently than what appears below. To
-            review, open the file in an editor that reveals hidden Unicode
-            characters.{' '}
-            <LinkButton uri="https://github.co/hiddenchars">
-              Learn more about bidirectional Unicode characters
-            </LinkButton>
-          </div>
-        ) : null}
         {diff !== null ? (
           <Diff
             repository={repository}

--- a/app/src/ui/diff/seamless-diff-switcher.tsx
+++ b/app/src/ui/diff/seamless-diff-switcher.tsx
@@ -23,6 +23,9 @@ import {
   IFileContents,
 } from './syntax-highlighting'
 import { getTextDiffWithBottomDummyHunk } from './text-diff-expansion'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+import { LinkButton } from '../lib/link-button'
 
 /**
  * The time (in milliseconds) we allow when loading a diff before
@@ -333,6 +336,20 @@ export class SeamlessDiffSwitcher extends React.Component<
 
     return (
       <div className={className}>
+        {diff !== null &&
+        diff.kind === DiffType.Text &&
+        diff.hasHiddenBidiChars ? (
+          <div className="hidden-bidi-chars-warning">
+            <Octicon symbol={OcticonSymbol.alert} />
+            This file contains bidirectional Unicode text that may be
+            interpreted or compiled differently than what appears below. To
+            review, open the file in an editor that reveals hidden Unicode
+            characters.{' '}
+            <LinkButton uri="https://github.co/hiddenchars">
+              Learn more about bidirectional Unicode characters
+            </LinkButton>
+          </div>
+        ) : null}
         {diff !== null ? (
           <Diff
             repository={repository}

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -56,6 +56,7 @@ import {
   expandWholeTextDiff,
 } from './text-diff-expansion'
 import { IMenuItem } from '../../lib/menu-item'
+import { HiddenBidiCharsWarning } from './hidden-bidi-chars-warning'
 
 const DefaultRowHeight = 20
 const MaxLineLengthToCalculateDiff = 240
@@ -276,6 +277,7 @@ export class SideBySideDiff extends React.Component<
 
     return (
       <div className={containerClassName} onMouseDown={this.onMouseDown}>
+        {diff.hasHiddenBidiChars && <HiddenBidiCharsWarning />}
         {this.state.isSearching && (
           <DiffSearchInput
             onSearch={this.onSearch}

--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -8,6 +8,7 @@ import {
   ITextDiff,
 } from '../../models/diff'
 import { getLargestLineNumber } from './diff-helpers'
+import { HiddenBidiCharsRegex } from '../../lib/diff-parser'
 
 /** How many new lines will be added to a diff hunk by default. */
 export const DefaultDiffExpansionStep = 20
@@ -273,6 +274,13 @@ export function expandTextDiffHunk(
     )
   })
 
+  let hasHiddenBidiChars = diff.hasHiddenBidiChars
+  if (!hasHiddenBidiChars) {
+    hasHiddenBidiChars = newLines.some(
+      line => line.match(HiddenBidiCharsRegex) !== null
+    )
+  }
+
   // Update the resulting hunk header with the new line count
   const newHunkHeader = new DiffHunkHeader(
     isExpandingUp
@@ -394,6 +402,7 @@ export function expandTextDiffHunk(
     text: newDiffText,
     hunks: newHunks,
     maxLineNumber: getLargestLineNumber(newHunks),
+    hasHiddenBidiChars,
   }
 }
 

--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -277,7 +277,7 @@ export function expandTextDiffHunk(
   // Look for hidden bidi chars in the new lines, if the diff didn't have any already
   const hasHiddenBidiChars =
     diff.hasHiddenBidiChars ||
-    newLines.some(line => line.match(HiddenBidiCharsRegex) !== null)
+    newLines.some(line => HiddenBidiCharsRegex.test(line))
 
   // Update the resulting hunk header with the new line count
   const newHunkHeader = new DiffHunkHeader(

--- a/app/src/ui/diff/text-diff-expansion.ts
+++ b/app/src/ui/diff/text-diff-expansion.ts
@@ -274,12 +274,10 @@ export function expandTextDiffHunk(
     )
   })
 
-  let hasHiddenBidiChars = diff.hasHiddenBidiChars
-  if (!hasHiddenBidiChars) {
-    hasHiddenBidiChars = newLines.some(
-      line => line.match(HiddenBidiCharsRegex) !== null
-    )
-  }
+  // Look for hidden bidi chars in the new lines, if the diff didn't have any already
+  const hasHiddenBidiChars =
+    diff.hasHiddenBidiChars ||
+    newLines.some(line => line.match(HiddenBidiCharsRegex) !== null)
 
   // Update the resulting hunk header with the new line count
   const newHunkHeader = new DiffHunkHeader(

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -56,6 +56,7 @@ import { createOcticonElement } from '../octicons/octicon'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { PopoverCaretPosition } from '../lib/popover'
+import { HiddenBidiCharsWarning } from './hidden-bidi-chars-warning'
 
 /** The longest line for which we'd try to calculate a line diff. */
 const MaxIntraLineDiffStringLength = 4096
@@ -1548,24 +1549,28 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
   }
 
   public render() {
+    const { diff } = this.state
     const doc = this.getCodeMirrorDocument(
-      this.state.diff.text,
+      diff.text,
       this.getNoNewlineIndicatorLines(this.state.diff.hunks)
     )
 
     return (
-      <CodeMirrorHost
-        className="diff-code-mirror"
-        value={doc}
-        options={defaultEditorOptions}
-        isSelectionEnabled={this.isSelectionEnabled}
-        onSwapDoc={this.onSwapDoc}
-        onAfterSwapDoc={this.onAfterSwapDoc}
-        onViewportChange={this.onViewportChange}
-        ref={this.getAndStoreCodeMirrorInstance}
-        onContextMenu={this.onContextMenu}
-        onCopy={this.onCopy}
-      />
+      <>
+        {diff.hasHiddenBidiChars && <HiddenBidiCharsWarning />}
+        <CodeMirrorHost
+          className="diff-code-mirror"
+          value={doc}
+          options={defaultEditorOptions}
+          isSelectionEnabled={this.isSelectionEnabled}
+          onSwapDoc={this.onSwapDoc}
+          onAfterSwapDoc={this.onAfterSwapDoc}
+          onViewportChange={this.onViewportChange}
+          ref={this.getAndStoreCodeMirrorInstance}
+          onContextMenu={this.onContextMenu}
+          onCopy={this.onCopy}
+        />
+      </>
     )
   }
 }

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -431,6 +431,11 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red};
 
+  /** File warning */
+  --file-warning-background-color: #{$yellow-200};
+  --file-warning-color: #{$yellow-800};
+  --file-warning-border-color: #{rgba($yellow-700, 0.4)};
+
   /** Tooltips */
   --tooltip-background-color: #{$gray-900};
   --tooltip-color: #{$gray-100};

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -328,6 +328,11 @@ body.theme-dark {
   --dialog-information-color: #{$blue-400};
   --dialog-error-color: #{$red-600};
 
+  /** File warning */
+  --file-warning-background-color: #{rgba($yellow-900, 0.4)};
+  --file-warning-color: #{$yellow-700};
+  --file-warning-border-color: #{rgba($yellow-800, 0.4)};
+
   /** Tooltips */
   --tooltip-background-color: #{$gray-800};
   --tooltip-color: #{$gray-100};

--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -761,6 +761,7 @@
 
 .seamless-diff-switcher {
   display: flex;
+  flex-direction: column;
   flex-grow: 1;
   min-width: 0;
   overflow: hidden;
@@ -773,6 +774,22 @@
     display: none;
     opacity: 0;
     pointer-events: none;
+  }
+
+  .hidden-bidi-chars-warning {
+    background-color: var(--file-warning-background-color);
+    padding: var(--spacing) var(--spacing-double);
+    border-bottom: var(--file-warning-border-color) solid 1px;
+
+    .octicon {
+      margin-right: var(--spacing);
+      color: var(--file-warning-color);
+      vertical-align: text-bottom;
+    }
+
+    a.link-button-component {
+      display: unset;
+    }
   }
 
   // When loading a diff

--- a/app/test/unit/text-diff-expansion-test.ts
+++ b/app/test/unit/text-diff-expansion-test.ts
@@ -59,6 +59,7 @@ async function prepareDiff(
     text: diff.contents,
     hunks: diff.hunks,
     maxLineNumber: diff.maxLineNumber,
+    hasHiddenBidiChars: diff.hasHiddenBidiChars,
   }
 
   const resultDiff = getTextDiffWithBottomDummyHunk(


### PR DESCRIPTION
## Description

This PR adds a file-level warning when hidden bidi characters are found in diffs. For this, I've used the same text and style used in dotcom.

### Screenshots

https://user-images.githubusercontent.com/1083228/142419897-38148e72-0522-4908-b79e-1b0fd713e941.mov

With dark theme:
![image](https://user-images.githubusercontent.com/1083228/142420682-f611c1ac-0dab-4376-8c23-409167c7fe11.png)

## Release notes

Notes: [Improved] Warn users when files contain bidirectional Unicode text
