### PR TITLE
Differentiate check runs by event

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -382,6 +382,7 @@ export interface IAPIWorkflowRun {
   readonly name: string
   readonly rerun_url: string
   readonly check_suite_id: number
+  readonly event: string
 }
 
 export interface IAPIWorkflowJobs {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -341,6 +341,7 @@ export interface IAPIRefCheckRun {
   readonly completed_at: string
   readonly started_at: string
   readonly html_url: string
+  readonly pull_requests: ReadonlyArray<IAPIPullRequest>
 }
 
 // NB. Only partially mapped

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -546,10 +546,15 @@ export function getFormattedCheckRunDuration(
  * Goal: Action Workflow Name / workflow run name
  * If no workflow run name (non-actions check), then just return the name.
  */
-export function getCheckRunDisplayName(checkRun: IRefCheck): string {
+export function getCheckRunDisplayName(
+  checkRun: IRefCheck,
+  showEvent: boolean
+): string {
   if (checkRun.actionsWorkflow !== undefined) {
     const { name, event } = checkRun.actionsWorkflow
-    return `${name} / ${checkRun.name} (${event})`
+    return showEvent
+      ? `${name} / ${checkRun.name} (${event})`
+      : `${name} / ${checkRun.name}`
   }
   const wfName =
     checkRun.appName === 'GitHub Code Scanning'

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -25,6 +25,9 @@ interface ICICheckRunListItemProps {
   /** Whether to show the logs for this check run */
   readonly isCheckRunExpanded: boolean
 
+  /** Whether or not to show the action workflow event in the title */
+  readonly showEventInTitle: boolean
+
   /** Callback for when a check run is clicked */
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
@@ -92,7 +95,7 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderCheckRunName = (): JSX.Element => {
     const { checkRun } = this.props
-    const name = getCheckRunDisplayName(checkRun)
+    const name = getCheckRunDisplayName(checkRun, this.props.showEventInTitle)
     return (
       <div className="ci-check-list-item-detail">
         <TooltippedContent

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -77,8 +77,7 @@ export class CICheckRunList extends React.PureComponent<
     )
     return {
       checkRunExpanded,
-      hasUserToggledCheckRun:
-        currentState !== null ? currentState.hasUserToggledCheckRun : false,
+      hasUserToggledCheckRun: currentState?.hasUserToggledCheckRun || false,
       checkRunsHaveMultipleEventTypes: checkRunEvents.size > 1,
     }
   }

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -30,6 +30,7 @@ interface ICICheckRunListProps {
 interface ICICheckRunListState {
   readonly checkRunExpanded: string | null
   readonly hasUserToggledCheckRun: boolean
+  readonly checkRunsHaveMultipleEventTypes: boolean
 }
 
 /** The CI Check list. */
@@ -69,11 +70,16 @@ export class CICheckRunList extends React.PureComponent<
           : props.checkRuns[0].id.toString()
     }
 
+    const checkRunEvents = new Set(
+      props.checkRuns
+        .map(c => c.actionsWorkflow?.event)
+        .filter(c => c !== undefined && c.trim() !== '')
+    )
     return {
       checkRunExpanded,
-      hasUserToggledCheckRun: currentState
-        ? currentState.hasUserToggledCheckRun
-        : false,
+      hasUserToggledCheckRun:
+        currentState !== null ? currentState.hasUserToggledCheckRun : false,
+      checkRunsHaveMultipleEventTypes: checkRunEvents.size > 1,
     }
   }
 
@@ -90,7 +96,12 @@ export class CICheckRunList extends React.PureComponent<
   private renderList = (): JSX.Element | null => {
     const list = [...this.props.checkRuns]
       .sort((a, b) =>
-        getCheckRunDisplayName(a).localeCompare(getCheckRunDisplayName(b))
+        getCheckRunDisplayName(
+          a,
+          this.state.checkRunsHaveMultipleEventTypes
+        ).localeCompare(
+          getCheckRunDisplayName(b, this.state.checkRunsHaveMultipleEventTypes)
+        )
       )
       .map((c, i) => {
         return (
@@ -103,6 +114,7 @@ export class CICheckRunList extends React.PureComponent<
             onCheckRunExpansionToggleClick={this.onCheckRunClick}
             onViewCheckExternally={this.props.onViewCheckDetails}
             onViewJobStep={this.props.onViewJobStep}
+            showEventInTitle={this.state.checkRunsHaveMultipleEventTypes}
           />
         )
       })


### PR DESCRIPTION
## Description
During the beta release, I was watching the release branch with the new check runs component and noticed that it did not show the job steps for the check runs like it normally would.. and on dotcom the check runs were listed twice one with "(push)" after the name and one with "(pull_request)" after the name.

Found out that release branches... tho seems I can't replicate on a test release... :/ can have check-runs that are triggered by `push` events from a generated branch during release.

Our existing check run logic will retrieve all check runs for a pull request git reference from the checks api. This means if a pull request check runs have been rerun due to additional commits or just being rerun, we get all of them back. Those types are `pull_request` events. Thus, we were filtering to the ones of the same name with the highest check run id (most recent). Unfortunately, ones that are run with a `push` also have the same name but are treated separately on dotcom's list as they have different origination.. not exactly just a re-run. Since, the `push` events occurred on deployment of the release branch, they were the most recent ones. Thus, those are the ones we filtered to and kept to show in the check run list. 

First problem is now we only show each one once where dotcom shows them twice. This PR addresses that by also taking into account if a check run has a pull request associated with it as that means it is the `pull_request` event type... a little hacky but check runs from the checks api do not have a concept of event type as that is an actions construct and check runs on checks api is check runner agnostic.

Second problem is the check runs job steps do not show for `push` event check runs. This was because we make a call to the actions api to get all the workflow runs for the branch name. Unfortunately, those `push` events on the release pull request were not actually made by that same branch; it was made with another generated branch but presumedly for the same commit/git ref (how it gets associated with the PR)... Thus, the workflow runs call does not pull the workflow runs associated with the `push` event check runs back in this case. Thus I have opened [an issue](https://github.com/github/c2c-actions-checks/issues/177) with the actions team requesting a way to retrieve these workflow runs (either using the git ref like check runs api does or by check suite id since that is what we are ultimately matching check runs to action workflows with). 


_Other notes: After thinking on it more.. we technically could address the second problem as we can retrieve action workflows runs by date and we have a create date on the  check run. Thus, we could retrieve all workflow runs with the same date. But that would retrieve them for any other pull request/workflow run from that date.. which for some repos may mean retrieving numerous unrelated workflow runs that have nothing to do with the that desktop user and then also having to deal with pagination limitations... definitely not ideal._

### Screenshots
... Shouldn't have merged the beta release...  after that my testing came from just hard coding the different types in as I couldn't reproduce on a test release.. must have a different flow.

This is how it will look at this point in time for push events (duplicate rows without the expansion arrow):
![image](https://user-images.githubusercontent.com/75402236/142423381-4aa5009c-46ae-430f-b570-8b2fa2214b0c.png)

This is how it will look when we can differentiate between push and pull_request events if action teams makes it so we can get the workflow runs for push events. Note: I only append the event if there are more than one kind of event since this is not a common. If I get sticky headers working, will probably have multiple headers for different events like. CI (push) and CI (pull_request).
![image](https://user-images.githubusercontent.com/75402236/142423861-cc8430ff-2499-41b4-ae60-87846cbdb1c3.png)


## Release notes
Notes: no-notes
