### PR TITLE
CI Check run Sticky Headers

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -541,28 +541,11 @@ export function getFormattedCheckRunDuration(
     .format('d[d] h[h] m[m] s[s]', { largest: 4 })
 }
 
-/** Get check run display name
+/**
+ * Get check run display name
  *
- * Goal: Action Workflow Name / workflow run name
- * If no workflow run name (non-actions check), then just return the name.
-
-export function getCheckRunDisplayName(
-  checkRun: IRefCheck,
-  showEvent: boolean
-): string {
-  if (checkRun.actionsWorkflow !== undefined) {
-    const { name, event } = checkRun.actionsWorkflow
-    return showEvent
-      ? `${name} / ${checkRun.name} (${event})`
-      : `${name} / ${checkRun.name}`
-  }
-  const wfName =
-    checkRun.appName === 'GitHub Code Scanning'
-      ? 'Code scanning results' // seems this is hardcoded on dotcom too :/
-      : undefined
-  return wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
-}
-*/
+ * Optionally display check run event
+ **/
 export function getCheckRunDisplayName(
   checkRun: IRefCheck,
   showEvent: boolean

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -545,7 +545,7 @@ export function getFormattedCheckRunDuration(
  *
  * Goal: Action Workflow Name / workflow run name
  * If no workflow run name (non-actions check), then just return the name.
- */
+
 export function getCheckRunDisplayName(
   checkRun: IRefCheck,
   showEvent: boolean
@@ -561,4 +561,15 @@ export function getCheckRunDisplayName(
       ? 'Code scanning results' // seems this is hardcoded on dotcom too :/
       : undefined
   return wfName !== undefined ? `${wfName} / ${checkRun.name}` : checkRun.name
+}
+*/
+export function getCheckRunDisplayName(
+  checkRun: IRefCheck,
+  showEvent: boolean
+): string {
+  if (checkRun.actionsWorkflow !== undefined && showEvent) {
+    const { event } = checkRun.actionsWorkflow
+    return `${checkRun.name} (${event})`
+  }
+  return checkRun.name
 }

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -32,8 +32,7 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
         step.number === this.props.firstFailedStep.number &&
         stepHeaderRef !== null
       ) {
-        stepHeaderRef.scrollIntoView({ behavior: 'smooth', block: 'center' })
-        // stepHeaderRef.scrollTop -= 500
+        stepHeaderRef.scrollIntoView({ behavior: 'smooth', block: 'start' })
       }
     }
   }
@@ -41,31 +40,32 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
   public render() {
     const { step } = this.props
     return (
-      <div className="ci-check-run-job-step">
-        <div className="list-item" ref={this.onStepHeaderRef(step)}>
-          <div className="job-step-status-symbol">
-            <Octicon
-              className={classNames(
-                'ci-status',
-                `ci-status-${getClassNameForCheck(step)}`
-              )}
-              symbol={getSymbolForLogStep(step)}
-            />
-          </div>
+      <div
+        className="ci-check-run-job-step list-item"
+        ref={this.onStepHeaderRef(step)}
+      >
+        <div className="job-step-status-symbol">
+          <Octicon
+            className={classNames(
+              'ci-status',
+              `ci-status-${getClassNameForCheck(step)}`
+            )}
+            symbol={getSymbolForLogStep(step)}
+          />
+        </div>
 
-          <TooltippedContent
-            className="job-step-name"
-            tooltip={step.name}
-            onlyWhenOverflowed={true}
-            tagName="div"
-            direction={TooltipDirection.NORTH}
-          >
-            <span onClick={this.onViewJobStepExternally}>{step.name}</span>
-          </TooltippedContent>
+        <TooltippedContent
+          className="job-step-name"
+          tooltip={step.name}
+          onlyWhenOverflowed={true}
+          tagName="div"
+          direction={TooltipDirection.NORTH}
+        >
+          <span onClick={this.onViewJobStepExternally}>{step.name}</span>
+        </TooltippedContent>
 
-          <div className="job-step-duration">
-            {getFormattedCheckRunDuration(step)}
-          </div>
+        <div className="job-step-duration">
+          {getFormattedCheckRunDuration(step)}
         </div>
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-actions-job-step-item.tsx
@@ -32,7 +32,8 @@ export class CICheckRunActionsJobStepListItem extends React.PureComponent<
         step.number === this.props.firstFailedStep.number &&
         stepHeaderRef !== null
       ) {
-        stepHeaderRef.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        stepHeaderRef.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        // stepHeaderRef.scrollTop -= 500
       }
     }
   }

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -120,7 +120,7 @@ export class CICheckRunListItem extends React.PureComponent<
       sticky: isCheckRunExpanded,
     })
     return (
-      <>
+      <div className="ci-check-list-item-group">
         <div className={classes} onClick={this.toggleCheckRunExpansion}>
           {this.renderCheckStatusSymbol()}
           {this.renderCheckRunName()}
@@ -132,7 +132,7 @@ export class CICheckRunListItem extends React.PureComponent<
             onViewJobStep={this.onViewJobStep}
           />
         ) : null}
-      </>
+      </div>
     )
   }
 }

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -116,12 +116,12 @@ export class CICheckRunListItem extends React.PureComponent<
   public render() {
     const { checkRun, isCheckRunExpanded } = this.props
 
+    const classes = classNames('ci-check-list-item', 'list-item', {
+      sticky: isCheckRunExpanded,
+    })
     return (
       <>
-        <div
-          className="ci-check-list-item list-item"
-          onClick={this.toggleCheckRunExpansion}
-        >
+        <div className={classes} onClick={this.toggleCheckRunExpansion}>
           {this.renderCheckStatusSymbol()}
           {this.renderCheckRunName()}
           {this.renderCheckJobStepToggle()}

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -191,12 +191,10 @@ export class CICheckRunList extends React.PureComponent<
     const checkRunGroups = this.getCheckRunsGroupedByWorkflowAction()
     const groups = checkRunGroupNames.map((groupName, i) => {
       return (
-        <>
-          <div className="ci-check-run-list-group-header" key={i}>
-            {groupName}
-          </div>
+        <div className="ci-check-run-list-group" key={i}>
+          <div className="ci-check-run-list-group-header">{groupName}</div>
           {this.renderListItems(checkRunGroups[groupName])}
-        </>
+        </div>
       )
     })
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -310,8 +310,8 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --drag-overlay-z-index: 15;
   --side-panel-z-index: 14;
   // We want second level to fall under top level when scrolling
-  --list-sticky-header-top-level: 11;
-  --list-sticky-header-second-level: 10;
+  --list-sticky-header-top-level-z-index: 11;
+  --list-sticky-header-second-level-z-index: 10;
 
   /**
    * Toast notifications are shown temporarily for things like the zoom

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -308,6 +308,9 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   --nudge-arrow-z-index: 16;
   --drag-overlay-z-index: 15;
   --side-panel-z-index: 14;
+  // We want second level to fall under top level when scrolling
+  --list-sticky-header-top-level: 11;
+  --list-sticky-header-second-level: 10;
 
   /**
    * Toast notifications are shown temporarily for things like the zoom

--- a/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-job-steps.scss
@@ -6,6 +6,11 @@
     border-bottom: var(--base-border);
     background-color: var(--box-alt-background-color);
 
+    // This is the height of a check run step and check run group header so that
+    // when a first failed step is scroll into view it doesn't end up under the
+    // sticky headers (which are like fixed headers)
+    scroll-margin-top: 72px;
+
     .job-step-duration {
       color: var(--text-secondary-color);
     }

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -8,7 +8,7 @@
     position: sticky;
     background-color: var(--background-color);
     top: 29px;
-    z-index: 10;
+    z-index: var(--list-sticky-header-second-level);
   }
 
   .ci-check-name span {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -4,6 +4,12 @@
   border-bottom: var(--base-border);
   height: 100%;
 
+  &.sticky {
+    position: sticky;
+    background-color: var(--background-color);
+    top: 28px;
+  }
+
   .ci-check-name span {
     &:hover {
       color: var(--link-button-color);

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -7,7 +7,8 @@
   &.sticky {
     position: sticky;
     background-color: var(--background-color);
-    top: 28px;
+    top: 29px;
+    z-index: 10;
   }
 
   .ci-check-name span {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -8,7 +8,7 @@
     position: sticky;
     background-color: var(--background-color);
     top: 29px;
-    z-index: var(--list-sticky-header-second-level);
+    z-index: var(--list-sticky-header-second-level-z-index);
   }
 
   &.selected .ci-check-name span {

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -12,6 +12,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    z-index: var(--list-sticky-header-top-level);
+    z-index: var(--list-sticky-header-top-level-z-index);
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -4,13 +4,14 @@
 
   .ci-check-run-list-group-header {
     position: sticky;
-    top: 0px;
+    top: 0;
     padding: var(--spacing-half);
-    background-color: var(--box-alt-background-color);
+    background-color: var(--background-color);
     border-bottom: var(--base-border);
     filter: brightness(98%);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    z-index: 10;
   }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,5 +1,16 @@
 .ci-check-run-list {
   overflow-y: auto;
   overflow-x: hidden;
-  border-radius: var(--border-radius);
+
+  .ci-check-run-list-group-header {
+    position: sticky;
+    top: 0px;
+    padding: var(--spacing-half);
+    background-color: var(--box-alt-background-color);
+    border-bottom: var(--base-border);
+    filter: brightness(98%);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
 }

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -12,6 +12,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    z-index: 10;
+    z-index: var(--list-sticky-header-top-level);
   }
 }


### PR DESCRIPTION
## Description
Add group headers for the different types of action workflow app types to remove redundant name convention of {app name} / {check run name}

Follow up PRs:
- Need to adjust the "find first failed checkrun" logic as now it finds it and then does the grouping/sorting so the first one may not be first anymore. :)
- Add event type groupings in the headers.  Example: If you have under CI, Windows x64 (pull request) and Windows x64 (push), we will split this into groups of CI (pull request) and CI (push) with check runs of Windows x64 underneath. Expecting there would be multiple in each group.

### Screenshots

https://user-images.githubusercontent.com/75402236/142648080-0ab6eca7-45cc-406d-b84a-de8c7761d138.mov

## Release notes
Notes: [Improved] Add group headers to CI Check run list
