### PR TITLE
Group CI check runs by event 

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -589,8 +589,8 @@ export function getCheckRunStepURL(
 
 /**
  * Groups check runs by their actions workflow name and actions workflow event type.
- *
  * Event type only gets grouped if there are more than one event.
+ *
  * @param checkRuns
  * @returns A map of grouped check runs.
  */

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -543,22 +543,6 @@ export function getFormattedCheckRunDuration(
 }
 
 /**
- * Get check run display name
- *
- * Optionally display check run event
- **/
-export function getCheckRunDisplayName(
-  checkRun: IRefCheck,
-  showEvent: boolean
-): string {
-  if (checkRun.actionsWorkflow !== undefined && showEvent) {
-    const { event } = checkRun.actionsWorkflow
-    return `${checkRun.name} (${event})`
-  }
-  return checkRun.name
-}
-
-/**
  * Generates the URL pointing to the details of a given check run. If that check
  * run has no specific URL, returns the URL of the associated pull request.
  *

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react'
-import {
-  getCheckRunDisplayName,
-  IRefCheck,
-} from '../../lib/ci-checks/ci-checks'
+import { IRefCheck } from '../../lib/ci-checks/ci-checks'
 import { Octicon } from '../octicons'
 import { getClassNameForCheck, getSymbolForCheck } from '../branches/ci-status'
 import classNames from 'classnames'
@@ -24,9 +21,6 @@ interface ICICheckRunListItemProps {
 
   /** Whether to show the logs for this check run */
   readonly isCheckRunExpanded: boolean
-
-  /** Whether or not to show the action workflow event in the title */
-  readonly showEventInTitle: boolean
 
   /** Whether the list item can be selected */
   readonly selectable: boolean
@@ -100,8 +94,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckRunName = (): JSX.Element => {
-    const { checkRun } = this.props
-    const name = getCheckRunDisplayName(checkRun, this.props.showEventInTitle)
+    const { name, description } = this.props.checkRun
     return (
       <div className="ci-check-list-item-detail">
         <TooltippedContent
@@ -114,7 +107,7 @@ export class CICheckRunListItem extends React.PureComponent<
           <span onClick={this.onViewCheckExternally}>{name}</span>
         </TooltippedContent>
 
-        <div className="ci-check-description">{checkRun.description}</div>
+        <div className="ci-check-description">{description}</div>
       </div>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -38,7 +38,6 @@ interface ICICheckRunListProps {
 interface ICICheckRunListState {
   readonly checkRunExpanded: string | null
   readonly hasUserToggledCheckRun: boolean
-  readonly checkRunsHaveMultipleEventTypes: boolean
 }
 
 /** The CI Check list. */
@@ -76,15 +75,9 @@ export class CICheckRunList extends React.PureComponent<
       checkRunExpanded = checkRun.id.toString()
     }
 
-    const checkRunEvents = new Set(
-      props.checkRuns
-        .map(c => c.actionsWorkflow?.event)
-        .filter(c => c !== undefined && c.trim() !== '')
-    )
     return {
       checkRunExpanded,
       hasUserToggledCheckRun: currentState?.hasUserToggledCheckRun || false,
-      checkRunsHaveMultipleEventTypes: checkRunEvents.size > 1,
     }
   }
 
@@ -132,7 +125,6 @@ export class CICheckRunList extends React.PureComponent<
             onCheckRunExpansionToggleClick={this.onCheckRunClick}
             onViewCheckExternally={this.props.onViewCheckDetails}
             onViewJobStep={this.props.onViewJobStep}
-            showEventInTitle={this.state.checkRunsHaveMultipleEventTypes}
           />
         )
       })

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import * as React from 'react'
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import {

--- a/app/test/unit/ci-checks-test.ts
+++ b/app/test/unit/ci-checks-test.ts
@@ -1,0 +1,106 @@
+import { APICheckConclusion, APICheckStatus } from '../../src/lib/api'
+import {
+  getCheckRunsGroupedByActionWorkflowNameAndEvent,
+  IRefCheck,
+} from '../../src/lib/ci-checks/ci-checks'
+
+describe('getCheckRunsGroupedByActionWorkflowNameAndEvent', () => {
+  it('groups by actions workflow name', () => {
+    const checkRuns = [
+      buildMockCheckRun('1', '', 'test1'),
+      buildMockCheckRun('1', '', 'test2'),
+    ]
+    const groups = getCheckRunsGroupedByActionWorkflowNameAndEvent(checkRuns)
+    const groupNames = [...groups.keys()]
+    expect(groupNames.includes('test1')).toBe(true)
+    expect(groupNames.includes('test2')).toBe(true)
+  })
+
+  it('groups any check run without an actions workflow name into Other', () => {
+    const checkRuns = [
+      buildMockCheckRun('1', '', 'test1'),
+      buildMockCheckRun('1', ''),
+    ]
+    const groups = getCheckRunsGroupedByActionWorkflowNameAndEvent(checkRuns)
+    const groupNames = [...groups.keys()]
+    expect(groupNames.includes('test1')).toBe(true)
+    expect(groupNames.includes('Other')).toBe(true)
+  })
+
+  it('groups any check run without an actions workflow name with an app name of "GitHub Code Scanning" into "Code scanning results"', () => {
+    const checkRuns = [
+      buildMockCheckRun('1', '', 'test1'),
+      buildMockCheckRun('1', ''),
+      buildMockCheckRun('1', 'GitHub Code Scanning'),
+    ]
+    const groups = getCheckRunsGroupedByActionWorkflowNameAndEvent(checkRuns)
+    const groupNames = [...groups.keys()]
+    expect(groupNames.includes('test1')).toBe(true)
+    expect(groupNames.includes('Other')).toBe(true)
+    expect(groupNames.includes('Code scanning results')).toBe(true)
+  })
+
+  it('groups by actions event type if more than one event type', () => {
+    const checkRuns = [
+      buildMockCheckRun('1', '', 'test1'),
+      buildMockCheckRun('1', '', 'test2'),
+    ]
+    let groups = getCheckRunsGroupedByActionWorkflowNameAndEvent(checkRuns)
+    let groupNames = [...groups.keys()]
+
+    // no event types
+    expect(groupNames.includes('test1')).toBe(true)
+    expect(groupNames.includes('test2')).toBe(true)
+
+    checkRuns.push(buildMockCheckRun('1', '', 'test3', 'pull_request'))
+    groups = getCheckRunsGroupedByActionWorkflowNameAndEvent(checkRuns)
+    groupNames = [...groups.keys()]
+
+    // only one event
+    expect(groupNames.includes('test1')).toBe(true)
+    expect(groupNames.includes('test2')).toBe(true)
+    expect(groupNames.includes('test3')).toBe(true)
+
+    checkRuns.push(buildMockCheckRun('1', '', 'test4', 'push'))
+    groups = getCheckRunsGroupedByActionWorkflowNameAndEvent(checkRuns)
+    groupNames = [...groups.keys()]
+
+    // two event types for test3 and test4
+    expect(groupNames.includes('test1')).toBe(true)
+    expect(groupNames.includes('test2')).toBe(true)
+    expect(groupNames.includes('test3 (pull_request)')).toBe(true)
+    expect(groupNames.includes('test4 (push)')).toBe(true)
+  })
+})
+
+function buildMockCheckRun(
+  name: string,
+  appName: string = '',
+  actionWorkflowName?: string,
+  actionWorkflowEvent?: string
+): IRefCheck {
+  return {
+    id: 1,
+    name,
+    description: '',
+    status: APICheckStatus.Completed,
+    conclusion: APICheckConclusion.Success,
+    appName,
+    htmlUrl: null,
+    checkSuiteId: null,
+    actionsWorkflow:
+      actionWorkflowName || actionWorkflowEvent
+        ? {
+            name: actionWorkflowName || '',
+            event: actionWorkflowEvent || '',
+            id: 1,
+            workflow_id: 1,
+            cancel_url: '',
+            created_at: '',
+            logs_url: '',
+            rerun_url: '',
+            check_suite_id: 1,
+          }
+        : undefined,
+  }
+}


### PR DESCRIPTION
Built on top of [sticky headers PR.](https://github.com/desktop/desktop/pull/13348)

## Description

Groups checks with event identifier when more than one event type. 

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/142660366-fb226233-7eb1-49a0-83d7-903f1d2c1326.png)

## Release notes
Notes: no-notes
