### PR TITLE
Make selected boxes without keyboard focus more visible in light theme

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -116,7 +116,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
   /**
    * Background color for selected boxes without keyboard focus
    */
-  --box-selected-background-color: #ebeef1;
+  --box-selected-background-color: #{$gray-200};
 
   /**
    * Text color for when a user hovers over a boxe with a


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13353

## Description

-  This changes the light themes boxe color when it does not have keyboard focus to be gray, as opposed to white.
- This matches the existing behavior in dark theme where the non focused boxe had a noticeable color difference.

### Screenshots
Existing Dark theme showing color change on selected boxes without keyboard focus
![image](https://user-images.githubusercontent.com/11286791/142780262-5e979714-5e16-4e09-8ed1-d3690b6c62b9.png)

Updated Light Theme
![image](https://user-images.githubusercontent.com/11286791/142780197-021df5c9-562f-4249-b8e0-c5186a0a2c8d.png)
![image](https://user-images.githubusercontent.com/11286791/142780211-a46f090e-b357-4204-b7c5-928241641236.png)

Also applies to the `Changes` tab when a boxe losses keyboard focus
![image](https://user-images.githubusercontent.com/11286791/142794748-60ab92e5-e800-46aa-8b99-866c384d5e8e.png)

Also applies to the file list under `Stashed Changes`
![image](https://user-images.githubusercontent.com/11286791/142795745-d25e99a9-5259-49d6-b4a4-d344465d2ad4.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
