### PR TITLE
Select actual first failed check run

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -615,7 +615,7 @@ export function getCheckRunsGroupedByActionWorkflowNameAndEvent(
 
   sortedGroupNames.forEach(gn => {
     const group = groups.get(gn)
-    if (group) {
+    if (group !== undefined) {
       const sortedGroup = group.sort((a, b) => a.name.localeCompare(b.name))
       groups.set(gn, sortedGroup)
     }

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -574,6 +574,7 @@ export function getCheckRunStepURL(
 /**
  * Groups check runs by their actions workflow name and actions workflow event type.
  * Event type only gets grouped if there are more than one event.
+ * Also sorts the check runs in the groups by their names.
  *
  * @param checkRuns
  * @returns A map of grouped check runs.
@@ -588,7 +589,7 @@ export function getCheckRunsGroupedByActionWorkflowNameAndEvent(
   )
   const checkRunsHaveMultipleEventTypes = checkRunEvents.size > 1
 
-  const groups = new Map<string, ReadonlyArray<IRefCheck>>()
+  const groups = new Map<string, IRefCheck[]>()
   for (const checkRun of checkRuns) {
     let group = checkRun.actionsWorkflow?.name || 'Other'
 
@@ -609,6 +610,16 @@ export function getCheckRunsGroupedByActionWorkflowNameAndEvent(
       existingGroup !== undefined ? [...existingGroup, checkRun] : [checkRun]
     groups.set(group, newGroup)
   }
+
+  const sortedGroupNames = getCheckRunGroupNames(groups)
+
+  sortedGroupNames.forEach(gn => {
+    const group = groups.get(gn)
+    if (group) {
+      const sortedGroup = group.sort((a, b) => a.name.localeCompare(b.name))
+      groups.set(gn, sortedGroup)
+    }
+  })
 
   return groups
 }

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -75,14 +75,12 @@ export class CICheckRunList extends React.PureComponent<
         ? getCheckRunsGroupedByActionWorkflowNameAndEvent(props.checkRuns)
         : currentState.checkRunGroups
 
-    let checkRunExpanded = currentState?.checkRunExpanded ?? null
+    let checkRunExpanded = null
 
     // If there is a failure, we want the first check run with a failure, to
     // be opened so the user doesn't have to click through to find it.
-    let firstFailure: IRefCheck | undefined
-    checkRunExpanded = null
     for (const group of checkRunGroups.values()) {
-      firstFailure = group.find(
+      const firstFailure = group.find(
         cr => isFailure(cr) && cr.actionJobSteps !== undefined
       )
       if (firstFailure !== undefined) {

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -36,6 +36,7 @@ interface ICICheckRunListProps {
 }
 
 interface ICICheckRunListState {
+  readonly checkRunGroups: Map<string, ReadonlyArray<IRefCheck>>
   readonly checkRunExpanded: string | null
   readonly hasUserToggledCheckRun: boolean
 }
@@ -52,30 +53,46 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   public componentDidUpdate(prevProps: ICICheckRunListProps) {
-    this.setState(
-      this.setupStateAfterCheckRunPropChange(this.props, this.state)
-    )
+    const {
+      checkRunExpanded,
+      hasUserToggledCheckRun,
+    } = this.setupStateAfterCheckRunPropChange(this.props, this.state)
+    this.setState({ checkRunExpanded, hasUserToggledCheckRun })
   }
 
   private setupStateAfterCheckRunPropChange(
     props: ICICheckRunListProps,
     currentState: ICICheckRunListState | null
   ): ICICheckRunListState {
+    // If the user has expanded something and then a load occurs, we don't want
+    // to reset their position.
+    if (currentState !== null && currentState.hasUserToggledCheckRun) {
+      return currentState
+    }
+
+    const checkRunGroups =
+      currentState === null
+        ? getCheckRunsGroupedByActionWorkflowNameAndEvent(props.checkRuns)
+        : currentState.checkRunGroups
+
     let checkRunExpanded = currentState?.checkRunExpanded ?? null
 
-    if (currentState === null || !currentState.hasUserToggledCheckRun) {
-      // If there is a failure, we want the first check run with a failure, to
-      // be opened so the user doesn't have to click through to find it.
-      // Otherwise, just open the first one. (Only actions type can be expanded.)
-      const firstFailure = props.checkRuns.find(
+    // If there is a failure, we want the first check run with a failure, to
+    // be opened so the user doesn't have to click through to find it.
+    let firstFailure: IRefCheck | undefined
+    checkRunExpanded = null
+    for (const group of checkRunGroups.values()) {
+      firstFailure = group.find(
         cr => isFailure(cr) && cr.actionJobSteps !== undefined
       )
-
-      const checkRun = firstFailure ?? props.checkRuns[0]
-      checkRunExpanded = checkRun.id.toString()
+      if (firstFailure !== undefined) {
+        checkRunExpanded = firstFailure.id.toString()
+        break
+      }
     }
 
     return {
+      checkRunGroups,
       checkRunExpanded,
       hasUserToggledCheckRun: currentState?.hasUserToggledCheckRun || false,
     }
@@ -106,28 +123,26 @@ export class CICheckRunList extends React.PureComponent<
       return null
     }
 
-    const list = [...checkRuns]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((c, i) => {
-        const checkRunExpanded = this.state.checkRunExpanded === c.id.toString()
-        const selectable = this.props.selectable === true
+    const list = checkRuns.map((c, i) => {
+      const checkRunExpanded = this.state.checkRunExpanded === c.id.toString()
+      const selectable = this.props.selectable === true
 
-        return (
-          <CICheckRunListItem
-            checkRun={c}
-            key={i}
-            loadingActionLogs={this.props.loadingActionLogs}
-            loadingActionWorkflows={this.props.loadingActionWorkflows}
-            selectable={selectable}
-            selected={selectable && checkRunExpanded}
-            // Only expand check runs if the list is not selectable
-            isCheckRunExpanded={!selectable && checkRunExpanded}
-            onCheckRunExpansionToggleClick={this.onCheckRunClick}
-            onViewCheckExternally={this.props.onViewCheckDetails}
-            onViewJobStep={this.props.onViewJobStep}
-          />
-        )
-      })
+      return (
+        <CICheckRunListItem
+          checkRun={c}
+          key={i}
+          loadingActionLogs={this.props.loadingActionLogs}
+          loadingActionWorkflows={this.props.loadingActionWorkflows}
+          selectable={selectable}
+          selected={selectable && checkRunExpanded}
+          // Only expand check runs if the list is not selectable
+          isCheckRunExpanded={!selectable && checkRunExpanded}
+          onCheckRunExpansionToggleClick={this.onCheckRunClick}
+          onViewCheckExternally={this.props.onViewCheckDetails}
+          onViewJobStep={this.props.onViewJobStep}
+        />
+      )
+    })
 
     return (
       <FocusContainer className="list-focus-container">{list}</FocusContainer>
@@ -135,9 +150,7 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   private renderList = (): JSX.Element | null => {
-    const checkRunGroups = getCheckRunsGroupedByActionWorkflowNameAndEvent(
-      this.props.checkRuns
-    )
+    const { checkRunGroups } = this.state
     const checkRunGroupNames = getCheckRunGroupNames(checkRunGroups)
     if (checkRunGroupNames.length === 1 && checkRunGroupNames[0] === 'Other') {
       return this.renderListItems(this.props.checkRuns)

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,6 +1,7 @@
 .ci-check-run-list {
   overflow-y: auto;
   overflow-x: hidden;
+  scroll-padding-top: 35px;
 
   .ci-check-run-list-group-header {
     position: sticky;


### PR DESCRIPTION
## Description

Since updates to grouping/sorting methods the first failed check runs logic didn't correctly get the first failed check run as it was searching on the unsorted list.

## Release notes
Notes: no-notes
