### PR TITLE
Initial support for real-time notifications

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@github/multimap": "^1.0.0",
+    "@github/stable-socket": "^1.1.0",
     "app-path": "^3.3.0",
     "byline": "^5.0.0",
     "chalk": "^2.3.0",

--- a/app/src/lib/alive/alive-session.ts
+++ b/app/src/lib/alive/alive-session.ts
@@ -1,0 +1,487 @@
+/* eslint-disable */
+import {
+  AlivePresence,
+  AlivePresenceData,
+  PresenceItem,
+  UserPresence,
+  getPresenceKey,
+  isPresenceChannel,
+} from './alive/presence'
+import {
+  IDLE_METADATA_KEY,
+  MetadataUpdate,
+  PresenceMetadataSet,
+} from './alive/presence-metadata'
+import type { Subscription, Topic } from './subscription-set'
+
+import type { Socket } from '@github/stable-socket'
+import { StableSocket } from '@github/stable-socket'
+import { SubscriptionSet } from './subscription-set'
+import { eachSlice } from './iterables'
+import { retry } from './eventloop-tasks'
+
+const enum SocketDisconnectReasons {
+  Deploy = 'Alive Redeploy', // Alive server is shutting down, likely due to a redeploy
+  Reconnect = 'Alive Reconnect', // Routine disconnect to keep the lifespan of WebSockets short (every 25-35 mins).  Server is not deploying.
+}
+
+interface AliveMessageData {
+  timestamp: number
+  wait: number
+  gid?: string
+}
+
+export type AliveData = AliveMessageData | AlivePresenceData
+
+interface Ack {
+  e: 'ack'
+  off: string
+  health: boolean
+}
+
+interface Message {
+  e: 'msg'
+  ch: string
+  off: string
+  data: AliveData
+}
+
+interface MessageEvent {
+  type: 'message'
+  data: AliveMessageData
+}
+
+interface PresenceEvent {
+  type: 'presence'
+  data: UserPresence[]
+}
+
+export type AliveEvent = { channel: string } & (MessageEvent | PresenceEvent)
+export type Notifier<T> = (subscribers: Iterable<T>, event: AliveEvent) => void
+
+function generatePresenceId() {
+  // outputs a string like 2118047710_1628653223
+  return `${Math.round(Math.random() * (Math.pow(2, 31) - 1))}_${Math.round(
+    Date.now() / 1000
+  )}`
+}
+
+function getUserIdFromSocketUrl(url: string): number {
+  const match = url.match(/\/u\/(\d+)\/ws/)
+  return match ? +match[1] : 0
+}
+
+export default class AliveSession<T> {
+  private socket: Socket
+  private subscriptions = new SubscriptionSet<T>()
+  private notify: Notifier<T>
+  private refreshUrl: string
+  private shared: boolean
+  private state: 'online' | 'offline' = 'online'
+  private redeployEarlyReconnectTimeout:
+    | ReturnType<typeof setTimeout>
+    | undefined
+  private retrying: AbortController | null = null
+  // presenceId is a random number specific to this AliveSession
+  private readonly presenceId: string
+  private readonly userId: number
+  // presenceId is a combination of the userId and the presenceId.  It can be used to identify presence items from this AliveSession
+  private readonly presenceKey: string
+  private connectionCount = 0
+  private presence = new AlivePresence()
+  private presenceMetadata = new PresenceMetadataSet<T>()
+  private intentionallyDisconnected = false
+  private lastCameOnline = 0
+
+  constructor(
+    private url: string,
+    refreshUrl: string,
+    shared: boolean,
+    notify: Notifier<T>
+  ) {
+    this.userId = getUserIdFromSocketUrl(url)
+    this.presenceId = generatePresenceId()
+    this.presenceKey = getPresenceKey(this.userId, this.presenceId)
+    this.refreshUrl = refreshUrl
+    this.notify = notify
+    this.shared = shared
+    this.socket = this.connect()
+  }
+
+  subscribe(subscriptions: Array<Subscription<T>>) {
+    const added = this.subscriptions.add(...subscriptions)
+    this.sendSubscribe(added)
+
+    // Send locally cached presence items to presence channels.
+    // This is necessary because we only receive a full presence state when we initially subscribe to a presence channel.
+    // If a second subscription is addded to the same presence channel, it will never receive another full state from Alive.
+    for (const subscription of subscriptions) {
+      const channel = subscription.topic.name
+      if (!isPresenceChannel(channel)) {
+        continue
+      }
+
+      this.notifyCachedPresence(subscription.subscriber, channel)
+    }
+  }
+
+  unsubscribe(subscriptions: Array<Subscription<T>>) {
+    const removed = this.subscriptions.delete(...subscriptions)
+    this.sendUnsubscribe(removed)
+  }
+
+  unsubscribeAll(...subscribers: T[]) {
+    const removed = this.subscriptions.drain(...subscribers)
+    this.sendUnsubscribe(removed)
+
+    // Remove metadata for these subscribers and send metadata updates
+    const updatedPresenceChannels = this.presenceMetadata.removeSubscribers(
+      subscribers
+    )
+    this.sendPresenceMetadataUpdate(updatedPresenceChannels)
+  }
+
+  requestPresence(subscriber: T, channels: string[]) {
+    // This is used for SharedWorker to send presence items on new subscriptions.
+    // This will only be called when the tab already has a subscription to the presence channel and receives another (redundant) subscription
+    for (const channel of channels) {
+      this.notifyCachedPresence(subscriber, channel)
+    }
+  }
+
+  private notifyCachedPresence(subscriber: T, channel: string) {
+    const presenceItems = this.presence.getChannelItems(channel)
+    if (presenceItems.length === 0) {
+      return
+    }
+
+    // Presence items exist for this channel, send them to the subscriber immediately.
+    this.notifyPresenceChannel(channel, presenceItems)
+  }
+
+  updatePresenceMetadata(metadataUpdates: Array<MetadataUpdate<T>>) {
+    const updatedChannels = new Set<string>()
+    for (const update of metadataUpdates) {
+      this.presenceMetadata.setMetadata(update)
+      updatedChannels.add(update.channelName)
+    }
+
+    this.sendPresenceMetadataUpdate(updatedChannels)
+  }
+
+  private sendPresenceMetadataUpdate(channelNames: Set<string>) {
+    if (!channelNames.size) {
+      return
+    }
+
+    const topics: Topic[] = []
+    for (const channelName of channelNames) {
+      // Get the topic associated with the channel
+      // If there is no topic, the channel has been fully unsubscribed so we don't need to send an update
+      const topic = this.subscriptions.topic(channelName)
+      if (topic) {
+        topics.push(topic)
+      }
+    }
+
+    // Send a new subscribe for all associated topics
+    // This subscribe will automatically include the new metadata values
+    this.sendSubscribe(topics)
+  }
+
+  online() {
+    this.lastCameOnline = Date.now()
+    this.state = 'online'
+    this.retrying?.abort()
+    this.socket.open()
+  }
+
+  offline() {
+    this.state = 'offline'
+    this.retrying?.abort()
+    this.socket.close()
+  }
+
+  shutdown() {
+    if (this.shared) {
+      self.close()
+    }
+  }
+
+  get reconnectWindow() {
+    const wasRecentlyOffline = Date.now() - this.lastCameOnline < 60 * 1000
+    if (
+      this.connectionCount === 0 ||
+      this.intentionallyDisconnected ||
+      wasRecentlyOffline
+    ) {
+      return 0
+    }
+
+    // Possibly disconnected due to a server crashing.  Provide a longer reconnect window so that we spread reconnects out over time to reduce the thundering herd.
+    // It's also possible we get here with small network blips that don't trigger "offline" state.
+    //   In that case, we want to reconnect immediately, but we can't effectively distinguish between those events and a server crashing.
+    return 10 * 1000
+  }
+
+  socketDidOpen() {
+    this.intentionallyDisconnected = false
+    this.connectionCount++
+    // force a new url into the socket so that the server can pick up the new presence id
+    // TODO: we should add a method to StableSocket to allow url to be updated
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(this.socket as any).url = this.getUrlWithPresenceId()
+
+    // Subscribe again after connection failure.
+    this.sendSubscribe(this.subscriptions.topics())
+  }
+
+  socketDidClose(socket: Socket, code: number, reason: string) {
+    if (this.redeployEarlyReconnectTimeout !== undefined) {
+      clearTimeout(this.redeployEarlyReconnectTimeout)
+    }
+
+    if (reason === SocketDisconnectReasons.Reconnect) {
+      this.intentionallyDisconnected = true
+    } else if (reason === SocketDisconnectReasons.Deploy) {
+      this.intentionallyDisconnected = true
+
+      // When Alive re-deploys, it will drain the existing connections over a 3 minute period.
+      // Alive also forces clients clients to reconnect every 25-35 minutes by disconnecting from the server side.
+      // After a deploy, this ~30 minute reconnect will cause big ripples in the number of connections.
+      // To avoid those ripples, the client should manually reconnect after 3-25 minutes after a deploy.
+      const reconnectDelayMinutes = 3 + Math.random() * 22 // 3-25 minutes
+      const reconnectDelay = reconnectDelayMinutes * 60 * 1000
+
+      this.redeployEarlyReconnectTimeout = setTimeout(() => {
+        this.intentionallyDisconnected = true
+
+        // Send the same code back to the server so that it knows this is a reconnect due to a deploy.
+        // The Alive will keep gathering messages for the currently subscribed channels, so that we can do a catchup after reconnect.
+        // eslint-disable-next-line i18n-text/no-en
+        this.socket.close(1000, 'Alive Redeploy Early Client Reconnect')
+      }, reconnectDelay)
+    }
+  }
+
+  socketDidFinish() {
+    if (this.state === 'offline') return
+    this.reconnect()
+  }
+
+  socketDidReceiveMessage(_: Socket, message: string) {
+    const payload = JSON.parse(message)
+    console.log('Received Alive message:', payload)
+    switch (payload.e) {
+      case 'ack': {
+        this.handleAck(payload)
+        break
+      }
+      case 'msg': {
+        this.handleMessage(payload)
+        break
+      }
+    }
+  }
+
+  private handleAck(ack: Ack) {
+    for (const topic of this.subscriptions.topics()) {
+      topic.offset = ack.off
+    }
+  }
+
+  private handleMessage(msg: Message) {
+    const channel = msg.ch
+    const topic = this.subscriptions.topic(channel)
+    if (!topic) return
+    topic.offset = msg.off
+
+    if ('e' in msg.data) {
+      // Process the message to update the presence items
+      const presenceItems = this.presence.handleMessage(channel, msg.data)
+
+      // Notify all subscribers with the new presence items
+      this.notifyPresenceChannel(channel, presenceItems)
+      return
+    }
+
+    if (!msg.data.wait) msg.data.wait = 0
+    this.notify(this.subscriptions.subscribers(channel), {
+      channel,
+      type: 'message',
+      data: msg.data,
+    })
+  }
+
+  notifyPresenceChannel(channel: string, presenceItems: PresenceItem[]) {
+    // Build UserPresence objects from the PresenceItems
+    const userPresenceById = new Map<number, UserPresence>()
+    for (const presenceItem of presenceItems) {
+      const { userId, metadata, presenceKey } = presenceItem
+      const userPresence = userPresenceById.get(userId) || {
+        userId,
+        isOwnUser: userId === this.userId,
+        metadata: [],
+      }
+
+      if (presenceKey === this.presenceKey) {
+        // Local metadata will be included in the notify loop below
+        continue
+      }
+
+      for (const data of metadata) {
+        // extract idle state if presence
+        if (IDLE_METADATA_KEY in data) {
+          if (userPresence.isIdle !== false) {
+            userPresence.isIdle = Boolean(data[IDLE_METADATA_KEY])
+          }
+          // We assume that idle metadata is sent in it's own object, so don't add this to the metadata array.
+          continue
+        }
+
+        // otherwise pass along metadata as-is
+        userPresence.metadata.push(data)
+      }
+
+      userPresenceById.set(userId, userPresence)
+    }
+
+    // Notify each subscriber.  This needs to be done individually so that we can localize the metadata for the current user.
+    for (const subscriber of this.subscriptions.subscribers(channel)) {
+      const userId = this.userId
+      const otherUsers = Array.from(userPresenceById.values()).filter(
+        user => user.userId !== userId
+      )
+
+      const ownUserRemoteMetadata =
+        userPresenceById.get(this.userId)?.metadata ?? []
+      // Use local metadata for this presence connection to avoid any round trip lag
+      // Pass the specific subscriber receiving this data so that the isLocal flag can be set properly
+      const ownUserLocalMetadata = this.presenceMetadata.getChannelMetadata(
+        channel,
+        {
+          subscriber,
+          // For a single tab, we want everything to be considered "local"
+          // In the SharedWorker, we only want to mark items from the specific subscriber as "local"
+          markAllAsLocal: !this.shared,
+        }
+      )
+
+      this.notify([subscriber], {
+        channel,
+        type: 'presence',
+        data: [
+          {
+            userId,
+            isOwnUser: true,
+            metadata: [...ownUserRemoteMetadata, ...ownUserLocalMetadata],
+            // Note that we do not include isIdle on own user.  It's assumed you never want to see yourself as idle.
+          },
+          ...otherUsers,
+        ],
+      })
+    }
+  }
+
+  private async reconnect() {
+    if (this.retrying) return
+    try {
+      this.retrying = new AbortController()
+      const fn = () => fetchRefreshUrl(this.refreshUrl)
+      const url = await retry(fn, Infinity, 60000, this.retrying.signal)
+      if (url) {
+        this.url = url
+        this.socket = this.connect()
+      } else {
+        this.shutdown()
+      }
+    } catch (e) {
+      if (e.name !== 'AbortError') throw e
+    } finally {
+      this.retrying = null
+    }
+  }
+
+  private getUrlWithPresenceId() {
+    const liveUrl = new URL(this.url, self.location.origin)
+    liveUrl.searchParams.set('shared', this.shared.toString())
+    liveUrl.searchParams.set('p', `${this.presenceId}.${this.connectionCount}`)
+    return liveUrl.toString()
+  }
+
+  private connect(): Socket {
+    const socket = new StableSocket(this.getUrlWithPresenceId(), this, {
+      timeout: 4000,
+      attempts: 7,
+    })
+    socket.open()
+    return socket
+  }
+
+  private sendSubscribe(topics: Iterable<Topic>) {
+    const entries = Array.from(topics)
+    for (const slice of eachSlice(entries, 25)) {
+      const subscribe: { [signed: string]: string } = {}
+
+      for (const topic of slice) {
+        if (isPresenceChannel(topic.name)) {
+          // presence channels send metadata as the value
+          subscribe[topic.signed] = JSON.stringify(
+            this.presenceMetadata.getChannelMetadata(topic.name)
+          )
+        } else {
+          // other channels send the current offset as the value
+          subscribe[topic.signed] = topic.offset
+        }
+      }
+
+      this.socket.send(JSON.stringify({ subscribe }))
+    }
+  }
+
+  private sendUnsubscribe(topics: Iterable<Topic>) {
+    const signed = Array.from(topics, t => t.signed)
+    for (const slice of eachSlice(signed, 25)) {
+      this.socket.send(JSON.stringify({ unsubscribe: slice }))
+    }
+
+    // Clear cached presence items for unsubscribed channels
+    for (const topic of topics) {
+      if (isPresenceChannel(topic.name)) {
+        this.presence.clearChannel(topic.name)
+      }
+    }
+  }
+}
+
+type PostUrl = { url?: string; token?: string }
+async function fetchRefreshUrl(url: string): Promise<string | null> {
+  const data = await fetchJSON<PostUrl>(url)
+  return data && data.url && data.token ? post(data.url, data.token) : null
+}
+
+async function fetchJSON<T>(url: string): Promise<T | null> {
+  const response = await fetch(url, { headers: { Accept: 'application/json' } })
+  if (response.ok) {
+    return response.json()
+  } else if (response.status === 404) {
+    return null
+  } else {
+    throw new Error('fetch error')
+  }
+}
+
+async function post(url: string, csrf: string): Promise<string> {
+  const response = await fetch(url, {
+    method: 'POST',
+    mode: 'same-origin',
+    headers: {
+      'Scoped-CSRF-Token': csrf,
+    },
+  })
+  if (response.ok) {
+    return response.text()
+  } else {
+    throw new Error('fetch error')
+  }
+}

--- a/app/src/lib/alive/alive/presence-metadata.ts
+++ b/app/src/lib/alive/alive/presence-metadata.ts
@@ -1,0 +1,133 @@
+/* eslint-disable */
+export const IDLE_METADATA_KEY = '_i'
+export type Metadata = Record<string, unknown> & { [IDLE_METADATA_KEY]?: 0 | 1 }
+
+export interface MetadataUpdate<T> {
+  subscriber: T
+  channelName: string
+  metadata: Metadata[]
+}
+
+interface LocalizationOptions<T> {
+  subscriber: T
+  markAllAsLocal: boolean
+}
+
+function markMetadataAsLocal(metadata: Metadata): Metadata {
+  return {
+    ...metadata,
+    isLocal: true,
+  }
+}
+
+class PresenceMetadataForChannel<T> {
+  private subscriberMetadata = new Map<T, Metadata[]>()
+
+  public setMetadata(subscriber: T, value: Metadata[]) {
+    this.subscriberMetadata.set(subscriber, value)
+  }
+
+  public removeSubscribers(subscribers: T[]) {
+    let found = false
+
+    for (const subscriber of subscribers) {
+      found = this.subscriberMetadata.delete(subscriber) || found
+    }
+
+    return found
+  }
+
+  // Get all the metadata for this channel, combining metadata arrays from all subscribers
+  public getMetadata(localizationOptions?: LocalizationOptions<T>) {
+    if (!localizationOptions) {
+      // No need to add `isLocal`. We can just flatten the metadata arrays from the subscribers
+      const allMetadata: Metadata[] = []
+      let idle: boolean | undefined
+
+      for (const subscriberMetadata of this.subscriberMetadata.values()) {
+        for (const metadata of subscriberMetadata) {
+          if (IDLE_METADATA_KEY in metadata) {
+            // Since each subscriber can have an idle record, we want to dedupe them into a single idle record
+            // This saves a lot of space in the presence payload if a user has many tabs or elements subscribed to the same channel
+            const subscriberIsIdle = Boolean(metadata[IDLE_METADATA_KEY])
+            idle =
+              idle === undefined ? subscriberIsIdle : subscriberIsIdle && idle
+          } else {
+            allMetadata.push(metadata)
+          }
+        }
+      }
+
+      if (idle !== undefined) {
+        allMetadata.push({ [IDLE_METADATA_KEY]: idle ? 1 : 0 })
+      }
+
+      return allMetadata
+    }
+
+    // Localization requested.  Add `isLocal` to the appropriate metadata items
+    // We do not need to de-dupe idle records because this data is not going over the wire
+    const metadata = []
+    const { subscriber, markAllAsLocal } = localizationOptions
+
+    for (const [fromSubscriber, subscriberMetadata] of this
+      .subscriberMetadata) {
+      const shouldLocalizeMetadata =
+        markAllAsLocal || fromSubscriber === subscriber
+      const metadataToAdd = shouldLocalizeMetadata
+        ? subscriberMetadata.map(markMetadataAsLocal)
+        : subscriberMetadata
+      metadata.push(...metadataToAdd)
+    }
+
+    return metadata
+  }
+
+  hasSubscribers() {
+    return this.subscriberMetadata.size > 0
+  }
+}
+
+export class PresenceMetadataSet<T> {
+  private metadataByChannel = new Map<string, PresenceMetadataForChannel<T>>()
+
+  public setMetadata({ subscriber, channelName, metadata }: MetadataUpdate<T>) {
+    let channelMetadata = this.metadataByChannel.get(channelName)
+
+    if (!channelMetadata) {
+      channelMetadata = new PresenceMetadataForChannel()
+      this.metadataByChannel.set(channelName, channelMetadata)
+    }
+
+    channelMetadata.setMetadata(subscriber, metadata)
+  }
+
+  public removeSubscribers(subscribers: T[]) {
+    const channelsWithSubscribers = new Set<string>()
+
+    for (const [channelName, channelMetadata] of this.metadataByChannel) {
+      const channelHadSubscriber = channelMetadata.removeSubscribers(
+        subscribers
+      )
+
+      if (channelHadSubscriber) {
+        channelsWithSubscribers.add(channelName)
+      }
+
+      // Clean up the channel if it has no subscribers
+      if (!channelMetadata.hasSubscribers()) {
+        this.metadataByChannel.delete(channelName)
+      }
+    }
+
+    return channelsWithSubscribers
+  }
+
+  getChannelMetadata(
+    channelName: string,
+    localizationOptions?: LocalizationOptions<T>
+  ) {
+    const channelMetadata = this.metadataByChannel.get(channelName)
+    return channelMetadata?.getMetadata(localizationOptions) || []
+  }
+}

--- a/app/src/lib/alive/alive/presence.ts
+++ b/app/src/lib/alive/alive/presence.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+import { Metadata } from './presence-metadata'
+
+// This is the compact data format that Alive sends to the client
+export interface PresenceItemCompact {
+  u: number // user id
+  p: string // presence id with connection count 123:456.1
+  m?: Metadata[] // metadata
+}
+
+interface FullPresenceData {
+  e: 'pf'
+  d: PresenceItemCompact[]
+}
+
+interface AddPresenceData {
+  e: 'pa'
+  d: PresenceItemCompact
+}
+
+interface RemovePresenceData {
+  e: 'pr'
+  d: PresenceItemCompact
+}
+
+export type AlivePresenceData =
+  | FullPresenceData
+  | AddPresenceData
+  | RemovePresenceData
+
+export interface UserPresence {
+  userId: number
+  metadata: Metadata[]
+  isOwnUser: boolean
+  isIdle?: boolean
+}
+
+export interface PresenceItem {
+  userId: number
+  metadata: Metadata[]
+  presenceKey: string
+  connectionCount: number
+}
+
+export function getPresenceKey(userId: number, presenceId: string) {
+  return `${userId}:${presenceId}`
+}
+
+export function decompressItem(data: PresenceItemCompact): PresenceItem {
+  const [presenceId, connectionCount] = data.p.split('.')
+
+  return {
+    userId: data.u,
+    // presenceId is randomly generated and is not guaranteed to be unique
+    // if we combine it with the userId, we have less chances of collisions, and we prevent tampering by other users manually setting their presenceId
+    presenceKey: getPresenceKey(data.u, presenceId),
+    connectionCount: Number(connectionCount),
+    metadata: data.m || [],
+  }
+}
+
+const presenceChannelPrefix = 'presence-'
+export function isPresenceChannel(channelName: string) {
+  return channelName.startsWith(presenceChannelPrefix)
+}
+
+class PresenceChannel {
+  private presenceItems: Map<string, PresenceItem> = new Map()
+
+  private shouldUsePresenceItem(item: PresenceItem) {
+    const existingItem = this.presenceItems.get(item.presenceKey)
+
+    // We only want to use presence items that are for the same or higher connection count
+    // If we don't already have an item for this presence id, we should use it
+    // If we do have an item, and the connection count is equal or higher, we should use it
+    // Otherwise, we know the item we just received is actually older, so we should ignore it
+    return !existingItem || existingItem.connectionCount <= item.connectionCount
+  }
+
+  addPresenceItem(item: PresenceItem) {
+    if (!this.shouldUsePresenceItem(item)) {
+      return
+    }
+
+    this.presenceItems.set(item.presenceKey, item)
+  }
+
+  removePresenceItem(item: PresenceItem) {
+    if (!this.shouldUsePresenceItem(item)) {
+      // We have this item, but the item we received is older, so we should ignore it
+      return
+    }
+
+    this.presenceItems.delete(item.presenceKey)
+  }
+
+  replacePresenceItems(items: PresenceItem[]) {
+    this.presenceItems.clear()
+
+    for (const item of items) {
+      this.addPresenceItem(item)
+    }
+  }
+
+  getPresenceItems(): PresenceItem[] {
+    return Array.from(this.presenceItems.values())
+  }
+}
+
+export class AlivePresence {
+  private presenceChannels: Map<string, PresenceChannel> = new Map()
+
+  private getPresenceChannel(channelName: string): PresenceChannel {
+    const channel =
+      this.presenceChannels.get(channelName) || new PresenceChannel()
+    this.presenceChannels.set(channelName, channel)
+    return channel
+  }
+
+  handleMessage(channelName: string, data: AlivePresenceData) {
+    const channel = this.getPresenceChannel(channelName)
+
+    switch (data.e) {
+      case 'pf':
+        channel.replacePresenceItems(data.d.map(decompressItem))
+        break
+      case 'pa':
+        channel.addPresenceItem(decompressItem(data.d))
+        break
+      case 'pr':
+        channel.removePresenceItem(decompressItem(data.d))
+        break
+    }
+
+    return this.getChannelItems(channelName)
+  }
+
+  getChannelItems(channelName: string): PresenceItem[] {
+    const channel = this.getPresenceChannel(channelName)
+    return channel.getPresenceItems()
+  }
+
+  clearChannel(channelName: string) {
+    this.presenceChannels.delete(channelName)
+  }
+}

--- a/app/src/lib/alive/eventloop-tasks.ts
+++ b/app/src/lib/alive/eventloop-tasks.ts
@@ -1,0 +1,139 @@
+/* eslint-disable */
+// This is a simple function that just returns Promise.resolve() It is used in instances when we want to queue a
+// microtask before moving onto the next operation, but want to do so in a very explicit manner: `await microtask`
+// looks a lot clearer in intent than `await void 0` or `await Promise.resolve()`.
+//
+// You would want to use `await microtask()` if you have something that needs to be done very urgently, but still
+// needs to be done asynchronously. This will _not_ yield to the browser for any UI updates or wait for idle, instead
+// it queues a task in the "microtask" which is run immediately after the current stack. Use this sparingly. This
+// will likely delay subsequent code for 0-10ms.
+export function microtask(): Promise<void> {
+  return Promise.resolve()
+}
+
+// This function simply Promisifies requestAnimationFrame so it is awaitable.
+//
+// You would want to use `await animationFrame()` if you're happy to yield to the browser to complete any UI updates
+// before calling your next piece of code. This is useful if - for example - you need to wait for scroll events,
+// or CSS transitions or something. This will likely delay subsequent code for 16ms or so - much longer (30-60ms)
+// if the tab is not focussed.
+export function animationFrame(): Promise<number> {
+  return new Promise(window.requestAnimationFrame)
+}
+
+// Rejects a promise after a timeout has elapsed. The promise is never
+// successfully fulfilled.
+//
+// Examples
+//
+//   try {
+//     const value = await Promise.race([timeout(100), somethingSlow()])
+//     console.log('Slow operation finished within the timeout', value)
+//   } catch (e) {
+//     console.log('Slow operation did not finish', e)
+//   }
+//
+// Returns a rejected Promise rejected after a timeout.
+export async function timeout(ms: number, signal?: AbortSignal): Promise<void> {
+  let id
+  const done = new Promise<void>((resolve, reject) => {
+    id = self.setTimeout(() => reject(new Error('timeout')), ms)
+  })
+  if (!signal) return done
+  try {
+    await Promise.race([done, whenAborted(signal)])
+  } catch (e) {
+    self.clearTimeout(id)
+    throw e
+  }
+}
+
+// Fulfills a promise after a timeout has elapsed. The promise is never rejected.
+//
+// Examples
+//
+//   step1()
+//   await wait(100)
+//   step2()
+//
+// Returns a Promise fulfilled after a timeout.
+export async function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  let id
+  const done = new Promise<void>(resolve => {
+    id = self.setTimeout(resolve, ms)
+  })
+  if (!signal) return done
+  try {
+    await Promise.race([done, whenAborted(signal)])
+  } catch (e) {
+    self.clearTimeout(id)
+    throw e
+  }
+}
+
+// Attempt to yield a value from an async function, retrying on rejections
+// with an exponential backoff delay between attempts. If the function never
+// yields a fulfilled promise, the final rejection error is thrown.
+//
+// Examples
+//
+//   try {
+//     const connect = async () => {…}
+//     const value = await retry(connect, 3)
+//     console.log('Connected eventually', value)
+//   } catch (e) {
+//     console.log('Could not connect after three attempts', e)
+//   }
+//
+// Returns a promise fulfilled by the function or rejected after attempts expire.
+export async function retry<T>(
+  fn: () => Promise<T>,
+  attempts: number,
+  maxDelay = Infinity,
+  signal?: AbortSignal
+): Promise<T> {
+  const aborted = signal ? whenAborted(signal) : null
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const op = aborted ? Promise.race([fn(), aborted]) : fn()
+      return await op
+    } catch (e) {
+      if (e.name === 'AbortError') throw e
+      if (i === attempts - 1) throw e
+      const ms = Math.pow(2, i) * 1000
+      const vary = rand(ms * 0.1)
+      await wait(Math.min(maxDelay, ms + vary), signal)
+    }
+  }
+  throw new Error('retry failed')
+}
+
+function whenAborted(signal: AbortSignal): Promise<never> {
+  return new Promise((resolve, reject) => {
+    const error = new Error('aborted')
+    error.name = 'AbortError'
+    if (signal.aborted) {
+      reject(error)
+    } else {
+      signal.addEventListener('abort', () => reject(error))
+    }
+  })
+}
+
+function rand(max: number): number {
+  return Math.floor(Math.random() * Math.floor(max))
+}
+
+export function taskQueue<T>(fn: (values: T[]) => unknown): (value: T) => void {
+  const queue: T[] = []
+  return function (value: T) {
+    queue.push(value)
+    if (queue.length === 1) {
+      queueMicrotask(() => {
+        const values = [...queue]
+        queue.length = 0
+        fn(values)
+      })
+    }
+  }
+}

--- a/app/src/lib/alive/iterables.ts
+++ b/app/src/lib/alive/iterables.ts
@@ -1,0 +1,17 @@
+export function* eachSlice<T>(values: T[], size: number): Iterable<T[]> {
+  for (let i = 0; i < values.length; i += size) {
+    yield values.slice(i, i + size)
+  }
+}
+
+export function* filterMap<T, U>(
+  items: T[],
+  map: (item: T) => U | null | undefined
+): Iterable<U> {
+  for (const item of items) {
+    const value = map(item)
+    if (value != null) {
+      yield value
+    }
+  }
+}

--- a/app/src/lib/alive/subscription-set.ts
+++ b/app/src/lib/alive/subscription-set.ts
@@ -1,0 +1,84 @@
+/* eslint-disable */
+import MultiMap from '@github/multimap'
+
+export type Subscription<T> = {
+  subscriber: T
+  topic: Topic
+}
+
+export class SubscriptionSet<T> {
+  private subscriptions = new MultiMap<string, T>()
+  private signatures = new Map<string, Topic>()
+
+  add(...subscriptions: Array<Subscription<T>>): Topic[] {
+    const added = []
+    for (const { subscriber, topic } of subscriptions) {
+      if (!this.subscriptions.has(topic.name)) {
+        added.push(topic)
+        this.signatures.set(topic.name, topic)
+      }
+      this.subscriptions.set(topic.name, subscriber)
+    }
+    return added
+  }
+
+  delete(...subscriptions: Array<Subscription<T>>): Topic[] {
+    const removed = []
+    for (const { subscriber, topic } of subscriptions) {
+      const deleted = this.subscriptions.delete(topic.name, subscriber)
+      if (deleted && !this.subscriptions.has(topic.name)) {
+        removed.push(topic)
+        this.signatures.delete(topic.name)
+      }
+    }
+    return removed
+  }
+
+  drain(...subscribers: T[]): Topic[] {
+    const removed = []
+    for (const subscriber of subscribers) {
+      for (const name of this.subscriptions.drain(subscriber)) {
+        const topic = this.signatures.get(name)!
+        this.signatures.delete(name)
+        removed.push(topic)
+      }
+    }
+    return removed
+  }
+
+  topics(): Iterable<Topic> {
+    return this.signatures.values()
+  }
+
+  topic(name: string): Topic | null {
+    return this.signatures.get(name) || null
+  }
+
+  subscribers(topic: string): Iterable<T> {
+    return this.subscriptions.get(topic).values()
+  }
+}
+
+export class Topic {
+  public name: string
+  public signed: string
+  public offset: string
+
+  // eslint-disable-next-line
+  static parse(data: string): Topic | null {
+    const [content, signature] = data.split('--')
+    if (!content || !signature) return null
+
+    const sub = JSON.parse(atob(content))
+    if (!sub.c || !sub.t) return null
+
+    return new Topic(sub.c, data)
+  }
+
+  // eslint-disable-next-line
+  constructor(name: string, signed: string) {
+    this.name = name
+    this.signed = signed
+    this.offset = ''
+  }
+}

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -15,7 +15,6 @@ import username from 'username'
 import { GitProtocol } from './remote-parsing'
 import { Emitter } from 'event-kit'
 import JSZip from 'jszip'
-import { getGUID } from './stats'
 
 const envEndpoint = process.env['DESKTOP_GITHUB_DOTCOM_API_ENDPOINT']
 const envHTMLURL = process.env['DESKTOP_GITHUB_DOTCOM_HTML_URL']
@@ -690,11 +689,7 @@ export class API {
 
   public async getAliveWebSocket(): Promise<string | null> {
     try {
-      const res = await this.request(
-        'GET',
-        // TODO: use a proper session ID that's unique per launch
-        `/live_internal/websocket-url?session_id=${getGUID()}`
-      )
+      const res = await this.request('GET', `/live_internal/websocket-url`)
       const websocket = await parsedResponse<IAPIAliveWebSocket>(res)
       return websocket.url
     } catch (e) {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -639,6 +639,7 @@ function toGitHubIsoDateString(date: Date) {
 }
 
 interface IAPIAliveSignedChannel {
+  readonly channel_name: string
   readonly signed_channel: string
 }
 
@@ -676,11 +677,11 @@ export class API {
     this.token = token
   }
 
-  public async getAliveDesktopChannel(): Promise<string | null> {
+  public async getAliveDesktopChannel(): Promise<IAPIAliveSignedChannel | null> {
     try {
       const res = await this.request('GET', '/desktop_internal/live-channel')
       const signedChannel = await parsedResponse<IAPIAliveSignedChannel>(res)
-      return signedChannel.signed_channel
+      return signedChannel
     } catch (e) {
       log.warn(`Alive channel request failed: ${e}`)
       return null

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -15,6 +15,7 @@ import username from 'username'
 import { GitProtocol } from './remote-parsing'
 import { Emitter } from 'event-kit'
 import JSZip from 'jszip'
+import { getGUID } from './stats'
 
 const envEndpoint = process.env['DESKTOP_GITHUB_DOTCOM_API_ENDPOINT']
 const envHTMLURL = process.env['DESKTOP_GITHUB_DOTCOM_HTML_URL']
@@ -637,6 +638,14 @@ function toGitHubIsoDateString(date: Date) {
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
 }
 
+interface IAPIAliveSignedChannel {
+  readonly signed_channel: string
+}
+
+interface IAPIAliveWebSocket {
+  readonly url: string
+}
+
 /**
  * An object for making authenticated requests to the GitHub API
  */
@@ -665,6 +674,32 @@ export class API {
   public constructor(endpoint: string, token: string) {
     this.endpoint = endpoint
     this.token = token
+  }
+
+  public async getAliveDesktopChannel(): Promise<string | null> {
+    try {
+      const res = await this.request('GET', '/desktop_internal/live-channel')
+      const signedChannel = await parsedResponse<IAPIAliveSignedChannel>(res)
+      return signedChannel.signed_channel
+    } catch (e) {
+      log.warn(`Alive channel request failed: ${e}`)
+      return null
+    }
+  }
+
+  public async getAliveWebSocket(): Promise<string | null> {
+    try {
+      const res = await this.request(
+        'GET',
+        // TODO: use a proper session ID that's unique per launch
+        `/live_internal/websocket-url?session_id=${getGUID()}`
+      )
+      const websocket = await parsedResponse<IAPIAliveWebSocket>(res)
+      return websocket.url
+    } catch (e) {
+      log.warn(`Alive channel request failed: ${e}`)
+      return null
+    }
   }
 
   /** Fetch a repo by its owner and name. */

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -104,7 +104,7 @@ export class AliveStore {
 
     this.sessionPerEndpoint.delete(account.endpoint)
 
-    // TODO: shutdown the session (close its websocket)
+    endpointSession.session.offline()
 
     console.log('Unubscribed from Alive channel!')
   }

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -1,0 +1,147 @@
+import { AccountsStore } from './accounts-store'
+import { Account, accountEquals } from '../../models/account'
+import { API } from '../api'
+import AliveSession, { AliveEvent } from '../alive/alive-session'
+import { Subscription } from '../alive/subscription-set'
+import { Emitter } from 'event-kit'
+
+function accountIncluded(account: Account, accounts: ReadonlyArray<Account>) {
+  return accounts.find(a => accountEquals(a, account))
+}
+
+interface IAliveSubscription {
+  readonly account: Account
+  readonly subscription: Subscription<AliveStore>
+}
+
+interface IAliveEndpointSession {
+  readonly session: AliveSession<AliveStore>
+  readonly webSocketUrl: string
+}
+
+export class AliveStore {
+  private readonly ALIVE_EVENT_RECEIVED_EVENT = 'alive-event-received'
+
+  private sessionPerEndpoint: Map<string, IAliveEndpointSession> = new Map()
+  private subscriptions: Array<IAliveSubscription> = []
+  private readonly emitter = new Emitter()
+
+  public constructor(private readonly accountsStore: AccountsStore) {
+    this.accountsStore.onDidUpdate(this.subscribeToAccounts)
+  }
+
+  private subscribeToAccounts = (accounts: ReadonlyArray<Account>) => {
+    const subscribedAccounts = this.subscriptions.map(s => s.account)
+
+    for (const account of subscribedAccounts) {
+      if (!accountIncluded(account, accounts)) {
+        this.unsubscribeFromAccount(account)
+      }
+    }
+
+    for (const account of accounts) {
+      if (!accountIncluded(account, subscribedAccounts)) {
+        this.subscribeToAccount(account)
+      }
+    }
+  }
+
+  private sessionForAccount(
+    account: Account
+  ): IAliveEndpointSession | undefined {
+    return this.sessionPerEndpoint.get(account.endpoint)
+  }
+
+  private async createSessionForAccount(
+    account: Account
+  ): Promise<IAliveEndpointSession | null> {
+    const session = this.sessionForAccount(account)
+    if (session !== undefined) {
+      return session
+    }
+
+    const api = API.fromAccount(account)
+    const webSocketUrl = await api.getAliveWebSocket()
+
+    if (webSocketUrl === null) {
+      return null
+    }
+
+    const aliveSession = new AliveSession(
+      webSocketUrl,
+      webSocketUrl,
+      false,
+      this.notify
+    )
+
+    const newSession = {
+      session: aliveSession,
+      webSocketUrl,
+    }
+
+    this.sessionPerEndpoint.set(account.endpoint, newSession)
+
+    return newSession
+  }
+
+  private unsubscribeFromAccount(account: Account) {
+    const endpointSession = this.sessionForAccount(account)
+    if (endpointSession === undefined) {
+      return
+    }
+
+    const subscription = this.subscriptions.find(s =>
+      accountEquals(s.account, account)
+    )
+    if (subscription === undefined) {
+      return
+    }
+
+    endpointSession.session.unsubscribe([subscription.subscription])
+    this.subscriptions = this.subscriptions.filter(
+      s => !accountEquals(s.account, account)
+    )
+  }
+
+  private subscribeToAccount = async (account: Account) => {
+    const endpointSession = await this.createSessionForAccount(account)
+    const api = API.fromAccount(account)
+    const channelInfo = await api.getAliveDesktopChannel()
+
+    if (endpointSession === null || channelInfo === null) {
+      return
+    }
+
+    const subscription = {
+      subscriber: this,
+      topic: {
+        name: channelInfo.channel_name,
+        signed: channelInfo.signed_channel,
+        offset: '', // TODO: do we need to set an offset?
+      },
+    }
+
+    endpointSession.session.subscribe([subscription])
+
+    this.subscriptions.push({
+      account,
+      subscription,
+    })
+
+    console.log('Subscribed to Alive channel!')
+  }
+
+  private notify = (subscribers: Iterable<AliveStore>, event: AliveEvent) => {
+    console.log('Alive event received:', event)
+
+    if (event.type !== 'message') {
+      return
+    }
+
+    this.emitter.emit(this.ALIVE_EVENT_RECEIVED_EVENT, event)
+  }
+
+  public onNotificationReceived(callback: (event: AliveEvent) => void) {
+    this.emitter.on(this.ALIVE_EVENT_RECEIVED_EVENT, callback)
+  }
+}

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -101,6 +101,12 @@ export class AliveStore {
     this.subscriptions = this.subscriptions.filter(
       s => !accountEquals(s.account, account)
     )
+
+    this.sessionPerEndpoint.delete(account.endpoint)
+
+    // TODO: shutdown the session (close its websocket)
+
+    console.log('Unubscribed from Alive channel!')
   }
 
   private subscribeToAccount = async (account: Account) => {

--- a/app/src/lib/stores/api-repositories-store.ts
+++ b/app/src/lib/stores/api-repositories-store.ts
@@ -1,20 +1,8 @@
 import { BaseStore } from './base-store'
 import { AccountsStore } from './accounts-store'
 import { IAPIRepository, API } from '../api'
-import { Account } from '../../models/account'
+import { Account, accountEquals } from '../../models/account'
 import { merge } from '../merge'
-
-/**
- * Returns a value indicating whether two account instances
- * can be considered equal. Equality is determined by comparing
- * the two instances' endpoints and user id. This allows
- * us to keep receiving updated Account details from the API
- * while still maintaining the association between repositories
- * and a particular account.
- */
-function accountEquals(x: Account, y: Account) {
-  return x.endpoint === y.endpoint && x.id === y.id
-}
 
 /**
  * Attempt to look up an existing account in the account state

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -284,6 +284,7 @@ import { reorder } from '../git/reorder'
 import { DragAndDropIntroType } from '../../ui/history/drag-and-drop-intro'
 import { UseWindowsOpenSSHKey } from '../ssh/ssh'
 import { isConflictsFlow } from '../multi-commit-operation'
+import { AliveStore } from './alive-store'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -473,7 +474,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     private readonly repositoriesStore: RepositoriesStore,
     private readonly pullRequestCoordinator: PullRequestCoordinator,
     private readonly repositoryStateCache: RepositoryStateCache,
-    private readonly apiRepositoriesStore: ApiRepositoriesStore
+    private readonly apiRepositoriesStore: ApiRepositoriesStore,
+    private readonly aliveStore: AliveStore
   ) {
     super()
 
@@ -534,6 +536,17 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }, InitialRepositoryIndicatorTimeout)
 
     API.onTokenInvalidated(this.onTokenInvalidated)
+
+    this.aliveStore.onNotificationReceived(e => {
+      const eventData = e.data as any
+
+      const notification = new remote.Notification({
+        title: 'Notification from Alive',
+        body: eventData.reason,
+      })
+
+      notification.show()
+    })
   }
 
   private onTokenInvalidated = (endpoint: string) => {

--- a/app/src/models/account.ts
+++ b/app/src/models/account.ts
@@ -1,6 +1,18 @@
 import { getDotComAPIEndpoint, IAPIEmail } from '../lib/api'
 
 /**
+ * Returns a value indicating whether two account instances
+ * can be considered equal. Equality is determined by comparing
+ * the two instances' endpoints and user id. This allows
+ * us to keep receiving updated Account details from the API
+ * while still maintaining the association between repositories
+ * and a particular account.
+ */
+export function accountEquals(x: Account, y: Account) {
+  return x.endpoint === y.endpoint && x.id === y.id
+}
+
+/**
  * A GitHub account, representing the user found on GitHub The Website or GitHub Enterprise.
  *
  * This contains a token that will be used for operations that require authentication.

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -83,6 +83,7 @@ import {
   supportsSystemThemeChanges,
 } from './lib/application-theme'
 import { trampolineUIHelper } from '../lib/trampoline/trampoline-ui-helper'
+import { AliveStore } from '../lib/stores/alive-store'
 
 if (__DEV__) {
   installDevGlobals()
@@ -258,6 +259,8 @@ const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
 const commitStatusStore = new CommitStatusStore(accountsStore)
 const aheadBehindStore = new AheadBehindStore()
 
+const aliveStore = new AliveStore(accountsStore)
+
 const appStore = new AppStore(
   gitHubUserStore,
   cloningRepositoriesStore,
@@ -268,7 +271,8 @@ const appStore = new AppStore(
   repositoriesStore,
   pullRequestCoordinator,
   repositoryStateManager,
-  apiRepositoriesStore
+  apiRepositoriesStore,
+  aliveStore
 )
 
 appStore.onDidUpdate(state => {

--- a/app/test/unit/app-store-test.ts
+++ b/app/test/unit/app-store-test.ts
@@ -43,6 +43,7 @@ import { ApiRepositoriesStore } from '../../src/lib/stores/api-repositories-stor
 import { getStatusOrThrow } from '../helpers/status'
 import { AppFileStatusKind } from '../../src/models/status'
 import { ManualConflictResolution } from '../../src/models/manual-conflict-resolution'
+import { AliveStore } from '../../src/lib/stores/alive-store'
 
 // enable mocked version
 jest.mock('../../src/lib/window-state')
@@ -78,6 +79,8 @@ describe('AppStore', () => {
 
     const apiRepositoriesStore = new ApiRepositoriesStore(accountsStore)
 
+    const aliveStore = new AliveStore(accountsStore)
+
     const appStore = new AppStore(
       githubUserStore,
       new CloningRepositoriesStore(),
@@ -88,7 +91,8 @@ describe('AppStore', () => {
       repositoriesStore,
       pullRequestCoordinator,
       repositoryStateManager,
-      apiRepositoriesStore
+      apiRepositoriesStore,
+      aliveStore
     )
 
     return { appStore, repositoriesStore }

--- a/app/test/unit/app-test.tsx
+++ b/app/test/unit/app-test.tsx
@@ -30,6 +30,7 @@ import { RepositoryStateCache } from '../../src/lib/stores/repository-state-cach
 import { ApiRepositoriesStore } from '../../src/lib/stores/api-repositories-store'
 import { CommitStatusStore } from '../../src/lib/stores/commit-status-store'
 import { AheadBehindStore } from '../../src/lib/stores/ahead-behind-store'
+import { AliveStore } from '../../src/lib/stores/alive-store'
 
 describe('App', () => {
   let appStore: AppStore
@@ -74,6 +75,8 @@ describe('App', () => {
     const commitStatusStore = new CommitStatusStore(accountsStore)
     aheadBehindStore = new AheadBehindStore()
 
+    const aliveStore = new AliveStore(accountsStore)
+
     appStore = new AppStore(
       githubUserStore,
       new CloningRepositoriesStore(),
@@ -84,7 +87,8 @@ describe('App', () => {
       repositoriesStore,
       pullRequestCoordinator,
       repositoryStateManager,
-      apiRepositoriesStore
+      apiRepositoriesStore,
+      aliveStore
     )
 
     dispatcher = new InMemoryDispatcher(

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -16,6 +16,16 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@github/multimap@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@github/multimap/-/multimap-1.0.0.tgz#541bf212d088d1c2762691762d0017a84382cfba"
+  integrity sha512-7SQfzFHXSWXcSgKCvHAE2sG7ixseghr8W12VbnKDMY+NYN8t63Aq/l619xTIJMOM/1DHHej16m7WJlBXL/XYhA==
+
+"@github/stable-socket@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@github/stable-socket/-/stable-socket-1.1.0.tgz#b8598c02df1a935fb0c970252f0b0062f4bdaa29"
+  integrity sha512-kzLHnrWGvmXka7AIUnsyF+SO5dP4dxEXX2sMixXW5ngRf3i4RhvXzFNgXVy4qBKsIsg6V3fNb3NOto0z6o4XAw==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
## Description

This PR has the first steps to support real-time notifications. It mainly has an AliveStore that will handle the subscriptions when the user signs in/out from GH and GHE, as well as listen to the notifications.

There will probably be another component in charge of handling those notifications in case they require additional steps (like fetching the info of the checks from the API for a "checks failed" notification).

## Release notes

Notes: no-notes
