### PR TITLE
Rerun check run dialog

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -364,6 +364,8 @@ export interface IAPICheckSuite {
   readonly id: number
   readonly rerequestable: boolean
   readonly runs_rerequestable: boolean
+  readonly status: APICheckStatus
+  readonly created_at: string
 }
 
 export interface IAPIRefCheckRuns {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -360,6 +360,12 @@ export interface IAPIRefCheckRunCheckSuite {
   readonly id: number
 }
 
+export interface IAPICheckSuite {
+  readonly id: number
+  readonly rerequestable: boolean
+  readonly runs_rerequestable: boolean
+}
+
 export interface IAPIRefCheckRuns {
   readonly total_count: number
   readonly check_runs: IAPIRefCheckRun[]
@@ -1108,6 +1114,28 @@ export class API {
     }
 
     return false
+  }
+
+  /**
+   * Gets a single check suite using its id
+   */
+  public async fetchCheckSuite(
+    owner: string,
+    name: string,
+    checkSuiteId: number
+  ): Promise<IAPICheckSuite | null> {
+    const path = `/repos/${owner}/${name}/check-suites/${checkSuiteId}`
+    const response = await this.request('GET', path)
+
+    try {
+      return await parsedResponse<IAPICheckSuite>(response)
+    } catch (_) {
+      log.debug(
+        `[fetchCheckSuite] Failed fetch check suite id ${checkSuiteId} (${owner}/${name})`
+      )
+    }
+
+    return null
   }
 
   /**

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -440,7 +440,7 @@ export async function getLatestPRWorkflowRunsLogsForCheckRun(
  * @param branchName Name of the branch to which the check runs belong
  * @param checkRuns List of check runs to augment
  */
-export async function getCheckRunActionsJobsAndLogURLS(
+export async function getCheckRunActionsWorkflowRuns(
   api: API,
   owner: string,
   repo: string,
@@ -458,7 +458,7 @@ export async function getCheckRunActionsJobsAndLogURLS(
     return checkRuns
   }
 
-  return getCheckRunWithActionsJobAndLogURLs(checkRuns, latestWorkflowRuns)
+  return mapActionWorkflowsRunsToCheckRuns(checkRuns, latestWorkflowRuns)
 }
 
 // Gets only the latest PR workflow runs hashed by name
@@ -499,7 +499,7 @@ async function getLatestPRWorkflowRuns(
   return Array.from(wrMap.values())
 }
 
-function getCheckRunWithActionsJobAndLogURLs(
+function mapActionWorkflowsRunsToCheckRuns(
   checkRuns: ReadonlyArray<IRefCheck>,
   actionWorkflowRuns: ReadonlyArray<IAPIWorkflowRun>
 ): ReadonlyArray<IRefCheck> {

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -19,7 +19,7 @@ import {
   getLatestCheckRunsByName,
   apiStatusToRefCheck,
   getLatestPRWorkflowRunsLogsForCheckRun,
-  getCheckRunActionsJobsAndLogURLS,
+  getCheckRunActionsWorkflowRuns,
 } from '../ci-checks/ci-checks'
 
 interface ICommitStatusCacheEntry {
@@ -401,10 +401,10 @@ export class CommitStatusStore {
   }
 
   /**
-   * Retrieve GitHub Actions workflows and populates the job and log url if
-   * applicable to the checkruns
+   * Retrieve GitHub Actions workflows and maps them to the check runs if
+   * applicable
    */
-  public async getCheckRunActionsJobsAndLogURLS(
+  public async getCheckRunActionsWorkflowRuns(
     repository: GitHubRepository,
     ref: string,
     branchName: string,
@@ -423,7 +423,7 @@ export class CommitStatusStore {
     }
 
     const api = API.fromAccount(account)
-    return getCheckRunActionsJobsAndLogURLS(
+    return getCheckRunActionsWorkflowRuns(
       api,
       owner,
       name,

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -4,7 +4,7 @@ import QuickLRU from 'quick-lru'
 import { Account } from '../../models/account'
 import { AccountsStore } from './accounts-store'
 import { GitHubRepository } from '../../models/github-repository'
-import { API, getAccountForEndpoint } from '../api'
+import { API, getAccountForEndpoint, IAPICheckSuite } from '../api'
 import { IDisposable, Disposable } from 'event-kit'
 import {
   ICombinedRefCheck,
@@ -427,5 +427,19 @@ export class CommitStatusStore {
 
     const api = API.fromAccount(account)
     return api.rerequestCheckSuite(owner.login, name, checkSuiteId)
+  }
+
+  public async fetchCheckSuite(
+    repository: GitHubRepository,
+    checkSuiteId: number
+  ): Promise<IAPICheckSuite | null> {
+    const { owner, name } = repository
+    const account = getAccountForEndpoint(this.accounts, repository.endpoint)
+    if (account === null) {
+      return null
+    }
+
+    const api = API.fromAccount(account)
+    return api.fetchCheckSuite(owner.login, name, checkSuiteId)
   }
 }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -19,6 +19,7 @@ import { RepositorySettingsTab } from '../ui/repository-settings/repository-sett
 import { ICommitMessage } from './commit-message'
 import { IAuthor } from './author'
 import { IRefCheck } from '../lib/ci-checks/ci-checks'
+import { GitHubRepository } from './github-repository'
 
 export enum PopupType {
   RenameBranch = 1,
@@ -77,6 +78,7 @@ export enum PopupType {
   AddSSHHost,
   SSHKeyPassphrase,
   PullRequestChecksFailed,
+  CICheckRunRerun,
 }
 
 export type Popup =
@@ -319,4 +321,9 @@ export type Popup =
       commitMessage: string
       commitSha: string
       checks: ReadonlyArray<IRefCheck>
+    }
+  | {
+      type: PopupType.CICheckRunRerun
+      checkRuns: ReadonlyArray<IRefCheck>
+      repository: GitHubRepository
     }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -326,4 +326,5 @@ export type Popup =
       type: PopupType.CICheckRunRerun
       checkRuns: ReadonlyArray<IRefCheck>
       repository: GitHubRepository
+      prRef: string
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2074,6 +2074,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             checkRuns={popup.checkRuns}
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
+            prRef={popup.prRef}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -143,6 +143,7 @@ import { SSHKeyPassphrase } from './ssh/ssh-key-passphrase'
 import { getMultiCommitOperationChooseBranchStep } from '../lib/multi-commit-operation'
 import { ConfirmForcePush } from './rebase/confirm-force-push'
 import { PullRequestChecksFailed } from './notifications/pull-request-checks-failed'
+import { CICheckRunRerunDialog } from './check-runs/ci-check-run-rerun-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2062,6 +2063,17 @@ export class App extends React.Component<IAppProps, IAppState> {
             checks={popup.checks}
             accounts={this.state.accounts}
             onSubmit={onPopupDismissedFn}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.CICheckRunRerun: {
+        return (
+          <CICheckRunRerunDialog
+            key="rerun-check-runs"
+            checkRuns={popup.checkRuns}
+            dispatcher={this.props.dispatcher}
+            repository={popup.repository}
             onDismissed={onPopupDismissedFn}
           />
         )

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -32,7 +32,7 @@ interface ICICheckRunListItemProps {
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
   /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
-  readonly onViewCheckExternally: (checkRun: IRefCheck) => void
+  readonly onViewCheckExternally?: (checkRun: IRefCheck) => void
 
   /** Callback to open a job steps link on dotcom*/
   readonly onViewJobStep?: (
@@ -50,7 +50,7 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private onViewCheckExternally = () => {
-    this.props.onViewCheckExternally(this.props.checkRun)
+    this.props.onViewCheckExternally?.(this.props.checkRun)
   }
 
   private onViewJobStep = (step: IAPIWorkflowJobStep) => {
@@ -104,7 +104,14 @@ export class CICheckRunListItem extends React.PureComponent<
           tagName="div"
           direction={TooltipDirection.NORTH}
         >
-          <span onClick={this.onViewCheckExternally}>{name}</span>
+          <span
+            className={classNames({
+              isLink: this.props.onViewCheckExternally !== undefined,
+            })}
+            onClick={this.onViewCheckExternally}
+          >
+            {name}
+          </span>
         </TooltippedContent>
 
         <div className="ci-check-description">{description}</div>

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -66,10 +66,7 @@ export class CICheckRunList extends React.PureComponent<
   ): ICICheckRunListState {
     let checkRunExpanded = currentState?.checkRunExpanded ?? null
 
-    if (
-      (currentState === null || !currentState.hasUserToggledCheckRun) &&
-      !this.props.notExpandable
-    ) {
+    if (currentState?.hasUserToggledCheckRun !== true && !this.props.notExpandable) {
       // If there is a failure, we want the first check run with a failure, to
       // be opened so the user doesn't have to click through to find it.
       // Otherwise, just open the first one. (Only actions type can be expanded.)

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -22,6 +22,9 @@ interface ICICheckRunListProps {
   /** Whether check runs can be selected. Default: false */
   readonly selectable?: boolean
 
+  /** Whether check runs can be expanded. Default: false */
+  readonly notExpandable?: boolean
+
   /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
   readonly onViewCheckDetails?: (checkRun: IRefCheck) => void
 
@@ -63,7 +66,10 @@ export class CICheckRunList extends React.PureComponent<
   ): ICICheckRunListState {
     let checkRunExpanded = currentState?.checkRunExpanded ?? null
 
-    if (currentState === null || !currentState.hasUserToggledCheckRun) {
+    if (
+      (currentState === null || !currentState.hasUserToggledCheckRun) &&
+      !this.props.notExpandable
+    ) {
       // If there is a failure, we want the first check run with a failure, to
       // be opened so the user doesn't have to click through to find it.
       // Otherwise, just open the first one. (Only actions type can be expanded.)
@@ -82,6 +88,10 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   private onCheckRunClick = (checkRun: IRefCheck): void => {
+    if (this.props.notExpandable === true) {
+      return
+    }
+
     // If the list is selectable, we don't want to toggle when the selected
     // item is clicked again.
     const checkRunExpanded =

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -98,10 +98,6 @@ export class CICheckRunList extends React.PureComponent<
     this.props.onCheckRunClick?.(checkRun)
   }
 
-  private onViewCheckExternally = (checkRun: IRefCheck) => {
-    this.props.onViewCheckDetails?.(checkRun)
-  }
-
   private renderListItems = (
     checkRuns: ReadonlyArray<IRefCheck> | undefined
   ) => {
@@ -127,7 +123,7 @@ export class CICheckRunList extends React.PureComponent<
             // Only expand check runs if the list is not selectable
             isCheckRunExpanded={!selectable && checkRunExpanded}
             onCheckRunExpansionToggleClick={this.onCheckRunClick}
-            onViewCheckExternally={this.onViewCheckExternally}
+            onViewCheckExternally={this.props.onViewCheckDetails}
             onViewJobStep={this.props.onViewJobStep}
           />
         )

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -23,7 +23,7 @@ interface ICICheckRunListProps {
   readonly selectable?: boolean
 
   /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
-  readonly onViewCheckDetails: (checkRun: IRefCheck) => void
+  readonly onViewCheckDetails?: (checkRun: IRefCheck) => void
 
   /** Callback when a check run is clicked */
   readonly onCheckRunClick?: (checkRun: IRefCheck) => void
@@ -98,6 +98,10 @@ export class CICheckRunList extends React.PureComponent<
     this.props.onCheckRunClick?.(checkRun)
   }
 
+  private onViewCheckExternally = (checkRun: IRefCheck) => {
+    this.props.onViewCheckDetails?.(checkRun)
+  }
+
   private renderListItems = (
     checkRuns: ReadonlyArray<IRefCheck> | undefined
   ) => {
@@ -123,7 +127,7 @@ export class CICheckRunList extends React.PureComponent<
             // Only expand check runs if the list is not selectable
             isCheckRunExpanded={!selectable && checkRunExpanded}
             onCheckRunExpansionToggleClick={this.onCheckRunClick}
-            onViewCheckExternally={this.props.onViewCheckDetails}
+            onViewCheckExternally={this.onViewCheckExternally}
             onViewJobStep={this.props.onViewJobStep}
           />
         )

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -174,7 +174,7 @@ export class CICheckRunPopover extends React.PureComponent<
       that we know we can go ahead and display the checkrun `output` content if
       a check run does not have action logs to retrieve/parse.
     */
-    const checkRunsWithActionsUrls = await this.props.dispatcher.getCheckRunActionsJobsAndLogURLS(
+    const checkRunsWithActionsUrls = await this.props.dispatcher.getCheckRunActionsWorkflowRuns(
       this.props.repository,
       this.getCommitRef(this.props.prNumber),
       this.props.branchName,

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -305,7 +305,7 @@ export class CICheckRunPopover extends React.PureComponent<
         onClick={this.rerunJobs}
         disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
       >
-        <Octicon symbol={syncClockwise} /> Re-run jobs
+        <Octicon symbol={syncClockwise} /> Re-run checks
       </Button>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -168,11 +168,7 @@ export class CICheckRunPopover extends React.PureComponent<
 
     /*
       Until we retrieve the actions workflows, we don't know if a check run has
-      action logs to output, thus, we want to show loading until then. However,
-      once the workflows have been retrieved and since the logs retrieval and
-      parsing can be noticeably time consuming. We go ahead and flip a flag so
-      that we know we can go ahead and display the checkrun `output` content if
-      a check run does not have action logs to retrieve/parse.
+      action logs to output, thus, we want to show loading until then.
     */
     const checkRunsWithActionsUrls = await this.props.dispatcher.getCheckRunActionsWorkflowRuns(
       this.props.repository,

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -15,6 +15,7 @@ import { Popover, PopoverCaretPosition } from '../lib/popover'
 import { CICheckRunList } from './ci-check-run-list'
 import _ from 'lodash'
 import { encodePathAsUrl } from '../../lib/path'
+import { PopupType } from '../../models/popup'
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
   'static/empty-no-pull-requests.svg'
@@ -276,10 +277,11 @@ export class CICheckRunPopover extends React.PureComponent<
   }
 
   private rerunJobs = () => {
-    this.props.dispatcher.rerequestCheckSuites(
-      this.props.repository,
-      this.state.checkRuns
-    )
+    this.props.dispatcher.showPopup({
+      type: PopupType.CICheckRunRerun,
+      checkRuns: this.state.checkRuns,
+      repository: this.props.repository,
+    })
   }
 
   private getPopoverPositioningStyles = (): React.CSSProperties => {

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -276,11 +276,12 @@ export class CICheckRunPopover extends React.PureComponent<
     return `${summaryArray[0].count} ${summaryArray[0].conclusion} ${pluralize}`
   }
 
-  private rerunJobs = () => {
+  private rerunChecks = () => {
     this.props.dispatcher.showPopup({
       type: PopupType.CICheckRunRerun,
       checkRuns: this.state.checkRuns,
       repository: this.props.repository,
+      prRef: this.getCommitRef(this.props.prNumber),
     })
   }
 
@@ -302,7 +303,7 @@ export class CICheckRunPopover extends React.PureComponent<
     const { checkRuns } = this.state
     return (
       <Button
-        onClick={this.rerunJobs}
+        onClick={this.rerunChecks}
         disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
       >
         <Octicon symbol={syncClockwise} /> Re-run checks

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -301,7 +301,10 @@ export class CICheckRunPopover extends React.PureComponent<
   private renderRerunButton = () => {
     const { checkRuns } = this.state
     return (
-      <Button onClick={this.rerunJobs} disabled={checkRuns.length === 0}>
+      <Button
+        onClick={this.rerunJobs}
+        disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
+      >
         <Octicon symbol={syncClockwise} /> Re-run jobs
       </Button>
     )

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -156,7 +156,7 @@ export class CICheckRunRerunDialog extends React.Component<
     return (
       <Dialog
         id="rerun-check-runs"
-        title={__DARWIN__ ? 'Re-run checks' : 'Re-run checks'}
+        title={__DARWIN__ ? 'Re-run Checks' : 'Re-run checks'}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={this.state.loadingCheckSuites || this.state.loadingRerun}

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { IRefCheck } from '../../lib/ci-checks/ci-checks'
+import { CICheckRunList } from './ci-check-run-list'
+import { GitHubRepository } from '../../models/github-repository'
+import { Dispatcher } from '../dispatcher'
+
+interface ICICheckRunRerunDialogProps {
+  readonly dispatcher: Dispatcher
+  readonly repository: GitHubRepository
+  /** List of all the check runs (some of which are not rerunnable) */
+  readonly checkRuns: ReadonlyArray<IRefCheck>
+  readonly onDismissed: () => void
+}
+
+/**
+ * Dialog that informs the user of which jobs will be rerun
+ */
+export class CICheckRunRerunDialog extends React.Component<
+  ICICheckRunRerunDialogProps
+> {
+  public constructor(props: ICICheckRunRerunDialogProps) {
+    super(props)
+  }
+
+  private onSubmit = async () => {
+    // TODO: filter to only rerunable jobs
+    this.props.dispatcher.rerequestCheckSuites(
+      this.props.repository,
+      this.props.checkRuns
+    )
+  }
+
+  private renderRerunnableJobsList = () => {
+    // TODO: Only display rerunable jobs
+    // Display a note about how many jobs were not rerunable, or toggle the list?
+    return (
+      <div className="ci-check-run-list check-run-rerun-list">
+        <CICheckRunList
+          checkRuns={this.props.checkRuns}
+          loadingActionLogs={false}
+          loadingActionWorkflows={false}
+        />
+      </div>
+    )
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="rerun-check-runs"
+        title={__DARWIN__ ? 'Re-run Jobs' : 'Re-run jobs'}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>{this.renderRerunnableJobsList()}</DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? 'Re-run Jobs' : 'Re-run jobs'}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+}

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -89,17 +89,21 @@ export class CICheckRunRerunDialog extends React.Component<
     }
 
     return (
-      <div className="ci-check-run-list check-run-rerun-list">
-        <CICheckRunList
-          checkRuns={this.state.rerunnable}
-          loadingActionLogs={false}
-          loadingActionWorkflows={false}
-          selectable={true}
-        />
-        <div>
-          There are {this.state.nonRerunnable.length} jobs that cannot be rerun.
+      <>
+        <div className="non-re-run-info">
+          There are {this.state.nonRerunnable.length} checks that cannot be
+          rerun. The following checks that will be rerun.
         </div>
-      </div>
+
+        <div className="ci-check-run-list check-run-rerun-list">
+          <CICheckRunList
+            checkRuns={this.state.rerunnable}
+            loadingActionLogs={false}
+            loadingActionWorkflows={false}
+            selectable={true}
+          />
+        </div>
+      </>
     )
   }
 
@@ -107,14 +111,14 @@ export class CICheckRunRerunDialog extends React.Component<
     return (
       <Dialog
         id="rerun-check-runs"
-        title={__DARWIN__ ? 'Re-run Jobs' : 'Re-run jobs'}
+        title={__DARWIN__ ? 'Re-run checks' : 'Re-run checks'}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
       >
         <DialogContent>{this.renderRerunnableJobsList()}</DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
-            okButtonText={__DARWIN__ ? 'Re-run Jobs' : 'Re-run jobs'}
+            okButtonText={__DARWIN__ ? 'Re-run checks' : 'Re-run checks'}
           />
         </DialogFooter>
       </Dialog>

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -5,7 +5,8 @@ import { IRefCheck } from '../../lib/ci-checks/ci-checks'
 import { CICheckRunList } from './ci-check-run-list'
 import { GitHubRepository } from '../../models/github-repository'
 import { Dispatcher } from '../dispatcher'
-import { IAPICheckSuite } from '../../lib/api'
+import { APICheckStatus, IAPICheckSuite } from '../../lib/api'
+import moment from 'moment'
 
 interface ICICheckRunRerunDialogProps {
   readonly dispatcher: Dispatcher
@@ -64,7 +65,13 @@ export class CICheckRunRerunDialog extends React.Component<
         continue
       }
 
-      if (cs.rerequestable) {
+      const created = moment(cs.created_at)
+      const monthsSinceCreated = moment().diff(created, 'months')
+      if (
+        cs.rerequestable &&
+        monthsSinceCreated < 1 && // Must be less than a month old
+        cs.status === APICheckStatus.Completed // Must be completed
+      ) {
         rerequestableCheckSuiteIds.push(cs.id)
       }
     }

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -11,8 +11,13 @@ import moment from 'moment'
 interface ICICheckRunRerunDialogProps {
   readonly dispatcher: Dispatcher
   readonly repository: GitHubRepository
+
   /** List of all the check runs (some of which are not rerunnable) */
   readonly checkRuns: ReadonlyArray<IRefCheck>
+
+  /** The git reference of the pr */
+  readonly prRef: string
+
   readonly onDismissed: () => void
 }
 
@@ -42,10 +47,15 @@ export class CICheckRunRerunDialog extends React.Component<
   }
 
   private onSubmit = async () => {
-    this.props.dispatcher.rerequestCheckSuites(
-      this.props.repository,
+    const { dispatcher, repository, prRef } = this.props
+    this.setState({ loadingRerun: true })
+    await dispatcher.rerequestCheckSuites(repository, this.state.rerunnable)
+    await dispatcher.manualRefreshSubscription(
+      repository,
+      prRef,
       this.state.rerunnable
     )
+    this.props.onDismissed()
   }
 
   private determineRerunnability = async () => {

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -121,7 +121,7 @@ export class CICheckRunRerunDialog extends React.Component<
             checkRuns={this.state.rerunnable}
             loadingActionLogs={false}
             loadingActionWorkflows={false}
-            selectable={true}
+            notExpandable={true}
           />
         ) : null}
       </div>

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -165,7 +165,7 @@ export class CICheckRunRerunDialog extends React.Component<
         <DialogFooter>
           {this.renderRerunInfo()}
           <OkCancelButtonGroup
-            okButtonText={__DARWIN__ ? 'Re-run checks' : 'Re-run checks'}
+            okButtonText={__DARWIN__ ? 'Re-run Checks' : 'Re-run checks'}
             okButtonDisabled={this.state.rerunnable.length === 0}
           />
         </DialogFooter>

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -140,13 +140,13 @@ export class CICheckRunRerunDialog extends React.Component<
         <Octicon symbol={OcticonSymbol.alert} />
 
         {this.state.rerunnable.length === 0
-          ? `There are no checks that can be rerun. `
-          : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be rerun. `}
+          ? `There are no checks that can be re-run. `
+          : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be re-run. `}
 
         {this.state.nonRerunnable.length > 0
-          ? `A check run cannot be rerun if the check is more than one month old,
+          ? `A check run cannot be re-run if the check is more than one month old,
           the check has not completed, or the check is not configured to be
-          rerun.`
+          re-run.`
           : null}
       </Row>
     )

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -111,35 +111,38 @@ export class CICheckRunRerunDialog extends React.Component<
       return <>Please wait. Determining which checks can be rerun.</>
     }
 
+    return (
+      <div className="ci-check-run-list check-run-rerun-list">
+        {this.state.rerunnable.length > 0 ? (
+          <CICheckRunList
+            checkRuns={this.state.rerunnable}
+            loadingActionLogs={false}
+            loadingActionWorkflows={false}
+            selectable={true}
+          />
+        ) : null}
+      </div>
+    )
+  }
+
+  private renderRerunInfo = () => {
+    if (this.state.loadingCheckSuites) {
+      return null
+    }
+
     const pluralize = `check${this.state.nonRerunnable.length !== 1 ? 's' : ''}`
     const verb = this.state.nonRerunnable.length !== 1 ? 'are' : 'is'
     return (
-      <>
-        <div className="non-re-run-info">
-          {this.state.rerunnable.length === 0
-            ? `There are no checks that can be rerun. `
-            : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be rerun. `}
-          {this.state.nonRerunnable.length > 0
-            ? `A check run cannot be rerun if the check is more than one month old,
+      <div className="non-re-run-info">
+        {this.state.rerunnable.length === 0
+          ? `There are no checks that can be rerun. `
+          : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be rerun. `}
+        {this.state.nonRerunnable.length > 0
+          ? `A check run cannot be rerun if the check is more than one month old,
           the check has not completed, or the check is not configured to be
-          rerun. `
-            : null}
-          {this.state.rerunnable.length > 0
-            ? 'The following checks will be rerun.'
-            : null}
-        </div>
-
-        <div className="ci-check-run-list check-run-rerun-list">
-          {this.state.rerunnable.length > 0 ? (
-            <CICheckRunList
-              checkRuns={this.state.rerunnable}
-              loadingActionLogs={false}
-              loadingActionWorkflows={false}
-              selectable={true}
-            />
-          ) : null}
-        </div>
-      </>
+          rerun.`
+          : null}
+      </div>
     )
   }
 
@@ -154,6 +157,7 @@ export class CICheckRunRerunDialog extends React.Component<
       >
         <DialogContent>{this.renderRerunnableJobsList()}</DialogContent>
         <DialogFooter>
+          {this.renderRerunInfo()}
           <OkCancelButtonGroup
             okButtonText={__DARWIN__ ? 'Re-run checks' : 'Re-run checks'}
             okButtonDisabled={this.state.rerunnable.length === 0}

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -7,6 +7,9 @@ import { GitHubRepository } from '../../models/github-repository'
 import { Dispatcher } from '../dispatcher'
 import { APICheckStatus, IAPICheckSuite } from '../../lib/api'
 import moment from 'moment'
+import { Octicon } from '../octicons'
+import * as OcticonSymbol from './../octicons/octicons.generated'
+import { Row } from '../lib/row'
 
 interface ICICheckRunRerunDialogProps {
   readonly dispatcher: Dispatcher
@@ -133,16 +136,19 @@ export class CICheckRunRerunDialog extends React.Component<
     const pluralize = `check${this.state.nonRerunnable.length !== 1 ? 's' : ''}`
     const verb = this.state.nonRerunnable.length !== 1 ? 'are' : 'is'
     return (
-      <div className="non-re-run-info">
+      <Row className="non-re-run-info warning-helper-text">
+        <Octicon symbol={OcticonSymbol.alert} />
+
         {this.state.rerunnable.length === 0
           ? `There are no checks that can be rerun. `
           : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be rerun. `}
+
         {this.state.nonRerunnable.length > 0
           ? `A check run cannot be rerun if the check is more than one month old,
           the check has not completed, or the check is not configured to be
           rerun.`
           : null}
-      </div>
+      </Row>
     )
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2447,15 +2447,16 @@ export class Dispatcher {
   }
 
   /**
-   * Populates Actions workflow log and job url's for provided checkruns if applicable
+   * Retrieve GitHub Actions workflows and maps them to the check runs if
+   * applicable
    */
-  public getCheckRunActionsJobsAndLogURLS(
+  public getCheckRunActionsWorkflowRuns(
     repository: GitHubRepository,
     ref: string,
     branchName: string,
     checkRuns: ReadonlyArray<IRefCheck>
   ): Promise<ReadonlyArray<IRefCheck>> {
-    return this.commitStatusStore.getCheckRunActionsJobsAndLogURLS(
+    return this.commitStatusStore.getCheckRunActionsWorkflowRuns(
       repository,
       ref,
       branchName,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -5,6 +5,7 @@ import {
   IAPIOrganization,
   IAPIPullRequest,
   IAPIFullRepository,
+  IAPICheckSuite,
 } from '../../lib/api'
 import { shell } from '../../lib/app-shell'
 import {
@@ -2470,6 +2471,16 @@ export class Dispatcher {
     }
 
     await Promise.all(promises)
+  }
+
+  /**
+   * Gets a single check suite using its id
+   */
+  public async fetchCheckSuite(
+    repository: GitHubRepository,
+    checkSuiteId: number
+  ): Promise<IAPICheckSuite | null> {
+    return this.commitStatusStore.fetchCheckSuite(repository, checkSuiteId)
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2417,6 +2417,21 @@ export class Dispatcher {
   }
 
   /**
+   * Invoke a manual refresh of the status for a particular ref
+   */
+  public manualRefreshSubscription(
+    repository: GitHubRepository,
+    ref: string,
+    pendingChecks: ReadonlyArray<IRefCheck>
+  ): Promise<void> {
+    return this.commitStatusStore.manualRefreshSubscription(
+      repository,
+      ref,
+      pendingChecks
+    )
+  }
+
+  /**
    * Populates Actions workflow logs for provided checkruns if applicable
    */
   public getActionsWorkflowRunLogs(
@@ -2455,7 +2470,7 @@ export class Dispatcher {
   public async rerequestCheckSuites(
     repository: GitHubRepository,
     checkRuns: ReadonlyArray<IRefCheck>
-  ): Promise<void> {
+  ): Promise<ReadonlyArray<boolean>> {
     // Get unique set of check suite ids
     const checkSuiteIds = new Set<number | null>([
       ...checkRuns.map(cr => cr.checkSuiteId),
@@ -2470,7 +2485,7 @@ export class Dispatcher {
       promises.push(this.commitStatusStore.rerequestCheckSuite(repository, id))
     }
 
-    await Promise.all(promises)
+    return Promise.all(promises)
   }
 
   /**

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -271,14 +271,14 @@ export class PullRequestChecksFailed extends React.Component<
     const { checks } = this.state
     return (
       <div className="ci-check-rerun">
-        <Button onClick={this.rerunJobs} disabled={checks.length === 0}>
+        <Button onClick={this.rerunChecks} disabled={checks.length === 0}>
           <Octicon symbol={syncClockwise} /> Re-run checks
         </Button>
       </div>
     )
   }
 
-  private rerunJobs = () => {
+  private rerunChecks = () => {
     this.props.dispatcher.rerequestCheckSuites(
       this.props.repository.gitHubRepository,
       this.state.checks

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -272,7 +272,7 @@ export class PullRequestChecksFailed extends React.Component<
     return (
       <div className="ci-check-rerun">
         <Button onClick={this.rerunJobs} disabled={checks.length === 0}>
-          <Octicon symbol={syncClockwise} /> Re-run jobs
+          <Octicon symbol={syncClockwise} /> Re-run checks
         </Button>
       </div>
     )

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -8,7 +8,7 @@ import { CICheckRunList } from '../check-runs/ci-check-run-list'
 import {
   IRefCheck,
   getLatestPRWorkflowRunsLogsForCheckRun,
-  getCheckRunActionsJobsAndLogURLS,
+  getCheckRunActionsWorkflowRuns,
   isFailure,
   getCheckRunStepURL,
 } from '../../lib/ci-checks/ci-checks'
@@ -311,7 +311,7 @@ export class PullRequestChecksFailed extends React.Component<
       that we know we can go ahead and display the checkrun `output` content if
       a check run does not have action logs to retrieve/parse.
     */
-    const checkRunsWithActionsUrls = await getCheckRunActionsJobsAndLogURLS(
+    const checkRunsWithActionsUrls = await getCheckRunActionsWorkflowRuns(
       api,
       gitHubRepository.owner.login,
       gitHubRepository.name,

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -243,11 +243,12 @@ export class BranchDropdown extends React.Component<
 
     const { target } = event
     const prBadgeElem = document.getElementById('pr-badge')
+    const rerunDialog = document.getElementById('rerun-check-runs')
     if (
-      prBadgeElem !== null &&
       target !== null &&
       target instanceof Node &&
-      prBadgeElem.contains(target)
+      ((prBadgeElem !== null && prBadgeElem.contains(target)) ||
+        (rerunDialog !== null && rerunDialog.contains(target)))
     ) {
       return
     }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -18,6 +18,7 @@
 @import 'dialogs/thank-you';
 @import 'dialogs/commit-message';
 @import 'dialogs/choose-branch';
+@import 'dialogs/ci-check-run-rerun';
 
 // The styles herein attempt to follow a flow where margins are only applied
 // to the bottom of elements (with the exception of the last child). This to

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -11,14 +11,14 @@
     z-index: var(--list-sticky-header-second-level-z-index);
   }
 
-  &.selected .ci-check-name span {
+  &.selected .ci-check-name span.isLink {
     &:hover {
       color: var(--link-button-selected-hover-color);
       cursor: pointer !important;
     }
   }
 
-  &:not(.selected) .ci-check-name span {
+  &:not(.selected) .ci-check-name span.isLink {
     &:hover {
       color: var(--link-button-color);
       cursor: pointer !important;

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -7,7 +7,7 @@
     max-height: 300px;
 
     .ci-check-run-list-group-header {
-      padding-left: var(--spacing-double);
+      padding-left: 15px;
     }
 
     .ci-check-list-item {

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -1,0 +1,7 @@
+#rerun-check-runs {
+  .check-run-rerun-list {
+    max-height: 300px;
+    border: var(--base-border);
+    border-radius: var(--border-radius);
+  }
+}

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -5,11 +5,18 @@
 
   .check-run-rerun-list {
     max-height: 300px;
+
+    .ci-check-run-list-group-header {
+      padding-left: var(--spacing-double);
+    }
+
+    .ci-check-list-item {
+      padding-left: var(--spacing);
+    }
   }
 
   .non-re-run-info {
-    padding: var(--spacing);
-    border-bottom: var(--base-border);
+    padding-bottom: var(--spacing-double);
     max-width: 400px;
   }
 }

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -10,5 +10,6 @@
   .non-re-run-info {
     padding: var(--spacing);
     border-bottom: var(--base-border);
+    max-width: 400px;
   }
 }

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -1,7 +1,14 @@
 #rerun-check-runs {
+  .dialog-content {
+    padding: 0;
+  }
+
   .check-run-rerun-list {
     max-height: 300px;
-    border: var(--base-border);
-    border-radius: var(--border-radius);
+  }
+
+  .non-re-run-info {
+    padding: var(--spacing);
+    border-bottom: var(--base-border);
   }
 }

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -16,7 +16,7 @@
   }
 
   .non-re-run-info {
-    padding-bottom: var(--spacing-double);
     max-width: 400px;
+    margin-bottom: var(--spacing-double);
   }
 }


### PR DESCRIPTION
## Description

A dialog to communicate to users which check runs will be rerun as not all check runs can be.

Something left to figure out.. Currently, if you have a check job steps expanded and then hit rerun. It manually updates the check statuses to pending, but this triggers a check job step retrieval.. but it is too fast and just retrieves the stale job steps.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/143092570-5484c142-f2ee-4565-9b8c-162e572a2773.png)

## Release notes
Notes: [Improved] Added rerun check dialog to know which checks will be rerun.
