### PR TITLE
Allow amending pushed commits

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -540,8 +540,8 @@ export interface IBranchesState {
    */
   readonly pullWithRebase?: boolean
 
-  /** Tracking branches that have been rebased within Desktop */
-  readonly rebasedBranches: ReadonlyMap<string, string>
+  /** Tracking branches that have been allowed to be force-pushed within Desktop */
+  readonly forcePushBranches: ReadonlyMap<string, string>
 }
 
 export interface ICommitSelection {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -447,8 +447,8 @@ export interface IRepositoryState {
   /** Is a commit in progress? */
   readonly isCommitting: boolean
 
-  /** Is an amend in progress? */
-  readonly isAmending: boolean
+  /** Commit being amended, or null if none. */
+  readonly commitToAmend: Commit | null
 
   /** The date the repository was last fetched. */
   readonly lastFetched: Date | null

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -10,6 +10,7 @@ import { stageManualConflictResolution } from './stage'
  * @param repository repository to execute merge in
  * @param message commit message
  * @param files files to commit
+ * @returns the commit SHA
  */
 export async function createCommit(
   repository: Repository,

--- a/app/src/lib/rebase.ts
+++ b/app/src/lib/rebase.ts
@@ -25,16 +25,16 @@ export function isCurrentBranchForcePush(
     return false
   }
 
-  const { tip, rebasedBranches } = branchesState
+  const { tip, forcePushBranches } = branchesState
   const { ahead, behind } = aheadBehind
 
-  let branchWasRebased = false
+  let canForcePushBranch = false
   if (tip.kind === TipState.Valid) {
     const localBranchName = tip.branch.nameWithoutRemote
     const { sha } = tip.branch.tip
-    const foundEntry = rebasedBranches.get(localBranchName)
-    branchWasRebased = foundEntry === sha
+    const foundEntry = forcePushBranches.get(localBranchName)
+    canForcePushBranch = foundEntry === sha
   }
 
-  return branchWasRebased && behind > 0 && ahead > 0
+  return canForcePushBranch && behind > 0 && ahead > 0
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -2672,7 +2672,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
         this.repositoryStateCache.update(repository, () => {
           return {
-            isAmending: false,
+            commitToAmend: null,
           }
         })
 
@@ -4268,10 +4268,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this._refreshRepository(repository)
   }
 
-  public _setAmendingRepository(repository: Repository, amending: boolean) {
+  public _setRepositoryCommitToAmend(
+    repository: Repository,
+    commit: Commit | null
+  ) {
     this.repositoryStateCache.update(repository, () => {
       return {
-        isAmending: amending,
+        commitToAmend: commit,
       }
     })
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -45,21 +45,22 @@ export class RepositoryStateCache {
     const newValues = fn(currentState)
     const newState = merge(currentState, newValues)
 
-    const isSameLastLocalCommit =
-      currentState.localCommitSHAs.length > 0 &&
-      newState.localCommitSHAs.length > 0 &&
-      currentState.localCommitSHAs[0] === newState.localCommitSHAs[0]
+    const currentTip = currentState.branchesState.tip
+    const newTip = newState.branchesState.tip
 
-    // Only keep the "is amending" state if the last local commit hasn't changed
-    // and there is no "fixing conflicts" state.
-    const newIsAmending =
-      newState.isAmending &&
-      isSameLastLocalCommit &&
+    // Only keep the "is amending" state if the head commit hasn't changed, it
+    // matches the commit to amend, and there is no "fixing conflicts" state.
+    const isAmending =
+      newState.commitToAmend !== null &&
+      newTip.kind === TipState.Valid &&
+      currentTip.kind === TipState.Valid &&
+      currentTip.branch.tip.sha === newTip.branch.tip.sha &&
+      newTip.branch.tip.sha === newState.commitToAmend.sha &&
       newState.changesState.conflictState === null
 
     this.repositoryState.set(repository.hash, {
       ...newState,
-      isAmending: newIsAmending,
+      commitToAmend: isAmending ? newState.commitToAmend : null,
     })
   }
 
@@ -222,7 +223,7 @@ function getInitialRepositoryState(): IRepositoryState {
     remote: null,
     isPushPullFetchInProgress: false,
     isCommitting: false,
-    isAmending: false,
+    commitToAmend: null,
     lastFetched: null,
     checkoutProgress: null,
     pushPullFetchProgress: null,

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -199,7 +199,7 @@ function getInitialRepositoryState(): IRepositoryState {
       openPullRequests: new Array<PullRequest>(),
       currentPullRequest: null,
       isLoadingPullRequests: false,
-      rebasedBranches: new Map<string, string>(),
+      forcePushBranches: new Map<string, string>(),
     },
     compareState: {
       formState: {

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -77,6 +77,7 @@ export enum PopupType {
   AddSSHHost,
   SSHKeyPassphrase,
   PullRequestChecksFailed,
+  WarnForcePush,
 }
 
 export type Popup =
@@ -319,4 +320,9 @@ export type Popup =
       commitMessage: string
       commitSha: string
       checks: ReadonlyArray<IRefCheck>
+    }
+  | {
+      type: PopupType.WarnForcePush
+      operation: string
+      onBegin: () => void
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -143,6 +143,7 @@ import { SSHKeyPassphrase } from './ssh/ssh-key-passphrase'
 import { getMultiCommitOperationChooseBranchStep } from '../lib/multi-commit-operation'
 import { ConfirmForcePush } from './rebase/confirm-force-push'
 import { PullRequestChecksFailed } from './notifications/pull-request-checks-failed'
+import { WarnForcePushDialog } from './multi-commit-operation/dialog/warn-force-push-dialog'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2066,8 +2067,34 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       }
+      case PopupType.WarnForcePush: {
+        const { askForConfirmationOnForcePush } = this.state
+        return (
+          <WarnForcePushDialog
+            key="warn-force-push"
+            dispatcher={this.props.dispatcher}
+            operation={popup.operation}
+            askForConfirmationOnForcePush={askForConfirmationOnForcePush}
+            onBegin={this.getWarnForcePushDialogOnBegin(
+              popup.onBegin,
+              onPopupDismissedFn
+            )}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
       default:
         return assertNever(popup, `Unknown popup type: ${popup}`)
+    }
+  }
+
+  private getWarnForcePushDialogOnBegin(
+    onBegin: () => void,
+    onPopupDismissedFn: () => void
+  ) {
+    return () => {
+      onBegin()
+      onPopupDismissedFn()
     }
   }
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -144,7 +144,7 @@ interface IChangesListProps {
   readonly dispatcher: Dispatcher
   readonly availableWidth: number
   readonly isCommitting: boolean
-  readonly isAmending: boolean
+  readonly commitToAmend: Commit | null
   readonly currentBranchProtected: boolean
 
   /**
@@ -617,7 +617,7 @@ export class ChangesList extends React.Component<
       repositoryAccount,
       dispatcher,
       isCommitting,
-      isAmending,
+      commitToAmend,
       currentBranchProtected,
     } = this.props
 
@@ -679,7 +679,7 @@ export class ChangesList extends React.Component<
         focusCommitMessage={this.props.focusCommitMessage}
         autocompletionProviders={this.props.autocompletionProviders}
         isCommitting={isCommitting}
-        commitToAmend={isAmending ? this.props.mostRecentLocalCommit : null}
+        commitToAmend={commitToAmend}
         showCoAuthoredBy={this.props.showCoAuthoredBy}
         coAuthors={this.props.coAuthors}
         placeholder={this.getPlaceholderMessage(

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -671,7 +671,7 @@ export class CommitMessage extends React.Component<
   }
 
   private onStopAmending = () => {
-    this.props.dispatcher.setAmendingRepository(this.props.repository, false)
+    this.props.dispatcher.stopAmendingRepository(this.props.repository)
   }
 
   private renderSubmitButton() {

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -49,7 +49,7 @@ interface IChangesSidebarProps {
   readonly issuesStore: IssuesStore
   readonly availableWidth: number
   readonly isCommitting: boolean
-  readonly isAmending: boolean
+  readonly commitToAmend: Commit | null
   readonly isPushPullFetchInProgress: boolean
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
@@ -301,7 +301,11 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
     // We don't allow undoing commits that have tags associated to them, since then
     // the commit won't be completely deleted because the tag will still point to it.
     // Also, don't allow undoing commits while the user is amending the last one.
-    if (commit && commit.tags.length === 0 && !this.props.isAmending) {
+    if (
+      commit &&
+      commit.tags.length === 0 &&
+      this.props.commitToAmend === null
+    ) {
       child = (
         <CSSTransition
           classNames="undo"
@@ -390,7 +394,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           availableWidth={this.props.availableWidth}
           onIgnore={this.onIgnore}
           isCommitting={this.props.isCommitting}
-          isAmending={this.props.isAmending}
+          commitToAmend={this.props.commitToAmend}
           showCoAuthoredBy={showCoAuthoredBy}
           coAuthors={coAuthors}
           externalEditorLabel={this.props.externalEditorLabel}

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -43,7 +43,7 @@ interface ICommitProps {
   readonly onCreateBranch?: (commit: CommitOneLine) => void
   readonly onCreateTag?: (targetCommitSha: string) => void
   readonly onDeleteTag?: (tagName: string) => void
-  readonly onAmendCommit?: () => void
+  readonly onAmendCommit?: (commit: Commit, isLocalCommit: boolean) => void
   readonly onCherryPick?: (commits: ReadonlyArray<CommitOneLine>) => void
   readonly onRenderCommitDragElement?: (commit: Commit) => void
   readonly onRemoveDragElement?: () => void
@@ -218,9 +218,7 @@ export class CommitListItem extends React.PureComponent<
   }
 
   private onAmendCommit = () => {
-    if (this.props.onAmendCommit !== undefined) {
-      this.props.onAmendCommit()
-    }
+    this.props.onAmendCommit?.(this.props.commit, this.props.isLocal)
   }
 
   private onCopySHA = () => {
@@ -280,7 +278,6 @@ export class CommitListItem extends React.PureComponent<
     if (this.props.canBeAmended && enableAmendingCommits()) {
       items.push({
         label: __DARWIN__ ? 'Amend Commit…' : 'Amend commit…',
-        enabled: this.props.isLocal,
         action: this.onAmendCommit,
       })
     }

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -63,7 +63,7 @@ interface ICommitListProps {
   /** Callback to fire to revert a given commit in the current repository */
   readonly onRevertCommit: ((commit: Commit) => void) | undefined
 
-  readonly onAmendCommit?: () => void
+  readonly onAmendCommit?: (commit: Commit, isLocalCommit: boolean) => void
 
   /** Callback to fire to open a given commit on GitHub */
   readonly onViewCommitOnGitHub: (sha: string) => void
@@ -217,7 +217,7 @@ export class CommitList extends React.Component<
         gitHubRepository={this.props.gitHubRepository}
         isLocal={isLocal}
         canBeUndone={this.props.canUndoCommits && isLocal && row === 0}
-        canBeAmended={this.props.canAmendCommits && isLocal && row === 0}
+        canBeAmended={this.props.canAmendCommits && row === 0}
         canBeResetTo={this.props.canResetToCommits && isResettableCommit}
         showUnpushedIndicator={showUnpushedIndicator}
         unpushedIndicatorTitle={this.getUnpushedIndicatorTitle(

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -43,7 +43,7 @@ interface ICompareSidebarProps {
   readonly currentBranch: Branch | null
   readonly selectedCommitShas: ReadonlyArray<string>
   readonly onRevertCommit: (commit: Commit) => void
-  readonly onAmendCommit: () => void
+  readonly onAmendCommit: (commit: Commit, isLocalCommit: boolean) => void
   readonly onViewCommitOnGitHub: (sha: string) => void
   readonly onCompareListScrolled: (scrollTop: number) => void
   readonly onCherryPick: (

--- a/app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx
+++ b/app/src/ui/multi-commit-operation/dialog/warn-force-push-dialog.tsx
@@ -12,6 +12,7 @@ interface IWarnForcePushProps {
    *  - Rebase
    *  - Squash
    *  - Reorder
+   *  - Amend
    */
   readonly operation: string
   readonly dispatcher: Dispatcher

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -234,7 +234,7 @@ export class RepositoryView extends React.Component<
         availableWidth={availableWidth}
         gitHubUserStore={this.props.gitHubUserStore}
         isCommitting={this.props.state.isCommitting}
-        isAmending={this.props.state.isAmending}
+        commitToAmend={this.props.state.commitToAmend}
         isPushPullFetchInProgress={this.props.state.isPushPullFetchInProgress}
         focusCommitMessage={this.props.focusCommitMessage}
         askForConfirmationOnDiscardChanges={
@@ -558,8 +558,12 @@ export class RepositoryView extends React.Component<
     this.props.dispatcher.revertCommit(this.props.repository, commit)
   }
 
-  private onAmendCommit = () => {
-    this.props.dispatcher.setAmendingRepository(this.props.repository, true)
+  private onAmendCommit = (commit: Commit, isLocalCommit: boolean) => {
+    this.props.dispatcher.startAmendingRepository(
+      this.props.repository,
+      commit,
+      isLocalCommit
+    )
   }
 
   public componentDidMount() {


### PR DESCRIPTION
## Description

This PR changes the current behavior of `Amend Commit`, which is limited to non-pushed commits, to allow amending commits that have already been pushed to the remote.

However, since this means users will have to force-push the branch after amending the commit, they will be warned before the amend flow starts.

### Screenshots

https://user-images.githubusercontent.com/1083228/143425240-fead5924-9345-4992-858d-a76aaf93f472.mov

## Release notes

Notes: [Improved] Allow amending commits that have been already pushed
