### PR TITLE
Checks failed dialog UX improvements

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -167,8 +167,6 @@ export class CICheckRunList extends React.PureComponent<
   }
 
   public render() {
-    return (
-      <div className="ci-check-run-list-container">{this.renderList()}</div>
-    )
+    return <div className="ci-check-run-list">{this.renderList()}</div>
   }
 }

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -19,7 +19,6 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Button } from '../lib/button'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
 import { CICheckRunActionsJobStepList } from '../check-runs/ci-check-run-actions-job-step-list'
-import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { LinkButton } from '../lib/link-button'
 import { encodePathAsUrl } from '../../lib/path'
 
@@ -28,7 +27,6 @@ const BlankSlateImage = encodePathAsUrl(
   __dirname,
   'static/empty-no-pull-requests.svg'
 )
-const MaxCommitMessageLength = 72
 
 interface IPullRequestChecksFailedProps {
   readonly dispatcher: Dispatcher
@@ -107,14 +105,10 @@ export class PullRequestChecksFailed extends React.Component<
       <div className="ci-check-run-dialog-header">
         <Octicon symbol={OcticonSymbol.xCircleFill} />
         <div className="title-container">
-          <span className="summary">
+          <div className="summary">
             {failedChecks.length} {pluralChecks} failed in your pull request
-          </span>
+          </div>
           <span className="pr-title">
-            <Octicon
-              className={pullRequest.draft ? 'draft' : undefined}
-              symbol={OcticonSymbol.gitPullRequest}
-            />
             <span className="pr-title">{pullRequest.title}</span>{' '}
             <span className="pr-number">#{pullRequest.pullRequestNumber}</span>{' '}
           </span>
@@ -136,7 +130,6 @@ export class PullRequestChecksFailed extends React.Component<
         <DialogContent>
           <Row>
             <div className="ci-check-run-dialog-container">
-              {this.renderCheckRunHeader()}
               <div className="ci-check-run-content">
                 {this.renderCheckRunJobs()}
                 {this.renderCheckRunSteps()}
@@ -163,26 +156,11 @@ export class PullRequestChecksFailed extends React.Component<
     const failedChecks = this.state.checks.filter(isFailure)
     const pluralThem = failedChecks.length > 1 ? 'them' : 'it'
     return (
-      <span className="summary">
-        Do you want to switch to that Pull Request now and start fixing{' '}
-        {pluralThem}?
-      </span>
-    )
-  }
-
-  private renderCheckRunHeader() {
-    return (
-      <div className="ci-check-run-header">
-        <span className="message">
-          {truncateWithEllipsis(
-            this.props.commitMessage,
-            MaxCommitMessageLength
-          )}
+      <div className="footer-question">
+        <span>
+          Do you want to switch to that Pull Request now and start fixing{' '}
+          {pluralThem}?
         </span>
-        <span aria-hidden="true">
-          <Octicon symbol={OcticonSymbol.gitCommit} />
-        </span>{' '}
-        <span className="sha">{this.props.commitSha.slice(0, 9)}</span>
       </div>
     )
   }

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -98,31 +98,42 @@ export class PullRequestChecksFailed extends React.Component<
 
     const { pullRequest } = this.props
 
-    const dialogTitle = (
-      <span className="custom-title">
-        <Octicon
-          className={pullRequest.draft ? 'draft' : undefined}
-          symbol={OcticonSymbol.gitPullRequest}
-        />
-        <span className="pr-title">{pullRequest.title}</span>{' '}
-        <span className="pr-number">#{pullRequest.pullRequestNumber}</span>{' '}
-      </span>
-    )
-
     const loadingChecksInfo = this.loadingChecksInfo
+
+    const failedChecks = this.state.checks.filter(isFailure)
+    const pluralChecks = failedChecks.length > 1 ? 'checks' : 'check'
+
+    const header = (
+      <div className="ci-check-run-dialog-header">
+        <Octicon symbol={OcticonSymbol.xCircleFill} />
+        <div className="title-container">
+          <span className="summary">
+            {failedChecks.length} {pluralChecks} failed in your pull request
+          </span>
+          <span className="pr-title">
+            <Octicon
+              className={pullRequest.draft ? 'draft' : undefined}
+              symbol={OcticonSymbol.gitPullRequest}
+            />
+            <span className="pr-title">{pullRequest.title}</span>{' '}
+            <span className="pr-number">#{pullRequest.pullRequestNumber}</span>{' '}
+          </span>
+        </div>
+        {this.renderRerunButton()}
+      </div>
+    )
 
     return (
       <Dialog
         id="pull-request-checks-failed"
         type="normal"
-        title={dialogTitle}
+        title={header}
         dismissable={false}
         onSubmit={this.props.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={loadingChecksInfo || this.state.switchingToPullRequest}
       >
         <DialogContent>
-          <Row>{this.renderSummary()}</Row>
           <Row>
             <div className="ci-check-run-dialog-container">
               {this.renderCheckRunHeader()}
@@ -134,12 +145,15 @@ export class PullRequestChecksFailed extends React.Component<
           </Row>
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup
-            onCancelButtonClick={this.props.onDismissed}
-            cancelButtonText="Dismiss"
-            okButtonText={okButtonTitle}
-            onOkButtonClick={this.onSubmit}
-          />
+          <Row>
+            {this.renderSummary()}
+            <OkCancelButtonGroup
+              onCancelButtonClick={this.props.onDismissed}
+              cancelButtonText="Dismiss"
+              okButtonText={okButtonTitle}
+              onOkButtonClick={this.onSubmit}
+            />
+          </Row>
         </DialogFooter>
       </Dialog>
     )
@@ -147,12 +161,11 @@ export class PullRequestChecksFailed extends React.Component<
 
   private renderSummary() {
     const failedChecks = this.state.checks.filter(isFailure)
-    const pluralChecks = failedChecks.length > 1 ? 'checks' : 'check'
     const pluralThem = failedChecks.length > 1 ? 'them' : 'it'
     return (
       <span className="summary">
-        {failedChecks.length} {pluralChecks} failed in your pull request. Do you
-        want to switch to that Pull Request now and start fixing {pluralThem}?
+        Do you want to switch to that Pull Request now and start fixing{' '}
+        {pluralThem}?
       </span>
     )
   }
@@ -170,7 +183,6 @@ export class PullRequestChecksFailed extends React.Component<
           <Octicon symbol={OcticonSymbol.gitCommit} />
         </span>{' '}
         <span className="sha">{this.props.commitSha.slice(0, 9)}</span>
-        {this.renderRerunButton()}
       </div>
     )
   }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -147,6 +147,7 @@ dialog {
       margin: 0;
       padding: 0;
       margin-right: var(--spacing);
+      width: 100%;
 
       @include ellipsis;
     }

--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -141,12 +141,15 @@ dialog {
       margin-right: var(--spacing);
     }
 
+    .spin {
+      margin-left: var(--spacing);
+    }
+
     h1 {
       font-weight: var(--font-weight-semibold);
       font-size: var(--font-size-md);
       margin: 0;
       padding: 0;
-      margin-right: var(--spacing);
       width: 100%;
 
       @include ellipsis;

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -41,13 +41,17 @@
     }
   }
 
-  .summary {
-    font-size: var(--font-size-md);
+  .footer-question {
     flex-grow: 1;
+
+    span {
+      vertical-align: sub;
+    }
   }
 
   .dialog-content {
     padding: 0;
+
     .ci-check-run-dialog-container {
       height: 300px;
       width: 100%;
@@ -55,32 +59,6 @@
       overflow-x: hidden;
       display: flex;
       flex-direction: column;
-
-      .ci-check-run-header {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        padding: var(--spacing);
-        border-bottom: var(--base-border);
-
-        .message {
-          margin-right: var(--spacing);
-          font-weight: bold;
-        }
-
-        .octicon {
-          margin-right: var(--spacing-third);
-          vertical-align: bottom; // For some reason, `bottom` places the text in the middle
-        }
-
-        .sha {
-          user-select: text;
-        }
-
-        .ci-check-rerun {
-          margin-left: auto;
-        }
-      }
 
       .ci-check-run-content {
         display: flex;

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -1,130 +1,166 @@
 #pull-request-checks-failed {
-  .custom-title {
+  .dialog-header {
+    height: unset;
+  }
+
+  .ci-check-run-dialog-header {
     display: flex;
-    column-gap: 4px;
+    flex-direction: row;
     align-items: center;
 
-    .pr-number {
-      color: var(--text-secondary-color);
+    > .octicon {
+      width: 20px;
+      height: 20px;
+      color: var(--status-error-color);
+      margin-right: var(--spacing);
     }
 
-    .octicon {
-      vertical-align: bottom; // For some reason, `bottom` places the text in the middle
-      color: var(--pr-open-icon-color);
+    .title-container {
+      flex-grow: 1;
 
-      &.draft {
-        color: var(--pr-draft-icon-color);
+      .pr-title {
+        display: flex;
+        column-gap: 4px;
+        align-items: center;
+        font-weight: normal;
+        font-size: var(--font-size);
+
+        .pr-number {
+          color: var(--text-secondary-color);
+        }
+
+        .octicon {
+          vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+          color: var(--pr-open-icon-color);
+
+          &.draft {
+            color: var(--pr-draft-icon-color);
+          }
+        }
       }
     }
   }
 
-  .ci-check-run-dialog-container {
-    height: 300px;
-    width: 100%;
-    border-radius: var(--border-radius);
-    border: var(--base-border);
-    overflow-y: hidden;
-    overflow-x: hidden;
-    display: flex;
-    flex-direction: column;
+  .summary {
+    font-size: var(--font-size-md);
+    flex-grow: 1;
+  }
 
-    .ci-check-run-header {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      padding: var(--spacing);
-      border-bottom: var(--base-border);
-
-      .message {
-        margin-right: var(--spacing);
-        font-weight: bold;
-      }
-
-      .octicon {
-        margin-right: var(--spacing-third);
-        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
-      }
-
-      .sha {
-        user-select: text;
-      }
-
-      .ci-check-rerun {
-        margin-left: auto;
-      }
-    }
-
-    .ci-check-run-content {
-      display: flex;
-      flex-direction: row;
-      align-items: stretch;
-      justify-content: stretch;
-      overflow-x: hidden;
+  .dialog-content {
+    padding: 0;
+    .ci-check-run-dialog-container {
+      height: 300px;
+      width: 100%;
       overflow-y: hidden;
-      height: 100%;
-    }
+      overflow-x: hidden;
+      display: flex;
+      flex-direction: column;
 
-    .ci-check-run-list {
-      width: 40%;
-      border-radius: 0;
-    }
+      .ci-check-run-header {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: var(--spacing);
+        border-bottom: var(--base-border);
 
-    .ci-check-run-job-steps-container {
-      width: 60%;
-      overflow-y: auto;
+        .message {
+          margin-right: var(--spacing);
+          font-weight: bold;
+        }
 
-      .ci-check-run-job-steps-list {
-        box-shadow: none;
-        border: none;
-        border-left: var(--base-border);
-        border-right: none;
+        .octicon {
+          margin-right: var(--spacing-third);
+          vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+        }
+
+        .sha {
+          user-select: text;
+        }
+
+        .ci-check-rerun {
+          margin-left: auto;
+        }
       }
 
-      .no-steps-to-display {
+      .ci-check-run-content {
         display: flex;
-        padding: var(--spacing);
-        align-items: center;
+        flex-direction: row;
+        align-items: stretch;
+        justify-content: stretch;
+        overflow-x: hidden;
+        overflow-y: hidden;
         height: 100%;
+      }
 
-        .text {
-          flex: 1;
-          margin-right: var(--spacing);
+      .ci-check-run-list {
+        width: 40%;
+        border-radius: 0;
 
-          div {
-            margin-top: var(--spacing);
+        // Make sure Octicons use the ambient color when the check run is
+        // selected and the list focused
+        .focus-within .ci-check-list-item.list-item.selected .octicon {
+          color: var(--text-color);
+        }
+      }
+
+      .ci-check-run-job-steps-container {
+        width: 60%;
+        overflow-y: auto;
+
+        .ci-check-run-job-steps-list {
+          border: none;
+
+          .ci-check-run-job-step {
+            border: none;
           }
         }
 
-        .blankslate-image {
-          flex: 0;
-          height: 140px;
-          width: 146px;
-          min-width: 140px;
-          min-height: 146px;
-          align-self: flex-end;
+        .no-steps-to-display {
+          display: flex;
+          padding: var(--spacing);
+          align-items: center;
+          height: 100%;
+
+          .text {
+            flex: 1;
+            margin-right: var(--spacing);
+
+            div {
+              margin-top: var(--spacing);
+            }
+          }
+
+          .blankslate-image {
+            flex: 0;
+            height: 140px;
+            width: 146px;
+            min-width: 140px;
+            min-height: 146px;
+            align-self: flex-end;
+          }
         }
-      }
 
-      .loading-check-runs {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-        padding: var(--spacing);
-        padding-bottom: var(--spacing-double);
-
-        .blankslate-image {
+        .loading-check-runs {
           width: 100%;
-          min-width: auto;
-        }
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+          padding: var(--spacing);
+          padding-bottom: var(--spacing-double);
 
-        .title {
-          font-weight: var(--font-weight-semibold);
-        }
+          .blankslate-image {
+            width: 100%;
+            min-width: auto;
+          }
 
-        .call-to-action {
-          font-size: var(--font-size-sm);
+          .title {
+            font-weight: var(--font-weight-semibold);
+          }
+
+          .call-to-action {
+            font-size: var(--font-size-sm);
+          }
         }
       }
     }

--- a/app/styles/ui/_pull-request-checks-failed.scss
+++ b/app/styles/ui/_pull-request-checks-failed.scss
@@ -79,6 +79,14 @@
         .focus-within .ci-check-list-item.list-item.selected .octicon {
           color: var(--text-color);
         }
+
+        .ci-check-run-list-group-header {
+          padding-left: var(--spacing-double);
+        }
+
+        .ci-check-list-item {
+          padding-left: var(--spacing);
+        }
       }
 
       .ci-check-run-job-steps-container {
@@ -95,7 +103,7 @@
 
         .no-steps-to-display {
           display: flex;
-          padding: var(--spacing);
+          padding: var(--spacing-double);
           align-items: center;
           height: 100%;
 


### PR DESCRIPTION
## Description

This PR introduces some UX improvements to the checks failed dialog suggested in https://github.com/desktop/desktop/pull/13207#pullrequestreview-810016263 and https://github.com/desktop/desktop/pull/13207#issuecomment-974272620

Things I'm not 100% convinced about:
- Removing the commit SHA and message. I think that might be important info when looking at checks that failed.
- The alignment of the check icons feels somehow uneven since I had to add a margin to align them with the dialog icon.
- The re-run jobs button is displaced to the left to make room for the loading indicator when needed.

From an implementation-wise perspective, I change a few things in the `dialog-header` and `dialog-content` classes that feel too hacky, maybe I should adapt the Dialog API to accommodate these new needs.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/143580457-4429a05e-4cfd-494a-b0fe-a03683449c3a.png)

## Release notes

Notes: no-notes
