### PR TITLE
Install same origin filter on ready event

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -281,6 +281,10 @@ app.on('ready', () => {
 
   createWindow()
 
+  // Ensures auth-related headers won't traverse http redirects to hosts
+  // on different origins than the originating request.
+  installSameOriginFilter(session.defaultSession.webRequest)
+
   Menu.setApplicationMenu(
     buildDefaultMenu({
       selectedShell: null,
@@ -434,10 +438,6 @@ app.on('ready', () => {
         Menu.setApplicationMenu(currentMenu)
         mainWindow.sendAppMenu()
       }
-
-      // Ensures auth-related headers won't traverse http redirects to hosts
-      // on different origins than the originating request.
-      installSameOriginFilter(session.defaultSession.webRequest)
     }
   )
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description

In https://github.com/desktop/desktop/pull/13108 I added a network filter to prevent accidental disclosure of auth tokens when following redirects across origins. Today I happened to spot that the installation method was being called from the event handler of the `update-preferred-app-menu-item-labels` IPC method 🤦

Now luckily for us this shouldn't have had much of an impact given that this particular method gets called invoked rather frequently and that Electron's `WebRequest` only supports one concurrent listener. It's conceivable though that an ill-timed invocation could lead to state loss in the same origin filter which could lead to an auth-ed redirect slipping through its defenses.

Not to mention it's just straight up wrong to install it in an IPC method 😄 

This PR moves the installation to the ready event handler where it was supposed to live all along. I don't know if I had a temporary glitch in my brain or if there was some merge conflict resolution madness that caused it to end up where it did. I guess we'll never know.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
