### PR TITLE
Enable scroll in unified diff

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -4,6 +4,7 @@
 .diff-code-mirror {
   flex-grow: 1;
   min-width: 0;
+  overflow-y: auto;
 }
 
 .diff-code-mirror .CodeMirror {


### PR DESCRIPTION
Closes #13393

## Description

Adding #13343 to Desktop broke scroll in unified diffs. It was this specific line: https://github.com/desktop/desktop/pull/13343/files#diff-7d407fe8b5dd12c9f129984f4323ffe56e240b5aebfcd8df293e274e50db74d3R764

This PR re-enables the scroll for unified diffs… and doesn't seem to break anything else 🤞 

## Release notes

Notes: no-notes
