### PR TITLE
Show jobs as pending after checks are rerun

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -391,9 +391,7 @@ export async function getLatestPRWorkflowRunsLogsForCheckRun(
       jobsCache.get(wfId) ?? (await api.fetchWorkflowRunJobs(owner, repo, wfId))
     jobsCache.set(wfId, workFlowRunJobs)
 
-    // Here check run and jobs only share their names.
-    // Thus, unfortunately cannot match on a numerical id.
-    const matchingJob = workFlowRunJobs?.jobs.find(j => j.name === cr.name)
+    const matchingJob = workFlowRunJobs?.jobs.find(j => j.id === cr.id)
     if (matchingJob === undefined) {
       mappedCheckRuns.push(cr)
       continue

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -649,3 +649,29 @@ export function getCheckRunGroupNames(
 
   return groupNames
 }
+
+export function manuallySetChecksToPending(
+  cachedChecks: ReadonlyArray<IRefCheck>,
+  pendingChecks: ReadonlyArray<IRefCheck>
+): ICombinedRefCheck | null {
+  const updatedChecks: IRefCheck[] = []
+  for (const check of cachedChecks) {
+    const matchingCheck = pendingChecks.find(c => check.id === c.id)
+    if (matchingCheck === undefined) {
+      updatedChecks.push(check)
+      continue
+    }
+
+    updatedChecks.push({
+      ...check,
+      status: APICheckStatus.InProgress,
+      conclusion: null,
+      actionJobSteps: check.actionJobSteps?.map(js => ({
+        ...js,
+        status: APICheckStatus.InProgress,
+        conclusion: null,
+      })),
+    })
+  }
+  return createCombinedCheckFromChecks(updatedChecks)
+}

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -342,8 +342,7 @@ export class CommitStatusStore {
     if (
       existingChecks !== undefined &&
       existingChecks.check !== null &&
-      existingChecks.check.checks.find(c => c.actionsWorkflow !== undefined) !==
-        undefined &&
+      existingChecks.check.checks.some(c => c.actionsWorkflow !== undefined) &&
       _.xor(
         existingChecks.check.checks.map(cr => cr.id),
         checks.map(cr => cr.id)
@@ -408,6 +407,11 @@ export class CommitStatusStore {
       if (cache !== undefined) {
         this.cache.set(key, {
           ...cache,
+          // The commit status store is set to only retreive on a refresh
+          // trigger if the subscription has not been fetched for 60 minutes
+          // (cache/api limit). This sets this sub back to 61 so that on next
+          // refresh triggered, it will be reretreived, as this time, it will be
+          // different given the branch name is provided.
           fetchedAt: moment(new Date()).subtract(61, 'minutes').toDate(),
         })
       }

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -4,12 +4,7 @@ import QuickLRU from 'quick-lru'
 import { Account } from '../../models/account'
 import { AccountsStore } from './accounts-store'
 import { GitHubRepository } from '../../models/github-repository'
-import {
-  API,
-  APICheckStatus,
-  getAccountForEndpoint,
-  IAPICheckSuite,
-} from '../api'
+import { API, getAccountForEndpoint, IAPICheckSuite } from '../api'
 import { IDisposable, Disposable } from 'event-kit'
 import {
   ICombinedRefCheck,
@@ -20,7 +15,10 @@ import {
   apiStatusToRefCheck,
   getLatestPRWorkflowRunsLogsForCheckRun,
   getCheckRunActionsWorkflowRuns,
+  manuallySetChecksToPending,
 } from '../ci-checks/ci-checks'
+import _ from 'lodash'
+import moment from 'moment'
 
 interface ICommitStatusCacheEntry {
   /**
@@ -61,6 +59,9 @@ interface IRefStatusSubscription {
 
   /** One or more callbacks to notify when the commit status is updated */
   readonly callbacks: Set<StatusCallBack>
+
+  /** If provided, we retrieve the actions workflow runs or the checks with this sub */
+  readonly branchName?: string
 }
 
 /**
@@ -258,23 +259,7 @@ export class CommitStatusStore {
       return
     }
 
-    const updatedChecks: IRefCheck[] = []
-    for (const check of cache.checks) {
-      const matchingCheck = pendingChecks.find(c => check.id === c.id)
-      if (matchingCheck === undefined) {
-        updatedChecks.push(check)
-        continue
-      }
-
-      updatedChecks.push({
-        ...check,
-        status: APICheckStatus.InProgress,
-        conclusion: null,
-        actionJobSteps: undefined,
-      })
-    }
-
-    const check = createCombinedCheckFromChecks(updatedChecks)
+    const check = manuallySetChecksToPending(cache.checks, pendingChecks)
     this.cache.set(key, { check, fetchedAt: new Date() })
     subscription.callbacks.forEach(cb => cb(check))
   }
@@ -331,9 +316,54 @@ export class CommitStatusStore {
       checks.push(...latestCheckRunsByName.map(apiCheckRunToRefCheck))
     }
 
-    const check = createCombinedCheckFromChecks(checks)
+    let checksWithActions = null
+    if (subscription.branchName !== undefined) {
+      checksWithActions = await this.getAndMapActionWorkflowRunsToCheckRuns(
+        checks,
+        key,
+        subscription.branchName
+      )
+    }
+
+    const check = createCombinedCheckFromChecks(checksWithActions ?? checks)
     this.cache.set(key, { check, fetchedAt: new Date() })
     subscription.callbacks.forEach(cb => cb(check))
+  }
+
+  private async getAndMapActionWorkflowRunsToCheckRuns(
+    checks: ReadonlyArray<IRefCheck>,
+    key: string,
+    branchName: string
+  ): Promise<ReadonlyArray<IRefCheck> | null> {
+    const existingChecks = this.cache.get(key)
+
+    // If the checks haven't changed since last status refresh, don't bother
+    // retrieving actions workflows and they could be stale if this is directly after a rerun
+    if (
+      existingChecks !== undefined &&
+      existingChecks.check !== null &&
+      existingChecks.check.checks.find(c => c.actionsWorkflow !== undefined) !==
+        undefined &&
+      _.xor(
+        existingChecks.check.checks.map(cr => cr.id),
+        checks.map(cr => cr.id)
+      ).length === 0
+    ) {
+      return null
+    }
+
+    const checkRunsWithActionsWorkflows = await this.getCheckRunActionsWorkflowRuns(
+      key,
+      branchName,
+      checks
+    )
+
+    const checkRunsWithActionsWorkflowJobs = await this.mapActionWorkflowRunsJobsToCheckRuns(
+      key,
+      checkRunsWithActionsWorkflows
+    )
+
+    return checkRunsWithActionsWorkflowJobs
   }
 
   /**
@@ -345,18 +375,44 @@ export class CommitStatusStore {
    */
   public tryGetStatus(
     repository: GitHubRepository,
-    ref: string
+    ref: string,
+    branchName?: string
   ): ICombinedRefCheck | null {
     const key = getCacheKeyForRepository(repository, ref)
+    if (
+      branchName !== undefined &&
+      this.subscriptions.get(key)?.branchName !== branchName
+    ) {
+      return null
+    }
+
     return this.cache.get(key)?.check ?? null
   }
 
-  private getOrCreateSubscription(repository: GitHubRepository, ref: string) {
+  private getOrCreateSubscription(
+    repository: GitHubRepository,
+    ref: string,
+    branchName?: string
+  ) {
     const key = getCacheKeyForRepository(repository, ref)
     let subscription = this.subscriptions.get(key)
 
     if (subscription !== undefined) {
-      return subscription
+      if (subscription.branchName === branchName) {
+        return subscription
+      }
+
+      const withBranchName = { ...subscription, branchName }
+      this.subscriptions.set(key, withBranchName)
+      const cache = this.cache.get(key)
+      if (cache !== undefined) {
+        this.cache.set(key, {
+          ...cache,
+          fetchedAt: moment(new Date()).subtract(61, 'minutes').toDate(),
+        })
+      }
+
+      return withBranchName
     }
 
     subscription = {
@@ -365,6 +421,7 @@ export class CommitStatusStore {
       name: repository.name,
       ref,
       callbacks: new Set<StatusCallBack>(),
+      branchName,
     }
 
     this.subscriptions.set(key, subscription)
@@ -384,10 +441,15 @@ export class CommitStatusStore {
   public subscribe(
     repository: GitHubRepository,
     ref: string,
-    callback: StatusCallBack
+    callback: StatusCallBack,
+    branchName?: string
   ): IDisposable {
     const key = getCacheKeyForRepository(repository, ref)
-    const subscription = this.getOrCreateSubscription(repository, ref)
+    const subscription = this.getOrCreateSubscription(
+      repository,
+      ref,
+      branchName
+    )
 
     subscription.callbacks.add(callback)
     this.queueRefresh()
@@ -404,13 +466,11 @@ export class CommitStatusStore {
    * Retrieve GitHub Actions workflows and maps them to the check runs if
    * applicable
    */
-  public async getCheckRunActionsWorkflowRuns(
-    repository: GitHubRepository,
-    ref: string,
+  private async getCheckRunActionsWorkflowRuns(
+    key: string,
     branchName: string,
     checkRuns: ReadonlyArray<IRefCheck>
   ): Promise<ReadonlyArray<IRefCheck>> {
-    const key = getCacheKeyForRepository(repository, ref)
     const subscription = this.subscriptions.get(key)
     if (subscription === undefined) {
       return checkRuns
@@ -435,12 +495,10 @@ export class CommitStatusStore {
   /**
    * Retrieve GitHub Actions job and logs for the check runs.
    */
-  public async getLatestPRWorkflowRunsLogsForCheckRun(
-    repository: GitHubRepository,
-    ref: string,
+  private async mapActionWorkflowRunsJobsToCheckRuns(
+    key: string,
     checkRuns: ReadonlyArray<IRefCheck>
   ): Promise<ReadonlyArray<IRefCheck>> {
-    const key = getCacheKeyForRepository(repository, ref)
     const subscription = this.subscriptions.get(key)
     if (subscription === undefined) {
       return checkRuns

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -28,6 +28,9 @@ interface ICICheckRunListItemProps {
   /** Whether the list item is selected */
   readonly selected: boolean
 
+  /** Whether check runs can be expanded. Default: false */
+  readonly notExpandable?: boolean
+
   /** Callback for when a check run is clicked */
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
@@ -74,9 +77,18 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckJobStepToggle = (): JSX.Element | null => {
-    const { checkRun, isCheckRunExpanded, selectable } = this.props
+    const {
+      checkRun,
+      isCheckRunExpanded,
+      selectable,
+      notExpandable,
+    } = this.props
 
-    if (checkRun.actionJobSteps === undefined || selectable) {
+    if (
+      checkRun.actionJobSteps === undefined ||
+      selectable ||
+      notExpandable === true
+    ) {
       return null
     }
 

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -143,6 +143,7 @@ export class CICheckRunList extends React.PureComponent<
           selected={selectable && checkRunExpanded}
           // Only expand check runs if the list is not selectable
           isCheckRunExpanded={!selectable && checkRunExpanded}
+          notExpandable={this.props.notExpandable}
           onCheckRunExpansionToggleClick={this.onCheckRunClick}
           onViewCheckExternally={this.props.onViewCheckDetails}
           onViewJobStep={this.props.onViewJobStep}

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -51,7 +51,6 @@ export class CICheckRunList extends React.PureComponent<
 > {
   public constructor(props: ICICheckRunListProps) {
     super(props)
-
     this.state = this.setupStateAfterCheckRunPropChange(this.props, null)
   }
 
@@ -60,7 +59,29 @@ export class CICheckRunList extends React.PureComponent<
       checkRunExpanded,
       hasUserToggledCheckRun,
     } = this.setupStateAfterCheckRunPropChange(this.props, this.state)
-    this.setState({ checkRunExpanded, hasUserToggledCheckRun })
+
+    let foundDiffStatus = false
+    for (const prevCR of prevProps.checkRuns) {
+      const diffStatus = this.props.checkRuns.find(
+        cr => cr.id === prevCR.id && cr.status !== prevCR.status
+      )
+      if (diffStatus !== undefined) {
+        foundDiffStatus = true
+        break
+      }
+    }
+
+    if (foundDiffStatus) {
+      this.setState({
+        checkRunExpanded,
+        hasUserToggledCheckRun,
+        checkRunGroups: getCheckRunsGroupedByActionWorkflowNameAndEvent(
+          this.props.checkRuns
+        ),
+      })
+    } else {
+      this.setState({ checkRunExpanded, hasUserToggledCheckRun })
+    }
   }
 
   private setupStateAfterCheckRunPropChange(
@@ -73,10 +94,9 @@ export class CICheckRunList extends React.PureComponent<
       return currentState
     }
 
-    const checkRunGroups =
-      currentState === null
-        ? getCheckRunsGroupedByActionWorkflowNameAndEvent(props.checkRuns)
-        : currentState.checkRunGroups
+    const checkRunGroups = getCheckRunsGroupedByActionWorkflowNameAndEvent(
+      props.checkRuns
+    )
     let checkRunExpanded = null
 
     if (this.props.notExpandable !== true) {

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -10,6 +10,12 @@ import moment from 'moment'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from './../octicons/octicons.generated'
 import { Row } from '../lib/row'
+import { encodePathAsUrl } from '../../lib/path'
+
+const BlankSlateImage = encodePathAsUrl(
+  __dirname,
+  'static/empty-no-pull-requests.svg'
+)
 
 interface ICICheckRunRerunDialogProps {
   readonly dispatcher: Dispatcher
@@ -111,7 +117,15 @@ export class CICheckRunRerunDialog extends React.Component<
 
   private renderRerunnableJobsList = () => {
     if (this.state.loadingCheckSuites) {
-      return <>Please wait. Determining which checks can be rerun.</>
+      return (
+        <div className="loading-rerun-checks">
+          <img src={BlankSlateImage} className="blankslate-image" />
+          <div className="title">Please wait</div>
+          <div className="call-to-action">
+            Determining which checks can be re-run.
+          </div>
+        </div>
+      )
     }
 
     return (

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2394,9 +2394,10 @@ export class Dispatcher {
    */
   public tryGetCommitStatus(
     repository: GitHubRepository,
-    ref: string
+    ref: string,
+    branchName?: string
   ): ICombinedRefCheck | null {
-    return this.commitStatusStore.tryGetStatus(repository, ref)
+    return this.commitStatusStore.tryGetStatus(repository, ref, branchName)
   }
 
   /**
@@ -2407,13 +2408,21 @@ export class Dispatcher {
    *                   fetch status.
    * @param callback   A callback which will be invoked whenever the
    *                   store updates a commit status for the given ref.
+   * @param branchName If we want to retrieve action workflow checks with the
+   *                   sub, we provide the branch name for it.
    */
   public subscribeToCommitStatus(
     repository: GitHubRepository,
     ref: string,
-    callback: StatusCallBack
+    callback: StatusCallBack,
+    branchName?: string
   ): IDisposable {
-    return this.commitStatusStore.subscribe(repository, ref, callback)
+    return this.commitStatusStore.subscribe(
+      repository,
+      ref,
+      callback,
+      branchName
+    )
   }
 
   /**
@@ -2428,39 +2437,6 @@ export class Dispatcher {
       repository,
       ref,
       pendingChecks
-    )
-  }
-
-  /**
-   * Populates Actions workflow logs for provided checkruns if applicable
-   */
-  public getActionsWorkflowRunLogs(
-    repository: GitHubRepository,
-    ref: string,
-    checkRuns: ReadonlyArray<IRefCheck>
-  ): Promise<ReadonlyArray<IRefCheck>> {
-    return this.commitStatusStore.getLatestPRWorkflowRunsLogsForCheckRun(
-      repository,
-      ref,
-      checkRuns
-    )
-  }
-
-  /**
-   * Retrieve GitHub Actions workflows and maps them to the check runs if
-   * applicable
-   */
-  public getCheckRunActionsWorkflowRuns(
-    repository: GitHubRepository,
-    ref: string,
-    branchName: string,
-    checkRuns: ReadonlyArray<IRefCheck>
-  ): Promise<ReadonlyArray<IRefCheck>> {
-    return this.commitStatusStore.getCheckRunActionsWorkflowRuns(
-      repository,
-      ref,
-      branchName,
-      checkRuns
     )
   }
 

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -19,4 +19,27 @@
     max-width: 400px;
     margin-bottom: var(--spacing-double);
   }
+
+  .loading-rerun-checks {
+    min-height: 300px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: var(--spacing);
+    padding-bottom: var(--spacing-double);
+
+    .blankslate-image {
+      width: 100%;
+      min-width: auto;
+    }
+
+    .title {
+      font-weight: var(--font-weight-semibold);
+    }
+
+    .call-to-action {
+      font-size: var(--font-size-sm);
+    }
+  }
 }


### PR DESCRIPTION
## Description

TLDR; Timing and cache issues caused job steps to not show pending; moved job steps into cache so they would show pending. Also, addressed toggle indicator showing when it shouldn't.

An issue with current rerun dialog is that after you rerun it, I manually update the checks to be pending because an immediate re-retrieve will be stale as the rerun has not triggered yet and we don't know when the rerun will fire exactly.

However, the job steps were not stored in the cache they were retrieved on the fly when the user opens the popover. Thus, I could not modify their state such that it would reflect in the dialog.

Therefore, I moved jobs steps also to be store in the commit status store cache. This was problematic before because we do not want to retrieve jobs steps (and previously logs) for all pull requests when the user may not even open the check run popover for more than the one they are working on. Thus, I have set an optional branch name for the subscriptions such that it only retrieve them if the branch name is set (something required to retrieve them anyways). Thus, by default, it won't be set, but when the user opens the popover, we resubscribe for that pull request and when doing so update the subscription to have the branch name and go get the job steps.

This is a two for one improvement as now the job steps are cached and no longer have to be retrieved every time the user opens the popover. But, for the point of this PR, we can set the job steps in the cache to pending until the next cycle of commit status store retrieve.

Unfortunately... there is still a timing issue here to note - if user hits rerun at the same time as the commit-status-store cycles they could end up with stale data in the popover. But, I think this is not terribly likely, and not as bad as trying to set a timer to guess when the rerun happens on the server.

Another not so nice about this is, the links for the check runs in the popover or for the run before the pending one, so at this point if the user clicks on the link they will go to one on dotcom that tells them they are one attempt behind... but we can't remedy this until we get a fresh retrieve back.. only option would be to disable them.. but I think that is worse. :/

Also addressed some UI feedback from Sergio in last PR -> toggle indicators hidden (I had that and then changed approach and didn't realize those came back.) and found out the job ids.. do match check run ids so I could match on an id and not a name.. I believe this may have changed with recent actions update.

### Screenshots


https://user-images.githubusercontent.com/75402236/143910354-a0a076f5-47d7-4085-9afd-4029be5230e0.mov



## Release notes

Notes: no-notes
