### PR TITLE
app/src/ui/resizable.tsx - change 'files list' maximum width to 500 px

### DIFF
--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -9,7 +9,7 @@ import * as React from 'react'
 export class Resizable extends React.Component<IResizableProps, {}> {
   public static defaultProps: IResizableProps = {
     width: 250,
-    maximumWidth: 350,
+    maximumWidth: 500,
     minimumWidth: 200,
   }
 


### PR DESCRIPTION
#2745 asks for better user control over column widths, along with better widths for 4K or larger monitors.

## Description

Current code sets the max width on History's 'file list' to 350px.  When one is displaying 'Changes', its file list display is approx 500px.  This allows the History's 'file list' to be resized to 500px

### Screenshots

## Release notes

Allow re-sizing 'History' file list pane to 500 px, from 350px.

Notes: