### PR TITLE
Check run interaction stats

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -451,6 +451,18 @@ export interface IDailyMeasures {
 
   /** The number of times the user reset to a previous commit. */
   readonly resetToCommitCount: number
+
+  /** The number of times the user opens the check run popover. */
+  readonly opensCheckRunsPopover: number
+
+  /** The number of times the user clicks link to view a check online */
+  readonly viewsCheckOnline: number
+
+  /** The number of times the user clicks link to view a check job step online */
+  readonly viewsCheckJobStepOnline: number
+
+  /** The number of times the user reruns checks */
+  readonly rerunsChecks: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -174,6 +174,10 @@ const DefaultDailyMeasures: IDailyMeasures = {
   squashMergeSuccessfulCount: 0,
   squashMergeInvokedCount: 0,
   resetToCommitCount: 0,
+  opensCheckRunsPopover: 0,
+  viewsCheckOnline: 0,
+  viewsCheckJobStepOnline: 0,
+  rerunsChecks: 0,
 }
 
 interface IOnboardingStats {
@@ -1702,6 +1706,30 @@ export class StatsStore implements IStatsStore {
   public recordSquashMergeInvokedCount(): Promise<void> {
     return this.updateDailyMeasures(m => ({
       squashMergeInvokedCount: m.squashMergeInvokedCount + 1,
+    }))
+  }
+
+  public recordCheckRunsPopoverOpened(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      opensCheckRunsPopover: m.opensCheckRunsPopover + 1,
+    }))
+  }
+
+  public recordCheckViewedOnline(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      viewsCheckOnline: m.viewsCheckOnline + 1,
+    }))
+  }
+
+  public recordCheckJobStepViewedOnline(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      viewsCheckJobStepOnline: m.viewsCheckJobStepOnline + 1,
+    }))
+  }
+
+  public recordRerunChecks(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      rerunsChecks: m.rerunsChecks + 1,
     }))
   }
 

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -124,6 +124,7 @@ export class CICheckRunPopover extends React.PureComponent<
       `${this.props.repository.htmlURL}/pull/${this.props.prNumber}`
 
     this.props.dispatcher.openInBrowser(url)
+    this.props.dispatcher.recordCheckViewedOnline()
   }
 
   private onViewJobStep = (
@@ -136,6 +137,7 @@ export class CICheckRunPopover extends React.PureComponent<
 
     if (url !== null) {
       dispatcher.openInBrowser(url)
+      this.props.dispatcher.recordCheckJobStepViewedOnline()
     }
   }
 

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -64,6 +64,7 @@ export class CICheckRunRerunDialog extends React.Component<
       prRef,
       this.state.rerunnable
     )
+    dispatcher.recordRerunChecks()
     this.props.onDismissed()
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3725,14 +3725,13 @@ export class Dispatcher {
 
   public setShowCIStatusPopover(showCIStatusPopover: boolean) {
     this.appStore._setShowCIStatusPopover(showCIStatusPopover)
+    if (showCIStatusPopover) {
+      this.statsStore.recordCheckRunsPopoverOpened()
+    }
   }
 
   public _toggleCIStatusPopover() {
     this.appStore._toggleCIStatusPopover()
-  }
-
-  public recordCheckRunsPopoverOpened() {
-    this.statsStore.recordCheckRunsPopoverOpened()
   }
 
   public recordCheckViewedOnline() {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3730,4 +3730,20 @@ export class Dispatcher {
   public _toggleCIStatusPopover() {
     this.appStore._toggleCIStatusPopover()
   }
+
+  public recordCheckRunsPopoverOpened() {
+    this.statsStore.recordCheckRunsPopoverOpened()
+  }
+
+  public recordCheckViewedOnline() {
+    this.statsStore.recordCheckViewedOnline()
+  }
+
+  public recordCheckJobStepViewedOnline() {
+    this.statsStore.recordCheckJobStepViewedOnline()
+  }
+
+  public recordRerunChecks() {
+    this.statsStore.recordRerunChecks()
+  }
 }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -276,8 +276,6 @@ export class BranchDropdown extends React.Component<
       return null
     }
 
-    this.props.dispatcher.recordCheckRunsPopoverOpened()
-
     return (
       <CICheckRunPopover
         prNumber={pr.pullRequestNumber}

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -276,6 +276,8 @@ export class BranchDropdown extends React.Component<
       return null
     }
 
+    this.props.dispatcher.recordCheckRunsPopoverOpened()
+
     return (
       <CICheckRunPopover
         prNumber={pr.pullRequestNumber}


### PR DESCRIPTION
## Description
A few questions that could be answered:

If we find that users that open the check runs popover and also are viewing the checks or job steps online at a high rate, it would indicate that the users do want to see the logs or more detail of some kind. I would think > 25% of popover opens result in viewing online would be highly indicative. Even >5% would be interesting.. I would expect if it is not important, it would be hardly at all < 1%. If so, would result, it revisiting the idea of viewing logs in Desktop.

If there is a low user count (< 1%?) on opening the check runs popover, it could indicate that the feature is not desired or that it is not easily discoverable.  If so, may consider a "Did you know?"  one time popup like we did for cherry-picking.

If there is a low user count (< 5%) of users who open the check runs popover and also rerun jobs, that would indicate to me that being able to rerun jobs is not a desirable feature from Desktop. -> Maybe not worth investing time in rerunning of individual actions jobs or only failed checks. (Currently is not available via api and/or may entail rerunning an entire check suite)

Stats added:
- opensCheckRunsPopover
- viewsCheckOnline (This applies to action and non action checks)
- viewsCheckJobStepOnline (If user is viewing this frequently, it would indicate they would like to see actions logs).
- rerunsChecks 

## Release notes
Notes: no-notes
