### PR TITLE
Target Branch is the original branch

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -565,7 +565,7 @@ export class Dispatcher {
       },
       null,
       commits,
-      null
+      targetBranch
     )
 
     this.repositoryStateManager.updateMultiCommitOperationState(


### PR DESCRIPTION
Closes #13204

## Description

Repo steps from issue:
>Clone a repo from GitHub.
git config pull.rebase true
git config rebase.autoStash true
On GitHub web, add a file "j" with content "123" and commit.
On local cloned repo, do not pull latest change, but add a file "j" with content "456" and commit.
On Github Desktop, click Repository -> Pull, a window pops out, showing 1 conflicted file.
Click "Open in some editor", resolve the conflict, then save the file, go back to Github Desktop.
Now the pop-out window shows 0 conflicted files, so click "Continue rebase".
The window will stuck forever, have to force quit the app then reopen, this time the "Continue rebase" can complete.

Now rebase continues as expected.

## Release notes
Notes: [Fixed] Rebase from pull error now continues after conflicts are resolved.
