### PR TITLE
Cherry-pick regression: On stash, we clear multiCommitOperation, we need to reset on retry

### DIFF
--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2695,7 +2695,7 @@ export class Dispatcher {
   }
 
   /** Initializes multi commit operation state for cherry pick if it is null */
-  public resetMultiCommitOperationStateCherryPick(
+  public initializeMultiCommitOperationStateCherryPick(
     repository: Repository,
     targetBranch: Branch,
     commits: ReadonlyArray<CommitOneLine>,
@@ -2731,7 +2731,7 @@ export class Dispatcher {
   ): Promise<void> {
     // If uncommitted changes are stashed, we had to clear the multi commit
     // operation in case user hit cancel. (This method only sets it, if it null)
-    this.resetMultiCommitOperationStateCherryPick(
+    this.initializeMultiCommitOperationStateCherryPick(
       repository,
       targetBranch,
       commits,
@@ -2835,7 +2835,7 @@ export class Dispatcher {
 
     // If uncommitted changes are stashed, we had to clear the multi commit
     // operation in case user hit cancel. (This method only sets it, if it null)
-    this.resetMultiCommitOperationStateCherryPick(
+    this.initializeMultiCommitOperationStateCherryPick(
       repository,
       targetBranch,
       commits,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2694,6 +2694,34 @@ export class Dispatcher {
     log.info(`[cherryPick] - git reset ${beforeSha} --hard`)
   }
 
+  /** Initializes multi commit operation state for cherry pick if it is null */
+  public resetMultiCommitOperationStateCherryPick(
+    repository: Repository,
+    targetBranch: Branch,
+    commits: ReadonlyArray<CommitOneLine>,
+    sourceBranch: Branch | null
+  ): void {
+    if (
+      this.repositoryStateManager.get(repository).multiCommitOperationState !==
+      null
+    ) {
+      return
+    }
+
+    this.initializeMultiCommitOperation(
+      repository,
+      {
+        kind: MultiCommitOperationKind.CherryPick,
+        sourceBranch,
+        branchCreated: false,
+        commits,
+      },
+      targetBranch,
+      commits,
+      sourceBranch?.tip.sha ?? null
+    )
+  }
+
   /** Starts a cherry pick of the given commits onto the target branch */
   public async cherryPick(
     repository: Repository,
@@ -2701,6 +2729,15 @@ export class Dispatcher {
     commits: ReadonlyArray<CommitOneLine>,
     sourceBranch: Branch | null
   ): Promise<void> {
+    // If uncommitted changes are stashed, we had to clear the multi commit
+    // operation in case user hit cancel. (This method only sets it, if it null)
+    this.resetMultiCommitOperationStateCherryPick(
+      repository,
+      targetBranch,
+      commits,
+      sourceBranch
+    )
+
     this.appStore._initializeCherryPickProgress(repository, commits)
     this.switchMultiCommitOperationToShowProgress(repository)
     this.markDragAndDropIntroAsSeen(DragAndDropIntroType.CherryPick)
@@ -2796,6 +2833,14 @@ export class Dispatcher {
       return
     }
 
+    // If uncommitted changes are stashed, we had to clear the multi commit
+    // operation in case user hit cancel. (This method only sets it, if it null)
+    this.resetMultiCommitOperationStateCherryPick(
+      repository,
+      targetBranch,
+      commits,
+      sourceBranch
+    )
     this.appStore._setMultiCommitOperationTargetBranch(repository, targetBranch)
     this.appStore._setCherryPickBranchCreated(repository, true)
     this.statsStore.recordCherryPickBranchCreatedCount()


### PR DESCRIPTION
Closes #13419

## Description

Repro steps:
1. Have uncommitted changes
2. Attempt to cherry-pick a commit. Note there are three entry points. 1) drag and drop to an existing branch 2). drag to new branch and 3) context menu. 
3. On popup, hit stash and continue 

As reported in the bug, the app would freeze during cherry-pick stashing, because on attempt to run retry method the multi commit operation would be null. This is because the Local Changes Overridden dialog is not part of the multi commit operation flow and yet dismissing it would technically end the flow. Thus, we end the flow on the dialog opening so that it is not in a state of cherry-pick if the user dismisses. Unfortunately, during refactor the initialization of the mutli comitt operation was moved farther back then the retry method. Thus, this PR adds an if clause in the retry methods (there are 2 since there are 3 entry points to cherry-pick) to re initialize if state does not exist.

## Release notes
Notes: [Fixed] App no longer freezes on stash dialog if cherry-picking with uncommitted changes present.
