### PR TITLE
Move items to trash from main process

### DIFF
--- a/app/src/lib/app-shell.ts
+++ b/app/src/lib/app-shell.ts
@@ -35,6 +35,9 @@ export interface IAppShell {
 }
 
 export const shell: IAppShell = {
+  // Since Electron 13, shell.trashItem doesn't work from the renderer process
+  // on Windows. Therefore, we must invoke it from the main process. See
+  // https://github.com/electron/electron/issues/29598
   moveItemToTrash: path => {
     return new Promise<void>((resolve, reject) => {
       ipcRenderer.once(

--- a/app/src/lib/app-shell.ts
+++ b/app/src/lib/app-shell.ts
@@ -39,36 +39,11 @@ export const shell: IAppShell = {
   // on Windows. Therefore, we must invoke it from the main process. See
   // https://github.com/electron/electron/issues/29598
   moveItemToTrash: path => {
-    return new Promise<void>((resolve, reject) => {
-      ipcRenderer.once(
-        'move-to-trash-result',
-        (
-          event: Electron.IpcRendererEvent,
-          { error }: { error: Error | null }
-        ) => {
-          if (error === null) {
-            resolve()
-          } else {
-            reject(error)
-          }
-        }
-      )
-
-      ipcRenderer.send('move-to-trash', { path })
-    })
+    return ipcRenderer.invoke('move-to-trash', path)
   },
   beep: electronShell.beep,
   openExternal: path => {
-    return new Promise<boolean>((resolve, reject) => {
-      ipcRenderer.once(
-        'open-external-result',
-        (event: Electron.IpcRendererEvent, { result }: { result: boolean }) => {
-          resolve(result)
-        }
-      )
-
-      ipcRenderer.send('open-external', { path })
-    })
+    return ipcRenderer.invoke('open-external', path)
   },
   showItemInFolder: path => {
     ipcRenderer.send('show-item-in-folder', { path })

--- a/app/src/lib/app-shell.ts
+++ b/app/src/lib/app-shell.ts
@@ -35,7 +35,25 @@ export interface IAppShell {
 }
 
 export const shell: IAppShell = {
-  moveItemToTrash: electronShell.trashItem,
+  moveItemToTrash: path => {
+    return new Promise<void>((resolve, reject) => {
+      ipcRenderer.once(
+        'move-to-trash-result',
+        (
+          event: Electron.IpcRendererEvent,
+          { error }: { error: Error | null }
+        ) => {
+          if (error === null) {
+            resolve()
+          } else {
+            reject(error)
+          }
+        }
+      )
+
+      ipcRenderer.send('move-to-trash', { path })
+    })
+  },
   beep: electronShell.beep,
   openExternal: path => {
     return new Promise<boolean>((resolve, reject) => {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -550,6 +550,20 @@ app.on('ready', () => {
   )
 
   ipcMain.on(
+    'move-to-trash',
+    async (event: Electron.IpcMainEvent, { path }: { path: string }) => {
+      let error: Error | null = null
+      try {
+        await shell.trashItem(path)
+      } catch (e) {
+        log.error(`Call to trashItem failed: '${e}'`)
+        error = e
+      }
+      event.sender.send('move-to-trash-result', { error })
+    }
+  )
+
+  ipcMain.on(
     'show-item-in-folder',
     (event: Electron.IpcMainEvent, { path }: { path: string }) => {
       Fs.stat(path, err => {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -526,9 +526,12 @@ app.on('ready', () => {
     }
   )
 
-  ipcMain.on(
+  ipcMain.handle(
     'open-external',
-    async (event: Electron.IpcMainEvent, { path }: { path: string }) => {
+    async (
+      event: Electron.IpcMainInvokeEvent,
+      path: string
+    ): Promise<boolean> => {
       const pathLowerCase = path.toLowerCase()
       if (
         pathLowerCase.startsWith('http://') ||
@@ -537,29 +540,20 @@ app.on('ready', () => {
         log.info(`opening in browser: ${path}`)
       }
 
-      let result
       try {
         await shell.openExternal(path)
-        result = true
+        return true
       } catch (e) {
         log.error(`Call to openExternal failed: '${e}'`)
-        result = false
+        return false
       }
-      event.sender.send('open-external-result', { result })
     }
   )
 
-  ipcMain.on(
+  ipcMain.handle(
     'move-to-trash',
-    async (event: Electron.IpcMainEvent, { path }: { path: string }) => {
-      let error: Error | null = null
-      try {
-        await shell.trashItem(path)
-      } catch (e) {
-        log.error(`Call to trashItem failed: '${e}'`)
-        error = e
-      }
-      event.sender.send('move-to-trash-result', { error })
+    (event: Electron.IpcMainInvokeEvent, path: string): Promise<void> => {
+      return shell.trashItem(path)
     }
   )
 


### PR DESCRIPTION
Closes #13433

## Description

With the upgrade to Electron 13 in #13426 we introduced a regression in the app when running on Windows where `electron.shell.trashItem` would fail with `Failed to create FileOperation instance`. According to https://github.com/electron/electron/issues/29598 the solution (at least for now) is to invoke that `trashItem` method from the main process.

On macOS, this doesn't seem to be necessary. However, since this approach works too, I preferred to keep the same implementation for both OS.

## Release notes

Notes: no-notes
