### PR TITLE
Dynamic constraints for resizable components

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -867,6 +867,12 @@ export type MultiCommitOperationConflictState = {
 }
 
 /**
+ * An interface for describing a desired value and a valid range
+ *
+ * Note that the value can be greater than `max` or less than `min`, it's
+ * an indication of the desired value. The real value needs to be validated
+ * or coerced using a function like `clamp`.
+ *
  * Yeah this is a terrible name.
  */
 export interface IConstrainedValue {

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -163,13 +163,13 @@ export interface IAppState {
    * because it's used in the toolbar as well as the
    * repository.
    */
-  readonly sidebarWidth: number
+  readonly sidebarWidth: IConstrainedValue
 
   /** The width of the commit summary column in the history view */
-  readonly commitSummaryWidth: number
+  readonly commitSummaryWidth: IConstrainedValue
 
   /** The width of the files list in the stash view */
-  readonly stashedFilesWidth: number
+  readonly stashedFilesWidth: IConstrainedValue
 
   /**
    * Used to highlight access keys throughout the app when the
@@ -864,4 +864,13 @@ export type MultiCommitOperationConflictState = {
    * stored in state.
    */
   readonly theirBranch?: string
+}
+
+/**
+ * Yeah this is a terrible name.
+ */
+export interface IConstrainedValue {
+  readonly value: number
+  readonly max: number
+  readonly min: number
 }

--- a/app/src/lib/clamp.ts
+++ b/app/src/lib/clamp.ts
@@ -9,18 +9,12 @@ export function clamp(value: number, min: number, max: number): number
 export function clamp(value: IConstrainedValue): number
 export function clamp(
   value: IConstrainedValue | number,
-  min?: number,
-  max?: number
+  min = -Infinity,
+  max = Infinity
 ): number {
   if (typeof value !== 'number') {
     return clamp(value.value, value.min, value.max)
   }
-
-  // This condition could only occur at runtime if someone called clamp(1234).
-  // That's pretty nonsensical so we'll assume that if we're called without
-  // min/max we'll just be an identify function.
-  min = min ?? -Infinity
-  max = max ?? Infinity
 
   if (value < min) {
     return min

--- a/app/src/lib/clamp.ts
+++ b/app/src/lib/clamp.ts
@@ -16,9 +16,9 @@ export function clamp(
     return clamp(value.value, value.min, value.max)
   }
 
-  // These condition could only occur at runtime if someone called
-  // clamp(1234). That's pretty nonsensical so we'll assume that if
-  // we're called without min/max we'll just be an identify function.
+  // This condition could only occur at runtime if someone called clamp(1234).
+  // That's pretty nonsensical so we'll assume that if we're called without
+  // min/max we'll just be an identify function.
   min = min ?? -Infinity
   max = max ?? Infinity
 

--- a/app/src/lib/clamp.ts
+++ b/app/src/lib/clamp.ts
@@ -9,8 +9,8 @@ export function clamp(value: number, min: number, max: number): number
 export function clamp(value: IConstrainedValue): number
 export function clamp(
   value: IConstrainedValue | number,
-  max?: number,
-  min?: number
+  min?: number,
+  max?: number
 ): number {
   if (typeof value !== 'number') {
     return clamp(value.value, value.min, value.max)

--- a/app/src/lib/clamp.ts
+++ b/app/src/lib/clamp.ts
@@ -1,10 +1,27 @@
+import { IConstrainedValue } from './app-state'
+
 /**
  * Helper function to coerce a number into a valid range.
  *
- * Ensures that the returned value is at least min and at most
- * (inclusive) max.
+ * Ensures that the returned value is at least min and at most (inclusive) max.
  */
-export function clamp(value: number, min: number, max: number): number {
+export function clamp(value: number, min: number, max: number): number
+export function clamp(value: IConstrainedValue): number
+export function clamp(
+  value: IConstrainedValue | number,
+  max?: number,
+  min?: number
+): number {
+  if (typeof value !== 'number') {
+    return clamp(value.value, value.min, value.max)
+  }
+
+  // These condition could only occur at runtime if someone called
+  // clamp(1234). That's pretty nonsensical so we'll assume that if
+  // we're called without min/max we'll just be an identify function.
+  min = min ?? -Infinity
+  max = max ?? Infinity
+
   if (value < min) {
     return min
   } else if (value > max) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1873,21 +1873,50 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.accountsStore.refresh()
   }
 
+  /**
+   * Calculate the constraints of our resizable panes whenever the window
+   * dimensions change.
+   */
   private updateResizableConstraints() {
+    // Start with all the available width
     let available = window.innerWidth
-    this.sidebarWidth = { ...this.sidebarWidth, min: 200, max: available - 460 }
+
+    // The combined width of the branch dropdown and the push pull fetch button
+    const toolbarButtonsWidth = 460
+
+    // Working our way from left to right (i.e. giving priority to the leftmost
+    // pane when we need to constrain the width)
+    this.sidebarWidth = {
+      ...this.sidebarWidth,
+      // 220 is the smallest width that will still fit the placeholder text in
+      // the branch selector textbox of the history tab
+      min: 220,
+      // Since the repository list toolbar button width is tied to the width of
+      // the sidebar we can't let it push the branch, and push/pull/fetch
+      // buttons off screen.
+      max: available - toolbarButtonsWidth,
+    }
+
+    // Now calculate the width we have left to distribute for the other panes
     available -= clamp(this.sidebarWidth)
+
+    // This is a pretty silly width for a diff but it will fit ~9 chars per line
+    // in unified mode after subtracting the width of the unified gutter and ~4
+    // chars per side in split diff mode. No one would want to use it this way
+    // but it doesn't break the layout and it allows users to temporarily
+    // maximize the width of the file list to see long path names.
+    const diffPaneMinWidth = 150
 
     this.commitSummaryWidth = {
       ...this.commitSummaryWidth,
-      min: 200,
-      max: available - 200,
+      min: 100,
+      max: available - diffPaneMinWidth,
     }
 
     this.stashedFilesWidth = {
       ...this.stashedFilesWidth,
-      min: 200,
-      max: available - 200,
+      min: 100,
+      max: available - diffPaneMinWidth,
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1876,11 +1876,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private updateResizableConstraints() {
     let available = window.innerWidth
     this.sidebarWidth = { ...this.sidebarWidth, min: 200, max: available - 460 }
-    available -= clamp(
-      this.sidebarWidth.value,
-      this.sidebarWidth.min ?? 0,
-      this.sidebarWidth.max ?? Infinity
-    )
+    available -= clamp(this.sidebarWidth)
 
     this.commitSummaryWidth = {
       ...this.commitSummaryWidth,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1883,6 +1883,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // the sidebar we can't let it push the branch, and push/pull/fetch buttons
     // off screen.
     const toolbarButtonsWidth = 460
+
     // Start with all the available width
     let available = window.innerWidth
 
@@ -1904,10 +1905,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // but it doesn't break the layout and it allows users to temporarily
     // maximize the width of the file list to see long path names.
     const diffPaneMinWidth = 150
-    available -= diffPaneMinWidth
+    const filesMax = available - diffPaneMinWidth
 
-    this.commitSummaryWidth = constrain(this.commitSummaryWidth, 100, available)
-    this.stashedFilesWidth = constrain(this.stashedFilesWidth, 100, available)
+    this.commitSummaryWidth = constrain(this.commitSummaryWidth, 100, filesMax)
+    this.stashedFilesWidth = constrain(this.stashedFilesWidth, 100, filesMax)
   }
 
   private updateSelectedExternalEditor(

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -400,21 +400,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   private appIsFocused: boolean = false
 
-  private sidebarWidth: IConstrainedValue = {
-    value: defaultSidebarWidth,
-    min: 0,
-    max: Infinity,
-  }
-  private commitSummaryWidth: IConstrainedValue = {
-    value: defaultCommitSummaryWidth,
-    min: 0,
-    max: Infinity,
-  }
-  private stashedFilesWidth: IConstrainedValue = {
-    value: defaultStashedFilesWidth,
-    min: 0,
-    max: Infinity,
-  }
+  private sidebarWidth = constrain(defaultSidebarWidth)
+  private commitSummaryWidth = constrain(defaultCommitSummaryWidth)
+  private stashedFilesWidth = constrain(defaultStashedFilesWidth)
+
   private windowState: WindowState
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false
@@ -1769,18 +1758,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.updateRepositorySelectionAfterRepositoriesChanged()
 
-    this.sidebarWidth = {
-      ...this.sidebarWidth,
-      value: getNumber(sidebarWidthConfigKey, defaultSidebarWidth),
-    }
-    this.commitSummaryWidth = {
-      ...this.sidebarWidth,
-      value: getNumber(commitSummaryWidthConfigKey, defaultCommitSummaryWidth),
-    }
-    this.stashedFilesWidth = {
-      ...this.sidebarWidth,
-      value: getNumber(stashedFilesWidthConfigKey, defaultStashedFilesWidth),
-    }
+    this.sidebarWidth = constrain(
+      getNumber(sidebarWidthConfigKey, defaultSidebarWidth)
+    )
+    this.commitSummaryWidth = constrain(
+      getNumber(commitSummaryWidthConfigKey, defaultCommitSummaryWidth)
+    )
+    this.stashedFilesWidth = constrain(
+      getNumber(stashedFilesWidthConfigKey, defaultStashedFilesWidth)
+    )
 
     this.updateResizableConstraints()
 
@@ -6902,9 +6888,9 @@ function isLocalChangesOverwrittenError(error: Error): boolean {
 }
 
 function constrain(
-  value: IConstrainedValue,
-  min: number,
-  max: number
+  value: IConstrainedValue | number,
+  min = -Infinity,
+  max = Infinity
 ): IConstrainedValue {
-  return { value: value.value, min, max }
+  return { value: typeof value === 'number' ? value : value.value, min, max }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1884,7 +1884,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // off screen.
     const toolbarButtonsWidth = 460
     // Start with all the available width
-    let available = window.innerWidth - toolbarButtonsWidth
+    let available = window.innerWidth
 
     // Working our way from left to right (i.e. giving priority to the leftmost
     // pane when we need to constrain the width)
@@ -1892,11 +1892,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // 220 was determined as the minimum value since it is the smallest width
     // that will still fit the placeholder text in the branch selector textbox
     // of the history tab
-    this.sidebarWidth = constrain(this.sidebarWidth, 220, available)
+    const maxSidebarWidth = available - toolbarButtonsWidth
+    this.sidebarWidth = constrain(this.sidebarWidth, 220, maxSidebarWidth)
 
     // Now calculate the width we have left to distribute for the other panes
-    const actualSidebarWidth = clamp(this.sidebarWidth)
-    available -= actualSidebarWidth
+    available -= clamp(this.sidebarWidth)
 
     // This is a pretty silly width for a diff but it will fit ~9 chars per line
     // in unified mode after subtracting the width of the unified gutter and ~4

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2414,11 +2414,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const tooltip = repository && !isOpen ? repository.path : undefined
 
-    const foldoutWidth = clamp(
-      this.state.sidebarWidth.value,
-      this.state.sidebarWidth.min,
-      this.state.sidebarWidth.max
-    )
+    const foldoutWidth = clamp(this.state.sidebarWidth)
 
     const foldoutStyle: React.CSSProperties = {
       position: 'absolute',
@@ -2638,11 +2634,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       return null
     }
 
-    const width = clamp(
-      this.state.sidebarWidth.value,
-      this.state.sidebarWidth.min,
-      this.state.sidebarWidth.max
-    )
+    const width = clamp(this.state.sidebarWidth)
 
     return (
       <Toolbar id="desktop-app-toolbar">

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -145,6 +145,7 @@ import { ConfirmForcePush } from './rebase/confirm-force-push'
 import { PullRequestChecksFailed } from './notifications/pull-request-checks-failed'
 import { CICheckRunRerunDialog } from './check-runs/ci-check-run-rerun-dialog'
 import { WarnForcePushDialog } from './multi-commit-operation/dialog/warn-force-push-dialog'
+import { clamp } from '../lib/clamp'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2413,11 +2414,17 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const tooltip = repository && !isOpen ? repository.path : undefined
 
+    const foldoutWidth = clamp(
+      this.state.sidebarWidth.value,
+      this.state.sidebarWidth.min,
+      this.state.sidebarWidth.max
+    )
+
     const foldoutStyle: React.CSSProperties = {
       position: 'absolute',
       marginLeft: 0,
-      width: this.state.sidebarWidth,
-      minWidth: this.state.sidebarWidth,
+      width: foldoutWidth,
+      minWidth: foldoutWidth,
       height: '100%',
       top: 0,
     }
@@ -2631,12 +2638,15 @@ export class App extends React.Component<IAppProps, IAppState> {
       return null
     }
 
+    const width = clamp(
+      this.state.sidebarWidth.value,
+      this.state.sidebarWidth.min,
+      this.state.sidebarWidth.max
+    )
+
     return (
       <Toolbar id="desktop-app-toolbar">
-        <div
-          className="sidebar-section"
-          style={{ width: this.state.sidebarWidth }}
-        >
+        <div className="sidebar-section" style={{ width }}>
           {this.renderRepositoryToolbarButton()}
         </div>
         {this.renderBranchToolbarButton()}

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -31,6 +31,8 @@ import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
 import { getDotComAPIEndpoint } from '../../lib/api'
 import { IMenuItem } from '../../lib/menu-item'
 import { IChangesetData } from '../../lib/git'
+import { IConstrainedValue } from '../../lib/app-state'
+import { clamp } from '../../lib/clamp'
 
 interface ISelectedCommitProps {
   readonly repository: Repository
@@ -42,7 +44,7 @@ interface ISelectedCommitProps {
   readonly changesetData: IChangesetData
   readonly selectedFile: CommittedFileChange | null
   readonly currentDiff: IDiff | null
-  readonly commitSummaryWidth: number
+  readonly commitSummaryWidth: IConstrainedValue
   readonly selectedDiffType: ImageDiffType
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
@@ -222,8 +224,15 @@ export class SelectedCommit extends React.Component<
       return <div className="fill-window">No files in commit</div>
     }
 
+    const { commitSummaryWidth } = this.props
+
     // -1 for right hand side border
-    const availableWidth = this.props.commitSummaryWidth - 1
+    const availableWidth =
+      clamp(
+        commitSummaryWidth.value,
+        commitSummaryWidth.min,
+        commitSummaryWidth.max
+      ) - 1
 
     return (
       <FileList
@@ -258,13 +267,16 @@ export class SelectedCommit extends React.Component<
     }
 
     const className = this.state.isExpanded ? 'expanded' : 'collapsed'
+    const { commitSummaryWidth } = this.props
 
     return (
       <div id="history" ref={this.onHistoryRef} className={className}>
         {this.renderCommitSummary(commit)}
         <div className="commit-details">
           <Resizable
-            width={this.props.commitSummaryWidth}
+            width={commitSummaryWidth.value}
+            minimumWidth={commitSummaryWidth.min}
+            maximumWidth={commitSummaryWidth.max}
             onResize={this.onCommitSummaryResize}
             onReset={this.onCommitSummaryReset}
           >

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -227,12 +227,7 @@ export class SelectedCommit extends React.Component<
     const { commitSummaryWidth } = this.props
 
     // -1 for right hand side border
-    const availableWidth =
-      clamp(
-        commitSummaryWidth.value,
-        commitSummaryWidth.min,
-        commitSummaryWidth.max
-      ) - 1
+    const availableWidth = clamp(commitSummaryWidth) - 1
 
     return (
       <FileList

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -224,10 +224,8 @@ export class SelectedCommit extends React.Component<
       return <div className="fill-window">No files in commit</div>
     }
 
-    const { commitSummaryWidth } = this.props
-
     // -1 for right hand side border
-    const availableWidth = clamp(commitSummaryWidth) - 1
+    const availableWidth = clamp(this.props.commitSummaryWidth) - 1
 
     return (
       <FileList

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -14,6 +14,7 @@ import {
   IRepositoryState,
   RepositorySectionTab,
   ChangesSelectionKind,
+  IConstrainedValue,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
 import { IssuesStore, GitHubUserStore } from '../lib/stores'
@@ -35,18 +36,16 @@ import {
   AvailableDragAndDropIntroKeys,
 } from './history/drag-and-drop-intro'
 import { MultiCommitOperationKind } from '../models/multi-commit-operation'
-
-/** The widest the sidebar can be with the minimum window size. */
-const MaxSidebarWidth = 495
+import { clamp } from '../lib/clamp'
 
 interface IRepositoryViewProps {
   readonly repository: Repository
   readonly state: IRepositoryState
   readonly dispatcher: Dispatcher
   readonly emoji: Map<string, string>
-  readonly sidebarWidth: number
-  readonly commitSummaryWidth: number
-  readonly stashedFilesWidth: number
+  readonly sidebarWidth: IConstrainedValue
+  readonly commitSummaryWidth: IConstrainedValue
+  readonly stashedFilesWidth: IConstrainedValue
   readonly issuesStore: IssuesStore
   readonly gitHubUserStore: GitHubUserStore
   readonly onViewCommitOnGitHub: (SHA: string, filePath?: string) => void
@@ -213,7 +212,12 @@ export class RepositoryView extends React.Component<
         : null) || null
 
     // -1 Because of right hand side border
-    const availableWidth = this.props.sidebarWidth - 1
+    const availableWidth =
+      clamp(
+        this.props.sidebarWidth.value,
+        this.props.sidebarWidth.min,
+        this.props.sidebarWidth.max
+      ) - 1
 
     const scrollTop =
       this.previousSection === RepositorySectionTab.History
@@ -338,10 +342,11 @@ export class RepositoryView extends React.Component<
       <FocusContainer onFocusWithinChanged={this.onSidebarFocusWithinChanged}>
         <Resizable
           id="repository-sidebar"
-          width={this.props.sidebarWidth}
+          width={this.props.sidebarWidth.value}
+          maximumWidth={this.props.sidebarWidth.max}
+          minimumWidth={this.props.sidebarWidth.min}
           onReset={this.handleSidebarWidthReset}
           onResize={this.handleSidebarResize}
-          maximumWidth={MaxSidebarWidth}
         >
           {this.renderTabs()}
           {this.renderSidebarContents()}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -212,12 +212,7 @@ export class RepositoryView extends React.Component<
         : null) || null
 
     // -1 Because of right hand side border
-    const availableWidth =
-      clamp(
-        this.props.sidebarWidth.value,
-        this.props.sidebarWidth.min,
-        this.props.sidebarWidth.max
-      ) - 1
+    const availableWidth = clamp(this.props.sidebarWidth) - 1
 
     const scrollTop =
       this.previousSection === RepositorySectionTab.History

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -10,7 +10,7 @@ const DefaultMinWidth = 200
  * Note: this component is pure, consumers must subscribe to the
  * onResize and onReset event and update the width prop accordingly.
  */
-export class Resizable extends React.Component<IResizableProps, {}> {
+export class Resizable extends React.Component<IResizableProps> {
   private startWidth: number | null = null
   private startX: number | null = null
 

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -39,7 +39,7 @@ export class Resizable extends React.Component<IResizableProps> {
    */
   private handleDragStart = (e: React.MouseEvent<any>) => {
     this.startX = e.clientX
-    this.startWidth = this.getCurrentWidth() || null
+    this.startWidth = this.getCurrentWidth()
 
     document.addEventListener('mousemove', this.handleDragMove)
     document.addEventListener('mouseup', this.handleDragStop)

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -51,7 +51,7 @@ export class Resizable extends React.Component<IResizableProps> {
    * Handler for when the user moves the mouse while dragging
    */
   private handleDragMove = (e: MouseEvent) => {
-    if (this.startWidth == null || this.startX == null) {
+    if (this.startWidth === null || this.startX === null) {
       return
     }
 

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -57,10 +57,14 @@ export class Resizable extends React.Component<IResizableProps> {
 
     const deltaX = e.clientX - this.startX
     const newWidth = this.startWidth + deltaX
-    const newWidthClamped = this.clampWidth(newWidth)
 
-    this.props.onResize(newWidthClamped)
+    this.props.onResize(this.clampWidth(newWidth))
     e.preventDefault()
+  }
+
+  private unsubscribeFromGlobalEvents() {
+    document.removeEventListener('mousemove', this.handleDragMove)
+    document.removeEventListener('mouseup', this.handleDragStop)
   }
 
   /**
@@ -68,9 +72,7 @@ export class Resizable extends React.Component<IResizableProps> {
    * a resize operation.
    */
   private handleDragStop = (e: MouseEvent) => {
-    document.removeEventListener('mousemove', this.handleDragMove)
-    document.removeEventListener('mouseup', this.handleDragStop)
-
+    this.unsubscribeFromGlobalEvents()
     e.preventDefault()
   }
 

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react'
+import { clamp } from '../../lib/clamp'
+
+const DefaultMaxWidth = 350
+const DefaultMinWidth = 200
 
 /**
  * Component abstracting a resizable panel.
@@ -7,12 +11,6 @@ import * as React from 'react'
  * onResize and onReset event and update the width prop accordingly.
  */
 export class Resizable extends React.Component<IResizableProps, {}> {
-  public static defaultProps: IResizableProps = {
-    width: 250,
-    maximumWidth: 350,
-    minimumWidth: 200,
-  }
-
   private startWidth: number | null = null
   private startX: number | null = null
 
@@ -31,10 +29,9 @@ export class Resizable extends React.Component<IResizableProps, {}> {
    * maximum widths as determined by props
    */
   private clampWidth(width: number) {
-    return Math.max(
-      this.props.minimumWidth!,
-      Math.min(this.props.maximumWidth!, width)
-    )
+    const minWidth = this.props.minimumWidth ?? DefaultMinWidth
+    const maxWidth = this.props.maximumWidth ?? DefaultMaxWidth
+    return clamp(width, minWidth, maxWidth)
   }
 
   /**

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -29,9 +29,8 @@ export class Resizable extends React.Component<IResizableProps> {
    * maximum widths as determined by props
    */
   private clampWidth(width: number) {
-    const minWidth = this.props.minimumWidth ?? DefaultMinWidth
-    const maxWidth = this.props.maximumWidth ?? DefaultMaxWidth
-    return clamp(width, minWidth, maxWidth)
+    const { minimumWidth: min, maximumWidth: max } = this.props
+    return clamp(width, min ?? DefaultMinWidth, max ?? DefaultMaxWidth)
   }
 
   /**

--- a/app/src/ui/resizable/resizable.tsx
+++ b/app/src/ui/resizable/resizable.tsx
@@ -60,10 +60,7 @@ export class Resizable extends React.Component<IResizableProps, {}> {
     const newWidth = this.startWidth + deltaX
     const newWidthClamped = this.clampWidth(newWidth)
 
-    if (this.props.onResize) {
-      this.props.onResize(newWidthClamped)
-    }
-
+    this.props.onResize(newWidthClamped)
     e.preventDefault()
   }
 
@@ -78,18 +75,6 @@ export class Resizable extends React.Component<IResizableProps, {}> {
     e.preventDefault()
   }
 
-  /**
-   * Handler for when the resize handle is double clicked.
-   *
-   * Resets the panel width to its default value and clears
-   * any persisted value.
-   */
-  private handleDoubleClick = () => {
-    if (this.props.onReset) {
-      this.props.onReset()
-    }
-  }
-
   public render() {
     const style: React.CSSProperties = {
       width: this.getCurrentWidth(),
@@ -102,7 +87,7 @@ export class Resizable extends React.Component<IResizableProps, {}> {
         {this.props.children}
         <div
           onMouseDown={this.handleDragStart}
-          onDoubleClick={this.handleDoubleClick}
+          onDoubleClick={this.props.onReset}
           className="resize-handle"
         />
       </div>
@@ -133,12 +118,12 @@ export interface IResizableProps {
    * Handler called when the width of the component has changed
    * through an explicit resize event (dragging the handle).
    */
-  readonly onResize?: (newWidth: number) => void
+  readonly onResize: (newWidth: number) => void
 
   /**
    * Handler called when the resizable component has been
    * reset (ie restored to its original width by double clicking
    * on the resize handle).
    */
-  readonly onReset?: () => void
+  readonly onReset: () => void
 }

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -101,11 +101,7 @@ export class StashDiffViewer extends React.PureComponent<
         />
       ) : null
 
-    const availableWidth = clamp(
-      fileListWidth.value,
-      fileListWidth.min,
-      fileListWidth.max
-    )
+    const availableWidth = clamp(fileListWidth)
 
     return (
       <section id="stash-diff-viewer">

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -8,6 +8,8 @@ import { IDiff, ImageDiffType } from '../../models/diff'
 import { Resizable } from '../resizable'
 import { StashDiffHeader } from './stash-diff-header'
 import { SeamlessDiffSwitcher } from '../diff/seamless-diff-switcher'
+import { IConstrainedValue } from '../../lib/app-state'
+import { clamp } from '../../lib/clamp'
 
 interface IStashDiffViewerProps {
   /** The stash in question. */
@@ -21,7 +23,7 @@ interface IStashDiffViewerProps {
   readonly imageDiffType: ImageDiffType
 
   /** width to use for the files list pane */
-  readonly fileListWidth: number
+  readonly fileListWidth: IConstrainedValue
   readonly repository: Repository
   readonly dispatcher: Dispatcher
 
@@ -99,6 +101,12 @@ export class StashDiffViewer extends React.PureComponent<
         />
       ) : null
 
+    const availableWidth = clamp(
+      fileListWidth.value,
+      fileListWidth.min,
+      fileListWidth.max
+    )
+
     return (
       <section id="stash-diff-viewer">
         <StashDiffHeader
@@ -109,7 +117,9 @@ export class StashDiffViewer extends React.PureComponent<
         />
         <div className="commit-details">
           <Resizable
-            width={this.props.fileListWidth}
+            width={fileListWidth.value}
+            minimumWidth={fileListWidth.min}
+            maximumWidth={fileListWidth.max}
             onResize={this.onResize}
             onReset={this.onReset}
           >
@@ -117,7 +127,7 @@ export class StashDiffViewer extends React.PureComponent<
               files={files}
               onSelectedFileChanged={this.onSelectedFileChanged}
               selectedFile={selectedStashedFile}
-              availableWidth={fileListWidth}
+              availableWidth={availableWidth}
             />
           </Resizable>
           {diffComponent}


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #2745 

## Description

Since the very first versions of GitHub Desktop we've enforced a max width for our resizable components (the changes/history list, and the file list in the stashed changes view and in the selected commit view).

These constraints were put in place to ensure that you couldn't resize these components to a point where you could no longer use parts of the UI because they were now being rendered outside of the window bounds. 

The constraints we set where based on running the app in the minimum window size such that it wouldn't be possible to maximize the app, resize the panes, and then restore the window size and find yourself in a situation where parts of the UI were being rendered outside of the window bounds.

This was always intended to be a temporary solution until we could get around to implementing a dynamic max-width that got recalculated based on the layout of the app and the window size (see https://github.com/desktop/desktop/issues/1588#issuecomment-329405096). There's been several attempts by community contributors to address this issue that we've unfortunately had to reject since they focused on removing/increasing the constraints, not making the constraints themselves adapt to the window dimensions.

In this PR we're making the resizable panes remember their "desired" value and dynamically calculate their max width depending on the width of other resizable panes that affect the available space and the windows dimensions while making sure the the UI is usable.

By keeping track of the desired width we can support resizing the application in a consistent way where maximizing the app, resizing the panes then restoring its size will cause the panes to shrink to fit their constraints but (unless modified again) they will inflate to their desired size again once the app is maximized again.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/634063/144614563-1b7dd6d7-3231-470f-b494-3cfd491027d9.png)
![image](https://user-images.githubusercontent.com/634063/144614619-70a75074-d086-4eb8-a0fe-bd0ed5353234.png)
![image](https://user-images.githubusercontent.com/634063/144614680-0294e66c-329c-42a5-867c-689c6b5c6b44.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

![image](https://user-images.githubusercontent.com/634063/144614283-9ae410cd-be8b-42a2-8062-be5dfd876bc1.png)
