### PR TITLE
Pull Request Quick View Component - Getting started

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -493,6 +493,7 @@ export interface IAPIPullRequest {
   readonly user: IAPIIdentity
   readonly head: IAPIPullRequestRef
   readonly base: IAPIPullRequestRef
+  readonly body: string
   readonly state: 'open' | 'closed'
   readonly draft?: boolean
 }

--- a/app/src/lib/databases/pull-request-database.ts
+++ b/app/src/lib/databases/pull-request-database.ts
@@ -23,6 +23,9 @@ export interface IPullRequest {
   /** The title. */
   readonly title: string
 
+  /** The body of the PR - This is markdown. */
+  readonly body: string
+
   /** The string formatted date on which the PR was created. */
   readonly createdAt: string
 
@@ -121,6 +124,15 @@ export class PullRequestDatabase extends BaseDatabase {
        * and unless the draft PRs get updated at some point in the future we'll
        * never pick up on it so we'll clear the db to seed it with fresh data
        * from the API.
+       */
+      tx.table('pullRequests').clear()
+      tx.table('pullRequestsLastUpdated').clear()
+    })
+
+    this.conditionalVersion(9, {}, async tx => {
+      /**
+       * We're introducing the `body` property on PRs in version 8 in order
+       * to be able to display the body of the pr.
        */
       tx.table('pullRequests').clear()
       tx.table('pullRequestsLastUpdated').clear()

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -157,3 +157,8 @@ export function enableCICheckRunsLogs(): boolean {
 export function enablePreviousTagSuggestions(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we show a pull-requests quick view? */
+export function enablePullRequestQuickView(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -194,7 +194,8 @@ export class PullRequestStore {
           new PullRequestRef(record.head.ref, record.head.sha, headRepository),
           new PullRequestRef(record.base.ref, record.base.sha, baseRepository),
           record.author,
-          record.draft ?? false
+          record.draft ?? false,
+          record.body
         )
       )
     }
@@ -316,6 +317,7 @@ export class PullRequestStore {
           sha: pr.base.sha,
           repoId: baseGitHubRepo.dbID,
         },
+        body: pr.body,
         author: pr.user.login,
         draft: pr.draft ?? false,
       })

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -32,6 +32,7 @@ export class PullRequest {
     public readonly head: PullRequestRef,
     public readonly base: PullRequestRef,
     public readonly author: string,
-    public readonly draft: boolean
+    public readonly draft: boolean,
+    public readonly body: string
   ) {}
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -121,11 +121,9 @@ export class BranchesContainer extends React.Component<
   }
 
   private onMouseLeavePullRequestQuickView = () => {
-    /*
     this.setState({
       pullRequestBeingViewed: null,
     })
-    */
   }
 
   private renderMergeButtonRow() {

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -80,9 +80,7 @@ export class BranchesContainer extends React.Component<
     return null
   }
 
-  private pullRequestQuickViewRef: React.RefObject<
-    HTMLDivElement
-  > = React.createRef()
+  private pullRequestQuickViewTimerId: number | null = null
 
   public constructor(props: IBranchesContainerProps) {
     super(props)
@@ -94,6 +92,10 @@ export class BranchesContainer extends React.Component<
       branchFilterText: '',
       pullRequestBeingViewed: null,
     }
+  }
+
+  public componentWillUnmount = () => {
+    this.clearPullRequestQuickViewTimer()
   }
 
   public render() {
@@ -117,18 +119,23 @@ export class BranchesContainer extends React.Component<
 
     return (
       <PullRequestQuickView
-        ref={this.pullRequestQuickViewRef}
         dispatcher={this.props.dispatcher}
         pullRequest={this.state.pullRequestBeingViewed}
+        onMouseEnter={this.onMouseEnterPullRequestQuickView}
         onMouseLeave={this.onMouseLeavePullRequestQuickView}
       />
     )
+  }
+
+  private onMouseEnterPullRequestQuickView = () => {
+    this.clearPullRequestQuickViewTimer()
   }
 
   private onMouseLeavePullRequestQuickView = () => {
     this.setState({
       pullRequestBeingViewed: null,
     })
+    this.clearPullRequestQuickViewTimer()
   }
 
   private renderMergeButtonRow() {
@@ -317,26 +324,20 @@ export class BranchesContainer extends React.Component<
   private onMouseEnterPullRequestListItem = (
     pullRequestBeingViewed: PullRequest
   ) => {
-    this.setState({ pullRequestBeingViewed })
+    this.clearPullRequestQuickViewTimer()
+    this.setState({ pullRequestBeingViewed: null })
+    this.pullRequestQuickViewTimerId = window.setTimeout(
+      () => this.setState({ pullRequestBeingViewed }),
+      250
+    )
   }
 
-  private onMouseLeavePullRequestListItem = async (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
-    // If we leave a list item, onto the pull request quick view, we don't want
-    // to close the quick view
-    const { relatedTarget } = event
-    const prQuickView = this.pullRequestQuickViewRef.current
-    if (
-      relatedTarget !== null &&
-      relatedTarget instanceof Node &&
-      prQuickView !== null &&
-      prQuickView.contains(relatedTarget)
-    ) {
-      return
-    }
-
-    this.setState({ pullRequestBeingViewed: null })
+  private onMouseLeavePullRequestListItem = async () => {
+    this.clearPullRequestQuickViewTimer()
+    this.pullRequestQuickViewTimerId = window.setTimeout(
+      () => this.setState({ pullRequestBeingViewed: null }),
+      500
+    )
   }
 
   private onTabClicked = (tab: BranchesTab) => {
@@ -467,5 +468,14 @@ export class BranchesContainer extends React.Component<
     if (dragAndDropManager.isDragOfType(DragType.Commit)) {
       this.props.dispatcher.recordDragStartedAndCanceled()
     }
+  }
+
+  private clearPullRequestQuickViewTimer = () => {
+    if (this.pullRequestQuickViewTimerId === null) {
+      return
+    }
+
+    window.clearTimeout(this.pullRequestQuickViewTimerId)
+    this.pullRequestQuickViewTimerId = null
   }
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -28,6 +28,8 @@ import { IMatches } from '../../lib/fuzzy-find'
 import { startTimer } from '../lib/timing'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DragType, DropTargetType } from '../../models/drag-drop'
+import { enablePullRequestQuickView } from '../../lib/feature-flag'
+import { PullRequestQuickView } from '../pull-request-quick-view'
 
 interface IBranchesContainerProps {
   readonly dispatcher: Dispatcher
@@ -94,7 +96,21 @@ export class BranchesContainer extends React.Component<
         {this.renderTabBar()}
         {this.renderSelectedTab()}
         {this.renderMergeButtonRow()}
+        {this.renderPullRequestQuickView()}
       </div>
+    )
+  }
+
+  private renderPullRequestQuickView = (): JSX.Element | null => {
+    if (!enablePullRequestQuickView()) {
+      return null
+    }
+
+    return (
+      <PullRequestQuickView
+        dispatcher={this.props.dispatcher}
+        repository={this.props.pullRequests[0].base.gitHubRepository}
+      />
     )
   }
 

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -80,6 +80,10 @@ export class BranchesContainer extends React.Component<
     return null
   }
 
+  private pullRequestQuickViewRef: React.RefObject<
+    HTMLDivElement
+  > = React.createRef()
+
   public constructor(props: IBranchesContainerProps) {
     super(props)
 
@@ -113,6 +117,7 @@ export class BranchesContainer extends React.Component<
 
     return (
       <PullRequestQuickView
+        ref={this.pullRequestQuickViewRef}
         dispatcher={this.props.dispatcher}
         pullRequest={this.state.pullRequestBeingViewed}
         onMouseLeave={this.onMouseLeavePullRequestQuickView}
@@ -321,7 +326,7 @@ export class BranchesContainer extends React.Component<
     // If we leave a list item, onto the pull request quick view, we don't want
     // to close the quick view
     const { relatedTarget } = event
-    const prQuickView = document.getElementById('pull-request-quick-view')
+    const prQuickView = this.pullRequestQuickViewRef.current
     if (
       relatedTarget !== null &&
       relatedTarget instanceof Node &&

--- a/app/src/ui/branches/pull-request-badge.tsx
+++ b/app/src/ui/branches/pull-request-badge.tsx
@@ -15,11 +15,11 @@ interface IPullRequestBadgeProps {
   readonly repository: GitHubRepository
 
   /** The GitHub repository to use when looking up commit status. */
-  readonly onBadgeClick: () => void
+  readonly onBadgeClick?: () => void
 
   /** When the bottom edge of the pull request badge position changes. For
    * example, on a mac, this changes when the user maximizes Desktop. */
-  readonly onBadgeBottomPositionUpdate: (bottom: number) => void
+  readonly onBadgeBottomPositionUpdate?: (bottom: number) => void
 }
 
 interface IPullRequestBadgeState {
@@ -51,7 +51,7 @@ export class PullRequestBadge extends React.Component<
       this.badgeRef.getBoundingClientRect().bottom !== this.badgeBoundingBottom
     ) {
       this.badgeBoundingBottom = this.badgeRef.getBoundingClientRect().bottom
-      this.props.onBadgeBottomPositionUpdate(this.badgeBoundingBottom)
+      this.props.onBadgeBottomPositionUpdate?.(this.badgeBoundingBottom)
     }
   }
 
@@ -67,7 +67,7 @@ export class PullRequestBadge extends React.Component<
     }
 
     event.stopPropagation()
-    this.props.onBadgeClick()
+    this.props.onBadgeClick?.()
   }
 
   private onCheckChange = (check: ICombinedRefCheck | null) => {
@@ -77,7 +77,7 @@ export class PullRequestBadge extends React.Component<
   public render() {
     const ref = `refs/pull/${this.props.number}/head`
     return (
-      <div id="pr-badge" onClick={this.onBadgeClick} ref={this.onRef}>
+      <div className="pr-badge" onClick={this.onBadgeClick} ref={this.onRef}>
         <span className="number">#{this.props.number}</span>
         <CIStatus
           commitRef={ref}

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -46,6 +46,14 @@ export interface IPullRequestListItemProps {
 
   /** When a drag element has landed on a pull request */
   readonly onDropOntoPullRequest: (prNumber: number) => void
+
+  /** When mouse enters a PR */
+  readonly onMouseEnter: (prNumber: number) => void
+
+  /** When mouse leaves a PR */
+  readonly onMouseLeave: (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => void
 }
 
 interface IPullRequestListItemState {
@@ -82,14 +90,18 @@ export class PullRequestListItem extends React.Component<
         branchName: this.props.title,
       })
     }
+    this.props.onMouseEnter(this.props.number)
   }
 
-  private onMouseLeave = () => {
+  private onMouseLeave = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
     if (dragAndDropManager.isDragInProgress) {
       this.setState({ isDragInProgress: false })
 
       dragAndDropManager.emitLeaveDropTarget()
     }
+    this.props.onMouseLeave(event)
   }
 
   private onMouseUp = () => {

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -65,6 +65,14 @@ interface IPullRequestListProps {
 
   /** Are we currently loading pull requests? */
   readonly isLoadingPullRequests: boolean
+
+  /** When mouse enters a PR */
+  readonly onMouseEnterPullRequest: (prNumber: PullRequest) => void
+
+  /** When mouse leaves a PR */
+  readonly onMouseLeavePullRequest: (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => void
 }
 
 interface IPullRequestListState {
@@ -173,8 +181,30 @@ export class PullRequestList extends React.Component<
         dispatcher={this.props.dispatcher}
         repository={pr.base.gitHubRepository}
         onDropOntoPullRequest={this.onDropOntoPullRequest}
+        onMouseEnter={this.onMouseEnterPullRequest}
+        onMouseLeave={this.onMouseLeavePullRequest}
       />
     )
+  }
+
+  private onMouseEnterPullRequest = (prNumber: number) => {
+    const { pullRequests } = this.props
+
+    // If not the currently checked out pull request, find the full pull request
+    // object to start the cherry-pick
+    const pr = pullRequests.find(pr => pr.pullRequestNumber === prNumber)
+    if (pr === undefined) {
+      log.error('[onMouseEnterPullReqest] - Could not find pull request.')
+      return
+    }
+
+    this.props.onMouseEnterPullRequest(pr)
+  }
+
+  private onMouseLeavePullRequest = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    this.props.onMouseLeavePullRequest(event)
   }
 
   private onDropOntoPullRequest = (prNumber: number) => {

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -173,7 +173,7 @@ export class SandboxedMarkdown extends React.PureComponent<
 
     const styleSheet = await this.getInlineStyleSheet()
 
-    const parsedMarkdown = marked(this.props.markdown, {
+    const parsedMarkdown = marked(this.props.markdown ?? '', {
       gfm: true,
     })
 

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { GitHubRepository } from '../models/github-repository'
+import { PullRequest } from '../models/pull-request'
 import { PullRequestBadge } from './branches'
 import { Dispatcher } from './dispatcher'
 import { Button } from './lib/button'
@@ -7,22 +7,12 @@ import { SandboxedMarkdown } from './lib/sandboxed-markdown'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 
-interface IPullRequest {
-  /** The GitHub PR number. */
-  readonly number: number
-
-  /** The title. */
-  readonly title: string
-
-  /** The body - Markdown */
-  readonly body: string
-}
-
 interface IPullRequestQuickViewProps {
   readonly dispatcher: Dispatcher
+  readonly pullRequest: PullRequest
 
-  /** The GitHub repository to use when looking up commit status. */
-  readonly repository: GitHubRepository
+  /** When mouse leaves the PR quick view */
+  readonly onMouseLeave: () => void
 }
 
 export class PullRequestQuickView extends React.Component<
@@ -30,21 +20,17 @@ export class PullRequestQuickView extends React.Component<
   {}
 > {
   // TO BE PROPS
-  private mockPR: IPullRequest = {
-    number: 13432,
-    title:
-      'Cherry-pick regression: On stash, we clear multiCommitOperation, we need to reset on retry',
-    body:
-      'Closes #13419\n' +
-      '\n## Description\n\n' +
-      '\nRepro steps:\n' +
-      '1. Have uncommitted changes\n' +
-      '2. Attempt to cherry-pick a commit. Note there are three entry points. 1) drag and drop to an existing branch 2). drag to new branch and 3) context menu.\n' +
-      '3. On popup, hit stash and continue\n' +
-      'As reported in the bug, the app would freeze during cherry-pick stashing, because on attempt to run retry method the multi commit operation would be null. This is because the Local Changes Overridden dialog is not part of the multi commit operation flow and yet dismissing it would technically end the flow. Thus, we end the flow on the dialog opening so that it is not in a state of cherry-pick if the user dismisses. Unfortunately, during refactor the initialization of the mutli comitt operation was moved farther back then the retry method. Thus, this PR adds an if clause in the retry methods (there are 2 since there are 3 entry points to cherry-pick) to re initialize if state does not exist.\n' +
-      '\n## Release notes\n' +
-      'Notes: [Fixed] App no longer freezes on stash dialog if cherry-picking with uncommitted changes present.\n',
-  }
+  private mockPRBody =
+    'Closes #13419\n' +
+    '\n## Description\n\n' +
+    '\nRepro steps:\n' +
+    '1. Have uncommitted changes\n' +
+    '2. Attempt to cherry-pick a commit. Note there are three entry points. 1) drag and drop to an existing branch 2). drag to new branch and 3) context menu.\n' +
+    '3. On popup, hit stash and continue\n' +
+    'As reported in the bug, the app would freeze during cherry-pick stashing, because on attempt to run retry method the multi commit operation would be null. This is because the Local Changes Overridden dialog is not part of the multi commit operation flow and yet dismissing it would technically end the flow. Thus, we end the flow on the dialog opening so that it is not in a state of cherry-pick if the user dismisses. Unfortunately, during refactor the initialization of the mutli comitt operation was moved farther back then the retry method. Thus, this PR adds an if clause in the retry methods (there are 2 since there are 3 entry points to cherry-pick) to re initialize if state does not exist.\n' +
+    '\n## Release notes\n' +
+    'Notes: [Fixed] App no longer freezes on stash dialog if cherry-picking with uncommitted changes present.\n'
+
   private baseHref = 'https://github.com/'
 
   private renderHeader = (): JSX.Element => {
@@ -61,6 +47,7 @@ export class PullRequestQuickView extends React.Component<
   }
 
   private renderPR = (): JSX.Element => {
+    const { title, pullRequestNumber, base } = this.props.pullRequest
     return (
       <div className="pull-request">
         <div className="status">
@@ -68,26 +55,32 @@ export class PullRequestQuickView extends React.Component<
           <span className="state">Open</span>
         </div>
         <div className="title">
-          <h2>{this.mockPR.title}</h2>
+          <h2>{title}</h2>
           <PullRequestBadge
-            number={this.mockPR.number}
+            number={pullRequestNumber}
             dispatcher={this.props.dispatcher}
-            repository={this.props.repository}
+            repository={base.gitHubRepository}
           />
         </div>
         <SandboxedMarkdown
-          markdown={this.mockPR.body}
+          markdown={this.mockPRBody}
           baseHref={this.baseHref}
         />
       </div>
     )
   }
 
+  private onMouseLeave = () => {
+    this.props.onMouseLeave()
+  }
+
   public render() {
     return (
-      <div id="pull-request-quick-view">
-        {this.renderHeader()}
-        {this.renderPR()}
+      <div id="pull-request-quick-view" onMouseLeave={this.onMouseLeave}>
+        <div className="pull-request-quick-view-contents">
+          {this.renderHeader()}
+          {this.renderPR()}
+        </div>
       </div>
     )
   }

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -15,62 +15,73 @@ interface IPullRequestQuickViewProps {
   readonly onMouseLeave: () => void
 }
 
-export class PullRequestQuickView extends React.Component<
-  IPullRequestQuickViewProps,
-  {}
-> {
-  private baseHref = 'https://github.com/'
+export const PullRequestQuickView = React.forwardRef<
+  HTMLDivElement,
+  IPullRequestQuickViewProps
+>((props, ref) => {
+  class PullRequestQuickView extends React.Component<
+    IPullRequestQuickViewProps,
+    {}
+  > {
+    private baseHref = 'https://github.com/'
 
-  private renderHeader = () => {
-    return (
-      <header className="header">
-        <Octicon symbol={OcticonSymbol.listUnordered} />
-        <div className="action-needed">Review requested</div>
-        <Button className="button-with-icon">
-          View on GitHub
-          <Octicon symbol={OcticonSymbol.linkExternal} />
-        </Button>
-      </header>
-    )
-  }
+    private renderHeader = () => {
+      return (
+        <header className="header">
+          <Octicon symbol={OcticonSymbol.listUnordered} />
+          <div className="action-needed">Review requested</div>
+          <Button className="button-with-icon">
+            View on GitHub
+            <Octicon symbol={OcticonSymbol.linkExternal} />
+          </Button>
+        </header>
+      )
+    }
 
-  private renderPR = () => {
-    const { title, pullRequestNumber, base, body } = this.props.pullRequest
-    const displayBody =
-      body !== undefined && body !== null && body.trim() !== ''
-        ? body
-        : '_No description provided._'
-    return (
-      <div className="pull-request">
-        <div className="status">
-          <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
-          <span className="state">Open</span>
+    private renderPR = () => {
+      const { title, pullRequestNumber, base, body } = this.props.pullRequest
+      const displayBody =
+        body !== undefined && body !== null && body.trim() !== ''
+          ? body
+          : '_No description provided._'
+      return (
+        <div className="pull-request">
+          <div className="status">
+            <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
+            <span className="state">Open</span>
+          </div>
+          <div className="title">
+            <h2>{title}</h2>
+            <PullRequestBadge
+              number={pullRequestNumber}
+              dispatcher={this.props.dispatcher}
+              repository={base.gitHubRepository}
+            />
+          </div>
+          <SandboxedMarkdown markdown={displayBody} baseHref={this.baseHref} />
         </div>
-        <div className="title">
-          <h2>{title}</h2>
-          <PullRequestBadge
-            number={pullRequestNumber}
-            dispatcher={this.props.dispatcher}
-            repository={base.gitHubRepository}
-          />
+      )
+    }
+
+    private onMouseLeave = () => {
+      this.props.onMouseLeave()
+    }
+
+    public render() {
+      return (
+        <div
+          id="pull-request-quick-view"
+          ref={ref}
+          onMouseLeave={this.onMouseLeave}
+        >
+          <div className="pull-request-quick-view-contents">
+            {this.renderHeader()}
+            {this.renderPR()}
+          </div>
         </div>
-        <SandboxedMarkdown markdown={displayBody} baseHref={this.baseHref} />
-      </div>
-    )
+      )
+    }
   }
 
-  private onMouseLeave = () => {
-    this.props.onMouseLeave()
-  }
-
-  public render() {
-    return (
-      <div id="pull-request-quick-view" onMouseLeave={this.onMouseLeave}>
-        <div className="pull-request-quick-view-contents">
-          {this.renderHeader()}
-          {this.renderPR()}
-        </div>
-      </div>
-    )
-  }
-}
+  return <PullRequestQuickView {...props} />
+})

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -34,7 +34,7 @@ export class PullRequestQuickView extends React.Component<
     )
   }
 
-  private renderPR = (): JSX.Element => {
+  private renderPR = () => {
     const { title, pullRequestNumber, base, body } = this.props.pullRequest
     const displayBody =
       body !== undefined && body !== null && body.trim() !== ''

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -21,7 +21,7 @@ export class PullRequestQuickView extends React.Component<
 > {
   private baseHref = 'https://github.com/'
 
-  private renderHeader = (): JSX.Element => {
+  private renderHeader = () => {
     return (
       <header className="header">
         <Octicon symbol={OcticonSymbol.listUnordered} />

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -19,18 +19,6 @@ export class PullRequestQuickView extends React.Component<
   IPullRequestQuickViewProps,
   {}
 > {
-  // TO BE PROPS
-  private mockPRBody =
-    'Closes #13419\n' +
-    '\n## Description\n\n' +
-    '\nRepro steps:\n' +
-    '1. Have uncommitted changes\n' +
-    '2. Attempt to cherry-pick a commit. Note there are three entry points. 1) drag and drop to an existing branch 2). drag to new branch and 3) context menu.\n' +
-    '3. On popup, hit stash and continue\n' +
-    'As reported in the bug, the app would freeze during cherry-pick stashing, because on attempt to run retry method the multi commit operation would be null. This is because the Local Changes Overridden dialog is not part of the multi commit operation flow and yet dismissing it would technically end the flow. Thus, we end the flow on the dialog opening so that it is not in a state of cherry-pick if the user dismisses. Unfortunately, during refactor the initialization of the mutli comitt operation was moved farther back then the retry method. Thus, this PR adds an if clause in the retry methods (there are 2 since there are 3 entry points to cherry-pick) to re initialize if state does not exist.\n' +
-    '\n## Release notes\n' +
-    'Notes: [Fixed] App no longer freezes on stash dialog if cherry-picking with uncommitted changes present.\n'
-
   private baseHref = 'https://github.com/'
 
   private renderHeader = (): JSX.Element => {
@@ -47,7 +35,11 @@ export class PullRequestQuickView extends React.Component<
   }
 
   private renderPR = (): JSX.Element => {
-    const { title, pullRequestNumber, base } = this.props.pullRequest
+    const { title, pullRequestNumber, base, body } = this.props.pullRequest
+    const displayBody =
+      body !== undefined && body !== null && body.trim() !== ''
+        ? body
+        : '_No description provided._'
     return (
       <div className="pull-request">
         <div className="status">
@@ -62,10 +54,7 @@ export class PullRequestQuickView extends React.Component<
             repository={base.gitHubRepository}
           />
         </div>
-        <SandboxedMarkdown
-          markdown={this.mockPRBody}
-          baseHref={this.baseHref}
-        />
+        <SandboxedMarkdown markdown={displayBody} baseHref={this.baseHref} />
       </div>
     )
   }

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -12,76 +12,72 @@ interface IPullRequestQuickViewProps {
   readonly pullRequest: PullRequest
 
   /** When mouse leaves the PR quick view */
+  readonly onMouseEnter: () => void
+
+  /** When mouse leaves the PR quick view */
   readonly onMouseLeave: () => void
 }
 
-export const PullRequestQuickView = React.forwardRef<
-  HTMLDivElement,
-  IPullRequestQuickViewProps
->((props, ref) => {
-  class PullRequestQuickView extends React.Component<
-    IPullRequestQuickViewProps,
-    {}
-  > {
-    private baseHref = 'https://github.com/'
+export class PullRequestQuickView extends React.Component<
+  IPullRequestQuickViewProps,
+  {}
+> {
+  private baseHref = 'https://github.com/'
 
-    private renderHeader = () => {
-      return (
-        <header className="header">
-          <Octicon symbol={OcticonSymbol.listUnordered} />
-          <div className="action-needed">Review requested</div>
-          <Button className="button-with-icon">
-            View on GitHub
-            <Octicon symbol={OcticonSymbol.linkExternal} />
-          </Button>
-        </header>
-      )
-    }
-
-    private renderPR = () => {
-      const { title, pullRequestNumber, base, body } = this.props.pullRequest
-      const displayBody =
-        body !== undefined && body !== null && body.trim() !== ''
-          ? body
-          : '_No description provided._'
-      return (
-        <div className="pull-request">
-          <div className="status">
-            <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
-            <span className="state">Open</span>
-          </div>
-          <div className="title">
-            <h2>{title}</h2>
-            <PullRequestBadge
-              number={pullRequestNumber}
-              dispatcher={this.props.dispatcher}
-              repository={base.gitHubRepository}
-            />
-          </div>
-          <SandboxedMarkdown markdown={displayBody} baseHref={this.baseHref} />
-        </div>
-      )
-    }
-
-    private onMouseLeave = () => {
-      this.props.onMouseLeave()
-    }
-
-    public render() {
-      return (
-        <div
-          id="pull-request-quick-view"
-          ref={ref}
-          onMouseLeave={this.onMouseLeave}
-        >
-          <div className="pull-request-quick-view-contents">
-            {this.renderHeader()}
-            {this.renderPR()}
-          </div>
-        </div>
-      )
-    }
+  private renderHeader = () => {
+    return (
+      <header className="header">
+        <Octicon symbol={OcticonSymbol.listUnordered} />
+        <div className="action-needed">Review requested</div>
+        <Button className="button-with-icon">
+          View on GitHub
+          <Octicon symbol={OcticonSymbol.linkExternal} />
+        </Button>
+      </header>
+    )
   }
 
-  return <PullRequestQuickView {...props} />
-})
+  private renderPR = () => {
+    const { title, pullRequestNumber, base, body } = this.props.pullRequest
+    const displayBody =
+      body !== undefined && body !== null && body.trim() !== ''
+        ? body
+        : '_No description provided._'
+    return (
+      <div className="pull-request">
+        <div className="status">
+          <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
+          <span className="state">Open</span>
+        </div>
+        <div className="title">
+          <h2>{title}</h2>
+          <PullRequestBadge
+            number={pullRequestNumber}
+            dispatcher={this.props.dispatcher}
+            repository={base.gitHubRepository}
+          />
+        </div>
+        <SandboxedMarkdown markdown={displayBody} baseHref={this.baseHref} />
+      </div>
+    )
+  }
+
+  private onMouseLeave = () => {
+    this.props.onMouseLeave()
+  }
+
+  public render() {
+    return (
+      <div
+        id="pull-request-quick-view"
+        onMouseEnter={this.props.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
+        <div className="pull-request-quick-view-contents">
+          {this.renderHeader()}
+          {this.renderPR()}
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -69,7 +69,7 @@ export class PullRequestQuickView extends React.Component<
   public render() {
     return (
       <div
-        id="pull-request-quick-view"
+        className="pull-request-quick-view"
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
       >

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { GitHubRepository } from '../models/github-repository'
+import { PullRequestBadge } from './branches'
+import { Dispatcher } from './dispatcher'
+import { Button } from './lib/button'
+import { SandboxedMarkdown } from './lib/sandboxed-markdown'
+import { Octicon } from './octicons'
+import * as OcticonSymbol from './octicons/octicons.generated'
+
+interface IPullRequest {
+  /** The GitHub PR number. */
+  readonly number: number
+
+  /** The title. */
+  readonly title: string
+
+  /** The body - Markdown */
+  readonly body: string
+}
+
+interface IPullRequestQuickViewProps {
+  readonly dispatcher: Dispatcher
+
+  /** The GitHub repository to use when looking up commit status. */
+  readonly repository: GitHubRepository
+}
+
+export class PullRequestQuickView extends React.Component<
+  IPullRequestQuickViewProps,
+  {}
+> {
+  // TO BE PROPS
+  private mockPR: IPullRequest = {
+    number: 13432,
+    title:
+      'Cherry-pick regression: On stash, we clear multiCommitOperation, we need to reset on retry',
+    body:
+      'Closes #13419\n' +
+      '\n## Description\n\n' +
+      '\nRepro steps:\n' +
+      '1. Have uncommitted changes\n' +
+      '2. Attempt to cherry-pick a commit. Note there are three entry points. 1) drag and drop to an existing branch 2). drag to new branch and 3) context menu.\n' +
+      '3. On popup, hit stash and continue\n' +
+      'As reported in the bug, the app would freeze during cherry-pick stashing, because on attempt to run retry method the multi commit operation would be null. This is because the Local Changes Overridden dialog is not part of the multi commit operation flow and yet dismissing it would technically end the flow. Thus, we end the flow on the dialog opening so that it is not in a state of cherry-pick if the user dismisses. Unfortunately, during refactor the initialization of the mutli comitt operation was moved farther back then the retry method. Thus, this PR adds an if clause in the retry methods (there are 2 since there are 3 entry points to cherry-pick) to re initialize if state does not exist.\n' +
+      '\n## Release notes\n' +
+      'Notes: [Fixed] App no longer freezes on stash dialog if cherry-picking with uncommitted changes present.\n',
+  }
+  private baseHref = 'https://github.com/'
+
+  private renderHeader = (): JSX.Element => {
+    return (
+      <header className="header">
+        <Octicon symbol={OcticonSymbol.listUnordered} />
+        <div className="action-needed">Review requested</div>
+        <Button className="button-with-icon">
+          View on GitHub
+          <Octicon symbol={OcticonSymbol.linkExternal} />
+        </Button>
+      </header>
+    )
+  }
+
+  private renderPR = (): JSX.Element => {
+    return (
+      <div className="pull-request">
+        <div className="status">
+          <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
+          <span className="state">Open</span>
+        </div>
+        <div className="title">
+          <h2>{this.mockPR.title}</h2>
+          <PullRequestBadge
+            number={this.mockPR.number}
+            dispatcher={this.props.dispatcher}
+            repository={this.props.repository}
+          />
+        </div>
+        <SandboxedMarkdown
+          markdown={this.mockPR.body}
+          baseHref={this.baseHref}
+        />
+      </div>
+    )
+  }
+
+  public render() {
+    return (
+      <div id="pull-request-quick-view">
+        {this.renderHeader()}
+        {this.renderPR()}
+      </div>
+    )
+  }
+}

--- a/app/static/common/markdown.css
+++ b/app/static/common/markdown.css
@@ -14,7 +14,8 @@ changes from the original, just a note that this will not match 1-1)
 	font-size: var(--font-size);
   color: var(--text-color);
 	line-height: 1.5;
-	word-wrap: break-word
+	word-wrap: break-word;
+	margin: 0;
 }
 
 .markdown-body::before {

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -95,3 +95,4 @@
 @import 'ui/check-runs/ci-check-run-job-steps';
 @import 'ui/_pull-request-checks-failed';
 @import 'ui/_sandboxed-markdown';
+@import 'ui/_pull-request-quick-view';

--- a/app/styles/ui/_pull-request-badge.scss
+++ b/app/styles/ui/_pull-request-badge.scss
@@ -1,12 +1,12 @@
-.toolbar-dropdown.open #pr-badge {
+.toolbar-dropdown.open .pr-badge {
   background: var(--toolbar-badge-active-background-color);
 }
 
-.toolbar-dropdown:not(.open) #pr-badge {
+.toolbar-dropdown:not(.open) .pr-badge {
   background: var(--toolbar-badge-background-color);
 }
 
-#pr-badge {
+.pr-badge {
   --height: 18px;
 
   display: flex;

--- a/app/styles/ui/_pull-request-quick-view.scss
+++ b/app/styles/ui/_pull-request-quick-view.scss
@@ -7,6 +7,7 @@
     margin: var(--spacing-double);
     min-width: 400px;
     border-radius: var(--border-radius);
+    overflow: hidden;
 
     .header {
       display: flex;
@@ -22,6 +23,8 @@
 
     .pull-request {
       padding: var(--spacing-double);
+      max-height: 500px;
+      overflow: scroll;
 
       .status {
         background-color: var(--pr-open-icon-color);

--- a/app/styles/ui/_pull-request-quick-view.scss
+++ b/app/styles/ui/_pull-request-quick-view.scss
@@ -1,0 +1,47 @@
+#pull-request-quick-view {
+  position: absolute;
+  left: 365px;
+  background-color: var(--background-color);
+  margin: var(--spacing-double);
+  min-width: 400px;
+  border-radius: var(--border-radius);
+
+  .header {
+    display: flex;
+    padding: var(--spacing-double);
+    padding-bottom: var(--spacing);
+    border-bottom: var(--base-border);
+
+    .action-needed {
+      flex-grow: 1;
+      padding-left: var(--spacing-double);
+    }
+  }
+
+  .pull-request {
+    padding: var(--spacing-double);
+
+    .status {
+      background-color: var(--pr-open-icon-color);
+      color: #{$white};
+      display: inline-flex;
+      align-items: center;
+      padding: var(--spacing-half) var(--spacing);
+      font-size: var(--font-size-md);
+      font-weight: var(--font-weight-semibold);
+      border-radius: 2em;
+
+      .state {
+        margin-left: var(--spacing-half);
+      }
+    }
+
+    .title {
+      margin-top: var(--spacing) 0;
+
+      .pr-badge {
+        display: inline-flex;
+      }
+    }
+  }
+}

--- a/app/styles/ui/_pull-request-quick-view.scss
+++ b/app/styles/ui/_pull-request-quick-view.scss
@@ -1,4 +1,4 @@
-#pull-request-quick-view {
+.pull-request-quick-view {
   position: absolute;
   left: 365px;
 

--- a/app/styles/ui/_pull-request-quick-view.scss
+++ b/app/styles/ui/_pull-request-quick-view.scss
@@ -1,46 +1,49 @@
 #pull-request-quick-view {
   position: absolute;
   left: 365px;
-  background-color: var(--background-color);
-  margin: var(--spacing-double);
-  min-width: 400px;
-  border-radius: var(--border-radius);
 
-  .header {
-    display: flex;
-    padding: var(--spacing-double);
-    padding-bottom: var(--spacing);
-    border-bottom: var(--base-border);
+  .pull-request-quick-view-contents {
+    background-color: var(--background-color);
+    margin: var(--spacing-double);
+    min-width: 400px;
+    border-radius: var(--border-radius);
 
-    .action-needed {
-      flex-grow: 1;
-      padding-left: var(--spacing-double);
-    }
-  }
+    .header {
+      display: flex;
+      padding: var(--spacing-double);
+      padding-bottom: var(--spacing);
+      border-bottom: var(--base-border);
 
-  .pull-request {
-    padding: var(--spacing-double);
-
-    .status {
-      background-color: var(--pr-open-icon-color);
-      color: #{$white};
-      display: inline-flex;
-      align-items: center;
-      padding: var(--spacing-half) var(--spacing);
-      font-size: var(--font-size-md);
-      font-weight: var(--font-weight-semibold);
-      border-radius: 2em;
-
-      .state {
-        margin-left: var(--spacing-half);
+      .action-needed {
+        flex-grow: 1;
+        padding-left: var(--spacing-double);
       }
     }
 
-    .title {
-      margin-top: var(--spacing) 0;
+    .pull-request {
+      padding: var(--spacing-double);
 
-      .pr-badge {
+      .status {
+        background-color: var(--pr-open-icon-color);
+        color: #{$white};
         display: inline-flex;
+        align-items: center;
+        padding: var(--spacing-half) var(--spacing);
+        font-size: var(--font-size-md);
+        font-weight: var(--font-weight-semibold);
+        border-radius: 2em;
+
+        .state {
+          margin-left: var(--spacing-half);
+        }
+      }
+
+      .title {
+        margin: var(--spacing) 0;
+
+        .pr-badge {
+          display: inline-flex;
+        }
       }
     }
   }

--- a/app/test/unit/find-forked-remotes-to-prune-test.ts
+++ b/app/test/unit/find-forked-remotes-to-prune-test.ts
@@ -26,7 +26,8 @@ function createSamplePullRequest(
       gitHubRepository,
     },
     userName,
-    false
+    false,
+    'sample body'
   )
 }
 

--- a/app/test/unit/repository-state-cache-test.ts
+++ b/app/test/unit/repository-state-cache-test.ts
@@ -27,7 +27,8 @@ function createSamplePullRequest(gitHubRepository: GitHubRepository) {
       gitHubRepository,
     },
     'shiftkey',
-    false
+    false,
+    'something body'
   )
 }
 


### PR DESCRIPTION
Part of #11517

This is feature flagged to development.

## Description

As part of the work to bring pull requests into the app, we need a way to view pull requests details. 

This PR is to create the first stab/draft of the component for the pull request quick view component modeled after these designs:
![image](https://user-images.githubusercontent.com/75402236/144638994-455097ae-8b95-453e-9d57-44dd4b4a4700.png)

Work to be built on top of this PR:
- Dynamic status (draft/open) #13480
- View on github button works #13478 
- Base href isn't hard coded. #13481
- Currently when switching between different PR's, the height of the containing div of the markdown parser is not dynamically shrinking and growing as expected and sometimes gives a console error (seems there is a timing issue) #13482
- Responsive positioning/sizing/look feel
  - The popover should move to align with the hovered over pr list item (This may mean align top for upper list items and align bottom for lower list items) #13491
  - The popover width could be dynamic for larger screens.
  - We could have an arrow pointing from the modal to the list item to make it obvious which one is being displayed (This especially needed when we have a pr checked out and therefore one of the list items is in a selected state.. which is confusing when it is not the one you are looking at in the card) #13498 
- Actions Footer; Dynamic Actions needed header
- Markdown Parser GitHub Custom filters (Things like commit links and emojis)
- More meta data - such labels/assignee

Bugs found during dev:
- Sometimes branch/pr tabs get squished on screen resizing since adding pr quick view card.

### Screenshots

https://user-images.githubusercontent.com/75402236/144881726-82cb324b-ca2e-49c5-b47b-623469c51057.mov


## Release notes
Notes: [Added] User can hover over a pull request to see a quick view of that pull request.
