### PR TITLE
Release 2.9.6-beta2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.6-beta1",
+  "version": "2.9.6-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -3,7 +3,7 @@
     "2.9.6-beta2": [
       "[Fixed] Stashing dialog no longer hangs when intiating cherry-pick - #13419",
       "[Fixed] Rebase no longer hangs after conflicts resolved when intiated through pull conflict error - #13204",
-      "[Fixed] Discarding files and repositories would fail to move items to trash - #13433",
+      "[Fixed] Discarding files and repositories successfully moves items to trash - #13433",
       "[Improved] Added check runs overall completeness indicator in check run popover header - #13423"
     ],
     "2.9.6-beta1": [

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,11 @@
 {
   "releases": {
+    "2.9.6-beta2": [
+      "[Fixed] Stashing dialog no longer hangs when intiating cherry-pick - #13419",
+      "[Fixed] Rebase no longer hangs after conflicts resolved when intiated through pull conflict error - #13204",
+      "[Fixed] Able to discard files and repositories - #13433",
+      "[Improved] Added check runs overall completeness indicator in check run popover header - #13423"
+    ],
     "2.9.6-beta1": [
       "[Improved] Upgrade to Electron 13.6.2 - #12978",
       "[Improved] Allow amending pushed commits - #13384"

--- a/changelog.json
+++ b/changelog.json
@@ -3,7 +3,7 @@
     "2.9.6-beta2": [
       "[Fixed] Stashing dialog no longer hangs when intiating cherry-pick - #13419",
       "[Fixed] Rebase no longer hangs after conflicts resolved when intiated through pull conflict error - #13204",
-      "[Fixed] Able to discard files and repositories - #13433",
+      "[Fixed] Discarding files and repositories would fail to move items to trash - #13433",
       "[Improved] Added check runs overall completeness indicator in check run popover header - #13423"
     ],
     "2.9.6-beta1": [


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming second beta of the v2.9.6 series? Well, you've just found it, congratulations!

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
--- Feature Flags have not changed - check runs still beta.
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
Metrics added for check runs - PR are merged/deployed.
- [central](https://github.com/github/central/pull/565)
- [desktop.github.com](https://github.com/github/desktop.github.com/pull/164)