### PR TITLE
Tooltips touchups and polish

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -732,7 +732,7 @@ export class CommitMessage extends React.Component<
       >
         <>
           {loading}
-          <span>{commitButton}</span>
+          {commitButton}
         </>
       </Button>
     )

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -729,6 +729,7 @@ export class CommitMessage extends React.Component<
         onClick={this.onSubmit}
         disabled={!buttonEnabled}
         tooltip={tooltip}
+        onlyShowTooltipWhenOverflowed={buttonEnabled}
       >
         <>
           {loading}

--- a/app/src/ui/lib/button.tsx
+++ b/app/src/ui/lib/button.tsx
@@ -68,6 +68,12 @@ export interface IButtonProps {
 
   readonly role?: string
   readonly ariaExpanded?: boolean
+
+  /**
+   * Whether to only show the tooltip when the tooltip target overflows its
+   * bounds. Typically this is used in conjunction with an ellipsis CSS ruleset.
+   */
+  readonly onlyShowTooltipWhenOverflowed?: boolean
 }
 
 /**
@@ -126,6 +132,7 @@ export class Button extends React.Component<IButtonProps, {}> {
             direction={TooltipDirection.NORTH}
             // Show the tooltip immediately on hover if the button is disabled
             delay={disabled && tooltip ? 0 : undefined}
+            onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
           >
             {tooltip}
           </Tooltip>

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -18,6 +18,7 @@ import { enableRepositoryAliases } from '../../lib/feature-flag'
 import classNames from 'classnames'
 import { createObservableRef } from '../lib/observable-ref'
 import { Tooltip } from '../lib/tooltip'
+import { TooltippedContent } from '../lib/tooltipped-content'
 
 interface IRepositoryListItemProps {
   readonly repository: Repositoryish
@@ -283,12 +284,12 @@ const renderAheadBehindIndicator = (aheadBehind: IAheadBehind) => {
 
 const renderChangesIndicator = () => {
   return (
-    <div
+    <TooltippedContent
       className="change-indicator-wrapper"
-      title="There are uncommitted changes in this repository"
+      tooltip="There are uncommitted changes in this repository"
     >
       <Octicon symbol={OcticonSymbol.dotFill} />
-    </div>
+    </TooltippedContent>
   )
 }
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -18,6 +18,7 @@ import classNames from 'classnames'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DragType } from '../../models/drag-drop'
 import { CICheckRunPopover } from '../check-runs/ci-check-run-popover'
+import { TooltipTarget } from '../lib/tooltip'
 
 interface IBranchDropdownProps {
   readonly dispatcher: Dispatcher
@@ -141,8 +142,7 @@ export class BranchDropdown extends React.Component<
       icon = OcticonSymbol.gitCommit
       description = 'Detached HEAD'
     } else if (tip.kind === TipState.Valid) {
-      title = tip.branch.name
-      tooltip = `Current branch is ${title}`
+      title = tooltip = tip.branch.name
     } else {
       return assertNever(tip, `Unknown tip state: ${tipKind}`)
     }
@@ -158,6 +158,7 @@ export class BranchDropdown extends React.Component<
         description = `${description} (${friendlyProgress}%)`
       }
 
+      tooltip = `Switching to ${checkoutProgress.targetBranch}`
       progressValue = checkoutProgress.value
       icon = syncClockwise
       iconClassName = 'spin'
@@ -168,6 +169,7 @@ export class BranchDropdown extends React.Component<
       icon = OcticonSymbol.gitBranch
       canOpen = false
       disabled = true
+      tooltip = `Rebasing ${conflictState.targetBranch}`
     }
 
     const isOpen = this.props.isOpen
@@ -193,6 +195,8 @@ export class BranchDropdown extends React.Component<
           progressValue={progressValue}
           buttonClassName={buttonClassName}
           onMouseEnter={this.onMouseEnter}
+          onlyShowTooltipWhenOverflowed={true}
+          isOverflowed={isDescriptionOverflowed}
         >
           {this.renderPullRequestInfo()}
         </ToolbarDropdown>
@@ -305,4 +309,9 @@ export class BranchDropdown extends React.Component<
       />
     )
   }
+}
+
+const isDescriptionOverflowed = (target: TooltipTarget) => {
+  const elem = target.querySelector('.title') ?? target
+  return elem.scrollWidth > elem.clientWidth
 }

--- a/app/src/ui/toolbar/button.tsx
+++ b/app/src/ui/toolbar/button.tsx
@@ -5,7 +5,7 @@ import { assertNever } from '../../lib/fatal-error'
 import { Button } from '../lib/button'
 import { clamp } from '../../lib/clamp'
 import { createObservableRef } from '../lib/observable-ref'
-import { Tooltip, TooltipDirection } from '../lib/tooltip'
+import { Tooltip, TooltipDirection, TooltipTarget } from '../lib/tooltip'
 
 /** The button style. */
 export enum ToolbarButtonStyle {
@@ -100,6 +100,28 @@ export interface IToolbarButtonProps {
 
   readonly role?: string
   readonly ariaExpanded?: boolean
+
+  /**
+   * Whether to only show the tooltip when the tooltip target overflows its
+   * bounds. Typically this is used in conjunction with an ellipsis CSS ruleset.
+   */
+  readonly onlyShowTooltipWhenOverflowed?: boolean
+
+  /**
+   * Optional, custom overrided of the Tooltip components internal logic for
+   * determining whether the tooltip target is overflowed or not.
+   *
+   * The internal overflow logic is simple and relies on the target itself
+   * having the `text-overflow` CSS rule applied to it. In some scenarios
+   * consumers may have a deep child element which is the one that should be
+   * tested for overflow while still having the parent element be the pointer
+   * device hit area.
+   *
+   * Consumers may pass a boolean if the overflowed state is known at render
+   * time or they may pass a function which gets executed just before showing
+   * the tooltip.
+   */
+  readonly isOverflowed?: ((target: TooltipTarget) => boolean) | boolean
 }
 
 /**
@@ -173,7 +195,12 @@ export class ToolbarButton extends React.Component<IToolbarButtonProps, {}> {
         ref={this.wrapperRef}
       >
         {tooltip && (
-          <Tooltip target={this.wrapperRef} direction={TooltipDirection.SOUTH}>
+          <Tooltip
+            target={this.wrapperRef}
+            direction={TooltipDirection.SOUTH}
+            onlyWhenOverflowed={this.props.onlyShowTooltipWhenOverflowed}
+            isTargetOverflowed={this.props.isOverflowed}
+          >
             {tooltip}
           </Tooltip>
         )}

--- a/app/src/ui/toolbar/dropdown.tsx
+++ b/app/src/ui/toolbar/dropdown.tsx
@@ -7,6 +7,7 @@ import { rectEquals } from '../lib/rect'
 import classNames from 'classnames'
 import FocusTrap from 'focus-trap-react'
 import { Options as FocusTrapOptions } from 'focus-trap'
+import { TooltipTarget } from '../lib/tooltip'
 
 export type DropdownState = 'open' | 'closed'
 
@@ -140,6 +141,28 @@ export interface IToolbarDropdownProps {
 
   /** Classes to be appended to `ToolbarButton` component */
   readonly buttonClassName?: string
+
+  /**
+   * Whether to only show the tooltip when the tooltip target overflows its
+   * bounds. Typically this is used in conjunction with an ellipsis CSS ruleset.
+   */
+  readonly onlyShowTooltipWhenOverflowed?: boolean
+
+  /**
+   * Optional, custom overrided of the Tooltip components internal logic for
+   * determining whether the tooltip target is overflowed or not.
+   *
+   * The internal overflow logic is simple and relies on the target itself
+   * having the `text-overflow` CSS rule applied to it. In some scenarios
+   * consumers may have a deep child element which is the one that should be
+   * tested for overflow while still having the parent element be the pointer
+   * device hit area.
+   *
+   * Consumers may pass a boolean if the overflowed state is known at render
+   * time or they may pass a function which gets executed just before showing
+   * the tooltip.
+   */
+  readonly isOverflowed?: ((target: TooltipTarget) => boolean) | boolean
 }
 
 interface IToolbarDropdownState {
@@ -364,6 +387,10 @@ export class ToolbarDropdown extends React.Component<
           tabIndex={this.props.tabIndex}
           progressValue={this.props.progressValue}
           role={this.props.buttonRole}
+          onlyShowTooltipWhenOverflowed={
+            this.props.onlyShowTooltipWhenOverflowed
+          }
+          isOverflowed={this.props.isOverflowed}
         >
           {this.props.children}
           {this.renderDropdownArrow()}

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -187,6 +187,9 @@
       flex-shrink: 0;
       flex-grow: 0;
       margin-right: var(--spacing-half);
+      height: 12px;
+      // In order to center it vertically in the button
+      margin-bottom: 1px;
     }
   }
 }

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -180,25 +180,13 @@
   .commit-button {
     max-width: 100%;
     margin-top: var(--spacing);
-    display: flex;
-    justify-content: center;
-    align-items: center;
+
+    @include ellipsis;
 
     .octicon {
       flex-shrink: 0;
       flex-grow: 0;
       margin-right: var(--spacing-half);
-    }
-
-    /* Due to some weirdo bug in Chrome that affects Windows
-     * and possible other platforms we can't change the opacity
-     * for disabled buttons if the button also has a
-     * overflow: hidden property set. The workaround is to put
-     * the contents of the button in a block element and put
-     * ellipsis on that instead. See commit 67fad24ed
-     */
-    > span {
-      @include ellipsis;
     }
   }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13452
Closes #13449

## Description

This PR extends our custom tooltips to be able to support nested tooltips (#13449) as well as supporting custom logic for determining whether a tooltip target is overflowed when configuring tooltips to only show when the target has overflowed (#13452).

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Only show tooltip when the branch name gets truncated
<img src="https://user-images.githubusercontent.com/634063/145066982-dfd48f7a-350a-4a0d-9dd6-a4d44f79844d.gif" width="454" />

<img src="https://user-images.githubusercontent.com/634063/145067007-395cefc3-1c5f-4472-b564-0ebe582b5d9b.gif" width="550" />

#### Support nested tooltips and only show tooltip for the deepest target

<img src="https://user-images.githubusercontent.com/634063/145067002-371e42ed-e01e-4ba8-a533-f31e21ebc709.gif" width="454" />

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
