### PR TITLE
Pr Quick View: Dynamic status

### DIFF
--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -131,7 +131,14 @@ export class PullRequestListItem extends React.Component<
         onMouseUp={this.onMouseUp}
       >
         <div>
-          <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
+          <Octicon
+            className="icon"
+            symbol={
+              this.props.draft
+                ? OcticonSymbol.gitPullRequestDraft
+                : OcticonSymbol.gitPullRequest
+            }
+          />
         </div>
         <div className="info">
           <div className="title" title={title}>

--- a/app/src/ui/octicons/octicons.generated.ts
+++ b/app/src/ui/octicons/octicons.generated.ts
@@ -750,6 +750,14 @@ export const gitPullRequest: OcticonSymbolType = {
   fr: 'evenodd',
 }
 
+export const gitPullRequestDraft: OcticonSymbolType = {
+  w: 16,
+  h: 16,
+  d:
+    'M2.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.25 1a2.25 2.25 0 00-.75 4.372v5.256a2.251 2.251 0 101.5 0V5.372A2.25 2.25 0 003.25 1zm0 11a.75.75 0 100 1.5.75.75 0 000-1.5zm9.5 3a2.25 2.25 0 100-4.5 2.25 2.25 0 000 4.5zm0-3a.75.75 0 100 1.5.75.75 0 000-1.5zM14 7.5a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0zm0-4.25a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0z',
+  fr: 'evenodd',
+}
+
 export const globe: OcticonSymbolType = {
   w: 16,
   h: 16,

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -38,7 +38,7 @@ export class PullRequestQuickView extends React.Component<
     )
   }
 
-  private renderPRStatus(isDraft: boolean): JSX.Element {
+  private renderPRStatus(isDraft: boolean) {
     return (
       <div className={classNames('status', { draft: isDraft })}>
         <Octicon

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -6,6 +6,7 @@ import { Button } from './lib/button'
 import { SandboxedMarkdown } from './lib/sandboxed-markdown'
 import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
+import classNames from 'classnames'
 
 interface IPullRequestQuickViewProps {
   readonly dispatcher: Dispatcher
@@ -34,18 +35,38 @@ export class PullRequestQuickView extends React.Component<
     )
   }
 
+  private renderPRStatus(isDraft: boolean): JSX.Element {
+    return (
+      <div className={classNames('status', { draft: isDraft })}>
+        <Octicon
+          className="icon"
+          symbol={
+            isDraft
+              ? OcticonSymbol.gitPullRequestDraft
+              : OcticonSymbol.gitPullRequest
+          }
+        />
+        <span className="state">{isDraft ? 'Draft' : 'Open'}</span>
+      </div>
+    )
+  }
+
   private renderPR = (): JSX.Element => {
-    const { title, pullRequestNumber, base, body } = this.props.pullRequest
+    const {
+      title,
+      pullRequestNumber,
+      base,
+      body,
+      draft,
+    } = this.props.pullRequest
     const displayBody =
       body !== undefined && body !== null && body.trim() !== ''
         ? body
         : '_No description provided._'
+
     return (
       <div className="pull-request">
-        <div className="status">
-          <Octicon className="icon" symbol={OcticonSymbol.gitPullRequest} />
-          <span className="state">Open</span>
-        </div>
+        {this.renderPRStatus(draft)}
         <div className="title">
           <h2>{title}</h2>
           <PullRequestBadge

--- a/app/styles/ui/_pull-request-quick-view.scss
+++ b/app/styles/ui/_pull-request-quick-view.scss
@@ -39,6 +39,10 @@
         .state {
           margin-left: var(--spacing-half);
         }
+
+        &.draft {
+          background-color: var(--pr-draft-icon-color);
+        }
       }
 
       .title {


### PR DESCRIPTION
Warning: Compared to #13441 (Review/merge it first).

Part of #11517

## Description

Makes the pull request state indicator dynamic for draft versus open. Also, updates the pull request list item's icon to be the draft icon for consistency.

### Screenshots
https://user-images.githubusercontent.com/75402236/145252612-3c0e8ac5-b151-4bd8-bf3d-b84c19587b54.mov

## Release notes
Notes: no-notes
