### PR TITLE
Pr Quick View: base href

### DIFF
--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -19,8 +19,6 @@ export class PullRequestQuickView extends React.Component<
   IPullRequestQuickViewProps,
   {}
 > {
-  private baseHref = 'https://github.com/'
-
   private renderHeader = (): JSX.Element => {
     return (
       <header className="header">
@@ -54,7 +52,10 @@ export class PullRequestQuickView extends React.Component<
             repository={base.gitHubRepository}
           />
         </div>
-        <SandboxedMarkdown markdown={displayBody} baseHref={this.baseHref} />
+        <SandboxedMarkdown
+          markdown={displayBody}
+          baseHref={base.gitHubRepository.htmlURL}
+        />
       </div>
     )
   }


### PR DESCRIPTION
Warning: Compared to #13441 (Review/merge it first).

Part of #11517

## Description
Remove hard-coded base href -> Use repo html url... Haven't run into/know of a real test case for this yet. (So far I have only seen full urls provided in pr body for links - not a need for a basehref)

## Release notes
Notes: no-notes
