### PR TITLE
Pr  Quick View: Dynamic height markdown adjustment

### DIFF
--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -124,8 +124,23 @@ export class SandboxedMarkdown extends React.PureComponent<
     ) {
       return
     }
-    const docEl = frameRef.contentDocument.documentElement
-    const divHeight = docEl.clientHeight
+
+    /*
+     * We added an additional wrapper div#content around the markdown to
+     * determine a more accurate scroll height as the iframe's document or body
+     * element was not adjusting it's height dynamically when new content was
+     * provided.
+     */
+    const docEl = frameRef.contentDocument.documentElement.querySelector(
+      '#content'
+    )
+    if (docEl === null) {
+      return
+    }
+
+    // Not sure why the content height != body height exactly. But, 50px seems
+    // to prevent scrollbar/content cut off.
+    const divHeight = docEl.clientHeight + 50
     this.frameContainingDivRef.style.height = `${divHeight}px`
   }
 
@@ -186,7 +201,9 @@ export class SandboxedMarkdown extends React.PureComponent<
           ${styleSheet}
         </head>
         <body class="markdown-body">
+          <div id="content">
           ${sanitizedHTML}
+          </div
         </body>
       </html>
     `
@@ -194,6 +211,11 @@ export class SandboxedMarkdown extends React.PureComponent<
     // We used this `Buffer.toString('base64')` approach because `btoa` could not
     // convert non-latin strings that existed in the markedjs.
     const b64src = Buffer.from(src, 'utf8').toString('base64')
+
+    if (this.frameRef === null) {
+      // If frame is destroyed before markdown parsing completes, frameref will be null.
+      return
+    }
 
     // We are using `src` and data uri as opposed to an html string in the
     // `srcdoc` property because the `srcdoc` property renders the html in the


### PR DESCRIPTION
Warning: Compared to #13441 (Review/merge it first).

Part of #11517

## Description

There was an issue where if you switched from a PR that had a really long body that had a short body. The scroll height of the containing div remained the really long height of the first PR thus making lots of scrollable whitespace. 
- I found that the iframe body tag was not dynamically updating it's height to the new contents.. assuming this is a issue when dealing with iframes since they expect to be static width/height. (which we are overriding so we can pass the scrolling handling to a parent div.
- Thus, I added an additional #content div around the parsed markdown and used it's height to determine the height of the containing div. This div correctly dynamically adapted its height to the new contents. Only quirk was that divs height was slightly smaller than the body tags height.. which I couldn't' find a reason for but padded with 50 px as that seemed to resolve it.

Also, I found that if you quickly move your mouse down the list of PRs/on and off the list and thus rapidly changing the quick view card. This was sometimes removing the iframe from the dom before the last pr markdown was parsed resulting in markdown trying to be added to a non existent iframe. This would result in a console error.
- Added a null check right after parsing to resolve this.

### Screenshots

Uploading Screen Recording 2021-12-08 at 1.54.40 PM.mov…

## Release notes
Notes: no-notes
