### PR TITLE
Release 2.9.6-beta-3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.6-beta2",
+  "version": "2.9.6-beta3",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -2,7 +2,7 @@
   "releases": {
     "2.9.6-beta3": [
       "[Fixed] Tooltips touchups and polish - #13452 #13449",
-      "[Fixed] Dynamic constraints for resizable components - #2745",
+      "[Improved] Add dynamic constraints for resizable components - #2745",
       "[Improved] Remove re-run button for repositories that cannot re-run checks. - #13460"
     ],
     "2.9.6-beta2": [

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "2.9.6-beta3": [
+      "[Fixed] Tooltips touchups and polish - #13452 #13449",
+      "[Fixed] Dynamic constraints for resizable components - #2745",
+      "[Improved] Remove re-run button for repositories that cannot re-run checks. - #13460"
+    ],
     "2.9.6-beta2": [
       "[Fixed] Stashing dialog no longer hangs when intiating cherry-pick - #13419",
       "[Fixed] Rebase no longer hangs after conflicts resolved when intiated through pull conflict error - #13204",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.9.6-beta3": [
-      "[Fixed] Tooltips touchups and polish - #13452 #13449",
+      "[Fixed] Tooltip improvements and polish - #13452 #13449",
       "[Improved] Add dynamic constraints for resizable components - #2745",
       "[Improved] Remove re-run button for repositories that cannot re-run checks. - #13460"
     ],


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming third beta of the v2.9.6 series? Well, you've just found it, congratulations!

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
--- Feature Flags have not changed - Check runs still beta.
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
-- No new metrics