### PR TITLE
Pluralize changes header tooltip

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -762,8 +762,8 @@ export class ChangesList extends React.Component<
     const selectedChangeCount = files.filter(
       file => file.selection.getSelectionType() !== DiffSelectionType.None
     ).length
-    const selectedFilesPlural = selectedChangeCount === 1 ? 'file' : 'files'
-    const selectedChangesDescription = `${selectedChangeCount}/${files.length} changed ${selectedFilesPlural} selected`
+    const totalFilesPlural = files.length === 1 ? 'file' : 'files'
+    const selectedChangesDescription = `${selectedChangeCount}/${files.length} changed ${totalFilesPlural} selected`
 
     const includeAllValue = getIncludeAllValue(
       workingDirectory,


### PR DESCRIPTION
Closes #13479

## Description

Fix the pluralization of "files" in the changes header tooltip.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
