### PR TITLE
Take alias into account when sorting repositories

### DIFF
--- a/app/src/ui/repositories-list/group-repositories.ts
+++ b/app/src/ui/repositories-list/group-repositories.ts
@@ -83,7 +83,9 @@ export function groupRepositories(
       names.set(repository.name, existingCount + 1)
     }
 
-    repositories.sort((x, y) => caseInsensitiveCompare(x.name, y.name))
+    repositories.sort((x, y) =>
+      caseInsensitiveCompare(repositorySortingKey(x), repositorySortingKey(y))
+    )
     const items: ReadonlyArray<IRepositoryListItem> = repositories.map(r => {
       const nameCount = names.get(r.name) || 0
       const { aheadBehind, changedFilesCount } =
@@ -171,3 +173,8 @@ export function makeRecentRepositoriesGroup(
     items,
   }
 }
+
+// Use either the configured alias or the repository name when sorting the
+// repository list.
+const repositorySortingKey = (r: Repositoryish) =>
+  r instanceof Repository && r.alias !== null ? r.alias : r.name


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13429

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Take repository aliases into account when sorting the repository list.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Repository aliases are taken into account when sorting the repository list