### PR TITLE
On commit status refresh and with no check run updates, use cached version of action retrieves

### DIFF
--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -348,7 +348,27 @@ export class CommitStatusStore {
         checks.map(cr => cr.id)
       ).length === 0
     ) {
-      return null
+      // Apply existing action workflow and job steps from cache to refreshed checks
+      const mapped = new Array<IRefCheck>()
+      for (const cr of checks) {
+        const matchingCheck = existingChecks.check.checks.find(
+          c => c.id === cr.id
+        )
+
+        if (matchingCheck === undefined) {
+          // Shouldn't happen, but if it did just keep what we have
+          mapped.push(cr)
+          continue
+        }
+
+        const { actionsWorkflow, actionJobSteps } = matchingCheck
+        mapped.push({
+          ...cr,
+          actionsWorkflow,
+          actionJobSteps,
+        })
+      }
+      return mapped
     }
 
     const checkRunsWithActionsWorkflows = await this.getCheckRunActionsWorkflowRuns(


### PR DESCRIPTION
## Description

@sergiou87 caught a caching bug that was most reproducible if you opened the check runs popover and then navigate away from desktop for a > minute (status refresh wait time). Then return to app and close and open the popover, the action job steps will no longer show but the checks will. Apparently loading the checks as if action job steps/workflow were not applicable to the repo. 

Below showing no job steps when jobs steps should be present.
![image](https://user-images.githubusercontent.com/75402236/145998244-98ce6538-97f8-4e5d-8307-641ab8a5e076.png)

@niik paired with me on it and narrowed it down to where we have a condition that says not to retrieve the action steps if the checks did not change between last refresh. Currently we were just using the new checks with no action steps. This PR updates it to map the currently cached action workflow and job steps to the just refreshed checks. 

In a future PR, we may try to split the actions workflow and job step caching from the commit store to make this logic cleaner and hopefully easier to catch this sort of problem.

### Screenshots

After trying 3 times to reproduce, I am unable too.
![image](https://user-images.githubusercontent.com/75402236/145998837-2e117431-a2cd-4bf5-9b6f-daaa14c985ef.png)


## Release notes
Notes: [Fixed] Job steps on pull-request check run list are no longer intermittently missing
