### PR TITLE
Sticky sticky headers (also weird scrollbar overhang issue fixed)

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -208,7 +208,7 @@ export class CICheckRunPopover extends React.PureComponent<
 
   private getPopoverPositioningStyles = (): React.CSSProperties => {
     const top = this.props.badgeBottom + 10
-    return { top, maxHeight: `calc(100% - ${top + 10}px)` }
+    return { top }
   }
 
   private getListHeightStyles = (): React.CSSProperties => {
@@ -360,7 +360,10 @@ export class CICheckRunPopover extends React.PureComponent<
     }
 
     return (
-      <div className="ci-check-run-list" style={this.getListHeightStyles()}>
+      <div
+        className="ci-check-run-list-container"
+        style={this.getListHeightStyles()}
+      >
         <CICheckRunList
           checkRuns={checkRuns}
           loadingActionLogs={loadingActionLogs}

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,8 +1,4 @@
 .ci-check-run-list {
-  overflow-y: auto;
-  overflow-x: hidden;
-  scroll-padding-top: 35px;
-
   .ci-check-run-list-group-header {
     position: sticky;
     top: 0;

--- a/app/styles/ui/check-runs/_ci-check-run-popover.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-popover.scss
@@ -91,6 +91,12 @@
     }
   }
 
+  .ci-check-run-list-container {
+    overflow-y: auto;
+    overflow-x: hidden;
+    scroll-padding-top: 35px;
+  }
+
   .loading-check-runs {
     width: 100%;
     display: flex;


### PR DESCRIPTION
## Description
@sergiou87  noticed that the sticky headers in the check run popover were no longer sticky. 🍍  

I suspected it regressed after check run popover positioning logic improvements pr... however, it appears we just had a merge conflict resolving wrong at some point where we had a div of class `check-run-list` inside another div with the same class.

Also, when I was testing this, I noticed that sometimes the scroll bar on the popover over-hanged the popover which was due to trying to calculate the list height and the popover height where the popover height was % and list height must be exact pixels for sticky headers to work. Turns out that since we have exact height on list we don't need a max-height on popover as the list height determines the height of popover just fine.


### Screenshots

https://user-images.githubusercontent.com/75402236/146006036-afd45001-18b3-4653-be71-9fb8f0242af0.mov


## Release notes
Notes: [Improved] Check run group headers and checks stay in view while scrolling the children checks or job steps.
