### PR TITLE
PR Quick View: position quick view relative to list item shown (take 2)

### DIFF
--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -58,7 +58,10 @@ interface IBranchesContainerState {
   readonly selectedPullRequest: PullRequest | null
   readonly selectedBranch: Branch | null
   readonly branchFilterText: string
-  readonly pullRequestBeingViewed: PullRequest | null
+  readonly pullRequestBeingViewed: {
+    pr: PullRequest
+    prListItemTop: number
+  } | null
 }
 
 /** The unified Branches and Pull Requests component. */
@@ -117,10 +120,13 @@ export class BranchesContainer extends React.Component<
       return null
     }
 
+    const { pr, prListItemTop } = this.state.pullRequestBeingViewed
+
     return (
       <PullRequestQuickView
         dispatcher={this.props.dispatcher}
-        pullRequest={this.state.pullRequestBeingViewed}
+        pullRequest={pr}
+        pullRequestItemTop={prListItemTop}
         onMouseEnter={this.onMouseEnterPullRequestQuickView}
         onMouseLeave={this.onMouseLeavePullRequestQuickView}
       />
@@ -322,12 +328,13 @@ export class BranchesContainer extends React.Component<
   }
 
   private onMouseEnterPullRequestListItem = (
-    pullRequestBeingViewed: PullRequest
+    pr: PullRequest,
+    prListItemTop: number
   ) => {
     this.clearPullRequestQuickViewTimer()
     this.setState({ pullRequestBeingViewed: null })
     this.pullRequestQuickViewTimerId = window.setTimeout(
-      () => this.setState({ pullRequestBeingViewed }),
+      () => this.setState({ pullRequestBeingViewed: { pr, prListItemTop } }),
       250
     )
   }

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -48,7 +48,7 @@ export interface IPullRequestListItemProps {
   readonly onDropOntoPullRequest: (prNumber: number) => void
 
   /** When mouse enters a PR */
-  readonly onMouseEnter: (prNumber: number) => void
+  readonly onMouseEnter: (prNumber: number, prListItemTop: number) => void
 
   /** When mouse leaves a PR */
   readonly onMouseLeave: (
@@ -81,7 +81,7 @@ export class PullRequestListItem extends React.Component<
     return this.props.draft ? `${subtitle} • Draft` : subtitle
   }
 
-  private onMouseEnter = () => {
+  private onMouseEnter = (e: React.MouseEvent) => {
     if (dragAndDropManager.isDragInProgress) {
       this.setState({ isDragInProgress: true })
 
@@ -90,7 +90,8 @@ export class PullRequestListItem extends React.Component<
         branchName: this.props.title,
       })
     }
-    this.props.onMouseEnter(this.props.number)
+    const { top } = e.currentTarget.getBoundingClientRect()
+    this.props.onMouseEnter(this.props.number, top)
   }
 
   private onMouseLeave = (

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -67,7 +67,10 @@ interface IPullRequestListProps {
   readonly isLoadingPullRequests: boolean
 
   /** When mouse enters a PR */
-  readonly onMouseEnterPullRequest: (prNumber: PullRequest) => void
+  readonly onMouseEnterPullRequest: (
+    prNumber: PullRequest,
+    prListItemTop: number
+  ) => void
 
   /** When mouse leaves a PR */
   readonly onMouseLeavePullRequest: (
@@ -187,7 +190,10 @@ export class PullRequestList extends React.Component<
     )
   }
 
-  private onMouseEnterPullRequest = (prNumber: number) => {
+  private onMouseEnterPullRequest = (
+    prNumber: number,
+    prListItemTop: number
+  ) => {
     const { pullRequests } = this.props
 
     // If not the currently checked out pull request, find the full pull request
@@ -198,7 +204,7 @@ export class PullRequestList extends React.Component<
       return
     }
 
-    this.props.onMouseEnterPullRequest(pr)
+    this.props.onMouseEnterPullRequest(pr, prListItemTop)
   }
 
   private onMouseLeavePullRequest = (

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -12,6 +12,8 @@ interface IPullRequestQuickViewProps {
   readonly dispatcher: Dispatcher
   readonly pullRequest: PullRequest
 
+  readonly pullRequestItemTop: number
+
   /** When mouse leaves the PR quick view */
   readonly onMouseEnter: () => void
 

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -105,9 +105,9 @@ export class PullRequestQuickView extends React.Component<
 
     // Can't align to top -> likely bottom half of list check if has room to display aligned to bottom.
     if (prListItemTop - quickViewHeight > 0) {
-      const alignedBottom =
-        window.innerHeight - prListItemTop - heightPRListItem
-      return { bottom: clamp(alignedBottom, minTop, maxTop) }
+      const alignedTop = prListItemTop - topOfPRList
+      const alignedBottom = alignedTop - quickViewHeight + heightPRListItem
+      return { top: clamp(alignedBottom, minTop, maxTop) }
     }
 
     // If not enough room to display aligned top or bottom, attempt to center on

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -51,7 +51,8 @@ export class PullRequestQuickView extends React.Component<
 
   public componentDidUpdate = (prevProps: IPullRequestQuickViewProps) => {
     if (
-      prevProps.pullRequest.body === this.props.pullRequest.body ||
+      prevProps.pullRequest.pullRequestNumber ===
+        this.props.pullRequest.pullRequestNumber ||
       this.quickViewRef === null
     ) {
       return

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -94,12 +94,51 @@ export class PullRequestQuickView extends React.Component<
     this.props.onMouseLeave()
   }
 
+  private calculatePosition(
+    prListItemTop: number
+  ): React.CSSProperties | undefined {
+    /** The max height of the visible quick view card is 556 (500 for scrollable
+     * body and 56 for header)
+     */
+    const maxQuickViewHeight = 556
+
+    // Important to retrieve as it changes for maximization on macOS and quick
+    // view is relative to the top of branch container = foldout-container. But
+    // if we can't find it (unlikely) we can atleast compensate for the toolbar
+    // being 50px
+    const topOfPRList =
+      document.getElementById('foldout-container')?.getBoundingClientRect()
+        .top ?? 50
+
+    // This is currently staticly defined so not bothering to attain it from
+    // dom searching.
+    const heightPRListItem = 47
+
+    // Top half of list with room to display aligned to top
+    if (window.innerHeight - prListItemTop > maxQuickViewHeight) {
+      return { top: prListItemTop - topOfPRList }
+    }
+
+    // Bottom half of list with room to display aligned to bottom.
+    if (prListItemTop - maxQuickViewHeight > 0) {
+      return { bottom: window.innerHeight - prListItemTop - heightPRListItem }
+    }
+
+    // If not enough room to display aligned top or bottom, attempt to center on
+    // pr list item (won't be centered but close for prs with a body < max
+    // height)
+    const middlePrListItem = prListItemTop + heightPRListItem / 2
+    const middleQuickView = maxQuickViewHeight / 2
+    return { top: middlePrListItem - middleQuickView }
+  }
+
   public render() {
     return (
       <div
         className="pull-request-quick-view"
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
+        style={this.calculatePosition(this.props.pullRequestItemTop)}
       >
         <div className="pull-request-quick-view-contents">
           {this.renderHeader()}

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { clamp } from '../lib/clamp'
 import { PullRequest } from '../models/pull-request'
 import { PullRequestBadge } from './branches'
 import { Dispatcher } from './dispatcher'
@@ -124,12 +125,13 @@ export class PullRequestQuickView extends React.Component<
       return { bottom: window.innerHeight - prListItemTop - heightPRListItem }
     }
 
-    // If not enough room to display aligned top or bottom, attempt to center on
-    // pr list item (won't be centered but close for prs with a body < max
-    // height)
+    // If not enough room to display aligned top or bottom, attempt to center
+    // with a minimum top/bottom pr list item (won't be centered but close for
+    // prs with a body < max height)
     const middlePrListItem = prListItemTop + heightPRListItem / 2
     const middleQuickView = maxQuickViewHeight / 2
-    return { top: middlePrListItem - middleQuickView }
+    const maxTop = window.innerHeight - topOfPRList - maxQuickViewHeight
+    return { top: clamp(middlePrListItem - middleQuickView, 0, maxTop) }
   }
 
   public render() {

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -9,6 +9,12 @@ import { Octicon } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
 import classNames from 'classnames'
 
+/**
+ * The max height of the visible quick view card is 556 (500 for scrollable
+ * body and 56 for header)
+ */
+const maxQuickViewHeight = 556
+
 interface IPullRequestQuickViewProps {
   readonly dispatcher: Dispatcher
   readonly pullRequest: PullRequest
@@ -22,15 +28,92 @@ interface IPullRequestQuickViewProps {
   readonly onMouseLeave: () => void
 }
 
+interface IPullRequestQuickViewState {
+  readonly position: React.CSSProperties | undefined
+}
+
 export class PullRequestQuickView extends React.Component<
   IPullRequestQuickViewProps,
-  {}
+  IPullRequestQuickViewState
 > {
+  private quickViewRef: HTMLDivElement | null = null
+
+  public constructor(props: IPullRequestQuickViewProps) {
+    super(props)
+
+    this.state = {
+      position: this.calculatePosition(
+        props.pullRequestItemTop,
+        maxQuickViewHeight
+      ),
+    }
+  }
+
+  public componentDidUpdate = (prevProps: IPullRequestQuickViewProps) => {
+    if (
+      prevProps.pullRequest.body === this.props.pullRequest.body ||
+      this.quickViewRef === null
+    ) {
+      return
+    }
+
+    this.setState({
+      position: this.calculatePosition(
+        this.props.pullRequestItemTop,
+        this.quickViewRef.clientHeight
+      ),
+    })
+  }
+
   private viewOnGitHub = () => {
     this.props.dispatcher.showPullRequestByPR(this.props.pullRequest)
   }
 
-  private renderHeader = () => {
+  /**
+   * Important to retrieve as it changes for maximization on macOS and quick
+   * view is relative to the top of branch container = foldout-container. But if
+   * we can't find it (unlikely) we can atleast compensate for the toolbar being
+   * 50px
+   */
+  private getTopPRList(): number {
+    return (
+      document.getElementById('foldout-container')?.getBoundingClientRect()
+        .top ?? 50
+    )
+  }
+
+  private calculatePosition(
+    prListItemTop: number,
+    quickViewHeight: number
+  ): React.CSSProperties | undefined {
+    const topOfPRList = this.getTopPRList()
+    // This is currently staticly defined so not bothering to attain it from
+    // dom searching.
+    const heightPRListItem = 47
+
+    // Check if it has room to display aligned to top (likely top half of list)
+    if (window.innerHeight - prListItemTop > quickViewHeight) {
+      return { top: prListItemTop - topOfPRList }
+    }
+
+    // Can't align to top -> likely bottom half of list check if has room to display aligned to bottom.
+    if (prListItemTop - quickViewHeight > 0) {
+      return { bottom: window.innerHeight - prListItemTop - heightPRListItem }
+    }
+
+    // If not enough room to display aligned top or bottom, attempt to center
+    // with a minimum top/bottom pr list item
+    const middlePrListItem = prListItemTop + heightPRListItem / 2
+    const middleQuickView = quickViewHeight / 2
+    const maxTop = window.innerHeight - topOfPRList - quickViewHeight
+    return { top: clamp(middlePrListItem - middleQuickView, 0, maxTop) }
+  }
+
+  private onQuickViewRef = (quickViewRef: HTMLDivElement) => {
+    this.quickViewRef = quickViewRef
+  }
+
+  private renderHeader = (): JSX.Element => {
     return (
       <header className="header">
         <Octicon symbol={OcticonSymbol.listUnordered} />
@@ -95,52 +178,14 @@ export class PullRequestQuickView extends React.Component<
     this.props.onMouseLeave()
   }
 
-  private calculatePosition(
-    prListItemTop: number
-  ): React.CSSProperties | undefined {
-    /** The max height of the visible quick view card is 556 (500 for scrollable
-     * body and 56 for header)
-     */
-    const maxQuickViewHeight = 556
-
-    // Important to retrieve as it changes for maximization on macOS and quick
-    // view is relative to the top of branch container = foldout-container. But
-    // if we can't find it (unlikely) we can atleast compensate for the toolbar
-    // being 50px
-    const topOfPRList =
-      document.getElementById('foldout-container')?.getBoundingClientRect()
-        .top ?? 50
-
-    // This is currently staticly defined so not bothering to attain it from
-    // dom searching.
-    const heightPRListItem = 47
-
-    // Top half of list with room to display aligned to top
-    if (window.innerHeight - prListItemTop > maxQuickViewHeight) {
-      return { top: prListItemTop - topOfPRList }
-    }
-
-    // Bottom half of list with room to display aligned to bottom.
-    if (prListItemTop - maxQuickViewHeight > 0) {
-      return { bottom: window.innerHeight - prListItemTop - heightPRListItem }
-    }
-
-    // If not enough room to display aligned top or bottom, attempt to center
-    // with a minimum top/bottom pr list item (won't be centered but close for
-    // prs with a body < max height)
-    const middlePrListItem = prListItemTop + heightPRListItem / 2
-    const middleQuickView = maxQuickViewHeight / 2
-    const maxTop = window.innerHeight - topOfPRList - maxQuickViewHeight
-    return { top: clamp(middlePrListItem - middleQuickView, 0, maxTop) }
-  }
-
   public render() {
     return (
       <div
         className="pull-request-quick-view"
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
-        style={this.calculatePosition(this.props.pullRequestItemTop)}
+        style={this.state.position}
+        ref={this.onQuickViewRef}
       >
         <div className="pull-request-quick-view-contents">
           {this.renderHeader()}

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -91,22 +91,33 @@ export class PullRequestQuickView extends React.Component<
     // dom searching.
     const heightPRListItem = 47
 
+    // We want to make sure that the quick view is always visible and highest
+    // being aligned to top of branch/pr dropdown (which is 0 since this is a
+    // child element of the branch dropdown)
+    const minTop = 0
+    const maxTop = window.innerHeight - topOfPRList - quickViewHeight
+
     // Check if it has room to display aligned to top (likely top half of list)
     if (window.innerHeight - prListItemTop > quickViewHeight) {
-      return { top: prListItemTop - topOfPRList }
+      const alignedTop = prListItemTop - topOfPRList
+      return { top: clamp(alignedTop, minTop, maxTop) }
     }
 
     // Can't align to top -> likely bottom half of list check if has room to display aligned to bottom.
     if (prListItemTop - quickViewHeight > 0) {
-      return { bottom: window.innerHeight - prListItemTop - heightPRListItem }
+      const alignedBottom =
+        window.innerHeight - prListItemTop - heightPRListItem
+      return { bottom: clamp(alignedBottom, minTop, maxTop) }
     }
 
-    // If not enough room to display aligned top or bottom, attempt to center
-    // with a minimum top/bottom pr list item
+    // If not enough room to display aligned top or bottom, attempt to center on
+    // list item. For short height screens with max height quick views, this
+    // will likely end up being clamped so will be anchored to top or bottom
+    // depending on position in list.
     const middlePrListItem = prListItemTop + heightPRListItem / 2
     const middleQuickView = quickViewHeight / 2
-    const maxTop = window.innerHeight - topOfPRList - quickViewHeight
-    return { top: clamp(middlePrListItem - middleQuickView, 0, maxTop) }
+    const alignedMiddle = middlePrListItem - middleQuickView
+    return { top: clamp(alignedMiddle, minTop, maxTop) }
   }
 
   private onQuickViewRef = (quickViewRef: HTMLDivElement) => {

--- a/app/styles/ui/_pull-request-quick-view.scss
+++ b/app/styles/ui/_pull-request-quick-view.scss
@@ -4,7 +4,7 @@
 
   .pull-request-quick-view-contents {
     background-color: var(--background-color);
-    margin: var(--spacing-double);
+    margin: 0 var(--spacing-double);
     min-width: 400px;
     border-radius: var(--border-radius);
     overflow: hidden;


### PR DESCRIPTION
Part of #11517

(take 2 - other branch got accidentally messed up when I tried to update it...)

## Description

This is to position the quick view card relative to the the position of the pr list item. It will align top if there is height enough and otherwise align bottom if there is height enough. Otherwise, it will attempt to center the quick view card on the pr list view item with a min top position of the top of the list and a min bottom position of visible on screen. 

### Screenshots
https://user-images.githubusercontent.com/75402236/145462507-ad67a560-bbb1-4f91-b53c-2673b7dde324.mov

## Release notes
Notes: no-notes
