### PR TITLE
Add "View on GitHub" context menu option

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2323,6 +2323,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           this.state.askForConfirmationOnRepositoryRemoval
         }
         onRemoveRepository={this.removeRepository}
+        onViewOnGitHub={this.viewOnGitHub}
         onOpenInShell={this.openInShell}
         onShowRepository={this.showRepository}
         onOpenInExternalEditor={this.openInExternalEditor}
@@ -2331,6 +2332,18 @@ export class App extends React.Component<IAppProps, IAppState> {
         dispatcher={this.props.dispatcher}
       />
     )
+  }
+
+  private viewOnGitHub = (repository: Repository | CloningRepository) => {
+    if (!(repository instanceof Repository)) {
+      return
+    }
+
+    const url = getGitHubHtmlUrl(repository)
+
+    if (url) {
+      this.props.dispatcher.openInBrowser(url)
+    }
   }
 
   private openInShell = (repository: Repository | CloningRepository) => {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1148,13 +1148,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   private viewRepositoryOnGitHub() {
     const repository = this.getRepository()
 
-    if (repository instanceof Repository) {
-      const url = getGitHubHtmlUrl(repository)
-
-      if (url) {
-        this.props.dispatcher.openInBrowser(url)
-      }
-    }
+    this.viewOnGitHub(repository)
   }
 
   /** Returns the URL to the current repository if hosted on GitHub */
@@ -2334,7 +2328,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     )
   }
 
-  private viewOnGitHub = (repository: Repository | CloningRepository) => {
+  private viewOnGitHub = (
+    repository: Repository | CloningRepository | null
+  ) => {
     if (!(repository instanceof Repository)) {
       return
     }

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -49,6 +49,9 @@ interface IRepositoriesListProps {
   /** Called when the repository should be shown in Finder/Explorer/File Manager. */
   readonly onShowRepository: (repository: Repositoryish) => void
 
+  /** Called when the repository should be opened on GitHub in the default web browser. */
+  readonly onViewOnGitHub: (repository: Repositoryish) => void
+
   /** Called when the repository should be shown in the shell. */
   readonly onOpenInShell: (repository: Repositoryish) => void
 
@@ -137,6 +140,7 @@ export class RepositoriesList extends React.Component<
         }
         onRemoveRepository={this.props.onRemoveRepository}
         onShowRepository={this.props.onShowRepository}
+        onViewOnGitHub={this.props.onViewOnGitHub}
         onOpenInShell={this.props.onOpenInShell}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onChangeRepositoryAlias={this.onChangeRepositoryAlias}

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -32,6 +32,9 @@ interface IRepositoryListItemProps {
   /** Called when the repository should be shown in Finder/Explorer/File Manager. */
   readonly onShowRepository: (repository: Repositoryish) => void
 
+  /** Called when the repository should be opened on GitHub in the default web browser. */
+  readonly onViewOnGitHub: (repository: Repositoryish) => void
+
   /** Called when the repository should be shown in the shell. */
   readonly onOpenInShell: (repository: Repositoryish) => void
 
@@ -165,6 +168,10 @@ export class RepositoryListItem extends React.Component<
       },
       { type: 'separator' },
       {
+        label: 'View on GitHub',
+        action: this.viewOnGitHub,
+      },
+      {
         label: `Open in ${this.props.shellLabel}`,
         action: this.openInShell,
         enabled: !missing,
@@ -222,6 +229,10 @@ export class RepositoryListItem extends React.Component<
 
   private showRepository = () => {
     this.props.onShowRepository(this.props.repository)
+  }
+
+  private viewOnGitHub = () => {
+    this.props.onViewOnGitHub(this.props.repository)
   }
 
   private openInShell = () => {

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -156,6 +156,8 @@ export class RepositoryListItem extends React.Component<
 
     const repository = this.props.repository
     const missing = repository instanceof Repository && repository.missing
+    const github =
+      repository instanceof Repository && repository.gitHubRepository != null
     const openInExternalEditor = this.props.externalEditorLabel
       ? `Open in ${this.props.externalEditorLabel}`
       : DefaultEditorLabel
@@ -170,6 +172,7 @@ export class RepositoryListItem extends React.Component<
       {
         label: 'View on GitHub',
         action: this.viewOnGitHub,
+        enabled: github,
       },
       {
         label: `Open in ${this.props.shellLabel}`,


### PR DESCRIPTION
Closes #13227 

## Description

- Adds a "View on GitHub" context menu option when right clicking a repository in the repository list
- "View on GitHub" option is available regardless of whether or not the repository can be found locally

Please let me know if my code could be improved in any way as this is my first PR to this repo! 😀

### Screenshots

<img width="323" alt="ss" src="https://user-images.githubusercontent.com/40507205/146779969-70b05bd3-6bc6-4861-9098-355d479055df.png">

## Release notes

Notes: [ADDED] Add "View on GitHub" context menu option to repositories list
