### PR TITLE
Issue Mention Filter

### DIFF
--- a/app/src/lib/databases/issues-database.ts
+++ b/app/src/lib/databases/issues-database.ts
@@ -7,6 +7,7 @@ export interface IIssue {
   readonly number: number
   readonly title: string
   readonly updated_at?: string
+  readonly html_url?: string
 }
 
 export class IssuesDatabase extends BaseDatabase {

--- a/app/src/lib/markdown-filters/issue-mention-filter.ts
+++ b/app/src/lib/markdown-filters/issue-mention-filter.ts
@@ -1,0 +1,133 @@
+import { fatalError } from '../fatal-error'
+import { INodeFilter } from './node-filter'
+
+/**
+ * The Issue Mention filter matches for issue references in user-supplied
+ * content one of two formats:
+ *
+ *  1. As a plain text reference, like #1234, gh-1234, /issues/1234, /pull/1234, or /discussions/1234
+ *      Note: gh- is a legacy marker before #.
+ *
+ *  2. TO DO - anchor tags with links
+ *
+ */
+export class IssueMentionFilter implements INodeFilter {
+  /** A regular expression string to match a group of any digit follow by a word
+   * bounding character. */
+  private readonly number = `?(?<refNumber>\\d+)\\b`
+
+  /** A regular expression string to match a group of an repo name or name with
+   * owner -> github/github or github  */
+  private readonly nameOrNWO = `(?<nameOrNWO>w+(?:-w+)*(?:\/[.w-]+)?)`
+
+  /** A regular expression string to match a group possible preceding markers are
+   * gh-, #, /issues/, /pull/, or /discussions/ followed by a digit
+   */
+  private readonly marker = `(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\\d)`
+
+  /**
+   * A regular expression string of a lookbehind is used so that valid
+   * matches for the issue reference have the leader precede them but the leader
+   * is not considered part of the match. An issue reference much have a
+   * whitespace, beginning of line, or some other non-word character must
+   * preceding it.
+   * */
+  private readonly leader = `(?<=^|\\W)`
+
+  /**
+   * A regular expression matching an issue reference.
+   * Issue reference must:
+   * 1) Be preceded by a beginning of a line or some some other non-word
+   *    character.
+   * 2) Start with an issue marker: gh-, #, /issues/, /pull/, or /discussions/
+   * 3) The issue marker must be followed by a number
+   * 4) The number must end in a word bounding character. Additionally, the
+   *    issue reference match may be such that the marker may be preceded by a
+   *    repo references of owner/repo or repo/
+   * */
+  private readonly issueReferenceWithLeader = new RegExp(
+    this.leader + this.nameOrNWO + '?' + this.marker + this.number,
+    'ig'
+  )
+
+  public constructor() {
+    // Todo... probably need something to look up issue references
+  }
+
+  /**
+   * Issue mention filter iterates on all text nodes that are not inside a pre, code, or anchor tag.
+   */
+  public createFilterTreeWalker(doc: Document): TreeWalker {
+    return doc.createTreeWalker(doc, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        return node.parentNode !== null &&
+          ['CODE', 'PRE', 'A'].includes(node.parentNode.nodeName)
+          ? NodeFilter.FILTER_SKIP
+          : NodeFilter.FILTER_ACCEPT
+      },
+    })
+  }
+
+  /**
+   * Takes a text node and creates multiple text and image nodes by inserting
+   * anchor tags  where the references are.
+   *
+   * Example:
+   * Node = "Issue #1234 is the same thing"
+   * Output = ["Issue ", <a href="https://github.com/owner/repo/issues/1234">#1234</a>, " is the same thing"]
+   */
+  public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
+    if (!(node instanceof Text)) {
+      fatalError(
+        'Issue filter requires text nodes; otherwise we may inadvertently replace non text elements.'
+      )
+    }
+
+    const { textContent: text } = node
+    const markerRegexp = new RegExp(this.marker, 'i')
+    if (text === null || !markerRegexp.test(text)) {
+      return null
+    }
+
+    let lastMatchEndingPosition = 0
+    const nodes: Array<Text | HTMLAnchorElement> = []
+    const matches = text.matchAll(this.issueReferenceWithLeader)
+    for (const match of matches) {
+      if (match.groups === undefined || match.index === undefined) {
+        continue
+      }
+
+      const { marker, refNumber } = match.groups
+      if (marker === undefined || refNumber === undefined) {
+        continue
+      }
+
+      const textBefore = text.slice(lastMatchEndingPosition, match.index)
+      const textNodeBefore = document.createTextNode(textBefore)
+      nodes.push(textNodeBefore)
+
+      nodes.push(await this.createIssueAnchorElement(marker, refNumber))
+
+      lastMatchEndingPosition = match.index + marker.length + refNumber.length
+    }
+
+    const trailingText = text.slice(lastMatchEndingPosition)
+    if (trailingText !== '') {
+      nodes.push(document.createTextNode(trailingText))
+    }
+
+    return nodes
+  }
+
+  /**
+   * Method to create the issue mention anchor
+   *
+   * TODO: Determine if refNumber is an issue reference and build current href (issue vs pull vs discussion)
+   */
+  private async createIssueAnchorElement(marker: string, refNumber: string) {
+    const anchor = document.createElement('a')
+    anchor.href = `https://github.com/desktop/desktop/issues/${refNumber}`
+    anchor.textContent = `${marker}${refNumber}`
+    return anchor
+  }
+}

--- a/app/src/lib/markdown-filters/issue-mention-filter.ts
+++ b/app/src/lib/markdown-filters/issue-mention-filter.ts
@@ -11,14 +11,14 @@ import { INodeFilter } from './node-filter'
  * Examples:  #1234, gh-1234, /issues/1234, /pull/1234, or /discussions/1234,
  * desktop/dugite#1, desktop/dugite/issues/1234
  *
- * Each references is made up of {nameOrNWO}{marker}{number} and must be
+ * Each references is made up of {ownerOrOwnerRepo}{marker}{number} and must be
  * preceded by a non-word character.
- *   - nameOrNWO: Optional. If both owner/repo is provided, it can be used to
- *                specify an issue outside of the parent repository. Redundant
- *                references will be trimmed. Single owners can be redundant,
- *                but single repo names are treated as non-matches.
+ *   - ownerOrOwnerRepo: Optional. If both owner/repo is provided, it can be
+ *              used to specify an issue outside of the parent repository.
+ *              Redundant references will be trimmed. Single owners can be
+ *              redundant, but single repo names are treated as non-matches.
  *
- *                Example: When viewing from the tidy-dev/foo repo,
+ *              Example: When viewing from the tidy-dev/foo repo,
  *                  a. tidy-dev/foo#1 becomes linked as #1.
  *                  b. tidy-dev#1 becomes linked as #1,
  *                  c. foo#1 is not linked and is a non-match.
@@ -31,19 +31,21 @@ import { INodeFilter } from './node-filter'
  *
  */
 export class IssueMentionFilter implements INodeFilter {
-  /** A regular expression string to match a group of any digit follow by a word
+  /** A regular expression to match a group of any digit follow by a word
    * bounding character. */
-  private readonly number = `?(?<refNumber>\\d+)\\b`
+  private readonly refNumber = /(?<refNumber>\d+)\b/
 
-  /** A regular expression string to match a group of an repo name or name with
-   * owner -> github/github or github  */
-  private readonly nameOrNWO = `(?<nameOrNWO>w+(?:-w+)*(?:\/[.w-]+)?)`
+  /** A regular expression to match a group of an repo name or name with owner
+   * Example: github/github or github  */
+  private readonly ownerOrOwnerRepo = /(?<ownerOrOwnerRepo>\w+(?:-\w+)*(?:\/[.\w-]+)?)/
 
-  /** A regular expression string to match a group possible preceding markers are
+  /** A regular expression to match a group possible preceding markers are
    * gh-, #, /issues/, /pull/, or /discussions/ followed by a digit
    */
-  private readonly marker = `(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\\d)`
-
+  private readonly marker = /(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\d)/
+  // `(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\\d)`
+  //?<marker>
+  // MARKER = %r<(?:#|gh-|/(?:issues|pull|discussions)/)(?=\d)>i
   /**
    * A regular expression string of a lookbehind is used so that valid
    * matches for the issue reference have the leader precede them but the leader
@@ -51,7 +53,7 @@ export class IssueMentionFilter implements INodeFilter {
    * whitespace, beginning of line, or some other non-word character must
    * preceding it.
    * */
-  private readonly leader = `(?<=^|\\W)`
+  private readonly leader = /(?<=^|\W)/
 
   /**
    * A regular expression matching an issue reference.
@@ -65,12 +67,22 @@ export class IssueMentionFilter implements INodeFilter {
    *    repo references of owner/repo or owner
    * */
   private readonly issueReferenceWithLeader = new RegExp(
-    this.leader + this.nameOrNWO + '?' + this.marker + this.number,
+    this.leader.source +
+      this.ownerOrOwnerRepo.source +
+      '?' +
+      this.marker.source +
+      this.refNumber.source,
     'ig'
   )
 
+  /** App dispatcher used to retrieve/verify issue, pull request, and discussion urls. */
   private readonly dispatcher: Dispatcher
+
+  /** The parent github repository of which the content the filter is being applied to belongs  */
   private readonly repository: GitHubRepository
+
+  /** Cache of retrieved url references such that we don't keep repeating api calls */
+  private readonly referencesUrlCache: Map<string, string | null> = new Map()
 
   public constructor(dispatcher: Dispatcher, repository: GitHubRepository) {
     this.dispatcher = dispatcher
@@ -121,8 +133,17 @@ export class IssueMentionFilter implements INodeFilter {
         continue
       }
 
-      const { marker, refNumber, nameOrNWO } = match.groups
+      const { marker, refNumber, ownerOrOwnerRepo } = match.groups
       if (marker === undefined || refNumber === undefined) {
+        continue
+      }
+
+      const referenceURL = await this.getReferencesURL(
+        refNumber,
+        ownerOrOwnerRepo
+      )
+
+      if (referenceURL === null) {
         continue
       }
 
@@ -130,11 +151,19 @@ export class IssueMentionFilter implements INodeFilter {
       const textNodeBefore = document.createTextNode(textBefore)
       nodes.push(textNodeBefore)
 
-      nodes.push(
-        await this.createIssueAnchorElement(marker, refNumber, nameOrNWO)
+      const link = this.createLinkElement(
+        referenceURL,
+        marker,
+        refNumber,
+        ownerOrOwnerRepo
       )
+      nodes.push(link)
 
-      lastMatchEndingPosition = match.index + marker.length + refNumber.length
+      lastMatchEndingPosition =
+        match.index +
+        (ownerOrOwnerRepo?.length ?? 0) +
+        marker.length +
+        refNumber.length
     }
 
     const trailingText = text.slice(lastMatchEndingPosition)
@@ -146,27 +175,109 @@ export class IssueMentionFilter implements INodeFilter {
   }
 
   /**
-   * Method to create the issue mention anchor or returns a text node with the ref if unable.
+   * The ownerOrOwnerRepo may be of the form owner or owner/repo.
+   * 1) If owner/repo and they don't both match the current repo, then we return
+   *    them as to distinguish them as a different from the current repo for the
+   *    reference url.
+   * 2) If (owner) and the owner !== current repo owner, it is an invalid
+   *    references - return null.
+   * 3) Otherwise, return [] as it is an valid references, but, in the current
+   *    repo and is redundant owner/repo info.
    */
-  private async createIssueAnchorElement(
-    marker: string,
-    refNumber: string,
-    nwo?: string
-  ) {
-    // TODO: build a cache... so we don't retrieve same issue many times
-    const issueOrDiscussionURL = await this.dispatcher.fetchIssueOrDiscussionURL(
-      this.repository,
-      refNumber
-    )
-    const anchorText = `${marker}${refNumber}`
-
-    if (issueOrDiscussionURL === null) {
-      return document.createTextNode(anchorText)
+  private resolveOwnerRepo(
+    ownerOrOwnerRepo: string | undefined
+  ): ReadonlyArray<string> | null {
+    if (ownerOrOwnerRepo === undefined) {
+      return []
     }
 
+    const ownerAndRepo = ownerOrOwnerRepo.split('/')
+    if (ownerAndRepo.length > 3) {
+      // Invalid data
+      return null
+    }
+
+    // If owner and repo are provided, we only care if they differ from the current repo.
+    if (
+      ownerAndRepo.length === 2 &&
+      (ownerAndRepo[0] !== this.repository.owner.login ||
+        ownerAndRepo[1] !== this.repository.name)
+    ) {
+      return ownerAndRepo
+    }
+
+    if (
+      ownerAndRepo.length === 1 &&
+      ownerAndRepo[0] !== this.repository.owner.login
+    ) {
+      return null
+    }
+
+    return []
+  }
+
+  /** Checks a references url cache and if not present, retrieves it and sets cache if not null */
+  private async getReferencesURL(
+    refNumber: string,
+    ownerOrOwnerRepo?: string
+  ): Promise<string | null> {
+    let refKey = `${refNumber}`
+
+    const ownerRepo = this.resolveOwnerRepo(ownerOrOwnerRepo)
+    if (ownerRepo === null) {
+      // We had in invalid reference due to owner/repo prefacing the issue
+      // references.
+      return null
+    }
+
+    const keyOwnerRepoPreface = ownerRepo.length === 2 ? ownerOrOwnerRepo : ''
+    refKey = `${keyOwnerRepoPreface}${refKey}`
+
+    const cachedReferenceUrl = this.referencesUrlCache.get(refKey)
+    if (cachedReferenceUrl !== undefined) {
+      return cachedReferenceUrl
+    }
+
+    const [owner, repo] = ownerRepo
+    const referencesURL = await this.dispatcher.fetchIssueOrDiscussionURL(
+      this.repository,
+      refNumber,
+      owner,
+      repo
+    )
+
+    this.referencesUrlCache.set(refKey, referencesURL)
+
+    return referencesURL
+  }
+
+  /**
+   * Method to create the issue mention anchor. If unable to parse ownerRepo,
+   * then returns a text node as this would indicate an invalid reference.
+   */
+  private createLinkElement(
+    href: string,
+    marker: string,
+    refNumber: string,
+    ownerOrOwnerRepo?: string
+  ) {
+    let text = `${marker}${refNumber}`
+
+    const ownerRepo = this.resolveOwnerRepo(ownerOrOwnerRepo)
+    if (ownerRepo === null) {
+      // Technically, this shouldn't happen at this point since we have a href,
+      // but if it did it means we had in invalid reference due to owner/repo
+      // prefacing the issue references and we just want to put a text node
+      // back.
+      return document.createTextNode(`${ownerOrOwnerRepo}${text}`)
+    }
+
+    const keyOwnerRepoPreface = ownerRepo.length === 2 ? ownerOrOwnerRepo : ''
+    text = `${keyOwnerRepoPreface}${text}`
+
     const anchor = document.createElement('a')
-    anchor.textContent = anchorText
-    anchor.href = issueOrDiscussionURL
+    anchor.textContent = text
+    anchor.href = href
     return anchor
   }
 }

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -1,4 +1,5 @@
 import { EmojiFilter } from './emoji-filter'
+import { IssueMentionFilter } from './issue-mention-filter'
 
 export interface INodeFilter {
   /**
@@ -33,7 +34,7 @@ export interface INodeFilter {
 export function buildCustomMarkDownNodeFilterPipe(
   emoji: Map<string, string>
 ): ReadonlyArray<INodeFilter> {
-  return [new EmojiFilter(emoji)]
+  return [new EmojiFilter(emoji), new IssueMentionFilter()]
 }
 
 /**

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -39,8 +39,8 @@ export function buildCustomMarkDownNodeFilterPipe(
   dispatcher: Dispatcher
 ): ReadonlyArray<INodeFilter> {
   return [
-    new EmojiFilter(emoji),
     new IssueMentionFilter(dispatcher, repository),
+    new EmojiFilter(emoji),
   ]
 }
 

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -1,3 +1,5 @@
+import { GitHubRepository } from '../../models/github-repository'
+import { Dispatcher } from '../../ui/dispatcher'
 import { EmojiFilter } from './emoji-filter'
 import { IssueMentionFilter } from './issue-mention-filter'
 
@@ -32,9 +34,14 @@ export interface INodeFilter {
  * @param emoji Map from the emoji shortcut (e.g., :+1:) to the image's local path.
  */
 export function buildCustomMarkDownNodeFilterPipe(
-  emoji: Map<string, string>
+  emoji: Map<string, string>,
+  repository: GitHubRepository,
+  dispatcher: Dispatcher
 ): ReadonlyArray<INodeFilter> {
-  return [new EmojiFilter(emoji), new IssueMentionFilter()]
+  return [
+    new EmojiFilter(emoji),
+    new IssueMentionFilter(dispatcher, repository),
+  ]
 }
 
 /**

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6838,7 +6838,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public async fetchIssueOrDiscussionURL(
     repository: GitHubRepository,
-    issueNumber: string
+    issueNumber: string,
+    owner?: string,
+    repo?: string
   ): Promise<string | null> {
     const account = getAccountForEndpoint(this.accounts, repository.endpoint)
     if (account === null) {
@@ -6847,8 +6849,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const api = API.fromAccount(account)
 
     return api.fetchIssueOrDiscussionUrl(
-      repository.owner.login,
-      repository.name,
+      owner ?? repository.owner.login,
+      repo ?? repository.name,
       issueNumber
     )
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6848,10 +6848,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
     const api = API.fromAccount(account)
 
-    return api.fetchIssueOrDiscussionUrl(
-      owner ?? repository.owner.login,
-      repo ?? repository.name,
-      issueNumber
+    const matchingIssue = await this.issuesStore.getIssue(
+      repository,
+      parseInt(issueNumber, 10)
+    )
+
+    return (
+      matchingIssue?.html_url ??
+      api.fetchIssueOrDiscussionUrl(
+        owner ?? repository.owner.login,
+        repo ?? repository.name,
+        issueNumber
+      )
     )
   }
 }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -6835,6 +6835,23 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.showCIStatusPopover = !this.showCIStatusPopover
     this.emitUpdate()
   }
+
+  public async fetchIssueOrDiscussionURL(
+    repository: GitHubRepository,
+    issueNumber: string
+  ): Promise<string | null> {
+    const account = getAccountForEndpoint(this.accounts, repository.endpoint)
+    if (account === null) {
+      return null
+    }
+    const api = API.fromAccount(account)
+
+    return api.fetchIssueOrDiscussionUrl(
+      repository.owner.login,
+      repository.name,
+      issueNumber
+    )
+  }
 }
 
 /**

--- a/app/src/lib/stores/issues-store.ts
+++ b/app/src/lib/stores/issues-store.ts
@@ -195,6 +195,17 @@ export class IssuesStore {
       .map(h => h.hit)
   }
 
+  public async getIssue(
+    repository: GitHubRepository,
+    issueNumber: number
+  ): Promise<IIssue | undefined> {
+    return this.db.issues
+      .where('[gitHubRepositoryID+number]')
+      .equals([repository.dbID, issueNumber])
+      .limit(1)
+      .first()
+  }
+
   private setQueryCache(
     repository: GitHubRepository,
     issues: ReadonlyArray<IIssueHit>

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3827,8 +3827,15 @@ export class Dispatcher {
 
   public fetchIssueOrDiscussionURL(
     repository: GitHubRepository,
-    issueNumber: string
+    issueNumber: string,
+    owner?: string,
+    repo?: string
   ): Promise<string | null> {
-    return this.appStore.fetchIssueOrDiscussionURL(repository, issueNumber)
+    return this.appStore.fetchIssueOrDiscussionURL(
+      repository,
+      issueNumber,
+      owner,
+      repo
+    )
   }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3824,4 +3824,11 @@ export class Dispatcher {
   public recordRerunChecks() {
     this.statsStore.recordRerunChecks()
   }
+
+  public fetchIssueOrDiscussionURL(
+    repository: GitHubRepository,
+    issueNumber: string
+  ): Promise<string | null> {
+    return this.appStore.fetchIssueOrDiscussionURL(repository, issueNumber)
+  }
 }

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -7,6 +7,8 @@ import {
   applyNodeFilters,
   buildCustomMarkDownNodeFilterPipe,
 } from '../../lib/markdown-filters/node-filter'
+import { Dispatcher } from '../dispatcher'
+import { GitHubRepository } from '../../models/github-repository'
 
 interface ISandboxedMarkdownProps {
   /** A string of unparsed markdown to display */
@@ -26,6 +28,11 @@ interface ISandboxedMarkdownProps {
 
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>
+
+  /** The GitHub repository to use when looking up commit status. */
+  readonly repository: GitHubRepository
+
+  readonly dispatcher: Dispatcher
 }
 
 /**
@@ -240,7 +247,12 @@ export class SandboxedMarkdown extends React.PureComponent<
    * mentions, etc.
    */
   private applyCustomMarkdownFilters(parsedMarkdown: string): Promise<string> {
-    const nodeFilters = buildCustomMarkDownNodeFilterPipe(this.props.emoji)
+    const { emoji, dispatcher, repository } = this.props
+    const nodeFilters = buildCustomMarkDownNodeFilterPipe(
+      emoji,
+      repository,
+      dispatcher
+    )
     return applyNodeFilters(nodeFilters, parsedMarkdown)
   }
 

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -154,7 +154,10 @@ export class SandboxedMarkdown extends React.PureComponent<
 
     // Not sure why the content height != body height exactly. But, 50px seems
     // to prevent scrollbar/content cut off.
-    const divHeight = docEl.clientHeight + 50
+    const divHeight = Math.max(
+      frameRef.contentDocument.documentElement.clientHeight,
+      docEl.clientHeight
+    )
     this.frameContainingDivRef.style.height = `${divHeight}px`
   }
 

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -185,9 +185,16 @@ export class PullRequestQuickView extends React.Component<
           markdown={displayBody}
           emoji={this.props.emoji}
           baseHref={base.gitHubRepository.htmlURL}
+          repository={base.gitHubRepository}
+          dispatcher={this.props.dispatcher}
+          onMarkdownLinkClicked={this.onMarkdownLinkClicked}
         />
       </div>
     )
+  }
+
+  private onMarkdownLinkClicked = (url: string) => {
+    this.props.dispatcher.openInBrowser(url)
   }
 
   private onMouseLeave = () => {

--- a/app/static/common/markdown.css
+++ b/app/static/common/markdown.css
@@ -16,6 +16,7 @@ changes from the original, just a note that this will not match 1-1)
 	line-height: 1.5;
 	word-wrap: break-word;
 	margin: 0;
+	white-space: pre-line;
 }
 
 .markdown-body::before {


### PR DESCRIPTION
Built on top of https://github.com/desktop/desktop/pull/13548

## Description

Based on dotcom's issue mention filter, it matches for issue references such as #1234, gh-1234, /issues/1234, /pull/1234, or /discussions/1234 and replaces them with anchor tags linking to the issue, pull request, or discussion in the parent repository. (Issues and pull-requests are the same thing) Those issue mentions can also be prefixed with an owner/repo which allows linking to a non-parent repo such as desktop/dugite#1.

Questions:
1 - I couldn't find an GitHub Rest Api for discussion links.. So I used graph ql api.. are there cons to this asides from it feeling much messier?

2. How to address lag?
Current approach appears very slow... I have added a filter cache, but that will only apply to multiple api requests for same issue reference in a single PR (not switching between pr quick views). Additionally, I do check the issue store before making an api call. But.. still noticeable lag.

Thoughts on speeding things up:
1. Since, we are going out to a dispatcher anyways, we could cache these api calls in a store outside of the filter so that at least if a user has opened the pr quick view once, it should be relatively quick the second time.

2. Dotcom has some of it's filters split into two parts (this being one of them), first is a synchronous filter that just goes and looks for issue references and marks them with a unique tag and the second asynchronous filter that matches for those tags and does the check against the api. I am not 100% sure how this works.. But, I think it goes ahead and shows the user the parsed markdown and filters that are asynchronous will update the output as they resolve. This is more feasible since dotcom is not waiting on filters before putting it into a sandboxed iframe and it is manipulating dom nodes.... But.. maybe we could do something similar by keeping a DOM version that as filters resolve we update them and then pass down into the iframe.

3.  We don't hit the api and have more false positives... if something says `#99999999`, we simply make it refer to `current repo owner/current repo/99999999` whether that issue exists or not. Note... dotcom has popovers over issues links that we are not currently doing, which makes this more feasible. But, does mean a different behavior than in dotcom. (This is currently our approach in our ~~autocompletion~~ text-token-parser logic)


### Screenshots
Testing against - https://github.com/tidy-dev/foo-really-not/pull/2

https://user-images.githubusercontent.com/75402236/147777747-d9785ec1-b042-4425-bc00-3d26ebe50cc2.mov


## Release notes
Notes: Adding an issue mentions node filter for markdown parsing.
