### PR TITLE
you cant download the official version of linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download the official installer for your operating system:
 You can install this alongside your existing GitHub Desktop for Mac or GitHub
 Desktop for Windows application.
 
-There is no way of downloading the official Github Desktop on Linux for now, but there are some community releases that give you the option to download it on Linux, please check out the community guidelines section.
+Linux is not officially supported; however, you can find installers created for Linux from a fork of GitHub Desktop in the [Community Releases](https://github.com/desktop/desktop#community-releases) section.
 
 **NOTE**: there is no current migration path to import your existing
 repositories into the new application - you can drag-and-drop your repositories

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ Download the official installer for your operating system:
 You can install this alongside your existing GitHub Desktop for Mac or GitHub
 Desktop for Windows application.
 
+There is no way of downloading the official Github Desktop on Linux for now, but there are some community releases that give you the option to download it on Linux, please check out the community guidelines section.
 
 **NOTE**: there is no current migration path to import your existing
 repositories into the new application - you can drag-and-drop your repositories
 from disk onto the application to get started.
+
 
 ### Beta Channel
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Added a comment, that Github Desktop Official isn't on Linux yet but there is a community release.

