### PR TITLE
Fix commit message dialog inherited styles

### DIFF
--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -755,7 +755,6 @@ export class CommitMessage extends React.Component<
 
     return (
       <div
-        id="commit-message"
         role="group"
         aria-label="Create commit"
         className={className}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -740,7 +740,7 @@ export class CommitMessage extends React.Component<
   }
 
   public render() {
-    const className = classNames({
+    const className = classNames('commit-message-component', {
       'with-action-bar': this.isActionBarEnabled,
       'with-co-authors': this.isCoAuthorInputVisible,
     })

--- a/app/src/ui/changes/commit-warning.tsx
+++ b/app/src/ui/changes/commit-warning.tsx
@@ -34,7 +34,7 @@ export const CommitWarning: React.FunctionComponent<{
   readonly icon: CommitWarningIcon
 }> = props => {
   return (
-    <div id="commit-warning" onContextMenu={ignoreContextMenu}>
+    <div className="commit-warning-component" onContextMenu={ignoreContextMenu}>
       <div className="warning-icon-container">{renderIcon(props.icon)}</div>
       <div className="warning-message">{props.children}</div>
     </div>

--- a/app/styles/ui/changes/_commit-message.scss
+++ b/app/styles/ui/changes/_commit-message.scss
@@ -1,7 +1,7 @@
 @import '../../mixins';
 
 /** A React component holding the commit message entry */
-#commit-message {
+.commit-message-component {
   border-top: 1px solid var(--box-border-color);
   flex-direction: column;
   flex-shrink: 0;

--- a/app/styles/ui/changes/_commit-warning.scss
+++ b/app/styles/ui/changes/_commit-warning.scss
@@ -1,6 +1,6 @@
 @import '../../mixins';
 
-#commit-warning {
+.commit-warning-component {
   border-top: 1px solid var(--box-border-color);
   flex-direction: column;
   flex-shrink: 0;

--- a/app/styles/ui/dialogs/_commit-message.scss
+++ b/app/styles/ui/dialogs/_commit-message.scss
@@ -2,12 +2,13 @@ dialog#commit-message-dialog {
   .dialog-content {
     padding: 0;
   }
-  #commit-message,
-  #commit-warning {
+
+  .commit-message-component,
+  .commit-warning-component {
     background-color: inherit;
   }
 
-  #commit-warning {
+  .commit-warning-component {
     .warning-icon-container {
       .warning-icon,
       .information-icon {

--- a/app/styles/ui/dialogs/_commit-message.scss
+++ b/app/styles/ui/dialogs/_commit-message.scss
@@ -2,7 +2,17 @@ dialog#commit-message-dialog {
   .dialog-content {
     padding: 0;
   }
-  #commit-message {
+  #commit-message,
+  #commit-warning {
     background-color: inherit;
+  }
+
+  #commit-warning {
+    .warning-icon-container {
+      .warning-icon,
+      .information-icon {
+        background-color: var(--background-color);
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #13606 

## Description
My use case is different from the bug ticket, but it is the same div, just a different warning.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/147681321-00c057b9-3edc-4d83-8981-2de8b593331e.png)

## Release notes
Notes: [Improved] Commit message dialog warning background styles congruent with dialog.
