### PR TITLE
Fetch before opening branch from url

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -286,7 +286,6 @@ import { DragAndDropIntroType } from '../../ui/history/drag-and-drop-intro'
 import { UseWindowsOpenSSHKey } from '../ssh/ssh'
 import { isConflictsFlow } from '../multi-commit-operation'
 import { clamp } from '../clamp'
-import { findDefaultRemote } from './helpers/find-default-remote'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -5778,25 +5777,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (prBranch !== undefined) {
       await this._checkoutBranch(repository, prBranch)
       this.statsStore.recordPRBranchCheckout()
-    }
-  }
-
-  /**
-   *
-   * Fetches from "origin" or the first alphabetical remote if "origin" doesn't exist.
-   * This function is a no-op if no remote is configured.
-   */
-  public async _fetchDefaultRemote(
-    repository: RepositoryWithGitHubRepository
-  ): Promise<void> {
-    const remotes = await getRemotes(repository)
-    const defaultRemote = findDefaultRemote(remotes)
-    if (defaultRemote) {
-      await this._fetchRemote(
-        repository,
-        defaultRemote,
-        FetchType.UserInitiatedTask
-      )
     }
   }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -286,6 +286,7 @@ import { DragAndDropIntroType } from '../../ui/history/drag-and-drop-intro'
 import { UseWindowsOpenSSHKey } from '../ssh/ssh'
 import { isConflictsFlow } from '../multi-commit-operation'
 import { clamp } from '../clamp'
+import { findDefaultRemote } from './helpers/find-default-remote'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -5777,6 +5778,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
     if (prBranch !== undefined) {
       await this._checkoutBranch(repository, prBranch)
       this.statsStore.recordPRBranchCheckout()
+    }
+  }
+
+  /**
+   *
+   * Fetches from "origin" or the first alphabetical remote if "origin" doesn't exist.
+   * This function is a no-op if no remote is configured.
+   */
+  public async _fetchDefaultRemote(
+    repository: RepositoryWithGitHubRepository
+  ): Promise<void> {
+    const remotes = await getRemotes(repository)
+    const defaultRemote = findDefaultRemote(remotes)
+    if (defaultRemote) {
+      await this._fetchRemote(
+        repository,
+        defaultRemote,
+        FetchType.UserInitiatedTask
+      )
     }
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1690,7 +1690,7 @@ export class Dispatcher {
     // if the repo has a remote, fetch before switching branches to ensure
     // the checkout will be successful
     if (isRepositoryWithGitHubRepository(repository)) {
-      await this.appStore._fetchDefaultRemote(repository)
+      await this.appStore._fetch(repository, FetchType.UserInitiatedTask)
     }
 
     await this.checkoutLocalBranch(repository, branchName)

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1687,6 +1687,12 @@ export class Dispatcher {
     // up-to-date before performing the "Clone in Desktop" steps
     await this.appStore._refreshRepository(repository)
 
+    // if the repo has a remote, fetch before switching branches to ensure
+    // the checkout will be successful
+    if (isRepositoryWithGitHubRepository(repository)) {
+      await this.appStore._fetchDefaultRemote(repository)
+    }
+
     await this.checkoutLocalBranch(repository, branchName)
 
     return repository

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1688,10 +1688,8 @@ export class Dispatcher {
     await this.appStore._refreshRepository(repository)
 
     // if the repo has a remote, fetch before switching branches to ensure
-    // the checkout will be successful
-    if (isRepositoryWithGitHubRepository(repository)) {
-      await this.appStore._fetch(repository, FetchType.UserInitiatedTask)
-    }
+    // the checkout will be successful. This operation could be a no-op.
+    await this.appStore._fetch(repository, FetchType.UserInitiatedTask)
 
     await this.checkoutLocalBranch(repository, branchName)
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Part of https://github.com/github/special-projects/issues/804

## Description
Currently, if a user creates a new branch on github.com, the GitHub Desktop client will be unable to open a link to the branch without manually fetching first. 

When we parse a link to a PR, we'll automatically try to fetch from the relevant remote here: https://github.com/desktop/desktop/blob/b81cdc419e8adebf30a4f55c26866331c37a050a/app/src/lib/stores/app-store.ts#L5832-L5841

This PR makes the desktop client fetch from the default remote (`origin` or the first one in alphabetical order if `origin` isn't configured) before switching branches. 

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

### Screenshots

https://user-images.githubusercontent.com/2043348/148781727-acccfdc8-b97c-4bdf-a359-75a70bf07489.mp4


<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes
- GitHub desktop will now fetch before trying to follow a URL link to a specific branch
<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:

- I'll need help seeing if there's an idiomatic way to unit test any of this.
- Does fetching seem like a reasonable default, or do we want to hide this behind a query parameter in the URL?