### PR TITLE
Issue Mention Filter - Assume issues exist

### DIFF
--- a/app/src/lib/markdown-filters/issue-link-filter.ts
+++ b/app/src/lib/markdown-filters/issue-link-filter.ts
@@ -1,0 +1,178 @@
+import { GitHubRepository } from '../../models/github-repository'
+import { getHTMLURL } from '../api'
+import { escapeRegExp } from '../helpers/regex'
+import { INodeFilter } from './node-filter'
+
+/**
+ * The Issue Link filter matches the target and text of an anchor element that
+ * is an issue, pull request, or discussion and changes the text to a uniform
+ * reference.
+ *
+ * Example:
+ * <a href="https://github.com/github/github/issues/99872">https://github.com/github/github/issues/99872</a>
+ * Becomes
+ * <a href="https://github.com/github/github/issues/99872">#99872</a>
+ *
+ * Additionally if a link has an anchor tag such as #discussioncomment-1858985.
+ * We will append a relevant description.
+ *
+ * The intention behind this node filter is for use after the markdown parser
+ * that has taken raw urls and auto tagged them them as anchor elements.
+ */
+export class IssueLinkFilter implements INodeFilter {
+  /** A regexp that searches for the owner/name pattern in issue href */
+  private readonly nameWithOwner = /(?<nameWithOwner>\w+(?:-\w+)*\/[.\w-]+)/
+
+  /** A regexp that searches for the number and #anchor of an issue reference */
+  private readonly numberWithAnchor = /(?<refNumber>\d+)(?<anchor>#[\w-]+)?\b/
+
+  /** A regexp that matches a full issue, pull request, or discussion url
+   * including the anchor */
+  private get issueUrl(): RegExp {
+    const gitHubURL = getHTMLURL(this.repository.endpoint)
+    return new RegExp(
+      escapeRegExp(gitHubURL) +
+        '/' +
+        this.nameWithOwner.source +
+        '/' +
+        /(?:issues|pull|discussions)/.source +
+        '/' +
+        this.numberWithAnchor.source
+    )
+  }
+
+  /** The parent github repository of which the content the filter is being
+   * applied to belongs  */
+  private readonly repository: GitHubRepository
+
+  public constructor(repository: GitHubRepository) {
+    this.repository = repository
+  }
+
+  /**
+   * Issue link mention filter iterates on all anchor elements that are not
+   * inside a pre, code, or anchor tag and resemble an issue, pull request, or
+   * discussion link and their href matches their inner text.
+   *
+   * Looking for something like:
+   * <a href="https://github.com/github/github/issues/99872">https://github.com/github/github/issues/99872</a>
+   * Where the href could be like:
+   * - https://github.com/github/github/issues/99872
+   * - https://github.com/github/github/pulls/99872
+   * - https://github.com/github/github/discussions/99872
+   * - https://github.com/github/github/discussions/99872#discussioncomment-1858985
+   */
+  public createFilterTreeWalker(doc: Document): TreeWalker {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const filter = this
+    return doc.createTreeWalker(doc, NodeFilter.SHOW_ELEMENT, {
+      acceptNode: function (el: Element) {
+        return (el.parentNode !== null &&
+          ['CODE', 'PRE', 'A'].includes(el.parentNode.nodeName)) ||
+          !(el instanceof HTMLAnchorElement) ||
+          el.href !== el.innerText ||
+          !filter.isGitHubIssuePullDiscussionLink(el)
+          ? NodeFilter.FILTER_SKIP
+          : NodeFilter.FILTER_ACCEPT
+      },
+    })
+  }
+
+  /**
+   * Returns true if the given anchor element is a link to a GitHub issue,
+   * discussion, or the default tab of a pull request.
+   */
+  private isGitHubIssuePullDiscussionLink(anchor: HTMLAnchorElement) {
+    const isIssuePullOrDiscussion = /(issue|pull|discussion)/.test(anchor.href)
+    if (!isIssuePullOrDiscussion) {
+      return false
+    }
+
+    const isPullRequestTab = /\d+\/(files|commits|conflicts|checks)/.test(
+      anchor.href
+    )
+    if (isPullRequestTab) {
+      return false
+    }
+
+    const isURlCustomFormat = /\.[a-z]+\z/.test(anchor.href)
+    if (isURlCustomFormat) {
+      return false
+    }
+
+    return this.issueUrl.test(anchor.href)
+  }
+
+  /**
+   * Takes an anchor element that's href and inner text looks like a github
+   * references and prepares an anchor element with a consistent issue reference
+   * as the inner text to replace it with.
+   *
+   * Example:
+   * Anchor tag of = <a href="https://github.com/owner/repo/issues/1234">https://github.com/owner/repo/issues/1234</a>
+   * Output = [<a href="https://github.com/owner/repo/issues/1234">#1234</a>]
+   */
+  public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
+    const { textContent: text } = node
+    if (!(node instanceof HTMLAnchorElement) || text === null) {
+      return null
+    }
+
+    const match = text.match(this.issueUrl)
+    if (match === null || match.groups === undefined) {
+      return null
+    }
+
+    const { refNumber, anchor } = match.groups
+    const newNode = node.cloneNode(true)
+    newNode.textContent = this.getConsistentIssueReferenceText(
+      refNumber,
+      anchor
+    )
+
+    return [newNode]
+  }
+
+  /**
+   * Creates a standard issue references and description.
+   *
+   * Examples:
+   *  Issue 1 => #1
+   *  Issue 1#discussion-comment-1234 => #1 (comment)
+   */
+  private getConsistentIssueReferenceText(refNumber: string, anchor?: string) {
+    const text = `#${refNumber}`
+    const anchorDescription = this.getAnchorDescription(anchor)
+    return `${text} ${anchorDescription}`
+  }
+
+  /**
+   * Provides generic description for a provided href anchor.
+   *
+   * Example: An anchor "#commits-pushed-1234" returns "(commits)".
+   *
+   * If the anchor does not fit a common anchor type , it defaults `(comment)`
+   */
+  private getAnchorDescription(anchor: string | undefined) {
+    if (anchor === undefined) {
+      return ''
+    }
+
+    switch (true) {
+      case /discussion-diff-/.test(anchor):
+        return '(diff)'
+      case /commits-pushed-/.test(anchor):
+        return '(commits)'
+      case /ref-/.test(anchor):
+        return '(reference)'
+      case /pullrequestreview/.test(anchor):
+        return '(review)'
+      // Note: On dotcom, there is an additional case
+      // /discussioncomment-/.test(anchor): and a check for threaded that
+      // returns '(reply in thread)' as opposed to '(comment)', but this would
+      // require an api call to determine.
+    }
+
+    return '(comment)'
+  }
+}

--- a/app/src/lib/markdown-filters/issue-mention-filter.ts
+++ b/app/src/lib/markdown-filters/issue-mention-filter.ts
@@ -1,0 +1,245 @@
+import { GitHubRepository } from '../../models/github-repository'
+import { getHTMLURL } from '../api'
+import { INodeFilter } from './node-filter'
+
+/**
+ * The Issue Mention filter matches for text issue references. For this purpose,
+ * issues, pull requests, and discussions all share reference patterns and
+ * therefore are all filtered.
+ *
+ * Examples:  #1234, gh-1234, /issues/1234, /pull/1234, or /discussions/1234,
+ * desktop/dugite#1, desktop/dugite/issues/1234
+ *
+ * Each references is made up of {ownerOrOwnerRepo}{marker}{number} and must be
+ * preceded by a non-word character.
+ *   - ownerOrOwnerRepo: Optional. If both owner/repo is provided, it can be
+ *              used to specify an issue outside of the parent repository.
+ *              Redundant references will be trimmed. Single owners can be
+ *              redundant, but single repo names are treated as non-matches.
+ *
+ *              Example: When viewing from the tidy-dev/foo repo,
+ *                  a. tidy-dev/foo#1 becomes linked as #1.
+ *                  b. tidy-dev#1 becomes linked as #1,
+ *                  c. foo#1 is not linked and is a non-match.
+ *                  d. desktop/desktop#1 is linked and stays desktop/desktop#1
+ *
+ *   - marker: Required #, gh-, /issues/, /pull/, or /discussions/
+ *   - number: Required and must be digits followed by a word bounding
+ *             character like a whitespace or period.
+ *
+ */
+export class IssueMentionFilter implements INodeFilter {
+  /** A regular expression to match a group of any digit follow by a word
+   * bounding character.
+   * Example: 123 or 123.
+   */
+  private readonly refNumber = /(?<refNumber>\d+)\b/
+
+  /** A regular expression to match a group of an repo name or name with owner
+   * Example: desktop/dugite or desktop
+   */
+  private readonly ownerOrOwnerRepo = /(?<ownerOrOwnerRepo>\w+(?:-\w+)*(?:\/[.\w-]+)?)/
+
+  /** A regular expression to match a group possible of preceding markers are
+   * gh-, #, /issues/, /pull/, or /discussions/ followed by a digit
+   */
+  private readonly marker = /(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\d)/
+
+  /**
+   * A regular expression string of a lookbehind is used so that valid matches
+   * for the issue reference have the leader precede them but the leader is not
+   * considered part of the match. An issue reference much have a whitespace,
+   * beginning of line, or some other non-word character must precede it.
+   * */
+  private readonly leader = /(?<=^|\W)/
+
+  /**
+   * A regular expression matching an issue reference.
+   * Issue reference must:
+   * 1) Be preceded by a beginning of a line or some some other non-word
+   *    character.
+   * 2) Start with an issue marker: gh-, #, /issues/, /pull/, or /discussions/
+   * 3) The issue marker must be followed by a number
+   * 4) The number must end in a word bounding character. Additionally, the
+   *    issue reference match may be such that the marker may be preceded by a
+   *    repo references of owner/repo or owner
+   * */
+  private readonly issueReferenceWithLeader = new RegExp(
+    this.leader.source +
+      this.ownerOrOwnerRepo.source +
+      '?' +
+      this.marker.source +
+      this.refNumber.source,
+    'ig'
+  )
+
+  /** The parent github repository of which the content the filter is being
+   * applied to belongs  */
+  private readonly repository: GitHubRepository
+
+  public constructor(repository: GitHubRepository) {
+    this.repository = repository
+  }
+
+  /**
+   * Returns tree walker that iterates on all text nodes that are not inside a
+   * pre, code, or anchor tag.
+   */
+  public createFilterTreeWalker(doc: Document): TreeWalker {
+    return doc.createTreeWalker(doc, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        return node.parentNode !== null &&
+          ['CODE', 'PRE', 'A'].includes(node.parentNode.nodeName)
+          ? NodeFilter.FILTER_SKIP
+          : NodeFilter.FILTER_ACCEPT
+      },
+    })
+  }
+
+  /**
+   * Takes a text node and creates multiple text and anchor nodes by inserting
+   * anchor tags where the matched issue mentions exist.
+   *
+   * Warning: This filter can create false positives. It assumes the issues
+   * exists that are mentioned. Thus, if a user references a non-existent
+   * #99999999 issue, it will still create a link for it. This is a deviation
+   * from dotcoms approach that verifies each link, but we do not want to incur
+   * the performance penalty of making that call.
+   *
+   * Example:
+   * Node = "Issue #1234 is the same thing"
+   * Output = ["Issue ", <a href="https://github.com/owner/repo/issues/1234">#1234</a>, " is the same thing"]
+   */
+  public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
+    const { textContent: text } = node
+    const markerRegexp = new RegExp(this.marker, 'i')
+    if (
+      node.nodeType !== node.TEXT_NODE ||
+      text === null ||
+      !markerRegexp.test(text)
+    ) {
+      return null
+    }
+
+    let lastMatchEndingPosition = 0
+    const nodes: Array<Text | HTMLAnchorElement> = []
+    const matches = text.matchAll(this.issueReferenceWithLeader)
+    for (const match of matches) {
+      if (match.groups === undefined || match.index === undefined) {
+        continue
+      }
+
+      const { marker, refNumber, ownerOrOwnerRepo } = match.groups
+      if (marker === undefined || refNumber === undefined) {
+        continue
+      }
+
+      const link = this.createLinkElement(marker, refNumber, ownerOrOwnerRepo)
+      if (link === null) {
+        continue
+      }
+
+      const textBefore = text.slice(lastMatchEndingPosition, match.index)
+      const textNodeBefore = document.createTextNode(textBefore)
+      nodes.push(textNodeBefore)
+      nodes.push(link)
+
+      lastMatchEndingPosition =
+        match.index +
+        (ownerOrOwnerRepo?.length ?? 0) +
+        marker.length +
+        refNumber.length
+    }
+
+    const trailingText = text.slice(lastMatchEndingPosition)
+    if (trailingText !== '') {
+      nodes.push(document.createTextNode(trailingText))
+    }
+
+    return nodes
+  }
+
+  /**
+   * Method to create the issue mention anchor. If unable to parse ownerRepo,
+   * then returns a null as this would indicate an invalid reference.
+   */
+  private createLinkElement(
+    marker: string,
+    refNumber: string,
+    ownerOrOwnerRepo?: string
+  ) {
+    let text = `${marker}${refNumber}`
+
+    const ownerRepo = this.resolveOwnerRepo(ownerOrOwnerRepo)
+    if (ownerRepo === null) {
+      return null
+    }
+
+    let [owner, repo] = ownerRepo
+    if (owner !== undefined && repo !== undefined) {
+      text = `${ownerOrOwnerRepo}${text}`
+    } else {
+      owner = this.repository.owner.login
+      repo = this.repository.name
+    }
+
+    const baseHref = getHTMLURL(this.repository.endpoint)
+    // We are choosing to use issues as GitHub will redirect an issues url to
+    // pull requests and discussions as needed. However, if a user erroneously
+    // referenced a pull request #2 with /discussions/2 marker, and we were to use
+    // `discussions` because of that, the user would end up at a not found page.
+    // This way they will end up at the pull request (same behavior in dotcom).
+    const href = `${baseHref}/${owner}/${repo}/issues/${refNumber}`
+
+    const anchor = document.createElement('a')
+    anchor.textContent = text
+    anchor.href = href
+    return anchor
+  }
+
+  /**
+   * The ownerOrOwnerRepo may be of the form owner or owner/repo.
+   * 1) If owner/repo and they don't both match the current repo, then we return
+   *    them as to distinguish them as a different from the current repo for the
+   *    reference url.
+   * 2) If (owner) and the owner !== current repo owner, it is an invalid
+   *    references - return null.
+   * 3) Otherwise, return [] as it is an valid references, but, was either and
+   *    empty string or in the current repo and is redundant owner/repo info.
+   */
+  private resolveOwnerRepo(
+    ownerOrOwnerRepo: string | undefined
+  ): ReadonlyArray<string> | null {
+    if (ownerOrOwnerRepo === undefined) {
+      return []
+    }
+
+    const ownerAndRepo = ownerOrOwnerRepo.split('/')
+    // Invalid - This shouldn't happen based on the regex, but would mean
+    // something/something/something/#1 which isn't an issue ref.
+    if (ownerAndRepo.length > 3) {
+      return null
+    }
+
+    // Invalid - If it is only something/#1 and that `something` isn't the
+    // current repositories owner login, then we is not an actual, 'relative to
+    // this user', issue ref.
+    if (
+      ownerAndRepo.length === 1 &&
+      ownerAndRepo[0] !== this.repository.owner.login
+    ) {
+      return null
+    }
+
+    // If owner and repo are provided, we only care if they differ from the current repo.
+    if (
+      ownerAndRepo.length === 2 &&
+      (ownerAndRepo[0] !== this.repository.owner.login ||
+        ownerAndRepo[1] !== this.repository.name)
+    ) {
+      return ownerAndRepo
+    }
+
+    return []
+  }
+}

--- a/app/src/lib/markdown-filters/issue-mention-filter.ts
+++ b/app/src/lib/markdown-filters/issue-mention-filter.ts
@@ -222,7 +222,7 @@ export class IssueMentionFilter implements INodeFilter {
     }
 
     // Invalid - If it is only something/#1 and that `something` isn't the
-    // current repositories owner login, then we is not an actual, 'relative to
+    // current repositories owner login, then it is not an actual, 'relative to
     // this user', issue ref.
     if (
       ownerAndRepo.length === 1 &&

--- a/app/src/lib/markdown-filters/issue-mention-filter.ts
+++ b/app/src/lib/markdown-filters/issue-mention-filter.ts
@@ -43,7 +43,7 @@ export class IssueMentionFilter implements INodeFilter {
   /** A regular expression to match a group possible of preceding markers are
    * gh-, #, /issues/, /pull/, or /discussions/ followed by a digit
    */
-  private readonly marker = /(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\d)/
+  private readonly marker = /(?<marker>#|gh-|\/(?:issues|pull|discussions)\/)(?=\d)/i
 
   /**
    * A regular expression string of a lookbehind is used so that valid matches
@@ -112,11 +112,10 @@ export class IssueMentionFilter implements INodeFilter {
    */
   public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
     const { textContent: text } = node
-    const markerRegexp = new RegExp(this.marker, 'i')
     if (
       node.nodeType !== node.TEXT_NODE ||
       text === null ||
-      !markerRegexp.test(text)
+      !this.marker.test(text)
     ) {
       return null
     }

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -1,5 +1,8 @@
 import memoizeOne from 'memoize-one'
+import { GitHubRepository } from '../../models/github-repository'
 import { EmojiFilter } from './emoji-filter'
+import { IssueLinkFilter } from './issue-link-filter'
+import { IssueMentionFilter } from './issue-mention-filter'
 
 export interface INodeFilter {
   /**
@@ -32,7 +35,12 @@ export interface INodeFilter {
  * @param emoji Map from the emoji shortcut (e.g., :+1:) to the image's local path.
  */
 export const buildCustomMarkDownNodeFilterPipe = memoizeOne(
-  (emoji: Map<string, string>): ReadonlyArray<INodeFilter> => [
+  (
+    emoji: Map<string, string>,
+    repository: GitHubRepository
+  ): ReadonlyArray<INodeFilter> => [
+    new IssueMentionFilter(repository),
+    new IssueLinkFilter(repository),
     new EmojiFilter(emoji),
   ]
 )

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -244,7 +244,10 @@ export class SandboxedMarkdown extends React.PureComponent<
    * mentions, etc.
    */
   private applyCustomMarkdownFilters(parsedMarkdown: string): Promise<string> {
-    const nodeFilters = buildCustomMarkDownNodeFilterPipe(this.props.emoji)
+    const nodeFilters = buildCustomMarkDownNodeFilterPipe(
+      this.props.emoji,
+      this.props.repository
+    )
     return applyNodeFilters(nodeFilters, parsedMarkdown)
   }
 

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -7,6 +7,7 @@ import {
   applyNodeFilters,
   buildCustomMarkDownNodeFilterPipe,
 } from '../../lib/markdown-filters/node-filter'
+import { GitHubRepository } from '../../models/github-repository'
 
 interface ISandboxedMarkdownProps {
   /** A string of unparsed markdown to display */
@@ -26,6 +27,9 @@ interface ISandboxedMarkdownProps {
 
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>
+
+  /** The GitHub repository to use when looking up commit status. */
+  readonly repository: GitHubRepository
 }
 
 /**

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -185,6 +185,7 @@ export class PullRequestQuickView extends React.Component<
           markdown={displayBody}
           emoji={this.props.emoji}
           baseHref={base.gitHubRepository.htmlURL}
+          repository={base.gitHubRepository}
         />
       </div>
     )

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -128,6 +128,10 @@ export class PullRequestQuickView extends React.Component<
     this.quickViewRef = quickViewRef
   }
 
+  private onMarkdownLinkClicked = (url: string) => {
+    this.props.dispatcher.openInBrowser(url)
+  }
+
   private renderHeader = (): JSX.Element => {
     return (
       <header className="header">
@@ -186,6 +190,7 @@ export class PullRequestQuickView extends React.Component<
           emoji={this.props.emoji}
           baseHref={base.gitHubRepository.htmlURL}
           repository={base.gitHubRepository}
+          onMarkdownLinkClicked={this.onMarkdownLinkClicked}
         />
       </div>
     )


### PR DESCRIPTION
Part of #11517

## Description

Based on dotcom's issue mention filter, it matches for issue references such as #1234, gh-1234, /issues/1234, /pull/1234, or /discussions/1234 and replaces them with anchor tags linking to the issue, pull request, or discussion in the parent repository. Those issue mentions can also be prefixed with an owner/repo which allows linking to a non-parent repo such as desktop/dugite#1. 

Additionally dotcom's issue filter searches for auto tagged urls such as `https://github.com/desktop/desktop/issues/1` and replaces the inner text with a uniform issue mention. This PR does that but I separated it into it's own filter since the logic was not really similar.

My first stabs #13573 and #13617 at this attempted to follow dotcom's approach tightly and verify the issue links through api calls. However, I found that to be very sluggish. This PR is trimming all the api call logic out and working on the assumption that issue mentions exist. This creates 2 scenarios for false positives, but they are both not likely/it doesn't benefit a user to do them anyways. Those 2 scenarios are linking to a non-existing issue such as #99999 and a non-exist or private repos that the user doesn't have access to external issue such as private/private#1. In both cases, the user attempts to follow the links, they will get a 404 not found page.

### Screenshots

Testing against - tidy-dev/foo-really-not#2

https://user-images.githubusercontent.com/75402236/149148530-87c6cb60-9286-4e6d-808b-7dd72f7725dd.mov


## Release notes
Notes: [Improved] Sandbox markdown parser parses issue mentions and auto tag issue links.
