### PR TITLE
Use breaks: true option of marked.js

### DIFF
--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -196,7 +196,13 @@ export class SandboxedMarkdown extends React.PureComponent<
     const styleSheet = await this.getInlineStyleSheet()
 
     const parsedMarkdown = marked(this.props.markdown ?? '', {
+      // https://marked.js.org/using_advanced  If true, use approved GitHub
+      // Flavored Markdown (GFM) specification.
       gfm: true,
+      // https://marked.js.org/using_advanced, If true, add <br> on a single
+      // line break (copies GitHub behavior on comments, but not on rendered
+      // markdown files). Requires gfm be true.
+      breaks: true,
     })
 
     const sanitizedHTML = DOMPurify.sanitize(parsedMarkdown)


### PR DESCRIPTION
## Description
While working on the issue mention filter, I noticed that even with same styles applied to markdown on dotcom and in desktop. Where ever a newline character`\n` existed, we were not getting a line break in Desktop. Inspection on dotcom showed that it's markdown parser was inserting `<br>` where those were. I looked up the specs and it is part of GitHub Flavored Markdown (GFM), but there is a flag to enable in [Marked.js](https://marked.js.org/using_advanced). I enabled that flag. 

### Screenshots
Before 
![Screen Shot 2022-01-12 at 8 31 29 AM](https://user-images.githubusercontent.com/75402236/149155596-019bb196-aa1a-4f57-aaf6-68093ef5b7d0.png)

After:
![image](https://user-images.githubusercontent.com/75402236/149155298-ac4ae9d4-5c73-48ec-9a80-d9d5d0ecc93a.png)

## Release notes
Notes: [Improved] Sandbox Markdown Parser inserts newline characters with br tags.
