### PR TITLE
Alive fixes and improvements

### DIFF
--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -153,3 +153,9 @@ export const supportsRerunningChecks = endpointSatisfies({
   ae: '>= 3.4.0',
   es: '>= 3.4.0',
 })
+
+export const supportsAliveSessions = endpointSatisfies({
+  dotcom: true,
+  ae: false,
+  es: false,
+})

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -1,6 +1,6 @@
 import { AccountsStore } from './accounts-store'
 import { Account, accountEquals } from '../../models/account'
-import { API } from '../api'
+import { API, getDotComAPIEndpoint } from '../api'
 import { AliveSession, AliveEvent, Subscription } from '@github/alive-client'
 import { Emitter } from 'event-kit'
 import { enableHighSignalNotifications } from '../feature-flag'
@@ -192,6 +192,11 @@ export class AliveStore {
   }
 
   private subscribeToAccount = async (account: Account) => {
+    // For now, Alive is only available for GitHub.com accounts
+    if (account.endpoint !== getDotComAPIEndpoint()) {
+      return
+    }
+
     const endpointSession = await this.createSessionForAccount(account)
     const api = API.fromAccount(account)
     const channelInfo = await api.getAliveDesktopChannel()

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -195,7 +195,7 @@ export class AliveStore {
 
     endpointSession.session.offline()
 
-    console.log('Unubscribed from Alive channel!')
+    log.info(`Unubscribed '${account.login}' from Alive channel`)
   }
 
   private subscribeToAccount = async (account: Account) => {
@@ -223,11 +223,11 @@ export class AliveStore {
       subscription,
     })
 
-    console.log('Subscribed to Alive channel!')
+    log.info(`Subscribed '${account.login}' to Alive channel`)
   }
 
   private notify = (subscribers: Iterable<AliveStore>, event: AliveEvent) => {
-    console.log('Alive event received:', event)
+    console.log('Alive event received:', event) // TODO: delete this line after testing
 
     if (event.type !== 'message') {
       return

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -1,9 +1,10 @@
 import { AccountsStore } from './accounts-store'
 import { Account, accountEquals } from '../../models/account'
-import { API, getDotComAPIEndpoint } from '../api'
+import { API } from '../api'
 import { AliveSession, AliveEvent, Subscription } from '@github/alive-client'
 import { Emitter } from 'event-kit'
 import { enableHighSignalNotifications } from '../feature-flag'
+import { supportsAliveSessions } from '../endpoint-capabilities'
 
 /** Checks whether or not an account is included in a list of accounts. */
 function accountIncluded(account: Account, accounts: ReadonlyArray<Account>) {
@@ -192,8 +193,7 @@ export class AliveStore {
   }
 
   private subscribeToAccount = async (account: Account) => {
-    // For now, Alive is only available for GitHub.com accounts
-    if (account.endpoint !== getDotComAPIEndpoint()) {
+    if (!supportsAliveSessions(account.endpoint)) {
       return
     }
 

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -149,16 +149,9 @@ export class AliveStore {
       return null
     }
 
-    // Wrap the `api` instance in a function that will be passed to the Alive
-    // session. This function will be called multiple times if the session
-    // needs to reconnect.
-    const getRetryAliveURL = () => {
-      return api.getAliveWebSocketURL()
-    }
-
     const aliveSession = new AliveSession(
       webSocketUrl,
-      getRetryAliveURL,
+      () => api.getAliveWebSocketURL(),
       false,
       this.notify
     )

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -133,9 +133,16 @@ export class AliveStore {
       return null
     }
 
+    // Wrap the `api` instance in a function that will be passed to the Alive
+    // session. This function will be called multiple times if the session
+    // needs to reconnect.
+    const getRetryAliveURL = () => {
+      return api.getAliveWebSocketURL()
+    }
+
     const aliveSession = new AliveSession(
       webSocketUrl,
-      api.getAliveWebSocketURL,
+      getRetryAliveURL,
       false,
       this.notify
     )

--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -227,8 +227,6 @@ export class AliveStore {
   }
 
   private notify = (subscribers: Iterable<AliveStore>, event: AliveEvent) => {
-    console.log('Alive event received:', event) // TODO: delete this line after testing
-
     if (event.type !== 'message') {
       return
     }

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -184,6 +184,14 @@ export class NotificationsStore {
     const numberOfFailedChecks = checks.filter(
       check => check.conclusion === APICheckConclusion.Failure
     ).length
+
+    // Sometimes we could get a checks-failed event for a PR whose checks just
+    // got restarted, so we won't get failed checks at that point. In that
+    // scenario, just ignore the event and don't show a notification.
+    if (numberOfFailedChecks === 0) {
+      return
+    }
+
     const pluralChecks =
       numberOfFailedChecks === 1 ? 'check was' : 'checks were'
 

--- a/app/src/main-process/install-web-request-filters.ts
+++ b/app/src/main-process/install-web-request-filters.ts
@@ -60,7 +60,7 @@ export function installWebRequestFilters(webRequest: WebRequest) {
     // If it's a WebSocket Secure request directed to a github.com subdomain,
     // probably related to the Alive server, we need to override the `Origin`
     // header with a valid value.
-    if (protocol === 'wss:' && host.includes('github.com')) {
+    if (protocol === 'wss:' && /(^|\.)github\.com$/.test(host)) {
       return cb({
         requestHeaders: {
           ...details.requestHeaders,

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -28,7 +28,7 @@ import { ISerializableMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
 import { stat } from 'fs-extra'
 import { isApplicationBundle } from '../lib/is-application-bundle'
-import { installSameOriginFilter } from './same-origin-filter'
+import { installWebRequestFilters } from './install-web-request-filters'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -283,7 +283,7 @@ app.on('ready', () => {
 
   // Ensures auth-related headers won't traverse http redirects to hosts
   // on different origins than the originating request.
-  installSameOriginFilter(session.defaultSession.webRequest)
+  installWebRequestFilters(session.defaultSession.webRequest)
 
   Menu.setApplicationMenu(
     buildDefaultMenu({


### PR DESCRIPTION
## Description
This PR includes a number of fixes and improvements around Alive support:
- Fixed issue where Alive tried to reconnect but we were passing a deallocated instance of the `API` class.
- Fixed an issue where the app would subscribe twice to the Alive channel of the user's account.
- Fixed an issue where Alive would reject a WebSocket connection due to having the wrong `Origin` header. Still have to discuss with the Alive team about the best value for this `Origin` header.
- Clean up logging a bit.

## Release notes

Notes: no-notes
