### PR TITLE
Fix close button in full screen mode on macOS

### DIFF
--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -83,7 +83,13 @@ export class AppWindow {
       this.window.on('close', e => {
         if (!quitting) {
           e.preventDefault()
-          app.hide()
+          // https://github.com/desktop/desktop/issues/12838
+          if (this.window.isFullScreen()) {
+            this.window.setFullScreen(false)
+            this.window.once('leave-full-screen', () => app.hide())
+          } else {
+            app.hide()
+          }
         }
       })
     }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #12838

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Ran into this issue today and I can't for the life of me understand when it broke or if it's possibly never worked properly (since adding app hiding instead of close at least).

The problem is that `App.hide()` doesn't work when the window is in full screen mode. `BrowserWindow.hide()` does hide the window but leaves the user stuck with a blank screen in full screen mode. Taking the window out of full screen mode and then hiding it is the least controversial fix I could come up with here. The only downside is that users closing the window in full screen mode will have to wait for the macOS transition effect before the window gets hidden.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Closing the window using the title bar buttons on macOS now hides the window