### PR TITLE
Upgrade marked to latest for vulnerability fix

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "^9.0.1",
     "fuzzaldrin-plus": "^0.6.0",
     "keytar": "^7.7.0",
-    "marked": "^3.0.7",
+    "marked": "^4.0.10",
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",
     "moment": "^2.24.0",

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as FSE from 'fs-extra'
 import * as Path from 'path'
-import marked from 'marked'
+import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import {
   applyNodeFilters,

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -895,10 +895,10 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-marked@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.7.tgz#343aad9e91b96249b495c99c512ea09cfe06de1e"
-  integrity sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==
+marked@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.10.tgz#423e295385cc0c3a70fa495e0df68b007b879423"
+  integrity sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==
 
 material-colors@^1.2.1:
   version "1.2.6"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@primer/octicons": "^10.0.0",
-    "@types/marked": "^3.0.1",
+    "@types/marked": "^4.0.1",
     "@types/plist": "^3.0.2",
     "@types/react-color": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,10 +1215,10 @@
   resolved "https://registry.yarnpkg.com/@types/loglevel/-/loglevel-1.5.3.tgz#adfce55383edc5998a2170ad581b3e23d6adb5b8"
   integrity sha512-TzzIZihV+y9kxSg5xJMkyIkaoGkXi50isZTtGHObNHRqAAwjGNjSCNPI7AUAv0tZUKTq9f2cdkCUd/2JVZUTrA==
 
-"@types/marked@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-3.0.1.tgz#748645ecde30d8cf7861c3e1c360c6f694172f92"
-  integrity sha512-jry/WUAC511P2NBCeiCkfTRCN2VXobeeQa8p8gImOYsRfnuIVfeEsqOJ1pk+CzCwfMCdv3dkTQRCYaNkkFGtxw==
+"@types/marked@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.1.tgz#d588a7bbc4d6551c5e75249bc106ffda96ae33c5"
+  integrity sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==
 
 "@types/memoize-one@^3.1.1":
   version "3.1.1"


### PR DESCRIPTION
## Description

We got a [high-severity dependabot](https://github.com/desktop/desktop/security/dependabot/app/yarn.lock/marked/open) alert about marked. This pull request bumps it from 3.07 to latest at 4.0.10 that has the security fix in it. The differences from those versions are mostly bug fixes with a few maintenance things. Breaking at 4.0 was just the way that marked is imported and for that I needed to upgrade the typing import to match. [Link to marked releases ](https://github.com/markedjs/marked/releases) if you are curious. Also, we are only using marked in the sandboxed-markdown parser which is currently only used in dev builds.

## Release notes
Notes: no-notes
