### PR TITLE
Shared IPC type contract between renderer and main process

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -162,6 +162,11 @@ rules:
           message:
             "Please use 'import * as ipcRenderer' from 'ipc-renderer' instead to
             get strongly typed IPC methods."
+        - name: electron
+          importNames: ['ipcMain']
+          message:
+            "Please use 'import * as ipcMain' from 'ipc-main' instead to get
+            strongly typed IPC methods."
         - name: electron/main
           importNames: ['ipcMain']
           message:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -149,6 +149,24 @@ rules:
     - error
     - global
   no-buffer-constructor: error
+  no-restricted-imports:
+    - error
+    - paths:
+        - name: electron
+          importNames: ['ipcRenderer']
+          message:
+            "Please use 'import * as ipcRenderer' from 'ipc-renderer' instead to
+            get strongly typed IPC methods."
+        - name: electron/renderer
+          importNames: ['ipcRenderer']
+          message:
+            "Please use 'import * as ipcRenderer' from 'ipc-renderer' instead to
+            get strongly typed IPC methods."
+        - name: electron/main
+          importNames: ['ipcMain']
+          message:
+            "Please use 'import * as ipcMain' from 'ipc-main' instead to get
+            strongly typed IPC methods."
 
   ###########
   # SPECIAL #

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -25,6 +25,7 @@ rules:
   react-no-unbound-dispatcher-props: error
   react-readonly-props-and-state: error
   react-proper-lifecycle-methods: error
+  no-loosely-typed-webcontents-ipc: error
 
   ###########
   # PLUGINS #

--- a/app/src/crash/crash-app.tsx
+++ b/app/src/crash/crash-app.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react'
-import { ipcRenderer, remote } from 'electron'
-import { ICrashDetails, ErrorType } from './shared'
+import { remote } from 'electron'
+import { ErrorType } from './shared'
 import { TitleBar } from '../ui/window/title-bar'
 import { encodePathAsUrl } from '../lib/path'
-import {
-  WindowState,
-  getWindowState,
-  windowStateChannelName,
-} from '../lib/window-state'
+import { WindowState, getWindowState } from '../lib/window-state'
 import { Octicon } from '../ui/octicons'
 import * as OcticonSymbol from '../ui/octicons/octicons.generated'
 import { Button } from '../ui/lib/button'
 import { LinkButton } from '../ui/lib/link-button'
 import { getVersion } from '../ui/lib/app-proxy'
 import { getOS } from '../lib/get-os'
+import * as ipcRenderer from '../lib/ipc-renderer'
 
 // This is a weird one, let's leave it as a placeholder
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -101,16 +98,11 @@ export class CrashApp extends React.Component<ICrashAppProps, ICrashAppState> {
   public componentDidMount() {
     const window = remote.getCurrentWindow()
 
-    ipcRenderer.on(windowStateChannelName, () => {
+    ipcRenderer.on('window-state-changed', () => {
       this.setState({ windowState: getWindowState(window) })
     })
 
-    ipcRenderer.on(
-      'error',
-      (event: Electron.IpcRendererEvent, crashDetails: ICrashDetails) => {
-        this.setState(crashDetails)
-      }
-    )
+    ipcRenderer.on('error', (_, crashDetails) => this.setState(crashDetails))
 
     ipcRenderer.send('crash-ready')
   }

--- a/app/src/lib/app-shell.ts
+++ b/app/src/lib/app-shell.ts
@@ -1,7 +1,13 @@
-import { shell as electronShell, ipcRenderer } from 'electron'
+import { shell as electronShell } from 'electron'
 import * as Path from 'path'
 
 import { Repository } from '../models/repository'
+import {
+  showItemInFolder,
+  showFolderContents,
+  openExternal,
+  moveItemToTrash,
+} from '../ui/main-process-proxy'
 
 export interface IAppShell {
   readonly moveItemToTrash: (path: string) => Promise<void>
@@ -38,19 +44,11 @@ export const shell: IAppShell = {
   // Since Electron 13, shell.trashItem doesn't work from the renderer process
   // on Windows. Therefore, we must invoke it from the main process. See
   // https://github.com/electron/electron/issues/29598
-  moveItemToTrash: path => {
-    return ipcRenderer.invoke('move-to-trash', path)
-  },
+  moveItemToTrash,
   beep: electronShell.beep,
-  openExternal: path => {
-    return ipcRenderer.invoke('open-external', path)
-  },
-  showItemInFolder: path => {
-    ipcRenderer.send('show-item-in-folder', { path })
-  },
-  showFolderContents: path => {
-    ipcRenderer.send('show-folder-contents', { path })
-  },
+  openExternal,
+  showItemInFolder,
+  showFolderContents,
   openPath: electronShell.openPath,
 }
 

--- a/app/src/lib/ipc-renderer.ts
+++ b/app/src/lib/ipc-renderer.ts
@@ -26,6 +26,18 @@ export function send<T extends keyof RequestChannels>(
 }
 
 /**
+ * Send a message to the main process via channel synchronously. This is the
+ * equivalent of ipcRenderer.sendSync except with strong typing guarantees.
+ */
+export function sendSync<T extends keyof RequestChannels>(
+  channel: T,
+  ...args: Parameters<RequestChannels[T]>
+): void {
+  // eslint-disable-next-line no-sync
+  return ipcRenderer.sendSync(channel, ...args) as any
+}
+
+/**
  * Subscribes to the specified IPC channel and provides strong typing of
  * the channel name, and request parameters. This is the equivalent of
  * using ipcRenderer.on.

--- a/app/src/lib/ipc-renderer.ts
+++ b/app/src/lib/ipc-renderer.ts
@@ -1,6 +1,6 @@
 import { RequestResponseChannels, RequestChannels } from './ipc-shared'
 // eslint-disable-next-line no-restricted-imports
-import { ipcRenderer, IpcRendererEvent } from 'electron/renderer'
+import { ipcRenderer, IpcRendererEvent } from 'electron'
 
 /**
  * Send a message to the main process via channel and expect a result

--- a/app/src/lib/ipc-renderer.ts
+++ b/app/src/lib/ipc-renderer.ts
@@ -1,0 +1,70 @@
+import { RequestResponseChannels, RequestChannels } from './ipc-shared'
+import { ipcRenderer, IpcRendererEvent } from 'electron/renderer'
+
+/**
+ * Send a message to the main process via channel and expect a result
+ * asynchronously. This is the equivalent of ipcRenderer.invoke except with
+ * strong typing guarantees.
+ */
+export function invoke<T extends keyof RequestResponseChannels>(
+  channel: T,
+  ...args: Parameters<RequestResponseChannels[T]>
+): ReturnType<RequestResponseChannels[T]> {
+  return ipcRenderer.invoke(channel, ...args) as any
+}
+
+/**
+ * Send a message to the main process via channel asynchronously. This is the
+ * equivalent of ipcRenderer.send except with strong typing guarantees.
+ */
+export function send<T extends keyof RequestChannels>(
+  channel: T,
+  ...args: Parameters<RequestChannels[T]>
+): void {
+  return ipcRenderer.send(channel, ...args) as any
+}
+
+/**
+ * Subscribes to the specified IPC channel and provides strong typing of
+ * the channel name, and request parameters. This is the equivalent of
+ * using ipcRenderer.on.
+ */
+export function on<T extends keyof RequestChannels>(
+  channel: T,
+  listener: (
+    event: IpcRendererEvent,
+    ...args: Parameters<RequestChannels[T]>
+  ) => void
+) {
+  ipcRenderer.on(channel, listener as any)
+}
+
+/**
+ * Subscribes to the specified IPC channel and provides strong typing of
+ * the channel name, and request parameters. This is the equivalent of
+ * using ipcRenderer.once
+ */
+export function once<T extends keyof RequestChannels>(
+  channel: T,
+  listener: (
+    event: IpcRendererEvent,
+    ...args: Parameters<RequestChannels[T]>
+  ) => void
+) {
+  ipcRenderer.once(channel, listener as any)
+}
+
+/**
+ * Unsubscribes from the specified IPC channel and provides strong typing of
+ * the channel name, and request parameters. This is the equivalent of
+ * using ipcRenderer.removeListener
+ */
+export function removeListener<T extends keyof RequestChannels>(
+  channel: T,
+  listener: (
+    event: IpcRendererEvent,
+    ...args: Parameters<RequestChannels[T]>
+  ) => void
+) {
+  ipcRenderer.removeListener(channel, listener as any)
+}

--- a/app/src/lib/ipc-renderer.ts
+++ b/app/src/lib/ipc-renderer.ts
@@ -1,4 +1,5 @@
 import { RequestResponseChannels, RequestChannels } from './ipc-shared'
+// eslint-disable-next-line no-restricted-imports
 import { ipcRenderer, IpcRendererEvent } from 'electron/renderer'
 
 /**

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -52,6 +52,8 @@ export type RequestChannels = {
     error: string,
     url: string
   ) => void
+  focus: () => void
+  blur: () => void
 }
 
 /**

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -4,7 +4,11 @@ import { ISerializableMenuItem } from './menu-item'
 import { MenuLabelsEvent } from '../models/menu-labels'
 import { MenuEvent } from '../main-process/menu'
 import { LogLevel } from './logging/log-level'
+import { ICrashDetails } from '../crash/shared'
 import { WindowState } from './window-state'
+import { IMenu } from '../models/app-menu'
+import { ILaunchStats } from './stats'
+import { URLActionType } from './parse-app-url'
 
 /**
  * Defines the simplex IPC channel names we use from the renderer
@@ -35,8 +39,14 @@ export type RequestChannels = {
   'menu-event': (name: MenuEvent) => void
   log: (level: LogLevel, message: string) => void
   'will-quit': () => void
+  'crash-ready': () => void
+  'crash-quit': () => void
   'window-state-changed': (windowState: WindowState) => void
+  error: (crashDetails: ICrashDetails) => void
+  'zoom-factor-changed': (zoomFactor: number) => void
   'app-menu': (menu: IMenu) => void
+  'launch-timing-stats': (stats: ILaunchStats) => void
+  'url-action': (action: URLActionType) => void
 }
 
 /**

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -47,6 +47,11 @@ export type RequestChannels = {
   'app-menu': (menu: IMenu) => void
   'launch-timing-stats': (stats: ILaunchStats) => void
   'url-action': (action: URLActionType) => void
+  'certificate-error': (
+    certificate: Electron.Certificate,
+    error: string,
+    url: string
+  ) => void
 }
 
 /**

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -1,0 +1,53 @@
+import { IMenuItemState } from './menu-update'
+import { MenuIDs } from '../models/menu-ids'
+import { ISerializableMenuItem } from './menu-item'
+import { MenuLabelsEvent } from '../models/menu-labels'
+import { MenuEvent } from '../main-process/menu'
+import { LogLevel } from './logging/log-level'
+
+/**
+ * Defines the simplex IPC channel names we use from the renderer
+ * process along with their signatures. This type is used from both
+ * the renderer and the main process to ensure a common contract between
+ * the two over the untyped IPC framework.
+ */
+export type RequestChannels = {
+  'update-menu-state': (
+    state: Array<{ id: MenuIDs; state: IMenuItemState }>
+  ) => void
+  'renderer-ready': (time: number) => void
+  'execute-menu-item-by-id': (id: string) => void
+  'show-certificate-trust-dialog': (
+    certificate: Electron.Certificate,
+    message: string
+  ) => void
+  'get-app-menu': () => void
+  'update-preferred-app-menu-item-labels': (labels: MenuLabelsEvent) => void
+  'uncaught-exception': (error: Error) => void
+  'send-error-report': (
+    error: Error,
+    extra: Record<string, string>,
+    nonFatal: boolean
+  ) => void
+  'show-item-in-folder': (path: string) => void
+  'show-folder-contents': (path: string) => void
+  'menu-event': (name: MenuEvent) => void
+  log: (level: LogLevel, message: string) => void
+  'will-quit': () => void
+}
+
+/**
+ * Defines the duplex IPC channel names we use from the renderer
+ * process along with their signatures. This type is used from both
+ * the renderer and the main process to ensure a common contract between
+ * the two over the untyped IPC framework.
+ *
+ * Return signatures must be promises
+ */
+export type RequestResponseChannels = {
+  'move-to-trash': (path: string) => Promise<void>
+  'show-contextual-menu': (
+    items: ReadonlyArray<ISerializableMenuItem>
+  ) => Promise<ReadonlyArray<number> | null>
+  'open-external': (path: string) => Promise<boolean>
+}

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -4,6 +4,7 @@ import { ISerializableMenuItem } from './menu-item'
 import { MenuLabelsEvent } from '../models/menu-labels'
 import { MenuEvent } from '../main-process/menu'
 import { LogLevel } from './logging/log-level'
+import { WindowState } from './window-state'
 
 /**
  * Defines the simplex IPC channel names we use from the renderer
@@ -34,6 +35,8 @@ export type RequestChannels = {
   'menu-event': (name: MenuEvent) => void
   log: (level: LogLevel, message: string) => void
   'will-quit': () => void
+  'window-state-changed': (windowState: WindowState) => void
+  'app-menu': (menu: IMenu) => void
 }
 
 /**

--- a/app/src/lib/logging/renderer/install.ts
+++ b/app/src/lib/logging/renderer/install.ts
@@ -1,8 +1,9 @@
-import { ipcRenderer } from 'electron'
 import { LogLevel } from '../log-level'
 import { formatLogMessage } from '../format-log-message'
+import { sendProxy } from '../../../ui/main-process-proxy'
 
 const g = global as any
+const ipcLog = sendProxy('log')
 
 /**
  * Dispatches the given log entry to the main process where it will be picked
@@ -10,11 +11,7 @@ const g = global as any
  * details about what transports we set up.
  */
 function log(level: LogLevel, message: string, error?: Error) {
-  ipcRenderer.send(
-    'log',
-    level,
-    formatLogMessage(`[${__PROCESS_KIND__}] ${message}`, error)
-  )
+  ipcLog(level, formatLogMessage(`[${__PROCESS_KIND__}] ${message}`, error))
 }
 
 g.log = {

--- a/app/src/lib/window-state.ts
+++ b/app/src/lib/window-state.ts
@@ -61,5 +61,5 @@ function sendWindowStateEvent(
   window: Electron.BrowserWindow,
   state: WindowState
 ) {
-  window.webContents.send(windowStateChannelName, state)
+  window.webContents.send('window-state-changed', state)
 }

--- a/app/src/lib/window-state.ts
+++ b/app/src/lib/window-state.ts
@@ -1,6 +1,3 @@
-// The name of the ipc channel over which state changes are communicated.
-export const windowStateChannelName = 'window-state-changed'
-
 export type WindowState =
   | 'minimized'
   | 'normal'

--- a/app/src/lib/window-state.ts
+++ b/app/src/lib/window-state.ts
@@ -1,3 +1,5 @@
+import * as ipcWebContents from '../main-process/ipc-webcontents'
+
 export type WindowState =
   | 'minimized'
   | 'normal'
@@ -58,5 +60,5 @@ function sendWindowStateEvent(
   window: Electron.BrowserWindow,
   state: WindowState
 ) {
-  window.webContents.send('window-state-changed', state)
+  ipcWebContents.send(window.webContents, 'window-state-changed', state)
 }

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -10,6 +10,7 @@ import { now } from './now'
 import * as path from 'path'
 import windowStateKeeper from 'electron-window-state'
 import * as ipcMain from './ipc-main'
+import * as ipcWebContents from './ipc-webcontents'
 
 export class AppWindow {
   private window: Electron.BrowserWindow
@@ -159,8 +160,12 @@ export class AppWindow {
       this.maybeEmitDidLoad()
     })
 
-    this.window.on('focus', () => this.window.webContents.send('focus'))
-    this.window.on('blur', () => this.window.webContents.send('blur'))
+    this.window.on('focus', () =>
+      ipcWebContents.send(this.window.webContents, 'focus')
+    )
+    this.window.on('blur', () =>
+      ipcWebContents.send(this.window.webContents, 'blur')
+    )
 
     registerWindowStateChangedEvents(this.window)
     this.window.loadURL(encodePathAsUrl(__dirname, 'index.html'))
@@ -227,19 +232,19 @@ export class AppWindow {
   public sendMenuEvent(name: MenuEvent) {
     this.show()
 
-    this.window.webContents.send('menu-event', name)
+    ipcWebContents.send(this.window.webContents, 'menu-event', name)
   }
 
   /** Send the URL action to the renderer. */
   public sendURLAction(action: URLActionType) {
     this.show()
 
-    this.window.webContents.send('url-action', action)
+    ipcWebContents.send(this.window.webContents, 'url-action', action)
   }
 
   /** Send the app launch timing stats to the renderer. */
   public sendLaunchTimingStats(stats: ILaunchStats) {
-    this.window.webContents.send('launch-timing-stats', stats)
+    ipcWebContents.send(this.window.webContents, 'launch-timing-stats', stats)
   }
 
   /** Send the app menu to the renderer. */
@@ -247,7 +252,7 @@ export class AppWindow {
     const appMenu = Menu.getApplicationMenu()
     if (appMenu) {
       const menu = menuFromElectronMenu(appMenu)
-      this.window.webContents.send('app-menu', menu)
+      ipcWebContents.send(this.window.webContents, 'app-menu', menu)
     }
   }
 
@@ -257,7 +262,13 @@ export class AppWindow {
     error: string,
     url: string
   ) {
-    this.window.webContents.send('certificate-error', certificate, error, url)
+    ipcWebContents.send(
+      this.window.webContents,
+      'certificate-error',
+      certificate,
+      error,
+      url
+    )
   }
 
   public showCertificateTrustDialog(

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, Menu, app, dialog } from 'electron'
+import { BrowserWindow, Menu, app, dialog } from 'electron'
 import { Emitter, Disposable } from 'event-kit'
 import { encodePathAsUrl } from '../lib/path'
 import { registerWindowStateChangedEvents } from '../lib/window-state'
@@ -9,6 +9,7 @@ import { menuFromElectronMenu } from '../models/app-menu'
 import { now } from './now'
 import * as path from 'path'
 import windowStateKeeper from 'electron-window-state'
+import { onIpcMainEvent } from './ipc-main'
 
 export class AppWindow {
   private window: Electron.BrowserWindow
@@ -71,7 +72,7 @@ export class AppWindow {
       quitting = true
     })
 
-    ipcMain.on('will-quit', (event: Electron.IpcMainEvent) => {
+    onIpcMainEvent('will-quit', event => {
       quitting = true
       event.returnValue = true
     })
@@ -153,13 +154,13 @@ export class AppWindow {
     })
 
     // TODO: This should be scoped by the window.
-    ipcMain.once(
+    onIpcMainEvent(
       'renderer-ready',
-      (event: Electron.IpcMainEvent, readyTime: number) => {
+      (_, readyTime) => {
         this._rendererReadyTime = readyTime
-
         this.maybeEmitDidLoad()
-      }
+      },
+      { once: true }
     )
 
     this.window.on('focus', () => this.window.webContents.send('focus'))

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -9,7 +9,7 @@ import { menuFromElectronMenu } from '../models/app-menu'
 import { now } from './now'
 import * as path from 'path'
 import windowStateKeeper from 'electron-window-state'
-import { onIpcMainEvent } from './ipc-main'
+import * as ipcMain from './ipc-main'
 
 export class AppWindow {
   private window: Electron.BrowserWindow
@@ -72,7 +72,7 @@ export class AppWindow {
       quitting = true
     })
 
-    onIpcMainEvent('will-quit', event => {
+    ipcMain.on('will-quit', event => {
       quitting = true
       event.returnValue = true
     })
@@ -154,14 +154,10 @@ export class AppWindow {
     })
 
     // TODO: This should be scoped by the window.
-    onIpcMainEvent(
-      'renderer-ready',
-      (_, readyTime) => {
-        this._rendererReadyTime = readyTime
-        this.maybeEmitDidLoad()
-      },
-      { once: true }
-    )
+    ipcMain.once('renderer-ready', (_, readyTime) => {
+      this._rendererReadyTime = readyTime
+      this.maybeEmitDidLoad()
+    })
 
     this.window.on('focus', () => this.window.webContents.send('focus'))
     this.window.on('blur', () => this.window.webContents.send('blur'))

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -274,18 +274,6 @@ export class AppWindow {
     )
   }
 
-  /** Report the exception to the renderer. */
-  public sendException(error: Error) {
-    // `Error` can't be JSONified so it doesn't transport nicely over IPC. So
-    // we'll just manually copy the properties we care about.
-    const friendlyError = {
-      stack: error.stack,
-      message: error.message,
-      name: error.name,
-    }
-    this.window.webContents.send('main-process-exception', friendlyError)
-  }
-
   /**
    * Get the time (in milliseconds) spent loading the page.
    *

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -227,19 +227,19 @@ export class AppWindow {
   public sendMenuEvent(name: MenuEvent) {
     this.show()
 
-    this.window.webContents.send('menu-event', { name })
+    this.window.webContents.send('menu-event', name)
   }
 
   /** Send the URL action to the renderer. */
   public sendURLAction(action: URLActionType) {
     this.show()
 
-    this.window.webContents.send('url-action', { action })
+    this.window.webContents.send('url-action', action)
   }
 
   /** Send the app launch timing stats to the renderer. */
   public sendLaunchTimingStats(stats: ILaunchStats) {
-    this.window.webContents.send('launch-timing-stats', { stats })
+    this.window.webContents.send('launch-timing-stats', stats)
   }
 
   /** Send the app menu to the renderer. */
@@ -247,7 +247,7 @@ export class AppWindow {
     const appMenu = Menu.getApplicationMenu()
     if (appMenu) {
       const menu = menuFromElectronMenu(appMenu)
-      this.window.webContents.send('app-menu', { menu })
+      this.window.webContents.send('app-menu', menu)
     }
   }
 
@@ -257,11 +257,7 @@ export class AppWindow {
     error: string,
     url: string
   ) {
-    this.window.webContents.send('certificate-error', {
-      certificate,
-      error,
-      url,
-    })
+    this.window.webContents.send('certificate-error', certificate, error, url)
   }
 
   public showCertificateTrustDialog(

--- a/app/src/main-process/crash-window.ts
+++ b/app/src/main-process/crash-window.ts
@@ -3,6 +3,7 @@ import { Emitter, Disposable } from 'event-kit'
 import { ICrashDetails, ErrorType } from '../crash/shared'
 import { registerWindowStateChangedEvents } from '../lib/window-state'
 import * as ipcMain from './ipc-main'
+import * as ipcWebContents from './ipc-webcontents'
 
 const minWidth = 600
 const minHeight = 500
@@ -163,7 +164,7 @@ export class CrashWindow {
       error: friendlyError,
     }
 
-    this.window.webContents.send('error', details)
+    ipcWebContents.send(this.window.webContents, 'error', details)
   }
 
   public destroy() {

--- a/app/src/main-process/crash-window.ts
+++ b/app/src/main-process/crash-window.ts
@@ -1,7 +1,8 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { BrowserWindow } from 'electron'
 import { Emitter, Disposable } from 'event-kit'
 import { ICrashDetails, ErrorType } from '../crash/shared'
 import { registerWindowStateChangedEvents } from '../lib/window-state'
+import * as ipcMain from './ipc-main'
 
 const minWidth = 600
 const minHeight = 500
@@ -92,7 +93,7 @@ export class CrashWindow {
       }
     })
 
-    ipcMain.on('crash-ready', (event: Electron.IpcMainEvent) => {
+    ipcMain.on('crash-ready', () => {
       log.debug(`Crash process is ready`)
 
       this.hasSentReadyEvent = true
@@ -101,7 +102,7 @@ export class CrashWindow {
       this.maybeEmitDidLoad()
     })
 
-    ipcMain.on('crash-quit', (event: Electron.IpcMainEvent) => {
+    ipcMain.on('crash-quit', () => {
       log.debug('Got quit signal from crash process')
       this.window.close()
     })

--- a/app/src/main-process/ipc-main.ts
+++ b/app/src/main-process/ipc-main.ts
@@ -1,0 +1,38 @@
+import { RequestChannels, RequestResponseChannels } from '../lib/ipc-shared'
+import { ipcMain } from 'electron'
+import { IpcMainEvent, IpcMainInvokeEvent } from 'electron/main'
+
+/**
+ * Subscribes to the specified IPC channel and provides strong typing of
+ * the channel name, and request parameters. This is the equivalent of
+ * using ipcMain.on (or ipcMain.once if the once option is specified)
+ */
+export function onIpcMainEvent<T extends keyof RequestChannels>(
+  channel: T,
+  listener: (
+    event: IpcMainEvent,
+    ...args: Parameters<RequestChannels[T]>
+  ) => void,
+  options?: { once: boolean }
+) {
+  if (options?.once === true) {
+    ipcMain.once(channel, (event, ...args) => listener(event, ...(args as any)))
+  } else {
+    ipcMain.on(channel, (event, ...args) => listener(event, ...(args as any)))
+  }
+}
+
+/**
+ * Subscribes to the specified invokeable IPC channel and provides strong typing
+ * of the channel name, and request parameters. This is the equivalent of using
+ * ipcMain.handle.
+ */
+export function onIpcMainRequest<T extends keyof RequestResponseChannels>(
+  channel: T,
+  listener: (
+    event: IpcMainInvokeEvent,
+    ...args: Parameters<RequestResponseChannels[T]>
+  ) => ReturnType<RequestResponseChannels[T]>
+) {
+  ipcMain.handle(channel, (event, ...args) => listener(event, ...(args as any)))
+}

--- a/app/src/main-process/ipc-main.ts
+++ b/app/src/main-process/ipc-main.ts
@@ -5,21 +5,31 @@ import { IpcMainEvent, IpcMainInvokeEvent } from 'electron/main'
 /**
  * Subscribes to the specified IPC channel and provides strong typing of
  * the channel name, and request parameters. This is the equivalent of
- * using ipcMain.on (or ipcMain.once if the once option is specified)
+ * using ipcMain.on.
  */
-export function onIpcMainEvent<T extends keyof RequestChannels>(
+export function on<T extends keyof RequestChannels>(
   channel: T,
   listener: (
     event: IpcMainEvent,
     ...args: Parameters<RequestChannels[T]>
-  ) => void,
-  options?: { once: boolean }
+  ) => void
 ) {
-  if (options?.once === true) {
-    ipcMain.once(channel, (event, ...args) => listener(event, ...(args as any)))
-  } else {
-    ipcMain.on(channel, (event, ...args) => listener(event, ...(args as any)))
-  }
+  ipcMain.on(channel, (event, ...args) => listener(event, ...(args as any)))
+}
+
+/**
+ * Subscribes to the specified IPC channel and provides strong typing of
+ * the channel name, and request parameters. This is the equivalent of
+ * using ipcMain.once
+ */
+export function once<T extends keyof RequestChannels>(
+  channel: T,
+  listener: (
+    event: IpcMainEvent,
+    ...args: Parameters<RequestChannels[T]>
+  ) => void
+) {
+  ipcMain.once(channel, (event, ...args) => listener(event, ...(args as any)))
 }
 
 /**
@@ -27,7 +37,7 @@ export function onIpcMainEvent<T extends keyof RequestChannels>(
  * of the channel name, and request parameters. This is the equivalent of using
  * ipcMain.handle.
  */
-export function onIpcMainRequest<T extends keyof RequestResponseChannels>(
+export function handle<T extends keyof RequestResponseChannels>(
   channel: T,
   listener: (
     event: IpcMainInvokeEvent,

--- a/app/src/main-process/ipc-main.ts
+++ b/app/src/main-process/ipc-main.ts
@@ -1,4 +1,5 @@
 import { RequestChannels, RequestResponseChannels } from '../lib/ipc-shared'
+// eslint-disable-next-line no-restricted-imports
 import { ipcMain } from 'electron'
 import { IpcMainEvent, IpcMainInvokeEvent } from 'electron/main'
 

--- a/app/src/main-process/ipc-webcontents.ts
+++ b/app/src/main-process/ipc-webcontents.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-loosely-typed-webcontents-ipc */
+
+import { WebContents } from 'electron'
+import { RequestChannels } from '../lib/ipc-shared'
+
+/**
+ * Send a message to a renderer process via its webContents asynchronously. This
+ * is the equivalent of webContents.send except with strong typing guarantees.
+ */
+export function send<T extends keyof RequestChannels>(
+  webContents: WebContents,
+  channel: T,
+  ...args: Parameters<RequestChannels[T]>
+): void {
+  webContents.send(channel, ...args)
+}

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -1,20 +1,16 @@
 import '../lib/logging/main/install'
 
-import { app, Menu, ipcMain, BrowserWindow, shell, session } from 'electron'
+import { app, Menu, BrowserWindow, shell, session } from 'electron'
 import * as Fs from 'fs'
 import * as URL from 'url'
 
-import { MenuLabelsEvent } from '../models/menu-labels'
-
 import { AppWindow } from './app-window'
-import { buildDefaultMenu, MenuEvent, getAllMenuItems } from './menu'
+import { buildDefaultMenu, getAllMenuItems } from './menu'
 import { shellNeedsPatching, updateEnvironmentForProcess } from '../lib/shell'
 import { parseAppURL } from '../lib/parse-app-url'
 import { handleSquirrelEvent } from './squirrel-updater'
 import { fatalError } from '../lib/fatal-error'
 
-import { IMenuItemState } from '../lib/menu-update'
-import { LogLevel } from '../lib/logging/log-level'
 import { log as writeLog } from './log'
 import { UNSAFE_openDirectory } from './shell'
 import { reportError } from './exception-reporting'
@@ -24,11 +20,11 @@ import {
 } from '../lib/source-map-support'
 import { now } from './now'
 import { showUncaughtException } from './show-uncaught-exception'
-import { ISerializableMenuItem } from '../lib/menu-item'
 import { buildContextMenu } from './menu/build-context-menu'
 import { stat } from 'fs-extra'
 import { isApplicationBundle } from '../lib/is-application-bundle'
 import { installWebRequestFilters } from './install-web-request-filters'
+import { onIpcMainEvent, onIpcMainRequest } from './ipc-main'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -294,152 +290,132 @@ app.on('ready', () => {
     })
   )
 
-  ipcMain.on(
-    'update-preferred-app-menu-item-labels',
-    (event: Electron.IpcMainEvent, labels: MenuLabelsEvent) => {
-      // The current application menu is mutable and we frequently
-      // change whether particular items are enabled or not through
-      // the update-menu-state IPC event. This menu that we're creating
-      // now will have all the items enabled so we need to merge the
-      // current state with the new in order to not get a temporary
-      // race conditions where menu items which shouldn't be enabled
-      // are.
-      const newMenu = buildDefaultMenu(labels)
+  onIpcMainEvent('update-preferred-app-menu-item-labels', (_, labels) => {
+    // The current application menu is mutable and we frequently
+    // change whether particular items are enabled or not through
+    // the update-menu-state IPC event. This menu that we're creating
+    // now will have all the items enabled so we need to merge the
+    // current state with the new in order to not get a temporary
+    // race conditions where menu items which shouldn't be enabled
+    // are.
+    const newMenu = buildDefaultMenu(labels)
 
-      const currentMenu = Menu.getApplicationMenu()
+    const currentMenu = Menu.getApplicationMenu()
 
-      // This shouldn't happen but whenever one says that it does
-      // so here's the escape hatch when we can't merge the current
-      // menu with the new one; we just use the new one.
-      if (currentMenu === null) {
-        // https://github.com/electron/electron/issues/2717
-        Menu.setApplicationMenu(newMenu)
+    // This shouldn't happen but whenever one says that it does
+    // so here's the escape hatch when we can't merge the current
+    // menu with the new one; we just use the new one.
+    if (currentMenu === null) {
+      // https://github.com/electron/electron/issues/2717
+      Menu.setApplicationMenu(newMenu)
 
-        if (mainWindow !== null) {
-          mainWindow.sendAppMenu()
-        }
-
-        return
-      }
-
-      // It's possible that after rebuilding the menu we'll end up
-      // with the exact same structural menu as we had before so we
-      // keep track of whether anything has actually changed in order
-      // to avoid updating the global menu and telling the renderer
-      // about it.
-      let menuHasChanged = false
-
-      for (const newItem of getAllMenuItems(newMenu)) {
-        // Our menu items always have ids and Electron.MenuItem takes on whatever
-        // properties was defined on the MenuItemOptions template used to create it
-        // but doesn't surface those in the type declaration.
-        const id = (newItem as any).id
-
-        if (!id) {
-          continue
-        }
-
-        const currentItem = currentMenu.getMenuItemById(id)
-
-        // Unfortunately the type information for getMenuItemById
-        // doesn't specify if it'll return null or undefined when
-        // the item doesn't exist so we'll do a falsy check here.
-        if (!currentItem) {
-          menuHasChanged = true
-        } else {
-          if (currentItem.label !== newItem.label) {
-            menuHasChanged = true
-          }
-
-          // Copy the enabled property from the existing menu
-          // item since it'll be the most recent reflection of
-          // what the renderer wants.
-          if (currentItem.enabled !== newItem.enabled) {
-            newItem.enabled = currentItem.enabled
-            menuHasChanged = true
-          }
-        }
-      }
-
-      if (menuHasChanged && mainWindow) {
-        // https://github.com/electron/electron/issues/2717
-        Menu.setApplicationMenu(newMenu)
+      if (mainWindow !== null) {
         mainWindow.sendAppMenu()
       }
-    }
-  )
 
-  ipcMain.on('menu-event', (event: Electron.IpcMainEvent, args: any[]) => {
-    const { name }: { name: MenuEvent } = event as any
-    if (mainWindow) {
-      mainWindow.sendMenuEvent(name)
+      return
+    }
+
+    // It's possible that after rebuilding the menu we'll end up
+    // with the exact same structural menu as we had before so we
+    // keep track of whether anything has actually changed in order
+    // to avoid updating the global menu and telling the renderer
+    // about it.
+    let menuHasChanged = false
+
+    for (const newItem of getAllMenuItems(newMenu)) {
+      // Our menu items always have ids and Electron.MenuItem takes on whatever
+      // properties was defined on the MenuItemOptions template used to create it
+      // but doesn't surface those in the type declaration.
+      const id = (newItem as any).id
+
+      if (!id) {
+        continue
+      }
+
+      const currentItem = currentMenu.getMenuItemById(id)
+
+      // Unfortunately the type information for getMenuItemById
+      // doesn't specify if it'll return null or undefined when
+      // the item doesn't exist so we'll do a falsy check here.
+      if (!currentItem) {
+        menuHasChanged = true
+      } else {
+        if (currentItem.label !== newItem.label) {
+          menuHasChanged = true
+        }
+
+        // Copy the enabled property from the existing menu
+        // item since it'll be the most recent reflection of
+        // what the renderer wants.
+        if (currentItem.enabled !== newItem.enabled) {
+          newItem.enabled = currentItem.enabled
+          menuHasChanged = true
+        }
+      }
+    }
+
+    if (menuHasChanged && mainWindow) {
+      // https://github.com/electron/electron/issues/2717
+      Menu.setApplicationMenu(newMenu)
+      mainWindow.sendAppMenu()
     }
   })
+
+  onIpcMainEvent('menu-event', (_, name) => mainWindow?.sendMenuEvent(name))
 
   /**
    * An event sent by the renderer asking that the menu item with the given id
    * is executed (ie clicked).
    */
-  ipcMain.on(
-    'execute-menu-item',
-    (event: Electron.IpcMainEvent, { id }: { id: string }) => {
-      const currentMenu = Menu.getApplicationMenu()
+  onIpcMainEvent('execute-menu-item-by-id', (event, id) => {
+    const currentMenu = Menu.getApplicationMenu()
 
-      if (currentMenu === null) {
-        return
-      }
+    if (currentMenu === null) {
+      return
+    }
+
+    const menuItem = currentMenu.getMenuItemById(id)
+    if (menuItem) {
+      const window = BrowserWindow.fromWebContents(event.sender) || undefined
+      const fakeEvent = { preventDefault: () => {}, sender: event.sender }
+      menuItem.click(fakeEvent, window, event.sender)
+    }
+  })
+
+  onIpcMainEvent('update-menu-state', (_, items) => {
+    let sendMenuChangedEvent = false
+
+    const currentMenu = Menu.getApplicationMenu()
+
+    if (currentMenu === null) {
+      log.debug(`unable to get current menu, bailing out...`)
+      return
+    }
+
+    for (const item of items) {
+      const { id, state } = item
 
       const menuItem = currentMenu.getMenuItemById(id)
+
       if (menuItem) {
-        const window = BrowserWindow.fromWebContents(event.sender) || undefined
-        const fakeEvent = { preventDefault: () => {}, sender: event.sender }
-        menuItem.click(fakeEvent, window, event.sender)
-      }
-    }
-  )
-
-  ipcMain.on(
-    'update-menu-state',
-    (
-      event: Electron.IpcMainEvent,
-      items: Array<{ id: string; state: IMenuItemState }>
-    ) => {
-      let sendMenuChangedEvent = false
-
-      const currentMenu = Menu.getApplicationMenu()
-
-      if (currentMenu === null) {
-        log.debug(`unable to get current menu, bailing out...`)
-        return
-      }
-
-      for (const item of items) {
-        const { id, state } = item
-
-        const menuItem = currentMenu.getMenuItemById(id)
-
-        if (menuItem) {
-          // Only send the updated app menu when the state actually changes
-          // or we might end up introducing a never ending loop between
-          // the renderer and the main process
-          if (
-            state.enabled !== undefined &&
-            menuItem.enabled !== state.enabled
-          ) {
-            menuItem.enabled = state.enabled
-            sendMenuChangedEvent = true
-          }
-        } else {
-          fatalError(`Unknown menu id: ${id}`)
+        // Only send the updated app menu when the state actually changes
+        // or we might end up introducing a never ending loop between
+        // the renderer and the main process
+        if (state.enabled !== undefined && menuItem.enabled !== state.enabled) {
+          menuItem.enabled = state.enabled
+          sendMenuChangedEvent = true
         }
-      }
-
-      if (sendMenuChangedEvent && mainWindow) {
-        Menu.setApplicationMenu(currentMenu)
-        mainWindow.sendAppMenu()
+      } else {
+        fatalError(`Unknown menu id: ${id}`)
       }
     }
-  )
+
+    if (sendMenuChangedEvent && mainWindow) {
+      Menu.setApplicationMenu(currentMenu)
+      mainWindow.sendAppMenu()
+    }
+  })
 
   /**
    * Handle the action to show a contextual menu.
@@ -448,178 +424,124 @@ app.on('ready', () => {
    * the menu (or submenu) item that was clicked or null if the menu
    * was closed without clicking on any item.
    */
-  ipcMain.handle(
-    'show-contextual-menu',
-    (
-      event: Electron.IpcMainInvokeEvent,
-      items: ReadonlyArray<ISerializableMenuItem>
-    ): Promise<ReadonlyArray<number> | null> => {
-      return new Promise(resolve => {
-        const menu = buildContextMenu(items, indices => resolve(indices))
-        const window = BrowserWindow.fromWebContents(event.sender) || undefined
+  onIpcMainRequest('show-contextual-menu', (event, items) => {
+    return new Promise(resolve => {
+      const menu = buildContextMenu(items, indices => resolve(indices))
+      const window = BrowserWindow.fromWebContents(event.sender) || undefined
 
-        menu.popup({ window, callback: () => resolve(null) })
-      })
-    }
-  )
+      menu.popup({ window, callback: () => resolve(null) })
+    })
+  })
 
   /**
    * An event sent by the renderer asking for a copy of the current
    * application menu.
    */
-  ipcMain.on('get-app-menu', () => {
-    if (mainWindow) {
-      mainWindow.sendAppMenu()
+  onIpcMainEvent('get-app-menu', () => mainWindow?.sendAppMenu())
+
+  onIpcMainEvent('show-certificate-trust-dialog', (_, certificate, message) => {
+    // This API is only implemented for macOS and Windows right now.
+    if (__DARWIN__ || __WIN32__) {
+      onDidLoad(window => {
+        window.showCertificateTrustDialog(certificate, message)
+      })
     }
   })
 
-  ipcMain.on(
-    'show-certificate-trust-dialog',
-    (
-      event: Electron.IpcMainEvent,
+  onIpcMainEvent('log', (_, level, message) => writeLog(level, message))
+
+  onIpcMainEvent('uncaught-exception', (_, error) =>
+    handleUncaughtException(error)
+  )
+
+  onIpcMainEvent('send-error-report', (_, error, extra, nonFatal) => {
+    reportError(
+      error,
       {
-        certificate,
-        message,
-      }: { certificate: Electron.Certificate; message: string }
-    ) => {
-      // This API is only implemented for macOS and Windows right now.
-      if (__DARWIN__ || __WIN32__) {
-        onDidLoad(window => {
-          window.showCertificateTrustDialog(certificate, message)
-        })
+        ...getExtraErrorContext(),
+        ...extra,
+      },
+      nonFatal
+    )
+  })
+
+  onIpcMainRequest('open-external', async (_, path: string) => {
+    const pathLowerCase = path.toLowerCase()
+    if (
+      pathLowerCase.startsWith('http://') ||
+      pathLowerCase.startsWith('https://')
+    ) {
+      log.info(`opening in browser: ${path}`)
+    }
+
+    try {
+      await shell.openExternal(path)
+      return true
+    } catch (e) {
+      log.error(`Call to openExternal failed: '${e}'`)
+      return false
+    }
+  })
+
+  onIpcMainRequest('move-to-trash', (_, path) => shell.trashItem(path))
+
+  onIpcMainEvent('show-item-in-folder', (_, path) => {
+    Fs.stat(path, err => {
+      if (err) {
+        log.error(`Unable to find file at '${path}'`, err)
+        return
       }
-    }
-  )
+      shell.showItemInFolder(path)
+    })
+  })
 
-  ipcMain.on(
-    'log',
-    (event: Electron.IpcMainEvent, level: LogLevel, message: string) => {
-      writeLog(level, message)
-    }
-  )
+  onIpcMainEvent('show-folder-contents', async (_, path) => {
+    const stats = await stat(path).catch(err => {
+      log.error(`Unable to retrieve file information for ${path}`, err)
+      return null
+    })
 
-  ipcMain.on(
-    'uncaught-exception',
-    (event: Electron.IpcMainEvent, error: Error) => {
-      handleUncaughtException(error)
+    if (!stats) {
+      return
     }
-  )
 
-  ipcMain.on(
-    'send-error-report',
-    (
-      event: Electron.IpcMainEvent,
-      {
-        error,
-        extra,
-        nonFatal,
-      }: { error: Error; extra: { [key: string]: string }; nonFatal?: boolean }
-    ) => {
-      reportError(
-        error,
-        {
-          ...getExtraErrorContext(),
-          ...extra,
-        },
-        nonFatal
+    if (!stats.isDirectory()) {
+      log.error(
+        `Trying to get the folder contents of a non-folder at '${path}'`
       )
+      shell.showItemInFolder(path)
+      return
     }
-  )
 
-  ipcMain.handle(
-    'open-external',
-    async (
-      event: Electron.IpcMainInvokeEvent,
-      path: string
-    ): Promise<boolean> => {
-      const pathLowerCase = path.toLowerCase()
-      if (
-        pathLowerCase.startsWith('http://') ||
-        pathLowerCase.startsWith('https://')
-      ) {
-        log.info(`opening in browser: ${path}`)
-      }
-
-      try {
-        await shell.openExternal(path)
-        return true
-      } catch (e) {
-        log.error(`Call to openExternal failed: '${e}'`)
-        return false
-      }
+    // On Windows and Linux we can count on a directory being just a
+    // directory.
+    if (!__DARWIN__) {
+      UNSAFE_openDirectory(path)
+      return
     }
-  )
 
-  ipcMain.handle(
-    'move-to-trash',
-    (event: Electron.IpcMainInvokeEvent, path: string): Promise<void> => {
-      return shell.trashItem(path)
+    // On macOS a directory might also be an app bundle and if it is
+    // and we attempt to open it we're gonna execute that app which
+    // it far from ideal so we'll look up the metadata for the path
+    // and attempt to determine whether it's an app bundle or not.
+    //
+    // If we fail loading the metadata we'll assume it's an app bundle
+    // out of an abundance of caution.
+    const isBundle = await isApplicationBundle(path).catch(err => {
+      log.error(`Failed to load metadata for path '${path}'`, err)
+      return true
+    })
+
+    if (isBundle) {
+      log.info(
+        `Preventing direct open of path '${path}' as it appears to be an application bundle`
+      )
+
+      shell.showItemInFolder(path)
+    } else {
+      UNSAFE_openDirectory(path)
     }
-  )
-
-  ipcMain.on(
-    'show-item-in-folder',
-    (event: Electron.IpcMainEvent, { path }: { path: string }) => {
-      Fs.stat(path, err => {
-        if (err) {
-          log.error(`Unable to find file at '${path}'`, err)
-          return
-        }
-        shell.showItemInFolder(path)
-      })
-    }
-  )
-
-  ipcMain.on(
-    'show-folder-contents',
-    async (event: Electron.IpcMainEvent, { path }: { path: string }) => {
-      const stats = await stat(path).catch(err => {
-        log.error(`Unable to retrieve file information for ${path}`, err)
-        return null
-      })
-
-      if (!stats) {
-        return
-      }
-
-      if (!stats.isDirectory()) {
-        log.error(
-          `Trying to get the folder contents of a non-folder at '${path}'`
-        )
-        shell.showItemInFolder(path)
-        return
-      }
-
-      // On Windows and Linux we can count on a directory being just a
-      // directory.
-      if (!__DARWIN__) {
-        UNSAFE_openDirectory(path)
-        return
-      }
-
-      // On macOS a directory might also be an app bundle and if it is
-      // and we attempt to open it we're gonna execute that app which
-      // it far from ideal so we'll look up the metadata for the path
-      // and attempt to determine whether it's an app bundle or not.
-      //
-      // If we fail loading the metadata we'll assume it's an app bundle
-      // out of an abundance of caution.
-      const isBundle = await isApplicationBundle(path).catch(err => {
-        log.error(`Failed to load metadata for path '${path}'`, err)
-        return true
-      })
-
-      if (isBundle) {
-        log.info(
-          `Preventing direct open of path '${path}' as it appears to be an application bundle`
-        )
-
-        shell.showItemInFolder(path)
-      } else {
-        UNSAFE_openDirectory(path)
-      }
-    }
-  )
+  })
 })
 
 app.on('activate', () => {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -362,8 +362,6 @@ app.on('ready', () => {
     }
   })
 
-  onIpcMainEvent('menu-event', (_, name) => mainWindow?.sendMenuEvent(name))
-
   /**
    * An event sent by the renderer asking that the menu item with the given id
    * is executed (ie clicked).

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -613,7 +613,9 @@ function emit(name: MenuEvent): ClickHandler {
     // can be fairly certain that the first BrowserWindow we find is the one we
     // want.
     const window = focusedWindow ?? BrowserWindow.getAllWindows()[0]
-    window?.webContents.send('menu-event', name)
+    if (window !== undefined) {
+      ipcWebContents.send(window.webContents, 'menu-event', name)
+    }
   }
 }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -612,7 +612,7 @@ function emit(name: MenuEvent): ClickHandler {
     // can be fairly certain that the first BrowserWindow we find is the one we
     // want.
     const window = focusedWindow ?? BrowserWindow.getAllWindows()[0]
-    window?.webContents.send('menu-event', { name })
+    window?.webContents.send('menu-event', name)
   }
 }
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -7,6 +7,7 @@ import { ensureDir } from 'fs-extra'
 import { UNSAFE_openDirectory } from '../shell'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { enableSquashMerging } from '../../lib/feature-flag'
+import * as ipcWebContents from '../ipc-webcontents'
 
 const platformDefaultShell = __WIN32__ ? 'Command Prompt' : 'Terminal'
 const createPullRequestLabel = __DARWIN__
@@ -646,7 +647,7 @@ function zoom(direction: ZoomDirection): ClickHandler {
 
     if (direction === ZoomDirection.Reset) {
       webContents.zoomFactor = 1
-      webContents.send('zoom-factor-changed', 1)
+      ipcWebContents.send(webContents, 'zoom-factor-changed', 1)
     } else {
       const rawZoom = webContents.zoomFactor
       const zoomFactors =
@@ -668,7 +669,7 @@ function zoom(direction: ZoomDirection): ClickHandler {
       const newZoom = nextZoomLevel === undefined ? currentZoom : nextZoomLevel
 
       webContents.zoomFactor = newZoom
-      webContents.send('zoom-factor-changed', newZoom)
+      ipcWebContents.send(webContents, 'zoom-factor-changed', newZoom)
     }
   }
 }

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -1,4 +1,4 @@
-import { Menu, ipcMain, shell, app } from 'electron'
+import { Menu, shell, app, BrowserWindow } from 'electron'
 import { ensureItemIds } from './ensure-item-ids'
 import { MenuEvent } from './menu-event'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
@@ -605,12 +605,14 @@ type ClickHandler = (
  * the provided menu event over IPC.
  */
 function emit(name: MenuEvent): ClickHandler {
-  return (menuItem, window) => {
-    if (window) {
-      window.webContents.send('menu-event', { name })
-    } else {
-      ipcMain.emit('menu-event', { name })
-    }
+  return (_, focusedWindow) => {
+    // focusedWindow can be null if the menu item was clicked without the window
+    // being in focus. A simple way to reproduce this is to click on a menu item
+    // while in DevTools. Since Desktop only supports one window at a time we
+    // can be fairly certain that the first BrowserWindow we find is the one we
+    // want.
+    const window = focusedWindow ?? BrowserWindow.getAllWindows()[0]
+    window?.webContents.send('menu-event', { name })
   }
 }
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -6,7 +6,7 @@ import * as Path from 'path'
 
 import * as moment from 'moment'
 
-import { ipcRenderer, remote } from 'electron'
+import { remote } from 'electron'
 
 import { App } from './app'
 import {
@@ -39,7 +39,6 @@ import {
   PullRequestStore,
 } from '../lib/stores'
 import { GitHubUserDatabase } from '../lib/databases'
-import { URLActionType } from '../lib/parse-app-url'
 import { SelectionType, IAppState } from '../lib/app-state'
 import { StatsDatabase, StatsStore } from '../lib/stats'
 import {
@@ -85,6 +84,7 @@ import {
 import { trampolineUIHelper } from '../lib/trampoline/trampoline-ui-helper'
 import { AliveStore } from '../lib/stores/alive-store'
 import { NotificationsStore } from '../lib/stores/notifications-store'
+import * as ipcRenderer from '../lib/ipc-renderer'
 
 if (__DEV__) {
   installDevGlobals()
@@ -339,11 +339,8 @@ ipcRenderer.on('blur', () => {
   dispatcher.setAppFocusState(false)
 })
 
-ipcRenderer.on(
-  'url-action',
-  (event: Electron.IpcRendererEvent, { action }: { action: URLActionType }) => {
-    dispatcher.dispatchURLAction(action)
-  }
+ipcRenderer.on('url-action', (_, action) =>
+  dispatcher.dispatchURLAction(action)
 )
 
 ReactDOM.render(

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -192,7 +192,7 @@ const sendErrorWithContext = (
       /* ignore */
     }
 
-    sendErrorReport(error, extra, nonFatal)
+    sendErrorReport(error, extra, nonFatal ?? false)
   }
 }
 

--- a/app/src/ui/lib/ui-activity-monitor.ts
+++ b/app/src/ui/lib/ui-activity-monitor.ts
@@ -1,5 +1,5 @@
 import { Emitter, Disposable } from 'event-kit'
-import { ipcRenderer } from 'electron'
+import * as ipcRenderer from '../../lib/ipc-renderer'
 
 /**
  * Describes the interface of a UI activity monitor.

--- a/app/src/ui/lib/ui-activity-monitor.ts
+++ b/app/src/ui/lib/ui-activity-monitor.ts
@@ -98,9 +98,7 @@ export class UiActivityMonitor implements IUiActivityMonitor {
     this.emit('keyboard')
   }
 
-  private onMenuEvent = (event: Electron.IpcRendererEvent) => {
-    this.emit('menu')
-  }
+  private onMenuEvent = () => this.emit('menu')
 }
 
 const interactionTargets = new Set(

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -1,8 +1,8 @@
-// eslint-disable-next-line no-restricted-imports
-import { ipcRenderer, remote } from 'electron'
+import { remote } from 'electron'
 import { IMenuItem, ISerializableMenuItem } from '../lib/menu-item'
 import { RequestResponseChannels, RequestChannels } from '../lib/ipc-shared'
 import { ExecutableMenuItem } from '../models/app-menu'
+import * as ipcRenderer from '../lib/ipc-renderer'
 
 /**
  * Creates a strongly typed proxy method for sending a duplex IPC message to the

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -1,10 +1,7 @@
 import { ipcRenderer, remote } from 'electron'
-import { ExecutableMenuItem } from '../models/app-menu'
-import { MenuIDs } from '../models/menu-ids'
-import { IMenuItemState } from '../lib/menu-update'
 import { IMenuItem, ISerializableMenuItem } from '../lib/menu-item'
-import { MenuLabelsEvent } from '../models/menu-labels'
 import { RequestResponseChannels, RequestChannels } from '../lib/ipc-shared'
+import { ExecutableMenuItem } from '../models/app-menu'
 
 /**
  * Creates a strongly typed proxy method for sending a duplex IPC message to the
@@ -30,26 +27,27 @@ export function sendProxy<T extends keyof RequestChannels>(
   return (...args) => ipcRenderer.send(channel, ...args)
 }
 
-/** Tell the main process to execute (i.e. simulate a click of) the menu item. */
-export function executeMenuItem(item: ExecutableMenuItem) {
-  ipcRenderer.send('execute-menu-item', { id: item.id })
-}
+/** Set the menu item's enabledness. */
+export const updateMenuState = sendProxy('update-menu-state')
+
+/** Tell the main process that the renderer is ready. */
+export const sendReady = sendProxy('renderer-ready')
 
 /** Tell the main process to execute (i.e. simulate a click of) the menu item. */
-export function executeMenuItemById(id: MenuIDs) {
-  ipcRenderer.send('execute-menu-item', { id })
-}
+export const executeMenuItem = (item: ExecutableMenuItem) =>
+  executeMenuItemById(item.id)
+
+/** Tell the main process to execute (i.e. simulate a click of) the menu item. */
+export const executeMenuItemById = sendProxy('execute-menu-item-by-id')
+
 
 /**
  * Show the OS-provided certificate trust dialog for the certificate, using the
  * given message.
  */
-export function showCertificateTrustDialog(
-  certificate: Electron.Certificate,
-  message: string
-) {
-  ipcRenderer.send('show-certificate-trust-dialog', { certificate, message })
-}
+export const showCertificateTrustDialog = sendProxy(
+  'show-certificate-trust-dialog'
+)
 
 /**
  * Tell the main process that we're going to quit. This means it should allow
@@ -68,9 +66,7 @@ export function sendWillQuitSync() {
  * The response will be send as a separate event with the name 'app-menu' and
  * will be received by the dispatcher.
  */
-export function getAppMenu() {
-  ipcRenderer.send('get-app-menu')
-}
+export const getAppMenu = sendProxy('get-app-menu')
 
 function findSubmenuItem(
   currentContextualMenuItems: ReadonlyArray<IMenuItem>,
@@ -185,6 +181,8 @@ function getSpellCheckLanguageMenuItem(
   }
 }
 
+const _showContextualMenu = invokeProxy('show-contextual-menu')
+
 /** Show the given menu items in a contextual menu. */
 export async function showContextualMenu(
   items: ReadonlyArray<IMenuItem>,
@@ -216,10 +214,7 @@ export async function showContextualMenu(
   This is a regular context menu that does not need to merge with spellcheck
   items. They can be shown right away.
   */
-  const indices: ReadonlyArray<number> | null = await ipcRenderer.invoke(
-    'show-contextual-menu',
-    serializeMenuItems(items)
-  )
+  const indices = await _showContextualMenu(serializeMenuItems(items))
 
   if (indices !== null) {
     const menuItem = findSubmenuItem(items, indices)
@@ -245,9 +240,9 @@ function serializeMenuItems(
 }
 
 /** Update the menu item labels with the user's preferred apps. */
-export function updatePreferredAppMenuItemLabels(labels: MenuLabelsEvent) {
-  ipcRenderer.send('update-preferred-app-menu-item-labels', labels)
-}
+export const updatePreferredAppMenuItemLabels = sendProxy(
+  'update-preferred-app-menu-item-labels'
+)
 
 function getIpcFriendlyError(error: Error) {
   return {
@@ -257,15 +252,18 @@ function getIpcFriendlyError(error: Error) {
   }
 }
 
+export const _reportUncaughtException = sendProxy('uncaught-exception')
+
 export function reportUncaughtException(error: Error) {
-  ipcRenderer.send('uncaught-exception', getIpcFriendlyError(error))
+  _reportUncaughtException(getIpcFriendlyError(error))
 }
+
+const _sendErrorReport = sendProxy('send-error-report')
 
 export function sendErrorReport(
   error: Error,
-  extra: Record<string, string> = {},
-  nonFatal?: boolean
+  extra: Record<string, string>,
+  nonFatal: boolean
 ) {
-  const event = { error: getIpcFriendlyError(error), extra, nonFatal }
-  ipcRenderer.send('send-error-report', event)
+  _sendErrorReport(getIpcFriendlyError(error), extra, nonFatal)
 }

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -4,17 +4,30 @@ import { MenuIDs } from '../models/menu-ids'
 import { IMenuItemState } from '../lib/menu-update'
 import { IMenuItem, ISerializableMenuItem } from '../lib/menu-item'
 import { MenuLabelsEvent } from '../models/menu-labels'
+import { RequestResponseChannels, RequestChannels } from '../lib/ipc-shared'
 
-/** Set the menu item's enabledness. */
-export function updateMenuState(
-  state: Array<{ id: MenuIDs; state: IMenuItemState }>
-) {
-  ipcRenderer.send('update-menu-state', state)
+/**
+ * Creates a strongly typed proxy method for sending a duplex IPC message to the
+ * main process. The parameter types and return type are infered from the
+ * RequestResponseChannels type which defines the valid duplex channel names.
+ */
+export function invokeProxy<T extends keyof RequestResponseChannels>(
+  channel: T
+): (
+  ...args: Parameters<RequestResponseChannels[T]>
+) => ReturnType<RequestResponseChannels[T]> {
+  return (...args) => ipcRenderer.invoke(channel, ...args) as any
 }
 
-/** Tell the main process that the renderer is ready. */
-export function sendReady(time: number) {
-  ipcRenderer.send('renderer-ready', time)
+/**
+ * Creates a strongly typed proxy method for sending a simplex IPC message to
+ * the main process. The parameter types are infered from the
+ * RequestResponseChannels type which defines the valid duplex channel names.
+ */
+export function sendProxy<T extends keyof RequestChannels>(
+  channel: T
+): (...args: Parameters<RequestChannels[T]>) => void {
+  return (...args) => ipcRenderer.send(channel, ...args)
 }
 
 /** Tell the main process to execute (i.e. simulate a click of) the menu item. */

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -40,6 +40,10 @@ export const executeMenuItem = (item: ExecutableMenuItem) =>
 /** Tell the main process to execute (i.e. simulate a click of) the menu item. */
 export const executeMenuItemById = sendProxy('execute-menu-item-by-id')
 
+export const showItemInFolder = sendProxy('show-item-in-folder')
+export const showFolderContents = sendProxy('show-folder-contents')
+export const openExternal = invokeProxy('open-external')
+export const moveItemToTrash = invokeProxy('move-to-trash')
 
 /**
  * Show the OS-provided certificate trust dialog for the certificate, using the

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { ipcRenderer, remote } from 'electron'
 import { IMenuItem, ISerializableMenuItem } from '../lib/menu-item'
 import { RequestResponseChannels, RequestChannels } from '../lib/ipc-shared'

--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react'
-import { ipcRenderer, remote } from 'electron'
-import {
-  WindowState,
-  getWindowState,
-  windowStateChannelName,
-} from '../../lib/window-state'
+import { remote } from 'electron'
+import { WindowState, getWindowState } from '../../lib/window-state'
 import classNames from 'classnames'
+import * as ipcRenderer from '../../lib/ipc-renderer'
 
 // These paths are all drawn to a 10x10 view box and replicate the symbols
 // seen on Windows 10 window controls.
@@ -36,12 +33,12 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
   public componentWillMount() {
     this.setState({ windowState: getWindowState(remote.getCurrentWindow()) })
 
-    ipcRenderer.on(windowStateChannelName, this.onWindowStateChanged)
+    ipcRenderer.on('window-state-changed', this.onWindowStateChanged)
   }
 
   public componentWillUnmount() {
     ipcRenderer.removeListener(
-      windowStateChannelName,
+      'window-state-changed',
       this.onWindowStateChanged
     )
   }
@@ -51,7 +48,7 @@ export class WindowControls extends React.Component<{}, IWindowControlState> {
   }
 
   private onWindowStateChanged = (
-    event: Electron.IpcRendererEvent,
+    _: Electron.IpcRendererEvent,
     windowState: WindowState
   ) => {
     this.setState({ windowState })

--- a/eslint-rules/no-loosely-typed-webcontents-ipc.js
+++ b/eslint-rules/no-loosely-typed-webcontents-ipc.js
@@ -1,0 +1,58 @@
+// @ts-check
+
+/**
+ * @typedef {import('eslint').Rule.RuleModule} RuleModule
+ */
+
+function isLooselyTypesWebContentsCall(context, node) {
+  const { callee } = node
+
+  if (!['MemberExpression', 'OptionalMemberExpression'].includes(callee.type)) {
+    return
+  }
+
+  const prop = callee.property
+
+  if (prop.type !== 'Identifier' || prop.name !== 'send') {
+    return
+  }
+
+  // wc.send() but not foo.wc.send
+  if (callee.object.type === 'Identifier' && callee.object.name === 'wc') {
+    context.report({ node, messageId: 'useStronglyTypedWebContentsIPC' })
+    return
+  }
+
+  const obj = callee.object
+
+  // *.webContents?.send
+  if (obj.type === 'MemberExpression' && obj.property.name === 'webContents') {
+    context.report({ node, messageId: 'useStronglyTypedWebContentsIPC' })
+  }
+
+  // webContents.send
+  if (obj.type === 'Identifier' && obj.name === 'webContents') {
+    context.report({ node, messageId: 'useStronglyTypedWebContentsIPC' })
+  }
+}
+
+/** @type {RuleModule} */
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Do not use loosely typed webContents methods',
+      category: 'Best Practices',
+    },
+    // strings from https://github.com/Microsoft/tslint-microsoft-contrib/blob/b720cd9/src/insecureRandomRule.ts
+    messages: {
+      useStronglyTypedWebContentsIPC:
+        'Please use the strongly typed IPC helper methods from `ipc-webcontents` instead',
+    },
+  },
+  create(context) {
+    return {
+      OptionalCallExpression: n => isLooselyTypesWebContentsCall(context, n),
+      CallExpression: n => isLooselyTypesWebContentsCall(context, n),
+    }
+  },
+}

--- a/eslint-rules/no-loosely-typed-webcontents-ipc.js
+++ b/eslint-rules/no-loosely-typed-webcontents-ipc.js
@@ -26,7 +26,11 @@ function isLooselyTypesWebContentsCall(context, node) {
   const obj = callee.object
 
   // *.webContents?.send
-  if (obj.type === 'MemberExpression' && obj.property.name === 'webContents') {
+  if (
+    (obj.type === 'MemberExpression' ||
+      obj.type === 'OptionalMemberExpression') &&
+    obj.property.name === 'webContents'
+  ) {
     context.report({ node, messageId: 'useStronglyTypedWebContentsIPC' })
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This relates to #13689 which we discussed this synchronously today. Our current IPC approach relies on copy-pasted code between the renderer and the main process where we hope that the channel names and the type signature match between the two.

This attempts to reduce that brittle approach by sharing a common type contract between the renderer and the main process.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
