### PR TITLE
Let's not mix IPC with random events

### DIFF
--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -369,13 +369,6 @@ app.on('ready', () => {
     }
   )
 
-  ipcMain.on('menu-event', (event: Electron.IpcMainEvent, args: any[]) => {
-    const { name }: { name: MenuEvent } = event as any
-    if (mainWindow) {
-      mainWindow.sendMenuEvent(name)
-    }
-  })
-
   /**
    * An event sent by the renderer asking that the menu item with the given id
    * is executed (ie clicked).

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -7,7 +7,7 @@ import * as URL from 'url'
 import { MenuLabelsEvent } from '../models/menu-labels'
 
 import { AppWindow } from './app-window'
-import { buildDefaultMenu, MenuEvent, getAllMenuItems } from './menu'
+import { buildDefaultMenu, getAllMenuItems } from './menu'
 import { shellNeedsPatching, updateEnvironmentForProcess } from '../lib/shell'
 import { parseAppURL } from '../lib/parse-app-url'
 import { handleSquirrelEvent } from './squirrel-updater'

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -1,4 +1,4 @@
-import { Menu, ipcMain, shell, app } from 'electron'
+import { Menu, shell, app, BrowserWindow } from 'electron'
 import { ensureItemIds } from './ensure-item-ids'
 import { MenuEvent } from './menu-event'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
@@ -605,12 +605,14 @@ type ClickHandler = (
  * the provided menu event over IPC.
  */
 function emit(name: MenuEvent): ClickHandler {
-  return (menuItem, window) => {
-    if (window) {
-      window.webContents.send('menu-event', { name })
-    } else {
-      ipcMain.emit('menu-event', { name })
-    }
+  return (_, focusedWindow) => {
+    // focusedWindow can be null if the menu item was clicked without the window
+    // being in focus. A simple way to reproduce this is to click on a menu item
+    // while in DevTools. Since Desktop only supports one window at a time we
+    // can be fairly certain that the first BrowserWindow we find is the one we
+    // want.
+    const window = focusedWindow ?? BrowserWindow.getAllWindows()[0]
+    window?.webContents.send('menu-event', { name })
   }
 }
 


### PR DESCRIPTION
While working on #13702 I ran into this [supremely placed joke](https://github.com/desktop/desktop/commit/41d26346b96a70257394cc8da742bdfef7068e5f) by @joshaber where we relied on the fact that Electron's `ipcMain` is a not just a host for IPC events but also a generic EventEmitter (even though you'd never use it that way).

When a menu item got clicked without a window being in focus (yeah, it happens) we emitted a custom event on the ipcMain module with the same name (`menu-event`) as we use to tell the renderer process that a menu item was clicked. That then got picked up in main.ts and then forwarded to the AppWindow which then passed the `menu-event` event along to the renderer.

https://github.com/desktop/desktop/blob/43593c62f23e7af0e66f13f52c342e5dd59aab0e/app/src/main-process/main.ts#L372-L377

This `ipcMain.on` is intermixed among a bunch of other almost identical calls with the key difference here is that the type signatures for EventEmitter's `.on` and ipcMain's `.on` are subtly different.

```ts
on(channel: string, listener: (event: IpcMainEvent, ...args: any[]) => void): this;
on(eventName: string | symbol, listener: (...args: any[]) => void): this;
```

Note that a regular subscription for an event from the renderer works on both of these thanks to `(...args: any[])`. So the listener here never actually got an `IpcMainEvent` as its first parameter, it just got the menu name (wrapped in an object which is another joke I've yet to grasp).

Instead of having this confusing-at-best logic sitting here waiting for the next unsuspecting developer to come along let's try a different approach entirely. While we can't hold of the mainWindow instance from `build-default-menu` we can rely on the fact that we never have more than one window open at a time and, in the event that a menu item is clicked without a window in focus, just toss that event to the first window we can find. Should that happen to be the crash window for example then no harm no foul since it doesn't listen to those any of these menu events anyway.