### PR TITLE
Preserve login case

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -196,6 +196,11 @@ async function createOwnerKey(tx: Dexie.Transaction) {
     const key = getOwnerKey(owner.endpoint, owner.login)
     const existingOwner = ownerByKey.get(key)
 
+    // If we've found a duplicate owner where that only differs by case we
+    // can't know which one of the two is accurate but that doesn't matter
+    // as it will eventually get corrected from fresh API data, we just need
+    // to pick one over the other and update any GitHubRepository still pointing
+    // to the owner to be deleted.
     if (existingOwner !== undefined) {
       assertNonNullable(existingOwner.id, 'Missing existing owner id')
       console.warn('Conflicting owner data', owner, existingOwner)

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -170,14 +170,13 @@ async function ensureNoUndefinedParentID(tx: Dexie.Transaction) {
  * Replace the case-sensitive [endpoint+login] index with a case-insensitive
  * lookup key in order to allow us to persist the proper case of a login.
  *
- * In addition to adding the key this transition will, out of an abundance
- * of caution, guard against the possibility that the previous table (being
- * case-sensitive) will contain two rows for the same user (only differing
- * in case). This can happen if a user changes their login by case only
- * while one of their repositories is tracked in Desktop or if the Desktop
- * installation as been constantly transitioned since before we started storing
- * logins in lower case (https://github.com/desktop/desktop/pull/1242). The
- * latter scenario is unlikely.
+ * In addition to adding the key this transition will, out of an abundance of
+ * caution, guard against the possibility that the previous table (being
+ * case-sensitive) will contain two rows for the same user (only differing in
+ * case). This could happen if the Desktop installation as been constantly
+ * transitioned since before we started storing logins in lower case
+ * (https://github.com/desktop/desktop/pull/1242). This scenario ought to be
+ * incredibly unlikely.
  */
 async function createOwnerKey(tx: Dexie.Transaction) {
   const ownersTable = tx.table<IDatabaseOwner, number>('owners')

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -3,6 +3,7 @@ import {
   IDatabaseGitHubRepository,
   IDatabaseProtectedBranch,
   IDatabaseRepository,
+  getOwnerKey,
 } from '../databases/repositories-database'
 import { Owner } from '../../models/owner'
 import {
@@ -15,7 +16,7 @@ import {
   assertIsRepositoryWithGitHubRepository,
   isRepositoryWithGitHubRepository,
 } from '../../models/repository'
-import { fatalError, assertNonNullable } from '../fatal-error'
+import { fatalError, assertNonNullable, forceUnwrap } from '../fatal-error'
 import { IAPIRepository, IAPIBranch, IAPIFullRepository } from '../api'
 import { TypedBaseStore } from './base-store'
 import { WorkflowPreferences } from '../../models/workflow-preferences'
@@ -371,18 +372,25 @@ export class RepositoriesStore extends TypedBaseStore<
   }
 
   private async putOwner(endpoint: string, login: string): Promise<Owner> {
-    login = login.toLowerCase()
+    const key = getOwnerKey(endpoint, login)
+    const existingOwner = await this.db.owners.get({ key })
+    let id
 
-    const existingOwner = await this.db.owners
-      .where('[endpoint+login]')
-      .equals([endpoint, login])
-      .first()
-
-    if (existingOwner) {
-      return new Owner(login, endpoint, existingOwner.id!)
+    // Since we look up the owner based on a key which is the product of the
+    // lowercased endpoint and login we know that we've found our match but it's
+    // possible that the case differs (i.e we found `usera` but the actual login
+    // is `userA`). In that case we want to update our database to persist the
+    // login with the proper case.
+    if (existingOwner === undefined || existingOwner.login !== login) {
+      if (existingOwner !== undefined) {
+        console.log('Updating existing owner: ', existingOwner, login)
+      }
+      id = existingOwner?.id
+      id = await this.db.owners.put({ id, key, endpoint, login })
+    } else {
+      id = forceUnwrap('Missing owner id', existingOwner.id)
     }
 
-    const id = await this.db.owners.add({ login, endpoint })
     return new Owner(login, endpoint, id)
   }
 
@@ -465,8 +473,7 @@ export class RepositoriesStore extends TypedBaseStore<
           )
         : await Promise.resolve(null) // Dexie gets confused if we return null
 
-    const login = gitHubRepository.owner.login.toLowerCase()
-    const owner = await this.putOwner(endpoint, login)
+    const owner = await this.putOwner(endpoint, gitHubRepository.owner.login)
 
     const existingRepo = await this.db.gitHubRepositories
       .where('[ownerID+name]')

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -382,9 +382,6 @@ export class RepositoriesStore extends TypedBaseStore<
     // is `userA`). In that case we want to update our database to persist the
     // login with the proper case.
     if (existingOwner === undefined || existingOwner.login !== login) {
-      if (existingOwner !== undefined) {
-        console.log('Updating existing owner: ', existingOwner, login)
-      }
       id = existingOwner?.id
       id = await this.db.owners.put({ id, key, endpoint, login })
     } else {

--- a/app/test/unit/repositories-database-test.ts
+++ b/app/test/unit/repositories-database-test.ts
@@ -1,6 +1,8 @@
 import {
   RepositoriesDatabase,
   IDatabaseGitHubRepository,
+  IDatabaseOwner,
+  getOwnerKey,
 } from '../../src/lib/databases'
 
 describe('RepositoriesDatabase', () => {
@@ -34,6 +36,82 @@ describe('RepositoriesDatabase', () => {
 
     const dupe = await db.gitHubRepositories.get(duplicateId)
     expect(dupe).toBeUndefined()
+
+    await db.delete()
+  })
+
+  it('migrates from version 8 to 9 by deleting duplicate owners', async () => {
+    const dbName = 'TestRepositoriesDatabase'
+    let db = new RepositoriesDatabase(dbName, 8)
+    await db.delete()
+    await db.open()
+
+    type OwnersModelBeforeUpgrade = Omit<IDatabaseOwner, 'key'>
+    const ownersTableBeforeUpgrade = db.table<OwnersModelBeforeUpgrade, number>(
+      'owners'
+    )
+    const endpoint = 'A'
+
+    const ownerA = await ownersTableBeforeUpgrade.add({
+      endpoint,
+      login: 'desktop',
+    })
+    const ownerB = await ownersTableBeforeUpgrade.add({
+      endpoint,
+      login: 'DeskTop',
+    })
+
+    const originalRepoA: IDatabaseGitHubRepository = {
+      ownerID: ownerA,
+      name: 'desktop',
+      private: false,
+      htmlURL: 'http://github.com/desktop/desktop',
+      defaultBranch: 'master',
+      cloneURL: 'http://github.com/desktop/desktop.git',
+      parentID: null,
+      lastPruneDate: null,
+      permissions: 'write',
+      issuesEnabled: true,
+    }
+    const originalRepoB: IDatabaseGitHubRepository = {
+      ownerID: ownerB,
+      name: 'dugite',
+      private: false,
+      htmlURL: 'http://github.com/desktop/dugite',
+      defaultBranch: 'master',
+      cloneURL: 'http://github.com/desktop/dugite.git',
+      parentID: null,
+      lastPruneDate: null,
+      permissions: 'write',
+      issuesEnabled: true,
+    }
+
+    const repoAId = await db.gitHubRepositories.add(originalRepoA)
+    const repoBId = await db.gitHubRepositories.add(originalRepoB)
+
+    expect(await db.gitHubRepositories.count()).toEqual(2)
+    expect(await db.owners.count()).toEqual(2)
+
+    db.close()
+
+    db = new RepositoriesDatabase(dbName, 9)
+    await db.open()
+
+    expect(await db.gitHubRepositories.count()).toEqual(2)
+    expect(await db.owners.count()).toEqual(1)
+
+    const migratedRepoA = await db.gitHubRepositories.get(repoAId)
+    expect(migratedRepoA).toEqual(originalRepoA)
+
+    const migratedRepoB = await db.gitHubRepositories.get(repoBId)
+    expect(migratedRepoB).not.toEqual(originalRepoB)
+
+    const migratedOwner = await db.owners.toCollection().first()
+
+    expect(migratedOwner).not.toBeUndefined()
+    expect(migratedRepoA?.ownerID).toEqual(migratedOwner?.id)
+    expect(migratedOwner?.endpoint).toEqual(endpoint)
+    expect(migratedOwner?.key).toEqual(getOwnerKey(endpoint, 'DeskTop'))
 
     await db.delete()
   })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Fixes: #9890
Superseedes: #10013

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Adds a migration for our owners table to add a case-insensitive unique key so that we can preserve case in the `login` field.

This migration will not magically fix the cases where we've lost information by lowercasing logins but it will mean that we'll gradually swap out incorrectly cased logins for the accurate ones as we receive fresh data from the API. We typically refresh the repository API information when switching repositories and since there's potentially multiple repositories pointing to the same owner one repository refresh should sort of the login case for all repositories owned by that user.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: 
