### PR TITLE
Support CLion as an external editor

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -351,6 +351,13 @@ const editors: WindowsExternalEditor[] = [
     displayNamePrefix: 'PyCharm ',
     publisher: 'JetBrains s.r.o.',
   },
+  {
+    name: 'JetBrains CLion',
+    registryKeys: registryKeysForJetBrainsIDE('CLion'),
+    executableShimPaths: executableShimPathsForJetBrainsIDE('clion'),
+    displayNamePrefix: 'CLion ',
+    publisher: 'JetBrains s.r.o.',
+  },
 ]
 
 function getKeyOrEmpty(

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -35,6 +35,7 @@ These editors are currently supported:
  - [JetBrains Phpstorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
  - [JetBrains CLion](https://www.jetbrains.com/clion/)
+ - [JetBrains PyCharm](https://www.jetbrains.com/pycharm/)
  - [Notepad++](https://notepad-plus-plus.org/)
  - [RStudio](https://rstudio.com/)
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -34,6 +34,7 @@ These editors are currently supported:
  - [JetBrains WebStorm](https://www.jetbrains.com/webstorm/)
  - [JetBrains Phpstorm](https://www.jetbrains.com/phpstorm/)
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
+ - [JetBrains CLion](https://www.jetbrains.com/clion/)
  - [Notepad++](https://notepad-plus-plus.org/)
  - [RStudio](https://rstudio.com/)
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->



## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds support for JetBrains CLion as an external editor on Windows. I tested this on Windows and it seems to work.

### Screenshots
<img width="518" alt="Screenshot 2022-01-25 155150" src="https://user-images.githubusercontent.com/16691846/151000754-cda9f52f-cde8-425d-8978-499d2a81f6b5.png">
<img width="448" alt="Screenshot 2022-01-25 155059" src="https://user-images.githubusercontent.com/16691846/151000765-b68fef3a-bdc7-4230-92bf-6b5f1e4b8e68.png">

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: added CLion support as an external editor on Windows.
