### PR TITLE
Refactor remote resolveProxy calls to be called from main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -70,4 +70,5 @@ export type RequestResponseChannels = {
     items: ReadonlyArray<ISerializableMenuItem>
   ) => Promise<ReadonlyArray<number> | null>
   'open-external': (path: string) => Promise<boolean>
+  'resolve-proxy': (url: string) => Promise<string>
 }

--- a/app/src/lib/resolve-git-proxy.ts
+++ b/app/src/lib/resolve-git-proxy.ts
@@ -1,4 +1,4 @@
-import { remote } from 'electron'
+import { resolveProxy } from '../ui/main-process-proxy'
 import { parsePACString } from './parse-pac-string'
 
 export async function resolveGitProxy(
@@ -10,12 +10,10 @@ export async function resolveGitProxy(
   // error (if the URL we're given is null or undefined despite
   // our best type efforts for example).
   // Better safe than sorry.
-  const pacString = await remote.session.defaultSession
-    .resolveProxy(url)
-    .catch(err => {
-      log.error(`Failed resolving proxy for '${url}'`, err)
-      return 'DIRECT'
-    })
+  const pacString = await resolveProxy(url).catch(err => {
+    log.error(`Failed resolving proxy for '${url}'`, err)
+    return 'DIRECT'
+  })
 
   const proxies = parsePACString(pacString)
 

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -531,6 +531,13 @@ app.on('ready', () => {
       UNSAFE_openDirectory(path)
     }
   })
+
+  /**
+   * Handle action to resolve proxy
+   */
+  ipcMain.handle('resolve-proxy', async (_, url: string) => {
+    return session.defaultSession.resolveProxy(url)
+  })
 })
 
 app.on('activate', () => {

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -273,7 +273,6 @@ export function sendErrorReport(
   _sendErrorReport(getIpcFriendlyError(error), extra, nonFatal)
 }
 
-
 /** Tells the main process to resolve the proxy for a given url */
 export const resolveProxy = invokeProxy('resolve-proxy')
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -272,3 +272,6 @@ export function sendErrorReport(
 ) {
   _sendErrorReport(getIpcFriendlyError(error), extra, nonFatal)
 }
+
+/** Tells the main process to resolve the proxy for a given url */
+export const resolveProxy = invokeProxy('resolve-proxy')


### PR DESCRIPTION
## Description

This refactors the `resolveGitProxy` method to use IPC messaging to the main process instead calling `session.defaultSession
    .resolveProxy` directly using the `remote` module.

I am not very familiar with using proxies. For testing this, I put debuggers in the `catch` block to make sure it wasn't throwing an error and then a debugger after to ensure I was getting the same result as before the change. (which is 'DIRECT'). Thus, it is correctly getting a result back from the main process. Not sure how to further test this.

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
