### PR TITLE
Refactor `remote.dialog.showOpenDialog` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -70,4 +70,7 @@ export type RequestResponseChannels = {
     items: ReadonlyArray<ISerializableMenuItem>
   ) => Promise<ReadonlyArray<number> | null>
   'open-external': (path: string) => Promise<boolean>
+  'show-open-dialog': (
+    options: Electron.OpenDialogOptions
+  ) => Promise<string | null>
 }

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -307,4 +307,17 @@ export class AppWindow {
   public destroy() {
     this.window.destroy()
   }
+
+  /**
+   * Method to show the open dialog and return the first file path it returns.
+   */
+  public async showOpenDialog(options: Electron.OpenDialogOptions) {
+    const { filePaths } = await dialog.showOpenDialog(this.window, options)
+
+    if (filePaths.length === 0) {
+      return null
+    }
+
+    return filePaths[0]
+  }
 }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -531,6 +531,20 @@ app.on('ready', () => {
       UNSAFE_openDirectory(path)
     }
   })
+
+  /**
+   * An event sent by the renderer asking to show the open dialog
+   */
+  ipcMain.handle(
+    'show-open-dialog',
+    async (_, options: Electron.OpenDialogOptions) => {
+      if (mainWindow === null) {
+        return null
+      }
+
+      return mainWindow.showOpenDialog(options)
+    }
+  )
 })
 
 app.on('activate', () => {

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import * as Path from 'path'
-
-import { remote } from 'electron'
 import { Dispatcher } from '../dispatcher'
 import { isGitRepository } from '../../lib/git'
 import { isBareRepository } from '../../lib/git'
@@ -16,6 +14,7 @@ import { PopupType } from '../../models/popup'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 import untildify from 'untildify'
+import { showOpenDialog } from '../main-process-proxy'
 
 interface IAddExistingRepositoryProps {
   readonly dispatcher: Dispatcher
@@ -172,15 +171,14 @@ export class AddExistingRepository extends React.Component<
   }
 
   private showFilePicker = async () => {
-    const window = remote.getCurrentWindow()
-    const { filePaths } = await remote.dialog.showOpenDialog(window, {
+    const path = await showOpenDialog({
       properties: ['createDirectory', 'openDirectory'],
     })
-    if (filePaths.length === 0) {
+
+    if (path === null) {
       return
     }
 
-    const path = filePaths[0]
     const isRepository = await isGitRepository(path)
     const isRepositoryBare = await isBareRepository(path)
 

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -1,4 +1,3 @@
-import { remote } from 'electron'
 import * as React from 'react'
 import * as Path from 'path'
 import * as FSE from 'fs-extra'
@@ -31,6 +30,7 @@ import { PopupType } from '../../models/popup'
 import { Ref } from '../lib/ref'
 import { enableReadmeOverwriteWarning } from '../../lib/feature-flag'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { showOpenDialog } from '../main-process-proxy'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -162,16 +162,14 @@ export class CreateRepository extends React.Component<
   }
 
   private showFilePicker = async () => {
-    const window = remote.getCurrentWindow()
-    const { filePaths } = await remote.dialog.showOpenDialog(window, {
+    const path = await showOpenDialog({
       properties: ['createDirectory', 'openDirectory'],
     })
 
-    if (filePaths.length === 0) {
+    if (path === null) {
       return
     }
 
-    const path = filePaths[0]
     const isRepository = await isGitRepository(path)
 
     this.setState({ isRepository, path })

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -25,6 +25,7 @@ import { merge } from '../../lib/merge'
 import { ClickSource } from '../lib/list'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { enableSaveDialogOnCloneRepository } from '../../lib/feature-flag'
+import { showOpenDialog } from '../main-process-proxy'
 
 interface ICloneRepositoryProps {
   readonly dispatcher: Dispatcher
@@ -512,20 +513,19 @@ export class CloneRepository extends React.Component<
   }
 
   private onChooseWithOpenDialog = async (): Promise<string | undefined> => {
-    const window = remote.getCurrentWindow()
-    const { filePaths } = await remote.dialog.showOpenDialog(window, {
+    const path = await showOpenDialog({
       properties: ['createDirectory', 'openDirectory'],
     })
 
-    if (filePaths.length === 0) {
+    if (path === null) {
       return
     }
 
     const tabState = this.getSelectedTabState()
     const lastParsedIdentifier = tabState.lastParsedIdentifier
     const directory = lastParsedIdentifier
-      ? Path.join(filePaths[0], lastParsedIdentifier.name)
-      : filePaths[0]
+      ? Path.join(path, lastParsedIdentifier.name)
+      : path
 
     this.setSelectedTabState(
       { path: directory, error: null },

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -89,7 +89,7 @@ import { Banner, BannerType } from '../../models/banner'
 
 import { ApplicationTheme, ICustomTheme } from '../lib/application-theme'
 import { installCLI } from '../lib/install-cli'
-import { executeMenuItem } from '../main-process-proxy'
+import { executeMenuItem, showOpenDialog } from '../main-process-proxy'
 import {
   CommitStatusStore,
   StatusCallBack,
@@ -1533,14 +1533,12 @@ export class Dispatcher {
    * Update the location of an existing repository and clear the missing flag.
    */
   public async relocateRepository(repository: Repository): Promise<void> {
-    const window = remote.getCurrentWindow()
-    const { filePaths } = await remote.dialog.showOpenDialog(window, {
+    const path = await showOpenDialog({
       properties: ['openDirectory'],
     })
 
-    if (filePaths.length > 0) {
-      const newPath = filePaths[0]
-      await this.updateRepositoryPath(repository, newPath)
+    if (path !== null) {
+      await this.updateRepositoryPath(repository, path)
     }
   }
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -272,3 +272,8 @@ export function sendErrorReport(
 ) {
   _sendErrorReport(getIpcFriendlyError(error), extra, nonFatal)
 }
+
+/**
+ * Tell the main process to show open dialog
+ */
+export const showOpenDialog = invokeProxy('show-open-dialog')


### PR DESCRIPTION
## Description

This refactors the `remote` module use of `remote.dialog.showOpenDialog` method to use IPC messaging to the main process instead.

Impacts:
- Adding, cloning, creating a repo
- Relocating a missing repo

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
