### PR TITLE
Refactor `remote.getCurrentWebContents().selectAll()` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -17,6 +17,7 @@ import { URLActionType } from './parse-app-url'
  * the two over the untyped IPC framework.
  */
 export type RequestChannels = {
+  'select-all-window-contents': () => void
   'update-menu-state': (
     state: Array<{ id: MenuIDs; state: IMenuItemState }>
   ) => void

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -217,6 +217,11 @@ export class AppWindow {
     this.window.focus()
   }
 
+  /** Selects all the windows web contents */
+  public selectAllWindowContents() {
+    this.window.webContents.selectAll()
+  }
+
   /** Show the window. */
   public show() {
     this.window.show()

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -532,6 +532,11 @@ app.on('ready', () => {
     }
   })
 
+  /** An event sent by the renderer asking to select all of the window's contents */
+  ipcMain.on('select-all-window-contents', () =>
+    mainWindow?.selectAllWindowContents()
+  )
+
   /**
    * Handle action to resolve proxy
    */

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -54,7 +54,11 @@ import {
 } from './toolbar'
 import { iconForRepository, OcticonSymbolType } from './octicons'
 import * as OcticonSymbol from './octicons/octicons.generated'
-import { showCertificateTrustDialog, sendReady } from './main-process-proxy'
+import {
+  showCertificateTrustDialog,
+  sendReady,
+  selectAllWindowContents,
+} from './main-process-proxy'
 import { DiscardChanges } from './discard-changes'
 import { Welcome } from './welcome'
 import { AppMenuBar } from './app-menu'
@@ -498,7 +502,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       document.activeElement != null &&
       document.activeElement.dispatchEvent(event)
     ) {
-      remote.getCurrentWebContents().selectAll()
+      selectAllWindowContents()
     }
   }
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -28,6 +28,11 @@ export function sendProxy<T extends keyof RequestChannels>(
   return (...args) => ipcRenderer.send(channel, ...args)
 }
 
+/**
+ * Tell the main process to select all of the current web contents
+ */
+export const selectAllWindowContents = sendProxy('select-all-window-contents')
+
 /** Set the menu item's enabledness. */
 export const updateMenuState = sendProxy('update-menu-state')
 


### PR DESCRIPTION
## Description

This refactors the `remote` module use of `remote.getCurrentWebContents().selectAll()` method to use IPC messaging to the main process instead.

Impacts:
- key shortcut: CMD + A 
- menu item: File > Select All 

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/151246378-b33a3787-78cc-4a75-a6f2-7eb5e9bf3b47.png)

## Release notes
Notes: no-notes
