### PR TITLE
Refactor `remote.getCurrentWindow().isFocused` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -69,6 +69,7 @@ export type RequestResponseChannels = {
   'show-contextual-menu': (
     items: ReadonlyArray<ISerializableMenuItem>
   ) => Promise<ReadonlyArray<number> | null>
+  'is-window-focused': () => Promise<boolean>
   'open-external': (path: string) => Promise<boolean>
   'resolve-proxy': (url: string) => Promise<string>
   'show-open-dialog': (

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -213,6 +213,10 @@ export class AppWindow {
     this.window.restore()
   }
 
+  public isFocused() {
+    return this.window.isFocused()
+  }
+
   public focus() {
     this.window.focus()
   }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -552,6 +552,14 @@ app.on('ready', () => {
       return mainWindow.showOpenDialog(options)
     }
   )
+
+  /**
+   * An event sent by the renderer asking obtain whether the window is focused
+   */
+  ipcMain.handle(
+    'is-window-focused',
+    async () => mainWindow?.isFocused() ?? false
+  )
 })
 
 app.on('activate', () => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -89,7 +89,11 @@ import { Banner, BannerType } from '../../models/banner'
 
 import { ApplicationTheme, ICustomTheme } from '../lib/application-theme'
 import { installCLI } from '../lib/install-cli'
-import { executeMenuItem, showOpenDialog } from '../main-process-proxy'
+import {
+  executeMenuItem,
+  isWindowFocused,
+  showOpenDialog,
+} from '../main-process-proxy'
 import {
   CommitStatusStore,
   StatusCallBack,
@@ -1576,6 +1580,11 @@ export class Dispatcher {
     }
   }
 
+  public async initializeAppFocusState(): Promise<void> {
+    const isFocused = await isWindowFocused()
+    this.setAppFocusState(isFocused)
+  }
+
   /**
    * Find an existing repository that can be used for checking out
    * the passed pull request.
@@ -1765,8 +1774,8 @@ export class Dispatcher {
         if (__DARWIN__) {
           // workaround for user reports that the application doesn't receive focus
           // after completing the OAuth signin in the browser
-          const window = remote.getCurrentWindow()
-          if (!window.isFocused()) {
+          const isFocused = await isWindowFocused()
+          if (!isFocused) {
             log.info(
               `refocusing the main window after the OAuth flow is completed`
             )

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -6,8 +6,6 @@ import * as Path from 'path'
 
 import * as moment from 'moment'
 
-import { remote } from 'electron'
-
 import { App } from './app'
 import {
   Dispatcher,
@@ -311,7 +309,7 @@ dispatcher.registerErrorHandler(refusedWorkflowUpdate)
 
 document.body.classList.add(`platform-${process.platform}`)
 
-dispatcher.setAppFocusState(remote.getCurrentWindow().isFocused())
+dispatcher.initializeAppFocusState()
 
 // The trampoline UI helper needs a reference to the dispatcher before it's used
 trampolineUIHelper.setDispatcher(dispatcher)

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -41,6 +41,11 @@ export const executeMenuItem = (item: ExecutableMenuItem) =>
 /** Tell the main process to execute (i.e. simulate a click of) the menu item. */
 export const executeMenuItemById = sendProxy('execute-menu-item-by-id')
 
+/**
+ * Tell the main process to obtain whether the window is focused.
+ */
+export const isWindowFocused = invokeProxy('is-window-focused')
+
 export const showItemInFolder = sendProxy('show-item-in-folder')
 export const showFolderContents = sendProxy('show-folder-contents')
 export const openExternal = invokeProxy('open-external')


### PR DESCRIPTION
## Description
This refactors the `remote` module use in `remote.getCurrentWindow().isFocused)` method to use IPC messaging to main process instead.

Impacts: 

- Index.tsx -> initial app state setup
- dispatcher.ts -> On mac, after oauth, used to determine if app needs refocused.

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

### Screenshots
With window in focus,
![image](https://user-images.githubusercontent.com/75402236/151257116-116c82a0-4acb-459a-9203-43c9d32558bc.png)


With window not in focus,
![image](https://user-images.githubusercontent.com/75402236/151257209-2342d785-b510-4ffb-9ee5-aa5a3f8f4d52.png)

## Release notes
Notes: no-notes
