### PR TITLE
Add "Copy Relative File Path" Option to Changed Files' Context Menu

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -411,7 +411,7 @@ export class ChangesList extends React.Component<
   ): IMenuItem => {
     return {
       label: CopyRelativeFilePathLabel,
-      action: () => clipboard.writeText(Path.normalize(file.path))
+      action: () => clipboard.writeText(Path.normalize(file.path)),
     }
   }
 

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -23,6 +23,7 @@ import {
   CopyFilePathLabel,
   RevealInFileManagerLabel,
   OpenWithDefaultProgramLabel,
+  CopyRelativeFilePathLabel,
 } from '../lib/context-menu'
 import { CommitMessage } from './commit-message'
 import { ChangedFile } from './changed-file'
@@ -405,6 +406,15 @@ export class ChangesList extends React.Component<
     }
   }
 
+  private getCopyRelativePathMenuItem = (
+    file: WorkingDirectoryFileChange
+  ): IMenuItem => {
+    return {
+      label: CopyRelativeFilePathLabel,
+      action: () => clipboard.writeText(Path.normalize(file.path))
+    }
+  }
+
   private getRevealInFileManagerMenuItem = (
     file: WorkingDirectoryFileChange
   ): IMenuItem => {
@@ -517,6 +527,8 @@ export class ChangesList extends React.Component<
     items.push(
       { type: 'separator' },
       this.getCopyPathMenuItem(file),
+      this.getCopyRelativePathMenuItem(file),
+      { type: 'separator' },
       this.getRevealInFileManagerMenuItem(file),
       this.getOpenInExternalEditorMenuItem(file, enabled),
       {
@@ -549,6 +561,8 @@ export class ChangesList extends React.Component<
 
     items.push(
       this.getCopyPathMenuItem(file),
+      this.getCopyRelativePathMenuItem(file),
+      { type: 'separator' },
       this.getRevealInFileManagerMenuItem(file),
       this.getOpenInExternalEditorMenuItem(file, enabled),
       {

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -18,6 +18,7 @@ import {
   DefaultEditorLabel,
   RevealInFileManagerLabel,
   OpenWithDefaultProgramLabel,
+  CopyRelativeFilePathLabel,
 } from '../lib/context-menu'
 import { ThrottledScheduler } from '../lib/throttled-scheduler'
 
@@ -363,6 +364,10 @@ export class SelectedCommit extends React.Component<
         label: CopyFilePathLabel,
         action: () => clipboard.writeText(fullPath),
       },
+      {
+        label: CopyRelativeFilePathLabel,
+        action: () => clipboard.writeText(Path.normalize(file.path)),
+      },
     ]
 
     let viewOnGitHubLabel = 'View on GitHub'
@@ -375,14 +380,17 @@ export class SelectedCommit extends React.Component<
       viewOnGitHubLabel = 'View on GitHub Enterprise'
     }
 
-    items.push({
-      label: viewOnGitHubLabel,
-      action: () => this.onViewOnGitHub(file),
-      enabled:
-        !this.props.isLocal &&
-        !!gitHubRepository &&
-        !!this.props.selectedCommit,
-    })
+    items.push(
+      { type: 'separator' },
+      {
+        label: viewOnGitHubLabel,
+        action: () => this.onViewOnGitHub(file),
+        enabled:
+          !this.props.isLocal &&
+          !!gitHubRepository &&
+          !!this.props.selectedCommit,
+      }
+    )
 
     showContextualMenu(items)
   }

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -368,6 +368,7 @@ export class SelectedCommit extends React.Component<
         label: CopyRelativeFilePathLabel,
         action: () => clipboard.writeText(Path.normalize(file.path)),
       },
+      { type: 'separator' },
     ]
 
     let viewOnGitHubLabel = 'View on GitHub'
@@ -380,17 +381,14 @@ export class SelectedCommit extends React.Component<
       viewOnGitHubLabel = 'View on GitHub Enterprise'
     }
 
-    items.push(
-      { type: 'separator' },
-      {
-        label: viewOnGitHubLabel,
-        action: () => this.onViewOnGitHub(file),
-        enabled:
-          !this.props.isLocal &&
-          !!gitHubRepository &&
-          !!this.props.selectedCommit,
-      }
-    )
+    items.push({
+      label: viewOnGitHubLabel,
+      action: () => this.onViewOnGitHub(file),
+      enabled:
+        !this.props.isLocal &&
+        !!gitHubRepository &&
+        !!this.props.selectedCommit,
+    })
 
     showContextualMenu(items)
   }

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -3,6 +3,10 @@ export const CopyFilePathLabel = __DARWIN__
   ? 'Copy File Path'
   : 'Copy file path'
 
+export const CopyRelativeFilePathLabel = __DARWIN__
+  ? 'Copy Relative File Path'
+  : 'Copy relative file path'
+
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
   : 'Open in external editor'


### PR DESCRIPTION
Closes #12589

## Description
Add the ability to copy a changed files' relative path

### Screenshots
![image](https://user-images.githubusercontent.com/56562649/151267885-d70bc53a-8a1c-4e37-92e8-6e9391d2459c.png)

## Release notes
Notes:
- [ADDED] Copy the Relative File Path of a Changed File