### PR TITLE
Refactor `remote.app.moveToApplicationFolder` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -54,6 +54,7 @@ export type RequestChannels = {
   ) => void
   focus: () => void
   blur: () => void
+  'move-to-applications-folder': () => void
 }
 
 /**

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -472,6 +472,14 @@ app.on('ready', () => {
     }
   })
 
+  /**
+   * An event sent by the renderer asking to move the app to the application
+   * folder
+   */
+  ipcMain.on('move-to-applications-folder', () => {
+    app.moveToApplicationsFolder?.()
+  })
+
   ipcMain.handle('move-to-trash', (_, path) => shell.trashItem(path))
 
   ipcMain.on('show-item-in-folder', (_, path) => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -89,7 +89,11 @@ import { Banner, BannerType } from '../../models/banner'
 
 import { ApplicationTheme, ICustomTheme } from '../lib/application-theme'
 import { installCLI } from '../lib/install-cli'
-import { executeMenuItem, showOpenDialog } from '../main-process-proxy'
+import {
+  executeMenuItem,
+  moveToApplicationsFolder,
+  showOpenDialog,
+} from '../main-process-proxy'
 import {
   CommitStatusStore,
   StatusCallBack,
@@ -1367,7 +1371,7 @@ export class Dispatcher {
   }
 
   public moveToApplicationsFolder() {
-    remote.app.moveToApplicationsFolder?.()
+    moveToApplicationsFolder()
   }
 
   /**

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -67,6 +67,11 @@ export function sendWillQuitSync() {
 }
 
 /**
+ * Tell the main process to move the application to the application folder
+ */
+export const moveToApplicationsFolder = sendProxy('move-to-applications-folder')
+
+/**
  * Ask the main-process to send over a copy of the application menu.
  * The response will be send as a separate event with the name 'app-menu' and
  * will be received by the dispatcher.


### PR DESCRIPTION
## Description

This refactors the `remote` module use of `remote.app.moveToApplicationFolder` method to use IPC messaging to the main process instead.

Impacts: on mac os, if app is not in applications folder, you are presented with a dialog and when you click "move and restart", this event should fire to move and restart app.

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
