### PR TITLE
Refactor `remote.app.getVersion()` to main process

### DIFF
--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -1,4 +1,4 @@
-import * as appProxy from '../ui/lib/app-proxy'
+import { getVersion } from '../ui/lib/app-proxy'
 import { URL } from 'url'
 
 /** The HTTP methods available. */
@@ -113,7 +113,7 @@ export function getAbsoluteUrl(endpoint: string, path: string): string {
  * the resource from the remote server without first looking in the cache, but
  * then will update the cache with the downloaded resource.
  */
-export function request(
+export async function request(
   endpoint: string,
   token: string | null,
   method: HTTPMethod,
@@ -127,7 +127,7 @@ export function request(
   let headers: any = {
     Accept: 'application/vnd.github.v3+json, application/json',
     'Content-Type': 'application/json',
-    'User-Agent': getUserAgent(),
+    'User-Agent': await getUserAgent(),
   }
 
   if (token) {
@@ -153,9 +153,9 @@ export function request(
 }
 
 /** Get the user agent to use for all requests. */
-function getUserAgent() {
+async function getUserAgent() {
   const platform = __DARWIN__ ? 'Macintosh' : 'Windows'
-  return `GitHubDesktop/${appProxy.getVersion()} (${platform})`
+  return `GitHubDesktop/${await getVersion()} (${platform})`
 }
 
 /**

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -76,4 +76,5 @@ export type RequestResponseChannels = {
   'show-open-dialog': (
     options: Electron.OpenDialogOptions
   ) => Promise<string | null>
+  'get-app-version': () => Promise<string>
 }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -518,7 +518,7 @@ export class StatsStore implements IStatsStore {
 
     return {
       eventType: 'usage',
-      version: getVersion(),
+      version: await getVersion(),
       osVersion: getOS(),
       platform: process.platform,
       architecture: getArchitecture(remote.app),

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -565,6 +565,11 @@ app.on('ready', () => {
     'is-window-focused',
     async () => mainWindow?.isFocused() ?? false
   )
+
+  /**
+   * An event sent by the renderer asking obtain the apps version
+   */
+  ipcMain.handle('get-app-version', async () => app.getVersion())
 })
 
 app.on('activate', () => {

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -37,7 +37,7 @@ interface IAboutProps {
   /**
    * The currently installed (and running) version of the app.
    */
-  readonly applicationVersion: string
+  readonly applicationVersion: Promise<string>
 
   /**
    * The currently installed (and running) architecture of the app.
@@ -55,6 +55,7 @@ interface IAboutProps {
 
 interface IAboutState {
   readonly updateState: IUpdateState
+  readonly appVersion: string | null
 }
 
 /**
@@ -69,7 +70,9 @@ export class About extends React.Component<IAboutProps, IAboutState> {
 
     this.state = {
       updateState: updateStore.state,
+      appVersion: null,
     }
+    this.initializeAppVersion()
   }
 
   private onUpdateStateChanged = (updateState: IUpdateState) => {
@@ -88,6 +91,11 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       this.updateStoreEventHandle.dispose()
       this.updateStoreEventHandle = null
     }
+  }
+
+  private initializeAppVersion = async () => {
+    const appVersion = await this.props.applicationVersion
+    this.setState({ appVersion })
   }
 
   private onQuitAndInstall = () => {
@@ -238,12 +246,14 @@ export class About extends React.Component<IAboutProps, IAboutState> {
 
   public render() {
     const name = this.props.applicationName
-    const version = this.props.applicationVersion
+    const { appVersion } = this.state
     const releaseNotesLink = (
       <LinkButton uri={ReleaseNotesUri}>release notes</LinkButton>
     )
 
-    const versionText = __DEV__ ? `Build ${version}` : `Version ${version}`
+    const versionText = __DEV__
+      ? `Build ${appVersion}`
+      : `Version ${appVersion ?? 'loading'}`
 
     return (
       <Dialog

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -16,7 +16,7 @@ interface IAcknowledgementsProps {
   /**
    * The currently installed (and running) version of the app.
    */
-  readonly applicationVersion: string
+  readonly applicationVersion: Promise<string>
 }
 
 interface ILicense {
@@ -29,6 +29,7 @@ type Licenses = { [key: string]: ILicense }
 
 interface IAcknowledgementsState {
   readonly licenses: Licenses | null
+  readonly appVersion: string | null
 }
 
 /** The component which displays the licenses for packages used in the app. */
@@ -39,7 +40,8 @@ export class Acknowledgements extends React.Component<
   public constructor(props: IAcknowledgementsProps) {
     super(props)
 
-    this.state = { licenses: null }
+    this.state = { licenses: null, appVersion: null }
+    this.initializeAppVersion()
   }
 
   public componentDidMount() {
@@ -58,6 +60,11 @@ export class Acknowledgements extends React.Component<
 
       this.setState({ licenses: parsed })
     })
+  }
+
+  private initializeAppVersion = async () => {
+    const appVersion = await this.props.applicationVersion
+    this.setState({ appVersion })
   }
 
   private renderLicenses(licenses: Licenses) {
@@ -103,11 +110,11 @@ export class Acknowledgements extends React.Component<
   }
 
   public render() {
-    const licenses = this.state.licenses
+    const { licenses, appVersion } = this.state
 
     let desktopLicense: JSX.Element | null = null
-    if (licenses) {
-      const key = `desktop@${this.props.applicationVersion}`
+    if (licenses && appVersion !== null) {
+      const key = `desktop@${appVersion}`
       const entry = licenses[key]
       desktopLicense = <p className="license-text">{entry.sourceText}</p>
     }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1510,7 +1510,9 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       case PopupType.About:
-        const version = __DEV__ ? __SHA__.substr(0, 10) : getVersion()
+        const version = __DEV__
+          ? Promise.resolve(__SHA__.substr(0, 10))
+          : getVersion()
 
         return (
           <About

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -292,7 +292,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     window.clearInterval(this.updateIntervalHandle)
   }
 
-  private performDeferredLaunchActions() {
+  private async performDeferredLaunchActions() {
     // Loading emoji is super important but maybe less important that loading
     // the app. So defer it until we have some breathing space.
     this.props.appStore.loadEmoji()
@@ -305,7 +305,8 @@ export class App extends React.Component<IAppProps, IAppState> {
     setInterval(() => this.checkForUpdates(true), UpdateCheckInterval)
     this.checkForUpdates(true)
 
-    log.info(`launching: ${getVersion()} (${getOS()})`)
+    const appVersion = await getVersion()
+    log.info(`launching: ${appVersion} (${getOS()})`)
     log.info(`execPath: '${process.execPath}'`)
 
     // Only show the popup in beta/production releases and mac machines
@@ -2897,7 +2898,8 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     const { lastThankYou } = this.state
     const { login } = dotComAccount
-    if (hasUserAlreadyBeenCheckedOrThanked(lastThankYou, login, getVersion())) {
+    const appVersion = await getVersion()
+    if (hasUserAlreadyBeenCheckedOrThanked(lastThankYou, login, appVersion)) {
       return
     }
 
@@ -2910,19 +2912,14 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (userContributions === null) {
       // This will prevent unnecessary release note retrieval on every time the
       // app is opened for a non-contributor.
-      updateLastThankYou(
-        this.props.dispatcher,
-        lastThankYou,
-        login,
-        getVersion()
-      )
+      updateLastThankYou(this.props.dispatcher, lastThankYou, login, appVersion)
       return
     }
 
     // If this is the first time user has seen the card, we want to thank them
     // for all previous versions. Thus, only specify current version if they
     // have been thanked before.
-    const displayVersion = isOnlyLastRelease ? getVersion() : null
+    const displayVersion = isOnlyLastRelease ? appVersion : null
     const banner: Banner = {
       type: BannerType.OpenThankYouCard,
       // Grab emoji's by reference because we could still be loading emoji's
@@ -2934,7 +2931,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           this.props.dispatcher,
           lastThankYou,
           login,
-          getVersion()
+          appVersion
         )
       },
     }

--- a/app/src/ui/lib/app-proxy.ts
+++ b/app/src/ui/lib/app-proxy.ts
@@ -1,4 +1,5 @@
 import { remote } from 'electron'
+import { getAppVersion } from '../main-process-proxy'
 
 let app: Electron.App | null = null
 let version: string | null = null
@@ -20,9 +21,9 @@ function getApp(): Electron.App {
  *
  * This is preferable to using `remote` directly because we cache the result.
  */
-export function getVersion(): string {
+export async function getVersion(): Promise<string> {
   if (!version) {
-    version = getApp().getVersion()
+    version = await getAppVersion()
   }
 
   return version

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -290,3 +290,6 @@ export const resolveProxy = invokeProxy('resolve-proxy')
  * Tell the main process to show open dialog
  */
 export const showOpenDialog = invokeProxy('show-open-dialog')
+
+/** Tell the main process to obtain the app's version */
+export const getAppVersion = invokeProxy('get-app-version')


### PR DESCRIPTION
## Description
This refactors the `remote` module uses of `remote.app.getVersion()` method to use IPC messaging to the main process instead.

Impacts: (Some are easier to test if you build:prod)
- About Dialog
- Acknowledgments Dialog
- Crash App
- Thank you logic
- Http request headers - user agent header
- Stats store

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

### Screenshots

- About Dialog
<img width="621" alt="Screen Shot 2022-01-27 at 11 30 54 AM" src="https://user-images.githubusercontent.com/75402236/151410491-afa2eb0b-7bbc-4c60-b0b5-5b2a7197e918.png">

- Acknowledgments Dialog
![image](https://user-images.githubusercontent.com/75402236/151410655-b8f6c3fb-0ab1-4ba9-b9a4-1a70ef615855.png)


- Crash App
<img width="621" alt="Screen Shot 2022-01-27 at 11 30 54 AM" src="https://user-images.githubusercontent.com/75402236/151409722-d71491b1-08b8-4c17-9216-597326604ae7.png">


- Thank you logic
![image](https://user-images.githubusercontent.com/75402236/151409973-9fd6e346-f9bb-4e61-a658-ca7be958e803.png)


- Http request headers - user agent header
![image](https://user-images.githubusercontent.com/75402236/151411210-1001bef4-9967-4cdf-80c7-17b6fa3a3855.png)


- Stats store
![image](https://user-images.githubusercontent.com/75402236/151412056-30d8cedd-4185-425b-8ad5-e616d23cdd6a.png)


## Release notes
Notes: no-notes
