### PR TITLE
Refactor `remote.app.getName()` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -77,4 +77,5 @@ export type RequestResponseChannels = {
   'show-open-dialog': (
     options: Electron.OpenDialogOptions
   ) => Promise<string | null>
+  'get-app-name': () => Promise<string>
 }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -573,6 +573,11 @@ app.on('ready', () => {
     'is-window-focused',
     async () => mainWindow?.isFocused() ?? false
   )
+
+  /**
+   * An event sent by the renderer asking obtain the apps name
+   */
+  ipcMain.handle('get-app-name', async () => app.getName())
 })
 
 app.on('activate', () => {

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -32,7 +32,7 @@ interface IAboutProps {
   /**
    * The name of the currently installed (and running) application
    */
-  readonly applicationName: string
+  readonly applicationName: Promise<string>
 
   /**
    * The currently installed (and running) version of the app.
@@ -55,6 +55,7 @@ interface IAboutProps {
 
 interface IAboutState {
   readonly updateState: IUpdateState
+  readonly appName: string | null
 }
 
 /**
@@ -69,7 +70,9 @@ export class About extends React.Component<IAboutProps, IAboutState> {
 
     this.state = {
       updateState: updateStore.state,
+      appName: null,
     }
+    this.initializeAppName()
   }
 
   private onUpdateStateChanged = (updateState: IUpdateState) => {
@@ -88,6 +91,11 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       this.updateStoreEventHandle.dispose()
       this.updateStoreEventHandle = null
     }
+  }
+
+  private initializeAppName = async () => {
+    const appName = await this.props.applicationName
+    this.setState({ appName })
   }
 
   private onQuitAndInstall = () => {
@@ -237,7 +245,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
   }
 
   public render() {
-    const name = this.props.applicationName
+    const { appName } = this.state
     const version = this.props.applicationVersion
     const releaseNotesLink = (
       <LinkButton uri={ReleaseNotesUri}>release notes</LinkButton>
@@ -261,7 +269,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
               height="64"
             />
           </Row>
-          <h2>{name}</h2>
+          <h2>{appName ?? 'Loading...'}</h2>
           <p className="no-padding">
             <span className="selectable-text">
               {versionText} ({this.props.applicationArchitecture})

--- a/app/src/ui/lib/app-proxy.ts
+++ b/app/src/ui/lib/app-proxy.ts
@@ -1,4 +1,5 @@
 import { remote } from 'electron'
+import { getAppName } from '../main-process-proxy'
 
 let app: Electron.App | null = null
 let version: string | null = null
@@ -31,11 +32,12 @@ export function getVersion(): string {
 /**
  * Get the name of the app.
  *
- * This is preferable to using `remote` directly because we cache the result.
+ * This is preferable to using requesting from main process directly because we
+ * cache the result.
  */
-export function getName(): string {
+export async function getName(): Promise<string> {
   if (!name) {
-    name = getApp().getName()
+    name = await getAppName()
   }
 
   return name

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -295,3 +295,6 @@ export const resolveProxy = invokeProxy('resolve-proxy')
  * Tell the main process to show open dialog
  */
 export const showOpenDialog = invokeProxy('show-open-dialog')
+
+/** Tell the main process to obtain the app's name */
+export const getAppName = invokeProxy('get-app-name')


### PR DESCRIPTION
## Description
This refactors the `remote` module uses in `remote.app.getName()` method to use IPC messaging to the main process instead.

Impacts: About Dialog

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/151429040-5e87fd22-6390-46c3-9bf5-d7eb2c8cd8de.png)


## Release notes
Notes: no-notes
