### PR TITLE
Use perl to resolve symlinks on macOS

### DIFF
--- a/app/static/darwin/github.sh
+++ b/app/static/darwin/github.sh
@@ -2,7 +2,7 @@
 
 # The least terrible way to resolve a symlink to its real path.
 function realpath() {
-  /usr/bin/python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0";
+  /usr/bin/perl -e "use Cwd;print Cwd::abs_path(@ARGV[0])" "$0";
 }
 
 CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"


### PR DESCRIPTION
## Description
Starting in macOS 12.3, [Python 2.7 has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes#Python) from the base macOS install. As the `github` command line tool relies on Python 2.7 currently, a modification to support this is required.

Ideally, one would be able to update this to depend on `readlink -f`. However, the minimum macOS deployment version is Yosemite (10.10), and the `-f` flag to canonicalize did not appear until later (possibly High Sierra, exact version is unclear).

Another alternative would be to depend on Python 3, as it's unlikely that `os.path.realpath` would break across future Python releases. Unfortunately, Yosemite does not include Python 3. One could switch based on macOS version, but that does not sound ideal to implement.

I opted to switch to use Perl as Yosemite includes Perl 5.18, containing the `Cwd` module. I do not have access to a Yosemite machine to test this on - I only extracted the InstallESD and and verified its presence. Anyone who could please verify this is correct in operation would be highly appreciated!
While future versions of macOS may switch to bundling Perl via the Command Line Tools package, hopefully `/usr/bin/perl` will exist as a shim.

Two alternatives could be considered:
 - It may be possible to use Tcl with [`file readlink`](https://tcl.tk/man/tcl8.7/TclCmd/file.html#M29).
 - There are several concoctions of pure bash implementations of recursive `readlink -f`/`realpath` across Stack Overflow that may or may not function. However, shell compatibility may be a concern.

## Release notes
Notes: modify GitHub CLI tool to be compatible with future macOS versions 