### PR TITLE
Embed product name and version at compile time

### DIFF
--- a/app/app-info.ts
+++ b/app/app-info.ts
@@ -3,6 +3,7 @@ import * as Path from 'path'
 
 import { getSHA } from './git-info'
 import { getUpdatesURL, getChannel } from '../script/dist-info'
+import { version, productName } from './package.json'
 
 const projectRoot = Path.dirname(__dirname)
 
@@ -24,6 +25,8 @@ export function getCLICommands() {
 const s = JSON.stringify
 
 export function getReplacements() {
+  const isDevBuild = channel === 'development'
+
   return {
     __OAUTH_CLIENT_ID__: s(process.env.DESKTOP_OAUTH_CLIENT_ID || devClientId),
     __OAUTH_SECRET__: s(
@@ -32,7 +35,9 @@ export function getReplacements() {
     __DARWIN__: process.platform === 'darwin',
     __WIN32__: process.platform === 'win32',
     __LINUX__: process.platform === 'linux',
-    __DEV__: channel === 'development',
+    __APP_NAME__: s(productName),
+    __APP_VERSION__: s(version),
+    __DEV__: isDevBuild,
     __RELEASE_CHANNEL__: s(channel),
     __UPDATES_URL__: s(getUpdatesURL()),
     __SHA__: s(getSHA()),

--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -18,6 +18,20 @@ declare const __WIN32__: boolean
 declare const __LINUX__: boolean
 
 /**
+ * The product name of the app, this is intended to be a compile-time
+ * replacement for app.getName
+ * (https://www.electronjs.org/docs/latest/api/app#appgetname)
+ */
+declare const __APP_NAME__: string
+
+/**
+ * The current version of the app, this is intended to be a compile-time
+ * replacement for app.getVersion
+ * (https://www.electronjs.org/docs/latest/api/app#appgetname)
+ */
+declare const __APP_VERSION__: string
+
+/**
  * The commit id of the repository HEAD at build time.
  * Represented as a 40 character SHA-1 hexadecimal digest string.
  */

--- a/app/src/ui/lib/app-proxy.ts
+++ b/app/src/ui/lib/app-proxy.ts
@@ -1,8 +1,6 @@
 import * as remote from '@electron/remote'
 
 let app: Electron.App | null = null
-let version: string | null = null
-let name: string | null = null
 let path: string | null = null
 let userDataPath: string | null = null
 let documentsPath: string | null = null
@@ -21,24 +19,14 @@ function getApp(): Electron.App {
  * This is preferable to using `remote` directly because we cache the result.
  */
 export function getVersion(): string {
-  if (!version) {
-    version = getApp().getVersion()
-  }
-
-  return version
+  return __APP_VERSION__
 }
 
 /**
  * Get the name of the app.
- *
- * This is preferable to using `remote` directly because we cache the result.
  */
 export function getName(): string {
-  if (!name) {
-    name = getApp().getName()
-  }
-
-  return name
+  return __APP_NAME__
 }
 
 /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Superseedes #13761

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Product name and version are determined at build time so we might as well embed them as global constants so avoid having to do any IPC roundtrip to get them.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes