### PR TITLE
Refactor crash app to not use `remote` module

### DIFF
--- a/app/src/crash/crash-app.tsx
+++ b/app/src/crash/crash-app.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
-import * as remote from '@electron/remote'
 import { ErrorType } from './shared'
 import { TitleBar } from '../ui/window/title-bar'
 import { encodePathAsUrl } from '../lib/path'
-import { WindowState, getWindowState } from '../lib/window-state'
+import { WindowState } from '../lib/window-state'
 import { Octicon } from '../ui/octicons'
 import * as OcticonSymbol from '../ui/octicons/octicons.generated'
 import { Button } from '../ui/lib/button'
@@ -11,6 +10,7 @@ import { LinkButton } from '../ui/lib/link-button'
 import { getVersion } from '../ui/lib/app-proxy'
 import { getOS } from '../lib/get-os'
 import * as ipcRenderer from '../lib/ipc-renderer'
+import { getCurrentWindowState } from '../ui/main-process-proxy'
 
 // This is a weird one, let's leave it as a placeholder
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -32,7 +32,7 @@ interface ICrashAppState {
   /**
    * The current state of the Window, ie maximized, minimized full-screen etc.
    */
-  readonly windowState: WindowState
+  readonly windowState: WindowState | null
 }
 
 // Note that we're reusing the welcome illustration here, any changes to it
@@ -91,20 +91,41 @@ export class CrashApp extends React.Component<ICrashAppProps, ICrashAppState> {
     super(props)
 
     this.state = {
-      windowState: getWindowState(remote.getCurrentWindow()),
+      windowState: null,
     }
+
+    this.initializeWindowState()
   }
 
   public componentDidMount() {
-    const window = remote.getCurrentWindow()
-
-    ipcRenderer.on('window-state-changed', () => {
-      this.setState({ windowState: getWindowState(window) })
-    })
+    ipcRenderer.on('window-state-changed', this.onWindowStateChanged)
 
     ipcRenderer.on('error', (_, crashDetails) => this.setState(crashDetails))
 
     ipcRenderer.send('crash-ready')
+  }
+
+  public componentWillUnmount() {
+    ipcRenderer.removeListener(
+      'window-state-changed',
+      this.onWindowStateChanged
+    )
+  }
+
+  private initializeWindowState = async () => {
+    const windowState = await getCurrentWindowState()
+    if (windowState === undefined) {
+      return
+    }
+
+    this.setState({ windowState })
+  }
+
+  private onWindowStateChanged = (
+    _: Electron.IpcRendererEvent,
+    windowState: WindowState
+  ) => {
+    this.setState({ windowState })
   }
 
   private onQuitButtonClicked = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/app/src/ui/window/window-controls.tsx
+++ b/app/src/ui/window/window-controls.tsx
@@ -38,11 +38,11 @@ interface IWindowControlState {
 export class WindowControls extends React.Component<{}, IWindowControlState> {
   public componentWillMount() {
     this.setState({ windowState: null })
-    this.intializeWindowState()
+    this.initializeWindowState()
     ipcRenderer.on('window-state-changed', this.onWindowStateChanged)
   }
 
-  private intializeWindowState = async () => {
+  private initializeWindowState = async () => {
     const windowState = await getCurrentWindowState()
     if (windowState === undefined) {
       return


### PR DESCRIPTION
## Description
This refactors the `remote` module in the crash app to the main process instead.

Impacts: Crash app -> getting/setting the window state

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
