### PR TITLE
Refactor `remote` usage in title to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -100,4 +100,8 @@ export type RequestResponseChannels = {
   'show-open-dialog': (
     options: Electron.OpenDialogOptions
   ) => Promise<string | null>
+  'is-window-maximized': () => Promise<boolean>
+  'get-apple-action-on-double-click': () => Promise<
+    Electron.AppleActionOnDoubleClickPref
+  >
 }

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -399,6 +399,10 @@ export class AppWindow {
     this.window.close()
   }
 
+  public isMaximized() {
+    return this.window.isMaximized()
+  }
+
   public getCurrentWindowState() {
     return getWindowState(this.window)
   }

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -1,6 +1,13 @@
 import '../lib/logging/main/install'
 
-import { app, Menu, BrowserWindow, shell, session } from 'electron'
+import {
+  app,
+  Menu,
+  BrowserWindow,
+  shell,
+  session,
+  systemPreferences,
+} from 'electron'
 import * as Fs from 'fs'
 import * as URL from 'url'
 
@@ -470,6 +477,15 @@ app.on('ready', () => {
   ipcMain.on('unmaximize-window', () => mainWindow?.unmaximizeWindow())
 
   ipcMain.on('close-window', () => mainWindow?.closeWindow())
+
+  ipcMain.handle(
+    'is-window-maximized',
+    async () => mainWindow?.isMaximized() ?? false
+  )
+
+  ipcMain.handle('get-apple-action-on-double-click', async () =>
+    systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string')
+  )
 
   ipcMain.handle('get-current-window-state', async () =>
     mainWindow?.getCurrentWindowState()

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -155,6 +155,16 @@ export const restoreWindow = sendProxy('unmaximize-window', 0)
 /** Tell the main process to close the window */
 export const closeWindow = sendProxy('close-window', 0)
 
+/** Tell the main process to get whether the window is maximized */
+export const isWindowMaximized = invokeProxy('is-window-maximized', 0)
+
+/** Tell the main process to get the users system preference for app action on
+ * double click */
+export const getAppleActionOnDoubleClick = invokeProxy(
+  'get-apple-action-on-double-click',
+  0
+)
+
 /**
  * Show the OS-provided certificate trust dialog for the certificate, using the
  * given message.

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -60,17 +60,22 @@ export class TitleBar extends React.Component<ITitleBarProps> {
   private onTitlebarDoubleClickDarwin = async () => {
     const actionOnDoubleClick = await getAppleActionOnDoubleClick()
 
+    // Electron.AppleActionOnDoubleClickPre should only be 'Minimize',
+    // 'Maximize', or 'None'. But, if a user deletes their action on double
+    // click setting via terminal, then it returns an empty string. The macOs
+    // convention is to treat this as the default behavior of 'Maximize'.
     switch (actionOnDoubleClick) {
-      case 'Maximize':
+      case 'Minimize':
+        minimizeWindow()
+        break
+      case 'None':
+        return
+      default:
         if (await isWindowMaximized()) {
           restoreWindow()
         } else {
           maximizeWindow()
         }
-        break
-      case 'Minimize':
-        minimizeWindow()
-        break
     }
   }
 

--- a/app/src/ui/window/title-bar.tsx
+++ b/app/src/ui/window/title-bar.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react'
 import memoizeOne from 'memoize-one'
-import * as remote from '@electron/remote'
 import { WindowState } from '../../lib/window-state'
 import { WindowControls } from './window-controls'
 import { Octicon } from '../octicons/octicon'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { isMacOSBigSurOrLater } from '../../lib/get-os'
+import {
+  getAppleActionOnDoubleClick,
+  isWindowMaximized,
+  maximizeWindow,
+  minimizeWindow,
+  restoreWindow,
+} from '../main-process-proxy'
 
 /** Get the height (in pixels) of the title bar depending on the platform */
 export function getTitleBarHeight() {
@@ -51,23 +57,19 @@ export class TitleBar extends React.Component<ITitleBarProps> {
     return style
   })
 
-  private onTitlebarDoubleClickDarwin = () => {
-    const actionOnDoubleClick = remote.systemPreferences.getUserDefault(
-      'AppleActionOnDoubleClick',
-      'string'
-    )
-    const mainWindow = remote.getCurrentWindow()
+  private onTitlebarDoubleClickDarwin = async () => {
+    const actionOnDoubleClick = await getAppleActionOnDoubleClick()
 
     switch (actionOnDoubleClick) {
       case 'Maximize':
-        if (mainWindow.isMaximized()) {
-          mainWindow.unmaximize()
+        if (await isWindowMaximized()) {
+          restoreWindow()
         } else {
-          mainWindow.maximize()
+          maximizeWindow()
         }
         break
       case 'Minimize':
-        mainWindow.minimize()
+        minimizeWindow()
         break
     }
   }


### PR DESCRIPTION
## Description
This refactors the `remote` module usage  in the `title-bar.tsx` to the main process instead.

Impacts: On mac, when you double click the title bar, it should minimize/maximize the app depending on user's system preference. 

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
