### PR TITLE
Refactor `remote.app.runningUnderRosettaTranslation` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -83,6 +83,7 @@ export type RequestChannels = {
  */
 export type RequestResponseChannels = {
   'get-app-architecture': () => Promise<Architecture>
+  'is-running-under-rosetta-translation': () => Promise<boolean>
   'move-to-trash': (path: string) => Promise<void>
   'show-contextual-menu': (
     items: ReadonlyArray<ISerializableMenuItem>

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -542,6 +542,15 @@ app.on('ready', () => {
   ipcMain.handle('get-app-architecture', async () => getArchitecture(app))
 
   /**
+   * An event sent by the renderer asking for whether the app is running under
+   * rosetta translation
+   */
+  ipcMain.handle(
+    'is-running-under-rosetta-translation',
+    async () => app.runningUnderRosettaTranslation
+  )
+
+  /**
    * An event sent by the renderer asking to move the app to the application
    * folder
    */

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -1,10 +1,10 @@
-import * as remote from '@electron/remote'
 const lastSuccessfulCheckKey = 'last-successful-update-check'
 
 import { Emitter, Disposable } from 'event-kit'
 
 import {
   checkForUpdates,
+  isRunningUnderRosettaTranslation,
   onAutoUpdaterCheckingForUpdate,
   onAutoUpdaterError,
   onAutoUpdaterUpdateAvailable,
@@ -160,7 +160,7 @@ class UpdateStore {
     // the arm64 binary.
     if (
       enableUpdateFromEmulatedX64ToARM64() &&
-      (remote.app.runningUnderRosettaTranslation === true ||
+      ((await isRunningUnderRosettaTranslation()) === true ||
         isRunningUnderARM64Translation() === true)
     ) {
       const url = new URL(updatesURL)

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -180,6 +180,15 @@ export const showCertificateTrustDialog = sendProxy(
 export const getAppArchitecture = invokeProxy('get-app-architecture', 0)
 
 /**
+ * Tell the main process to obtain whether the app is running under a rosetta
+ * translation
+ */
+export const isRunningUnderRosettaTranslation = invokeProxy(
+  'is-running-under-rosetta-translation',
+  0
+)
+
+/**
  * Tell the main process that we're going to quit. This means it should allow
  * the window to close.
  *


### PR DESCRIPTION
## Description
This refactors the `remote` module usage of `remote.app.runningUnderRosettaTranslation` to the main process instead.

Impacts: 
- The update store checks against this and and Arm64Translation to determine if it should request an arm64 update. 

I tested this locally by debugger and verified I received the same value as before which was false.

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
