### PR TITLE
Release 2.9.7-beta1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.6",
+  "version": "2.9.7-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -165,5 +165,5 @@ export function enablePullRequestQuickView(): boolean {
 
 /** Should we enable high-signal notifications? */
 export function enableHighSignalNotifications(): boolean {
-  return enableDevelopmentFeatures()
+  return __DARWIN__ ? enableBetaFeatures() : enableDevelopmentFeatures()
 }

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.9.7-beta1": [
-      "[New] Initial support for high-signal notifications in macOS - #13655",
+      "[New] Initial support for system notifications when checks fail in macOS - #13655",
       "[Added] Support pushing workflow files for GitHub Actions to GitHub Enterprise Server - #13640",
       "[Added] Support CLion as an external editor - #13739. Thanks @Pinzauti!",
       "[Fixed] Fix close button in full screen mode on macOS - #12838",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,20 @@
 {
   "releases": {
+    "2.9.7-beta1": [
+      "[Added] Initial support for high-signal notifications in macOS - #13655",
+      "[Added] Support pushing workflow files for GitHub Actions to GitHub Enterprise Server - #13640",
+      "[Added] Support CLion as an external editor - #13739. Thanks @Pinzauti!",
+      "[Fixed] Fix close button in full screen mode on macOS - #12838",
+      "[Fixed] Commit message dialog background styles match dialog - #13606",
+      "[Fixed] Job steps on pull-request check run list are no longer intermittently missing - #13531",
+      "[Fixed] Take alias into account when sorting repositories - #13429",
+      "[Improved] Support avatars on GitHub Enterprise Server - #13719",
+      "[Improved] Fetch before trying to follow a URL link to a specific branch - #13641. Thanks @Bestra!",
+      "[Improved] Add \"View on GitHub\" context menu option - #13227. Thanks @lhvy!",
+      "[Improved] Signal when a commit summary is getting long - #2055. Thanks @Twixes!",
+      "[Improved] Check run group headers and checks stay in view while scrolling the sub checks or job steps. - #13532",
+      "[Improved] Removed unnecessary punctuation in appearance settings- #13715. Thanks @Pinzauti!"
+    ],
     "2.9.6": [
       "[Added] View and re-run the check runs for the checked out pull request.",
       "[Fixed] Tooltip improvements and polish - #13452 #13449",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.9.7-beta1": [
-      "[Added] Initial support for high-signal notifications in macOS - #13655",
+      "[New] Initial support for high-signal notifications in macOS - #13655",
       "[Added] Support pushing workflow files for GitHub Actions to GitHub Enterprise Server - #13640",
       "[Added] Support CLion as an external editor - #13739. Thanks @Pinzauti!",
       "[Fixed] Fix close button in full screen mode on macOS - #12838",

--- a/changelog.json
+++ b/changelog.json
@@ -7,7 +7,7 @@
       "[Fixed] Fix close button in full screen mode on macOS - #12838",
       "[Fixed] Commit message dialog background styles match dialog - #13606",
       "[Fixed] Ensure job steps on pull request check run list are always present - #13531",
-      "[Fixed] Take alias into account when sorting repositories - #13429",
+      "[Improved] Take alias into account when sorting repositories - #13429",
       "[Improved] Upgrade to Electron v14.2.3 - #13689",
       "[Improved] Support avatars on GitHub Enterprise Server - #13719",
       "[Improved] Fetch before trying to follow a URL link to a specific branch - #13641. Thanks @Bestra!",

--- a/changelog.json
+++ b/changelog.json
@@ -11,7 +11,7 @@
       "[Improved] Upgrade to Electron v14.2.3 - #13689",
       "[Improved] Support avatars on GitHub Enterprise Server - #13719",
       "[Improved] Fetch before trying to follow a URL link to a specific branch - #13641. Thanks @Bestra!",
-      "[Improved] Add \"View on GitHub\" context menu option - #13227. Thanks @lhvy!",
+      "[Improved] Add \"View on GitHub\" context menu option to repository list items - #13227. Thanks @lhvy!",
       "[Improved] Signal when a commit summary is getting long - #2055. Thanks @Twixes!",
       "[Improved] Check run group headers and checks stay in view while scrolling the sub checks or job steps. - #13532",
       "[Improved] Remove unnecessary punctuation in appearance settings- #13715. Thanks @Pinzauti!"

--- a/changelog.json
+++ b/changelog.json
@@ -6,7 +6,7 @@
       "[Added] Support CLion as an external editor - #13739. Thanks @Pinzauti!",
       "[Fixed] Fix close button in full screen mode on macOS - #12838",
       "[Fixed] Commit message dialog background styles match dialog - #13606",
-      "[Fixed] Job steps on pull-request check run list are no longer intermittently missing - #13531",
+      "[Fixed] Ensure job steps on pull request check run list are always present - #13531",
       "[Fixed] Take alias into account when sorting repositories - #13429",
       "[Improved] Upgrade to Electron v14.2.3 - #13689",
       "[Improved] Support avatars on GitHub Enterprise Server - #13719",

--- a/changelog.json
+++ b/changelog.json
@@ -14,7 +14,7 @@
       "[Improved] Add \"View on GitHub\" context menu option - #13227. Thanks @lhvy!",
       "[Improved] Signal when a commit summary is getting long - #2055. Thanks @Twixes!",
       "[Improved] Check run group headers and checks stay in view while scrolling the sub checks or job steps. - #13532",
-      "[Improved] Removed unnecessary punctuation in appearance settings- #13715. Thanks @Pinzauti!"
+      "[Improved] Remove unnecessary punctuation in appearance settings- #13715. Thanks @Pinzauti!"
     ],
     "2.9.6": [
       "[Added] View and re-run the check runs for the checked out pull request.",

--- a/changelog.json
+++ b/changelog.json
@@ -8,6 +8,7 @@
       "[Fixed] Commit message dialog background styles match dialog - #13606",
       "[Fixed] Job steps on pull-request check run list are no longer intermittently missing - #13531",
       "[Fixed] Take alias into account when sorting repositories - #13429",
+      "[Improved] Upgrade to Electron v14.2.3 - #13689",
       "[Improved] Support avatars on GitHub Enterprise Server - #13719",
       "[Improved] Fetch before trying to follow a URL link to a specific branch - #13641. Thanks @Bestra!",
       "[Improved] Add \"View on GitHub\" context menu option - #13227. Thanks @lhvy!",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming first beta of the v2.9.7 series? Well, you've just found it, congratulations!

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
- Pull request quick view is set to dev
- Notifications beta enabled or macOs
![image](https://user-images.githubusercontent.com/75402236/151835245-0d3e0895-9f1c-4852-ab70-a99b44755b69.png)
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
-- Metrics added for notifications



