### PR TITLE
Refactor `remote.app.getAppPath()` to main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -83,6 +83,7 @@ export type RequestChannels = {
  */
 export type RequestResponseChannels = {
   'get-app-architecture': () => Promise<Architecture>
+  'get-app-path': () => Promise<string>
   'is-running-under-rosetta-translation': () => Promise<boolean>
   'move-to-trash': (path: string) => Promise<void>
   'show-contextual-menu': (

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -739,8 +739,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   /** Load the emoji from disk. */
-  public loadEmoji() {
-    const rootDir = getAppPath()
+  public async loadEmoji() {
+    const rootDir = await getAppPath()
     readEmoji(rootDir)
       .then(emoji => {
         this.emoji = emoji

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -542,6 +542,11 @@ app.on('ready', () => {
   ipcMain.handle('get-app-architecture', async () => getArchitecture(app))
 
   /**
+   * An event sent by the renderer asking for the app's path
+   */
+  ipcMain.handle('get-app-path', async () => app.getAppPath())
+
+  /**
    * An event sent by the renderer asking for whether the app is running under
    * rosetta translation
    */

--- a/app/src/ui/acknowledgements/acknowledgements.tsx
+++ b/app/src/ui/acknowledgements/acknowledgements.tsx
@@ -42,8 +42,8 @@ export class Acknowledgements extends React.Component<
     this.state = { licenses: null }
   }
 
-  public componentDidMount() {
-    const path = Path.join(getAppPath(), 'static', 'licenses.json')
+  public async componentDidMount() {
+    const path = Path.join(await getAppPath(), 'static', 'licenses.json')
     Fs.readFile(path, 'utf8', (err, data) => {
       if (err) {
         log.error('Error loading licenses', err)

--- a/app/src/ui/lib/app-proxy.ts
+++ b/app/src/ui/lib/app-proxy.ts
@@ -1,4 +1,5 @@
 import * as remote from '@electron/remote'
+import { getAppPathProxy } from '../main-process-proxy'
 
 let app: Electron.App | null = null
 let path: string | null = null
@@ -33,9 +34,9 @@ export function getName(): string {
  *
  * This is preferable to using `remote` directly because we cache the result.
  */
-export function getAppPath(): string {
+export async function getAppPath(): Promise<string> {
   if (!path) {
-    path = getApp().getAppPath()
+    path = await getAppPathProxy()
   }
 
   return path

--- a/app/src/ui/lib/app-proxy.ts
+++ b/app/src/ui/lib/app-proxy.ts
@@ -2,7 +2,6 @@ import * as remote from '@electron/remote'
 
 let app: Electron.App | null = null
 let path: string | null = null
-let userDataPath: string | null = null
 let documentsPath: string | null = null
 
 function getApp(): Electron.App {
@@ -40,19 +39,6 @@ export function getAppPath(): string {
   }
 
   return path
-}
-
-/**
- * Get the path to the user's data.
- *
- * This is preferable to using `remote` directly because we cache the result.
- */
-export function getUserDataPath(): string {
-  if (!userDataPath) {
-    userDataPath = getApp().getPath('userData')
-  }
-
-  return userDataPath
 }
 
 /**

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -180,6 +180,11 @@ export const showCertificateTrustDialog = sendProxy(
 export const getAppArchitecture = invokeProxy('get-app-architecture', 0)
 
 /**
+ * Tell the main process to obtain the application's app path
+ */
+export const getAppPathProxy = invokeProxy('get-app-path', 0)
+
+/**
  * Tell the main process to obtain whether the app is running under a rosetta
  * translation
  */


### PR DESCRIPTION
## Description
This refactors the `remote` module usage in `remote.app.getAppPath()` to the main-process.

Impacts:
- Loading emoji's is now async - being a deferred independent action, seems like it is reasonable to be async not be waited upon
- Acknowledgements: loading the licences.json is now async

Note: This is one of several PR's to refactor our usage of the `remote` module to instead use the IPC messaging with the main process so that we can remove our [undesired](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) `remote` module dependency (supporting ultimate goal of upgrading to electron 16).

## Release notes
Notes: no-notes
