### PR TITLE
Enable manual "check for updates" on test builds

### DIFF
--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -90,8 +90,8 @@ export async function getChangeLog(
     'https://central.github.com/deployments/desktop/desktop/changelog.json'
   )
 
-  if (__RELEASE_CHANNEL__ === 'beta') {
-    changelogURL.searchParams.set('env', 'beta')
+  if (__RELEASE_CHANNEL__ === 'beta' || __RELEASE_CHANNEL__ === 'test') {
+    changelogURL.searchParams.set('env', __RELEASE_CHANNEL__)
   }
 
   if (limit !== undefined) {

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -177,14 +177,11 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       return null
     }
 
-    if (
-      __RELEASE_CHANNEL__ === 'development' ||
-      __RELEASE_CHANNEL__ === 'test'
-    ) {
+    if (__RELEASE_CHANNEL__ === 'development') {
       return (
         <p>
-          The application is currently running in development or test mode and
-          will not receive any updates.
+          The application is currently running in development and will not
+          receive any updates.
         </p>
       )
     }
@@ -213,10 +210,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       return null
     }
 
-    if (
-      __RELEASE_CHANNEL__ === 'development' ||
-      __RELEASE_CHANNEL__ === 'test'
-    ) {
+    if (__RELEASE_CHANNEL__ === 'development') {
       return null
     }
 

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -95,10 +95,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
   }
 
   private renderUpdateButton() {
-    if (
-      __RELEASE_CHANNEL__ === 'development' ||
-      __RELEASE_CHANNEL__ === 'test'
-    ) {
+    if (__RELEASE_CHANNEL__ === 'development') {
       return null
     }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -253,10 +253,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       const status = state.status
 
       if (
-        !(
-          __RELEASE_CHANNEL__ === 'development' ||
-          __RELEASE_CHANNEL__ === 'test'
-        ) &&
+        !(__RELEASE_CHANNEL__ === 'development') &&
         status === UpdateStatus.UpdateReady
       ) {
         this.props.dispatcher.setUpdateBannerVisibility(true)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -302,8 +302,14 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     this.props.dispatcher.installGlobalLFSFilters(false)
 
-    setInterval(() => this.checkForUpdates(true), UpdateCheckInterval)
-    this.checkForUpdates(true)
+    // We only want to automatically check for updates on beta and prod
+    if (
+      __RELEASE_CHANNEL__ !== 'development' &&
+      __RELEASE_CHANNEL__ !== 'test'
+    ) {
+      setInterval(() => this.checkForUpdates(true), UpdateCheckInterval)
+      this.checkForUpdates(true)
+    }
 
     log.info(`launching: ${getVersion()} (${getOS()})`)
     log.info(`execPath: '${process.execPath}'`)
@@ -555,14 +561,7 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private checkForUpdates(inBackground: boolean) {
-    if (__LINUX__) {
-      return
-    }
-
-    if (
-      __RELEASE_CHANNEL__ === 'development' ||
-      __RELEASE_CHANNEL__ === 'test'
-    ) {
+    if (__LINUX__ || __RELEASE_CHANNEL__ === 'development') {
       return
     }
 


### PR DESCRIPTION
## Description
This PR enables manual updates for the test channel. 

Release 2.7.1-test21 is a release with these changes. 

The behaviors should be that - it should not check for updates on load. I checked that by putting a debugger here:
![image](https://user-images.githubusercontent.com/75402236/152241652-b8eb744b-e099-4261-b0f9-483b98ff9035.png)

Then, when you go to the About dialog, you should see a update state and "Check for Updates" button.
![image](https://user-images.githubusercontent.com/75402236/152241730-7873e660-1b54-4256-95ae-6cde675b88dc.png)

Pressing "Check for Updates" should hit the "onCheckingForUpdate" method in the "update-store".
![image](https://user-images.githubusercontent.com/75402236/152241832-ba29e6f6-9d21-46da-832c-bce4cf9f9d26.png)

Now that I have test 2.7.1-test22, it should download that update. Note: test22 does not have this manual check for updates change it. It is the electron 16 upgrade.

As for my prev mention that "MacOs it doesn't and gets the prod release", I forgot that the central test release changes were rolled back when Sergio's notifications metric branch was deployed. I redeployed central with the test build changes and now everything works as expected from Desktop and Central.

## Release notes
Notes: no-notes
