### PR TITLE
Use `desktop-notifications` only on Windows 10 and 11

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-notifications": "^0.1.5",
+    "desktop-notifications": "^0.1.6",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "detect-arm64-translation": "https://github.com/desktop/node-detect-arm64-translation#v1.0.4",
     "dexie": "^2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-notifications": "^0.1.4",
+    "desktop-notifications": "^0.1.5",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "detect-arm64-translation": "https://github.com/desktop/node-detect-arm64-translation#v1.0.4",
     "dexie": "^2.0.0",

--- a/app/src/lib/stores/helpers/show-notification.ts
+++ b/app/src/lib/stores/helpers/show-notification.ts
@@ -2,6 +2,7 @@ import { focusWindow } from '../../../ui/main-process-proxy'
 import {
   DesktopNotification,
   initializeNotifications,
+  supportsNotifications,
 } from 'desktop-notifications'
 import { findToastActivatorClsid } from '../../find-toast-activator-clsid'
 
@@ -37,7 +38,7 @@ export function showNotification(
   body: string,
   onClick: () => void
 ) {
-  if (__WIN32__) {
+  if (supportsNotifications()) {
     initializeWindowsNotifications()
 
     const notification = new DesktopNotification(title, body)

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -541,14 +541,17 @@ export function buildDefaultMenu({
         ],
       },
       {
-        label: 'Show notification',
-        click: emit('test-show-notification'),
-      },
-      {
         label: 'Prune branches',
         click: emit('test-prune-branches'),
       }
     )
+  }
+
+  if (__RELEASE_CHANNEL__ === 'development' || __RELEASE_CHANNEL__ === 'test') {
+    helpItems.push({
+      label: 'Show notification',
+      click: emit('test-show-notification'),
+    })
   }
 
   if (__DARWIN__) {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -484,7 +484,10 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private testShowNotification() {
-    if (!__DEV__) {
+    if (
+      __RELEASE_CHANNEL__ !== 'development' &&
+      __RELEASE_CHANNEL__ !== 'test'
+    ) {
       return
     }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -333,14 +333,14 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-notifications@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.1.5.tgz#896d42753b356db9027ef26ddc0dc1714c87e778"
-  integrity sha512-yuOZsux22TCjeztMXS5tua889DZTIXpA7q9jKXds2M9BJl/a657/Z7Pv1sC3X0QtEuow1udEiMWWVFUkudGZVg==
+desktop-notifications@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.1.6.tgz#a9bd2774b3385019f849801c5314dbc43af11433"
+  integrity sha512-wIMhqmm2LVxs9+utPb2LtFzrts7SFl99ZLhU0Wy9F41IyTcGNMrutP6o/MUSGBVjSI8HpqjO5NwvqohpEUd+EQ==
   dependencies:
-    lru-cache "^6.0.0"
     node-addon-api "^4.3.0"
     prebuild-install "^7.0.1"
+    quick-lru "^3.0.0"
     uuid "^8.3.2"
 
 desktop-trampoline@desktop/desktop-trampoline#v0.9.8:

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -333,11 +333,12 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-notifications@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.1.4.tgz#698c5822fb88d7a2289f36b4f64eaac8b5bdefed"
-  integrity sha512-3ADhNvqL9ISbN17x/hWcYUcGHvWJxPnoxxsQbmrU26wpk2eakvDplCm0fvNIpHx/Ar5O7n1VmMOVmLr8W6B8sQ==
+desktop-notifications@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.1.5.tgz#896d42753b356db9027ef26ddc0dc1714c87e778"
+  integrity sha512-yuOZsux22TCjeztMXS5tua889DZTIXpA7q9jKXds2M9BJl/a657/Z7Pv1sC3X0QtEuow1udEiMWWVFUkudGZVg==
   dependencies:
+    lru-cache "^6.0.0"
     node-addon-api "^4.3.0"
     prebuild-install "^7.0.1"
     uuid "^8.3.2"


### PR DESCRIPTION
## Description

This PR bumps `desktop-notifications` to version 0.1.6, which includes:
- Memory usage improvements: https://github.com/desktop/desktop-notifications/pull/3
- A check to only enable `desktop-notifications` on Windows 10 and newer: https://github.com/desktop/desktop-notifications/pull/4

Also, I used this PR to enable the `Show notification` debug menu in test builds, as testing notifications in a prod-like environment is usually very important.

## Release notes

Notes: no-notes
