### PR TITLE
Surround `api.getAliveWebSocketURL` in try-catch

### DIFF
--- a/app/src/lib/stores/alive-store.ts
+++ b/app/src/lib/stores/alive-store.ts
@@ -144,7 +144,14 @@ export class AliveStore {
     }
 
     const api = API.fromAccount(account)
-    const webSocketUrl = await api.getAliveWebSocketURL()
+    let webSocketUrl = null
+
+    try {
+      webSocketUrl = await api.getAliveWebSocketURL()
+    } catch (e) {
+      log.error(`Could not get Alive web socket URL for '${account.login}'`, e)
+      return null
+    }
 
     if (webSocketUrl === null) {
       return null


### PR DESCRIPTION
## Description

Probably harmless, but still cleaner this way. I ran into this while I tried to repro the "white screen" issue mentioned in https://github.com/desktop/desktop/pull/13797#issuecomment-1027983548

It's worth mentioning that we only need to catch errors in this specific usage of `api.getAliveWebSocketURL`, but not in the lambda passed to the `AliveSession`. That `AliveSession` will catch any exceptions `getAliveWebSocketURL` throws and handle them accordingly.

## Release notes

Notes: no-notes
