### PR TITLE
Add 128 again as successful code for `git remote` commands

### DIFF
--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -45,7 +45,7 @@ export async function removeRemote(
   name: string
 ): Promise<void> {
   const options = {
-    successExitCodes: new Set([0, 2]),
+    successExitCodes: new Set([0, 2, 128]),
   }
 
   await git(
@@ -79,7 +79,7 @@ export async function getRemoteURL(
     ['remote', 'get-url', name],
     repository.path,
     'getRemoteURL',
-    { successExitCodes: new Set([0, 2]) }
+    { successExitCodes: new Set([0, 2, 128]) }
   )
 
   if (result.exitCode !== 0) {


### PR DESCRIPTION
## Description

Last time I bumped our bundled git (https://github.com/desktop/desktop/pull/13000/files) I had to change some of the expected successful codes so that tests passed. I noticed some `die` (which exit with code 128) were replace with other `exit` calls with specific does, however I didn't notice that **not all** `die` statements were replaced:
- https://github.com/git/git/commit/9144ba4cf52bb0e891d7c10a331fc32c1d3e8f64#diff-d1216797fe2c919ca196cd3f78ac01f8119b1f5f04df11c0cd11011ee753c857R1597
- https://github.com/git/git/commit/9144ba4cf52bb0e891d7c10a331fc32c1d3e8f64#diff-d1216797fe2c919ca196cd3f78ac01f8119b1f5f04df11c0cd11011ee753c857R858
- https://github.com/git/git/commit/9144ba4cf52bb0e891d7c10a331fc32c1d3e8f64#diff-d1216797fe2c919ca196cd3f78ac01f8119b1f5f04df11c0cd11011ee753c857R866

This PR brings 128 back as expected successful code for those remaining `die`.

## Release notes

Notes: [Fixed] Fix error managing remotes under some circumstances.
