### PR TITLE
Share and unify limit for intra line diffs

### DIFF
--- a/app/src/ui/diff/diff-helpers.tsx
+++ b/app/src/ui/diff/diff-helpers.tsx
@@ -387,3 +387,9 @@ export function getLargestLineNumber(hunks: DiffHunk[]): number {
 export function getNumberOfDigits(val: number): number {
   return (Math.log(val) * Math.LOG10E + 1) | 0
 }
+
+/**
+ * The longest line for which we'd try to calculate a line diff, this matches
+ * GitHub.com's behavior.
+ **/
+export const MaxIntraLineDiffStringLength = 1024

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -45,6 +45,7 @@ import {
   DiffColumn,
   getLineWidthFromDigitCount,
   getNumberOfDigits,
+  MaxIntraLineDiffStringLength,
 } from './diff-helpers'
 import { showContextualMenu } from '../main-process-proxy'
 import { getTokens } from './diff-syntax-mode'
@@ -59,7 +60,6 @@ import { IMenuItem } from '../../lib/menu-item'
 import { HiddenBidiCharsWarning } from './hidden-bidi-chars-warning'
 
 const DefaultRowHeight = 20
-const MaxLineLengthToCalculateDiff = 240
 
 export interface ISelectionPoint {
   readonly column: DiffColumn
@@ -1164,8 +1164,8 @@ function getModifiedRows(
       const deletedLine = deletedLines[i]
 
       if (
-        addedLine.line.content.length < MaxLineLengthToCalculateDiff &&
-        deletedLine.line.content.length < MaxLineLengthToCalculateDiff
+        addedLine.line.content.length < MaxIntraLineDiffStringLength &&
+        deletedLine.line.content.length < MaxIntraLineDiffStringLength
       ) {
         const { before, after } = getDiffTokens(
           deletedLine.line.content,

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -46,6 +46,7 @@ import {
   canSelect,
   getLineWidthFromDigitCount,
   getNumberOfDigits,
+  MaxIntraLineDiffStringLength,
 } from './diff-helpers'
 import {
   expandTextDiffHunk,
@@ -57,9 +58,6 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { WhitespaceHintPopover } from './whitespace-hint-popover'
 import { PopoverCaretPosition } from '../lib/popover'
 import { HiddenBidiCharsWarning } from './hidden-bidi-chars-warning'
-
-/** The longest line for which we'd try to calculate a line diff. */
-const MaxIntraLineDiffStringLength = 4096
 
 // This is a custom version of the no-newline octicon that's exactly as
 // tall as it needs to be (8px) which helps with aligning it on the line.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13838

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I was surprised to learn that we had different limits on how long of a line we'd calculate intraline diffs (i.e highlighting the changed part of a diff) in the unified diff view and the side-by-side view. The screenshots below show the same diff in the two modes.

I did some digging and the 240 char limit for the side-by-side diff was introduced in https://github.com/desktop/desktop/commit/7070f0625b0211e7cd3bb333740eedaf344c81a8#diff-4e8bcad7e5dc3e8973a7f02420bf97a727f6dbe1ea72d4446c9ef887ac10d560R28 with now special callout to 240 being significant. The 4096 limit for unified mode was similarly introduced without fanfare in https://github.com/desktop/desktop/commit/0b66194409fa7c04ce5d6e27d714fd7af72d5c39#diff-93a97971dea4186b7445f010cdada081f05aeefd49b7b8900109e403d7b3a8ddR50.

Taking a gander at GitHub.com's behavior I found that it stops marking intra line changes at 1024 characters so I figured thta was a good middle ground to unify on.

## Screenshots

![image](https://user-images.githubusercontent.com/634063/152816717-e34a6a43-2a5c-40c1-9dc4-100328362496.png)
![image](https://user-images.githubusercontent.com/634063/152816746-af1e4b9b-dbec-4d52-a336-c275315d0fb1.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Changes within lines are presented the same way in side-by-side and unified modes.
