### PR TITLE
Replace `node-detect-arm64-translation` dependency with `app.runningUnderARM64Translation`

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,6 @@
     "deep-equal": "^1.0.1",
     "desktop-notifications": "^0.1.6",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
-    "detect-arm64-translation": "https://github.com/desktop/node-detect-arm64-translation#v1.0.4",
     "dexie": "^2.0.0",
     "dompurify": "^2.3.3",
     "double-ended-queue": "^2.1.0-0",

--- a/app/src/lib/get-architecture.ts
+++ b/app/src/lib/get-architecture.ts
@@ -1,5 +1,4 @@
 import { App } from 'electron'
-import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
 
@@ -10,12 +9,23 @@ export type Architecture = 'x64' | 'arm64' | 'x64-emulated'
  * Rosetta).
  */
 export function getArchitecture(app: App): Architecture {
-  if (
-    app.runningUnderRosettaTranslation === true ||
-    isRunningUnderARM64Translation() === true
-  ) {
+  if (isAppRunningUnderARM64Translation(app)) {
     return 'x64-emulated'
   }
 
   return process.arch === 'arm64' ? 'arm64' : 'x64'
+}
+
+/**
+ * Returns true if the app is an x64 process running under arm64 translation.
+ */
+export function isAppRunningUnderARM64Translation(app: App): boolean {
+  // HACK: We cannot just use runningUnderARM64Translation because on Windows,
+  // it relies on IsWow64Process2 which, as of today, on Windows 11 (22000.469),
+  // always returns IMAGE_FILE_MACHINE_UNKNOWN as the process machine, which
+  // indicates that the process is NOT being emulated. This means, Electron's
+  // runningUnderARM64Translation will always return true for arm binaries on
+  // Windows, so we will use process.arch to check if node (and therefore the
+  // whole process) was compiled for x64.
+  return process.arch === 'x64' && app.runningUnderARM64Translation === true
 }

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -88,7 +88,7 @@ export type RequestResponseChannels = {
   'get-path': (path: PathType) => Promise<string>
   'get-app-architecture': () => Promise<Architecture>
   'get-app-path': () => Promise<string>
-  'is-running-under-rosetta-translation': () => Promise<boolean>
+  'is-running-under-arm64-translation': () => Promise<boolean>
   'move-to-trash': (path: string) => Promise<void>
   'show-contextual-menu': (
     items: ReadonlyArray<ISerializableMenuItem>,

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -36,7 +36,10 @@ import { installAuthenticatedAvatarFilter } from './authenticated-avatar-filter'
 import { installAliveOriginFilter } from './alive-origin-filter'
 import { installSameOriginFilter } from './same-origin-filter'
 import * as ipcMain from './ipc-main'
-import { getArchitecture } from '../lib/get-architecture'
+import {
+  getArchitecture,
+  isAppRunningUnderARM64Translation,
+} from '../lib/get-architecture'
 import { buildSpellCheckMenu } from './menu/build-spell-check-menu'
 
 app.setAppLogsPath()
@@ -565,9 +568,8 @@ app.on('ready', () => {
    * An event sent by the renderer asking for whether the app is running under
    * rosetta translation
    */
-  ipcMain.handle(
-    'is-running-under-rosetta-translation',
-    async () => app.runningUnderRosettaTranslation
+  ipcMain.handle('is-running-under-arm64-translation', async () =>
+    isAppRunningUnderARM64Translation(app)
   )
 
   /**

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -4,7 +4,7 @@ import { Emitter, Disposable } from 'event-kit'
 
 import {
   checkForUpdates,
-  isRunningUnderRosettaTranslation,
+  isRunningUnderARM64Translation,
   onAutoUpdaterCheckingForUpdate,
   onAutoUpdaterError,
   onAutoUpdaterUpdateAvailable,
@@ -20,7 +20,6 @@ import { ReleaseSummary } from '../../models/release-notes'
 import { generateReleaseSummary } from '../../lib/release-notes'
 import { setNumber, getNumber } from '../../lib/local-storage'
 import { enableUpdateFromEmulatedX64ToARM64 } from '../../lib/feature-flag'
-import { isRunningUnderARM64Translation } from 'detect-arm64-translation'
 
 /** The states the auto updater can be in. */
 export enum UpdateStatus {
@@ -155,13 +154,11 @@ class UpdateStore {
 
     let updatesURL = __UPDATES_URL__
 
-    // If the app is running under Rosetta (i.e. it's a macOS x64 binary running
-    // on an arm64 machine), we need to tweak the update URL here to point at
-    // the arm64 binary.
+    // If the app is running under arm64 to x64 translation, we need to tweak the
+    // update URL here to point at the arm64 binary.
     if (
       enableUpdateFromEmulatedX64ToARM64() &&
-      ((await isRunningUnderRosettaTranslation()) === true ||
-        isRunningUnderARM64Translation() === true)
+      (await isRunningUnderARM64Translation()) === true
     ) {
       const url = new URL(updatesURL)
       url.pathname = url.pathname.replace(

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -197,8 +197,8 @@ export const getAppPathProxy = invokeProxy('get-app-path', 0)
  * Tell the main process to obtain whether the app is running under a rosetta
  * translation
  */
-export const isRunningUnderRosettaTranslation = invokeProxy(
-  'is-running-under-rosetta-translation',
+export const isRunningUnderARM64Translation = invokeProxy(
+  'is-running-under-arm64-translation',
   0
 )
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -350,13 +350,6 @@ desktop-trampoline@desktop/desktop-trampoline#v0.9.8:
     node-addon-api "^3.1.0"
     prebuild-install "^6.0.0"
 
-"detect-arm64-translation@https://github.com/desktop/node-detect-arm64-translation#v1.0.4":
-  version "1.0.3"
-  resolved "https://github.com/desktop/node-detect-arm64-translation#d03110738f94fa684fc20cdfa412e83cd7984c89"
-  dependencies:
-    node-addon-api "^3.1.0"
-    prebuild-install "^5.3.5"
-
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"


### PR DESCRIPTION
## Description

Now that we upgraded to Electron 16, we can use `app.runningUnderARM64Translation` instead of our [node-detect-arm64-translation](https://github.com/desktop/node-detect-arm64-translation) package. While testing this, I noticed a change in the behavior of IsWow64Process2 since I made the package, which is what both `app.runningUnderARM64Translation` and [node-detect-arm64-translation](https://github.com/desktop/node-detect-arm64-translation) use: it used to return a non-success value when the current process wasn't being translated. Now, it returns a success value even when the process is arm64. This means that the current implementation of both Electron's API and our package will return `true` when the CPU is arm64.

So I tried to make some changes to stick to the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2), and look for `nativeMachine == IMAGE_FILE_MACHINE_ARM64 && processMachine != IMAGE_FILE_MACHINE_UNKNOWN`

However, on the latest Windows 11 build (22000.469) for arm, `processMachine` is always `IMAGE_FILE_MACHINE_UNKNOWN`, meaning we think it's not emulated whenever the app is running on an arm64 device, no matter what the architecture of the process is.

That's why this PR takes the current implementation of `app.runningUnderARM64Translation` and also checks `process.arch == 'x64'` to determine whether or not we're running a x64 build of the app on arm64 devices.

## Release notes

Notes: no-notes
