### PR TITLE
Loosen detection of web flow committer on GHES

### DIFF
--- a/app/src/lib/web-flow-committer.ts
+++ b/app/src/lib/web-flow-committer.ts
@@ -31,9 +31,19 @@ export function isWebFlowCommitter(
     return true
   }
 
-  if (name === 'GitHub Enterprise') {
-    const host = new URL(endpoint).host.toLowerCase()
-    return email.endsWith(`@${host}`)
+  if (endpoint !== getDotComAPIEndpoint() && name === 'GitHub Enterprise') {
+    // We can't assume that the email address will match any specific format
+    // here since the web flow committer email address on GHES is the same as
+    // the noreply email which can be configured by domain administrators so
+    // we'll just have to assume that for a GitHub hosted repository (but not
+    // GitHub.com) a commit author of the name 'GitHub Enterprise' is the web
+    // flow author.
+    //
+    // Hello future contributor: Turns out the web flow committer name is based
+    // on the "flavor" of GitHub so it's possible that you're here wondering why
+    // this isn't working and chances are it's because we've updated the
+    // GHES branding or introduced some new flavor.
+    return true
   }
 
   return false


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13848

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Turns out the email address used for the web flow committer on GHES is admin-configurable so we can't rely on it matching the domain of the GHES instance.

I did briefly consider trying match on a substring of the domain but while likely rare it is possible for a company to have their GHES hosted on `domainA.com` while having their noreply emails originating from `domainB.com`.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Hide committer for commits made using the web flow on GitHub Enterprise Server