### PR TITLE
Cherry-pick: Show target branch is success banner when cherry-pick through context menu

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2874,7 +2874,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         branchCreated: false,
         commits,
       },
-      tip.branch,
+      null,
       commits,
       tip.branch.tip.sha
     )

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3192,6 +3192,19 @@ export class Dispatcher {
     return this.appStore._setMultiCommitOperationStep(repository, step)
   }
 
+  /** Set the multi commit operation target branch */
+  public setMultiCommitOperationTargetBranch(
+    repository: Repository,
+    targetBranch: Branch
+  ): void {
+    this.repositoryStateManager.updateMultiCommitOperationState(
+      repository,
+      () => ({
+        targetBranch,
+      })
+    )
+  }
+
   /** Set cherry-pick branch created state */
   public setCherryPickBranchCreated(
     repository: Repository,

--- a/app/src/ui/multi-commit-operation/cherry-pick.tsx
+++ b/app/src/ui/multi-commit-operation/cherry-pick.tsx
@@ -160,7 +160,7 @@ export abstract class CherryPick extends BaseMultiCommitOperation {
     }
 
     const { commits, sourceBranch } = operationDetail
-
+    dispatcher.setMultiCommitOperationTargetBranch(repository, targetBranch)
     dispatcher.setCherryPickBranchCreated(repository, false)
     dispatcher.cherryPick(repository, targetBranch, commits, sourceBranch)
   }


### PR DESCRIPTION
Closes #13849

## Description
I think this may have been a regression from a different bug fix. :/ But, when initializing the target branch for a context menu, it was setting the source and target to the current branch. Target should be null at this point, because the user has not yet selected a target branch. Then, upon selecting the target branch the cherry pick state needs to be updated to reflect that.

### Screenshots
https://user-images.githubusercontent.com/75402236/153201748-af7a9675-27e9-4936-855d-aa15f0def677.mov

## Release notes
Notes: [Fixed] Cherry-pick success message always correctly reflects target branch.
