### PR TITLE
Select Integration Tab Automatically when Changing Default Editor 

### DIFF
--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -277,7 +277,7 @@ export class NoChanges extends React.Component<
   private openIntegrationPreferences = () => {
     this.props.dispatcher.showPopup({
       type: PopupType.Preferences,
-      initialSelectedTab: PreferencesTab.Integrations
+      initialSelectedTab: PreferencesTab.Integrations,
     })
   }
 

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -8,7 +8,6 @@ import { IMenu, MenuItem } from '../../models/app-menu'
 import memoizeOne from 'memoize-one'
 import { getPlatformSpecificNameOrSymbolForModifier } from '../../lib/menu-item'
 import { MenuBackedSuggestedAction } from '../suggested-actions'
-import { executeMenuItemById } from '../main-process-proxy'
 import { IRepositoryState } from '../../lib/app-state'
 import { TipState, IValidBranch } from '../../models/tip'
 import { Ref } from '../lib/ref'
@@ -18,6 +17,8 @@ import { isCurrentBranchForcePush } from '../../lib/rebase'
 import { StashedChangesLoadStates } from '../../models/stash-entry'
 import { Dispatcher } from '../dispatcher'
 import { SuggestedActionGroup } from '../suggested-actions'
+import { PreferencesTab } from '../../models/preferences'
+import { PopupType } from '../../models/popup'
 
 function formatMenuItemLabel(text: string) {
   if (__WIN32__ || __LINUX__) {
@@ -273,8 +274,11 @@ export class NoChanges extends React.Component<
   private onViewOnGitHubClicked = () =>
     this.props.dispatcher.recordSuggestedStepViewOnGitHub()
 
-  private openPreferences = () => {
-    executeMenuItemById('preferences')
+  private openIntegrationPreferences = () => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.Preferences,
+      initialSelectedTab: PreferencesTab.Integrations
+    })
   }
 
   private renderOpenInExternalEditor() {
@@ -302,7 +306,7 @@ export class NoChanges extends React.Component<
     const description = (
       <>
         Select your editor in{' '}
-        <LinkButton onClick={this.openPreferences}>
+        <LinkButton onClick={this.openIntegrationPreferences}>
           {__DARWIN__ ? 'Preferences' : 'Options'}
         </LinkButton>
       </>


### PR DESCRIPTION
## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
![image](https://user-images.githubusercontent.com/56562649/153289119-77aa4e53-a090-4bc4-be9e-7f5ecbbd266d.png)
Currently, selecting `Options` to change your default editor will open the options menu but wouldn't select the Integrations tab automatically, which is what most users would want when changing their editor.

This PR will have the options menu open with the Integrations Tab.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes