### PR TITLE
Auto apply bug label to bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41B Bug report"
 about: Report a bug while using GitHub Desktop. The full template is required.
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

The bug report issue template, doesn't apply "bug" automatically as a label.

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Add label "bug" automatically as a label when user uses the Bug Report template.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
