### PR TITLE
Format abbrev relative time same as verbose

### DIFF
--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -91,14 +91,13 @@ export class RelativeTime extends React.Component<
     const diff = then.diff(now)
     const duration = Math.abs(diff)
     const absoluteText = then.format('LLLL')
-    const relativeText =
-      this.props.abbreviate === true
-        ? moment
-            .duration(duration, 'milliseconds')
-            .format('y[y] M[m] w[w] d[d] h[h] m[m]', {
-              largest: 1,
-            })
-        : then.from(now)
+    const format = this.props.abbreviate
+      ? 'y[y] M[m] w[w] d[d] h[h] m[m]'
+      : 'y [years] ago M [months] ago d [days] ago h [hours] ago m [minutes] ago'
+
+    const relativeText = moment
+      .duration(duration, 'milliseconds')
+      .format(format, { largest: 1 })
 
     // Future date, let's just show as absolute and reschedule. If it's less
     // than a minute into the future we'll treat it as 'just now'.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13862

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Use the same logic to format both long and abbreviated relative dates. I've opted to use the logic we currently use in the commit list as we haven't had any issues reported regarding its accuracy that I know of.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/634063/153590675-f949fd64-6dcb-4094-a81e-8a82cf3d2c5f.png)

#### After
![image](https://user-images.githubusercontent.com/634063/153590790-32bf2a81-f87f-4fc8-be3d-7775130aac0b.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
