### PR TITLE
Implement retrieving Actions Workflow Runs via check suite id

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1066,7 +1066,7 @@ export class API {
    * List workflow runs for a repository filtered by branch and event type of
    * pull_request
    */
-  public async fetchPRWorkflowRuns(
+  public async fetchPRWorkflowRunsByBranchName(
     owner: string,
     name: string,
     branchName: string
@@ -1083,6 +1083,43 @@ export class API {
     } catch (err) {
       log.debug(
         `Failed fetching workflow runs for ${branchName} (${owner}/${name})`
+      )
+    }
+    return null
+  }
+
+  /**
+   * Return the workflow run for a given check_suite_id.
+   *
+   * A check suite is a reference for a set check runs.
+   * A workflow run is a reference for set a of workflows for the GitHub Actions
+   * check runner.
+   *
+   * If a check suite is comprised of check runs ran by actions, there will be
+   * one workflow run that represents that check suite. Thus, if this api should
+   * eitehr return an empty array indicating there are no actions runs for that
+   * check_suite_id (so check suite was not ran by actions) or an array with a
+   * single element.
+   */
+  public async fetchPRActionWorkflowRunByCheckSuiteId(
+    owner: string,
+    name: string,
+    checkSuiteId: number
+  ): Promise<IAPIWorkflowRun | null> {
+    const path = `repos/${owner}/${name}/actions/runs?event=pull_request&check_suite_id=${checkSuiteId}`
+    const customHeaders = {
+      Accept: 'application/vnd.github.antiope-preview+json',
+    }
+    const response = await this.request('GET', path, { customHeaders })
+    try {
+      const apiWorkflowRuns = await parsedResponse<IAPIWorkflowRuns>(response)
+
+      if (apiWorkflowRuns.workflow_runs.length > 0) {
+        return apiWorkflowRuns.workflow_runs[0]
+      }
+    } catch (err) {
+      log.debug(
+        `Failed fetching workflow runs for ${checkSuiteId} (${owner}/${name})`
       )
     }
     return null

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1097,7 +1097,7 @@ export class API {
    *
    * If a check suite is comprised of check runs ran by actions, there will be
    * one workflow run that represents that check suite. Thus, if this api should
-   * eitehr return an empty array indicating there are no actions runs for that
+   * either return an empty array indicating there are no actions runs for that
    * check_suite_id (so check suite was not ran by actions) or an array with a
    * single element.
    */

--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -160,8 +160,8 @@ export const supportsRerunningChecks = endpointSatisfies({
  */
 export const supportsRetrieveActionWorkflowByCheckSuiteId = endpointSatisfies({
   dotcom: true,
-  ae: '>= 3.4.0',
-  es: '>= 3.4.0',
+  ae: false,
+  es: false,
 })
 
 export const supportsAliveSessions = endpointSatisfies({

--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -154,6 +154,16 @@ export const supportsRerunningChecks = endpointSatisfies({
   es: '>= 3.4.0',
 })
 
+/**
+ * Whether or not the endpoint supports the retrieval of action workflows by
+ * check suite id.
+ */
+export const supportsRetrieveActionWorkflowByCheckSuiteId = endpointSatisfies({
+  dotcom: true,
+  ae: '>= 3.4.0',
+  es: '>= 3.4.0',
+})
+
 export const supportsAliveSessions = endpointSatisfies({
   dotcom: true,
   ae: false,

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -506,9 +506,8 @@ export class CommitStatusStore {
       return checkRuns
     }
 
-    const api = API.fromAccount(account)
     return getCheckRunActionsWorkflowRuns(
-      api,
+      account,
       owner,
       name,
       branchName,

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -312,7 +312,7 @@ export class PullRequestChecksFailed extends React.Component<
       a check run does not have action logs to retrieve/parse.
     */
     const checkRunsWithActionsUrls = await getCheckRunActionsWorkflowRuns(
-      api,
+      account,
       gitHubRepository.owner.login,
       gitHubRepository.name,
       pullRequest.head.ref,


### PR DESCRIPTION
## Description

Currently, for retrieving GitHub Action info/steps about check runs for a PR, we use an Action's api query to get all the Action Workflow Runs for a repo filtered on the PR branch name. This works for most cases. But, we found in the case of a release branch that might look like `releases/some.version` and when we release that branch, an auto generated `releases_random number stuff` is made that has the check runs that actually publish the release. Thus, in that case, we would not get information about the release check runs. This will result in these check runs being under a group header `Other` and not having the Action Workflow steps displayed. 

Other code maintenance pitfalls about this approach is that when we query with branch name and the PR Action workflows have been rerun many times for multiple commits, this will retrieve all of them and thus we have to client side filter down to the latest one before then matching the Action workflow runs to the check runs based on their `check_suite_id`. 

Fortunately, the Actions team helped us out and [added an additional query parameter](https://github.com/github/github/pull/205075) to the same Action's api query to filter by the `check_suite_id` that we ultimately match the check runs by. Thank you @soelinn!

This PR switches our approach to using the new `check_suite_id` query parameter. However, this new api query will not be on GHE until next version; thus, I added an GHE endpoint capability flag and I have kept the original approach for those users 

### Screenshots

![Screen Shot 2022-02-11 at 9 35 39 AM](https://user-images.githubusercontent.com/75402236/153611130-d06462d6-fa43-42fb-8791-858d236d28a6.png)

## Release notes
Notes: [Improved] The check runs list for pull requests with multiple branches displays all actions workflow steps and headers.