### PR TITLE
Fix duplicated first character on Windows when dealing with submodules or repos-within-repos

### DIFF
--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -141,9 +141,9 @@ export function truncatePath(path: string, length: number) {
 export function extract(
   normalizedPath: string
 ): { normalizedFileName: string; normalizedDirectory: string } {
-  // for directories the status entry is returned as a path with a trailing
-  // which causes the directory to be trimmed in a weird way below. let's try
-  // and resolve this here
+  // for untracked submodules the status entry is returned as a path with a
+  // trailing path separator which causes the directory to be trimmed in a weird
+  // way below. let's try to resolve this here
   normalizedPath = normalizedPath.endsWith(Path.sep)
     ? normalizedPath.substring(0, normalizedPath.length - 1)
     : normalizedPath

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -86,8 +86,8 @@ export function truncateMid(value: string, length: number) {
   }
 
   const mid = (length - 1) / 2
-  const pre = value.substr(0, Math.floor(mid))
-  const post = value.substr(value.length - Math.ceil(mid))
+  const pre = value.substring(0, Math.floor(mid))
+  const post = value.substring(value.length - Math.ceil(mid))
 
   return `${pre}…${post}`
 }
@@ -127,8 +127,8 @@ export function truncatePath(path: string, length: number) {
     return truncateMid(path, length)
   }
 
-  const pre = path.substr(0, length - filenameLength - 2)
-  const post = path.substr(lastSeparator)
+  const pre = path.substring(0, length - filenameLength - 2)
+  const post = path.substring(lastSeparator)
 
   return `${pre}…${post}`
 }
@@ -145,11 +145,11 @@ export function extract(
   // which causes the directory to be trimmed in a weird way below. let's try
   // and resolve this here
   normalizedPath = normalizedPath.endsWith(Path.sep)
-    ? normalizedPath.substr(0, normalizedPath.length - 1)
+    ? normalizedPath.substring(0, normalizedPath.length - 1)
     : normalizedPath
 
   const normalizedFileName = Path.basename(normalizedPath)
-  const normalizedDirectory = normalizedPath.substr(
+  const normalizedDirectory = normalizedPath.substring(
     0,
     normalizedPath.length - normalizedFileName.length
   )
@@ -215,8 +215,8 @@ function createPathDisplayState(
     }
   }
 
-  const fileText = truncatedPath.substr(directoryLength)
-  const directoryText = truncatedPath.substr(0, directoryLength)
+  const fileText = truncatedPath.substring(directoryLength)
+  const directoryText = truncatedPath.substring(0, directoryLength)
 
   return { normalizedPath, directoryText, fileText, length }
 }

--- a/app/src/ui/lib/path-text.tsx
+++ b/app/src/ui/lib/path-text.tsx
@@ -141,10 +141,10 @@ export function truncatePath(path: string, length: number) {
 export function extract(
   normalizedPath: string
 ): { normalizedFileName: string; normalizedDirectory: string } {
-  // for untracked submodules, the status entry is returned as a directory,
-  // with a trailing / which causes the directory to be trimmed in a weird way
-  // below. let's try and resolve this here
-  normalizedPath = normalizedPath.endsWith('/')
+  // for directories the status entry is returned as a path with a trailing
+  // which causes the directory to be trimmed in a weird way below. let's try
+  // and resolve this here
+  normalizedPath = normalizedPath.endsWith(Path.sep)
     ? normalizedPath.substr(0, normalizedPath.length - 1)
     : normalizedPath
 

--- a/app/test/unit/path-text-test.ts
+++ b/app/test/unit/path-text-test.ts
@@ -84,7 +84,7 @@ describe('PathText', () => {
       )
       expect(normalizedFileName).toBe('path')
       expect(normalizedDirectory).toBe(
-        __WIN32__ ? 'some\\submodule' : 'some/submodule/'
+        __WIN32__ ? 'some\\submodule\\' : 'some/submodule/'
       )
     })
 

--- a/app/test/unit/path-text-test.ts
+++ b/app/test/unit/path-text-test.ts
@@ -80,26 +80,32 @@ describe('PathText', () => {
   describe('extract', () => {
     it('converts untracked submodule correctly', () => {
       const { normalizedFileName, normalizedDirectory } = extract(
-        'some/submodule/path/'
+        __WIN32__ ? 'some\\submodule\\path\\' : 'some/submodule/path/'
       )
       expect(normalizedFileName).toBe('path')
-      expect(normalizedDirectory).toBe('some/submodule/')
+      expect(normalizedDirectory).toBe(
+        __WIN32__ ? 'some\\submodule' : 'some/submodule/'
+      )
     })
 
     it('converts tracked submodule correctly', () => {
       const { normalizedFileName, normalizedDirectory } = extract(
-        'some/submodule/path'
+        __WIN32__ ? 'some\\submodule\\path' : 'some/submodule/path'
       )
       expect(normalizedFileName).toBe('path')
-      expect(normalizedDirectory).toBe('some/submodule/')
+      expect(normalizedDirectory).toBe(
+        __WIN32__ ? 'some\\submodule\\' : 'some/submodule/'
+      )
     })
 
     it('converts file path correctly', () => {
       const { normalizedFileName, normalizedDirectory } = extract(
-        'some/repository/path.tsx'
+        __WIN32__ ? 'some\\repository\\path.tsx' : 'some/repository/path.tsx'
       )
       expect(normalizedFileName).toBe('path.tsx')
-      expect(normalizedDirectory).toBe('some/repository/')
+      expect(normalizedDirectory).toBe(
+        __WIN32__ ? 'some\\repository\\' : 'some/repository/'
+      )
     })
   })
 })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #12314

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

When running `git status` on a repository with untracked submodules (or folders containing `.git` folders, i.e. repositories within repositories) Git will report the path with a trailing slash (i.e. `repo-a/` instead of `repo-a`). This caused our path text component to mistakenly treat the first character of the path as the directory name

https://github.com/desktop/desktop/blob/ab48d526da6feb6a47fa9a4f4a77eaaf9293cc35/app/src/ui/lib/path-text.tsx#L151-L155

There was an attempt to solve this in https://github.com/desktop/desktop/pull/785 but unfortunately that PR didn't account for the fact that Windows uses `\` as its path separator character and not `/`.

This PR updates the code to be platform agnostic by leveraging `Path.sep`.

Note that users will still not be able to commit these repositories within repositories but that's a separate issue concerning our support for submodules and how best to handle repositories within repositories.

The fix for this is contained in 4f33cd66ea2ec312e0bf74f8cfe8b5a5aea8eefc but I also took the opportunity to swap out our uses of `.substr` (which is now deprecated) in favor of `.substring`

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/634063/154043685-6ae39965-644d-4b6d-8668-df514035a58f.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Repositories containing untracked submodules no longer display an duplicated first character on Windows