### PR TITLE
Await moveToApplicationsFolder invocation on main process

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -72,7 +72,6 @@ export type RequestChannels = {
   'auto-updater-update-downloaded': () => void
   'native-theme-updated': () => void
   'set-native-theme-source': (themeName: ThemeSource) => void
-  'move-to-applications-folder': () => void
   'focus-window': () => void
 }
 
@@ -97,6 +96,7 @@ export type RequestResponseChannels = {
   'is-window-focused': () => Promise<boolean>
   'open-external': (path: string) => Promise<boolean>
   'is-in-application-folder': () => Promise<boolean | null>
+  'move-to-applications-folder': () => Promise<void>
   'check-for-updates': (url: string) => Promise<Error | undefined>
   'get-current-window-state': () => Promise<WindowState | undefined>
   'get-current-window-zoom-factor': () => Promise<number | undefined>

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -576,7 +576,7 @@ app.on('ready', () => {
    * An event sent by the renderer asking to move the app to the application
    * folder
    */
-  ipcMain.on('move-to-applications-folder', () => {
+  ipcMain.handle('move-to-applications-folder', async () => {
     app.moveToApplicationsFolder?.()
   })
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1375,8 +1375,9 @@ export class Dispatcher {
     return this.appStore.setStatsOptOut(optOut, userViewedPrompt)
   }
 
+  /** Moves the app to the /Applications folder on macOS. */
   public moveToApplicationsFolder() {
-    moveToApplicationsFolder()
+    return moveToApplicationsFolder()
   }
 
   /**

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -217,7 +217,7 @@ export function sendWillQuitSync() {
 /**
  * Tell the main process to move the application to the application folder
  */
-export const moveToApplicationsFolder = sendProxy(
+export const moveToApplicationsFolder = invokeProxy(
   'move-to-applications-folder',
   0
 )

--- a/app/src/ui/move-to-applications-folder.tsx
+++ b/app/src/ui/move-to-applications-folder.tsx
@@ -97,11 +97,11 @@ export class MoveToApplicationsFolder extends React.Component<
     )
   }
 
-  private onSubmit = () => {
+  private onSubmit = async () => {
     this.props.onDismissed()
 
     try {
-      this.props.dispatcher.moveToApplicationsFolder()
+      await this.props.dispatcher.moveToApplicationsFolder()
     } catch (error) {
       this.props.dispatcher.postError(error)
     }


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in https://github.com/desktop/desktop/pull/13752, where moving the invocation of `app.moveToApplicationsFolder` to the main process prevented the renderer process from catching exceptions.
It required to change the proxy `moveToApplicationsFolder` function from a "send" type to an "invoke" type, and then make sure the `Promise` is bubbled up and awaited from the `MoveToApplicationsFolder` dialog.

## Release notes

Notes: [Fixed] Fix crash when attempting to move the app to the /Applications folder on macOS
