### PR TITLE
Update uninstall iconURL path

### DIFF
--- a/script/package.ts
+++ b/script/package.ts
@@ -83,7 +83,8 @@ function packageWindows() {
     process.exit(1)
   }
 
-  const iconUrl = 'https://desktop.githubusercontent.com/app-icon.ico'
+  const iconUrl =
+    'https://desktop.githubusercontent.com/github-desktop/app-icon.ico'
 
   const nugetPkgName = getWindowsIdentifierName()
   const options: electronInstaller.Options = {


### PR DESCRIPTION
## Description
When the cdn was updated to azure, blobs containers had to be specified by the name unlike aws. Evidently missed this reference to the cdn.

This fixes this install error:
`[14-02-22 15:23:12] info: InstallHelperImpl: Couldn't write uninstall icon, don't care: System.Net.WebException: The remote server returned an error: (404) Not Found. `

Side note.. I think at the time I tried to make the cdn point to the container name as the root so that updates like this shouldn't be needed, but there was an issue with the cdn health check.


## Release notes
Notes: no-notes
