### PR TITLE
Discarding changes displays error

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4360,7 +4360,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.emitError(
         new Error(
-          `Failed to discard changes to ${TrashNameLabel}.\n\nA common reason for this is that the directory or one of its files is open in another program or the ${TrashNameLabel} is set to delete items immediately.`
+          `Failed to discard changes to ${TrashNameLabel}.\n\nA common reason for this is that the ${TrashNameLabel} is set to delete items immediately.`
         )
       )
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4360,7 +4360,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.emitError(
         new Error(
-          `Failed to discard changes to ${TrashNameLabel}.\n\nA common reason for this is that the directory or one of its files is open in another program or the your ${TrashNameLabel} is set to delete items immediately.`
+          `Failed to discard changes to ${TrashNameLabel}.\n\nA common reason for this is that the directory or one of its files is open in another program or the ${TrashNameLabel} is set to delete items immediately.`
         )
       )
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4352,7 +4352,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
     files: ReadonlyArray<WorkingDirectoryFileChange>
   ) {
     const gitStore = this.gitStoreCache.get(repository)
-    await gitStore.discardChanges(files)
+
+    try {
+      await gitStore.discardChanges(files)
+    } catch (error) {
+      log.error('Failed discarding changes', error)
+
+      this.emitError(
+        new Error(
+          `Failed to discard changes to ${TrashNameLabel}.\n\nA common reason for this is that the directory or one of its files is open in another program or the your ${TrashNameLabel} is set to delete items immediately.`
+        )
+      )
+    }
 
     return this._refreshRepository(repository)
   }


### PR DESCRIPTION
Partially addresses #13888

## Description

An issue reported in 2.9.7 which is a result of the Electron upgrade is that discarding changes may now fail if the user has their recycling bin set to "Don't move files to the Recycle Bin. Remove files immediately when deleted". It is a bad failure case in that the application just hangs and must be force quitted. This PR captures the error thrown my the electron `shell.trashItem()` method and informs the user of the failure.

I marked this as partially addressing #13888. This is because in prior versions of Desktop on an Electron version prior to 13, the trashItem method did not error and simply did not move the files to the Recycle Bin (silently failing). This a bug because we expected the files to be moved to the recycle bin and we inform users of this on the discard pop up. However, to only display error here feels like a regression as we are preventing users from discarding changes when they used to be able to. 

### Screenshots
![image](https://user-images.githubusercontent.com/75402236/154127752-3405cd4e-1cc3-4538-bdc5-21eed2bc1fe7.png)


## Release notes

Notes: [Fixed] App does not hang when discarding changes in some scenarios.
