### PR TITLE
Tokenize unicode emoji

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.104.0",
     "electron-window-state": "^5.0.3",
+    "emoji-regex": "^10.0.0",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",
     "file-uri-to-path": "^2.0.0",

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -69,7 +69,10 @@ export function wrapRichTextCommitMessage(
         // complex for now.
         summary.push(text(token.text.substr(0, remainder)))
         overflow.push(text(token.text.substr(remainder)))
-      } else if (token.kind === TokenType.Emoji) {
+      } else if (
+        token.kind === TokenType.Emoji ||
+        token.kind === TokenType.UnicodeEmoji
+      ) {
         // Can't hard-wrap inside an emoji
         overflow.push(token)
       } else if (token.kind === TokenType.Link) {

--- a/app/src/ui/lib/rich-text.tsx
+++ b/app/src/ui/lib/rich-text.tsx
@@ -67,6 +67,12 @@ function getElements(
         }
       case TokenType.Text:
         return <span key={index}>{token.text}</span>
+      case TokenType.UnicodeEmoji:
+        return (
+          <span key={index} className="unicode-emoji">
+            {token.text}
+          </span>
+        )
       default:
         return assertNever(token, `Unknown token type: ${token}`)
     }

--- a/app/styles/ui/_emoji.scss
+++ b/app/styles/ui/_emoji.scss
@@ -3,3 +3,9 @@
   height: 16px;
   vertical-align: text-bottom;
 }
+
+.unicode-emoji {
+  // See https://github.com/desktop/desktop/issues/13911#issuecomment-1041360884
+  // Can be removed once we move to Electron 17+
+  font-weight: normal;
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -471,6 +471,11 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
+emoji-regex@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.0.0.tgz#96559e19f82231b436403e059571241d627c42b8"
+  integrity sha512-KmJa8l6uHi1HrBI34udwlzZY1jOEuID/ft4d8BSSEdRyap7PwBEt910453PJa5MuGvxkLqlt4Uvhu7tttFHViw==
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13911 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This works around the Chromium bug described in https://github.com/desktop/desktop/issues/13911#issuecomment-1041360884 by wrapping all unicode emoji sequences in a `span` with the `unicode-emoji` class on it. That way we can select all unicode emoji ranges in CSS and explicitly set their font weight.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Unicode emoji on Windows no longer render as monochrome outlines