### PR TITLE
Handle trampoline data weirdness more gracefully

### DIFF
--- a/app/src/lib/trampoline/trampoline-command-parser.ts
+++ b/app/src/lib/trampoline/trampoline-command-parser.ts
@@ -106,8 +106,7 @@ export class TrampolineCommandParser {
       const error = new Error(
         'The command cannot be generated if parsing is not finished'
       )
-      log.error('Error creating trampoline command:', error)
-      sendNonFatalException('trampolineCommandParser', error)
+      this.logCommandCreationError(error)
       return null
     }
 
@@ -121,8 +120,7 @@ export class TrampolineCommandParser {
           this.environmentVariables.keys()
         )}`
       )
-      log.error('Error creating trampoline command:', error)
-      sendNonFatalException('trampolineCommandParser', error)
+      this.logCommandCreationError(error)
       return null
     }
 
@@ -135,8 +133,7 @@ export class TrampolineCommandParser {
       const error = new Error(
         `The command identifier ${identifierString} is not supported`
       )
-      log.error('Error creating trampoline command:', error)
-      sendNonFatalException('trampolineCommandParser', error)
+      this.logCommandCreationError(error)
       return null
     }
 
@@ -146,8 +143,7 @@ export class TrampolineCommandParser {
 
     if (trampolineToken === undefined) {
       const error = new Error(`The trampoline token is missing`)
-      log.error('Error creating trampoline command:', error)
-      sendNonFatalException('trampolineCommandParser', error)
+      this.logCommandCreationError(error)
       return null
     }
 
@@ -157,5 +153,10 @@ export class TrampolineCommandParser {
       parameters: this.parameters,
       environmentVariables: this.environmentVariables,
     }
+  }
+
+  private logCommandCreationError(error: Error) {
+    log.error('Error creating trampoline command:', error)
+    sendNonFatalException('trampolineCommandParser', error)
   }
 }

--- a/app/src/lib/trampoline/trampoline-command-parser.ts
+++ b/app/src/lib/trampoline/trampoline-command-parser.ts
@@ -1,4 +1,5 @@
 import { parseEnumValue } from '../enum'
+import { sendNonFatalException } from '../helpers/non-fatal-exception'
 import {
   ITrampolineCommand,
   TrampolineCommandIdentifier,
@@ -97,14 +98,17 @@ export class TrampolineCommandParser {
   /**
    * Returns a command.
    *
-   * Throws an error if the parser hasn't finished yet, or if the identifier
+   * It will return null if the parser hasn't finished yet, or if the identifier
    * is missing or invalid.
    **/
-  public toCommand(): ITrampolineCommand {
+  public toCommand(): ITrampolineCommand | null {
     if (this.hasFinished() === false) {
-      throw new Error(
+      const error = new Error(
         'The command cannot be generated if parsing is not finished'
       )
+      log.error('Error creating trampoline command:', error)
+      sendNonFatalException('trampolineCommandParser', error)
+      return null
     }
 
     const identifierString = this.environmentVariables.get(
@@ -112,7 +116,14 @@ export class TrampolineCommandParser {
     )
 
     if (identifierString === undefined) {
-      throw new Error('The command identifier is missing')
+      const error = new Error(
+        `The command identifier is missing. Env variables received: ${Array.from(
+          this.environmentVariables.keys()
+        )}`
+      )
+      log.error('Error creating trampoline command:', error)
+      sendNonFatalException('trampolineCommandParser', error)
+      return null
     }
 
     const identifier = parseEnumValue(
@@ -121,9 +132,12 @@ export class TrampolineCommandParser {
     )
 
     if (identifier === undefined) {
-      throw new Error(
+      const error = new Error(
         `The command identifier ${identifierString} is not supported`
       )
+      log.error('Error creating trampoline command:', error)
+      sendNonFatalException('trampolineCommandParser', error)
+      return null
     }
 
     const trampolineToken = this.environmentVariables.get(
@@ -131,7 +145,10 @@ export class TrampolineCommandParser {
     )
 
     if (trampolineToken === undefined) {
-      throw new Error(`The trampoline token is missing`)
+      const error = new Error(`The trampoline token is missing`)
+      log.error('Error creating trampoline command:', error)
+      sendNonFatalException('trampolineCommandParser', error)
+      return null
     }
 
     return {

--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -131,9 +131,17 @@ export class TrampolineServer {
     const value = data.toString('utf8')
     parser.processValue(value)
 
-    if (parser.hasFinished()) {
-      this.processCommand(socket, parser.toCommand())
+    if (!parser.hasFinished()) {
+      return
     }
+
+    const command = parser.toCommand()
+    if (command === null) {
+      socket.end()
+      return
+    }
+
+    this.processCommand(socket, command)
   }
 
   /**

--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -185,7 +185,7 @@ export class TrampolineServer {
   }
 
   private onClientError = (error: Error) => {
-    console.error('Trampoline client error', error)
+    log.error('Trampoline client error', error)
   }
 }
 


### PR DESCRIPTION
## Description

We've seen many app crashes due to connections to the trampoline that didn't have a command identifier (which is required). Instead of crashing the app, this PR will just log the error, send it to Sentry as a non-fatal error with additional debug info (which env variables -but not their values- were passed to the trampoline), and then just close the socket and do nothing.

## Release notes

Notes: [Fixed] Fix random crash under random circumstances??? 🤣  I seriously have no idea how this could happen.
