### PR TITLE
Optimize validating repository when adding existing repository

### DIFF
--- a/app/src/lib/directory-exists.ts
+++ b/app/src/lib/directory-exists.ts
@@ -4,7 +4,11 @@ import { stat } from 'fs/promises'
  * Helper method to stat a path and check both that it exists and that it's
  * a directory.
  */
-export const directoryExists = (path: string) =>
-  stat(path)
-    .catch(null)
-    .then(s => s?.isDirectory() ?? false)
+export const directoryExists = async (path: string) => {
+  try {
+    const s = await stat(path)
+    return s.isDirectory()
+  } catch (e) {
+    return false
+  }
+}

--- a/app/src/lib/directory-exists.ts
+++ b/app/src/lib/directory-exists.ts
@@ -1,0 +1,10 @@
+import { stat } from 'fs/promises'
+
+/**
+ * Helper method to stat a path and check both that it exists and that it's
+ * a directory.
+ */
+export const directoryExists = (path: string) =>
+  stat(path)
+    .catch(null)
+    .then(s => s?.isDirectory() ?? false)

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { Dispatcher } from '../dispatcher'
-import { isGitRepository } from '../../lib/git'
-import { isBareRepository } from '../../lib/git'
+import { getRepositoryType } from '../../lib/git'
 import { Button } from '../lib/button'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -15,7 +14,6 @@ import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 
 import untildify from 'untildify'
 import { showOpenDialog } from '../main-process-proxy'
-import { stat } from 'fs-extra'
 
 interface IAddExistingRepositoryProps {
   readonly dispatcher: Dispatcher
@@ -72,28 +70,39 @@ export class AddExistingRepository extends React.Component<
   }
 
   public async componentDidMount() {
-    const pathToCheck = this.state.path
-    // We'll only have a path at this point if the dialog was opened with a path
-    // to prefill.
-    if (pathToCheck.length < 1) {
+    const { path } = this.state
+
+    if (path.length !== 0) {
+      await this.validatePath(path)
+    }
+  }
+
+  private async updatePath(path: string) {
+    this.setState({ path, isRepository: false })
+    await this.validatePath(path)
+  }
+
+  private async validatePath(path: string) {
+    if (path.length === 0) {
+      this.setState({
+        isRepository: false,
+        isRepositoryBare: false,
+        showNonGitRepositoryWarning: false,
+      })
       return
     }
 
-    const isRepository = await isGitRepository(pathToCheck)
-    // The path might have changed while we were checking, in which case we
-    // don't care about the result anymore.
-    if (this.state.path !== pathToCheck) {
-      return
-    }
+    const type = await getRepositoryType(path)
 
-    const isBare = await isBareRepository(this.state.path)
-    if (isBare === true) {
-      this.setState({ isRepositoryBare: true })
-      return
-    }
+    const isRepository = type !== 'missing'
+    const isRepositoryBare = type === 'bare'
+    const showNonGitRepositoryWarning = !isRepository || isRepositoryBare
 
-    this.setState({ isRepository, showNonGitRepositoryWarning: !isRepository })
-    this.setState({ isRepositoryBare: false })
+    this.setState(state =>
+      path === state.path
+        ? { isRepository, isRepositoryBare, showNonGitRepositoryWarning }
+        : null
+    )
   }
 
   private renderWarning() {
@@ -166,38 +175,10 @@ export class AddExistingRepository extends React.Component<
   }
 
   private onPathChanged = async (path: string) => {
-    this.setState({ path })
-
-    // Fast check to avoid invoking Git
-    const pathExists = await stat(path).catch(_ => null)
-
-    if (!pathExists) {
-      this.setState(state =>
-        state.path === path
-          ? {
-              isRepository: false,
-              isRepositoryBare: false,
-              showNonGitRepositoryWarning: true,
-            }
-          : null
-      )
-      return
+    if (this.state.path !== path) {
+      this.setState({ path, isRepository: false })
+      this.validatePath(path)
     }
-
-    const [isRepository, isRepositoryBare] = await Promise.all([
-      isGitRepository(path),
-      isBareRepository(path),
-    ])
-
-    this.setState(state =>
-      state.path === path
-        ? {
-            isRepository,
-            isRepositoryBare,
-            showNonGitRepositoryWarning: !isRepository || isRepositoryBare,
-          }
-        : null
-    )
   }
 
   private showFilePicker = async () => {
@@ -209,15 +190,7 @@ export class AddExistingRepository extends React.Component<
       return
     }
 
-    const isRepository = await isGitRepository(path)
-    const isRepositoryBare = await isBareRepository(path)
-
-    this.setState({
-      path,
-      isRepository,
-      showNonGitRepositoryWarning: !isRepository || isRepositoryBare,
-      isRepositoryBare,
-    })
+    this.updatePath(path)
   }
 
   private resolvedPath(path: string): string {

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -174,7 +174,11 @@ export class AddExistingRepository extends React.Component<
     if (!pathExists) {
       this.setState(state =>
         state.path === path
-          ? { isRepository: false, isRepositoryBare: false }
+          ? {
+              isRepository: false,
+              isRepositoryBare: false,
+              showNonGitRepositoryWarning: true,
+            }
           : null
       )
       return

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -190,7 +190,7 @@ export class AddExistingRepository extends React.Component<
         ? {
             isRepository,
             isRepositoryBare,
-            showNonGitRepositoryWarning: !isRepository || !isRepositoryBare,
+            showNonGitRepositoryWarning: !isRepository || isRepositoryBare,
           }
         : null
     )

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -176,8 +176,7 @@ export class AddExistingRepository extends React.Component<
 
   private onPathChanged = async (path: string) => {
     if (this.state.path !== path) {
-      this.setState({ path, isRepository: false })
-      this.validatePath(path)
+      this.updatePath(path)
     }
   }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13901

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This takes care of the race condition in add-existing-repository where we would update the state with the new path only after having received the response from `git rev-parse`.

This also optimizes the validation process by checking if the path exists before spawning Git (significantly faster on Windows) and by leveraging `rev-parse` to both check if the repository exists _and_ if it's a bare repository instead of doing it twice.

Finally it reuses the logic to update and validate the path which was previously duplicated between the different methods of updating path (component mount, file picked, and manual input)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
