### PR TITLE
Fix "Create new repository" using the wrong path

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -116,7 +116,10 @@ export class CreateRepository extends React.Component<
       isRepository: false,
       readMeExists: false,
     }
-    this.initializePath()
+
+    if (path === null) {
+      this.initializePath()
+    }
   }
 
   public async componentDidMount() {


### PR DESCRIPTION
Closes #13909

## Description

This PR fixes a subtle regression introduced in https://github.com/desktop/desktop/pull/13804

The problem is we were always picking the default app path even when the dialog was created with an initial path.

## Release notes

Notes: [Fixed] "Create New Repository" dialog preserves the path set from "Add Local Repository" dialog
