### PR TITLE
Upgrade to Electron 17.0.1

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 16.0.8
+target = 17.0.1

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "=16.0.8",
+    "electron": "17.0.1",
     "electron-builder": "^22.7.0",
     "electron-packager": "^15.1.0",
     "electron-winstaller": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,10 +3933,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@=16.0.8:
-  version "16.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.0.8.tgz#7ebd3e23c4883c239f53d8b7af1100f455ac8a02"
-  integrity sha512-znTVkl8LaGcPNdfc6SRr+6LYg2GtSCKXln/nW/PC+urBfAFnOYIuDock8QyGVFfzr5PuAa+g8YQQAboHV77D7g==
+electron@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.0.1.tgz#e6c7ad2be26e7be8a5a9bac16b21920ad2671224"
+  integrity sha512-CBReR/QEOpgwMdt59lWCtj9wC8oHB6aAjMF1lhXcGew132xtp+C5N6EaXb/fmDceVYLouziYjbNcpeXsWrqdpA==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
## Description
We recently released Electron 16.0.8 and have found users hitting [a chromium bug](https://github.com/electron/electron/issues/32440)  where [they cannot launch the app.](https://github.com/desktop/desktop/issues/13906). With a test build, these users have been able to launch the app with Electron 17.0.1. 

## Release notes
Notes: Bump to Electron 17.0.1
