### PR TITLE
Release 2.9.9

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,3 +1,3 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 16.0.8
+target = 17.0.1

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.8",
+  "version": "2.9.9-beta1",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.9-beta1",
+  "version": "2.9.9",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -116,7 +116,10 @@ export class CreateRepository extends React.Component<
       isRepository: false,
       readMeExists: false,
     }
-    this.initializePath()
+
+    if (path === null) {
+      this.initializePath()
+    }
   }
 
   public async componentDidMount() {

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,10 @@
 {
   "releases": {
+    "2.9.9": [
+      "[Fixed] \"Create New Repository\" dialog preserves the path set from \"Add Local Repository\" dialog - #13928",
+      "[Fixed] User guides now opens the correct page - #13920",
+      "[Fixed] Fixes crash on some Windows machines - #13930"
+    ],
     "2.9.9-beta1": [
       "[Fixed] App no longer crashes intermittently when running remote Git operations - #13916",
       "[Fixed] Unicode emoji on Windows no longer render as monochrome outlines - #13914",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 {
   "releases": {
+    "2.9.9-beta1": [
+      "[Fixed] App no longer crashes intermittently when running remote Git operations - #13916",
+      "[Fixed] Unicode emoji on Windows no longer render as monochrome outlines - #13914",
+      "[Fixed] App no longer hangs when discarding changes in some scenarios - #13899",
+      "[Fixed] App no longer crashes intermittently when rebasing and cherry-picking - #13889",
+      "[Fixed] Fix crash when attempting to move the app to the /Applications folder on macOS - #13886",
+      "[Fixed] App no longer crashes when checking for updates while the closing the window - #13892",
+      "[Fixed] Restore application icon in \"Apps & Features\" on Windows - #13890",
+      "[Improved] Relative dates in branch menu and commit history match - #13867"
+    ],
     "2.9.8": [
       "[Fixed] Unicode emoji on Windows no longer render as monochrome outlines - #13914",
       "[Fixed] App no longer hangs when discarding changes in some scenarios - #13899",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@types/webpack-merge": "^4.1.3",
     "@types/winston": "^2.2.0",
     "@types/xml2js": "^0.4.0",
-    "electron": "=16.0.8",
+    "electron": "17.0.1",
     "electron-builder": "^22.7.0",
     "electron-packager": "^15.1.0",
     "electron-winstaller": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,10 +3933,10 @@ electron-winstaller@*, electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@=16.0.8:
-  version "16.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.0.8.tgz#7ebd3e23c4883c239f53d8b7af1100f455ac8a02"
-  integrity sha512-znTVkl8LaGcPNdfc6SRr+6LYg2GtSCKXln/nW/PC+urBfAFnOYIuDock8QyGVFfzr5PuAa+g8YQQAboHV77D7g==
+electron@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.0.1.tgz#e6c7ad2be26e7be8a5a9bac16b21920ad2671224"
+  integrity sha512-CBReR/QEOpgwMdt59lWCtj9wC8oHB6aAjMF1lhXcGew132xtp+C5N6EaXb/fmDceVYLouziYjbNcpeXsWrqdpA==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming v2.9.9 production release? Well you've just found it, congratulations! :tada:

This is based on development up to 307cdc993 which has #13920 - Fix broken link to user documentation
and then cherry-picked
- #13921 (beta merge for changelog not conflicting.. which didn't work :P can resolve after release)
-  #13928
-  #13930

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
This is a hotfix release to some sentry and user reported issues.
- [x] Verify that all feature flags are flipped appropriately
no changes
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
N/A