### PR TITLE
Add tooltip to show types of file changes in a commit

### DIFF
--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -418,20 +418,29 @@ export class CommitSummary extends React.Component<
     const filesLongDescription = (
       <>
         {filesAdded > 0 ? (
-          <span className="files-added">
-            <Octicon symbol={OcticonSymbol.diffAdded} />
+          <span>
+            <Octicon
+              className="files-added-icon"
+              symbol={OcticonSymbol.diffAdded}
+            />
             {filesAdded} added
           </span>
         ) : null}
         {filesModified > 0 ? (
-          <span className="files-modified">
-            <Octicon symbol={OcticonSymbol.diffModified} />
+          <span>
+            <Octicon
+              className="files-modified-icon"
+              symbol={OcticonSymbol.diffModified}
+            />
             {filesModified} modified
           </span>
         ) : null}
         {filesRemoved > 0 ? (
-          <span className="files-deleted">
-            <Octicon symbol={OcticonSymbol.diffRemoved} />
+          <span>
+            <Octicon
+              className="files-deleted-icon"
+              symbol={OcticonSymbol.diffRemoved}
+            />
             {filesRemoved} deleted
           </span>
         ) : null}

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -417,17 +417,32 @@ export class CommitSummary extends React.Component<
 
     const filesLongDescription = (
       <>
-        {filesAdded ? <li>{filesAdded} added</li> : null}
-        {filesModified ? <li>{filesModified} modified</li> : null}
-        {filesRemoved ? <li>{filesRemoved} deleted</li> : null}
+        {filesAdded > 0 ? (
+          <span className="files-added">
+            <Octicon symbol={OcticonSymbol.diffAdded} />
+            {filesAdded} added
+          </span>
+        ) : null}
+        {filesModified > 0 ? (
+          <span className="files-modified">
+            <Octicon symbol={OcticonSymbol.diffModified} />
+            {filesModified} modified
+          </span>
+        ) : null}
+        {filesRemoved > 0 ? (
+          <span className="files-deleted">
+            <Octicon symbol={OcticonSymbol.diffRemoved} />
+            {filesRemoved} deleted
+          </span>
+        ) : null}
       </>
     )
 
     return (
       <TooltippedContent
-        tagName="li"
         className="commit-summary-meta-item without-truncation"
-        tooltip={filesLongDescription}
+        tooltipClassName="changed-files-description-tooltip"
+        tooltip={fileCount > 0 ? filesLongDescription : undefined}
       >
         <Octicon symbol={OcticonSymbol.diff} />
         {filesShortDescription}

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -180,15 +180,15 @@ body > .tooltip,
       flex-direction: column;
       gap: var(--spacing-third);
 
-      .files-added {
+      .files-added-icon {
         color: var(--color-new);
       }
 
-      .files-modified {
+      .files-modified-icon {
         color: var(--color-modified);
       }
 
-      .files-deleted {
+      .files-deleted-icon {
         color: var(--color-deleted);
       }
 

--- a/app/styles/ui/window/_tooltips.scss
+++ b/app/styles/ui/window/_tooltips.scss
@@ -173,4 +173,29 @@ body > .tooltip,
       }
     }
   }
+
+  &.changed-files-description-tooltip {
+    .tooltip-content {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing-third);
+
+      .files-added {
+        color: var(--color-new);
+      }
+
+      .files-modified {
+        color: var(--color-modified);
+      }
+
+      .files-deleted {
+        color: var(--color-deleted);
+      }
+
+      .octicon {
+        margin-right: var(--spacing-third);
+        vertical-align: bottom; // For some reason, `bottom` places the text in the middle
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
Currently, the tooltip shown when hovering over the number of changed files just repeats the same information:
![image](https://user-images.githubusercontent.com/56562649/154863400-354491f1-ee65-4bca-8909-c18721352a1c.png)

This PR changes the tooltip to show the types of files changes in the commit:
![image](https://user-images.githubusercontent.com/56562649/154863504-b4ee08d6-76f5-4231-8c70-41e328f9e602.png)


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
