### PR TITLE
Never report more than one fatal error

### DIFF
--- a/app/src/main-process/exception-reporting.ts
+++ b/app/src/main-process/exception-reporting.ts
@@ -5,6 +5,8 @@ const ErrorEndpoint = 'https://central.github.com/api/desktop/exception'
 const NonFatalErrorEndpoint =
   'https://central.github.com/api/desktop-non-fatal/exception'
 
+let hasSentFatalError = false
+
 /** Report the error to Central. */
 export async function reportError(
   error: Error,
@@ -13,6 +15,17 @@ export async function reportError(
 ) {
   if (__DEV__) {
     return
+  }
+
+  // We never want to send more than one fatal error (i.e. crash) per
+  // application session. This guards against us ending up in a feedback loop
+  // where the act of reporting a crash triggers another unhandled exception
+  // which causes us to report a crash and so on and so forth.
+  if (nonFatal !== true) {
+    if (hasSentFatalError) {
+      return
+    }
+    hasSentFatalError = true
   }
 
   const data = new Map<string, string>()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Related to #13962, this PR ensures we never spam `central` with more than one fatal error per application session. Our non-fatal errors already have rate-limiting built-in (see https://github.com/desktop/desktop/blob/development/app/src/lib/helpers/non-fatal-exception.ts).

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes