### PR TITLE
24-Hour time format support

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -299,6 +299,11 @@ export interface IAppState {
    * Whether or not the user enabled high-signal notifications.
    */
   readonly notificationsEnabled: boolean
+
+  /**
+   * Whether or not to use 24-Hour date formating.
+   */
+  readonly is24hourFormat: boolean
 }
 
 export enum FoldoutType {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -350,6 +350,7 @@ const InitialRepositoryIndicatorTimeout = 2 * 60 * 1000
 
 const MaxInvalidFoldersToDisplay = 3
 
+export const timeFormatKey = '24hour-time-format'
 const hasShownCherryPickIntroKey = 'has-shown-cherry-pick-intro'
 const dragAndDropIntroTypesShownKey = 'drag-and-drop-intro-types-shown'
 const lastThankYouKey = 'version-and-users-of-last-thank-you'
@@ -471,6 +472,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private lastThankYou: ILastThankYou | undefined
   private showCIStatusPopover: boolean = false
 
+  private is24hourTimeFormat: boolean = false
+
   public constructor(
     private readonly gitHubUserStore: GitHubUserStore,
     private readonly cloningRepositoriesStore: CloningRepositoriesStore,
@@ -498,6 +501,14 @@ export class AppStore extends TypedBaseStore<IAppState> {
       } else {
         this.useWindowsOpenSSH = useWindowsOpenSSH
       }
+    }
+
+    const timeFormat = getBoolean(timeFormatKey)
+
+    if (timeFormat === undefined) {
+      this._setIs24HourTimeFormat(this.is24hourTimeFormat)
+    } else {
+      this.is24hourTimeFormat = timeFormat
     }
 
     this.gitStoreCache = new GitStoreCache(
@@ -887,6 +898,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       lastThankYou: this.lastThankYou,
       showCIStatusPopover: this.showCIStatusPopover,
       notificationsEnabled: getNotificationsEnabled(),
+      is24hourFormat: this.is24hourTimeFormat,
     }
   }
 
@@ -3195,6 +3207,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _setNotificationsEnabled(notificationsEnabled: boolean) {
     this.notificationsStore.setNotificationsEnabled(notificationsEnabled)
+    this.emitUpdate()
+  }
+
+  public _setIs24HourTimeFormat(format: boolean) {
+    setBoolean(timeFormatKey, format)
+    this.is24hourTimeFormat = format
     this.emitUpdate()
   }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1404,6 +1404,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             notificationsEnabled={this.state.notificationsEnabled}
+            is24hourFormat={this.state.is24hourFormat}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             enterpriseAccount={this.getEnterpriseAccount()}
             repository={repository}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2704,6 +2704,10 @@ export class Dispatcher {
     this.appStore._setNotificationsEnabled(notificationsEnabled)
   }
 
+  public setTimeFormat(is24hour: boolean) {
+    this.appStore._setIs24HourTimeFormat(is24hour)
+  }
+
   public recordDiffOptionsViewed() {
     return this.statsStore.recordDiffOptionsViewed()
   }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -12,10 +12,12 @@ interface IAdvancedPreferencesProps {
   readonly useWindowsOpenSSH: boolean
   readonly optOutOfUsageTracking: boolean
   readonly notificationsEnabled: boolean
+  readonly is24hourFormat: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly repositoryIndicatorsEnabled: boolean
   readonly onUseWindowsOpenSSHChanged: (checked: boolean) => void
   readonly onNotificationsEnabledChanged: (checked: boolean) => void
+  readonly onTimeFormatChanged: (checked: boolean) => void
   readonly onOptOutofReportingChanged: (checked: boolean) => void
   readonly onUncommittedChangesStrategyChanged: (
     value: UncommittedChangesStrategy
@@ -85,6 +87,10 @@ export class Advanced extends React.Component<
     this.props.onNotificationsEnabledChanged(event.currentTarget.checked)
   }
 
+  private onTimeFormatChanged = (event: React.FormEvent<HTMLInputElement>) => {
+    this.props.onTimeFormatChanged(event.currentTarget.checked)
+  }
+
   private reportDesktopUsageLabel() {
     return (
       <span>
@@ -148,6 +154,7 @@ export class Advanced extends React.Component<
         </div>
         {this.renderSSHSettings()}
         {this.renderNotificationsSettings()}
+        {this.renderTimeFormatingSettings()}
         <div className="advanced-section">
           <h2>Usage</h2>
           <Checkbox
@@ -178,6 +185,21 @@ export class Advanced extends React.Component<
             this.props.useWindowsOpenSSH ? CheckboxValue.On : CheckboxValue.Off
           }
           onChange={this.onUseWindowsOpenSSHChanged}
+        />
+      </div>
+    )
+  }
+
+  private renderTimeFormatingSettings() {
+    return (
+      <div className="advanced-section">
+        <h2>Time Format</h2>
+        <Checkbox
+          label="Use 24-Hour Time"
+          value={
+            this.props.is24hourFormat ? CheckboxValue.On : CheckboxValue.Off
+          }
+          onChange={this.onTimeFormatChanged}
         />
       </div>
     )

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -49,6 +49,7 @@ interface IPreferencesProps {
   readonly onDismissed: () => void
   readonly useWindowsOpenSSH: boolean
   readonly notificationsEnabled: boolean
+  readonly is24hourFormat: boolean
   readonly optOutOfUsageTracking: boolean
   readonly initialSelectedTab?: PreferencesTab
   readonly confirmRepositoryRemoval: boolean
@@ -73,6 +74,7 @@ interface IPreferencesState {
   readonly disallowedCharactersMessage: string | null
   readonly useWindowsOpenSSH: boolean
   readonly notificationsEnabled: boolean
+  readonly is24hourFormat: boolean
   readonly optOutOfUsageTracking: boolean
   readonly confirmRepositoryRemoval: boolean
   readonly confirmDiscardChanges: boolean
@@ -113,6 +115,7 @@ export class Preferences extends React.Component<
       availableEditors: [],
       useWindowsOpenSSH: false,
       notificationsEnabled: true,
+      is24hourFormat: false,
       optOutOfUsageTracking: false,
       confirmRepositoryRemoval: false,
       confirmDiscardChanges: false,
@@ -167,6 +170,7 @@ export class Preferences extends React.Component<
       initialDefaultBranch,
       useWindowsOpenSSH: this.props.useWindowsOpenSSH,
       notificationsEnabled: this.props.notificationsEnabled,
+      is24hourFormat: this.props.is24hourFormat,
       optOutOfUsageTracking: this.props.optOutOfUsageTracking,
       confirmRepositoryRemoval: this.props.confirmRepositoryRemoval,
       confirmDiscardChanges: this.props.confirmDiscardChanges,
@@ -336,11 +340,13 @@ export class Preferences extends React.Component<
           <Advanced
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             notificationsEnabled={this.state.notificationsEnabled}
+            is24hourFormat={this.state.is24hourFormat}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
             repositoryIndicatorsEnabled={this.state.repositoryIndicatorsEnabled}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             onUseWindowsOpenSSHChanged={this.onUseWindowsOpenSSHChanged}
             onNotificationsEnabledChanged={this.onNotificationsEnabledChanged}
+            onTimeFormatChanged={this.onTimeFormatChanged}
             onOptOutofReportingChanged={this.onOptOutofReportingChanged}
             onUncommittedChangesStrategyChanged={
               this.onUncommittedChangesStrategyChanged
@@ -379,6 +385,10 @@ export class Preferences extends React.Component<
 
   private onNotificationsEnabledChanged = (notificationsEnabled: boolean) => {
     this.setState({ notificationsEnabled })
+  }
+
+  private onTimeFormatChanged = (is24hourFormat: boolean) => {
+    this.setState({ is24hourFormat })
   }
 
   private onOptOutofReportingChanged = (value: boolean) => {
@@ -524,6 +534,8 @@ export class Preferences extends React.Component<
     this.props.dispatcher.setNotificationsEnabled(
       this.state.notificationsEnabled
     )
+
+    this.props.dispatcher.setTimeFormat(this.state.is24hourFormat)
 
     await this.props.dispatcher.setStatsOptOut(
       this.state.optOutOfUsageTracking,

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import moment from 'moment'
 import { TooltippedContent } from './lib/tooltipped-content'
+import { getBoolean } from '../lib/local-storage'
+import { timeFormatKey } from '../lib/stores'
 
 interface IRelativeTimeProps {
   /**
@@ -63,6 +65,11 @@ export class RelativeTime extends React.Component<
   public constructor(props: IRelativeTimeProps) {
     super(props)
     this.state = { absoluteText: '', relativeText: '' }
+    if (getBoolean(timeFormatKey) === true) {
+      moment.locale('en-gb')
+    } else {
+      moment.locale('en')
+    }
   }
 
   private clearTimer() {

--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -51,7 +51,8 @@ const commonConfig: webpack.Configuration = {
     new CleanWebpackPlugin([outputDir], { verbose: false }),
     // This saves us a bunch of bytes by pruning locales (which we don't use)
     // from moment.
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    // new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en-gb/),
   ],
   resolve: {
     extensions: ['.js', '.ts', '.tsx'],


### PR DESCRIPTION
Closes #13943 

## Description
- Allow visualization of 24-Hour time format

Note: Defaults to 12-Hour time format

### Screenshots

![image](https://user-images.githubusercontent.com/9341546/155006201-4c460c6f-dffd-425a-96fe-a5fcb8d5939e.png)

![image](https://user-images.githubusercontent.com/9341546/155006459-0c7ad668-9ecc-4403-b7d2-9702357cc6f6.png)

## Release notes

Added: Support for 24-Hour Time Format
