### PR TITLE
Clone repo dialog: update local path after the initial one is retrieved

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -213,6 +213,11 @@ export class CloneRepository extends React.Component<
       enterpriseTabState,
       urlTabState,
     })
+
+    // Update the local path based on the current url now that we have an
+    // initial path
+    const selectedTabState = this.getSelectedTabState()
+    this.updateUrl(selectedTabState.url)
   }
 
   public componentWillUnmount() {
@@ -580,9 +585,15 @@ export class CloneRepository extends React.Component<
     const tabState = this.getSelectedTabState()
     const lastParsedIdentifier = tabState.lastParsedIdentifier
 
+    // If there is no path yet, just update the url
+    if (tabState.path === null) {
+      this.setSelectedTabState({ url }, this.validatePath)
+      return
+    }
+
     let newPath: string
 
-    const dirPath = tabState.path ?? ''
+    const dirPath = tabState.path
     if (lastParsedIdentifier) {
       if (parsed) {
         newPath = Path.join(Path.dirname(dirPath), parsed.name)


### PR DESCRIPTION
Closes #13971

## Description

The changes in #13804 introduced another regression when the `getDefaultPath` function was made async. In this case, it would manifest when clicking on a link like `x-github-client://openRepo/https://github.com/desktop/askpass-trampoline`. In this case, the URL would be ready before the initial path, and when the initial path is retrieved, it wouldn't get the repo name added to it.

## Release notes

Notes: [Fixed] Pre-fill clone path with repository name
