### PR TITLE
Prevent crash when console.log fails as part of logging to stdout/stderr

### DIFF
--- a/app/src/main-process/desktop-console-transport.ts
+++ b/app/src/main-process/desktop-console-transport.ts
@@ -30,8 +30,8 @@ export class DesktopConsoleTransport extends TransportStream {
     // Node.js only differentiates between warn and log but we'll use info and
     // debug here as well in case we're used in the renderer
     // https://github.com/nodejs/node/blob/916227b3ed041ff13d588b02f98e9be0846a5a7c/lib/internal/console/constructor.js#L666-L670
-    const level = info[LEVEL]
-    const logFn = logFunctions[level] ?? console.log
+    const logFn = logFunctions[info[LEVEL]] ?? console.log
+
     // Surprisingly we are seeing rare crashes originating from within
     // console.log when the underlying stream is closed. Our understanding based
     // on reading the Node source code was that only stack overflow errors would


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Continuation of #13962, apparently `console.log` in Node isn't entirely safe from exceptions either.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes