### PR TITLE
Leverage comspec when opening protocol handler in CLI

### DIFF
--- a/app/src/cli/open-desktop.ts
+++ b/app/src/cli/open-desktop.ts
@@ -11,7 +11,9 @@ export function openDesktop(url: string = '') {
   if (__DARWIN__) {
     return ChildProcess.spawn('open', [url], { env })
   } else if (__WIN32__) {
-    return ChildProcess.spawn('cmd', ['/c', 'start', url], { env })
+    // https://github.com/nodejs/node/blob/b39dabefe6d/lib/child_process.js#L565-L577
+    const shell = process.env.comspec || 'cmd.exe'
+    return ChildProcess.spawn(shell, ['/d', '/c', 'start', url], { env })
   } else {
     throw new Error(
       `Desktop command line interface not currently supported on platform ${process.platform}`


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This matches Node's behavior when spawning a process with `shell: true` with the exception that we don't account for other shells than `cmd.exe`.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes