### PR TITLE
Use built-in fileURLToPath

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,6 @@
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "file-metadata": "^1.0.0",
-    "file-uri-to-path": "^2.0.0",
     "file-url": "^2.0.2",
     "focus-trap-react": "^8.1.0",
     "fs-admin": "^0.19.0",

--- a/app/src/lib/markdown-filters/emoji-filter.ts
+++ b/app/src/lib/markdown-filters/emoji-filter.ts
@@ -1,7 +1,7 @@
 import { INodeFilter } from './node-filter'
 import * as FSE from 'fs-extra'
 import { escapeRegExp } from '../helpers/regex'
-import uri2path from 'file-uri-to-path'
+import { fileURLToPath } from 'url'
 
 /**
  * The Emoji Markdown filter will take a text node and create multiple text and
@@ -122,7 +122,7 @@ export class EmojiFilter implements INodeFilter {
     if (cached !== undefined) {
       return cached
     }
-    const imageBuffer = await FSE.readFile(uri2path(filePath))
+    const imageBuffer = await FSE.readFile(fileURLToPath(filePath))
     const b64src = imageBuffer.toString('base64')
     const uri = `data:image/png;base64,${b64src}`
     this.emojiBase64URICache.set(filePath, uri)

--- a/app/src/lib/source-map-support.ts
+++ b/app/src/lib/source-map-support.ts
@@ -1,7 +1,7 @@
 import * as Path from 'path'
 import * as Fs from 'fs'
-import fileUriToPath from 'file-uri-to-path'
 import sourceMapSupport from 'source-map-support'
+import { fileURLToPath } from 'url'
 
 /**
  * This array tells the source map logic which files that we can expect to
@@ -23,7 +23,7 @@ function retrieveSourceMap(source: string) {
 
   // We get a file uri when we're inside a renderer, convert to a path
   if (source.startsWith('file://')) {
-    source = fileUriToPath(source)
+    source = fileURLToPath(source)
   }
 
   // We store our source maps right next to the bundle

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -597,11 +597,6 @@ file-stream-rotator@^0.6.1:
   dependencies:
     moment "^2.29.1"
 
-file-uri-to-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
-  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
-
 file-url@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/file-url/-/file-url-2.0.2.tgz#e951784d79095127d3713029ab063f40818ca2ae"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Stumbled upon this while looking at something completely unrelated. Turns out there's a built-in function for converting file URIs to platform-specific paths. Might as well use that and save us a dependency!

@tidy-dev This function was introduced in Node 10 so I guess it was there when I asked you to use the package :shrug:

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
