### PR TITLE
Flip expanded state icon in CheckRunListItem

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -97,8 +97,8 @@ export class CICheckRunListItem extends React.PureComponent<
         <Octicon
           symbol={
             isCheckRunExpanded
-              ? OcticonSymbol.chevronDown
-              : OcticonSymbol.chevronUp
+              ? OcticonSymbol.chevronUp
+              : OcticonSymbol.chevronDown
           }
         />
       </div>


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Noticed that the icon used to signal whether the check run list item is expanded or not was flipped compared to how we traditionally render exanded/collapsed state (like in our toolbar dropdowns)

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before
<img width="478" alt="image" src="https://user-images.githubusercontent.com/634063/155985254-16c3b187-fc44-4f8c-affd-5f964f358d7e.png">

#### After
<img width="457" alt="image" src="https://user-images.githubusercontent.com/634063/155985452-a2b1f383-4854-4a3e-ae43-00c34d68a562.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes (not released)