### PR TITLE
Fix discarding submodules in paths containing spaces

### DIFF
--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -53,7 +53,7 @@ export async function listSubmodules(
   // about it if you want to learn more:
   //
   // https://git-scm.com/docs/git-describe
-  const statusRe = /^.([a-f0-9]{40}) (.+?) \((.+?)\)$/gm
+  const statusRe = /^.([^ ]+) (.+) \((.+?)\)$/gm
 
   for (const [, sha, path, describe] of stdout.matchAll(statusRe)) {
     submodules.push(new SubmoduleEntry(sha, path, describe))

--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -21,56 +21,42 @@ export async function listSubmodules(
   // We don't recurse when listing submodules here because we don't have a good
   // story about managing these currently. So for now we're only listing
   // changes to the top-level submodules to be consistent with `git status`
-  const result = await git(
+  const { stdout, exitCode } = await git(
     ['submodule', 'status', '--'],
     repository.path,
     'listSubmodules',
-    {
-      successExitCodes: new Set([0, 128]),
-    }
+    { successExitCodes: new Set([0, 128]) }
   )
 
-  if (result.exitCode === 128) {
+  if (exitCode === 128) {
     // unable to parse submodules in repository, giving up
     return []
   }
 
   const submodules = new Array<SubmoduleEntry>()
 
-  for (const entry of result.stdout.split('\n')) {
-    if (entry.length === 0) {
-      continue
-    }
+  // entries are of the format:
+  //  1eaabe34fc6f486367a176207420378f587d3b48 git (v2.16.0-rc0)
+  //
+  // first character:
+  //   - " " if no change
+  //   - "-" if the submodule is not initialized
+  //   - "+" if the currently checked out submodule commit does not match the SHA-1 found in the index of the containing repository
+  //   - "U" if the submodule has merge conflicts
+  //
+  // then the 40-character SHA represents the current commit
+  //
+  // then the path to the submodule
+  //
+  // then the output of `git describe` for the submodule in braces
+  // we're not leveraging this in the app, so go and read the docs
+  // about it if you want to learn more:
+  //
+  // https://git-scm.com/docs/git-describe
+  const statusRe = /^.([a-f0-9]{40}) (.+?) \((.+?)\)$/gm
 
-    // entries are of the format:
-    //  1eaabe34fc6f486367a176207420378f587d3b48 git (v2.16.0-rc0)
-    //
-    // first character:
-    //   - " " if no change
-    //   - "-" if the submodule is not initialized
-    //   - "+" if the currently checked out submodule commit does not match the SHA-1 found in the index of the containing repository
-    //   - "U" if the submodule has merge conflicts
-    //
-    // then the 40-character SHA represents the current commit
-    const sha = entry.substr(1, 40)
-
-    //
-    // then the path to the submodule
-    //
-    // then the output of `git describe` for the submodule in braces
-    // we're not leveraging this in the app, so go and read the docs
-    // about it if you want to learn more:
-    //
-    // https://git-scm.com/docs/git-describe
-
-    const [path, describeOutput] = entry.substr(42).split(/\s+/)
-
-    // if the submodule has not been initialized, no describe output is set
-    // this means we don't have a submodule to work with
-    if (describeOutput != null) {
-      const describe = describeOutput.substr(1, describeOutput.length - 2)
-      submodules.push(new SubmoduleEntry(sha, path, describe))
-    }
+  for (const [, sha, path, describe] of stdout.matchAll(statusRe)) {
+    submodules.push(new SubmoduleEntry(sha, path, describe))
   }
 
   return submodules


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

As I was working on removing our use of `substr` in the app (due to it being deprecated) I noticed something that didn't look right in our submodule status parsing logic:

https://github.com/desktop/desktop/blob/b6d027924a37a22acaf69346dd3b72908e4359a3/app/src/lib/git/submodule.ts#L66

This does not account for the case of submodules with spaces in their path.

```
Markuss-MBP:submodule-test markus$ git submodule status --
 39078e1b2fa43e4b32c80eba9a87053c5e2b6e4a and another submodule (heads/main)
 0334f75648d6254988b4e0378c4fafe394bc4ae9 look at me i am a submodule (remotes/origin/HEAD)
```

The end result of this oversight is that submodules residing in paths with spaces in them will have the entire submodule folder tossed in the trash when discarding changes instead of running `git submodule update` on them

https://github.com/desktop/desktop/blob/b6d027924a37a22acaf69346dd3b72908e4359a3/app/src/lib/stores/git-store.ts#L1466 

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Discarding submodules with spaces in their relative path now correctly updates the submodule instead of moving it to Trash