### PR TITLE
Stop using substr, part one

### DIFF
--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -104,7 +104,7 @@ export async function getRebaseInternalState(
     )
 
     if (targetBranch.startsWith('refs/heads/')) {
-      targetBranch = targetBranch.substr(11).trim()
+      targetBranch = targetBranch.substring(11).trim()
     }
 
     baseBranchTip = await FSE.readFile(

--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -63,7 +63,7 @@ export async function listSubmodules(
     //
     // https://git-scm.com/docs/git-describe
 
-    const [path, describeOutput] = entry.substr(42).split(/\s+/)
+    const [path, describeOutput] = entry.substring(42).split(/\s+/)
 
     // if the submodule has not been initialized, no describe output is set
     // this means we don't have a submodule to work with

--- a/app/src/lib/http.ts
+++ b/app/src/lib/http.ts
@@ -84,9 +84,9 @@ async function deserialize<T>(response: Response): Promise<T> {
  * @param path The resource path (should be relative to the root of the server)
  */
 export function getAbsoluteUrl(endpoint: string, path: string): string {
-  let relativePath = path[0] === '/' ? path.substr(1) : path
+  let relativePath = path[0] === '/' ? path.substring(1) : path
   if (relativePath.startsWith('api/v3/')) {
-    relativePath = relativePath.substr(7)
+    relativePath = relativePath.substring(7)
   }
 
   // Our API endpoints are a bit sloppy in that they don't typically

--- a/app/src/lib/parse-app-url.ts
+++ b/app/src/lib/parse-app-url.ts
@@ -101,7 +101,7 @@ export function parseAppURL(url: string): URLActionType {
   }
 
   // Trim the trailing / from the URL
-  const parsedPath = pathName.substr(1)
+  const parsedPath = pathName.substring(1)
 
   if (actionName === 'openrepo') {
     const pr = getQueryStringValue(query, 'pr')

--- a/app/src/lib/patch-formatter.ts
+++ b/app/src/lib/patch-formatter.ts
@@ -191,7 +191,7 @@ export function formatPatch(
         // is concerned which means that we should treat it as if it's still
         // in the old file so we'll convert it to a context line.
         if (line.type === DiffLineType.Delete) {
-          hunkBuf += ` ${line.text.substr(1)}\n`
+          hunkBuf += ` ${line.text.substring(1)}\n`
           oldCount++
           newCount++
         } else {
@@ -280,10 +280,10 @@ export function formatPatchToDiscardChanges(
       } else if (selection.isSelected(absoluteIndex)) {
         // Reverse the change (if it was an added line, treat it as removed and vice versa).
         if (line.type === DiffLineType.Add) {
-          hunkBuf += `-${line.text.substr(1)}\n`
+          hunkBuf += `-${line.text.substring(1)}\n`
           newCount++
         } else if (line.type === DiffLineType.Delete) {
-          hunkBuf += `+${line.text.substr(1)}\n`
+          hunkBuf += `+${line.text.substring(1)}\n`
           oldCount++
         } else {
           assertNever(line.type, `Unsupported line type ${line.type}`)
@@ -296,7 +296,7 @@ export function formatPatchToDiscardChanges(
           // so we just print it untouched on the diff.
           oldCount++
           newCount++
-          hunkBuf += ` ${line.text.substr(1)}\n`
+          hunkBuf += ` ${line.text.substring(1)}\n`
         } else if (line.type === DiffLineType.Delete) {
           // An unselected removed line has no impact on this patch since it's not
           // found on the current working copy of the file, so we can ignore it.

--- a/app/src/lib/progress/git.ts
+++ b/app/src/lib/progress/git.ts
@@ -253,8 +253,8 @@ export function parse(line: string): IGitProgressInfo | null {
     return null
   }
 
-  const title = line.substr(0, titleLength)
-  const progressText = line.substr(title.length + 2).trim()
+  const title = line.substring(0, titleLength)
+  const progressText = line.substring(title.length + 2).trim()
 
   if (!progressText.length) {
     return null

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -72,11 +72,11 @@ export function parsePorcelainStatus(
 
   while ((field = queue.shift())) {
     if (field.startsWith('# ') && field.length > 2) {
-      entries.push({ kind: 'header', value: field.substr(2) })
+      entries.push({ kind: 'header', value: field.substring(2) })
       continue
     }
 
-    const entryKind = field.substr(0, 1)
+    const entryKind = field.substring(0, 1)
 
     if (entryKind === ChangedEntryType) {
       entries.push(parseChangedEntry(field))
@@ -159,7 +159,7 @@ function parseUnmergedEntry(field: string): IStatusEntry {
 }
 
 function parseUntrackedEntry(field: string): IStatusEntry {
-  const path = field.substr(2)
+  const path = field.substring(2)
   return {
     kind: 'entry',
     // NOTE: We return ?? instead of ? here to play nice with mapStatus,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -191,7 +191,7 @@ export class GitStore extends BaseStore {
       log.debug(
         `reconciling history - adding ${
           commits.length
-        } commits before merge base ${mergeBase.substr(0, 8)}`
+        } commits before merge base ${mergeBase.substring(0, 8)}`
       )
 
       // rebuild the local history state by combining the commits _before_ the
@@ -528,7 +528,7 @@ export class GitStore extends BaseStore {
         // strip out everything related to the remote because this
         // is likely to be a tracked branch locally
         // e.g. `main`, `develop`, etc
-        return match.substr(remoteNamespace.length)
+        return match.substring(remoteNamespace.length)
       }
     }
 

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -226,7 +226,7 @@ export class BranchPruner {
         continue
       }
 
-      const branchName = branchCanonicalRef.substr(branchRefPrefix.length)
+      const branchName = branchCanonicalRef.substring(branchRefPrefix.length)
 
       if (options.deleteBranch) {
         const isDeleted = await gitStore.performFailableOperation(() =>

--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -162,7 +162,7 @@ export class Tokenizer {
     }
 
     this.flush()
-    const id = parseInt(maybeIssue.substr(1), 10)
+    const id = parseInt(maybeIssue.substring(1), 10)
     if (isNaN(id)) {
       return null
     }
@@ -198,7 +198,7 @@ export class Tokenizer {
     }
 
     this.flush()
-    const name = maybeMention.substr(1)
+    const name = maybeMention.substring(1)
     const url = `${getHTMLURL(repository.endpoint)}/${name}`
     this._results.push({ kind: TokenType.Link, text: maybeMention, url })
     return { nextIndex }

--- a/app/src/lib/wrap-rich-text-commit-message.ts
+++ b/app/src/lib/wrap-rich-text-commit-message.ts
@@ -67,8 +67,8 @@ export function wrapRichTextCommitMessage(
         // We always hard-wrap text, it'd be nice if we could attempt
         // to break at word boundaries in the future but that's too
         // complex for now.
-        summary.push(text(token.text.substr(0, remainder)))
-        overflow.push(text(token.text.substr(remainder)))
+        summary.push(text(token.text.substring(0, remainder)))
+        overflow.push(text(token.text.substring(remainder)))
       } else if (token.kind === TokenType.Emoji) {
         // Can't hard-wrap inside an emoji
         overflow.push(token)
@@ -79,8 +79,8 @@ export function wrapRichTextCommitMessage(
         // text showing otherwise we'll end up with weird links like "h"
         // or "@"
         if (!token.text.startsWith('#') && remainder > 5) {
-          summary.push(link(token.text.substr(0, remainder), token.text))
-          overflow.push(link(token.text.substr(remainder), token.text))
+          summary.push(link(token.text.substring(0, remainder), token.text))
+          overflow.push(link(token.text.substring(remainder), token.text))
         } else {
           overflow.push(token)
         }

--- a/app/src/models/diff/diff-line.ts
+++ b/app/src/models/diff/diff-line.ts
@@ -36,6 +36,6 @@ export class DiffLine {
 
   /** The content of the line, i.e., without the line type marker. */
   public get content(): string {
-    return this.text.substr(1)
+    return this.text.substring(1)
   }
 }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1528,7 +1528,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           />
         )
       case PopupType.About:
-        const version = __DEV__ ? __SHA__.substr(0, 10) : getVersion()
+        const version = __DEV__ ? __SHA__.substring(0, 10) : getVersion()
 
         return (
           <About

--- a/app/src/ui/autocompletion/autocompleting-text-input.tsx
+++ b/app/src/ui/autocompletion/autocompleting-text-input.tsx
@@ -351,7 +351,8 @@ export abstract class AutocompletingTextInput<
       originalText.substr(0, range.start - 1) + autoCompleteText + ' '
 
     const newText =
-      textWithAutoCompleteText + originalText.substr(range.start + range.length)
+      textWithAutoCompleteText +
+      originalText.substring(range.start + range.length)
 
     element.value = newText
 

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -104,9 +104,9 @@ export class EmojiAutocompletionProvider
 
     return (
       <div className="title">
-        {emoji.substr(0, hit.matchStart)}
+        {emoji.substring(0, hit.matchStart)}
         <mark>{emoji.substr(hit.matchStart, hit.matchLength)}</mark>
-        {emoji.substr(hit.matchStart + hit.matchLength)}
+        {emoji.substring(hit.matchStart + hit.matchLength)}
       </div>
     )
   }

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -105,7 +105,9 @@ export class EmojiAutocompletionProvider
     return (
       <div className="title">
         {emoji.substring(0, hit.matchStart)}
-        <mark>{emoji.substr(hit.matchStart, hit.matchLength)}</mark>
+        <mark>
+          {emoji.substring(hit.matchStart, hit.matchStart + hit.matchLength)}
+        </mark>
         {emoji.substring(hit.matchStart + hit.matchLength)}
       </div>
     )

--- a/app/src/ui/create-branch/create-branch-dialog.tsx
+++ b/app/src/ui/create-branch/create-branch-dialog.tsx
@@ -146,7 +146,7 @@ export class CreateBranch extends React.Component<
       return (
         <p>
           Your new branch will be based on the commit '{targetCommit.summary}' (
-          {targetCommit.sha.substr(0, 7)}) from your repository.
+          {targetCommit.sha.substring(0, 7)}) from your repository.
         </p>
       )
     } else if (tip.kind === TipState.Detached) {
@@ -154,7 +154,7 @@ export class CreateBranch extends React.Component<
         <p>
           You do not currently have any branch checked out (your HEAD reference
           is detached). As such your new branch will be based on your currently
-          checked out commit ({tip.currentSha.substr(0, 7)}
+          checked out commit ({tip.currentSha.substring(0, 7)}
           ).
         </p>
       )

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -861,7 +861,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         if (i === 0 && range.head.ch > 0) {
           lineContent.push(line)
         } else {
-          lineContent.push(line.substr(1))
+          lineContent.push(line.substring(1))
         }
       }
 

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -656,6 +656,6 @@ function getRemoteMessage(stderr: string) {
   return stderr
     .split(/\r?\n/)
     .filter(x => x.startsWith(needle))
-    .map(x => x.substr(needle.length))
+    .map(x => x.substring(needle.length))
     .join('\n')
 }

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -141,7 +141,7 @@ export class BranchDropdown extends React.Component<
         b => !b.isDesktopForkRemoteBranch
       )
     } else if (tip.kind === TipState.Detached) {
-      title = `On ${tip.currentSha.substr(0, 7)}`
+      title = `On ${tip.currentSha.substring(0, 7)}`
       tooltip = 'Currently on a detached HEAD'
       icon = OcticonSymbol.gitCommit
       description = 'Detached HEAD'

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -229,5 +229,5 @@ async function getBranchesFromGit(repository: Repository) {
   return gitOutput.stdout
     .split('\n')
     .filter(s => s.length > 0)
-    .map(s => s.substr(2))
+    .map(s => s.substring(2))
 }

--- a/app/test/unit/custom-theme-test.ts
+++ b/app/test/unit/custom-theme-test.ts
@@ -9,15 +9,13 @@ describe('CustomTheme', () => {
     it('sets the first line to body.theme-high-contrast {', () => {
       const customTheme = CustomThemeDefaults[ApplicationTheme.HighContrast]
       const customThemeStyles = buildCustomThemeStyles(customTheme)
-      expect(customThemeStyles.split('\n')[0]).toBe(
-        'body.theme-high-contrast {'
-      )
+      expect(customThemeStyles).toStartWith('body.theme-high-contrast {\n')
     })
 
     it('sets the last line to }', () => {
       const customTheme = CustomThemeDefaults[ApplicationTheme.HighContrast]
       const customThemeStyles = buildCustomThemeStyles(customTheme)
-      expect(customThemeStyles.substr(-1, 1)).toBe('}')
+      expect(customThemeStyles).toEndWith('}')
     })
 
     it('prefaces all variable lines with --', () => {
@@ -31,8 +29,7 @@ describe('CustomTheme', () => {
         if (trimmedLine === '') {
           continue
         }
-        const firstTwoChar = trimmedLine.substring(0, 2)
-        expect(firstTwoChar).toBe('--')
+        expect(trimmedLine).toStartWith('--')
       }
     })
 
@@ -47,8 +44,7 @@ describe('CustomTheme', () => {
         if (trimmedLine === '') {
           continue
         }
-        const firstTwoChar = trimmedLine.substr(-1, 1)
-        expect(firstTwoChar).toBe(';')
+        expect(trimmedLine).toEndWith(';')
       }
     })
   })

--- a/app/test/unit/custom-theme-test.ts
+++ b/app/test/unit/custom-theme-test.ts
@@ -31,7 +31,7 @@ describe('CustomTheme', () => {
         if (trimmedLine === '') {
           continue
         }
-        const firstTwoChar = trimmedLine.substr(0, 2)
+        const firstTwoChar = trimmedLine.substring(0, 2)
         expect(firstTwoChar).toBe('--')
       }
     })

--- a/app/test/unit/wrap-rich-text-commit-message-test.ts
+++ b/app/test/unit/wrap-rich-text-commit-message-test.ts
@@ -46,14 +46,14 @@ describe('wrapRichTextCommitMessage', () => {
     expect(body.length).toBe(2)
 
     expect(summary[0].kind).toBe(TokenType.Text)
-    expect(summary[0].text).toBe(summaryText.substr(0, 72))
+    expect(summary[0].text).toBe(summaryText.substring(0, 72))
     expect(summary[1].kind).toBe(TokenType.Text)
     expect(summary[1].text).toBe('…')
 
     expect(body[0].kind).toBe(TokenType.Text)
     expect(body[0].text).toBe('…')
     expect(body[1].kind).toBe(TokenType.Text)
-    expect(body[1].text).toBe(summaryText.substr(72))
+    expect(body[1].text).toBe(summaryText.substring(72))
   })
 
   it('hard wraps text longer than 72 chars and joins it with the body', async () => {
@@ -66,12 +66,12 @@ describe('wrapRichTextCommitMessage', () => {
     expect(body.length).toBe(4)
 
     expect(summary[0].kind).toBe(TokenType.Text)
-    expect(summary[0].text).toBe(summaryText.substr(0, 72))
+    expect(summary[0].text).toBe(summaryText.substring(0, 72))
     expect(summary[1].kind).toBe(TokenType.Text)
     expect(summary[1].text).toBe('…')
 
     expect(body[0].text).toBe('…')
-    expect(body[1].text).toBe(summaryText.substr(72))
+    expect(body[1].text).toBe(summaryText.substring(72))
     expect(body[2].text).toBe('\n\n')
     expect(body[3].text).toBe(bodyText)
   })

--- a/script/draft-release/run.ts
+++ b/script/draft-release/run.ts
@@ -39,7 +39,7 @@ async function getLatestRelease(options: {
     releaseTags = releaseTags.filter(tag => !tag.includes('-beta'))
   }
 
-  const releaseVersions = releaseTags.map(tag => tag.substr(8))
+  const releaseVersions = releaseTags.map(tag => tag.substring(8))
 
   const sortedTags = semverSort(releaseVersions)
   const latestTag = sortedTags[sortedTags.length - 1]

--- a/script/draft-release/version.ts
+++ b/script/draft-release/version.ts
@@ -13,7 +13,7 @@ function isTestTag(version: SemVer) {
 function tryGetBetaNumber(version: SemVer): number | null {
   if (isBetaTag(version)) {
     const tag = version.prerelease[0]
-    const text = tag.substr(4)
+    const text = tag.substring(4)
     const betaNumber = parseInt(text, 10)
     return isNaN(betaNumber) ? null : betaNumber
   }

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -32,7 +32,7 @@ import request from 'request'
 console.log('Packaging…')
 execSync('yarn package', { stdio: 'inherit' })
 
-const sha = platforms.getSha().substr(0, 8)
+const sha = platforms.getSha().substring(0, 8)
 
 function getSecret() {
   if (process.env.DEPLOYMENT_SECRET != null) {

--- a/script/validate-changelog.ts
+++ b/script/validate-changelog.ts
@@ -24,7 +24,7 @@ function formatErrors(errors: ErrorObject[]): string {
       }
 
       // dataPath starts with a leading "."," which is a bit confusing
-      const element = dataPath.substr(1)
+      const element = dataPath.substring(1)
 
       return ` - ${element} - ${message}${additionalPropertyText}`
     })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

[`substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) has been deprecated in favor of [`substring`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) and now VSCode is letting us know by showing our substr code in ~~strikethrough~~ which I can't stand.

This PR updates all of our `.substr` uses with `substring` (except for `submodule.ts` which is addresses in #14024).

There's three commits in this PR and my recommendation to anyone who reviews this PR is to review them separately, and in order. The first (09f16b4184a54da4eea9ae40743a1dbe188a7f8a) contains only mechanical translations following these assumptions (verify my assumptions pls).

```
Any call using .substr(X) can be substituted for .substring(X)
Any call using .substr(0, X) can be substituted for .substring(0, X)
```

So while this commit will look like it's introducing a lot of changes a reviewer only needs to verify that the changes within it correspond to the two rules above.

The second (1f72120cb8247ea2f1325ecd723192fcabb29b53) and third (2f70c3c470043346610d00776f98475b74cb2773) commits deal with the cases where mechanical translation wasn't possible and require a little more review since they're "hand written"

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
