### PR TITLE
Avoid spawning from main process on Catalina

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -21,6 +21,11 @@ function systemVersionGreaterThanOrEqualTo(version: string) {
   return sysver === undefined ? false : compare(sysver, version, '>=')
 }
 
+function systemVersionLessThan(version: string) {
+  const sysver = getSystemVersionSafe()
+  return sysver === undefined ? false : compare(sysver, version, '<')
+}
+
 /** Get the OS we're currently running on. */
 export function getOS() {
   const version = getSystemVersionSafe()
@@ -32,6 +37,11 @@ export function getOS() {
     return `${OS.type()} ${version}`
   }
 }
+
+/** We're currently running macOS and it is macOS Catalina or earlier. */
+export const isMacOSCatalinaOrEarlier = memoizeOne(
+  () => __DARWIN__ && systemVersionLessThan('10.16')
+)
 
 /** We're currently running macOS and it is at least Mojave. */
 export const isMacOSMojaveOrLater = memoizeOne(

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -39,8 +39,7 @@ export type RequestChannels = {
     extra: Record<string, string>,
     nonFatal: boolean
   ) => void
-  'show-item-in-folder': (path: string) => void
-  'show-folder-contents': (path: string) => void
+  'unsafe-open-directory': (path: string) => void
   'menu-event': (name: MenuEvent) => void
   log: (level: LogLevel, message: string) => void
   'will-quit': () => void
@@ -76,7 +75,7 @@ export type RequestChannels = {
 }
 
 /**
- * Defines the duplex IPC channel names we use from the renderer
+ * Define the duplex IPC channel names we use from the renderer
  * process along with their signatures. This type is used from both
  * the renderer and the main process to ensure a common contract between
  * the two over the untyped IPC framework.
@@ -89,6 +88,7 @@ export type RequestResponseChannels = {
   'get-app-path': () => Promise<string>
   'is-running-under-arm64-translation': () => Promise<boolean>
   'move-to-trash': (path: string) => Promise<void>
+  'show-item-in-folder': (path: string) => Promise<void>
   'show-contextual-menu': (
     items: ReadonlyArray<ISerializableMenuItem>,
     addSpellCheckMenu: boolean

--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -75,7 +75,7 @@ export type RequestChannels = {
 }
 
 /**
- * Define the duplex IPC channel names we use from the renderer
+ * Defines the duplex IPC channel names we use from the renderer
  * process along with their signatures. This type is used from both
  * the renderer and the main process to ensure a common contract between
  * the two over the untyped IPC framework.

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -2,6 +2,7 @@
 
 import * as ChildProcess from 'child_process'
 import * as os from 'os'
+import { isMacOSCatalinaOrEarlier } from './get-os'
 
 type IndexLookup = {
   [propName: string]: string
@@ -23,6 +24,15 @@ const ExcludedEnvironmentVars = new Set(['LOCAL_GIT_DIRECTORY'])
  * @param process The process to inspect.
  */
 export function shellNeedsPatching(process: NodeJS.Process): boolean {
+  // We don't want to run this in the main process until the following issues
+  // are closed (and possibly not after they're closed either)
+  //
+  // See https://github.com/desktop/desktop/issues/13974
+  // See https://github.com/electron/electron/issues/32718
+  if (process.type === 'browser' && isMacOSCatalinaOrEarlier()) {
+    return false
+  }
+
   return __DARWIN__ && !process.env.PWD
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #13974

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We're tracking a bug that causes a harmless but annoying crash report dialog to appear when launching the app and when clicking `Show in Finder` on macOS Catalina (or lower). While we don't know the root cause of the problem yet we know that spawning from the main process is what triggers it (see @sergiou87's excellent repro case at https://github.com/electron/electron/issues/32718#issuecomment-1050009071).

As such we're trying to mitigate this by auditing the places in the main process where we spawn and relocating them where possible to the renderer.

Fortunately for us there seems to be only two cases to worry about. The first being the patching of the process enviroment and the second being our use of the `file-metadata` package which will spawn `mdls`.

Patching the main process environment is likely not necessary at all but in order to minimize the surface area of this change we (@sergiou87 and I) opted to only disable it on the affected platforms for now.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Prevent crash report dialog from appearing when launching on macOS Catalina or earlier