### PR TITLE
Use `command` in our CLI script to prevent the use of aliases

### DIFF
--- a/app/static/darwin/github.sh
+++ b/app/static/darwin/github.sh
@@ -5,8 +5,8 @@ function realpath() {
   /usr/bin/perl -e "use Cwd;print Cwd::abs_path(@ARGV[0])" "$0";
 }
 
-CONTENTS="$(command dirname "$(command dirname "$(command dirname "$(command dirname "$(command realpath "$0")")")")")"
-BINARY_NAME="$(LSCOLORS= CLICOLOR= command ls "$CONTENTS/MacOS/")"
+CONTENTS="$(command dirname "$(command dirname "$(command dirname "$(command dirname "$(realpath "$0")")")")")"
+BINARY_NAME="$(TERM=dumb command ls "$CONTENTS/MacOS/")"
 ELECTRON="$CONTENTS/MacOS/$BINARY_NAME"
 CLI="$CONTENTS/Resources/app/cli.js"
 

--- a/app/static/darwin/github.sh
+++ b/app/static/darwin/github.sh
@@ -5,8 +5,8 @@ function realpath() {
   /usr/bin/perl -e "use Cwd;print Cwd::abs_path(@ARGV[0])" "$0";
 }
 
-CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
-BINARY_NAME="$(ls "$CONTENTS/MacOS/")"
+CONTENTS="$(command dirname "$(command dirname "$(command dirname "$(command dirname "$(command realpath "$0")")")")")"
+BINARY_NAME="$(LSCOLORS= CLICOLOR= command ls "$CONTENTS/MacOS/")"
 ELECTRON="$CONTENTS/MacOS/$BINARY_NAME"
 CLI="$CONTENTS/Resources/app/cli.js"
 


### PR DESCRIPTION
Closes #13935

## Description
This PR changes our CLI script to use `command` to run `dirname` and `ls`, to avoid running into oddities caused by users' aliases around those commands.

## Release notes

Notes: [Fixed] Command Line Tool ignores command aliases set by user on macOS
