### PR TITLE
Fix error storing repository owners in database

### DIFF
--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -383,7 +383,8 @@ export class RepositoriesStore extends TypedBaseStore<
     // login with the proper case.
     if (existingOwner === undefined || existingOwner.login !== login) {
       id = existingOwner?.id
-      id = await this.db.owners.put({ id, key, endpoint, login })
+      const existingId = id !== undefined ? { id } : {}
+      id = await this.db.owners.put({ ...existingId, key, endpoint, login })
     } else {
       id = forceUnwrap('Missing owner id', existingOwner.id)
     }


### PR DESCRIPTION
## Description

Introduced in #13706 (and I suspect after upgrading Electron/Chromium), the IndexDB doesn't like when we pass an `undefined` id, because it tries to store it. Instead, we shouldn't even set that `id: undefined` if we don't have an `id` at all and it will generate one by incrementing the last one in 1.

## Release notes

Notes: no-notes (not released to prod yet)
