### PR TITLE
We can have nice things! (ES2021)

### DIFF
--- a/app/src/highlighter/tsconfig.json
+++ b/app/src/highlighter/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
-    "target": "es2017",
+    "target": "ES2021",
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "noImplicitReturns": true,
@@ -11,7 +11,7 @@
     "sourceMap": true,
     "strict": true,
     "outDir": "../../../out",
-    "lib": ["scripthost", "webworker", "es2017"],
+    "lib": ["scripthost", "webworker", "es2021"],
     "types": []
   },
   "compileOnSave": false

--- a/eslint-rules/tsconfig.json
+++ b/eslint-rules/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
-    "target": "es2015",
+    "target": "ES2021",
     "skipLibCheck": true,
     "moduleResolution": "node"
   },

--- a/script/tsconfig.json
+++ b/script/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "importHelpers": true,
-    "target": "es2017",
+    "target": "ES2021",
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "jsx": "react",
     "strict": true,
     "outDir": "./out",
-    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "useUnknownInCatchVariables": false
   },
   "include": ["app/**/*.ts", "app/**/*.tsx", "app/**/*.d.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
-    "target": "es2017",
+    "target": "ES2021",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "importHelpers": true,
@@ -15,7 +15,7 @@
     "jsx": "react",
     "strict": true,
     "outDir": "./out",
-    "lib": ["ES2017", "DOM", "DOM.Iterable", "ES2018.Promise", "ES2020.string"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "useUnknownInCatchVariables": false
   },
   "include": ["app/**/*.ts", "app/**/*.tsx", "app/**/*.d.tsx"],


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
The much awaited follow-up to the box-office hit [This is why we can't have nice things](https://github.com/desktop/desktop/commit/0356ce451b57426afa84c798bbf67fd793f2f1ab)!

Thanks to #13894 and our recent electron upgrades we're now able to [target ES2021](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping).

Not only does this give us a bunch of new [language features](https://h3manth.com/ES2021/) it also means the code we write will be output almost verbatim without any shims or rewrites by TS. Take this little snippet for example:

```ts
(async function() {
'foo' ?? 'bar'
const { a, b, ...rest } = { a: 1, b: 2, c: 3, d: 4, e: 5 }
const back = { a, b, ...rest }

const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
async function* g() {
  yield 1;
  await sleep(100);
  yield* [2, 3];
}

for await (const line of g()) {
  console.log(line)
}
})()
```

With our previous target this would compile to 

```js
var __rest = (this && this.__rest) || function (s, e) {
    var t = {};
    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
        t[p] = s[p];
    if (s != null && typeof Object.getOwnPropertySymbols === "function")
        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
                t[p[i]] = s[p[i]];
        }
    return t;
};
var __await = (this && this.__await) || function (v) { return this instanceof __await ? (this.v = v, this) : new __await(v); }
var __asyncValues = (this && this.__asyncValues) || function (o) {
    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
    var m = o[Symbol.asyncIterator], i;
    return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
    function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
    function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
};
var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
    var i, p;
    return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
    function verb(n, f) { i[n] = o[n] ? function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : f ? f(v) : v; } : f; }
};
var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
    var g = generator.apply(thisArg, _arguments || []), i, q = [];
    return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
    function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
    function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
    function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r); }
    function fulfill(value) { resume("next", value); }
    function reject(value) { resume("throw", value); }
    function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
};
(async function () {
    var e_1, _a;
    'foo' !== null && 'foo' !== void 0 ? 'foo' : 'bar';
    const _b = { a: 1, b: 2, c: 3, d: 4, e: 5 }, { a, b } = _b, rest = __rest(_b, ["a", "b"]);
    const back = Object.assign({ a, b }, rest);
    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
    function g() {
        return __asyncGenerator(this, arguments, function* g_1() {
            yield yield __await(1);
            yield __await(sleep(100));
            yield __await(yield* __asyncDelegator(__asyncValues([2, 3])));
        });
    }
    try {
        for (var _c = __asyncValues(g()), _d; _d = await _c.next(), !_d.done;) {
            const line = _d.value;
            console.log(line);
        }
    }
    catch (e_1_1) { e_1 = { error: e_1_1 }; }
    finally {
        try {
            if (_d && !_d.done && (_a = _c.return)) await _a.call(_c);
        }
        finally { if (e_1) throw e_1.error; }
    }
})();
```

Now, it looks like this

```ts
(async function () {
    'foo' ?? 'bar';
    const { a, b, ...rest } = { a: 1, b: 2, c: 3, d: 4, e: 5 };
    const back = { a, b, ...rest };
    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
    async function* g() {
        yield 1;
        await sleep(100);
        yield* [2, 3];
    }
    for await (const line of g()) {
        console.log(line);
    }
})()
```

Pretty sweet right? Obviously the example is an exaggeration since the shims only ship once but this target change will still knock off 27Kb from our bundle and hopefully mean that we can reap the benefits of low-level optimizations in V8 enabled by improved static analysis capabilities.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes