### PR TITLE
fs/promises: readFile

### DIFF
--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -53,39 +53,6 @@ export function tailByLine(
 }
 
 /**
- * Asynchronous readFile - Asynchronously reads the entire contents of a file.
- *
- * @param fileName
- * @param options An object with optional {encoding} and {flag} properties.  If {encoding} is specified, readFile returns a string; otherwise it returns a Buffer.
- * @param callback - The callback is passed two arguments (err, data), where data is the contents of the file.
- */
-export async function readFile(
-  filename: string,
-  options?: { flag?: string }
-): Promise<Buffer>
-// eslint-disable-next-line no-redeclare
-export async function readFile(
-  filename: string,
-  options?: { encoding: BufferEncoding; flag?: string }
-): Promise<string>
-// eslint-disable-next-line no-redeclare
-export async function readFile(
-  filename: string,
-  options?: { encoding?: string; flag?: string }
-): Promise<Buffer | string> {
-  return new Promise<string | Buffer>((resolve, reject) => {
-    options = options || { flag: 'r' }
-    FSE.readFile(filename, options, (err, data) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(data)
-      }
-    })
-  })
-}
-
-/**
  * Read a specific region from a file.
  *
  * @param path  Path to the file

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -20,6 +20,7 @@ import { ManualConflictResolution } from '../../models/manual-conflict-resolutio
 import { stageManualConflictResolution } from './stage'
 import { getCommit } from '.'
 import { IMultiCommitOperationProgress } from '../../models/progress'
+import { readFile } from 'fs/promises'
 
 /** The app-specific results from attempting to cherry pick commits*/
 export enum CherryPickResult {
@@ -239,7 +240,7 @@ export async function getCherryPickSnapshot(
   // or aborted at the same time.
   try {
     abortSafetySha = (
-      await FSE.readFile(
+      await readFile(
         Path.join(repository.path, '.git', 'sequencer', 'abort-safety'),
         'utf8'
       )
@@ -252,7 +253,7 @@ export async function getCherryPickSnapshot(
     }
 
     headSha = (
-      await FSE.readFile(
+      await readFile(
         Path.join(repository.path, '.git', 'sequencer', 'head'),
         'utf8'
       )
@@ -265,7 +266,7 @@ export async function getCherryPickSnapshot(
     }
 
     const remainingPicks = (
-      await FSE.readFile(
+      await readFile(
         Path.join(repository.path, '.git', 'sequencer', 'todo'),
         'utf8'
       )
@@ -306,7 +307,7 @@ export async function getCherryPickSnapshot(
     // If cherry-pick is in progress, then there was only one commit cherry-picked
     // thus sequencer files were not used.
     const cherryPickHeadSha = (
-      await FSE.readFile(
+      await readFile(
         Path.join(repository.path, '.git', 'CHERRY_PICK_HEAD'),
         'utf8'
       )

--- a/app/src/lib/git/description.ts
+++ b/app/src/lib/git/description.ts
@@ -1,5 +1,6 @@
 import * as Path from 'path'
 import * as FSE from 'fs-extra'
+import { readFile } from 'fs/promises'
 
 const GitDescriptionPath = '.git/description'
 
@@ -13,7 +14,7 @@ export async function getGitDescription(
   const path = Path.join(repositoryPath, GitDescriptionPath)
 
   try {
-    const data = await FSE.readFile(path, 'utf8')
+    const data = await readFile(path, 'utf8')
     if (data === DefaultGitDescription) {
       return ''
     }

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -1,5 +1,4 @@
 import * as Path from 'path'
-import * as fileSystem from '../../lib/file-system'
 
 import { getBlobContents } from './show'
 
@@ -26,6 +25,7 @@ import { spawnAndComplete } from './spawn'
 import { DiffParser } from '../diff-parser'
 import { getOldPathOrDefault } from '../get-old-path'
 import { getCaptures } from '../helpers/regex'
+import { readFile } from 'fs/promises'
 
 /**
  * V8 has a limit on the size of string it can create (~256MB), and unless we want to
@@ -432,9 +432,7 @@ export async function getWorkingDirectoryImage(
   repository: Repository,
   file: FileChange
 ): Promise<Image> {
-  const contents = await fileSystem.readFile(
-    Path.join(repository.path, file.path)
-  )
+  const contents = await readFile(Path.join(repository.path, file.path))
   return new Image(
     contents.toString('base64'),
     getMediaType(Path.extname(file.path)),

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -28,6 +28,7 @@ import { stageFiles } from './update-index'
 import { getStatus } from './status'
 import { getCommitsBetweenCommits } from './rev-list'
 import { Branch } from '../../models/branch'
+import { readFile } from 'fs/promises'
 
 /** The app-specific results from attempting to rebase a repository */
 export enum RebaseResult {
@@ -91,14 +92,14 @@ export async function getRebaseInternalState(
   let baseBranchTip: string | null = null
 
   try {
-    originalBranchTip = await FSE.readFile(
+    originalBranchTip = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'orig-head'),
       'utf8'
     )
 
     originalBranchTip = originalBranchTip.trim()
 
-    targetBranch = await FSE.readFile(
+    targetBranch = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'head-name'),
       'utf8'
     )
@@ -107,7 +108,7 @@ export async function getRebaseInternalState(
       targetBranch = targetBranch.substring(11).trim()
     }
 
-    baseBranchTip = await FSE.readFile(
+    baseBranchTip = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'onto'),
       'utf8'
     )
@@ -161,7 +162,7 @@ export async function getRebaseSnapshot(
 
   try {
     // this contains the patch number that was recently applied to the repository
-    const nextText = await FSE.readFile(
+    const nextText = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'msgnum'),
       'utf8'
     )
@@ -176,7 +177,7 @@ export async function getRebaseSnapshot(
     }
 
     // this contains the total number of patches to be applied to the repository
-    const lastText = await FSE.readFile(
+    const lastText = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'end'),
       'utf8'
     )
@@ -190,14 +191,14 @@ export async function getRebaseSnapshot(
       last = -1
     }
 
-    originalBranchTip = await FSE.readFile(
+    originalBranchTip = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'orig-head'),
       'utf8'
     )
 
     originalBranchTip = originalBranchTip.trim()
 
-    baseBranchTip = await FSE.readFile(
+    baseBranchTip = await readFile(
       Path.join(repository.path, '.git', 'rebase-merge', 'onto'),
       'utf8'
     )
@@ -258,7 +259,7 @@ export async function getRebaseSnapshot(
 async function readRebaseHead(repository: Repository): Promise<string | null> {
   try {
     const rebaseHead = Path.join(repository.path, '.git', 'REBASE_HEAD')
-    const rebaseCurrentCommitOutput = await FSE.readFile(rebaseHead, 'utf8')
+    const rebaseCurrentCommitOutput = await readFile(rebaseHead, 'utf8')
     return rebaseCurrentCommitOutput.trim()
   } catch (err) {
     log.warn(

--- a/app/src/lib/markdown-filters/emoji-filter.ts
+++ b/app/src/lib/markdown-filters/emoji-filter.ts
@@ -1,7 +1,7 @@
 import { INodeFilter } from './node-filter'
-import * as FSE from 'fs-extra'
 import { escapeRegExp } from '../helpers/regex'
 import { fileURLToPath } from 'url'
+import { readFile } from 'fs/promises'
 
 /**
  * The Emoji Markdown filter will take a text node and create multiple text and
@@ -122,7 +122,7 @@ export class EmojiFilter implements INodeFilter {
     if (cached !== undefined) {
       return cached
     }
-    const imageBuffer = await FSE.readFile(fileURLToPath(filePath))
+    const imageBuffer = await readFile(fileURLToPath(filePath))
     const b64src = imageBuffer.toString('base64')
     const uri = `data:image/png;base64,${b64src}`
     this.emojiBase64URICache.set(filePath, uri)

--- a/app/src/ui/add-repository/gitignores.ts
+++ b/app/src/ui/add-repository/gitignores.ts
@@ -1,5 +1,6 @@
 import * as Path from 'path'
-import { readdir, writeFile, readFile } from 'fs-extra'
+import { readdir, writeFile } from 'fs-extra'
+import { readFile } from 'fs/promises'
 
 const GitIgnoreExtension = '.gitignore'
 

--- a/app/src/ui/add-repository/licenses.ts
+++ b/app/src/ui/add-repository/licenses.ts
@@ -1,5 +1,6 @@
 import * as Path from 'path'
-import { writeFile, readFile } from 'fs-extra'
+import { writeFile } from 'fs-extra'
+import { readFile } from 'fs/promises'
 
 export interface ILicense {
   /** The human-readable name. */


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

`readFile` from fs-extra is just [a promisified version](https://github.com/jprichardson/node-fs-extra/blob/9.0.1/lib/fs/index.js#L30) of the readFile from `fs` so we can safely replace it with `fs/promises` instead.

Our custom `readFile` method is a promise-wrapper over an already promised-based FSE.readFile offering no added benefits (the default options [match the default options of fsPromises](https://nodejs.org/api/fs.html#fspromisesreadfilepath-options))

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes