### PR TITLE
fs/promises: mkdtemp, createReadStream, writeFile, appendFile, readlink, symlink, unlink, readdir, and realpath

### DIFF
--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -5,6 +5,7 @@ import { Disposable } from 'event-kit'
 import { Tailer } from './tailer'
 import byline from 'byline'
 import * as Crypto from 'crypto'
+import { mkdtemp } from 'fs/promises'
 
 /**
  * Get a path to a temp file using the given name. Note that the file itself
@@ -12,7 +13,7 @@ import * as Crypto from 'crypto'
  */
 export async function getTempFilePath(name: string): Promise<string> {
   const tempDir = Path.join(Os.tmpdir(), `${name}-`)
-  const directory = await FSE.mkdtemp(tempDir)
+  const directory = await mkdtemp(tempDir)
   return Path.join(directory, name)
 }
 

--- a/app/src/lib/file-system.ts
+++ b/app/src/lib/file-system.ts
@@ -1,10 +1,10 @@
-import * as FSE from 'fs-extra'
 import * as Os from 'os'
 import * as Path from 'path'
 import { Disposable } from 'event-kit'
 import { Tailer } from './tailer'
 import byline from 'byline'
 import * as Crypto from 'crypto'
+import { createReadStream } from 'fs'
 import { mkdtemp } from 'fs/promises'
 
 /**
@@ -71,7 +71,7 @@ export async function readPartialFile(
     const chunks = new Array<Buffer>()
     let total = 0
 
-    FSE.createReadStream(path, { start, end })
+    createReadStream(path, { start, end })
       .on('data', (chunk: Buffer) => {
         chunks.push(chunk)
         total += chunk.length
@@ -88,7 +88,7 @@ export async function getFileHash(
   return new Promise((resolve, reject) => {
     const hash = Crypto.createHash(type)
     hash.setEncoding('hex')
-    const input = FSE.createReadStream(path)
+    const input = createReadStream(path)
 
     hash.on('finish', () => {
       resolve(hash.read() as string)

--- a/app/src/lib/git/description.ts
+++ b/app/src/lib/git/description.ts
@@ -1,6 +1,5 @@
 import * as Path from 'path'
-import * as FSE from 'fs-extra'
-import { readFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 
 const GitDescriptionPath = '.git/description'
 
@@ -30,5 +29,5 @@ export async function writeGitDescription(
   description: string
 ): Promise<void> {
   const fullPath = Path.join(repositoryPath, GitDescriptionPath)
-  await FSE.writeFile(fullPath, description)
+  await writeFile(fullPath, description)
 }

--- a/app/src/lib/git/gitignore.ts
+++ b/app/src/lib/git/gitignore.ts
@@ -2,6 +2,7 @@ import * as Path from 'path'
 import * as FS from 'fs'
 import { Repository } from '../../models/repository'
 import { getConfigValue } from './config'
+import { writeFile } from 'fs/promises'
 
 /**
  * Read the contents of the repository .gitignore.
@@ -55,15 +56,7 @@ export async function saveGitIgnore(
   }
 
   const fileContents = await formatGitIgnoreContents(text, repository)
-  return new Promise<void>((resolve, reject) => {
-    FS.writeFile(ignorePath, fileContents, err => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve()
-      }
-    })
-  })
+  await writeFile(ignorePath, fileContents)
 }
 
 /** Add the given pattern or patterns to the root gitignore file */

--- a/app/src/lib/git/reorder.ts
+++ b/app/src/lib/git/reorder.ts
@@ -1,4 +1,5 @@
 import * as FSE from 'fs-extra'
+import { appendFile } from 'fs/promises'
 import { getCommits, revRange } from '.'
 import { Commit } from '../../models/commit'
 import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
@@ -67,10 +68,7 @@ export async function reorder(
         // If it is toMove commit and we have found the base commit, we
         // can go ahead and insert them (as we will hold any picks till after)
         if (foundBaseCommitInLog) {
-          await FSE.appendFile(
-            todoPath,
-            `pick ${commit.sha} ${commit.summary}\n`
-          )
+          await appendFile(todoPath, `pick ${commit.sha} ${commit.summary}\n`)
         } else {
           // However, if we have not found the base commit yet we want to
           // keep track of them in the order of the log. Thus, we use a new
@@ -89,7 +87,7 @@ export async function reorder(
         toReplayAfterReorder.push(commit)
 
         for (let j = 0; j < toReplayBeforeBaseCommit.length; j++) {
-          await FSE.appendFile(
+          await appendFile(
             todoPath,
             `pick ${toReplayBeforeBaseCommit[j].sha} ${toReplayBeforeBaseCommit[j].summary}\n`
           )
@@ -108,12 +106,12 @@ export async function reorder(
 
       // If it is not one toMove nor the base commit and have not found the base
       // commit, we simply record it is an unchanged pick (before the base commit)
-      await FSE.appendFile(todoPath, `pick ${commit.sha} ${commit.summary}\n`)
+      await appendFile(todoPath, `pick ${commit.sha} ${commit.summary}\n`)
     }
 
     if (toReplayAfterReorder.length > 0) {
       for (let i = 0; i < toReplayAfterReorder.length; i++) {
-        await FSE.appendFile(
+        await appendFile(
           todoPath,
           `pick ${toReplayAfterReorder[i].sha} ${toReplayAfterReorder[i].summary}\n`
         )
@@ -122,7 +120,7 @@ export async function reorder(
 
     if (beforeCommit === null) {
       for (let i = 0; i < toReplayBeforeBaseCommit.length; i++) {
-        await FSE.appendFile(
+        await appendFile(
           todoPath,
           `pick ${toReplayBeforeBaseCommit[i].sha} ${toReplayBeforeBaseCommit[i].summary}\n`
         )

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -1,4 +1,5 @@
 import * as FSE from 'fs-extra'
+import { appendFile, writeFile } from 'fs/promises'
 import { getCommits, revRange } from '.'
 import { Commit } from '../../models/commit'
 import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
@@ -77,10 +78,7 @@ export async function squash(
         // If it is toSquash commit and we have found the squashOnto commit, we
         // can go ahead and squash them (as we will hold any picks till after)
         if (foundSquashOntoCommitInLog) {
-          await FSE.appendFile(
-            todoPath,
-            `squash ${commit.sha} ${commit.summary}\n`
-          )
+          await appendFile(todoPath, `squash ${commit.sha} ${commit.summary}\n`)
         } else {
           // However, if we have not found the squashOnto commit yet we want to
           // keep track of them in the order of the log. Thus, we use a new
@@ -100,7 +98,7 @@ export async function squash(
 
         for (let j = 0; j < toReplayAtSquash.length; j++) {
           const action = j === 0 ? 'pick' : 'squash'
-          await FSE.appendFile(
+          await appendFile(
             todoPath,
             `${action} ${toReplayAtSquash[j].sha} ${toReplayAtSquash[j].summary}\n`
           )
@@ -121,12 +119,12 @@ export async function squash(
       // If it is not one toSquash nor the squashOnto and have not found the
       // squashOnto commit, we simply record it is an unchanged pick (before the
       // squash)
-      await FSE.appendFile(todoPath, `pick ${commit.sha} ${commit.summary}\n`)
+      await appendFile(todoPath, `pick ${commit.sha} ${commit.summary}\n`)
     }
 
     if (toReplayAfterSquash.length > 0) {
       for (let i = 0; i < toReplayAfterSquash.length; i++) {
-        await FSE.appendFile(
+        await appendFile(
           todoPath,
           `pick ${toReplayAfterSquash[i].sha} ${toReplayAfterSquash[i].summary}\n`
         )
@@ -141,7 +139,7 @@ export async function squash(
 
     if (commitMessage.trim() !== '') {
       messagePath = await getTempFilePath('squashCommitMessage')
-      await FSE.writeFile(messagePath, commitMessage)
+      await writeFile(messagePath, commitMessage)
     }
 
     // if no commit message provided, accept default editor

--- a/app/src/lib/large-files.ts
+++ b/app/src/lib/large-files.ts
@@ -1,7 +1,7 @@
 import { WorkingDirectoryStatus } from '../models/status'
 import { DiffSelectionType } from '../models/diff'
 import { Repository } from '../models/repository'
-import { stat } from 'fs-extra'
+import { stat } from 'fs/promises'
 import { join } from 'path'
 
 /**

--- a/app/src/lib/path.ts
+++ b/app/src/lib/path.ts
@@ -1,5 +1,5 @@
 import * as Path from 'path'
-import { realpath } from 'fs-extra'
+import { realpath } from 'fs/promises'
 import { pathToFileURL } from 'url'
 
 /**

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -94,7 +94,7 @@ import { StatsStore } from '../stats'
 import { getTagsToPush, storeTagsToPush } from './helpers/tags-to-push-storage'
 import { DiffSelection, ITextDiff } from '../../models/diff'
 import { getDefaultBranch } from '../helpers/default-branch'
-import { stat } from 'fs-extra'
+import { stat } from 'fs/promises'
 import { findForkedRemotesToPrune } from './helpers/find-forked-remotes-to-prune'
 
 /** The number of commits to load from history per batch. */

--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -1,7 +1,8 @@
 import * as Path from 'path'
 
 import { Account } from '../../../models/account'
-import { writeFile, pathExists, ensureDir } from 'fs-extra'
+import { pathExists, ensureDir } from 'fs-extra'
+import { writeFile } from 'fs/promises'
 import { API } from '../../api'
 import { APIError } from '../../http'
 import {

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -1,7 +1,8 @@
 import * as Path from 'path'
 import * as Os from 'os'
 
-import { pathExists, ensureDir, writeFile } from 'fs-extra'
+import { pathExists, ensureDir } from 'fs-extra'
+import { writeFile } from 'fs/promises'
 import { spawn, getPathSegments, setPathSegments } from '../lib/process/win32'
 
 const appFolder = Path.resolve(process.execPath, '..')

--- a/app/src/ui/add-repository/git-attributes.ts
+++ b/app/src/ui/add-repository/git-attributes.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs-extra'
+import { writeFile } from 'fs/promises'
 import { join } from 'path'
 
 /**

--- a/app/src/ui/add-repository/gitignores.ts
+++ b/app/src/ui/add-repository/gitignores.ts
@@ -1,6 +1,6 @@
 import * as Path from 'path'
-import { readdir, writeFile } from 'fs-extra'
-import { readFile } from 'fs/promises'
+import { readdir } from 'fs-extra'
+import { readFile, writeFile } from 'fs/promises'
 
 const GitIgnoreExtension = '.gitignore'
 

--- a/app/src/ui/add-repository/gitignores.ts
+++ b/app/src/ui/add-repository/gitignores.ts
@@ -1,6 +1,5 @@
 import * as Path from 'path'
-import { readdir } from 'fs/promises'
-import { readFile, writeFile } from 'fs/promises'
+import { readdir, readFile, writeFile } from 'fs/promises'
 
 const GitIgnoreExtension = '.gitignore'
 

--- a/app/src/ui/add-repository/gitignores.ts
+++ b/app/src/ui/add-repository/gitignores.ts
@@ -1,5 +1,5 @@
 import * as Path from 'path'
-import { readdir } from 'fs-extra'
+import { readdir } from 'fs/promises'
 import { readFile, writeFile } from 'fs/promises'
 
 const GitIgnoreExtension = '.gitignore'

--- a/app/src/ui/add-repository/licenses.ts
+++ b/app/src/ui/add-repository/licenses.ts
@@ -1,6 +1,5 @@
 import * as Path from 'path'
-import { writeFile } from 'fs-extra'
-import { readFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 
 export interface ILicense {
   /** The human-readable name. */

--- a/app/src/ui/add-repository/write-default-readme.ts
+++ b/app/src/ui/add-repository/write-default-readme.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs-extra'
+import { writeFile } from 'fs/promises'
 import * as Path from 'path'
 
 const DefaultReadmeName = 'README.md'

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -1,6 +1,5 @@
 import * as Path from 'path'
 import * as React from 'react'
-import { readdir } from 'fs-extra'
 import { Dispatcher } from '../dispatcher'
 import { getDefaultDir, setDefaultDir } from '../lib/default-dir'
 import { Account } from '../../models/account'
@@ -24,6 +23,7 @@ import { ClickSource } from '../lib/list'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { enableSaveDialogOnCloneRepository } from '../../lib/feature-flag'
 import { showOpenDialog, showSaveDialog } from '../main-process-proxy'
+import { readdir } from 'fs/promises'
 
 interface ICloneRepositoryProps {
   readonly dispatcher: Dispatcher

--- a/app/src/ui/lib/config-lock-file-exists.tsx
+++ b/app/src/ui/lib/config-lock-file-exists.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Ref } from './ref'
 import { LinkButton } from './link-button'
-import { unlink } from 'fs-extra'
+import { unlink } from 'fs/promises'
 
 interface IConfigLockFileExistsProps {
   /**

--- a/app/src/ui/lib/install-cli.ts
+++ b/app/src/ui/lib/install-cli.ts
@@ -2,6 +2,7 @@ import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
 import * as fsAdmin from 'fs-admin'
+import { readlink, symlink, unlink } from 'fs/promises'
 
 /** The path for the installed command line tool. */
 export const InstalledCLIPath = '/usr/local/bin/github'
@@ -26,7 +27,7 @@ export async function installCLI(): Promise<void> {
 
 async function getResolvedInstallPath(): Promise<string | null> {
   try {
-    return await FSE.readlink(InstalledCLIPath)
+    return await readlink(InstalledCLIPath)
   } catch {
     return null
   }
@@ -34,7 +35,7 @@ async function getResolvedInstallPath(): Promise<string | null> {
 
 function removeExistingSymlink(asAdmin: boolean) {
   if (!asAdmin) {
-    return FSE.unlink(InstalledCLIPath)
+    return unlink(InstalledCLIPath)
   }
 
   return new Promise<void>((resolve, reject) => {
@@ -78,7 +79,7 @@ function createDirectories(asAdmin: boolean) {
 
 function createNewSymlink(asAdmin: boolean) {
   if (!asAdmin) {
-    return FSE.symlink(PackagedPath, InstalledCLIPath)
+    return symlink(PackagedPath, InstalledCLIPath)
   }
 
   return new Promise<void>((resolve, reject) => {

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import * as FSE from 'fs-extra'
 import * as Path from 'path'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
@@ -8,6 +7,7 @@ import {
   buildCustomMarkDownNodeFilterPipe,
 } from '../../lib/markdown-filters/node-filter'
 import { GitHubRepository } from '../../models/github-repository'
+import { readFile } from 'fs/promises'
 
 interface ISandboxedMarkdownProps {
   /** A string of unparsed markdown to display */
@@ -80,7 +80,7 @@ export class SandboxedMarkdown extends React.PureComponent<
    * document body and provide them aswell.
    */
   private async getInlineStyleSheet(): Promise<string> {
-    const css = await FSE.readFile(
+    const css = await readFile(
       Path.join(__dirname, 'static', 'markdown.css'),
       'utf8'
     )

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -1,7 +1,7 @@
 import { ExecutableMenuItem } from '../models/app-menu'
 import { RequestResponseChannels, RequestChannels } from '../lib/ipc-shared'
 import * as ipcRenderer from '../lib/ipc-renderer'
-import { stat } from 'fs-extra'
+import { stat } from 'fs/promises'
 import { isApplicationBundle } from '../lib/is-application-bundle'
 
 /**

--- a/script/licenses/update-license-dump.ts
+++ b/script/licenses/update-license-dump.ts
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import * as fs from 'fs-extra'
 import { promisify } from 'util'
 
 import { licenseOverrides } from './license-overrides'
@@ -8,7 +7,7 @@ import _legalEagle from 'legal-eagle'
 const legalEagle = promisify(_legalEagle)
 
 import { getVersion } from '../../app/package-info'
-import { readFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 
 export async function updateLicenseDump(
   projectRoot: string,
@@ -55,7 +54,5 @@ export async function updateLicenseDump(
     sourceText: licenseText,
   }
 
-  await fs.writeFile(outPath, JSON.stringify(summary), {
-    encoding: 'utf8',
-  })
+  await writeFile(outPath, JSON.stringify(summary), { encoding: 'utf8' })
 }

--- a/script/licenses/update-license-dump.ts
+++ b/script/licenses/update-license-dump.ts
@@ -8,6 +8,7 @@ import _legalEagle from 'legal-eagle'
 const legalEagle = promisify(_legalEagle)
 
 import { getVersion } from '../../app/package-info'
+import { readFile } from 'fs/promises'
 
 export async function updateLicenseDump(
   projectRoot: string,
@@ -44,9 +45,7 @@ export async function updateLicenseDump(
   // this injects the current license and pins the source URL before we
   // dump the JSON file to disk
   const licenseSource = path.join(projectRoot, 'LICENSE')
-  const licenseText = await fs.readFile(licenseSource, {
-    encoding: 'utf-8',
-  })
+  const licenseText = await readFile(licenseSource, { encoding: 'utf-8' })
   const appVersion = getVersion()
 
   summary[`desktop@${appVersion}`] = {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Based on #14078, this replaces our use of the following `fs-extra` functions: `mkdtemp`, `createReadStream`, `writeFile`, `appendFile`, `readlink`, `symlink`, `unlink`, `readdir`, and `realpath`.

`createReadStream` is the exact same function as that from `fs` and the others are [promisified versions](https://github.com/jprichardson/node-fs-extra/blob/7b12b058e27df560ba777756f38f977662c23750/lib/fs/index.js#L8-L40) of their fs counterparts and can be safely replaced.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes