### PR TITLE
fs/promises: ensureDir

### DIFF
--- a/app/src/lib/stores/helpers/create-tutorial-repository.ts
+++ b/app/src/lib/stores/helpers/create-tutorial-repository.ts
@@ -1,8 +1,7 @@
 import * as Path from 'path'
 
 import { Account } from '../../../models/account'
-import { ensureDir } from 'fs-extra'
-import { writeFile } from 'fs/promises'
+import { mkdir, writeFile } from 'fs/promises'
 import { API } from '../../api'
 import { APIError } from '../../http'
 import {
@@ -120,7 +119,7 @@ export async function createTutorialRepository(
   const branch = repo.default_branch ?? (await getDefaultBranch())
   progressCb('Initializing local repository', 0.2)
 
-  await ensureDir(path)
+  await mkdir(path, { recursive: true })
 
   await git(
     ['-c', `init.defaultBranch=${branch}`, 'init'],

--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -2,11 +2,11 @@ import * as Path from 'path'
 import * as winston from 'winston'
 import { getLogDirectoryPath } from '../lib/logging/get-log-path'
 import { LogLevel } from '../lib/logging/log-level'
-import { ensureDir } from 'fs-extra'
 import { noop } from 'lodash'
 import { DesktopConsoleTransport } from './desktop-console-transport'
 import 'winston-daily-rotate-file'
 import memoizeOne from 'memoize-one'
+import { mkdir } from 'fs/promises'
 
 /**
  * The maximum number of log files we should have on disk before pruning old
@@ -65,7 +65,7 @@ function initializeWinston(path: string): winston.LogMethod {
  */
 const getLogger = memoizeOne(async () => {
   const logDirectory = getLogDirectoryPath()
-  await ensureDir(logDirectory)
+  await mkdir(logDirectory, { recursive: true })
   return initializeWinston(logDirectory)
 })
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -3,11 +3,11 @@ import { ensureItemIds } from './ensure-item-ids'
 import { MenuEvent } from './menu-event'
 import { truncateWithEllipsis } from '../../lib/truncate-with-ellipsis'
 import { getLogDirectoryPath } from '../../lib/logging/get-log-path'
-import { ensureDir } from 'fs-extra'
 import { UNSAFE_openDirectory } from '../shell'
 import { MenuLabelsEvent } from '../../models/menu-labels'
 import { enableSquashMerging } from '../../lib/feature-flag'
 import * as ipcWebContents from '../ipc-webcontents'
+import { mkdir } from 'fs/promises'
 
 const platformDefaultShell = __WIN32__ ? 'Command Prompt' : 'Terminal'
 const createPullRequestLabel = __DARWIN__
@@ -500,13 +500,9 @@ export function buildDefaultMenu({
     label: showLogsLabel,
     click() {
       const logPath = getLogDirectoryPath()
-      ensureDir(logPath)
-        .then(() => {
-          UNSAFE_openDirectory(logPath)
-        })
-        .catch(err => {
-          log.error('Failed opening logs directory', err)
-        })
+      mkdir(logPath, { recursive: true })
+        .then(() => UNSAFE_openDirectory(logPath))
+        .catch(err => log.error('Failed opening logs directory', err))
     },
   }
 

--- a/app/src/main-process/squirrel-updater.ts
+++ b/app/src/main-process/squirrel-updater.ts
@@ -1,8 +1,7 @@
 import * as Path from 'path'
 import * as Os from 'os'
 
-import { ensureDir } from 'fs-extra'
-import { writeFile } from 'fs/promises'
+import { mkdir, writeFile } from 'fs/promises'
 import { spawn, getPathSegments, setPathSegments } from '../lib/process/win32'
 import { pathExists } from '../ui/lib/path-exists'
 
@@ -49,7 +48,7 @@ async function handleUpdated(): Promise<void> {
 
 async function installCLI(): Promise<void> {
   const binPath = getBinPath()
-  await ensureDir(binPath)
+  await mkdir(binPath, { recursive: true })
   await writeBatchScriptCLITrampoline(binPath)
   await writeShellScriptCLITrampoline(binPath)
   try {

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as Path from 'path'
-import * as FSE from 'fs-extra'
 
 import { Dispatcher } from '../dispatcher'
 import {
@@ -32,6 +31,7 @@ import { enableReadmeOverwriteWarning } from '../../lib/feature-flag'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { showOpenDialog } from '../main-process-proxy'
 import { pathExists } from '../lib/path-exists'
+import { mkdir } from 'fs/promises'
 
 /** The sentinel value used to indicate no gitignore should be used. */
 const NoGitIgnoreValue = 'None'
@@ -207,7 +207,7 @@ export class CreateRepository extends React.Component<
       // if the user provided an initial path and didn't change it, we should
       // validate it is an existing path and use that for the repository
       try {
-        await FSE.ensureDir(currentPath)
+        await mkdir(currentPath, { recursive: true })
         return currentPath
       } catch {}
     }
@@ -226,7 +226,7 @@ export class CreateRepository extends React.Component<
     }
 
     try {
-      await FSE.ensureDir(fullPath)
+      await mkdir(fullPath, { recursive: true })
       this.setState({ isValidPath: true })
     } catch (e) {
       if (e.code === 'EACCES' && e.errno === -13) {

--- a/app/src/ui/lib/install-cli.ts
+++ b/app/src/ui/lib/install-cli.ts
@@ -2,7 +2,7 @@ import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
 import * as fsAdmin from 'fs-admin'
-import { readlink, symlink, unlink } from 'fs/promises'
+import { mkdir, readlink, symlink, unlink } from 'fs/promises'
 
 /** The path for the installed command line tool. */
 export const InstalledCLIPath = '/usr/local/bin/github'
@@ -58,7 +58,7 @@ function createDirectories(asAdmin: boolean) {
   const path = Path.dirname(InstalledCLIPath)
 
   if (!asAdmin) {
-    return FSE.mkdirp(path)
+    return mkdir(path, { recursive: true })
   }
 
   return new Promise<void>((resolve, reject) => {

--- a/app/src/ui/lib/install-cli.ts
+++ b/app/src/ui/lib/install-cli.ts
@@ -1,4 +1,3 @@
-import * as FSE from 'fs-extra'
 import * as Path from 'path'
 
 import * as fsAdmin from 'fs-admin'


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Based on #14080, this PR substitutes our use of `ensureDir` from `fs-extra` for mkdir with the `recursive` option from `fs/promises`.

Note that `ensureDir` and `mkdirp` are both aliases for [fs-extras internal makeDir](https://github.com/jprichardson/node-fs-extra/blob/c8815e3ccf130422b427484007f73029075b56b6/lib/mkdirs/index.js#L10-L13).

Our implementation here differs from that of `fs-extra` in that it doesn't resolve the path to an absolute path before passing it to `mkdir`, see https://github.com/jprichardson/node-fs-extra/blob/c8815e3ccf130422b427484007f73029075b56b6/lib/mkdirs/make-dir.js#L49

As far as I can tell that shouldn't be necessary except on Windows. On posix systems Node will call [mkdir(2)](https://github.com/nodejs/node/blob/master/deps/uv/src/unix/fs.c#L1717) which handles relative paths just fine and on Windows Node will call [toNamespacedPath](https://github.com/nodejs/node/blob/b35ee26f03021eb196fff0dec47291b0bb2f1c3a/lib/internal/fs/promises.js#L665) which will [resolve on Windows](https://github.com/nodejs/node/blob/b35ee26f03021eb196fff0dec47291b0bb2f1c3a/lib/path.js#L623) (toNamespacedPath is noop on unix).

There's also no mention about special care or treatment of relative paths in the Node docs for mkdir so I'm inclined to not add any extra behavior until we know we need it.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes