### PR TITLE
fs/promises: ensureFile

### DIFF
--- a/app/src/lib/progress/lfs.ts
+++ b/app/src/lib/progress/lfs.ts
@@ -1,12 +1,18 @@
-import * as FSE from 'fs-extra'
 import { getTempFilePath } from '../file-system'
 import { IGitProgress, IGitProgressInfo, IGitOutput } from './git'
 import { formatBytes } from '../../ui/lib/bytes'
+import { open } from 'fs/promises'
 
 /** Create the Git LFS progress reporting file and return the path. */
 export async function createLFSProgressFile(): Promise<string> {
   const path = await getTempFilePath('GitHubDesktop-lfs-progress')
-  await FSE.ensureFile(path)
+
+  // getTempFilePath will take care of creating the directory, we only need
+  // to make sure the file exists as well. We use `wx` to throw if the file
+  // already exists since we don't expect it to given that getTempFilePath
+  // creates a random path.
+  await open(path, 'wx').then(f => f.close())
+
   return path
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Based on #14081 this removes our dependency on the `ensureFile` method of fs-extra. The [ensureFile method](https://github.com/jprichardson/node-fs-extra/blob/c8815e3ccf130422b427484007f73029075b56b6/lib/ensure/file.js#L8-L41) takes care of creating both the file and the directory (recursively). Luckily for us we don't need that as `mkdtemp` (in getTempFilePath) will already have taken care of creating the directory.

There's a behavioral change here in that this new method will throw if the file already exists rather than overwriting its contents. If the file exists then mkdtemp has been broken somehow and we can't trust it to not give us a location that's dangerous to overwrite.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes