### PR TITLE
fs/promises: remove

### DIFF
--- a/app/src/lib/git/reorder.ts
+++ b/app/src/lib/git/reorder.ts
@@ -1,5 +1,4 @@
-import * as FSE from 'fs-extra'
-import { appendFile } from 'fs/promises'
+import { appendFile, rm } from 'fs/promises'
 import { getCommits, revRange } from '.'
 import { Commit } from '../../models/commit'
 import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
@@ -145,7 +144,7 @@ export async function reorder(
     return RebaseResult.Error
   } finally {
     if (todoPath !== undefined) {
-      FSE.remove(todoPath)
+      await rm(todoPath, { recursive: true, force: true })
     }
   }
 

--- a/app/src/lib/git/squash.ts
+++ b/app/src/lib/git/squash.ts
@@ -1,5 +1,4 @@
-import * as FSE from 'fs-extra'
-import { appendFile, writeFile } from 'fs/promises'
+import { appendFile, rm, writeFile } from 'fs/promises'
 import { getCommits, revRange } from '.'
 import { Commit } from '../../models/commit'
 import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
@@ -160,11 +159,11 @@ export async function squash(
     return RebaseResult.Error
   } finally {
     if (todoPath !== undefined) {
-      FSE.remove(todoPath)
+      await rm(todoPath, { recursive: true, force: true })
     }
 
     if (messagePath !== undefined) {
-      FSE.remove(messagePath)
+      await rm(messagePath, { recursive: true, force: true })
     }
   }
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -46,6 +46,7 @@ import { isCircleCI, isGitHubActions } from './build-platforms'
 
 import { updateLicenseDump } from './licenses/update-license-dump'
 import { verifyInjectedSassVariables } from './validate-sass/validate-all'
+import { rmSync } from 'fs'
 
 const projectRoot = path.join(__dirname, '..')
 const entitlementsPath = `${projectRoot}/script/entitlements.plist`
@@ -58,7 +59,7 @@ const isDevelopmentBuild = getChannel() === 'development'
 console.log(`Building for ${getChannel()}…`)
 
 console.log('Removing old distribution…')
-fs.removeSync(getDistRoot())
+rmSync(getDistRoot(), { recursive: true, force: true })
 
 console.log('Copying dependencies…')
 copyDependencies()
@@ -230,7 +231,7 @@ function packageApp() {
 }
 
 function removeAndCopy(source: string, destination: string) {
-  fs.removeSync(destination)
+  rmSync(destination, { recursive: true, force: true })
   fs.copySync(source, destination)
 }
 
@@ -249,7 +250,7 @@ function copyStaticResources() {
   const platformSpecific = path.join(projectRoot, 'app', 'static', dirName)
   const common = path.join(projectRoot, 'app', 'static', 'common')
   const destination = path.join(outRoot, 'static')
-  fs.removeSync(destination)
+  rmSync(destination, { recursive: true, force: true })
   if (fs.existsSync(platformSpecific)) {
     fs.copySync(platformSpecific, destination)
   }
@@ -290,7 +291,10 @@ function copyDependencies() {
       : {}
 
   fs.writeFileSync(path.join(outRoot, 'package.json'), JSON.stringify(pkg))
-  fs.removeSync(path.resolve(outRoot, 'node_modules'))
+  rmSync(path.resolve(outRoot, 'node_modules'), {
+    recursive: true,
+    force: true,
+  })
 
   console.log('  Installing dependencies via yarn…')
   cp.execSync('yarn install', { cwd: outRoot, env: process.env })
@@ -301,7 +305,7 @@ function copyDependencies() {
     process.platform === 'win32'
       ? 'desktop-trampoline.exe'
       : 'desktop-trampoline'
-  fs.removeSync(desktopTrampolineDir)
+  rmSync(desktopTrampolineDir, { recursive: true, force: true })
   fs.mkdirSync(desktopTrampolineDir)
   fs.copySync(
     path.resolve(
@@ -328,7 +332,7 @@ function copyDependencies() {
 
   console.log('  Copying git environment…')
   const gitDir = path.resolve(outRoot, 'git')
-  fs.removeSync(gitDir)
+  rmSync(gitDir, { recursive: true, force: true })
   fs.mkdirpSync(gitDir)
   fs.copySync(path.resolve(projectRoot, 'app/node_modules/dugite/git'), gitDir)
 
@@ -363,7 +367,7 @@ function copyDependencies() {
   if (process.platform === 'darwin') {
     console.log('  Copying app-path binary…')
     const appPathMain = path.resolve(outRoot, 'main')
-    fs.removeSync(appPathMain)
+    rmSync(appPathMain, { recursive: true, force: true })
     fs.copySync(
       path.resolve(projectRoot, 'app/node_modules/app-path/main'),
       appPathMain
@@ -425,7 +429,7 @@ ${licenseText}`
   fs.writeFileSync(licenseDestination, licenseWithHeader, 'utf8')
 
   // sweep up the choosealicense directory as the important bits have been bundled in the app
-  fs.removeSync(chooseALicense)
+  rmSync(chooseALicense, { recursive: true, force: true })
 }
 
 function getNotarizationCredentials(): OsxNotarizeOptions | undefined {

--- a/script/package.ts
+++ b/script/package.ts
@@ -16,6 +16,7 @@ import {
   getIconFileName,
 } from './dist-info'
 import { isAppveyor, isGitHubActions } from './build-platforms'
+import { rmSync } from 'fs-extra'
 
 const distPath = getDistPath()
 const productName = getProductName()
@@ -34,7 +35,7 @@ if (process.platform === 'darwin') {
 
 function packageOSX() {
   const dest = getOSXZipPath()
-  fs.removeSync(dest)
+  rmSync(dest, { recursive: true, force: true })
 
   console.log('Packaging for macOS…')
   cp.execSync(


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Based on #14082 this PR substitutes the `remove` method from `fs-extra` for the `rm` method in fs/promises. This is exactly what the `remove` method does currently: https://github.com/jprichardson/node-fs-extra/blob/c8815e3ccf130422b427484007f73029075b56b6/lib/remove/index.js#L9

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes