### PR TITLE
fs/promises: synchronous methods

### DIFF
--- a/script/licenses/update-license-dump.ts
+++ b/script/licenses/update-license-dump.ts
@@ -1,5 +1,4 @@
 import * as path from 'path'
-import * as fs from 'fs-extra'
 import { promisify } from 'util'
 
 import { licenseOverrides } from './license-overrides'
@@ -8,7 +7,7 @@ import _legalEagle from 'legal-eagle'
 const legalEagle = promisify(_legalEagle)
 
 import { getVersion } from '../../app/package-info'
-import { readFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 
 export async function updateLicenseDump(
   projectRoot: string,
@@ -55,7 +54,5 @@ export async function updateLicenseDump(
     sourceText: licenseText,
   }
 
-  await fs.writeFile(outPath, JSON.stringify(summary), {
-    encoding: 'utf8',
-  })
+  await writeFile(outPath, JSON.stringify(summary), { encoding: 'utf8' })
 }

--- a/script/package.ts
+++ b/script/package.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-sync */
 
-import * as fs from 'fs-extra'
 import * as cp from 'child_process'
 import * as path from 'path'
 import * as electronInstaller from 'electron-winstaller'
@@ -16,7 +15,7 @@ import {
   getIconFileName,
 } from './dist-info'
 import { isAppveyor, isGitHubActions } from './build-platforms'
-import { rmSync } from 'fs-extra'
+import { existsSync, rmSync } from 'fs'
 
 const distPath = getDistPath()
 const productName = getProductName()
@@ -67,7 +66,7 @@ function packageWindows() {
     `${getIconFileName()}.ico`
   )
 
-  if (!fs.existsSync(iconSource)) {
+  if (!existsSync(iconSource)) {
     console.error(`expected setup icon not found at location: ${iconSource}`)
     process.exit(1)
   }
@@ -77,7 +76,7 @@ function packageWindows() {
     '../app/static/logos/win32-installer-splash.gif'
   )
 
-  if (!fs.existsSync(splashScreenPath)) {
+  if (!existsSync(splashScreenPath)) {
     console.error(
       `expected setup splash screen gif not found at location: ${splashScreenPath}`
     )


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Based on #14083 this PR replaces all synchronous fs-extra methods (ie. in our scripts) with their fs counterparts with the exception of `copySync` which will recursively copy a directory and for which `fs-extra` still seems to be the [recommended option](https://stackoverflow.com/a/64498004/2114).

Note that we'll still be able to remove `fs-extra` from our app, this only affects the root level package.json which governs the build process.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes