### PR TITLE
Simplify updateEnvironmentForProcess

### DIFF
--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -1,12 +1,8 @@
 /* eslint-disable no-sync */
 
-import * as ChildProcess from 'child_process'
-import * as os from 'os'
+import { ExecFileOptions } from 'child_process'
+import { execFile } from './exec-file'
 import { isMacOSCatalinaOrEarlier } from './get-os'
-
-type IndexLookup = {
-  [propName: string]: string
-}
 
 /**
  * The names of any env vars that we shouldn't copy from the shell environment.
@@ -36,144 +32,38 @@ export function shellNeedsPatching(process: NodeJS.Process): boolean {
   return __DARWIN__ && !process.env.PWD
 }
 
-type ShellResult = {
-  stdout: string
-  error: Error | null
-}
-
 /**
  * Gets a dump of the user's configured shell environment.
  *
  * @returns the output of the `env` command or `null` if there was an error.
  */
-async function getRawShellEnv(): Promise<string | null> {
-  const shell = getUserShell()
+function getRawShellEnv(): Promise<string | null> {
+  const shell = process.env.SHELL || '/bin/bash'
+  // This timeout and the excessive maxBuffer are leftovers of previous
+  // implementations and could _probably_ be removed. The default maxBuffer is
+  // 1Mb and I don't know why anyone would have 1Mb of env vars. The timeout
+  // was a
+  const opts: ExecFileOptions = { timeout: 5000, maxBuffer: 10 * 1024 * 1024 }
 
-  const promise = new Promise<ShellResult>(resolve => {
-    let child: ChildProcess.ChildProcess | null = null
-    let error: Error | null = null
-    let stdout = ''
-    let done = false
-
-    // ensure we clean up eventually, in case things go bad
-    const cleanup = () => {
-      if (!done && child) {
-        child.kill()
-        done = true
-      }
-    }
-    process.once('exit', cleanup)
-    setTimeout(() => {
-      cleanup()
-    }, 5000)
-
-    child = ChildProcess.spawn(shell, ['-ilc', 'command env'], {
-      detached: true,
-      stdio: ['ignore', 'pipe', process.stderr],
-    })
-
-    const buffers: Array<Buffer> = []
-
-    child.on('error', (e: Error) => {
-      done = true
-      error = e
-    })
-
-    // If Node.js encounters a synchronous runtime error while spawning
-    // `stdout` will be undefined and the error will be emitted asynchronously
-    if (child.stdout) {
-      child.stdout.on('data', (data: Buffer) => {
-        buffers.push(data)
-      })
-    }
-
-    child.on('close', (code: number, signal) => {
-      done = true
-      process.removeListener('exit', cleanup)
-      if (buffers.length) {
-        stdout = Buffer.concat(buffers).toString('utf8')
-      }
-
-      resolve({ stdout, error })
-    })
-  })
-
-  const { stdout, error } = await promise
-
-  if (error) {
-    // just swallow the error and move on with everything
-    return null
-  }
-
-  return stdout
-}
-
-function getUserShell() {
-  if (process.env.SHELL) {
-    return process.env.SHELL
-  }
-
-  return '/bin/bash'
-}
-
-/**
- * Get the environment variables from the user's current shell and update the
- * current environment.
- *
- * @param updateEnvironment a callback to fire if a valid environment is found
- */
-async function getEnvironmentFromShell(
-  updateEnvironment: (env: IndexLookup) => void
-): Promise<void> {
-  if (__WIN32__) {
-    return
-  }
-
-  const shellEnvText = await getRawShellEnv()
-  if (!shellEnvText) {
-    return
-  }
-
-  const env: IndexLookup = {}
-
-  for (const line of shellEnvText.split(os.EOL)) {
-    if (line.includes('=')) {
-      const components = line.split('=')
-      if (components.length === 2) {
-        env[components[0]] = components[1]
-      } else {
-        const k = components.shift()
-        const v = components.join('=')
-        if (k) {
-          env[k] = v
-        }
-      }
-    }
-  }
-
-  updateEnvironment(env)
-}
-
-/**
- * Apply new environment variables to the current process, ignoring
- * Node-specific environment variables which need to be preserved.
- *
- * @param env The new environment variables from the user's shell.
- */
-function mergeEnvironmentVariables(env: IndexLookup) {
-  for (const key in env) {
-    if (ExcludedEnvironmentVars.has(key)) {
-      continue
-    }
-
-    process.env[key] = env[key]
-  }
+  return execFile(shell, ['-ilc', 'command env'], opts)
+    .then(({ stdout }) => stdout)
+    .catch(() => null)
 }
 
 /**
  * Update the current process's environment variables using environment
  * variables from the user's shell, if they can be retrieved successfully.
  */
-export function updateEnvironmentForProcess(): Promise<void> {
-  return getEnvironmentFromShell(mergeEnvironmentVariables)
+export async function updateEnvironmentForProcess(): Promise<void> {
+  if (!__DARWIN__) {
+    return
+  }
+
+  const shellEnvText = (await getRawShellEnv()) ?? ''
+
+  for (const [, k, v] of shellEnvText.matchAll(/^(.+?)=(.*)$/gm)) {
+    if (!ExcludedEnvironmentVars.has(k)) {
+      process.env[k] = v
+    }
+  }
 }

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -41,21 +41,28 @@ export async function updateEnvironmentForProcess(): Promise<void> {
     return
   }
 
-  const shell = process.env.SHELL || '/bin/bash'
-  // This timeout and the excessive maxBuffer are leftovers of previous
-  // implementations and could _probably_ be removed. The default maxBuffer is
-  // 1Mb and I don't know why anyone would have 1Mb of env vars. The timeout
-  // is a leftover from when the process was detached and the reason we still
-  // have it is that if we happen to await this method it could block app launch
-  const opts: ExecFileOptions = { timeout: 5000, maxBuffer: 10 * 1024 * 1024 }
+  try {
+    const shell = process.env.SHELL || '/bin/bash'
+    // These options are leftovers of previous implementations and could
+    // _probably_ be removed. The default maxBuffer is 1Mb and I don't know why
+    // anyone would have 1Mb of env vars (previous implementation had no limit).
+    //
+    // The timeout is a leftover from when the process was detached and the
+    // reason we still have it is that if we happen to await this method it
+    // could block app launch
+    const opts: ExecFileOptions = { timeout: 5000, maxBuffer: 10 * 1024 * 1024 }
 
-  const rawEnv = await execFile(shell, ['-ilc', 'command env'], opts)
-    .then(({ stdout }) => stdout)
-    .catch(() => '')
+    // Deal with environment variables containing newlines by separating with \0
+    // https://github.com/atom/atom/blob/d04abd683/src/update-process-env.js#L17
+    const cmd = `command awk 'BEGIN{for(k in ENVIRON) printf("%c%s=%s%c", 0, k, ENVIRON[k], 0)}'`
+    const { stdout } = await execFile(shell, ['-ilc', cmd], opts)
 
-  for (const [, k, v] of rawEnv.matchAll(/^(.+?)=(.*)$/gm)) {
-    if (!ExcludedEnvironmentVars.has(k)) {
-      process.env[k] = v
+    for (const [, k, v] of stdout.matchAll(/\0(.+?)=(.+?)\0/g)) {
+      if (!ExcludedEnvironmentVars.has(k)) {
+        process.env[k] = v
+      }
     }
+  } catch (err) {
+    log.error('Failed updating process environment from shell', err)
   }
 }

--- a/app/src/lib/shell.ts
+++ b/app/src/lib/shell.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-sync */
-
 import { ExecFileOptions } from 'child_process'
 import { execFile } from './exec-file'
 import { isMacOSCatalinaOrEarlier } from './get-os'


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->


## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This is a cleanup me and @sergiou87 discovered while working on #14034. We have no reason to suspect that we need the env process to run detached so we can simplify things a lot by leveraging the promise based execFile implementation introduced in #14051

As I was writing this up I took a look at [Atom's current implementation](https://github.com/atom/atom/blob/d016186110ffbe588a45d594803f9f9078804085/src/update-process-env.js) (that's where we got this from initially) and realized that they had run into an issue with environment variables containing newlines and had switched to using `awk` instead of `env` for that reason. So I figured we could do the same.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes