### PR TITLE
Use our own slightly more type safe pick

### DIFF
--- a/app/src/lib/pick.ts
+++ b/app/src/lib/pick.ts
@@ -1,3 +1,7 @@
+/**
+ * Returns a shallow copy of the given object containing only the given subset
+ * of keys. This is to be thought of as a runtime equivalent of Pick<T, K>
+ */
 export function pick<T extends object, K extends keyof T>(o: T, ...keys: K[]) {
   const isOwn = (k: K) => Object.prototype.hasOwnProperty.call(o, k)
   const toEntry = (k: K) => [k, o[k]]

--- a/app/src/lib/pick.ts
+++ b/app/src/lib/pick.ts
@@ -1,5 +1,5 @@
 export function pick<T extends object, K extends keyof T>(o: T, ...keys: K[]) {
-  const own = (k: K) => Object.prototype.hasOwnProperty.call(o, k)
-  const entry = (k: K) => [k, o[k]]
-  return Object.fromEntries(keys.filter(own).map(entry)) as Pick<T, K>
+  const isOwn = (k: K) => Object.prototype.hasOwnProperty.call(o, k)
+  const toEntry = (k: K) => [k, o[k]]
+  return Object.fromEntries(keys.filter(isOwn).map(toEntry)) as Pick<T, K>
 }

--- a/app/src/lib/pick.ts
+++ b/app/src/lib/pick.ts
@@ -1,0 +1,5 @@
+export function pick<T extends object, K extends keyof T>(o: T, ...keys: K[]) {
+  const own = (k: K) => Object.prototype.hasOwnProperty.call(o, k)
+  const entry = (k: K) => [k, o[k]]
+  return Object.fromEntries(keys.filter(own).map(entry)) as Pick<T, K>
+}

--- a/app/src/lib/pick.ts
+++ b/app/src/lib/pick.ts
@@ -2,8 +2,5 @@
  * Returns a shallow copy of the given object containing only the given subset
  * of keys. This is to be thought of as a runtime equivalent of Pick<T, K>
  */
-export function pick<T extends object, K extends keyof T>(o: T, ...keys: K[]) {
-  const isOwn = (k: K) => Object.prototype.hasOwnProperty.call(o, k)
-  const toEntry = (k: K) => [k, o[k]]
-  return Object.fromEntries(keys.filter(isOwn).map(toEntry)) as Pick<T, K>
-}
+export const pick = <T extends object, K extends keyof T>(o: T, ...keys: K[]) =>
+  Object.fromEntries(keys.map(k => [k, o[k]])) as Pick<T, K>

--- a/app/src/lib/pick.ts
+++ b/app/src/lib/pick.ts
@@ -2,5 +2,8 @@
  * Returns a shallow copy of the given object containing only the given subset
  * of keys. This is to be thought of as a runtime equivalent of Pick<T, K>
  */
-export const pick = <T extends object, K extends keyof T>(o: T, ...keys: K[]) =>
-  Object.fromEntries(keys.map(k => [k, o[k]])) as Pick<T, K>
+export function pick<T extends object, K extends keyof T>(o: T, ...keys: K[]) {
+  const hasProperty = (k: K) => k in o
+  const toEntry = (k: K) => [k, o[k]]
+  return Object.fromEntries(keys.filter(hasProperty).map(toEntry)) as Pick<T, K>
+}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -35,7 +35,7 @@ import { IdealSummaryLength } from '../../lib/wrap-rich-text-commit-message'
 import { isEmptyOrWhitespace } from '../../lib/is-empty-or-whitespace'
 import { TooltippedContent } from '../lib/tooltipped-content'
 import { TooltipDirection } from '../lib/tooltip'
-import { pick } from 'lodash'
+import { pick } from '../../lib/pick'
 
 const addAuthorIcon = {
   w: 18,

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -11,10 +11,11 @@ import { ICommitMessage } from '../../models/commit-message'
 import { IAutocompletionProvider } from '../autocompletion'
 import { IAuthor } from '../../models/author'
 import { CommitMessage } from '../changes/commit-message'
-import { noop, pick } from 'lodash'
+import { noop } from 'lodash'
 import { Popup } from '../../models/popup'
 import { Foldout } from '../../lib/app-state'
 import { Account } from '../../models/account'
+import { pick } from '../../lib/pick'
 
 interface ICommitMessageDialogProps {
   /**


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

We (as in myself mainly) recently started using lodash's `pick` method and I kinda like it. One thing I don't like about it though is that it accepts property paths as well as key names. I.e. you can do

```ts
const a = { foo: { bar: true } }
pick(a, 'foo.bar')
```
This means that we can't get autocompletion on property names like we would if we used a `keyof` parameter. It also means that typos runs the risk of going unnoticed as it'll happily accept any string as a property name.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes