### PR TITLE
Remove double-ended-queue dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,6 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^2.0.0",
     "dompurify": "^2.3.3",
-    "double-ended-queue": "^2.1.0-0",
     "dugite": "^1.104.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -161,9 +161,7 @@ function parseUntrackedEntry(field: string): IStatusEntry {
  */
 export function mapStatus(status: string): FileEntry {
   if (status === '??') {
-    return {
-      kind: 'untracked',
-    }
+    return { kind: 'untracked' }
   }
 
   if (status === '.M') {

--- a/app/src/lib/status-parser.ts
+++ b/app/src/lib/status-parser.ts
@@ -1,5 +1,3 @@
-import Deque from 'double-ended-queue'
-
 import {
   FileEntry,
   GitStatusEntry,
@@ -66,11 +64,9 @@ export function parsePorcelainStatus(
   // backslash-escaping is performed.
 
   const tokens = output.split('\0')
-  const queue = new Deque(tokens)
 
-  let field: string | undefined
-
-  while ((field = queue.shift())) {
+  for (let i = 0; i < tokens.length; i++) {
+    const field = tokens[i]
     if (field.startsWith('# ') && field.length > 2) {
       entries.push({ kind: 'header', value: field.substring(2) })
       continue
@@ -81,7 +77,7 @@ export function parsePorcelainStatus(
     if (entryKind === ChangedEntryType) {
       entries.push(parseChangedEntry(field))
     } else if (entryKind === RenamedOrCopiedEntryType) {
-      entries.push(parsedRenamedOrCopiedEntry(field, queue.shift()))
+      entries.push(parsedRenamedOrCopiedEntry(field, tokens[++i]))
     } else if (entryKind === UnmergedEntryType) {
       entries.push(parseUnmergedEntry(field))
     } else if (entryKind === UntrackedEntryType) {
@@ -105,11 +101,7 @@ function parseChangedEntry(field: string): IStatusEntry {
     throw new Error(`Failed to parse status line for changed entry`)
   }
 
-  return {
-    kind: 'entry',
-    statusCode: match[1],
-    path: match[8],
-  }
+  return { kind: 'entry', statusCode: match[1], path: match[8] }
 }
 
 // 2 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <X><score> <path><sep><origPath>
@@ -132,12 +124,7 @@ function parsedRenamedOrCopiedEntry(
     )
   }
 
-  return {
-    kind: 'entry',
-    statusCode: match[1],
-    oldPath,
-    path: match[9],
-  }
+  return { kind: 'entry', statusCode: match[1], oldPath, path: match[9] }
 }
 
 // u <xy> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -434,11 +434,6 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-double-ended-queue@^2.1.0-0:
-  version "2.1.0-0"
-  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
-  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
-
 dugite@^1.104.0:
   version "1.104.0"
   resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.104.0.tgz#378ab4b86a875bf9173fb915d178c994ae528499"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "@types/codemirror": "5.60.4",
     "@types/deep-equal": "^1.0.1",
     "@types/dompurify": "^2.3.1",
-    "@types/double-ended-queue": "^2.1.0",
     "@types/electron-winstaller": "^4.0.0",
     "@types/eslint": "^8.4.1",
     "@types/estree": "^0.0.49",

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,11 +932,6 @@
   dependencies:
     "@types/trusted-types" "*"
 
-"@types/double-ended-queue@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/double-ended-queue/-/double-ended-queue-2.1.0.tgz#adc862d8d53bdf7d1b23a7d85559815ec1fbb92c"
-  integrity sha512-pCS41/Odn6GMQyqnt8aPTSTQFGriAryYQwVONKk1QhUEhulxueLPE1kDNqDOuJqiv34VLVWXxF4I1EKz3+ftzQ==
-
 "@types/electron-winstaller@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/electron-winstaller/-/electron-winstaller-4.0.0.tgz#7377b2cdaab361956cbf1fc41419abb77172d8eb"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

I'm doing some bundle analysis following our removal of fs-extra and have identified a few candidates for easy removal. This particular change is an easy win, swapping out `double-ended-queue` for a simple loop over the array.

The introduction of `double-ended-queue` was done in https://github.com/desktop/desktop/pull/5186 as a way to mitigate performance problems with `Array.shift`. Swapping out the array for a double ended queue certainly solved that particular performance problem but simply iterating over the array eliminates one step (and one dependency).

I've done performance regression testing on these two using a 50kb status output and they're equivalent with the loop implementation usually scoring a little better but not anything worth shouting from the rooftops about.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes