### PR TITLE
Markdown Mention filter

### DIFF
--- a/app/src/lib/markdown-filters/mention-filter.ts
+++ b/app/src/lib/markdown-filters/mention-filter.ts
@@ -23,7 +23,7 @@ export class MentionFilter implements INodeFilter {
   // beginning of string or non-word, non-` char
   private readonly beginStringNonWord = /(^|[^a-zA-Z0-9_`])/
 
-  // @username and @username_emu for emu support
+  // @username and @username_emu for enterprise managed users support
   private readonly userNameRef = /(?<userNameRef>@[a-z0-9][a-z0-9-]*_[a-zA-Z0-9]+|@[a-z0-9][a-z0-9-]*)/
 
   // without a trailing slash
@@ -56,13 +56,10 @@ export class MentionFilter implements INodeFilter {
     'ig'
   )
 
-  /** The parent github repository of which the content the filter is being
-   * applied to belongs  */
-  private readonly repository: GitHubRepository
-
-  public constructor(repository: GitHubRepository) {
-    this.repository = repository
-  }
+  public constructor(
+    /** The repository which the markdown content originated from */
+    private readonly repository: GitHubRepository
+  ) {}
 
   /**
    * Mention filters iterates on all text nodes that are not inside a pre, code,
@@ -112,10 +109,6 @@ export class MentionFilter implements INodeFilter {
       }
 
       const link = this.createLinkElement(userNameRef)
-      if (link === null) {
-        continue
-      }
-
       const refPosition = match.index === 0 ? 0 : match.index + 1
       const textBefore = text.slice(lastMatchEndingPosition, refPosition)
       const textNodeBefore = document.createTextNode(textBefore)

--- a/app/src/lib/markdown-filters/mention-filter.ts
+++ b/app/src/lib/markdown-filters/mention-filter.ts
@@ -1,0 +1,138 @@
+import { INodeFilter } from './node-filter'
+
+/**
+ * The Mention Markdown filter looks for user logins and replaces them with
+ * links the users profile. Specifically looking at text nodes and if a
+ * reference like @user is found, it will replace the text node with three nodes
+ * - one being a link.
+ *
+ * Mentions in <pre>, <code> and <a> elements are ignored. Contrary to dotcom
+ * where it confirms whether the user exists or not, we assume they do exist for
+ * the sake of performance (not doing database hits to see if the mentioned user
+ * exists)
+ *
+ * Example: A text node of "That is great @tidy-dev! Good Job!"
+ * Becomes three nodes:
+ * 1) "That is great "
+ * 2) <link src="github.com/tidy-dev">@tidy-dev</link>
+ * 3) "! Good Job!"
+ */
+export class MentionFilter implements INodeFilter {
+  // beginning of string or non-word, non-` char
+  private readonly beginStringNonWord = /(^|[^a-zA-Z0-9_`])/
+
+  // @username and @username_emu for emu support
+  private readonly userName = /@(?<username>[a-z0-9][a-z0-9-]*_[a-zA-Z0-9]+|[a-z0-9][a-z0-9-]*)/
+
+  // without a trailing slash
+  private readonly withoutTrailingSlash = /(?!\/)/
+
+  // dots followed by space or non-word character
+  private readonly dotsFollowedBySpace = /\.+[\t\W]/
+
+  // dots at end of line
+  private readonly dotsAtEndOfLine = /\.+$/
+
+  // non-word character except dot or `
+  private readonly nonWordExceptDotOrBackTick = /[^0-9a-zA-Z_.`]/
+
+  // Pattern used to extract @mentions from text
+  // Looking for @user or @user_user
+  // Note: Enterprise managed users may have underscores
+  private readonly mentionRegex = new RegExp(
+    this.beginStringNonWord.source +
+      this.userName.source +
+      this.withoutTrailingSlash.source +
+      '(' +
+      this.dotsFollowedBySpace.source +
+      '|' +
+      this.dotsAtEndOfLine.source +
+      '|' +
+      this.nonWordExceptDotOrBackTick.source +
+      '|' +
+      '$)', // end of line
+    'ig'
+  )
+
+  public constructor() {}
+
+  /**
+   * Mention filters iterates on all text nodes that are not inside a pre, code,
+   * or anchor tag.
+   */
+  public createFilterTreeWalker(doc: Document): TreeWalker {
+    return doc.createTreeWalker(doc, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        return node.parentNode !== null &&
+          ['CODE', 'PRE', 'A'].includes(node.parentNode.nodeName)
+          ? NodeFilter.FILTER_SKIP
+          : NodeFilter.FILTER_ACCEPT
+      },
+    })
+  }
+
+  /**
+   * Takes a text node and creates multiple text and link nodes by inserting
+   * user link nodes where username references are.
+   *
+   * Warning: This filter can create false positives. It assumes the users exist.
+   *
+   * Note: Mention filter requires text nodes; otherwise we may inadvertently
+   * replace non text elements.
+   */
+  public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
+    const { textContent: text } = node
+    if (
+      node.nodeType !== node.TEXT_NODE ||
+      text === null ||
+      !text.includes('@')
+    ) {
+      return null
+    }
+
+    let lastMatchEndingPosition = 0
+    const nodes: Array<Text | HTMLAnchorElement> = []
+    const matches = text.matchAll(this.mentionRegex)
+    for (const match of matches) {
+      if (match.groups === undefined || match.index === undefined) {
+        continue
+      }
+
+      const { username } = match.groups
+      if (username === undefined) {
+        continue
+      }
+
+      const link = this.createLinkElement(username)
+      if (link === null) {
+        continue
+      }
+
+      const textBefore = text.slice(lastMatchEndingPosition, match.index)
+      const textNodeBefore = document.createTextNode(textBefore)
+      nodes.push(textNodeBefore)
+      nodes.push(link)
+
+      // +1 for the @
+      lastMatchEndingPosition = match.index + (username.length ?? 0) + 1
+    }
+
+    const trailingText = text.slice(lastMatchEndingPosition)
+    if (trailingText !== '') {
+      nodes.push(document.createTextNode(trailingText))
+    }
+
+    return nodes
+  }
+
+  /**
+   * Method to create the user mention anchor.
+   **/
+  private createLinkElement(username: string) {
+    const href = `https://github.com/${username}`
+    const anchor = document.createElement('a')
+    anchor.textContent = `@${username}`
+    anchor.href = href
+    return anchor
+  }
+}

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -43,7 +43,7 @@ export const buildCustomMarkDownNodeFilterPipe = memoizeOne(
     new IssueMentionFilter(repository),
     new IssueLinkFilter(repository),
     new EmojiFilter(emoji),
-    new MentionFilter(),
+    new MentionFilter(repository),
   ]
 )
 

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -3,6 +3,7 @@ import { GitHubRepository } from '../../models/github-repository'
 import { EmojiFilter } from './emoji-filter'
 import { IssueLinkFilter } from './issue-link-filter'
 import { IssueMentionFilter } from './issue-mention-filter'
+import { MentionFilter } from './mention-filter'
 
 export interface INodeFilter {
   /**
@@ -42,6 +43,7 @@ export const buildCustomMarkDownNodeFilterPipe = memoizeOne(
     new IssueMentionFilter(repository),
     new IssueLinkFilter(repository),
     new EmojiFilter(emoji),
+    new MentionFilter(),
   ]
 )
 


### PR DESCRIPTION
## Description
This markdown filter is meant to take username mentions such as @tidy-dev and turn them into a link to that user's profile. This filter assumes that the user exists and builds a link of `https://github.com/tidy-dev`. For enterprise users, it will use their enterprise base url to form the link. This is based on the repo passed into the filter.

This filter deviates from dotcom in that dotcom verifies the user exists and then uses the user's profile url from pulling back the users data. Thus, this filter will have false positives for users that don't exist. It shouldn't be common and worse case user clicks a link to a 404.

## Release notes
Notes: [Improved] Sandbox markdown parser parses username mentions and auto tag issue links.
