### PR TITLE
toMilliseconds helper function

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -216,7 +216,6 @@ import { ManualConflictResolution } from '../../models/manual-conflict-resolutio
 import { BranchPruner } from './helpers/branch-pruner'
 import { enableHideWhitespaceInDiffOption } from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
-import moment from 'moment'
 import { ComputedAction } from '../../models/computed-action'
 import {
   createDesktopStashEntry,
@@ -295,6 +294,7 @@ import {
 } from './notifications-store'
 import * as ipcRenderer from '../ipc-renderer'
 import { pathExists } from '../../ui/lib/path-exists'
+import { toMilliseconds } from '../to-milliseconds'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -3051,11 +3051,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const lastStashEntryCheck = await this.repositoriesStore.getLastStashCheckDate(
       repository
     )
-    const dateNow = moment()
-    const threshold = dateNow.subtract(24, 'hours')
+    const threshold = Date.now() - toMilliseconds(24, 'hours')
     // `lastStashEntryCheck` being equal to `null` means
     // we've never checked for the given repo
-    if (lastStashEntryCheck == null || threshold.isAfter(lastStashEntryCheck)) {
+    if (lastStashEntryCheck == null || threshold > lastStashEntryCheck) {
       await this.repositoriesStore.updateLastStashCheckDate(repository)
       const numEntriesCreatedOutsideDesktop =
         stashEntryCount - desktopStashEntryCount

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -18,7 +18,7 @@ import {
   manuallySetChecksToPending,
 } from '../ci-checks/ci-checks'
 import _ from 'lodash'
-import moment from 'moment'
+import { toMilliseconds } from '../to-milliseconds'
 
 interface ICommitStatusCacheEntry {
   /**
@@ -432,7 +432,7 @@ export class CommitStatusStore {
           // (cache/api limit). This sets this sub back to 61 so that on next
           // refresh triggered, it will be reretreived, as this time, it will be
           // different given the branch name is provided.
-          fetchedAt: moment(new Date()).subtract(61, 'minutes').toDate(),
+          fetchedAt: new Date(Date.now() - toMilliseconds(61, 'minutes')),
         })
       }
 

--- a/app/src/lib/to-milliseconds.ts
+++ b/app/src/lib/to-milliseconds.ts
@@ -1,11 +1,8 @@
 import { assertNever } from './fatal-error'
 
 type Unit = 'year' | 'day' | 'hour' | 'minute' | 'second'
-type Plural = `${Unit}s`
 
-export function toMilliseconds(value: 1, unit: Unit): number
-export function toMilliseconds(value: number, unit: Plural): number
-export function toMilliseconds(value: number, unit: Unit | Plural): number {
+export function toMilliseconds(value: number, unit: Unit | `${Unit}s`): number {
   switch (unit) {
     case 'year':
     case 'years':

--- a/app/src/lib/to-milliseconds.ts
+++ b/app/src/lib/to-milliseconds.ts
@@ -1,0 +1,28 @@
+import { assertNever } from './fatal-error'
+
+type Unit = 'year' | 'day' | 'hour' | 'minute' | 'second'
+type Plural = `${Unit}s`
+
+export function toMilliseconds(value: 1, unit: Unit): number
+export function toMilliseconds(value: number, unit: Plural): number
+export function toMilliseconds(value: number, unit: Unit | Plural): number {
+  switch (unit) {
+    case 'year':
+    case 'years':
+      return value * 1000 * 60 * 60 * 24 * 365
+    case 'day':
+    case 'days':
+      return value * 1000 * 60 * 60 * 24
+    case 'hour':
+    case 'hours':
+      return value * 1000 * 60 * 60
+    case 'minute':
+    case 'minutes':
+      return value * 1000 * 60
+    case 'second':
+    case 'seconds':
+      return value * 1000
+    default:
+      assertNever(unit, `Unknown time unit ${unit}`)
+  }
+}

--- a/app/src/lib/to-milliseconds.ts
+++ b/app/src/lib/to-milliseconds.ts
@@ -1,25 +1,15 @@
-import { assertNever } from './fatal-error'
-
-type Unit = 'year' | 'day' | 'hour' | 'minute' | 'second'
-
-export function toMilliseconds(value: number, unit: Unit | `${Unit}s`): number {
-  switch (unit) {
-    case 'year':
-    case 'years':
-      return value * 1000 * 60 * 60 * 24 * 365
-    case 'day':
-    case 'days':
-      return value * 1000 * 60 * 60 * 24
-    case 'hour':
-    case 'hours':
-      return value * 1000 * 60 * 60
-    case 'minute':
-    case 'minutes':
-      return value * 1000 * 60
-    case 'second':
-    case 'seconds':
-      return value * 1000
-    default:
-      assertNever(unit, `Unknown time unit ${unit}`)
-  }
+const units = {
+  year: 31536000000,
+  years: 31536000000,
+  day: 86400000,
+  days: 86400000,
+  hour: 3600000,
+  hours: 3600000,
+  minute: 60000,
+  minutes: 60000,
+  second: 1000,
+  seconds: 1000,
 }
+
+export const toMilliseconds = (value: number, unit: keyof typeof units) =>
+  value * units[unit]

--- a/app/src/lib/to-milliseconds.ts
+++ b/app/src/lib/to-milliseconds.ts
@@ -11,5 +11,6 @@ const units = {
   seconds: 1000,
 }
 
+/** Converts the given value and time unit to milliseconds */
 export const toMilliseconds = (value: number, unit: keyof typeof units) =>
   value * units[unit]

--- a/app/test/unit/branch-pruner-test.ts
+++ b/app/test/unit/branch-pruner-test.ts
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import { BranchPruner } from '../../src/lib/stores/helpers/branch-pruner'
 import { Repository } from '../../src/models/repository'
 import { GitStoreCache } from '../../src/lib/stores/git-store-cache'
@@ -14,6 +13,7 @@ import {
 } from '../helpers/repository-builder-branch-pruner'
 import { StatsStore, StatsDatabase } from '../../src/lib/stats'
 import { UiActivityMonitor } from '../../src/ui/lib/ui-activity-monitor'
+import { toMilliseconds } from '../../src/lib/to-milliseconds'
 
 describe('BranchPruner', () => {
   const onGitStoreUpdated = () => {}
@@ -71,8 +71,7 @@ describe('BranchPruner', () => {
   })
 
   it('prunes for GitHub repository', async () => {
-    const fixedDate = moment()
-    const lastPruneDate = fixedDate.subtract(1, 'day')
+    const lastPruneDate = new Date(Date.now() - toMilliseconds(1, 'day'))
 
     const path = await setupFixtureRepository('branch-prune-tests')
     const repo = await setupRepository(
@@ -81,7 +80,7 @@ describe('BranchPruner', () => {
       repositoriesStateCache,
       true,
       'master',
-      lastPruneDate.toDate()
+      lastPruneDate
     )
     const branchPruner = new BranchPruner(
       repo,
@@ -99,8 +98,7 @@ describe('BranchPruner', () => {
   })
 
   it('does not prune if the last prune date is less than 24 hours ago', async () => {
-    const fixedDate = moment()
-    const lastPruneDate = fixedDate.subtract(4, 'hours')
+    const lastPruneDate = new Date(Date.now() - toMilliseconds(4, 'hours'))
     const path = await setupFixtureRepository('branch-prune-tests')
     const repo = await setupRepository(
       path,
@@ -108,7 +106,7 @@ describe('BranchPruner', () => {
       repositoriesStateCache,
       true,
       'master',
-      lastPruneDate.toDate()
+      lastPruneDate
     )
     const branchPruner = new BranchPruner(
       repo,
@@ -126,8 +124,7 @@ describe('BranchPruner', () => {
   })
 
   it('does not prune if there is no default branch', async () => {
-    const fixedDate = moment()
-    const lastPruneDate = fixedDate.subtract(1, 'day')
+    const lastPruneDate = new Date(Date.now() - toMilliseconds(1, 'day'))
     const path = await setupFixtureRepository('branch-prune-tests')
 
     const repo = await setupRepository(
@@ -136,7 +133,7 @@ describe('BranchPruner', () => {
       repositoriesStateCache,
       true,
       '',
-      lastPruneDate.toDate()
+      lastPruneDate
     )
     const branchPruner = new BranchPruner(
       repo,
@@ -154,8 +151,7 @@ describe('BranchPruner', () => {
   })
 
   it('does not prune reserved branches', async () => {
-    const fixedDate = moment()
-    const lastPruneDate = fixedDate.subtract(1, 'day')
+    const lastPruneDate = new Date(Date.now() - toMilliseconds(1, 'day'))
 
     const path = await setupFixtureRepository('branch-prune-tests')
     const repo = await setupRepository(
@@ -164,7 +160,7 @@ describe('BranchPruner', () => {
       repositoriesStateCache,
       true,
       'master',
-      lastPruneDate.toDate()
+      lastPruneDate
     )
     const branchPruner = new BranchPruner(
       repo,
@@ -196,8 +192,7 @@ describe('BranchPruner', () => {
   it('never prunes a branch that lacks an upstream', async () => {
     const path = await createPrunedRepository()
 
-    const fixedDate = moment()
-    const lastPruneDate = fixedDate.subtract(1, 'day')
+    const lastPruneDate = new Date(Date.now() - toMilliseconds(1, 'day'))
 
     const repo = await setupRepository(
       path,
@@ -205,7 +200,7 @@ describe('BranchPruner', () => {
       repositoriesStateCache,
       true,
       'master',
-      lastPruneDate.toDate()
+      lastPruneDate
     )
 
     const branchPruner = new BranchPruner(

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -10,6 +10,7 @@ import {
 import { setupFixtureRepository } from '../../helpers/repositories'
 import moment from 'moment'
 import { GitProcess } from 'dugite'
+import { toMilliseconds } from '../../../src/lib/to-milliseconds'
 
 async function createAndCheckout(
   repository: Repository,
@@ -90,7 +91,7 @@ describe('git/reflog', () => {
 
       const branches = await getBranchCheckouts(
         repository,
-        moment().subtract(1, 'hour').toDate()
+        new Date(Date.now() - toMilliseconds(1, 'hour'))
       )
       expect(branches.size).toBe(2)
     })
@@ -104,7 +105,7 @@ describe('git/reflog', () => {
 
       const branches = await getBranchCheckouts(
         repository,
-        moment().subtract(1, 'hour').toDate()
+        new Date(Date.now() - toMilliseconds(1, 'hour'))
       )
       expect(branches.size).toBe(0)
     })


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
I'm investigating what it would take to get rid of our moment.js dependency both for the sake of our bundle size but also for the sake of internationalization. One thing we use moment.js for is for date calculations such as `moment().subtract(24, 'hours')`. This isn't :rocket: 👩‍🔬 but it's a bit hard to read all of the `x * 60 * 60 * 1000` inline calculations everywhere. Therefore I wrote this little helper method that let's us do things like `Date.now() - toMilliseconds(24, 'hours')`.

Extracted from my WIP branch to reduce the review burden on the final thing.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes