### PR TITLE
Allow selecting emojis in commit text

### DIFF
--- a/app/styles/ui/history/_commit-summary.scss
+++ b/app/styles/ui/history/_commit-summary.scss
@@ -111,13 +111,12 @@
   // Enable text selection inside the title and description elements.
   &-title,
   &-description {
-    span,
-    a {
-      -webkit-user-select: text;
-      user-select: text;
-    }
+    user-select: text;
+    cursor: text;
 
-    span {
+    * {
+      user-select: unset;
+      pointer-events: unset;
       cursor: text;
     }
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14111

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Images weren't part of the allow list of elements in the `RichText` component that could be selected.


### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Allow selecting and copying emojis as well as text in commit descriptions