### PR TITLE
Dialogs overflow should be unset

### DIFF
--- a/app/styles/ui/_dialog.scss
+++ b/app/styles/ui/_dialog.scss
@@ -25,6 +25,7 @@
 // allow easy layout using generalized components and elements such as <Row>
 // and <p>.
 dialog {
+  overflow: unset;
   // These are the 24px versions of the alert and stop octicons
   // from oction v10.0.0
   //


### PR DESCRIPTION
Closes #13944

## Description
With the electron upgrade comes chromium upgrade which evidently means updated user agent stylesheets!

Dialog User Agent Stylesheet Before:
![image](https://user-images.githubusercontent.com/75402236/157285185-483fe337-5356-48c8-8a47-cbdbe28bfbf6.png)

Dialog User Agent Stylesheet After:
![image](https://user-images.githubusercontent.com/75402236/157285197-293c2028-2cd4-43ab-ab03-82c2d0b3ebac.png)

The previous user agent style sheet did not set an `overflow` property for `dialog` elements and the new one sets it to `overflow: auto`. As can be seen in the [issue](https://github.com/desktop/desktop/issues/13944), this makes it so content overflowing the set height/width now scrolls. 

I have noticed this a few other instance too like in preferences if you click into the high contrast mode you get a scroll bar and I believe I have see a weird scrollbar appear on other dialogs when an error/warning is added after initial view.

This PR simply sets dialog elements `overflow: unset` so it is back they way we expected. 

Other notes: on looking at the differences in the two screenshots above it is surprising the positioning styles don't appear to interfere with anything.. but good to be aware of in case we see any other weird style changes.

## Release notes
Notes: [Fixed] Dialogs do not scroll overflow content.
