### PR TITLE
Format absolute dates using Intl.DateTimeFormat

### DIFF
--- a/app/src/lib/format-date.ts
+++ b/app/src/lib/format-date.ts
@@ -10,6 +10,11 @@ const getDateFormatter = mem(Intl.DateTimeFormat, {
   cacheKey: (...args) => JSON.stringify(args),
 })
 
+/**
+ * Format a date in en-US locale, customizable with Intl.DateTimeFormatOptions.
+ *
+ * See Intl.DateTimeFormat for more information
+ */
 export const formatDate = (date: Date, options: Intl.DateTimeFormatOptions) =>
   isNaN(date.valueOf())
     ? 'Invalid date'

--- a/app/src/lib/format-date.ts
+++ b/app/src/lib/format-date.ts
@@ -1,0 +1,12 @@
+import mem from 'mem'
+
+// Initializing a date formatter is expensive but formatting is relatively cheap
+// so we cache them based on the locale and their options.
+const getDateFormatter = mem(Intl.DateTimeFormat, {
+  cacheKey: (...args) => JSON.stringify(args),
+})
+
+export const formatDate = (date: Date, options: Intl.DateTimeFormatOptions) =>
+  isNaN(date.valueOf())
+    ? 'Invalid date'
+    : getDateFormatter('en-US', options).format(date)

--- a/app/src/lib/format-date.ts
+++ b/app/src/lib/format-date.ts
@@ -1,8 +1,12 @@
 import mem from 'mem'
+import QuickLRU from 'quick-lru'
 
 // Initializing a date formatter is expensive but formatting is relatively cheap
-// so we cache them based on the locale and their options.
+// so we cache them based on the locale and their options. The maxSize of a 100
+// is only as an escape hatch, we don't expect to ever create more than a
+// handful different formatters.
 const getDateFormatter = mem(Intl.DateTimeFormat, {
+  cache: new QuickLRU({ maxSize: 100 }),
   cacheKey: (...args) => JSON.stringify(args),
 })
 

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -1,10 +1,9 @@
-import moment from 'moment'
-
 import {
   ReleaseMetadata,
   ReleaseNote,
   ReleaseSummary,
 } from '../models/release-notes'
+import { formatDate } from './format-date'
 import { encodePathAsUrl } from './path'
 
 // expects a release note entry to contain a header and then some text
@@ -69,11 +68,11 @@ export function getReleaseSummary(
   const other = entries.filter(e => e.kind === 'removed' || e.kind === 'other')
   const thankYous = entries.filter(e => e.message.includes(' Thanks @'))
 
-  const datePublished = moment(latestRelease.pub_date).format('MMMM Do YYYY')
-
   return {
     latestVersion: latestRelease.version,
-    datePublished,
+    datePublished: formatDate(new Date(latestRelease.pub_date), {
+      dateStyle: 'medium',
+    }),
     // TODO: find pretext entry
     pretext: undefined,
     enhancements,

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -71,7 +71,7 @@ export function getReleaseSummary(
   return {
     latestVersion: latestRelease.version,
     datePublished: formatDate(new Date(latestRelease.pub_date), {
-      dateStyle: 'medium',
+      dateStyle: 'long',
     }),
     // TODO: find pretext entry
     pretext: undefined,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -151,6 +151,7 @@ import { clamp } from '../lib/clamp'
 import * as ipcRenderer from '../lib/ipc-renderer'
 import { showNotification } from '../lib/stores/helpers/show-notification'
 import { DiscardChangesRetryDialog } from './discard-changes/discard-changes-retry-dialog'
+import { getReleaseSummary } from '../lib/release-notes'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -432,54 +433,21 @@ export class App extends React.Component<IAppProps, IAppState> {
     if (__DEV__) {
       this.props.dispatcher.showPopup({
         type: PopupType.ReleaseNotes,
-        newRelease: {
-          latestVersion: '42.7.99',
-          datePublished: 'Awesomeber 71, 2025',
-          pretext:
-            'There is something so different here that we wanted to include some pretext for it',
-          enhancements: [
-            {
-              kind: 'new',
-              message: 'An awesome new feature!',
-            },
-            {
-              kind: 'improved',
-              message: 'This is so much better',
-            },
-            {
-              kind: 'improved',
-              message:
-                'Testing links to profile pages by a mention to @shiftkey',
-            },
+        newRelease: getReleaseSummary({
+          name: '',
+          version: '42.7.99',
+          notes: [
+            '[New] An awesome new feature!',
+            '[Improved] This is so much better',
+            '[Improved] Testing links to profile pages by a mention to @shiftkey',
+            '[Fixed] Fixed this one thing',
+            '[Fixed] Fixed this thing over here too',
+            '[Fixed] Testing links to issues by calling out #42. Assuming it is fixed by now.',
+            '[OhHai] Look at me, a new category!',
+            '[Added] In other news... . Thanks @some-body-to-thank!',
           ],
-          bugfixes: [
-            {
-              kind: 'fixed',
-              message: 'Fixed this one thing',
-            },
-            {
-              kind: 'fixed',
-              message: 'Fixed this thing over here too',
-            },
-            {
-              kind: 'fixed',
-              message:
-                'Testing links to issues by calling out #42. Assuming it is fixed by now.',
-            },
-          ],
-          other: [
-            {
-              kind: 'other',
-              message: 'In other news...',
-            },
-          ],
-          thankYous: [
-            {
-              kind: 'other',
-              message: 'In other news... . Thanks @some-body-to-thank!',
-            },
-          ],
-        },
+          pub_date: '2025-11-07T09:52:34Z',
+        }),
       })
     }
   }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Based on #14119 this PR switches us to using `Intl.DateTimeFormat` when converting dates to strings for human consumption.

| Format | Output |
| :--- | :--- |
| formatDate: full/short | `Tuesday, March 8, 2022 at 6:23 PM` |
| moment: `LLLL` | `Tuesday, March 8, 2022 6:23 PM` |
| formatDate: medium/short |  `Mar 8, 2022, 6:23 PM` |
| moment: `lll` | `Mar 8, 2022 6:23 PM` |
| formatDate: medium | `Mar 8, 2022` |
| moment: `ll` | `Mar 8, 2022` |

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes