### PR TITLE
Make "Initialize LFS" dialog non dismissable

### DIFF
--- a/app/src/ui/lfs/initialize-lfs.tsx
+++ b/app/src/ui/lfs/initialize-lfs.tsx
@@ -35,6 +35,7 @@ export class InitializeLFS extends React.Component<IInitializeLFSProps, {}> {
       <Dialog
         id="initialize-lfs"
         title="Initialize Git LFS"
+        dismissable={false}
         onDismissed={this.props.onDismissed}
         onSubmit={this.onInitialize}
       >


### PR DESCRIPTION
## Description

It has happened a few times to me that I'm doing something else while I'm cloning a LFS repo and, when it finishes, the "Initialize LFS" popup shows up but I click outside of it by mistake, the popup is closed and there is no way of opening it again until an LFS repo is cloned again.

This PR changes the popup to be non-dismissable to prevent this kind of mistakes.

## Release notes

Notes: [Improved] Prompt to initialize Git LFS cannot be dismissed by clicking outside of it
