### PR TITLE
Fix height issues with Markdown component

### DIFF
--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -147,15 +147,17 @@ export class SandboxedMarkdown extends React.PureComponent<
      */
     const docEl = frameRef.contentDocument.documentElement.querySelector(
       '#content'
-    )
+    ) as HTMLDivElement
+
     if (docEl === null) {
       return
     }
 
-    // Not sure why the content height != body height exactly. But, 50px seems
-    // to prevent scrollbar/content cut off.
-    const divHeight = docEl.clientHeight + 50
+    // Not sure why the content height != body height exactly. But we need to
+    // set the height explicitly to prevent scrollbar/content cut off.
+    const divHeight = docEl.clientHeight
     this.frameContainingDivRef.style.height = `${divHeight}px`
+    docEl.style.height = `${divHeight}px`
     this.props.onMarkdownParsed?.()
   }
 

--- a/app/static/common/markdown.css
+++ b/app/static/common/markdown.css
@@ -9,6 +9,14 @@ desktop font-size variables. (This is not meant to be an exhaustive list of
 changes from the original, just a note that this will not match 1-1)
  */
 
+#content {
+	/*
+	We need to set overflow-y to hidden to make sure this element calculates the
+	right height to fit its content.
+	 */
+	overflow-y: hidden;
+}
+
 .markdown-body {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 	font-size: var(--font-size);

--- a/app/styles/ui/_sandboxed-markdown.scss
+++ b/app/styles/ui/_sandboxed-markdown.scss
@@ -1,6 +1,5 @@
 .sandboxed-markdown-iframe-container {
   position: relative;
-  min-height: 50px;
 
   .sandboxed-markdown-component {
     // With combination of setting height of containing div.


### PR DESCRIPTION
## Description

Right now we were adding 50px to the calculated height because depending on the content, it would still be cut off. This PR makes a few (hacky) changes in an attempt to make our Markdown component properly adjust its height to the content. I honestly can't tell why most of the things in this PR work but they all seem to be necessary to make any effect 😂 

I've tested it with a bunch of PR descriptions and comments, and haven't found any issues with the component height so far 🤞 

## Release notes

Notes: no-notes
