### PR TITLE
Custom formatter for "precise" durations

### DIFF
--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -14,7 +14,7 @@ import { enableCICheckRunsLogs } from '../feature-flag'
 import { GitHubRepository } from '../../models/github-repository'
 import { Account } from '../../models/account'
 import { supportsRetrieveActionWorkflowByCheckSuiteId } from '../endpoint-capabilities'
-import { formatDuration } from '../format-duration'
+import { formatPreciseDuration } from '../format-duration'
 
 /**
  * A Desktop-specific model closely related to a GitHub API Check Run.
@@ -184,8 +184,7 @@ function getCheckRunShortDescription(
   const preposition = conclusion === APICheckConclusion.Success ? 'in' : 'after'
 
   if (durationMs !== undefined && durationMs > 0) {
-    const duration = formatDuration(durationMs, 'narrow')
-    return `${adjective} ${preposition} ${duration}`
+    return `${adjective} ${preposition} ${formatPreciseDuration(durationMs)}`
   }
 
   return adjective
@@ -602,7 +601,7 @@ export function getFormattedCheckRunDuration(
   checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
 ) {
   const duration = getCheckDurationInMilliseconds(checkRun)
-  return isNaN(duration) ? '' : formatDuration(duration, 'narrow')
+  return isNaN(duration) ? '' : formatPreciseDuration(duration)
 }
 
 /**

--- a/app/src/lib/ci-checks/ci-checks.ts
+++ b/app/src/lib/ci-checks/ci-checks.ts
@@ -10,11 +10,11 @@ import {
   IAPIWorkflowRun,
 } from '../api'
 import JSZip from 'jszip'
-import moment from 'moment'
 import { enableCICheckRunsLogs } from '../feature-flag'
 import { GitHubRepository } from '../../models/github-repository'
 import { Account } from '../../models/account'
 import { supportsRetrieveActionWorkflowByCheckSuiteId } from '../endpoint-capabilities'
+import { formatDuration } from '../format-duration'
 
 /**
  * A Desktop-specific model closely related to a GitHub API Check Run.
@@ -156,12 +156,12 @@ export function getCheckRunConclusionAdjective(
  * or failing...
  * @param conclusion - The conclusion of the check, something like success or
  * skipped...
- * @param durationSeconds - The time in seconds it took to complete.
+ * @param durationMs - The time in milliseconds it took to complete.
  */
 function getCheckRunShortDescription(
   status: APICheckStatus,
   conclusion: APICheckConclusion | null,
-  durationSeconds?: number
+  durationMs?: number
 ): string {
   if (status !== APICheckStatus.Completed || conclusion === null) {
     return 'In progress'
@@ -183,11 +183,8 @@ function getCheckRunShortDescription(
 
   const preposition = conclusion === APICheckConclusion.Success ? 'in' : 'after'
 
-  if (durationSeconds !== undefined && durationSeconds > 0) {
-    const duration =
-      durationSeconds < 60
-        ? `${durationSeconds}s`
-        : `${Math.round(durationSeconds / 60)}m`
+  if (durationMs !== undefined && durationMs > 0) {
+    const duration = formatDuration(durationMs, 'narrow')
     return `${adjective} ${preposition} ${duration}`
   }
 
@@ -195,25 +192,12 @@ function getCheckRunShortDescription(
 }
 
 /**
- * Attempts to get the duration of a check run in seconds.
- * If it fails, it returns 0
+ * Attempts to get the duration of a check run in milliseconds. Returns NaN if
+ * parsing either completed_at or started_at fails
  */
-export function getCheckDurationInSeconds(
+export const getCheckDurationInMilliseconds = (
   checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
-): number {
-  try {
-    // This could fail if the dates cannot be parsed.
-    const completedAt = new Date(checkRun.completed_at).getTime()
-    const startedAt = new Date(checkRun.started_at).getTime()
-    const duration = (completedAt - startedAt) / 1000
-
-    if (!isNaN(duration)) {
-      return duration
-    }
-  } catch (e) {}
-
-  return 0
-}
+) => Date.parse(checkRun.completed_at) - Date.parse(checkRun.started_at)
 
 /**
  * Convert an API check run object to a RefCheck model
@@ -225,7 +209,7 @@ export function apiCheckRunToRefCheck(checkRun: IAPIRefCheckRun): IRefCheck {
     description: getCheckRunShortDescription(
       checkRun.status,
       checkRun.conclusion,
-      getCheckDurationInSeconds(checkRun)
+      getCheckDurationInMilliseconds(checkRun)
     ),
     status: checkRun.status,
     conclusion: checkRun.conclusion,
@@ -616,14 +600,9 @@ function mapActionWorkflowsRunsToCheckRuns(
  */
 export function getFormattedCheckRunDuration(
   checkRun: IAPIRefCheckRun | IAPIWorkflowJobStep
-): string {
-  if (checkRun.completed_at === null || checkRun.started_at === null) {
-    return ''
-  }
-
-  return moment
-    .duration(getCheckDurationInSeconds(checkRun), 'seconds')
-    .format('d[d] h[h] m[m] s[s]', { largest: 4 })
+) {
+  const duration = getCheckDurationInMilliseconds(checkRun)
+  return isNaN(duration) ? '' : formatDuration(duration, 'narrow')
 }
 
 /**

--- a/app/src/lib/format-duration.ts
+++ b/app/src/lib/format-duration.ts
@@ -1,20 +1,26 @@
 export const units: [string, number][] = [
-  ['day', 86400000],
-  ['hour', 3600000],
-  ['minute', 60000],
-  ['second', 1000],
+  ['d', 86400000],
+  ['h', 3600000],
+  ['m', 60000],
+  ['s', 1000],
 ]
 
-type DurationStyle = 'narrow' | 'long'
-
-export const formatDuration = (duration: number, style: DurationStyle) => {
+/**
+ * Creates a narrow style precise duration format used for displaying things
+ * like check run durations that typically only last for a few minutes.
+ *
+ * Example: formatPreciseDuration(3670000) -> "1h 1m 10s"
+ *
+ * @param ms The duration in milliseconds
+ */
+export const formatPreciseDuration = (ms: number) => {
   const parts = new Array<string>()
 
   for (const [unit, value] of units) {
-    if (parts.length > 0 || duration >= value) {
-      const qty = Math.floor(duration / value)
-      duration -= qty * value
-      parts.push(`${qty}${style === 'narrow' ? unit[0] : unit}`)
+    if (parts.length > 0 || ms >= value) {
+      const qty = Math.floor(ms / value)
+      ms -= qty * value
+      parts.push(`${qty}${unit}`)
     }
   }
 

--- a/app/src/lib/format-duration.ts
+++ b/app/src/lib/format-duration.ts
@@ -15,9 +15,10 @@ export const units: [string, number][] = [
  */
 export const formatPreciseDuration = (ms: number) => {
   const parts = new Array<string>()
+  ms = Math.abs(ms)
 
   for (const [unit, value] of units) {
-    if (parts.length > 0 || ms >= value) {
+    if (parts.length > 0 || ms >= value || unit === 's') {
       const qty = Math.floor(ms / value)
       ms -= qty * value
       parts.push(`${qty}${unit}`)

--- a/app/src/lib/format-duration.ts
+++ b/app/src/lib/format-duration.ts
@@ -7,14 +7,16 @@ export const units: [string, number][] = [
 
 type DurationStyle = 'narrow' | 'long'
 
-export const formatDuration = (duration: number, style: DurationStyle) =>
-  units
-    .reduce((parts, [u, ms]) => {
-      if (parts.length > 0 || duration >= ms) {
-        const qty = Math.floor(duration / ms)
-        duration -= qty * ms
-        parts.push(`${qty}${style === 'narrow' ? u[0] : u}`)
-      }
-      return parts
-    }, new Array<string>())
-    .join(' ')
+export const formatDuration = (duration: number, style: DurationStyle) => {
+  const parts = new Array<string>()
+
+  for (const [unit, value] of units) {
+    if (parts.length > 0 || duration >= value) {
+      const qty = Math.floor(duration / value)
+      duration -= qty * value
+      parts.push(`${qty}${style === 'narrow' ? unit[0] : unit}`)
+    }
+  }
+
+  return parts.join(' ')
+}

--- a/app/src/lib/format-duration.ts
+++ b/app/src/lib/format-duration.ts
@@ -1,0 +1,20 @@
+export const units: [string, number][] = [
+  ['day', 86400000],
+  ['hour', 3600000],
+  ['minute', 60000],
+  ['second', 1000],
+]
+
+type DurationStyle = 'narrow' | 'long'
+
+export const formatDuration = (duration: number, style: DurationStyle) =>
+  units
+    .reduce((parts, [u, ms]) => {
+      if (parts.length > 0 || duration >= ms) {
+        const qty = Math.floor(duration / ms)
+        duration -= qty * ms
+        parts.push(`${qty}${style === 'narrow' ? u[0] : u}`)
+      }
+      return parts
+    }, new Array<string>())
+    .join(' ')

--- a/app/test/unit/format-duration-test.ts
+++ b/app/test/unit/format-duration-test.ts
@@ -1,0 +1,18 @@
+import { formatPreciseDuration } from '../../src/lib/format-duration'
+
+describe('formatPreciseDuration', () => {
+  it('returns 0s for ms less than 1000', () => {
+    expect(formatPreciseDuration(1)).toBe('0s')
+  })
+
+  it('return 0[unit] after encountering first whole unit', () => {
+    expect(formatPreciseDuration(86400000)).toBe('1d 0h 0m 0s')
+    expect(formatPreciseDuration(3600000)).toBe('1h 0m 0s')
+    expect(formatPreciseDuration(60000)).toBe('1m 0s')
+    expect(formatPreciseDuration(1000)).toBe('1s')
+  })
+
+  it('treats negative values as absolute numbers', () => {
+    expect(formatPreciseDuration(-1000)).toBe('1s')
+  })
+})


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Following up on #14123, this PR introduces a custom formatter for "precise" (that term is lifted directly from .com's code dealing with check run duration formatting) to replace moment when formatting check run durations.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes