### PR TITLE
Replace moment relative time formatting with custom formatRelative

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,6 @@
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",
     "moment": "^2.24.0",
-    "moment-duration-format": "^2.3.2",
     "mri": "^1.1.0",
     "p-limit": "^2.2.0",
     "primer-support": "^4.0.0",

--- a/app/src/lib/format-relative.ts
+++ b/app/src/lib/format-relative.ts
@@ -1,0 +1,49 @@
+import mem from 'mem'
+import QuickLRU from 'quick-lru'
+
+// Initializing a date formatter is expensive but formatting is relatively cheap
+// so we cache them based on the locale and their options. The maxSize of a 100
+// is only as an escape hatch, we don't expect to ever create more than a
+// handful different formatters.
+const getRelativeFormatter = mem(
+  (locale: string, options: Intl.RelativeTimeFormatOptions) =>
+    new Intl.RelativeTimeFormat(locale, options),
+  {
+    cache: new QuickLRU({ maxSize: 100 }),
+    cacheKey: (...args) => JSON.stringify(args),
+  }
+)
+
+export function formatRelative(ms: number) {
+  const formatter = getRelativeFormatter('en-US', { numeric: 'auto' })
+
+  // https://github.com/github/time-elements/blob/428b02c9/src/relative-time.ts#L57
+  const sign = ms < 0 ? -1 : 1
+
+  const sec = Math.round(Math.abs(ms) / 1000)
+  const min = Math.round(sec / 60)
+  const hr = Math.round(min / 60)
+  const day = Math.round(hr / 24)
+  const month = Math.round(day / 30)
+  const year = Math.round(month / 12)
+
+  if (sec < 45) {
+    return formatter.format(sec * sign, 'second')
+  } else if (sec < 90) {
+    return formatter.format(min * sign, 'minute')
+  } else if (min < 45) {
+    return formatter.format(min * sign, 'minute')
+  } else if (min < 90) {
+    return formatter.format(hr * sign, 'hour')
+  } else if (hr < 24) {
+    return formatter.format(hr * sign, 'hour')
+  } else if (hr < 36) {
+    return formatter.format(day * sign, 'day')
+  } else if (day < 30) {
+    return formatter.format(day * sign, 'day')
+  } else if (month < 18) {
+    return formatter.format(month * sign, 'month')
+  } else {
+    return formatter.format(year * sign, 'year')
+  }
+}

--- a/app/src/lib/format-relative.ts
+++ b/app/src/lib/format-relative.ts
@@ -17,9 +17,10 @@ const getRelativeFormatter = mem(
 export function formatRelative(ms: number) {
   const formatter = getRelativeFormatter('en-US', { numeric: 'auto' })
 
-  // https://github.com/github/time-elements/blob/428b02c9/src/relative-time.ts#L57
-  const sign = ms < 0 ? -1 : 1
+  const sign = ms < 0 ? 1 : -1
 
+  // Lifted and adopted from
+  // https://github.com/github/time-elements/blob/428b02c9/src/relative-time.ts#L57
   const sec = Math.round(Math.abs(ms) / 1000)
   const min = Math.round(sec / 60)
   const hr = Math.round(min / 60)
@@ -29,16 +30,10 @@ export function formatRelative(ms: number) {
 
   if (sec < 45) {
     return formatter.format(sec * sign, 'second')
-  } else if (sec < 90) {
-    return formatter.format(min * sign, 'minute')
   } else if (min < 45) {
     return formatter.format(min * sign, 'minute')
-  } else if (min < 90) {
-    return formatter.format(hr * sign, 'hour')
   } else if (hr < 24) {
     return formatter.format(hr * sign, 'hour')
-  } else if (hr < 36) {
-    return formatter.format(day * sign, 'day')
   } else if (day < 30) {
     return formatter.format(day * sign, 'day')
   } else if (month < 18) {

--- a/app/src/lib/stores/helpers/branch-pruner.ts
+++ b/app/src/lib/stores/helpers/branch-pruner.ts
@@ -15,8 +15,8 @@ import {
 } from '../../git'
 import { fatalError } from '../../fatal-error'
 import { RepositoryStateCache } from '../repository-state-cache'
-import moment from 'moment'
 import { offsetFromNow } from '../../offset-from'
+import { formatRelative } from '../../format-relative'
 
 /** Check if a repo needs to be pruned at least every 4 hours */
 const BackgroundPruneMinimumInterval = 1000 * 60 * 60 * 4
@@ -150,11 +150,8 @@ export class BranchPruner {
       lastPruneDate != null &&
       threshold < lastPruneDate
     ) {
-      log.info(
-        `[BranchPruner] Last prune took place ${moment(
-          lastPruneDate
-        ).fromNow()} - skipping`
-      )
+      const timeAgo = formatRelative(lastPruneDate - Date.now())
+      log.info(`[BranchPruner] Last prune took place ${timeAgo} - skipping`)
       return
     }
 

--- a/app/src/ui/branches/pull-request-list-item.tsx
+++ b/app/src/ui/branches/pull-request-list-item.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import moment from 'moment'
 import classNames from 'classnames'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -11,6 +10,7 @@ import { Dispatcher } from '../dispatcher'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
 import { DropTargetType } from '../../models/drag-drop'
 import { getPullRequestCommitRef } from '../../models/pull-request'
+import { formatRelative } from '../../lib/format-relative'
 
 export interface IPullRequestListItemProps {
   /** The title. */
@@ -76,7 +76,7 @@ export class PullRequestListItem extends React.Component<
       return undefined
     }
 
-    const timeAgo = moment(this.props.created).fromNow()
+    const timeAgo = formatRelative(this.props.created.getTime() - Date.now())
     const subtitle = `#${this.props.number} opened ${timeAgo} by ${this.props.author}`
 
     return this.props.draft ? `${subtitle} • Draft` : subtitle

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import moment from 'moment'
 import {
   FilterList,
   IFilterListGroup,
@@ -21,6 +20,7 @@ import { FoldoutType } from '../../lib/app-state'
 import { startTimer } from '../lib/timing'
 import { DragType } from '../../models/drag-drop'
 import { dragAndDropManager } from '../../lib/drag-and-drop-manager'
+import { formatRelative } from '../../lib/format-relative'
 
 interface IPullRequestListItem extends IFilterListItem {
   readonly id: string
@@ -318,7 +318,7 @@ export class PullRequestList extends React.Component<
 }
 
 function getSubtitle(pr: PullRequest) {
-  const timeAgo = moment(pr.created).fromNow()
+  const timeAgo = formatRelative(pr.created.getTime() - Date.now())
   return `#${pr.pullRequestNumber} opened ${timeAgo} by ${pr.author}`
 }
 

--- a/app/src/ui/index.tsx
+++ b/app/src/ui/index.tsx
@@ -3,7 +3,6 @@ import '../lib/logging/renderer/install'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 import * as Path from 'path'
-import * as moment from 'moment'
 import { App } from './app'
 import {
   Dispatcher,
@@ -68,9 +67,6 @@ import { PullRequestCoordinator } from '../lib/stores/pull-request-coordinator'
 //   Focus Ring! -- A11ycasts #16: https://youtu.be/ilj2P5-5CjI
 import 'wicg-focus-ring'
 
-// setup this moment.js plugin so we can use easier
-// syntax for formatting time duration
-import momentDurationFormatSetup from 'moment-duration-format'
 import { sendNonFatalException } from '../lib/helpers/non-fatal-exception'
 import { enableUnhandledRejectionReporting } from '../lib/feature-flag'
 import { AheadBehindStore } from '../lib/stores/ahead-behind-store'
@@ -102,8 +98,6 @@ process.env['LOCAL_GIT_DIRECTORY'] = Path.resolve(__dirname, 'git')
 // instead of just blindly trusting what's set in
 // the current environment. See https://git.io/JJ7KF
 delete process.env.GIT_EXEC_PATH
-
-momentDurationFormatSetup(moment)
 
 const startTime = performance.now()
 

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import moment from 'moment'
 import { TooltippedContent } from './lib/tooltipped-content'
 import { formatDate } from '../lib/format-date'
+import { formatRelative } from '../lib/format-relative'
 
 interface IRelativeTimeProps {
   /**
@@ -87,7 +87,7 @@ export class RelativeTime extends React.Component<
   }
 
   private updateWithDate(then: Date) {
-    const { abbreviate, onlyRelative } = this.props
+    const { onlyRelative } = this.props
 
     const diff = then.getTime() - Date.now()
     const duration = Math.abs(diff)
@@ -97,13 +97,7 @@ export class RelativeTime extends React.Component<
       timeStyle: 'short',
     })
 
-    const format = abbreviate
-      ? 'y[y] M[m] w[w] d[d] h[h] m[m]'
-      : 'y [years] ago M [months] ago d [days] ago h [hours] ago m [minutes] ago'
-
-    const relativeText = moment
-      .duration(duration, 'milliseconds')
-      .format(format, { largest: 1 })
+    const relativeText = formatRelative(duration)
 
     // Future date, let's just show as absolute and reschedule. If it's less
     // than a minute into the future we'll treat it as 'just now'.

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1027,11 +1027,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.5"
 
-moment-duration-format@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-2.3.2.tgz#5fa2b19b941b8d277122ff3f87a12895ec0d6212"
-  integrity sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==
-
 moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "@types/klaw-sync": "^6.0.0",
     "@types/legal-eagle": "^0.15.0",
     "@types/memoize-one": "^3.1.1",
-    "@types/moment-duration-format": "^2.2.2",
     "@types/mri": "^1.1.0",
     "@types/node": "16.11.11",
     "@types/prettier": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,13 +1148,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/moment-duration-format@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@types/moment-duration-format/-/moment-duration-format-2.2.2.tgz#da0c9501861661d19fdb62415907a93c44709a81"
-  integrity sha512-CuYswsMI3y5uR5sD9i/VUqIbZrsYN2eaCs7nH3qpDl2CZlNI48mjMf4ve2RpQ/65irprtnQVetfnea9my+jqcg==
-  dependencies:
-    moment ">=2.14.0"
-
 "@types/mri@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/mri/-/mri-1.1.0.tgz#66555e4d797713789ea0fefdae0898d8170bf5af"
@@ -6828,11 +6821,6 @@ moment@2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
   integrity sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=
-
-moment@>=2.14.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 mrmime@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Based on #14148 this PR replaces all of our uses of moment's relative time formatting in favor of a custom (based on GitHub.com's [relative-time.ts](https://github.com/github/time-elements/blob/428b02c98d1b6f6743acdfae27a32dccd52b866a/src/relative-time.ts) functions) relative time formatter.

One noteworthy, user facing change, in this PR is the removal of our ultra-compact (or so called "abbreviated") relative time format in favor of the regular format

#### Before
<img width="264" alt="image" src="https://user-images.githubusercontent.com/634063/157859998-bf0c68e8-ae0a-480b-926b-22714a9d818f.png">


#### After
<img width="277" alt="image" src="https://user-images.githubusercontent.com/634063/157860040-799d2a8a-a46f-4933-a8bc-1b830418c04f.png">

This is in line with what GitHub.com does these days. Commits, PR lists, etc, all use the regular format instead of the micro format.

With this we're able to unship `moment-duration-format` and we're inches away from unshipping all of moment

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes