### PR TITLE
Unship moment.js from the renderer bundle

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,6 @@
     "marked": "^4.0.10",
     "mem": "^4.3.0",
     "memoize-one": "^4.0.3",
-    "moment": "^2.24.0",
     "mri": "^1.1.0",
     "p-limit": "^2.2.0",
     "primer-support": "^4.0.0",

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -6,11 +6,11 @@ import { CICheckRunList } from './ci-check-run-list'
 import { GitHubRepository } from '../../models/github-repository'
 import { Dispatcher } from '../dispatcher'
 import { APICheckStatus, IAPICheckSuite } from '../../lib/api'
-import moment from 'moment'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from './../octicons/octicons.generated'
 import { Row } from '../lib/row'
 import { encodePathAsUrl } from '../../lib/path'
+import { offsetFromNow } from '../../lib/offset-from'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -91,11 +91,10 @@ export class CICheckRunRerunDialog extends React.Component<
         continue
       }
 
-      const created = moment(cs.created_at)
-      const monthsSinceCreated = moment().diff(created, 'months')
+      const createdAt = Date.parse(cs.created_at)
       if (
         cs.rerequestable &&
-        monthsSinceCreated < 1 && // Must be less than a month old
+        createdAt > offsetFromNow(-30, 'days') && // Must be less than a month old
         cs.status === APICheckStatus.Completed // Must be completed
       ) {
         rerequestableCheckSuiteIds.push(cs.id)

--- a/app/test/unit/git/reflog-test.ts
+++ b/app/test/unit/git/reflog-test.ts
@@ -8,7 +8,6 @@ import {
   getBranchCheckouts,
 } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
-import moment from 'moment'
 import { GitProcess } from 'dugite'
 import { offsetFromNow } from '../../../src/lib/offset-from'
 
@@ -79,7 +78,7 @@ describe('git/reflog', () => {
 
       const branches = await getBranchCheckouts(
         repository,
-        moment().add(1, 'day').toDate()
+        new Date(offsetFromNow(1, 'day'))
       )
       expect(branches.size).toBe(0)
     })

--- a/app/webpack.common.ts
+++ b/app/webpack.common.ts
@@ -49,14 +49,6 @@ const commonConfig: webpack.Configuration = {
       },
     ],
   },
-  plugins: [
-    // This saves us a bunch of bytes by pruning locales (which we don't use)
-    // from moment.
-    new webpack.IgnorePlugin({
-      resourceRegExp: /^\.\/locale$/,
-      contextRegExp: /moment$/,
-    }),
-  ],
   resolve: {
     extensions: ['.js', '.ts', '.tsx'],
   },

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1027,11 +1027,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.5"
 
-moment@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
 moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Based on #14149, this PR removes the last callsites using moment() and removes our dependency on the same. Unfortunately that doesn't mean we've unshipped moment completely. We still depend on packages which in turn depend on moment (stop-build in / and winston-daily-rotate-file in /app). We'll address those two separately though.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes