### PR TITLE
Remove winston-daily-rotate-file in favor of custom implementation

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -63,8 +63,7 @@
     "username": "^5.1.0",
     "uuid": "^3.0.1",
     "wicg-focus-ring": "^1.0.1",
-    "winston": "^3.6.0",
-    "winston-daily-rotate-file": "^4.6.1"
+    "winston": "^3.6.0"
   },
   "devDependencies": {
     "devtron": "^1.4.0",

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -6,7 +6,6 @@ import { EOL } from 'os'
 import { readdir, unlink } from 'fs/promises'
 import { escapeRegExp } from '../lib/helpers/regex'
 import { offsetFromNow } from '../lib/offset-from'
-import { omit } from 'lodash'
 
 type DesktopFileTransportOptions = TransportStreamOptions & {
   readonly logDirectory: string
@@ -39,8 +38,9 @@ export class DesktopFileTransport extends TransportStream {
   private logDirectory: string
 
   public constructor(opts: DesktopFileTransportOptions) {
-    super(omit(opts, 'logDirectory'))
-    this.logDirectory = opts.logDirectory
+    const { logDirectory, ...rest } = opts
+    super(rest)
+    this.logDirectory = logDirectory
   }
 
   public async log(info: any, callback: () => void) {

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -13,7 +13,9 @@ type DesktopFileTransportOptions = TransportStreamOptions & {
 }
 
 const fileSuffix = `.desktop.${__RELEASE_CHANNEL__}.log`
-const pathRe = new RegExp('(d{4}-d{2}-d{2})' + escapeRegExp(fileSuffix) + '$')
+const pathRe = new RegExp(
+  '(\\d{4}-\\d{2}-\\d{2})' + escapeRegExp(fileSuffix) + '$'
+)
 
 /**
  * A re-implementation of the winston-daily-rotate-file module

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -41,7 +41,9 @@ export class DesktopFileTransport extends TransportStream {
 
     if (this.stream === undefined || this.stream.path !== path) {
       this.stream?.end()
-      this.stream = createStream(path).on('error', e => this.emit('error', e))
+      this.stream = await createStream(path)
+      this.stream.on('error', e => this.emit('error', e))
+
       await pruneDirectory(this.logDirectory).catch(e => this.emit('error', e))
     }
 

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -78,14 +78,14 @@ const getFilePrefix = (d = new Date()) => d.toISOString().split('T', 1)[0]
 const getFilePath = (p: string) => join(p, `${getFilePrefix()}${fileSuffix}`)
 
 const pruneDirectory = async (p: string) => {
-  const treshold = offsetFromNow(-14, 'days')
+  const threshold = offsetFromNow(-14, 'days')
   const files = await readdir(p).catch(debug)
 
   for (const f of files ?? []) {
     const m = pathRe.exec(f)
     const d = m ? Date.parse(m[1]) : NaN
 
-    if (!isNaN(d) && d < treshold) {
+    if (!isNaN(d) && d < threshold) {
       await unlink(join(p, f)).catch(e =>
         console.debug(`DesktopFileTransport: Error removing old log file`, e)
       )

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -1,0 +1,74 @@
+import { createWriteStream, WriteStream } from 'fs'
+import { join } from 'path'
+import { MESSAGE } from 'triple-beam'
+import TransportStream, { TransportStreamOptions } from 'winston-transport'
+import { EOL } from 'os'
+import { readdir, unlink } from 'fs/promises'
+import { escapeRegExp } from '../lib/helpers/regex'
+import { offsetFromNow } from '../lib/offset-from'
+import { omit } from 'lodash'
+
+type DesktopFileTransportOptions = TransportStreamOptions & {
+  readonly logDirectory: string
+}
+
+const fileSuffix = `.desktop.${__RELEASE_CHANNEL__}.log`
+const pathRe = new RegExp('(d{4}-d{2}-d{2})' + escapeRegExp(fileSuffix) + '$')
+
+/**
+ * A re-implementation of the winston-daily-rotate-file module
+ *
+ * winston-daily-rotate-file depends on moment.js which we're trying to unship
+ * so we're using this instead.
+ *
+ * Please note that this is in no way a general purpose transpot like
+ * winston-daily-rotate-file, it's highly specific to the needs of GitHub
+ * Desktop.
+ */
+export class DesktopFileTransport extends TransportStream {
+  private stream?: WriteStream
+  private logDirectory: string
+
+  public constructor(opts: DesktopFileTransportOptions) {
+    super(omit(opts, 'logDirectory'))
+    this.logDirectory = opts.logDirectory
+  }
+
+  public async log(info: any, callback: () => void) {
+    const path = getFilePath(this.logDirectory)
+
+    if (this.stream === undefined || this.stream.path !== path) {
+      this.stream?.end()
+      this.stream = createStream(path).on('error', e => this.emit('error', e))
+      await pruneDirectory(this.logDirectory).catch(e => this.emit('error', e))
+    }
+
+    this.stream.write(`${info[MESSAGE]}${EOL}`, () => this.emit('logged', info))
+    callback?.()
+  }
+
+  public close() {
+    this.stream?.end()
+    this.stream = undefined
+  }
+}
+
+const getFilePrefix = (d = new Date()) => d.toISOString().split('T', 1)[0]
+const getFilePath = (p: string) => join(p, `${getFilePrefix()}${fileSuffix}`)
+const createStream = (p: string) => createWriteStream(p, { flags: 'a' })
+
+const pruneDirectory = async (p: string) => {
+  const treshold = offsetFromNow(14, 'days')
+  const files = await readdir(p)
+
+  for (const f of files) {
+    const m = pathRe.exec(f)
+    const d = m ? Date.parse(m[1]) : NaN
+
+    if (!isNaN(d) && d < treshold) {
+      await unlink(join(p, f)).catch(e =>
+        console.debug(`DesktopFileTransport: Error removing old log file`, e)
+      )
+    }
+  }
+}

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -60,7 +60,7 @@ const getFilePath = (p: string) => join(p, `${getFilePrefix()}${fileSuffix}`)
 const createStream = (p: string) => createWriteStream(p, { flags: 'a' })
 
 const pruneDirectory = async (p: string) => {
-  const treshold = offsetFromNow(14, 'days')
+  const treshold = offsetFromNow(-14, 'days')
   const files = await readdir(p)
 
   for (const f of files) {

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -6,6 +6,7 @@ import { EOL } from 'os'
 import { readdir, unlink } from 'fs/promises'
 import { escapeRegExp } from '../lib/helpers/regex'
 import { offsetFromNow } from '../lib/offset-from'
+import { promisify } from 'util'
 
 type DesktopFileTransportOptions = TransportStreamOptions & {
   readonly logDirectory: string
@@ -67,10 +68,7 @@ export class DesktopFileTransport extends TransportStream {
     this.stream = undefined
   }
 }
-const write = (s: WriteStream, chunk: string) =>
-  new Promise<void>((resolve, reject) =>
-    s.write(chunk, e => (e ? reject(e) : resolve()))
-  )
+const write = promisify<WriteStream, string, void>((s, c, cb) => s.write(c, cb))
 
 const getFilePrefix = (d = new Date()) => d.toISOString().split('T', 1)[0]
 const getFilePath = (p: string) => join(p, `${getFilePrefix()}${fileSuffix}`)

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -77,7 +77,7 @@ const getFilePath = (p: string) => join(p, `${getFilePrefix()}${fileSuffix}`)
 
 const pruneDirectory = async (p: string) => {
   const threshold = offsetFromNow(-14, 'days')
-  const files = await readdir(p).catch(error('readlink'))
+  const files = await readdir(p).catch(error('readdir'))
 
   for (const f of files ?? []) {
     const m = pathRe.exec(f)

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -45,8 +45,14 @@ export class DesktopFileTransport extends TransportStream {
       await pruneDirectory(this.logDirectory).catch(e => this.emit('error', e))
     }
 
-    this.stream.write(`${info[MESSAGE]}${EOL}`, () => this.emit('logged', info))
-    callback?.()
+    this.stream.write(`${info[MESSAGE]}${EOL}`, err => {
+      if (err) {
+        this.emit('error', err)
+      } else {
+        this.emit('logged', info)
+      }
+      callback?.()
+    })
   }
 
   public close(cb?: () => void) {

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -30,7 +30,7 @@ const error = (operation: string) => (error: any) => {
  * winston-daily-rotate-file depends on moment.js which we're trying to unship
  * so we're using this instead.
  *
- * Please note that this is in no way a general purpose transpot like
+ * Please note that this is in no way a general purpose transport like
  * winston-daily-rotate-file, it's highly specific to the needs of GitHub
  * Desktop.
  */

--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -1,19 +1,11 @@
-import * as Path from 'path'
 import * as winston from 'winston'
 import { getLogDirectoryPath } from '../lib/logging/get-log-path'
 import { LogLevel } from '../lib/logging/log-level'
 import { noop } from 'lodash'
 import { DesktopConsoleTransport } from './desktop-console-transport'
-import 'winston-daily-rotate-file'
 import memoizeOne from 'memoize-one'
 import { mkdir } from 'fs/promises'
 import { DesktopFileTransport } from './desktop-file-transport'
-
-/**
- * The maximum number of log files we should have on disk before pruning old
- * ones.
- */
-const MaxLogFiles = 14
 
 /**
  * Initializes winston and returns a subset of the available log level
@@ -33,11 +25,8 @@ function initializeWinston(path: string): winston.LogMethod {
     ),
   })
 
-  // The file logger handles errors when it can't write to an existing file but
-  // emits an error when attempting to create a file and failing (for example
-  // due to permissions or the disk being full). If logging fails that's not a
-  // big deal so we'll just suppress any error, besides, the console logger will
-  // likely still work.
+  // The file transport shouldn't emit anything but just in case it does we want
+  // a listener or else it'll bubble to an unhandled exception.
   fileLogger.on('error', noop)
 
   const consoleLogger = new DesktopConsoleTransport({

--- a/app/src/main-process/log.ts
+++ b/app/src/main-process/log.ts
@@ -7,6 +7,7 @@ import { DesktopConsoleTransport } from './desktop-console-transport'
 import 'winston-daily-rotate-file'
 import memoizeOne from 'memoize-one'
 import { mkdir } from 'fs/promises'
+import { DesktopFileTransport } from './desktop-file-transport'
 
 /**
  * The maximum number of log files we should have on disk before pruning old
@@ -22,14 +23,11 @@ const MaxLogFiles = 14
  * @param path The path where to write log files.
  */
 function initializeWinston(path: string): winston.LogMethod {
-  const filename = Path.join(path, `%DATE%.desktop.${__RELEASE_CHANNEL__}.log`)
   const timestamp = () => new Date().toISOString()
 
-  const fileLogger = new winston.transports.DailyRotateFile({
-    filename,
-    datePattern: 'YYYY-MM-DD',
+  const fileLogger = new DesktopFileTransport({
+    logDirectory: path,
     level: 'info',
-    maxFiles: MaxLogFiles,
     format: winston.format.printf(
       ({ level, message }) => `${timestamp()} - ${level}: ${message}`
     ),

--- a/app/test/helpers/temp.ts
+++ b/app/test/helpers/temp.ts
@@ -4,6 +4,7 @@
  * `temp` Node module
  */
 import * as temp from 'temp'
+import { promisify } from 'util'
 const _temp = temp.track()
 
 /**
@@ -16,3 +17,5 @@ export const mkdirSync = _temp.mkdirSync
  * should use
  */
 export const openSync = _temp.openSync
+
+export const createTempDirectory = promisify(_temp.mkdir.bind(_temp))

--- a/app/test/unit/desktop-file-transport-test.ts
+++ b/app/test/unit/desktop-file-transport-test.ts
@@ -1,0 +1,72 @@
+import { readdir } from 'fs/promises'
+import { LEVEL } from 'triple-beam'
+import { DesktopFileTransport } from '../../src/main-process/desktop-file-transport'
+import { createTempDirectory } from '../helpers/temp'
+
+const info = (t: DesktopFileTransport, message: string) => {
+  const chunk = { message, [LEVEL]: 'info', level: 'info' }
+  return new Promise<void>((resolve, reject) =>
+    t.write(chunk, e => (e ? reject(e) : resolve()))
+  )
+}
+
+describe('DesktopFileTransport', () => {
+  it('creates a file on demand', async () => {
+    const d = await createTempDirectory('desktop-logs')
+    const t = new DesktopFileTransport({ logDirectory: d })
+
+    expect(await readdir(d)).toBeArrayOfSize(0)
+    await info(t, 'heyo')
+    expect(await readdir(d)).toBeArrayOfSize(1)
+
+    t.close()
+  })
+
+  it('creates a file for each day', async () => {
+    const originalToISOString = Date.prototype.toISOString
+    const globalDate = global.Date as any
+    const d = await createTempDirectory('desktop-logs')
+    const t = new DesktopFileTransport({ logDirectory: d })
+
+    try {
+      expect(await readdir(d)).toBeArrayOfSize(0)
+
+      globalDate.prototype.toISOString = () => '2022-03-10T10:00:00.000Z'
+      await info(t, 'heyo')
+
+      globalDate.prototype.toISOString = () => '2022-03-11T11:00:00.000Z'
+      await info(t, 'heyo')
+
+      expect(await readdir(d)).toBeArrayOfSize(2)
+
+      t.close()
+    } finally {
+      globalDate.toISOString = originalToISOString
+    }
+  })
+
+  it('cleans up files older than 14 days', async () => {
+    const originalNow = Date.now
+    const originalToISOString = Date.prototype.toISOString
+    const globalDate = global.Date as any
+    const d = await createTempDirectory('desktop-logs')
+    const t = new DesktopFileTransport({ logDirectory: d })
+
+    try {
+      expect(await readdir(d)).toBeArrayOfSize(0)
+      for (let i = 1; i < 20; i++) {
+        const date = `${i}`.padStart(2, '0')
+        globalDate.now = () => Date.parse(`2022-03-${date}T10:00:00.000Z`)
+        globalDate.prototype.toISOString = () => `2022-03-${date}T10:00:00.000Z`
+        await info(t, 'heyo')
+      }
+
+      expect(await readdir(d)).toBeArrayOfSize(14)
+
+      t.close()
+    } finally {
+      globalDate.now = originalNow
+      globalDate.prototype.toISOString = originalToISOString
+    }
+  })
+})

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -568,13 +568,6 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-file-stream-rotator@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz#007019e735b262bb6c6f0197e58e5c87cb96cec3"
-  integrity sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==
-  dependencies:
-    moment "^2.29.1"
-
 fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
@@ -1037,11 +1030,6 @@ moment@^2.24.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-moment@^2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
 mri@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
@@ -1130,11 +1118,6 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
-object-hash@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
-  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1872,17 +1855,7 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-winston-daily-rotate-file@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.6.1.tgz#35c9db5669c381ed32acdb5849de69ab046a7a71"
-  integrity sha512-Ycch4LZmTycbhgiI2eQXBKI1pKcEQgAqmBjyq7/dC6Dk77nasdxvhLKraqTdCw7wNDSs8/M0jXaLATHquG7xYg==
-  dependencies:
-    file-stream-rotator "^0.6.1"
-    object-hash "^2.0.1"
-    triple-beam "^1.3.0"
-    winston-transport "^4.4.0"
-
-winston-transport@^4.4.0, winston-transport@^4.5.0:
+winston-transport@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
   integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
As noted in #14152 our attempts to remove `moment.js` got thwarted at the last minute when we realized that `winston-daily-rotate-file` depended on it.

This is an attempt to rip out `winston-daily-rotate-file` in favor of a custom file rotator.

N.B if this lands there's very little of winston's logic left so it's worth thinking about simplifying even further

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes