### PR TITLE
Shared formatter caching

### DIFF
--- a/app/src/lib/format-date.ts
+++ b/app/src/lib/format-date.ts
@@ -1,25 +1,4 @@
-import mem from 'mem'
-import QuickLRU from 'quick-lru'
-import { getFormattingLocales } from './formatting-locale'
-
-// Initializing a date formatter is expensive but formatting is relatively cheap
-// so we cache them based on the locale and their options. The maxSize of a 100
-// is only as an escape hatch, we don't expect to ever create more than a
-// handful different formatters.
-const getDateFormatter = mem(
-  (locale: string | string[], options: Intl.DateTimeFormatOptions) => {
-    try {
-      return new Intl.DateTimeFormat(locale, options)
-    } catch (e) {
-      log.error(`Error creating DateTimeFormat with locale '${locale}'`, e)
-      return new Intl.DateTimeFormat(undefined, options)
-    }
-  },
-  {
-    cache: new QuickLRU({ maxSize: 100 }),
-    cacheKey: (...args) => JSON.stringify(args),
-  }
-)
+import { getDefaultDateTimeFormatter } from './get-intl-formatter'
 
 /**
  * Format a date in the user's formatting locale customizable with
@@ -30,4 +9,4 @@ const getDateFormatter = mem(
 export const formatDate = (date: Date, options: Intl.DateTimeFormatOptions) =>
   isNaN(date.valueOf())
     ? 'Invalid date'
-    : getDateFormatter(getFormattingLocales(), options).format(date)
+    : getDefaultDateTimeFormatter(options).format(date)

--- a/app/src/lib/format-number.ts
+++ b/app/src/lib/format-number.ts
@@ -1,25 +1,4 @@
-import mem from 'mem'
-import QuickLRU from 'quick-lru'
-import { getFormattingLocales } from './formatting-locale'
-
-// Initializing a nuumber formatter is expensive but formatting is relatively
-// cheap so we cache them based on the locale and their options. The maxSize of
-// a 100 is only as an escape hatch, we don't expect to ever create more than a
-// handful different formatters.
-const getNumber = mem(
-  (locale: string | string[], options?: Intl.NumberFormatOptions) => {
-    try {
-      return new Intl.NumberFormat(locale, options)
-    } catch (e) {
-      log.error(`Error creating NumberFormat with locale '${locale}'`, e)
-      return new Intl.NumberFormat(undefined, options)
-    }
-  },
-  {
-    cache: new QuickLRU({ maxSize: 100 }),
-    cacheKey: (...args) => JSON.stringify(args),
-  }
-)
+import { getDefaultNumberFormatter } from './get-intl-formatter'
 
 /**
  * Format a date in the user's formatting locale, customizable with
@@ -28,4 +7,4 @@ const getNumber = mem(
  * See Intl.NumberFormat for more information
  */
 export const formatNumber = (num: number, options?: Intl.NumberFormatOptions) =>
-  getNumber(getFormattingLocales(), options).format(num)
+  getDefaultNumberFormatter(options).format(num)

--- a/app/src/lib/format-relative.ts
+++ b/app/src/lib/format-relative.ts
@@ -1,31 +1,7 @@
-import mem from 'mem'
-import QuickLRU from 'quick-lru'
-import { getFormattingLocales } from './formatting-locale'
-
-// Initializing a date formatter is expensive but formatting is relatively cheap
-// so we cache them based on the locale and their options. The maxSize of a 100
-// is only as an escape hatch, we don't expect to ever create more than a
-// handful different formatters.
-const getRelativeFormatter = mem(
-  (locales: string | string[], options: Intl.RelativeTimeFormatOptions) => {
-    try {
-      return new Intl.RelativeTimeFormat(locales, options)
-    } catch (e) {
-      log.error(`Error creating RelativeTimeFormat with locale '${locales}'`, e)
-      return new Intl.RelativeTimeFormat(undefined, options)
-    }
-  },
-  {
-    cache: new QuickLRU({ maxSize: 100 }),
-    cacheKey: (...args) => JSON.stringify(args),
-  }
-)
+import { getDefaultRelativeTimeFormatter } from './get-intl-formatter'
 
 export function formatRelative(ms: number) {
-  const formatter = getRelativeFormatter(getFormattingLocales(), {
-    numeric: 'auto',
-  })
-
+  const formatter = getDefaultRelativeTimeFormatter({ numeric: 'auto' })
   const sign = ms < 0 ? 1 : -1
 
   // Lifted and adopted from

--- a/app/src/lib/get-intl-formatter.ts
+++ b/app/src/lib/get-intl-formatter.ts
@@ -1,0 +1,38 @@
+import mem from 'mem'
+import QuickLRU from 'quick-lru'
+import { getFormattingLocales } from './formatting-locale'
+
+type Locales = string | string[] | undefined
+
+function createIntlFormatter<T, Opts>(
+  formatter: { new (locales?: Locales, options?: Opts): T },
+  locales?: string | string[],
+  options?: Opts
+): T {
+  try {
+    return new formatter(locales, options)
+  } catch (e) {
+    log.error(`Error creating DateTimeFormat with locale '${locales}'`, e)
+    return new formatter(undefined, options)
+  }
+}
+
+// Initializing an Intl formatter is expensive but formatting is relatively
+// cheap so we cache them based on the locale and their options. The maxSize of
+// a 100 is only as an escape hatch, we don't expect to ever create more than a
+// handful different formatters.
+export const getIntlFormatter = mem(createIntlFormatter, {
+  cache: new QuickLRU({ maxSize: 100 }),
+  cacheKey: (...args) => JSON.stringify(args),
+})
+
+export const getDefaultDateTimeFormatter = (
+  opts?: Intl.DateTimeFormatOptions
+) => getIntlFormatter(Intl.DateTimeFormat, getFormattingLocales(), opts)
+
+export const getDefaultRelativeTimeFormatter = (
+  opts?: Intl.RelativeTimeFormatOptions
+) => getIntlFormatter(Intl.RelativeTimeFormat, getFormattingLocales(), opts)
+
+export const getDefaultNumberFormatter = (opts?: Intl.NumberFormatOptions) =>
+  getIntlFormatter(Intl.NumberFormat, getFormattingLocales(), opts)


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Building on #14174, this PR centralizes the logic for creating, and caching, Intl.* formatters. This is mainly a cleanup PR but sharing this (semi-complex) logic will minimize the risk of hard-to-detect bugs in one of our less used formatters.

We can also extend this for the other formatters in the Intl namespace as we need to.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes