### PR TITLE
Fix `Not Now` button in "initialize LFS" dialog

### DIFF
--- a/app/src/ui/lfs/initialize-lfs.tsx
+++ b/app/src/ui/lfs/initialize-lfs.tsx
@@ -36,7 +36,6 @@ export class InitializeLFS extends React.Component<IInitializeLFSProps, {}> {
         id="initialize-lfs"
         title="Initialize Git LFS"
         dismissable={false}
-        onDismissed={this.props.onDismissed}
         onSubmit={this.onInitialize}
       >
         <DialogContent>{this.renderRepositories()}</DialogContent>
@@ -45,6 +44,7 @@ export class InitializeLFS extends React.Component<IInitializeLFSProps, {}> {
           <OkCancelButtonGroup
             okButtonText="Initialize Git LFS"
             cancelButtonText={__DARWIN__ ? 'Not Now' : 'Not now'}
+            onCancelButtonClick={this.props.onDismissed}
           />
         </DialogFooter>
       </Dialog>


### PR DESCRIPTION
## Description

With #14131 I made the dialog non-dismissable, but the `Not Now` button relied on the `onDismiss` callback. This PR changes that by using `onCancelButtonClick` instead of `onDismiss`.

## Release notes

Notes: no-notes (regression only in beta)
