### PR TITLE
Fix Markdown height issue (round 2)

### DIFF
--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -100,6 +100,10 @@ export class SandboxedMarkdown extends React.PureComponent<
     }
   }
 
+  public componentWillUnmount() {
+    this.resizeObserver.disconnect()
+  }
+
   /**
    * Since iframe styles are isolated from the rest of the app, we have a
    * markdown.css file that we added to app/static directory that we can read in
@@ -171,6 +175,7 @@ export class SandboxedMarkdown extends React.PureComponent<
     ) as HTMLDivElement
 
     if (this.contentDivRef !== null) {
+      this.resizeObserver.disconnect()
       this.resizeObserver.observe(this.contentDivRef)
     }
   }

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -44,6 +44,36 @@ export class SandboxedMarkdown extends React.PureComponent<
 > {
   private frameRef: HTMLIFrameElement | null = null
   private frameContainingDivRef: HTMLDivElement | null = null
+  private contentDivRef: HTMLDivElement | null = null
+
+  /**
+   * Resize observer used for tracking height changes in the markdown
+   * content and update the size of the iframe container.
+   */
+  private readonly resizeObserver: ResizeObserver
+  private resizeDebounceId: number | null = null
+
+  public constructor(props: ISandboxedMarkdownProps) {
+    super(props)
+
+    this.resizeObserver = new ResizeObserver(this.scheduleResizeEvent)
+  }
+
+  private scheduleResizeEvent = () => {
+    if (this.resizeDebounceId !== null) {
+      cancelAnimationFrame(this.resizeDebounceId)
+      this.resizeDebounceId = null
+    }
+    this.resizeDebounceId = requestAnimationFrame(this.onContentResized)
+  }
+
+  private onContentResized = () => {
+    if (this.frameRef === null) {
+      return
+    }
+
+    this.setFrameContainerHeight(this.frameRef)
+  }
 
   private onFrameRef = (frameRef: HTMLIFrameElement | null) => {
     this.frameRef = frameRef
@@ -119,9 +149,30 @@ export class SandboxedMarkdown extends React.PureComponent<
    */
   private setupFrameLoadListeners(frameRef: HTMLIFrameElement): void {
     frameRef.addEventListener('load', () => {
+      this.setupContentDivRef(frameRef)
       this.setupLinkInterceptor(frameRef)
       this.setFrameContainerHeight(frameRef)
     })
+  }
+
+  private setupContentDivRef(frameRef: HTMLIFrameElement): void {
+    if (frameRef.contentDocument === null) {
+      return
+    }
+
+    /*
+     * We added an additional wrapper div#content around the markdown to
+     * determine a more accurate scroll height as the iframe's document or body
+     * element was not adjusting it's height dynamically when new content was
+     * provided.
+     */
+    this.contentDivRef = frameRef.contentDocument.documentElement.querySelector(
+      '#content'
+    ) as HTMLDivElement
+
+    if (this.contentDivRef !== null) {
+      this.resizeObserver.observe(this.contentDivRef)
+    }
   }
 
   /**
@@ -133,31 +184,17 @@ export class SandboxedMarkdown extends React.PureComponent<
    */
   private setFrameContainerHeight(frameRef: HTMLIFrameElement): void {
     if (
-      frameRef.contentDocument == null ||
-      this.frameContainingDivRef == null
+      frameRef.contentDocument === null ||
+      this.frameContainingDivRef === null ||
+      this.contentDivRef === null
     ) {
-      return
-    }
-
-    /*
-     * We added an additional wrapper div#content around the markdown to
-     * determine a more accurate scroll height as the iframe's document or body
-     * element was not adjusting it's height dynamically when new content was
-     * provided.
-     */
-    const docEl = frameRef.contentDocument.documentElement.querySelector(
-      '#content'
-    ) as HTMLDivElement
-
-    if (docEl === null) {
       return
     }
 
     // Not sure why the content height != body height exactly. But we need to
     // set the height explicitly to prevent scrollbar/content cut off.
-    const divHeight = docEl.clientHeight
+    const divHeight = this.contentDivRef.clientHeight
     this.frameContainingDivRef.style.height = `${divHeight}px`
-    docEl.style.height = `${divHeight}px`
     this.props.onMarkdownParsed?.()
   }
 

--- a/app/static/common/markdown.css
+++ b/app/static/common/markdown.css
@@ -9,14 +9,6 @@ desktop font-size variables. (This is not meant to be an exhaustive list of
 changes from the original, just a note that this will not match 1-1)
  */
 
-#content {
-	/*
-	We need to set overflow-y to hidden to make sure this element calculates the
-	right height to fit its content.
-	 */
-	overflow-y: hidden;
-}
-
 .markdown-body {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 	font-size: var(--font-size);
@@ -37,11 +29,11 @@ changes from the original, just a note that this will not match 1-1)
 	content: ""
 }
 
-.markdown-body>*:first-child {
+.markdown-body>#content>*:first-child {
 	margin-top: 0 !important
 }
 
-.markdown-body>*:last-child {
+.markdown-body>#content>*:last-child {
 	margin-bottom: 0 !important
 }
 


### PR DESCRIPTION
## Description

#14140 attempted to fix the issue in a hacky i-dont-know-what-im-doing.gif way, and it seemed to work for a bunch of PRs/comments I ran into, but not for all.

This PR presents a more deterministic attempt to fix the problem: I found that part of the CSS was wrong (probably due to a refactor or to wrapping stuff into the `<div class="content">` element). I also added a `ResizeObserver` to react to whenever the `#content` div is resized due to content changes.

This approach seems to work in many situations but I see it still presents a scrollbar in other like #13201 , I will investigate…

## Release notes

Notes: no-notes
