### PR TITLE
Fix some "checks failed" notification metrics

### DIFF
--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -271,7 +271,7 @@ export class PullRequestChecksFailed extends React.Component<
   }
 
   private rerunChecks = () => {
-    this.props.dispatcher.recordChecksFailedDialogSwitchToPullRequest()
+    this.props.dispatcher.recordChecksFailedDialogRerunChecks()
 
     const prRef = getPullRequestCommitRef(
       this.props.pullRequest.pullRequestNumber
@@ -373,6 +373,8 @@ export class PullRequestChecksFailed extends React.Component<
   private onSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
     const { dispatcher, repository, pullRequest } = this.props
+
+    this.props.dispatcher.recordChecksFailedDialogSwitchToPullRequest()
 
     this.setState({ switchingToPullRequest: true })
     await dispatcher.selectRepository(repository)


### PR DESCRIPTION
## Description

While working on the metrics for the new PR review notifications, I ran into this mistake 🤦 

The "rerun checks" button was recording events for the "switch to PR" action, and the "switch to PR" button wasn't recording any events…

## Release notes

Notes: no-notes
