### PR TITLE
Pull request review notification metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -484,6 +484,42 @@ export interface IDailyMeasures {
    * failed" dialog.
    */
   readonly checksFailedDialogRerunChecksCount: number
+
+  /** The number of "approved PR" notifications the user received */
+  readonly pullRequestReviewApprovedNotificationCount: number
+
+  /** The number of "approved PR" notifications the user clicked */
+  readonly pullRequestReviewApprovedNotificationClicked: number
+
+  /**
+   * The number of times the user decided to switch to the affected pull request
+   * from the "approved PR" dialog.
+   */
+  readonly pullRequestReviewApprovedDialogSwitchToPullRequestCount: number
+
+  /** The number of "commented PR" notifications the user received */
+  readonly pullRequestReviewCommentedNotificationCount: number
+
+  /** The number of "commented PR" notifications the user clicked */
+  readonly pullRequestReviewCommentedNotificationClicked: number
+
+  /**
+   * The number of times the user decided to switch to the affected pull request
+   * from the "commented PR" dialog.
+   */
+  readonly pullRequestReviewCommentedDialogSwitchToPullRequestCount: number
+
+  /** The number of "changes requested" notifications the user received */
+  readonly pullRequestReviewChangesRequestedNotificationCount: number
+
+  /** The number of "changes requested" notifications the user clicked */
+  readonly pullRequestReviewChangesRequestedNotificationClicked: number
+
+  /**
+   * The number of times the user decided to switch to the affected pull request
+   * from the "changes requested" dialog.
+   */
+  readonly pullRequestReviewChangesRequestedDialogSwitchToPullRequestCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stores/notifications-store.ts
+++ b/app/src/lib/stores/notifications-store.ts
@@ -153,6 +153,8 @@ export class NotificationsStore {
     }\n${truncateWithEllipsis(review.body, 50)}`
 
     showNotification(title, body, () => {
+      this.statsStore.recordPullRequestReviewNotificationClicked(review.state)
+
       this.onPullRequestReviewSubmitCallback?.(
         repository,
         pullRequest,
@@ -160,6 +162,8 @@ export class NotificationsStore {
         event.number_of_comments
       )
     })
+
+    this.statsStore.recordPullRequestReviewNotificationShown(review.state)
   }
 
   private async handleChecksFailedEvent(event: IDesktopChecksFailedAliveEvent) {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -119,6 +119,7 @@ import {
 import { DragAndDropIntroType } from '../history/drag-and-drop-intro'
 import { getMultiCommitOperationChooseBranchStep } from '../../lib/multi-commit-operation'
 import { ICombinedRefCheck, IRefCheck } from '../../lib/ci-checks/ci-checks'
+import { ValidNotificationPullRequestReviewState } from '../../lib/valid-notification-pull-request-review'
 
 /**
  * An error handler function.
@@ -3885,5 +3886,11 @@ export class Dispatcher {
 
   public recordChecksFailedDialogRerunChecks() {
     this.statsStore.recordChecksFailedDialogRerunChecks()
+  }
+
+  public recordPullRequestReviewDialogSwitchToPullRequest(
+    reviewType: ValidNotificationPullRequestReviewState
+  ) {
+    this.statsStore.recordPullRequestReviewDialogSwitchToPullRequest(reviewType)
   }
 }

--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -283,6 +283,8 @@ export class PullRequestReview extends React.Component<
       await dispatcher.selectRepository(repository)
       await dispatcher.checkoutPullRequest(repository, pullRequest)
       this.setState({ switchingToPullRequest: false })
+
+      dispatcher.recordPullRequestReviewDialogSwitchToPullRequest(review.state)
     }
 
     this.props.onDismissed()


### PR DESCRIPTION
## Description

This PR is based on #14175 

It adds metrics for our new Pull Request review notifications:
- Track when this kind of notifications are displayed to users.
- Track when users click on this kind of notifications.
- Track when users click on "Switch to Pull Request" from the PR review dialog shown for this kind of notifications.

In order to reuse some code and at the same time keep our code compile-time safe, I've used [some TypeScript magic](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html). I can't say if it's too much magic or not enough, though 😂  I'll leave some inline comments for more detail.

## Release notes

Notes: no-notes
