### PR TITLE
Swap escapeRegExp for lodash method

### DIFF
--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -49,7 +49,8 @@ export function getMatches(text: string, re: RegExp): Array<RegExpExecArray> {
  * example return [ "LargeFile.exe (150.00 MB)", "AlsoTooLargeOfAFile.txt (1.00 GB)" ]
  */
 export function getFileFromExceedsError(error: string): string[] {
-  const endRegex = /(;\sthis\sexceeds\sGitHub's\sfile\ssize\slimit\sof\s100.00\sMB)/gm
+  const endRegex =
+    /(;\sthis\sexceeds\sGitHub's\sfile\ssize\slimit\sof\s100.00\sMB)/gm
   const beginRegex = /(^remote:\serror:\sFile\s)/gm
   const beginMatches = Array.from(error.matchAll(beginRegex))
   const endMatches = Array.from(error.matchAll(endRegex))

--- a/app/src/lib/helpers/regex.ts
+++ b/app/src/lib/helpers/regex.ts
@@ -42,16 +42,6 @@ export function getMatches(text: string, re: RegExp): Array<RegExpExecArray> {
   return matches
 }
 
-/**
- * Replaces characters that have a semantic meaning inside of a regexp with
- * their escaped equivalent (i.e. `*` becomes `\*` etc).
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
- */
-export function escapeRegExp(expression: string) {
-  return expression.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
-}
-
 /*
  * Looks for the phrases "remote: error File " and " is (file size I.E. 106.5 MB); this exceeds GitHub's file size limit of 100.00 MB"
  * inside of a string containing errors and return an array of all the filenames and their sizes located between these two strings.
@@ -59,8 +49,7 @@ export function escapeRegExp(expression: string) {
  * example return [ "LargeFile.exe (150.00 MB)", "AlsoTooLargeOfAFile.txt (1.00 GB)" ]
  */
 export function getFileFromExceedsError(error: string): string[] {
-  const endRegex =
-    /(;\sthis\sexceeds\sGitHub's\sfile\ssize\slimit\sof\s100.00\sMB)/gm
+  const endRegex = /(;\sthis\sexceeds\sGitHub's\sfile\ssize\slimit\sof\s100.00\sMB)/gm
   const beginRegex = /(^remote:\serror:\sFile\s)/gm
   const beginMatches = Array.from(error.matchAll(beginRegex))
   const endMatches = Array.from(error.matchAll(endRegex))

--- a/app/src/lib/markdown-filters/emoji-filter.ts
+++ b/app/src/lib/markdown-filters/emoji-filter.ts
@@ -1,7 +1,7 @@
 import { INodeFilter } from './node-filter'
-import { escapeRegExp } from '../helpers/regex'
 import { fileURLToPath } from 'url'
 import { readFile } from 'fs/promises'
+import { escapeRegExp } from 'lodash'
 
 /**
  * The Emoji Markdown filter will take a text node and create multiple text and

--- a/app/src/lib/markdown-filters/issue-link-filter.ts
+++ b/app/src/lib/markdown-filters/issue-link-filter.ts
@@ -1,6 +1,6 @@
+import { escapeRegExp } from 'lodash'
 import { GitHubRepository } from '../../models/github-repository'
 import { getHTMLURL } from '../api'
-import { escapeRegExp } from '../helpers/regex'
 import { INodeFilter } from './node-filter'
 
 /**

--- a/app/src/lib/markdown-filters/video-url-regex.ts
+++ b/app/src/lib/markdown-filters/video-url-regex.ts
@@ -1,4 +1,4 @@
-import { escapeRegExp } from '../helpers/regex'
+import { escapeRegExp } from 'lodash'
 
 const user_images_cdn_url = 'https://user-images.githubusercontent.com'
 

--- a/app/src/main-process/desktop-file-transport.ts
+++ b/app/src/main-process/desktop-file-transport.ts
@@ -4,8 +4,8 @@ import { MESSAGE } from 'triple-beam'
 import TransportStream, { TransportStreamOptions } from 'winston-transport'
 import { EOL } from 'os'
 import { readdir, unlink } from 'fs/promises'
-import { escapeRegExp } from '../lib/helpers/regex'
 import { promisify } from 'util'
+import { escapeRegExp } from 'lodash'
 
 type DesktopFileTransportOptions = TransportStreamOptions & {
   readonly logDirectory: string

--- a/app/src/ui/diff/side-by-side-diff.tsx
+++ b/app/src/ui/diff/side-by-side-diff.tsx
@@ -51,7 +51,6 @@ import {
 import { showContextualMenu } from '../../lib/menu-item'
 import { getTokens } from './diff-syntax-mode'
 import { DiffSearchInput } from './diff-search-input'
-import { escapeRegExp } from '../../lib/helpers/regex'
 import {
   expandTextDiffHunk,
   DiffExpansionKind,
@@ -59,6 +58,7 @@ import {
 } from './text-diff-expansion'
 import { IMenuItem } from '../../lib/menu-item'
 import { HiddenBidiCharsWarning } from './hidden-bidi-chars-warning'
+import { escapeRegExp } from 'lodash'
 
 const DefaultRowHeight = 20
 


### PR DESCRIPTION
## Description
I keep running into where I use the `escapeRegExp` method and my auto importer chooses the lodash method. I looked into what was the difference between our method and the one in lodash and it seems to be that our regex escape also escapes the hyphen. That should be inconsequential as the hyphen is only a special character when used as a range inside brackets and brackets will be escaped.  Example: `[a-z]`  escaped become `\[a-z\]` so in a regex it literally searches for `[`, `a` `-` `z` `]` as opposed to any lowercase letter; thus, the hyphen does not need escaped.

Our Regex: (linked to regex 101 tester)
[`/[.*+\-?^${}()|[\]\\]/g`](https://regex101.com/r/lHktx8/1)

Lodash Regex: (linked to regex 101 tester)
[`/[\\^$.*+?()[\]{}|]/g`](https://regex101.com/r/SUYxUW/1)

As it seems there should be no impact with removing our custom method in favor of lodash. That is what this PR does.

Current usages:
- Markdown filters (still flagged to dev): emoji-filter, issue-link-filter, and video-url filter. Technically some of these had hypen so feel more "directly" to be potentially impacted, but I did some spot testing appeared good.
- The desktop-file-transport: Escapes `.desktop.${__RELEASE_CHANNEL__}.log` which doesn't have hyphens currently.
- Side-by-side diff uses it in the calcSearchTokens for the find feature of the diff. This one is escaping user input and feels the mostly likely to be able to be impacted.. but with the reasoning above and some spot testing.. I think it is safe.

## Release notes
Notes: no-notes
