### PR TITLE
Add caller info on unexpected git exit codes

### DIFF
--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -111,7 +111,7 @@ export async function spawnAndComplete(
             } else {
               reject(
                 new Error(
-                  `Git returned an unexpected exit code '${code}' which should be handled by the caller.'`
+                  `Git returned an unexpected exit code '${code}' which should be handled by the caller (${name}).'`
                 )
               )
             }


### PR DESCRIPTION
## Description

Sometimes we get non-fatal errors for unexpected git exit codes and the stack trace doesn't show which specific git command was. This adds our custom identifiers to the error description.

## Release notes

Notes: no-notes
