### PR TITLE
Add option to configure signing key in Preferences & Repository settings

### DIFF
--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -36,6 +36,7 @@ interface IConfigureGitUserProps {
 interface IConfigureGitUserState {
   readonly globalUserName: string | null
   readonly globalUserEmail: string | null
+  readonly globalSigningKey: string | null
 
   readonly manualName: string
   readonly manualEmail: string
@@ -66,6 +67,8 @@ export class ConfigureGitUser extends React.Component<
 > {
   private readonly globalUsernamePromise = getGlobalConfigValue('user.name')
   private readonly globalEmailPromise = getGlobalConfigValue('user.email')
+  private readonly globalSigningKeyPromise =
+    getGlobalConfigValue('user.signingkey')
   private loadInitialDataPromise: Promise<void> | null = null
 
   public constructor(props: IConfigureGitUserProps) {
@@ -76,6 +79,7 @@ export class ConfigureGitUser extends React.Component<
     this.state = {
       globalUserName: null,
       globalUserEmail: null,
+      globalSigningKey: null,
       manualName: '',
       manualEmail: '',
       useGitHubAuthorInfo: this.account !== null,
@@ -96,15 +100,18 @@ export class ConfigureGitUser extends React.Component<
     // was at mount-time.
     const accounts = this.props.accounts
 
-    const [globalUserName, globalUserEmail] = await Promise.all([
-      this.globalUsernamePromise,
-      this.globalEmailPromise,
-    ])
+    const [globalUserName, globalUserEmail, globalSigningKey] =
+      await Promise.all([
+        this.globalUsernamePromise,
+        this.globalEmailPromise,
+        this.globalSigningKeyPromise,
+      ])
 
     this.setState(
       prevState => ({
         globalUserName,
         globalUserEmail,
+        globalSigningKey,
         manualName:
           prevState.manualName.length === 0
             ? globalUserName || ''

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -10,6 +10,7 @@ const OtherEmailSelectValue = 'Other'
 interface IGitConfigUserFormProps {
   readonly name: string
   readonly email: string
+  readonly signingKey: string
 
   readonly dotComAccount: Account | null
   readonly enterpriseAccount: Account | null
@@ -18,6 +19,7 @@ interface IGitConfigUserFormProps {
 
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
+  readonly onSigningKeyChanged: (signingKey: string) => void
 }
 
 interface IGitConfigUserFormState {
@@ -101,6 +103,14 @@ export class GitConfigUserForm extends React.Component<
           accounts={this.accounts}
           email={this.props.email}
         />
+        <Row>
+          <TextBox
+            label="Signing key"
+            value={this.props.signingKey}
+            disabled={this.props.disabled}
+            onValueChanged={this.props.onSigningKeyChanged}
+          />
+        </Row>
       </div>
     )
   }

--- a/app/src/ui/preferences/git.tsx
+++ b/app/src/ui/preferences/git.tsx
@@ -11,6 +11,7 @@ interface IGitProps {
   readonly name: string
   readonly email: string
   readonly defaultBranch: string
+  readonly signingKey: string
 
   readonly dotComAccount: Account | null
   readonly enterpriseAccount: Account | null
@@ -18,6 +19,7 @@ interface IGitProps {
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
   readonly onDefaultBranchChanged: (defaultBranch: string) => void
+  readonly onSigningKeyChanged: (signingKey: string) => void
 }
 
 interface IGitState {
@@ -72,10 +74,12 @@ export class Git extends React.Component<IGitProps, IGitState> {
       <GitConfigUserForm
         email={this.props.email}
         name={this.props.name}
+        signingKey={this.props.signingKey}
         enterpriseAccount={this.props.enterpriseAccount}
         dotComAccount={this.props.dotComAccount}
         onEmailChanged={this.props.onEmailChanged}
         onNameChanged={this.props.onNameChanged}
+        onSigningKeyChanged={this.props.onSigningKeyChanged}
       />
     )
   }

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -67,6 +67,7 @@ interface IPreferencesState {
   readonly selectedIndex: PreferencesTab
   readonly committerName: string
   readonly committerEmail: string
+  readonly committerSigningKey: string
   readonly defaultBranch: string
   readonly initialCommitterName: string | null
   readonly initialCommitterEmail: string | null
@@ -107,6 +108,7 @@ export class Preferences extends React.Component<
       selectedIndex: this.props.initialSelectedTab || PreferencesTab.Accounts,
       committerName: '',
       committerEmail: '',
+      committerSigningKey: '',
       defaultBranch: '',
       initialCommitterName: null,
       initialCommitterEmail: null,
@@ -300,12 +302,14 @@ export class Preferences extends React.Component<
             <Git
               name={this.state.committerName}
               email={this.state.committerEmail}
+              signingKey={this.state.committerSigningKey}
               defaultBranch={this.state.defaultBranch}
               dotComAccount={this.props.dotComAccount}
               enterpriseAccount={this.props.enterpriseAccount}
               onNameChanged={this.onCommitterNameChanged}
               onEmailChanged={this.onCommitterEmailChanged}
               onDefaultBranchChanged={this.onDefaultBranchChanged}
+              onSigningKeyChanged={this.onCommitterSigningKeyChanged}
             />
           </>
         )
@@ -433,6 +437,10 @@ export class Preferences extends React.Component<
 
   private onDefaultBranchChanged = (defaultBranch: string) => {
     this.setState({ defaultBranch })
+  }
+
+  private onCommitterSigningKeyChanged = (committerSigningKey: string) => {
+    this.setState({ committerSigningKey })
   }
 
   private onSelectedEditorChanged = (editor: string) => {

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -12,12 +12,15 @@ interface IGitConfigProps {
   readonly gitConfigLocation: GitConfigLocation
   readonly name: string
   readonly email: string
+  readonly signingKey: string
   readonly globalName: string
   readonly globalEmail: string
+  readonly globalSigningKey: string
 
   readonly onGitConfigLocationChanged: (value: GitConfigLocation) => void
   readonly onNameChanged: (name: string) => void
   readonly onEmailChanged: (email: string) => void
+  readonly onSigningKeyChanged: (signingKey: string) => void
 }
 
 export enum GitConfigLocation {
@@ -38,6 +41,11 @@ export class GitConfig extends React.Component<IGitConfigProps> {
     const enterpriseAccount = isDotComAccount ? null : this.props.account
     const dotComAccount = isDotComAccount ? this.props.account : null
 
+    const isGlobalConfig =
+      this.props.gitConfigLocation === GitConfigLocation.Global
+    const isLocalConfig =
+      this.props.gitConfigLocation === GitConfigLocation.Local
+
     return (
       <DialogContent>
         <div className="advanced-section">
@@ -46,38 +54,32 @@ export class GitConfig extends React.Component<IGitConfigProps> {
             <div>
               <RadioButton
                 label="Use my global Git config"
-                checked={
-                  this.props.gitConfigLocation === GitConfigLocation.Global
-                }
+                checked={isGlobalConfig}
                 value={GitConfigLocation.Global}
                 onSelected={this.onGitConfigLocationChanged}
               />
               <RadioButton
                 label="Use a local Git config"
-                checked={
-                  this.props.gitConfigLocation === GitConfigLocation.Local
-                }
+                checked={isLocalConfig}
                 value={GitConfigLocation.Local}
                 onSelected={this.onGitConfigLocationChanged}
               />
             </div>
           </Row>
           <GitConfigUserForm
-            email={
-              this.props.gitConfigLocation === GitConfigLocation.Global
-                ? this.props.globalEmail
-                : this.props.email
-            }
-            name={
-              this.props.gitConfigLocation === GitConfigLocation.Global
-                ? this.props.globalName
-                : this.props.name
+            email={isGlobalConfig ? this.props.globalEmail : this.props.email}
+            name={isGlobalConfig ? this.props.globalName : this.props.name}
+            signingKey={
+              isGlobalConfig
+                ? this.props.globalSigningKey
+                : this.props.signingKey
             }
             enterpriseAccount={enterpriseAccount}
             dotComAccount={dotComAccount}
-            disabled={this.props.gitConfigLocation === GitConfigLocation.Global}
+            disabled={isGlobalConfig}
             onEmailChanged={this.props.onEmailChanged}
             onNameChanged={this.props.onNameChanged}
+            onSigningKeyChanged={this.props.onSigningKeyChanged}
           />
         </div>
       </DialogContent>

--- a/app/src/ui/repository-settings/repository-settings.tsx
+++ b/app/src/ui/repository-settings/repository-settings.tsx
@@ -56,11 +56,14 @@ interface IRepositorySettingsState {
   readonly gitConfigLocation: GitConfigLocation
   readonly committerName: string
   readonly committerEmail: string
+  readonly committerSigningKey: string
   readonly globalCommitterName: string
   readonly globalCommitterEmail: string
+  readonly globalCommitterSigningKey: string
   readonly initialGitConfigLocation: GitConfigLocation
   readonly initialCommitterName: string | null
   readonly initialCommitterEmail: string | null
+  readonly initialCommitterSigningKey: string | null
   readonly errors?: ReadonlyArray<JSX.Element | string>
   readonly forkContributionTarget: ForkContributionTarget
 }
@@ -84,11 +87,14 @@ export class RepositorySettings extends React.Component<
       gitConfigLocation: GitConfigLocation.Global,
       committerName: '',
       committerEmail: '',
+      committerSigningKey: '',
       globalCommitterName: '',
       globalCommitterEmail: '',
+      globalCommitterSigningKey: '',
       initialGitConfigLocation: GitConfigLocation.Global,
       initialCommitterName: null,
       initialCommitterEmail: null,
+      initialCommitterSigningKey: null,
     }
   }
 
@@ -114,10 +120,17 @@ export class RepositorySettings extends React.Component<
       'user.email',
       true
     )
+    const localCommitterSigningKey = await getConfigValue(
+      this.props.repository,
+      'user.signingkey',
+      true
+    )
 
     const globalCommitterName = (await getGlobalConfigValue('user.name')) || ''
     const globalCommitterEmail =
       (await getGlobalConfigValue('user.email')) || ''
+    const globalCommitterSigningKey =
+      (await getGlobalConfigValue('user.signingkey')) || ''
 
     const gitConfigLocation =
       localCommitterName === null && localCommitterEmail === null
@@ -126,21 +139,26 @@ export class RepositorySettings extends React.Component<
 
     let committerName = globalCommitterName
     let committerEmail = globalCommitterEmail
+    let committerSigningKey = globalCommitterSigningKey
 
     if (gitConfigLocation === GitConfigLocation.Local) {
       committerName = localCommitterName ?? ''
       committerEmail = localCommitterEmail ?? ''
+      committerSigningKey = localCommitterSigningKey ?? ''
     }
 
     this.setState({
       gitConfigLocation,
       committerName,
       committerEmail,
+      committerSigningKey,
       globalCommitterName,
       globalCommitterEmail,
+      globalCommitterSigningKey,
       initialGitConfigLocation: gitConfigLocation,
       initialCommitterName: localCommitterName,
       initialCommitterEmail: localCommitterEmail,
+      initialCommitterSigningKey: localCommitterSigningKey,
     })
   }
 
@@ -259,10 +277,13 @@ export class RepositorySettings extends React.Component<
             onGitConfigLocationChanged={this.onGitConfigLocationChanged}
             name={this.state.committerName}
             email={this.state.committerEmail}
+            signingKey={this.state.committerSigningKey}
             globalName={this.state.globalCommitterName}
             globalEmail={this.state.globalCommitterEmail}
+            globalSigningKey={this.state.globalCommitterSigningKey}
             onNameChanged={this.onCommitterNameChanged}
             onEmailChanged={this.onCommitterEmailChanged}
+            onSigningKeyChanged={this.onCommitterSigningKeyChanged}
           />
         )
       }
@@ -346,6 +367,7 @@ export class RepositorySettings extends React.Component<
       // user info in this repository.
       await removeConfigValue(this.props.repository, 'user.name')
       await removeConfigValue(this.props.repository, 'user.email')
+      await removeConfigValue(this.props.repository, 'user.signingkey')
 
       shouldRefreshAuthor = true
     } else if (this.state.gitConfigLocation === GitConfigLocation.Local) {
@@ -426,5 +448,9 @@ export class RepositorySettings extends React.Component<
 
   private onCommitterEmailChanged = (committerEmail: string) => {
     this.setState({ committerEmail })
+  }
+
+  private onCommitterSigningKeyChanged = (committerSigningKey: string) => {
+    this.setState({ committerSigningKey })
   }
 }


### PR DESCRIPTION
## Description

Adds 3rd, after Name and Email, option to GitConfigUserForm. After GPG key is generated, user is able to easily configure Signing key both on global and repository level.

### Screenshots

Couldn't run the app on Node 17. :(

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Add option to configure GPG signing key in Preferences & Repository settings
