### PR TITLE
Fix PRs appearing to be created in the future

### DIFF
--- a/app/src/lib/format-relative.ts
+++ b/app/src/lib/format-relative.ts
@@ -17,7 +17,7 @@ const getRelativeFormatter = mem(
 export function formatRelative(ms: number) {
   const formatter = getRelativeFormatter('en-US', { numeric: 'auto' })
 
-  const sign = ms < 0 ? -1 : 0
+  const sign = ms < 0 ? -1 : 1
 
   // Lifted and adopted from
   // https://github.com/github/time-elements/blob/428b02c9/src/relative-time.ts#L57

--- a/app/src/lib/format-relative.ts
+++ b/app/src/lib/format-relative.ts
@@ -17,7 +17,7 @@ const getRelativeFormatter = mem(
 export function formatRelative(ms: number) {
   const formatter = getRelativeFormatter('en-US', { numeric: 'auto' })
 
-  const sign = ms < 0 ? 1 : -1
+  const sign = ms < 0 ? -1 : 0
 
   // Lifted and adopted from
   // https://github.com/github/time-elements/blob/428b02c9/src/relative-time.ts#L57

--- a/app/src/ui/relative-time.tsx
+++ b/app/src/ui/relative-time.tsx
@@ -97,7 +97,7 @@ export class RelativeTime extends React.Component<
       timeStyle: 'short',
     })
 
-    const relativeText = formatRelative(duration)
+    const relativeText = formatRelative(diff)
 
     // Future date, let's just show as absolute and reschedule. If it's less
     // than a minute into the future we'll treat it as 'just now'.


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14238

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Fixes the issue with pull requests, and one log message (skipping background fetch), being shown as happening in the future due to me mistakenly switching the sign order.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Pull requests adhere to temporal laws again 

(we should come up with a better changelog entry)