### PR TITLE
Fix CI check status popover not closing when clicking on PR badge

### DIFF
--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -51,14 +51,14 @@ export class Popover extends React.Component<IPopoverProps> {
   }
 
   public componentDidMount() {
-    document.addEventListener('mousedown', this.onDocumentMouseDown)
+    document.addEventListener('click', this.onDocumentClick)
   }
 
   public componentWillUnmount() {
-    document.removeEventListener('mousedown', this.onDocumentMouseDown)
+    document.removeEventListener('click', this.onDocumentClick)
   }
 
-  private onDocumentMouseDown = (event: MouseEvent) => {
+  private onDocumentClick = (event: MouseEvent) => {
     const { current: ref } = this.containerDivRef
     const { target } = event
 

--- a/app/src/ui/toolbar/branch-dropdown.tsx
+++ b/app/src/ui/toolbar/branch-dropdown.tsx
@@ -223,16 +223,11 @@ export class BranchDropdown extends React.Component<
   }
 
   private onBadgeClick = () => {
-    this.togglePopover()
-  }
-
-  private togglePopover() {
-    if (this.props.showCIStatusPopover) {
-      this.closePopover()
-    } else {
-      this.props.dispatcher.closeFoldout(FoldoutType.Branch)
-      this.openPopover()
-    }
+    // The badge can't be clicked while the CI status popover is shown, because
+    // in that case the Popover component will recognize the "click outside"
+    // event and close the popover.
+    this.props.dispatcher.closeFoldout(FoldoutType.Branch)
+    this.openPopover()
   }
 
   private updateBadgeBottomPosition = (badgeBottom: number) => {

--- a/app/styles/ui/check-runs/_ci-check-run-popover.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-popover.scss
@@ -5,6 +5,10 @@
     width: 440px;
     top: 60;
     margin-left: -302px;
+
+    &::after {
+      border-bottom-color: var(--box-alt-background-color);
+    }
   }
 
   .ci-check-run-list-header {


### PR DESCRIPTION
## Description
When the CI check status popover is open and the user clicks on the PR badge, it flashes for a bit and is reopened again:

https://user-images.githubusercontent.com/1083228/160805700-356e27c7-ff68-4d4c-971e-66e8ecbd6bfd.mov

The problem is the `onClickOutside` callback from our `Popover` component is invoked on `mousedown` events on the document. That means the `mousedown` event would close the popover (because the user clicked outside of it), and then the app would handle the 'click' event on the PR badge, which would open the popover again.

This PR changes the `Popover` component to listen to `click` events as well. With this change, the `onClickOutside` will be invoked (and therefore popovers will be dismissed) when the user releases the mouse button to complete the `click` event.

## Release notes

Notes: [Fixed] Pull request checks popover is closed when the pull request number badge is clicked
