### PR TITLE
Fix layout of re-run checks dialog

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -131,20 +131,12 @@ export class CICheckRunRerunDialog extends React.Component<
     return (
       <div className="ci-check-run-list check-run-rerun-list">
         {this.state.rerunnable.length > 0 ? (
-          <>
-            <CICheckRunList
-              checkRuns={this.state.rerunnable}
-              loadingActionLogs={false}
-              loadingActionWorkflows={false}
-              notExpandable={true}
-            />
-            <CICheckRunList
-              checkRuns={this.state.rerunnable}
-              loadingActionLogs={false}
-              loadingActionWorkflows={false}
-              notExpandable={true}
-            />
-          </>
+          <CICheckRunList
+            checkRuns={this.state.rerunnable}
+            loadingActionLogs={false}
+            loadingActionWorkflows={false}
+            notExpandable={true}
+          />
         ) : null}
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -131,37 +131,46 @@ export class CICheckRunRerunDialog extends React.Component<
     return (
       <div className="ci-check-run-list check-run-rerun-list">
         {this.state.rerunnable.length > 0 ? (
-          <CICheckRunList
-            checkRuns={this.state.rerunnable}
-            loadingActionLogs={false}
-            loadingActionWorkflows={false}
-            notExpandable={true}
-          />
+          <>
+            <CICheckRunList
+              checkRuns={this.state.rerunnable}
+              loadingActionLogs={false}
+              loadingActionWorkflows={false}
+              notExpandable={true}
+            />
+            <CICheckRunList
+              checkRuns={this.state.rerunnable}
+              loadingActionLogs={false}
+              loadingActionWorkflows={false}
+              notExpandable={true}
+            />
+          </>
         ) : null}
       </div>
     )
   }
 
   private renderRerunInfo = () => {
-    if (this.state.loadingCheckSuites) {
+    if (
+      this.state.loadingCheckSuites ||
+      this.state.nonRerunnable.length === 0
+    ) {
       return null
     }
 
     const pluralize = `check${this.state.nonRerunnable.length !== 1 ? 's' : ''}`
     const verb = this.state.nonRerunnable.length !== 1 ? 'are' : 'is'
+    const warningPrefix =
+      this.state.rerunnable.length === 0
+        ? `There are no checks that can be re-run`
+        : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be re-run`
     return (
       <Row className="non-re-run-info warning-helper-text">
         <Octicon symbol={OcticonSymbol.alert} />
 
-        {this.state.rerunnable.length === 0
-          ? `There are no checks that can be re-run. `
-          : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be re-run. `}
-
-        {this.state.nonRerunnable.length > 0
-          ? `A check run cannot be re-run if the check is more than one month old,
+        {`${warningPrefix}. A check run cannot be re-run if the check is more than one month old,
           the check has not completed, or the check is not configured to be
-          re-run.`
-          : null}
+          re-run.`}
       </Row>
     )
   }

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -1,6 +1,7 @@
 #rerun-check-runs {
   .dialog-content {
     padding: 0;
+    overflow: auto;
   }
 
   .check-run-rerun-list {


### PR DESCRIPTION
Closes #14246

## Description

This PR fixes two issues in the re-run dialog:
- When all jobs are re-runnable, we'd show a `There are 0 jobs that cannot be re-run` warning.
- When the list of jobs is too long, they would overlap with the footer even go beyond the boundaries of the dialog.

## Release notes

Notes:
- [Fixed] Re-run Checks dialog doesn't show warning when all checks can be re-run.
- [Fixed] Re-run Checks dialog can be scrolled for long lists of checks.
