### PR TITLE
Fix relative time of pull request reviews

### DIFF
--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -117,8 +117,7 @@ export class PullRequestReview extends React.Component<
 
     const submittedAt = new Date(review.submitted_at)
     const diff = submittedAt.getTime() - Date.now()
-    const duration = Math.abs(diff)
-    const relativeReviewDate = formatRelative(duration)
+    const relativeReviewDate = formatRelative(diff)
 
     return (
       <div className="timeline-item-container">


### PR DESCRIPTION
## Description

The recent fix of #14239 uncovered wrong math introduced in #14175 for the time at which PR reviews were submitted. This PR fixes that math 😅 

## Release notes

Notes: [Fixed] Pull request review notifications adhere to temporal laws again too 
