### PR TITLE
Enable code signing on macOS for dev builds

### DIFF
--- a/script/entitlements-dev.plist
+++ b/script/entitlements-dev.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
Closes #13639

## Description
As part of some improvements I wanted to do for notifications using the latest native APIs for macOS, I realized I could only use them on dev builds if it was signed, so I enabled code signing as Xcode does to run the app locally.

Not only this worked, but I also noticed a performance improvement on dev builds running on Apple Silicon, which got degraded when we moved to Electron 13 due to an issue with spawn on Big Sur and newer (see #13639 for more info).

### Screenshots

#### Before signing
![image](https://user-images.githubusercontent.com/1083228/161713666-e1b0d352-dc41-47c5-93a8-e4096a0a2d89.png)

#### After signing
![image](https://user-images.githubusercontent.com/1083228/161713715-2c337da2-1b2f-4d1e-9177-c5119c897595.png)

## Release notes

Notes: no-notes
