### PR TITLE
Remove link to old issue template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,8 +53,7 @@ reports :mag_right:.
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report)
 as you might find out that you don't need to create one. When you are creating
 a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
-Fill out [the required template](ISSUE_TEMPLATE/bug_report.md), the information
-it asks for helps us resolve issues faster.
+Fill out the required template, the information it asks for helps us resolve issues faster.
 
 #### Before Submitting A Bug Report
 


### PR DESCRIPTION

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Ever since https://github.com/desktop/desktop/pull/14126 we're using issue forms instead of issue templates. Rather than linking users to a yaml file we'll just remove the link and let the text speak for itself.

Closes #14285

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
