### PR TITLE
Add link to the OS notification settings

### DIFF
--- a/app/src/lib/get-os.ts
+++ b/app/src/lib/get-os.ts
@@ -59,3 +59,8 @@ export const isMacOSBigSurOrLater = memoizeOne(
 export const isWindows10And1809Preview17666OrLater = memoizeOne(
   () => __WIN32__ && systemVersionGreaterThanOrEqualTo('10.0.17666')
 )
+
+/** We're currently running Windows 10 or later. */
+export const isWindows10OrLater = memoizeOne(
+  () => __WIN32__ && systemVersionGreaterThanOrEqualTo('10.0')
+)

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -7,6 +7,7 @@ import { UncommittedChangesStrategy } from '../../models/uncommitted-changes-str
 import { RadioButton } from '../lib/radio-button'
 import { isWindowsOpenSSHAvailable } from '../../lib/ssh/ssh'
 import { enableHighSignalNotifications } from '../../lib/feature-flag'
+import { isWindows10OrLater } from '../../lib/get-os'
 
 interface IAdvancedPreferencesProps {
   readonly useWindowsOpenSSH: boolean
@@ -188,10 +189,6 @@ export class Advanced extends React.Component<
       return null
     }
 
-    const notificationSettingsURL = __DARWIN__
-      ? 'x-apple.systempreferences:com.apple.preference.notifications'
-      : 'ms-settings:notifications'
-
     return (
       <div className="advanced-section">
         <h2>Notifications</h2>
@@ -206,14 +203,30 @@ export class Advanced extends React.Component<
         />
         <p className="git-settings-description">
           Allows the display of notifications when high-signal events take place
-          in the current repository. Make sure notifications are enabled for
-          GitHub Desktop in the{' '}
-          <LinkButton uri={notificationSettingsURL}>
-            Notifications Settings
-          </LinkButton>
-          .
+          in the current repository.{this.renderNotificationSettingsLink()}
         </p>
       </div>
+    )
+  }
+
+  private renderNotificationSettingsLink() {
+    if (!__DARWIN__ && !isWindows10OrLater()) {
+      return null
+    }
+
+    const notificationSettingsURL = __DARWIN__
+      ? 'x-apple.systempreferences:com.apple.preference.notifications'
+      : 'ms-settings:notifications'
+
+    return (
+      <>
+        {' '}
+        Make sure notifications are enabled for GitHub Desktop in the{' '}
+        <LinkButton uri={notificationSettingsURL}>
+          Notifications Settings
+        </LinkButton>
+        .
+      </>
     )
   }
 }

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -188,6 +188,10 @@ export class Advanced extends React.Component<
       return null
     }
 
+    const notificationSettingsURL = __DARWIN__
+      ? 'x-apple.systempreferences:com.apple.preference.notifications'
+      : 'ms-settings:notifications'
+
     return (
       <div className="advanced-section">
         <h2>Notifications</h2>
@@ -202,7 +206,12 @@ export class Advanced extends React.Component<
         />
         <p className="git-settings-description">
           Allows the display of notifications when high-signal events take place
-          in the current repository.
+          in the current repository. Make sure notifications are enabled for
+          GitHub Desktop in the{' '}
+          <LinkButton uri={notificationSettingsURL}>
+            Notifications Settings
+          </LinkButton>
+          .
         </p>
       </div>
     )


### PR DESCRIPTION
## Description

This PR adds a link under our "Enable notifications" settings to the system notification settings. We plan to improve this so that we show this link only if we detect the app has no permission to display notifications.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/161744988-f7d6d3b7-f8cd-4070-8e11-f34eefc22a66.png)

## Release notes

Notes: no-notes
