### PR TITLE
Markdown Close Keyword Filter

### DIFF
--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -26,7 +26,7 @@ export function isIssueClosingContext(markdownContext: MarkdownContext) {
  * Closes keywords are close, closes, closed, fix, fixes, fixed, resolve,
  * resolves, and resolved.
  *
- * Issue reference can be plain test like #1234 or can bea  pasted issue link
+ * Issue reference can be plain test like #1234 or can be a pasted issue link
  * like https://github.com/owner/repo/issues/1234.
  *
  * Example:

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -1,6 +1,17 @@
 import { IssueReference } from './issue-mention-filter'
 import { INodeFilter, MarkdownContext } from './node-filter'
 
+/** Markdown locations that can have closing keywords */
+const IssueClosingContext: ReadonlyArray<MarkdownContext> = [
+  'Commit',
+  'PullRequest',
+]
+
+/** Determines if markdown context could have issue closing mention */
+export function isIssueClosingContext(markdownContext: MarkdownContext) {
+  return IssueClosingContext.includes(markdownContext)
+}
+
 export class CloseKeywordFilter implements INodeFilter {
   /**
    * Searches for the words: close, closes, closed, fix, fixes, fixed, resolve,

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -1,6 +1,12 @@
 import { INodeFilter, MarkdownContext } from './node-filter'
 
 export class CloseKeywordFilter implements INodeFilter {
+  /** Markdown locations that can have closing keywords */
+  private issueClosingLocations: ReadonlyArray<MarkdownContext> = [
+    'Commit',
+    'PullRequest',
+  ]
+
   public constructor(
     /** The context from which the markdown content originated from - such as a PullRequest or PullRequest Comment */
     private readonly markdownContext: MarkdownContext
@@ -22,10 +28,7 @@ export class CloseKeywordFilter implements INodeFilter {
   }
 
   public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
-    if (
-      this.markdownContext !== 'Commit' &&
-      this.markdownContext !== 'PullRequest'
-    ) {
+    if (!this.issueClosingLocations.includes(this.markdownContext)) {
       return null
     }
 

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -1,6 +1,11 @@
-import { INodeFilter } from './node-filter'
+import { INodeFilter, MarkdownContext } from './node-filter'
 
 export class CloseKeywordFilter implements INodeFilter {
+  public constructor(
+    /** The context from which the markdown content originated from - such as a PullRequest or PullRequest Comment */
+    private readonly markdownContext: MarkdownContext
+  ) {}
+
   /**
    *  Close keyword filter iterates on all text nodes that are not inside a pre,
    *  code, or anchor tag.
@@ -16,7 +21,14 @@ export class CloseKeywordFilter implements INodeFilter {
     })
   }
 
-  public filter(node: Node): Promise<readonly Node[] | null> {
-    throw new Error('Method not implemented.')
+  public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
+    if (
+      this.markdownContext !== 'Commit' &&
+      this.markdownContext !== 'PullRequest'
+    ) {
+      return null
+    }
+
+    return null
   }
 }

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -12,6 +12,25 @@ export function isIssueClosingContext(markdownContext: MarkdownContext) {
   return IssueClosingContext.includes(markdownContext)
 }
 
+/**
+ * The Closes keyword filter matches text nodes for a set of key words that
+ * indicate the markdown closes an issue (Closes, fixes) followed by a issue
+ * reference. It replaces the closes keywords it with a span to be styled and
+ * provide a tooltip indicating the markdown will close the referenced issue.
+ *
+ * Markdown that can have these keywords are pull request bodies and commit
+ * messages.
+ *
+ * Closes keywords are close, closes, closed, fix, fixes, fixed, resolve,
+ * resolves, and resolved.
+ *
+ * Issue reference can be plain test like #1234 or can bea  pasted issue link
+ * like https://github.com/owner/repo/issues/1234.
+ *
+ * Example:
+ * 'Closes #1234' becomes
+ * '<span class="issue-keyword" title="This pull request closes #1234."]>Closes</span> #1234'
+ */
 export class CloseKeywordFilter implements INodeFilter {
   /**
    * Searches for the words: close, closes, closed, fix, fixes, fixed, resolve,
@@ -49,6 +68,14 @@ export class CloseKeywordFilter implements INodeFilter {
     })
   }
 
+  /**
+   * Takes a text node that matches a close keyword pattern and returns an array
+   * of nodes to replace the text node where the matching keyword becomes a span
+   * element.
+   *
+   * Example: Closes #1 becomes [<span class="issue-keyword" title="This pull
+   * request closes #1."]>Closes</span>, ' #1']
+   */
   public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
     const text = node.textContent
     if (node.nodeType !== node.TEXT_NODE || text === null) {

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -21,16 +21,11 @@ export class CloseKeywordFilter implements INodeFilter {
    * owner/fixops#1
    */
   private closeText =
-    /\b(?<close_text>close[sd]?|fix(e[sd])?|resolve[sd]?)(?<close_spacer>\s*:?\s+)/i
+    /\b(?<closeText>close[sd]?|fix(e[sd])?|resolve[sd]?)(\s*:?\s+)/i
 
   private closesWithTextReference = new RegExp(
     this.closeText.source + '(?<issue_reference>' + IssueReference.source + ')',
-    'i'
-  )
-
-  private closesAtEndOfText = new RegExp(
-    this.closeText.source + /$/.source,
-    'i'
+    'ig'
   )
 
   public constructor(
@@ -60,9 +55,43 @@ export class CloseKeywordFilter implements INodeFilter {
       return null
     }
 
-    console.log(this.closesWithTextReference)
-    console.log(this.closesAtEndOfText)
+    const matches = [...text.matchAll(this.closesWithTextReference)]
+    if (matches.length === 0) {
+      return null
+    }
 
-    return null
+    let lastMatchEndingPosition = 0
+    const nodes: Array<Text | HTMLSpanElement> = []
+    for (const match of matches) {
+      if (match.groups === undefined || match.index === undefined) {
+        continue
+      }
+      const { closeText, issue_reference } = match.groups
+
+      const span = this.createTooltipContent(closeText, issue_reference)
+
+      const textBefore = text.slice(lastMatchEndingPosition, match.index)
+      nodes.push(document.createTextNode(textBefore))
+      nodes.push(span)
+
+      lastMatchEndingPosition = match.index + closeText.length
+    }
+
+    const trailingText = text.slice(lastMatchEndingPosition)
+    if (trailingText !== '') {
+      nodes.push(document.createTextNode(trailingText))
+    }
+
+    return nodes
+  }
+
+  private createTooltipContent(closesText: string, issueNumber: string) {
+    const tooltipSpan = document.createElement('span')
+    tooltipSpan.textContent = closesText
+    tooltipSpan.classList.add('issue-keyword')
+    tooltipSpan.title = `This ${
+      this.markdownContext === 'Commit' ? 'commit' : 'pull request'
+    } closes issue ${issueNumber}.`
+    return tooltipSpan
   }
 }

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -184,7 +184,7 @@ export class CloseKeywordFilter implements INodeFilter {
     tooltipSpan.classList.add('issue-keyword')
     tooltipSpan.title = `This ${
       this.markdownContext === 'Commit' ? 'commit' : 'pull request'
-    } closes issue ${issueNumber}.`
+    } closes ${issueNumber}.`
     return tooltipSpan
   }
 }

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -1,8 +1,19 @@
 import { INodeFilter } from './node-filter'
 
 export class CloseKeywordFilter implements INodeFilter {
+  /**
+   *  Close keyword filter iterates on all text nodes that are not inside a pre,
+   *  code, or anchor tag.
+   */
   public createFilterTreeWalker(doc: Document): TreeWalker {
-    throw new Error('Method not implemented.')
+    return doc.createTreeWalker(doc, NodeFilter.SHOW_TEXT, {
+      acceptNode: node => {
+        return node.parentNode !== null &&
+          ['CODE', 'PRE', 'A'].includes(node.parentNode.nodeName)
+          ? NodeFilter.FILTER_SKIP
+          : NodeFilter.FILTER_ACCEPT
+      },
+    })
   }
 
   public filter(node: Node): Promise<readonly Node[] | null> {

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -1,0 +1,11 @@
+import { INodeFilter } from './node-filter'
+
+export class CloseKeywordFilter implements INodeFilter {
+  public createFilterTreeWalker(doc: Document): TreeWalker {
+    throw new Error('Method not implemented.')
+  }
+
+  public filter(node: Node): Promise<readonly Node[] | null> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -1,6 +1,27 @@
+import { IssueReference } from './issue-mention-filter'
 import { INodeFilter, MarkdownContext } from './node-filter'
 
 export class CloseKeywordFilter implements INodeFilter {
+  /**
+   * Searches for the words: close, closes, closed, fix, fixes, fixed, resolve,
+   * resolves, resolved
+   *
+   * Expects one or more spaces at the end to avoid false matches like
+   * owner/fixops#1
+   */
+  private closeText =
+    /\b(?<close_text>close[sd]?|fix(e[sd])?|resolve[sd]?)(?<close_spacer>\s*:?\s+)/i
+
+  private closesWithTextReference = new RegExp(
+    this.closeText.source + '(?<issue_reference>' + IssueReference.source + ')',
+    'i'
+  )
+
+  private closesAtEndOfText = new RegExp(
+    this.closeText.source + /$/.source,
+    'i'
+  )
+
   /** Markdown locations that can have closing keywords */
   private issueClosingLocations: ReadonlyArray<MarkdownContext> = [
     'Commit',
@@ -31,6 +52,9 @@ export class CloseKeywordFilter implements INodeFilter {
     if (!this.issueClosingLocations.includes(this.markdownContext)) {
       return null
     }
+
+    console.log(this.closesWithTextReference)
+    console.log(this.closesAtEndOfText)
 
     return null
   }

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -33,12 +33,6 @@ export class CloseKeywordFilter implements INodeFilter {
     'i'
   )
 
-  /** Markdown locations that can have closing keywords */
-  private issueClosingLocations: ReadonlyArray<MarkdownContext> = [
-    'Commit',
-    'PullRequest',
-  ]
-
   public constructor(
     /** The context from which the markdown content originated from - such as a PullRequest or PullRequest Comment */
     private readonly markdownContext: MarkdownContext
@@ -61,7 +55,8 @@ export class CloseKeywordFilter implements INodeFilter {
   }
 
   public async filter(node: Node): Promise<ReadonlyArray<Node> | null> {
-    if (!this.issueClosingLocations.includes(this.markdownContext)) {
+    const text = node.textContent
+    if (node.nodeType !== node.TEXT_NODE || text === null) {
       return null
     }
 

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -51,8 +51,9 @@ export class CloseKeywordFilter implements INodeFilter {
   public createFilterTreeWalker(doc: Document): TreeWalker {
     return doc.createTreeWalker(doc, NodeFilter.SHOW_TEXT, {
       acceptNode: node => {
-        return node.parentNode !== null &&
-          ['CODE', 'PRE', 'A'].includes(node.parentNode.nodeName)
+        return (node.parentNode !== null &&
+          ['CODE', 'PRE', 'A'].includes(node.parentNode.nodeName)) ||
+          node.textContent === null
           ? NodeFilter.FILTER_SKIP
           : NodeFilter.FILTER_ACCEPT
       },

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -52,7 +52,11 @@ export const buildCustomMarkDownNodeFilterPipe = memoizeOne(
     const filterPipe: Array<INodeFilter> = isIssueClosingContext(
       markdownContext
     )
-      ? [new CloseKeywordFilter(markdownContext)]
+      ? /* The CloseKeywordFilter must be applied before the IssueMentionFilter or
+         * IssueLinkFilter so we can scan for plain text or pasted link issue
+         * mentions in conjunction wth the keyword.
+         */
+        [new CloseKeywordFilter(markdownContext, repository)]
       : []
 
     filterPipe.push(

--- a/app/src/lib/markdown-filters/node-filter.ts
+++ b/app/src/lib/markdown-filters/node-filter.ts
@@ -8,6 +8,7 @@ import { VideoLinkFilter } from './video-link-filter'
 import { VideoTagFilter } from './video-tag-filter'
 import { TeamMentionFilter } from './team-mention-filter'
 import { CommitMentionFilter } from './commit-mention-filter'
+import { CloseKeywordFilter } from './close-keyword-filter'
 
 export interface INodeFilter {
   /**
@@ -42,8 +43,10 @@ export interface INodeFilter {
 export const buildCustomMarkDownNodeFilterPipe = memoizeOne(
   (
     emoji: Map<string, string>,
-    repository: GitHubRepository
+    repository: GitHubRepository,
+    markdownContext: MarkdownContext
   ): ReadonlyArray<INodeFilter> => [
+    new CloseKeywordFilter(markdownContext),
     new IssueMentionFilter(repository),
     new IssueLinkFilter(repository),
     new EmojiFilter(emoji),
@@ -111,3 +114,10 @@ async function applyNodeFilter(
     currentNode.parentNode?.removeChild(currentNode)
   }
 }
+
+/** The context of which markdown resides */
+export type MarkdownContext =
+  | 'PullRequest'
+  | 'PullRequestComment'
+  | 'IssueComment'
+  | 'Commit'

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -5,6 +5,7 @@ import DOMPurify from 'dompurify'
 import {
   applyNodeFilters,
   buildCustomMarkDownNodeFilterPipe,
+  MarkdownContext,
 } from '../../lib/markdown-filters/node-filter'
 import { GitHubRepository } from '../../models/github-repository'
 import { readFile } from 'fs/promises'
@@ -28,11 +29,15 @@ interface ISandboxedMarkdownProps {
   /** A callback for after the markdown has been parsed and the contents have
    * been mounted to the iframe */
   readonly onMarkdownParsed?: () => void
+
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>
 
   /** The GitHub repository to use when looking up commit status. */
   readonly repository: GitHubRepository
+
+  /** The context of which markdown resides - such as PullRequest, PullRequestComment, Commit */
+  readonly markdownContext: MarkdownContext
 }
 
 /**
@@ -299,7 +304,8 @@ export class SandboxedMarkdown extends React.PureComponent<ISandboxedMarkdownPro
   private applyCustomMarkdownFilters(parsedMarkdown: string): Promise<string> {
     const nodeFilters = buildCustomMarkDownNodeFilterPipe(
       this.props.emoji,
-      this.props.repository
+      this.props.repository,
+      this.props.markdownContext
     )
     return applyNodeFilters(nodeFilters, parsedMarkdown)
   }

--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -228,6 +228,7 @@ export class PullRequestReview extends React.Component<
         baseHref={base.gitHubRepository.htmlURL}
         repository={base.gitHubRepository}
         onMarkdownLinkClicked={this.onMarkdownLinkClicked}
+        markdownContext={'PullRequestComment'}
       />
     )
   }

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -208,6 +208,7 @@ export class PullRequestQuickView extends React.Component<
           emoji={this.props.emoji}
           baseHref={base.gitHubRepository.htmlURL}
           repository={base.gitHubRepository}
+          markdownContext={'PullRequest'}
           onMarkdownLinkClicked={this.onMarkdownLinkClicked}
           onMarkdownParsed={this.onMarkdownParsed}
         />

--- a/app/static/common/markdown.css
+++ b/app/static/common/markdown.css
@@ -529,3 +529,7 @@ changes from the original, just a note that this will not match 1-1)
   color: var(--md-accent-fg-color);
   text-decoration: none;
 }
+
+.markdown-body .issue-keyword {
+	border-bottom: 1px dotted var(--md-border-default-color);
+}


### PR DESCRIPTION
## Description
This pr adds a markdown filter for the close keyword.
 
It looks for patterns like Closes #1234 and wraps the Closes keyword in a span that can be styled and has the title attribute.

Notable differences from dotcom:
1. Does not verify the mentioned issue exists (no api call - increased performance) - leading to false positives.
2. Because no api call is done about the issue references, we can not determine if it is an issue or a pull request. Thus the tooltip in dotcom will say "This pull request closes **issue** `#1234`" where this filter omits the "issue" descriptor. Additionally, we just make use of the issue reference as it is given and do no owner/repo verification.

To follow up on:
1) The markdown is sandboxed out of the scope our our react components. Thus, I could not easily make use of our tooltip component. This means these tool tips are the default system styles for the `title` attribute. It would be nice to explore the effort to make them consistent with the rest of the app.
2) Our issue mention filter does do some minimal owner/repo verification against the markdown context repo. This could be replicated here.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/161827714-dedd1745-c781-45a8-b4d0-abf9c8702157.png)

## Release notes
Notes: no-notes
