### PR TITLE
Re-run Individual/Failed action jobs - UI (non-functional)

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -167,3 +167,8 @@ export function enableHighSignalNotifications(): boolean {
 export function enablePullRequestReviewNotifications(): boolean {
   return enableBetaFeatures()
 }
+
+/** Should we enable the rerunning of failed and single jobs aka action based checks */
+export function enableReRunFailedAndSingleCheckJobs(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -540,6 +540,10 @@ export function buildDefaultMenu({
             label: 'Release notes',
             click: emit('show-release-notes-popup'),
           },
+          {
+            label: 'Pull Request Check Run Failed',
+            click: emit('pull-request-check-run-failed'),
+          },
         ],
       },
       {

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -41,3 +41,4 @@ export type MenuEvent =
   | 'test-prune-branches'
   | 'find-text'
   | 'create-issue-in-repository-on-github'
+  | 'pull-request-check-run-failed'

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -331,6 +331,7 @@ export type Popup =
       checkRuns: ReadonlyArray<IRefCheck>
       repository: GitHubRepository
       prRef: string
+      failedOnly: boolean
     }
   | { type: PopupType.WarnForcePush; operation: string; onBegin: () => void }
   | {

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2049,6 +2049,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             prRef={popup.prRef}
             onDismissed={onPopupDismissedFn}
+            failedOnly={popup.failedOnly}
           />
         )
       }

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -502,14 +502,22 @@ export class App extends React.Component<IAppProps, IAppState> {
     const popup: Popup = {
       type: PopupType.PullRequestChecksFailed,
       pullRequest: new PullRequest(
-        new Date(),
-        'Test PR',
-        9999,
-        new PullRequestRef('test', '123456', repository.gitHubRepository),
-        new PullRequestRef('test', '123456', repository.gitHubRepository),
-        'tidy-dev',
-        false,
-        'test'
+        new Date('2021-10-28T08:36:18Z'),
+        'IGNORE: Fail CI tasks immediately',
+        13201,
+        new PullRequestRef(
+          'development',
+          'a7bca44088b105a04714dc4628f4af50f6f179c3',
+          repository.gitHubRepository
+        ),
+        new PullRequestRef(
+          'fail-ci-immediately',
+          '665eb4810ea65d73ec7720c779dc9f8cd7b97d9e',
+          repository.gitHubRepository
+        ),
+        'sergiou87',
+        true,
+        'This is a test PR'
       ),
       repository,
       shouldChangeRepository: true,
@@ -517,14 +525,78 @@ export class App extends React.Component<IAppProps, IAppState> {
       commitSha: '123456',
       checks: [
         {
-          id: 1234,
-          name: 'test',
-          description: 'test',
+          id: 5873122372,
+          name: 'macOS arm64',
+          description: 'Failed after 5s',
           status: APICheckStatus.Completed,
           conclusion: APICheckConclusion.Failure,
-          appName: 'test',
-          htmlUrl: '',
-          checkSuiteId: 1234,
+          appName: 'GitHub Actions',
+          htmlUrl:
+            'https://github.com/desktop/desktop/runs/5873122372?check_suite_focus=true',
+          checkSuiteId: 5767392356,
+          actionsWorkflow: {
+            id: 2027842572,
+            workflow_id: 1835763,
+            cancel_url:
+              'https://api.github.com/repos/desktop/desktop/actions/runs/2027842572/cancel',
+            created_at: '2022-03-23T10:38:05Z',
+            logs_url:
+              'https://api.github.com/repos/desktop/desktop/actions/runs/2027842572/logs',
+            rerun_url:
+              'https://api.github.com/repos/desktop/desktop/actions/runs/2027842572/rerun',
+            name: 'CI',
+            check_suite_id: 5767392356,
+            event: 'pull_request',
+          },
+          actionJobSteps: [
+            {
+              completed_at: '2022-04-07T13:30:33.000-04:00',
+              conclusion: APICheckConclusion.Success,
+              name: 'Set up job',
+              number: 1,
+              started_at: '2022-04-07T13:30:30.000-04:00',
+              status: APICheckStatus.Completed,
+              log: '',
+            },
+            {
+              completed_at: '2022-04-07T13:30:33.000-04:00',
+              conclusion: APICheckConclusion.Failure,
+              name: 'Fail immediately',
+              number: 1,
+              started_at: '2022-04-07T13:30:30.000-04:00',
+              status: APICheckStatus.Completed,
+              log: '',
+            },
+            {
+              completed_at: '2022-04-07T13:30:33.000-04:00',
+              conclusion: APICheckConclusion.Skipped,
+              name: 'Run actions/checkout@v2',
+              number: 1,
+              started_at: '2022-04-07T13:30:30.000-04:00',
+              status: APICheckStatus.Completed,
+              log: '',
+            },
+            {
+              completed_at: '2022-04-07T13:30:33.000-04:00',
+              conclusion: APICheckConclusion.Skipped,
+              name: 'Use Node.js 16.13.0',
+              number: 1,
+              started_at: '2022-04-07T13:30:30.000-04:00',
+              status: APICheckStatus.Completed,
+              log: '',
+            },
+          ],
+        },
+        {
+          id: 5873122309,
+          name: 'CodeQL-Build',
+          description: 'Failed after 5s',
+          status: APICheckStatus.Completed,
+          conclusion: APICheckConclusion.Success,
+          appName: 'GitHub Actions',
+          htmlUrl:
+            'https://github.com/desktop/desktop/runs/5873122309?check_suite_focus=true',
+          checkSuiteId: 5767392357,
         },
       ],
     }

--- a/app/src/ui/check-runs/ci-check-re-run-button.tsx
+++ b/app/src/ui/check-runs/ci-check-re-run-button.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
+import { Button } from '../lib/button'
+import { Octicon, syncClockwise } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+
+interface ICICheckReRunButtonProps {
+  readonly disabled: boolean
+  readonly onRerunChecks: (failedOnly: boolean) => void
+}
+
+export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonProps> {
+  private onRerunChecks = () => {
+    const items: IMenuItem[] = [
+      {
+        label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
+        action: () => this.props.onRerunChecks(true),
+      },
+      {
+        label: __DARWIN__ ? 'Re-run All Checks' : 'Re-run all checks',
+        action: () => this.props.onRerunChecks(false),
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
+  public render() {
+    return (
+      <Button onClick={this.onRerunChecks} disabled={this.props.disabled}>
+        <Octicon symbol={syncClockwise} /> Re-run{' '}
+        <Octicon symbol={OcticonSymbol.triangleDown} />
+      </Button>
+    )
+  }
+}

--- a/app/src/ui/check-runs/ci-check-re-run-button.tsx
+++ b/app/src/ui/check-runs/ci-check-re-run-button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { enableReRunFailedAndSingleCheckJobs } from '../../lib/feature-flag'
 import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
 import { Button } from '../lib/button'
 import { Octicon, syncClockwise } from '../octicons'
@@ -11,6 +12,11 @@ interface ICICheckReRunButtonProps {
 
 export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonProps> {
   private onRerunChecks = () => {
+    if (!enableReRunFailedAndSingleCheckJobs()) {
+      this.props.onRerunChecks(false)
+      return
+    }
+
     const items: IMenuItem[] = [
       {
         label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
@@ -26,10 +32,16 @@ export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonP
   }
 
   public render() {
+    const text = enableReRunFailedAndSingleCheckJobs() ? (
+      <>
+        Re-run <Octicon symbol={OcticonSymbol.triangleDown} />
+      </>
+    ) : (
+      'Re-run Checks'
+    )
     return (
       <Button onClick={this.onRerunChecks} disabled={this.props.disabled}>
-        <Octicon symbol={syncClockwise} /> Re-run{' '}
-        <Octicon symbol={OcticonSymbol.triangleDown} />
+        <Octicon symbol={syncClockwise} /> {text}
       </Button>
     )
   }

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -49,7 +49,7 @@ interface ICICheckRunListItemProps {
 }
 
 interface ICICheckRunListItemState {
-  readonly mouseOver: boolean
+  readonly mouseEnter: boolean
 }
 
 /** The CI check list item. */
@@ -59,7 +59,7 @@ export class CICheckRunListItem extends React.PureComponent<
 > {
   public constructor(props: ICICheckRunListItemProps) {
     super(props)
-    this.state = { mouseOver: false }
+    this.state = { mouseEnter: false }
   }
 
   private toggleCheckRunExpansion = () => {
@@ -83,14 +83,14 @@ export class CICheckRunListItem extends React.PureComponent<
     this.props.onRerunJob?.(this.props.checkRun)
   }
 
-  private onMouseOver = () => {
-    if (!this.state.mouseOver) {
-      this.setState({ mouseOver: true })
+  private onMouseEnter = () => {
+    if (!this.state.mouseEnter) {
+      this.setState({ mouseEnter: true })
     }
   }
 
   private onMouseOut = (e: React.MouseEvent) => {
-    this.setState({ mouseOver: false })
+    this.setState({ mouseEnter: false })
   }
 
   private renderCheckStatusSymbol = (): JSX.Element => {
@@ -162,10 +162,10 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderJobRerun = (): JSX.Element | null => {
     const { checkRun, onRerunJob } = this.props
-    const { mouseOver } = this.state
+    const { mouseEnter } = this.state
 
     if (
-      !mouseOver ||
+      !mouseEnter ||
       onRerunJob === undefined ||
       !enableReRunFailedAndSingleCheckJobs()
     ) {
@@ -200,7 +200,7 @@ export class CICheckRunListItem extends React.PureComponent<
     return (
       <div
         className="ci-check-list-item-group"
-        onMouseOver={this.onMouseOver}
+        onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseOut}
       >
         <div

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -174,7 +174,7 @@ export class CICheckRunListItem extends React.PureComponent<
     const tooltip =
       checkRun.actionJobSteps !== undefined
         ? 'Re-run this check'
-        : 'This check cannot individually re-run.'
+        : 'This check cannot be re-run individually.'
 
     return (
       <div className={classes} onClick={this.rerunJob}>

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -89,7 +89,7 @@ export class CICheckRunListItem extends React.PureComponent<
     }
   }
 
-  private onMouseOut = (e: React.MouseEvent) => {
+  private onMouseLeave = (e: React.MouseEvent) => {
     this.setState({ isMouseOver: false })
   }
 
@@ -201,7 +201,7 @@ export class CICheckRunListItem extends React.PureComponent<
       <div
         className="ci-check-list-item-group"
         onMouseEnter={this.onMouseEnter}
-        onMouseLeave={this.onMouseOut}
+        onMouseLeave={this.onMouseLeave}
       >
         <div
           className={classes}

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -49,7 +49,7 @@ interface ICICheckRunListItemProps {
 }
 
 interface ICICheckRunListItemState {
-  readonly mouseEnter: boolean
+  readonly isMouseOver: boolean
 }
 
 /** The CI check list item. */
@@ -59,7 +59,7 @@ export class CICheckRunListItem extends React.PureComponent<
 > {
   public constructor(props: ICICheckRunListItemProps) {
     super(props)
-    this.state = { mouseEnter: false }
+    this.state = { isMouseOver: false }
   }
 
   private toggleCheckRunExpansion = () => {
@@ -84,13 +84,13 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private onMouseEnter = () => {
-    if (!this.state.mouseEnter) {
-      this.setState({ mouseEnter: true })
+    if (!this.state.isMouseOver) {
+      this.setState({ isMouseOver: true })
     }
   }
 
   private onMouseOut = (e: React.MouseEvent) => {
-    this.setState({ mouseEnter: false })
+    this.setState({ isMouseOver: false })
   }
 
   private renderCheckStatusSymbol = (): JSX.Element => {
@@ -162,10 +162,10 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private renderJobRerun = (): JSX.Element | null => {
     const { checkRun, onRerunJob } = this.props
-    const { mouseEnter } = this.state
+    const { isMouseOver } = this.state
 
     if (
-      !mouseEnter ||
+      !isMouseOver ||
       onRerunJob === undefined ||
       !enableReRunFailedAndSingleCheckJobs()
     ) {

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -42,6 +42,9 @@ interface ICICheckRunListItemProps {
     checkRun: IRefCheck,
     step: IAPIWorkflowJobStep
   ) => void
+
+  /** Callback to rerun a job*/
+  readonly onRerunJob?: (checkRun: IRefCheck) => void
 }
 
 interface ICICheckRunListItemState {
@@ -68,6 +71,25 @@ export class CICheckRunListItem extends React.PureComponent<
 
   private onViewJobStep = (step: IAPIWorkflowJobStep) => {
     this.props.onViewJobStep?.(this.props.checkRun, step)
+  }
+
+  private rerunJob = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (this.props.checkRun.actionJobSteps === undefined) {
+      return
+    }
+
+    this.props.onRerunJob?.(this.props.checkRun)
+  }
+
+  private onMouseOver = () => {
+    if (!this.state.mouseOver) {
+      this.setState({ mouseOver: true })
+    }
+  }
+
+  private onMouseOut = (e: React.MouseEvent) => {
+    this.setState({ mouseOver: false })
   }
 
   private renderCheckStatusSymbol = (): JSX.Element => {
@@ -138,10 +160,10 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderJobRerun = (): JSX.Element | null => {
-    const { checkRun } = this.props
+    const { checkRun, onRerunJob } = this.props
     const { mouseOver } = this.state
 
-    if (!mouseOver) {
+    if (!mouseOver || onRerunJob === undefined) {
       return null
     }
 
@@ -161,26 +183,6 @@ export class CICheckRunListItem extends React.PureComponent<
         </TooltippedContent>
       </div>
     )
-  }
-
-  private rerunJob = (e: React.MouseEvent) => {
-    e.stopPropagation()
-
-    if (this.props.checkRun.actionJobSteps === undefined) {
-      console.log('Cannot re-run:', this.props.checkRun.name)
-    } else {
-      console.log('Re-run:', this.props.checkRun.name)
-    }
-  }
-
-  private onMouseOver = () => {
-    if (!this.state.mouseOver) {
-      this.setState({ mouseOver: true })
-    }
-  }
-
-  private onMouseOut = (e: React.MouseEvent) => {
-    this.setState({ mouseOver: false })
   }
 
   public render() {

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -8,6 +8,7 @@ import { TooltippedContent } from '../lib/tooltipped-content'
 import { CICheckRunActionsJobStepList } from './ci-check-run-actions-job-step-list'
 import { IAPIWorkflowJobStep } from '../../lib/api'
 import { TooltipDirection } from '../lib/tooltip'
+import { enableReRunFailedAndSingleCheckJobs } from '../../lib/feature-flag'
 
 interface ICICheckRunListItemProps {
   /** The check run to display **/
@@ -163,7 +164,11 @@ export class CICheckRunListItem extends React.PureComponent<
     const { checkRun, onRerunJob } = this.props
     const { mouseOver } = this.state
 
-    if (!mouseOver || onRerunJob === undefined) {
+    if (
+      !mouseOver ||
+      onRerunJob === undefined ||
+      !enableReRunFailedAndSingleCheckJobs()
+    ) {
       return null
     }
 

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -44,8 +44,20 @@ interface ICICheckRunListItemProps {
   ) => void
 }
 
+interface ICICheckRunListItemState {
+  readonly mouseOver: boolean
+}
+
 /** The CI check list item. */
-export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemProps> {
+export class CICheckRunListItem extends React.PureComponent<
+  ICICheckRunListItemProps,
+  ICICheckRunListItemState
+> {
+  public constructor(props: ICICheckRunListItemProps) {
+    super(props)
+    this.state = { mouseOver: false }
+  }
+
   private toggleCheckRunExpansion = () => {
     this.props.onCheckRunExpansionToggleClick(this.props.checkRun)
   }
@@ -125,6 +137,52 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
     )
   }
 
+  private renderJobRerun = (): JSX.Element | null => {
+    const { checkRun } = this.props
+    const { mouseOver } = this.state
+
+    if (!mouseOver) {
+      return null
+    }
+
+    const classes = classNames('job-rerun', {
+      'not-action-job': checkRun.actionJobSteps === undefined,
+    })
+
+    const tooltip =
+      checkRun.actionJobSteps !== undefined
+        ? 'Re-run this check'
+        : 'This check cannot individually re-run.'
+
+    return (
+      <div className={classes} onClick={this.rerunJob}>
+        <TooltippedContent tooltip={tooltip}>
+          <Octicon symbol={OcticonSymbol.sync} />
+        </TooltippedContent>
+      </div>
+    )
+  }
+
+  private rerunJob = (e: React.MouseEvent) => {
+    e.stopPropagation()
+
+    if (this.props.checkRun.actionJobSteps === undefined) {
+      console.log('Cannot re-run:', this.props.checkRun.name)
+    } else {
+      console.log('Re-run:', this.props.checkRun.name)
+    }
+  }
+
+  private onMouseOver = () => {
+    if (!this.state.mouseOver) {
+      this.setState({ mouseOver: true })
+    }
+  }
+
+  private onMouseOut = (e: React.MouseEvent) => {
+    this.setState({ mouseOver: false })
+  }
+
   public render() {
     const { checkRun, isCheckRunExpanded } = this.props
 
@@ -133,7 +191,11 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
       selected: this.props.selected,
     })
     return (
-      <div className="ci-check-list-item-group">
+      <div
+        className="ci-check-list-item-group"
+        onMouseOver={this.onMouseOver}
+        onMouseLeave={this.onMouseOut}
+      >
         <div
           className={classes}
           onClick={this.toggleCheckRunExpansion}
@@ -141,6 +203,7 @@ export class CICheckRunListItem extends React.PureComponent<ICICheckRunListItemP
         >
           {this.renderCheckStatusSymbol()}
           {this.renderCheckRunName()}
+          {this.renderJobRerun()}
           {this.renderCheckJobStepToggle()}
         </div>
         {isCheckRunExpanded && checkRun.actionJobSteps !== undefined ? (

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -36,6 +36,9 @@ interface ICICheckRunListProps {
     checkRun: IRefCheck,
     step: IAPIWorkflowJobStep
   ) => void
+
+  /** Callback to rerun a job*/
+  readonly onRerunJob?: (checkRun: IRefCheck) => void
 }
 
 interface ICICheckRunListState {
@@ -165,6 +168,7 @@ export class CICheckRunList extends React.PureComponent<
           onCheckRunExpansionToggleClick={this.onCheckRunClick}
           onViewCheckExternally={this.props.onViewCheckDetails}
           onViewJobStep={this.props.onViewJobStep}
+          onRerunJob={this.props.onRerunJob}
         />
       )
     })

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -198,15 +198,17 @@ export class CICheckRunPopover extends React.PureComponent<
       checkRuns: [check],
       repository: this.props.repository,
       prRef: getPullRequestCommitRef(this.props.prNumber),
+      failedOnly: false,
     })
   }
 
-  private rerunChecks = () => {
+  private rerunChecks = (failedOnly: boolean) => {
     this.props.dispatcher.showPopup({
       type: PopupType.CICheckRunRerun,
       checkRuns: this.state.checkRuns,
       repository: this.props.repository,
       prRef: getPullRequestCommitRef(this.props.prNumber),
+      failedOnly,
     })
   }
 
@@ -245,11 +247,11 @@ export class CICheckRunPopover extends React.PureComponent<
     const items: IMenuItem[] = [
       {
         label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
-        action: () => this.rerunChecks(),
+        action: () => this.rerunChecks(true),
       },
       {
         label: __DARWIN__ ? 'Re-run All Checks' : 'Re-run all checks',
-        action: () => this.rerunChecks(),
+        action: () => this.rerunChecks(false),
       },
     ]
 

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -191,20 +191,13 @@ export class CICheckRunPopover extends React.PureComponent<
     return `${summaryArray[0].count} ${summaryArray[0].conclusion} ${pluralize}`
   }
 
-  private rerunCheck = (check: IRefCheck) => {
+  private rerunChecks = (
+    failedOnly: boolean,
+    checkRuns?: ReadonlyArray<IRefCheck>
+  ) => {
     this.props.dispatcher.showPopup({
       type: PopupType.CICheckRunRerun,
-      checkRuns: [check],
-      repository: this.props.repository,
-      prRef: getPullRequestCommitRef(this.props.prNumber),
-      failedOnly: false,
-    })
-  }
-
-  private rerunChecks = (failedOnly: boolean) => {
-    this.props.dispatcher.showPopup({
-      type: PopupType.CICheckRunRerun,
-      checkRuns: this.state.checkRuns,
+      checkRuns: checkRuns ?? this.state.checkRuns,
       repository: this.props.repository,
       prRef: getPullRequestCommitRef(this.props.prNumber),
       failedOnly,
@@ -356,6 +349,10 @@ export class CICheckRunPopover extends React.PureComponent<
     )
   }
 
+  private onRerunJob = (check: IRefCheck) => {
+    this.rerunChecks(false, [check])
+  }
+
   public renderList = (): JSX.Element => {
     const { checkRuns, loadingActionLogs, loadingActionWorkflows } = this.state
     if (loadingActionWorkflows) {
@@ -373,7 +370,7 @@ export class CICheckRunPopover extends React.PureComponent<
           loadingActionWorkflows={loadingActionWorkflows}
           onViewCheckDetails={this.onViewCheckDetails}
           onViewJobStep={this.onViewJobStep}
-          onRerunJob={this.rerunCheck}
+          onRerunJob={this.onRerunJob}
         />
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -11,7 +11,6 @@ import {
   FailingCheckConclusions,
 } from '../../lib/ci-checks/ci-checks'
 import { Octicon, syncClockwise } from '../octicons'
-import { Button } from '../lib/button'
 import { APICheckConclusion, IAPIWorkflowJobStep } from '../../lib/api'
 import { Popover, PopoverCaretPosition } from '../lib/popover'
 import { CICheckRunList } from './ci-check-run-list'
@@ -21,7 +20,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Donut } from '../donut'
 import { supportsRerunningChecks } from '../../lib/endpoint-capabilities'
 import { getPullRequestCommitRef } from '../../models/pull-request'
-import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
+import { CICheckReRunButton } from './ci-check-re-run-button'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -233,29 +232,11 @@ export class CICheckRunPopover extends React.PureComponent<
     }
 
     return (
-      <Button
-        onClick={this.onRerunChecksButton}
+      <CICheckReRunButton
         disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
-      >
-        <Octicon symbol={syncClockwise} /> Re-run checks{' '}
-        <Octicon symbol={OcticonSymbol.triangleDown} />
-      </Button>
+        onRerunChecks={this.rerunChecks}
+      />
     )
-  }
-
-  private onRerunChecksButton = () => {
-    const items: IMenuItem[] = [
-      {
-        label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
-        action: () => this.rerunChecks(true),
-      },
-      {
-        label: __DARWIN__ ? 'Re-run All Checks' : 'Re-run all checks',
-        action: () => this.rerunChecks(false),
-      },
-    ]
-
-    showContextualMenu(items)
   }
 
   private renderCheckRunLoadings(): JSX.Element {

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -21,6 +21,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Donut } from '../donut'
 import { supportsRerunningChecks } from '../../lib/endpoint-capabilities'
 import { getPullRequestCommitRef } from '../../models/pull-request'
+import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
 
 const BlankSlateImage = encodePathAsUrl(
   __dirname,
@@ -231,12 +232,28 @@ export class CICheckRunPopover extends React.PureComponent<
 
     return (
       <Button
-        onClick={this.rerunChecks}
+        onClick={this.onRerunChecksButton}
         disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
       >
-        <Octicon symbol={syncClockwise} /> Re-run checks
+        <Octicon symbol={syncClockwise} /> Re-run checks{' '}
+        <Octicon symbol={OcticonSymbol.triangleDown} />
       </Button>
     )
+  }
+
+  private onRerunChecksButton = () => {
+    const items: IMenuItem[] = [
+      {
+        label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
+        action: () => this.rerunChecks(),
+      },
+      {
+        label: __DARWIN__ ? 'Re-run All Checks' : 'Re-run all checks',
+        action: () => this.rerunChecks(),
+      },
+    ]
+
+    showContextualMenu(items)
   }
 
   private renderCheckRunLoadings(): JSX.Element {

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -191,6 +191,15 @@ export class CICheckRunPopover extends React.PureComponent<
     return `${summaryArray[0].count} ${summaryArray[0].conclusion} ${pluralize}`
   }
 
+  private rerunCheck = (check: IRefCheck) => {
+    this.props.dispatcher.showPopup({
+      type: PopupType.CICheckRunRerun,
+      checkRuns: [check],
+      repository: this.props.repository,
+      prRef: getPullRequestCommitRef(this.props.prNumber),
+    })
+  }
+
   private rerunChecks = () => {
     this.props.dispatcher.showPopup({
       type: PopupType.CICheckRunRerun,
@@ -364,6 +373,7 @@ export class CICheckRunPopover extends React.PureComponent<
           loadingActionWorkflows={loadingActionWorkflows}
           onViewCheckDetails={this.onViewCheckDetails}
           onViewJobStep={this.onViewJobStep}
+          onRerunJob={this.rerunCheck}
         />
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -5,7 +5,11 @@ import { IRefCheck } from '../../lib/ci-checks/ci-checks'
 import { CICheckRunList } from './ci-check-run-list'
 import { GitHubRepository } from '../../models/github-repository'
 import { Dispatcher } from '../dispatcher'
-import { APICheckStatus, IAPICheckSuite } from '../../lib/api'
+import {
+  APICheckConclusion,
+  APICheckStatus,
+  IAPICheckSuite,
+} from '../../lib/api'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from './../octicons/octicons.generated'
 import { Row } from '../lib/row'
@@ -26,6 +30,9 @@ interface ICICheckRunRerunDialogProps {
 
   /** The git reference of the pr */
   readonly prRef: string
+
+  /** Whether to only rerun failed checks */
+  readonly failedOnly: boolean
 
   readonly onDismissed: () => void
 }
@@ -69,9 +76,15 @@ export class CICheckRunRerunDialog extends React.Component<
   }
 
   private determineRerunnability = async () => {
+    const checkRunsToConsider = this.props.failedOnly
+      ? this.props.checkRuns.filter(
+          cr => cr.conclusion === APICheckConclusion.Failure
+        )
+      : this.props.checkRuns
+
     // Get unique set of check suite ids
     const checkSuiteIds = new Set(
-      this.props.checkRuns.map(cr => cr.checkSuiteId)
+      checkRunsToConsider.map(cr => cr.checkSuiteId)
     )
 
     const checkSuitesPromises = new Array<Promise<IAPICheckSuite | null>>()
@@ -101,7 +114,7 @@ export class CICheckRunRerunDialog extends React.Component<
       }
     }
 
-    const rerunnable = this.props.checkRuns.filter(
+    const rerunnable = checkRunsToConsider.filter(
       cr =>
         cr.checkSuiteId !== null &&
         rerequestableCheckSuiteIds.includes(cr.checkSuiteId)
@@ -109,7 +122,8 @@ export class CICheckRunRerunDialog extends React.Component<
     const nonRerunnable = this.props.checkRuns.filter(
       cr =>
         cr.checkSuiteId === null ||
-        !rerequestableCheckSuiteIds.includes(cr.checkSuiteId)
+        !rerequestableCheckSuiteIds.includes(cr.checkSuiteId) ||
+        (this.props.failedOnly && cr.conclusion === APICheckConclusion.Failure)
     )
 
     this.setState({ loadingCheckSuites: false, rerunnable, nonRerunnable })
@@ -168,10 +182,15 @@ export class CICheckRunRerunDialog extends React.Component<
   }
 
   public render() {
+    const failed = this.props.failedOnly
+      ? __DARWIN__
+        ? 'Failed '
+        : 'failed '
+      : ''
     return (
       <Dialog
         id="rerun-check-runs"
-        title={__DARWIN__ ? 'Re-run Checks' : 'Re-run checks'}
+        title={__DARWIN__ ? `Re-run ${failed}Checks` : 'Re-run ${failed}checks'}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={this.state.loadingCheckSuites || this.state.loadingRerun}
@@ -180,7 +199,9 @@ export class CICheckRunRerunDialog extends React.Component<
         <DialogFooter>
           {this.renderRerunInfo()}
           <OkCancelButtonGroup
-            okButtonText={__DARWIN__ ? 'Re-run Checks' : 'Re-run checks'}
+            okButtonText={
+              __DARWIN__ ? `Re-run ${failed}Checks` : `Re-run ${failed}checks`
+            }
             okButtonDisabled={this.state.rerunnable.length === 0}
           />
         </DialogFooter>

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -190,7 +190,7 @@ export class CICheckRunRerunDialog extends React.Component<
     return (
       <Dialog
         id="rerun-check-runs"
-        title={__DARWIN__ ? `Re-run ${failed}Checks` : 'Re-run ${failed}checks'}
+        title={__DARWIN__ ? `Re-run ${failed}Checks` : `Re-run ${failed}checks`}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={this.state.loadingCheckSuites || this.state.loadingRerun}

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -22,6 +22,7 @@ import { CICheckRunActionsJobStepList } from '../check-runs/ci-check-run-actions
 import { LinkButton } from '../lib/link-button'
 import { encodePathAsUrl } from '../../lib/path'
 import { PopupType } from '../../models/popup'
+import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
 
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 const BlankSlateImage = encodePathAsUrl(
@@ -264,14 +265,33 @@ export class PullRequestChecksFailed extends React.Component<
     const { checks } = this.state
     return (
       <div className="ci-check-rerun">
-        <Button onClick={this.rerunChecks} disabled={checks.length === 0}>
-          <Octicon symbol={syncClockwise} /> Re-run checks
+        <Button
+          onClick={this.onRerunChecksButton}
+          disabled={checks.length === 0}
+        >
+          <Octicon symbol={syncClockwise} /> Re-run checks{' '}
+          <Octicon symbol={OcticonSymbol.triangleDown} />
         </Button>
       </div>
     )
   }
 
-  private rerunChecks = () => {
+  private onRerunChecksButton = () => {
+    const items: IMenuItem[] = [
+      {
+        label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
+        action: () => this.rerunChecks(true),
+      },
+      {
+        label: __DARWIN__ ? 'Re-run All Checks' : 'Re-run all checks',
+        action: () => this.rerunChecks(false),
+      },
+    ]
+
+    showContextualMenu(items)
+  }
+
+  private rerunChecks = (failedOnly: boolean) => {
     this.props.dispatcher.recordChecksFailedDialogRerunChecks()
 
     const prRef = getPullRequestCommitRef(
@@ -283,6 +303,7 @@ export class PullRequestChecksFailed extends React.Component<
       checkRuns: this.state.checks,
       repository: this.props.repository.gitHubRepository,
       prRef,
+      failedOnly,
     })
   }
 
@@ -298,6 +319,7 @@ export class PullRequestChecksFailed extends React.Component<
       checkRuns: [check],
       repository: this.props.repository.gitHubRepository,
       prRef,
+      failedOnly: false,
     })
   }
 

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -176,6 +176,7 @@ export class PullRequestChecksFailed extends React.Component<
         selectable={true}
         onViewCheckDetails={this.onViewOnGitHub}
         onCheckRunClick={this.onCheckRunClick}
+        onRerunJob={this.rerunCheck}
       />
     )
   }
@@ -280,6 +281,21 @@ export class PullRequestChecksFailed extends React.Component<
     this.props.dispatcher.showPopup({
       type: PopupType.CICheckRunRerun,
       checkRuns: this.state.checks,
+      repository: this.props.repository.gitHubRepository,
+      prRef,
+    })
+  }
+
+  private rerunCheck = (check: IRefCheck) => {
+    this.props.dispatcher.recordChecksFailedDialogRerunChecks()
+
+    const prRef = getPullRequestCommitRef(
+      this.props.pullRequest.pullRequestNumber
+    )
+
+    this.props.dispatcher.showPopup({
+      type: PopupType.CICheckRunRerun,
+      checkRuns: [check],
       repository: this.props.repository.gitHubRepository,
       prRef,
     })

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -14,15 +14,14 @@ import {
 } from '../../lib/ci-checks/ci-checks'
 import { Account } from '../../models/account'
 import { API, IAPIWorkflowJobStep } from '../../lib/api'
-import { Octicon, syncClockwise } from '../octicons'
+import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
-import { Button } from '../lib/button'
 import { RepositoryWithGitHubRepository } from '../../models/repository'
 import { CICheckRunActionsJobStepList } from '../check-runs/ci-check-run-actions-job-step-list'
 import { LinkButton } from '../lib/link-button'
 import { encodePathAsUrl } from '../../lib/path'
 import { PopupType } from '../../models/popup'
-import { IMenuItem, showContextualMenu } from '../../lib/menu-item'
+import { CICheckReRunButton } from '../check-runs/ci-check-re-run-button'
 
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 const BlankSlateImage = encodePathAsUrl(
@@ -265,30 +264,12 @@ export class PullRequestChecksFailed extends React.Component<
     const { checks } = this.state
     return (
       <div className="ci-check-rerun">
-        <Button
-          onClick={this.onRerunChecksButton}
+        <CICheckReRunButton
           disabled={checks.length === 0}
-        >
-          <Octicon symbol={syncClockwise} /> Re-run checks{' '}
-          <Octicon symbol={OcticonSymbol.triangleDown} />
-        </Button>
+          onRerunChecks={this.rerunChecks}
+        />
       </div>
     )
-  }
-
-  private onRerunChecksButton = () => {
-    const items: IMenuItem[] = [
-      {
-        label: __DARWIN__ ? 'Re-run Failed Checks' : 'Re-run failed checks',
-        action: () => this.rerunChecks(true),
-      },
-      {
-        label: __DARWIN__ ? 'Re-run All Checks' : 'Re-run all checks',
-        action: () => this.rerunChecks(false),
-      },
-    ]
-
-    showContextualMenu(items)
   }
 
   private rerunChecks = (failedOnly: boolean) => {

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -167,6 +167,10 @@ export class PullRequestChecksFailed extends React.Component<
     )
   }
 
+  private onRerunJob = (check: IRefCheck) => {
+    this.rerunChecks(false, [check])
+  }
+
   private renderCheckRunJobs() {
     return (
       <CICheckRunList
@@ -176,7 +180,7 @@ export class PullRequestChecksFailed extends React.Component<
         selectable={true}
         onViewCheckDetails={this.onViewOnGitHub}
         onCheckRunClick={this.onCheckRunClick}
-        onRerunJob={this.rerunCheck}
+        onRerunJob={this.onRerunJob}
       />
     )
   }
@@ -272,7 +276,10 @@ export class PullRequestChecksFailed extends React.Component<
     )
   }
 
-  private rerunChecks = (failedOnly: boolean) => {
+  private rerunChecks = (
+    failedOnly: boolean,
+    checks?: ReadonlyArray<IRefCheck>
+  ) => {
     this.props.dispatcher.recordChecksFailedDialogRerunChecks()
 
     const prRef = getPullRequestCommitRef(
@@ -281,26 +288,10 @@ export class PullRequestChecksFailed extends React.Component<
 
     this.props.dispatcher.showPopup({
       type: PopupType.CICheckRunRerun,
-      checkRuns: this.state.checks,
+      checkRuns: checks ?? this.state.checks,
       repository: this.props.repository.gitHubRepository,
       prRef,
       failedOnly,
-    })
-  }
-
-  private rerunCheck = (check: IRefCheck) => {
-    this.props.dispatcher.recordChecksFailedDialogRerunChecks()
-
-    const prRef = getPullRequestCommitRef(
-      this.props.pullRequest.pullRequestNumber
-    )
-
-    this.props.dispatcher.showPopup({
-      type: PopupType.CICheckRunRerun,
-      checkRuns: [check],
-      repository: this.props.repository.gitHubRepository,
-      prRef,
-      failedOnly: false,
     })
   }
 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -20,6 +20,7 @@ $overlay-background-color: rgba(0, 0, 0, 0.4);
 
   --text-color: #{$gray-900};
   --text-secondary-color: #{$gray-500};
+  --text-secondary-color-muted: #{lighten($gray-500, 30%)};
   --background-color: #{$white};
 
   --button-height: 25px;

--- a/app/styles/themes/_dark.scss
+++ b/app/styles/themes/_dark.scss
@@ -19,6 +19,7 @@ body.theme-dark {
 
   --text-color: #{$gray-300};
   --text-secondary-color: #{$gray-400};
+  --text-secondary-color-muted: #{darken($gray-500, 10%)};
   --background-color: #{$gray-900};
 
   --button-background: #{$blue};

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -30,7 +30,8 @@
   }
 
   .ci-check-status-symbol,
-  .job-step-toggled-indicator {
+  .job-step-toggled-indicator,
+  .job-rerun {
     padding: var(--spacing);
     padding-top: 11px;
   }
@@ -38,6 +39,14 @@
   .job-step-toggled-indicator {
     padding-left: 0px;
     color: var(--text-secondary-color);
+  }
+
+  .job-rerun {
+    color: var(--text-secondary-color);
+
+    &.not-action-job {
+      color: var(--toolbar-text-secondary-color);
+    }
   }
 
   .ci-check-list-item-detail {

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -33,7 +33,7 @@
   .job-step-toggled-indicator,
   .job-rerun {
     padding: var(--spacing);
-    padding-top: 11px;
+    padding-top: calc(var(--spacing-half) * 3);
   }
 
   .job-step-toggled-indicator {
@@ -45,7 +45,7 @@
     color: var(--text-secondary-color);
 
     &.not-action-job {
-      color: var(--toolbar-text-secondary-color);
+      color: var(--text-secondary-color-muted);
     }
   }
 

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -10,10 +10,6 @@
     .ci-check-run-list-group-header {
       padding-left: 15px;
     }
-
-    .ci-check-list-item {
-      padding-left: var(--spacing);
-    }
   }
 
   .non-re-run-info {


### PR DESCRIPTION
## Description
This is the first of a few PR's to introduce the ability to rerun individual and failed action checks. This PR is simply to introduce the UI interaction for the functionality. Thus, it is feature flagged to development. Future PR's to add the logic to actually rerun individual/vs failed jobs. The little bit of logic changed in the Re-run dialog will evolve with future PRs.

Also, added a new dev/test menu item to show a mock Pull Request Checks Failed Dialog for easier testing to make sure I don't introduce regressions there. 

### Screenshots


https://user-images.githubusercontent.com/75402236/162270751-c6a719e9-ec4b-4d75-a741-4cd051a854b8.mov


## Release notes
Notes: no-notes
