### PR TITLE
Add ability to re-run a single job and failed jobs

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1237,7 +1237,7 @@ export class API {
    * Re-run all of the failed jobs and their dependent jobs in a workflow run
    * using the id of the workflow run.
    */
-  public async rerunFailedJob(
+  public async rerunFailedJobs(
     owner: string,
     name: string,
     workflowRunId: number

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1234,6 +1234,45 @@ export class API {
   }
 
   /**
+   * Re-run all of the failed jobs and their dependent jobs in a workflow run
+   * using the id of the workflow run.
+   */
+  public async rerunFailedJob(
+    owner: string,
+    name: string,
+    workflowRunId: number
+  ): Promise<boolean> {
+    const path = `/repos/${owner}/${name}/actions/runs/${workflowRunId}/rerun-failed-jobs`
+    const response = await this.request('POST', path)
+    try {
+      return response.ok
+    } catch (err) {
+      log.debug(
+        `Failed to rerun failed workflow jobs for (${owner}/${name}): ${workflowRunId}`
+      )
+    }
+    return false
+  }
+
+  /**
+   * Re-run a job and its dependent jobs in a workflow run.
+   */
+  public async rerunJob(
+    owner: string,
+    name: string,
+    jobId: number
+  ): Promise<boolean> {
+    const path = `/repos/${owner}/${name}/actions/jobs/${jobId}/rerun`
+    const response = await this.request('POST', path)
+    try {
+      return response.ok
+    } catch (err) {
+      log.debug(`Failed to rerun workflow job (${owner}/${name}): ${jobId}`)
+    }
+    return false
+  }
+
+  /**
    * Gets a single check suite using its id
    */
   public async fetchCheckSuite(

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1220,17 +1220,16 @@ export class API {
     checkSuiteId: number
   ): Promise<boolean> {
     const path = `/repos/${owner}/${name}/check-suites/${checkSuiteId}/rerequest`
-    const response = await this.request('POST', path)
 
-    try {
-      return response.ok
-    } catch (_) {
-      log.debug(
-        `Failed retry check suite id ${checkSuiteId} (${owner}/${name})`
-      )
-    }
-
-    return false
+    return this.request('POST', path)
+      .then(x => x.ok)
+      .catch(err => {
+        log.debug(
+          `Failed retry check suite id ${checkSuiteId} (${owner}/${name})`,
+          err
+        )
+        return false
+      })
   }
 
   /**
@@ -1243,15 +1242,16 @@ export class API {
     workflowRunId: number
   ): Promise<boolean> {
     const path = `/repos/${owner}/${name}/actions/runs/${workflowRunId}/rerun-failed-jobs`
-    const response = await this.request('POST', path)
-    try {
-      return response.ok
-    } catch (err) {
-      log.debug(
-        `Failed to rerun failed workflow jobs for (${owner}/${name}): ${workflowRunId}`
-      )
-    }
-    return false
+
+    return this.request('POST', path)
+      .then(x => x.ok)
+      .catch(err => {
+        log.debug(
+          `Failed to rerun failed workflow jobs for (${owner}/${name}): ${workflowRunId}`,
+          err
+        )
+        return false
+      })
   }
 
   /**
@@ -1263,13 +1263,16 @@ export class API {
     jobId: number
   ): Promise<boolean> {
     const path = `/repos/${owner}/${name}/actions/jobs/${jobId}/rerun`
-    const response = await this.request('POST', path)
-    try {
-      return response.ok
-    } catch (err) {
-      log.debug(`Failed to rerun workflow job (${owner}/${name}): ${jobId}`)
-    }
-    return false
+
+    return this.request('POST', path)
+      .then(x => x.ok)
+      .catch(err => {
+        log.debug(
+          `Failed to rerun workflow job (${owner}/${name}): ${jobId}`,
+          err
+        )
+        return false
+      })
   }
 
   /**

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -551,7 +551,7 @@ export class CommitStatusStore {
     return api.rerequestCheckSuite(owner.login, name, checkSuiteId)
   }
 
-  public async rerenJob(
+  public async rerunJob(
     repository: GitHubRepository,
     jobId: number
   ): Promise<boolean> {

--- a/app/src/lib/stores/commit-status-store.ts
+++ b/app/src/lib/stores/commit-status-store.ts
@@ -551,6 +551,34 @@ export class CommitStatusStore {
     return api.rerequestCheckSuite(owner.login, name, checkSuiteId)
   }
 
+  public async rerenJob(
+    repository: GitHubRepository,
+    jobId: number
+  ): Promise<boolean> {
+    const { owner, name } = repository
+    const account = getAccountForEndpoint(this.accounts, repository.endpoint)
+    if (account === null) {
+      return false
+    }
+
+    const api = API.fromAccount(account)
+    return api.rerunJob(owner.login, name, jobId)
+  }
+
+  public async rerunFailedJobs(
+    repository: GitHubRepository,
+    workflowRunId: number
+  ): Promise<boolean> {
+    const { owner, name } = repository
+    const account = getAccountForEndpoint(this.accounts, repository.endpoint)
+    if (account === null) {
+      return false
+    }
+
+    const api = API.fromAccount(account)
+    return api.rerunFailedJobs(owner.login, name, workflowRunId)
+  }
+
   public async fetchCheckSuite(
     repository: GitHubRepository,
     checkSuiteId: number

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -65,7 +65,11 @@ export class CICheckRunRerunDialog extends React.Component<
   private onSubmit = async () => {
     const { dispatcher, repository, prRef } = this.props
     this.setState({ loadingRerun: true })
-    await dispatcher.rerequestCheckSuites(repository, this.state.rerunnable)
+    await dispatcher.rerequestCheckSuites(
+      repository,
+      this.state.rerunnable,
+      this.props.failedOnly
+    )
     await dispatcher.manualRefreshSubscription(
       repository,
       prRef,
@@ -163,6 +167,12 @@ export class CICheckRunRerunDialog extends React.Component<
     ) {
       return null
     }
+
+    /**
+     * Verbiage from dotcom:
+     * Single Job: "A new attempt of this workflow will be started, including macOS x64 and dependents"
+     * Failed Jobs: "A new attempt of this workflow will be started, including all failed jobs and dependents"
+     * */
 
     const pluralize = `check${this.state.nonRerunnable.length !== 1 ? 's' : ''}`
     const verb = this.state.nonRerunnable.length !== 1 ? 'are' : 'is'

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -2553,23 +2553,17 @@ export class Dispatcher {
       }
 
       // There could still be failed ones that are not action and only way to
-      // rerun them it rerun their whole check suite
+      // rerun them is to rerun their whole check suite
       if (cr.checkSuiteId !== null) {
         checkSuiteIds.add(cr.checkSuiteId)
       }
     }
 
     for (const id of workflowRunIds) {
-      if (id === null) {
-        continue
-      }
       promises.push(this.commitStatusStore.rerunFailedJobs(repository, id))
     }
 
     for (const id of checkSuiteIds) {
-      if (id === null) {
-        continue
-      }
       promises.push(this.commitStatusStore.rerequestCheckSuite(repository, id))
     }
 


### PR DESCRIPTION
Based on #14304

## Description
This adds the api calls and links them up to the re-request dispatcher call to add the functionally to rerun an individual job or failed jobs.  This is still flagged to development.

Remaining work:
- Rework the wording on the re-run dialog for single/failed jobs - probably follow dotcom wording.
- If all checks are successful, don't have dropdown button for failed option.
- If a check is pending, disable individual rerun button for all checks in that workflow run. On dotcom it is actually just not shown, but since we show it muted with tooltip for other non-rerunnable circumstances, I think it makes sense to do it here as well. Maybe with a custom message -> "Cannot rerun while other checks in this workflow are pending".

## Release notes
Notes: no-notes
