### PR TITLE
Better markdown tooltips w niik ideas

### DIFF
--- a/app/src/lib/globals.d.ts
+++ b/app/src/lib/globals.d.ts
@@ -157,6 +157,7 @@ declare namespace Electron {
 // https://github.com/microsoft/TypeScript/issues/21568#issuecomment-362473070
 interface Window {
   Element: typeof Element
+  HTMLElement: typeof HTMLElement
 }
 
 interface HTMLDialogElement {

--- a/app/src/lib/markdown-filters/close-keyword-filter.ts
+++ b/app/src/lib/markdown-filters/close-keyword-filter.ts
@@ -182,7 +182,7 @@ export class CloseKeywordFilter implements INodeFilter {
     const tooltipSpan = document.createElement('span')
     tooltipSpan.textContent = closesText
     tooltipSpan.classList.add('issue-keyword')
-    tooltipSpan.title = `This ${
+    tooltipSpan.ariaLabel = `This ${
       this.markdownContext === 'Commit' ? 'commit' : 'pull request'
     } closes ${issueNumber}.`
     return tooltipSpan

--- a/app/src/ui/lib/object-id.ts
+++ b/app/src/ui/lib/object-id.ts
@@ -1,0 +1,21 @@
+import { randomBytes } from 'crypto'
+
+const idMap = new WeakMap<object, string>()
+
+/**
+ * Generates a unique ID for the given object reference.
+ *
+ * The same (by reference equality) object will get the same id for the lifetime
+ * of the application. This is achieved by using a weak reference to the object.
+ *
+ */
+export function getObjectId(obj: object): string {
+  let id = idMap.get(obj)
+
+  if (id === undefined) {
+    id = randomBytes(8).toString('base64url')
+    idMap.set(obj, id)
+  }
+
+  return id
+}

--- a/app/src/ui/lib/observable-ref.ts
+++ b/app/src/ui/lib/observable-ref.ts
@@ -13,7 +13,7 @@ export type ObservableRef<T> = {
  * exception that refs created using `createObservableRef` can notify consumers
  * when the underlying ref change without having to resort to callback refs.
  */
-export function createObservableRef<T>(): ObservableRef<T> {
+export function createObservableRef<T>(current?: T): ObservableRef<T> {
   const subscribers = new Set<RefCallback<T>>()
 
   const callback: ObservableRef<T> = Object.assign(
@@ -22,7 +22,7 @@ export function createObservableRef<T>(): ObservableRef<T> {
       subscribers.forEach(cb => cb(instance))
     },
     {
-      current: null,
+      current: current ?? null,
       subscribe: (cb: RefCallback<T>) => subscribers.add(cb),
       unsubscribe: (cb: RefCallback<T>) => subscribers.delete(cb),
     }

--- a/app/src/ui/lib/rect.ts
+++ b/app/src/ui/lib/rect.ts
@@ -33,3 +33,6 @@ export function rectContains(x: ClientRect, y: ClientRect) {
     y.right <= x.right
   )
 }
+
+export const offsetRect = (rect: DOMRect, x: number, y: number) =>
+  new DOMRect(rect.x + x, rect.y + y, rect.width, rect.height)

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -9,6 +9,9 @@ import {
 } from '../../lib/markdown-filters/node-filter'
 import { GitHubRepository } from '../../models/github-repository'
 import { readFile } from 'fs/promises'
+import { Tooltip } from './tooltip'
+import { createObservableRef } from './observable-ref'
+import { getObjectId } from './object-id'
 
 interface ISandboxedMarkdownProps {
   /** A string of unparsed markdown to display */
@@ -192,8 +195,6 @@ export class SandboxedMarkdown extends React.PureComponent<
       tooltipElements,
       tooltipOffset: frameRef.getBoundingClientRect(),
     })
-
-    console.log(this.state.tooltipElements, this.state.tooltipOffset)
   }
 
   private setupContentDivRef(frameRef: HTMLIFrameElement): void {
@@ -344,6 +345,8 @@ export class SandboxedMarkdown extends React.PureComponent<
   }
 
   public render() {
+    const { tooltipElements, tooltipOffset } = this.state
+
     return (
       <div
         className="sandboxed-markdown-iframe-container"
@@ -354,6 +357,15 @@ export class SandboxedMarkdown extends React.PureComponent<
           sandbox=""
           ref={this.onFrameRef}
         />
+        {tooltipElements.map(e => (
+          <Tooltip
+            target={createObservableRef(e)}
+            key={getObjectId(e)}
+            tooltipOffset={tooltipOffset}
+          >
+            {e.ariaLabel}
+          </Tooltip>
+        ))}
       </div>
     )
   }

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -12,6 +12,7 @@ import { readFile } from 'fs/promises'
 import { Tooltip } from './tooltip'
 import { createObservableRef } from './observable-ref'
 import { getObjectId } from './object-id'
+import { debounce } from 'lodash'
 
 interface ISandboxedMarkdownProps {
   /** A string of unparsed markdown to display */
@@ -67,6 +68,12 @@ export class SandboxedMarkdown extends React.PureComponent<
   private readonly resizeObserver: ResizeObserver
   private resizeDebounceId: number | null = null
 
+  private onDocumentScroll = debounce(() => {
+    this.setState({
+      tooltipOffset: this.frameRef?.getBoundingClientRect() ?? new DOMRect(),
+    })
+  }, 100)
+
   public constructor(props: ISandboxedMarkdownProps) {
     super(props)
 
@@ -106,6 +113,10 @@ export class SandboxedMarkdown extends React.PureComponent<
     if (this.frameRef !== null) {
       this.setupFrameLoadListeners(this.frameRef)
     }
+
+    document.addEventListener('scroll', this.onDocumentScroll, {
+      capture: true,
+    })
   }
 
   public async componentDidUpdate(prevProps: ISandboxedMarkdownProps) {
@@ -117,6 +128,7 @@ export class SandboxedMarkdown extends React.PureComponent<
 
   public componentWillUnmount() {
     this.resizeObserver.disconnect()
+    document.removeEventListener('scroll', this.onDocumentScroll)
   }
 
   /**


### PR DESCRIPTION
## Description
This is a follow up to the closed keyword markdown filter (#14289). It made use of the title attribute in order to show the "This pull request closes x" tooltip.  Thanks to @niik, this pull request adds a way for us to make use of Desktop's beautiful custom tooltips in our markdown.

### Screenshots

![image](https://user-images.githubusercontent.com/75402236/162739500-5d014f05-e137-412c-9944-f014f06a2d45.png)

(before)
![image](https://user-images.githubusercontent.com/75402236/162739944-11bc2345-ea56-4f32-b7ad-68342373fb75.png)


## Release notes
Notes: no-notes
