### PR TITLE
Release 2.9.13-beta2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.13-beta1",
+  "version": "2.9.13-beta2",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.9.13-beta2": [
-      "[Added] Add include and exclude to the context menu of multiple selected files in the changes list - #7790. Thanks @tsvetilian-ty!",
+      "[Added] Add ability to include or exclude multiple selected files for a commit from the context menu - #7790. Thanks @tsvetilian-ty!",
       "[Added] Add \"View Branch on GitHub\" to the branches menu - #14224. Thanks @tsvetilian-ty!",
       "[Fixed] Fix relative time of pull request review notification dialogs - #14261",
       "[Fixed] Fix CI check status popover not closing when clicking on PR badge - #14256",

--- a/changelog.json
+++ b/changelog.json
@@ -2,7 +2,7 @@
   "releases": {
     "2.9.13-beta2": [
       "[Added] Add include and exclude to the context menu of multiple selected files in the changes list - #7790. Thanks @tsvetilian-ty!",
-      "[Added] Add the option to view the current branch on GitHub - #14224. Thanks @tsvetilian-ty!",
+      "[Added] Add \"View Branch on GitHub\" to the branches menu - #14224. Thanks @tsvetilian-ty!",
       "[Fixed] Fix relative time of pull request review notification dialogs - #14261",
       "[Fixed] Fix CI check status popover not closing when clicking on PR badge - #14256",
       "[Fixed] Fix checks list overflow handling on re-run checks dialog - #14246",

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 {
   "releases": {
     "2.9.13-beta2": [
-      "[Added] Add include and exclude functionality to selected files - #7790. Thanks @tsvetilian-ty!",
+      "[Added] Add include and exclude to the context menu of multiple selected files in the changes list - #7790. Thanks @tsvetilian-ty!",
       "[Added] Add the option to view the current branch on GitHub - #14224. Thanks @tsvetilian-ty!",
       "[Fixed] Fix relative time of pull request review notification dialogs - #14261",
       "[Fixed] Fix CI check status popover not closing when clicking on PR badge - #14256",

--- a/changelog.json
+++ b/changelog.json
@@ -8,7 +8,7 @@
       "[Fixed] Fix checks list overflow handling on re-run checks dialog - #14246",
       "[Improved] Close keywords are now formatted and have informational tooltips in markdown - #14253",
       "[Improved] Commit mentions in markdown are now formatted and linked - #14282",
-      "[Improved] Adds a link under our \"Enable notifications\" settings to the user's OS system notification settings - #14288"
+      "[Improved] Add a link under \"Enable notifications\" settings to the user's OS system notification settings - #14288"
     ],
     "2.9.13-beta1": [
       "[New] Add support for notifications of pull request reviews - #14175",

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 {
   "releases": {
+    "2.9.13-beta2": [
+      "[Added] Add include and exclude functionality to selected files - #7790. Thanks @tsvetilian-ty!",
+      "[Added] Add the option to view the current branch on GitHub - #14224. Thanks @tsvetilian-ty!",
+      "[Fixed] Fix relative time of pull request review notification dialogs - #14261",
+      "[Fixed] Fix CI check status popover not closing when clicking on PR badge - #14256",
+      "[Fixed] Fix checks list overflow handling on re-run checks dialog - #14246",
+      "[Improved] Close keywords are now formatted and have informational tooltips in markdown - #14253",
+      "[Improved] Commit mentions in markdown are now formatted and linked - #14282",
+      "[Improved] Adds a link under our \"Enable notifications\" settings to the user's OS system notification settings - #14288"
+    ],
     "2.9.13-beta1": [
       "[New] Add support for notifications of pull request reviews - #14175",
       "[Fixed] Pull requests adhere to temporal laws again - #14238",


### PR DESCRIPTION
## Description
Looking for the PR for the upcoming second beta of the v2.9.13 series? Well, you've just found it, congratulations!

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
PR Review notifications still flagged to beta
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
No Changes