### PR TITLE
Update re run dialog

### DIFF
--- a/app/src/lib/endpoint-capabilities.ts
+++ b/app/src/lib/endpoint-capabilities.ts
@@ -153,6 +153,12 @@ export const supportsRerunningChecks = endpointSatisfies({
   es: '>= 3.4.0',
 })
 
+export const supportsRerunningIndividualOrFailedChecks = endpointSatisfies({
+  dotcom: true,
+  ae: false,
+  es: false,
+})
+
 /**
  * Whether or not the endpoint supports the retrieval of action workflows by
  * check suite id.

--- a/app/src/ui/check-runs/ci-check-re-run-button.tsx
+++ b/app/src/ui/check-runs/ci-check-re-run-button.tsx
@@ -10,6 +10,7 @@ import * as OcticonSymbol from '../octicons/octicons.generated'
 interface ICICheckReRunButtonProps {
   readonly disabled: boolean
   readonly checkRuns: ReadonlyArray<IRefCheck>
+  readonly canReRunFailed: boolean
   readonly onRerunChecks: (failedOnly: boolean) => void
 }
 
@@ -21,7 +22,11 @@ export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonP
   }
 
   private onRerunChecks = () => {
-    if (!enableReRunFailedAndSingleCheckJobs() || !this.failedChecksExist) {
+    if (
+      !enableReRunFailedAndSingleCheckJobs() ||
+      !this.props.canReRunFailed ||
+      !this.failedChecksExist
+    ) {
       this.props.onRerunChecks(false)
       return
     }
@@ -42,7 +47,9 @@ export class CICheckReRunButton extends React.PureComponent<ICICheckReRunButtonP
 
   public render() {
     const text =
-      enableReRunFailedAndSingleCheckJobs() && this.failedChecksExist ? (
+      enableReRunFailedAndSingleCheckJobs() &&
+      this.props.canReRunFailed &&
+      this.failedChecksExist ? (
         <>
           Re-run <Octicon symbol={OcticonSymbol.triangleDown} />
         </>

--- a/app/src/ui/check-runs/ci-check-run-list-item.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list-item.tsx
@@ -32,6 +32,9 @@ interface ICICheckRunListItemProps {
   /** Whether check runs can be expanded. Default: false */
   readonly notExpandable?: boolean
 
+  /** Showing a condensed view */
+  readonly isCondensedView?: boolean
+
   /** Callback for when a check run is clicked */
   readonly onCheckRunExpansionToggleClick: (checkRun: IRefCheck) => void
 
@@ -135,7 +138,8 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   private renderCheckRunName = (): JSX.Element => {
-    const { name, description } = this.props.checkRun
+    const { checkRun, isCondensedView, onViewCheckExternally } = this.props
+    const { name, description } = checkRun
     return (
       <div className="ci-check-list-item-detail">
         <TooltippedContent
@@ -147,7 +151,7 @@ export class CICheckRunListItem extends React.PureComponent<
         >
           <span
             className={classNames({
-              isLink: this.props.onViewCheckExternally !== undefined,
+              isLink: onViewCheckExternally !== undefined,
             })}
             onClick={this.onViewCheckExternally}
           >
@@ -155,7 +159,9 @@ export class CICheckRunListItem extends React.PureComponent<
           </span>
         </TooltippedContent>
 
-        <div className="ci-check-description">{description}</div>
+        {isCondensedView ? null : (
+          <div className="ci-check-description">{description}</div>
+        )}
       </div>
     )
   }
@@ -191,11 +197,13 @@ export class CICheckRunListItem extends React.PureComponent<
   }
 
   public render() {
-    const { checkRun, isCheckRunExpanded } = this.props
+    const { checkRun, isCheckRunExpanded, selected, isCondensedView } =
+      this.props
 
     const classes = classNames('ci-check-list-item', 'list-item', {
       sticky: isCheckRunExpanded,
-      selected: this.props.selected,
+      selected,
+      condensed: isCondensedView,
     })
     return (
       <div

--- a/app/src/ui/check-runs/ci-check-run-list.tsx
+++ b/app/src/ui/check-runs/ci-check-run-list.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../lib/ci-checks/ci-checks'
 import { CICheckRunListItem } from './ci-check-run-list-item'
 import { FocusContainer } from '../lib/focus-container'
+import classNames from 'classnames'
 
 interface ICICheckRunListProps {
   /** List of check runs to display */
@@ -24,6 +25,9 @@ interface ICICheckRunListProps {
 
   /** Whether check runs can be expanded. Default: false */
   readonly notExpandable?: boolean
+
+  /** Showing a condensed view */
+  readonly isCondensedView?: boolean
 
   /** Callback to opens check runs target url (maybe GitHub, maybe third party) */
   readonly onViewCheckDetails?: (checkRun: IRefCheck) => void
@@ -169,6 +173,7 @@ export class CICheckRunList extends React.PureComponent<
           onViewCheckExternally={this.props.onViewCheckDetails}
           onViewJobStep={this.props.onViewJobStep}
           onRerunJob={this.props.onRerunJob}
+          isCondensedView={this.props.isCondensedView}
         />
       )
     })
@@ -181,14 +186,21 @@ export class CICheckRunList extends React.PureComponent<
   private renderList = (): JSX.Element | null => {
     const { checkRunGroups } = this.state
     const checkRunGroupNames = getCheckRunGroupNames(checkRunGroups)
-    if (checkRunGroupNames.length === 1 && checkRunGroupNames[0] === 'Other') {
+    if (
+      checkRunGroupNames.length === 1 &&
+      (checkRunGroupNames[0] === 'Other' || this.props.isCondensedView)
+    ) {
       return this.renderListItems(this.props.checkRuns)
     }
+
+    const groupHeaderClasses = classNames('ci-check-run-list-group-header', {
+      condensed: this.props.isCondensedView,
+    })
 
     const groups = checkRunGroupNames.map((groupName, i) => {
       return (
         <div className="ci-check-run-list-group" key={i}>
-          <div className="ci-check-run-list-group-header">{groupName}</div>
+          <div className={groupHeaderClasses}>{groupName}</div>
           {this.renderListItems(checkRunGroups.get(groupName))}
         </div>
       )

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -227,6 +227,7 @@ export class CICheckRunPopover extends React.PureComponent<
     return (
       <CICheckReRunButton
         disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
+        checkRuns={checkRuns}
         onRerunChecks={this.rerunChecks}
       />
     )

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -18,7 +18,10 @@ import { encodePathAsUrl } from '../../lib/path'
 import { PopupType } from '../../models/popup'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { Donut } from '../donut'
-import { supportsRerunningChecks } from '../../lib/endpoint-capabilities'
+import {
+  supportsRerunningChecks,
+  supportsRerunningIndividualOrFailedChecks,
+} from '../../lib/endpoint-capabilities'
 import { getPullRequestCommitRef } from '../../models/pull-request'
 import { CICheckReRunButton } from './ci-check-re-run-button'
 
@@ -228,6 +231,9 @@ export class CICheckRunPopover extends React.PureComponent<
       <CICheckReRunButton
         disabled={checkRuns.length === 0 || this.state.loadingActionWorkflows}
         checkRuns={checkRuns}
+        canReRunFailed={supportsRerunningIndividualOrFailedChecks(
+          this.props.repository.endpoint
+        )}
         onRerunChecks={this.rerunChecks}
       />
     )
@@ -371,7 +377,13 @@ export class CICheckRunPopover extends React.PureComponent<
           loadingActionWorkflows={loadingActionWorkflows}
           onViewCheckDetails={this.onViewCheckDetails}
           onViewJobStep={this.onViewJobStep}
-          onRerunJob={this.onRerunJob}
+          onRerunJob={
+            supportsRerunningIndividualOrFailedChecks(
+              this.props.repository.endpoint
+            )
+              ? this.onRerunJob
+              : undefined
+          }
         />
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -160,7 +160,7 @@ export class CICheckRunRerunDialog extends React.Component<
       ) : (
         'these workflows'
       )
-    const dependentAdj = this.props.checkRuns.length === 1 ? "it's" : 'their'
+    const dependentAdj = this.props.checkRuns.length === 1 ? "its" : 'their'
 
     return (
       <div className="re-run-dependents-message">

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -193,7 +193,7 @@ export class CICheckRunRerunDialog extends React.Component<
         <Octicon symbol={OcticonSymbol.alert} />
 
         {`${warningPrefix}. A check run cannot be re-run if the check is more than one month old,
-          the check or it's dependent has not completed, or the check is not configured to be
+          the check or its dependent has not completed, or the check is not configured to be
           re-run.`}
       </div>
     )

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../lib/api'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from './../octicons/octicons.generated'
-import { Row } from '../lib/row'
 import { encodePathAsUrl } from '../../lib/path'
 import { offsetFromNow } from '../../lib/offset-from'
 
@@ -123,7 +122,7 @@ export class CICheckRunRerunDialog extends React.Component<
         cr.checkSuiteId !== null &&
         rerequestableCheckSuiteIds.includes(cr.checkSuiteId)
     )
-    const nonRerunnable = this.props.checkRuns.filter(
+    const nonRerunnable = checkRunsToConsider.filter(
       cr =>
         cr.checkSuiteId === null ||
         !rerequestableCheckSuiteIds.includes(cr.checkSuiteId) ||
@@ -154,13 +153,31 @@ export class CICheckRunRerunDialog extends React.Component<
             loadingActionLogs={false}
             loadingActionWorkflows={false}
             notExpandable={true}
+            isCondensedView={true}
           />
         ) : null}
       </div>
     )
   }
 
-  private renderRerunInfo = () => {
+  private renderRerunDependentsMessage = () => {
+    const name =
+      this.props.checkRuns.length === 1 ? (
+        <strong>{this.props.checkRuns[0].name}</strong>
+      ) : (
+        'these workflows'
+      )
+    const dependentAdj = this.props.checkRuns.length === 1 ? "it's" : 'their'
+
+    return (
+      <div className="re-run-dependents-message">
+        A new attempt of {name} will be started, including all of {dependentAdj}{' '}
+        dependents:
+      </div>
+    )
+  }
+
+  private renderRerunWarning = () => {
     if (
       this.state.loadingCheckSuites ||
       this.state.nonRerunnable.length === 0
@@ -168,50 +185,61 @@ export class CICheckRunRerunDialog extends React.Component<
       return null
     }
 
-    /**
-     * Verbiage from dotcom:
-     * Single Job: "A new attempt of this workflow will be started, including macOS x64 and dependents"
-     * Failed Jobs: "A new attempt of this workflow will be started, including all failed jobs and dependents"
-     * */
-
     const pluralize = `check${this.state.nonRerunnable.length !== 1 ? 's' : ''}`
     const verb = this.state.nonRerunnable.length !== 1 ? 'are' : 'is'
     const warningPrefix =
       this.state.rerunnable.length === 0
-        ? `There are no checks that can be re-run`
-        : `There ${verb} ${this.state.nonRerunnable.length} ${pluralize} that cannot be re-run`
+        ? `There are no ${
+            this.props.failedOnly ? 'failed ' : ''
+          }checks that can be re-run`
+        : `There ${verb} ${this.state.nonRerunnable.length} ${
+            this.props.failedOnly ? 'failed ' : ''
+          }${pluralize} that cannot be re-run`
     return (
-      <Row className="non-re-run-info warning-helper-text">
+      <div className="non-re-run-info warning-helper-text">
         <Octicon symbol={OcticonSymbol.alert} />
 
         {`${warningPrefix}. A check run cannot be re-run if the check is more than one month old,
-          the check has not completed, or the check is not configured to be
+          the check or it's dependent has not completed, or the check is not configured to be
           re-run.`}
-      </Row>
+      </div>
     )
   }
 
+  public getTitle = (showDescriptor: boolean = true) => {
+    const { checkRuns, failedOnly } = this.props
+    const s = checkRuns.length === 1 ? '' : 's'
+    const c = __DARWIN__ ? 'C' : 'c'
+
+    let descriptor = ''
+    if (showDescriptor && checkRuns.length === 1) {
+      descriptor = __DARWIN__ ? 'Single ' : 'single '
+    }
+
+    if (showDescriptor && failedOnly) {
+      descriptor = __DARWIN__ ? 'Failed ' : 'failed '
+    }
+
+    return `Re-run ${descriptor}${c}heck${s}`
+  }
+
   public render() {
-    const failed = this.props.failedOnly
-      ? __DARWIN__
-        ? 'Failed '
-        : 'failed '
-      : ''
     return (
       <Dialog
         id="rerun-check-runs"
-        title={__DARWIN__ ? `Re-run ${failed}Checks` : `Re-run ${failed}checks`}
+        title={this.getTitle()}
         onSubmit={this.onSubmit}
         onDismissed={this.props.onDismissed}
         loading={this.state.loadingCheckSuites || this.state.loadingRerun}
       >
-        <DialogContent>{this.renderRerunnableJobsList()}</DialogContent>
+        <DialogContent>
+          {this.renderRerunDependentsMessage()}
+          {this.renderRerunnableJobsList()}
+          {this.renderRerunWarning()}
+        </DialogContent>
         <DialogFooter>
-          {this.renderRerunInfo()}
           <OkCancelButtonGroup
-            okButtonText={
-              __DARWIN__ ? `Re-run ${failed}Checks` : `Re-run ${failed}checks`
-            }
+            okButtonText={this.getTitle(false)}
             okButtonDisabled={this.state.rerunnable.length === 0}
           />
         </DialogFooter>

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -132,18 +132,6 @@ export class CICheckRunRerunDialog extends React.Component<
   }
 
   private renderRerunnableJobsList = () => {
-    if (this.state.loadingCheckSuites) {
-      return (
-        <div className="loading-rerun-checks">
-          <img src={BlankSlateImage} className="blankslate-image" />
-          <div className="title">Please wait</div>
-          <div className="call-to-action">
-            Determining which checks can be re-run.
-          </div>
-        </div>
-      )
-    }
-
     if (this.state.rerunnable.length === 0) {
       return null
     }
@@ -228,6 +216,28 @@ export class CICheckRunRerunDialog extends React.Component<
     return `Re-run ${descriptor}${c}heck${s}`
   }
 
+  private renderDialogContent = () => {
+    if (this.state.loadingCheckSuites && this.props.checkRuns.length > 1) {
+      return (
+        <div className="loading-rerun-checks">
+          <img src={BlankSlateImage} className="blankslate-image" />
+          <div className="title">Please wait</div>
+          <div className="call-to-action">
+            Determining which checks can be re-run.
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <>
+        {this.renderRerunDependentsMessage()}
+        {this.renderRerunnableJobsList()}
+        {this.renderRerunWarning()}
+      </>
+    )
+  }
+
   public render() {
     return (
       <Dialog
@@ -237,11 +247,7 @@ export class CICheckRunRerunDialog extends React.Component<
         onDismissed={this.props.onDismissed}
         loading={this.state.loadingCheckSuites || this.state.loadingRerun}
       >
-        <DialogContent>
-          {this.renderRerunDependentsMessage()}
-          {this.renderRerunnableJobsList()}
-          {this.renderRerunWarning()}
-        </DialogContent>
+        <DialogContent>{this.renderDialogContent()}</DialogContent>
         <DialogFooter>
           <OkCancelButtonGroup
             okButtonText={this.getTitle(false)}

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -160,7 +160,7 @@ export class CICheckRunRerunDialog extends React.Component<
       ) : (
         'these workflows'
       )
-    const dependentAdj = this.props.checkRuns.length === 1 ? "its" : 'their'
+    const dependentAdj = this.props.checkRuns.length === 1 ? 'its' : 'their'
 
     return (
       <div className="re-run-dependents-message">

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -125,8 +125,7 @@ export class CICheckRunRerunDialog extends React.Component<
     const nonRerunnable = checkRunsToConsider.filter(
       cr =>
         cr.checkSuiteId === null ||
-        !rerequestableCheckSuiteIds.includes(cr.checkSuiteId) ||
-        (this.props.failedOnly && cr.conclusion === APICheckConclusion.Failure)
+        !rerequestableCheckSuiteIds.includes(cr.checkSuiteId)
     )
 
     this.setState({ loadingCheckSuites: false, rerunnable, nonRerunnable })

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -145,22 +145,28 @@ export class CICheckRunRerunDialog extends React.Component<
       )
     }
 
+    if (this.state.rerunnable.length === 0) {
+      return null
+    }
+
     return (
       <div className="ci-check-run-list check-run-rerun-list">
-        {this.state.rerunnable.length > 0 ? (
-          <CICheckRunList
-            checkRuns={this.state.rerunnable}
-            loadingActionLogs={false}
-            loadingActionWorkflows={false}
-            notExpandable={true}
-            isCondensedView={true}
-          />
-        ) : null}
+        <CICheckRunList
+          checkRuns={this.state.rerunnable}
+          loadingActionLogs={false}
+          loadingActionWorkflows={false}
+          notExpandable={true}
+          isCondensedView={true}
+        />
       </div>
     )
   }
 
   private renderRerunDependentsMessage = () => {
+    if (this.state.rerunnable.length === 0) {
+      return null
+    }
+
     const name =
       this.props.checkRuns.length === 1 ? (
         <strong>{this.props.checkRuns[0].name}</strong>

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -22,6 +22,7 @@ import { LinkButton } from '../lib/link-button'
 import { encodePathAsUrl } from '../../lib/path'
 import { PopupType } from '../../models/popup'
 import { CICheckReRunButton } from '../check-runs/ci-check-re-run-button'
+import { supportsRerunningIndividualOrFailedChecks } from '../../lib/endpoint-capabilities'
 
 const PaperStackImage = encodePathAsUrl(__dirname, 'static/paper-stack.svg')
 const BlankSlateImage = encodePathAsUrl(
@@ -180,7 +181,13 @@ export class PullRequestChecksFailed extends React.Component<
         selectable={true}
         onViewCheckDetails={this.onViewOnGitHub}
         onCheckRunClick={this.onCheckRunClick}
-        onRerunJob={this.onRerunJob}
+        onRerunJob={
+          supportsRerunningIndividualOrFailedChecks(
+            this.props.repository.gitHubRepository.endpoint
+          )
+            ? this.onRerunJob
+            : undefined
+        }
       />
     )
   }
@@ -271,6 +278,9 @@ export class PullRequestChecksFailed extends React.Component<
         <CICheckReRunButton
           disabled={checks.length === 0}
           checkRuns={checks}
+          canReRunFailed={supportsRerunningIndividualOrFailedChecks(
+            this.props.repository.gitHubRepository.endpoint
+          )}
           onRerunChecks={this.rerunChecks}
         />
       </div>

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -270,6 +270,7 @@ export class PullRequestChecksFailed extends React.Component<
       <div className="ci-check-rerun">
         <CICheckReRunButton
           disabled={checks.length === 0}
+          checkRuns={checks}
           onRerunChecks={this.rerunChecks}
         />
       </div>

--- a/app/styles/ui/check-runs/_ci-check-run-list-item.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list-item.scss
@@ -4,6 +4,18 @@
   border-bottom: var(--base-border);
   height: auto;
 
+  &.condensed {
+    border-bottom: none;
+    align-items: center;
+    justify-content: center;
+
+    .ci-check-status-symbol {
+      padding: var(--spacing-third);
+      display: flex;
+      margin: 0;
+    }
+  }
+
   &.sticky {
     position: sticky;
     background-color: var(--background-color);

--- a/app/styles/ui/check-runs/_ci-check-run-list.scss
+++ b/app/styles/ui/check-runs/_ci-check-run-list.scss
@@ -1,4 +1,16 @@
 .ci-check-run-list {
+  :first-child {
+    &.ci-check-run-list-group {
+      :first-child {
+        &.ci-check-run-list-group-header {
+          &.condensed {
+            padding-top: 0;
+          }
+        }
+      }
+    }
+  }
+
   .ci-check-run-list-group-header {
     position: sticky;
     top: 0;
@@ -10,5 +22,12 @@
     white-space: nowrap;
     overflow: hidden;
     z-index: var(--list-sticky-header-top-level-z-index);
+
+    &.condensed {
+      font-weight: var(--font-weight-semibold);
+      background-color: inherit;
+      border-bottom: none;
+      padding: var(--spacing-half);
+    }
   }
 }

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -1,5 +1,5 @@
 #rerun-check-runs {
-  max-width: 550px;
+  max-width: 500px;
 
   .dialog-content {
     overflow: auto;
@@ -29,13 +29,11 @@
   }
 
   .loading-rerun-checks {
-    min-height: 300px;
     display: flex;
     flex-direction: column;
     align-items: center;
     text-align: center;
-    padding: var(--spacing);
-    padding-bottom: var(--spacing-double);
+    min-height: 100px;
 
     .blankslate-image {
       width: 100%;

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -1,20 +1,39 @@
 #rerun-check-runs {
+  max-width: 550px;
+
   .dialog-content {
     padding: 0;
     overflow: auto;
   }
 
   .check-run-rerun-list {
+    margin: var(--spacing);
+    border: var(--base-border);
+    border-radius: var(--border-radius);
     max-height: 300px;
+    padding: var(--spacing);
+    overflow: auto;
 
     .ci-check-run-list-group-header {
-      padding-left: 15px;
+      &:not(.condensed) {
+        padding-left: 15px;
+      }
     }
   }
 
+  .re-run-dependents-message {
+    padding: var(--spacing);
+    padding-bottom: 0px;
+  }
+
   .non-re-run-info {
-    max-width: 400px;
-    margin-bottom: var(--spacing-double);
+    padding: var(--spacing);
+    padding-top: 0px;
+    display: flex;
+
+    .octicon {
+      margin: 0px var(--spacing-half);
+    }
   }
 
   .loading-rerun-checks {

--- a/app/styles/ui/dialogs/_ci-check-run-rerun.scss
+++ b/app/styles/ui/dialogs/_ci-check-run-rerun.scss
@@ -2,12 +2,11 @@
   max-width: 550px;
 
   .dialog-content {
-    padding: 0;
     overflow: auto;
   }
 
   .check-run-rerun-list {
-    margin: var(--spacing);
+    margin: var(--spacing) 0px;
     border: var(--base-border);
     border-radius: var(--border-radius);
     max-height: 300px;
@@ -21,14 +20,7 @@
     }
   }
 
-  .re-run-dependents-message {
-    padding: var(--spacing);
-    padding-bottom: 0px;
-  }
-
   .non-re-run-info {
-    padding: var(--spacing);
-    padding-top: 0px;
     display: flex;
 
     .octicon {


### PR DESCRIPTION
Based on #14310

## Description
This PR updates the re-run dialog to have consistent copy to dotcom about re-running failed and single checks. Dotcom however is only dealing with action jobs and we are dealing with any kind of check; thus, our copy is not identical.

Additionally, dotcom action view uses the circle status octicons in the actions view and the non-circle in the pull request view. Since, our view more closely aligns with the pull-request view, we maintained the non-circle octicons in our lists. I chose to carry that forward to the re-run dialog (but, if someone has strong feelings that this re-run dialog's icons should match dotcoms, I am more than willing to switch). 

Also added in this PR:
- Added enterprise support flagging - right now just flagged to dotcom as we don't know what version this is to be release to enterprise yet.
- Made re-run button not be a dropdown if all checks are successful.


Things to follow up on:
- Not ~~sure if it was introduced as part of this work, but there is clearly a bug on the count of "non-rerunnable" jobs as can be seen when I look at rerunning all failed jobs it says there are 4 non-rerunnable failed jobs and it can rerun 4 failed jobs and there are only 4, not 8~~.
   - Went ahead and addressed on this PR since it was a one line change
- ~~The loader flashing when rerunning one individual job is annoying..~~ It is less annoying now..
- ~~Limited windows testing~~

### Screenshots
https://user-images.githubusercontent.com/75402236/162829574-33c3ecc8-2748-4d0e-9b43-fe4b5ff3e1ac.mov

## Release notes
Notes: [Improved] Reduced noise on the rerun dialog user interface.
