### PR TITLE
Release 2.9.13

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,7 @@
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^2.0.0",
     "dompurify": "^2.3.3",
-    "dugite": "^1.104.0",
+    "dugite": "^1.105.0",
     "electron-window-state": "^5.0.3",
     "event-kit": "^2.0.0",
     "focus-trap-react": "^8.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "2.9.13-beta2",
+  "version": "2.9.13",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -434,10 +434,10 @@ dompurify@^2.3.3:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
   integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
 
-dugite@^1.104.0:
-  version "1.104.0"
-  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.104.0.tgz#378ab4b86a875bf9173fb915d178c994ae528499"
-  integrity sha512-7fLSbie3OD3wDlCtauG082A8Ox7V0qG4065tFsBiNNP4yBWtKM28xY6u68ujpdjCPsSXCVmASNb8X4diKCqTDA==
+dugite@^1.105.0:
+  version "1.105.0"
+  resolved "https://registry.yarnpkg.com/dugite/-/dugite-1.105.0.tgz#51a645004c29d42c42435441f829ef96334dd469"
+  integrity sha512-0KNmQ5pU4+6IRYlhCKa63F6/r/qZtfNLBulEoU78s5gaWtAtgznt1yFwD7rM45+7C323L9qfJyzl9ZWLvOKiYw==
   dependencies:
     checksum "^0.1.1"
     got "^9.6.0"

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 {
   "releases": {
+    "2.9.13": [
+      "[Added] Add ability to include or exclude multiple selected files for a commit from the context menu - #7790. Thanks @tsvetilian-ty!",
+      "[Added] Add \"View Branch on GitHub\" to the branches menu - #14224. Thanks @tsvetilian-ty!",
+      "[Fixed] Fix CI check status popover not closing when clicking on PR badge - #14256",
+      "[Fixed] Fix checks list overflow handling on re-run checks dialog - #14246",
+      "[Fixed] Pull requests adhere to temporal laws again - #14238",
+      "[Fixed] Fix repository group header overflow when text is too long - #14233. Thanks @tsvetilian-ty!",
+      "[Fixed] Clone dialog \"Choose\" button uses an open dialog for directory selection on Windows - #12812",
+      "[Improved] Add a link under \"Enable notifications\" settings to the user's OS system notification settings - #14288"
+    ],
     "2.9.13-beta2": [
       "[Added] Add ability to include or exclude multiple selected files for a commit from the context menu - #7790. Thanks @tsvetilian-ty!",
       "[Added] Add \"View Branch on GitHub\" to the branches menu - #14224. Thanks @tsvetilian-ty!",


### PR DESCRIPTION
## Description

Looking for the PR for the upcoming v2.9.13 production release? Well you've just found it, congratulations! :tada:

This is based on the v2.9.13-beta2 release with the addition of the dugite upgrade in order to bump the git to 2.32.1.

## Release checklist

- [x] Check to see if there are any errors in Sentry that have only occurred since the last production release
- [x] Verify that all feature flags are flipped appropriately
no changes
![image](https://user-images.githubusercontent.com/75402236/163058276-c9646e21-b703-4044-b9cd-c078dfca96ac.png)
- [x] If there are any new metrics, ensure that central and desktop.github.com have been updated
N/A