### PR TITLE
Alert users of potentially unsafe directories

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -149,6 +149,14 @@ export async function setGlobalConfigValue(
   return setConfigValueInPath(name, value, null, env)
 }
 
+/** Set the global config value by name. */
+export async function addGlobalConfigValue(
+  name: string,
+  value: string,
+): Promise<void> {
+  await git(['config', '--global', '--add', name, value], __dirname, 'addGlobalConfigValue')
+}
+
 /**
  * Set config value by name
  *

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -152,9 +152,13 @@ export async function setGlobalConfigValue(
 /** Set the global config value by name. */
 export async function addGlobalConfigValue(
   name: string,
-  value: string,
+  value: string
 ): Promise<void> {
-  await git(['config', '--global', '--add', name, value], __dirname, 'addGlobalConfigValue')
+  await git(
+    ['config', '--global', '--add', name, value],
+    __dirname,
+    'addGlobalConfigValue'
+  )
 }
 
 /**

--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -161,6 +161,23 @@ export async function addGlobalConfigValue(
   )
 }
 
+/** Set the global config value by name. */
+export async function addGlobalConfigValueIfMissing(
+  name: string,
+  value: string
+): Promise<void> {
+  const { stdout, exitCode } = await git(
+    ['config', '--global', '-z', '--get-all', name, value],
+    __dirname,
+    'addGlobalConfigValue',
+    { successExitCodes: new Set([0, 1]) }
+  )
+
+  if (exitCode === 1 || !stdout.split('\0').includes(value)) {
+    await addGlobalConfigValue(name, value)
+  }
+}
+
 /**
  * Set config value by name
  *

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -82,6 +82,9 @@ export async function isGitRepository(path: string): Promise<boolean> {
   return (await getTopLevelWorkingDirectory(path)) !== null
 }
 
+type RepositoryType =
+  { kind: 'bare' } | { kind:'regular' } | {kind: 'missing'} | { kind: 'unsafe', path: string}
+
 /**
  * Attempts to fulfill the work of isGitRepository and isBareRepository while
  * requiring only one Git process to be spawned.
@@ -91,9 +94,9 @@ export async function isGitRepository(path: string): Promise<boolean> {
  */
 export async function getRepositoryType(
   path: string
-): Promise<'bare' | 'regular' | 'missing'> {
+): Promise<RepositoryType> {
   if (!(await directoryExists(path))) {
-    return 'missing'
+    return { kind: 'missing' }
   }
 
   try {
@@ -105,16 +108,22 @@ export async function getRepositoryType(
     )
 
     if (result.exitCode === 0) {
-      return result.stdout.trim() === 'true' ? 'bare' : 'regular'
+      return {kind: result.stdout.trim() === 'true' ? 'bare' : 'regular' }
     }
-    return 'missing'
+
+    const unsafeMatch = /fatal: unsafe repository \('(.+)\' is owned by someone else\)/.exec(result.stderr)
+    if(unsafeMatch) {
+      return { kind: 'unsafe', path: unsafeMatch[1] }
+    }
+
+    return { kind: 'missing' }
   } catch (err) {
     // This could theoretically mean that the Git executable didn't exist but
     // in reality it's almost always going to be that the process couldn't be
     // launched inside of `path` meaning it didn't exist. This would constitute
     // a race condition given that we stat the path before executing Git.
     if (err.code === 'ENOENT') {
-      return 'missing'
+      return { kind: 'missing' }
     }
     throw err
   }

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -83,7 +83,10 @@ export async function isGitRepository(path: string): Promise<boolean> {
 }
 
 type RepositoryType =
-  { kind: 'bare' } | { kind:'regular' } | {kind: 'missing'} | { kind: 'unsafe', path: string}
+  | { kind: 'bare' }
+  | { kind: 'regular' }
+  | { kind: 'missing' }
+  | { kind: 'unsafe'; path: string }
 
 /**
  * Attempts to fulfill the work of isGitRepository and isBareRepository while
@@ -92,9 +95,7 @@ type RepositoryType =
  * Returns 'bare', 'regular', or 'missing' if the repository couldn't be
  * found.
  */
-export async function getRepositoryType(
-  path: string
-): Promise<RepositoryType> {
+export async function getRepositoryType(path: string): Promise<RepositoryType> {
   if (!(await directoryExists(path))) {
     return { kind: 'missing' }
   }
@@ -108,11 +109,14 @@ export async function getRepositoryType(
     )
 
     if (result.exitCode === 0) {
-      return {kind: result.stdout.trim() === 'true' ? 'bare' : 'regular' }
+      return { kind: result.stdout.trim() === 'true' ? 'bare' : 'regular' }
     }
 
-    const unsafeMatch = /fatal: unsafe repository \('(.+)\' is owned by someone else\)/.exec(result.stderr)
-    if(unsafeMatch) {
+    const unsafeMatch =
+      /fatal: unsafe repository \('(.+)\' is owned by someone else\)/.exec(
+        result.stderr
+      )
+    if (unsafeMatch) {
       return { kind: 'unsafe', path: unsafeMatch[1] }
     }
 

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -69,7 +69,7 @@ export class AddExistingRepository extends React.Component<
       isRepository: false,
       showNonGitRepositoryWarning: false,
       isRepositoryBare: false,
-      isRepositoryUnsafe: false
+      isRepositoryUnsafe: false,
     }
   }
 
@@ -82,7 +82,7 @@ export class AddExistingRepository extends React.Component<
   }
 
   private onTrustDirectory = () => {
-    if(this.state.repositoryUnsafePath) {
+    if (this.state.repositoryUnsafePath) {
       addGlobalConfigValue('safe.directory', this.state.repositoryUnsafePath)
     }
     this.validatePath(this.state.path)
@@ -113,7 +113,13 @@ export class AddExistingRepository extends React.Component<
 
     this.setState(state =>
       path === state.path
-        ? { isRepository, isRepositoryBare, isRepositoryUnsafe, showNonGitRepositoryWarning, repositoryUnsafePath }
+        ? {
+            isRepository,
+            isRepositoryBare,
+            isRepositoryUnsafe,
+            showNonGitRepositoryWarning,
+            repositoryUnsafePath,
+          }
         : null
     )
   }
@@ -140,16 +146,19 @@ export class AddExistingRepository extends React.Component<
         <Row className="warning-helper-text">
           <Octicon symbol={OcticonSymbol.alert} />
           <div>
-          <p>
-            The Git repository at <Ref>{this.state.repositoryUnsafePath}</Ref> appears to
-            be owned by another user on your machine. Adding untrusted
-            repositories may automatically execute files in the repository.
-          </p>
-          <p>
-            If you trust the owner of the directory you can
-            <LinkButton onClick={this.onTrustDirectory}>add an exception for
-            this directory</LinkButton> in order to continue.
-          </p>
+            <p>
+              The Git repository at <Ref>{this.state.repositoryUnsafePath}</Ref>
+              appears to be owned by another user on your machine. Adding
+              untrusted repositories may automatically execute files in the
+              repository.
+            </p>
+            <p>
+              If you trust the owner of the directory you can
+              <LinkButton onClick={this.onTrustDirectory}>
+                add an exception for this directory
+              </LinkButton>{' '}
+              in order to continue.
+            </p>
           </div>
         </Row>
       )

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { Dispatcher } from '../dispatcher'
-import { addGlobalConfigValue, getRepositoryType } from '../../lib/git'
+import { addGlobalConfigValueIfMissing, getRepositoryType } from '../../lib/git'
 import { Button } from '../lib/button'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -82,10 +82,11 @@ export class AddExistingRepository extends React.Component<
   }
 
   private onTrustDirectory = () => {
-    if (this.state.repositoryUnsafePath) {
-      addGlobalConfigValue('safe.directory', this.state.repositoryUnsafePath)
+    const { repositoryUnsafePath, path } = this.state
+    if (repositoryUnsafePath) {
+      addGlobalConfigValueIfMissing('safe.directory', repositoryUnsafePath)
     }
-    this.validatePath(this.state.path)
+    this.validatePath(path)
   }
 
   private async updatePath(path: string) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Related to #14336 
Closes #14352

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
In the latest production release we upgraded Git to 2.32.1 which contained a protections against a security vulnerability when a repository was owned by a different user.

This PR introduces support in GitHub Desktop for detecting this specific condition and letting users chose to add the repository to an allow-list just like the CLI does:

```
fatal: unsafe repository ('C:/' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory C:/
```

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="858" alt="image" src="https://user-images.githubusercontent.com/634063/163181530-0ce7b220-c5fc-4ea6-ab37-62222bfcaea9.png">

<img src="https://user-images.githubusercontent.com/634063/163180849-d60846e9-6e0a-475b-95ae-bbc6e45423bc.png" width="425">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Surface Git's warning about unsafe directories and provide a way to trust repositories not owned by the current user