### PR TITLE
Add UNC path prefix before adding to safe directory list

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -161,6 +161,21 @@ export async function addGlobalConfigValue(
   )
 }
 
+/**
+ * Adds a path to the `safe.directories` configuration variable if it's not
+ * already present. Adding a path to `safe.directory` will cause Git to ignore
+ * if the path is owner by a different user than the current.
+ */
+export async function addSafeDirectory(path: string) {
+  // UNC-paths on Windows need to be prefixed with `%(prefix)/`, see
+  // https://github.com/git-for-windows/git/commit/e394a16023cbb62784e380f70ad8a833fb960d68
+  if (__WIN32__ && path[0] === '/') {
+    path = `%(prefix)/${path}`
+  }
+
+  addGlobalConfigValueIfMissing('safe.directory', path)
+}
+
 /** Set the global config value by name. */
 export async function addGlobalConfigValueIfMissing(
   name: string,

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as Path from 'path'
 import { Dispatcher } from '../dispatcher'
-import { addGlobalConfigValueIfMissing, getRepositoryType } from '../../lib/git'
+import { addSafeDirectory, getRepositoryType } from '../../lib/git'
 import { Button } from '../lib/button'
 import { TextBox } from '../lib/text-box'
 import { Row } from '../lib/row'
@@ -81,10 +81,10 @@ export class AddExistingRepository extends React.Component<
     }
   }
 
-  private onTrustDirectory = () => {
+  private onTrustDirectory = async () => {
     const { repositoryUnsafePath, path } = this.state
     if (repositoryUnsafePath) {
-      addGlobalConfigValueIfMissing('safe.directory', repositoryUnsafePath)
+      await addSafeDirectory(repositoryUnsafePath)
     }
     this.validatePath(path)
   }

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -90,7 +90,7 @@ export class MissingRepository extends React.Component<
           onClick={this.onTrustDirectory}
           type="submit"
         >
-          {__DARWIN__ ? 'Trust Repository…' : 'Trust repository…'}
+          {__DARWIN__ ? 'Trust Repository' : 'Trust repository'}
         </Button>
       )
     }

--- a/app/src/ui/missing-repository.tsx
+++ b/app/src/ui/missing-repository.tsx
@@ -7,7 +7,7 @@ import { Repository } from '../models/repository'
 import { Button } from './lib/button'
 import { Row } from './lib/row'
 import { LinkButton } from './lib/link-button'
-import { addGlobalConfigValueIfMissing, getRepositoryType } from '../lib/git'
+import { addSafeDirectory, getRepositoryType } from '../lib/git'
 import { Ref } from './lib/ref'
 
 interface IMissingRepositoryProps {
@@ -31,12 +31,12 @@ export class MissingRepository extends React.Component<
   }
 
   private onTrustDirectory = async () => {
-    if (this.state.unsafePath) {
-      await addGlobalConfigValueIfMissing(
-        'safe.directory',
-        this.state.unsafePath
-      )
-      const type = await getRepositoryType(this.props.repository.path)
+    const { unsafePath } = this.state
+    const { repository } = this.props
+
+    if (unsafePath) {
+      await addSafeDirectory(unsafePath)
+      const type = await getRepositoryType(repository.path)
 
       if (type.kind !== 'unsafe') {
         this.checkAgain()


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This matches the fix for Git CLI over at https://github.com/git-for-windows/git/pull/3791. Whenever we encounter a UNC path (i.e path starting with `//`) from Git's unsafe error warning we'll prepend `%(prefix)/` to get Git to ultimately resolve it to the same path as the repository.

So when we encounter an error message like this:

```
unsafe repository ('//wsl/something' is owned by someone else)
To add an exception for this directory, call:
    git config --global --add safe.directory %(prefix)//wsl/something
```

We'll extract `//wsl/something` from the first line and prepend it with `%(prefix)/`. The reason we're not just plucking the path from the last line (i.e. the "example") is that that path will be quoted for use in a shell whereas we'll rely on Node to do our quoting for us.

Note that this will not have any effect until we're able to upgrade to a version of Git which supports `%(prefix)` (2.34.0 or higher). We're working with the fine folks on the Git side to hopefully get our hands on a Git for Windows version we can sign and ship today.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Fixed] Support adding repositories located on network drives (such as NAS, WSL, SMB etc) to the list of safe directories in Git

cc @vdye @derrickstolee