### PR TITLE
Update create repository dialog to understand unsafe paths

### DIFF
--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -2,10 +2,6 @@ import { git } from './core'
 import { directoryExists } from '../directory-exists'
 import { resolve } from 'path'
 
-/** Is the path a git repository? */
-export const isGitRepository = (path: string) =>
-  getRepositoryType(path).then(t => t.kind === 'regular')
-
 export type RepositoryType =
   | { kind: 'bare' }
   | { kind: 'regular'; topLevelWorkingDirectory: string }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -139,7 +139,6 @@ import {
   appendIgnoreRule,
   createMergeCommit,
   getBranchesPointedAt,
-  isGitRepository,
   abortRebase,
   continueRebase,
   rebase,
@@ -2971,7 +2970,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     const foundRepository =
       (await pathExists(repository.path)) &&
-      (await isGitRepository(repository.path)) &&
+      (await getRepositoryType(repository.path)).kind === 'regular' &&
       (await this._loadStatus(repository)) !== null
 
     if (foundRepository) {

--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -541,15 +541,15 @@ export class CreateRepository extends React.Component<
   }
 
   private onAddRepositoryClicked = () => {
-    if (this.state.path === null) {
-      // Shouldn't be able to even get here if path is null.
-      return
-    }
+    const { path, name } = this.state
 
-    return this.props.dispatcher.showPopup({
-      type: PopupType.AddRepository,
-      path: this.state.path,
-    })
+    // Shouldn't be able to even get here if path is null.
+    if (path !== null) {
+      this.props.dispatcher.showPopup({
+        type: PopupType.AddRepository,
+        path: Path.join(path, sanitizedRepositoryName(name)),
+      })
+    }
   }
 
   public render() {

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -3,10 +3,7 @@ import * as FSE from 'fs-extra'
 import * as os from 'os'
 
 import { Repository } from '../../../src/models/repository'
-import {
-  isGitRepository,
-  getRepositoryType,
-} from '../../../src/lib/git/rev-parse'
+import { getRepositoryType } from '../../../src/lib/git/rev-parse'
 import { git } from '../../../src/lib/git/core'
 import {
   setupFixtureRepository,
@@ -21,18 +18,6 @@ describe('git/rev-parse', () => {
   beforeEach(async () => {
     const testRepoPath = await setupFixtureRepository('test-repo')
     repository = new Repository(testRepoPath, -1, null, false)
-  })
-
-  describe('isGitRepository', () => {
-    it('should return true for a repository', async () => {
-      const result = await isGitRepository(repository.path)
-      expect(result).toBe(true)
-    })
-
-    it('should return false for a directory', async () => {
-      const result = await isGitRepository(path.dirname(repository.path))
-      expect(result).toBe(false)
-    })
   })
 
   describe('getRepositoryType', () => {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This is hopefully the last piece to the unsafe path handling fixes started in (#14344, #14368, and #14374).

This deals with the Create Repository dialog and makes it aware of the fact that directories can now be considered unsafe. It also fixes a bug where we would only consider the path, not the path + name when checking for a repository. That fix also applies to the "Add existing repository" shortcut which previously would only send along the base path, not the full path.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

![image](https://user-images.githubusercontent.com/634063/163452001-a9fe7ee3-8693-44df-9c71-dbb9ecf3f7d6.png)

![image](https://user-images.githubusercontent.com/634063/163452015-457dbfa4-4aea-4992-9d7e-3024741ae38d.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
