### PR TITLE
Await the results of adGlobalConfigValueIfMissing

### DIFF
--- a/app/src/lib/git/config.ts
+++ b/app/src/lib/git/config.ts
@@ -173,7 +173,7 @@ export async function addSafeDirectory(path: string) {
     path = `%(prefix)/${path}`
   }
 
-  addGlobalConfigValueIfMissing('safe.directory', path)
+  await addGlobalConfigValueIfMissing('safe.directory', path)
 }
 
 /** Set the global config value by name. */


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Noticed this while testing, when clicking the "trust repository" button it wouldn't always react to the config change because we were executing the "git rev-parse" command before writing to the config.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
