### PR TITLE
Fix reference to GitLab in Bitbucket doc

### DIFF
--- a/docs/integrations/bitbucket.md
+++ b/docs/integrations/bitbucket.md
@@ -14,7 +14,7 @@ To authenticate against Bitbucket repositories you will need to create a persona
 
 4. Under the **Details** section in **Add app password** enter a label for your password
 
-5. Under **Permissions** select `read` and `write` in the **Repositories** section to ensure that GitHub Desktop has the correct read/write access to your GitLab repositories.
+5. Under **Permissions** select `Read` and `Write` in the **Repositories** section to ensure that GitHub Desktop has the correct read/write access to your Bitbucket repositories.
 
 6. Click **Create** to create a new token, and then copy the token to your clipboard.
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14391

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Fixes a reference to GitLab (should be Bitbucket) in https://github.com/desktop/desktop/blob/development/docs/integrations/bitbucket.md

Before:

> Under **Permissions** select `read` and `write` in the **Repositories** section to ensure that GitHub Desktop has the correct read/write access to your GitLab repositories.

After:

> Under **Permissions** select `Read` and `Write` in the **Repositories** section to ensure that GitHub Desktop has the correct read/write access to your Bitbucket repositories.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
