### PR TITLE
Fix incorrect menu item in Bitbucket doc

### DIFF
--- a/docs/integrations/bitbucket.md
+++ b/docs/integrations/bitbucket.md
@@ -4,7 +4,7 @@
 
 To authenticate against Bitbucket repositories you will need to create a personal access token.
 
-1. Go to your Bitbucket account and select **Bitbucket settings** in the user profile dropdown.
+1. Go to your Bitbucket account and select **Personal settings** in the user profile dropdown.
 
 2. Select **App passwords**
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14393

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Fixes an incorrect menu item referenced in https://github.com/desktop/desktop/blob/development/docs/integrations/bitbucket.md

Before:

> select **Bitbucket settings** in the user profile dropdown

After:

> select **Personal settings** in the user profile dropdown


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
