### PR TITLE
Allow disabling commit summary length hint

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -195,6 +195,9 @@ export interface IAppState {
   /** Should the app prompt the user to confirm a force push? */
   readonly askForConfirmationOnForcePush: boolean
 
+  /** Should the app show a hint when the commit summary is over 50 characters? */
+  readonly showSummaryLengthHint: boolean
+
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
 

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -196,7 +196,7 @@ export interface IAppState {
   readonly askForConfirmationOnForcePush: boolean
 
   /** Should the app show a hint when the commit summary is over 50 characters? */
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
 
   /** How the app should handle uncommitted changes when switching branches */
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -321,14 +321,14 @@ const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
-const showSummaryLengthHintDefault = true
+const showCommitSummaryLengthHintDefault = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmDiscardChangesPermanentlyKey: string =
   'confirmDiscardChangesPermanentlyKey'
 const confirmForcePushKey: string = 'confirmForcePush'
-const showSummaryLengthHintKey: string = 'showSummaryLengthHint'
+const showCommitSummaryLengthHintKey: string = 'showCommitSummaryLengthHint'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -432,7 +432,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmDiscardChangesPermanently: boolean =
     confirmDiscardChangesPermanentlyDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
-  private showSummaryLengthHint: boolean = showSummaryLengthHintDefault
+  private showCommitSummaryLengthHint: boolean =
+    showCommitSummaryLengthHintDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -884,7 +885,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnDiscardChangesPermanently:
         this.confirmDiscardChangesPermanently,
       askForConfirmationOnForcePush: this.askForConfirmationOnForcePush,
-      showSummaryLengthHint: this.showSummaryLengthHint,
+      showCommitSummaryLengthHint: this.showCommitSummaryLengthHint,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -1844,9 +1845,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnForcePushDefault
     )
 
-    this.showSummaryLengthHint = getBoolean(
-      showSummaryLengthHintKey,
-      showSummaryLengthHintDefault
+    this.showCommitSummaryLengthHint = getBoolean(
+      showCommitSummaryLengthHintKey,
+      showCommitSummaryLengthHintDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -5075,9 +5076,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
-  public _setShowSummaryLengthHintSetting(value: boolean): Promise<void> {
-    this.showSummaryLengthHint = value
-    setBoolean(showSummaryLengthHintKey, value)
+  public _setShowCommitSummaryLengthHintSetting(value: boolean): Promise<void> {
+    this.showCommitSummaryLengthHint = value
+    setBoolean(showCommitSummaryLengthHintKey, value)
 
     this.emitUpdate()
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -321,12 +321,14 @@ const confirmRepoRemovalDefault: boolean = true
 const confirmDiscardChangesDefault: boolean = true
 const confirmDiscardChangesPermanentlyDefault: boolean = true
 const askForConfirmationOnForcePushDefault = true
+const showSummaryLengthHintDefault = true
 const askToMoveToApplicationsFolderKey: string = 'askToMoveToApplicationsFolder'
 const confirmRepoRemovalKey: string = 'confirmRepoRemoval'
 const confirmDiscardChangesKey: string = 'confirmDiscardChanges'
 const confirmDiscardChangesPermanentlyKey: string =
   'confirmDiscardChangesPermanentlyKey'
 const confirmForcePushKey: string = 'confirmForcePush'
+const showSummaryLengthHintKey: string = 'showSummaryLengthHint'
 
 const uncommittedChangesStrategyKey = 'uncommittedChangesStrategyKind'
 
@@ -430,6 +432,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private confirmDiscardChangesPermanently: boolean =
     confirmDiscardChangesPermanentlyDefault
   private askForConfirmationOnForcePush = askForConfirmationOnForcePushDefault
+  private showSummaryLengthHint: boolean = showSummaryLengthHintDefault
   private imageDiffType: ImageDiffType = imageDiffTypeDefault
   private hideWhitespaceInChangesDiff: boolean =
     hideWhitespaceInChangesDiffDefault
@@ -881,6 +884,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       askForConfirmationOnDiscardChangesPermanently:
         this.confirmDiscardChangesPermanently,
       askForConfirmationOnForcePush: this.askForConfirmationOnForcePush,
+      showSummaryLengthHint: this.showSummaryLengthHint,
       uncommittedChangesStrategy: this.uncommittedChangesStrategy,
       selectedExternalEditor: this.selectedExternalEditor,
       imageDiffType: this.imageDiffType,
@@ -1838,6 +1842,11 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.askForConfirmationOnForcePush = getBoolean(
       confirmForcePushKey,
       askForConfirmationOnForcePushDefault
+    )
+
+    this.showSummaryLengthHint = getBoolean(
+      showSummaryLengthHintKey,
+      showSummaryLengthHintDefault
     )
 
     this.uncommittedChangesStrategy =
@@ -5060,6 +5069,15 @@ export class AppStore extends TypedBaseStore<IAppState> {
     setBoolean(confirmForcePushKey, value)
 
     this.updateMenuLabelsForSelectedRepository()
+
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _setShowSummaryLengthHintSetting(value: boolean): Promise<void> {
+    this.showSummaryLengthHint = value
+    setBoolean(showSummaryLengthHintKey, value)
 
     this.emitUpdate()
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1515,7 +1515,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               this.state.askForConfirmationOnDiscardChangesPermanently
             }
             confirmForcePush={this.state.askForConfirmationOnForcePush}
-            showSummaryLengthHint={this.state.showSummaryLengthHint}
+            showCommitSummaryLengthHint={this.state.showCommitSummaryLengthHint}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
@@ -2064,7 +2064,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             }
             showCoAuthoredBy={popup.showCoAuthoredBy}
             showNoWriteAccess={!hasWritePermissionForRepository}
-            showSummaryLengthHint={this.state.showSummaryLengthHint}
+            showCommitSummaryLengthHint={this.state.showCommitSummaryLengthHint}
             onDismissed={onPopupDismissedFn}
             onSubmitCommitMessage={popup.onSubmitCommitMessage}
             repositoryAccount={repositoryAccount}
@@ -2865,7 +2865,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           askForConfirmationOnDiscardChanges={
             state.askForConfirmationOnDiscardChanges
           }
-          showSummaryLengthHint={state.showSummaryLengthHint}
+          showCommitSummaryLengthHint={state.showCommitSummaryLengthHint}
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}
           resolvedExternalEditor={state.resolvedExternalEditor}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1515,6 +1515,7 @@ export class App extends React.Component<IAppProps, IAppState> {
               this.state.askForConfirmationOnDiscardChangesPermanently
             }
             confirmForcePush={this.state.askForConfirmationOnForcePush}
+            showSummaryLengthHint={this.state.showSummaryLengthHint}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
@@ -2063,6 +2064,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             }
             showCoAuthoredBy={popup.showCoAuthoredBy}
             showNoWriteAccess={!hasWritePermissionForRepository}
+            showSummaryLengthHint={this.state.showSummaryLengthHint}
             onDismissed={onPopupDismissedFn}
             onSubmitCommitMessage={popup.onSubmitCommitMessage}
             repositoryAccount={repositoryAccount}
@@ -2863,6 +2865,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           askForConfirmationOnDiscardChanges={
             state.askForConfirmationOnDiscardChanges
           }
+          showSummaryLengthHint={state.showSummaryLengthHint}
           accounts={state.accounts}
           externalEditorLabel={externalEditorLabel}
           resolvedExternalEditor={state.resolvedExternalEditor}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -127,6 +127,7 @@ interface IChangesListProps {
   readonly onCreateCommit: (context: ICommitContext) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly showSummaryLengthHint: boolean
   readonly focusCommitMessage: boolean
   readonly onDiscardChangesFromFiles: (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
@@ -740,6 +741,7 @@ export class ChangesList extends React.Component<
         key={repository.id}
         showBranchProtected={fileCount > 0 && currentBranchProtected}
         showNoWriteAccess={fileCount > 0 && !hasWritePermissionForRepository}
+        showSummaryLengthHint={this.props.showSummaryLengthHint}
         shouldNudge={this.props.shouldNudgeToCommit}
         commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
         onCoAuthorsUpdated={this.onCoAuthorsUpdated}

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -127,7 +127,7 @@ interface IChangesListProps {
   readonly onCreateCommit: (context: ICommitContext) => Promise<boolean>
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
   readonly focusCommitMessage: boolean
   readonly onDiscardChangesFromFiles: (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
@@ -741,7 +741,7 @@ export class ChangesList extends React.Component<
         key={repository.id}
         showBranchProtected={fileCount > 0 && currentBranchProtected}
         showNoWriteAccess={fileCount > 0 && !hasWritePermissionForRepository}
-        showSummaryLengthHint={this.props.showSummaryLengthHint}
+        showCommitSummaryLengthHint={this.props.showCommitSummaryLengthHint}
         shouldNudge={this.props.shouldNudgeToCommit}
         commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
         onCoAuthorsUpdated={this.onCoAuthorsUpdated}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -71,6 +71,7 @@ interface ICommitMessageProps {
   readonly prepopulateCommitSummary: boolean
   readonly showBranchProtected: boolean
   readonly showNoWriteAccess: boolean
+  readonly showSummaryLengthHint: boolean
 
   /**
    * Whether or not to show a field for adding co-authors to
@@ -741,7 +742,9 @@ export class CommitMessage extends React.Component<
       'with-overflow': this.state.descriptionObscured,
     })
 
-    const showSummaryLengthHint = this.state.summary.length > IdealSummaryLength
+    const showSummaryLengthHint =
+      this.props.showSummaryLengthHint &&
+      this.state.summary.length > IdealSummaryLength
     const summaryClassName = classNames('summary', {
       'with-length-hint': showSummaryLengthHint,
     })

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -71,7 +71,7 @@ interface ICommitMessageProps {
   readonly prepopulateCommitSummary: boolean
   readonly showBranchProtected: boolean
   readonly showNoWriteAccess: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
 
   /**
    * Whether or not to show a field for adding co-authors to
@@ -743,7 +743,7 @@ export class CommitMessage extends React.Component<
     })
 
     const showSummaryLengthHint =
-      this.props.showSummaryLengthHint &&
+      this.props.showCommitSummaryLengthHint &&
       this.state.summary.length > IdealSummaryLength
     const summaryClassName = classNames('summary', {
       'with-length-hint': showSummaryLengthHint,

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -54,7 +54,7 @@ interface IChangesSidebarProps {
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
   readonly accounts: ReadonlyArray<Account>
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
@@ -388,7 +388,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
           }
-          showSummaryLengthHint={this.props.showSummaryLengthHint}
+          showCommitSummaryLengthHint={this.props.showCommitSummaryLengthHint}
           onDiscardChangesFromFiles={this.onDiscardChangesFromFiles}
           onOpenItem={this.onOpenItem}
           onRowClick={this.onChangedItemClick}

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -54,6 +54,7 @@ interface IChangesSidebarProps {
   readonly gitHubUserStore: GitHubUserStore
   readonly focusCommitMessage: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly showSummaryLengthHint: boolean
   readonly accounts: ReadonlyArray<Account>
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
@@ -387,6 +388,7 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           askForConfirmationOnDiscardChanges={
             this.props.askForConfirmationOnDiscardChanges
           }
+          showSummaryLengthHint={this.props.showSummaryLengthHint}
           onDiscardChangesFromFiles={this.onDiscardChangesFromFiles}
           onOpenItem={this.onOpenItem}
           onRowClick={this.onChangedItemClick}

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -79,6 +79,9 @@ interface ICommitMessageDialogProps {
   /** Whether to warn the user that they don't have write access */
   readonly showNoWriteAccess: boolean
 
+  /** Whether to show a hint if the commit summary is over 50 characters */
+  readonly showSummaryLengthHint: boolean
+
   /** Method to run when dialog is dismissed */
   readonly onDismissed: () => void
 
@@ -126,6 +129,7 @@ export class CommitMessageDialog extends React.Component<
             key={this.props.repository.id}
             showBranchProtected={this.props.showBranchProtected}
             showNoWriteAccess={this.props.showNoWriteAccess}
+            showSummaryLengthHint={this.props.showSummaryLengthHint}
             commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
             onCoAuthorsUpdated={this.onCoAuthorsUpdated}
             onShowCoAuthoredByChanged={this.onShowCoAuthorsChanged}

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -80,7 +80,7 @@ interface ICommitMessageDialogProps {
   readonly showNoWriteAccess: boolean
 
   /** Whether to show a hint if the commit summary is over 50 characters */
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
 
   /** Method to run when dialog is dismissed */
   readonly onDismissed: () => void
@@ -129,7 +129,7 @@ export class CommitMessageDialog extends React.Component<
             key={this.props.repository.id}
             showBranchProtected={this.props.showBranchProtected}
             showNoWriteAccess={this.props.showNoWriteAccess}
-            showSummaryLengthHint={this.props.showSummaryLengthHint}
+            showCommitSummaryLengthHint={this.props.showCommitSummaryLengthHint}
             commitSpellcheckEnabled={this.props.commitSpellcheckEnabled}
             onCoAuthorsUpdated={this.onCoAuthorsUpdated}
             onShowCoAuthoredByChanged={this.onShowCoAuthorsChanged}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1872,6 +1872,13 @@ export class Dispatcher {
   }
 
   /**
+   * Sets the user's preference so that a hint for a commit summary over 50 characters is not shown
+   */
+  public setShowSummaryLengthHint(value: boolean) {
+    return this.appStore._setShowSummaryLengthHintSetting(value)
+  }
+
+  /**
    * Sets the user's preference for handling uncommitted changes when switching branches
    */
   public setUncommittedChangesStrategySetting(

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1874,8 +1874,8 @@ export class Dispatcher {
   /**
    * Sets the user's preference so that a hint for a commit summary over 50 characters is not shown
    */
-  public setShowSummaryLengthHint(value: boolean) {
-    return this.appStore._setShowSummaryLengthHintSetting(value)
+  public setShowCommitSummaryLengthHint(value: boolean) {
+    return this.appStore._setShowCommitSummaryLengthHintSetting(value)
   }
 
   /**

--- a/app/src/ui/preferences/advanced.tsx
+++ b/app/src/ui/preferences/advanced.tsx
@@ -98,7 +98,7 @@ export class Advanced extends React.Component<
   public render() {
     return (
       <DialogContent>
-        <div className="advanced-section">
+        <div className="preferences-tab-section">
           <h2>If I have changes and I switch branches...</h2>
 
           <RadioButton
@@ -131,7 +131,7 @@ export class Advanced extends React.Component<
             onSelected={this.onUncommittedChangesStrategyChanged}
           />
         </div>
-        <div className="advanced-section">
+        <div className="preferences-tab-section">
           <h2>Background updates</h2>
           <Checkbox
             label="Periodically fetch and refresh status of all repositories"
@@ -149,7 +149,7 @@ export class Advanced extends React.Component<
         </div>
         {this.renderSSHSettings()}
         {this.renderNotificationsSettings()}
-        <div className="advanced-section">
+        <div className="preferences-tab-section">
           <h2>Usage</h2>
           <Checkbox
             label={this.reportDesktopUsageLabel()}
@@ -171,7 +171,7 @@ export class Advanced extends React.Component<
     }
 
     return (
-      <div className="advanced-section">
+      <div className="preferences-tab-section">
         <h2>SSH</h2>
         <Checkbox
           label="Use system OpenSSH (recommended)"
@@ -190,7 +190,7 @@ export class Advanced extends React.Component<
     }
 
     return (
-      <div className="advanced-section">
+      <div className="preferences-tab-section">
         <h2>Notifications</h2>
         <Checkbox
           label="Enable notifications"

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -55,7 +55,7 @@ interface IPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
@@ -80,7 +80,7 @@ interface IPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly availableEditors: ReadonlyArray<string>
   readonly selectedExternalEditor: string | null
@@ -122,7 +122,7 @@ export class Preferences extends React.Component<
       confirmDiscardChanges: false,
       confirmDiscardChangesPermanently: false,
       confirmForcePush: false,
-      showSummaryLengthHint: false,
+      showCommitSummaryLengthHint: false,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -179,7 +179,7 @@ export class Preferences extends React.Component<
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
       confirmForcePush: this.props.confirmForcePush,
-      showSummaryLengthHint: this.props.showSummaryLengthHint,
+      showCommitSummaryLengthHint: this.props.showCommitSummaryLengthHint,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
@@ -334,7 +334,7 @@ export class Preferences extends React.Component<
               this.state.confirmDiscardChangesPermanently
             }
             confirmForcePush={this.state.confirmForcePush}
-            showSummaryLengthHint={this.state.showSummaryLengthHint}
+            showCommitSummaryLengthHint={this.state.showCommitSummaryLengthHint}
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -343,7 +343,9 @@ export class Preferences extends React.Component<
             onConfirmDiscardChangesPermanentlyChanged={
               this.onConfirmDiscardChangesPermanentlyChanged
             }
-            onShowSummaryLengthHintChanged={this.onShowSummaryLengthHintChanged}
+            onShowCommitSummaryLengthHintChanged={
+              this.onShowCommitSummaryLengthHintChanged
+            }
           />
         )
         break
@@ -418,8 +420,8 @@ export class Preferences extends React.Component<
     this.setState({ confirmForcePush: value })
   }
 
-  private onShowSummaryLengthHintChanged = (value: boolean) => {
-    this.setState({ showSummaryLengthHint: value })
+  private onShowCommitSummaryLengthHintChanged = (value: boolean) => {
+    this.setState({ showCommitSummaryLengthHint: value })
   }
 
   private onUncommittedChangesStrategyChanged = (
@@ -562,8 +564,8 @@ export class Preferences extends React.Component<
       this.state.confirmForcePush
     )
 
-    await this.props.dispatcher.setShowSummaryLengthHint(
-      this.state.showSummaryLengthHint
+    await this.props.dispatcher.setShowCommitSummaryLengthHint(
+      this.state.showCommitSummaryLengthHint
     )
 
     if (this.state.selectedExternalEditor) {

--- a/app/src/ui/preferences/preferences.tsx
+++ b/app/src/ui/preferences/preferences.tsx
@@ -55,6 +55,7 @@ interface IPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly showSummaryLengthHint: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly selectedExternalEditor: string | null
   readonly selectedShell: Shell
@@ -79,6 +80,7 @@ interface IPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly showSummaryLengthHint: boolean
   readonly uncommittedChangesStrategy: UncommittedChangesStrategy
   readonly availableEditors: ReadonlyArray<string>
   readonly selectedExternalEditor: string | null
@@ -120,6 +122,7 @@ export class Preferences extends React.Component<
       confirmDiscardChanges: false,
       confirmDiscardChangesPermanently: false,
       confirmForcePush: false,
+      showSummaryLengthHint: false,
       uncommittedChangesStrategy: defaultUncommittedChangesStrategy,
       selectedExternalEditor: this.props.selectedExternalEditor,
       availableShells: [],
@@ -176,6 +179,7 @@ export class Preferences extends React.Component<
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
       confirmForcePush: this.props.confirmForcePush,
+      showSummaryLengthHint: this.props.showSummaryLengthHint,
       uncommittedChangesStrategy: this.props.uncommittedChangesStrategy,
       availableShells,
       availableEditors,
@@ -330,6 +334,7 @@ export class Preferences extends React.Component<
               this.state.confirmDiscardChangesPermanently
             }
             confirmForcePush={this.state.confirmForcePush}
+            showSummaryLengthHint={this.state.showSummaryLengthHint}
             onConfirmRepositoryRemovalChanged={
               this.onConfirmRepositoryRemovalChanged
             }
@@ -338,6 +343,7 @@ export class Preferences extends React.Component<
             onConfirmDiscardChangesPermanentlyChanged={
               this.onConfirmDiscardChangesPermanentlyChanged
             }
+            onShowSummaryLengthHintChanged={this.onShowSummaryLengthHintChanged}
           />
         )
         break
@@ -410,6 +416,10 @@ export class Preferences extends React.Component<
 
   private onConfirmForcePushChanged = (value: boolean) => {
     this.setState({ confirmForcePush: value })
+  }
+
+  private onShowSummaryLengthHintChanged = (value: boolean) => {
+    this.setState({ showSummaryLengthHint: value })
   }
 
   private onUncommittedChangesStrategyChanged = (
@@ -550,6 +560,10 @@ export class Preferences extends React.Component<
 
     await this.props.dispatcher.setConfirmForcePushSetting(
       this.state.confirmForcePush
+    )
+
+    await this.props.dispatcher.setShowSummaryLengthHint(
+      this.state.showSummaryLengthHint
     )
 
     if (this.state.selectedExternalEditor) {

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -7,10 +7,12 @@ interface IPromptsPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly showSummaryLengthHint: boolean
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesPermanentlyChanged: (checked: boolean) => void
   readonly onConfirmRepositoryRemovalChanged: (checked: boolean) => void
   readonly onConfirmForcePushChanged: (checked: boolean) => void
+  readonly onShowSummaryLengthHintChanged: (checked: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -18,6 +20,7 @@ interface IPromptsPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
+  readonly showSummaryLengthHint: boolean
 }
 
 export class Prompts extends React.Component<
@@ -33,6 +36,7 @@ export class Prompts extends React.Component<
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
       confirmForcePush: this.props.confirmForcePush,
+      showSummaryLengthHint: this.props.showSummaryLengthHint,
     }
   }
 
@@ -72,44 +76,67 @@ export class Prompts extends React.Component<
     this.props.onConfirmRepositoryRemovalChanged(value)
   }
 
+  private onShowSummaryLengthHintChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const value = event.currentTarget.checked
+
+    this.setState({ showSummaryLengthHint: value })
+    this.props.onShowSummaryLengthHintChanged(value)
+  }
+
   public render() {
     return (
       <DialogContent>
-        <h2>Show a confirmation dialog before...</h2>
-        <Checkbox
-          label="Removing repositories"
-          value={
-            this.state.confirmRepositoryRemoval
-              ? CheckboxValue.On
-              : CheckboxValue.Off
-          }
-          onChange={this.onConfirmRepositoryRemovalChanged}
-        />
-        <Checkbox
-          label="Discarding changes"
-          value={
-            this.state.confirmDiscardChanges
-              ? CheckboxValue.On
-              : CheckboxValue.Off
-          }
-          onChange={this.onConfirmDiscardChangesChanged}
-        />
-        <Checkbox
-          label="Discarding changes permanently"
-          value={
-            this.state.confirmDiscardChangesPermanently
-              ? CheckboxValue.On
-              : CheckboxValue.Off
-          }
-          onChange={this.onConfirmDiscardChangesPermanentlyChanged}
-        />
-        <Checkbox
-          label="Force pushing"
-          value={
-            this.state.confirmForcePush ? CheckboxValue.On : CheckboxValue.Off
-          }
-          onChange={this.onConfirmForcePushChanged}
-        />
+        <div className="preferences-tab-section">
+          <h2>Show a confirmation dialog before...</h2>
+          <Checkbox
+            label="Removing repositories"
+            value={
+              this.state.confirmRepositoryRemoval
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onConfirmRepositoryRemovalChanged}
+          />
+          <Checkbox
+            label="Discarding changes"
+            value={
+              this.state.confirmDiscardChanges
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onConfirmDiscardChangesChanged}
+          />
+          <Checkbox
+            label="Discarding changes permanently"
+            value={
+              this.state.confirmDiscardChangesPermanently
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onConfirmDiscardChangesPermanentlyChanged}
+          />
+          <Checkbox
+            label="Force pushing"
+            value={
+              this.state.confirmForcePush ? CheckboxValue.On : CheckboxValue.Off
+            }
+            onChange={this.onConfirmForcePushChanged}
+          />
+        </div>
+        <div className="preferences-tab-section">
+          <h2>Show a hint for...</h2>
+          <Checkbox
+            label="Lengthy commit summaries"
+            value={
+              this.state.showSummaryLengthHint
+                ? CheckboxValue.On
+                : CheckboxValue.Off
+            }
+            onChange={this.onShowSummaryLengthHintChanged}
+          />
+        </div>
       </DialogContent>
     )
   }

--- a/app/src/ui/preferences/prompts.tsx
+++ b/app/src/ui/preferences/prompts.tsx
@@ -7,12 +7,12 @@ interface IPromptsPreferencesProps {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
   readonly onConfirmDiscardChangesChanged: (checked: boolean) => void
   readonly onConfirmDiscardChangesPermanentlyChanged: (checked: boolean) => void
   readonly onConfirmRepositoryRemovalChanged: (checked: boolean) => void
   readonly onConfirmForcePushChanged: (checked: boolean) => void
-  readonly onShowSummaryLengthHintChanged: (checked: boolean) => void
+  readonly onShowCommitSummaryLengthHintChanged: (checked: boolean) => void
 }
 
 interface IPromptsPreferencesState {
@@ -20,7 +20,7 @@ interface IPromptsPreferencesState {
   readonly confirmDiscardChanges: boolean
   readonly confirmDiscardChangesPermanently: boolean
   readonly confirmForcePush: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
 }
 
 export class Prompts extends React.Component<
@@ -36,7 +36,7 @@ export class Prompts extends React.Component<
       confirmDiscardChangesPermanently:
         this.props.confirmDiscardChangesPermanently,
       confirmForcePush: this.props.confirmForcePush,
-      showSummaryLengthHint: this.props.showSummaryLengthHint,
+      showCommitSummaryLengthHint: this.props.showCommitSummaryLengthHint,
     }
   }
 
@@ -76,13 +76,13 @@ export class Prompts extends React.Component<
     this.props.onConfirmRepositoryRemovalChanged(value)
   }
 
-  private onShowSummaryLengthHintChanged = (
+  private onShowCommitSummaryLengthHintChanged = (
     event: React.FormEvent<HTMLInputElement>
   ) => {
     const value = event.currentTarget.checked
 
-    this.setState({ showSummaryLengthHint: value })
-    this.props.onShowSummaryLengthHintChanged(value)
+    this.setState({ showCommitSummaryLengthHint: value })
+    this.props.onShowCommitSummaryLengthHintChanged(value)
   }
 
   public render() {
@@ -130,11 +130,11 @@ export class Prompts extends React.Component<
           <Checkbox
             label="Lengthy commit summaries"
             value={
-              this.state.showSummaryLengthHint
+              this.state.showCommitSummaryLengthHint
                 ? CheckboxValue.On
                 : CheckboxValue.Off
             }
-            onChange={this.onShowSummaryLengthHintChanged}
+            onChange={this.onShowCommitSummaryLengthHintChanged}
           />
         </div>
       </DialogContent>

--- a/app/src/ui/repository-settings/git-config.tsx
+++ b/app/src/ui/repository-settings/git-config.tsx
@@ -40,7 +40,7 @@ export class GitConfig extends React.Component<IGitConfigProps> {
 
     return (
       <DialogContent>
-        <div className="advanced-section">
+        <div className="preferences-tab-section">
           <h2>For this repository I wish to</h2>
           <Row>
             <div>

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -54,7 +54,7 @@ interface IRepositoryViewProps {
   readonly hideWhitespaceInHistoryDiff: boolean
   readonly showSideBySideDiff: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
-  readonly showSummaryLengthHint: boolean
+  readonly showCommitSummaryLengthHint: boolean
   readonly focusCommitMessage: boolean
   readonly commitSpellcheckEnabled: boolean
   readonly accounts: ReadonlyArray<Account>
@@ -240,7 +240,7 @@ export class RepositoryView extends React.Component<
         askForConfirmationOnDiscardChanges={
           this.props.askForConfirmationOnDiscardChanges
         }
-        showSummaryLengthHint={this.props.showSummaryLengthHint}
+        showCommitSummaryLengthHint={this.props.showCommitSummaryLengthHint}
         accounts={this.props.accounts}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -54,6 +54,7 @@ interface IRepositoryViewProps {
   readonly hideWhitespaceInHistoryDiff: boolean
   readonly showSideBySideDiff: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
+  readonly showSummaryLengthHint: boolean
   readonly focusCommitMessage: boolean
   readonly commitSpellcheckEnabled: boolean
   readonly accounts: ReadonlyArray<Account>
@@ -239,6 +240,7 @@ export class RepositoryView extends React.Component<
         askForConfirmationOnDiscardChanges={
           this.props.askForConfirmationOnDiscardChanges
         }
+        showSummaryLengthHint={this.props.showSummaryLengthHint}
         accounts={this.props.accounts}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}

--- a/app/styles/ui/_preferences.scss
+++ b/app/styles/ui/_preferences.scss
@@ -6,7 +6,7 @@
       flex: 1;
     }
 
-    .advanced-section {
+    .preferences-tab-section {
       &:not(:last-child) {
         margin-bottom: var(--spacing);
       }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Partially addresses #14255

## Description

- Adds a new section to the `Prompts` preferences tab to allow disabling the commit summary length hint that appears when a commit summary is over 50 characters

#14255 also mentioned customising this option per-repository, and setting a custom character limit for the hint. I'm unsure of the value of a custom number since the hint is pretty explicit about the 50 character limit. In terms of the per-repo configuration, is this useful and has it been done before in the codebase? That seems more difficult and I may need some assistance to start that change.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

Here is a photo of the hint in question:

<img width="395" alt="Screenshot of the hint" src="https://user-images.githubusercontent.com/40507205/163924483-93027720-f178-47f4-86bf-3077d4893b75.png">

Here is the updated `Prompts` tab which allows disabling the hint:

<img width="606" alt="image" src="https://user-images.githubusercontent.com/40507205/163924568-40a286b2-a114-456a-aacc-b3fd16d1d05b.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [IMPROVED] Add an option to disable the commit summary length hint
