### PR TITLE
Show progress indicator when adding directory to `safe.directory`

### DIFF
--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -146,13 +146,26 @@ export class AddExistingRepository extends React.Component<
       )
     }
 
-    if (this.state.isRepositoryUnsafe) {
+    const { isRepositoryUnsafe, repositoryUnsafePath, path } = this.state
+
+    if (isRepositoryUnsafe && repositoryUnsafePath !== undefined) {
+      // Git for Windows will replace backslashes with slashes in the error
+      // message so we'll do the same to not show "the repo at path c:/repo"
+      // when the entered path is `c:\repo`.
+      const convertedPath = __WIN32__ ? path.replaceAll('\\', '/') : path
+
       return (
         <Row className="warning-helper-text">
           <Octicon symbol={OcticonSymbol.alert} />
           <div>
             <p>
-              The Git repository at <Ref>{this.state.repositoryUnsafePath}</Ref>
+              The Git repository
+              {repositoryUnsafePath !== convertedPath && (
+                <>
+                  {' at '}
+                  <Ref>{repositoryUnsafePath}</Ref>
+                </>
+              )}{' '}
               appears to be owned by another user on your machine. Adding
               untrusted repositories may automatically execute files in the
               repository.

--- a/app/src/ui/add-repository/add-existing-repository.tsx
+++ b/app/src/ui/add-repository/add-existing-repository.tsx
@@ -52,6 +52,7 @@ interface IAddExistingRepositoryState {
   readonly isRepositoryBare: boolean
   readonly isRepositoryUnsafe: boolean
   readonly repositoryUnsafePath?: string
+  readonly isTrustingRepository: boolean
 }
 
 /** The component for adding an existing local repository. */
@@ -70,6 +71,7 @@ export class AddExistingRepository extends React.Component<
       showNonGitRepositoryWarning: false,
       isRepositoryBare: false,
       isRepositoryUnsafe: false,
+      isTrustingRepository: false,
     }
   }
 
@@ -82,11 +84,13 @@ export class AddExistingRepository extends React.Component<
   }
 
   private onTrustDirectory = async () => {
+    this.setState({ isTrustingRepository: true })
     const { repositoryUnsafePath, path } = this.state
     if (repositoryUnsafePath) {
       await addSafeDirectory(repositoryUnsafePath)
     }
-    this.validatePath(path)
+    await this.validatePath(path)
+    this.setState({ isTrustingRepository: false })
   }
 
   private async updatePath(path: string) {
@@ -193,6 +197,7 @@ export class AddExistingRepository extends React.Component<
         title={__DARWIN__ ? 'Add Local Repository' : 'Add local repository'}
         onSubmit={this.addRepository}
         onDismissed={this.props.onDismissed}
+        loading={this.state.isTrustingRepository}
       >
         <DialogContent>
           <Row>

--- a/app/styles/ui/_missing-repository-view.scss
+++ b/app/styles/ui/_missing-repository-view.scss
@@ -62,6 +62,11 @@
 
   button {
     // the three buttons should rougly fill the width of the panel
-    width: 120px;
+    min-width: 120px;
+
+    .octicon.spin {
+      margin-right: var(--spacing-half);
+      height: 11px;
+    }
   }
 }


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
Several users in #14336 reported a delay between clicking on the `trust repository` button and the interface updating itself. This PR adds a little progress spinner to the missing repository view and enables the `loading` state of the add local repo dialog when adding a path to `safe.directory`.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="637" alt="Screenshot 2022-04-19 at 09 46 00" src="https://user-images.githubusercontent.com/634063/163984051-0c3d4f33-fd8e-4fc2-925a-138f7311d89e.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Improved] Show progress indicator when trusting a repository directory
