### PR TITLE
Add default option for pulling divergent paths

### DIFF
--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -131,12 +131,15 @@ export async function pull(
 async function getDefaultPullDivergentBranchArguments(
   repository: Repository
 ): Promise<ReadonlyArray<string>> {
-  const pullRebase = await getConfigValue(repository, 'pull.rebase')
-  const pullFF = await getConfigValue(repository, 'pull.ff')
-
-  if (pullRebase !== null || pullFF !== null) {
-    return []
+  try {
+    const pullFF = await getConfigValue(repository, 'pull.ff')
+    return pullFF !== null ? [] : ['--ff']
+  } catch (e) {
+    log.error("Couldn't read 'pull.ff' config", e)
   }
 
-  return ['--ff']
+  // If there is a failure in checking the config, we still want to use any
+  // config and not overwrite the user's set config behavior. This will show the
+  // git error if no config is set.
+  return []
 }


### PR DESCRIPTION
Closes #14431, Closes #14423

## Description
We have had a few reports since upgraded git about running to the following error:
![image](https://user-images.githubusercontent.com/75402236/164743560-a5645c22-c97f-4db0-a00b-16864ffdb6dd.png)

For users unfamiliar with using the command line, this error is not terribly helpful.

This PR proposes to check to see if the user has a configuration set for pulling divergent paths and, if not, default to using the [`-ff` flag](https://git-scm.com/docs/git-pull#Documentation/git-pull.txt---ff). When possible, it will attempt to fast forward the current branch and if not will perform a merge to reconcile the divergent paths.

Since we are checking the config first, users whom have a preference for rebase can specify that in their config.

## Release notes
Notes: [Fixed] Allow users to pull divergent paths without specifying a pull config
