### PR TITLE
More useful test pull request checks failed

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -8,7 +8,7 @@ import {
   SelectionType,
   HistoryTabMode,
 } from '../lib/app-state'
-import { Dispatcher } from './dispatcher'
+import { defaultErrorHandler, Dispatcher } from './dispatcher'
 import { AppStore, GitHubUserStore, IssuesStore } from '../lib/stores'
 import { assertNever } from '../lib/fatal-error'
 import { shell } from '../lib/app-shell'
@@ -486,6 +486,12 @@ export class App extends React.Component<IAppProps, IAppState> {
       selectedState == null ||
       selectedState.type !== SelectionType.Repository
     ) {
+      defaultErrorHandler(
+        new Error(
+          'You must be in a GitHub repo, on a pull request branch, and your branch tip must be in a valid state.'
+        ),
+        this.props.dispatcher
+      )
       return
     }
 
@@ -506,6 +512,12 @@ export class App extends React.Component<IAppProps, IAppState> {
       pullRequest === null ||
       currentBranchName === ''
     ) {
+      defaultErrorHandler(
+        new Error(
+          'You must be in a GitHub repo, on a pull request branch, and your branch tip must be in a valid state.'
+        ),
+        this.props.dispatcher
+      )
       return
     }
 
@@ -515,6 +527,13 @@ export class App extends React.Component<IAppProps, IAppState> {
     )
 
     if (cachedStatus?.checks === undefined) {
+      // Probably be hard for this to happen as the checks start loading in the background for pr statuses
+      defaultErrorHandler(
+        new Error(
+          'Your pull request must have cached checks. Try opening the checks popover and then try again.'
+        ),
+        this.props.dispatcher
+      )
       return
     }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -16,11 +16,7 @@ import { updateStore, UpdateStatus } from './lib/update-store'
 import { RetryAction } from '../models/retry-actions'
 import { shouldRenderApplicationMenu } from './lib/features'
 import { matchExistingRepository } from '../lib/repository-matching'
-import {
-  APICheckConclusion,
-  APICheckStatus,
-  getDotComAPIEndpoint,
-} from '../lib/api'
+import { getDotComAPIEndpoint } from '../lib/api'
 import { getVersion, getName } from './lib/app-proxy'
 import { getOS } from '../lib/get-os'
 import { MenuEvent } from '../main-process/menu'
@@ -156,7 +152,7 @@ import { showNotification } from '../lib/stores/helpers/show-notification'
 import { DiscardChangesRetryDialog } from './discard-changes/discard-changes-retry-dialog'
 import { getReleaseSummary } from '../lib/release-notes'
 import { PullRequestReview } from './notifications/pull-request-review'
-import { PullRequest, PullRequestRef } from '../models/pull-request'
+import { getPullRequestCommitRef } from '../models/pull-request'
 import { getRepositoryType } from '../lib/git'
 
 const MinuteInMilliseconds = 1000 * 60
@@ -493,112 +489,45 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    const { repository } = selectedState
+    const {
+      repository,
+      state: {
+        branchesState: { currentPullRequest: pullRequest, tip },
+      },
+    } = selectedState
 
-    if (!isRepositoryWithGitHubRepository(repository)) {
+    const currentBranchName =
+      tip.kind === TipState.Valid
+        ? tip.branch.upstreamWithoutRemote ?? tip.branch.name
+        : ''
+
+    if (
+      !isRepositoryWithGitHubRepository(repository) ||
+      pullRequest === null ||
+      currentBranchName === ''
+    ) {
       return
     }
 
+    const cachedStatus = this.props.dispatcher.tryGetCommitStatus(
+      repository.gitHubRepository,
+      getPullRequestCommitRef(pullRequest.pullRequestNumber)
+    )
+
+    if (cachedStatus?.checks === undefined) {
+      return
+    }
+
+    const { checks } = cachedStatus
+
     const popup: Popup = {
       type: PopupType.PullRequestChecksFailed,
-      pullRequest: new PullRequest(
-        new Date('2021-10-28T08:36:18Z'),
-        'IGNORE: Fail CI tasks immediately',
-        13201,
-        new PullRequestRef(
-          'development',
-          'a7bca44088b105a04714dc4628f4af50f6f179c3',
-          repository.gitHubRepository
-        ),
-        new PullRequestRef(
-          'fail-ci-immediately',
-          '665eb4810ea65d73ec7720c779dc9f8cd7b97d9e',
-          repository.gitHubRepository
-        ),
-        'sergiou87',
-        true,
-        'This is a test PR'
-      ),
+      pullRequest,
       repository,
       shouldChangeRepository: true,
-      commitMessage: 'Some Test Commit Message',
-      commitSha: '123456',
-      checks: [
-        {
-          id: 5873122372,
-          name: 'macOS arm64',
-          description: 'Failed after 5s',
-          status: APICheckStatus.Completed,
-          conclusion: APICheckConclusion.Failure,
-          appName: 'GitHub Actions',
-          htmlUrl:
-            'https://github.com/desktop/desktop/runs/5873122372?check_suite_focus=true',
-          checkSuiteId: 5767392356,
-          actionsWorkflow: {
-            id: 2027842572,
-            workflow_id: 1835763,
-            cancel_url:
-              'https://api.github.com/repos/desktop/desktop/actions/runs/2027842572/cancel',
-            created_at: '2022-03-23T10:38:05Z',
-            logs_url:
-              'https://api.github.com/repos/desktop/desktop/actions/runs/2027842572/logs',
-            rerun_url:
-              'https://api.github.com/repos/desktop/desktop/actions/runs/2027842572/rerun',
-            name: 'CI',
-            check_suite_id: 5767392356,
-            event: 'pull_request',
-          },
-          actionJobSteps: [
-            {
-              completed_at: '2022-04-07T13:30:33.000-04:00',
-              conclusion: APICheckConclusion.Success,
-              name: 'Set up job',
-              number: 1,
-              started_at: '2022-04-07T13:30:30.000-04:00',
-              status: APICheckStatus.Completed,
-              log: '',
-            },
-            {
-              completed_at: '2022-04-07T13:30:33.000-04:00',
-              conclusion: APICheckConclusion.Failure,
-              name: 'Fail immediately',
-              number: 1,
-              started_at: '2022-04-07T13:30:30.000-04:00',
-              status: APICheckStatus.Completed,
-              log: '',
-            },
-            {
-              completed_at: '2022-04-07T13:30:33.000-04:00',
-              conclusion: APICheckConclusion.Skipped,
-              name: 'Run actions/checkout@v2',
-              number: 1,
-              started_at: '2022-04-07T13:30:30.000-04:00',
-              status: APICheckStatus.Completed,
-              log: '',
-            },
-            {
-              completed_at: '2022-04-07T13:30:33.000-04:00',
-              conclusion: APICheckConclusion.Skipped,
-              name: 'Use Node.js 16.13.0',
-              number: 1,
-              started_at: '2022-04-07T13:30:30.000-04:00',
-              status: APICheckStatus.Completed,
-              log: '',
-            },
-          ],
-        },
-        {
-          id: 5873122309,
-          name: 'CodeQL-Build',
-          description: 'Failed after 5s',
-          status: APICheckStatus.Completed,
-          conclusion: APICheckConclusion.Success,
-          appName: 'GitHub Actions',
-          htmlUrl:
-            'https://github.com/desktop/desktop/runs/5873122309?check_suite_focus=true',
-          checkSuiteId: 5767392357,
-        },
-      ],
+      commitMessage: 'Adding this feature',
+      commitSha: pullRequest.head.sha,
+      checks,
     }
 
     this.showPopup(popup)


### PR DESCRIPTION
## Description
When trying to make screen shots for blog post.. it was cumbersome to keep trying to redo a failed pr when I didn't get my screen recording just right - so I figured I could make something that used real data. This uses the currently checked out PR and shows the failed checks dialog (whether they are failed or not).

### Screenshots

https://user-images.githubusercontent.com/75402236/165079953-8884eac1-a35a-4556-97af-6139d43d1dad.mov

## Release notes
Notes: no-notes
