### PR TITLE
Show All release notes since last update.

### DIFF
--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -6,6 +6,7 @@ import {
 } from '../models/release-notes'
 import { getVersion } from '../ui/lib/app-proxy'
 import { formatDate } from './format-date'
+import { offsetFromNow } from './offset-from'
 import { encodePathAsUrl } from './path'
 
 // expects a release note entry to contain a header and then some text
@@ -111,13 +112,20 @@ export async function getChangeLog(
 export async function generateReleaseSummary(): Promise<
   ReadonlyArray<ReleaseSummary>
 > {
-  const releases = await getChangeLog()
+  const lastTenReleases = await getChangeLog()
   const currentVersion = new semver.SemVer(getVersion())
-  const releaseSinceCurrentVersion = releases.filter(r =>
-    semver.gte(new semver.SemVer(r.version), currentVersion)
+  const recentReleases = lastTenReleases.filter(
+    r =>
+      semver.gte(new semver.SemVer(r.version), currentVersion) &&
+      new Date(r.pub_date).getTime() > offsetFromNow(-90, 'days')
   )
 
-  return releaseSinceCurrentVersion.map(getReleaseSummary)
+  // We should only be pulling release notes when a release just happened, so
+  // there should be one within the past 90 days. Thus, this is just precaution
+  // to ensure we always show at least the last set of release notes.
+  return recentReleases.length > 0
+    ? recentReleases.map(getReleaseSummary)
+    : [getReleaseSummary(recentReleases[0])]
 }
 
 export const ReleaseNoteHeaderLeftUri = encodePathAsUrl(

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -116,7 +116,7 @@ export async function generateReleaseSummary(): Promise<
   const currentVersion = new semver.SemVer(getVersion())
   const recentReleases = lastTenReleases.filter(
     r =>
-      semver.gte(new semver.SemVer(r.version), currentVersion) &&
+      semver.gt(new semver.SemVer(r.version), currentVersion) &&
       new Date(r.pub_date).getTime() > offsetFromNow(-90, 'days')
   )
 

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -106,10 +106,12 @@ export async function getChangeLog(
   }
 }
 
-export async function generateReleaseSummary(): Promise<ReleaseSummary> {
+export async function generateReleaseSummary(): Promise<
+  ReadonlyArray<ReleaseSummary>
+> {
   const releases = await getChangeLog()
   const latestRelease = releases[0]
-  return getReleaseSummary(latestRelease)
+  return [getReleaseSummary(latestRelease)]
 }
 
 export const ReleaseNoteHeaderLeftUri = encodePathAsUrl(

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -110,8 +110,7 @@ export async function generateReleaseSummary(): Promise<
   ReadonlyArray<ReleaseSummary>
 > {
   const releases = await getChangeLog()
-  const latestRelease = releases[0]
-  return [getReleaseSummary(latestRelease)]
+  return releases.map(getReleaseSummary)
 }
 
 export const ReleaseNoteHeaderLeftUri = encodePathAsUrl(

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -125,7 +125,7 @@ export async function generateReleaseSummary(): Promise<
   // to ensure we always show at least the last set of release notes.
   return recentReleases.length > 0
     ? recentReleases.map(getReleaseSummary)
-    : [getReleaseSummary(recentReleases[0])]
+    : [getReleaseSummary(lastTenReleases[0])]
 }
 
 export const ReleaseNoteHeaderLeftUri = encodePathAsUrl(

--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -1,8 +1,10 @@
+import * as semver from 'semver'
 import {
   ReleaseMetadata,
   ReleaseNote,
   ReleaseSummary,
 } from '../models/release-notes'
+import { getVersion } from '../ui/lib/app-proxy'
 import { formatDate } from './format-date'
 import { encodePathAsUrl } from './path'
 
@@ -110,7 +112,12 @@ export async function generateReleaseSummary(): Promise<
   ReadonlyArray<ReleaseSummary>
 > {
   const releases = await getChangeLog()
-  return releases.map(getReleaseSummary)
+  const currentVersion = new semver.SemVer(getVersion())
+  const releaseSinceCurrentVersion = releases.filter(r =>
+    semver.gte(new semver.SemVer(r.version), currentVersion)
+  )
+
+  return releaseSinceCurrentVersion.map(getReleaseSummary)
 }
 
 export const ReleaseNoteHeaderLeftUri = encodePathAsUrl(

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -170,7 +170,7 @@ export type Popup =
     }
   | {
       type: PopupType.ReleaseNotes
-      newRelease: ReleaseSummary
+      newReleases: ReadonlyArray<ReleaseSummary>
     }
   | {
       type: PopupType.DeletePullRequest

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -150,7 +150,7 @@ import { clamp } from '../lib/clamp'
 import * as ipcRenderer from '../lib/ipc-renderer'
 import { showNotification } from '../lib/stores/helpers/show-notification'
 import { DiscardChangesRetryDialog } from './discard-changes/discard-changes-retry-dialog'
-import { getReleaseSummary } from '../lib/release-notes'
+import { generateReleaseSummary } from '../lib/release-notes'
 import { PullRequestReview } from './notifications/pull-request-review'
 import { getPullRequestCommitRef } from '../models/pull-request'
 import { getRepositoryType } from '../lib/git'
@@ -435,25 +435,11 @@ export class App extends React.Component<IAppProps, IAppState> {
    * make it easier to verify changes to the popup. Has no meaning
    * about a new release being available.
    */
-  private showFakeReleaseNotesPopup() {
+  private async showFakeReleaseNotesPopup() {
     if (__DEV__) {
       this.props.dispatcher.showPopup({
         type: PopupType.ReleaseNotes,
-        newRelease: getReleaseSummary({
-          name: '',
-          version: '42.7.99',
-          notes: [
-            '[New] An awesome new feature!',
-            '[Improved] This is so much better',
-            '[Improved] Testing links to profile pages by a mention to @shiftkey',
-            '[Fixed] Fixed this one thing',
-            '[Fixed] Fixed this thing over here too',
-            '[Fixed] Testing links to issues by calling out #42. Assuming it is fixed by now.',
-            '[OhHai] Look at me, a new category!',
-            '[Added] In other news... . Thanks @some-body-to-thank!',
-          ],
-          pub_date: '2025-11-07T09:52:34Z',
-        }),
+        newReleases: await generateReleaseSummary(),
       })
     }
   }
@@ -1727,7 +1713,7 @@ export class App extends React.Component<IAppProps, IAppState> {
           <ReleaseNotes
             key="release-notes"
             emoji={this.state.emoji}
-            newRelease={popup.newRelease}
+            newReleases={popup.newReleases}
             onDismissed={onPopupDismissedFn}
           />
         )
@@ -2726,7 +2712,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     return (
       <UpdateAvailable
         dispatcher={this.props.dispatcher}
-        newRelease={updateStore.state.newRelease}
+        newReleases={updateStore.state.newReleases}
         onDismissed={this.onUpdateAvailableDismissed}
         key={'update-available'}
       />

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -13,7 +13,7 @@ import { ReleaseNotesUri } from '../lib/releases'
 
 interface IUpdateAvailableProps {
   readonly dispatcher: Dispatcher
-  readonly newRelease: ReleaseSummary | null
+  readonly newReleases: ReadonlyArray<ReleaseSummary> | null
   readonly onDismissed: () => void
 }
 
@@ -47,14 +47,14 @@ export class UpdateAvailable extends React.Component<
   }
 
   private showReleaseNotes = () => {
-    if (this.props.newRelease == null) {
+    if (this.props.newReleases == null) {
       // if, for some reason we're not able to render the release notes we
       // should redirect the user to the website so we do _something_
       shell.openExternal(ReleaseNotesUri)
     } else {
       this.props.dispatcher.showPopup({
         type: PopupType.ReleaseNotes,
-        newRelease: this.props.newRelease,
+        newReleases: this.props.newReleases,
       })
     }
   }

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -39,7 +39,7 @@ export enum UpdateStatus {
 export interface IUpdateState {
   status: UpdateStatus
   lastSuccessfulCheck: Date | null
-  newRelease: ReleaseSummary | null
+  newReleases: ReadonlyArray<ReleaseSummary> | null
 }
 
 /** A store which contains the current state of the auto updater. */
@@ -47,7 +47,7 @@ class UpdateStore {
   private emitter = new Emitter()
   private status = UpdateStatus.UpdateNotAvailable
   private lastSuccessfulCheck: Date | null = null
-  private newRelease: ReleaseSummary | null = null
+  private newReleases: ReadonlyArray<ReleaseSummary> | null = null
 
   /** Is the most recent update check user initiated? */
   private userInitiatedUpdate = true
@@ -101,7 +101,7 @@ class UpdateStore {
   }
 
   private onUpdateDownloaded = async () => {
-    this.newRelease = await generateReleaseSummary()
+    this.newReleases = await generateReleaseSummary()
 
     this.status = UpdateStatus.UpdateReady
 
@@ -134,7 +134,7 @@ class UpdateStore {
     return {
       status: this.status,
       lastSuccessfulCheck: this.lastSuccessfulCheck,
-      newRelease: this.newRelease,
+      newReleases: this.newReleases,
     }
   }
 

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -90,6 +90,8 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         enhancements.length > 0 && bugfixes.length > 0
     )
 
+    const showHeader = this.props.newReleases.length > 1
+
     const contents = this.props.newReleases.map((r, i) => {
       const releaseContent = showTwoColumns
         ? this.drawTwoColumnLayout(r)
@@ -97,7 +99,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
 
       return (
         <div key={i} className="release-contents">
-          <h2 className="version-header">{r.latestVersion}</h2>
+          {showHeader && <h2 className="version-header">{r.latestVersion}</h2>}
           {releaseContent}
         </div>
       )

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -83,27 +83,39 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   }
 
   public render() {
-    const { latestVersion, datePublished } = this.props.newReleases[0]
+    let release = this.props.newReleases[0]
+    if (this.props.newReleases.length > 0) {
+      let enhancements = new Array<ReleaseNote>()
+      let bugfixes = new Array<ReleaseNote>()
 
-    const showTwoColumns = this.props.newReleases.some(
-      ({ enhancements, bugfixes }) =>
-        enhancements.length > 0 && bugfixes.length > 0
-    )
+      this.props.newReleases.forEach(r => {
+        enhancements = enhancements.concat(r.enhancements)
+        bugfixes = bugfixes.concat(r.bugfixes)
+      })
 
-    const showHeader = this.props.newReleases.length > 1
+      release = {
+        latestVersion: `${
+          this.props.newReleases[this.props.newReleases.length - 1]
+            .latestVersion
+        } - ${this.props.newReleases[0].latestVersion}`,
+        datePublished: `${
+          this.props.newReleases[this.props.newReleases.length - 1]
+            .datePublished
+        } to ${this.props.newReleases[0].datePublished}`,
+        enhancements,
+        bugfixes,
+        other: [],
+        thankYous: [],
+      }
+    }
 
-    const contents = this.props.newReleases.map((r, i) => {
-      const releaseContent = showTwoColumns
-        ? this.drawTwoColumnLayout(r)
-        : this.drawSingleColumnLayout(r)
+    const { latestVersion, datePublished, enhancements, bugfixes } = release
 
-      return (
-        <div key={i} className="release-contents">
-          {showHeader && <h2 className="version-header">{r.latestVersion}</h2>}
-          {releaseContent}
-        </div>
-      )
-    })
+    const showTwoColumns = enhancements.length > 0 && bugfixes.length > 0
+
+    const contents = showTwoColumns
+      ? this.drawTwoColumnLayout(release)
+      : this.drawSingleColumnLayout(release)
 
     const dialogHeader = (
       <div className="release-notes-header">

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -84,7 +84,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
 
   public render() {
     let release = this.props.newReleases[0]
-    if (this.props.newReleases.length > 0) {
+    if (this.props.newReleases.length > 1) {
       let enhancements = new Array<ReleaseNote>()
       let bugfixes = new Array<ReleaseNote>()
 

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -12,7 +12,6 @@ import {
   ReleaseNoteHeaderLeftUri,
   ReleaseNoteHeaderRightUri,
 } from '../../lib/release-notes'
-import { Row } from '../lib/row'
 
 interface IReleaseNotesProps {
   readonly onDismissed: () => void
@@ -86,13 +85,22 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   public render() {
     const { latestVersion, datePublished } = this.props.newReleases[0]
 
-    const contents = this.props.newReleases.map((r, i) => {
-      const releaseContent =
-        r.enhancements.length > 0 && r.bugfixes.length > 0
-          ? this.drawTwoColumnLayout(r)
-          : this.drawSingleColumnLayout(r)
+    const showTwoColumns = this.props.newReleases.some(
+      ({ enhancements, bugfixes }) =>
+        enhancements.length > 0 && bugfixes.length > 0
+    )
 
-      return <Row key={i}> {releaseContent}</Row>
+    const contents = this.props.newReleases.map((r, i) => {
+      const releaseContent = showTwoColumns
+        ? this.drawTwoColumnLayout(r)
+        : this.drawSingleColumnLayout(r)
+
+      return (
+        <div key={i} className="release-contents">
+          <h2 className="version-header">{r.latestVersion}</h2>
+          {releaseContent}
+        </div>
+      )
     })
 
     const dialogHeader = (

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -86,32 +86,26 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
    * If there is just one release, it returns it. If multiple, it merges the release notes.
    */
   private getDisplayRelease = () => {
-    if (this.props.newReleases.length === 1) {
-      return this.props.newReleases[0]
+    const { newReleases } = this.props
+    const latestRelease = newReleases[0]
+
+    if (newReleases.length === 1) {
+      return latestRelease
     }
 
-    const oldestRelease = this.props.newReleases.slice(-1)[0]
-
-    let enhancements = new Array<ReleaseNote>()
-    let bugfixes = new Array<ReleaseNote>()
-
-    for (const r of this.props.newReleases) {
-      enhancements = enhancements.concat(r.enhancements)
-      bugfixes = bugfixes.concat(r.bugfixes)
-    }
-
-    const {
-      latestVersion: earliestVersion,
-      datePublished: earliestDatePublished,
-    } = oldestRelease
-
-    const { latestVersion, datePublished } = this.props.newReleases[0]
+    const oldestRelease = newReleases.slice(-1)[0]
 
     return {
-      latestVersion: `${earliestVersion} - ${latestVersion}`,
-      datePublished: `${earliestDatePublished} to ${datePublished}`,
-      enhancements,
-      bugfixes,
+      latestVersion: `${oldestRelease.latestVersion} - ${latestRelease.latestVersion}`,
+      datePublished: `${oldestRelease.datePublished} to ${latestRelease.datePublished}`,
+      enhancements: newReleases.reduce(
+        (notes, release) => notes.concat(release.enhancements),
+        new Array<ReleaseNote>()
+      ),
+      bugfixes: newReleases.reduce(
+        (notes, release) => notes.concat(release.bugfixes),
+        new Array<ReleaseNote>()
+      ),
       other: [],
       thankYous: [],
     }

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -16,7 +16,7 @@ import {
 interface IReleaseNotesProps {
   readonly onDismissed: () => void
   readonly emoji: Map<string, string>
-  readonly newRelease: ReleaseSummary
+  readonly newReleases: ReadonlyArray<ReleaseSummary>
 }
 
 /**
@@ -83,7 +83,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   }
 
   public render() {
-    const release = this.props.newRelease
+    const release = this.props.newReleases[0]
 
     const contents =
       release.enhancements.length > 0 && release.bugfixes.length > 0

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -12,6 +12,7 @@ import {
   ReleaseNoteHeaderLeftUri,
   ReleaseNoteHeaderRightUri,
 } from '../../lib/release-notes'
+import { Row } from '../lib/row'
 
 interface IReleaseNotesProps {
   readonly onDismissed: () => void
@@ -83,12 +84,16 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
   }
 
   public render() {
-    const release = this.props.newReleases[0]
+    const { latestVersion, datePublished } = this.props.newReleases[0]
 
-    const contents =
-      release.enhancements.length > 0 && release.bugfixes.length > 0
-        ? this.drawTwoColumnLayout(release)
-        : this.drawSingleColumnLayout(release)
+    const contents = this.props.newReleases.map((r, i) => {
+      const releaseContent =
+        r.enhancements.length > 0 && r.bugfixes.length > 0
+          ? this.drawTwoColumnLayout(r)
+          : this.drawSingleColumnLayout(r)
+
+      return <Row key={i}> {releaseContent}</Row>
+    })
 
     const dialogHeader = (
       <div className="release-notes-header">
@@ -97,8 +102,8 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
           src={ReleaseNoteHeaderLeftUri}
         />
         <div className="title">
-          <p className="version">Version {release.latestVersion}</p>
-          <p className="date">{release.datePublished}</p>
+          <p className="version">Version {latestVersion}</p>
+          <p className="date">{datePublished}</p>
         </div>
         <img
           className="release-note-graphic-right"

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -90,7 +90,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
       return this.props.newReleases[0]
     }
 
-    const earliestRelease = this.props.newReleases.slice(-1)[0]
+    const oldestRelease = this.props.newReleases.slice(-1)[0]
 
     let enhancements = new Array<ReleaseNote>()
     let bugfixes = new Array<ReleaseNote>()
@@ -103,7 +103,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     const {
       latestVersion: earliestVersion,
       datePublished: earliestDatePublished,
-    } = earliestRelease
+    } = oldestRelease
 
     const { latestVersion, datePublished } = this.props.newReleases[0]
 

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -82,40 +82,49 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     )
   }
 
-  public render() {
-    let release = this.props.newReleases[0]
-    if (this.props.newReleases.length > 1) {
-      let enhancements = new Array<ReleaseNote>()
-      let bugfixes = new Array<ReleaseNote>()
-
-      this.props.newReleases.forEach(r => {
-        enhancements = enhancements.concat(r.enhancements)
-        bugfixes = bugfixes.concat(r.bugfixes)
-      })
-
-      release = {
-        latestVersion: `${
-          this.props.newReleases[this.props.newReleases.length - 1]
-            .latestVersion
-        } - ${this.props.newReleases[0].latestVersion}`,
-        datePublished: `${
-          this.props.newReleases[this.props.newReleases.length - 1]
-            .datePublished
-        } to ${this.props.newReleases[0].datePublished}`,
-        enhancements,
-        bugfixes,
-        other: [],
-        thankYous: [],
-      }
+  /**
+   * If there is just one release, it returns it. If multiple, it merges the release notes.
+   */
+  private getDisplayRelease = () => {
+    if (this.props.newReleases.length === 1) {
+      return this.props.newReleases[0]
     }
 
+    const earliestRelease = this.props.newReleases.slice(-1)[0]
+
+    let enhancements = new Array<ReleaseNote>()
+    let bugfixes = new Array<ReleaseNote>()
+
+    for (const r of this.props.newReleases) {
+      enhancements = enhancements.concat(r.enhancements)
+      bugfixes = bugfixes.concat(r.bugfixes)
+    }
+
+    const {
+      latestVersion: earliestVersion,
+      datePublished: earliestDatePublished,
+    } = earliestRelease
+
+    const { latestVersion, datePublished } = this.props.newReleases[0]
+
+    return {
+      latestVersion: `${earliestVersion} - ${latestVersion}`,
+      datePublished: `${earliestDatePublished} to ${datePublished}`,
+      enhancements,
+      bugfixes,
+      other: [],
+      thankYous: [],
+    }
+  }
+
+  public render() {
+    const release = this.getDisplayRelease()
     const { latestVersion, datePublished, enhancements, bugfixes } = release
 
-    const showTwoColumns = enhancements.length > 0 && bugfixes.length > 0
-
-    const contents = showTwoColumns
-      ? this.drawTwoColumnLayout(release)
-      : this.drawSingleColumnLayout(release)
+    const contents =
+      enhancements.length > 0 && bugfixes.length > 0
+        ? this.drawTwoColumnLayout(release)
+        : this.drawSingleColumnLayout(release)
 
     const dialogHeader = (
       <div className="release-notes-header">

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -98,14 +98,8 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     return {
       latestVersion: `${oldestRelease.latestVersion} - ${latestRelease.latestVersion}`,
       datePublished: `${oldestRelease.datePublished} to ${latestRelease.datePublished}`,
-      enhancements: newReleases.reduce(
-        (notes, release) => notes.concat(release.enhancements),
-        new Array<ReleaseNote>()
-      ),
-      bugfixes: newReleases.reduce(
-        (notes, release) => notes.concat(release.bugfixes),
-        new Array<ReleaseNote>()
-      ),
+      enhancements: newReleases.flatMap(r => r.enhancements),
+      bugfixes: newReleases.flatMap(r => r.bugfixes),
       other: [],
       thankYous: [],
     }

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -2,16 +2,12 @@
 
 #release-notes {
   max-height: 500px;
+  max-width: 800px;
 
   .dialog-content {
     // we'll own the layout inside here
-    padding: var(--spacing-double) 0;
-    overflow-y: scroll;
-
-    .version-header {
-      padding: var(--spacing);
-      margin: 0 var(--spacing-double);
-    }
+    padding: 0;
+    overflow-x: hidden;
   }
 
   .dialog-header {
@@ -80,8 +76,8 @@
   }
 
   .container {
-    width: 600px;
-    max-height: 200px;
+    width: 800px;
+    max-height: 300px;
     display: flex;
     flex-direction: row;
     padding-left: var(--spacing-triple);
@@ -97,6 +93,7 @@
       height: 100%;
 
       .section {
+        margin: var(--spacing-double) 0;
         .header {
           font-size: 12px;
           font-weight: var(--font-weight-semibold);

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -6,6 +6,8 @@
   .dialog-content {
     // we'll own the layout inside here
     padding: 0;
+    overflow-y: scroll;
+    max-height: 250px;
   }
 
   .dialog-header {
@@ -75,13 +77,11 @@
 
   .container {
     width: 600px;
-    max-height: 200px;
     display: flex;
     flex-direction: row;
     padding-left: var(--spacing-triple);
     padding-right: var(--spacing-triple);
     overflow-x: hidden;
-    overflow-y: auto;
     justify-content: space-around;
 
     .column {

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -7,6 +7,7 @@
     // we'll own the layout inside here
     padding: var(--spacing-double) 0;
     overflow-y: scroll;
+    overflow-x: hidden;
     max-height: 325px;
 
     .version-header {

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -7,8 +7,6 @@
     // we'll own the layout inside here
     padding: var(--spacing-double) 0;
     overflow-y: scroll;
-    overflow-x: hidden;
-    max-height: 325px;
 
     .version-header {
       padding: var(--spacing);
@@ -83,11 +81,13 @@
 
   .container {
     width: 600px;
+    max-height: 200px;
     display: flex;
     flex-direction: row;
     padding-left: var(--spacing-triple);
     padding-right: var(--spacing-triple);
     overflow-x: hidden;
+    overflow-y: auto;
     justify-content: space-around;
 
     .column {

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -76,7 +76,7 @@
   }
 
   .container {
-    width: 800px;
+    width: 675px;
     max-height: 300px;
     display: flex;
     flex-direction: row;

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -1,13 +1,18 @@
 @import '../../../styles/variables';
 
 #release-notes {
-  max-height: 450px;
+  max-height: 500px;
 
   .dialog-content {
     // we'll own the layout inside here
     padding: 0;
     overflow-y: scroll;
-    max-height: 250px;
+    max-height: 325px;
+
+    .version-header {
+      padding: var(--spacing);
+      margin: 0 var(--spacing-double);
+    }
   }
 
   .dialog-header {
@@ -91,7 +96,6 @@
       height: 100%;
 
       .section {
-        margin: var(--spacing-double) 0;
         .header {
           font-size: 12px;
           font-weight: var(--font-weight-semibold);

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -5,7 +5,7 @@
 
   .dialog-content {
     // we'll own the layout inside here
-    padding: 0;
+    padding: var(--spacing-double) 0;
     overflow-y: scroll;
     max-height: 325px;
 


### PR DESCRIPTION
## Description
Every so often we will release an update and the quickly determine we need to release a hotfix. What this means for release notes is if a user is on version x.x.1 and we update to x.x.2 with a cool new feature. The release notes will be for x.x.2 and talk about the cool new feature. However if we hotfix to x.x.3 before a user updates to x.x.2 updates, they get a release note about the fix and not about the cool new feature.

This PR attempts to combat that by checking the users current version and merging the release notes set between their current version in the latest. 

It limits releases to the past 10 releases or past 90 days (which ever is sooner). This working upon the assumption that, because of our auto updates, it is very unlikely scenario for someone to be 90 days or 10 versions behind and, even if so, there would be so many release notes, a user likely would not bother scrolling through them anyways. 

Other notes:
- Plan to investigate adding the ability to showcase by having the ability to add a markdown pretext to release notes.
- Plan to remove old "showcase" logic around drag/drop features and split views.

Testing this: 
In Dev environment, there is Help > Show popup > Release notes to assist in testing (I updated this to use actually release notes instead of the dummy ones so it would be closer to actual testing)

Adding that `x.x.x ?? ` in the semver construction is the easiest way up date what version the release notes thinks the app is running under. But you can also update the package.json and run yarn:build, to actually change the version the app believes it is running under.
![image](https://user-images.githubusercontent.com/75402236/165329268-4650b6f1-a891-4f26-b123-e52de21f703c.png)

### Screenshots
Last 90 days of releases:
![Multiple versions](https://user-images.githubusercontent.com/75402236/165325104-cca3701d-8a44-427a-8f9a-37205d64bc43.gif)

One release is fairly unchanged (max-width/height a bit more lax):
![image](https://user-images.githubusercontent.com/75402236/165325063-3422e461-3e80-4d2e-bfb6-860b3f1ac159.png)

## Release notes

Notes: [Improved] User can see all releases notes between their current version and the latest update.
