### PR TITLE
Exploring Pretext Changelog type for showcasing new features

### DIFF
--- a/app/src/lib/release-notes.ts
+++ b/app/src/lib/release-notes.ts
@@ -56,7 +56,14 @@ function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
 export function parseReleaseEntries(
   notes: ReadonlyArray<string>
 ): ReadonlyArray<ReleaseNote> {
-  return notes.map(n => parseEntry(n)).filter(notEmpty)
+  const pretext =
+    '<img style="width: 100%" src="https://user-images.githubusercontent.com/75402236/165329268-4650b6f1-a891-4f26-b123-e52de21f703c.png"/>' +
+    'Adding that `x.x.x ?? ` in the semver construction is the easiest way up date what version the release notes thinks the app is running under. ' +
+    '<div style="color:red">But you can also update the package.json and run yarn:build, to actually change the version the app believes it is running under.</div>'
+
+  const injectPretext = [...notes, '[pretext] ' + pretext]
+  console.log(injectPretext)
+  return injectPretext.map(n => parseEntry(n)).filter(notEmpty)
 }
 
 export function getReleaseSummary(
@@ -70,14 +77,14 @@ export function getReleaseSummary(
   const bugfixes = entries.filter(e => e.kind === 'fixed')
   const other = entries.filter(e => e.kind === 'removed' || e.kind === 'other')
   const thankYous = entries.filter(e => e.message.includes(' Thanks @'))
+  const pretext = entries.filter(e => e.kind === 'pretext')
 
   return {
     latestVersion: latestRelease.version,
     datePublished: formatDate(new Date(latestRelease.pub_date), {
       dateStyle: 'long',
     }),
-    // TODO: find pretext entry
-    pretext: undefined,
+    pretext,
     enhancements,
     bugfixes,
     other,
@@ -113,7 +120,7 @@ export async function generateReleaseSummary(): Promise<
   ReadonlyArray<ReleaseSummary>
 > {
   const lastTenReleases = await getChangeLog()
-  const currentVersion = new semver.SemVer(getVersion())
+  const currentVersion = new semver.SemVer('3.0.0' ?? getVersion())
   const recentReleases = lastTenReleases.filter(
     r =>
       semver.gte(new semver.SemVer(r.version), currentVersion) &&

--- a/app/src/models/release-notes.ts
+++ b/app/src/models/release-notes.ts
@@ -22,7 +22,7 @@ export type ReleaseNote = {
 export type ReleaseSummary = {
   readonly latestVersion: string
   readonly datePublished: string
-  readonly pretext?: string
+  readonly pretext: ReadonlyArray<ReleaseNote>
   readonly enhancements: ReadonlyArray<ReleaseNote>
   readonly bugfixes: ReadonlyArray<ReleaseNote>
   readonly other: ReadonlyArray<ReleaseNote>

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -15,7 +15,7 @@ interface ISandboxedMarkdownProps {
   readonly markdown: string
 
   /** The baseHref of the markdown content for when the markdown has relative links */
-  readonly baseHref: string | null
+  readonly baseHref?: string
 
   /**
    * A callback with the url of a link clicked in the parsed markdown
@@ -33,11 +33,11 @@ interface ISandboxedMarkdownProps {
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>
 
-  /** The GitHub repository to use when looking up commit status. */
-  readonly repository: GitHubRepository
+  /** The GitHub repository for some markdown filters such as issue and commits. */
+  readonly repository?: GitHubRepository
 
   /** The context of which markdown resides - such as PullRequest, PullRequestComment, Commit */
-  readonly markdownContext: MarkdownContext
+  readonly markdownContext?: MarkdownContext
 }
 
 /**
@@ -231,8 +231,8 @@ export class SandboxedMarkdown extends React.PureComponent<ISandboxedMarkdownPro
   /**
    * Builds a <base> tag for cases where markdown has relative links
    */
-  private getBaseTag(baseHref: string | null): string {
-    if (baseHref == null) {
+  private getBaseTag(baseHref?: string): string {
+    if (baseHref === undefined) {
       return ''
     }
 

--- a/app/src/ui/notifications/pull-request-review.tsx
+++ b/app/src/ui/notifications/pull-request-review.tsx
@@ -225,7 +225,7 @@ export class PullRequestReview extends React.Component<
       <SandboxedMarkdown
         markdown={review.body}
         emoji={emoji}
-        baseHref={base.gitHubRepository.htmlURL}
+        baseHref={base.gitHubRepository.htmlURL ?? undefined}
         repository={base.gitHubRepository}
         onMarkdownLinkClicked={this.onMarkdownLinkClicked}
         markdownContext={'PullRequestComment'}

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -206,7 +206,7 @@ export class PullRequestQuickView extends React.Component<
         <SandboxedMarkdown
           markdown={displayBody}
           emoji={this.props.emoji}
-          baseHref={base.gitHubRepository.htmlURL}
+          baseHref={base.gitHubRepository.htmlURL ?? undefined}
           repository={base.gitHubRepository}
           markdownContext={'PullRequest'}
           onMarkdownLinkClicked={this.onMarkdownLinkClicked}

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -12,6 +12,7 @@ import {
   ReleaseNoteHeaderLeftUri,
   ReleaseNoteHeaderRightUri,
 } from '../../lib/release-notes'
+import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
 
 interface IReleaseNotesProps {
   readonly onDismissed: () => void
@@ -94,10 +95,12 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
 
     let enhancements = new Array<ReleaseNote>()
     let bugfixes = new Array<ReleaseNote>()
+    let pretext = new Array<ReleaseNote>()
 
     for (const r of this.props.newReleases) {
       enhancements = enhancements.concat(r.enhancements)
       bugfixes = bugfixes.concat(r.bugfixes)
+      pretext = pretext.concat(r.pretext)
     }
 
     const {
@@ -110,6 +113,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     return {
       latestVersion: `${earliestVersion} - ${latestVersion}`,
       datePublished: `${earliestDatePublished} to ${datePublished}`,
+      pretext,
       enhancements,
       bugfixes,
       other: [],
@@ -117,9 +121,23 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     }
   }
 
+  private getPretext = (pretext: ReadonlyArray<ReleaseNote>) => {
+    if (pretext.length === 0) {
+      return
+    }
+
+    return (
+      <SandboxedMarkdown
+        markdown={pretext[0].message}
+        emoji={this.props.emoji}
+      />
+    )
+  }
+
   public render() {
     const release = this.getDisplayRelease()
-    const { latestVersion, datePublished, enhancements, bugfixes } = release
+    const { latestVersion, datePublished, enhancements, bugfixes, pretext } =
+      release
 
     const contents =
       enhancements.length > 0 && bugfixes.length > 0
@@ -150,7 +168,10 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         onSubmit={this.updateNow}
         title={dialogHeader}
       >
-        <DialogContent>{contents}</DialogContent>
+        <DialogContent>
+          {this.getPretext(pretext)}
+          {contents}
+        </DialogContent>
         <DialogFooter>
           <LinkButton onClick={this.showAllReleaseNotes}>
             View all release notes

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -6,8 +6,10 @@
 
   .dialog-content {
     // we'll own the layout inside here
-    padding: 0;
     overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 300px;
+    padding: var(--spacing) var(--spacing-triple);
   }
 
   .dialog-header {
@@ -77,19 +79,15 @@
 
   .container {
     width: 675px;
-    max-height: 300px;
     display: flex;
     flex-direction: row;
-    padding-left: var(--spacing-triple);
-    padding-right: var(--spacing-triple);
     overflow-x: hidden;
-    overflow-y: auto;
     justify-content: space-around;
 
     .column {
       flex: 1 1 275px;
       max-width: 75%;
-      margin: 0 calc(var(--spacing) * 1.5);
+      margin: 0 calc(var(--spacing) * 1.5) 0 0;
       height: 100%;
 
       .section {


### PR DESCRIPTION
Based on #14458

## Description
Something we have done on some releases is call out exciting new feature in very custom ways. For instance, we had a custom popover style information blurb about our recent drag/drop features (cherry-picking, re-ordering, squashing). But, currently we do not have an easy way to more generically showcase new features. This PR explores the possibility of having a release note of type "pretext" in the changelog in which the message would be markdown that is displayed first in the release notes dialog. By being markdown, means we can go as far as to implement inline styles to customize as desired. 

This doesn't preclude us from still making custom call outs as this will only be seen if a user clicks on the "what's new" in the update banner. The idea behind pretext would only be added for very splashing new features.

Here is an example of where I injected the following random markdown:

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/75402236/165364987-4ef94f66-cd04-412f-a940-6360f6943ed2.png">

![pretext release note](https://user-images.githubusercontent.com/75402236/165364746-0d47939e-4ff5-41bf-a177-0850105fd3f8.gif)

Some thoughts:
1. Even tho this pretext concept really isn't a release note, using a new "pretext" changelog type is a very simple and readily available. Also easily remotely updated.
2. Alternatives:
   a. we could create a new database field/table for our releases.
      - Pro: Database field is cleaner (not usurping the change log purpose). 
      - Con: Database field would require more building out of a way to modify it.
      
   b. we could go non-markdown route and build custom react pretext components. 
      - Pro: Ability to have call-to-actions that deep links within the app. Example: "Cherry-picking -> go to history to check it out now" or triggering a mini tutorial or learn more dialog.
      - Pro: Not likely that much more work than crafting a change log pretext/, but more flexible.
      - Con: Not remotely updatable. 
      - Con: heavy if we don't actually take advantage of in-app linking.
      - Con: Requires pruning (could be automated tho)
3. Could we have more than one thing to highlight/would more than one thing lead to the desire to expand this to a paginated style thing (multiple pretext release notes)? (thinking cherry-pick, reorder, squashing pagination we did)
4. Should showcasing be more prominent? 
   a. Interacted solely through clicking the "what's new" on a release
        -  giving user the choice on whether to learn more (not annoying them)
        -  The what new goes away once updated which can happen from opening/closing the app. Forgoing the chance to click on "what's new". 
       
   b. Make a permanent "what's new" call-to-action somewhere until a user interacts with it or sometime has passed since new release.
       - If we went route of non-markdown custom dialogs, this could be the start of a standard practice of having "call to action" bubbles anywhere that when clicked open a show case dialog. (again eventually prunned - probably having an expiration date on them) Thus, there could be a "What new" bubble button for show cases with new release and/or just "new" bubble buttons that are near the UI of the new feature.
       
   c. Popup a showcase dialog on update (force user to acknowledge)
     - From a discoverability standpoint, this is useful.
     - Dislike forced marketing. :D 
   

Just technical stuff/thoughts to determine (easy to resolve once definite path is known)
1. Do we have any db limitations on release notes that would hinder using markdown/would it need to be escaped?
2. What would the process for adding one of these look like? Currently, to preview/edit, one would have to programmatically inject a pretext release note to view in the dev build. Figured if we continue on this route, we could add logic to have our release notes dialog read in our changelog.json to preview on a dev build.
3. We would want images.. stored in our releases store, or stored as a static asset with the build? Seems indefinitely adding images to the build for things that are only seen once by the user is undesirable.
  
## Release notes
Notes: [Improved] Added ability to have showcasing of features through release notes.
