### PR TITLE
Make long lists of files scrollable within dialogs

### DIFF
--- a/app/src/ui/discard-changes/discard-changes-dialog.tsx
+++ b/app/src/ui/discard-changes/discard-changes-dialog.tsx
@@ -137,13 +137,15 @@ export class DiscardChanges extends React.Component<
       return (
         <div>
           <p>Are you sure you want to discard all changes to:</p>
-          <ul>
-            {this.props.files.map(p => (
-              <li key={p.id}>
-                <PathText path={p.path} />
-              </li>
-            ))}
-          </ul>
+          <div className="file-list">
+            <ul>
+              {this.props.files.map(p => (
+                <li key={p.id}>
+                  <PathText path={p.path} />
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       )
     }

--- a/app/styles/ui/_discard-changes.scss
+++ b/app/styles/ui/_discard-changes.scss
@@ -1,12 +1,17 @@
 #discard-changes {
-  .dialog-content ul {
-    list-style: none;
-    margin: var(--spacing) 0;
-    padding: 0;
+  .dialog-content .file-list {
+    max-height: 175px;
+    overflow-y: auto;
 
-    li {
-      padding-left: 0;
-      margin-bottom: 0;
+    ul {
+      list-style: none;
+      margin: var(--spacing) 0;
+      padding: 0;
+
+      li {
+        padding-left: 0;
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/app/styles/ui/dialogs/_commit-conflicts-warning.scss
+++ b/app/styles/ui/dialogs/_commit-conflicts-warning.scss
@@ -1,14 +1,19 @@
 #commit-conflict-markers-warning {
-  .dialog-content ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    margin-bottom: var(--spacing);
+  .dialog-content .conflicted-files-text {
+    max-height: 175px;
+    overflow-y: auto;
 
-    li {
-      padding-left: 0;
-      margin-bottom: 0;
-      font-family: var(--font-family-monospace);
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      margin-bottom: var(--spacing);
+
+      li {
+        padding-left: 0;
+        margin-bottom: 0;
+        font-family: var(--font-family-monospace);
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #14468 

## Description

Some of our dialogs with lists of files within them didn't account for very long lists that might overflow. More in particular, the "discard changes" and "commit conflicts warning" dialogs were affected by this issue, so I just applied the pattern I saw in [other](https://github.com/desktop/desktop/blob/784db4d386fa00eabf973014db8f6fcc15dcf5f2/app/styles/ui/_local-changes-overwritten.scss/#L3-L6) [dialogs](https://github.com/desktop/desktop/blob/784db4d386fa00eabf973014db8f6fcc15dcf5f2/app/styles/ui/changes/_oversized-files-warning.scss/#L5-L8).

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/165716468-69da0e93-3829-4c88-827a-09ea465803a3.png)
![image](https://user-images.githubusercontent.com/1083228/165716527-31b62fa2-f7cc-484e-b11a-76f166786648.png)

## Release notes

Notes: [Fixed] Long lists of conflicted files to commit or files to discard can be scrolled
