### PR TITLE
Do not crash the app when the trampoline server receives garbage

### DIFF
--- a/app/src/lib/trampoline/trampoline-server.ts
+++ b/app/src/lib/trampoline/trampoline-server.ts
@@ -129,7 +129,14 @@ export class TrampolineServer {
     data: Buffer
   ) {
     const value = data.toString('utf8')
-    parser.processValue(value)
+
+    try {
+      parser.processValue(value)
+    } catch (error) {
+      log.error('Error processing trampoline data', error)
+      socket.end()
+      return
+    }
 
     if (!parser.hasFinished()) {
       return


### PR DESCRIPTION
## Description

Looking into some of our Sentry errors, we decided to downgrade this crash to just a logged error, since it'd be possible for some random app to send garbage data to random open ports, and that shouldn't make Desktop crash.

## Release notes

Notes: no-notes
