### PR TITLE
Playing with a diff branch comparison

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -489,7 +489,9 @@ export async function getBranchDiff(
 ): Promise<IDiff> {
   const args = [
     'diff',
-    `${branchA}..${branchB}`,
+    '--merge-base',
+    branchA,
+    branchB,
     ...(hideWhitespaceInDiff ? ['-w'] : []),
     '--patch-with-raw',
     '-z',
@@ -515,10 +517,9 @@ export async function getBranchDiffChangedFiles(
 ): Promise<IChangesetData> {
   const baseArgs = [
     'diff',
-    `${branchA}..${branchB}`,
-    // TODO: learn why follow was added to commit change files (maybe we want the here?)
-    //'-C', detect copies as well as renames (see log.ts line 159 method getChangedFiles)
-    // '-M', detect renames (see log.ts line 159 method getChangedFiles)
+    '--merge-base',
+    branchA,
+    branchB,
     '--format=format:',
     '-z',
   ]

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -201,7 +201,7 @@ export async function getChangedFiles(
   }
 }
 
-function parseChangedFilesNumStat(stdout: string): {
+export function parseChangedFilesNumStat(stdout: string): {
   linesAdded: number
   linesDeleted: number
 } {

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -31,6 +31,7 @@ import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-autho
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
 import { enableCommitReordering } from '../../lib/feature-flag'
+import classNames from 'classnames'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -200,6 +201,23 @@ export class CompareSidebar extends React.Component<
     })
   }
 
+  private onAllFilesClicked = () => {
+    const formState = this.props.compareState.formState
+
+    if (
+      formState.kind === HistoryTabMode.History ||
+      formState.comparisonMode !== ComparisonMode.Ahead
+    ) {
+      return
+    }
+
+    this.props.dispatcher.executeCompare(this.props.repository, {
+      kind: HistoryTabMode.Compare,
+      branch: formState.comparisonBranch,
+      comparisonMode: ComparisonMode.Ahead,
+    })
+  }
+
   private renderCommitList() {
     const { formState, commitSHAs } = this.props.compareState
 
@@ -223,47 +241,67 @@ export class CompareSidebar extends React.Component<
         )
     }
 
+    const canSeeFilesOfAllCommits =
+      commitSHAs.length > 0 &&
+      formState.kind !== HistoryTabMode.History &&
+      formState.comparisonMode === ComparisonMode.Ahead
+
+    const isSeeingAllCommits = this.props.selectedCommitShas.length === 0
+
     return (
-      <CommitList
-        gitHubRepository={this.props.repository.gitHubRepository}
-        isLocalRepository={this.props.isLocalRepository}
-        commitLookup={this.props.commitLookup}
-        commitSHAs={commitSHAs}
-        selectedSHAs={this.props.selectedCommitShas}
-        localCommitSHAs={this.props.localCommitSHAs}
-        canResetToCommits={formState.kind === HistoryTabMode.History}
-        canUndoCommits={formState.kind === HistoryTabMode.History}
-        canAmendCommits={formState.kind === HistoryTabMode.History}
-        emoji={this.props.emoji}
-        reorderingEnabled={
-          enableCommitReordering() && formState.kind === HistoryTabMode.History
-        }
-        onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
-        onUndoCommit={this.onUndoCommit}
-        onResetToCommit={this.onResetToCommit}
-        onRevertCommit={
-          ableToRevertCommit(this.props.compareState.formState)
-            ? this.props.onRevertCommit
-            : undefined
-        }
-        onAmendCommit={this.props.onAmendCommit}
-        onCommitsSelected={this.onCommitsSelected}
-        onScroll={this.onScroll}
-        onCreateBranch={this.onCreateBranch}
-        onCreateTag={this.onCreateTag}
-        onDeleteTag={this.onDeleteTag}
-        onCherryPick={this.onCherryPick}
-        onDropCommitInsertion={this.onDropCommitInsertion}
-        onSquash={this.onSquash}
-        emptyListMessage={emptyListMessage}
-        onCompareListScrolled={this.props.onCompareListScrolled}
-        compareListScrollTop={this.props.compareListScrollTop}
-        tagsToPush={this.props.tagsToPush}
-        isCherryPickInProgress={this.props.isCherryPickInProgress}
-        onRenderCommitDragElement={this.onRenderCommitDragElement}
-        onRemoveCommitDragElement={this.onRemoveCommitDragElement}
-        disableSquashing={formState.kind === HistoryTabMode.Compare}
-      />
+      <>
+        {canSeeFilesOfAllCommits && (
+          <div
+            onClick={this.onAllFilesClicked}
+            className={classNames('all-files', 'list-item', {
+              selected: isSeeingAllCommits,
+            })}
+          >
+            View files of all ahead commits
+          </div>
+        )}
+        <CommitList
+          gitHubRepository={this.props.repository.gitHubRepository}
+          isLocalRepository={this.props.isLocalRepository}
+          commitLookup={this.props.commitLookup}
+          commitSHAs={commitSHAs}
+          selectedSHAs={this.props.selectedCommitShas}
+          localCommitSHAs={this.props.localCommitSHAs}
+          canResetToCommits={formState.kind === HistoryTabMode.History}
+          canUndoCommits={formState.kind === HistoryTabMode.History}
+          canAmendCommits={formState.kind === HistoryTabMode.History}
+          emoji={this.props.emoji}
+          reorderingEnabled={
+            enableCommitReordering() &&
+            formState.kind === HistoryTabMode.History
+          }
+          onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
+          onUndoCommit={this.onUndoCommit}
+          onResetToCommit={this.onResetToCommit}
+          onRevertCommit={
+            ableToRevertCommit(this.props.compareState.formState)
+              ? this.props.onRevertCommit
+              : undefined
+          }
+          onAmendCommit={this.props.onAmendCommit}
+          onCommitsSelected={this.onCommitsSelected}
+          onScroll={this.onScroll}
+          onCreateBranch={this.onCreateBranch}
+          onCreateTag={this.onCreateTag}
+          onDeleteTag={this.onDeleteTag}
+          onCherryPick={this.onCherryPick}
+          onDropCommitInsertion={this.onDropCommitInsertion}
+          onSquash={this.onSquash}
+          emptyListMessage={emptyListMessage}
+          onCompareListScrolled={this.props.onCompareListScrolled}
+          compareListScrollTop={this.props.compareListScrollTop}
+          tagsToPush={this.props.tagsToPush}
+          isCherryPickInProgress={this.props.isCherryPickInProgress}
+          onRenderCommitDragElement={this.onRenderCommitDragElement}
+          onRemoveCommitDragElement={this.onRemoveCommitDragElement}
+          disableSquashing={formState.kind === HistoryTabMode.Compare}
+        />
+      </>
     )
   }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -256,7 +256,7 @@ export class SelectedCommit extends React.Component<
       return this.renderMultipleCommitsSelected()
     }
 
-    if (commit == null) {
+    if (commit == null && this.props.changesetData.files.length === 0) {
       return <NoCommitSelected />
     }
 
@@ -265,7 +265,7 @@ export class SelectedCommit extends React.Component<
 
     return (
       <div id="history" ref={this.onHistoryRef} className={className}>
-        {this.renderCommitSummary(commit)}
+        {commit !== null && this.renderCommitSummary(commit)}
         <div className="commit-details">
           <Resizable
             width={commitSummaryWidth.value}

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -38,6 +38,20 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+
+    .all-files {
+      height: 50px;
+      padding: 0 var(--spacing);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-weight: var(--font-weight-semibold);
+
+      &.list-item.selected {
+        color: white;
+        background-color: var(--box-selected-active-background-color);
+      }
+    }
   }
 
   .merge-status {


### PR DESCRIPTION
## Description
For hack day, I explored what it might look like if we could have a way to view all the files that are ahead in our branch comparison feature. (Maybe someday some work to build from for an enhancement to the comparison feature or maybe someday some support for PR creation in Desktop)

First I spent way too long fumbling around dotcom code in hopes of figuring out how it does it's branch comparison.. to basically give up and try fiddling in desktop just to see what was feasible from `git dif` docs.  Thus, this is a **Very Very rough** implementation of the idea I was going for with little thought put into if this `git` command with the current flags makes the most sense/what are scenarios to be concerned about.

But, in the end, I got something that does do what I want for the one branch I testing. :D 

![Combine compare diff files](https://user-images.githubusercontent.com/75402236/166057657-98d8250f-486a-4d84-aeaa-aa63655d5a21.gif)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
