### PR TITLE
Add support for syntax highlighting .mjs/.cjs (and similar) extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ app/node_modules/
 .awcache
 .idea/
 .vs/
+.vscode/*.log
 .eslintcache
 *.iml
 .envrc

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -45,7 +45,11 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     install: () => import('codemirror/mode/javascript/javascript'),
     mappings: {
       '.ts': 'text/typescript',
+      '.mts': 'text/typescript',
+      '.cts': 'text/typescript',
       '.js': 'text/javascript',
+      '.mjs': 'text/javascript',
+      '.cjs': 'text/javascript',
       '.json': 'application/json',
     },
   },
@@ -59,7 +63,11 @@ const extensionModes: ReadonlyArray<IModeDefinition> = [
     install: () => import('codemirror/mode/jsx/jsx'),
     mappings: {
       '.tsx': 'text/typescript-jsx',
+      '.mtsx': 'text/typescript-jsx',
+      '.ctsx': 'text/typescript-jsx',
       '.jsx': 'text/jsx',
+      '.mjsx': 'text/jsx',
+      '.cjsx': 'text/jsx',
     },
   },
   {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes [N/A]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
This PR formats `.cjs`, `.mjs`, `.cts`, `.mts`, `.cjsx`, `.mjsx`, `.ctsx`, and `.mtsx` file extensions as JS/TS/JSX/TSX as appropriate. Note that I’m not sure that all tools support the JSX variants but I feel like it’s better to get ahead of adding them (especially since they don’t really have any other uses). But I think it would be reasonable to remove all the JSX extensions before merging this PR.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="1072" alt="Screenshot_2022-04-29 15 58 33" src="https://user-images.githubusercontent.com/25517624/166061114-23abc41c-d8c9-4b29-890e-ff2a54688ed7.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Add support for highlighting .mjs/.cjs/.mts/.cts files as JavaScript/TypeScript
