### PR TITLE
Add way to generate pretext notes from draft

### DIFF
--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -71,17 +71,19 @@ Run the script below (which relies on the your personal access token being set),
 For `production` and `beta` releases, run:
 
 ```shellsession
-$ yarn draft-release (production|beta)
+$ yarn draft-release (production|beta|test)
 ```
 
 If you are creating a new beta release, the `yarn draft-release beta` command will help you find the new release entries for the changelog.
 
 If you are create a new `production` release, you should just combine and sort the previous `beta` changelog entries.
 
-(For `test` releases, follow the directions in the steps below to update `app/package.json`'s `version` to a higher version and add a changelog entry. The script does not support test yet.)
+(For `test` releases, it will do a naive attempt to update the `app/package.json`'s `version` and add a changelog entry. You may have to adjust the test version and add a changelog entry to the `changelog.json`.)
 
 The script will output a draft changelog, which covers everything that's been merged, and probably needs some love.
 The output will then explain the next steps:
+
+If you have pretext release note drafted in `app/static/common/pretext-draft.md`, you can add the `--pretext` flag to generate a pretext change log entry it. Example: `yarn draft-release test --pretext`
 
 ```shellsession
 Here's what you should do next:

--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -78,7 +78,6 @@ If you are creating a new beta release, the `yarn draft-release beta` command wi
 
 If you are create a new `production` release, you should just combine and sort the previous `beta` changelog entries.
 
-(For `test` releases, it will do a naive attempt to update the `app/package.json`'s `version` and add a changelog entry. You may have to adjust the test version and add a changelog entry to the `changelog.json`.)
 
 The script will output a draft changelog, which covers everything that's been merged, and probably needs some love.
 The output will then explain the next steps:

--- a/script/draft-release/version.ts
+++ b/script/draft-release/version.ts
@@ -73,7 +73,33 @@ export function getNextVersionNumber(
         const firstBeta = `${nextVersion}-beta1`
         return firstBeta
       }
+    case 'test':
+      console.warn(
+        `WARNING: Since we do not tag test versions, the version provided will always be the first of test series respective of latest prod or beta.
+         You may need to adjust the -testX according to how many test releases already exist.`
+      )
 
+      if (isTestTag(semanticVersion)) {
+        /*Since we do not tag test versions, it "should be" impossible to reach
+        this first if, but added just for the case of future proofing the ideal
+        path. */
+        const tag = semanticVersion.prerelease[0]
+        const text = tag.substring(4)
+        const testNumber = parseInt(text, 10)
+        return semanticVersion.version.replace(
+          `-test${testNumber}`,
+          `-test${testNumber + 1}`
+        )
+      } else if (isBetaTag(semanticVersion)) {
+        return semanticVersion.version.replace(
+          semanticVersion.prerelease[0],
+          'test1'
+        )
+      } else {
+        const nextVersion = inc(semanticVersion, 'patch')
+        const firstTest = `${nextVersion}-test1`
+        return firstTest
+      }
     default:
       throw new Error(
         `Resolving the next version is not implemented for channel ${channel}`

--- a/script/draft-release/version.ts
+++ b/script/draft-release/version.ts
@@ -74,26 +74,19 @@ export function getNextVersionNumber(
         return firstBeta
       }
     case 'test':
-      console.warn(
-        `WARNING: Since we do not tag test versions, the version provided will always be the first of test series respective of latest prod or beta.
-         You may need to adjust the -testX according to how many test releases already exist.`
-      )
+      if (isBetaTag(semanticVersion)) {
+        throw new Error(
+          `Unable to draft test release using beta version '${version}'`
+        )
+      }
 
       if (isTestTag(semanticVersion)) {
-        /*Since we do not tag test versions, it "should be" impossible to reach
-        this first if, but added just for the case of future proofing the ideal
-        path. */
         const tag = semanticVersion.prerelease[0]
         const text = tag.substring(4)
         const testNumber = parseInt(text, 10)
         return semanticVersion.version.replace(
           `-test${testNumber}`,
           `-test${testNumber + 1}`
-        )
-      } else if (isBetaTag(semanticVersion)) {
-        return semanticVersion.version.replace(
-          semanticVersion.prerelease[0],
-          'test1'
         )
       } else {
         const nextVersion = inc(semanticVersion, 'patch')


### PR DESCRIPTION
## Description
This adds a way that if we create a pretext draft in the `pretext-draft.md`, as part of a release branch, we can add a `--pretext flag` to the draft release command to generate the note for us. 

In addition to making it easier to test, I added the ability to use the draft-release command for drafting in the test channel. (However, we add the actual tags during the deployment scripts so this is 1 of 2 pieces required to fully support it) 

## Release notes
Notes: no-notes
