### PR TITLE
Handle Invalid Clone Path & Uncommitted Changes on Branch

### DIFF
--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -725,9 +725,11 @@ export class App extends React.Component<IAppProps, IAppState> {
           pullRequest: currentPullRequest,
         })
       } else {
+        const aheadBehind = state.state.aheadBehind
         const existsOnRemote = state.state.aheadBehind !== null
 
         this.props.dispatcher.showPopup({
+          aheadBehind,
           type: PopupType.DeleteBranch,
           repository: state.repository,
           branch: tip.branch,
@@ -1374,6 +1376,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             branch={popup.branch}
             existsOnRemote={popup.existsOnRemote}
+            aheadBehind={popup.aheadBehind}
             onDismissed={onPopupDismissedFn}
             onDeleted={this.onBranchDeleted}
           />

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -151,7 +151,7 @@ export class CloneRepository extends React.Component<
     super(props)
 
     // Initialize initial path with a '/' to avoid invalid paths
-    const defaultDirectory = '/'
+    const defaultDirectory = __WIN32__? '\\' : '/'
 
     const initialBaseTabState: IBaseTabState = {
       error: null,

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -150,7 +150,8 @@ export class CloneRepository extends React.Component<
   public constructor(props: ICloneRepositoryProps) {
     super(props)
 
-    const defaultDirectory = null
+    // Initialize initial path with a '/' to avoid invalid paths
+    const defaultDirectory = '/'
 
     const initialBaseTabState: IBaseTabState = {
       error: null,

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -151,7 +151,7 @@ export class CloneRepository extends React.Component<
     super(props)
 
     // Initialize initial path with a '/' to avoid invalid paths
-    const defaultDirectory = __WIN32__? '\\' : '/'
+    const defaultDirectory = '/'
 
     const initialBaseTabState: IBaseTabState = {
       error: null,

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -7,14 +7,12 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { IAheadBehind } from '../../models/branch' 
 
 interface IDeleteBranchProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly branch: Branch
   readonly existsOnRemote: boolean
-  readonly aheadBehind: IAheadBehind | null
   readonly onDismissed: () => void
   readonly onDeleted: (repository: Repository) => void
 }
@@ -73,9 +71,6 @@ export class DeleteBranch extends React.Component<
               there as well?
             </strong>
           </p>
-          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? 
-          (<p><Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
-          unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.</p>) : null}
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -7,12 +7,14 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { IAheadBehind } from '../../models/branch' 
 
 interface IDeleteBranchProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly branch: Branch
   readonly existsOnRemote: boolean
+  readonly aheadBehind: IAheadBehind | null
   readonly onDismissed: () => void
   readonly onDeleted: (repository: Repository) => void
 }
@@ -71,6 +73,9 @@ export class DeleteBranch extends React.Component<
               there as well?
             </strong>
           </p>
+          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? 
+          (<p><Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
+          unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.</p>) : null}
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -64,8 +64,11 @@ export class DeleteBranch extends React.Component<
           </p>
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup destructive={true} cancelButtonText="No" 
-          okButtonText="Merge and Delete" />
+          <OkCancelButtonGroup
+            destructive={true}
+            cancelButtonText="No"
+            okButtonText="Merge and Delete"
+          />
         </DialogFooter>
       </Dialog>
     )
@@ -107,9 +110,12 @@ export class DeleteBranch extends React.Component<
               there as well?
             </strong>
           </p>
-          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? 
-          (<p><Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
-          unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.</p>) : null}
+          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? (
+            <p>
+              <Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
+              unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.
+            </p>
+          ) : null}
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={
@@ -154,7 +160,7 @@ export class DeleteBranch extends React.Component<
       this.props.repository,
       this.props.branch.name
     )
-    
+
     this.renderDeleteBranch()
   }
 }


### PR DESCRIPTION
**Issue #13816 Clone Error**
**Issue #4214 Warn User of Unmerged Commit**

## Description
**Issue #13816:**
Set the default directory for cloning to be the root, preventing invalid absolute paths.  

**Issue #4214:** 
Warn users of unmerged commits before deleting a branch.
New feature to Merge and Delete.

### Screenshots
**Issue #13816:**
<img width="502" alt="Screen Shot 2022-05-05 at 11 05 33 AM" src="https://user-images.githubusercontent.com/89805831/166859781-042d128d-3b4b-4b1b-9b20-91e90af83711.png">

## Release notes
Changed the default directory for cloning to the root directory to avoid invalid input directories.
Warn users of merged commits on a branch before deleting and allow "Merge and Delete".