### PR TITLE
Check Runs Popover Summary: Successful = success, neutral, skipped

### DIFF
--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -316,10 +316,19 @@ export class CICheckRunPopover extends React.PureComponent<
           FailingCheckConclusions.includes(v.conclusion)
       )
 
-    const allSuccess =
+    const successfulishConclusions = [
+      APICheckConclusion.Success,
+      APICheckConclusion.Neutral,
+      APICheckConclusion.Skipped,
+    ]
+    const allSuccessIsh =
       !loading && // quick return: if loading, no list
       !somePendingNoFailures && // quick return: if some pending, can't all be success
-      !checkRuns.some(v => v.conclusion !== APICheckConclusion.Success)
+      !checkRuns.some(
+        v =>
+          v.conclusion !== null &&
+          !successfulishConclusions.includes(v.conclusion)
+      )
 
     const allFailure =
       !loading && // quick return if loading, no list
@@ -334,7 +343,7 @@ export class CICheckRunPopover extends React.PureComponent<
       <div className="ci-check-run-list-header" tabIndex={0}>
         <div className="completeness-indicator">
           {this.renderCompletenessIndicator(
-            allSuccess,
+            allSuccessIsh,
             allFailure,
             loading,
             checkRuns
@@ -343,7 +352,7 @@ export class CICheckRunPopover extends React.PureComponent<
         <div className="ci-check-run-list-title-container">
           <div className="title">
             {this.getTitle(
-              allSuccess,
+              allSuccessIsh,
               allFailure,
               somePendingNoFailures,
               loading


### PR DESCRIPTION
Closes #14508

## Description
Reported that status didn't match dotcom for succesfull check runs when skipped were present. Seeing as I thought the logic matched dotcom.. I went back to it's source code and found where my ruby reading skills failed. For the summary, checks that have a conclusion of success, neutral or skipped are viewed as successful.

### Screenshots

<img width="456" alt="image" src="https://user-images.githubusercontent.com/75402236/166943960-8dc80a9a-164e-41ee-afb8-98d29e87dd43.png">
## Release notes

Notes: [Fixed] Checks popover summary correctly reflects a successful conclusion when skipped or neutral checks are present.
