### PR TITLE
Handle Invalid Clone Path & Uncommitted Changes on Branch

### DIFF
--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -21,6 +21,8 @@ import { IAuthor } from './author'
 import { IRefCheck } from '../lib/ci-checks/ci-checks'
 import { GitHubRepository } from './github-repository'
 import { ValidNotificationPullRequestReview } from '../lib/valid-notification-pull-request-review'
+import { IAheadBehind } from '../models/branch'
+import { MergeTreeResult } from '../models/merge'
 
 export enum PopupType {
   RenameBranch = 1,
@@ -83,6 +85,7 @@ export enum PopupType {
   WarnForcePush,
   DiscardChangesRetry,
   PullRequestReview,
+  IAheadBehind,
 }
 
 export type Popup =
@@ -92,6 +95,8 @@ export type Popup =
       repository: Repository
       branch: Branch
       existsOnRemote: boolean
+      mergeStatus: MergeTreeResult | null
+      aheadBehind: IAheadBehind | null
     }
   | {
       type: PopupType.DeleteRemoteBranch

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -726,14 +726,15 @@ export class App extends React.Component<IAppProps, IAppState> {
         })
       } else {
         const aheadBehind = state.state.aheadBehind
-        const existsOnRemote = state.state.aheadBehind !== null
+        const existsOnRemote = aheadBehind !== null
 
         this.props.dispatcher.showPopup({
-          aheadBehind,
           type: PopupType.DeleteBranch,
           repository: state.repository,
           branch: tip.branch,
+          mergeStatus: null,
           existsOnRemote: existsOnRemote,
+          aheadBehind: aheadBehind,
         })
       }
     }
@@ -1375,6 +1376,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             dispatcher={this.props.dispatcher}
             repository={popup.repository}
             branch={popup.branch}
+            mergeStatus={popup.mergeStatus}
             existsOnRemote={popup.existsOnRemote}
             aheadBehind={popup.aheadBehind}
             onDismissed={onPopupDismissedFn}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -725,9 +725,11 @@ export class App extends React.Component<IAppProps, IAppState> {
           pullRequest: currentPullRequest,
         })
       } else {
+        const aheadBehind = state.state.aheadBehind
         const existsOnRemote = state.state.aheadBehind !== null
 
         this.props.dispatcher.showPopup({
+          aheadBehind,
           type: PopupType.DeleteBranch,
           repository: state.repository,
           branch: tip.branch,
@@ -1374,6 +1376,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             repository={popup.repository}
             branch={popup.branch}
             existsOnRemote={popup.existsOnRemote}
+            aheadBehind={popup.aheadBehind}
             onDismissed={onPopupDismissedFn}
             onDeleted={this.onBranchDeleted}
           />

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -443,7 +443,9 @@ export class BranchesContainer extends React.Component<
       type: PopupType.DeleteBranch,
       repository: this.props.repository,
       branch,
+      mergeStatus: null,
       existsOnRemote: aheadBehind !== null,
+      aheadBehind: aheadBehind,
     })
   }
 

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -151,7 +151,7 @@ export class CloneRepository extends React.Component<
     super(props)
 
     // Initialize initial path with a '/' to avoid invalid paths
-    const defaultDirectory = '/'
+    const defaultDirectory = __WIN32__? '\\' : '/'
 
     const initialBaseTabState: IBaseTabState = {
       error: null,

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -150,7 +150,8 @@ export class CloneRepository extends React.Component<
   public constructor(props: ICloneRepositoryProps) {
     super(props)
 
-    const defaultDirectory = null
+    // Initialize initial path with a '/' to avoid invalid paths
+    const defaultDirectory = '/'
 
     const initialBaseTabState: IBaseTabState = {
       error: null,

--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -151,7 +151,7 @@ export class CloneRepository extends React.Component<
     super(props)
 
     // Initialize initial path with a '/' to avoid invalid paths
-    const defaultDirectory = __WIN32__? '\\' : '/'
+    const defaultDirectory = '/'
 
     const initialBaseTabState: IBaseTabState = {
       error: null,

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -7,14 +7,12 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
-import { IAheadBehind } from '../../models/branch' 
 
 interface IDeleteBranchProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly branch: Branch
   readonly existsOnRemote: boolean
-  readonly aheadBehind: IAheadBehind | null
   readonly onDismissed: () => void
   readonly onDeleted: (repository: Repository) => void
 }
@@ -73,9 +71,6 @@ export class DeleteBranch extends React.Component<
               there as well?
             </strong>
           </p>
-          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? 
-          (<p><Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
-          unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.</p>) : null}
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -7,12 +7,14 @@ import { Checkbox, CheckboxValue } from '../lib/checkbox'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { IAheadBehind } from '../../models/branch' 
 
 interface IDeleteBranchProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly branch: Branch
   readonly existsOnRemote: boolean
+  readonly aheadBehind: IAheadBehind | null
   readonly onDismissed: () => void
   readonly onDeleted: (repository: Repository) => void
 }
@@ -71,6 +73,9 @@ export class DeleteBranch extends React.Component<
               there as well?
             </strong>
           </p>
+          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? 
+          (<p><Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
+          unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.</p>) : null}
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -64,8 +64,11 @@ export class DeleteBranch extends React.Component<
           </p>
         </DialogContent>
         <DialogFooter>
-          <OkCancelButtonGroup destructive={true} cancelButtonText="No" 
-          okButtonText="Merge and Delete" />
+          <OkCancelButtonGroup
+            destructive={true}
+            cancelButtonText="No"
+            okButtonText="Merge and Delete"
+          />
         </DialogFooter>
       </Dialog>
     )
@@ -107,9 +110,12 @@ export class DeleteBranch extends React.Component<
               there as well?
             </strong>
           </p>
-          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? 
-          (<p><Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
-          unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.</p>) : null}
+          {this.props.aheadBehind && this.props.aheadBehind.ahead > 0 ? (
+            <p>
+              <Ref>{this.props.branch.name}</Ref> has <em>{unmergedCommits}</em>{' '}
+              unmerged {unmergedCommits === 1 ? 'commit' : 'commits'}.
+            </p>
+          ) : null}
           <Checkbox
             label="Yes, delete this branch on the remote"
             value={
@@ -154,7 +160,7 @@ export class DeleteBranch extends React.Component<
       this.props.repository,
       this.props.branch.name
     )
-    
+
     this.renderDeleteBranch()
   }
 }

--- a/app/src/ui/delete-branch/delete-branch-dialog.tsx
+++ b/app/src/ui/delete-branch/delete-branch-dialog.tsx
@@ -8,11 +8,13 @@ import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Ref } from '../lib/ref'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { IAheadBehind } from '../../models/branch'
+import { MergeTreeResult } from '../../models/merge'
 
 interface IDeleteBranchProps {
   readonly dispatcher: Dispatcher
   readonly repository: Repository
   readonly branch: Branch
+  readonly mergeStatus: MergeTreeResult | null
   readonly existsOnRemote: boolean
   readonly aheadBehind: IAheadBehind | null
   readonly onDismissed: () => void
@@ -101,6 +103,8 @@ export class DeleteBranch extends React.Component<
   }
 
   private renderDeleteOnRemote() {
+    const unmergedCommits = this.props.aheadBehind!.ahead
+
     if (this.props.branch.upstreamRemoteName && this.props.existsOnRemote) {
       return (
         <div>
@@ -158,7 +162,8 @@ export class DeleteBranch extends React.Component<
   private mergeAndDeleteBranch = async () => {
     await this.props.dispatcher.mergeBranch(
       this.props.repository,
-      this.props.branch.name
+      this.props.branch,
+      this.props.mergeStatus
     )
 
     this.renderDeleteBranch()


### PR DESCRIPTION
**Issue #13816 Clone Error**
**Issue #4214 Warn User of Unmerged Commit**

## Description
**Issue #13816:**
Set the default directory for cloning to be the root, preventing invalid absolute paths.  

**Issue #4214:** 
Warn users of unmerged commits before deleting a branch.
New feature to Merge and Delete.

## Release notes
Changed the default directory for cloning to the root directory to avoid invalid input directories.
Warn users of merged commits on a branch before deleting and allow "Merge and Delete".