### PR TITLE
Specify 64-bit exe path for Android Studio

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -22,7 +22,7 @@ type WindowsExternalEditorPathInfo =
   | {
       /**
        * Registry key with the install location of the app. If not provided,
-       * 'InstallLocation' will be used.
+       * 'InstallLocation' or 'UninstallString' will be assumed.
        **/
       readonly installLocationRegistryKey?:
         | 'InstallLocation'

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -24,7 +24,9 @@ type WindowsExternalEditorPathInfo =
        * Registry key with the install location of the app. If not provided,
        * 'InstallLocation' will be used.
        **/
-      readonly installLocationRegistryKey?: 'InstallLocation'
+      readonly installLocationRegistryKey?:
+        | 'InstallLocation'
+        | 'UninstallString'
 
       /**
        * List of lists of path components from the editor's installation folder to
@@ -314,7 +316,11 @@ const editors: WindowsExternalEditor[] = [
   {
     name: 'Android Studio',
     registryKeys: [LocalMachineUninstallKey('Android Studio')],
-    installLocationRegistryKey: 'DisplayIcon',
+    installLocationRegistryKey: 'UninstallString',
+    executableShimPaths: [
+      ['..', 'bin', `studio64.exe`],
+      ['..', 'bin', `studio.exe`],
+    ],
     displayNamePrefix: 'Android Studio',
     publisher: 'Google LLC',
   },


### PR DESCRIPTION
Closes #14519 

## Description
This PR makes sure Desktop looks for the 64bit version of the Android Studio executable and runs that one. Otherwise, the registry keys point to the 32-bit which won't be able to launch the 64-bit versions of the JVM DLLs.

These changes make Desktop pick the installation folder from the `UninstallString` registry key (which points to something like `C:\Program Files\Android\Android Studio\uninstall.exe`, and then append `..\bin\studio64.exe`.

Not sure when this broke because I tested #14054 and worked as expected. Unless... this wasn't a problem on Windows for ARM, which is where I tested it 🤔 

## Release notes

Notes: [Fixed] Fix opening files with Android Studio
