### PR TITLE
Fix PR review notification dialog dashed lines

### DIFF
--- a/app/styles/ui/_pull-request-review.scss
+++ b/app/styles/ui/_pull-request-review.scss
@@ -52,7 +52,6 @@
         line {
           stroke: var(--pr-timeline-line-color);
           stroke-width: 1px;
-          stroke-linecap: square;
         }
 
         &.top line {


### PR DESCRIPTION
## Description

Recently I noticed in a screenshot @niik shared that the dashed timeline lines in PR review notifications weren't actually dashed. It's a simple fix, but the problem seems to happen on high-density screens (happens on my MacBook but not on my external display).

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1083228/167828520-3685dfcb-860d-4402-ba56-f6e527a2a90a.png)

After:
![image](https://user-images.githubusercontent.com/1083228/167829217-24fef24d-d3b5-4574-9e08-68e9035cf158.png)

## Release notes

Notes: no-notes
