### PR TITLE
Pretext/Showcase Banner

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -180,7 +180,7 @@ export interface IAppState {
   readonly isUpdateAvailableBannerVisible: boolean
 
   /** Whether there is an update to showcase */
-  readonly isUpdateShowCaseVisible: boolean
+  readonly isUpdateShowcaseVisible: boolean
 
   /** Whether we should ask the user to move the app to /Applications */
   readonly askToMoveToApplicationsFolderSetting: boolean

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -179,6 +179,9 @@ export interface IAppState {
   /** Whether we should show the update banner */
   readonly isUpdateAvailableBannerVisible: boolean
 
+  /** Whether there is an update to showcase */
+  readonly isUpdateShowCaseVisible: boolean
+
   /** Whether we should ask the user to move the app to /Applications */
   readonly askToMoveToApplicationsFolderSetting: boolean
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -418,7 +418,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private windowState: WindowState | null = null
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false
-  private isUpdateShowCaseVisible: boolean = false
+  private isUpdateShowcaseVisible: boolean = false
 
   private askToMoveToApplicationsFolderSetting: boolean =
     askToMoveToApplicationsFolderDefault
@@ -864,7 +864,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       appMenuState: this.appMenu ? this.appMenu.openMenus : [],
       highlightAccessKeys: this.highlightAccessKeys,
       isUpdateAvailableBannerVisible: this.isUpdateAvailableBannerVisible,
-      isUpdateShowCaseVisible: this.isUpdateShowCaseVisible,
+      isUpdateShowcaseVisible: this.isUpdateShowcaseVisible,
       currentBanner: this.currentBanner,
       askToMoveToApplicationsFolderSetting:
         this.askToMoveToApplicationsFolderSetting,
@@ -5126,7 +5126,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   public _setUpdateShowCaseVisibility(visibility: boolean) {
-    this.isUpdateShowCaseVisible = visibility
+    this.isUpdateShowcaseVisible = visibility
 
     this.emitUpdate()
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -418,6 +418,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private windowState: WindowState | null = null
   private windowZoomFactor: number = 1
   private isUpdateAvailableBannerVisible: boolean = false
+  private isUpdateShowCaseVisible: boolean = false
 
   private askToMoveToApplicationsFolderSetting: boolean =
     askToMoveToApplicationsFolderDefault
@@ -863,6 +864,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       appMenuState: this.appMenu ? this.appMenu.openMenus : [],
       highlightAccessKeys: this.highlightAccessKeys,
       isUpdateAvailableBannerVisible: this.isUpdateAvailableBannerVisible,
+      isUpdateShowCaseVisible: this.isUpdateShowCaseVisible,
       currentBanner: this.currentBanner,
       askToMoveToApplicationsFolderSetting:
         this.askToMoveToApplicationsFolderSetting,
@@ -5119,6 +5121,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
   public _setUpdateBannerVisibility(visibility: boolean) {
     this.isUpdateAvailableBannerVisible = visibility
+
+    this.emitUpdate()
+  }
+
+  public _setUpdateShowCaseVisibility(visibility: boolean) {
+    this.isUpdateShowCaseVisible = visibility
 
     this.emitUpdate()
   }

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -114,7 +114,10 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       case UpdateStatus.CheckingForUpdates:
       case UpdateStatus.UpdateAvailable:
       case UpdateStatus.UpdateNotChecked:
-        const disabled = updateStatus !== UpdateStatus.UpdateNotAvailable
+        const disabled = ![
+          UpdateStatus.UpdateNotChecked,
+          UpdateStatus.UpdateNotAvailable,
+        ].includes(updateStatus)
 
         return (
           <Row>

--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -113,6 +113,7 @@ export class About extends React.Component<IAboutProps, IAboutState> {
       case UpdateStatus.UpdateNotAvailable:
       case UpdateStatus.CheckingForUpdates:
       case UpdateStatus.UpdateAvailable:
+      case UpdateStatus.UpdateNotChecked:
         const disabled = updateStatus !== UpdateStatus.UpdateNotAvailable
 
         return (
@@ -197,6 +198,8 @@ export class About extends React.Component<IAboutProps, IAboutState> {
         return this.renderUpdateNotAvailable()
       case UpdateStatus.UpdateReady:
         return this.renderUpdateReady()
+      case UpdateStatus.UpdateNotChecked:
+        return null
       default:
         return assertNever(
           updateState.status,

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2702,7 +2702,10 @@ export class App extends React.Component<IAppProps, IAppState> {
         this.props.dispatcher,
         this.onBannerDismissed
       )
-    } else if (this.state.isUpdateAvailableBannerVisible) {
+    } else if (
+      this.state.isUpdateAvailableBannerVisible ||
+      this.state.isUpdateShowCaseVisible
+    ) {
       banner = this.renderUpdateBanner()
     }
     return (
@@ -2722,6 +2725,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         dispatcher={this.props.dispatcher}
         newReleases={updateStore.state.newReleases}
         onDismissed={this.onUpdateAvailableDismissed}
+        isUpdateShowCaseVisible={this.state.isUpdateShowCaseVisible}
+        emoji={this.state.emoji}
         key={'update-available'}
       />
     )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -262,7 +262,11 @@ export class App extends React.Component<IAppProps, IAppState> {
       ) {
         this.props.dispatcher.setUpdateBannerVisibility(true)
       }
-      if (await updateStore.isUpdateShowcase()) {
+
+      if (
+        status !== UpdateStatus.UpdateReady &&
+        (await updateStore.isUpdateShowcase())
+      ) {
         this.props.dispatcher.setUpdateShowCaseVisibility(true)
       }
     })

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -253,7 +253,7 @@ export class App extends React.Component<IAppProps, IAppState> {
 
     ipcRenderer.on('menu-event', (_, name) => this.onMenuEvent(name))
 
-    updateStore.onDidChange(state => {
+    updateStore.onDidChange(async state => {
       const status = state.status
 
       if (
@@ -261,6 +261,9 @@ export class App extends React.Component<IAppProps, IAppState> {
         status === UpdateStatus.UpdateReady
       ) {
         this.props.dispatcher.setUpdateBannerVisibility(true)
+      }
+      if (await updateStore.isUpdateShowcase()) {
+        this.props.dispatcher.setUpdateShowCaseVisibility(true)
       }
     })
 
@@ -310,6 +313,11 @@ export class App extends React.Component<IAppProps, IAppState> {
     ) {
       setInterval(() => this.checkForUpdates(true), UpdateCheckInterval)
       this.checkForUpdates(true)
+    } else if (await updateStore.isUpdateShowcase()) {
+      // The only purpose of this call is so we can see the showcase on dev/test
+      // env. Prod and beta environment will trigger this during automatic check
+      // for updates.
+      this.props.dispatcher.setUpdateShowCaseVisibility(true)
     }
 
     log.info(`launching: ${getVersion()} (${getOS()})`)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2708,7 +2708,7 @@ export class App extends React.Component<IAppProps, IAppState> {
       )
     } else if (
       this.state.isUpdateAvailableBannerVisible ||
-      this.state.isUpdateShowCaseVisible
+      this.state.isUpdateShowcaseVisible
     ) {
       banner = this.renderUpdateBanner()
     }
@@ -2729,7 +2729,7 @@ export class App extends React.Component<IAppProps, IAppState> {
         dispatcher={this.props.dispatcher}
         newReleases={updateStore.state.newReleases}
         onDismissed={this.onUpdateAvailableDismissed}
-        isUpdateShowCaseVisible={this.state.isUpdateShowCaseVisible}
+        isUpdateShowcaseVisible={this.state.isUpdateShowcaseVisible}
         emoji={this.state.emoji}
         key={'update-available'}
       />

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -15,7 +15,7 @@ import { RichText } from '../lib/rich-text'
 interface IUpdateAvailableProps {
   readonly dispatcher: Dispatcher
   readonly newReleases: ReadonlyArray<ReleaseSummary> | null
-  readonly isUpdateShowCaseVisible: boolean
+  readonly isUpdateShowcaseVisible: boolean
   readonly emoji: Map<string, string>
   readonly onDismissed: () => void
 }
@@ -31,7 +31,7 @@ export class UpdateAvailable extends React.Component<
   public render() {
     return (
       <Banner id="update-available" onDismissed={this.props.onDismissed}>
-        {!this.props.isUpdateShowCaseVisible && (
+        {!this.props.isUpdateShowcaseVisible && (
           <Octicon
             className="download-icon"
             symbol={OcticonSymbol.desktopDownload}
@@ -44,7 +44,7 @@ export class UpdateAvailable extends React.Component<
   }
 
   private renderMessage = () => {
-    if (this.props.isUpdateShowCaseVisible) {
+    if (this.props.isUpdateShowcaseVisible) {
       const version =
         this.props.newReleases !== null
           ? ` with GitHub Desktop ${this.props.newReleases[0].latestVersion}`

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Dispatcher } from '../dispatcher/index'
 import { LinkButton } from '../lib/link-button'
-import { updateStore } from '../lib/update-store'
+import { lastShowCaseVersionSeen, updateStore } from '../lib/update-store'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
 import { PopupType } from '../../models/popup'
@@ -44,6 +44,21 @@ export class UpdateAvailable extends React.Component<
         </span>
       </Banner>
     )
+  }
+
+  private dismissUpdateShowCaseVisibility = () => {
+    // Note: under that scenario that this is being dismissed due to clicking
+    // what's new on a pending release and for some reason we don't have the
+    // releases. We will end up showing the showcase banner after restart. This
+    // shouldn't happen but even if it did it would just be a minor annoyance as
+    // user would need to dismiss it again.
+    const versionSeen =
+      this.props.newReleases === null
+        ? __APP_VERSION__
+        : this.props.newReleases[0].latestVersion
+
+    localStorage.setItem(lastShowCaseVersionSeen, versionSeen)
+    this.props.dispatcher.setUpdateShowCaseVisibility(false)
   }
 
   private showReleaseNotes = () => {

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -10,10 +10,13 @@ import { shell } from '../../lib/app-shell'
 import { ReleaseSummary } from '../../models/release-notes'
 import { Banner } from './banner'
 import { ReleaseNotesUri } from '../lib/releases'
+import { RichText } from '../lib/rich-text'
 
 interface IUpdateAvailableProps {
   readonly dispatcher: Dispatcher
   readonly newReleases: ReadonlyArray<ReleaseSummary> | null
+  readonly isUpdateShowCaseVisible: boolean
+  readonly emoji: Map<string, string>
   readonly onDismissed: () => void
 }
 
@@ -28,21 +31,50 @@ export class UpdateAvailable extends React.Component<
   public render() {
     return (
       <Banner id="update-available" onDismissed={this.props.onDismissed}>
-        <Octicon
-          className="download-icon"
-          symbol={OcticonSymbol.desktopDownload}
-        />
+        {!this.props.isUpdateShowCaseVisible && (
+          <Octicon
+            className="download-icon"
+            symbol={OcticonSymbol.desktopDownload}
+          />
+        )}
 
-        <span onSubmit={this.updateNow}>
-          An updated version of GitHub Desktop is available and will be
-          installed at the next launch. See{' '}
+        {this.renderMessage()}
+      </Banner>
+    )
+  }
+
+  private renderMessage = () => {
+    if (this.props.isUpdateShowCaseVisible) {
+      const version =
+        this.props.newReleases !== null
+          ? ` with GitHub Desktop ${this.props.newReleases[0].latestVersion}`
+          : ''
+
+      return (
+        <span>
+          <RichText
+            className="banner-emoji"
+            text={':tada:'}
+            emoji={this.props.emoji}
+          />
+          Exciting new features have been added{version}. See{' '}
           <LinkButton onClick={this.showReleaseNotes}>what's new</LinkButton> or{' '}
-          <LinkButton onClick={this.updateNow}>
-            restart GitHub Desktop
+          <LinkButton onClick={this.dismissUpdateShowCaseVisibility}>
+            dismiss
           </LinkButton>
           .
         </span>
-      </Banner>
+      )
+    }
+
+    return (
+      <span onSubmit={this.updateNow}>
+        An updated version of GitHub Desktop is available and will be installed
+        at the next launch. See{' '}
+        <LinkButton onClick={this.showReleaseNotes}>what's new</LinkButton> or{' '}
+        <LinkButton onClick={this.updateNow}>restart GitHub Desktop</LinkButton>
+        .
+      </span>
     )
   }
 
@@ -72,6 +104,8 @@ export class UpdateAvailable extends React.Component<
         newReleases: this.props.newReleases,
       })
     }
+
+    this.dismissUpdateShowCaseVisibility()
   }
 
   private updateNow = () => {

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -953,6 +953,13 @@ export class Dispatcher {
   }
 
   /**
+   * Set the update show case visibility
+   */
+  public setUpdateShowCaseVisibility(isVisible: boolean) {
+    return this.appStore._setUpdateShowCaseVisibility(isVisible)
+  }
+
+  /**
    * Set the banner state for the application
    */
   public setBanner(state: Banner) {

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -20,6 +20,7 @@ import { ReleaseSummary } from '../../models/release-notes'
 import { generateReleaseSummary } from '../../lib/release-notes'
 import { setNumber, getNumber } from '../../lib/local-storage'
 import { enableUpdateFromEmulatedX64ToARM64 } from '../../lib/feature-flag'
+import { offsetFromNow } from '../../lib/offset-from'
 
 /** The states the auto updater can be in. */
 export enum UpdateStatus {
@@ -34,6 +35,9 @@ export enum UpdateStatus {
 
   /** An update has been downloaded and is ready to be installed. */
   UpdateReady,
+
+  /** We have not checked for an update yet. */
+  UpdateNotChecked,
 }
 
 export interface IUpdateState {
@@ -45,7 +49,7 @@ export interface IUpdateState {
 /** A store which contains the current state of the auto updater. */
 class UpdateStore {
   private emitter = new Emitter()
-  private status = UpdateStatus.UpdateNotAvailable
+  private status = UpdateStatus.UpdateNotChecked
   private lastSuccessfulCheck: Date | null = null
   private newReleases: ReadonlyArray<ReleaseSummary> | null = null
 
@@ -94,7 +98,9 @@ class UpdateStore {
     this.emitDidChange()
   }
 
-  private onUpdateNotAvailable = () => {
+  private onUpdateNotAvailable = async () => {
+    // This is so we can check for pretext changelog for showcasing a recent update
+    this.newReleases = await generateReleaseSummary()
     this.touchLastChecked()
     this.status = UpdateStatus.UpdateNotAvailable
     this.emitDidChange()
@@ -102,9 +108,7 @@ class UpdateStore {
 
   private onUpdateDownloaded = async () => {
     this.newReleases = await generateReleaseSummary()
-
     this.status = UpdateStatus.UpdateReady
-
     this.emitDidChange()
   }
 
@@ -184,6 +188,34 @@ class UpdateStore {
     // eslint-disable-next-line no-sync
     sendWillQuitSync()
     quitAndInstallUpdate()
+  }
+
+  /**
+   * Method to determine if we should show an update showcase call to action.
+   *
+   * @returns true if there is a pretext on the latest releases and that release
+   * was published in the last 15 days.
+   */
+  public async isUpdateShowcase() {
+    if (
+      (__RELEASE_CHANNEL__ === 'development' ||
+        __RELEASE_CHANNEL__ === 'test') &&
+      this.newReleases === null &&
+      this.status === UpdateStatus.UpdateNotChecked
+    ) {
+      // On prod or with test manual check for updates, we are doing this during
+      // the automatic check for updates
+      this.newReleases = await generateReleaseSummary()
+    }
+
+    return (
+      this.newReleases !== null &&
+      this.newReleases
+        .filter(
+          r => new Date(r.datePublished).getTime() > offsetFromNow(-15, 'days')
+        )
+        .some(r => r.pretext.length > 0)
+    )
   }
 }
 

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -13,6 +13,7 @@ import {
   ReleaseNoteHeaderRightUri,
 } from '../../lib/release-notes'
 import { SandboxedMarkdown } from '../lib/sandboxed-markdown'
+import { Button } from '../lib/button'
 
 interface IReleaseNotesProps {
   readonly onDismissed: () => void
@@ -120,6 +121,32 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
     )
   }
 
+  private onDismissed = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    this.props.onDismissed()
+  }
+
+  private renderButtons = () => {
+    const latestVersion = this.props.newReleases[0].latestVersion
+    if (latestVersion === __APP_VERSION__) {
+      return (
+        <Button type="submit" onClick={this.onDismissed}>
+          Close
+        </Button>
+      )
+    }
+
+    return (
+      <OkCancelButtonGroup
+        destructive={true}
+        okButtonText={
+          __DARWIN__ ? 'Install and Restart' : 'Install and restart'
+        }
+        cancelButtonText="Close"
+      />
+    )
+  }
+
   public render() {
     const release = this.getDisplayRelease()
     const { latestVersion, datePublished, enhancements, bugfixes, pretext } =
@@ -162,13 +189,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
           <LinkButton onClick={this.showAllReleaseNotes}>
             View all release notes
           </LinkButton>
-          <OkCancelButtonGroup
-            destructive={true}
-            okButtonText={
-              __DARWIN__ ? 'Install and Restart' : 'Install and restart'
-            }
-            cancelButtonText="Close"
-          />
+          {this.renderButtons()}
         </DialogFooter>
       </Dialog>
     )

--- a/app/styles/ui/banners/_update-available.scss
+++ b/app/styles/ui/banners/_update-available.scss
@@ -2,4 +2,9 @@
   .download-icon {
     margin-right: var(--spacing);
   }
+
+  .banner-emoji {
+    display: inline-block;
+    margin-right: var(--spacing-half);
+  }
 }

--- a/app/styles/ui/dialogs/_release-notes.scss
+++ b/app/styles/ui/dialogs/_release-notes.scss
@@ -86,7 +86,6 @@
 
     .column {
       flex: 1 1 275px;
-      max-width: 75%;
       margin: 0 calc(var(--spacing) * 1.5) 0 0;
       height: 100%;
 


### PR DESCRIPTION
## Description
This PR modifies the update banner such that, if there is a pretext in a release within the last 15 days, it will display a showcase banner where the user can open the release notes to see the pretext. 

Like the update banner, this will not be present if any other banner is open. This will also not be present if there is a pending update (as it will show the regular update banner). Additionally, if a user clicks the "what's new" to view the release notes while the update is pending, that will prevent user from seeing this showcase banner as it would be redundant. 

Other notes: as can be seen in this screen recording.. need to do some css work when displaying only one column of release notes under a showcase, but that is not related to this and I will get it in a follow up PR.

### Screenshots
https://user-images.githubusercontent.com/75402236/168608260-92cd053e-7e80-47f3-91fe-cab1b3b32735.mov

## Release notes
Notes: [Improved] Display a banner when we have a pretext release note to highlight the new feature.
