### PR TITLE
Move markdown parsing to exportable/reusable method

### DIFF
--- a/app/src/lib/markdown-filters/markdown-filter.ts
+++ b/app/src/lib/markdown-filters/markdown-filter.ts
@@ -1,0 +1,59 @@
+import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+import { GitHubRepository } from '../../models/github-repository'
+import {
+  applyNodeFilters,
+  buildCustomMarkDownNodeFilterPipe,
+  MarkdownContext,
+} from './node-filter'
+
+interface ICustomMarkdownFilterOptions {
+  emoji: Map<string, string>
+  repository?: GitHubRepository
+  markdownContext?: MarkdownContext
+}
+
+/**
+ * Takes string of markdown and runs it through the MarkedJs parser with github
+ * flavored flags enabled followed by running that through domPurify, and lastly
+ * if custom markdown options are provided, it applies the custom markdown
+ * filters.
+ */
+export async function parseMarkdown(
+  markdown: string,
+  customMarkdownOptions?: ICustomMarkdownFilterOptions
+) {
+  const parsedMarkdown = marked(markdown, {
+    // https://marked.js.org/using_advanced  If true, use approved GitHub
+    // Flavored Markdown (GFM) specification.
+    gfm: true,
+    // https://marked.js.org/using_advanced, If true, add <br> on a single
+    // line break (copies GitHub behavior on comments, but not on rendered
+    // markdown files). Requires gfm be true.
+    breaks: true,
+  })
+
+  const sanitizedHTML = DOMPurify.sanitize(parsedMarkdown)
+
+  return customMarkdownOptions !== undefined
+    ? await applyCustomMarkdownFilters(sanitizedHTML, customMarkdownOptions)
+    : sanitizedHTML
+}
+
+/**
+ * Applies custom markdown filters to parsed markdown html. This is done
+ * through converting the markdown html into a DOM document and then
+ * traversing the nodes to apply custom filters such as emoji, issue, username
+ * mentions, etc.
+ */
+function applyCustomMarkdownFilters(
+  parsedMarkdown: string,
+  options: ICustomMarkdownFilterOptions
+): Promise<string> {
+  const nodeFilters = buildCustomMarkDownNodeFilterPipe(
+    options.emoji,
+    options.repository,
+    options.markdownContext
+  )
+  return applyNodeFilters(nodeFilters, parsedMarkdown)
+}

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -1,22 +1,20 @@
 import * as React from 'react'
 import * as Path from 'path'
-import { marked } from 'marked'
-import DOMPurify from 'dompurify'
-import {
-  applyNodeFilters,
-  buildCustomMarkDownNodeFilterPipe,
-  MarkdownContext,
-} from '../../lib/markdown-filters/node-filter'
+import { MarkdownContext } from '../../lib/markdown-filters/node-filter'
 import { GitHubRepository } from '../../models/github-repository'
 import { readFile } from 'fs/promises'
 import { Tooltip } from './tooltip'
 import { createObservableRef } from './observable-ref'
 import { getObjectId } from './object-id'
 import { debounce } from 'lodash'
+import { parseMarkdown } from '../../lib/markdown-filters/markdown-filter'
 
 interface ISandboxedMarkdownProps {
   /** A string of unparsed markdown to display */
   readonly markdown: string
+
+  /** Whether the markdown was pre-parsed - assumed false */
+  readonly isParsed?: boolean
 
   /** The baseHref of the markdown content for when the markdown has relative links */
   readonly baseHref?: string
@@ -297,19 +295,10 @@ export class SandboxedMarkdown extends React.PureComponent<
 
     const styleSheet = await this.getInlineStyleSheet()
 
-    const parsedMarkdown = marked(this.props.markdown ?? '', {
-      // https://marked.js.org/using_advanced  If true, use approved GitHub
-      // Flavored Markdown (GFM) specification.
-      gfm: true,
-      // https://marked.js.org/using_advanced, If true, add <br> on a single
-      // line break (copies GitHub behavior on comments, but not on rendered
-      // markdown files). Requires gfm be true.
-      breaks: true,
-    })
-
-    const sanitizedHTML = DOMPurify.sanitize(parsedMarkdown)
-
-    const filteredHTML = await this.applyCustomMarkdownFilters(sanitizedHTML)
+    const filteredHTML =
+      this.props.isParsed === true
+        ? this.props.markdown
+        : await parseMarkdown(this.props.markdown)
 
     const src = `
       <html>
@@ -339,21 +328,6 @@ export class SandboxedMarkdown extends React.PureComponent<
     // parent dom and we want all rendering to be isolated to our sandboxed iframe.
     // -- https://csplite.com/csp/test188/
     this.frameRef.src = `data:text/html;charset=utf-8;base64,${b64src}`
-  }
-
-  /**
-   * Applies custom markdown filters to parsed markdown html. This is done
-   * through converting the markdown html into a DOM document and then
-   * traversing the nodes to apply custom filters such as emoji, issue, username
-   * mentions, etc.
-   */
-  private applyCustomMarkdownFilters(parsedMarkdown: string): Promise<string> {
-    const nodeFilters = buildCustomMarkDownNodeFilterPipe(
-      this.props.emoji,
-      this.props.repository,
-      this.props.markdownContext
-    )
-    return applyNodeFilters(nodeFilters, parsedMarkdown)
   }
 
   public render() {


### PR DESCRIPTION
## Description
This is an initial step in process to make markdown be able to be parsed ahead of render time to reduce user wait time of markdown parsing. It just moves methods around to make them separated/reusable.

... next thing will be to handle markdown as a promise or maybe an observable type thing... 

## Release notes
Notes: none
