### PR TITLE
Fix regression from moving custom markdown filters

### DIFF
--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -295,10 +295,15 @@ export class SandboxedMarkdown extends React.PureComponent<
 
     const styleSheet = await this.getInlineStyleSheet()
 
+    const { emoji, repository, markdownContext } = this.props
     const filteredHTML =
       this.props.isParsed === true
         ? this.props.markdown
-        : await parseMarkdown(this.props.markdown)
+        : await parseMarkdown(this.props.markdown, {
+            emoji,
+            repository,
+            markdownContext,
+          })
 
     const src = `
       <html>


### PR DESCRIPTION
## Description
In https://github.com/desktop/desktop/pull/14622, I moved the parsing out into is own file and in doing so created custom markdown filter options.. which I neglected to add to that PR.. 🤦 Thus development is regressed not to apply the custom markdown filters at the moment. If https://github.com/desktop/desktop/pull/14625 is not merged, then this needs to be merged before a new release is shipped.

## Release notes
Notes: no-notes
