### PR TITLE
Pre-parse PR Quickview markdown

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -488,7 +488,7 @@ export interface IAPIPullRequest {
   readonly user: IAPIIdentity
   readonly head: IAPIPullRequestRef
   readonly base: IAPIPullRequestRef
-  readonly body: string
+  readonly body: string | undefined | null
   readonly state: 'open' | 'closed'
   readonly draft?: boolean
 }

--- a/app/src/lib/stores/pull-request-store.ts
+++ b/app/src/lib/stores/pull-request-store.ts
@@ -317,7 +317,7 @@ export class PullRequestStore {
           sha: pr.base.sha,
           repoId: baseGitHubRepo.dbID,
         },
-        body: pr.body,
+        body: pr.body ?? '',
         author: pr.user.login,
         draft: pr.draft ?? false,
       })

--- a/app/src/models/pull-request.ts
+++ b/app/src/models/pull-request.ts
@@ -1,3 +1,8 @@
+import { enablePullRequestQuickView } from '../lib/feature-flag'
+import {
+  MarkdownEmitter,
+  parseMarkdown,
+} from '../lib/markdown-filters/markdown-filter'
 import { GitHubRepository } from './github-repository'
 
 /** Returns the commit ref for a given pull request number. */
@@ -20,6 +25,8 @@ export class PullRequestRef {
 }
 
 export class PullRequest {
+  public parsedMarkdownBody?: MarkdownEmitter
+
   /**
    * @param created The date on which the PR was created.
    * @param status The status of the PR. This will be `null` if we haven't looked up its
@@ -40,4 +47,16 @@ export class PullRequest {
     public readonly draft: boolean,
     public readonly body: string
   ) {}
+
+  public generateParsedMarkdownBody(emoji: Map<string, string>) {
+    if (this.parsedMarkdownBody !== undefined && enablePullRequestQuickView()) {
+      return
+    }
+
+    this.parsedMarkdownBody = parseMarkdown(this.body, {
+      emoji,
+      repository: this.base.gitHubRepository,
+      markdownContext: 'PullRequest',
+    })
+  }
 }

--- a/app/src/ui/branches/branches-container.tsx
+++ b/app/src/ui/branches/branches-container.tsx
@@ -327,6 +327,7 @@ export class BranchesContainer extends React.Component<
         isLoadingPullRequests={this.props.isLoadingPullRequests}
         onMouseEnterPullRequest={this.onMouseEnterPullRequestListItem}
         onMouseLeavePullRequest={this.onMouseLeavePullRequestListItem}
+        emoji={this.props.emoji}
       />
     )
   }

--- a/app/src/ui/branches/pull-request-list.tsx
+++ b/app/src/ui/branches/pull-request-list.tsx
@@ -76,6 +76,9 @@ interface IPullRequestListProps {
   readonly onMouseLeavePullRequest: (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>
   ) => void
+
+  /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
+  readonly emoji: Map<string, string>
 }
 
 interface IPullRequestListState {
@@ -172,6 +175,11 @@ export class PullRequestList extends React.Component<
     matches: IMatches
   ) => {
     const pr = item.pullRequest
+    // Parsing the markdown is done at the rendering of a pull request so we
+    // only do it for the prs that users can interact with. We wouldn't want the
+    // performance hit of pre-parsing all pr's for repos that have hundreds when
+    // the user likely won't be interacting with the majority of them.
+    pr.generateParsedMarkdownBody(this.props.emoji)
 
     return (
       <PullRequestListItem

--- a/app/src/ui/lib/sandboxed-markdown.tsx
+++ b/app/src/ui/lib/sandboxed-markdown.tsx
@@ -157,7 +157,12 @@ export class SandboxedMarkdown extends React.PureComponent<
   }
 
   public componentWillUnmount() {
-    this.markdownEmitter?.dispose()
+    if (this.props.markdown !== 'string') {
+      this.markdownEmitter?.clear()
+    } else {
+      this.markdownEmitter?.dispose()
+    }
+
     this.resizeObserver.disconnect()
     document.removeEventListener('scroll', this.onDocumentScroll)
   }

--- a/app/src/ui/pull-request-quick-view.tsx
+++ b/app/src/ui/pull-request-quick-view.tsx
@@ -185,11 +185,11 @@ export class PullRequestQuickView extends React.Component<
   }
 
   private renderPR = () => {
-    const { title, pullRequestNumber, base, body, draft } =
+    const { title, pullRequestNumber, base, body, draft, parsedMarkdownBody } =
       this.props.pullRequest
     const displayBody =
-      body !== undefined && body !== null && body.trim() !== ''
-        ? body
+      body.trim() !== '' && parsedMarkdownBody !== undefined
+        ? parsedMarkdownBody
         : '_No description provided._'
 
     return (


### PR DESCRIPTION
This is based on #14625

## Description

This makes use of the markdown emitter functionality in #14625 and pre-parses the PR bodies displayed in the quick view markdown. The quick view is still feature-flagged to development.

## Release notes
Notes: no-notes
