### PR TITLE
Escape branch name

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1,5 +1,4 @@
 import * as Path from 'path'
-import { escape } from 'querystring'
 import {
   AccountsStore,
   CloningRepositoriesStore,
@@ -5788,7 +5787,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const urlEncodedBranchName = escape(branch.nameWithoutRemote)
+    const urlEncodedBranchName = encodeURIComponent(branch.nameWithoutRemote)
     const baseURL = `${gitHubRepository.htmlURL}/pull/new/${urlEncodedBranchName}`
 
     await this._openInBrowser(baseURL)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as crypto from 'crypto'
-import { escape } from 'querystring'
 import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import {
   IAppState,
@@ -691,7 +690,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    const urlEncodedBranchName = escape(branchTip.branch.upstreamWithoutRemote)
+    const urlEncodedBranchName = encodeURIComponent(
+      branchTip.branch.upstreamWithoutRemote
+    )
 
     const url = `${htmlURL}/${view}/${urlEncodedBranchName}`
     this.props.dispatcher.openInBrowser(url)

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as crypto from 'crypto'
+import { escape } from 'querystring'
 import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import {
   IAppState,
@@ -690,7 +691,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       return
     }
 
-    const url = `${htmlURL}/${view}/${branchTip.branch.upstreamWithoutRemote}`
+    const urlEncodedBranchName = escape(branchTip.branch.upstreamWithoutRemote)
+
+    const url = `${htmlURL}/${view}/${urlEncodedBranchName}`
     this.props.dispatcher.openInBrowser(url)
   }
 


### PR DESCRIPTION
Closes #14631

## Description
As an author of #14231 I had to fix this one 😄 

- Fix for unencoded branch name that causes issues with "View Branch on GitHub" and "Compare on GitHub".

### Screenshots
![test-branch-name-fix](https://user-images.githubusercontent.com/9341546/169109651-17f35c28-6d01-4fc4-bf4d-3934166ae90a.gif)

