### PR TITLE
Added support for Visual Studio Community, Professional, Enterprise 2017 (v15.2^), 2019, 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [GitHub Desktop](https://desktop.github.com)
-test
+
 [GitHub Desktop](https://desktop.github.com/) is an open source [Electron](https://www.electronjs.org/)-based
 GitHub app. It is written in [TypeScript](http://www.typescriptlang.org) and
 uses [React](https://reactjs.org/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [GitHub Desktop](https://desktop.github.com)
-
+test
 [GitHub Desktop](https://desktop.github.com/) is an open source [Electron](https://www.electronjs.org/)-based
 GitHub app. It is written in [TypeScript](http://www.typescriptlang.org) and
 uses [React](https://reactjs.org/).

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -142,7 +142,6 @@ const executableShimPathsForJetBrainsIDE = (
   ]
 }
 
-
 const visualStudioInstaller : WindowsVisualStudioInstaller = {
   name: 'Microsoft Visual Studio Installer',
   registryKeys: [LocalMachineUninstallKey('{6F320B93-EE3C-4826-85E0-ADF79F8D4C61}')],
@@ -610,8 +609,7 @@ export async function getAvailableEditors(): Promise<
         })
       }
     }
-  }
-  
+  } 
 
   return results
 }

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -151,16 +151,35 @@ const visualStudioInstaller : WindowsVisualStudioInstaller = {
   publisher: 'Microsoft Corporation'
 }
 
+/*
+  * Returns the path to VSWHERE.
+  *
+  * vswhere is a tool that is part of the Visual Studio Installer. It is used
+  * to find the path to the Visual Studio installation. 
+  * vswhere is included with the installer as of Visual Studio 2017 version 15.2 and later
+  * https://github.com/microsoft/vswhere
+  * 
+  */
 const getPathToVsWhere = async (visualStudioInstaller:WindowsVisualStudioInstaller): Promise<string | null> => {
     const path = await findApplication(visualStudioInstaller)
-    if (path !== null) {
-      log.debug("1 visualStudioInstaller.vswherePath: " + path)
-    } else {
+    if (!path) {
       log.debug('Visual Studio Installer not found');
-    }
+    } 
     return path;
 }
 
+/* 
+ * This list contains the list of Visual Studio IDEs that we support. 
+ * Add a new entry here to add support for a new Visual Studio version.
+ * 
+ * To find the product ID, please consult the following link:
+ * https://docs.microsoft.com/en-us/visualstudio/install/workload-and-component-ids?view=vs-2022 
+ * (change the year at the end of the url to the year you want)
+ * 
+ * To find the version, please consult the following link:
+ * https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2022
+ * (change the year at the end of the url to the year you want)
+ */
 const visualStudioEditors : WindowsVisualStudioEditor[] = [
   {
     name: 'Visual Studio Community 2022',
@@ -168,6 +187,62 @@ const visualStudioEditors : WindowsVisualStudioEditor[] = [
     publisher: 'Microsoft Corporation',
     version: '17',
     productId: 'Microsoft.VisualStudio.Product.Community',
+  },
+  {
+    name: 'Visual Studio Community 2019',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '16',
+    productId: 'Microsoft.VisualStudio.Product.Community',
+  },
+  {
+    name: 'Visual Studio Community 2017',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '15',
+    productId: 'Microsoft.VisualStudio.Product.Community',
+  },
+  {
+    name: 'Visual Studio Professional 2022',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '17',
+    productId: 'Microsoft.VisualStudio.Product.Professional',
+  },
+  {
+    name: 'Visual Studio Professional 2019',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '16',
+    productId: 'Microsoft.VisualStudio.Product.Professional',
+  },
+  {
+    name: 'Visual Studio Professional 2017',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '15',
+    productId: 'Microsoft.VisualStudio.Product.Professional',
+  },
+  {
+    name: 'Visual Studio Enterprise 2022',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '17',
+    productId: 'Microsoft.VisualStudio.Product.Enterprise',
+  },
+  {
+    name: 'Visual Studio Enterprise 2019',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '16',
+    productId: 'Microsoft.VisualStudio.Product.Enterprise',
+  },
+  {
+    name: 'Visual Studio Enterprise 2017',
+    displayNamePrefix: 'Microsoft Visual Studio Code',
+    publisher: 'Microsoft Corporation',
+    version: '15',
+    productId: 'Microsoft.VisualStudio.Product.Enterprise',
   }
 ]
 
@@ -461,20 +536,20 @@ function getAppInfo(
   const installLocation = getKeyOrEmpty(
     keys,
     editor.installLocationRegistryKey ?? 'InstallLocation'
-  ).replace(/(^"|"$)/g, '')
+  ).replace(/(^"|"$)/g, '') // remove leading and trailing quotes
   return { displayName, publisher, installLocation }
 }
 
 async function findApplication(editor: WindowsExternalEditor) {
   for (const { key, subKey } of editor.registryKeys) {
-    log.debug("subkey " + subKey + " key " + key )
+
     const keys = enumerateValues(key, subKey)
     if (keys.length === 0) {
       continue
     }
 
     const { displayName, publisher, installLocation } = getAppInfo(editor, keys)
-    log.debug("i" + installLocation)
+
     if (
       !displayName.startsWith(editor.displayNamePrefix) ||
       publisher !== editor.publisher
@@ -512,7 +587,6 @@ export async function getAvailableEditors(): Promise<
 
   for (const editor of editors) {
     const path = await findApplication(editor)
-    log.debug("tiiiitttt")
     if (path) {
       results.push({
         editor: editor.name,

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -66,7 +66,7 @@ type WindowsExternalEditorGenericInfo = {
 }
 
 type WindowsVisualStudioEditor = {
-  readonly version: string
+  readonly version: number
   readonly productId: string
 } & WindowsExternalEditorGenericInfo
 
@@ -184,63 +184,63 @@ const visualStudioEditors : WindowsVisualStudioEditor[] = [
     name: 'Visual Studio Community 2022',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '17',
+    version: 17,
     productId: 'Microsoft.VisualStudio.Product.Community',
   },
   {
     name: 'Visual Studio Community 2019',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '16',
+    version: 16,
     productId: 'Microsoft.VisualStudio.Product.Community',
   },
   {
     name: 'Visual Studio Community 2017',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '15',
+    version: 15,
     productId: 'Microsoft.VisualStudio.Product.Community',
   },
   {
     name: 'Visual Studio Professional 2022',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '17',
+    version: 17,
     productId: 'Microsoft.VisualStudio.Product.Professional',
   },
   {
     name: 'Visual Studio Professional 2019',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '16',
+    version: 16,
     productId: 'Microsoft.VisualStudio.Product.Professional',
   },
   {
     name: 'Visual Studio Professional 2017',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '15',
+    version: 15,
     productId: 'Microsoft.VisualStudio.Product.Professional',
   },
   {
     name: 'Visual Studio Enterprise 2022',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '17',
+    version: 17,
     productId: 'Microsoft.VisualStudio.Product.Enterprise',
   },
   {
     name: 'Visual Studio Enterprise 2019',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '16',
+    version: 16,
     productId: 'Microsoft.VisualStudio.Product.Enterprise',
   },
   {
     name: 'Visual Studio Enterprise 2017',
     displayNamePrefix: 'Microsoft Visual Studio Code',
     publisher: 'Microsoft Corporation',
-    version: '15',
+    version: 15,
     productId: 'Microsoft.VisualStudio.Product.Enterprise',
   }
 ]
@@ -598,7 +598,7 @@ export async function getAvailableEditors(): Promise<
   const vswherePath = await getPathToVsWhere(visualStudioInstaller);
   if (vswherePath!==null) {
     for (const editor of visualStudioEditors) {
-      const output = await execFile(vswherePath, ['-version', editor.version, '-products', editor.productId, '-property', 'productPath'] );
+      const output = await execFile(vswherePath, ['-version', '['+String(editor.version)+','+String(editor.version+1)+')', '-products', editor.productId, '-property', 'productPath'] );
       const path = output.stdout.trim();
       const exists = await pathExists(path);
       if (exists) {


### PR DESCRIPTION
Closes [#12946](https://github.com/desktop/desktop/issues/12946)

## Description
Implementing Visual Studio support required an unconventional approach since Visual Studio doesn't use a unique registry key like most other IDEs.

Thankfully as of Visual Studio 2017 v15.2, Microsoft includes a CLI tool called [vswhere](https://github.com/microsoft/vswhere) with the visual studio installer to help locate the path to their IDE.  The installer has a unique registry key that we can use to locate its install path which will then allow us to query VSWhere and find the install paths for various visual studio installs.

### Screenshots

#### Workstation 1
> Windows 11 64 bit - Visual Studio Community 2022

![VS Github](https://user-images.githubusercontent.com/93364146/169721838-ac95d64b-53c6-490b-ba09-59bd09066d79.gif)

#### Workstation 2
> Windows 10 64 bit - Visual Studio Professional 2019, 2022

![image](https://user-images.githubusercontent.com/93364146/169721826-ce9eec36-d70e-44de-b410-8f9cb7d65842.png)

## Release notes

Added IDE support for:
- Visual Studio Community 2022
- Visual Studio Professional 2022
- Visual Studio Enterprise 2022
- Visual Studio Community 2019
- Visual Studio Professional 2019
- Visual Studio Enterprise 2019
- Visual Studio Community 2017 (only version 15.2 and up)
- Visual Studio Professional 2017 (only version 15.2 and up)
- Visual Studio Enterprise 2017 (only version 15.2 and up)

Notes:

I don't have access to a 32 bit computer and therefore couldn't test my change on a 32 bit computer.  The registry location for the Visual Studio Installer might be different on a 32 bit computer.