### PR TITLE
Added support for Visual Studio Community, Professional, Enterprise - 2017 (v15.2^), 2019, 2022 on Windows 64-bit

### DIFF
--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -10,6 +10,10 @@ import { pathExists } from '../../ui/lib/path-exists'
 
 import { IFoundEditor } from './found-editor'
 
+import { execFileSync } from 'child_process'
+
+import {existsSync} from 'fs'
+
 interface IWindowsAppInformation {
   displayName: string
   publisher: string
@@ -81,6 +85,48 @@ const LocalMachineUninstallKey = (subKey: string) =>
 
 const Wow64LocalMachineUninstallKey = (subKey: string) =>
   registryKey(HKEY.HKEY_LOCAL_MACHINE, wow64UninstallSubKey, subKey)
+
+  const registryKeysForVisualStudioIDE = (
+  version: number,
+  productId: string
+): ReadonlyArray<RegistryKey> => {
+
+  const result = new Array<RegistryKey>()
+  let vswherePath = undefined;
+  if(process.env['ProgramFiles(x86)']){
+    const path = Path.join(process.env['ProgramFiles(x86)'], 'Microsoft Visual Studio', 'Installer', 'vswhere.exe');
+    log.debug('Checking for vswhere.exe at ' + path);
+    if(existsSync(path)){
+      vswherePath = path;
+    }
+  } 
+  
+  if(process.env['ProgramFiles']){
+    const path = Path.join(process.env['ProgramFiles'], 'Microsoft Visual Studio', 'Installer', 'vswhere.exe');
+    log.debug('Checking for vswhere.exe at ' + path);
+    if(existsSync(path)){
+      vswherePath = path;
+    }
+  }
+  log.debug(`program file 86 path: ${process.env['ProgramFiles(x86)']}`);
+  log.debug(`program file 86 path: ${process.env['ProgramFiles']}`);
+  if(vswherePath !== undefined){
+    const test = execFileSync(vswherePath, ['-version', '['+String(version)+','+String(version+1)+')', '-products', productId, '-property', 'instanceId']);
+    
+    
+      
+      const instanceId = test.toString().trim();
+      log.debug(`Visual Studio instanceId: ${instanceId}`);
+      result.push(Wow64LocalMachineUninstallKey(instanceId));
+
+
+  } else {
+    log.debug(`Unable to find Visual Studio: vswhere.exe not found`);
+  }
+
+  return result;
+  
+}
 
 // This function generates registry keys for a given JetBrains product for the
 // last 2 years, assuming JetBrains makes no more than 5 major releases and
@@ -198,6 +244,69 @@ const editors: WindowsExternalEditor[] = [
     ],
     executableShimPaths: [['bin', 'code-insiders.cmd']],
     displayNamePrefix: 'Microsoft Visual Studio Code Insiders',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Community 2022',
+    registryKeys: registryKeysForVisualStudioIDE(17, 'Microsoft.VisualStudio.Product.Community'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Community 2022',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Professional 2022',
+    registryKeys: registryKeysForVisualStudioIDE(17, 'Microsoft.VisualStudio.Product.Professional'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Professional 2022',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Enterprise 2022',
+    registryKeys: registryKeysForVisualStudioIDE(17, 'Microsoft.VisualStudio.Product.Enterprise'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Enterprise 2022',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Community 2019',
+    registryKeys: registryKeysForVisualStudioIDE(16, 'Microsoft.VisualStudio.Product.Community'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Community 2019',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Professional 2019',
+    registryKeys: registryKeysForVisualStudioIDE(16, 'Microsoft.VisualStudio.Product.Professional'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Professional 2019',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Enterprise 2019',
+    registryKeys: registryKeysForVisualStudioIDE(16, 'Microsoft.VisualStudio.Product.Enterprise'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Enterprise 2019',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Community 2017',
+    registryKeys: registryKeysForVisualStudioIDE(15, 'Microsoft.VisualStudio.Product.Community'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Community 2017',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Professional 2017',
+    registryKeys: registryKeysForVisualStudioIDE(15, 'Microsoft.VisualStudio.Product.Professional'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Professional 2017',
+    publisher: 'Microsoft Corporation',
+  },
+  {
+    name: 'Visual Studio Enterprise 2017',
+    registryKeys: registryKeysForVisualStudioIDE(15, 'Microsoft.VisualStudio.Product.Enterprise'),
+    executableShimPaths: [['common7', 'IDE', 'devenv.exe']],
+    displayNamePrefix: 'Visual Studio Enterprise 2017',
     publisher: 'Microsoft Corporation',
   },
   {

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -122,7 +122,7 @@ const registryKeysForVisualStudioIDE = (
   } 
   if(vswherePath !== undefined && existsSync(vswherePath)){
     try {
-      const vswhereStdOut = execFileSync(vswherePath, ['-version', '['+String(version)+','+String(version+1)+')', '-products', productId, '-property', 'instanceId'],{timeout: 200, killSignal: 'SIGKILL'});
+      const vswhereStdOut = execFileSync(vswherePath, ['-version', '['+String(version)+','+String(version+1)+')', '-products', productId, '-property', 'instanceId'],{timeout: 2000, killSignal: 'SIGKILL'});
       const instanceId = vswhereStdOut.toString().trim();
       result.push(Wow64LocalMachineUninstallKey(instanceId));
     } catch (error) {

--- a/app/src/lib/editors/win32.ts
+++ b/app/src/lib/editors/win32.ts
@@ -122,8 +122,8 @@ const registryKeysForVisualStudioIDE = (
   } 
   if(vswherePath !== undefined && existsSync(vswherePath)){
     try {
-      const test = execFileSync(vswherePath, ['-version', '['+String(version)+','+String(version+1)+')', '-products', productId, '-property', 'instanceId'],{timeout: 200, killSignal: 'SIGKILL'});
-      const instanceId = test.toString().trim();
+      const vswhereStdOut = execFileSync(vswherePath, ['-version', '['+String(version)+','+String(version+1)+')', '-products', productId, '-property', 'instanceId'],{timeout: 200, killSignal: 'SIGKILL'});
+      const instanceId = vswhereStdOut.toString().trim();
       result.push(Wow64LocalMachineUninstallKey(instanceId));
     } catch (error) {
       log.debug(`vswhere failed: ${error}`);


### PR DESCRIPTION
Closes [#12946](https://github.com/desktop/desktop/issues/12946)

## Description
Implementing Visual Studio support required an unconventional approach since Visual Studio doesn't use a unique registry key like most other IDEs.

Thankfully as of Visual Studio 2017 v15.2, Microsoft includes a CLI tool called [vswhere](https://github.com/microsoft/vswhere) with the visual studio installer to help locate the unique registry of their IDE.  

### Screenshots

#### Workstation 1
> Windows 11 64 bit - Visual Studio Community 2022

![VS Github](https://user-images.githubusercontent.com/93364146/169771026-5f0fd5b4-4f7a-4ca6-b6f9-954a90a6a7b8.gif)

#### Workstation 2
> Windows 10 64 bit - Visual Studio Professional 2019, 2022

![image](https://user-images.githubusercontent.com/93364146/169721826-ce9eec36-d70e-44de-b410-8f9cb7d65842.png)

## Release notes

Added IDE support for Windows 64 bit installations of:
- Visual Studio Community 2022
- Visual Studio Professional 2022
- Visual Studio Enterprise 2022
- Visual Studio Community 2019
- Visual Studio Professional 2019
- Visual Studio Enterprise 2019
- Visual Studio Community 2017 (only version 15.2 and up)
- Visual Studio Professional 2017 (only version 15.2 and up)
- Visual Studio Enterprise 2017 (only version 15.2 and up)

Notes:

I don't have access to a 32 bit computer and therefore couldn't explore what the root path of Visual Studio is on 32 bit computers.

It would be nice to have someone test this code with any version of visual studio 2017 15.2 and up and have someone test this with any supported version of visual studio enterprise.

A different implementation approach that I tried:
- https://github.com/desktop/desktop/pull/14662 <- was my first go at trying to implement support but I had to add too many customizations for visual studio.  