### PR TITLE
Add copy paths when multiple files are selected

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -437,7 +437,7 @@ export class ChangesList extends React.Component<
         const fullPaths = files.map(file =>
           Path.join(this.props.repository.path, file.path)
         )
-        clipboard.writeText(fullPaths.join(' '))
+        clipboard.writeText(fullPaths.join('\r\n'))
       },
     }
   }
@@ -449,7 +449,7 @@ export class ChangesList extends React.Component<
       label: CopySelectedRelativePathsLabel,
       action: () => {
         const paths = files.map(file => Path.normalize(file.path))
-        clipboard.writeText(paths.join(' '))
+        clipboard.writeText(paths.join('\r\n'))
       },
     }
   }

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -27,6 +27,8 @@ import {
   RevealInFileManagerLabel,
   OpenWithDefaultProgramLabel,
   CopyRelativeFilePathLabel,
+  CopySelectedPathsLabel,
+  CopySelectedRelativePathsLabel,
 } from '../lib/context-menu'
 import { CommitMessage } from './commit-message'
 import { ChangedFile } from './changed-file'
@@ -426,6 +428,32 @@ export class ChangesList extends React.Component<
     }
   }
 
+  private getCopySelectedPathsMenuItem = (
+    files: WorkingDirectoryFileChange[]
+  ): IMenuItem => {
+    return {
+      label: CopySelectedPathsLabel,
+      action: () => {
+        const fullPaths = files.map(file =>
+          Path.join(this.props.repository.path, file.path)
+        )
+        clipboard.writeText(fullPaths.join(' '))
+      },
+    }
+  }
+
+  private getCopySelectedRelativePathsMenuItem = (
+    files: WorkingDirectoryFileChange[]
+  ): IMenuItem => {
+    return {
+      label: CopySelectedRelativePathsLabel,
+      action: () => {
+        const paths = files.map(file => Path.normalize(file.path))
+        clipboard.writeText(paths.join(' '))
+      },
+    }
+  }
+
   private getRevealInFileManagerMenuItem = (
     file: WorkingDirectoryFileChange
   ): IMenuItem => {
@@ -556,15 +584,21 @@ export class ChangesList extends React.Component<
               this.props.onIncludeChanged(file.path, false)
             )
           },
-        }
+        },
+        { type: 'separator' },
+        this.getCopySelectedPathsMenuItem(selectedFiles),
+        this.getCopySelectedRelativePathsMenuItem(selectedFiles)
+      )
+    } else {
+      items.push(
+        { type: 'separator' },
+        this.getCopyPathMenuItem(file),
+        this.getCopyRelativePathMenuItem(file)
       )
     }
 
     const enabled = status.kind !== AppFileStatusKind.Deleted
     items.push(
-      { type: 'separator' },
-      this.getCopyPathMenuItem(file),
-      this.getCopyRelativePathMenuItem(file),
       { type: 'separator' },
       this.getRevealInFileManagerMenuItem(file),
       this.getOpenInExternalEditorMenuItem(file, enabled),

--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -53,6 +53,7 @@ import { hasConflictedFiles } from '../../lib/status'
 import { createObservableRef } from '../lib/observable-ref'
 import { Tooltip, TooltipDirection } from '../lib/tooltip'
 import { Popup } from '../../models/popup'
+import { EOL } from 'os'
 
 const RowHeight = 29
 const StashIcon: OcticonSymbol.OcticonSymbolType = {
@@ -437,7 +438,7 @@ export class ChangesList extends React.Component<
         const fullPaths = files.map(file =>
           Path.join(this.props.repository.path, file.path)
         )
-        clipboard.writeText(fullPaths.join('\r\n'))
+        clipboard.writeText(fullPaths.join(EOL))
       },
     }
   }
@@ -449,7 +450,7 @@ export class ChangesList extends React.Component<
       label: CopySelectedRelativePathsLabel,
       action: () => {
         const paths = files.map(file => Path.normalize(file.path))
-        clipboard.writeText(paths.join('\r\n'))
+        clipboard.writeText(paths.join(EOL))
       },
     }
   }

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -7,6 +7,12 @@ export const CopyRelativeFilePathLabel = __DARWIN__
   ? 'Copy Relative File Path'
   : 'Copy relative file path'
 
+export const CopySelectedPathsLabel = __DARWIN__ ? 'Copy Paths' : 'Copy paths'
+
+export const CopySelectedRelativePathsLabel = __DARWIN__
+  ? 'Copy Relative Paths'
+  : 'Copy relative paths'
+
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
   : 'Open in external editor'


### PR DESCRIPTION
Closes #14638

## Description
- Add "Copy Paths" and "Copy Relative Paths" when multiple files are selected

The paths are space-delimited as suggested in the feature request!

### Screenshots
![multiple-path-copy](https://user-images.githubusercontent.com/9341546/169862112-4c5a9f86-e567-4545-a647-56c5c9cba911.gif)


