### PR TITLE
Use diff not log for multi commit diffing

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -172,3 +172,8 @@ export function enablePullRequestReviewNotifications(): boolean {
 export function enableReRunFailedAndSingleCheckJobs(): boolean {
   return true
 }
+
+/** Should we enable displaying multi commit diffs. This also switches diff logic from one commit */
+export function enableMultiCommitDiffs(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/lib/git/diff-index.ts
+++ b/app/src/lib/git/diff-index.ts
@@ -68,7 +68,7 @@ function getNoRenameIndexStatus(status: string): NoRenameIndexStatus {
 }
 
 /** The SHA for the null tree. */
-const NullTreeSHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+export const NullTreeSHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
 
 /**
  * Get a list of files which have recorded changes in the index as compared to

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -181,13 +181,12 @@ export async function getCommitRangeDiff(
   // initial commit of a branch) and therefore `SHA^` is not a valid reference.
   // In which case, we will retry with the null tree sha.
   if (result.gitError === GitError.BadRevision && useNullTreeSHA === false) {
-    const useNullTreeSHA = true
     return getCommitRangeDiff(
       repository,
       file,
       commits,
       hideWhitespaceInDiff,
-      useNullTreeSHA
+      true
     )
   }
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -27,7 +27,7 @@ import { getOldPathOrDefault } from '../get-old-path'
 import { getCaptures } from '../helpers/regex'
 import { readFile } from 'fs/promises'
 import { forceUnwrap } from '../fatal-error'
-import { git } from '.'
+import { git } from './core'
 import { NullTreeSHA } from './diff-index'
 import { GitError } from 'dugite'
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -193,7 +193,7 @@ export async function getCommitRangeDiff(
   if (result.gitError !== null) {
     // This shouldn't happen...
     throw new Error(
-      `getCommitRangeDiff: Error in diffing the commit range of: ${oldestCommitRef} to ${commits[0]}`
+      `getCommitRangeDiff: Error in diffing the commit range of: ${oldestCommitRef} to ${commits[0]} - ${result.combinedOutput}`
     )
   }
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -190,13 +190,6 @@ export async function getCommitRangeDiff(
     )
   }
 
-  if (result.gitError !== null) {
-    // This shouldn't happen...
-    throw new Error(
-      `getCommitRangeDiff: Error in diffing the commit range of: ${oldestCommitRef} to ${commits[0]} - ${result.combinedOutput}`
-    )
-  }
-
   return buildDiff(
     Buffer.from(result.combinedOutput),
     repository,

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -151,11 +151,12 @@ export async function getCommitRangeDiff(
     throw new Error('No commits to diff...')
   }
 
-  const oldestCommitRef = useNullTreeSHA ? NullTreeSHA : `${commits.at(-1)}^`
+  const oldestCommitRef = useNullTreeSHA ? NullTreeSHA : `${commits[0]}^`
+  const latestCommit = commits.at(-1) ?? '' // can't be undefined since commits.length > 0
   const args = [
     'diff',
     oldestCommitRef,
-    commits[0],
+    latestCommit,
     ...(hideWhitespaceInDiff ? ['-w'] : []),
     '--patch-with-raw',
     '-z',
@@ -194,7 +195,7 @@ export async function getCommitRangeDiff(
     Buffer.from(result.combinedOutput),
     repository,
     file,
-    oldestCommitRef
+    latestCommit
   )
 }
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -27,6 +27,7 @@ import { getOldPathOrDefault } from '../get-old-path'
 import { getCaptures } from '../helpers/regex'
 import { readFile } from 'fs/promises'
 import { forceUnwrap } from '../fatal-error'
+import { git } from '.'
 
 /**
  * V8 has a limit on the size of string it can create (~256MB), and unless we want to
@@ -170,13 +171,16 @@ export async function getCommitsDiff(
     args.push(file.status.oldPath)
   }
 
-  const { output } = await spawnAndComplete(
-    args,
-    repository.path,
-    'getCommitsDiff'
-  )
+  const result = await git(args, repository.path, 'getCommitsDiff', {
+    maxBuffer: Infinity,
+  })
 
-  return buildDiff(output, repository, file, oldestCommit)
+  return buildDiff(
+    Buffer.from(result.combinedOutput),
+    repository,
+    file,
+    oldestCommit
+  )
 }
 
 /**

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -140,8 +140,8 @@ export async function getCommitDiff(
  */
 export async function getCommitsDiff(
   repository: Repository,
-  commits: ReadonlyArray<string>,
   file: FileChange,
+  commits: ReadonlyArray<string>,
   hideWhitespaceInDiff: boolean = false
 ): Promise<IDiff> {
   if (commits.length === 0) {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -160,6 +160,7 @@ import {
   appendIgnoreFile,
   getRepositoryType,
   RepositoryType,
+  getCommitsDiff,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -215,7 +216,10 @@ import {
 } from './updates/changes-state'
 import { ManualConflictResolution } from '../../models/manual-conflict-resolution'
 import { BranchPruner } from './helpers/branch-pruner'
-import { enableHideWhitespaceInDiffOption } from '../feature-flag'
+import {
+  enableHideWhitespaceInDiffOption,
+  enableMultiCommitDiffs,
+} from '../feature-flag'
 import { Banner, BannerType } from '../../models/banner'
 import { ComputedAction } from '../../models/computed-action'
 import {
@@ -1454,12 +1458,19 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const diff = await getCommitDiff(
-      repository,
-      file,
-      shas[0],
-      this.hideWhitespaceInHistoryDiff
-    )
+    const diff = enableMultiCommitDiffs()
+      ? await getCommitsDiff(
+          repository,
+          file,
+          shas,
+          this.hideWhitespaceInHistoryDiff
+        )
+      : await getCommitDiff(
+          repository,
+          file,
+          shas[0],
+          this.hideWhitespaceInHistoryDiff
+        )
 
     const stateAfterLoad = this.repositoryStateCache.get(repository)
     const { shas: shasAfter } = stateAfterLoad.commitSelection

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -160,7 +160,7 @@ import {
   appendIgnoreFile,
   getRepositoryType,
   RepositoryType,
-  getCommitsDiff,
+  getCommitRangeDiff,
 } from '../git'
 import {
   installGlobalLFSFilters,
@@ -1459,7 +1459,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     const diff = enableMultiCommitDiffs()
-      ? await getCommitsDiff(
+      ? await getCommitRangeDiff(
           repository,
           file,
           shas,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1458,19 +1458,20 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return
     }
 
-    const diff = enableMultiCommitDiffs()
-      ? await getCommitRangeDiff(
-          repository,
-          file,
-          shas,
-          this.hideWhitespaceInHistoryDiff
-        )
-      : await getCommitDiff(
-          repository,
-          file,
-          shas[0],
-          this.hideWhitespaceInHistoryDiff
-        )
+    const diff =
+      enableMultiCommitDiffs() && shas.length > 1
+        ? await getCommitRangeDiff(
+            repository,
+            file,
+            shas,
+            this.hideWhitespaceInHistoryDiff
+          )
+        : await getCommitDiff(
+            repository,
+            file,
+            shas[0],
+            this.hideWhitespaceInHistoryDiff
+          )
 
     const stateAfterLoad = this.repositoryStateCache.get(repository)
     const { shas: shasAfter } = stateAfterLoad.commitSelection


### PR DESCRIPTION
## Description
This is first step in the direction to support multi commit diffing for that we need to use `git diff`. This PR is to setup to use `git diff` as opposed to `git log` when more than one commit is selected. This works for one commit as well but due to this being a very impactful change if there are regressions as diff generation is core to the app, I am leaving `git log` in place for single commits. We may decide to remove it once confidence in this approach is built through implementing multi commit diffing. 

Scenarios considered/tested for a single commit: 
- adding
- changing
- renaming
- images
- initial commit
- squashing onto initial commit

## Release notes
Notes: no-notes
