### PR TITLE
Support SSH password prompts

### DIFF
--- a/app/src/lib/ssh/ssh-secret-storage.ts
+++ b/app/src/lib/ssh/ssh-secret-storage.ts
@@ -1,0 +1,61 @@
+import { TokenStore } from '../stores'
+
+const appName = __DEV__ ? 'GitHub Desktop Dev' : 'GitHub Desktop'
+
+export function getSSHSecretStoreKey(name: string) {
+  return `${appName} - ${name}`
+}
+
+type SSHSecretEntry = {
+  /** Store where this entry will be stored. */
+  store: string
+
+  /** Key used to identify the secret in the store (e.g. username or hash). */
+  key: string
+
+  /** Actual secret to be stored (password). */
+  secret: string
+}
+
+/**
+ * This map contains the SSH secrets that are pending to be stored. What this
+ * means is that a git operation is currently in progress, and the user wanted
+ * to store the passphrase for the SSH key, however we don't want to store it
+ * until we know the git operation finished successfully.
+ */
+const SSHSecretsToStore = new Map<string, SSHSecretEntry>()
+
+/**
+ * Keeps the SSH secret in memory to be stored later if the ongoing git operation
+ * succeeds.
+ *
+ * @param operationGUID A unique identifier for the ongoing git operation. In
+ *                      practice, it will always be the trampoline secret for the
+ *                      ongoing git operation.
+ * @param key           Key that identifies the SSH secret (e.g. username or key
+ *                      hash).
+ * @param secret        Actual SSH secret to store.
+ */
+export async function keepSSHSecretToStore(
+  operationGUID: string,
+  store: string,
+  key: string,
+  secret: string
+) {
+  SSHSecretsToStore.set(operationGUID, { store, key, secret })
+}
+
+/** Removes the SSH key passphrase from memory. */
+export function removePendingSSHSecretToStore(operationGUID: string) {
+  SSHSecretsToStore.delete(operationGUID)
+}
+
+/** Stores a pending SSH key passphrase if the operation succeeded. */
+export async function storePendingSSHSecret(operationGUID: string) {
+  const entry = SSHSecretsToStore.get(operationGUID)
+  if (entry === undefined) {
+    return
+  }
+
+  await TokenStore.setItem(entry.store, entry.key, entry.secret)
+}

--- a/app/src/lib/ssh/ssh-user-password.ts
+++ b/app/src/lib/ssh/ssh-user-password.ts
@@ -1,0 +1,37 @@
+import { TokenStore } from '../stores'
+import { getSSHSecretStoreKey, keepSSHSecretToStore } from './ssh-token-storage'
+
+const SSHUserPasswordTokenStoreKey = getSSHSecretStoreKey('SSH user password')
+
+/** Retrieves the password for the given SSH username. */
+export async function getSSHUserPassword(username: string) {
+  try {
+    return TokenStore.getItem(SSHUserPasswordTokenStoreKey, username)
+  } catch (e) {
+    log.error('Could not retrieve passphrase for SSH key:', e)
+    return null
+  }
+}
+
+/**
+ * Keeps the SSH user password in memory to be stored later if the ongoing git
+ * operation succeeds.
+ *
+ * @param operationGUID A unique identifier for the ongoing git operation. In
+ *                      practice, it will always be the trampoline token for the
+ *                      ongoing git operation.
+ * @param username      SSH user name. Usually in the form of `user@hostname`.
+ * @param password      Password for the given user.
+ */
+export async function keepSSHUserPasswordToStore(
+  operationGUID: string,
+  username: string,
+  password: string
+) {
+  keepSSHSecretToStore(
+    operationGUID,
+    SSHUserPasswordTokenStoreKey,
+    username,
+    password
+  )
+}

--- a/app/src/lib/ssh/ssh-user-password.ts
+++ b/app/src/lib/ssh/ssh-user-password.ts
@@ -1,5 +1,8 @@
 import { TokenStore } from '../stores'
-import { getSSHSecretStoreKey, keepSSHSecretToStore } from './ssh-token-storage'
+import {
+  getSSHSecretStoreKey,
+  keepSSHSecretToStore,
+} from './ssh-secret-storage'
 
 const SSHUserPasswordTokenStoreKey = getSSHSecretStoreKey('SSH user password')
 

--- a/app/src/lib/trampoline/trampoline-askpass-handler.ts
+++ b/app/src/lib/trampoline/trampoline-askpass-handler.ts
@@ -2,12 +2,12 @@ import { getKeyForEndpoint } from '../auth'
 import {
   getSSHKeyPassphrase,
   keepSSHKeyPassphraseToStore,
-  removePendingSSHKeyPassphraseToStore,
 } from '../ssh/ssh-key-passphrase'
 import { TokenStore } from '../stores'
 import { TrampolineCommandHandler } from './trampoline-command'
 import { trampolineUIHelper } from './trampoline-ui-helper'
 import { parseAddSSHHostPrompt } from '../ssh/ssh'
+import { removePendingSSHSecretToStore } from '../ssh/ssh-secret-storage'
 
 async function handleSSHHostAuthenticity(
   prompt: string
@@ -65,7 +65,7 @@ async function handleSSHKeyPassphrase(
     return storedPassphrase
   }
 
-  const { passphrase, storePassphrase } =
+  const { secret: passphrase, storeSecret: storePassphrase } =
     await trampolineUIHelper.promptSSHKeyPassphrase(keyPath)
 
   // If the user wanted us to remember the passphrase, we'll keep it around to
@@ -78,7 +78,7 @@ async function handleSSHKeyPassphrase(
   if (passphrase !== undefined && storePassphrase) {
     keepSSHKeyPassphraseToStore(operationGUID, keyPath, passphrase)
   } else {
-    removePendingSSHKeyPassphraseToStore(operationGUID)
+    removePendingSSHSecretToStore(operationGUID)
   }
 
   return passphrase ?? ''

--- a/app/src/lib/trampoline/trampoline-environment.ts
+++ b/app/src/lib/trampoline/trampoline-environment.ts
@@ -5,9 +5,9 @@ import { getDesktopTrampolineFilename } from 'desktop-trampoline'
 import { TrampolineCommandIdentifier } from '../trampoline/trampoline-command'
 import { getSSHEnvironment } from '../ssh/ssh'
 import {
-  removePendingSSHKeyPassphraseToStore,
-  storePendingSSHKeyPassphrase,
-} from '../ssh/ssh-key-passphrase'
+  removePendingSSHSecretToStore,
+  storePendingSSHSecret,
+} from '../ssh/ssh-secret-storage'
 
 /**
  * Allows invoking a function with a set of environment variables to use when
@@ -46,11 +46,11 @@ export async function withTrampolineEnv<T>(
         ...sshEnv,
       })
 
-      await storePendingSSHKeyPassphrase(token)
+      await storePendingSSHSecret(token)
 
       return result
     } finally {
-      removePendingSSHKeyPassphraseToStore(token)
+      removePendingSSHSecretToStore(token)
     }
   })
 }

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -44,6 +44,19 @@ class TrampolineUIHelper {
       })
     })
   }
+
+  public promptSSHUserPassword(
+    username: string
+  ): Promise<PromptSSHSecretResponse> {
+    return new Promise(resolve => {
+      this.dispatcher.showPopup({
+        type: PopupType.SSHUserPassword,
+        username,
+        onSubmit: (password, storePassword) =>
+          resolve({ secret: password, storeSecret: storePassword }),
+      })
+    })
+  }
 }
 
 export const trampolineUIHelper = new TrampolineUIHelper()

--- a/app/src/lib/trampoline/trampoline-ui-helper.ts
+++ b/app/src/lib/trampoline/trampoline-ui-helper.ts
@@ -1,9 +1,9 @@
 import { PopupType } from '../../models/popup'
 import { Dispatcher } from '../../ui/dispatcher'
 
-type PromptSSHKeyPassphraseResponse = {
-  readonly passphrase: string | undefined
-  readonly storePassphrase: boolean
+type PromptSSHSecretResponse = {
+  readonly secret: string | undefined
+  readonly storeSecret: boolean
 }
 
 class TrampolineUIHelper {
@@ -34,13 +34,13 @@ class TrampolineUIHelper {
 
   public promptSSHKeyPassphrase(
     keyPath: string
-  ): Promise<PromptSSHKeyPassphraseResponse> {
+  ): Promise<PromptSSHSecretResponse> {
     return new Promise(resolve => {
       this.dispatcher.showPopup({
         type: PopupType.SSHKeyPassphrase,
         keyPath,
         onSubmit: (passphrase, storePassphrase) =>
-          resolve({ passphrase, storePassphrase }),
+          resolve({ secret: passphrase, storeSecret: storePassphrase }),
       })
     })
   }

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -78,6 +78,7 @@ export enum PopupType {
   InvalidatedToken,
   AddSSHHost,
   SSHKeyPassphrase,
+  SSHUserPassword,
   PullRequestChecksFailed,
   CICheckRunRerun,
   WarnForcePush,
@@ -316,6 +317,11 @@ export type Popup =
         passphrase: string | undefined,
         storePassphrase: boolean
       ) => void
+    }
+  | {
+      type: PopupType.SSHUserPassword
+      username: string
+      onSubmit: (password: string | undefined, storePassword: boolean) => void
     }
   | {
       type: PopupType.PullRequestChecksFailed

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -154,6 +154,7 @@ import { generateDevReleaseSummary } from '../lib/release-notes'
 import { PullRequestReview } from './notifications/pull-request-review'
 import { getPullRequestCommitRef } from '../models/pull-request'
 import { getRepositoryType } from '../lib/git'
+import { SSHUserPassword } from './ssh/ssh-user-password'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2108,6 +2109,16 @@ export class App extends React.Component<IAppProps, IAppState> {
           <SSHKeyPassphrase
             key="ssh-key-passphrase"
             keyPath={popup.keyPath}
+            onSubmit={popup.onSubmit}
+            onDismissed={onPopupDismissedFn}
+          />
+        )
+      }
+      case PopupType.SSHUserPassword: {
+        return (
+          <SSHUserPassword
+            key="ssh-user-password"
+            username={popup.username}
             onSubmit={popup.onSubmit}
             onDismissed={onPopupDismissedFn}
           />

--- a/app/src/ui/ssh/ssh-user-password.tsx
+++ b/app/src/ui/ssh/ssh-user-password.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { Row } from '../lib/row'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+import { TextBox } from '../lib/text-box'
+import { Checkbox, CheckboxValue } from '../lib/checkbox'
+
+interface ISSHUserPasswordProps {
+  readonly username: string
+  readonly onSubmit: (
+    password: string | undefined,
+    storePassword: boolean
+  ) => void
+  readonly onDismissed: () => void
+}
+
+interface ISSHUserPasswordState {
+  readonly password: string
+  readonly rememberPassword: boolean
+}
+
+/**
+ * Dialog prompts the user the password of an SSH user.
+ */
+export class SSHUserPassword extends React.Component<
+  ISSHUserPasswordProps,
+  ISSHUserPasswordState
+> {
+  public constructor(props: ISSHUserPasswordProps) {
+    super(props)
+    this.state = { password: '', rememberPassword: false }
+  }
+
+  public render() {
+    return (
+      <Dialog
+        id="ssh-user-password"
+        type="normal"
+        title="SSH User Password"
+        dismissable={false}
+        onSubmit={this.onSubmit}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            <TextBox
+              label={`Enter password for '${this.props.username}':`}
+              value={this.state.password}
+              type="password"
+              onValueChanged={this.onValueChanged}
+            />
+          </Row>
+          <Row>
+            <Checkbox
+              label="Remember password"
+              value={
+                this.state.rememberPassword
+                  ? CheckboxValue.On
+                  : CheckboxValue.Off
+              }
+              onChange={this.onRememberPasswordChanged}
+            />
+          </Row>
+        </DialogContent>
+        <DialogFooter>
+          <OkCancelButtonGroup
+            onCancelButtonClick={this.onCancel}
+            okButtonDisabled={this.state.password.length === 0}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onRememberPasswordChanged = (
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    this.setState({ rememberPassword: event.currentTarget.checked })
+  }
+
+  private onValueChanged = (value: string) => {
+    this.setState({ password: value })
+  }
+
+  private submit(password: string | undefined, storePassword: boolean) {
+    const { onSubmit, onDismissed } = this.props
+
+    onSubmit(password, storePassword)
+    onDismissed()
+  }
+
+  private onSubmit = () => {
+    this.submit(this.state.password, this.state.rememberPassword)
+  }
+
+  private onCancel = () => {
+    this.submit(undefined, false)
+  }
+}


### PR DESCRIPTION
Closes #14676

## Description

This PR adds support for SSH password prompts when the user tries to interact with a repository via SSH and requires a password for it. I refactored the mechanism to remember passwords/passphrases a bit so I could reuse some code.

### Screenshots


https://user-images.githubusercontent.com/1083228/170300936-81e953f3-bb10-4fae-a740-70ed1aa2a3cf.mov


## Release notes

Notes: [Improved] Add support for SSH password prompts when accessing repositories
