### PR TITLE
Lets see a multi commit diff

### DIFF
--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1458,13 +1458,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    // We do not get a diff when multiple commits selected
-    if (shas.length > 1) {
+    if (shas.length > 1 && !enableMultiCommitDiffs()) {
       return
     }
 
     const diff =
-      enableMultiCommitDiffs() && shas.length > 1
+      shas.length > 1
         ? await getCommitRangeDiff(
             repository,
             file,
@@ -1481,9 +1480,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const stateAfterLoad = this.repositoryStateCache.get(repository)
     const { shas: shasAfter } = stateAfterLoad.commitSelection
     // A whole bunch of things could have happened since we initiated the diff load
-    if (shasAfter.length !== shas.length || shasAfter[0] !== shas[0]) {
+    if (
+      shasAfter.length !== shas.length ||
+      !shas.every((sha, i) => sha === shasAfter[i])
+    ) {
       return
     }
+
     if (!stateAfterLoad.commitSelection.file) {
       return
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1108,9 +1108,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ) {
     const state = this.repositoryStateCache.get(repository)
     let selectedSHA =
-      state.commitSelection.shas.length === 1
+      state.commitSelection.shas.length > 0
         ? state.commitSelection.shas[0]
         : null
+
     if (selectedSHA != null) {
       const index = commitSHAs.findIndex(sha => sha === selectedSHA)
       if (index < 0) {
@@ -1121,7 +1122,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    if (state.commitSelection.shas.length === 0 && commitSHAs.length > 0) {
+    if (selectedSHA === null && commitSHAs.length > 0) {
       this._changeCommitSelection(repository, [commitSHAs[0]])
       this._loadChangedFilesForCurrentSelection(repository)
     }

--- a/app/src/ui/history/index.ts
+++ b/app/src/ui/history/index.ts
@@ -1,2 +1,2 @@
-export { SelectedCommit } from './selected-commit'
+export { SelectedCommits } from './selected-commit'
 export { CompareSidebar } from './compare'

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -34,14 +34,15 @@ import { IChangesetData } from '../../lib/git'
 import { IConstrainedValue } from '../../lib/app-state'
 import { clamp } from '../../lib/clamp'
 import { pathExists } from '../lib/path-exists'
+import { enableMultiCommitDiffs } from '../../lib/feature-flag'
 
-interface ISelectedCommitProps {
+interface ISelectedCommitsProps {
   readonly repository: Repository
   readonly isLocalRepository: boolean
   readonly dispatcher: Dispatcher
   readonly emoji: Map<string, string>
-  readonly selectedCommit: Commit | null
-  readonly isLocal: boolean
+  readonly selectedCommits: ReadonlyArray<Commit>
+  readonly localCommitSHAs: ReadonlyArray<string>
   readonly changesetData: IChangesetData
   readonly selectedFile: CommittedFileChange | null
   readonly currentDiff: IDiff | null
@@ -77,27 +78,24 @@ interface ISelectedCommitProps {
   /** Called when the user opens the diff options popover */
   readonly onDiffOptionsOpened: () => void
 
-  /** Whether multiple commits are selected. */
-  readonly areMultipleCommitsSelected: boolean
-
   /** Whether or not to show the drag overlay */
   readonly showDragOverlay: boolean
 }
 
-interface ISelectedCommitState {
+interface ISelectedCommitsState {
   readonly isExpanded: boolean
   readonly hideDescriptionBorder: boolean
 }
 
 /** The History component. Contains the commit list, commit summary, and diff. */
-export class SelectedCommit extends React.Component<
-  ISelectedCommitProps,
-  ISelectedCommitState
+export class SelectedCommits extends React.Component<
+  ISelectedCommitsProps,
+  ISelectedCommitsState
 > {
   private readonly loadChangedFilesScheduler = new ThrottledScheduler(200)
   private historyRef: HTMLDivElement | null = null
 
-  public constructor(props: ISelectedCommitProps) {
+  public constructor(props: ISelectedCommitsProps) {
     super(props)
 
     this.state = {
@@ -114,16 +112,12 @@ export class SelectedCommit extends React.Component<
     this.historyRef = ref
   }
 
-  public componentWillUpdate(nextProps: ISelectedCommitProps) {
+  public componentWillUpdate(nextProps: ISelectedCommitsProps) {
     // reset isExpanded if we're switching commits.
-    const currentValue = this.props.selectedCommit
-      ? this.props.selectedCommit.sha
-      : undefined
-    const nextValue = nextProps.selectedCommit
-      ? nextProps.selectedCommit.sha
-      : undefined
+    const currentValue = this.props.selectedCommits.join('')
+    const nextValue = nextProps.selectedCommits.join('')
 
-    if ((currentValue || nextValue) && currentValue !== nextValue) {
+    if (currentValue !== nextValue) {
       if (this.state.isExpanded) {
         this.setState({ isExpanded: false })
       }
@@ -250,13 +244,13 @@ export class SelectedCommit extends React.Component<
   }
 
   public render() {
-    const commit = this.props.selectedCommit
+    const { selectedCommits } = this.props
 
-    if (this.props.areMultipleCommitsSelected) {
+    if (selectedCommits.length > 1 && !enableMultiCommitDiffs()) {
       return this.renderMultipleCommitsSelected()
     }
 
-    if (commit == null) {
+    if (selectedCommits.length === 0) {
       return <NoCommitSelected />
     }
 
@@ -265,7 +259,8 @@ export class SelectedCommit extends React.Component<
 
     return (
       <div id="history" ref={this.onHistoryRef} className={className}>
-        {this.renderCommitSummary(commit)}
+        {selectedCommits.length === 1 &&
+          this.renderCommitSummary(selectedCommits[0])}
         <div className="commit-details">
           <Resizable
             width={commitSummaryWidth.value}
@@ -322,7 +317,14 @@ export class SelectedCommit extends React.Component<
   ) => {
     event.preventDefault()
 
-    const fullPath = Path.join(this.props.repository.path, file.path)
+    const {
+      selectedCommits,
+      localCommitSHAs,
+      repository,
+      externalEditorLabel,
+    } = this.props
+
+    const fullPath = Path.join(repository.path, file.path)
     const fileExistsOnDisk = await pathExists(fullPath)
     if (!fileExistsOnDisk) {
       showContextualMenu([
@@ -339,14 +341,14 @@ export class SelectedCommit extends React.Component<
     const extension = Path.extname(file.path)
 
     const isSafeExtension = isSafeFileExtension(extension)
-    const openInExternalEditor = this.props.externalEditorLabel
-      ? `Open in ${this.props.externalEditorLabel}`
+    const openInExternalEditor = externalEditorLabel
+      ? `Open in ${externalEditorLabel}`
       : DefaultEditorLabel
 
     const items: IMenuItem[] = [
       {
         label: RevealInFileManagerLabel,
-        action: () => revealInFileManager(this.props.repository, file.path),
+        action: () => revealInFileManager(repository, file.path),
         enabled: fileExistsOnDisk,
       },
       {
@@ -372,7 +374,7 @@ export class SelectedCommit extends React.Component<
     ]
 
     let viewOnGitHubLabel = 'View on GitHub'
-    const gitHubRepository = this.props.repository.gitHubRepository
+    const gitHubRepository = repository.gitHubRepository
 
     if (
       gitHubRepository &&
@@ -383,20 +385,21 @@ export class SelectedCommit extends React.Component<
 
     items.push({
       label: viewOnGitHubLabel,
-      action: () => this.onViewOnGitHub(file),
+      action: () => this.onViewOnGitHub(selectedCommits[0].sha, file),
       enabled:
-        !this.props.isLocal &&
+        // TODO: maybe we can assume to use last commit in multi commit
+        // scenario?
+        selectedCommits.length === 1 &&
+        !localCommitSHAs.includes(selectedCommits[0].sha) &&
         !!gitHubRepository &&
-        !!this.props.selectedCommit,
+        this.props.selectedCommits.length > 0,
     })
 
     showContextualMenu(items)
   }
 
-  private onViewOnGitHub = (file: CommittedFileChange) => {
-    if (this.props.selectedCommit && this.props.onViewCommitOnGitHub) {
-      this.props.onViewCommitOnGitHub(this.props.selectedCommit.sha, file.path)
-    }
+  private onViewOnGitHub = (sha: string, file: CommittedFileChange) => {
+    this.props.onViewCommitOnGitHub(sha, file.path)
   }
 }
 

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -387,8 +387,6 @@ export class SelectedCommits extends React.Component<
       label: viewOnGitHubLabel,
       action: () => this.onViewOnGitHub(selectedCommits[0].sha, file),
       enabled:
-        // TODO: maybe we can assume to use last commit in multi commit
-        // scenario?
         selectedCommits.length === 1 &&
         !localCommitSHAs.includes(selectedCommits[0].sha) &&
         !!gitHubRepository &&

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -7,7 +7,7 @@ import { Changes, ChangesSidebar } from './changes'
 import { NoChanges } from './changes/no-changes'
 import { MultipleSelection } from './changes/multiple-selection'
 import { FilesChangedBadge } from './changes/files-changed-badge'
-import { SelectedCommit, CompareSidebar } from './history'
+import { SelectedCommits, CompareSidebar } from './history'
 import { Resizable } from './resizable'
 import { TabBar } from './tab-bar'
 import {
@@ -372,31 +372,28 @@ export class RepositoryView extends React.Component<
   }
 
   private renderContentForHistory(): JSX.Element {
-    const { commitSelection } = this.props.state
+    const { commitSelection, commitLookup, localCommitSHAs } = this.props.state
+    const { changesetData, file, diff, shas } = commitSelection
 
-    const sha =
-      commitSelection.shas.length === 1 ? commitSelection.shas[0] : null
-
-    const selectedCommit =
-      sha != null ? this.props.state.commitLookup.get(sha) || null : null
-
-    const isLocal =
-      selectedCommit != null &&
-      this.props.state.localCommitSHAs.includes(selectedCommit.sha)
-
-    const { changesetData, file, diff } = commitSelection
+    const selectedCommits = []
+    for (const sha of shas) {
+      const commit = commitLookup.get(sha)
+      if (commit !== undefined) {
+        selectedCommits.push(commit)
+      }
+    }
 
     const showDragOverlay = dragAndDropManager.isDragOfTypeInProgress(
       DragType.Commit
     )
 
     return (
-      <SelectedCommit
+      <SelectedCommits
         repository={this.props.repository}
         isLocalRepository={this.props.state.remote === null}
         dispatcher={this.props.dispatcher}
-        selectedCommit={selectedCommit}
-        isLocal={isLocal}
+        selectedCommits={selectedCommits}
+        localCommitSHAs={localCommitSHAs}
         changesetData={changesetData}
         selectedFile={file}
         currentDiff={diff}
@@ -411,7 +408,6 @@ export class RepositoryView extends React.Component<
         onOpenBinaryFile={this.onOpenBinaryFile}
         onChangeImageDiffType={this.onChangeImageDiffType}
         onDiffOptionsOpened={this.onDiffOptionsOpened}
-        areMultipleCommitsSelected={commitSelection.shas.length > 1}
         showDragOverlay={showDragOverlay}
       />
     )


### PR DESCRIPTION
This PR builds on #14679

## Description
This PR namely refactors the `SelectCommit` component (that displays the files list, diff, and commit summary in the history view) to accept a selection of multiple commits. Then displays the diff for multiple commits. Additionally, I had to allow to open up some single diff checks in the `app-store.ts` to allow multi commit selections.

This PR also contains a bug fix in the method `updateOrSelectFirstCommit` of `app-store.ts`. The expected behavior is that when you switch branches, this method should select the first commit in the history. I found that if a single commit was selected before branch switching, it just cleared the selection. If multi-commit was selected, it still shows the multi commit view even tho no commits are selected. The later part needed updated as part of this PR anyways.

As you may note from the screenshot, this pr does not include creating a multi-commit summary. (next pr)

Things to yet to figure out...
- merge commit in middle of range.
- non-contiguous selection.

### Screenshots
![May-26-2022 14-08-40](https://user-images.githubusercontent.com/75402236/170549443-ee626a61-6230-4d92-947b-65afd9cba759.gif)


## Release notes
Notes: no-notes
