### PR TITLE
Fix commit shortcut (Ctrl/Cmd + Enter)

### DIFF
--- a/app/src/ui/changes/changes-list.tsx
+++ b/app/src/ui/changes/changes-list.tsx
@@ -128,6 +128,8 @@ interface IChangesListProps {
   readonly onDiscardChanges: (file: WorkingDirectoryFileChange) => void
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly focusCommitMessage: boolean
+  readonly isShowingModal: boolean
+  readonly isShowingFoldout: boolean
   readonly onDiscardChangesFromFiles: (
     files: ReadonlyArray<WorkingDirectoryFileChange>,
     isDiscardingAllChanges: boolean
@@ -721,6 +723,8 @@ export class ChangesList extends React.Component<
         onCreateCommit={this.props.onCreateCommit}
         branch={this.props.branch}
         commitAuthor={this.props.commitAuthor}
+        isShowingModal={this.props.isShowingModal}
+        isShowingFoldout={this.props.isShowingFoldout}
         anyFilesSelected={anyFilesSelected}
         anyFilesAvailable={fileCount > 0}
         repository={repository}

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -343,8 +343,8 @@ export class CommitMessage extends React.Component<
 
     const isShortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
     if (isShortcutKey && event.key === 'Enter' && this.canCommit()) {
-      const openedDialogs = document.getElementsByTagName('dialog')
-      if (openedDialogs.length === 0) {
+      const openDialogs = document.getElementsByTagName('dialog')
+      if (openDialogs.length === 0) {
         this.createCommit()
         event.preventDefault()
       }

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -183,6 +183,11 @@ export class CommitMessage extends React.Component<
   public componentWillUnmount() {
     const { props, state } = this
     props.onPersistCommitMessage?.(pick(state, 'summary', 'description'))
+    window.removeEventListener('keydown', this.onKeyDown)
+  }
+
+  public componentDidMount() {
+    window.addEventListener('keydown', this.onKeyDown)
   }
 
   /**
@@ -331,15 +336,18 @@ export class CommitMessage extends React.Component<
     )
   }
 
-  private onKeyDown = (event: React.KeyboardEvent<Element>) => {
+  private onKeyDown = (event: React.KeyboardEvent<Element> | KeyboardEvent) => {
     if (event.defaultPrevented) {
       return
     }
 
     const isShortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
     if (isShortcutKey && event.key === 'Enter' && this.canCommit()) {
-      this.createCommit()
-      event.preventDefault()
+      const openedDialogs = document.getElementsByTagName('dialog')
+      if (openedDialogs.length === 0) {
+        this.createCommit()
+        event.preventDefault()
+      }
     }
   }
 

--- a/app/src/ui/changes/commit-message.tsx
+++ b/app/src/ui/changes/commit-message.tsx
@@ -54,6 +54,8 @@ interface ICommitMessageProps {
   readonly branch: string | null
   readonly commitAuthor: CommitIdentity | null
   readonly anyFilesSelected: boolean
+  readonly isShowingModal: boolean
+  readonly isShowingFoldout: boolean
 
   /**
    * Whether it's possible to select files for commit, affects messaging
@@ -336,18 +338,24 @@ export class CommitMessage extends React.Component<
     )
   }
 
+  private canExcecuteCommitShortcut(): boolean {
+    return !this.props.isShowingFoldout && !this.props.isShowingModal
+  }
+
   private onKeyDown = (event: React.KeyboardEvent<Element> | KeyboardEvent) => {
     if (event.defaultPrevented) {
       return
     }
 
     const isShortcutKey = __DARWIN__ ? event.metaKey : event.ctrlKey
-    if (isShortcutKey && event.key === 'Enter' && this.canCommit()) {
-      const openDialogs = document.getElementsByTagName('dialog')
-      if (openDialogs.length === 0) {
-        this.createCommit()
-        event.preventDefault()
-      }
+    if (
+      isShortcutKey &&
+      event.key === 'Enter' &&
+      this.canCommit() &&
+      this.canExcecuteCommitShortcut()
+    ) {
+      this.createCommit()
+      event.preventDefault()
     }
   }
 

--- a/app/src/ui/changes/sidebar.tsx
+++ b/app/src/ui/changes/sidebar.tsx
@@ -55,6 +55,8 @@ interface IChangesSidebarProps {
   readonly focusCommitMessage: boolean
   readonly askForConfirmationOnDiscardChanges: boolean
   readonly accounts: ReadonlyArray<Account>
+  readonly isShowingModal: boolean
+  readonly isShowingFoldout: boolean
   /** The name of the currently selected external editor */
   readonly externalEditorLabel?: string
 
@@ -394,6 +396,8 @@ export class ChangesSidebar extends React.Component<IChangesSidebarProps, {}> {
           branch={this.props.branch}
           commitMessage={commitMessage}
           focusCommitMessage={this.props.focusCommitMessage}
+          isShowingModal={this.props.isShowingModal}
+          isShowingFoldout={this.props.isShowingFoldout}
           autocompletionProviders={this.autocompletionProviders!}
           availableWidth={this.props.availableWidth}
           onIgnoreFile={this.onIgnoreFile}

--- a/app/src/ui/commit-message/commit-message-dialog.tsx
+++ b/app/src/ui/commit-message/commit-message-dialog.tsx
@@ -113,6 +113,8 @@ export class CommitMessageDialog extends React.Component<
           <CommitMessage
             branch={this.props.branch}
             commitAuthor={this.props.commitAuthor}
+            isShowingModal={true}
+            isShowingFoldout={false}
             commitButtonText={this.props.dialogButtonText}
             commitToAmend={null}
             repository={this.props.repository}

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -524,11 +524,14 @@ export class List extends React.Component<IListProps, IListState> {
       this.props.onRowKeyDown(rowIndex, event)
     }
 
+    const isSpecialShortcut = __DARWIN__ ? event.metaKey : event.ctrlKey
+
     // We give consumers the power to prevent the onRowClick event by subscribing
     // to the onRowKeyDown event and calling event.preventDefault. This lets
     // consumers add their own semantics for keyboard presses.
     if (
       !event.defaultPrevented &&
+      !isSpecialShortcut &&
       (event.key === 'Enter' || event.key === ' ')
     ) {
       this.toggleSelection(event)
@@ -537,8 +540,11 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private onFocusContainerKeyDown = (event: React.KeyboardEvent<any>) => {
+    const isSpecialShortcut = __DARWIN__ ? event.metaKey : event.ctrlKey
+
     if (
       !event.defaultPrevented &&
+      !isSpecialShortcut &&
       (event.key === 'Enter' || event.key === ' ')
     ) {
       this.toggleSelection(event)

--- a/app/src/ui/lib/list/list.tsx
+++ b/app/src/ui/lib/list/list.tsx
@@ -524,14 +524,15 @@ export class List extends React.Component<IListProps, IListState> {
       this.props.onRowKeyDown(rowIndex, event)
     }
 
-    const isSpecialShortcut = __DARWIN__ ? event.metaKey : event.ctrlKey
+    const hasModifier =
+      event.altKey || event.ctrlKey || event.metaKey || event.shiftKey
 
     // We give consumers the power to prevent the onRowClick event by subscribing
     // to the onRowKeyDown event and calling event.preventDefault. This lets
     // consumers add their own semantics for keyboard presses.
     if (
       !event.defaultPrevented &&
-      !isSpecialShortcut &&
+      !hasModifier &&
       (event.key === 'Enter' || event.key === ' ')
     ) {
       this.toggleSelection(event)
@@ -540,11 +541,12 @@ export class List extends React.Component<IListProps, IListState> {
   }
 
   private onFocusContainerKeyDown = (event: React.KeyboardEvent<any>) => {
-    const isSpecialShortcut = __DARWIN__ ? event.metaKey : event.ctrlKey
+    const hasModifier =
+      event.altKey || event.ctrlKey || event.metaKey || event.shiftKey
 
     if (
       !event.defaultPrevented &&
-      !isSpecialShortcut &&
+      !hasModifier &&
       (event.key === 'Enter' || event.key === ' ')
     ) {
       this.toggleSelection(event)

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -219,6 +219,8 @@ export class RepositoryView extends React.Component<
           this.props.askForConfirmationOnDiscardChanges
         }
         accounts={this.props.accounts}
+        isShowingModal={this.props.isShowingModal}
+        isShowingFoldout={this.props.isShowingFoldout}
         externalEditorLabel={this.props.externalEditorLabel}
         onOpenInExternalEditor={this.props.onOpenInExternalEditor}
         onChangesListScrolled={this.onChangesListScrolled}


### PR DESCRIPTION
Closes #14689

## Description
- Fix commit shortcut (Ctrl/Cmd + Enter)

> Note: With this implementation, the shortcut is still coupled to the lifecycle of `CommitMessage` component. 

### Screenshots
![fix-commit-shotcut](https://user-images.githubusercontent.com/9341546/171260697-87ceb539-b483-44ca-ad2d-6410b1f74a2c.gif)

