### PR TITLE
Fix Markdown highlighting

### DIFF
--- a/app/src/highlighter/globals.d.ts
+++ b/app/src/highlighter/globals.d.ts
@@ -19,6 +19,7 @@ declare namespace CodeMirror {
   interface StringStreamContext {
     lines: string[]
     line: number
+    lookAhead: (n: number) => string
   }
 
   /**

--- a/app/src/highlighter/index.ts
+++ b/app/src/highlighter/index.ts
@@ -635,7 +635,11 @@ onmessage = async (ev: MessageEvent) => {
       continue
     }
 
-    const lineCtx = { lines, line: ix }
+    const lineCtx = {
+      lines,
+      line: ix,
+      lookAhead: (n: number) => lines[ix + n],
+    }
     const lineStream = new StringStream(line, tabSize, lineCtx)
 
     while (!lineStream.eol()) {


### PR DESCRIPTION
## Description

I was pretty annoyed by this error for a while:
![image](https://user-images.githubusercontent.com/1083228/171396185-e4642937-46ab-4b3d-93aa-01a5cd66cbf9.png)

It only showed up with Markdown files. I can't tell if it every worked looking at the code, but it seems [the Markdown mode relied on `StringStream.lookAhead`](https://github.com/codemirror/CodeMirror/blob/74832f9ccf151f64c1eea53c305f60575cc41d76/mode/markdown/markdown.js#L256), which basically depended on the context/oracle object passed as 3rd parameter of the `StringStream` constructor. This is how it's initialized from codemirror: https://github.com/codemirror/CodeMirror/blob/7e2466f1653faf3832302fdee508ad886d5431e7/addon/runmode/runmode.js#L63-L67

This PR adds the missing `lookAhead` function required by the Markdown mode to our highlighter when it creates the `StringStream` instance.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1083228/171396812-b52c4689-1ec2-440a-b320-352359673b1a.png)

After:
![image](https://user-images.githubusercontent.com/1083228/171396736-ed227062-014a-4339-9d62-1dd5462023f7.png)


## Release notes

Notes: [Fixed] Fix Markdown syntax highlighting
