### PR TITLE
Improve draft-release script

### DIFF
--- a/script/changelog/api.ts
+++ b/script/changelog/api.ts
@@ -3,6 +3,7 @@ import * as HTTPS from 'https'
 export interface IAPIPR {
   readonly title: string
   readonly body: string
+  readonly headRefName: string
 }
 
 type GraphQLResponse = {
@@ -49,6 +50,7 @@ export function fetchPR(id: number): Promise<IAPIPR | null> {
     pullRequest(number: ${id}) {
       title
       body
+      headRefName
     }
   }
 }

--- a/script/changelog/test/parser-test.ts
+++ b/script/changelog/test/parser-test.ts
@@ -1,4 +1,4 @@
-import { findIssueRef } from '../parser'
+import { findIssueRef, findReleaseNote } from '../parser'
 
 describe('changelog/parser', () => {
   describe('findIssueRef', () => {
@@ -52,6 +52,57 @@ quam vel augue.`
     it('handles resolves syntax', () => {
       const body = `This resolves #2314 and is totally wild`
       expect(findIssueRef(body)).toBe(' #2314')
+    })
+  })
+
+  describe('findReleaseNote', () => {
+    it('detected release note at the end of the body', () => {
+      const body = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.
+
+Notes: [Fixed] Fix lorem impsum dolor sit amet
+`
+      expect(findReleaseNote(body)).toBe(
+        '[Fixed] Fix lorem impsum dolor sit amet'
+      )
+    })
+
+    it('removes dot at the end of release note', () => {
+      const body = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.
+
+Notes: [Fixed] Fix lorem impsum dolor sit amet.
+`
+      expect(findReleaseNote(body)).toBe(
+        '[Fixed] Fix lorem impsum dolor sit amet'
+      )
+    })
+
+    it('detected no release notes wanted for the PR', () => {
+      const body = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.
+
+Notes: no-notes
+`
+      expect(findReleaseNote(body)).toBeNull()
+    })
+
+    it('detected no release notes were added to the PR', () => {
+      const body = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.`
+      expect(findReleaseNote(body)).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Description

This PR makes a few improvements to our `draft-release` script that I've wanted to see for a while:
- It grabs the `Notes: ...` release note from the PRs if it exists.
- If that `Notes:` is set to `no-notes`, that PR will be skipped in the changelog.
- PRs from releases will be skipped (checking the `releases/` prefix).
- When we run `yarn draft-release`, it will create the release branch for us (with the `releases/` prefix)

## Release notes

Notes: no-notes
