### PR TITLE
Fix leaked background process on Windows

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-notifications": "^0.2.1",
+    "desktop-notifications": "^0.2.2",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -21,7 +21,10 @@ import * as path from 'path'
 import windowStateKeeper from 'electron-window-state'
 import * as ipcMain from './ipc-main'
 import * as ipcWebContents from './ipc-webcontents'
-import { installNotificationCallback } from './notifications'
+import {
+  installNotificationCallback,
+  terminateDesktopNotifications,
+} from './notifications'
 
 export class AppWindow {
   private window: Electron.BrowserWindow
@@ -107,6 +110,7 @@ export class AppWindow {
       }
       nativeTheme.removeAllListeners()
       autoUpdater.removeAllListeners()
+      terminateDesktopNotifications()
     })
 
     if (__WIN32__) {

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -45,10 +45,7 @@ import {
   requestNotificationsPermission,
   showNotification,
 } from 'desktop-notifications'
-import {
-  initializeDesktopNotifications,
-  terminateNotificationSystem,
-} from './notifications'
+import { initializeDesktopNotifications } from './notifications'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -740,7 +737,6 @@ function createWindow() {
   window.onClose(() => {
     mainWindow = null
     if (!__DARWIN__ && !preventQuit) {
-      terminateNotificationSystem()
       app.quit()
     }
   })

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -45,7 +45,10 @@ import {
   requestNotificationsPermission,
   showNotification,
 } from 'desktop-notifications'
-import { initializeDesktopNotifications } from './notifications'
+import {
+  initializeDesktopNotifications,
+  terminateNotificationSystem,
+} from './notifications'
 
 app.setAppLogsPath()
 enableSourceMaps()
@@ -737,6 +740,7 @@ function createWindow() {
   window.onClose(() => {
     mainWindow = null
     if (!__DARWIN__ && !preventQuit) {
+      terminateNotificationSystem()
       app.quit()
     }
   })

--- a/app/src/main-process/notifications.ts
+++ b/app/src/main-process/notifications.ts
@@ -1,6 +1,7 @@
 import {
   initializeNotifications,
   onNotificationEvent,
+  terminateNotifications,
 } from 'desktop-notifications'
 import { BrowserWindow } from 'electron'
 import { findToastActivatorClsid } from '../lib/find-toast-activator-clsid'
@@ -33,6 +34,10 @@ export function initializeDesktopNotifications() {
 
   log.info(`Using toast activator CLSID ${windowsToastActivatorClsid}`)
   initializeNotifications({ toastActivatorClsid: windowsToastActivatorClsid })
+}
+
+export function terminateNotificationSystem() {
+  terminateNotifications()
 }
 
 export function installNotificationCallback(window: BrowserWindow) {

--- a/app/src/main-process/notifications.ts
+++ b/app/src/main-process/notifications.ts
@@ -36,7 +36,7 @@ export function initializeDesktopNotifications() {
   initializeNotifications({ toastActivatorClsid: windowsToastActivatorClsid })
 }
 
-export function terminateNotificationSystem() {
+export function terminateDesktopNotifications() {
   terminateNotifications()
 }
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -363,10 +363,10 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-notifications@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.2.1.tgz#ff934e45ef6b47cfbbd6c596c759fc91b96ab753"
-  integrity sha512-ssB7SYsWlVgFCN/4KE5QIHM1hH4PXGHmlIYpUa4xR7WDHcjMEU6vrnrAFWx9SnPLVkCNDiWRwSDejlS1VF9BHw==
+desktop-notifications@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.2.2.tgz#197a32ee504a894ad074793dab285681c533e5ac"
+  integrity sha512-XMnxdWV6ZfiCzLZNC00n6h30Jt3z8yv21FAPBt/kK6hANI0PaoYWsRKEYya0zMUAX/9lrh429R5OtRGOKWZQSw==
   dependencies:
     node-addon-api "^5.0.0"
     prebuild-install "^7.0.1"


### PR DESCRIPTION
Related to #14732

## Description
Based on @275RR's observation in #14732, I narrowed the leaking background process to the `initializeNotifications` call in `notifications.ts` (if not present, GitHub Desktop is exiting as expected).

I'm tagging @sergiou87 as the most knowledgeable regarding desktop notifications because I'm not sure if that is the best fix!

### Additional information:
- The leak is not present on macOS
- It's possibly related to `OpenFailedError: UnknownError Internal error opening backing store for indexedDB.open.` (mentioned in  #14732 and #14730). I successfully reproduced the issue **before** the fix, but **after** applying it, I could not replicate it again. Also, the first reported instance of `OpenFailedError: UnknownError Internal error opening backing store for indexedDB.open.` is from the same update that contains the leaked process. But it's hard to test it because it happened at random after some start-close cycles.

### Before
![before-fix](https://user-images.githubusercontent.com/9341546/172009418-46a05ffa-3176-43df-ae89-7bff3e3632cc.gif)

### After
![after-fix](https://user-images.githubusercontent.com/9341546/172010271-ac0d6360-0c43-4b11-b462-2a29de357950.gif)

