### PR TITLE
#14469 Low res images

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -493,6 +493,7 @@
     min-width: 0;
     min-height: 0;
     text-align: center;
+    box-sizing: content-box;
   }
 
   .image-diff-previous {


### PR DESCRIPTION
Add the "box-sizing:content-box;"  to the image-wrapper styles

Closes #14469

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
All I did was edit the image-wrapper in the diff information to make the images to be a tiny bit bigger. 

 https://github.com/a2937/desktop/blob/2ea8cd128e3c9f64ccd560a2aa7b9d9a8b2f387d/app/styles/ui/_diff.scss#L496

### Screenshots

Before: 
![Before](https://i.imgur.com/YAlJn1Z.png)

After: 
![After](https://i.imgur.com/HquGuy0.png)
## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:


Edit: Copied the wrong imgur link originally 