### PR TITLE
Remember zoom level on update

### DIFF
--- a/app/src/lib/ipc-shared.ts
+++ b/app/src/lib/ipc-shared.ts
@@ -76,6 +76,7 @@ export type RequestChannels = {
   'set-native-theme-source': (themeName: ThemeSource) => void
   'focus-window': () => void
   'notification-event': NotificationCallback<DesktopAliveEvent>
+  'set-window-zoom-factor': (zoomFactor: number) => void
 }
 
 /**

--- a/app/src/lib/local-storage.ts
+++ b/app/src/lib/local-storage.ts
@@ -50,7 +50,7 @@ export function setBoolean(key: string, value: boolean) {
 }
 
 /**
- * Retrieve a `number` value from a given local storage entry if found, or the
+ * Retrieve a integer number value from a given local storage entry if found, or the
  * provided `defaultValue` if the key doesn't exist or if the value cannot be
  * converted into a number
  *
@@ -70,6 +70,34 @@ export function getNumber(
   }
 
   const value = parseInt(numberAsText, 10)
+  if (isNaN(value)) {
+    return defaultValue
+  }
+
+  return value
+}
+
+/**
+ * Retrieve a floating point number value from a given local storage entry if
+ * found, or the provided `defaultValue` if the key doesn't exist or if the
+ * value cannot be converted into a number
+ *
+ * @param key local storage entry to read
+ * @param defaultValue fallback value if unable to find key or valid value
+ */
+export function getFloatNumber(key: string): number | undefined
+export function getFloatNumber(key: string, defaultValue: number): number
+export function getFloatNumber(
+  key: string,
+  defaultValue?: number
+): number | undefined {
+  const numberAsText = localStorage.getItem(key)
+
+  if (numberAsText === null || numberAsText.length === 0) {
+    return defaultValue
+  }
+
+  const value = parseFloat(numberAsText)
   if (isNaN(value)) {
     return defaultValue
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -577,11 +577,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private initializeZoomFactor = async () => {
-    let zoomFactor = await getCurrentWindowZoomFactor()
+    const zoomFactor = await this.getWindowZoomFactor()
     if (zoomFactor === undefined) {
       return
     }
-    zoomFactor = this.checkZoomFactorLocalStorage(zoomFactor)
     this.onWindowZoomFactorChanged(zoomFactor)
   }
 
@@ -592,7 +591,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
    * Thus, on every update, the users set zoom level gets reset as there is not
    * defined value for the current app version.
    * */
-  private checkZoomFactorLocalStorage(zoomFactor: number) {
+  private async getWindowZoomFactor() {
+    const zoomFactor = await getCurrentWindowZoomFactor()
     // One is the default value, we only care about checking the locally stored
     // value if it is one because that is the default value after an
     // update

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -585,23 +585,26 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.onWindowZoomFactorChanged(zoomFactor)
   }
 
-  /** 
+  /**
    * On Windows OS, whenever a user toggles their zoom factor, chromium stores it
    * in their `%AppData%/Roaming/GitHub Desktop/Preferences.js` denoted by the
    * file path to the application. That file path contains the apps version.
    * Thus, on every update, the users set zoom level gets reset as there is not
    * defined value for the current app version.
    * */
-  private checkZoomFactorLocalStorage(zoomFactor: number)  {
+  private checkZoomFactorLocalStorage(zoomFactor: number) {
     // One is the default value, we only care about checking the locally stored
     // value if it is one because that is the default value after an
     // update
-    if(zoomFactor !== 1 || !__WIN32__) { 
+    if (zoomFactor !== 1 || !__WIN32__) {
       return zoomFactor
     }
 
     const locallyStoredZoomFactor = getFloatNumber('zoom-factor')
-    if(locallyStoredZoomFactor !== undefined && locallyStoredZoomFactor !== zoomFactor) {
+    if (
+      locallyStoredZoomFactor !== undefined &&
+      locallyStoredZoomFactor !== zoomFactor
+    ) {
       setWindowZoomFactor(locallyStoredZoomFactor)
       return locallyStoredZoomFactor
     }
@@ -829,7 +832,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private onWindowZoomFactorChanged(zoomFactor: number) {
     const current = this.windowZoomFactor
     this.windowZoomFactor = zoomFactor
-    
+
     if (zoomFactor !== current) {
       setNumber('zoom-factor', zoomFactor)
       this.updateResizableConstraints()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -76,6 +76,7 @@ import {
   getCurrentWindowZoomFactor,
   updatePreferredAppMenuItemLabels,
   updateAccounts,
+  setWindowZoomFactor,
 } from '../../ui/main-process-proxy'
 import {
   API,
@@ -205,6 +206,7 @@ import {
   getEnum,
   getObject,
   setObject,
+  getFloatNumber,
 } from '../local-storage'
 import { ExternalEditorError, suggestedExternalEditor } from '../editors/shared'
 import { ApiRepositoriesStore } from './api-repositories-store'
@@ -575,11 +577,36 @@ export class AppStore extends TypedBaseStore<IAppState> {
   }
 
   private initializeZoomFactor = async () => {
-    const zoomFactor = await getCurrentWindowZoomFactor()
+    let zoomFactor = await getCurrentWindowZoomFactor()
     if (zoomFactor === undefined) {
       return
     }
+    zoomFactor = this.checkZoomFactorLocalStorage(zoomFactor)
     this.onWindowZoomFactorChanged(zoomFactor)
+  }
+
+  /** 
+   * On Windows OS, whenever a user toggles their zoom factor, chromium stores it
+   * in their `%AppData%/Roaming/GitHub Desktop/Preferences.js` denoted by the
+   * file path to the application. That file path contains the apps version.
+   * Thus, on every update, the users set zoom level gets reset as there is not
+   * defined value for the current app version.
+   * */
+  private checkZoomFactorLocalStorage(zoomFactor: number)  {
+    // One is the default value, we only care about checking the locally stored
+    // value if it is one because that is the default value after an
+    // update
+    if(zoomFactor !== 1 || !__WIN32__) { 
+      return zoomFactor
+    }
+
+    const locallyStoredZoomFactor = getFloatNumber('zoom-factor')
+    if(locallyStoredZoomFactor !== undefined && locallyStoredZoomFactor !== zoomFactor) {
+      setWindowZoomFactor(locallyStoredZoomFactor)
+      return locallyStoredZoomFactor
+    }
+
+    return zoomFactor
   }
 
   private onTokenInvalidated = (endpoint: string) => {
@@ -802,8 +829,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private onWindowZoomFactorChanged(zoomFactor: number) {
     const current = this.windowZoomFactor
     this.windowZoomFactor = zoomFactor
-
+    
     if (zoomFactor !== current) {
+      setNumber('zoom-factor', zoomFactor)
       this.updateResizableConstraints()
       this.emitUpdate()
     }

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -417,7 +417,7 @@ export class AppWindow {
   }
 
   public setWindowZoomFactor(zoomFactor: number) {
-    return this.window.webContents.zoomFactor = zoomFactor
+    return (this.window.webContents.zoomFactor = zoomFactor)
   }
 
   /**

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -416,6 +416,10 @@ export class AppWindow {
     return this.window.webContents.zoomFactor
   }
 
+  public setWindowZoomFactor(zoomFactor: number) {
+    return this.window.webContents.zoomFactor = zoomFactor
+  }
+
   /**
    * Method to show the save dialog and return the first file path it returns.
    */

--- a/app/src/main-process/app-window.ts
+++ b/app/src/main-process/app-window.ts
@@ -417,7 +417,7 @@ export class AppWindow {
   }
 
   public setWindowZoomFactor(zoomFactor: number) {
-    return (this.window.webContents.zoomFactor = zoomFactor)
+    this.window.webContents.zoomFactor = zoomFactor
   }
 
   /**

--- a/app/src/main-process/main.ts
+++ b/app/src/main-process/main.ts
@@ -515,6 +515,10 @@ app.on('ready', () => {
     mainWindow?.getCurrentWindowZoomFactor()
   )
 
+  ipcMain.on('set-window-zoom-factor', (_, zoomFactor: number) =>
+    mainWindow?.setWindowZoomFactor(zoomFactor)
+  )
+
   /**
    * An event sent by the renderer asking for a copy of the current
    * application menu.

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -155,7 +155,7 @@ export const getCurrentWindowZoomFactor = invokeProxy(
   0
 )
 
-/** Tell the main process to obtain the current window's zoom factor */
+/** Tell the main process to set the current window's zoom factor */
 export const setWindowZoomFactor = sendProxy('set-window-zoom-factor', 1)
 
 /** Tell the main process to check for app updates */

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -155,6 +155,12 @@ export const getCurrentWindowZoomFactor = invokeProxy(
   0
 )
 
+/** Tell the main process to obtain the current window's zoom factor */
+export const setWindowZoomFactor = sendProxy(
+  'set-window-zoom-factor',
+  1
+)
+
 /** Tell the main process to check for app updates */
 export const checkForUpdates = invokeProxy('check-for-updates', 1)
 

--- a/app/src/ui/main-process-proxy.ts
+++ b/app/src/ui/main-process-proxy.ts
@@ -156,10 +156,7 @@ export const getCurrentWindowZoomFactor = invokeProxy(
 )
 
 /** Tell the main process to obtain the current window's zoom factor */
-export const setWindowZoomFactor = sendProxy(
-  'set-window-zoom-factor',
-  1
-)
+export const setWindowZoomFactor = sendProxy('set-window-zoom-factor', 1)
 
 /** Tell the main process to check for app updates */
 export const checkForUpdates = invokeProxy('check-for-updates', 1)


### PR DESCRIPTION
Closes #5315

## Description
This pr fixes the zoom level being reset on each update for windows users. Technically, it is chromium/electron issue as Desktop simply retrieves the zoom level from the electron web contents api. Unfortunately, it seems that is behaving as expected in that it stores the zoom preference in a preferences setting that is based on the applications file path. For windows users, that file path contains the Desktop app version. 

Thus, to fix this, as I can tell, we have three options:
1) Request chromium change where they store their preferences.. not likely I would think...
2) Read the preferences file ourselves and search for the latest desktop version and apply. 
3) Keep track of it in local storage. 

I chose 3 over 2 out of simplicity sake, we can more so trust that local storage retrieval won't change as opposed to a chromium controlled preference file, and just local storage usage convention in the Desktop app. 

Notes:  
- This approach only sets the zoom to the locally stored value when it receives the default value and the locally stored value differs. Thus, most of the time, it will just rely on the current functionality. 
- If user clears their local storage or locally stored files, this will reset. 

## Release notes
Notes: [Fixed] On Windows, remember the apps zoom level on update.
