### PR TITLE
Fix issue with some repositories not being properly persisted

### DIFF
--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -124,7 +124,7 @@ export class RepositoriesStore extends TypedBaseStore<
       )
     }
 
-    return new GitHubRepository(
+    const ghRepo = new GitHubRepository(
       repo.name,
       owner,
       repo.id,
@@ -137,6 +137,10 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.permissions,
       parent
     )
+
+    // Dexie gets confused if we return a non-promise value (e.g. if this function
+    // didn't need to await for the parent repo or the owner)
+    return Promise.resolve(ghRepo)
   }
 
   private async toRepository(repo: IDatabaseRepository) {


### PR DESCRIPTION
## Description
I noticed that _sometimes_ Desktop wasn't able to move repositories to the right owner in the list (leaving them in `Other`) under some circumstances, along with this console error:

![image](https://user-images.githubusercontent.com/1083228/172317028-383e074f-4c00-4683-a1e2-9e23417d7eb9.png)

It turns out Dexie doesn't like returning non-promise values from async functions used in transactions: https://dexie.org/docs/DexieErrors/Dexie.PrematureCommitError.html

This is something we've run into in the past: https://github.com/dexie/Dexie.js/issues/1186

This PR wraps the resulting `GitHubRepository` instance in a `Promise.resolve(…)` to make Dexie happy.

## Release notes

Notes: no-notes
