### PR TITLE
Multi commit diffing with interstitial screen POC

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -785,10 +785,14 @@ export interface ICompareToBranch {
   readonly comparisonMode: ComparisonMode.Ahead | ComparisonMode.Behind
 }
 
+export interface IDiffCommits {
+  readonly kind: HistoryTabMode.DiffCommits
+}
+
 /**
  * An action to send to the application store to update the compare state
  */
-export type CompareAction = IViewHistory | ICompareToBranch
+export type CompareAction = IViewHistory | ICompareToBranch | IDiffCommits
 
 /**
  * Undo state associated with a multi commit operation being performed on a

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -676,6 +676,7 @@ export interface IChangesState {
 export enum HistoryTabMode {
   History = 'History',
   Compare = 'Compare',
+  DiffCommits = 'DiffCommits',
 }
 
 /**
@@ -713,9 +714,16 @@ export interface ICompareBranch {
   readonly aheadBehind: IAheadBehind
 }
 
+/**
+ * When the user has chosen to view a diff of two commits
+ */
+export interface IDiffCommits {
+  readonly kind: HistoryTabMode.DiffCommits
+}
+
 export interface ICompareState {
   /** The current state of the compare form, based on user input */
-  readonly formState: IDisplayHistory | ICompareBranch
+  readonly formState: IDisplayHistory | ICompareBranch | IDiffCommits
 
   /** The result of merging the compare branch into the current branch, if a branch selected */
   readonly mergeStatus: MergeTreeResult | null

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -108,6 +108,7 @@ import {
   isMergeConflictState,
   IMultiCommitOperationState,
   IConstrainedValue,
+  IDiffCommits,
 } from '../app-state'
 import {
   findEditorOrDefault,
@@ -7052,9 +7053,12 @@ export class AppStore extends TypedBaseStore<IAppState> {
  * view contents.
  */
 function getInitialAction(
-  cachedState: IDisplayHistory | ICompareBranch
+  cachedState: IDisplayHistory | ICompareBranch | IDiffCommits
 ): CompareAction {
-  if (cachedState.kind === HistoryTabMode.History) {
+  if (
+    cachedState.kind === HistoryTabMode.History ||
+    cachedState.kind === HistoryTabMode.DiffCommits
+  ) {
     return {
       kind: HistoryTabMode.History,
     }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1299,7 +1299,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
       this.repositoryStateCache.updateCompareState(repository, () => ({
         formState: newState,
-        commitSHAs: shasInDiff,
+        commitSHAs: [...shasInDiff].reverse(),
       }))
 
       return this.emitUpdate()

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1289,6 +1289,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return this.updateCompareToBranch(repository, action)
     }
 
+    if (action.kind === HistoryTabMode.DiffCommits) {
+      const { commitSelection } = this.repositoryStateCache.get(repository)
+      const { shasInDiff } = commitSelection
+
+      const newState: IDiffCommits = {
+        kind: HistoryTabMode.DiffCommits,
+      }
+
+      this.repositoryStateCache.updateCompareState(repository, () => ({
+        formState: newState,
+        commitSHAs: shasInDiff,
+      }))
+
+      return this.emitUpdate()
+    }
+
     return assertNever(action, `Unknown action: ${kind}`)
   }
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -150,13 +150,17 @@ function getCommitSummary(
     ({ sha }) => !shasInDiff.includes(sha)
   )
 
-  const numInDiff = selectedCommits.length - excludedCommits.length
-  const countMsg =
+  const numInDiff = shasInDiff.length // selectedCommits.length - excludedCommits.length
+  let countMsg =
     excludedCommits.length === 0
       ? selectedCommits.length
       : `${numInDiff} of ${selectedCommits.length} selected `
 
-  return `Viewing the diff of ${countMsg} commits`
+  countMsg = `${shasInDiff[0].substring(0, 7)}^ and ${(
+    shasInDiff.at(-1) ?? ''
+  ).substring(0, 7)}`
+
+  return `Viewing the diff of ${countMsg}`
 }
 
 function getCommitCombinedDescription(commit: Commit) {
@@ -376,7 +380,7 @@ export class CommitSummary extends React.Component<
     )
 
     const countExcludedCommits = excludedCommits.length
-    if (countExcludedCommits === 0) {
+    if (countExcludedCommits === 0 || 1 === 1) {
       return
     }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -7,6 +7,7 @@ import {
   ICompareBranch,
   ComparisonMode,
   IDisplayHistory,
+  IDiffCommits,
 } from '../../lib/app-state'
 import { CommitList } from './commit-list'
 import { Repository } from '../../models/repository'
@@ -91,7 +92,8 @@ export class CompareSidebar extends React.Component<
 
     if (
       newFormState.kind !== oldFormState.kind &&
-      newFormState.kind === HistoryTabMode.History
+      (newFormState.kind === HistoryTabMode.History ||
+        newFormState.kind === HistoryTabMode.DiffCommits)
     ) {
       this.setState({
         focusedBranch: null,
@@ -101,7 +103,9 @@ export class CompareSidebar extends React.Component<
 
     if (
       newFormState.kind !== HistoryTabMode.History &&
-      oldFormState.kind !== HistoryTabMode.History
+      newFormState.kind !== HistoryTabMode.DiffCommits &&
+      oldFormState.kind !== HistoryTabMode.History &&
+      oldFormState.kind !== HistoryTabMode.DiffCommits
     ) {
       const oldBranch = oldFormState.comparisonBranch
       const newBranch = newFormState.comparisonBranch
@@ -179,7 +183,8 @@ export class CompareSidebar extends React.Component<
     const formState = this.props.compareState.formState
     return (
       <div className="compare-commit-list">
-        {formState.kind === HistoryTabMode.History
+        {formState.kind === HistoryTabMode.History ||
+        formState.kind === HistoryTabMode.DiffCommits
           ? this.renderCommitList()
           : this.renderTabBar(formState)}
       </div>
@@ -200,28 +205,35 @@ export class CompareSidebar extends React.Component<
     })
   }
 
-  private renderCommitList() {
-    const { formState, commitSHAs } = this.props.compareState
-
-    let emptyListMessage: string | JSX.Element
+  private getEmptyCommitListMessage(
+    formState: IDisplayHistory | ICompareBranch | IDiffCommits
+  ) {
     if (formState.kind === HistoryTabMode.History) {
-      emptyListMessage = 'No history'
-    } else {
+      return 'No history'
+    }
+
+    if (formState.kind === HistoryTabMode.Compare) {
       const currentlyComparedBranchName = formState.comparisonBranch.name
 
-      emptyListMessage =
-        formState.comparisonMode === ComparisonMode.Ahead ? (
-          <p>
-            The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
-            to date with your branch
-          </p>
-        ) : (
-          <p>
-            Your branch is up to date with the compared branch (
-            <Ref>{currentlyComparedBranchName}</Ref>)
-          </p>
-        )
+      return formState.comparisonMode === ComparisonMode.Ahead ? (
+        <p>
+          The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
+          to date with your branch
+        </p>
+      ) : (
+        <p>
+          Your branch is up to date with the compared branch (
+          <Ref>{currentlyComparedBranchName}</Ref>)
+        </p>
+      )
     }
+
+    return ''
+  }
+
+  private renderCommitList() {
+    const { formState, commitSHAs } = this.props.compareState
+    const emptyListMessage = this.getEmptyCommitListMessage(formState)
 
     return (
       <CommitList
@@ -366,7 +378,10 @@ export class CompareSidebar extends React.Component<
   private onTabClicked = (index: number) => {
     const formState = this.props.compareState.formState
 
-    if (formState.kind === HistoryTabMode.History) {
+    if (
+      formState.kind === HistoryTabMode.History ||
+      formState.kind === HistoryTabMode.DiffCommits
+    ) {
       return
     }
 
@@ -680,10 +695,11 @@ function getPlaceholderText(state: ICompareState) {
 // 1: History mode, 2: Comparison Mode with the 'Ahead' list shown.
 // When not exposed, the context menu item 'Revert this commit' is disabled.
 function ableToRevertCommit(
-  formState: IDisplayHistory | ICompareBranch
+  formState: IDisplayHistory | ICompareBranch | IDiffCommits
 ): boolean {
   return (
     formState.kind === HistoryTabMode.History ||
+    formState.kind === HistoryTabMode.DiffCommits ||
     formState.comparisonMode === ComparisonMode.Ahead
   )
 }

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -330,8 +330,8 @@ export class SelectedCommits extends React.Component<
     return (
       <SuggestedAction
         title={`Diff the first sha (${
-          selectedCommits.at(-1)?.shortSha
-        }) and last sha (${selectedCommits[0].shortSha})`}
+          selectedCommits[0]?.shortSha
+        }^) and last sha (${selectedCommits.at(-1)?.shortSha})`}
         description={'Something about how diffs are complicated'}
         buttonText={'Compare'}
         onClick={this.onCompareCommits}

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -36,6 +36,7 @@ import { clamp } from '../../lib/clamp'
 import { pathExists } from '../lib/path-exists'
 import { enableMultiCommitDiffs } from '../../lib/feature-flag'
 import { SuggestedAction, SuggestedActionGroup } from '../suggested-actions'
+import { LinkButton } from '../lib/link-button'
 
 interface ISelectedCommitsProps {
   readonly repository: Repository
@@ -326,13 +327,18 @@ export class SelectedCommits extends React.Component<
 
   private renderDiffSuggestion = () => {
     const { selectedCommits } = this.props
-
+    const description = (
+      <>
+        This diff may not include all the commits in your selection.{' '}
+        <LinkButton> Learn why? </LinkButton>
+      </>
+    )
     return (
       <SuggestedAction
         title={`Diff the first sha (${
           selectedCommits[0]?.shortSha
         }^) and last sha (${selectedCommits.at(-1)?.shortSha})`}
-        description={'Something about how diffs are complicated'}
+        description={description}
         buttonText={'Compare'}
         onClick={this.onCompareCommits}
       />

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -15,6 +15,7 @@ import {
   RepositorySectionTab,
   ChangesSelectionKind,
   IConstrainedValue,
+  HistoryTabMode,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
 import { IssuesStore, GitHubUserStore } from '../lib/stores'
@@ -372,7 +373,8 @@ export class RepositoryView extends React.Component<
   }
 
   private renderContentForHistory(): JSX.Element {
-    const { commitSelection, commitLookup, localCommitSHAs } = this.props.state
+    const { commitSelection, commitLookup, localCommitSHAs, compareState } =
+      this.props.state
     const { changesetData, file, diff, shas, shasInDiff, isContiguous } =
       commitSelection
 
@@ -412,6 +414,9 @@ export class RepositoryView extends React.Component<
         onChangeImageDiffType={this.onChangeImageDiffType}
         onDiffOptionsOpened={this.onDiffOptionsOpened}
         showDragOverlay={showDragOverlay}
+        isViewingMultiCommitDiff={
+          compareState.formState.kind === HistoryTabMode.DiffCommits
+        }
       />
     )
   }

--- a/app/src/ui/suggested-actions/suggested-action.tsx
+++ b/app/src/ui/suggested-actions/suggested-action.tsx
@@ -25,13 +25,13 @@ interface ISuggestedActionProps {
   /**
    * The text, or "label", for the action button.
    */
-  readonly buttonText: string | JSX.Element
+  readonly buttonText?: string | JSX.Element
 
   /**
    * A callback which is invoked when the user clicks
    * or activates the action using their keyboard.
    */
-  readonly onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+  readonly onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
 
   /**
    * The type of action, currently supported actions are
@@ -83,13 +83,15 @@ export class SuggestedAction extends React.Component<ISuggestedActionProps> {
             </p>
           )}
         </div>
-        <Button
-          type={primary ? 'submit' : undefined}
-          onClick={this.props.onClick}
-          disabled={this.props.disabled}
-        >
-          {this.props.buttonText}
-        </Button>
+        {this.props.buttonText !== undefined && (
+          <Button
+            type={primary ? 'submit' : undefined}
+            onClick={this.props.onClick}
+            disabled={this.props.disabled}
+          >
+            {this.props.buttonText}
+          </Button>
+        )}
       </div>
     )
   }

--- a/app/styles/ui/history/_history.scss
+++ b/app/styles/ui/history/_history.scss
@@ -26,6 +26,22 @@
     margin: 0;
   }
 
+  .commit-diff-header {
+    background: var(--box-alt-background-color);
+    padding: var(--spacing);
+    border-bottom: var(--base-border);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .commit-diff-footer {
+    button {
+      width: 100%;
+    }
+    background: var(--box-alt-background-color);
+    padding: var(--spacing-half);
+    border-top: var(--base-border);
+  }
+
   .compare-form {
     background: var(--box-alt-background-color);
     flex: initial;

--- a/app/styles/ui/history/_multiple_commits_selected.scss
+++ b/app/styles/ui/history/_multiple_commits_selected.scss
@@ -10,3 +10,45 @@
     text-align: left;
   }
 }
+
+#multiple-commits-selected-suggestions {
+  padding: var(--spacing-quad);
+  width: 100%;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  .content {
+    width: 100%;
+    max-width: 600px;
+
+    .header {
+      display: flex;
+      flex-direction: row;
+
+      > div {
+        flex-grow: 1;
+        h1 {
+          padding: 0;
+          margin: 0;
+          font-size: var(--font-size-xl);
+          font-weight: var(--font-weight-light);
+        }
+
+        p {
+          margin: 0;
+        }
+      }
+
+      margin-bottom: var(--spacing-double);
+    }
+  }
+
+  /** Lessen the padding at 1.5x zoom and above  **/
+  @media screen and (max-width: 640px) {
+    padding: var(--spacing-double);
+  }
+}


### PR DESCRIPTION
## Description
As you can read about in https://github.com/desktop/desktop/pull/14720, multi commit diffing can be complex. We discussed in the team sync a few days ago. The idea here is that if separate the UI action of range selection from the diff and make it an action to do diff of the first and last commit in the selection, we will be being more transparent of how it works and therefore it will be much more understandable. This comes with the con that for simple scenarios, the user must click to do the diff; thus adding friction. 

This draft PR is just for sake of having this out to check out the proof of concept. If we decide to go this route, I will break it into smaller PRs.

Additionally, there are a few other things that would need fixed/looked into... 
- squashing and reordering don't make a whole lot of sense here
- right now you can "return to history" but what if user was on the compare mode... 
- This also built on top of my other handling merged commit pr to have quick access to some of that work.. but some of it is non applicable and would be removed.
- this logic runs the multi commit diff and rev-list as soon as the user selects a range, maybe it would be better to move that to when the user actually chooses to do the diff? (maybe they just were squashing, reordering, or cherry-picking.. hmm may be an interesting stat.. how many range selections result in what action?)

### Screenshots
https://user-images.githubusercontent.com/75402236/172852275-b292122a-1af4-4e01-b1de-6e50f002e84a.mov

## Release notes
Notes: no-notes
