### PR TITLE
Fix no-response label

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -29,3 +29,4 @@ jobs:
             you answer our questions above, this issue will automatically
             reopen.
           daysUntilClose: 7
+          responseRequiredLabel: more-info-needed


### PR DESCRIPTION
## Description

Forgot to change the default from `more-information-needed` to `more-info-needed`. 🤦🏻 

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->
Notes: no-notes
