### PR TITLE
Add copy repo path

### DIFF
--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -13,6 +13,10 @@ export const CopySelectedRelativePathsLabel = __DARWIN__
   ? 'Copy Relative Paths'
   : 'Copy relative paths'
 
+export const CopyRepositoryLocationLabel = __DARWIN__
+  ? 'Copy Repository Path'
+  : 'Copy repository path'
+
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
   : 'Open in external editor'

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -13,10 +13,6 @@ export const CopySelectedRelativePathsLabel = __DARWIN__
   ? 'Copy Relative Paths'
   : 'Copy relative paths'
 
-export const CopyRepositoryLocationLabel = __DARWIN__
-  ? 'Copy Repository Path'
-  : 'Copy repository path'
-
 export const DefaultEditorLabel = __DARWIN__
   ? 'Open in External Editor'
   : 'Open in external editor'

--- a/app/src/ui/repositories-list/repository-list-item.tsx
+++ b/app/src/ui/repositories-list/repository-list-item.tsx
@@ -166,7 +166,11 @@ export class RepositoryListItem extends React.Component<
       ...this.buildAliasMenuItems(),
       {
         label: __DARWIN__ ? 'Copy Repo Name' : 'Copy repo name',
-        action: this.copyToClipboard,
+        action: this.copyNameToClipboard,
+      },
+      {
+        label: __DARWIN__ ? 'Copy Repo Path' : 'Copy repo path',
+        action: this.copyPathToClipboard,
       },
       { type: 'separator' },
       {
@@ -258,8 +262,12 @@ export class RepositoryListItem extends React.Component<
     }
   }
 
-  private copyToClipboard = () => {
+  private copyNameToClipboard = () => {
     clipboard.writeText(this.props.repository.name)
+  }
+
+  private copyPathToClipboard = () => {
+    clipboard.writeText(this.props.repository.path)
   }
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes https://github.com/desktop/desktop/issues/14741

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Adds a "Copy Repo Path" to the dropdown menu to allow users to copy their repository's path.

### Screenshots
![image](https://user-images.githubusercontent.com/35881688/173168078-0e38e54b-2452-4334-8275-a71c7d83118e.png)
Only the dropdown menu has changed.

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
- Added "Copy Repo Path" to allow users to copy their repository's path on their PC.