### PR TITLE
[WIP] Text selection is too tall in diff view’s shrunk code element

### DIFF
--- a/app/styles/ui/_diff.scss
+++ b/app/styles/ui/_diff.scss
@@ -33,8 +33,8 @@
     padding: 2px 0 2px var(--spacing-half);
 
     &.diff-hunk-expandable-both {
-      padding-top: 14px;
-      padding-bottom: 14px;
+      padding-top: 7px;
+      padding-bottom: 7px;
     }
 
     &.diff-hunk:not(.diff-hunk-expandable-both) {


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14760

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Reduced the height of diff view’s shrunk code element so when the text is selected it doesn`t get a big area

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

#### Before:
![image](https://user-images.githubusercontent.com/56176344/173683442-5198d7f9-fd16-4637-9dad-2567facc83b3.png)

#### After:
![image](https://user-images.githubusercontent.com/56176344/173699847-bb405c3b-daf3-480a-a9da-f2898d544ac3.png)

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
