### PR TITLE
Adding new history tab mode for diffing commits

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -661,6 +661,7 @@ export interface IChangesState {
 export enum HistoryTabMode {
   History = 'History',
   Compare = 'Compare',
+  DiffCommits = 'DiffCommits',
 }
 
 /**
@@ -698,9 +699,16 @@ export interface ICompareBranch {
   readonly aheadBehind: IAheadBehind
 }
 
+/**
+ * When the user has chosen to view a diff of two commits
+ */
+export interface IDiffCommits {
+  readonly kind: HistoryTabMode.DiffCommits
+}
+
 export interface ICompareState {
   /** The current state of the compare form, based on user input */
-  readonly formState: IDisplayHistory | ICompareBranch
+  readonly formState: IDisplayHistory | ICompareBranch | IDiffCommits
 
   /** The result of merging the compare branch into the current branch, if a branch selected */
   readonly mergeStatus: MergeTreeResult | null
@@ -762,10 +770,14 @@ export interface ICompareToBranch {
   readonly comparisonMode: ComparisonMode.Ahead | ComparisonMode.Behind
 }
 
+export interface IViewDiffCommits {
+  readonly kind: HistoryTabMode.DiffCommits
+}
+
 /**
  * An action to send to the application store to update the compare state
  */
-export type CompareAction = IViewHistory | ICompareToBranch
+export type CompareAction = IViewHistory | ICompareToBranch | IViewDiffCommits
 
 /**
  * Undo state associated with a multi commit operation being performed on a

--- a/app/src/ui/history/commit-list-item.tsx
+++ b/app/src/ui/history/commit-list-item.tsx
@@ -55,7 +55,7 @@ interface ICommitProps {
   readonly showUnpushedIndicator: boolean
   readonly unpushedIndicatorTitle?: string
   readonly unpushedTags?: ReadonlyArray<string>
-  readonly isCherryPickInProgress?: boolean
+  readonly disableCherryPicking?: boolean
   readonly disableSquashing?: boolean
 }
 
@@ -391,6 +391,7 @@ export class CommitListItem extends React.PureComponent<
           ? `Squash ${count} Commits…`
           : `Squash ${count} commits…`,
         action: this.onSquash,
+        enabled: !this.props.disableSquashing,
       })
     }
 
@@ -398,12 +399,11 @@ export class CommitListItem extends React.PureComponent<
   }
 
   private canCherryPick(): boolean {
-    const { onCherryPick, isCherryPickInProgress } = this.props
+    const { onCherryPick, disableCherryPicking } = this.props
     return (
       onCherryPick !== undefined &&
       this.onSquash !== undefined &&
-      isCherryPickInProgress === false
-      // TODO: isSquashInProgress === false
+      disableCherryPicking === false
     )
   }
 

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -118,8 +118,8 @@ interface ICommitListProps {
   /** Whether or not commits in this list can be reordered. */
   readonly reorderingEnabled: boolean
 
-  /** Whether a cherry pick is progress */
-  readonly isCherryPickInProgress: boolean
+  /** Whether a cherry picking is disabled for example cherry-picking is in progress */
+  readonly disableCherryPicking: boolean
 
   /** Callback to render commit drag element */
   readonly onRenderCommitDragElement: (
@@ -207,7 +207,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
         onAmendCommit={this.props.onAmendCommit}
         onViewCommitOnGitHub={this.props.onViewCommitOnGitHub}
         selectedCommits={this.lookupCommits(this.props.selectedSHAs)}
-        isCherryPickInProgress={this.props.isCherryPickInProgress}
+        disableCherryPicking={this.props.disableCherryPicking}
         onRenderCommitDragElement={this.onRenderCommitDragElement}
         onRemoveDragElement={this.props.onRemoveCommitDragElement}
         disableSquashing={this.props.disableSquashing}


### PR DESCRIPTION
## Description
This PR adds a new history tab mode and thus a new compare view to the app state. It is not implemented; just the logic to support a new the commit range diff view.

## Release notes
Notes: no-notes
