### PR TITLE
Revert handling of non contiguous multi commit selection commits

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -553,20 +553,6 @@ export interface ICommitSelection {
   /** The commits currently selected in the app */
   readonly shas: ReadonlyArray<string>
 
-  /**
-   * Whether the a selection of commits are group of adjacent to each other.
-   * Example: Given these are indexes of sha's in history, 3, 4, 5, 6 is contiguous as
-   * opposed to 3, 5, 8.
-   *
-   * Technically order does not matter, but shas are stored in order.
-   *
-   * Contiguous selections can be diffed. Non-contiguous selections can be
-   * cherry-picked, reordered, or squashed.
-   *
-   * Assumed that a selections of zero or one commit are contiguous.
-   * */
-  readonly isContiguous: boolean
-
   /** The changeset data associated with the selected commit */
   readonly changesetData: IChangesetData
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1111,8 +1111,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   /** This shouldn't be called directly. See `Dispatcher`. */
   public async _changeCommitSelection(
     repository: Repository,
-    shas: ReadonlyArray<string>,
-    isContiguous: boolean
+    shas: ReadonlyArray<string>
   ): Promise<void> {
     const { commitSelection } = this.repositoryStateCache.get(repository)
 
@@ -1125,7 +1124,6 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this.repositoryStateCache.updateCommitSelection(repository, () => ({
       shas,
-      isContiguous,
       file: null,
       changesetData: { files: [], linesAdded: 0, linesDeleted: 0 },
       diff: null,
@@ -1155,7 +1153,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     }
 
     if (selectedSHA === null && commitSHAs.length > 0) {
-      this._changeCommitSelection(repository, [commitSHAs[0]], true)
+      this._changeCommitSelection(repository, [commitSHAs[0]])
       this._loadChangedFilesForCurrentSelection(repository)
     }
   }
@@ -1410,10 +1408,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
   ): Promise<void> {
     const state = this.repositoryStateCache.get(repository)
     const { commitSelection } = state
-    const { shas: currentSHAs, isContiguous } = commitSelection
+    const currentSHAs = commitSelection.shas
     if (
       currentSHAs.length === 0 ||
-      (currentSHAs.length > 1 && (!enableMultiCommitDiffs() || !isContiguous))
+      (currentSHAs.length !== 1 && !enableMultiCommitDiffs())
     ) {
       return
     }
@@ -1479,7 +1477,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.emitUpdate()
 
     const stateBeforeLoad = this.repositoryStateCache.get(repository)
-    const { shas, isContiguous } = stateBeforeLoad.commitSelection
+    const shas = stateBeforeLoad.commitSelection.shas
 
     if (shas.length === 0) {
       if (__DEV__) {
@@ -1491,7 +1489,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       }
     }
 
-    if (shas.length > 1 && (!enableMultiCommitDiffs() || !isContiguous)) {
+    if (shas.length > 1 && !enableMultiCommitDiffs()) {
       return
     }
 

--- a/app/src/lib/stores/repository-state-cache.ts
+++ b/app/src/lib/stores/repository-state-cache.ts
@@ -178,7 +178,6 @@ function getInitialRepositoryState(): IRepositoryState {
   return {
     commitSelection: {
       shas: [],
-      isContiguous: true,
       file: null,
       changesetData: { files: [], linesAdded: 0, linesDeleted: 0 },
       diff: null,

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -235,10 +235,9 @@ export class Dispatcher {
    */
   public changeCommitSelection(
     repository: Repository,
-    shas: ReadonlyArray<string>,
-    isContiguous: boolean
+    shas: ReadonlyArray<string>
   ): Promise<void> {
-    return this.appStore._changeCommitSelection(repository, shas, isContiguous)
+    return this.appStore._changeCommitSelection(repository, shas)
   }
 
   /**
@@ -3149,7 +3148,7 @@ export class Dispatcher {
 
     switch (cherryPickResult) {
       case CherryPickResult.CompletedWithoutError:
-        await this.changeCommitSelection(repository, [commits[0].sha], true)
+        await this.changeCommitSelection(repository, [commits[0].sha])
         await this.completeMultiCommitOperation(repository, commits.length)
         break
       case CherryPickResult.ConflictsEncountered:
@@ -3553,11 +3552,7 @@ export class Dispatcher {
           // TODO: Look at history back to last retained commit and search for
           // squashed commit based on new commit message ... if there is more
           // than one, just take the most recent. (not likely?)
-          await this.changeCommitSelection(
-            repository,
-            [status.currentTip],
-            true
-          )
+          await this.changeCommitSelection(repository, [status.currentTip])
         }
 
         await this.completeMultiCommitOperation(

--- a/app/src/ui/history/commit-list.tsx
+++ b/app/src/ui/history/commit-list.tsx
@@ -41,10 +41,7 @@ interface ICommitListProps {
   readonly emptyListMessage: JSX.Element | string
 
   /** Callback which fires when a commit has been selected in the list */
-  readonly onCommitsSelected: (
-    commits: ReadonlyArray<Commit>,
-    isContiguous: boolean
-  ) => void
+  readonly onCommitsSelected: (commits: ReadonlyArray<Commit>) => void
 
   /** Callback that fires when a scroll event has occurred */
   readonly onScroll: (start: number, end: number) => void
@@ -272,34 +269,10 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     // reordering, they will need to do multiple cherry-picks.
     // Goal: first commit in history -> first on array
     const sorted = [...rows].sort((a, b) => b - a)
+
     const selectedShas = sorted.map(r => this.props.commitSHAs[r])
     const selectedCommits = this.lookupCommits(selectedShas)
-    this.props.onCommitsSelected(selectedCommits, this.isContiguous(sorted))
-  }
-
-  /**
-   * Accepts a sorted array of numbers in descending order. If the numbers ar
-   * contiguous order, 4, 3, 2 not 5, 3, 1, returns true.
-   *
-   * Defined an array of 0 and 1 are considered contiguous.
-   */
-  private isContiguous(indexes: ReadonlyArray<number>) {
-    if (indexes.length <= 1) {
-      return true
-    }
-
-    for (let i = 0; i < indexes.length; i++) {
-      const current = indexes[i]
-      if (i + 1 === indexes.length) {
-        continue
-      }
-
-      if (current - 1 !== indexes[i + 1]) {
-        return false
-      }
-    }
-
-    return true
+    this.props.onCommitsSelected(selectedCommits)
   }
 
   // This is required along with onSelectedRangeChanged in the case of a user
@@ -308,7 +281,7 @@ export class CommitList extends React.Component<ICommitListProps, {}> {
     const sha = this.props.commitSHAs[row]
     const commit = this.props.commitLookup.get(sha)
     if (commit) {
-      this.props.onCommitsSelected([commit], true)
+      this.props.onCommitsSelected([commit])
     }
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -460,14 +460,10 @@ export class CompareSidebar extends React.Component<
     }
   }
 
-  private onCommitsSelected = (
-    commits: ReadonlyArray<Commit>,
-    isContiguous: boolean
-  ) => {
+  private onCommitsSelected = (commits: ReadonlyArray<Commit>) => {
     this.props.dispatcher.changeCommitSelection(
       this.props.repository,
-      commits.map(c => c.sha),
-      isContiguous
+      commits.map(c => c.sha)
     )
 
     this.loadChangedFilesScheduler.queue(() => {

--- a/app/src/ui/history/selected-commit.tsx
+++ b/app/src/ui/history/selected-commit.tsx
@@ -80,9 +80,6 @@ interface ISelectedCommitsProps {
 
   /** Whether or not to show the drag overlay */
   readonly showDragOverlay: boolean
-
-  /** Whether or not the selection of commits is contiguous */
-  readonly isContiguous: boolean
 }
 
 interface ISelectedCommitsState {
@@ -247,13 +244,10 @@ export class SelectedCommits extends React.Component<
   }
 
   public render() {
-    const { selectedCommits, isContiguous } = this.props
+    const { selectedCommits } = this.props
 
-    if (
-      selectedCommits.length > 1 &&
-      (!isContiguous || !enableMultiCommitDiffs())
-    ) {
-      return this.renderMultipleCommitsBlankSlate()
+    if (selectedCommits.length > 1 && !enableMultiCommitDiffs()) {
+      return this.renderMultipleCommitsSelected()
     }
 
     if (selectedCommits.length === 0) {
@@ -291,7 +285,7 @@ export class SelectedCommits extends React.Component<
     return <div id="drag-overlay-background"></div>
   }
 
-  private renderMultipleCommitsBlankSlate(): JSX.Element {
+  private renderMultipleCommitsSelected(): JSX.Element {
     const BlankSlateImage = encodePathAsUrl(
       __dirname,
       'static/empty-no-commit.svg'
@@ -302,22 +296,11 @@ export class SelectedCommits extends React.Component<
         <div className="panel blankslate">
           <img src={BlankSlateImage} className="blankslate-image" />
           <div>
-            <p>
-              Unable to display diff when multiple{' '}
-              {enableMultiCommitDiffs() ? 'non-consecutive ' : ' '}commits are
-              selected.
-            </p>
+            <p>Unable to display diff when multiple commits are selected.</p>
             <div>You can:</div>
             <ul>
-              <li>
-                Select a single commit{' '}
-                {enableMultiCommitDiffs()
-                  ? 'or a range of consecutive commits '
-                  : ' '}
-                to view a diff.
-              </li>
+              <li>Select a single commit to view a diff.</li>
               <li>Drag the commits to the branch menu to cherry-pick them.</li>
-              <li>Drag the commits to squash or reorder them.</li>
               <li>Right click on multiple commits to see options.</li>
             </ul>
           </div>

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -373,7 +373,7 @@ export class RepositoryView extends React.Component<
 
   private renderContentForHistory(): JSX.Element {
     const { commitSelection, commitLookup, localCommitSHAs } = this.props.state
-    const { changesetData, file, diff, shas, isContiguous } = commitSelection
+    const { changesetData, file, diff, shas } = commitSelection
 
     const selectedCommits = []
     for (const sha of shas) {
@@ -393,7 +393,6 @@ export class RepositoryView extends React.Component<
         isLocalRepository={this.props.state.remote === null}
         dispatcher={this.props.dispatcher}
         selectedCommits={selectedCommits}
-        isContiguous={isContiguous}
         localCommitSHAs={localCommitSHAs}
         changesetData={changesetData}
         selectedFile={file}


### PR DESCRIPTION
## Description
This PR reverts the changes in https://github.com/desktop/desktop/pull/1470 as non-contiguous selections are not as much a concern with the change of multi commit diffing being handled with an interstitial screen asking user to diff the latest and earliest commit in their selection and not giving the expectation of the diff containing only the commits in the selection.

### Commits reverted
This reverts commit c6f6b1bdf670fe30eabd7df416ff667b5f76e42d.

Revert "More descriptive about the range"

This reverts commit 7475f5fb83d4dbcaa2063f97058e27eb19c18713.

Revert "Better words"

This reverts commit e45ffbde8d0560dcf9bbc393db0dac59dbffb665.

Revert "Show multiple commit blank slate for non-contiguous selections"

This reverts commit 4c45360a6caf2ed0cb519ef29ad70b537160d0ac.

Revert "Don't diff if not contiguous"

This reverts commit 663033389d658a3c229f8e9754ce552709a6cfb2.

## Release notes
Notes: no-notes
