### PR TITLE
Skip non `releases/` branches from "Create release PR" action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,9 +1,6 @@
 name: 'Create Release Pull Request'
 
-on:
-  create:
-    branches:
-      - releases/*
+on: create
 
 jobs:
   build:
@@ -13,10 +10,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v2
-        if: ${{ !contains(github.ref, 'test') }}
+        if: |
+          startsWith(github.ref, 'refs/heads/releases/') && !contains(github.ref, 'test')
 
       - name: Create Pull Request content
-        if: ${{ !contains(github.ref, 'test') }}
+        if: |
+          startsWith(github.ref, 'refs/heads/releases/') && !contains(github.ref, 'test')
         run: |
           PR_TITLE=`./script/draft-release/release-pr-content.sh title ${GITHUB_REF#refs/heads/}`
           PR_BODY=`./script/draft-release/release-pr-content.sh body ${GITHUB_REF#refs/heads/}`
@@ -31,14 +30,16 @@ jobs:
 
       - uses: tibdex/github-app-token@v1
         id: generate-token
-        if: ${{ !contains(github.ref, 'test') }}
+        if: |
+          startsWith(github.ref, 'refs/heads/releases/') && !contains(github.ref, 'test')
         with:
           app_id: ${{ secrets.DESKTOP_RELEASES_APP_ID }}
           private_key: ${{ secrets.DESKTOP_RELEASES_APP_PRIVATE_KEY }}
 
       - name: Create Release Pull Request
         uses: peter-evans/create-pull-request@v4.0.4
-        if: ${{ !contains(github.ref, 'test') }}
+        if: |
+          startsWith(github.ref, 'refs/heads/releases/') && !contains(github.ref, 'test')
         with:
           token: ${{ steps.generate-token.outputs.token }}
           title: ${{ env.PR_TITLE }}


### PR DESCRIPTION
## Description

I thought the `on create` event would allow us to filter by branches using the `branches:` key, just like `on push` does… but it doesn't. Instead, I added the check to the `if` clause.

This is not the best because it means the action will be triggered for every new branch we push, even if its steps are skipped, but I can't see another way for now.

## Release notes

Notes: no-notes
