### PR TITLE
Readonly tags input 

### DIFF
--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -179,7 +179,7 @@ export class CompareSidebar extends React.Component<
     )
   }
 
-  private onCommitDiffFormChange = (value: any) => {
+  private onCommitDiffFormChange = () => {
     this.handleCommitDiffEscape()
   }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -33,6 +33,7 @@ import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-d
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
 import { enableCommitReordering } from '../../lib/feature-flag'
 import { assertNever } from '../../lib/fatal-error'
+import { TagsInput } from '../lib/tags-input'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -178,10 +179,8 @@ export class CompareSidebar extends React.Component<
     )
   }
 
-  private onCommitDiffFormKeyDown = (
-    event: React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    this.viewHistoryForBranch()
+  private onCommitDiffFormChange = (value: any) => {
+    this.handleCommitDiffEscape()
   }
 
   private renderCommitDiffForm = () => {
@@ -190,16 +189,14 @@ export class CompareSidebar extends React.Component<
     const latestCommit = commitLookup.get(selectedCommitShas.at(-1) ?? '')
     const filterText = `${earliestCommit?.shortSha}^..${latestCommit?.shortSha}`
 
-    // TODO: change input to something where commit selection looks like ref
     return (
-      <FancyTextBox
-        symbol={OcticonSymbol.gitCommit}
-        type="search"
-        value={filterText}
-        onRef={this.onTextBoxRef}
-        onKeyDown={this.onCommitDiffFormKeyDown}
-        onSearchCleared={this.handleCommitDiffEscape}
-      />
+      <>
+        <TagsInput
+          symbol={OcticonSymbol.gitCommit}
+          values={[filterText]}
+          onChange={this.onCommitDiffFormChange}
+        />
+      </>
     )
   }
 
@@ -506,11 +503,10 @@ export class CompareSidebar extends React.Component<
     }
   }
 
-  private handleCommitDiffEscape = () => {
-    this.props.dispatcher.restorePreviousCompareState(this.props.repository)
-    if (this.textbox) {
-      this.textbox.blur()
-    }
+  private handleCommitDiffEscape = async () => {
+    await this.props.dispatcher.restorePreviousCompareState(
+      this.props.repository
+    )
   }
 
   private onCommitsSelected = (

--- a/app/src/ui/lib/select.tsx
+++ b/app/src/ui/lib/select.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { createUniqueId, releaseUniqueId } from './id-pool'
 
-interface ISelectProps {
+export interface ISelectProps {
   /** The label for the select control. */
   readonly label?: string
 

--- a/app/src/ui/lib/tags-input.tsx
+++ b/app/src/ui/lib/tags-input.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import { Octicon, OcticonSymbolType } from '../octicons'
+import * as OcticonSymbol from '../octicons/octicons.generated'
+import classNames from 'classnames'
+
+interface ITagsInputProps {
+  /** Icon to render */
+  readonly symbol?: OcticonSymbolType
+
+  /** The value of the input. */
+  readonly values: ReadonlyArray<string>
+
+  /** Called when the user changes the selected valued. */
+  readonly onChange?: (value: ReadonlyArray<string>) => void
+}
+
+interface ITagsInputState {
+  readonly isFocused: boolean
+}
+
+export class TagsInput extends React.Component<
+  ITagsInputProps,
+  ITagsInputState
+> {
+  public constructor(props: ITagsInputProps) {
+    super(props)
+
+    this.state = { isFocused: false }
+  }
+
+  private onTagBoxFocused = () => {
+    this.setState({ isFocused: true })
+  }
+
+  private onBlur = () => {
+    this.setState({ isFocused: false })
+  }
+
+  private onTagRemoved = (tag: string, index: number) => {
+    return () => {
+      this.props.onChange?.([])
+    }
+  }
+
+  private renderTag = (tag: string, index: number) => {
+    return (
+      <span className="tag" key={index}>
+        {tag}
+        <span className="remove" onClick={this.onTagRemoved(tag, index)}>
+          <Octicon symbol={OcticonSymbol.x} />
+        </span>
+      </span>
+    )
+  }
+
+  public render() {
+    const classes = classNames('tags-input-component', {
+      focused: this.state.isFocused,
+    })
+    return (
+      <div
+        className={classes}
+        tabIndex={1}
+        onClick={this.onTagBoxFocused}
+        onFocus={this.onTagBoxFocused}
+        onBlur={this.onBlur}
+      >
+        {this.props.symbol !== undefined ? (
+          <Octicon className="tags-input-octicon" symbol={this.props.symbol} />
+        ) : null}
+        <div className="tag-box">
+          {this.props.values.map((v, i) => this.renderTag(v, i))}
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/lib/tags-input.tsx
+++ b/app/src/ui/lib/tags-input.tsx
@@ -16,6 +16,7 @@ interface ITagsInputProps {
 
 interface ITagsInputState {
   readonly isFocused: boolean
+  readonly tags: ReadonlyArray<string>
 }
 
 export class TagsInput extends React.Component<
@@ -25,7 +26,7 @@ export class TagsInput extends React.Component<
   public constructor(props: ITagsInputProps) {
     super(props)
 
-    this.state = { isFocused: false }
+    this.state = { isFocused: false, tags: props.values }
   }
 
   private onTagBoxFocused = () => {
@@ -36,9 +37,12 @@ export class TagsInput extends React.Component<
     this.setState({ isFocused: false })
   }
 
-  private onTagRemoved = (tag: string, index: number) => {
+  private onTagRemoved = (index: number) => {
     return () => {
-      this.props.onChange?.([])
+      const tags = [...this.state.tags]
+      tags.splice(index, 1)
+      this.setState({ tags })
+      this.props.onChange?.(tags)
     }
   }
 
@@ -46,7 +50,7 @@ export class TagsInput extends React.Component<
     return (
       <span className="tag" key={index}>
         {tag}
-        <span className="remove" onClick={this.onTagRemoved(tag, index)}>
+        <span className="remove" onClick={this.onTagRemoved(index)}>
           <Octicon symbol={OcticonSymbol.x} />
         </span>
       </span>
@@ -54,8 +58,9 @@ export class TagsInput extends React.Component<
   }
 
   public render() {
+    const { isFocused, tags } = this.state
     const classes = classNames('tags-input-component', {
-      focused: this.state.isFocused,
+      focused: isFocused,
     })
     return (
       <div
@@ -69,7 +74,7 @@ export class TagsInput extends React.Component<
           <Octicon className="tags-input-octicon" symbol={this.props.symbol} />
         ) : null}
         <div className="tag-box">
-          {this.props.values.map((v, i) => this.renderTag(v, i))}
+          {tags.map((v, i) => this.renderTag(v, i))}
         </div>
       </div>
     )

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -99,3 +99,4 @@
 @import 'ui/_pull-request-quick-view';
 @import 'ui/discard-changes-retry';
 @import 'ui/_git-email-not-found-warning';
+@import 'ui/_tags-input';

--- a/app/styles/ui/_tags-input.scss
+++ b/app/styles/ui/_tags-input.scss
@@ -1,0 +1,47 @@
+@import '../mixins';
+
+.tags-input-component {
+  background: var(--box-background-color);
+  display: flex;
+  align-items: center;
+  border: var(--base-border);
+  border-radius: var(--border-radius);
+
+  .tag {
+    flex: 1 1 auto;
+    display: inline-flex;
+    align-items: center;
+    padding: 0 var(--spacing-half);
+    border-radius: var(--border-radius);
+    background: var(--list-item-badge-background-color);
+    box-shadow: 1px 0 0 var(--background-color);
+    margin-left: var(--spacing-half);
+
+    .remove {
+      display: inline-flex;
+
+      color: var(--text-secondary-color);
+
+      &:hover {
+        color: var(--text-color);
+      }
+    }
+  }
+
+  .tags-input-octicon {
+    height: var(--text-field-height);
+    padding: var(--spacing-half) 0 var(--spacing-half) 7px;
+    border-right: none;
+    border-radius: var(--border-radius) 0 0 var(--border-radius);
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+  }
+
+  &.focused {
+    @include textboxish-focus-styles;
+
+    .fancy-octicon {
+      opacity: 1;
+    }
+  }
+}


### PR DESCRIPTION
Based on #14827

## Description
This is a simple readonly component made to look like an input for tags (as in accepting an array of text elements where each is styled in it's own bubble - not specifically git tag)

Someday could be expanded to actually facilitate adding tags by adding a hidden textbox in the list that takes focus for user to input a new element. Other implementations use select style input if you want to limit user options.. but we don't need that right now...

### Screenshots
https://user-images.githubusercontent.com/75402236/174606571-354f66ce-9a19-478e-8826-830b29a3e8ff.mov


## Release notes
Notes: no-notes
