### PR TITLE
Improved handling of external editors

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -47,6 +47,7 @@ import {
   MultiCommitOperationStep,
 } from '../models/multi-commit-operation'
 import { IChangesetData } from './git'
+import { FoundEditor } from './editors/shared'
 
 export enum SelectionType {
   Repository,
@@ -202,6 +203,12 @@ export interface IAppState {
 
   /** The external editor to use when opening repositories */
   readonly selectedExternalEditor: string | null
+
+  /** Wheter or not the current editor is executable picked by the user */
+  readonly useExternalCustomEditor: boolean
+
+  /** The custom editor picked by the user */
+  readonly customExternalEditor: FoundEditor | null
 
   /** Whether or not the app should use Windows' OpenSSH client */
   readonly useWindowsOpenSSH: boolean

--- a/app/src/lib/editors/found-editor.ts
+++ b/app/src/lib/editors/found-editor.ts
@@ -2,4 +2,5 @@ export interface IFoundEditor<T> {
   readonly editor: T
   readonly path: string
   readonly usesShell?: boolean
+  readonly launchArgs?: string
 }

--- a/app/src/lib/editors/launch.ts
+++ b/app/src/lib/editors/launch.ts
@@ -1,6 +1,10 @@
 import { spawn, SpawnOptions } from 'child_process'
 import { pathExists } from '../../ui/lib/path-exists'
-import { ExternalEditorError, FoundEditor } from './shared'
+import {
+  ExternalEditorError,
+  FoundEditor,
+  processEditorLaunchArgs,
+} from './shared'
 
 /**
  * Open a given file or folder in the desired external editor.
@@ -22,6 +26,13 @@ export async function launchExternalEditor(
     )
   }
 
+  const processedArgs = await processEditorLaunchArgs(
+    fullPath,
+    editor.launchArgs
+  )
+
+  log.info(`Launch editor ${editor.editor} with args: ${processedArgs}`)
+
   const opts: SpawnOptions = {
     // Make sure the editor processes are detached from the Desktop app.
     // Otherwise, some editors (like Notepad++) will be killed when the
@@ -34,8 +45,8 @@ export async function launchExternalEditor(
   } else if (__DARWIN__) {
     // In macOS we can use `open`, which will open the right executable file
     // for us, we only need the path to the editor .app folder.
-    spawn('open', ['-a', editorPath, fullPath], opts)
+    spawn('open', ['-a', editorPath, ...processedArgs], opts)
   } else {
-    spawn(editorPath, [fullPath], opts)
+    spawn(editorPath, processedArgs, opts)
   }
 }

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -42,7 +42,7 @@ export const CustomEditorPickedLabel = 'External Editor'
 export const CustomEditorRepoEntityPathValue = '%REPO_PATH%'
 
 /**
- * Returns an array of valid lauch arguments
+ * Returns an array of valid launch arguments
  *
  * @param repoPath A folder or file path to pass as an argument when launching the editor.
  * @param launchArgs List of unverified launch arguments

--- a/app/src/lib/editors/shared.ts
+++ b/app/src/lib/editors/shared.ts
@@ -14,6 +14,8 @@ export type FoundEditor = {
    * the editor requires a shell spawn to launch
    */
   usesShell?: boolean
+  /** Arguments to use while launching the editor */
+  launchArgs?: string
 }
 
 interface IErrorMetadata {
@@ -33,6 +35,41 @@ export class ExternalEditorError extends Error {
 
     this.metadata = metadata
   }
+}
+
+export const CustomEditorPickedLabel = 'External Editor'
+
+export const CustomEditorRepoEntityPathValue = '%REPO_PATH%'
+
+/**
+ * Returns an array of valid lauch arguments
+ *
+ * @param repoPath A folder or file path to pass as an argument when launching the editor.
+ * @param launchArgs List of unverified launch arguments
+ */
+export async function processEditorLaunchArgs(
+  repoPath: string,
+  launchArgs: string | undefined
+): Promise<string[]> {
+  const defaultLaunchArgs = [repoPath]
+
+  if (launchArgs !== undefined) {
+    const normalizedArgs = normalizeLaunchArgs(repoPath, launchArgs)
+
+    if (normalizedArgs !== undefined) {
+      return normalizedArgs
+    }
+  }
+
+  return defaultLaunchArgs
+}
+
+function normalizeLaunchArgs(repoPath: string, launchArgs: string) {
+  const replaceRequiredArgs = launchArgs.replace(
+    CustomEditorRepoEntityPathValue,
+    repoPath
+  )
+  return replaceRequiredArgs.split(' ').filter(arg => arg !== '')
 }
 
 export const suggestedExternalEditor = {

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -177,3 +177,8 @@ export function enableReRunFailedAndSingleCheckJobs(): boolean {
 export function enableMultiCommitDiffs(): boolean {
   return enableDevelopmentFeatures()
 }
+
+/** Should we enable custom external editor? */
+export function enableCustomExternalEditor(): boolean {
+  return enableDevelopmentFeatures()
+}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -1468,6 +1468,8 @@ export class App extends React.Component<IAppProps, IAppState> {
             confirmForcePush={this.state.askForConfirmationOnForcePush}
             uncommittedChangesStrategy={this.state.uncommittedChangesStrategy}
             selectedExternalEditor={this.state.selectedExternalEditor}
+            useCustomExternalEditor={this.state.useExternalCustomEditor}
+            customExternalEditor={this.state.customExternalEditor}
             useWindowsOpenSSH={this.state.useWindowsOpenSSH}
             notificationsEnabled={this.state.notificationsEnabled}
             optOutOfUsageTracking={this.state.optOutOfUsageTracking}
@@ -2435,7 +2437,9 @@ export class App extends React.Component<IAppProps, IAppState> {
         onOpenInShell={this.openInShell}
         onShowRepository={this.showRepository}
         onOpenInExternalEditor={this.openInExternalEditor}
-        externalEditorLabel={externalEditorLabel}
+        externalEditorLabel={
+          this.state.useExternalCustomEditor ? undefined : externalEditorLabel
+        }
         shellLabel={shellLabel}
         dispatcher={this.props.dispatcher}
       />
@@ -2801,7 +2805,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     if (selectedState.type === SelectionType.Repository) {
-      const externalEditorLabel = state.selectedExternalEditor
+      const externalEditorLabel = state.useExternalCustomEditor
+        ? state.customExternalEditor?.editor
+        : state.selectedExternalEditor
         ? state.selectedExternalEditor
         : undefined
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -120,6 +120,7 @@ import { getMultiCommitOperationChooseBranchStep } from '../../lib/multi-commit-
 import { ICombinedRefCheck, IRefCheck } from '../../lib/ci-checks/ci-checks'
 import { ValidNotificationPullRequestReviewState } from '../../lib/valid-notification-pull-request-review'
 import { enableReRunFailedAndSingleCheckJobs } from '../../lib/feature-flag'
+import { FoundEditor } from '../../lib/editors/shared'
 
 /**
  * An error handler function.
@@ -1890,8 +1891,16 @@ export class Dispatcher {
   /**
    * Sets the user's preference for an external program to open repositories in.
    */
-  public setExternalEditor(editor: string): Promise<void> {
-    return this.appStore._setExternalEditor(editor)
+  public setExternalEditor(
+    editor: string,
+    customExternalEditor: FoundEditor | null,
+    useExternalCustomEditor: boolean
+  ): Promise<void> {
+    return this.appStore._setExternalEditor(
+      editor,
+      customExternalEditor,
+      useExternalCustomEditor
+    )
   }
 
   /**

--- a/app/src/ui/editor/editor-error.tsx
+++ b/app/src/ui/editor/editor-error.tsx
@@ -84,9 +84,7 @@ export class EditorError extends React.Component<IEditorErrorProps, {}> {
   }
 
   public render() {
-    const title = __DARWIN__
-      ? 'Unable to Open External Editor'
-      : 'Unable to open external editor'
+    const title = 'Unable to Open External Editor'
 
     return (
       <Dialog

--- a/app/src/ui/lib/context-menu.ts
+++ b/app/src/ui/lib/context-menu.ts
@@ -13,9 +13,7 @@ export const CopySelectedRelativePathsLabel = __DARWIN__
   ? 'Copy Relative Paths'
   : 'Copy relative paths'
 
-export const DefaultEditorLabel = __DARWIN__
-  ? 'Open in External Editor'
-  : 'Open in external editor'
+export const DefaultEditorLabel = 'Open in External Editor'
 
 export const RevealInFileManagerLabel = __DARWIN__
   ? 'Reveal in Finder'

--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -179,7 +179,7 @@ export class Integrations extends React.Component<
   private renderCustomEditorCheckbox() {
     return (
       <Checkbox
-        label="Use external editor of your choise"
+        label="Use external editor of your choice"
         value={
           this.state.useExternalCustomEditor
             ? CheckboxValue.On

--- a/app/src/ui/preferences/integrations.tsx
+++ b/app/src/ui/preferences/integrations.tsx
@@ -12,6 +12,7 @@ import {
 import { TextBox } from '../lib/text-box'
 import { Button } from '../lib/button'
 import { Checkbox, CheckboxValue } from '../lib/checkbox'
+import { enableCustomExternalEditor } from '../../lib/feature-flag'
 
 interface IIntegrationsPreferencesProps {
   readonly availableEditors: ReadonlyArray<string>
@@ -234,6 +235,21 @@ export class Integrations extends React.Component<
     )
   }
 
+  private renderCustomExternalEditorLayout() {
+    if (!enableCustomExternalEditor()) {
+      return
+    }
+
+    return (
+      <>
+        <Row>{this.renderCustomEditorCheckbox()}</Row>
+        <Row>{this.renderCustomEditorPicker()}</Row>
+        <Row>{this.renderCustomEditorLaunchArgs()}</Row>
+        {this.renderSuggestedArgWarning()}
+      </>
+    )
+  }
+
   private renderSuggestedArgWarning() {
     if (
       this.state.hasSuggestedArgument ||
@@ -257,10 +273,7 @@ export class Integrations extends React.Component<
         <h2>Applications</h2>
         <Row>{this.renderExternalEditor()}</Row>
         <Row>{this.renderSelectedShell()}</Row>
-        <Row>{this.renderCustomEditorCheckbox()}</Row>
-        <Row>{this.renderCustomEditorPicker()}</Row>
-        <Row>{this.renderCustomEditorLaunchArgs()}</Row>
-        {this.renderSuggestedArgWarning()}
+        {this.renderCustomExternalEditorLayout()}
       </DialogContent>
     )
   }

--- a/app/test/unit/editors/shared-test.ts
+++ b/app/test/unit/editors/shared-test.ts
@@ -1,0 +1,29 @@
+import {
+  CustomEditorRepoEntityPathValue,
+  processEditorLaunchArgs,
+} from '../../../src/lib/editors/shared'
+
+describe('shared editor', () => {
+  describe('processEditorLaunchArgs', () => {
+    it('returns an empty array when arguments are empty', async () => {
+      const args = await processEditorLaunchArgs('/home/test/dev', '')
+
+      expect(args).toBeArrayOfSize(0)
+    })
+
+    it('returns an array with path to repo if the args are undefined', async () => {
+      const args = await processEditorLaunchArgs('/home/test/dev', undefined)
+
+      expect(args).toEqual(['/home/test/dev'])
+    })
+
+    it('returns an array with properly removed white spaces in the arguments', async () => {
+      const args = await processEditorLaunchArgs(
+        '/home/test/dev',
+        `    --reuse-window    ${CustomEditorRepoEntityPathValue}`
+      )
+
+      expect(args).toEqual(['--reuse-window', '/home/test/dev'])
+    })
+  })
+})


### PR DESCRIPTION
## Description
The PR introduces improvements in the handling of external editors. The implementation is limited by a feature flag (`enableCustomExternalEditor`), and it's within the scope of development features.

With these improvements, GitHub Desktop will be able to: 
- handle previously unsupported editors and IDEs (unstable registry key or not using the registry at all)
- handle portable versions of editors
- have same-day support for new editors

### Issues with feedback regarding external editor
- https://github.com/desktop/desktop/issues/7033
- https://github.com/desktop/desktop/issues/14666
- https://github.com/desktop/desktop/issues/4465
- https://github.com/desktop/desktop/issues/5083

### Performance
The implementation doesn't require any additional computation for the detection of editors. It only uses local storage to store a boolean with information if a custom external editor is in use and the custom external editor entry as `FoundEditor` object.

### UI/UX changes
The PR brings three new fields in `Options/Preferences > Integrations`

- Checkbox `Use external editor of your choice` - if checked, shows the following two fields
- `Custom External Editor` - path to custom external editor
- `Launch arguments` - arguments used when launching the custom editor

> The text `%REPO_PATH% - reference to the current repository folder path or a file path.`  appears if `%REPO_PATH%` is not present in the launch arguments.

### Possible feature improvements
- The user can specify different arguments based on the type of path (file or directory)

### Notes
- Currently, there are no updates to the documentation in this PR, but as the discussion progress and the fields are confirmed, I will add it!
- Should we send a boolean in the usage report with information if the user's external editor is custom or one of the defaults?

## Screenshots

###  Eclipse integration
![eclipse-example](https://user-images.githubusercontent.com/9341546/174648950-40bebf17-146d-485f-857c-7b2d93b419db.gif)

###  Visual Studio integration
![visual-studio-example](https://user-images.githubusercontent.com/9341546/174649359-80bb3ba0-9a24-49c2-80b2-3535839fa872.gif)

### VS Code with custom arguments
![vscode-arg-example](https://user-images.githubusercontent.com/9341546/174649449-606d0836-0275-453a-a321-bcef7a995d03.gif)
