### PR TITLE
Fix release notes detection with multiple "Notes:" lines

### DIFF
--- a/script/changelog/parser.ts
+++ b/script/changelog/parser.ts
@@ -48,12 +48,21 @@ function capitalized(str: string): string {
  */
 export function findReleaseNote(body: string): string | null | undefined {
   const re = /^Notes: (.+)$/gm
-  const matches = re.exec(body)
-  if (!matches || matches.length < 2) {
+  let lastMatches = null
+
+  // There might be multiple lines starting with "Notes: ", but we're only
+  // interested in the last one.
+  let matches = re.exec(body)
+  while (matches) {
+    lastMatches = matches
+    matches = re.exec(body)
+  }
+
+  if (!lastMatches || lastMatches.length < 2) {
     return undefined
   }
 
-  const note = matches[1].replace(/\.$/, '')
+  const note = lastMatches[1].replace(/\.$/, '')
   return note === 'no-notes' ? null : note
 }
 

--- a/script/changelog/test/parser-test.ts
+++ b/script/changelog/test/parser-test.ts
@@ -84,6 +84,19 @@ Notes: [Fixed] Fix lorem impsum dolor sit amet.
       )
     })
 
+    it('looks for the last Notes entry if there are several', () => {
+      const body = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis
+tempor euismod fermentum. Nullam hendrerit neque eget risus faucibus volutpat. Donec
+ultrices, orci quis auctor ultrices, nulla lacus gravida lectus, non rutrum dolor
+quam vel augue.
+Notes: ignore this notes
+
+Notes: These are valid notes
+`
+      expect(findReleaseNote(body)).toBe('These are valid notes')
+    })
+
     it('detected no release notes wanted for the PR', () => {
       const body = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sollicitudin turpis


### PR DESCRIPTION
## Description
With the latest beta #14853 I tested the new scripts from #14727 and noticed that #14744 produced no release notes… because it has two lines with `Notes: ` 😂 

This PR changes the script to ignore all `Notes: ` matches except the last one.

## Release notes

Notes: no-notes
