### PR TITLE
Allow bypassing staggered releases

### DIFF
--- a/app/src/ui/about/about.tsx
+++ b/app/src/ui/about/about.tsx
@@ -144,10 +144,18 @@ export class About extends React.Component<IAboutProps, IAboutState> {
           ? this.props.onCheckForNonStaggeredUpdates
           : this.props.onCheckForUpdates
 
+        const buttonTitle = this.state.altKeyPressed
+          ? 'Ensure Latest Version'
+          : 'Check for Updates'
+
+        const tooltip = this.state.altKeyPressed
+          ? "GitHub Desktop may release updates to our user base gradually to ensure we catch any problems early. This lets you bypass the gradual rollout and jump straight to the latest version if there's one available."
+          : ''
+
         return (
           <Row>
-            <Button disabled={disabled} onClick={onClick}>
-              Check for Updates{this.state.altKeyPressed ? ' (Forced)' : ''}
+            <Button disabled={disabled} onClick={onClick} tooltip={tooltip}>
+              {buttonTitle}
             </Button>
           </Row>
         )

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -618,12 +618,15 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setCommitMessageFocus(true)
   }
 
-  private checkForUpdates(inBackground: boolean, staggered: boolean = true) {
+  private checkForUpdates(
+    inBackground: boolean,
+    skipGuidCheck: boolean = false
+  ) {
     if (__LINUX__ || __RELEASE_CHANNEL__ === 'development') {
       return
     }
 
-    updateStore.checkForUpdates(inBackground, staggered)
+    updateStore.checkForUpdates(inBackground, skipGuidCheck)
   }
 
   private getDotComAccount(): Account | null {
@@ -2301,9 +2304,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.performRetry(retryAction)
   }
 
-  private onCheckForUpdates = () => this.checkForUpdates(false, true)
+  private onCheckForUpdates = () => this.checkForUpdates(false)
   private onCheckForNonStaggeredUpdates = () =>
-    this.checkForUpdates(false, false)
+    this.checkForUpdates(false, true)
 
   private showAcknowledgements = () => {
     this.props.dispatcher.showPopup({ type: PopupType.Acknowledgements })

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -618,12 +618,12 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.setCommitMessageFocus(true)
   }
 
-  private checkForUpdates(inBackground: boolean) {
+  private checkForUpdates(inBackground: boolean, staggered: boolean = true) {
     if (__LINUX__ || __RELEASE_CHANNEL__ === 'development') {
       return
     }
 
-    updateStore.checkForUpdates(inBackground)
+    updateStore.checkForUpdates(inBackground, staggered)
   }
 
   private getDotComAccount(): Account | null {
@@ -1613,6 +1613,7 @@ export class App extends React.Component<IAppProps, IAppState> {
             applicationVersion={version}
             applicationArchitecture={process.arch}
             onCheckForUpdates={this.onCheckForUpdates}
+            onCheckForNonStaggeredUpdates={this.onCheckForNonStaggeredUpdates}
             onShowAcknowledgements={this.showAcknowledgements}
             onShowTermsAndConditions={this.showTermsAndConditions}
           />
@@ -2300,7 +2301,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.performRetry(retryAction)
   }
 
-  private onCheckForUpdates = () => this.checkForUpdates(false)
+  private onCheckForUpdates = () => this.checkForUpdates(false, true)
+  private onCheckForNonStaggeredUpdates = () =>
+    this.checkForUpdates(false, false)
 
   private showAcknowledgements = () => {
     this.props.dispatcher.showPopup({ type: PopupType.Acknowledgements })

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -150,10 +150,13 @@ class UpdateStore {
   /**
    * Check for updates.
    *
-   * @param inBackground - Are we checking for updates in the background, or was
+   * @param inBackground  - Are we checking for updates in the background, or was
    *                       this check user-initiated?
+   * @param skipGuidCheck - If true, don't check the GUID. If true, this will
+   *                       effectively disable the staggered releases system and
+   *                       attempt to retrieve the latest available deployment.
    */
-  public async checkForUpdates(inBackground: boolean, staggered: boolean) {
+  public async checkForUpdates(inBackground: boolean, skipGuidCheck: boolean) {
     // An update has been downloaded and the app is waiting to be restarted.
     // Checking for updates again may result in the running app being nuked
     // when it finds a subsequent update.
@@ -161,7 +164,7 @@ class UpdateStore {
       return
     }
 
-    const updatesUrl = await this.getUpdatesUrl(staggered)
+    const updatesUrl = await this.getUpdatesUrl(skipGuidCheck)
 
     if (updatesUrl === null) {
       return
@@ -176,7 +179,7 @@ class UpdateStore {
     }
   }
 
-  private async getUpdatesUrl(staggered: boolean) {
+  private async getUpdatesUrl(skipGuidCheck: boolean) {
     let url = null
 
     try {
@@ -189,9 +192,10 @@ class UpdateStore {
     // Send the GUID to the update server for staggered release support
     url.searchParams.set('guid', await getRendererGUID())
 
-    if (!staggered) {
-      // If omitted, staggered releases will be enabled by default
-      url.searchParams.set('staggered', '0')
+    if (skipGuidCheck) {
+      // This will effectively disable the staggered releases system and attempt
+      // to retrieve the latest available deployment.
+      url.searchParams.set('skipGuidCheck', '1')
     }
 
     // If the app is running under arm64 to x64 translation, we need to tweak the

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -153,7 +153,7 @@ class UpdateStore {
    * @param inBackground - Are we checking for updates in the background, or was
    *                       this check user-initiated?
    */
-  public async checkForUpdates(inBackground: boolean) {
+  public async checkForUpdates(inBackground: boolean, staggered: boolean) {
     // An update has been downloaded and the app is waiting to be restarted.
     // Checking for updates again may result in the running app being nuked
     // when it finds a subsequent update.
@@ -161,7 +161,7 @@ class UpdateStore {
       return
     }
 
-    const updatesUrl = await this.getUpdatesUrl()
+    const updatesUrl = await this.getUpdatesUrl(staggered)
 
     if (updatesUrl === null) {
       return
@@ -176,7 +176,7 @@ class UpdateStore {
     }
   }
 
-  private async getUpdatesUrl() {
+  private async getUpdatesUrl(staggered: boolean) {
     let url = null
 
     try {
@@ -188,6 +188,11 @@ class UpdateStore {
 
     // Send the GUID to the update server for staggered release support
     url.searchParams.set('guid', await getRendererGUID())
+
+    if (!staggered) {
+      // If omitted, staggered releases will be enabled by default
+      url.searchParams.set('staggered', '0')
+    }
 
     // If the app is running under arm64 to x64 translation, we need to tweak the
     // update URL here to point at the arm64 binary.


### PR DESCRIPTION
## Description

This PR makes a small change to allow users to bypass the (upcoming) staggered updates and get an update right away (unless they're completely disabled). The purpose of this will be mainly internal testing but also to help specific users to get an update if we're certain it will help them.

They way this works is by pressing <kbd>Alt</kbd> (or <kbd>Option</kbd> on a Mac keyboard) when clicking `Check for Updates` in the About dialog.

As macOS used to do in the Displays settings dialog, I've made the updates button to change when the <kbd>Alt</kbd> button is pressed, showing `Check for Updates (Forced)` instead (I'm open to suggestions 😂 about the wording)

### Screenshots

https://user-images.githubusercontent.com/1083228/176401369-70ab31ea-565a-4d72-aae8-e40b5e01ca82.mov



## Release notes

Notes: no-notes
