### PR TITLE
Bump desktop-notifications to 0.2.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,7 @@
     "codemirror-mode-elixir": "^1.1.2",
     "compare-versions": "^3.6.0",
     "deep-equal": "^1.0.1",
-    "desktop-notifications": "^0.2.2",
+    "desktop-notifications": "^0.2.4",
     "desktop-trampoline": "desktop/desktop-trampoline#v0.9.8",
     "dexie": "^3.2.2",
     "dompurify": "^2.3.3",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -363,10 +363,10 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-desktop-notifications@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.2.2.tgz#197a32ee504a894ad074793dab285681c533e5ac"
-  integrity sha512-XMnxdWV6ZfiCzLZNC00n6h30Jt3z8yv21FAPBt/kK6hANI0PaoYWsRKEYya0zMUAX/9lrh429R5OtRGOKWZQSw==
+desktop-notifications@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/desktop-notifications/-/desktop-notifications-0.2.4.tgz#d51db18be583784a296748efd361fe3a5aefea70"
+  integrity sha512-Au0CbBE4TQ09vsC4/L15FhDsCr/daIyYUY3vkx4S3Y0Sp9EPpbXxBdmz0ry1cOnQ8A47K45zTYsuKP7a+xHm7Q==
   dependencies:
     node-addon-api "^5.0.0"
     prebuild-install "^7.0.1"


### PR DESCRIPTION
Closes #14714

## Description

This will disable desktop-notifications for Windows versions prior to the Creators Update (see https://github.com/desktop/desktop-notifications/pull/22)

## Release notes

Notes: [Fixed] Fix notifications on Windows 10 builds prior to the Creators Update
