### PR TITLE
Add Neovide support

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -32,6 +32,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['org.vim.MacVim'],
   },
   {
+    name: 'Neovide',
+    bundleIdentifiers: ['com.neovide.neovide'],
+  },
+  {
     name: 'Visual Studio Code',
     bundleIdentifiers: ['com.microsoft.VSCode'],
   },

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -212,6 +212,7 @@ These editors are currently supported:
 
  - [Atom](https://atom.io/)
  - [MacVim](https://macvim-dev.github.io/macvim/)
+ - [Neovide](https://github.com/neovide/neovide)
  - [Visual Studio Code](https://code.visualstudio.com/) - both stable and Insiders channel
  - [Visual Studio Codium](https://vscodium.com/)
  - [Sublime Text](https://www.sublimetext.com/)


### PR DESCRIPTION
## Description
Add Neovide (https://github.com/neovide/neovide) editor support for MacOS



### Screenshots


## Release notes

Notes:
