### PR TITLE
Fix invalid URL state while the "Clone Repository" modal is open

### DIFF
--- a/app/src/ui/clone-repository/clone-repository.tsx
+++ b/app/src/ui/clone-repository/clone-repository.tsx
@@ -187,6 +187,10 @@ export class CloneRepository extends React.Component<
     if (prevProps.selectedTab !== this.props.selectedTab) {
       this.validatePath()
     }
+
+    if (prevProps.initialURL !== this.props.initialURL) {
+      this.updateUrl(this.props.initialURL || '')
+    }
   }
 
   public componentDidMount() {


### PR DESCRIPTION
Closes #7961

## Description

- If the user clicks the "Open in GitHub Desktop" button in https://github.com while the "Clone Repository" modal is open, the URL state is not updated, and it defaults to an empty string

### Screenshots
#### Before 
![before](https://user-images.githubusercontent.com/9341546/178121422-7d3b349a-6176-44c7-9aa9-2591e0cafe15.gif)
#### After
![after](https://user-images.githubusercontent.com/9341546/178121423-fcd55b55-8d98-4d79-80a4-c483480f9d64.gif)

