### PR TITLE
Fix support for unsafe repositories

### DIFF
--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -37,7 +37,7 @@ export async function getRepositoryType(path: string): Promise<RepositoryType> {
     }
 
     const unsafeMatch =
-      /fatal: detected dubious ownership in repository at '(.+)\' /.exec(
+      /fatal: detected dubious ownership in repository at '(.+)'/.exec(
         result.stderr
       )
     if (unsafeMatch) {

--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -101,5 +101,13 @@ describe('git/rev-parse', () => {
         kind: 'missing',
       })
     })
+
+    it('returns unsafe for unsafe repository', async () => {
+      process.env['GIT_TEST_ASSUME_DIFFERENT_OWNER'] = '1'
+      expect(await getRepositoryType(repository.path)).toMatchObject({
+        kind: 'unsafe',
+      })
+      process.env['GIT_TEST_ASSUME_DIFFERENT_OWNER'] = undefined
+    })
   })
 })


### PR DESCRIPTION
Closes #14970

## Description
With #14958 we introduced a regression around the detection of unsafe repositories. With the upgrade to Git 2.35.4, the string we had to look for changed but we introduced a typo when we introduced it in our regex to detect those unsafe repositories.

This PR fixes that typo and adds a test to make sure this doesn't happen again 😓 

## Release notes

Notes: [Fixed] Surface again Git's warning about unsafe directories and provide a way to trust repositories not owned by the current user
