### PR TITLE
Add Warp terminal integration for macOS

### DIFF
--- a/app/src/lib/shells/darwin.ts
+++ b/app/src/lib/shells/darwin.ts
@@ -12,6 +12,7 @@ export enum Shell {
   Kitty = 'Kitty',
   Alacritty = 'Alacritty',
   WezTerm = 'WezTerm',
+  Warp = 'Warp',
 }
 
 export const Default = Shell.Terminal
@@ -36,6 +37,8 @@ function getBundleID(shell: Shell): string {
       return 'io.alacritty'
     case Shell.WezTerm:
       return 'com.github.wez.wezterm'
+    case Shell.Warp:
+      return 'dev.warp.Warp-Stable'
     default:
       return assertNever(shell, `Unknown shell: ${shell}`)
   }
@@ -62,6 +65,7 @@ export async function getAvailableShells(): Promise<
     kittyPath,
     alacrittyPath,
     wezTermPath,
+    warpPath,
   ] = await Promise.all([
     getShellPath(Shell.Terminal),
     getShellPath(Shell.Hyper),
@@ -70,6 +74,7 @@ export async function getAvailableShells(): Promise<
     getShellPath(Shell.Kitty),
     getShellPath(Shell.Alacritty),
     getShellPath(Shell.WezTerm),
+    getShellPath(Shell.Warp),
   ])
 
   const shells: Array<IFoundShell<Shell>> = []
@@ -102,6 +107,11 @@ export async function getAvailableShells(): Promise<
   if (wezTermPath) {
     const wezTermExecutable = `${wezTermPath}/Contents/MacOS/wezterm`
     shells.push({ shell: Shell.WezTerm, path: wezTermExecutable })
+  }
+
+  if (warpPath) {
+    const warpExecutable = `${warpPath}/Contents/MacOS/stable`
+    shells.push({ shell: Shell.Warp, path: warpExecutable })
   }
 
   return shells


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14329 

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Added Warp as a new external shell option using the default command `open -b dev.warp.Warp-Stable /path/to/cwd`
- This works well except for a bug in Warp where the terminal will restore a session in the old cwd if not closed cleanly last time. (i.e. if Warp is closed using Cmd+Q instead of `exit` in the shell)
- The issue is on Warp's end and I am reporting appropriately. IMO this PR can still be merged as Warp support still works fine if the shell was closed correctly or is running in the background.

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

<img width="355" alt="image" src="https://user-images.githubusercontent.com/40507205/179343995-da1d31ee-f3c0-49f9-825a-2e1f607cda5c.png">

<img width="247" alt="image" src="https://user-images.githubusercontent.com/40507205/179343975-0724a09e-cf49-49ae-8105-f5827da5d6bb.png">


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: [Added] Add Warp terminal integration for macOS
