### PR TITLE
Multi-commit-diffing: Catch error when path not in ref

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -244,7 +244,11 @@ export async function getCommitRangeChangedFiles(
     return getCommitRangeChangedFiles(repository, shas, useNullTreeSHA)
   }
 
-  return parseChangedFilesAndNumStat(result.combinedOutput, oldestCommitRef)
+  return parseChangedFilesAndNumStat(
+    result.combinedOutput,
+    latestCommitRef,
+    oldestCommitRef
+  )
 }
 
 /**
@@ -275,7 +279,11 @@ export async function getCommitRangeChangedFiles(
  *    file_two_original_path
  *    file_two_new_path
  */
-function parseChangedFilesAndNumStat(stdout: string, committish: string) {
+function parseChangedFilesAndNumStat(
+  stdout: string,
+  committish: string,
+  parentCommitish: string
+) {
   const lines = stdout.split('\0')
   // Remove the trailing empty line
   lines.splice(-1, 1)
@@ -302,7 +310,9 @@ function parseChangedFilesAndNumStat(stdout: string, committish: string) {
       const status = mapStatus(statusText, oldPath)
       const path = lines[++i]
 
-      files.push(new CommittedFileChange(path, status, committish))
+      files.push(
+        new CommittedFileChange(path, status, committish, parentCommitish)
+      )
     }
 
     if (parts.length === 3) {

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -244,10 +244,7 @@ export async function getCommitRangeChangedFiles(
     return getCommitRangeChangedFiles(repository, shas, useNullTreeSHA)
   }
 
-  return parseChangedFilesAndNumStat(
-    result.combinedOutput,
-    `${oldestCommitRef}..${latestCommitRef}`
-  )
+  return parseChangedFilesAndNumStat(result.combinedOutput, oldestCommitRef)
 }
 
 /**

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -182,7 +182,7 @@ export async function getChangedFiles(
     'getChangedFilesNameStatus'
   )
 
-  const files = parseChangedFiles(resultNameStatus.stdout, sha)
+  const files = parseChangedFiles(resultNameStatus.stdout, sha, `${sha}^`)
 
   if (!enableLineChangesInCommit()) {
     return { files, linesAdded: 0, linesDeleted: 0 }
@@ -240,7 +240,8 @@ function parseChangedFilesNumStat(stdout: string): {
  */
 export function parseChangedFiles(
   stdout: string,
-  committish: string
+  committish: string,
+  parentCommitish: string
 ): ReadonlyArray<CommittedFileChange> {
   const lines = stdout.split('\0')
   // Remove the trailing empty line
@@ -262,7 +263,9 @@ export function parseChangedFiles(
 
     const path = lines[++i]
 
-    files.push(new CommittedFileChange(path, status, committish))
+    files.push(
+      new CommittedFileChange(path, status, committish, parentCommitish)
+    )
   }
 
   return files

--- a/app/src/lib/git/show.ts
+++ b/app/src/lib/git/show.ts
@@ -108,10 +108,15 @@ export async function getPartialBlobContentsCatchPathNotInRef(
 ): Promise<Buffer | null> {
   const args = ['show', `${commitish}:${path}`]
 
-  const result = await git(args, repository.path, 'getPartialBlobContents', {
-    maxBuffer: length,
-    expectedErrors: new Set([GitError.PathExistsButNotInRef]),
-  })
+  const result = await git(
+    args,
+    repository.path,
+    'getPartialBlobContentsCatchPathNotInRef',
+    {
+      maxBuffer: length,
+      expectedErrors: new Set([GitError.PathExistsButNotInRef]),
+    }
+  )
 
   if (result.gitError === GitError.PathExistsButNotInRef) {
     return null

--- a/app/src/lib/git/show.ts
+++ b/app/src/lib/git/show.ts
@@ -4,6 +4,8 @@ import { git } from './core'
 import { spawnAndComplete } from './spawn'
 
 import { Repository } from '../../models/repository'
+import { GitError } from 'dugite'
+import { enableMultiCommitDiffs } from '../feature-flag'
 
 /**
  * Retrieve the binary contents of a blob from the repository at a given
@@ -73,7 +75,16 @@ export async function getPartialBlobContents(
   commitish: string,
   path: string,
   length: number
-): Promise<Buffer> {
+): Promise<Buffer | null> {
+  if (enableMultiCommitDiffs()) {
+    return getPartialBlobContentsCatchPathNotInRef(
+      repository,
+      commitish,
+      path,
+      length
+    )
+  }
+
   const successExitCodes = new Set([0, 1])
 
   const args = ['show', `${commitish}:${path}`]
@@ -87,4 +98,24 @@ export async function getPartialBlobContents(
   )
 
   return output
+}
+
+export async function getPartialBlobContentsCatchPathNotInRef(
+  repository: Repository,
+  commitish: string,
+  path: string,
+  length: number
+): Promise<Buffer | null> {
+  const args = ['show', `${commitish}:${path}`]
+
+  const result = await git(args, repository.path, 'getPartialBlobContents', {
+    maxBuffer: length,
+    expectedErrors: new Set([GitError.PathExistsButNotInRef]),
+  })
+
+  if (result.gitError === GitError.PathExistsButNotInRef) {
+    return null
+  }
+
+  return Buffer.from(result.combinedOutput)
 }

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -285,7 +285,7 @@ async function getChangedFilesWithinStash(repository: Repository, sha: string) {
     successExitCodes: new Set([0, 128]),
   })
   if (result.exitCode === 0 && result.stdout.length > 0) {
-    return parseChangedFiles(result.stdout, sha)
+    return parseChangedFiles(result.stdout, sha, `${sha}^`)
   }
   return []
 }

--- a/app/src/models/status.ts
+++ b/app/src/models/status.ts
@@ -279,7 +279,8 @@ export class CommittedFileChange extends FileChange {
   public constructor(
     path: string,
     status: AppFileStatus,
-    public readonly commitish: string
+    public readonly commitish: string,
+    public readonly parentCommitish: string
   ) {
     super(path, status)
 

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -66,7 +66,7 @@ async function getOldFileContent(
     // actually committed to get the appropriate content.
     commitish = 'HEAD'
   } else if (file instanceof CommittedFileChange) {
-    commitish = `${file.commitish}^`
+    commitish = file.parentCommitish
   } else {
     return assertNever(file, 'Unknown file change type')
   }


### PR DESCRIPTION
## Description
For our syntax highlighter, we grab what the a file's contents in the current commit and the commit before to create appropriate highlighting. For the commit to be diffed, we know if a file was added/untracked, modified, or deleted in that commit. For highlighting, we are only interested in modified and deleted; if it is new, there is nothing to highlight. Thus, if a file is new or untracked, we do not try to look for it in the commit before. This works great when comparing only one commit at time.

However, with multi-commit diffing, given a history of A, B, C and we pick a range of B - C,  we want to compare changes from B and C against the commit A. If a file is added in B and modified in C, when doing a diff of B..C the status will show modified for that file. Thus, our current logic will attempt to find the file contents of that file in A that do not exist -> resulting in a git error. 

This PR returns null if that error is present (which is what the parent method would return if the file status was new or untracked).

## Release notes
Notes: no-notes
