### PR TITLE
Add multi commit diffing metrics

### DIFF
--- a/app/src/lib/stats/stats-database.ts
+++ b/app/src/lib/stats/stats-database.ts
@@ -520,6 +520,18 @@ export interface IDailyMeasures {
    * from the "changes requested" dialog.
    */
   readonly pullRequestReviewChangesRequestedDialogSwitchToPullRequestCount: number
+
+  /** The number of times the user did a multi commit diff where there were unreachable commits */
+  readonly multiCommitDiffWithUnreachableCommitWarningCount: number
+
+  /** The number of times the user does a multi commit diff from the history view */
+  readonly multiCommitDiffFromHistoryCount: number
+
+  /** The number of times the user does a multi commit diff from the compare */
+  readonly multiCommitDiffFromCompareCount: number
+
+  /** The number of times the user opens the unreachable commits dialog */
+  readonly multiCommitDiffUnreachableCommitsDialogOpenedCount: number
 }
 
 export class StatsDatabase extends Dexie {

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -208,6 +208,10 @@ const DefaultDailyMeasures: IDailyMeasures = {
   pullRequestReviewChangesRequestedNotificationCount: 0,
   pullRequestReviewChangesRequestedNotificationClicked: 0,
   pullRequestReviewChangesRequestedDialogSwitchToPullRequestCount: 0,
+  multiCommitDiffWithUnreachableCommitWarningCount: 0,
+  multiCommitDiffFromHistoryCount: 0,
+  multiCommitDiffFromCompareCount: 0,
+  multiCommitDiffUnreachableCommitsDialogOpenedCount: 0,
 }
 
 interface IOnboardingStats {
@@ -1792,6 +1796,32 @@ export class StatsStore implements IStatsStore {
     return this.updateDailyMeasures(m => ({
       checksFailedDialogRerunChecksCount:
         m.checksFailedDialogRerunChecksCount + 1,
+    }))
+  }
+
+  public recordMultiCommitDiffFromHistoryCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      multiCommitDiffFromHistoryCount: m.multiCommitDiffFromHistoryCount + 1,
+    }))
+  }
+
+  public recordMultiCommitDiffFromCompareCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      multiCommitDiffFromCompareCount: m.multiCommitDiffFromCompareCount + 1,
+    }))
+  }
+
+  public recordMultiCommitDiffWithUnreachableCommitWarningCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      multiCommitDiffWithUnreachableCommitWarningCount:
+        m.multiCommitDiffWithUnreachableCommitWarningCount + 1,
+    }))
+  }
+
+  public recordMultiCommitDiffUnreachableCommitsDialogOpenedCount(): Promise<void> {
+    return this.updateDailyMeasures(m => ({
+      multiCommitDiffUnreachableCommitsDialogOpenedCount:
+        m.multiCommitDiffUnreachableCommitsDialogOpenedCount + 1,
     }))
   }
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -119,6 +119,7 @@ import {
 import { getMultiCommitOperationChooseBranchStep } from '../../lib/multi-commit-operation'
 import { ICombinedRefCheck, IRefCheck } from '../../lib/ci-checks/ci-checks'
 import { ValidNotificationPullRequestReviewState } from '../../lib/valid-notification-pull-request-review'
+import { UnreachableCommitsTab } from '../history/unreachable-commits-dialog'
 
 /**
  * An error handler function.
@@ -3929,5 +3930,14 @@ export class Dispatcher {
     reviewType: ValidNotificationPullRequestReviewState
   ) {
     this.statsStore.recordPullRequestReviewDialogSwitchToPullRequest(reviewType)
+  }
+
+  public showUnreachableCommits(selectedTab: UnreachableCommitsTab) {
+    this.statsStore.recordMultiCommitDiffUnreachableCommitsDialogOpenedCount()
+
+    this.showPopup({
+      type: PopupType.UnreachableCommits,
+      selectedTab,
+    })
   }
 }

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -35,7 +35,6 @@ import { IConstrainedValue } from '../../lib/app-state'
 import { clamp } from '../../lib/clamp'
 import { pathExists } from '../lib/path-exists'
 import { enableMultiCommitDiffs } from '../../lib/feature-flag'
-import { PopupType } from '../../models/popup'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
 
 interface ISelectedCommitsProps {
@@ -190,10 +189,7 @@ export class SelectedCommits extends React.Component<
   }
 
   private showUnreachableCommits = (selectedTab: UnreachableCommitsTab) => {
-    this.props.dispatcher.showPopup({
-      type: PopupType.UnreachableCommits,
-      selectedTab,
-    })
+    this.props.dispatcher.showUnreachableCommits(selectedTab)
   }
 
   private onHighlightShas = (shasToHighlight: ReadonlyArray<string>) => {


### PR DESCRIPTION
## Description
This PR adds:

```
/** The number of times the user did a multi commit diff where there were unreachable commits */
readonly multiCommitDiffWithUnreachableCommitWarningCount: number

/** The number of times the user does a multi commit diff from the history view */
readonly multiCommitDiffFromHistoryCount: number

/** The number of times the user does a multi commit diff from the compare */
readonly multiCommitDiffFromCompareCount: number

/** The number of times the user opens the unreachable commits dialog */
readonly multiCommitDiffUnreachableCommitsDialogOpenedCount: number
```

With this we should be able to determine how often the feature is used (add history/compare count together), if is used more from history or in the compare view (assumption is history - but interesting to see about the compare view since we may provide a "Pr merge preview" from there with this feature), validate assumption that most users are not going to use it for odd selections that result in unreachable commits, and lastly see if unreachable commits dialog is used. 

As always, open for feedback if you think of another metric that could be useful. One I thought of was if in the compare view, how many users select all the commits to answer the question -> do users use the compare tool as a PR preview tool? At this point this seems very niche, and maybe more appropriate to add once we determine what we are doing for a PR preview tool as an extension of this work.

## Release notes
Notes: no-notes
