### PR TITLE
Auto-update macOS x64 builds to arm64 on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ uses [React](https://reactjs.org/).
 Download the official installer for your operating system:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
- - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
+ - [macOS (Apple silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
  - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)
 
@@ -31,10 +31,10 @@ Want to test out new features and get fixes before everyone else? Install the
 beta channel to get access to early builds of Desktop:
 
  - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
- - [macOS (Apple Silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
+ - [macOS (Apple silicon)](https://central.github.com/deployments/desktop/desktop/latest/darwin-arm64?env=beta)
  - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)
  - [Windows (ARM64)](https://central.github.com/deployments/desktop/desktop/latest/win32-arm64?env=beta)
- 
+
 The release notes for the latest beta versions are available [here](https://desktop.github.com/release-notes/?env=beta).
 
 ### Community Releases

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -73,11 +73,7 @@ export function enableUpdateFromEmulatedX64ToARM64(): boolean {
  * ARM64 builds IMMEDIATELY instead of waiting for the next release?
  */
 export function enableImmediateUpdateFromEmulatedX64ToARM64(): boolean {
-  return (
-    (__DARWIN__ && enableBetaFeatures()) ||
-    // No idea if this will work on win32, so let's keep that for test builds
-    (__WIN32__ && __RELEASE_CHANNEL__ === 'test')
-  )
+  return __RELEASE_CHANNEL__ === 'test'
 }
 
 /** Should we allow resetting to a previous commit? */

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -68,6 +68,18 @@ export function enableUpdateFromEmulatedX64ToARM64(): boolean {
   return enableBetaFeatures()
 }
 
+/**
+ * Should we allow x64 apps running under ARM translation to auto-update to
+ * ARM64 builds IMMEDIATELY instead of waiting for the next release?
+ */
+export function enableImmediateUpdateFromEmulatedX64ToARM64(): boolean {
+  return (
+    (__DARWIN__ && enableBetaFeatures()) ||
+    // No idea if this will work on win32, so let's keep that for test builds
+    (__WIN32__ && __RELEASE_CHANNEL__ === 'test')
+  )
+}
+
 /** Should we allow resetting to a previous commit? */
 export function enableResetToCommit(): boolean {
   return enableDevelopmentFeatures()

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -73,7 +73,7 @@ export function enableUpdateFromEmulatedX64ToARM64(): boolean {
  * ARM64 builds IMMEDIATELY instead of waiting for the next release?
  */
 export function enableImmediateUpdateFromEmulatedX64ToARM64(): boolean {
-  return __RELEASE_CHANNEL__ === 'test'
+  return __DARWIN__ && enableBetaFeatures()
 }
 
 /** Should we allow resetting to a previous commit? */

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -73,6 +73,8 @@ export function enableUpdateFromEmulatedX64ToARM64(): boolean {
  * ARM64 builds IMMEDIATELY instead of waiting for the next release?
  */
 export function enableImmediateUpdateFromEmulatedX64ToARM64(): boolean {
+  // Because of how Squirrel.Windows works, this is only available for macOS.
+  // See: https://github.com/desktop/desktop/pull/14998
   return __DARWIN__ && enableBetaFeatures()
 }
 

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -2816,6 +2816,9 @@ export class App extends React.Component<IAppProps, IAppState> {
       <UpdateAvailable
         dispatcher={this.props.dispatcher}
         newReleases={updateStore.state.newReleases}
+        isX64ToARM64ImmediateAutoUpdate={
+          updateStore.state.isX64ToARM64ImmediateAutoUpdate
+        }
         onDismissed={this.onUpdateAvailableDismissed}
         isUpdateShowcaseVisible={this.state.isUpdateShowcaseVisible}
         emoji={this.state.emoji}

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -15,6 +15,7 @@ import { RichText } from '../lib/rich-text'
 interface IUpdateAvailableProps {
   readonly dispatcher: Dispatcher
   readonly newReleases: ReadonlyArray<ReleaseSummary> | null
+  readonly isX64ToARM64ImmediateAutoUpdate: boolean
   readonly isUpdateShowcaseVisible: boolean
   readonly emoji: Map<string, string>
   readonly onDismissed: () => void
@@ -44,6 +45,19 @@ export class UpdateAvailable extends React.Component<
   }
 
   private renderMessage = () => {
+    if (this.props.isX64ToARM64ImmediateAutoUpdate) {
+      return (
+        <span onSubmit={this.updateNow}>
+          An optimized version of GitHub Desktop is available for your machine
+          and will be installed at the next launch. You can also{' '}
+          <LinkButton onClick={this.updateNow}>
+            restart GitHub Desktop
+          </LinkButton>{' '}
+          now.
+        </span>
+      )
+    }
+
     if (this.props.isUpdateShowcaseVisible) {
       const version =
         this.props.newReleases !== null

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -48,8 +48,9 @@ export class UpdateAvailable extends React.Component<
     if (this.props.isX64ToARM64ImmediateAutoUpdate) {
       return (
         <span onSubmit={this.updateNow}>
-          An optimized version of GitHub Desktop is available for your machine
-          and will be installed at the next launch. You can also{' '}
+          An optimized version of GitHub Desktop is available for your{' '}
+          {__DARWIN__ ? 'Apple Silicon' : 'Arm64'} machine and will be installed
+          at the next launch or{' '}
           <LinkButton onClick={this.updateNow}>
             restart GitHub Desktop
           </LinkButton>{' '}

--- a/app/src/ui/banners/update-available.tsx
+++ b/app/src/ui/banners/update-available.tsx
@@ -49,7 +49,7 @@ export class UpdateAvailable extends React.Component<
       return (
         <span onSubmit={this.updateNow}>
           An optimized version of GitHub Desktop is available for your{' '}
-          {__DARWIN__ ? 'Apple Silicon' : 'Arm64'} machine and will be installed
+          {__DARWIN__ ? 'Apple silicon' : 'Arm64'} machine and will be installed
           at the next launch or{' '}
           <LinkButton onClick={this.updateNow}>
             restart GitHub Desktop

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -26,6 +26,7 @@ import {
 import { offsetFromNow } from '../../lib/offset-from'
 import { gte, SemVer } from 'semver'
 import { getRendererGUID } from '../../lib/get-renderer-guid'
+import { getVersion } from './app-proxy'
 
 /** The last version a showcase was seen. */
 export const lastShowCaseVersionSeen = 'version-of-last-showcase'
@@ -119,11 +120,13 @@ class UpdateStore {
   private onUpdateDownloaded = async () => {
     this.newReleases = await generateReleaseSummary()
     // We know it's an "immediate" auto-update from x64 to arm64 if the app is
-    // running on arm64 under x64 emulation and there aren't new releases (which
-    // means we spoofed Central with an old version of the app).
+    // running on arm64 under x64 emulation and there is only one new release
+    // and it's the same version we have right now (which means we spoofed
+    // Central with an old version of the app).
     this.isX64ToARM64ImmediateAutoUpdate =
       this.newReleases !== null &&
-      this.newReleases.length === 0 &&
+      this.newReleases.length === 1 &&
+      this.newReleases[0].latestVersion === getVersion() &&
       (await isRunningUnderARM64Translation())
     this.status = UpdateStatus.UpdateReady
     this.emitDidChange()

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -216,7 +216,7 @@ class UpdateStore {
         '/desktop/desktop/arm64/latest'
       )
 
-      // If we want the app to force an auto-update form x64 to arm64 right
+      // If we want the app to force an auto-update from x64 to arm64 right
       // after being installed, we need to spoof a really old version to trick
       // both Central and Squirrel into thinking we need the update.
       if (enableImmediateUpdateFromEmulatedX64ToARM64()) {

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -220,7 +220,7 @@ class UpdateStore {
       // after being installed, we need to spoof a really old version to trick
       // both Central and Squirrel into thinking we need the update.
       if (enableImmediateUpdateFromEmulatedX64ToARM64()) {
-        url.searchParams.set('version', '1.6.4')
+        url.searchParams.set('version', '0.0.64')
       }
     }
 

--- a/app/src/ui/lib/update-store.ts
+++ b/app/src/ui/lib/update-store.ts
@@ -124,6 +124,7 @@ class UpdateStore {
     // and it's the same version we have right now (which means we spoofed
     // Central with an old version of the app).
     this.isX64ToARM64ImmediateAutoUpdate =
+      enableImmediateUpdateFromEmulatedX64ToARM64() &&
       this.newReleases !== null &&
       this.newReleases.length === 1 &&
       this.newReleases[0].latestVersion === getVersion() &&

--- a/changelog.json
+++ b/changelog.json
@@ -544,11 +544,11 @@
       "[Fixed] Disable partial change selection in split view while whitespace changes are hidden - #12129"
     ],
     "2.8.1-beta2": [
-      "[Improved] Add complete support for macOS on Apple Silicon devices - #12091",
-      "[Improved] From now on, macOS x64 builds running on Apple Silicon devices will auto update to arm64 builds"
+      "[Improved] Add complete support for macOS on Apple silicon devices - #12091",
+      "[Improved] From now on, macOS x64 builds running on Apple silicon devices will auto update to arm64 builds"
     ],
     "2.8.1-beta1": [
-      "[New] Preliminary support for macOS on Apple Silicon devices - #9691. Thanks @dennisameling!"
+      "[New] Preliminary support for macOS on Apple silicon devices - #9691. Thanks @dennisameling!"
     ],
     "2.8.0": [
       "[New] Expand diffs to view more context around your changes - #7014",

--- a/docs/process/roadmap.md
+++ b/docs/process/roadmap.md
@@ -16,9 +16,9 @@ The following are the larger areas of upcoming work the GitHub Desktop team inte
 - Amend last commit: [#12353](https://github.com/desktop/desktop/pull/12353)
 - Create a branch from a previous commit: [#12160](https://github.com/desktop/desktop/pull/12160)
 
-#### Native support for Apple Silicon (M1) machines (2.8.2)
+#### Native support for Apple silicon (M1) machines (2.8.2)
 
-- Provide support for Apple Silicon (M1) machines: [#9691](https://github.com/desktop/desktop/pull/9691)
+- Provide support for Apple silicon (M1) machines: [#9691](https://github.com/desktop/desktop/pull/9691)
 
 #### Expanding diffs (2.8.0)
 


### PR DESCRIPTION
## Description

As of today, users of Apple silicon devices that download x64 builds have a downgraded experience until a new version of GitHub Desktop is released. At that moment, the app automatically updates to the new version… but using arm64 binaries instead, getting the best performance for their hardware.

With the changes in this PR we intend to improve that a bit by helping users getting that update right after opening the app for the first time. What we do is we fool Electron's auto-updater making it think we're on an older version, so that it downloads the very same version again but built for arm64.

Unfortunately, this doesn't work on Windows because [Squirrel.Windows](https://github.com/Squirrel/Squirrel.Windows) relies on a smarter and more complex logic to detect whether or not it’s the latest version ([Squirrel.Mac](https://github.com/Squirrel/Squirrel.Mac) is much simpler/dumber and will download whatever we tell it to), and it also relies on placing every new version of the app in a different folder, named after the version (e.g. `app-3.0.6-test2`, `app-3.0.1`…), which in this case it’d be the very same folder so it fails to do its thing.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/179951595-410afdc7-563e-47ff-84b2-1f23f0efe5e3.png)

## Release notes

Notes: [Improved] On Apple silicon devices running unoptimized builds, auto-update on first run to an optimized build
