### PR TITLE
Fix unified diff discard changes availability

### DIFF
--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -747,6 +747,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         {
           label: this.getDiscardLabel(range.type, range.to - range.from + 1),
           action: () => this.onDiscardChanges(file, range.from, range.to),
+          enabled: !this.props.onHideWhitespaceInDiffChanged,
         },
       ]
     }
@@ -762,7 +763,9 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         {
           label: this.getDiscardLabel(range.type, 1),
           action: () => this.onDiscardChanges(file, lineNumber),
-          enabled: range.type !== DiffRangeType.Mixed,
+          enabled:
+            range.type !== DiffRangeType.Mixed &&
+            !this.props.onHideWhitespaceInDiffChanged,
         },
       ]
     }

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -747,7 +747,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
         {
           label: this.getDiscardLabel(range.type, range.to - range.from + 1),
           action: () => this.onDiscardChanges(file, range.from, range.to),
-          enabled: !this.props.onHideWhitespaceInDiffChanged,
+          enabled: !this.props.hideWhitespaceInDiff,
         },
       ]
     }

--- a/app/src/ui/diff/text-diff.tsx
+++ b/app/src/ui/diff/text-diff.tsx
@@ -765,7 +765,7 @@ export class TextDiff extends React.Component<ITextDiffProps, ITextDiffState> {
           action: () => this.onDiscardChanges(file, lineNumber),
           enabled:
             range.type !== DiffRangeType.Mixed &&
-            !this.props.onHideWhitespaceInDiffChanged,
+            !this.props.hideWhitespaceInDiff,
         },
       ]
     }

--- a/app/src/ui/diff/whitespace-hint-popover.tsx
+++ b/app/src/ui/diff/whitespace-hint-popover.tsx
@@ -19,7 +19,7 @@ export class WhitespaceHintPopover extends React.Component<IWhitespaceHintPopove
     return (
       <Popover
         caretPosition={this.props.caretPosition}
-        onClickOutside={this.onDismissed}
+        onMousedownOutside={this.onDismissed}
         className={'whitespace-hint'}
         style={this.props.style}
         appearEffect={PopoverAppearEffect.Shake}

--- a/app/src/ui/lib/popover.tsx
+++ b/app/src/ui/lib/popover.tsx
@@ -30,6 +30,7 @@ export enum PopoverAppearEffect {
 
 interface IPopoverProps {
   readonly onClickOutside?: (event?: MouseEvent) => void
+  readonly onMousedownOutside?: (event?: MouseEvent) => void
   readonly caretPosition: PopoverCaretPosition
   readonly className?: string
   readonly style?: React.CSSProperties
@@ -52,10 +53,12 @@ export class Popover extends React.Component<IPopoverProps> {
 
   public componentDidMount() {
     document.addEventListener('click', this.onDocumentClick)
+    document.addEventListener('mousedown', this.onDocumentMouseDown)
   }
 
   public componentWillUnmount() {
     document.removeEventListener('click', this.onDocumentClick)
+    document.removeEventListener('mousedown', this.onDocumentMouseDown)
   }
 
   private onDocumentClick = (event: MouseEvent) => {
@@ -70,6 +73,21 @@ export class Popover extends React.Component<IPopoverProps> {
       this.props.onClickOutside !== undefined
     ) {
       this.props.onClickOutside(event)
+    }
+  }
+
+  private onDocumentMouseDown = (event: MouseEvent) => {
+    const { current: ref } = this.containerDivRef
+    const { target } = event
+
+    if (
+      ref !== null &&
+      ref.parentElement !== null &&
+      target instanceof Node &&
+      !ref.parentElement.contains(target) &&
+      this.props.onMousedownOutside !== undefined
+    ) {
+      this.props.onMousedownOutside(event)
     }
   }
 


### PR DESCRIPTION
Closes #15003

## Description
It appears we overlooked disabling the context menu items to discard changes in the unified diff when whitespace changes are hidden. This pr adds that check.

Additionally, there was regression on fixing [another popover bug](https://github.com/desktop/desktop/pull/14256) in that, when unified diff gutter is clicked when whitespace changes are hidden, the whitespace informative popover doesn't stay open. This is due to how the whitespace popover is added to the react dom dynamically so a click event to show it is also getting registered in the whitespace popover which effectively dismisses it as being the doc clicked outside the popover. Originally, the popover click outside event was triggered for the mousedown event and not the click event which already fires before this is registered... thus sidestepping this timing issue. This PR adds the mousedown event back in while also leaving the click event in place so that we can use which ever works best for the given use case.

### Screenshots

https://user-images.githubusercontent.com/75402236/180268139-4602ee1b-9a91-439e-84f3-1258d5223254.mov


## Release notes

Notes: 
[Fixed] Unified diff line gutter context menu items for discard changes no longer enabled when whitespace is hidden.
[Fixed] "Show Whitespace Changes" popover appears as expected on unified diff.
