### PR TITLE
Show email label on the preferences form if email isn't defined

### DIFF
--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -47,7 +47,7 @@ export class GitConfigUserForm extends React.Component<
     super(props)
 
     this.state = {
-      emailIsOther: !this.accountEmails.includes(this.props.email),
+      emailIsOther: this.props.email ? !this.accountEmails.includes(this.props.email) : false
     }
   }
 

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -47,7 +47,9 @@ export class GitConfigUserForm extends React.Component<
     super(props)
 
     this.state = {
-      emailIsOther: this.props.email ? !this.accountEmails.includes(this.props.email) : false
+      emailIsOther:
+        this.accountEmails.length > 0 &&
+        !this.accountEmails.includes(this.props.email),
     }
   }
 
@@ -67,7 +69,9 @@ export class GitConfigUserForm extends React.Component<
     // from the user, to prevent annoying UI glitches.
     if (prevProps.email !== this.props.email && !isEmailInputFocused) {
       this.setState({
-        emailIsOther: this.props.email ? !this.accountEmails.includes(this.props.email) : false,
+        emailIsOther:
+          this.accountEmails.length > 0 &&
+          !this.accountEmails.includes(this.props.email),
       })
     }
 

--- a/app/src/ui/lib/git-config-user-form.tsx
+++ b/app/src/ui/lib/git-config-user-form.tsx
@@ -67,7 +67,7 @@ export class GitConfigUserForm extends React.Component<
     // from the user, to prevent annoying UI glitches.
     if (prevProps.email !== this.props.email && !isEmailInputFocused) {
       this.setState({
-        emailIsOther: !this.accountEmails.includes(this.props.email),
+        emailIsOther: this.props.email ? !this.accountEmails.includes(this.props.email) : false,
       })
     }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

This assists with #13736 but I'm not sure this fixes it, because the documentation is a little unclear.

## Description

The form has a couple of states.

When you are logged into GitHub you can choose a possible email address:

<img width="590" alt="Screen Shot 2022-07-21 at 1 40 02 PM" src="https://user-images.githubusercontent.com/74699/180312997-19aed4e5-e2f0-4b54-81d4-9eadd29df69b.png">

In this first case, the input text field isn't shown at all, just the drop down 👍🏾 

When you are logged into GitHub and would like to use a different email address:

<img width="595" alt="Screen Shot 2022-07-21 at 1 40 12 PM" src="https://user-images.githubusercontent.com/74699/180312927-50aaf007-6340-4f2a-8ca1-f3b7265a1610.png">

In this case the input text field is shown, but there's no need for an `Email` label, its on the field above 👍🏾 

And in the case referenced in the original issue  #13736, where you are not logged into GitHub and no other information (such as no `~/.gitconfig`) is available. As noted in the original issue, you get an odd form with no label above the `Email` field 😢 

I believe this is because we are using a boolean field to determine if we should show the label, but there are three possible states, as mentioned as above. In this last case when no other information is available `this.props.email` is going to be `null`. If that's the case we probably shouldn't take a look inside `accountEmails` to see if it's there, we can assume it's not other.

The result is we see the form label:

<img width="592" alt="Screen Shot 2022-07-21 at 1 53 33 PM" src="https://user-images.githubusercontent.com/74699/180313394-72a37c05-7ed1-45d8-96e5-726ace735cc8.png">

I didn't mark this as fixed because there were other questions about this form and I'm not expert on this flow and this was more just a quick drive by. But hopefully having the label `Email` above the field, makes it a little bit clearer.

I couldn't spot any unit tests for this particular form.


## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
