### PR TITLE
Add PyCharm CE bundle id

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -64,6 +64,10 @@ const editors: IDarwinExternalEditor[] = [
     bundleIdentifiers: ['com.jetbrains.PyCharm'],
   },
   {
+    name: 'PyCharm Community Edition',
+    bundleIdentifiers: ['com.jetbrains.pycharm.ce'],
+  },
+  {
     name: 'RubyMine',
     bundleIdentifiers: ['com.jetbrains.RubyMine'],
   },


### PR DESCRIPTION
Closes #15016

## Description
- Add bundle identifier to match PyCharm Community Edition

Note: All other Intellij IDEs seem to work correctly!

### Screenshots
![image](https://user-images.githubusercontent.com/9341546/180447308-70f84794-dfa0-4118-8559-cd42a3ac5184.png)

