### PR TITLE
Pull-request Preview POC WIP

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -727,7 +727,7 @@ export interface IPullRequestPreview {
   readonly kind: HistoryTabMode.PullRequestPreview
 
   /** The branch to diff --merge-base against */
-  readonly comparisonBranch: Branch
+  readonly mergeBaseBranch: Branch
 }
 
 export interface ICompareState {
@@ -799,7 +799,7 @@ export interface ICompareToBranch {
 
 export interface IPreviewPullRequest {
   readonly kind: HistoryTabMode.PullRequestPreview
-  readonly branch: Branch
+  readonly mergeBaseBranch: Branch
 }
 
 /**

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -680,6 +680,7 @@ export interface IChangesState {
 export enum HistoryTabMode {
   History = 'History',
   Compare = 'Compare',
+  PullRequestPreview = 'PullRequestPreview',
 }
 
 /**
@@ -717,9 +718,21 @@ export interface ICompareBranch {
   readonly aheadBehind: IAheadBehind
 }
 
+/**
+ * When the user has chosen to preview all the changes in their current branch
+ * against a given branch. The comparison branch defaults to the repo's default
+ * branch.
+ */
+export interface IPullRequestPreview {
+  readonly kind: HistoryTabMode.PullRequestPreview
+
+  /** The branch to diff --merge-base against */
+  readonly comparisonBranch: Branch
+}
+
 export interface ICompareState {
   /** The current state of the compare form, based on user input */
-  readonly formState: IDisplayHistory | ICompareBranch
+  readonly formState: IDisplayHistory | ICompareBranch | IPullRequestPreview
 
   /** The result of merging the compare branch into the current branch, if a branch selected */
   readonly mergeStatus: MergeTreeResult | null
@@ -784,10 +797,18 @@ export interface ICompareToBranch {
   readonly comparisonMode: ComparisonMode.Ahead | ComparisonMode.Behind
 }
 
+export interface IPreviewPullRequest {
+  readonly kind: HistoryTabMode.PullRequestPreview
+  readonly branch: Branch
+}
+
 /**
  * An action to send to the application store to update the compare state
  */
-export type CompareAction = IViewHistory | ICompareToBranch
+export type CompareAction =
+  | IViewHistory
+  | ICompareToBranch
+  | IPreviewPullRequest
 
 /**
  * Undo state associated with a multi commit operation being performed on a

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -32,6 +32,7 @@ import { git } from './core'
 import { NullTreeSHA } from './diff-index'
 import { GitError } from 'dugite'
 import { mapStatus } from './log'
+import { Branch } from '../../models/branch'
 
 /**
  * V8 has a limit on the size of string it can create (~256MB), and unless we want to
@@ -139,6 +140,49 @@ export async function getCommitDiff(
 }
 
 /**
+ * Render the diff between two branches with --merge-base for a file
+ */
+export async function getBranchMergeBaseDiff(
+  repository: Repository,
+  file: FileChange,
+  baseBranch: Branch,
+  comparisonBranch: Branch,
+  hideWhitespaceInDiff: boolean = false,
+  latestCommit: string
+): Promise<IDiff> {
+  const args = [
+    'diff',
+    '--merge-base',
+    baseBranch.name,
+    comparisonBranch.name,
+    ...(hideWhitespaceInDiff ? ['-w'] : []),
+    '--patch-with-raw',
+    '-z',
+    '--no-color',
+    '--',
+    file.path,
+  ]
+
+  if (
+    file.status.kind === AppFileStatusKind.Renamed ||
+    file.status.kind === AppFileStatusKind.Copied
+  ) {
+    args.push(file.status.oldPath)
+  }
+
+  const result = await git(args, repository.path, 'getBranchMergeBaseDiff', {
+    maxBuffer: Infinity,
+  })
+
+  return buildDiff(
+    Buffer.from(result.combinedOutput),
+    repository,
+    file,
+    latestCommit
+  )
+}
+
+/**
  * Render the difference between two commits for a file
  *
  */
@@ -197,6 +241,41 @@ export async function getCommitRangeDiff(
     repository,
     file,
     latestCommit
+  )
+}
+
+export async function getBranchMergeBaseChangedFiles(
+  repository: Repository,
+  baseBranch: Branch,
+  comparisonBranch: Branch,
+  oldestCommitRef: string
+): Promise<{
+  files: ReadonlyArray<CommittedFileChange>
+  linesAdded: number
+  linesDeleted: number
+}> {
+  const baseArgs = [
+    'diff',
+    '--merge-base',
+    baseBranch.name,
+    comparisonBranch.name,
+    '-C',
+    '-M',
+    '-z',
+    '--raw',
+    '--numstat',
+    '--',
+  ]
+
+  const result = await git(
+    baseArgs,
+    repository.path,
+    'getBranchMergeBaseChangedFiles'
+  )
+
+  return parseChangedFilesAndNumStat(
+    result.combinedOutput,
+    `${oldestCommitRef}`
   )
 }
 

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -4912,7 +4912,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
     repository: Repository,
     sourceBranch: Branch,
     mergeStatus: MergeTreeResult | null,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    targetBranch?: Branch
   ): Promise<void> {
     const { multiCommitOperationState: opState } =
       this.repositoryStateCache.get(repository)
@@ -4946,6 +4947,10 @@ export class AppStore extends TypedBaseStore<IAppState> {
       } else if (mergeStatus.kind === ComputedAction.Loading) {
         this.statsStore.recordUserProceededWhileLoading()
       }
+    }
+
+    if (targetBranch !== undefined) {
+      await this._checkoutBranch(repository, targetBranch)
     }
 
     const mergeResult = await gitStore.merge(sourceBranch, isSquash)

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -108,6 +108,8 @@ import {
   isMergeConflictState,
   IMultiCommitOperationState,
   IConstrainedValue,
+  IPullRequestPreview,
+  IPreviewPullRequest,
 } from '../app-state'
 import {
   findEditorOrDefault,
@@ -1327,7 +1329,18 @@ export class AppStore extends TypedBaseStore<IAppState> {
       return this.updateCompareToBranch(repository, action)
     }
 
+    if (action.kind === HistoryTabMode.PullRequestPreview) {
+      return this.updateToPreviewPullRequest(repository, action)
+    }
+
     return assertNever(action, `Unknown action: ${kind}`)
+  }
+
+  private async updateToPreviewPullRequest(
+    repository: Repository,
+    action: IPreviewPullRequest
+  ) {
+    console.log(action)
   }
 
   private async updateCompareToBranch(
@@ -7094,15 +7107,25 @@ export class AppStore extends TypedBaseStore<IAppState> {
  * view contents.
  */
 function getInitialAction(
-  cachedState: IDisplayHistory | ICompareBranch
+  cachedState: IDisplayHistory | ICompareBranch | IPullRequestPreview
 ): CompareAction {
-  if (cachedState.kind === HistoryTabMode.History) {
+  const { kind } = cachedState
+  if (kind === HistoryTabMode.History) {
     return {
       kind: HistoryTabMode.History,
     }
   }
 
-  const { comparisonMode, comparisonBranch } = cachedState
+  const { comparisonBranch } = cachedState
+
+  if (kind === HistoryTabMode.PullRequestPreview) {
+    return {
+      kind: HistoryTabMode.PullRequestPreview,
+      branch: comparisonBranch,
+    }
+  }
+
+  const { comparisonMode } = cachedState
 
   return {
     kind: HistoryTabMode.Compare,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1347,7 +1347,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
 
     this._executeCompare(repository, {
       kind: HistoryTabMode.PullRequestPreview,
-      comparisonBranch: defaultBranch,
+      mergeBaseBranch: defaultBranch,
     })
   }
 
@@ -1356,11 +1356,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     action: IPreviewPullRequest
   ) {
     const gitStore = this.gitStoreCache.get(repository)
-    const { comparisonBranch } = action
+    const { mergeBaseBranch } = action
 
-    const commits = await gitStore.getPreviewPullRequestCommits(
-      comparisonBranch
-    )
+    const commits = await gitStore.getPreviewPullRequestCommits(mergeBaseBranch)
 
     if (commits === null) {
       return
@@ -1378,9 +1376,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.repositoryStateCache.updateCompareState(repository, s => ({
       formState: {
         kind: HistoryTabMode.PullRequestPreview,
-        comparisonBranch,
+        mergeBaseBranch,
       },
-      filterText: comparisonBranch.name,
+      filterText: mergeBaseBranch.name,
       commitSHAs,
       mergeStatus: null,
     }))
@@ -1394,7 +1392,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return this.determineMergeabilityAfterCompare(
       repository,
       gitStore,
-      comparisonBranch
+      mergeBaseBranch
     )
   }
 
@@ -1639,7 +1637,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
     const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
     const pullRequestComparisonBranch =
       formState.kind === HistoryTabMode.PullRequestPreview
-        ? formState.comparisonBranch
+        ? formState.mergeBaseBranch
         : null
 
     const diff =
@@ -7198,16 +7196,15 @@ function getInitialAction(
     }
   }
 
-  const { comparisonBranch } = cachedState
-
   if (kind === HistoryTabMode.PullRequestPreview) {
+    const { mergeBaseBranch } = cachedState
     return {
       kind: HistoryTabMode.PullRequestPreview,
-      branch: comparisonBranch,
+      mergeBaseBranch,
     }
   }
 
-  const { comparisonMode } = cachedState
+  const { comparisonMode, comparisonBranch } = cachedState
 
   return {
     kind: HistoryTabMode.Compare,

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -1383,11 +1383,20 @@ export class AppStore extends TypedBaseStore<IAppState> {
       mergeStatus: null,
     }))
 
-    this.updateOrSelectFirstCommit(repository, commitSHAs)
-
     if (commitSHAs.length === 0) {
       return this.emitUpdate()
     }
+
+    this.repositoryStateCache.updateCommitSelection(repository, () => ({
+      shas: commitSHAs,
+      shasInDiff: commitSHAs,
+      isContiguous: true,
+      file: null,
+      changesetData: { files: [], linesAdded: 0, linesDeleted: 0 },
+      diff: null,
+    }))
+
+    this._loadChangedFilesForCurrentSelection(repository)
 
     return this.determineMergeabilityAfterCompare(
       repository,

--- a/app/src/lib/stores/git-store.ts
+++ b/app/src/lib/stores/git-store.ts
@@ -1648,6 +1648,28 @@ export class GitStore extends BaseStore {
     }
   }
 
+  /**
+   * Returns the commits associated with merging the checked out branch into
+   * another comparison branch
+   */
+  public async getPreviewPullRequestCommits(
+    comparisonBranch: Branch
+  ): Promise<ReadonlyArray<Commit> | null> {
+    if (this.tip.kind !== TipState.Valid) {
+      return null
+    }
+
+    const currentBranch = this.tip.branch
+    const revisionRange = revRange(comparisonBranch.name, currentBranch.name)
+    const commits = await getCommits(this.repository, revisionRange)
+
+    if (commits.length > 0) {
+      this.storeCommits(commits)
+    }
+
+    return commits
+  }
+
   public async pruneForkedRemotes(openPRs: ReadonlyArray<PullRequest>) {
     const remotes = await getRemotes(this.repository)
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -432,6 +432,14 @@ export function buildDefaultMenu({
       click: emit('open-pull-request'),
     },
   ]
+  if (!hasCurrentPullRequest) {
+    branchSubmenu.push({
+      label: __DARWIN__ ? 'Preview Pull Request' : 'Preview pull request',
+      id: 'preview-pull-request',
+      accelerator: 'CmdOrCtrl+Alt+P',
+      click: emit('preview-pull-request'),
+    })
+  }
 
   template.push({
     label: __DARWIN__ ? 'Branch' : '&Branch',

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -42,3 +42,4 @@ export type MenuEvent =
   | 'find-text'
   | 'create-issue-in-repository-on-github'
   | 'pull-request-check-run-failed'
+  | 'preview-pull-request'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -35,3 +35,4 @@ export type MenuIDs =
   | 'compare-to-branch'
   | 'toggle-stashed-changes'
   | 'create-issue-in-repository-on-github'
+  | 'preview-pull-request'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -423,6 +423,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.goToCommitMessage()
       case 'open-pull-request':
         return this.openPullRequest()
+      case 'preview-pull-request':
+        return this.previewPullRequest()
       case 'install-cli':
         return this.props.dispatcher.installCLI()
       case 'open-external-editor':
@@ -2725,6 +2727,16 @@ export class App extends React.Component<IAppProps, IAppState> {
     } else {
       dispatcher.showPullRequest(state.repository)
     }
+  }
+
+  private previewPullRequest = () => {
+    const state = this.state.selectedState
+
+    if (state == null || state.type !== SelectionType.Repository) {
+      return
+    }
+
+    this.props.dispatcher.previewPullRequest(state.repository)
   }
 
   private openCreatePullRequestInBrowser = (

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -366,7 +366,7 @@ export class NoChanges extends React.Component<
       defaultBranch !== null && tip.branch.name === defaultBranch.name
 
     if (isGitHub && !hasOpenPullRequest && !isDefaultBranch) {
-      return this.renderCreatePullRequestAction(tip)
+      return this.renderPreviewPullRequestAction(tip)
     }
 
     return null
@@ -632,8 +632,8 @@ export class NoChanges extends React.Component<
     )
   }
 
-  private renderCreatePullRequestAction(tip: IValidBranch) {
-    const itemId: MenuIDs = 'create-pull-request'
+  private renderPreviewPullRequestAction(tip: IValidBranch) {
+    const itemId: MenuIDs = 'preview-pull-request'
     const menuItem = this.getMenuItemInfo(itemId)
 
     if (menuItem === undefined) {
@@ -644,17 +644,16 @@ export class NoChanges extends React.Component<
     const description = (
       <>
         The current branch (<Ref>{tip.branch.name}</Ref>) is already published
-        to GitHub. Create a pull request to propose and collaborate on your
-        changes.
+        to GitHub. Preview a pull request into the default branch.
       </>
     )
 
-    const title = `Create a Pull Request from your current branch`
-    const buttonText = `Create Pull Request`
+    const title = `Preview a Pull Request into the default branch`
+    const buttonText = `Preview Pull Request`
 
     return (
       <MenuBackedSuggestedAction
-        key="create-pr-action"
+        key="preview-pr-action"
         title={title}
         menuItemId={itemId}
         description={description}
@@ -662,13 +661,14 @@ export class NoChanges extends React.Component<
         discoverabilityContent={this.renderDiscoverabilityElements(menuItem)}
         type="primary"
         disabled={!menuItem.enabled}
-        onClick={this.onCreatePullRequestClicked}
+        // onClick={this.onCreatePullRequestClicked}
       />
     )
   }
-
+  /**
   private onCreatePullRequestClicked = () =>
     this.props.dispatcher.recordSuggestedStepCreatePullRequest()
+**/
 
   private renderActions() {
     return (

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3930,4 +3930,12 @@ export class Dispatcher {
   ) {
     this.statsStore.recordPullRequestReviewDialogSwitchToPullRequest(reviewType)
   }
+
+  /**
+   *  Method to preview the merge of the current checked out branch against the
+   * repository's default branch.
+   * */
+  public previewPullRequest(repository: Repository) {
+    console.log('previewPullRequest')
+  }
 }

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -1084,9 +1084,16 @@ export class Dispatcher {
     repository: Repository,
     branch: Branch,
     mergeStatus: MergeTreeResult | null,
-    isSquash: boolean = false
+    isSquash: boolean = false,
+    targetBranch?: Branch
   ): Promise<void> {
-    return this.appStore._mergeBranch(repository, branch, mergeStatus, isSquash)
+    return this.appStore._mergeBranch(
+      repository,
+      branch,
+      mergeStatus,
+      isSquash,
+      targetBranch
+    )
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -3936,6 +3936,6 @@ export class Dispatcher {
    * repository's default branch.
    * */
   public previewPullRequest(repository: Repository) {
-    console.log('previewPullRequest')
+    this.appStore._previewPullRequest(repository)
   }
 }

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -467,10 +467,11 @@ export class CommitSummary extends React.Component<
       pullRequestPreviewBranch !== null &&
       pullRequestPreviewComparisonBranch
     ) {
-      const commitsPluralized = shasInDiff.length > 1 ? 'commits' : 'commit'
+      const commitsPluralized =
+        shasInDiff.length > 1 ? 'commits are ' : 'commit is '
       return (
         <div className={summaryClassNames}>
-          Showing files changed if {shasInDiff.length} {commitsPluralized} is
+          Showing files changed if {shasInDiff.length} {commitsPluralized}
           merged into
           <span className="ref-component">
             {pullRequestPreviewComparisonBranch.nameWithoutRemote}

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -21,11 +21,14 @@ import { AppFileStatusKind } from '../../models/status'
 import _ from 'lodash'
 import { LinkButton } from '../lib/link-button'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
+import { Branch } from '../../models/branch'
 
 interface ICommitSummaryProps {
   readonly repository: Repository
   readonly selectedCommits: ReadonlyArray<Commit>
   readonly shasInDiff: ReadonlyArray<string>
+  readonly pullRequestPreviewBranch: Branch | null
+  readonly pullRequestPreviewComparisonBranch: Branch | null
   readonly changesetData: IChangesetData
   readonly emoji: Map<string, string>
 
@@ -449,11 +452,36 @@ export class CommitSummary extends React.Component<
   }
 
   private renderSummary = () => {
-    const { selectedCommits, shasInDiff } = this.props
+    const {
+      selectedCommits,
+      shasInDiff,
+      pullRequestPreviewBranch,
+      pullRequestPreviewComparisonBranch,
+    } = this.props
     const { summary, hasEmptySummary } = this.state
     const summaryClassNames = classNames('commit-summary-title', {
       'empty-summary': hasEmptySummary,
     })
+
+    if (
+      pullRequestPreviewBranch !== null &&
+      pullRequestPreviewComparisonBranch
+    ) {
+      const commitsPluralized = shasInDiff.length > 1 ? 'commits' : 'commit'
+      return (
+        <div className={summaryClassNames}>
+          Showing files changed if {shasInDiff.length} {commitsPluralized} is
+          merged into
+          <span className="ref-component">
+            {pullRequestPreviewComparisonBranch.nameWithoutRemote}
+          </span>{' '}
+          from{' '}
+          <span className="ref-component">
+            {pullRequestPreviewBranch.nameWithoutRemote}
+          </span>
+        </div>
+      )
+    }
 
     if (selectedCommits.length === 1) {
       return (

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -31,6 +31,7 @@ import { PopupType } from '../../models/popup'
 import { getUniqueCoauthorsAsAuthors } from '../../lib/unique-coauthors-as-authors'
 import { getSquashedCommitDescription } from '../../lib/squash/squashed-commit-description'
 import { doMergeCommitsExistAfterCommit } from '../../lib/git'
+import { PullRequestPreviewCallToAction } from './pull-request-preview-call-to-action'
 
 interface ICompareSidebarProps {
   readonly repository: Repository
@@ -189,6 +190,9 @@ export class CompareSidebar extends React.Component<
         {formState.kind === HistoryTabMode.Compare
           ? this.renderTabBar(formState)
           : this.renderCommitList()}
+        {formState.kind === HistoryTabMode.PullRequestPreview
+          ? this.renderPRCallToAction(formState)
+          : null}
       </div>
     )
   }
@@ -375,6 +379,23 @@ export class CompareSidebar extends React.Component<
         currentBranch={this.props.currentBranch}
         comparisonBranch={formState.comparisonBranch}
         commitsBehind={formState.aheadBehind.behind}
+      />
+    )
+  }
+
+  private renderPRCallToAction(formState: IPullRequestPreview) {
+    if (this.props.currentBranch == null) {
+      return null
+    }
+
+    return (
+      <PullRequestPreviewCallToAction
+        repository={this.props.repository}
+        dispatcher={this.props.dispatcher}
+        mergeStatus={this.props.compareState.mergeStatus}
+        currentBranch={this.props.currentBranch}
+        mergeBaseBranch={formState.mergeBaseBranch}
+        commitsToMergeCount={this.props.compareState.commitSHAs.length}
       />
     )
   }

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -104,8 +104,14 @@ export class CompareSidebar extends React.Component<
       newFormState.kind !== HistoryTabMode.History &&
       oldFormState.kind !== HistoryTabMode.History
     ) {
-      const oldBranch = oldFormState.comparisonBranch
-      const newBranch = newFormState.comparisonBranch
+      const oldBranch =
+        oldFormState.kind === HistoryTabMode.Compare
+          ? oldFormState.comparisonBranch
+          : oldFormState.mergeBaseBranch
+      const newBranch =
+        newFormState.kind === HistoryTabMode.Compare
+          ? newFormState.comparisonBranch
+          : newFormState.mergeBaseBranch
 
       if (oldBranch.name !== newBranch.name) {
         // ensure the focused branch is in sync with the chosen branch
@@ -213,7 +219,7 @@ export class CompareSidebar extends React.Component<
         emptyListMessage = (
           <p>
             Your branch is up to date with the compared branch (
-            <Ref>{formState.comparisonBranch.name}</Ref>)
+            <Ref>{formState.mergeBaseBranch.name}</Ref>)
           </p>
         )
         break
@@ -376,7 +382,7 @@ export class CompareSidebar extends React.Component<
   private onTabClicked = (index: number) => {
     const formState = this.props.compareState.formState
 
-    if (formState.kind === HistoryTabMode.History) {
+    if (formState.kind !== HistoryTabMode.Compare) {
       return
     }
 

--- a/app/src/ui/history/compare.tsx
+++ b/app/src/ui/history/compare.tsx
@@ -7,6 +7,7 @@ import {
   ICompareBranch,
   ComparisonMode,
   IDisplayHistory,
+  IPullRequestPreview,
 } from '../../lib/app-state'
 import { CommitList } from './commit-list'
 import { Repository } from '../../models/repository'
@@ -179,9 +180,9 @@ export class CompareSidebar extends React.Component<
     const formState = this.props.compareState.formState
     return (
       <div className="compare-commit-list">
-        {formState.kind === HistoryTabMode.History
-          ? this.renderCommitList()
-          : this.renderTabBar(formState)}
+        {formState.kind === HistoryTabMode.Compare
+          ? this.renderTabBar(formState)
+          : this.renderCommitList()}
       </div>
     )
   }
@@ -204,23 +205,33 @@ export class CompareSidebar extends React.Component<
     const { formState, commitSHAs } = this.props.compareState
 
     let emptyListMessage: string | JSX.Element
-    if (formState.kind === HistoryTabMode.History) {
-      emptyListMessage = 'No history'
-    } else {
-      const currentlyComparedBranchName = formState.comparisonBranch.name
-
-      emptyListMessage =
-        formState.comparisonMode === ComparisonMode.Ahead ? (
-          <p>
-            The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is up
-            to date with your branch
-          </p>
-        ) : (
+    switch (formState.kind) {
+      case HistoryTabMode.History:
+        emptyListMessage = 'No history'
+        break
+      case HistoryTabMode.PullRequestPreview:
+        emptyListMessage = (
           <p>
             Your branch is up to date with the compared branch (
-            <Ref>{currentlyComparedBranchName}</Ref>)
+            <Ref>{formState.comparisonBranch.name}</Ref>)
           </p>
         )
+        break
+      case HistoryTabMode.Compare:
+        const currentlyComparedBranchName = formState.comparisonBranch.name
+
+        emptyListMessage =
+          formState.comparisonMode === ComparisonMode.Ahead ? (
+            <p>
+              The compared branch (<Ref>{currentlyComparedBranchName}</Ref>) is
+              up to date with your branch
+            </p>
+          ) : (
+            <p>
+              Your branch is up to date with the compared branch (
+              <Ref>{currentlyComparedBranchName}</Ref>)
+            </p>
+          )
     }
 
     return (
@@ -679,10 +690,10 @@ function getPlaceholderText(state: ICompareState) {
 // 1: History mode, 2: Comparison Mode with the 'Ahead' list shown.
 // When not exposed, the context menu item 'Revert this commit' is disabled.
 function ableToRevertCommit(
-  formState: IDisplayHistory | ICompareBranch
+  formState: IDisplayHistory | ICompareBranch | IPullRequestPreview
 ): boolean {
   return (
-    formState.kind === HistoryTabMode.History ||
+    formState.kind === HistoryTabMode.Compare &&
     formState.comparisonMode === ComparisonMode.Ahead
   )
 }

--- a/app/src/ui/history/pull-request-preview-call-to-action.tsx
+++ b/app/src/ui/history/pull-request-preview-call-to-action.tsx
@@ -1,0 +1,250 @@
+import * as React from 'react'
+
+import { HistoryTabMode } from '../../lib/app-state'
+import { Repository } from '../../models/repository'
+import { Branch } from '../../models/branch'
+import { Dispatcher } from '../dispatcher'
+import { ActionStatusIcon } from '../lib/action-status-icon'
+import { MergeTreeResult } from '../../models/merge'
+import { ComputedAction } from '../../models/computed-action'
+import {
+  DropdownSelectButton,
+  IDropdownSelectButtonOption,
+} from '../dropdown-select-button'
+import { MultiCommitOperationKind } from '../../models/multi-commit-operation'
+
+const enum PullRequestPreviewCallToActionKind {
+  CreatePullRequest = 'CreatePullRequest',
+  Merge = 'Merge',
+  Squash = 'Squash',
+}
+
+interface IPullRequestPreviewCallToActionProps {
+  readonly repository: Repository
+  readonly dispatcher: Dispatcher
+  readonly mergeStatus: MergeTreeResult | null
+  readonly currentBranch: Branch
+  readonly mergeBaseBranch: Branch
+  readonly commitsToMergeCount: number
+}
+
+interface IPullRequestPreviewCallToActionState {
+  readonly selectedOperation: PullRequestPreviewCallToActionKind
+}
+
+export class PullRequestPreviewCallToAction extends React.Component<
+  IPullRequestPreviewCallToActionProps,
+  IPullRequestPreviewCallToActionState
+> {
+  public constructor(props: IPullRequestPreviewCallToActionProps) {
+    super(props)
+
+    this.state = {
+      selectedOperation: PullRequestPreviewCallToActionKind.CreatePullRequest,
+    }
+  }
+
+  private isUpdateBranchDisabled(): boolean {
+    return (
+      this.props.commitsToMergeCount <= 0 ||
+      (this.props.mergeStatus != null &&
+        this.props.mergeStatus.kind === ComputedAction.Invalid)
+    )
+  }
+
+  private onOperationChange = (option: IDropdownSelectButtonOption) => {
+    const value = option.value as PullRequestPreviewCallToActionKind
+    this.setState({ selectedOperation: value })
+  }
+
+  private onOperationInvoked = async (
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedOption: IDropdownSelectButtonOption
+  ) => {
+    event.preventDefault()
+
+    const { dispatcher, repository } = this.props
+
+    await this.dispatchOperation(
+      selectedOption.value as PullRequestPreviewCallToActionKind
+    )
+
+    dispatcher.updateCompareForm(repository, {
+      showBranchList: false,
+      filterText: '',
+    })
+
+    dispatcher.executeCompare(repository, {
+      kind: HistoryTabMode.History,
+    })
+  }
+
+  private async dispatchOperation(
+    operation: PullRequestPreviewCallToActionKind
+  ): Promise<void> {
+    const {
+      dispatcher,
+      currentBranch,
+      mergeBaseBranch,
+      repository,
+      mergeStatus,
+    } = this.props
+
+    if (operation === PullRequestPreviewCallToActionKind.CreatePullRequest) {
+      return dispatcher.createPullRequest(repository)
+    }
+
+    const isSquash = operation === PullRequestPreviewCallToActionKind.Squash
+    dispatcher.initializeMultiCommitOperation(
+      repository,
+      {
+        kind: MultiCommitOperationKind.Merge,
+        isSquash,
+        sourceBranch: currentBranch,
+      },
+      mergeBaseBranch,
+      [],
+      currentBranch.tip.sha
+    )
+    dispatcher.recordCompareInitiatedMerge()
+
+    return dispatcher.mergeBranch(
+      repository,
+      currentBranch,
+      mergeStatus,
+      isSquash,
+      mergeBaseBranch
+    )
+  }
+
+  private getMergeOptions = () => {
+    return [
+      {
+        label: 'Create a Pull Request',
+        description: `The current branch (${this.props.currentBranch.name}) is already published to GitHub. Create a pull request to propose and collaborate on your changes.`,
+        value: PullRequestPreviewCallToActionKind.CreatePullRequest,
+      },
+      {
+        label: 'Create a merge commit',
+        description: `The commits from the current branch (${this.props.currentBranch.name}) will be added to the compared branch (${this.props.mergeBaseBranch.name}) via a merge commit.`,
+        value: PullRequestPreviewCallToActionKind.Merge,
+      },
+      {
+        label: 'Squash and merge',
+        description: `The commits in the current branch (${this.props.currentBranch.name}) will be combined into one commit and added the compared branch (${this.props.mergeBaseBranch.name}).`,
+        value: PullRequestPreviewCallToActionKind.Squash,
+      },
+    ]
+  }
+
+  public render() {
+    const disabled = this.isUpdateBranchDisabled()
+    const mergeDetails =
+      this.props.commitsToMergeCount > 0 ? this.renderMergeStatus() : null
+
+    return (
+      <div className="merge-cta">
+        {mergeDetails}
+
+        <DropdownSelectButton
+          selectedValue={this.state.selectedOperation}
+          options={this.getMergeOptions()}
+          disabled={disabled}
+          onSelectChange={this.onOperationChange}
+          onSubmit={this.onOperationInvoked}
+        />
+      </div>
+    )
+  }
+
+  private renderMergeStatus() {
+    if (this.props.mergeStatus === null) {
+      return null
+    }
+
+    return (
+      <div className="merge-status-component">
+        <ActionStatusIcon
+          status={{ kind: this.props.mergeStatus.kind }}
+          classNamePrefix="merge-status"
+        />
+
+        {this.renderStatusDetails()}
+      </div>
+    )
+  }
+
+  private renderStatusDetails() {
+    const { mergeStatus } = this.props
+
+    if (mergeStatus === null) {
+      return null
+    }
+
+    switch (mergeStatus.kind) {
+      case ComputedAction.Loading:
+        return this.renderLoadingMessage()
+      case ComputedAction.Clean:
+        return this.renderCleanMessage()
+      case ComputedAction.Invalid:
+        return this.renderInvalidMessage()
+      case ComputedAction.Conflicts:
+        return this.renderConflictedMergeMessage(mergeStatus.conflictedFiles)
+    }
+  }
+
+  private renderLoadingMessage() {
+    return (
+      <div className="merge-message merge-message-loading">
+        Checking for ability to merge…
+      </div>
+    )
+  }
+
+  private renderCleanMessage() {
+    const { commitsToMergeCount, currentBranch, mergeBaseBranch } = this.props
+    const { selectedOperation } = this.state
+    if (
+      commitsToMergeCount <= 0 ||
+      selectedOperation === PullRequestPreviewCallToActionKind.CreatePullRequest
+    ) {
+      return null
+    }
+
+    const pluralized = commitsToMergeCount === 1 ? 'commit' : 'commits'
+
+    return (
+      <div className="merge-message">
+        This will {selectedOperation.toLowerCase()}
+        <strong>{` ${commitsToMergeCount} ${pluralized}`}</strong>
+        {` from `}
+        <strong>{currentBranch.name}</strong>
+        {` into `}
+        <strong>{mergeBaseBranch.name}</strong>
+      </div>
+    )
+  }
+
+  private renderInvalidMessage() {
+    return (
+      <div className="merge-message">
+        Unable to merge unrelated histories in this repository
+      </div>
+    )
+  }
+
+  private renderConflictedMergeMessage(count: number) {
+    const { currentBranch, mergeBaseBranch } = this.props
+    const pluralized = count === 1 ? 'file' : 'files'
+    return (
+      <div className="merge-message">
+        There will be
+        <strong>{` ${count} conflicted ${pluralized}`}</strong>
+        {` when merging `}
+        <strong>{currentBranch.name}</strong>
+        {` into `}
+        <strong>{mergeBaseBranch.name}</strong>
+      </div>
+    )
+  }
+}

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -37,6 +37,7 @@ import { pathExists } from '../lib/path-exists'
 import { enableMultiCommitDiffs } from '../../lib/feature-flag'
 import { PopupType } from '../../models/popup'
 import { UnreachableCommitsTab } from './unreachable-commits-dialog'
+import { Branch } from '../../models/branch'
 
 interface ISelectedCommitsProps {
   readonly repository: Repository
@@ -86,6 +87,9 @@ interface ISelectedCommitsProps {
 
   /** Whether or not the selection of commits is contiguous */
   readonly isContiguous: boolean
+
+  readonly pullRequestPreviewBranch: Branch | null
+  readonly pullRequestPreviewComparisonBranch: Branch | null
 }
 
 interface ISelectedCommitsState {
@@ -185,6 +189,10 @@ export class SelectedCommits extends React.Component<
         onDiffOptionsOpened={this.props.onDiffOptionsOpened}
         onHighlightShas={this.onHighlightShas}
         showUnreachableCommits={this.showUnreachableCommits}
+        pullRequestPreviewBranch={this.props.pullRequestPreviewBranch}
+        pullRequestPreviewComparisonBranch={
+          this.props.pullRequestPreviewComparisonBranch
+        }
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -388,7 +388,7 @@ export class RepositoryView extends React.Component<
     const { formState } = compareState
     const pullRequestPreviewComparisonBranch =
       formState.kind === HistoryTabMode.PullRequestPreview
-        ? formState.comparisonBranch
+        ? formState.mergeBaseBranch
         : null
 
     const selectedCommits = []

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -15,6 +15,7 @@ import {
   RepositorySectionTab,
   ChangesSelectionKind,
   IConstrainedValue,
+  HistoryTabMode,
 } from '../lib/app-state'
 import { Dispatcher } from './dispatcher'
 import { IssuesStore, GitHubUserStore } from '../lib/stores'
@@ -373,9 +374,22 @@ export class RepositoryView extends React.Component<
   }
 
   private renderContentForHistory(): JSX.Element {
-    const { commitSelection, commitLookup, localCommitSHAs } = this.props.state
+    const {
+      commitSelection,
+      commitLookup,
+      localCommitSHAs,
+      branchesState,
+      compareState,
+    } = this.props.state
+    const { tip } = branchesState
+    const currentBranch = tip.kind === TipState.Valid ? tip.branch : null
     const { changesetData, file, diff, shas, shasInDiff, isContiguous } =
       commitSelection
+    const { formState } = compareState
+    const pullRequestPreviewComparisonBranch =
+      formState.kind === HistoryTabMode.PullRequestPreview
+        ? formState.comparisonBranch
+        : null
 
     const selectedCommits = []
     for (const sha of shas) {
@@ -413,6 +427,8 @@ export class RepositoryView extends React.Component<
         onChangeImageDiffType={this.onChangeImageDiffType}
         onDiffOptionsOpened={this.onDiffOptionsOpened}
         showDragOverlay={showDragOverlay}
+        pullRequestPreviewBranch={currentBranch}
+        pullRequestPreviewComparisonBranch={pullRequestPreviewComparisonBranch}
       />
     )
   }


### PR DESCRIPTION
## Description
This is a POC for what a Pull-request preview flow could look like in Desktop. 

Things to do something about:
- The view shows changes from all commits and when user selects any of the commits, it shows changes from all of them. Currently looking to make all the commits selected, and disable interaction with the commit list as the simplest solution... but if we made it so user could click through these, should we have something in this view to make it more obvious that you are not in the regular history or compare view/ would a user intuitively know to reselect all to get back to "looking at branch to branch" view?
- Getting here from the compare tool? I originally approached this from the compare tool, by adding a new dropdown to the merge button at the bottom of the compare behind section; but this is a little confusing because it would only make sense if you switched to your default branch and compared the feature branch your want to create the pr for.. usually developers are on their feature branch and then want to move to a pr. But.. we could add a button to bottom of "Ahead" section, so that when on a feature branch, you could compare to development (or other branch) and "Preview the PR" from there -> this would hide the compare view tabs (maybe not super clear you switched to a "new view". Other thoughts was compare tool gets a new tab of "Pull Request Preview". That is this new view.
- Should merge/squash and merge, and rebase be a thing here? Like if you don't need to do a pr - no collaboration, but want to use this simply to see the pr comparison before merging? I currently have merge and squash/merge added, but an issue with it is that in order to do so, we need to checkout the target branch... and if we abort the action, should we return to the pr preview (would require some more state remembering. 

Other functionality to add:
- Currently if you change the compare branch, it resets you to a "compare view", be better if this just changed to pull request view base branch. If so "create a pull request", functionality needs to be updated to take in a target branch instead of assuming repo default branch.

### Screenshots

https://user-images.githubusercontent.com/75402236/180788928-3fb3ee77-bbf8-45c0-a3e2-2fbebe1156a0.mov


## Release notes
Notes: no-notes
