### PR TITLE
update test to properly override `safe.directory` if set in system or global config

### DIFF
--- a/app/test/unit/git/rev-parse-test.ts
+++ b/app/test/unit/git/rev-parse-test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../helpers/repositories'
 import { GitProcess } from 'dugite'
 import { mkdirSync } from '../../helpers/temp'
+import { writeFile } from 'fs-extra'
 
 describe('git/rev-parse', () => {
   let repository: Repository
@@ -103,11 +104,31 @@ describe('git/rev-parse', () => {
     })
 
     it('returns unsafe for unsafe repository', async () => {
+      const previousHomeValue = process.env['HOME']
+
+      // Creating a stub global config so we can unset safe.directory config
+      // which will supersede any system config that might set * to ignore
+      // warnings about a different owner
+      //
+      // This is because safe.directory setting is ignored if found in local
+      // config, environment variables or command line arguments.
+      const testHomeDirectory = mkdirSync('test-home-directory')
+      const gitConfigPath = path.join(testHomeDirectory, '.gitconfig')
+      await writeFile(
+        gitConfigPath,
+        `[safe]
+directory=`
+      )
+
+      process.env['HOME'] = testHomeDirectory
       process.env['GIT_TEST_ASSUME_DIFFERENT_OWNER'] = '1'
+
       expect(await getRepositoryType(repository.path)).toMatchObject({
         kind: 'unsafe',
       })
+
       process.env['GIT_TEST_ASSUME_DIFFERENT_OWNER'] = undefined
+      process.env['HOME'] = previousHomeValue
     })
   })
 })


### PR DESCRIPTION
Related to https://github.com/desktop/desktop/pull/14974 and the test added in e4b3a13c075ed3c589d3790d6ee4af15a71cbbb7

## Description

While trying to cut a Linux release for 3.0.5 I hit failures with this test, that suggested the `GIT_TEST_ASSUME_DIFFERENT_OWNER=1` environment variable wasn't being used.

[Linux workflow run failure](https://github.com/shiftkey/desktop/runs/7529230227?check_suite_focus=true#step:13:64)

```
 ● git/rev-parse › getRepositoryType › returns unsafe for unsafe repository

    expect(received).toMatchObject(expected)

    - Expected  - 1
    + Received  + 1

      Object {
    -   "kind": "unsafe",
    +   "kind": "regular",
      }

      105 |     it('returns unsafe for unsafe repository', async () => {
      106 |       process.env['GIT_TEST_ASSUME_DIFFERENT_OWNER'] = '1'
    > 107 |       expect(await getRepositoryType(repository.path)).toMatchObject({
          |                                                        ^
      108 |         kind: 'unsafe',
      109 |       })
      110 |       process.env['GIT_TEST_ASSUME_DIFFERENT_OWNER'] = undefined

      at Object.<anonymous> (test/unit/git/rev-parse-test.ts:107:56)
```

Each OS has `safe.directory=*` set, so I'm not 100% sure why Linux is only the one that fails here.

 - [Linux](https://github.com/shiftkey/desktop/runs/7529230227?check_suite_focus=true#step:12:10) - system config
 - [Windows](https://github.com/shiftkey/desktop/runs/7529230051?check_suite_focus=true#step:12:24) - system config
 - [macOS](https://github.com/shiftkey/desktop/runs/7529229800?check_suite_focus=true#step:12:15) - global config

I was able to reproduce this locally with the `desktop` repo:

```
$ git --version
git version 2.37.1
$ git config -l --show-origin | grep safe.directory=
file:/etc/gitconfig     safe.directory=*
$ GIT_TEST_ASSUME_DIFFERENT_OWNER=1 git rev-parse --is-bare-repository --show-cdup
false
```

My hypothesis based on the lack of an error message from that last command seems to suggest it doesn't look at the environment variable when `safe.directory=*` is found in the system or global Git config. [Based on the docs for `safe.directory`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory) it looks like this setting can only be set at the system or global config:

> This config setting is only respected when specified in a system or global config, not when it is specified in a repository config, via the command line option `-c safe.directory=<path>`, or in environment variables.

Rather than mess with system or global config in the test run, I've updated this test to change the `HOME` directory to a stub `.gitconfig` and re-enable this protection for the test:

> If `safe.directory=*` is set in system config and you want to re-enable this protection, then initialize your list with an empty value before listing the repositories that you deem safe.

Not sure why the same issue isn't visible on macOS and Windows, but figured you might have more context to add around this feature.

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: no-notes
