### PR TITLE
Add git notes to commit summary history

### DIFF
--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -87,6 +87,7 @@ export async function getCommits(
     parents: '%P', // parent SHAs,
     trailers: '%(trailers:unfold,only)',
     refs: '%D',
+    notes: '%N',
   })
 
   const args = ['log']
@@ -144,7 +145,8 @@ export async function getCommits(
       //    pair is separated by ": ". Otherwise it shares the same semantics as
       //    separator=<SEP> above."
       parseRawUnfoldedTrailers(commit.trailers, ':'),
-      tags
+      tags,
+      commit.notes
     )
   })
 }

--- a/app/src/models/commit.ts
+++ b/app/src/models/commit.ts
@@ -115,7 +115,8 @@ export class Commit {
     public readonly committer: CommitIdentity,
     public readonly parentSHAs: ReadonlyArray<string>,
     public readonly trailers: ReadonlyArray<ITrailer>,
-    public readonly tags: ReadonlyArray<string>
+    public readonly tags: ReadonlyArray<string>,
+    public readonly notes: string
   ) {
     this.coAuthors = extractCoAuthors(trailers)
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -95,6 +95,12 @@ interface ICommitSummaryState {
    * the avatar stack and calculated whenever the commit prop changes.
    */
   readonly avatarUsers: ReadonlyArray<IAvatarUser>
+
+  /**
+   * The notes that are associated with this commit. Used when rendering
+   * the commit summary in a repository's history.
+   */
+  readonly notes: ReadonlyArray<TokenResult>
 }
 
 /**
@@ -134,7 +140,9 @@ function createState(
     (a, b) => a.email === b.email && a.name === b.name
   )
 
-  return { isOverflowed, summary, body, avatarUsers, hasEmptySummary }
+  const notes = tokenizer.tokenize(selectedCommits[0].notes)
+
+  return { isOverflowed, summary, body, avatarUsers, hasEmptySummary, notes }
 }
 
 function getCommitSummary(selectedCommits: ReadonlyArray<Commit>) {
@@ -320,6 +328,9 @@ export class CommitSummary extends React.Component<
       return null
     }
 
+    const body = this.state.body[0].text;
+    const notes = this.state.notes[0].text;
+
     return (
       <div
         className="commit-summary-description-container"
@@ -333,7 +344,7 @@ export class CommitSummary extends React.Component<
             className="commit-summary-description"
             emoji={this.props.emoji}
             repository={this.props.repository}
-            text={this.state.body}
+            text={`${body}\n\n** GIT NOTES **\n${notes}`}
           />
         </div>
 

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -328,8 +328,8 @@ export class CommitSummary extends React.Component<
       return null
     }
 
-    const body = this.state.body[0].text;
-    const notes = this.state.notes[0].text;
+    const body = this.state.body[0].text
+    const notes = this.state.notes[0].text
 
     return (
       <div

--- a/app/src/ui/lib/configure-git-user.tsx
+++ b/app/src/ui/lib/configure-git-user.tsx
@@ -236,7 +236,8 @@ export class ConfigureGitUser extends React.Component<
       author,
       [],
       [],
-      []
+      [],
+      'Novial is the coolest'
     )
     const emoji = new Map()
 

--- a/app/test/unit/squashed-commit-description-test.ts
+++ b/app/test/unit/squashed-commit-description-test.ts
@@ -68,6 +68,7 @@ function buildTestCommit(
     author,
     [],
     trailers,
-    []
+    [],
+    'test'
   )
 }

--- a/app/test/unit/unique-coauthors-as-authors-test.ts
+++ b/app/test/unit/unique-coauthors-as-authors-test.ts
@@ -118,7 +118,8 @@ function buildTestCommit(trailers: ReadonlyArray<ITrailer>): Commit {
     author,
     [],
     trailers,
-    []
+    [],
+    'test'
   )
 }
 


### PR DESCRIPTION
<!--
What GitHub Desktop issue does this PR address? (for example, #1234)
-->

Closes #14755

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
- Git notes have been added to `Commit` and the commit summary renderer.
- If the Git notes are in an improper place, please let me know. I wasn't sure how to do this. Maybe another collapsable section?

### Screenshots
This repository is from a very old project of mine. Please bare with the cringe commit messages. :D
<img width="977" alt="image" src="https://user-images.githubusercontent.com/35881688/184475001-89992bdc-0b68-4458-8d39-f2b54dd1bd6a.png">

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes: Added git notes support in repository commit history
