### PR TITLE
Search for all bundle identifier entries instead of just the first one

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -148,7 +148,7 @@ async function findApplication(
           : Promise.reject(e)
       )
 
-      if (installPath && await pathExists(installPath)) {
+      if (installPath && (await pathExists(installPath))) {
         return installPath
       }
 

--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -148,11 +148,7 @@ async function findApplication(
           : Promise.reject(e)
       )
 
-      if (installPath === null) {
-        return null
-      }
-
-      if (await pathExists(installPath)) {
+      if (installPath && await pathExists(installPath)) {
         return installPath
       }
 


### PR DESCRIPTION
This should fix a bug that caused GitHub Desktop to only find the latest version of supported text editors.

The issue has been described in #14197.

## Description
It should be possible to set the default text editor to older versions of editors officially supported by GitHub Desktop, but that did not work when a major version bump also caused the bundle identifier of the text editor to change. (For example, `com.sublimetext.3` and `com.sublimetext.4` are identifiers representing different versions of the same editor.)

## Release notes

Notes: [Fixed] Older versions of Sublime Text and SlickEdit are also recognized as external editors.
