### PR TITLE
external editor applications for macOS: Add Emacs

### DIFF
--- a/app/src/lib/editors/darwin.ts
+++ b/app/src/lib/editors/darwin.ts
@@ -132,6 +132,10 @@ const editors: IDarwinExternalEditor[] = [
     name: 'Nova',
     bundleIdentifiers: ['com.panic.Nova'],
   },
+  {
+    name: 'Emacs',
+    bundleIdentifiers: ['org.gnu.Emacs'],
+  },
 ]
 
 async function findApplication(

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -235,7 +235,7 @@ These editors are currently supported:
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
  - [Nova](https://nova.app/)
  - [Aptana Studio](http://www.aptana.com/)
- - [Emacs] (https://www.gnu.org/software/emacs/)
+ - [Emacs](https://www.gnu.org/software/emacs/)
 
 These are defined in a list at the top of the file:
 

--- a/docs/technical/editor-integration.md
+++ b/docs/technical/editor-integration.md
@@ -235,6 +235,7 @@ These editors are currently supported:
  - [JetBrains Rider](https://www.jetbrains.com/rider/)
  - [Nova](https://nova.app/)
  - [Aptana Studio](http://www.aptana.com/)
+ - [Emacs] (https://www.gnu.org/software/emacs/)
 
 These are defined in a list at the top of the file:
 


### PR DESCRIPTION
This commit follows the steps to add an external editor for macOS (please see: https://github.com/desktop/desktop/blob/1b30bfb027aa0c522bf2d2c48122ce0d9c11e2e2/docs/technical/editor-integration.md).

```
machine:~ $ defaults read /Applications/Emacs.app/Contents/Info CFBundleIdentifier
org.gnu.Emacs
machine:~ $
```
I intend this addresses #4785 (https://github.com/desktop/desktop/issues/4785).

## Description
- add Emacs to list of external editor applications for macOS