### PR TITLE
Fix org/repo#12345 links

### DIFF
--- a/app/src/lib/text-token-parser.ts
+++ b/app/src/lib/text-token-parser.ts
@@ -162,7 +162,14 @@ export class Tokenizer {
       return null
     }
 
-    const url = `${repository.htmlURL}/issues/${id}`
+    // handle an issue link to another repo
+    let repoUrl = repository.htmlURL;
+    const orgRepo = text.slice(0,index).match(/(\w+\/\w+)$/);
+    if (orgRepo) {
+      repoUrl = `https://github.com/${orgRepo[0]}`
+    }
+
+    const url = `${repoUrl}/issues/${id}`
     this._results.push({ kind: TokenType.Link, text: maybeIssue, url })
     return { nextIndex }
   }


### PR DESCRIPTION
Closes #8403

## Description
Compose links of the form org/repo#12345 correctly. The link still only appears on the issue number. More disruptive changes would be required to apply the link to the entire `org/repo#12345` string, since `tokenizeGitHubRepository` follows a linear scanning methodology.

### Screenshots
n/a

## Release notes
- Issue numbers preceded by org/project prefix are now linked to the correct destination.
