### PR TITLE
Bump macos-10.15 runners (deprecated) to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         node: [16.13.0]
-        os: [macos-10.15, windows-2019]
+        os: [macos-11, windows-2019]
         arch: [x64, arm64]
         include:
-          - os: macos-10.15
+          - os: macos-11
             friendlyName: macOS
           - os: windows-2019
             friendlyName: Windows
     timeout-minutes: 60
-    env:
-      # Needed for macOS arm64 until hosted macos-11.0 runners become available
-      SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

With [macos-10.15 runners being deprecated soon](https://github.com/actions/virtual-environments/issues/5583), this PR upgrades our CI workflow to use the new macos-11 runners.

## Release notes

Notes: no-notes
