### PR TITLE
Enable x64-to-arm64 immediate updates in prod builds

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -68,16 +68,6 @@ export function enableUpdateFromEmulatedX64ToARM64(): boolean {
   return enableBetaFeatures()
 }
 
-/**
- * Should we allow x64 apps running under ARM translation to auto-update to
- * ARM64 builds IMMEDIATELY instead of waiting for the next release?
- */
-export function enableImmediateUpdateFromEmulatedX64ToARM64(): boolean {
-  // Because of how Squirrel.Windows works, this is only available for macOS.
-  // See: https://github.com/desktop/desktop/pull/14998
-  return __DARWIN__
-}
-
 /** Should we allow resetting to a previous commit? */
 export function enableResetToCommit(): boolean {
   return enableDevelopmentFeatures()

--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -75,7 +75,7 @@ export function enableUpdateFromEmulatedX64ToARM64(): boolean {
 export function enableImmediateUpdateFromEmulatedX64ToARM64(): boolean {
   // Because of how Squirrel.Windows works, this is only available for macOS.
   // See: https://github.com/desktop/desktop/pull/14998
-  return __DARWIN__ && enableBetaFeatures()
+  return __DARWIN__
 }
 
 /** Should we allow resetting to a previous commit? */


### PR DESCRIPTION
Closes #14998

## Description
This PR enables in prod the feature flag created for #14998, so that users of prod builds will be prompted to upgrade x64 binaries to arm64 on macOS when running on Apple silicon devices.

## Release notes

Notes: [Improved] On Apple silicon devices running unoptimized builds, auto-update on first run to an optimized build
