### PR TITLE
Stop showing login prompts from GCM for git operations

### DIFF
--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -6,6 +6,7 @@ import { IRemote } from '../../models/remote'
 import { envForRemoteOperation } from './environment'
 import { IGitAccount } from '../../models/git-account'
 import { getSymbolicRef } from './refs'
+import { gitNetworkArguments } from '.'
 
 /**
  * List the remotes, sorted alphabetically by `name`, for a repository.
@@ -106,7 +107,7 @@ export async function updateRemoteHEAD(
   }
 
   await git(
-    ['remote', 'set-head', '-a', remote.name],
+    [...gitNetworkArguments(), 'remote', 'set-head', '-a', remote.name],
     repository.path,
     'updateRemoteHEAD',
     options


### PR DESCRIPTION
Closes #15163

## Description

This PR fixes a regression introduced in #14985 : one of the new git calls introduced performs a network call that might require authentication. If the user has any kind of credential helper installed (like [Git Credential Manger](https://github.com/GitCredentialManager/git-credential-manager)), they get a prompt asking to login on GitHub or other hosting services. The problem is we didn't disable external credential helpers, since GitHub Desktop should handle those authentication requirements using its [askpass trampoline](https://github.com/desktop/desktop-trampoline).

## Release notes

Notes: [Fixed] Do not show login prompt when repositories are fetched
