### PR TITLE
Address jsx-ally/alt-text rule Accessibility Linting Rule

### DIFF
--- a/app/src/crash/crash-app.tsx
+++ b/app/src/crash/crash-app.tsx
@@ -201,8 +201,9 @@ export class CrashApp extends React.Component<ICrashAppProps, ICrashAppState> {
   }
 
   private renderBackgroundGraphics() {
-    // eslint-disable-next-line jsx-a11y/alt-text
-    return <img className="background-graphic-bottom" src={BottomImageUri} />
+    return (
+      <img className="background-graphic-bottom" alt="" src={BottomImageUri} />
+    )
   }
 
   public render() {

--- a/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
+++ b/app/src/ui/autocompletion/emoji-autocompletion-provider.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { IAutocompletionProvider } from './index'
 import { compare } from '../../lib/compare'
@@ -91,7 +90,7 @@ export class EmojiAutocompletionProvider
 
     return (
       <div className="emoji" key={emoji}>
-        <img className="icon" src={this.emoji.get(emoji)} />
+        <img className="icon" src={this.emoji.get(emoji)} alt={emoji} />
         {this.renderHighlightedTitle(hit)}
       </div>
     )

--- a/app/src/ui/branches/no-branches.tsx
+++ b/app/src/ui/branches/no-branches.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 import { Button } from '../lib/button'
@@ -20,7 +19,7 @@ export class NoBranches extends React.Component<INoBranchesProps> {
     if (this.props.canCreateNewBranch) {
       return (
         <div className="no-branches">
-          <img src={BlankSlateImage} className="blankslate-image" />
+          <img src={BlankSlateImage} className="blankslate-image" alt="" />
 
           <div className="title">Sorry, I can't find that branch</div>
 

--- a/app/src/ui/branches/no-pull-requests.tsx
+++ b/app/src/ui/branches/no-pull-requests.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 import { Ref } from '../lib/ref'
@@ -34,7 +33,7 @@ export class NoPullRequests extends React.Component<INoPullRequestsProps, {}> {
   public render() {
     return (
       <div className="no-pull-requests">
-        <img src={BlankSlateImage} className="blankslate-image" />
+        <img src={BlankSlateImage} className="blankslate-image" alt="" />
         {this.renderTitle()}
         {this.renderCallToAction()}
       </div>

--- a/app/src/ui/changes/multiple-selection.tsx
+++ b/app/src/ui/changes/multiple-selection.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { encodePathAsUrl } from '../../lib/path'
 
@@ -19,7 +18,7 @@ export class MultipleSelection extends React.Component<
   public render() {
     return (
       <div className="panel blankslate" id="no-changes">
-        <img src={BlankSlateImage} className="blankslate-image" />
+        <img src={BlankSlateImage} className="blankslate-image" alt="" />
         <div>{this.props.count} files selected</div>
       </div>
     )

--- a/app/src/ui/changes/no-changes.tsx
+++ b/app/src/ui/changes/no-changes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 
 import { encodePathAsUrl } from '../../lib/path'
@@ -715,7 +714,7 @@ export class NoChanges extends React.Component<
                 some friendly suggestions for what to do next.
               </p>
             </div>
-            <img src={PaperStackImage} className="blankslate-image" />
+            <img src={PaperStackImage} className="blankslate-image" alt="" />
           </div>
           {this.renderActions()}
         </div>

--- a/app/src/ui/check-runs/ci-check-run-popover.tsx
+++ b/app/src/ui/check-runs/ci-check-run-popover.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { GitHubRepository } from '../../models/github-repository'
 import { DisposableLike } from 'event-kit'
@@ -243,7 +242,7 @@ export class CICheckRunPopover extends React.PureComponent<
   private renderCheckRunLoadings(): JSX.Element {
     return (
       <div className="loading-check-runs">
-        <img src={BlankSlateImage} className="blankslate-image" />
+        <img src={BlankSlateImage} className="blankslate-image" alt="" />
         <div className="title">Stand By</div>
         <div className="call-to-action">Check runs incoming!</div>
       </div>

--- a/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
+++ b/app/src/ui/check-runs/ci-check-run-rerun-dialog.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
@@ -221,7 +220,7 @@ export class CICheckRunRerunDialog extends React.Component<
     if (this.state.loadingCheckSuites && this.props.checkRuns.length > 1) {
       return (
         <div className="loading-rerun-checks">
-          <img src={BlankSlateImage} className="blankslate-image" />
+          <img src={BlankSlateImage} className="blankslate-image" alt="" />
           <div className="title">Please wait</div>
           <div className="call-to-action">
             Determining which checks can be re-run.

--- a/app/src/ui/diff/image-diffs/image-container.tsx
+++ b/app/src/ui/diff/image-diffs/image-container.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 
 import { Image } from '../../../models/diff'
@@ -21,7 +20,12 @@ export class ImageContainer extends React.Component<IImageProps, {}> {
 
     return (
       <div className="image-wrapper">
-        <img src={imageSource} style={this.props.style} onLoad={this.onLoad} />
+        <img
+          src={imageSource}
+          style={this.props.style}
+          onLoad={this.onLoad}
+          alt=""
+        />
       </div>
     )
   }

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 
 import { assertNever } from '../../lib/fatal-error'
@@ -169,7 +168,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
   private renderLargeTextDiff() {
     return (
       <div className="panel empty large-diff">
-        <img src={NoDiffImage} className="blankslate-image" />
+        <img src={NoDiffImage} className="blankslate-image" alt="" />
         <p>
           The diff is too large to be displayed by default.
           <br />
@@ -186,7 +185,7 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
   private renderUnrenderableDiff() {
     return (
       <div className="panel empty large-diff">
-        <img src={NoDiffImage} />
+        <img src={NoDiffImage} alt="" />
         <p>The diff is too large to be displayed.</p>
       </div>
     )

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { clipboard } from 'electron'
 import * as Path from 'path'
@@ -317,7 +316,7 @@ export class SelectedCommits extends React.Component<
     return (
       <div id="multiple-commits-selected" className="blankslate">
         <div className="panel blankslate">
-          <img src={BlankSlateImage} className="blankslate-image" />
+          <img src={BlankSlateImage} className="blankslate-image" alt="" />
           <div>
             <p>
               Unable to display diff when multiple{' '}
@@ -442,7 +441,7 @@ function NoCommitSelected() {
 
   return (
     <div className="panel blankslate">
-      <img src={BlankSlateImage} className="blankslate-image" />
+      <img src={BlankSlateImage} className="blankslate-image" alt="" />
       No commit selected
     </div>
   )

--- a/app/src/ui/no-repositories/no-repositories-view.tsx
+++ b/app/src/ui/no-repositories/no-repositories-view.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { UiView } from '../ui-view'
 import { Button } from '../lib/button'
@@ -143,10 +142,12 @@ export class NoRepositoriesView extends React.Component<
         <img
           className="no-repositories-graphic-top"
           src={WelcomeLeftTopImageUri}
+          alt=""
         />
         <img
           className="no-repositories-graphic-bottom"
           src={WelcomeLeftBottomImageUri}
+          alt=""
         />
       </UiView>
     )

--- a/app/src/ui/notifications/pull-request-checks-failed.tsx
+++ b/app/src/ui/notifications/pull-request-checks-failed.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { Dialog, DialogContent, DialogFooter } from '../dialog'
 import { Row } from '../lib/row'
@@ -222,7 +221,7 @@ export class PullRequestChecksFailed extends React.Component<
   private renderCheckRunStepsLoading(): JSX.Element {
     return (
       <div className="loading-check-runs">
-        <img src={BlankSlateImage} className="blankslate-image" />
+        <img src={BlankSlateImage} className="blankslate-image" alt="" />
         <div className="title">Stand By</div>
         <div className="call-to-action">Check run steps incoming!</div>
       </div>
@@ -239,7 +238,7 @@ export class PullRequestChecksFailed extends React.Component<
             </LinkButton>
           </div>
         </div>
-        <img src={PaperStackImage} className="blankslate-image" />
+        <img src={PaperStackImage} className="blankslate-image" alt="" />
       </div>
     )
   }

--- a/app/src/ui/release-notes/release-notes-dialog.tsx
+++ b/app/src/ui/release-notes/release-notes-dialog.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { ReleaseNote, ReleaseSummary } from '../../models/release-notes'
 import { updateStore } from '../lib/update-store'
@@ -173,6 +172,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         <img
           className="release-note-graphic-left"
           src={ReleaseNoteHeaderLeftUri}
+          alt=""
         />
         <div className="title">
           <p className="version">Version {latestVersion}</p>
@@ -181,6 +181,7 @@ export class ReleaseNotes extends React.Component<IReleaseNotesProps, {}> {
         <img
           className="release-note-graphic-right"
           src={ReleaseNoteHeaderRightUri}
+          alt=""
         />
       </div>
     )

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 
 import { RepositoryListItem } from './repository-list-item'
@@ -253,7 +252,7 @@ export class RepositoriesList extends React.Component<
   private renderNoItems = () => {
     return (
       <div className="no-items no-results-found">
-        <img src={BlankSlateImage} className="blankslate-image" />
+        <img src={BlankSlateImage} className="blankslate-image" alt="" />
         <div className="title">Sorry, I can't find that repository</div>
 
         <div className="protip">

--- a/app/src/ui/thank-you/thank-you.tsx
+++ b/app/src/ui/thank-you/thank-you.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { DesktopFakeRepository } from '../../lib/desktop-fake-repository'
 import {
@@ -67,11 +66,13 @@ export class ThankYou extends React.Component<IThankYouProps, {}> {
           <img
             className="release-note-graphic-left"
             src={ReleaseNoteHeaderLeftUri}
+            alt=""
           />
           <div className="img-space"></div>
           <img
             className="release-note-graphic-right"
             src={ReleaseNoteHeaderRightUri}
+            alt=""
           />
         </div>
         <div className="title">

--- a/app/src/ui/tutorial/done.tsx
+++ b/app/src/ui/tutorial/done.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 
 import { encodePathAsUrl } from '../../lib/path'
@@ -40,7 +39,11 @@ export class TutorialDone extends React.Component<ITutorialDoneProps, {}> {
                 some suggestions for what to do next.
               </p>
             </div>
-            <img src={ClappingHandsImage} className="image" />
+            <img
+              src={ClappingHandsImage}
+              className="image"
+              alt="Hands clapping"
+            />
           </div>
           <SuggestedActionGroup>
             <SuggestedAction

--- a/app/src/ui/tutorial/tutorial-panel.tsx
+++ b/app/src/ui/tutorial/tutorial-panel.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import { join } from 'path'
 import { LinkButton } from '../lib/link-button'
@@ -101,7 +100,7 @@ export class TutorialPanel extends React.Component<
       <div className="tutorial-panel-component panel">
         <div className="titleArea">
           <h3>Get started</h3>
-          <img src={TutorialPanelImage} />
+          <img src={TutorialPanelImage} alt="Partially checked check list" />
         </div>
         <ol>
           <TutorialStepInstructions

--- a/app/src/ui/tutorial/welcome.tsx
+++ b/app/src/ui/tutorial/welcome.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 
 import { encodePathAsUrl } from '../../lib/path'
@@ -26,20 +25,23 @@ export class TutorialWelcome extends React.Component {
         </div>
         <ul className="definitions">
           <li>
-            <img src={CodeImage} />
+            <img src={CodeImage} alt="Html syntax icon" />
             <p>
               <strong>Git</strong> is the version control system.
             </p>
           </li>
           <li>
-            <img src={TeamDiscussionImage} />
+            <img
+              src={TeamDiscussionImage}
+              alt="People with discussion bubbles overhead"
+            />
             <p>
               <strong>GitHub</strong> is where you store your code and
               collaborate with others.
             </p>
           </li>
           <li>
-            <img src={CloudServerImage} />
+            <img src={CloudServerImage} alt="Server stack with cloud" />
             <p>
               <strong>GitHub Desktop</strong> helps you work with GitHub
               locally.

--- a/app/src/ui/welcome/welcome.tsx
+++ b/app/src/ui/welcome/welcome.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/alt-text */
 import * as React from 'react'
 import classNames from 'classnames'
 
@@ -204,16 +203,21 @@ export class Welcome extends React.Component<IWelcomeProps, IWelcomeState> {
         <div className="welcome-left">
           <div className="welcome-content">
             {this.getComponentForCurrentStep()}
-            <img className="welcome-graphic-top" src={WelcomeLeftTopImageUri} />
+            <img
+              className="welcome-graphic-top"
+              src={WelcomeLeftTopImageUri}
+              alt=""
+            />
             <img
               className="welcome-graphic-bottom"
               src={WelcomeLeftBottomImageUri}
+              alt=""
             />
           </div>
         </div>
 
         <div className="welcome-right">
-          <img className="welcome-graphic" src={WelcomeRightImageUri} />
+          <img className="welcome-graphic" src={WelcomeRightImageUri} alt="" />
         </div>
       </UiView>
     )


### PR DESCRIPTION
## Description
This PR builds on #15159 and adds an `alt` tag to all of our images to fix the alt-text rule. This was fairly simple as the vast majority of our images are background/decorative images that just require adding `alt=""` as the images are not informative.

This addresses 30 of the 112 issues flagged by the accessibility linter.

## Release notes
Notes: no-notes
