### PR TITLE
Markdown Linting fixed and added to lint call

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,42 +8,44 @@ documentation.
 If you are interested in contributing to the project, you should read these
 resources to get familiar with how things work:
 
- - **[How Can I Contribute?](../.github/CONTRIBUTING.md#how-can-i-contribute)** -
-    details about how you can participate
- - **[Development Environment Setup](contributing/setup.md)** - everything
-    you need to know to get Desktop up and running
- - **[Engineering Values](contributing/engineering-values.md)** - our high-level engineering values
- - **[Style Guide](contributing/styleguide.md)** - notes on the coding style
- - **[Tooling](contributing/tooling.md)** - if you have a preferred IDE,
-    there's some enhancements to make your life easier
- - **[Troubleshooting](contributing/troubleshooting.md)** - some additional
-    known issues if you're having environment issues
+- **[How Can I Contribute?](../.github/CONTRIBUTING.md#how-can-i-contribute)** -
+   details about how you can participate
+- **[Development Environment Setup](contributing/setup.md)** - everything
+   you need to know to get Desktop up and running
+- **[Engineering Values](contributing/engineering-values.md)** - our high-level
+engineering values
+- **[Style Guide](contributing/styleguide.md)** - notes on the coding style
+- **[Tooling](contributing/tooling.md)** - if you have a preferred IDE,
+   there's some enhancements to make your life easier
+- **[Troubleshooting](contributing/troubleshooting.md)** - some additional
+   known issues if you're having environment issues
 
 ## Process
 
 Details about how the team is organizing and shipping GitHub Desktop:
 
- - **[Roadmap](process/roadmap.md)** - the future as planned so far
- - **[Release Planning](process/release-planning.md)** - how we plan and execute
-    releases
- - **[Issue Triage](process/issue-triage.md)** - how we address issues reported
-    by users
- - **[Pull Requests](process/pull-requests.md)** - how code contributions are submitted and reviewed
- - **[Releasing Updates](process/releasing-updates.md)** - how we deploy things
+- **[Roadmap](process/roadmap.md)** - the future as planned so far
+- **[Release Planning](process/release-planning.md)** - how we plan and execute
+   releases
+- **[Issue Triage](process/issue-triage.md)** - how we address issues reported
+   by users
+- **[Pull Requests](process/pull-requests.md)** - how code contributions are
+submitted and reviewed
+- **[Releasing Updates](process/releasing-updates.md)** - how we deploy things
 
 ## Technical
 
 These documents contain more details about the internals of GitHub Desktop
 and how things work:
 
- - **[Dialogs](technical/dialogs.md)** - details about the dialog component API
- - **[Windows menu bar](technical/windows-menu-bar.md)** - Electron doesn't
-    provide inbuilt support for styling the menu for Windows, so we've created
-    our own custom components to achieve this.
- - **[Developer OAuth App](technical/oauth.md)** - GitHub Desktop ships with
-    the ability to OAuth on behalf of a user. A developer OAuth app is bundled
-    to reduce the friction of getting started.
- - **[Building and Packaging Desktop](technical/packaging.md)** - Outlines how
-    Desktop is currently packaged for all platforms 
- - **[Automatic Git Proxy support](technical/proxies.md)** - A pre-launch overview
-    and troubleshooting guide for the Git automatic proxy support in GitHub Desktop.
+- **[Dialogs](technical/dialogs.md)** - details about the dialog component API
+- **[Windows menu bar](technical/windows-menu-bar.md)** - Electron doesn't
+   provide inbuilt support for styling the menu for Windows, so we've created
+   our own custom components to achieve this.
+- **[Developer OAuth App](technical/oauth.md)** - GitHub Desktop ships with
+   the ability to OAuth on behalf of a user. A developer OAuth app is bundled
+   to reduce the friction of getting started.
+- **[Building and Packaging Desktop](technical/packaging.md)** - Outlines how
+   Desktop is currently packaged for all platforms
+- **[Automatic Git Proxy support](technical/proxies.md)** - A pre-launch overview
+   and troubleshooting guide for the Git automatic proxy support in GitHub Desktop.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,44 +1,69 @@
 # Installing GitHub Desktop
 
-GitHub Desktop currently supports Windows 7 (or higher) and macOS 10.9 (or higher).
+GitHub Desktop currently supports Windows 7 (or higher) and
+macOS 10.9 (or higher).
 
-### macOS
+## macOS
 
-Download the `GitHub Desktop.zip`, unpack the application and put it wherever you want.
+Download the `GitHub Desktop.zip`, unpack the application and put it wherever
+you want.
 
-### Windows
+## Windows
 
 On Windows you have two options:
 
- - Download the `GitHubDesktopSetup.exe` and run it to install it for the current user.
- - Download the `GitHubDesktopSetup.msi` and run it to install a machine-wide version of GitHub Desktop - each logged-in user will then be able to run GitHub Desktop from the program at `%PROGRAMFILES(x86)\GitHub Desktop Installer\desktop.exe`.
+- Download the `GitHubDesktopSetup.exe` and run it to install it for the
+ current user.
+- Download the `GitHubDesktopSetup.msi` and run it to install a machine-wide
+ version of GitHub Desktop - each logged-in user will then be able to run
+ GitHub Desktop from the program at
+ `%PROGRAMFILES(x86)\GitHub Desktop Installer\desktop.exe`.
 
 ## Data Directories
 
-GitHub Desktop will create directories to manage the files and data it needs to function. If you manage a network of computers and want to install GitHub Desktop, here is more information about how things work.
+GitHub Desktop will create directories to manage the files and data it needs to
+function. If you manage a network of computers and want to install GitHub
+Desktop, here is more information about how things work.
 
 ### macOS
- - `~/Library/Application Support/GitHub Desktop/` - this directory contains user-specific data which the application requires to run, and is created on launch if it doesn't exist. Log files are also stored in this location.
+
+- `~/Library/Application Support/GitHub Desktop/` - this directory contains
+user-specific data which the application requires to run, and is created on
+launch if it doesn't exist. Log files are also stored in this location.
 
 ### Windows
 
- - `%LOCALAPPDATA%\GitHubDesktop\` - contains the latest versions of the app, and some older versions if the user has updated from a previous version.
- - `%APPDATA%\GitHub Desktop\` - this directory contains user-specific data which the application requires to run, and is created on launch if it doesn't exist. Log files are also stored in this location.
+- `%LOCALAPPDATA%\GitHubDesktop\` - contains the latest versions of the app,
+ and some older versions if the user has updated from a previous version.
+- `%APPDATA%\GitHub Desktop\` - this directory contains user-specific data
+ which the application requires to run, and is created on launch if it doesn't
+ exist. Log files are also stored in this location.
 
 ## Log Files
 
-GitHub Desktop will generate logs as part of its normal usage, to assist with troubleshooting. They are located in the data directory that GitHub Desktop uses (see above) under a `logs` subdirectory, organized by date using the format `YYYY-MM-DD.desktop.production.log`, where `YYYY-MM-DD` is the day the log was created.
+GitHub Desktop will generate logs as part of its normal usage, to assist with
+troubleshooting. They are located in the data directory that GitHub Desktop
+uses (see above) under a `logs` subdirectory, organized by date using the
+format `YYYY-MM-DD.desktop.production.log`, where `YYYY-MM-DD` is the day
+the log was created.
 
 ## Installer Logs
 
-Problems with installing or updating GitHub Desktop are tracked in a separate file which is managed by the updater frameworks used in the app.
+Problems with installing or updating GitHub Desktop are tracked in a separate
+file which is managed by the updater frameworks used in the app.
 
 ### macOS
 
- - `~/Library/Caches/com.github.GitHubClient.ShipIt/ShipIt_stderr.log` - this file will contain details about why the installation or update failed - check the end of the file for recent activity.
+- `~/Library/Caches/com.github.GitHubClient.ShipIt/ShipIt_stderr.log` - this
+  file will contain details about why the installation or update failed -
+  check the end of the file for recent activity.
 
 ### Windows
 
- - `%LOCALAPPDATA%\GitHubDesktop\SquirrelSetup.log` - this file will contain details about update attempts for GitHub Desktop after it's been successfully installed.
- - `%LOCALAPPDATA%\SquirrelSetup.log` - information about the initial installation may be found here. As this framework is used by different apps, it may also contain details about other apps. Ensure that you focus on mentions of `GitHubDesktop.exe` in the log.
-
+- `%LOCALAPPDATA%\GitHubDesktop\SquirrelSetup.log` - this file will contain
+ details about update attempts for GitHub Desktop after it's been successfully
+ installed.
+- `%LOCALAPPDATA%\SquirrelSetup.log` - information about the initial
+ installation may be found here. As this framework is used by different apps,
+ it may also contain details about other apps. Ensure that you focus on mentions
+  of `GitHubDesktop.exe` in the log.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,13 +25,13 @@ GitHub Desktop will create directories to manage the files and data it needs to
 function. If you manage a network of computers and want to install GitHub
 Desktop, here is more information about how things work.
 
-### macOS
+On macOs,
 
 - `~/Library/Application Support/GitHub Desktop/` - this directory contains
 user-specific data which the application requires to run, and is created on
 launch if it doesn't exist. Log files are also stored in this location.
 
-### Windows
+On Windows,
 
 - `%LOCALAPPDATA%\GitHubDesktop\` - contains the latest versions of the app,
  and some older versions if the user has updated from a previous version.
@@ -52,13 +52,13 @@ the log was created.
 Problems with installing or updating GitHub Desktop are tracked in a separate
 file which is managed by the updater frameworks used in the app.
 
-### macOS
+On macOS,
 
 - `~/Library/Caches/com.github.GitHubClient.ShipIt/ShipIt_stderr.log` - this
   file will contain details about why the installation or update failed -
   check the end of the file for recent activity.
 
-### Windows
+On Windows,
 
 - `%LOCALAPPDATA%\GitHubDesktop\SquirrelSetup.log` - this file will contain
  details about update attempts for GitHub Desktop after it's been successfully

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ GitHub Desktop will create directories to manage the files and data it needs to
 function. If you manage a network of computers and want to install GitHub
 Desktop, here is more information about how things work.
 
-On macOs,
+On macOS,
 
 - `~/Library/Application Support/GitHub Desktop/` - this directory contains
 user-specific data which the application requires to run, and is created on

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,8 +1,14 @@
-# Table of contents
+
+# Known Issues
+
+This document outlines acknowledged issues with GitHub Desktop, including
+workarounds if known.
+
+## Table of contents
 
 - [macOS](#macos)
-  - ['The username or passphrase you entered is not correct' error after signing into account](#the-username-or-passphrase-you-entered-is-not-correct-error-after-signing-into-account)
-  - [Checking for updates triggers a 'Could not create temporary directory: Permission denied' message](#checking-for-updates-triggers-a-could-not-create-temporary-directory-permission-denied-message)
+  - ['The username or passphrase you entered is not correct' error](#the-username-or-passphrase-you-entered-is-not-correct-error)
+  - ['Could not create temporary directory: Permission denied' message](#could-not-create-temporary-directory-permission-denied-message)
 - [Windows](#windows)
   - [Window is hidden after detaching secondary monitor](#window-is-hidden-after-detaching-secondary-monitor)
   - [Certificate revocation check fails](#certificate-revocation-check-fails)
@@ -12,31 +18,37 @@
   - [Failed to open CA file after an update](#failed-to-open-ca-file-after-an-update)
   - [Authentication errors due to modified registry entries](#authentication-errors-due-to-modified-registry-entries)
 
-# Known Issues
-
-This document outlines acknowledged issues with GitHub Desktop, including workarounds if known.
-
-## What should I do if...
+## What should I do if…
 
 ### I have encountered an issue listed here?
 
-Some known issues have a workaround that users have reported addresses the issue. Please try the workaround for yourself to confirm it addresses the issue.
+Some known issues have a workaround that users have reported addresses the
+issue. Please try the workaround for yourself to confirm it addresses the issue.
 
 ### I have additional questions about an issue listed here?
 
-Each known issue links off to an existing GitHub issue. If you have additional questions or feedback, please comment on the issue.
+Each known issue links off to an existing GitHub issue. If you have additional
+questions or feedback, please comment on the issue.
 
 ### My issue is not listed here?
 
-Please check the [open](https://github.com/desktop/desktop/labels/bug) and [closed](https://github.com/desktop/desktop/issues?q=is%3Aclosed+label%3Abug) bugs in the issue tracker for the details of your bug. If you can't find it, or if you're not sure, open a [new issue](https://github.com/desktop/desktop/issues/new?template=bug_report.md).
+Please check the [open](https://github.com/desktop/desktop/labels/bug) and
+[closed](https://github.com/desktop/desktop/issues?q=is%3Aclosed+label%3Abug)
+bugs in the issue tracker for the details of your bug. If you can't find it,
+or if you're not sure, open a [new issue](https://github.com/desktop/desktop/issues/new?template=bug_report.md).
 
 ## macOS
 
-### 'The username or passphrase you entered is not correct' error after signing into account
+### 'The username or passphrase you entered is not correct' error
+
+(after signing into account)
 
 Related issue: [#3263](https://github.com/desktop/desktop/issues/3263)
 
-This seems to be caused by the Keychain being in an invalid state, affecting applications that try to use the keychain to store or retrieve credentials. This has been reported from macOS High Sierra 10.13 (17A365) to macOS Mojave 10.14.5 (18F132).
+This seems to be caused by the Keychain being in an invalid state, affecting
+applications that try to use the keychain to store or retrieve credentials.
+This has been reported from macOS High Sierra 10.13 (17A365) to
+macOS Mojave 10.14.5 (18F132).
 
 **Workaround:**
 
@@ -45,21 +57,26 @@ This seems to be caused by the Keychain being in an invalid state, affecting app
 - Right-click on the `login` keychain and try unlocking it
 - Sign into your GitHub account again
 
-### Checking for updates triggers a 'Could not create temporary directory: Permission denied' message
+### 'Could not create temporary directory: Permission denied' message
+
+Triggered by checking for updates
 
 Related issue: [#4115](https://github.com/desktop/desktop/issues/4115)
 
-This issue seems to be caused by missing permissions for the `~/Library/Caches/com.github.GitHubClient.ShipIt` folder. This is a directory that Desktop uses to create and unpack temporary files as part of updating the application.
+This issue seems to be caused by missing permissions for
+the `~/Library/Caches/com.github.GitHubClient.ShipIt` folder. This is a
+directory that Desktop uses to create and unpack temporary files as part of
+updating the application.
 
 **Workaround:**
 
- - Close Desktop
- - Open Finder and navigate to `~/Library/Caches/`
- - Context-click `com.github.GitHubClient.ShipIt` and select **Get Info**
- - Expand the **Sharing & Permissions** section
- - If you do not see the "You can read and write" message, add yourself with
-   the "Read & Write" permissions
- - Start Desktop again and check for updates
+- Close Desktop
+- Open Finder and navigate to `~/Library/Caches/`
+- Context-click `com.github.GitHubClient.ShipIt` and select **Get Info**
+- Expand the **Sharing & Permissions** section
+- If you do not see the "You can read and write" message, add yourself with
+  the "Read & Write" permissions
+- Start Desktop again and check for updates
 
 ## Windows
 
@@ -67,45 +84,59 @@ This issue seems to be caused by missing permissions for the `~/Library/Caches/c
 
 Related issue: [#2107](https://github.com/desktop/desktop/issues/2107)
 
-This is related to Desktop tracking the window position between launches, but not changes to your display configuration such as removing the secondary monitor where Desktop was positioned.
+This is related to Desktop tracking the window position between launches,
+but not changes to your display configuration such as removing the secondary
+monitor where Desktop was positioned.
 
 **Workaround:**
 
- - Remove `%APPDATA%\GitHub Desktop\window-state.json`
- - Restart Desktop
+- Remove `%APPDATA%\GitHub Desktop\window-state.json`
+- Restart Desktop
 
 ### Certificate revocation check fails
 
 Related issue: [#3326](https://github.com/desktop/desktop/issues/3326)
 
-If you are using Desktop on a corporate network, you may encounter an error like this:
+If you are using Desktop on a corporate network, you may encounter an error
+like this:
 
-```
-fatal: unable to access 'https://github.com/owner/name.git/': schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.
-```
+> fatal: unable to access 'https://github.com/owner/name.git/': schannel:
+next InitializeSecurityContext failed: Unknown error (0x80092012) -
+The revocation function was unable to check revocation for the certificate.
 
-GitHub Desktop by default uses the Windows Secure Channel (SChannel) APIs to validate the certificate received from a server. Some networks will block the attempts by Windows to check the revocation status of a certificate, which then causes the whole operation to error.
+GitHub Desktop by default uses the Windows Secure Channel (SChannel) APIs to
+ validate the certificate received from a server. Some networks will block the
+ attempts by Windows to check the revocation status of a certificate, which
+  then causes the whole operation to error.
 
 **Workaround:**
 
-**We do not recommend setting this config value for normal Git usage**. This is intended to be an "escape hatch" for situations where the network administrator has restricted the normal usage of SChannel APIs on Windows that Git is trying to use.
+**We do not recommend setting this config value for normal Git usage**. This is
+ intended to be an "escape hatch" for situations where the network administrator
+has restricted the normal usage of SChannel APIs on Windows that Git is trying
+to use.
 
 Run this command in your Git shell to disable the revocation check:
 
 ```shellsession
-$ git config --global http.schannelCheckRevoke false
+git config --global http.schannelCheckRevoke false
 ```
 
 ### Using a repository configured with Folder Redirection
 
 Related issue: [#2972](https://github.com/desktop/desktop/issues/2972)
 
-[Folder Redirection](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc753996(v%3dws.11)) is a feature of Windows for administrators to ensure files and folders are managed on a network server, instead.
+[Folder Redirection](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc753996(v%3dws.11))
+is a feature of Windows for administrators to ensure files and folders are
+managed on a network server, instead.
 
 **Not supported** as Git is not able to resolve the working directory correctly:
 
 ```shellsession
-2017-09-21T23:16:05.933Z - error: [ui] `git -c credential.helper= lfs clone --recursive --progress --progress -- https://github.com/owner/name.git \\harvest\Redirected\andrewd\My Documents\GitHub\name` exited with an unexpected code: 2.
+2017-09-21T23:16:05.933Z - error: [ui] `git -c credential.helper= lfs clone
+--recursive --progress --progress -- https://github.com/owner/name.git
+\\harvest\Redirected\andrewd\My Documents\GitHub\name` exited with an unexpected
+ code: 2.
 Cloning into '\\harvest\Redirected\andrewd\My Documents\GitHub\name'...
 remote: Counting objects: 4, done.
 remote: Compressing objects:  33% (1/3)
@@ -126,10 +157,14 @@ git clone failed: exit status 128
 
 Related issue: [#3096](https://github.com/desktop/desktop/issues/3096)
 
-Windows 10 Fall Creators Edition (version 1709 or later) added enhancements to the Enhanced Mitigation Experience Toolkit, one being to enable Mandatory ASLR. This setting affects the embedded Git shipped in Desktop, and produces errors that look like this:
+Windows 10 Fall Creators Edition (version 1709 or later) added enhancements to
+the Enhanced Mitigation Experience Toolkit, one being to enable Mandatory ASLR.
+This setting affects the embedded Git shipped in Desktop, and produces errors
+that look like this:
 
-```
-      1 [main] sh (2072) C:\Users\bdorrans\AppData\Local\GitHubDesktop\app-1.0.4\resources\app\git\usr\bin\sh.exe: *** fatal error - cygheap base mismatch detected - 0x2E07408/0x2EC7408.
+``` shellsession
+1 [main] sh (2072) C:\Users\bdorrans\AppData\Local\GitHubDesktop\app-1.0.4\resources\app\git\usr\bin\sh.exe:
+ *** fatal error - cygheap base mismatch detected - 0x2E07408/0x2EC7408.
 This problem is probably due to using incompatible versions of the cygwin DLL.
 Search for cygwin1.dll using the Windows Start->Find/Search facility
 and delete all but the most recent version.  The most recent version *should*
@@ -138,17 +173,25 @@ installed the cygwin distribution.  Rebooting is also suggested if you
 are unable to find another cygwin DLL.
 ```
 
-Enabling Mandatory ASLR affects the MSYS2 core library, which is relied upon by Git for Windows to emulate process forking.
+Enabling Mandatory ASLR affects the MSYS2 core library, which is relied upon
+by Git for Windows to emulate process forking.
 
-**Not supported:** this is an upstream limitation of MSYS2, and it is recommended that you either disable Mandatory ASLR or explicitly allow all executables under `<Git>\usr\bin` which depend on MSYS2.
+**Not supported:** this is an upstream limitation of MSYS2, and it is
+recommended that you either disable Mandatory ASLR or explicitly allow all
+executables under `<Git>\usr\bin` which depend on MSYS2.
 
 ### I get a black screen when launching Desktop
 
 Related issue: [#3921](https://github.com/desktop/desktop/issues/3921)
 
-Electron enables hardware accelerated graphics by default, but some graphics cards have issues with hardware acceleration which means the application will launch successfully but it will be a black screen.
+Electron enables hardware accelerated graphics by default, but some graphics
+cards have issues with hardware acceleration which means the application will
+launch successfully but it will be a black screen.
 
-**Workaround:** if you set the `GITHUB_DESKTOP_DISABLE_HARDWARE_ACCELERATION` environment variable to any value and launch Desktop again it will disable hardware acceleration on launch, so the application is usable. Here are the steps to set the environment variable in PowerShell:
+**Workaround:** if you set the `GITHUB_DESKTOP_DISABLE_HARDWARE_ACCELERATION`
+environment variable to any value and launch Desktop again it will disable
+hardware acceleration on launch, so the application is usable. Here are the
+steps to set the environment variable in PowerShell:
 
 1. Open PowerShell
 2. Run the command `$env:GITHUB_DESKTOP_DISABLE_HARDWARE_ACCELERATION=1`
@@ -162,32 +205,44 @@ A recent upgrade to Git for Windows changed how it uses `http.sslCAInfo`.
 
 An example of this error:
 
-> fatal: unable to access 'https://github.com/\<owner>/\<repo>.git/': schannel: failed to open CA file 'C:/Users/\<account>/AppData/Local/GitHubDesktop/app-1.2.2/resources/app/git/mingw64/bin/curl-ca-bundle.crt': No such file or directory
+> fatal: unable to access 'https://github.com/\<owner>/\<repo>.git/': schannel:
+failed to open CA file 'C:/Users/\<account>/AppData/Local/GitHubDesktop/app-1.2.2/resources/app/git/mingw64/bin/curl-ca-bundle.crt':
+No such file or directory
 
-This is occurring because some users have an existing Git for Windows installation that created a special config at `C:\ProgramData\Git\config`, and this config may contain an `http.sslCAInfo` entry, which is inherited by Desktop.
+This is occurring because some users have an existing Git for Windows
+installation that created a special config at `C:\ProgramData\Git\config`,
+and this config may contain an `http.sslCAInfo` entry, which is inherited
+by Desktop.
 
 There's two problems with this current state:
 
- - Desktop doesn't need custom certificates for its Git operations - it uses SChannel by default, which uses the Windows Certificate Store to verify server certificates
- - this `http.sslCAInfo` config value may resolve to a location or file that doesn't exist in Desktop's Git installation
+- Desktop doesn't need custom certificates for its Git operations - it uses
+SChannel by default, which uses the Windows Certificate Store to verify server
+certificates, and
+- this `http.sslCAInfo` config value may resolve to a location or file that
+doesn't exist in Desktop's Git installation.
 
-**Workaround:**
+#### Verify
 
-1. Verify that you have the problem configuration by checking the output of this command:
+Start by verifying that you have the problem configuration by checking the output
+of this command:
 
-```
+``` sh
 > git config -l --show-origin
 ```
 
 You should have an entry that looks like this:
 
-```
+``` sh
 file:"C:\ProgramData/Git/config" http.sslcainfo=[some value here]
 ```
 
-2. Open `C:\ProgramData\Git\config` (requires elevated privileges) and remove the corresponding lines that look like this:
+#### Workaround
 
-```
+Open `C:\ProgramData\Git\config` (requires elevated privileges) and remove
+the corresponding lines that look like this:
+
+``` sh
 [http]
 sslCAInfo = [some value here]
 ```
@@ -196,9 +251,13 @@ sslCAInfo = [some value here]
 
 Related issue: [#2623](https://github.com/desktop/desktop/issues/2623)
 
-If either the user or an application has modified the `Command Processor` registry entries it can cause GitHub Desktop to throw an `Authentication failed` error. To check if these registry entries have been modified open the Registry Editor (regedit.exe) and navigate to the following locations:
+If either the user or an application has modified the `Command Processor`
+registry entries it can cause GitHub Desktop to throw an `Authentication failed`
+ error. To check if these registry entries have been modified open the
+ Registry Editor (regedit.exe) and navigate to the following locations:
 
 `HKEY_CURRENT_USER\Software\Microsoft\Command Processor\`
 `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Command Processor\`
 
-Check to see if there is an `Autorun` value in either of those location. If there is, deleting that value should resolve the `Authentication failed` error.
+Check to see if there is an `Autorun` value in either of those location. If
+there is, deleting that value should resolve the `Authentication failed` error.

--- a/eslint-rules/README.md
+++ b/eslint-rules/README.md
@@ -1,54 +1,69 @@
 # Custom ESLint rules for GitHub Desktop
 
-This document outlines the rules we have added to the GitHub Desktop project and how to interact with them.
+This document outlines the rules we have added to the GitHub Desktop project
+and how to interact with them.
 
 ## About
 
-This project uses rules from a number of sources, but sometimes we need specific rules that aren't available elsewhere. These are added to the `eslint-rules/` directory and are configured in the `.eslintrc.yml` file at the root of the project.
+This project uses rules from a number of sources, but sometimes we need
+specific rules that aren't available elsewhere. These are added to
+the `eslint-rules/` directory and are configured in the `.eslintrc.yml`
+file at the root of the project.
 
 ## Adding rules
 
-If you wish to add a new rule specific to the project, ensure that there isn't an existing rule available from one of the existing plugins used in the project:
+If you wish to add a new rule specific to the project, ensure that there
+isn't an existing rule available from one of the existing plugins used
+in the project:
 
- - `@typescript-eslint/eslint-plugin`
- - `eslint-plugin-babel`
- - `eslint-plugin-jsdoc`
- - `eslint-plugin-json`
- - `eslint-plugin-prettier`
- - `eslint-plugin-react`
- 
-This project supports two different kinds of ESLint plugins, based on what you are interested in linting:
+- `@typescript-eslint/eslint-plugin`
+- `eslint-plugin-babel`
+- `eslint-plugin-jsdoc`
+- `eslint-plugin-json`
+- `eslint-plugin-prettier`
+- `eslint-plugin-react`
 
- - Typescript-aware rules, that allow you to inspect the AST and relevant information of the source files - these leverage the `@typescript-eslint` parser
-    - example: `react-proper-lifecycle-methods` rule
- - Regular ESLint rules, that do not need to inspect the type information in the source files
-    - example: `no-unbound-dispatcher-props` rule
+This project supports two different kinds of ESLint plugins, based on what
+you are interested in linting:
 
-How to write a plugin is out of scope for this documentation, but I've added some resources at the end of this page to help you get started.
+- Typescript-aware rules, that allow you to inspect the AST and relevant
+information of the source files - these leverage the `@typescript-eslint` parser
+  - example: `react-proper-lifecycle-methods` rule
+- Regular ESLint rules, that do not need to inspect the type information in
+the source files
+  - example: `no-unbound-dispatcher-props` rule
+
+How to write a plugin is out of scope for this documentation, but I've added
+some resources at the end of this page to help you get started.
 
 ## Checking locally
 
-The custom ESLint rules are annotated with TypeScript types wherever available, and can be checked through `yarn`:
+The custom ESLint rules are annotated with TypeScript types wherever
+available, and can be checked through `yarn`:
 
-```
-$ yarn check:eslint
+``` sh
+yarn check:eslint
 ```
 
-The `eslint-rules/tsconfig.json` is setup to guide `tsc` to understand the environment for running the ESlint rules, and each rule is annotated
+The `eslint-rules/tsconfig.json` is setup to guide `tsc` to understand the
+environment for running the ESlint rules, and each rule is annotated
 with `@type` hints wherever possible to appease the typechecker.
 
 ## Testing locally
 
-Tests are added alongside each rule in the `eslint-rules/tests/` section, and can be run from the project root through `yarn`:
+Tests are added alongside each rule in the `eslint-rules/tests/` section,
+and can be run from the project root through `yarn`:
 
+``` sh
+yarn test:eslint
 ```
-$ yarn test:eslint
-```
 
-Each test suite is designed to exercise the relevant rule against code snippets that illustrate both valid and invalid code, and indicate which messages should be reported in case of failure.
+Each test suite is designed to exercise the relevant rule against code snippets
+that illustrate both valid and invalid code, and indicate which messages should
+be reported in case of failure.
 
-If you wish to debug the rules using VSCode, add this action to the `configurations` array of the `.vscode/launch.json` settings:
-
+If you wish to debug the rules using VSCode, add this action to
+the `configurations` array of the `.vscode/launch.json` settings:
 
 ```json
 {
@@ -59,9 +74,12 @@ If you wish to debug the rules using VSCode, add this action to the `configurati
 }
 ```
 
-Running this command will attach the debugger, and allow you to step through the rule with the available test cases.
+Running this command will attach the debugger, and allow you to step through
+the rule with the available test cases.
 
 ## Additional resources
 
- - [ESLint - Working with Rules](http://eslint.org/docs/developer-guide/working-with-rules)
- - [`typescript-estree` package](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/typescript-estree) - this is part of `@typescript-eslint` and allows for interop between Typescript code and the `estree` reference spec that ESLint uses for it's plugins.
+- [ESLint - Working with Rules](http://eslint.org/docs/developer-guide/working-with-rules)
+- [`typescript-estree` package](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/typescript-estree)
+  - This is part of `@typescript-eslint`and allows for interop between
+  Typescript code and the `estree` reference spec that ESLint uses for it's plugins.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package": "ts-node -P script/tsconfig.json script/package.ts",
     "generate-octicons": "ts-node -P script/tsconfig.json script/generate-octicons.ts",
     "compile:script": "tsc -P script/tsconfig.json",
-    "lint": "yarn prettier && yarn lint:src",
+    "lint": "yarn prettier && yarn lint:src && yarn markdownlint",
     "lint:fix": "yarn prettier --write && yarn lint:src:fix",
     "markdownlint": "markdownlint **/*.{md,mdx} --config .markdownlint.js --rules node_modules/@github/markdownlint-github --ignore node_modules --ignore gemoji",
     "prettier": "prettier --check \"./**/*.{ts,tsx,js,json,jsx,scss,html,yaml,yml}\"",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "compile:script": "tsc -P script/tsconfig.json",
     "lint": "yarn prettier && yarn lint:src && yarn markdownlint",
     "lint:fix": "yarn prettier --write && yarn lint:src:fix",
-    "markdownlint": "markdownlint **/*.{md,mdx} --config .markdownlint.js --rules node_modules/@github/markdownlint-github --ignore node_modules --ignore gemoji",
+    "markdownlint": "markdownlint **/*.{md,mdx} --config .markdownlint.js --rules node_modules/@github/markdownlint-github --ignore node_modules --ignore app/node_modules --ignore gemoji",
     "prettier": "prettier --check \"./**/*.{ts,tsx,js,json,jsx,scss,html,yaml,yml}\"",
     "lint:src": "yarn eslint-check && yarn eslint",
     "lint:src:fix": "yarn eslint --fix",


### PR DESCRIPTION
Builds on #15159 by addressing through our markdown linting errors. It is mostly line length errors, but some heading, list, and code fence formatting. This also adds the markdown lint call to our regular lint call so that future markdown written will be flagged in our ci checks.
