### PR TITLE
Add Learn more link to Commit Reachability Dialog

### DIFF
--- a/app/src/ui/history/unreachable-commits-dialog.tsx
+++ b/app/src/ui/history/unreachable-commits-dialog.tsx
@@ -4,6 +4,7 @@ import { TabBar } from '../tab-bar'
 import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
 import { Commit } from '../../models/commit'
 import { CommitList } from './commit-list'
+import { LinkButton } from '../lib/link-button'
 
 export enum UnreachableCommitsTab {
   Unreachable,
@@ -127,7 +128,10 @@ export class UnreachableCommitsDialog extends React.Component<
         {this.state.selectedTab === UnreachableCommitsTab.Unreachable
           ? 'not'
           : ''}{' '}
-        in the ancestry path of the most recent commit in your selection.
+        in the ancestry path of the most recent commit in your selection.{' '}
+        <LinkButton uri="https://github.com/desktop/desktop/blob/development/docs/learn-more/unreachable-commits.md">
+          Learn more.
+        </LinkButton>
       </div>
     )
   }


### PR DESCRIPTION
## Description
Based on feedback from usability tests of multi commit diffing, we added a learn-more doc on why some commits may be unreachable. This PR adds a learn more link to the dialog to this doc.

### Screenshots

https://user-images.githubusercontent.com/75402236/187672152-afe886f4-941c-4f54-96fa-2d64a71dd17c.mov

## Release notes
Notes: [Improved] Add "Learn more" link to "Commit Reachability" dialog.
