### PR TITLE
Simplify TooltippedCommitSHA component

### DIFF
--- a/app/src/ui/diff/submodule-diff.tsx
+++ b/app/src/ui/diff/submodule-diff.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { parseRepositoryIdentifier } from '../../lib/remote-parsing'
-import { shortenSHA } from '../../models/commit'
 import { ISubmoduleDiff } from '../../models/diff'
 import { LinkButton } from '../lib/link-button'
-import { Ref } from '../lib/ref'
 import { TooltippedCommitSHA } from '../lib/tooltipped-commit-sha'
 import { Octicon } from '../octicons'
 import * as OcticonSymbol from '../octicons/octicons.generated'
@@ -102,12 +100,7 @@ export class SubmoduleDiff extends React.Component<ISubmoduleDiffProps> {
   }
 
   private renderTooltippedCommitSHA(sha: string) {
-    return (
-      <TooltippedCommitSHA
-        shortSHA={<Ref>{shortenSHA(sha)}</Ref>}
-        longSHA={sha}
-      />
-    )
+    return <TooltippedCommitSHA commit={sha} asRef={true} />
   }
 
   private renderSubmodulesChangesInfo() {

--- a/app/src/ui/history/commit-summary.tsx
+++ b/app/src/ui/history/commit-summary.tsx
@@ -342,11 +342,6 @@ export class CommitSummary extends React.Component<
     )
   }
 
-  private getShaRef = (useShortSha?: boolean) => {
-    const { selectedCommits } = this.props
-    return useShortSha ? selectedCommits[0].shortSha : selectedCommits[0].sha
-  }
-
   private onHighlightShasInDiff = () => {
     this.props.onHighlightShas(this.props.shasInDiff)
   }
@@ -436,11 +431,7 @@ export class CommitSummary extends React.Component<
         aria-label="SHA"
       >
         <Octicon symbol={OcticonSymbol.gitCommit} />
-        <TooltippedCommitSHA
-          className="sha"
-          shortSHA={this.getShaRef(true)}
-          longSHA={this.getShaRef()}
-        />
+        <TooltippedCommitSHA className="sha" commit={selectedCommits[0]} />
       </li>
     )
   }

--- a/app/src/ui/lib/tooltipped-commit-sha.tsx
+++ b/app/src/ui/lib/tooltipped-commit-sha.tsx
@@ -1,51 +1,68 @@
 import { clipboard } from 'electron'
 import React from 'react'
+import { Commit, shortenSHA } from '../../models/commit'
+import { Ref } from './ref'
 import { TooltipDirection } from './tooltip'
 import { TooltippedContent } from './tooltipped-content'
 
 interface ITooltippedCommitSHAProps {
   readonly className?: string
-  /**
-   * Short SHA to display in the tooltipped element, or the tooltipped element
-   * itself.
-   */
-  readonly shortSHA: string | JSX.Element
+  /** Commit or long SHA of a commit to render in the component. */
+  readonly commit: string | Commit
 
-  /** Long SHA to display within the tooltip. */
-  readonly longSHA: string
+  /** Whether or not render the commit as a Ref component. Default: false */
+  readonly asRef?: boolean
 }
 
 export class TooltippedCommitSHA extends React.Component<
   ITooltippedCommitSHAProps,
   {}
 > {
+  private get shortSHA() {
+    const { commit } = this.props
+    return typeof commit === 'string' ? shortenSHA(commit) : commit.shortSha
+  }
+
+  private get longSHA() {
+    const { commit } = this.props
+    return typeof commit === 'string' ? commit : commit.sha
+  }
+
   public render() {
-    const { className, shortSHA } = this.props
+    const { className } = this.props
 
     return (
       <TooltippedContent
         className={className}
-        tooltip={this.renderShaTooltip()}
+        tooltip={this.renderSHATooltip()}
         tooltipClassName="sha-hint"
         interactive={true}
         direction={TooltipDirection.SOUTH}
       >
-        {shortSHA}
+        {this.renderShortSHA()}
       </TooltippedContent>
     )
   }
 
-  private renderShaTooltip() {
+  private renderShortSHA() {
+    return this.props.asRef === true ? (
+      <Ref>{this.shortSHA}</Ref>
+    ) : (
+      <>{this.shortSHA}</>
+    )
+  }
+
+  private renderSHATooltip() {
     return (
       <>
-        <code>{this.props.longSHA}</code>
-        <button onClick={this.onCopyShaButtonClick}>Copy</button>
+        <code>{this.longSHA}</code>
+        <button onClick={this.onCopySHAButtonClick}>Copy</button>
       </>
     )
   }
 
-  private onCopyShaButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  private onCopySHAButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
-    clipboard.writeText(this.props.longSHA)
+    clipboard.writeText(this.longSHA)
   }
 }

--- a/app/src/ui/lib/tooltipped-commit-sha.tsx
+++ b/app/src/ui/lib/tooltipped-commit-sha.tsx
@@ -48,7 +48,7 @@ export class TooltippedCommitSHA extends React.Component<
     return this.props.asRef === true ? (
       <Ref>{this.shortSHA}</Ref>
     ) : (
-      <>{this.shortSHA}</>
+      this.shortSHA
     )
   }
 


### PR DESCRIPTION
## Description
Per @tidy-dev 's suggestion in https://github.com/desktop/desktop/pull/15176#discussion_r959548519, this PR simplifies the new `TooltippedCommitSHA` component by only requiring to specify either a `Commit` or a long SHA, and from that render the short SHA with a tooltip with the long SHA (that can be copied).

Also added `asRef` to render the short SHA wrapped in a `Ref` component.

## Release notes

Notes: no-notes
