### PR TITLE
Fix tooltip positioning in dialogs

### DIFF
--- a/app/src/ui/lib/tooltip.tsx
+++ b/app/src/ui/lib/tooltip.tsx
@@ -133,9 +133,6 @@ interface ITooltipState {
   /** The size and position of the target element relative to the window */
   readonly targetRect: DOMRect
 
-  /** The size and position of the tooltip parent relative to the window */
-  readonly hostRect: DOMRect
-
   /** The size of the window */
   readonly windowRect: DOMRect
 
@@ -166,7 +163,6 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       measure: false,
       show: false,
       targetRect: new DOMRect(),
-      hostRect: new DOMRect(),
       windowRect: new DOMRect(),
       tooltipRect: new DOMRect(),
       tooltipHost: tooltipHostFor(target),
@@ -402,7 +398,6 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       measure: true,
       show: false,
       targetRect: this.getTargetRect(target),
-      hostRect: tooltipHost.getBoundingClientRect(),
       windowRect: new DOMRect(0, 0, window.innerWidth, window.innerHeight),
     })
   }
@@ -484,14 +479,14 @@ export class Tooltip<T extends TooltipTarget> extends React.Component<
       return null
     }
     const visible = show && !measure
-    const { targetRect, hostRect, windowRect, tooltipRect } = this.state
+    const { targetRect, windowRect, tooltipRect } = this.state
 
     const direction = visible
       ? getDirection(this.props.direction, targetRect, windowRect, tooltipRect)
       : TooltipDirection.SOUTH
 
     const style: React.CSSProperties = visible
-      ? getTooltipPositionStyle(direction, targetRect, hostRect, tooltipRect)
+      ? getTooltipPositionStyle(direction, targetRect, tooltipRect)
       : { visibility: 'hidden', left: `0px`, top: `0px` }
 
     const className = classNames('tooltip', this.props.className, {
@@ -612,13 +607,9 @@ function getDirection(
 function getTooltipPositionStyle(
   direction: TooltipDirection,
   target: DOMRect,
-  host: DOMRect,
   tooltip: DOMRect
 ): React.CSSProperties {
   const r = getTooltipRectRelativeTo(target, direction, tooltip)
-  r.x -= host.x
-  r.y -= host.y
-
   return { transform: `translate(${r.left}px, ${r.top}px)` }
 }
 


### PR DESCRIPTION
## Description
This PR addresses a problem displaying tooltips in dialogs, because they're actually rendered relative to the window, in the wrong place.

Unless I'm wrong, it looks like `position: fixed` expects coordinates relative to the window, and we're passing coordinates relative to the `tooltip-host` element (the `dialog` in this case), so we have two options:
1. Use `position: absolute` so that positioning is relative to the parent of the tooltip (the dialog itself).
1. Keep using `position: fixed`, but use coordinates relative to the window to position the tooltip (i.e. delete these two lines: https://github.com/desktop/desktop/blob/5a9963c30e44e4cc91533673f29a2c759e088b04/app/src/ui/lib/tooltip.tsx#L619-L620)

I chose the second one, because it seems the change from `absolute` to `fixed` was intentional in https://github.com/desktop/desktop/commit/b54339c0baeb8157dfa08ed7ed757be1373f1b49, although it'd be great to have more context from @niik before merging this.

### Screenshots

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/1083228/188471110-68cc9ac5-4c07-4408-8ddf-6e86adc05994.png) | ![image](https://user-images.githubusercontent.com/1083228/188470992-3ae53d9f-0cba-450d-952c-eef5e02a3266.png) |

## Release notes

Notes: [Fixed] Fix misplaced tooltips from dialogs
