### PR TITLE
Improve docs with new release stuff and known issues!

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -202,3 +202,11 @@ If either the user or an application has modified the `Command Processor` regist
 `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Command Processor\`
 
 Check to see if there is an `Autorun` value in either of those location. If there is, deleting that value should resolve the `Authentication failed` error.
+
+### "Not enough resources" error when signing in
+
+Related issue: [#15217](https://github.com/desktop/desktop/issues/15217)
+
+If you see an error that says "Not enough resources are available to process this command" when signing in to GitHub Desktop, it's likely that you have too many credentials stored in Windows Credentials Manager.
+
+**Workaround:** open the Credential Manager application, click on Windows Credentials and go through the list to see if there are some you can delete.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -61,6 +61,21 @@ This issue seems to be caused by missing permissions for the `~/Library/Caches/c
    the "Read & Write" permissions
  - Start Desktop again and check for updates
 
+### GitHub Desktop prompts admin password to install helper tool very frequently
+
+Related issue: [#13956](https://github.com/desktop/desktop/issues/13956)
+
+Users who use macOS' Migration Assistant to keep their stuff intact when moving to a new computer might run into this problem because the Migration Assistant changes the owner of the `/Applications/GitHub Desktop.app` folder to `root`.
+
+Since GitHub Desktop is able to auto-update by changing the contents of the `/Applications/GitHub Desktop.app` folder, it needs to be able to write to it. If the owner of the folder is not the current user, the user will be prompted for an admin password every time GitHub Desktop tries to update itself.
+
+**Workaround:** you need to restore the ownership and permissions of the application folder to the current user. If your app is located in `/Applications/GitHub Desktop.app`, you can probably do this by just running the following commands in Terminal:
+
+```sh
+sudo chown -R ${USER}:staff /Applications/GitHub\ Desktop.app
+chmod -R g+w /Applications/GitHub\ Desktop.app
+```
+
 ## Windows
 
 ### Window is hidden after detaching secondary monitor

--- a/docs/process/releasing-updates.md
+++ b/docs/process/releasing-updates.md
@@ -154,7 +154,7 @@ IMPORTANT NOTE: Ensure that you indicate which channel to release to. If not, ch
 
 ### 5. Check for Completed Release
 
-Go to [Central's Deployments](https://central.github.com/deployments) to find your release; you'll see something at the top of the page like:
+Go to [Central's Deployments](https://central.githubapp.com/deployments) to find your release; you'll see something at the top of the page like:
 ```
 desktop/desktop deployed from {YOUR_BRANCH}@{HASH_ABBREVIATION_FOR_COMMIT} to {production|beta|test}
 ```
@@ -163,7 +163,11 @@ it will initially specify its state as `State: pending` and will be completed wh
 You will also see this in Chat:
 `desktopbot tagged desktop/release-{YOUR_VERSION}`
 
-### 6. Test that your app auto-updates to new version
+### 6. Enable the Release
+
+Production releases are disabled by default. To enable them, go to [Central's Release Control](https://central.githubapp.com/release_control), select the percentage of users that will be able to auto-update to this new version, and then click the "Apply" button.
+
+### 7. Test that your app auto-updates to new version
 
 When the release in Central is in `State: released` for `beta` or `production`, switch to your installed Desktop instance and make sure that the corresponding (prod|beta) app auto-updates.
 
@@ -173,11 +177,11 @@ If you don't have the app for `beta`, for example, you can always download the p
 
 _Make sure you move your application out of the Downloads folder and into the Applications folder for macOS or it won't auto-update_.
 
-### 7. Merge PR with changelog entries
+### 8. Merge PR with changelog entries
 
 So that we keep the `changelog.json` up to date. Beta entries will be used for the upcoming production release.
 
-### 8. Check Error Reporting
+### 9. Check Error Reporting
 
 If an error occurs during the release process, a needle will be reported to Central's [Haystack](https://haystack.githubapp.com/central).
 
@@ -186,7 +190,7 @@ After the release is deployed, you should monitor Desktop's [Haystack](https://h
 #### Final Beta release
 If the active beta is the last beta prior to a production release, extra care should be taken when looking at Desktop's [Haystack](https://haystack.githubapp.com/desktop) roll-ups. The lead engineer responsible for deployment should produce a _Haystack report_ the day before and after the release. The report should contain a list of any new or unexpected errors from the past beta releases in the milestone and be published to the team's Slack channel.
 
-### 9. Celebrate
+### 10. Celebrate
 
 Once your app updates and you see the visible changes in your app and there are no spikes in errors, celebrate 🎉!!! You did it!
 


### PR DESCRIPTION
## Description

This PR updates our docs to include:
- A fix of a typo in the URL to Central's Deployments page.
- A mention in the release docs about staggered releases (more specifically, how we must enable prod versions sin they're disabled by default now).
- A new entry in the known issues docs for #15217 (thanks @tsvetilian-ty for following up with that issue 🙏 and linking VS Code's docs)
- A new entry in the known issues docs for #13956

## Release notes

Notes: no-notes
