### PR TITLE
More submodule improvements

### DIFF
--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -269,10 +269,14 @@ export async function getWorkingDirectoryDiff(
     '--no-color',
   ]
   const successExitCodes = new Set([0])
+  const isSubmodule = file.status.submoduleStatus !== undefined
 
+  // For added submodules, we'll use the "default" parameters, which are able
+  // to output the submodule commit.
   if (
-    file.status.kind === AppFileStatusKind.New ||
-    file.status.kind === AppFileStatusKind.Untracked
+    !isSubmodule &&
+    (file.status.kind === AppFileStatusKind.New ||
+      file.status.kind === AppFileStatusKind.Untracked)
   ) {
     // `git diff --no-index` seems to emulate the exit codes from `diff` irrespective of
     // whether you set --exit-code
@@ -494,7 +498,11 @@ async function buildSubmoduleDiff(
   let oldSHA = null
   let newSHA = null
 
-  if (status.commitChanged) {
+  if (
+    status.commitChanged ||
+    file.status.kind === AppFileStatusKind.New ||
+    file.status.kind === AppFileStatusKind.Deleted
+  ) {
     const diff = buffer.toString('utf-8')
     const lines = diff.split('\n')
     const baseRegex = 'Subproject commit ([^-]+)(-dirty)?$'

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -489,8 +489,7 @@ async function buildSubmoduleDiff(
 ): Promise<IDiff> {
   const path = file.path
   const fullPath = Path.join(repository.path, path)
-  const url =
-    (await getConfigValue(repository, `submodule.${path}.url`, true)) ?? ''
+  const url = await getConfigValue(repository, `submodule.${path}.url`, true)
 
   let oldSHA = null
   let newSHA = null

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -6,6 +6,7 @@ import {
   CopiedOrRenamedFileStatus,
   UntrackedFileStatus,
   AppFileStatus,
+  SubmoduleStatus,
 } from '../../models/status'
 import { Repository } from '../../models/repository'
 import { Commit } from '../../models/commit'
@@ -15,47 +16,82 @@ import { getCaptures } from '../helpers/regex'
 import { createLogParser } from './git-delimiter-parser'
 import { revRange } from '.'
 import { forceUnwrap } from '../fatal-error'
+import { enableSubmoduleDiff } from '../feature-flag'
+
+// File mode 160000 is used by git specifically for submodules:
+// https://github.com/git/git/blob/v2.37.3/cache.h#L62-L69
+const SubmoduleFileMode = '160000'
+
+function mapSubmoduleStatusFileModes(
+  status: string,
+  srcMode: string,
+  dstMode: string
+): SubmoduleStatus | undefined {
+  if (!enableSubmoduleDiff()) {
+    return undefined
+  }
+
+  return srcMode === SubmoduleFileMode &&
+    dstMode === SubmoduleFileMode &&
+    status == 'M'
+    ? {
+        commitChanged: true,
+        untrackedChanges: false,
+        modifiedChanges: false,
+      }
+    : (srcMode === SubmoduleFileMode && status === 'D') ||
+      (dstMode === SubmoduleFileMode && status === 'A')
+    ? {
+        commitChanged: false,
+        untrackedChanges: false,
+        modifiedChanges: false,
+      }
+    : undefined
+}
 
 /**
  * Map the raw status text from Git to an app-friendly value
  * shamelessly borrowed from GitHub Desktop (Windows)
  */
-export function mapStatus(
+function mapStatus(
   rawStatus: string,
-  oldPath?: string
+  oldPath: string | undefined,
+  srcMode: string,
+  dstMode: string
 ): PlainFileStatus | CopiedOrRenamedFileStatus | UntrackedFileStatus {
   const status = rawStatus.trim()
+  const submoduleStatus = mapSubmoduleStatusFileModes(status, srcMode, dstMode)
 
   if (status === 'M') {
-    return { kind: AppFileStatusKind.Modified }
+    return { kind: AppFileStatusKind.Modified, submoduleStatus }
   } // modified
   if (status === 'A') {
-    return { kind: AppFileStatusKind.New }
+    return { kind: AppFileStatusKind.New, submoduleStatus }
   } // added
   if (status === '?') {
-    return { kind: AppFileStatusKind.Untracked }
+    return { kind: AppFileStatusKind.Untracked, submoduleStatus }
   } // untracked
   if (status === 'D') {
-    return { kind: AppFileStatusKind.Deleted }
+    return { kind: AppFileStatusKind.Deleted, submoduleStatus }
   } // deleted
   if (status === 'R' && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath }
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus }
   } // renamed
   if (status === 'C' && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath }
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus }
   } // copied
 
   // git log -M --name-status will return a RXXX - where XXX is a percentage
   if (status.match(/R[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Renamed, oldPath }
+    return { kind: AppFileStatusKind.Renamed, oldPath, submoduleStatus }
   }
 
   // git log -C --name-status will return a CXXX - where XXX is a percentage
   if (status.match(/C[0-9]+/) && oldPath != null) {
-    return { kind: AppFileStatusKind.Copied, oldPath }
+    return { kind: AppFileStatusKind.Copied, oldPath, submoduleStatus }
   }
 
-  return { kind: AppFileStatusKind.Modified }
+  return { kind: AppFileStatusKind.Modified, submoduleStatus }
 }
 
 const isCopyOrRename = (
@@ -232,7 +268,19 @@ export function parseRawLogWithNumstat(
   for (let i = 0; i < lines.length - 1; i++) {
     const line = lines[i]
     if (line.startsWith(':')) {
-      const status = forceUnwrap('Invalid log output', line.split(' ').at(-1))
+      const lineComponents = line.split(' ')
+      const srcMode = forceUnwrap(
+        'Invalid log output (srcMode)',
+        lineComponents[0].replace(':', '')
+      )
+      const dstMode = forceUnwrap(
+        'Invalid log output (dstMode)',
+        lineComponents[1]
+      )
+      const status = forceUnwrap(
+        'Invalid log output (status)',
+        lineComponents.at(-1)
+      )
       const oldPath = /^R|C/.test(status)
         ? forceUnwrap('Missing old path', lines.at(++i))
         : undefined
@@ -242,7 +290,7 @@ export function parseRawLogWithNumstat(
       files.push(
         new CommittedFileChange(
           path,
-          mapStatus(status, oldPath),
+          mapStatus(status, oldPath, srcMode, dstMode),
           sha,
           parentCommitish
         )

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -33,7 +33,7 @@ function mapSubmoduleStatusFileModes(
 
   return srcMode === SubmoduleFileMode &&
     dstMode === SubmoduleFileMode &&
-    status == 'M'
+    status === 'M'
     ? {
         commitChanged: true,
         untrackedChanges: false,

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -271,7 +271,7 @@ export function parseRawLogWithNumstat(
       const lineComponents = line.split(' ')
       const srcMode = forceUnwrap(
         'Invalid log output (srcMode)',
-        lineComponents[0].replace(':', '')
+        lineComponents[0]?.replace(':', '')
       )
       const dstMode = forceUnwrap(
         'Invalid log output (dstMode)',

--- a/app/src/models/diff/diff-data.ts
+++ b/app/src/models/diff/diff-data.ts
@@ -98,7 +98,7 @@ export interface ISubmoduleDiff {
   readonly path: string
 
   /** URL of the submodule */
-  readonly url: string
+  readonly url: string | null
 
   /** Status of the submodule */
   readonly status: SubmoduleStatus

--- a/app/src/ui/diff/index.tsx
+++ b/app/src/ui/diff/index.tsx
@@ -252,7 +252,11 @@ export class Diff extends React.Component<IDiffProps, IDiffState> {
 
   private renderSubmoduleDiff(diff: ISubmoduleDiff) {
     return (
-      <SubmoduleDiff onOpenSubmodule={this.props.onOpenSubmodule} diff={diff} />
+      <SubmoduleDiff
+        onOpenSubmodule={this.props.onOpenSubmodule}
+        diff={diff}
+        readOnly={this.props.readOnly}
+      />
     )
   }
 

--- a/app/src/ui/diff/submodule-diff.tsx
+++ b/app/src/ui/diff/submodule-diff.tsx
@@ -50,7 +50,9 @@ export class SubmoduleDiff extends React.Component<ISubmoduleDiffProps> {
   }
 
   private renderSubmoduleInfo() {
-    // TODO: only for GH submodules?
+    if (this.props.diff.url === null) {
+      return null
+    }
 
     const repoIdentifier = parseRepositoryIdentifier(this.props.diff.url)
     if (repoIdentifier === null) {

--- a/app/src/ui/history/selected-commits.tsx
+++ b/app/src/ui/history/selected-commits.tsx
@@ -71,6 +71,9 @@ interface ISelectedCommitsProps {
    */
   readonly onOpenBinaryFile: (fullPath: string) => void
 
+  /** Called when the user requests to open a submodule. */
+  readonly onOpenSubmodule: (fullPath: string) => void
+
   /**
    * Called when the user is viewing an image diff and requests
    * to change the diff presentation mode.
@@ -161,6 +164,7 @@ export class SelectedCommits extends React.Component<
         onOpenBinaryFile={this.props.onOpenBinaryFile}
         onChangeImageDiffType={this.props.onChangeImageDiffType}
         onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
+        onOpenSubmodule={this.props.onOpenSubmodule}
       />
     )
   }

--- a/app/src/ui/repository.tsx
+++ b/app/src/ui/repository.tsx
@@ -358,6 +358,7 @@ export class RepositoryView extends React.Component<
           isWorkingTreeClean={isWorkingTreeClean}
           showSideBySideDiff={this.props.showSideBySideDiff}
           onOpenBinaryFile={this.onOpenBinaryFile}
+          onOpenSubmodule={this.onOpenSubmodule}
           onChangeImageDiffType={this.onChangeImageDiffType}
           onHideWhitespaceInDiffChanged={this.onHideWhitespaceInDiffChanged}
         />
@@ -412,6 +413,7 @@ export class RepositoryView extends React.Component<
         hideWhitespaceInDiff={this.props.hideWhitespaceInHistoryDiff}
         showSideBySideDiff={this.props.showSideBySideDiff}
         onOpenBinaryFile={this.onOpenBinaryFile}
+        onOpenSubmodule={this.onOpenSubmodule}
         onChangeImageDiffType={this.onChangeImageDiffType}
         onDiffOptionsOpened={this.onDiffOptionsOpened}
         showDragOverlay={showDragOverlay}

--- a/app/src/ui/stashing/stash-diff-viewer.tsx
+++ b/app/src/ui/stashing/stash-diff-viewer.tsx
@@ -47,6 +47,9 @@ interface IStashDiffViewerProps {
 
   /** Called when the user changes the hide whitespace in diffs setting. */
   readonly onHideWhitespaceInDiffChanged: (checked: boolean) => void
+
+  /** Called when the user requests to open a submodule. */
+  readonly onOpenSubmodule: (fullPath: string) => void
 }
 
 /**
@@ -75,6 +78,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
       fileListWidth,
       onOpenBinaryFile,
       onChangeImageDiffType,
+      onOpenSubmodule,
     } = this.props
     const files =
       stashEntry.files.kind === StashedChangesLoadStates.Loaded
@@ -96,6 +100,7 @@ export class StashDiffViewer extends React.PureComponent<IStashDiffViewerProps> 
           onHideWhitespaceInDiffChanged={
             this.props.onHideWhitespaceInDiffChanged
           }
+          onOpenSubmodule={onOpenSubmodule}
         />
       ) : null
 

--- a/app/styles/ui/changes/_submodule-diff.scss
+++ b/app/styles/ui/changes/_submodule-diff.scss
@@ -23,6 +23,14 @@
         color: var(--color-modified);
       }
 
+      &.added-icon {
+        color: var(--color-new);
+      }
+
+      &.deleted-icon {
+        color: var(--color-deleted);
+      }
+
       &.untracked-icon {
         color: var(--color-deleted);
       }

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -3,7 +3,6 @@ import { getChangedFiles, getCommits } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import { AppFileStatusKind } from '../../../src/models/status'
 import { setupLocalConfig } from '../../helpers/local-config'
-import { GitProcess } from 'dugite'
 
 describe('git/log', () => {
   let repository: Repository

--- a/app/test/unit/git/log-test.ts
+++ b/app/test/unit/git/log-test.ts
@@ -3,6 +3,7 @@ import { getChangedFiles, getCommits } from '../../../src/lib/git'
 import { setupFixtureRepository } from '../../helpers/repositories'
 import { AppFileStatusKind } from '../../../src/models/status'
 import { setupLocalConfig } from '../../helpers/local-config'
+import { GitProcess } from 'dugite'
 
 describe('git/log', () => {
   let repository: Repository
@@ -128,5 +129,15 @@ describe('git/log', () => {
         AppFileStatusKind.Modified
       )
     })
+  })
+
+  it('detects submodule changes within commits', async () => {
+    const repoPath = await setupFixtureRepository('submodule-basic-setup')
+    repository = new Repository(repoPath, -1, null, false)
+
+    const changesetData = await getChangedFiles(repository, 'HEAD')
+    expect(changesetData.files).toHaveLength(2)
+    expect(changesetData.files[1].path).toBe('foo/submodule')
+    expect(changesetData.files[1].status.submoduleStatus).not.toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #7691

## Description
While looking into #7691 I realized we could also render submodules nicely in the Commit/History view could be useful. This PR does exactly that. Main changes/differences:
- While for active changes we use `git status`, for commit changes we use `git log`, and the output is different. In order to detect submodules, we must look for the file mode `160000`.
- In commits, submodules cannot have untracked or modified changes.
- Verbs change in the submodule diff screen, reflecting active vs past change.
- Sometimes, a submodule referenced within a commit doesn't exist anymore and cannot be opened, therefore the `Open Repository` quick action must be removed.
- Suggestions also change: in active changes context we suggest the user which changes can be committed and which cannot. That doesn't make sense within a commit.
- Added info about the commit a submodule is pointing at for added/deleted submodules.

### Screenshots

![image](https://user-images.githubusercontent.com/1083228/188619268-b668e57e-91e6-4dba-bfcd-5491a8570b1f.png)
![image](https://user-images.githubusercontent.com/1083228/188619385-5c2e6a25-076e-47dc-8aad-517d501bdb9c.png)
![image](https://user-images.githubusercontent.com/1083228/188619718-a7ec6b97-d21e-49fc-8425-c072175d43e3.png)
![image](https://user-images.githubusercontent.com/1083228/188619459-ae7479c7-2ce4-4046-9665-b139d1602dc3.png)

## Release notes

Notes: no-notes
