### PR TITLE
Enable recursing submodules feature for git operations

### DIFF
--- a/app/src/lib/feature-flag.ts
+++ b/app/src/lib/feature-flag.ts
@@ -30,7 +30,7 @@ function enableBetaFeatures(): boolean {
 
 /** Should git pass `--recurse-submodules` when performing operations? */
 export function enableRecurseSubmodulesFlag(): boolean {
-  return enableBetaFeatures()
+  return true
 }
 
 export function enableReadmeOverwriteWarning(): boolean {


### PR DESCRIPTION
Closes #8221
Closes #9174

## Description
This PR just enables a feature that has been in beta for 4 years (it was added in #5154). This feature allows certain git commands (`checkout`, `fetch` and `pull`) to act recursively in the repository's submodules.

## Release notes

Notes: [Improved] Update submodules when fetching, pulling and checking out branches
